### PR TITLE
docs: add operational assumptions guide

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -78,5 +78,6 @@ GitHub Actions でも同じ検証を行います。
 - environment reference: `docs/environment/README.md` / `docs/environment/README.ja.md`
 - MCP ガイド: `docs/mcp/README.md` / `docs/mcp/README.ja.md`
 - バックアップガイド: `docs/backup/README.md` / `docs/backup/README.ja.md`
+- 運用前提: `docs/operations/README.md` / `docs/operations/README.ja.md`
 - ストレージモデル: `docs/storage/README.md` / `docs/storage/README.ja.md`
 - release ガイド: `docs/release/README.md` / `docs/release/README.ja.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,5 +78,6 @@ GitHub Actions runs the same check in CI.
 - environment reference: `docs/environment/README.md` / `docs/environment/README.ja.md`
 - MCP guide: `docs/mcp/README.md` / `docs/mcp/README.ja.md`
 - backup guide: `docs/backup/README.md` / `docs/backup/README.ja.md`
+- operational assumptions: `docs/operations/README.md` / `docs/operations/README.ja.md`
 - storage model: `docs/storage/README.md` / `docs/storage/README.ja.md`
 - release guide: `docs/release/README.md` / `docs/release/README.ja.md`

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -138,6 +138,8 @@ hooks やローカル SQLite store の挙動がおかしいときは `traceary d
 
 `doctor` は対象 client 自体を起動するわけではありません。file path、DB access、Traceary 管理下の hook entry の存在は確認できますが、第三者 client が検証時とまったく同じ形で hook を発火することまでは保証しません。
 
+SQLite concurrency の前提、PPID ベース hook state の注意点、その他の運用上の既知前提は [`../operations/README.ja.md`](../operations/README.ja.md) を参照してください。
+
 ### Claude Code
 
 1. `examples/hooks/claude.settings.json` を `.claude/settings.json` にコピーし、既存設定と merge する

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -138,6 +138,8 @@ The diagnostic command checks:
 
 `doctor` does not execute the target client for you. It verifies file paths, DB access, and whether Traceary-managed hook entries are present, but it cannot prove that a third-party client will actually fire every hook in the same way as the validated local builds.
 
+For SQLite concurrency expectations, PPID-based hook state caveats, and other known operational assumptions, see [`../operations/README.md`](../operations/README.md).
+
 ### Claude Code
 
 1. Copy `examples/hooks/claude.settings.json` into `.claude/settings.json` and merge with existing settings.

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -1,0 +1,101 @@
+# 運用前提
+
+[English](./README.md)
+
+このガイドでは、Traceary のローカル SQLite store と generated hook script が実行時に置いている前提を明文化します。
+何を保証しているのか、どこが best-effort なのか、どこで手動 override が必要になりうるのかを率直に説明します。
+
+## SQLite の concurrency model
+
+Traceary は、process 間調停を SQLite 自身に委ねています。
+
+現在の前提:
+
+- 通常利用は、同じ DB file を複数の短命な CLI / hook / MCP process が共有する形
+- write は小さな append 系操作（`events`、`command_audits`、session 境界）が中心
+- file level の write 直列化は SQLite が安全に扱う
+
+現在 Traceary が**追加していない**もの:
+
+- custom background writer や queue
+- 継続的な `database is locked` 圧に対する application-level retry loop
+- distributed / multi-host coordination
+
+実務上の見方:
+
+- 1 台のマシンで数本の並列 AI session を回す用途はスコープ内
+- 同じ DB path に対する極端に高い write volume は、現時点で tuning 対象ではない
+- SQLite lock error が繰り返し出る場合は、並列 writer を減らす、workflow ごとに DB path を分ける、競合 process が終わってから再実行する、の順で対処してください
+
+## Hook session state の前提
+
+generated hook script は、最後に解決した session ID を小さな local state file に保存します。
+
+既定の state key は次で決まります。
+
+- client 名
+- 明示指定された `TRACEARY_HOOK_STATE_KEY`
+- それが無ければ現在の `PPID`（必要なら `$$` に fallback）
+
+つまり、現在の hook 設計は次を前提にしています。
+
+- 1 つの interactive client session に属する hook invocation は、だいたい安定した parent process identity を共有する
+- client が、`PPID` を grouping key として使っても大きく崩れない process tree から hook を呼ぶ
+
+これは protocol level の保証ではなく、意図的に best-effort です。
+client 側の process model が変わった場合や、wrapper script により parent/child 関係が変わる場合は、`TRACEARY_HOOK_STATE_KEY` で grouping key を明示してください。
+
+## 既知の failure mode
+
+### `doctor` は通るが hooks が発火しない
+
+`traceary doctor` は、DB access、hook script の materialize、対象 config file に Traceary 管理下 entry があるか、までは確認します。
+ただし、third-party client 自体を起動して、検証時と同じ形で全 hook event が発火することまでは保証しません。
+
+### client によっては session end が best-effort
+
+- Claude Code: documented integration では dedicated `SessionEnd` を使える
+- Codex CLI: ローカル build では `Stop` しか見えていないため、stop/session-end capture は best-effort
+- Gemini CLI: `SessionEnd` も best-effort 扱い
+
+session end の精度が重要なら、明示的な end hook を持つ client integration を優先してください。
+
+### Hook state が別 session に付いてしまう
+
+多くの場合、既定の PPID ベース grouping がローカル client process topology に合っていません。
+より安定した grouping key が必要なら、hook 環境で `TRACEARY_HOOK_STATE_KEY` を明示してください。
+
+### active ingestion 中に cleanup を強く走らせる
+
+`traceary gc` は古い row を削除したあとに `VACUUM` を実行します。
+同じ DB に対して多くの session が書き込んでいる最中に、強めの cleanup を background maintenance のように常時回す前提ではありません。
+先に backup を取り、比較的静かなタイミングで実行してください。
+
+## support している範囲と、たまたま動く範囲
+
+現在 support している範囲:
+
+- 1 台のマシン
+- workflow / project group ごとに使う 1 つの local SQLite file
+- write volume が常識的な範囲の複数 human / AI session
+
+動く可能性はあるが積極的には tuning していない範囲:
+
+- 1 つの DB に対する高頻度な大量並列 writer
+- hook process topology を大きく変える client wrapper
+- non-POSIX な hook 実行環境
+
+## 推奨 mitigation
+
+1. hook generation を疑う前に `traceary doctor` を使う
+2. 複数 workflow で DB を分けたい場合は `TRACEARY_DB_PATH` を明示する
+3. PPID grouping が不安定なら `TRACEARY_HOOK_STATE_KEY` を明示する
+4. risky cleanup や手動調査の前に `traceary backup create` を実行する
+5. best-effort session-end hook に依存する場合は、自分たちの team automation に client 固有注意点を明記する
+
+## 関連文書
+
+- hooks integration: [`../hooks/README.ja.md`](../hooks/README.ja.md)
+- storage model: [`../storage/README.ja.md`](../storage/README.ja.md)
+- backup guide: [`../backup/README.ja.md`](../backup/README.ja.md)
+

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,101 @@
+# Operational assumptions
+
+[日本語](./README.ja.md)
+
+This guide documents the practical runtime assumptions behind Traceary's local SQLite store and generated hook scripts.
+It is intentionally candid about what Traceary assumes today, what is merely best-effort, and where users may still need manual overrides.
+
+## SQLite concurrency model
+
+Traceary relies on SQLite itself for cross-process coordination.
+
+Current assumptions:
+
+- normal usage is many short-lived CLI, hook, or MCP processes sharing one DB file
+- writes are small append-style operations (`events`, `command_audits`, session boundaries)
+- SQLite serializes those writes safely at the file level
+
+What Traceary does **not** add today:
+
+- no custom background writer or queue
+- no application-level retry loop for sustained `database is locked` pressure
+- no distributed or multi-host coordination
+
+Practical guidance:
+
+- a few parallel AI sessions on one machine are in scope
+- extremely high write volume to the same DB path is not a tuned use case today
+- if you repeatedly hit SQLite lock errors, reduce concurrent writers, split DB paths by workflow, or retry the operation after the short-lived competing process exits
+
+## Hook session-state assumptions
+
+The generated hook scripts persist the last resolved session ID in a small local state file.
+
+By default the state key is based on:
+
+- client name
+- `TRACEARY_HOOK_STATE_KEY`, when explicitly set
+- otherwise the current `PPID` (falling back to `$$` when needed)
+
+This means the current hook design assumes:
+
+- related hook invocations for one interactive client session usually share a stable parent process identity
+- the client keeps invoking hooks from a process tree that makes `PPID` a useful grouping key
+
+This is intentionally best-effort, not a protocol guarantee.
+If a client changes its process model, or if your wrapper scripts create a different parent/child layout, override the grouping with `TRACEARY_HOOK_STATE_KEY`.
+
+## Known failure modes
+
+### `doctor` passes but hooks still do not fire
+
+`traceary doctor` validates DB access, hook-script materialization, and whether Traceary-managed entries exist in the target config file.
+It does **not** launch the third-party client or prove that every hook event fires in exactly the same way as the local validated build.
+
+### Session end is best-effort for some clients
+
+- Claude Code: dedicated `SessionEnd` is supported in the documented integration
+- Codex CLI: stop/session-end capture is best-effort while the local build only exposes `Stop`
+- Gemini CLI: `SessionEnd` is also treated as best-effort
+
+If session-end fidelity matters, prefer the client integrations that expose an explicit end hook.
+
+### Hook state attaches to the wrong session
+
+This usually means the default PPID-based grouping does not match your local client process topology.
+Set `TRACEARY_HOOK_STATE_KEY` explicitly in the hook environment when you need a more stable grouping key.
+
+### Concurrent cleanup versus active ingestion
+
+`traceary gc` deletes old rows and then runs `VACUUM`.
+Do not treat aggressive cleanup as a background maintenance task while many sessions are actively writing to the same DB.
+Take a backup first and prefer running cleanup during a quieter period.
+
+## What is supported versus merely possible
+
+Supported today:
+
+- one machine
+- one local SQLite file per workflow or project group
+- several concurrent human/AI sessions with modest write volume
+
+Possible but not actively tuned:
+
+- many high-frequency parallel writers to a single DB
+- client wrappers that radically change hook process topology
+- non-POSIX hook environments
+
+## Recommended mitigations
+
+1. use `traceary doctor` before blaming hook generation
+2. set `TRACEARY_DB_PATH` explicitly when multiple workflows should not share one DB
+3. set `TRACEARY_HOOK_STATE_KEY` when PPID-based grouping is not stable enough
+4. run `traceary backup create` before risky cleanup or manual inspection
+5. document client-specific caveats in your own team automation if you rely on best-effort session-end hooks
+
+## Related docs
+
+- hooks integration: [`../hooks/README.md`](../hooks/README.md)
+- storage model: [`../storage/README.md`](../storage/README.md)
+- backup guide: [`../backup/README.md`](../backup/README.md)
+


### PR DESCRIPTION
## Summary
- add a dedicated operational assumptions guide in English and Japanese
- document SQLite concurrency expectations and hook-state caveats explicitly
- link the new guide from the hooks docs and docs index

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=/tmp/traceary-gocache GOMODCACHE=/tmp/traceary-gomod go test ./...
- GOCACHE=/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/tmp/traceary-golangci GOMODCACHE=/tmp/traceary-gomod go tool golangci-lint run --timeout=5m
- git diff --check

Closes #119
