### PR TITLE
fix: inherit session end attribution

### DIFF
--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -12,12 +13,28 @@ import (
 
 // RecordSessionBoundaryInput は session start/end の入力です。
 type RecordSessionBoundaryInput struct {
-	DBPath    string
-	Client    string
-	Agent     string
-	SessionID string
-	Repo      string
-	Kind      types.EventKind
+	DBPath        string
+	Client        string
+	DefaultClient string
+	Agent         string
+	DefaultAgent  string
+	SessionID     string
+	Repo          string
+	DefaultRepo   string
+	Kind          types.EventKind
+}
+
+// ErrSessionStartedEventNotFound は対象 session の開始イベントが存在しないことを表します。
+var ErrSessionStartedEventNotFound = xerrors.New("対象 session の開始イベントが存在しません")
+
+// SessionStartedEventFinder は session_started イベントの取得を提供します。
+type SessionStartedEventFinder interface {
+	// FindSessionStartedEvent は対象 session の直近の session_started イベントを返します。
+	FindSessionStartedEvent(
+		ctx context.Context,
+		dbPath string,
+		sessionID types.SessionID,
+	) (*model.Event, error)
 }
 
 // RecordSessionBoundaryUsecase は session 開始/終了イベントを記録します。
@@ -27,12 +44,19 @@ type RecordSessionBoundaryUsecase interface {
 }
 
 type recordSessionBoundaryUsecase struct {
-	eventSaver EventSaver
+	eventSaver                EventSaver
+	sessionStartedEventFinder SessionStartedEventFinder
 }
 
 // NewRecordSessionBoundaryUsecase は session 境界イベント記録ユースケースを生成します。
-func NewRecordSessionBoundaryUsecase(eventSaver EventSaver) RecordSessionBoundaryUsecase {
-	return &recordSessionBoundaryUsecase{eventSaver: eventSaver}
+func NewRecordSessionBoundaryUsecase(
+	eventSaver EventSaver,
+	sessionStartedEventFinder SessionStartedEventFinder,
+) RecordSessionBoundaryUsecase {
+	return &recordSessionBoundaryUsecase{
+		eventSaver:                eventSaver,
+		sessionStartedEventFinder: sessionStartedEventFinder,
+	}
 }
 
 // Run は session 境界イベントを保存します。
@@ -48,13 +72,22 @@ func (u *recordSessionBoundaryUsecase) Run(
 		return nil, xerrors.Errorf("DB パスは空にできません")
 	}
 
-	agent, err := types.AgentOf(input.Agent)
-	if err != nil {
-		return nil, xerrors.Errorf("agent の解決に失敗しました: %w", err)
-	}
 	sessionID, err := resolveSessionBoundaryID(input.Kind, input.SessionID)
 	if err != nil {
 		return nil, xerrors.Errorf("session ID の解決に失敗しました: %w", err)
+	}
+	resolvedClient, resolvedAgentValue, resolvedRepo, err := u.resolveSessionBoundaryAttribution(
+		ctx,
+		trimmedDBPath,
+		input,
+		sessionID,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("session 境界の attribution 解決に失敗しました: %w", err)
+	}
+	agent, err := types.AgentOf(resolvedAgentValue)
+	if err != nil {
+		return nil, xerrors.Errorf("agent の解決に失敗しました: %w", err)
 	}
 	eventID, err := newEventID()
 	if err != nil {
@@ -64,10 +97,10 @@ func (u *recordSessionBoundaryUsecase) Run(
 	event, err := model.NewEvent(
 		eventID,
 		input.Kind,
-		strings.TrimSpace(input.Client),
+		resolvedClient,
 		agent,
 		sessionID,
-		strings.TrimSpace(input.Repo),
+		resolvedRepo,
 		sessionBoundaryBody(input.Kind),
 	)
 	if err != nil {
@@ -78,6 +111,49 @@ func (u *recordSessionBoundaryUsecase) Run(
 	}
 
 	return event, nil
+}
+
+func (u *recordSessionBoundaryUsecase) resolveSessionBoundaryAttribution(
+	ctx context.Context,
+	dbPath string,
+	input RecordSessionBoundaryInput,
+	sessionID types.SessionID,
+) (string, string, string, error) {
+	resolvedClient := strings.TrimSpace(input.Client)
+	resolvedAgentValue := strings.TrimSpace(input.Agent)
+	resolvedRepo := strings.TrimSpace(input.Repo)
+
+	if input.Kind == types.EventKindSessionEnded && u.sessionStartedEventFinder != nil {
+		if resolvedClient == "" || resolvedAgentValue == "" || resolvedRepo == "" {
+			startedEvent, err := u.sessionStartedEventFinder.FindSessionStartedEvent(ctx, dbPath, sessionID)
+			if err != nil && !errors.Is(err, ErrSessionStartedEventNotFound) {
+				return "", "", "", xerrors.Errorf("session_started イベントの取得に失敗しました: %w", err)
+			}
+			if err == nil && startedEvent != nil {
+				if resolvedClient == "" {
+					resolvedClient = startedEvent.Client()
+				}
+				if resolvedAgentValue == "" {
+					resolvedAgentValue = startedEvent.Agent().String()
+				}
+				if resolvedRepo == "" {
+					resolvedRepo = startedEvent.Repo()
+				}
+			}
+		}
+	}
+
+	if resolvedClient == "" {
+		resolvedClient = strings.TrimSpace(input.DefaultClient)
+	}
+	if resolvedAgentValue == "" {
+		resolvedAgentValue = strings.TrimSpace(input.DefaultAgent)
+	}
+	if resolvedRepo == "" {
+		resolvedRepo = strings.TrimSpace(input.DefaultRepo)
+	}
+
+	return resolvedClient, resolvedAgentValue, resolvedRepo, nil
 }
 
 func resolveSessionBoundaryID(

--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -2,10 +2,13 @@ package usecase_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -16,7 +19,7 @@ func TestRecordSessionBoundaryUsecase_Run(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventRepositoryStub{}
-		sut := usecase.NewRecordSessionBoundaryUsecase(stub)
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, nil)
 
 		got, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
 			DBPath: "/tmp/traceary.db",
@@ -46,7 +49,7 @@ func TestRecordSessionBoundaryUsecase_Run(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventRepositoryStub{}
-		sut := usecase.NewRecordSessionBoundaryUsecase(stub)
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, nil)
 
 		_, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
 			DBPath: "/tmp/traceary.db",
@@ -62,7 +65,7 @@ func TestRecordSessionBoundaryUsecase_Run(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventRepositoryStub{}
-		sut := usecase.NewRecordSessionBoundaryUsecase(stub)
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, nil)
 
 		got, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
 			DBPath:    "/tmp/traceary.db",
@@ -85,4 +88,177 @@ func TestRecordSessionBoundaryUsecase_Run(t *testing.T) {
 			t.Fatalf("Body() = %q, want %q", got.Body(), "session ended")
 		}
 	})
+
+	t.Run("session end は開始時の client/agent/repo を引き継げる", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID, err := types.SessionIDOf("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDOf() error = %v", err)
+		}
+		startAgent, err := types.AgentOf("claude")
+		if err != nil {
+			t.Fatalf("AgentOf() error = %v", err)
+		}
+
+		stub := &eventRepositoryStub{}
+		finder := &sessionStartedEventFinderStub{
+			event: model.EventOf(
+				mustEventID(t, "event-started"),
+				types.EventKindSessionStarted,
+				"hook",
+				startAgent,
+				sessionID,
+				"repo-from-start",
+				"session started",
+				mustTime(t),
+			),
+		}
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, finder)
+
+		got, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath:        "/tmp/traceary.db",
+			DefaultClient: "cli",
+			DefaultAgent:  "manual",
+			SessionID:     "session-1",
+			Kind:          types.EventKindSessionEnded,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got.Client() != "hook" {
+			t.Fatalf("Client() = %q, want %q", got.Client(), "hook")
+		}
+		if got.Agent().String() != "claude" {
+			t.Fatalf("Agent() = %q, want %q", got.Agent(), "claude")
+		}
+		if got.Repo() != "repo-from-start" {
+			t.Fatalf("Repo() = %q, want %q", got.Repo(), "repo-from-start")
+		}
+	})
+
+	t.Run("session end は明示的な client/agent を優先する", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID, err := types.SessionIDOf("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDOf() error = %v", err)
+		}
+		startAgent, err := types.AgentOf("claude")
+		if err != nil {
+			t.Fatalf("AgentOf() error = %v", err)
+		}
+
+		stub := &eventRepositoryStub{}
+		finder := &sessionStartedEventFinderStub{
+			event: model.EventOf(
+				mustEventID(t, "event-started-2"),
+				types.EventKindSessionStarted,
+				"hook",
+				startAgent,
+				sessionID,
+				"repo-from-start",
+				"session started",
+				mustTime(t),
+			),
+		}
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, finder)
+
+		got, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath:        "/tmp/traceary.db",
+			Client:        "cli",
+			Agent:         "codex",
+			DefaultClient: "cli",
+			DefaultAgent:  "manual",
+			SessionID:     "session-1",
+			Repo:          "repo-explicit",
+			Kind:          types.EventKindSessionEnded,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got.Client() != "cli" {
+			t.Fatalf("Client() = %q, want %q", got.Client(), "cli")
+		}
+		if got.Agent().String() != "codex" {
+			t.Fatalf("Agent() = %q, want %q", got.Agent(), "codex")
+		}
+		if got.Repo() != "repo-explicit" {
+			t.Fatalf("Repo() = %q, want %q", got.Repo(), "repo-explicit")
+		}
+	})
+
+	t.Run("session_started が見つからない場合は fallback を使う", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		finder := &sessionStartedEventFinderStub{err: usecase.ErrSessionStartedEventNotFound}
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, finder)
+
+		got, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath:        "/tmp/traceary.db",
+			DefaultClient: "cli",
+			DefaultAgent:  "manual",
+			SessionID:     "session-1",
+			Kind:          types.EventKindSessionEnded,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got.Client() != "cli" {
+			t.Fatalf("Client() = %q, want %q", got.Client(), "cli")
+		}
+		if got.Agent().String() != "manual" {
+			t.Fatalf("Agent() = %q, want %q", got.Agent(), "manual")
+		}
+	})
+
+	t.Run("session_started 取得エラーはそのまま返す", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		finder := &sessionStartedEventFinderStub{err: errors.New("boom")}
+		sut := usecase.NewRecordSessionBoundaryUsecase(stub, finder)
+
+		_, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath:        "/tmp/traceary.db",
+			DefaultClient: "cli",
+			DefaultAgent:  "manual",
+			SessionID:     "session-1",
+			Kind:          types.EventKindSessionEnded,
+		})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+}
+
+type sessionStartedEventFinderStub struct {
+	event *model.Event
+	err   error
+}
+
+func (s *sessionStartedEventFinderStub) FindSessionStartedEvent(
+	_ context.Context,
+	_ string,
+	_ types.SessionID,
+) (*model.Event, error) {
+	return s.event, s.err
+}
+
+func mustEventID(t *testing.T, value string) types.EventID {
+	t.Helper()
+
+	eventID, err := types.EventIDOf(value)
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+
+	return eventID
+}
+
+func mustTime(t *testing.T) time.Time {
+	t.Helper()
+
+	return time.Date(2026, 4, 8, 13, 0, 0, 0, time.UTC)
 }

--- a/infrastructure/sqlite/find_session_started_event.go
+++ b/infrastructure/sqlite/find_session_started_event.go
@@ -1,0 +1,50 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+var _ usecase.SessionStartedEventFinder = (*Datasource)(nil)
+
+// FindSessionStartedEvent は対象 session の直近の session_started イベントを返します。
+func (d *Datasource) FindSessionStartedEvent(
+	ctx context.Context,
+	dbPath string,
+	sessionID types.SessionID,
+) (*model.Event, error) {
+	db, err := d.openDB(ctx, dbPath)
+	if err != nil {
+		return nil, xerrors.Errorf("session_started 取得用の DB オープンに失敗しました: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT id, kind, client, agent, session_id, repo, body, created_at
+		   FROM events
+		  WHERE kind = ?
+		    AND session_id = ?
+		  ORDER BY created_at DESC, id DESC
+		  LIMIT 1`,
+		types.EventKindSessionStarted.String(),
+		sessionID.String(),
+	)
+
+	event, err := d.scanEvent(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, usecase.ErrSessionStartedEventNotFound
+		}
+		return nil, xerrors.Errorf("session_started イベントの復元に失敗しました: %w", err)
+	}
+
+	return event, nil
+}

--- a/infrastructure/sqlite/find_session_started_event_test.go
+++ b/infrastructure/sqlite/find_session_started_event_test.go
@@ -1,0 +1,163 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestDatasource_FindSessionStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut := NewDatasource(fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';
+CREATE INDEX idx_events_created_at
+    ON events(created_at DESC, id DESC);`),
+		},
+	})
+	if err := sut.Initialize(context.Background(), dbPath); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := newFindSessionStartedEventFixture(
+		t,
+		"event-started",
+		types.EventKindSessionStarted,
+		"hook",
+		"codex",
+		"session-1",
+		"repo-1",
+		"session started",
+		time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+	)
+	ended := newFindSessionStartedEventFixture(
+		t,
+		"event-ended",
+		types.EventKindSessionEnded,
+		"hook",
+		"codex",
+		"session-1",
+		"repo-1",
+		"session ended",
+		time.Date(2026, 4, 8, 12, 5, 0, 0, time.UTC),
+	)
+	newerStarted := newFindSessionStartedEventFixture(
+		t,
+		"event-started-2",
+		types.EventKindSessionStarted,
+		"cli",
+		"claude",
+		"session-1",
+		"repo-2",
+		"session started",
+		time.Date(2026, 4, 8, 12, 10, 0, 0, time.UTC),
+	)
+	otherSession := newFindSessionStartedEventFixture(
+		t,
+		"event-started-other",
+		types.EventKindSessionStarted,
+		"cli",
+		"gemini",
+		"session-2",
+		"repo-3",
+		"session started",
+		time.Date(2026, 4, 8, 12, 20, 0, 0, time.UTC),
+	)
+	fixtures := []*model.Event{started, ended, newerStarted, otherSession}
+	for _, fixture := range fixtures {
+		if err := sut.Save(context.Background(), dbPath, fixture); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+
+	t.Run("対象 session の直近 session_started を返す", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID, err := types.SessionIDOf("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDOf() error = %v", err)
+		}
+
+		got, err := sut.FindSessionStartedEvent(context.Background(), dbPath, sessionID)
+		if err != nil {
+			t.Fatalf("FindSessionStartedEvent() error = %v", err)
+		}
+		if got.EventID().String() != "event-started-2" {
+			t.Fatalf("EventID() = %q, want %q", got.EventID(), "event-started-2")
+		}
+		if got.Client() != "cli" {
+			t.Fatalf("Client() = %q, want %q", got.Client(), "cli")
+		}
+		if got.Agent().String() != "claude" {
+			t.Fatalf("Agent() = %q, want %q", got.Agent(), "claude")
+		}
+		if got.Repo() != "repo-2" {
+			t.Fatalf("Repo() = %q, want %q", got.Repo(), "repo-2")
+		}
+	})
+
+	t.Run("見つからない場合は not found を返す", func(t *testing.T) {
+		t.Parallel()
+
+		sessionID, err := types.SessionIDOf("session-missing")
+		if err != nil {
+			t.Fatalf("SessionIDOf() error = %v", err)
+		}
+
+		_, err = sut.FindSessionStartedEvent(context.Background(), dbPath, sessionID)
+		if !errors.Is(err, usecase.ErrSessionStartedEventNotFound) {
+			t.Fatalf("error = %v, want ErrSessionStartedEventNotFound", err)
+		}
+	})
+}
+
+func newFindSessionStartedEventFixture(
+	t *testing.T,
+	eventIDValue string,
+	kind types.EventKind,
+	client string,
+	agentValue string,
+	sessionIDValue string,
+	repo string,
+	body string,
+	createdAt time.Time,
+) *model.Event {
+	t.Helper()
+
+	eventID, err := types.EventIDOf(eventIDValue)
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf(agentValue)
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf(sessionIDValue)
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	return model.EventOf(eventID, kind, client, agent, sessionID, repo, body, createdAt)
+}

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func run() error {
 	datasource := sqlite.NewDatasource(migrationsSubFS)
 	initializeStoreUsecase := usecase.NewInitializeStoreUsecase(datasource)
 	recordLogUsecase := usecase.NewRecordLogUsecase(datasource)
-	recordSessionBoundaryUsecase := usecase.NewRecordSessionBoundaryUsecase(datasource)
+	recordSessionBoundaryUsecase := usecase.NewRecordSessionBoundaryUsecase(datasource, datasource)
 	recordCommandAuditUsecase := usecase.NewRecordCommandAuditUsecase(datasource)
 	collectGarbageUsecase := usecase.NewCollectGarbageUsecase(datasource)
 	searchEventsQueryService := queryservice.NewSearchEventsQueryService(datasource)

--- a/presentation/cli/context.go
+++ b/presentation/cli/context.go
@@ -12,7 +12,7 @@ import (
 var detectRepoContextFunc = detectRepoContext
 
 func resolveRepoValue(ctx context.Context, flagValue string) string {
-	if repo := resolveOptionalValue(flagValue, "TRACEARY_REPO", ""); repo != "" {
+	if repo := resolveExplicitRepoValue(flagValue); repo != "" {
 		return repo
 	}
 
@@ -22,6 +22,10 @@ func resolveRepoValue(ctx context.Context, flagValue string) string {
 	}
 
 	return repo
+}
+
+func resolveExplicitRepoValue(flagValue string) string {
+	return resolveOptionalValue(flagValue, "TRACEARY_REPO", "")
 }
 
 func detectRepoContext(ctx context.Context) (string, error) {

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -207,12 +207,15 @@ func (c *RootCLI) runSessionBoundary(
 	}
 
 	event, err := c.recordSessionBoundaryUsecase.Run(ctx, usecase.RecordSessionBoundaryInput{
-		DBPath:    resolvedPath,
-		Client:    resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue),
-		Agent:     resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue),
-		SessionID: input.sessionID,
-		Repo:      resolveRepoValue(ctx, input.repo),
-		Kind:      input.kind,
+		DBPath:        resolvedPath,
+		Client:        resolveSessionBoundaryClient(input),
+		DefaultClient: defaultClientValue,
+		Agent:         resolveSessionBoundaryAgent(input),
+		DefaultAgent:  defaultAgentValue,
+		SessionID:     input.sessionID,
+		Repo:          resolveSessionBoundaryRepo(input),
+		DefaultRepo:   resolveRepoValue(ctx, input.repo),
+		Kind:          input.kind,
 	})
 	if err != nil {
 		return xerrors.Errorf("session 境界の記録に失敗しました: %w", err)
@@ -230,6 +233,30 @@ func (c *RootCLI) runSessionBoundary(
 	}
 
 	return nil
+}
+
+func resolveSessionBoundaryClient(input sessionBoundaryCommandInput) string {
+	if input.kind == types.EventKindSessionEnded {
+		return resolveOptionalValue(input.client, "TRACEARY_CLIENT", "")
+	}
+
+	return resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue)
+}
+
+func resolveSessionBoundaryAgent(input sessionBoundaryCommandInput) string {
+	if input.kind == types.EventKindSessionEnded {
+		return resolveOptionalValue(input.agent, "TRACEARY_AGENT", "")
+	}
+
+	return resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue)
+}
+
+func resolveSessionBoundaryRepo(input sessionBoundaryCommandInput) string {
+	if input.kind == types.EventKindSessionEnded {
+		return resolveExplicitRepoValue(input.repo)
+	}
+
+	return resolveRepoValue(context.Background(), input.repo)
 }
 
 func (c *RootCLI) runSessionLatest(

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -115,8 +115,63 @@ func TestRootCLI_SessionStartCommand(t *testing.T) {
 	}
 }
 
+func TestRootCLI_SessionStartCommand_UsesDetectedRepoByDefault(t *testing.T) {
+	t.Setenv("TRACEARY_REPO", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	eventID, err := types.EventIDOf("event-1b")
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf("codex")
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf("session-auto-repo")
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	initStub := &initializeStoreUsecaseStub{}
+	sessionStub := &recordSessionBoundaryUsecaseStub{
+		event: model.EventOf(
+			eventID,
+			types.EventKindSessionStarted,
+			"cli",
+			agent,
+			sessionID,
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 7, 13, 5, 0, 0, time.UTC),
+		),
+	}
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:       initStub,
+		RecordSessionBoundaryUsecase: sessionStub,
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "start", "--db-path", dbPath})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if sessionStub.receivedInput.Repo != "github.com/duck8823/traceary" {
+		t.Fatalf("Repo = %q, want %q", sessionStub.receivedInput.Repo, "github.com/duck8823/traceary")
+	}
+}
+
 func TestRootCLI_SessionEndCommand(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
+	t.Setenv("TRACEARY_REPO", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
 
 	eventID, err := types.EventIDOf("event-2")
 	if err != nil {
@@ -162,6 +217,24 @@ func TestRootCLI_SessionEndCommand(t *testing.T) {
 	}
 	if sessionStub.receivedInput.SessionID != "session-env" {
 		t.Fatalf("SessionID = %q, want %q", sessionStub.receivedInput.SessionID, "session-env")
+	}
+	if sessionStub.receivedInput.Client != "" {
+		t.Fatalf("Client = %q, want empty", sessionStub.receivedInput.Client)
+	}
+	if sessionStub.receivedInput.Agent != "" {
+		t.Fatalf("Agent = %q, want empty", sessionStub.receivedInput.Agent)
+	}
+	if sessionStub.receivedInput.DefaultClient != "cli" {
+		t.Fatalf("DefaultClient = %q, want %q", sessionStub.receivedInput.DefaultClient, "cli")
+	}
+	if sessionStub.receivedInput.DefaultAgent != "manual" {
+		t.Fatalf("DefaultAgent = %q, want %q", sessionStub.receivedInput.DefaultAgent, "manual")
+	}
+	if sessionStub.receivedInput.Repo != "" {
+		t.Fatalf("Repo = %q, want empty", sessionStub.receivedInput.Repo)
+	}
+	if sessionStub.receivedInput.DefaultRepo != "github.com/duck8823/traceary" {
+		t.Fatalf("DefaultRepo = %q, want %q", sessionStub.receivedInput.DefaultRepo, "github.com/duck8823/traceary")
 	}
 	if stdout.String() != "記録しました: event-2\n" {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), "記録しました: event-2\n")


### PR DESCRIPTION
## Motivation
- fix the attribution gap from #74 where `session end` fell back to `cli/manual` even when the session started with another client/agent
- keep session-end attribution aligned with the original session start unless the caller intentionally overrides it

## Changes
- add a session-started event lookup path in the SQLite datasource
- let the session-boundary use case inherit client/agent (and repo when missing) from the matching `session_started` event
- keep explicit `--client` / `--agent` values higher priority than inherited values
- add use case, CLI, and datasource coverage plus an end-to-end dogfood check

## Validation
- `python3 scripts/verify_docs_i18n.py`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci go tool golangci-lint run --timeout=5m`
- `git diff --check`
- end-to-end check with `session start` -> `session end` -> `list --json`

Closes #74.
