### PR TITLE
docs: add public OSS trust signals

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,9 @@
 
 [English](./README.md)
 
+[![CI](https://github.com/duck8823/traceary/actions/workflows/ci.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/ci.yml)
+[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
+
 [Changelog](./CHANGELOG.ja.md)
 
 [文書ガイド](./docs/README.ja.md)
@@ -83,6 +86,20 @@ release 導線とローカル snapshot build は [`docs/release/README.ja.md`](.
 - デフォルトの help / success message / よくある error は英語です
 - 日本語 UI を使いたい場合は `TRACEARY_LANG=ja` を指定してください
 - `--json` 出力は言語設定の影響を受けません
+
+## プライバシーとテレメトリ
+
+- Traceary は local-first であり、ローカル SQLite file に書き込むだけで、専用の hosted Traceary service は必要ありません
+- built-in の telemetry / analytics / crash reporting は含みません
+- データがマシン外へ出るのは、SQLite file を自分でコピーする、backup を公開する、別 tool 連携を自分で構成する、といった明示操作をした場合だけです
+
+ストレージの詳細は [`docs/storage/README.ja.md`](./docs/storage/README.ja.md)、脆弱性報告の窓口は [`SECURITY.ja.md`](./SECURITY.ja.md) を参照してください。
+
+## サポート期待値
+
+- Traceary は活発に変化している OSS tool であり、SLA つきの managed service ではありません
+- bug report や改善提案は GitHub Issues で受け付けます
+- `v0.x` の間は automation 周辺の変更が比較的速く起こりうるため、upgrade 前に changelog を確認してください
 
 ## クイックスタート
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [日本語](./README.ja.md)
 
+[![CI](https://github.com/duck8823/traceary/actions/workflows/ci.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/ci.yml)
+[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
+
 [Changelog](./CHANGELOG.md)
 
 [Documentation guide](./docs/README.md)
@@ -83,6 +86,20 @@ See [`docs/release/README.md`](./docs/release/README.md) for the release flow an
 - default operator-facing help, success messages, and common errors use English
 - set `TRACEARY_LANG=ja` when you want Japanese CLI messaging instead
 - `--json` output is language-neutral
+
+## Privacy and telemetry
+
+- Traceary is local-first: it writes to a local SQLite file and does not require a hosted Traceary service
+- the project does not include built-in telemetry, analytics, or crash reporting
+- your data leaves the machine only when you explicitly copy the SQLite file, publish a backup, or wire Traceary into another tool yourself
+
+See [`docs/storage/README.md`](./docs/storage/README.md) for the storage model and [`SECURITY.md`](./SECURITY.md) for the security disclosure path.
+
+## Support expectations
+
+- Traceary is maintained as an actively evolving OSS tool, not a managed service with an SLA
+- bug reports and improvement requests belong in GitHub Issues
+- changes can still happen quickly within `v0.x`, so read the changelog before upgrading automation around it
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- add CI and release badges to the README files
- document the project's no-telemetry / local-first privacy posture
- set light-weight support expectations for public OSS users

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=/tmp/traceary-gocache GOMODCACHE=/tmp/traceary-gomod go test ./...
- GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci GOMODCACHE=/tmp/traceary-gomod go tool golangci-lint run --timeout=5m
- git diff --check

Closes #118
