### PR TITLE
ci: use setup-go v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Motivation
- align the CI workflow with the current `actions/setup-go` major version documented upstream

## Changes
- switch both Go jobs from `actions/setup-go@v5` to `actions/setup-go@v6`

## Validation
- `python3 scripts/verify_docs_i18n.py`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`
