### PR TITLE
feat: add context handoff command

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func run() error {
 		CollectGarbageUsecase:         collectGarbageUsecase,
 		SearchEventsQueryService:      searchEventsQueryService,
 		ListEventsQueryService:        listRecentEventsQueryService,
+		GetContextQueryService:        getContextQueryService,
 		GetEventDetailsQueryService:   getEventDetailsQueryService,
 		FindLatestSessionQueryService: findLatestSessionQueryService,
 		MCPServerRunner:               mcpServer,

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+)
+
+func (c *RootCLI) newContextCommand() *cobra.Command {
+	var (
+		dbPath    string
+		sessionID string
+		client    string
+		agent     string
+		repo      string
+		limit     int
+		asJSON    bool
+	)
+
+	contextCmd := &cobra.Command{
+		Use:     "context",
+		Aliases: []string{"handoff"},
+		Short:   "次の AI session に渡す文脈を表示する",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runContext(cmd.Context(), cmd.OutOrStdout(), contextCommandInput{
+				dbPath:    dbPath,
+				sessionID: sessionID,
+				client:    client,
+				agent:     agent,
+				repo:      repo,
+				limit:     limit,
+				asJSON:    asJSON,
+			})
+		},
+	}
+	contextCmd.Flags().StringVar(&dbPath, "db-path", "", "SQLite DB パス")
+	contextCmd.Flags().StringVar(&sessionID, "session-id", "", "対象の session ID")
+	contextCmd.Flags().StringVar(&client, "client", "", "作業主体の入口で絞り込む")
+	contextCmd.Flags().StringVar(&agent, "agent", "", "作業主体で絞り込む")
+	contextCmd.Flags().StringVar(&repo, "repo", "", "補助的なコンテキスト識別子で絞り込む")
+	contextCmd.Flags().IntVar(&limit, "limit", 10, "表示件数")
+	contextCmd.Flags().BoolVar(&asJSON, "json", false, "JSON 形式で出力する")
+
+	return contextCmd
+}
+
+type contextCommandInput struct {
+	dbPath    string
+	sessionID string
+	client    string
+	agent     string
+	repo      string
+	limit     int
+	asJSON    bool
+}
+
+type contextOutput struct {
+	ResolvedSessionID string      `json:"resolved_session_id,omitempty"`
+	ResolvedRepo      string      `json:"resolved_repo,omitempty"`
+	Events            []eventJSON `json:"events"`
+}
+
+func (c *RootCLI) runContext(ctx context.Context, output io.Writer, input contextCommandInput) error {
+	if c.initializeStoreUsecase == nil {
+		return xerrors.Errorf("ストア初期化ユースケースが設定されていません")
+	}
+	if c.getContextQueryService == nil {
+		return xerrors.Errorf("文脈クエリサービスが設定されていません")
+	}
+
+	resolvedPath, err := resolveDBPath(input.dbPath)
+	if err != nil {
+		return xerrors.Errorf("DB パスの解決に失敗しました: %w", err)
+	}
+	if err := c.initializeStoreUsecase.Run(ctx, resolvedPath); err != nil {
+		return xerrors.Errorf("ストアの初期化に失敗しました: %w", err)
+	}
+
+	resolvedRepo := resolveRepoValue(ctx, input.repo)
+	resolvedSessionID, err := c.resolveContextSessionID(ctx, resolvedPath, contextCommandInput{
+		sessionID: input.sessionID,
+		client:    input.client,
+		agent:     input.agent,
+		repo:      resolvedRepo,
+	})
+	if err != nil {
+		return err
+	}
+
+	events, err := c.getContextQueryService.Run(ctx, resolvedPath, queryservice.GetContextInput{
+		Repo:      resolvedRepo,
+		SessionID: resolvedSessionID,
+		Limit:     input.limit,
+	})
+	if err != nil {
+		return xerrors.Errorf("文脈の取得に失敗しました: %w", err)
+	}
+
+	if input.asJSON {
+		return writeContextJSON(output, resolvedSessionID, resolvedRepo, events)
+	}
+
+	return writeContextText(output, resolvedSessionID, resolvedRepo, events)
+}
+
+func (c *RootCLI) resolveContextSessionID(
+	ctx context.Context,
+	dbPath string,
+	input contextCommandInput,
+) (string, error) {
+	trimmedSessionID := strings.TrimSpace(input.sessionID)
+	if trimmedSessionID != "" {
+		return trimmedSessionID, nil
+	}
+	if c.findLatestSessionQueryService == nil {
+		return "", nil
+	}
+
+	event, err := c.findLatestSessionQueryService.Run(ctx, dbPath, queryservice.FindLatestSessionInput{
+		Client: strings.TrimSpace(input.client),
+		Agent:  strings.TrimSpace(input.agent),
+		Repo:   strings.TrimSpace(input.repo),
+	})
+	if err != nil {
+		if queryservice.IsSessionLookupNotFound(err) {
+			return "", nil
+		}
+		return "", xerrors.Errorf("文脈用の直近 session 解決に失敗しました: %w", err)
+	}
+
+	return event.SessionID().String(), nil
+}
+
+func writeContextJSON(output io.Writer, sessionID string, repo string, events []*model.Event) error {
+	serializedEvents := make([]eventJSON, 0, len(events))
+	for _, event := range events {
+		serializedEvents = append(serializedEvents, newEventJSON(event))
+	}
+
+	return writeJSON(output, contextOutput{
+		ResolvedSessionID: sessionID,
+		ResolvedRepo:      repo,
+		Events:            serializedEvents,
+	})
+}
+
+func writeContextText(output io.Writer, sessionID string, repo string, events []*model.Event) error {
+	if _, err := fmt.Fprintln(output, "TRACEARY CONTEXT"); err != nil {
+		return xerrors.Errorf("文脈ヘッダーの出力に失敗しました: %w", err)
+	}
+	if _, err := fmt.Fprintf(output, "SESSION_ID: %s\n", formatOptionalColumn(sessionID)); err != nil {
+		return xerrors.Errorf("session ID の出力に失敗しました: %w", err)
+	}
+	if _, err := fmt.Fprintf(output, "REPO: %s\n", formatOptionalColumn(repo)); err != nil {
+		return xerrors.Errorf("repo の出力に失敗しました: %w", err)
+	}
+	if _, err := fmt.Fprintln(output, "EVENTS:"); err != nil {
+		return xerrors.Errorf("文脈イベント見出しの出力に失敗しました: %w", err)
+	}
+	if len(events) == 0 {
+		if _, err := fmt.Fprintln(output, "- 一致する文脈はありません"); err != nil {
+			return xerrors.Errorf("空文脈メッセージの出力に失敗しました: %w", err)
+		}
+		return nil
+	}
+
+	for _, event := range events {
+		if _, err := fmt.Fprintf(
+			output,
+			"- %s [%s] %s %s/%s %s\n",
+			event.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
+			event.Kind(),
+			event.EventID(),
+			formatOptionalColumn(event.Client()),
+			event.Agent(),
+			singleLineSummary(event.Body()),
+		); err != nil {
+			return xerrors.Errorf("文脈イベントの出力に失敗しました: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func singleLineSummary(value string) string {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return "-"
+	}
+
+	return strings.Join(fields, " ")
+}

--- a/presentation/cli/context_command_test.go
+++ b/presentation/cli/context_command_test.go
@@ -1,0 +1,231 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+type getContextQueryServiceStub struct {
+	receivedPath  string
+	receivedInput queryservice.GetContextInput
+	called        bool
+	events        []*model.Event
+	err           error
+}
+
+func (s *getContextQueryServiceStub) Run(
+	_ context.Context,
+	dbPath string,
+	input queryservice.GetContextInput,
+) ([]*model.Event, error) {
+	s.called = true
+	s.receivedPath = dbPath
+	s.receivedInput = input
+	return s.events, s.err
+}
+
+var _ queryservice.GetContextQueryService = (*getContextQueryServiceStub)(nil)
+
+type contextLatestSessionQueryServiceStub struct {
+	receivedPath  string
+	receivedInput queryservice.FindLatestSessionInput
+	called        bool
+	event         *model.Event
+	err           error
+}
+
+func (s *contextLatestSessionQueryServiceStub) Run(
+	_ context.Context,
+	dbPath string,
+	input queryservice.FindLatestSessionInput,
+) (*model.Event, error) {
+	s.called = true
+	s.receivedPath = dbPath
+	s.receivedInput = input
+	return s.event, s.err
+}
+
+var _ queryservice.FindLatestSessionQueryService = (*contextLatestSessionQueryServiceStub)(nil)
+
+func TestRootCLI_ContextCommand(t *testing.T) {
+	t.Setenv("TRACEARY_REPO", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	eventID, err := types.EventIDOf("event-1")
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf("codex")
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf("session-1")
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	t.Run("直近 session を解決して文脈を表示できる", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		contextStub := &getContextQueryServiceStub{
+			events: []*model.Event{
+				model.EventOf(
+					eventID,
+					types.EventKindNote,
+					"cli",
+					agent,
+					sessionID,
+					"github.com/duck8823/traceary",
+					"README を更新した\n次に release note を確認する",
+					time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+				),
+			},
+		}
+		latestStub := &contextLatestSessionQueryServiceStub{
+			event: model.EventOf(
+				eventID,
+				types.EventKindSessionStarted,
+				"cli",
+				agent,
+				sessionID,
+				"github.com/duck8823/traceary",
+				"session started",
+				time.Date(2026, 4, 8, 11, 0, 0, 0, time.UTC),
+			),
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:        initStub,
+			GetContextQueryService:        contextStub,
+			FindLatestSessionQueryService: latestStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"context", "--db-path", dbPath, "--limit", "5"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !latestStub.called {
+			t.Fatalf("FindLatestSessionQueryService.Run() was not called")
+		}
+		if !contextStub.called {
+			t.Fatalf("GetContextQueryService.Run() was not called")
+		}
+		if contextStub.receivedInput.SessionID != "session-1" {
+			t.Fatalf("SessionID = %q, want %q", contextStub.receivedInput.SessionID, "session-1")
+		}
+		want := "" +
+			"TRACEARY CONTEXT\n" +
+			"SESSION_ID: session-1\n" +
+			"REPO: github.com/duck8823/traceary\n" +
+			"EVENTS:\n" +
+			"- 2026-04-08T12:00:00Z [note] event-1 cli/codex README を更新した 次に release note を確認する\n"
+		if stdout.String() != want {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	})
+
+	t.Run("JSON 形式で文脈を表示できる", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		contextStub := &getContextQueryServiceStub{
+			events: []*model.Event{
+				model.EventOf(
+					eventID,
+					types.EventKindNote,
+					"cli",
+					agent,
+					sessionID,
+					"github.com/duck8823/traceary",
+					"hello context",
+					time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+				),
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initStub,
+			GetContextQueryService: contextStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"context",
+			"--db-path", dbPath,
+			"--session-id", "session-1",
+			"--json",
+		})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		want := "" +
+			"{\n" +
+			"  \"resolved_session_id\": \"session-1\",\n" +
+			"  \"resolved_repo\": \"github.com/duck8823/traceary\",\n" +
+			"  \"events\": [\n" +
+			"    {\n" +
+			"      \"event_id\": \"event-1\",\n" +
+			"      \"kind\": \"note\",\n" +
+			"      \"client\": \"cli\",\n" +
+			"      \"agent\": \"codex\",\n" +
+			"      \"session_id\": \"session-1\",\n" +
+			"      \"repo\": \"github.com/duck8823/traceary\",\n" +
+			"      \"message\": \"hello context\",\n" +
+			"      \"created_at\": \"2026-04-08T12:00:00Z\"\n" +
+			"    }\n" +
+			"  ]\n" +
+			"}\n"
+		if stdout.String() != want {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	})
+
+	t.Run("直近 session がなくても repo 文脈へフォールバックできる", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		contextStub := &getContextQueryServiceStub{}
+		latestStub := &contextLatestSessionQueryServiceStub{
+			err: queryservice.ErrSessionNotFound,
+		}
+
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:        initStub,
+			GetContextQueryService:        contextStub,
+			FindLatestSessionQueryService: latestStub,
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"context", "--db-path", dbPath})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if contextStub.receivedInput.SessionID != "" {
+			t.Fatalf("SessionID = %q, want empty", contextStub.receivedInput.SessionID)
+		}
+		if contextStub.receivedInput.Repo != "github.com/duck8823/traceary" {
+			t.Fatalf("Repo = %q, want %q", contextStub.receivedInput.Repo, "github.com/duck8823/traceary")
+		}
+	})
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -16,6 +16,7 @@ type RootCLI struct {
 	collectGarbageUsecase         usecase.CollectGarbageUsecase
 	searchEventsQueryService      queryservice.SearchEventsQueryService
 	listEventsQueryService        queryservice.ListRecentEventsQueryService
+	getContextQueryService        queryservice.GetContextQueryService
 	getEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	findLatestSessionQueryService queryservice.FindLatestSessionQueryService
 	mcpServerRunner               MCPServerRunner
@@ -30,6 +31,7 @@ type RootCLIOptions struct {
 	CollectGarbageUsecase         usecase.CollectGarbageUsecase
 	SearchEventsQueryService      queryservice.SearchEventsQueryService
 	ListEventsQueryService        queryservice.ListRecentEventsQueryService
+	GetContextQueryService        queryservice.GetContextQueryService
 	GetEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	FindLatestSessionQueryService queryservice.FindLatestSessionQueryService
 	MCPServerRunner               MCPServerRunner
@@ -45,6 +47,7 @@ func NewRootCLI(options RootCLIOptions) *RootCLI {
 		collectGarbageUsecase:         options.CollectGarbageUsecase,
 		searchEventsQueryService:      options.SearchEventsQueryService,
 		listEventsQueryService:        options.ListEventsQueryService,
+		getContextQueryService:        options.GetContextQueryService,
 		getEventDetailsQueryService:   options.GetEventDetailsQueryService,
 		findLatestSessionQueryService: options.FindLatestSessionQueryService,
 		mcpServerRunner:               options.MCPServerRunner,
@@ -63,6 +66,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newAuditCommand())
 	rootCmd.AddCommand(c.newGCCommand())
 	rootCmd.AddCommand(c.newSearchCommand())
+	rootCmd.AddCommand(c.newContextCommand())
 	rootCmd.AddCommand(c.newListCommand())
 	rootCmd.AddCommand(c.newShowCommand())
 	rootCmd.AddCommand(c.newSessionCommand())


### PR DESCRIPTION
## Summary
- add a `traceary context` / `traceary handoff` command for next-session context reuse
- resolve the latest matching session automatically when `--session-id` is omitted
- support both AI-friendly text output and machine-friendly JSON output

## Testing
- `GOCACHE=/tmp/traceary-gocache GOMODCACHE=/tmp/traceary-gomod go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci GOMODCACHE=/tmp/traceary-gomod go tool golangci-lint run --timeout=5m`
- `git diff --check`
- manual smoke: `go run . context --db-path ... --json`

## Motivation
- resolves #43
- Traceary should make it easy to carry useful context into the next AI session without manually stitching together list/search/show output