### PR TITLE
feat: add structured search filters

### DIFF
--- a/application/queryservice/search_events.go
+++ b/application/queryservice/search_events.go
@@ -8,15 +8,20 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
 )
 
 // SearchEventsInput は検索入力です。
 type SearchEventsInput struct {
-	Query string
-	Repo  string
-	From  time.Time
-	To    time.Time
-	Limit int
+	Query     string
+	Repo      string
+	SessionID string
+	Client    string
+	Agent     string
+	Kind      string
+	From      time.Time
+	To        time.Time
+	Limit     int
 }
 
 // EventSearcher はイベント検索を提供します。
@@ -52,8 +57,8 @@ func (s *searchEventsQueryService) Run(
 	if strings.TrimSpace(dbPath) == "" {
 		return nil, xerrors.Errorf("DB パスは空にできません")
 	}
-	if strings.TrimSpace(input.Query) == "" {
-		return nil, xerrors.Errorf("検索語は空にできません")
+	if !hasSearchConstraint(input) {
+		return nil, xerrors.Errorf("検索条件は1つ以上必要です")
 	}
 	if input.Limit <= 0 {
 		return nil, xerrors.Errorf("limit は 1 以上である必要があります")
@@ -61,6 +66,17 @@ func (s *searchEventsQueryService) Run(
 	if !input.From.IsZero() && !input.To.IsZero() && input.From.After(input.To) {
 		return nil, xerrors.Errorf("from は to より前である必要があります")
 	}
+	input.Query = strings.TrimSpace(input.Query)
+	input.Repo = strings.TrimSpace(input.Repo)
+	input.SessionID = strings.TrimSpace(input.SessionID)
+	input.Client = strings.TrimSpace(input.Client)
+	input.Agent = strings.TrimSpace(input.Agent)
+
+	kind, err := resolveOptionalSearchKind(input.Kind)
+	if err != nil {
+		return nil, err
+	}
+	input.Kind = kind.String()
 
 	events, err := s.eventSearcher.SearchEvents(ctx, dbPath, input)
 	if err != nil {
@@ -68,4 +84,29 @@ func (s *searchEventsQueryService) Run(
 	}
 
 	return events, nil
+}
+
+func hasSearchConstraint(input SearchEventsInput) bool {
+	return strings.TrimSpace(input.Query) != "" ||
+		strings.TrimSpace(input.Repo) != "" ||
+		strings.TrimSpace(input.SessionID) != "" ||
+		strings.TrimSpace(input.Client) != "" ||
+		strings.TrimSpace(input.Agent) != "" ||
+		strings.TrimSpace(input.Kind) != "" ||
+		!input.From.IsZero() ||
+		!input.To.IsZero()
+}
+
+func resolveOptionalSearchKind(value string) (types.EventKind, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return "", nil
+	}
+
+	kind, err := types.EventKindOf(trimmedValue)
+	if err != nil {
+		return "", xerrors.Errorf("kind の解決に失敗しました: %w", err)
+	}
+
+	return kind, nil
 }

--- a/application/queryservice/search_events_test.go
+++ b/application/queryservice/search_events_test.go
@@ -63,8 +63,13 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		sut := queryservice.NewSearchEventsQueryService(stub)
 
 		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
-			Query: "traceary",
-			Limit: 10,
+			Query:     "traceary",
+			Repo:      "github.com/duck8823/traceary",
+			SessionID: "session-1",
+			Client:    "cli",
+			Agent:     "codex",
+			Kind:      "note",
+			Limit:     10,
 		})
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
@@ -75,18 +80,54 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		if stub.receivedInput.Query != "traceary" {
 			t.Fatalf("received query = %q, want %q", stub.receivedInput.Query, "traceary")
 		}
+		if stub.receivedInput.Kind != "note" {
+			t.Fatalf("received kind = %q, want %q", stub.receivedInput.Kind, "note")
+		}
 		if len(got) != 1 {
 			t.Fatalf("len(events) = %d, want 1", len(got))
 		}
 	})
 
-	t.Run("検索語が空ならエラー", func(t *testing.T) {
+	t.Run("検索語が空でも構造フィルタがあれば検索できる", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventSearcherStub{}
+		sut := queryservice.NewSearchEventsQueryService(stub)
+
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+			SessionID: "session-1",
+			Limit:     10,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if stub.receivedInput.SessionID != "session-1" {
+			t.Fatalf("received session_id = %q, want %q", stub.receivedInput.SessionID, "session-1")
+		}
+	})
+
+	t.Run("検索条件が空ならエラー", func(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
 
 		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
 			Query: "   ",
+			Limit: 10,
+		})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+
+	t.Run("未知の kind ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
+
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+			Query: "traceary",
+			Kind:  "unknown",
 			Limit: 10,
 		})
 		if err == nil {

--- a/infrastructure/sqlite/search_events.go
+++ b/infrastructure/sqlite/search_events.go
@@ -24,7 +24,8 @@ func (d *Datasource) SearchEvents(
 	}
 	defer func() { _ = db.Close() }()
 
-	likeQuery := "%" + escapeLikeQuery(strings.TrimSpace(input.Query)) + "%"
+	queryValue := strings.TrimSpace(input.Query)
+	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
 	fromValue := ""
 	if !input.From.IsZero() {
 		fromValue = formatTimestamp(input.From)
@@ -39,21 +40,35 @@ func (d *Datasource) SearchEvents(
 		`SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at
 		   FROM events e
 		   LEFT JOIN command_audits a ON a.event_id = e.id
-		  WHERE (e.body LIKE ? ESCAPE '\' OR
+		  WHERE (? = '' OR
+		         e.body LIKE ? ESCAPE '\' OR
 		         COALESCE(a.command_text, '') LIKE ? ESCAPE '\' OR
 		         COALESCE(a.input_text, '') LIKE ? ESCAPE '\' OR
 		         COALESCE(a.output_text, '') LIKE ? ESCAPE '\')
 		    AND (? = '' OR e.repo = ?)
+		    AND (? = '' OR e.session_id = ?)
+		    AND (? = '' OR e.client = ?)
+		    AND (? = '' OR e.agent = ?)
+		    AND (? = '' OR e.kind = ?)
 		    AND (? = '' OR e.created_at >= ?)
 		    AND (? = '' OR e.created_at < ?)
 		  ORDER BY e.created_at DESC, e.id DESC
 		  LIMIT ?`,
+		queryValue,
 		likeQuery,
 		likeQuery,
 		likeQuery,
 		likeQuery,
 		input.Repo,
 		input.Repo,
+		input.SessionID,
+		input.SessionID,
+		input.Client,
+		input.Client,
+		input.Agent,
+		input.Agent,
+		input.Kind,
+		input.Kind,
 		fromValue,
 		fromValue,
 		toValue,

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -89,6 +89,28 @@ CREATE TABLE command_audits (
 	if got[0].EventID().String() != "event-audit" {
 		t.Fatalf("EventID() = %q, want %q", got[0].EventID(), "event-audit")
 	}
+
+	t.Run("構造フィルタだけで検索できる", func(t *testing.T) {
+		t.Parallel()
+
+		filtered, err := sut.SearchEvents(context.Background(), dbPath, queryservice.SearchEventsInput{
+			Repo:      "github.com/duck8823/traceary",
+			SessionID: "session-1",
+			Client:    "cli",
+			Agent:     "codex",
+			Kind:      "note",
+			Limit:     10,
+		})
+		if err != nil {
+			t.Fatalf("SearchEvents() error = %v", err)
+		}
+		if len(filtered) != 1 {
+			t.Fatalf("len(filtered) = %d, want 1", len(filtered))
+		}
+		if filtered[0].EventID().String() != "event-note" {
+			t.Fatalf("EventID() = %q, want %q", filtered[0].EventID(), "event-note")
+		}
+	})
 }
 
 func newSearchEventFixture(

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -14,34 +14,56 @@ import (
 
 func (c *RootCLI) newSearchCommand() *cobra.Command {
 	var (
-		dbPath string
-		repo   string
-		from   string
-		to     string
-		limit  int
-		asJSON bool
+		dbPath    string
+		repo      string
+		sessionID string
+		client    string
+		agent     string
+		kind      string
+		from      string
+		since     string
+		to        string
+		until     string
+		limit     int
+		asJSON    bool
 	)
 
 	searchCmd := &cobra.Command{
-		Use:   "search <query>",
+		Use:   "search [query]",
 		Short: "記録を検索する",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) == 1 {
+				query = args[0]
+			}
 			return c.runSearch(cmd.Context(), cmd.OutOrStdout(), searchCommandInput{
-				dbPath: dbPath,
-				repo:   repo,
-				from:   from,
-				to:     to,
-				limit:  limit,
-				query:  args[0],
-				asJSON: asJSON,
+				dbPath:    dbPath,
+				repo:      repo,
+				sessionID: sessionID,
+				client:    client,
+				agent:     agent,
+				kind:      kind,
+				from:      from,
+				since:     since,
+				to:        to,
+				until:     until,
+				limit:     limit,
+				query:     query,
+				asJSON:    asJSON,
 			})
 		},
 	}
 	searchCmd.Flags().StringVar(&dbPath, "db-path", "", "SQLite DB パス")
 	searchCmd.Flags().StringVar(&repo, "repo", "", "絞り込む work context (env: TRACEARY_REPO / current git remote)")
+	searchCmd.Flags().StringVar(&sessionID, "session-id", "", "絞り込む session ID")
+	searchCmd.Flags().StringVar(&client, "client", "", "絞り込む client")
+	searchCmd.Flags().StringVar(&agent, "agent", "", "絞り込む agent")
+	searchCmd.Flags().StringVar(&kind, "kind", "", "絞り込む kind")
 	searchCmd.Flags().StringVar(&from, "from", "", "開始日 (`YYYY-MM-DD`)")
+	searchCmd.Flags().StringVar(&since, "since", "", "開始日 (`YYYY-MM-DD`) (`--from` の別名)")
 	searchCmd.Flags().StringVar(&to, "to", "", "終了日 (`YYYY-MM-DD`)")
+	searchCmd.Flags().StringVar(&until, "until", "", "終了日 (`YYYY-MM-DD`) (`--to` の別名)")
 	searchCmd.Flags().IntVar(&limit, "limit", 20, "表示件数")
 	searchCmd.Flags().BoolVar(&asJSON, "json", false, "JSON 形式で出力する")
 
@@ -49,13 +71,19 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 }
 
 type searchCommandInput struct {
-	dbPath string
-	repo   string
-	from   string
-	to     string
-	limit  int
-	query  string
-	asJSON bool
+	dbPath    string
+	repo      string
+	sessionID string
+	client    string
+	agent     string
+	kind      string
+	from      string
+	since     string
+	to        string
+	until     string
+	limit     int
+	query     string
+	asJSON    bool
 }
 
 func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchCommandInput) error {
@@ -74,21 +102,34 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 		return xerrors.Errorf("ストアの初期化に失敗しました: %w", err)
 	}
 
-	fromTime, err := parseSearchDate(input.from, false)
+	fromValue, err := resolveSearchDateValue(input.from, input.since, "from", "since")
+	if err != nil {
+		return err
+	}
+	toValue, err := resolveSearchDateValue(input.to, input.until, "to", "until")
+	if err != nil {
+		return err
+	}
+
+	fromTime, err := parseSearchDate(fromValue, false)
 	if err != nil {
 		return xerrors.Errorf("from の解決に失敗しました: %w", err)
 	}
-	toTime, err := parseSearchDate(input.to, true)
+	toTime, err := parseSearchDate(toValue, true)
 	if err != nil {
 		return xerrors.Errorf("to の解決に失敗しました: %w", err)
 	}
 
 	events, err := c.searchEventsQueryService.Run(ctx, resolvedPath, queryservice.SearchEventsInput{
-		Query: input.query,
-		Repo:  resolveRepoValue(ctx, input.repo),
-		From:  fromTime,
-		To:    toTime,
-		Limit: input.limit,
+		Query:     input.query,
+		Repo:      resolveRepoValue(ctx, input.repo),
+		SessionID: input.sessionID,
+		Client:    input.client,
+		Agent:     input.agent,
+		Kind:      input.kind,
+		From:      fromTime,
+		To:        toTime,
+		Limit:     input.limit,
 	})
 	if err != nil {
 		return xerrors.Errorf("検索に失敗しました: %w", err)
@@ -116,4 +157,20 @@ func parseSearchDate(value string, endExclusive bool) (time.Time, error) {
 	}
 
 	return parsedTime, nil
+}
+
+func resolveSearchDateValue(primary string, alias string, primaryName string, aliasName string) (string, error) {
+	trimmedPrimary := strings.TrimSpace(primary)
+	trimmedAlias := strings.TrimSpace(alias)
+	if trimmedPrimary == "" {
+		return trimmedAlias, nil
+	}
+	if trimmedAlias == "" {
+		return trimmedPrimary, nil
+	}
+	if trimmedPrimary != trimmedAlias {
+		return "", xerrors.Errorf("%s と %s に異なる日付は指定できません", primaryName, aliasName)
+	}
+
+	return trimmedPrimary, nil
 }

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -78,8 +78,14 @@ func TestRootCLI_SearchCommand(t *testing.T) {
 	rootCmd.SetArgs([]string{
 		"search",
 		"--db-path", "/tmp/traceary.db",
+		"--session-id", "session-1",
+		"--client", "cli",
+		"--agent", "codex",
+		"--kind", "note",
 		"--from", "2026-04-07",
+		"--since", "2026-04-07",
 		"--to", "2026-04-07",
+		"--until", "2026-04-07",
 		"--limit", "5",
 		"traceary",
 	})
@@ -95,6 +101,18 @@ func TestRootCLI_SearchCommand(t *testing.T) {
 	}
 	if searchStub.receivedInput.Repo != "github.com/duck8823/traceary" {
 		t.Fatalf("Repo = %q, want %q", searchStub.receivedInput.Repo, "github.com/duck8823/traceary")
+	}
+	if searchStub.receivedInput.SessionID != "session-1" {
+		t.Fatalf("SessionID = %q, want %q", searchStub.receivedInput.SessionID, "session-1")
+	}
+	if searchStub.receivedInput.Client != "cli" {
+		t.Fatalf("Client = %q, want %q", searchStub.receivedInput.Client, "cli")
+	}
+	if searchStub.receivedInput.Agent != "codex" {
+		t.Fatalf("Agent = %q, want %q", searchStub.receivedInput.Agent, "codex")
+	}
+	if searchStub.receivedInput.Kind != "note" {
+		t.Fatalf("Kind = %q, want %q", searchStub.receivedInput.Kind, "note")
 	}
 	if stdout.String() == "" {
 		t.Fatalf("stdout is empty")
@@ -169,5 +187,40 @@ func TestRootCLI_SearchCommand_JSON(t *testing.T) {
 		"]\n"
 	if stdout.String() != want {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRootCLI_SearchCommand_FilterOnly(t *testing.T) {
+	t.Setenv("TRACEARY_REPO", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	initStub := &initializeStoreUsecaseStub{}
+	searchStub := &searchEventsQueryServiceStub{}
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:   initStub,
+		SearchEventsQueryService: searchStub,
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"search",
+		"--db-path", "/tmp/traceary.db",
+		"--session-id", "session-42",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !searchStub.called {
+		t.Fatalf("SearchEventsQueryService.Run() was not called")
+	}
+	if searchStub.receivedInput.Query != "" {
+		t.Fatalf("Query = %q, want empty", searchStub.receivedInput.Query)
+	}
+	if searchStub.receivedInput.SessionID != "session-42" {
+		t.Fatalf("SessionID = %q, want %q", searchStub.receivedInput.SessionID, "session-42")
 	}
 }


### PR DESCRIPTION
## Summary
- add structured search filters for session, client, agent, and kind
- allow filter-only searches and add --since/--until aliases for date ranges
- cover the new queryservice, CLI, and SQLite search behavior with tests

## Testing
- GOCACHE=/tmp/traceary-gocache GOMODCACHE=/tmp/traceary-gomod go test ./...
- GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci GOMODCACHE=/tmp/traceary-gomod go tool golangci-lint run --timeout=5m
- git diff --check
- manual smoke: go run . search --session-id ... --client cli --agent codex --kind note --json

## Motivation
- resolves #42
- text-only search gets noisy as dogfood data accumulates, so structured filters improve reuse of stored traces