### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 duck8823
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -145,6 +145,10 @@ Hooks 導入: [`docs/hooks/README.ja.md`](./docs/hooks/README.ja.md)
 
 CLI の失敗は stderr に plain text の `Error: ...` 形式で出力されます。hooks や shell script から JSON ログを剥がさず扱えるようにするためです。
 
+## ライセンス
+
+MIT License です。詳細は [`LICENSE`](./LICENSE) を参照してください。
+
 ## スコープ外
 
 - セマンティック検索 / 埋め込みベクトル

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ All commands resolve the SQLite path in this order: `--db-path` → `TRACEARY_DB
 
 CLI failures are printed to stderr as plain `Error: ...` lines so hooks and shell scripts can parse them without JSON log noise.
 
+## License
+
+MIT. See [`LICENSE`](./LICENSE).
+
 ## Non-goals
 
 - Semantic search / embeddings


### PR DESCRIPTION
## Motivation
- close the public-release blocker from #73 by making the project license explicit
- surface the chosen license from both the English and Japanese README

## Changes
- add an MIT `LICENSE` file at the repository root
- add short license sections to `README.md` and `README.ja.md`

## Validation
- `python3 scripts/verify_docs_i18n.py`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`

Closes #73.
