### PR TITLE
fix: localize CLI argument errors

### DIFF
--- a/presentation/cli/args.go
+++ b/presentation/cli/args.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func noArgsJP() cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+
+		return xerrors.Errorf("引数は不要です (受け取った引数数: %d)", len(args))
+	}
+}
+
+func exactArgsJP(expected int) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) == expected {
+			return nil
+		}
+
+		return xerrors.Errorf(
+			"引数はちょうど %d 個必要です (受け取った引数数: %d)",
+			expected,
+			len(args),
+		)
+	}
+}
+
+func maximumNArgsJP(maxArgs int) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) <= maxArgs {
+			return nil
+		}
+
+		return xerrors.Errorf(
+			"引数は最大 %d 個まで指定できます (受け取った引数数: %d)",
+			maxArgs,
+			len(args),
+		)
+	}
+}

--- a/presentation/cli/args_test.go
+++ b/presentation/cli/args_test.go
@@ -1,0 +1,59 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_ArgumentErrorsAreLocalized(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "log の引数不足は日本語",
+			args:    []string{"log"},
+			wantErr: "引数はちょうど 1 個必要です (受け取った引数数: 0)",
+		},
+		{
+			name:    "audit の引数不足は日本語",
+			args:    []string{"audit", "go test ./..."},
+			wantErr: "引数はちょうど 3 個必要です (受け取った引数数: 1)",
+		},
+		{
+			name:    "search の引数超過は日本語",
+			args:    []string{"search", "foo", "bar"},
+			wantErr: "引数は最大 1 個まで指定できます (受け取った引数数: 2)",
+		},
+		{
+			name:    "init の余分な引数は日本語",
+			args:    []string{"init", "extra"},
+			wantErr: "引数は不要です (受け取った引数数: 1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootCmd := cli.NewRootCLI(cli.RootCLIOptions{}).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs(tt.args)
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -28,7 +28,7 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 	auditCmd := &cobra.Command{
 		Use:   "audit <command> <input> <output>",
 		Short: "コマンド実行の監査ログを記録する",
-		Args:  cobra.ExactArgs(3),
+		Args:  exactArgsJP(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.runAudit(cmd.Context(), cmd.OutOrStdout(), auditCommandInput{
 				dbPath:         dbPath,

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -28,7 +28,7 @@ func (c *RootCLI) newContextCommand() *cobra.Command {
 		Use:     "context",
 		Aliases: []string{"handoff"},
 		Short:   "次の AI session に渡す文脈を表示する",
-		Args:    cobra.NoArgs,
+		Args:    noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runContext(cmd.Context(), cmd.OutOrStdout(), contextCommandInput{
 				dbPath:    dbPath,

--- a/presentation/cli/gc.go
+++ b/presentation/cli/gc.go
@@ -26,7 +26,7 @@ func (c *RootCLI) newGCCommand() *cobra.Command {
 	gcCmd := &cobra.Command{
 		Use:   "gc",
 		Short: "古いイベントを削除してストアを最適化する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runGC(cmd.Context(), cmd.OutOrStdout(), gcCommandInput{
 				dbPath:   dbPath,

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -78,7 +78,7 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 	installCmd := &cobra.Command{
 		Use:   "install",
 		Short: "標準の設定パスへ hook 設定例を書き出す",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runHooksInstall(cmd.Context(), cmd.OutOrStdout(), hooksInstallCommandInput{
 				client:      client,
@@ -111,7 +111,7 @@ func (c *RootCLI) newHooksPrintCommand() *cobra.Command {
 	printCmd := &cobra.Command{
 		Use:   "print",
 		Short: "現在の環境向けの hook 設定例を出力する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runHooksPrint(cmd.Context(), cmd.OutOrStdout(), hooksPrintCommandInput{
 				client:      client,

--- a/presentation/cli/init.go
+++ b/presentation/cli/init.go
@@ -35,7 +35,7 @@ func (c *RootCLI) newInitCommand() *cobra.Command {
 			"  traceary init",
 			"  TRACEARY_DB_PATH=/tmp/traceary.db traceary init",
 		}, "\n"),
-		Args: cobra.NoArgs,
+		Args: noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runInit(cmd.Context(), cmd.OutOrStdout(), dbPath)
 		},

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -18,7 +18,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "直近のログを一覧表示する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runList(cmd.Context(), cmd.OutOrStdout(), dbPath, limit, asJSON)
 		},

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -31,7 +31,7 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 	logCmd := &cobra.Command{
 		Use:   "log <message>",
 		Short: "セッションログを追記する",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgsJP(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.runLog(cmd.Context(), cmd.OutOrStdout(), logCommandInput{
 				dbPath:    dbPath,

--- a/presentation/cli/mcp_server.go
+++ b/presentation/cli/mcp_server.go
@@ -20,7 +20,7 @@ func (c *RootCLI) newMCPServerCommand() *cobra.Command {
 	mcpServerCmd := &cobra.Command{
 		Use:   "mcp-server",
 		Short: "Traceary の MCP server を stdio で起動する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runMCPServer(cmd.Context(), cmd.OutOrStdout(), dbPath)
 		},

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -31,7 +31,7 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 	searchCmd := &cobra.Command{
 		Use:   "search [query]",
 		Short: "記録を検索する",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  maximumNArgsJP(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query := ""
 			if len(args) == 1 {

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -42,7 +42,7 @@ func (c *RootCLI) newSessionLatestCommand() *cobra.Command {
 	latestCmd := &cobra.Command{
 		Use:   "latest",
 		Short: "直近のセッション ID を表示する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessionLatest(cmd.Context(), cmd.OutOrStdout(), sessionLatestCommandInput{
 				dbPath: dbPath,
@@ -72,7 +72,7 @@ func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "セッション開始を記録する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessionBoundary(cmd.Context(), cmd.OutOrStdout(), sessionBoundaryCommandInput{
 				dbPath:    dbPath,
@@ -105,7 +105,7 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 	endCmd := &cobra.Command{
 		Use:   "end",
 		Short: "セッション終了を記録する",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessionBoundary(cmd.Context(), cmd.OutOrStdout(), sessionBoundaryCommandInput{
 				dbPath:    dbPath,
@@ -158,7 +158,7 @@ func (c *RootCLI) newSessionActiveCommand() *cobra.Command {
 	activeCmd := &cobra.Command{
 		Use:   "active",
 		Short: "現在アクティブな session ID を表示する (既定では 24h 超の stale を除外)",
-		Args:  cobra.NoArgs,
+		Args:  noArgsJP(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessionLatest(cmd.Context(), cmd.OutOrStdout(), sessionLatestCommandInput{
 				dbPath:     dbPath,

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -20,7 +20,7 @@ func (c *RootCLI) newShowCommand() *cobra.Command {
 	showCmd := &cobra.Command{
 		Use:   "show <event-id>",
 		Short: "イベント詳細を表示する",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgsJP(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.runShow(cmd.Context(), cmd.OutOrStdout(), dbPath, args[0], asJSON)
 		},


### PR DESCRIPTION
## Summary
- replace Cobra's default positional-arg validators with Japanese user-facing messages
- cover no-arg, exact-arg, and maximum-arg commands consistently
- add regression tests for representative commands

## Motivation
Issue #63 came from Claude dogfood: positional-argument errors such as `accepts 1 arg(s), received 0` were the last obvious English errors in the CLI. This PR localizes those messages while keeping the plain `Error: ...` stderr contract.

Closes #63
