### PR TITLE
docs: add storage model transparency guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,8 @@
 
 [バックアップガイド](./docs/backup/README.ja.md)
 
+[ストレージモデル](./docs/storage/README.ja.md)
+
 [リリースガイド](./docs/release/README.ja.md)
 
 [CLI リファレンス](./docs/cli/README.ja.md)
@@ -233,6 +235,8 @@ Environment variables and runtime assumptions: [`docs/environment/README.ja.md`]
 MCP integration: [`docs/mcp/README.ja.md`](./docs/mcp/README.ja.md)
 
 バックアップとマシン移行: [`docs/backup/README.ja.md`](./docs/backup/README.ja.md)
+
+ストレージモデル、schema、GC 既定値: [`docs/storage/README.ja.md`](./docs/storage/README.ja.md)
 
 すべてのコマンドは SQLite path を `--db-path` → `TRACEARY_DB_PATH` → `~/.config/traceary/traceary.db` の順で解決します。
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 [Backup guide](./docs/backup/README.md)
 
+[Storage model](./docs/storage/README.md)
+
 [Release guide](./docs/release/README.md)
 
 [CLI reference](./docs/cli/README.md)
@@ -233,6 +235,8 @@ Environment variables and runtime assumptions: [`docs/environment/README.md`](./
 MCP integration: [`docs/mcp/README.md`](./docs/mcp/README.md)
 
 Backup and machine transfer: [`docs/backup/README.md`](./docs/backup/README.md)
+
+Storage model, schema, and GC defaults: [`docs/storage/README.md`](./docs/storage/README.md)
 
 All commands resolve the SQLite path in this order: `--db-path` → `TRACEARY_DB_PATH` → `~/.config/traceary/traceary.db`.
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -78,4 +78,5 @@ GitHub Actions でも同じ検証を行います。
 - environment reference: `docs/environment/README.md` / `docs/environment/README.ja.md`
 - MCP ガイド: `docs/mcp/README.md` / `docs/mcp/README.ja.md`
 - バックアップガイド: `docs/backup/README.md` / `docs/backup/README.ja.md`
+- ストレージモデル: `docs/storage/README.md` / `docs/storage/README.ja.md`
 - release ガイド: `docs/release/README.md` / `docs/release/README.ja.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,4 +78,5 @@ GitHub Actions runs the same check in CI.
 - environment reference: `docs/environment/README.md` / `docs/environment/README.ja.md`
 - MCP guide: `docs/mcp/README.md` / `docs/mcp/README.ja.md`
 - backup guide: `docs/backup/README.md` / `docs/backup/README.ja.md`
+- storage model: `docs/storage/README.md` / `docs/storage/README.ja.md`
 - release guide: `docs/release/README.md` / `docs/release/README.ja.md`

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -1,0 +1,107 @@
+# ストレージモデル
+
+[English](./README.md)
+
+Traceary は、ローカル状態を 1 つの SQLite DB file に保存します。
+このガイドでは、何がどこに保存されるのか、schema がどう構成されているのか、現在の `gc` / backup の既定動作が何かを説明します。
+
+## local-first な配置
+
+- 既定の DB path: `~/.config/traceary/traceary.db`
+- 上書き方法: `--db-path` または `TRACEARY_DB_PATH`
+- file permission: parent directory は `0700`、DB file は `0600` で作成
+- hidden remote service はなし: CLI / hooks / MCP server は同じローカル SQLite file を読み書きします
+
+`traceary init` は任意です。ストアが必要なコマンドは、必要に応じて DB を作成し、migration を自動適用します。
+
+## 現在の schema
+
+現在の Traceary は次の table を作成します。
+
+### `events`
+
+append-only な event stream です。note、session 境界、review record、command audit はすべてここから始まります。
+
+column:
+
+- `id`: event identifier
+- `kind`: `note`、`command_executed`、`session_started`、`session_ended` などの event kind
+- `agent`: `codex`、`claude`、`gemini`、`manual` などの logical actor
+- `session_id`: session grouping identifier
+- `body`: event の人間向けメッセージ
+- `created_at`: RFC3339 timestamp
+- `client`: `cli`、`claude`、`codex`、`gemini` などの ingestion path
+- `repo`: 利用可能な場合の current repository / workspace identifier
+
+主な index:
+
+- `idx_events_session_created_at` on `(session_id, created_at)`
+- `idx_events_created_at` on `(created_at DESC, id DESC)`
+
+### `command_audits`
+
+`command_executed` event に紐づく構造化 audit detail です。
+
+column:
+
+- `event_id`: primary key かつ `events.id` への foreign key
+- `command_text`: 記録した command line
+- `input_text`: 保存した command input payload
+- `output_text`: 保存した command output payload
+- `input_truncated`: input を切り詰めたかどうか
+- `output_truncated`: output を切り詰めたかどうか
+
+`command_audits.event_id` は `ON DELETE CASCADE` なので、`gc` によって event を削除すると対応する audit payload も同時に消えます。
+
+## Traceary が保存しないもの
+
+現在の non-goals:
+
+- SQLite file 以外に置く background daemon metadata
+- hidden な cloud sync や hosted history service
+- line-oriented export format を主 persistence layer にすること
+- `schema/sqlite/migrations` に埋め込まれた SQL 以外の migration registry
+
+## migration と互換性
+
+- migration は `schema/sqlite/migrations` から binary に埋め込みます
+- 通常コマンドの実行前に store initialization が走るため、upgrade 時も migration は自動適用されます
+- backup restore は、まず SQLite file をコピーし、その後に store initialization を再実行して newer migration を適用します
+
+任意の手動 schema edit との後方互換は保証しません。
+持ち運べるコピーが必要な場合は、DB を直接編集する代わりに `traceary backup create` を使ってください。
+
+## `gc` の既定動作
+
+`traceary gc` は古い event を retention ベースで掃除するコマンドです。
+
+- 既定 retention: `90` 日 (`--keep-days 90`)
+- 選択条件: `created_at < cutoff` の row を削除
+- `--dry-run`: 削除候補件数だけ表示
+- 削除後に `VACUUM` を実行
+
+実務上の意味:
+
+- `gc` は opt-in であり、Traceary が background で自動削除することはありません
+- `gc` を実行すると、該当 event と紐づく `command_audits` も削除されます
+- 長期履歴を残したい場合は、強めの cleanup の前に backup を取ってください
+
+## backup の既定動作
+
+サポートする backup 導線は意図的にシンプルです。
+
+- `traceary backup create` で compact な SQLite backup file を出力
+- `traceary backup restore` で destination DB path へその file をコピー
+- restore 後に、現在の binary がより新しい schema version を知っていれば migration を再適用
+
+マシン移行や破壊的 restore の注意点は専用ガイドを参照してください:
+[`../backup/README.ja.md`](../backup/README.ja.md)
+
+## 運用透明性のチェックリスト
+
+ローカルで Traceary が何をしているか確認したいときは:
+
+1. `traceary doctor` で解決された DB path と書き込み可否を確認する
+2. 正確な SQL が必要なら `schema/sqlite/migrations/` を見る
+3. 手動調査や risky cleanup の前に `traceary backup create` を実行する
+

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -1,0 +1,107 @@
+# Storage model
+
+[日本語](./README.ja.md)
+
+Traceary stores its local state in a single SQLite database file.
+This guide explains what gets written there, how the schema is organized, and what the current `gc` / backup defaults mean.
+
+## Local-first layout
+
+- default DB path: `~/.config/traceary/traceary.db`
+- override: `--db-path` or `TRACEARY_DB_PATH`
+- file permissions: Traceary creates the parent directory with `0700` and the DB file with `0600`
+- no hidden remote service: the CLI, hooks, and MCP server all read and write the same local SQLite file
+
+`traceary init` is optional. Any command that needs the store will create the DB and apply migrations on demand.
+
+## Current schema
+
+Traceary currently creates these tables:
+
+### `events`
+
+The append-only event stream. Every note, session boundary, review record, and command audit starts here.
+
+Columns:
+
+- `id`: event identifier
+- `kind`: event kind such as `note`, `command_executed`, `session_started`, `session_ended`
+- `agent`: logical actor such as `codex`, `claude`, `gemini`, or `manual`
+- `session_id`: session grouping identifier
+- `body`: human-facing message for the event
+- `created_at`: RFC3339 timestamp
+- `client`: ingestion path such as `cli`, `claude`, `codex`, `gemini`
+- `repo`: current repository / workspace identifier when available
+
+Important indexes:
+
+- `idx_events_session_created_at` on `(session_id, created_at)`
+- `idx_events_created_at` on `(created_at DESC, id DESC)`
+
+### `command_audits`
+
+Structured audit details for `command_executed` events.
+
+Columns:
+
+- `event_id`: primary key and foreign key to `events.id`
+- `command_text`: captured command line
+- `input_text`: stored command input payload
+- `output_text`: stored command output payload
+- `input_truncated`: whether Traceary truncated the stored input
+- `output_truncated`: whether Traceary truncated the stored output
+
+Because `command_audits.event_id` uses `ON DELETE CASCADE`, deleting an event through `gc` also deletes its audit payload.
+
+## What Traceary does not store
+
+Current non-goals:
+
+- no background daemon metadata outside the SQLite file
+- no hidden cloud sync or hosted history service
+- no line-oriented export format as the primary persistence layer
+- no schema migration registry outside the embedded SQL migrations in `schema/sqlite/migrations`
+
+## Migrations and compatibility
+
+- migrations are embedded in the binary from `schema/sqlite/migrations`
+- the store is initialized before normal command execution, so upgrades apply migrations automatically
+- backup restore copies the SQLite file first and then reruns store initialization so newer migrations can be applied
+
+Traceary does not promise backward compatibility for arbitrary manual schema edits.
+If you need a portable copy, use `traceary backup create` instead of editing the DB directly.
+
+## `gc` defaults
+
+`traceary gc` is retention-based cleanup for old events.
+
+- default retention: `90` days (`--keep-days 90`)
+- selection rule: delete rows where `created_at < cutoff`
+- `--dry-run`: print only the candidate count
+- after deletion, Traceary runs `VACUUM`
+
+Practical implications:
+
+- `gc` is opt-in; Traceary does not delete history automatically in the background
+- a `gc` run removes matching events and their linked `command_audits`
+- if you care about long-term history, take a backup before an aggressive cleanup
+
+## Backup defaults
+
+The supported backup story is intentionally simple:
+
+- `traceary backup create` writes a compact SQLite backup file
+- `traceary backup restore` copies that file into the destination DB path
+- restore then reapplies migrations if the current binary knows newer schema versions
+
+See the dedicated backup guide for machine transfer and destructive restore behavior:
+[`../backup/README.md`](../backup/README.md)
+
+## Operational transparency checklist
+
+When you need to understand what Traceary is doing locally:
+
+1. run `traceary doctor` to confirm the resolved DB path and writeability
+2. inspect `schema/sqlite/migrations/` if you need the exact SQL
+3. use `traceary backup create` before manual investigation or risky cleanup
+


### PR DESCRIPTION
## Summary
- add a dedicated storage model guide in English and Japanese
- document the current SQLite schema, local-first layout, and migration behavior
- explain gc defaults, backup behavior, and transparency expectations

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=/tmp/traceary-gocache GOMODCACHE=/tmp/traceary-gomod go test ./...
- GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci GOMODCACHE=/tmp/traceary-gomod go tool golangci-lint run --timeout=5m
- git diff --check

Closes #114
