### PR TITLE
refactor: inject RootCLI dependencies via options

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,18 +95,18 @@ func run() error {
 	if err != nil {
 		return xerrors.Errorf("MCP server の初期化に失敗しました: %w", err)
 	}
-	rootCmd := cli.NewRootCLI(
-		initializeStoreUsecase,
-		recordLogUsecase,
-		recordSessionBoundaryUsecase,
-		recordCommandAuditUsecase,
-		collectGarbageUsecase,
-		searchEventsQueryService,
-		listRecentEventsQueryService,
-		getEventDetailsQueryService,
-		findLatestSessionQueryService,
-		mcpServer,
-	).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:        initializeStoreUsecase,
+		RecordLogUsecase:              recordLogUsecase,
+		RecordSessionBoundaryUsecase:  recordSessionBoundaryUsecase,
+		RecordCommandAuditUsecase:     recordCommandAuditUsecase,
+		CollectGarbageUsecase:         collectGarbageUsecase,
+		SearchEventsQueryService:      searchEventsQueryService,
+		ListEventsQueryService:        listRecentEventsQueryService,
+		GetEventDetailsQueryService:   getEventDetailsQueryService,
+		FindLatestSessionQueryService: findLatestSessionQueryService,
+		MCPServerRunner:               mcpServer,
+	}).Command()
 	rootCmd.Version = versionString()
 	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 

--- a/presentation/cli/audit_test.go
+++ b/presentation/cli/audit_test.go
@@ -73,7 +73,10 @@ func TestRootCLI_AuditCommand(t *testing.T) {
 		commandAudit: commandAudit,
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, nil, auditStub, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:    initStub,
+		RecordCommandAuditUsecase: auditStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{

--- a/presentation/cli/gc_test.go
+++ b/presentation/cli/gc_test.go
@@ -39,7 +39,10 @@ func TestRootCLI_GCCommand(t *testing.T) {
 		}
 		initStub := &initializeStoreUsecaseStub{}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, stub, nil, nil, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			CollectGarbageUsecase:  stub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"gc", "--db-path", "/tmp/traceary.db", "--keep-days", "30", "--dry-run"})
@@ -68,7 +71,10 @@ func TestRootCLI_GCCommand(t *testing.T) {
 		}
 		initStub := &initializeStoreUsecaseStub{}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, stub, nil, nil, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			CollectGarbageUsecase:  stub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"gc", "--db-path", "/tmp/traceary.db", "--keep-days", "30"})

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -94,7 +94,7 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 	t.Run("未対応 client はエラー", func(t *testing.T) {
 		t.Parallel()
 
-		rootCmd := cli.NewRootCLI(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{}).Command()
 		rootCmd.SetOut(&bytes.Buffer{})
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{
@@ -119,7 +119,7 @@ func executeHooksPrint(
 ) *printedHooksSettings {
 	t.Helper()
 
-	rootCmd := cli.NewRootCLI(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{}).Command()
 	stdout := &bytes.Buffer{}
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -150,7 +150,7 @@ func executeHooksPrintWithoutTracearyBin(
 ) *printedHooksSettings {
 	t.Helper()
 
-	rootCmd := cli.NewRootCLI(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{}).Command()
 	stdout := &bytes.Buffer{}
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})

--- a/presentation/cli/init_test.go
+++ b/presentation/cli/init_test.go
@@ -32,7 +32,9 @@ func TestRootCLI_InitCommand(t *testing.T) {
 	stub := &initializeStoreUsecaseStub{}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(stub, nil, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase: stub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(stderr)
 	rootCmd.SetArgs([]string{"init", "--db-path", dbPath})

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -70,7 +70,10 @@ func TestRootCLI_ListCommand(t *testing.T) {
 			},
 		}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, listStub, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			ListEventsQueryService: listStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"list", "--db-path", dbPath, "--limit", "5"})
@@ -130,7 +133,10 @@ func TestRootCLI_ListCommand(t *testing.T) {
 			},
 		}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, listStub, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			ListEventsQueryService: listStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"list", "--db-path", dbPath, "--json"})
@@ -164,7 +170,10 @@ func TestRootCLI_ListCommand(t *testing.T) {
 		initStub := &initializeStoreUsecaseStub{}
 		listStub := &listEventsQueryServiceStub{}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, listStub, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			ListEventsQueryService: listStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"list", "--db-path", dbPath})

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -60,7 +60,10 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		}
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, logStub, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			RecordLogUsecase:       logStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
 		rootCmd.SetArgs([]string{
@@ -116,7 +119,10 @@ func TestRootCLI_LogCommand(t *testing.T) {
 				fixedLogTime(),
 			),
 		}
-		rootCmd := cli.NewRootCLI(initStub, logStub, nil, nil, nil, nil, nil, nil, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			RecordLogUsecase:       logStub,
+		}).Command()
 		rootCmd.SetOut(&bytes.Buffer{})
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"log", "--db-path", dbPath, "hello"})

--- a/presentation/cli/mcp_server_test.go
+++ b/presentation/cli/mcp_server_test.go
@@ -25,7 +25,9 @@ func TestRootCLI_MCPServer(t *testing.T) {
 		t.Parallel()
 
 		runner := &mcpServerRunnerStub{}
-		sut := cli.NewRootCLI(nil, nil, nil, nil, nil, nil, nil, nil, nil, runner)
+		sut := cli.NewRootCLI(cli.RootCLIOptions{
+			MCPServerRunner: runner,
+		})
 		command := sut.Command()
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
@@ -44,7 +46,7 @@ func TestRootCLI_MCPServer(t *testing.T) {
 	t.Run("ランナー未設定ならエラー", func(t *testing.T) {
 		t.Parallel()
 
-		sut := cli.NewRootCLI(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		sut := cli.NewRootCLI(cli.RootCLIOptions{})
 		command := sut.Command()
 		command.SetArgs([]string{"mcp-server"})
 

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -21,30 +21,33 @@ type RootCLI struct {
 	mcpServerRunner               MCPServerRunner
 }
 
+// RootCLIOptions は RootCLI の依存関係をまとめた設定です。
+type RootCLIOptions struct {
+	InitializeStoreUsecase        usecase.InitializeStoreUsecase
+	RecordLogUsecase              usecase.RecordLogUsecase
+	RecordSessionBoundaryUsecase  usecase.RecordSessionBoundaryUsecase
+	RecordCommandAuditUsecase     usecase.RecordCommandAuditUsecase
+	CollectGarbageUsecase         usecase.CollectGarbageUsecase
+	SearchEventsQueryService      queryservice.SearchEventsQueryService
+	ListEventsQueryService        queryservice.ListRecentEventsQueryService
+	GetEventDetailsQueryService   queryservice.GetEventDetailsQueryService
+	FindLatestSessionQueryService queryservice.FindLatestSessionQueryService
+	MCPServerRunner               MCPServerRunner
+}
+
 // NewRootCLI は新しい RootCLI を生成します。
-func NewRootCLI(
-	initializeStoreUsecase usecase.InitializeStoreUsecase,
-	recordLogUsecase usecase.RecordLogUsecase,
-	recordSessionBoundaryUsecase usecase.RecordSessionBoundaryUsecase,
-	recordCommandAuditUsecase usecase.RecordCommandAuditUsecase,
-	collectGarbageUsecase usecase.CollectGarbageUsecase,
-	searchEventsQueryService queryservice.SearchEventsQueryService,
-	listEventsQueryService queryservice.ListRecentEventsQueryService,
-	getEventDetailsQueryService queryservice.GetEventDetailsQueryService,
-	findLatestSessionQueryService queryservice.FindLatestSessionQueryService,
-	mcpServerRunner MCPServerRunner,
-) *RootCLI {
+func NewRootCLI(options RootCLIOptions) *RootCLI {
 	return &RootCLI{
-		initializeStoreUsecase:        initializeStoreUsecase,
-		recordLogUsecase:              recordLogUsecase,
-		recordSessionBoundaryUsecase:  recordSessionBoundaryUsecase,
-		recordCommandAuditUsecase:     recordCommandAuditUsecase,
-		collectGarbageUsecase:         collectGarbageUsecase,
-		searchEventsQueryService:      searchEventsQueryService,
-		listEventsQueryService:        listEventsQueryService,
-		getEventDetailsQueryService:   getEventDetailsQueryService,
-		findLatestSessionQueryService: findLatestSessionQueryService,
-		mcpServerRunner:               mcpServerRunner,
+		initializeStoreUsecase:        options.InitializeStoreUsecase,
+		recordLogUsecase:              options.RecordLogUsecase,
+		recordSessionBoundaryUsecase:  options.RecordSessionBoundaryUsecase,
+		recordCommandAuditUsecase:     options.RecordCommandAuditUsecase,
+		collectGarbageUsecase:         options.CollectGarbageUsecase,
+		searchEventsQueryService:      options.SearchEventsQueryService,
+		listEventsQueryService:        options.ListEventsQueryService,
+		getEventDetailsQueryService:   options.GetEventDetailsQueryService,
+		findLatestSessionQueryService: options.FindLatestSessionQueryService,
+		mcpServerRunner:               options.MCPServerRunner,
 	}
 }
 

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -69,7 +69,10 @@ func TestRootCLI_SearchCommand(t *testing.T) {
 		},
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, searchStub, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:   initStub,
+		SearchEventsQueryService: searchStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{
@@ -134,7 +137,10 @@ func TestRootCLI_SearchCommand_JSON(t *testing.T) {
 		},
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, searchStub, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:   initStub,
+		SearchEventsQueryService: searchStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -84,7 +84,10 @@ func TestRootCLI_SessionStartCommand(t *testing.T) {
 		),
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, sessionStub, nil, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:       initStub,
+		RecordSessionBoundaryUsecase: sessionStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{
@@ -141,7 +144,10 @@ func TestRootCLI_SessionEndCommand(t *testing.T) {
 		),
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, sessionStub, nil, nil, nil, nil, nil, nil, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:       initStub,
+		RecordSessionBoundaryUsecase: sessionStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{"session", "end", "--db-path", dbPath})
@@ -191,7 +197,10 @@ func TestRootCLI_SessionLatestCommand(t *testing.T) {
 		),
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, nil, latestStub, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:        initStub,
+		FindLatestSessionQueryService: latestStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{
@@ -257,7 +266,10 @@ func TestRootCLI_SessionActiveCommand(t *testing.T) {
 		),
 	}
 	stdout := &bytes.Buffer{}
-	rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, nil, latestStub, nil).Command()
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:        initStub,
+		FindLatestSessionQueryService: latestStub,
+	}).Command()
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -80,7 +80,10 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		}
 		showStub := &getEventDetailsQueryServiceStub{eventDetails: eventDetails}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, showStub, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:      initStub,
+			GetEventDetailsQueryService: showStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"show", "--db-path", dbPath, "event-1"})
@@ -146,7 +149,10 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		}
 		showStub := &getEventDetailsQueryServiceStub{eventDetails: eventDetails}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, showStub, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:      initStub,
+			GetEventDetailsQueryService: showStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"show", "--db-path", dbPath, "event-1"})
@@ -189,7 +195,10 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		}
 		showStub := &getEventDetailsQueryServiceStub{eventDetails: eventDetails}
 		stdout := &bytes.Buffer{}
-		rootCmd := cli.NewRootCLI(initStub, nil, nil, nil, nil, nil, nil, showStub, nil, nil).Command()
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:      initStub,
+			GetEventDetailsQueryService: showStub,
+		}).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
 		rootCmd.SetArgs([]string{"show", "--db-path", dbPath, "--json", "event-1"})


### PR DESCRIPTION
## Summary
- replace `NewRootCLI` positional arguments with a `RootCLIOptions` struct
- update production wiring and CLI tests to use named dependency injection
- keep command behavior unchanged while reducing constructor churn

## Motivation
Follow-up for v0.1.2 dogfood: `NewRootCLI` had grown to ten positional dependencies, which made tests noisy and expanded the blast radius for each new command.

## Testing
- `GOCACHE=/tmp/traceary-gocache go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`
- `GOCACHE=/tmp/traceary-gocache go run . hooks print --client claude --project-dir /tmp/project | sed -n '1,5p'`

Closes #32
