### PR TITLE
fix: handle session latest no rows

### DIFF
--- a/infrastructure/sqlite/find_latest_session.go
+++ b/infrastructure/sqlite/find_latest_session.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"golang.org/x/xerrors"
 
@@ -43,7 +44,7 @@ func (d *Datasource) FindLatestSessionStartedEvent(
 
 	event, err := d.scanEvent(row)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, xerrors.Errorf("条件に一致する session は存在しません")
 		}
 		return nil, xerrors.Errorf("直近セッションイベントの復元に失敗しました: %w", err)

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -105,6 +106,9 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		)
 		if err == nil {
 			t.Fatalf("FindLatestSessionStartedEvent() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "条件に一致する session は存在しません") {
+			t.Fatalf("error = %q, want no rows message", err.Error())
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- use `errors.Is(err, sql.ErrNoRows)` in latest-session lookup
- assert the no-rows message in the SQLite datasource test

## Motivation
Follow-up for v0.1.2 dogfood: `traceary session latest` returned a generic restore failure when no matching session existed because the underlying `sql.ErrNoRows` was wrapped before comparison.

## Testing
- `GOCACHE=/tmp/traceary-gocache go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`
- `tmpdir=$(mktemp -d /tmp/traceary-session-no-rows.XXXXXX) && db="$tmpdir/traceary.db" && GOCACHE=/tmp/traceary-gocache go build -o "$tmpdir/traceary" . && "$tmpdir/traceary" init --db-path "$db" >/dev/null && "$tmpdir/traceary" session latest --db-path "$db"`

Closes #28
