### PR TITLE
docs: add quick start to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,7 +44,7 @@ event_id=$(
     "go test ./..." \
     '{"stdin":""}' \
     '{"stdout":"panic: boom","stderr":"stacktrace","exitCode":1}' |
-    sed -n 's/^記録しました: //p'
+    awk '{print $2}'
 )
 traceary search boom --json
 traceary show "$event_id" --json
@@ -60,6 +60,9 @@ $ traceary init
 $ traceary session start --client dogfood --agent codex
 session-1ceee1eaa50a31687cfdb2c8a6fcc85d
 
+$ traceary audit ... | awk '{print $2}'
+0dc6d0c579df5e539c27df56e131570a
+
 $ traceary search boom --json
 [
   {
@@ -68,6 +71,17 @@ $ traceary search boom --json
     "message": "go test ./..."
   }
 ]
+
+$ traceary show 0dc6d0c579df5e539c27df56e131570a --json
+{
+  "event": {
+    "kind": "command_executed",
+    "message": "go test ./..."
+  },
+  "command_audit": {
+    "output": "{\"stdout\":\"panic: boom\",\"stderr\":\"stacktrace\",\"exitCode\":1}"
+  }
+}
 
 $ traceary session active
 session-1ceee1eaa50a31687cfdb2c8a6fcc85d

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ event_id=$(
     "go test ./..." \
     '{"stdin":""}' \
     '{"stdout":"panic: boom","stderr":"stacktrace","exitCode":1}' |
-    sed -n 's/^記録しました: //p'
+    awk '{print $2}'
 )
 traceary search boom --json
 traceary show "$event_id" --json
@@ -60,6 +60,9 @@ $ traceary init
 $ traceary session start --client dogfood --agent codex
 session-1ceee1eaa50a31687cfdb2c8a6fcc85d
 
+$ traceary audit ... | awk '{print $2}'
+0dc6d0c579df5e539c27df56e131570a
+
 $ traceary search boom --json
 [
   {
@@ -68,6 +71,17 @@ $ traceary search boom --json
     "message": "go test ./..."
   }
 ]
+
+$ traceary show 0dc6d0c579df5e539c27df56e131570a --json
+{
+  "event": {
+    "kind": "command_executed",
+    "message": "go test ./..."
+  },
+  "command_audit": {
+    "output": "{\"stdout\":\"panic: boom\",\"stderr\":\"stacktrace\",\"exitCode\":1}"
+  }
+}
 
 $ traceary session active
 session-1ceee1eaa50a31687cfdb2c8a6fcc85d


### PR DESCRIPTION
## Summary
- add a 5-minute quick start to the English and Japanese README
- replace the old v0.1 planned-command wording with current core commands
- show sample outputs so the basic value is obvious without hooks or MCP setup

## Motivation
Follow-up for v0.1.4 onboarding: README needed a shorter path from concept to first successful local run.

## Testing
- `git diff --check`

Closes #40
