### PR TITLE
feat: add session active command

### DIFF
--- a/application/queryservice/find_latest_session.go
+++ b/application/queryservice/find_latest_session.go
@@ -11,9 +11,10 @@ import (
 
 // FindLatestSessionInput は直近セッション取得の入力です。
 type FindLatestSessionInput struct {
-	Client string
-	Agent  string
-	Repo   string
+	Client     string
+	Agent      string
+	Repo       string
+	ActiveOnly bool
 }
 
 // LatestSessionFinder は直近セッション開始イベントの取得を提供します。

--- a/application/queryservice/find_latest_session_test.go
+++ b/application/queryservice/find_latest_session_test.go
@@ -61,9 +61,10 @@ func TestFindLatestSessionQueryService_Run(t *testing.T) {
 		sut := queryservice.NewFindLatestSessionQueryService(stub)
 
 		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.FindLatestSessionInput{
-			Client: "cli",
-			Agent:  "codex",
-			Repo:   "github.com/duck8823/traceary",
+			Client:     "cli",
+			Agent:      "codex",
+			Repo:       "github.com/duck8823/traceary",
+			ActiveOnly: true,
 		})
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
@@ -73,6 +74,9 @@ func TestFindLatestSessionQueryService_Run(t *testing.T) {
 		}
 		if stub.receivedInput.Agent != "codex" {
 			t.Fatalf("received agent = %q, want %q", stub.receivedInput.Agent, "codex")
+		}
+		if !stub.receivedInput.ActiveOnly {
+			t.Fatalf("received activeOnly = %t, want true", stub.receivedInput.ActiveOnly)
 		}
 		if got.SessionID() != sessionID {
 			t.Fatalf("SessionID() = %q, want %q", got.SessionID(), sessionID)

--- a/infrastructure/sqlite/find_latest_session.go
+++ b/infrastructure/sqlite/find_latest_session.go
@@ -28,23 +28,47 @@ func (d *Datasource) FindLatestSessionStartedEvent(
 
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT id, kind, client, agent, session_id, repo, body, created_at
-		   FROM events
-		  WHERE kind = ?
-		    AND (? = '' OR client = ?)
-		    AND (? = '' OR agent = ?)
-		    AND (? = '' OR repo = ?)
-		  ORDER BY created_at DESC, id DESC
+		`SELECT started.id,
+		        started.kind,
+		        started.client,
+		        started.agent,
+		        started.session_id,
+		        started.repo,
+		        started.body,
+		        started.created_at
+		   FROM events started
+		  WHERE started.kind = ?
+		    AND (? = '' OR started.client = ?)
+		    AND (? = '' OR started.agent = ?)
+		    AND (? = '' OR started.repo = ?)
+		    AND (
+		         ? = 0 OR NOT EXISTS (
+		             SELECT 1
+		               FROM events ended
+		              WHERE ended.kind = ?
+		                AND ended.session_id = started.session_id
+		                AND (
+		                     ended.created_at > started.created_at OR
+		                     (ended.created_at = started.created_at AND ended.id > started.id)
+		                )
+		         )
+		    )
+		  ORDER BY started.created_at DESC, started.id DESC
 		  LIMIT 1`,
 		types.EventKindSessionStarted.String(),
 		input.Client, input.Client,
 		input.Agent, input.Agent,
 		input.Repo, input.Repo,
+		input.ActiveOnly,
+		types.EventKindSessionEnded.String(),
 	)
 
 	event, err := d.scanEvent(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			if input.ActiveOnly {
+				return nil, xerrors.Errorf("条件に一致する active session は存在しません")
+			}
 			return nil, xerrors.Errorf("条件に一致する session は存在しません")
 		}
 		return nil, xerrors.Errorf("直近セッションイベントの復元に失敗しました: %w", err)

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
@@ -40,10 +41,11 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		t.Fatalf("Initialize() error = %v", err)
 	}
 
-	oldEvent := newSearchEventFixture(
+	oldEvent := newFindLatestSessionEventFixture(
 		t,
 		"event-1",
 		types.EventKindSessionStarted,
+		"session-old",
 		"github.com/duck8823/traceary",
 		"session started",
 		time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC),
@@ -52,10 +54,11 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		t.Fatalf("Save(old) error = %v", err)
 	}
 
-	endedEvent := newSearchEventFixture(
+	endedEvent := newFindLatestSessionEventFixture(
 		t,
 		"event-2",
 		types.EventKindSessionEnded,
+		"session-old",
 		"github.com/duck8823/traceary",
 		"session ended",
 		time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
@@ -64,16 +67,43 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		t.Fatalf("Save(ended) error = %v", err)
 	}
 
-	latestEvent := newSearchEventFixture(
+	activeEvent := newFindLatestSessionEventFixture(
 		t,
 		"event-3",
 		types.EventKindSessionStarted,
+		"session-active",
 		"github.com/duck8823/traceary",
 		"session started",
 		time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
 	)
-	if err := sut.Save(context.Background(), dbPath, latestEvent); err != nil {
-		t.Fatalf("Save(latest) error = %v", err)
+	if err := sut.Save(context.Background(), dbPath, activeEvent); err != nil {
+		t.Fatalf("Save(active) error = %v", err)
+	}
+
+	finishedStartEvent := newFindLatestSessionEventFixture(
+		t,
+		"event-4",
+		types.EventKindSessionStarted,
+		"session-finished",
+		"github.com/duck8823/traceary",
+		"session started",
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), dbPath, finishedStartEvent); err != nil {
+		t.Fatalf("Save(finished start) error = %v", err)
+	}
+
+	finishedEndEvent := newFindLatestSessionEventFixture(
+		t,
+		"event-5",
+		types.EventKindSessionEnded,
+		"session-finished",
+		"github.com/duck8823/traceary",
+		"session ended",
+		time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), dbPath, finishedEndEvent); err != nil {
+		t.Fatalf("Save(finished end) error = %v", err)
 	}
 
 	t.Run("直近の session_started を返す", func(t *testing.T) {
@@ -86,6 +116,27 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 				Client: "cli",
 				Agent:  "codex",
 				Repo:   "github.com/duck8823/traceary",
+			},
+		)
+		if err != nil {
+			t.Fatalf("FindLatestSessionStartedEvent() error = %v", err)
+		}
+		if got.EventID().String() != "event-4" {
+			t.Fatalf("EventID() = %q, want %q", got.EventID(), "event-4")
+		}
+	})
+
+	t.Run("active only のとき未終了 session を返す", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := sut.FindLatestSessionStartedEvent(
+			context.Background(),
+			dbPath,
+			queryservice.FindLatestSessionInput{
+				Client:     "cli",
+				Agent:      "codex",
+				Repo:       "github.com/duck8823/traceary",
+				ActiveOnly: true,
 			},
 		)
 		if err != nil {
@@ -111,4 +162,59 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 			t.Fatalf("error = %q, want no rows message", err.Error())
 		}
 	})
+
+	t.Run("一致する active session がなければエラー", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := sut.FindLatestSessionStartedEvent(
+			context.Background(),
+			dbPath,
+			queryservice.FindLatestSessionInput{
+				Agent:      "claude",
+				ActiveOnly: true,
+			},
+		)
+		if err == nil {
+			t.Fatalf("FindLatestSessionStartedEvent() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "条件に一致する active session は存在しません") {
+			t.Fatalf("error = %q, want active no rows message", err.Error())
+		}
+	})
+}
+
+func newFindLatestSessionEventFixture(
+	t *testing.T,
+	eventIDValue string,
+	kind types.EventKind,
+	sessionIDValue string,
+	repo string,
+	body string,
+	createdAt time.Time,
+) *model.Event {
+	t.Helper()
+
+	eventID, err := types.EventIDOf(eventIDValue)
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf("codex")
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf(sessionIDValue)
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	return model.EventOf(
+		eventID,
+		kind,
+		"cli",
+		agent,
+		sessionID,
+		repo,
+		body,
+		createdAt,
+	)
 }

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -22,6 +22,7 @@ func (c *RootCLI) newSessionCommand() *cobra.Command {
 	sessionCmd.AddCommand(c.newSessionStartCommand())
 	sessionCmd.AddCommand(c.newSessionEndCommand())
 	sessionCmd.AddCommand(c.newSessionLatestCommand())
+	sessionCmd.AddCommand(c.newSessionActiveCommand())
 
 	return sessionCmd
 }
@@ -131,10 +132,41 @@ type sessionBoundaryCommandInput struct {
 }
 
 type sessionLatestCommandInput struct {
-	dbPath string
-	client string
-	agent  string
-	repo   string
+	dbPath     string
+	client     string
+	agent      string
+	repo       string
+	activeOnly bool
+}
+
+func (c *RootCLI) newSessionActiveCommand() *cobra.Command {
+	var (
+		dbPath string
+		client string
+		agent  string
+		repo   string
+	)
+
+	activeCmd := &cobra.Command{
+		Use:   "active",
+		Short: "現在アクティブなセッション ID を表示する",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runSessionLatest(cmd.Context(), cmd.OutOrStdout(), sessionLatestCommandInput{
+				dbPath:     dbPath,
+				client:     client,
+				agent:      agent,
+				repo:       repo,
+				activeOnly: true,
+			})
+		},
+	}
+	activeCmd.Flags().StringVar(&dbPath, "db-path", "", "SQLite DB パス")
+	activeCmd.Flags().StringVar(&client, "client", "", "記録経路で絞り込む")
+	activeCmd.Flags().StringVar(&agent, "agent", "", "作業主体で絞り込む")
+	activeCmd.Flags().StringVar(&repo, "repo", "", "補助的なコンテキスト識別子で絞り込む")
+
+	return activeCmd
 }
 
 func (c *RootCLI) runSessionBoundary(
@@ -197,11 +229,15 @@ func (c *RootCLI) runSessionLatest(
 	}
 
 	event, err := c.findLatestSessionQueryService.Run(ctx, resolvedPath, queryservice.FindLatestSessionInput{
-		Client: resolveOptionalValue(input.client, "TRACEARY_CLIENT", ""),
-		Agent:  resolveOptionalValue(input.agent, "TRACEARY_AGENT", ""),
-		Repo:   resolveRepoValue(ctx, input.repo),
+		Client:     resolveOptionalValue(input.client, "TRACEARY_CLIENT", ""),
+		Agent:      resolveOptionalValue(input.agent, "TRACEARY_AGENT", ""),
+		Repo:       resolveRepoValue(ctx, input.repo),
+		ActiveOnly: input.activeOnly,
 	})
 	if err != nil {
+		if input.activeOnly {
+			return xerrors.Errorf("アクティブ session の取得に失敗しました: %w", err)
+		}
 		return xerrors.Errorf("直近セッションの取得に失敗しました: %w", err)
 	}
 

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -218,7 +218,65 @@ func TestRootCLI_SessionLatestCommand(t *testing.T) {
 	if latestStub.receivedInput.Agent != "codex" {
 		t.Fatalf("Agent = %q, want %q", latestStub.receivedInput.Agent, "codex")
 	}
+	if latestStub.receivedInput.ActiveOnly {
+		t.Fatalf("ActiveOnly = %t, want false", latestStub.receivedInput.ActiveOnly)
+	}
 	if stdout.String() != "session-latest\n" {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), "session-latest\n")
+	}
+}
+
+func TestRootCLI_SessionActiveCommand(t *testing.T) {
+	t.Parallel()
+
+	eventID, err := types.EventIDOf("event-4")
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf("codex")
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf("session-active")
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	initStub := &initializeStoreUsecaseStub{}
+	latestStub := &findLatestSessionQueryServiceStub{
+		event: model.EventOf(
+			eventID,
+			types.EventKindSessionStarted,
+			"cli",
+			agent,
+			sessionID,
+			"duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		),
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, nil, latestStub, nil).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session",
+		"active",
+		"--db-path", dbPath,
+		"--agent", "codex",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !latestStub.called {
+		t.Fatalf("FindLatestSessionQueryService.Run() was not called")
+	}
+	if !latestStub.receivedInput.ActiveOnly {
+		t.Fatalf("ActiveOnly = %t, want true", latestStub.receivedInput.ActiveOnly)
+	}
+	if stdout.String() != "session-active\n" {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), "session-active\n")
 	}
 }


### PR DESCRIPTION
## Summary
- add `traceary session active` to resolve the latest unclosed session
- teach the latest-session query to distinguish active sessions from ended ones
- cover the active-session path in CLI, query service, and SQLite tests

## Motivation
Follow-up for v0.1.2 dogfood: `session latest` returns the latest `session_started`, but hooks and day-to-day usage often need the current active session specifically.

## Testing
- `GOCACHE=/tmp/traceary-gocache go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`
- `tmpdir=$(mktemp -d /tmp/traceary-session-active.XXXXXX) && ... && traceary session latest && traceary session active`

Closes #30
