### PR TITLE
Multi-agent era improvements (v0.1.17)

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -1,0 +1,75 @@
+package queryservice
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// SessionSummary holds aggregated information about a single session.
+type SessionSummary struct {
+	SessionID    string
+	Repo         string
+	StartedAt    time.Time
+	EndedAt      *time.Time
+	Status       string
+	TotalEvents  int
+	CommandCount int
+	Agents       []string
+}
+
+// ListSessionsInput is the input for session listing.
+type ListSessionsInput struct {
+	Limit  int
+	Offset int
+	Repo   string
+	Agent  string
+	From   string
+	To     string
+}
+
+// SessionSummaryFinder provides session summary lookup.
+type SessionSummaryFinder interface {
+	ListSessionSummaries(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+}
+
+// ListSessionsQueryService returns session summaries.
+type ListSessionsQueryService interface {
+	Run(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+}
+
+type listSessionsQueryService struct {
+	finder SessionSummaryFinder
+}
+
+// NewListSessionsQueryService creates a ListSessionsQueryService.
+func NewListSessionsQueryService(finder SessionSummaryFinder) ListSessionsQueryService {
+	return &listSessionsQueryService{finder: finder}
+}
+
+func (s *listSessionsQueryService) Run(
+	ctx context.Context,
+	dbPath string,
+	input ListSessionsInput,
+) ([]*SessionSummary, error) {
+	if s.finder == nil {
+		return nil, xerrors.Errorf("session summary finder is not configured")
+	}
+	if dbPath == "" {
+		return nil, xerrors.Errorf("DB path must not be empty")
+	}
+	if input.Limit <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if input.Offset < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	summaries, err := s.finder.ListSessionSummaries(ctx, dbPath, input)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list session summaries: %w", err)
+	}
+
+	return summaries, nil
+}

--- a/infrastructure/sqlite/datasource.go
+++ b/infrastructure/sqlite/datasource.go
@@ -47,8 +47,8 @@ func (d *Datasource) Initialize(ctx context.Context, dbPath string) (err error) 
 			err = xerrors.Errorf("failed to close SQLite connection: %w", closeErr)
 		}
 	}()
-	if err := os.Chmod(trimmedPath, 0o600); err != nil {
-		return xerrors.Errorf("failed to set SQLite DB file permissions: %w", err)
+	if chmodErr := os.Chmod(trimmedPath, 0o600); chmodErr != nil && !os.IsPermission(chmodErr) {
+		return xerrors.Errorf("failed to set SQLite DB file permissions: %w", chmodErr)
 	}
 
 	if err := d.migrate(ctx, db); err != nil {

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -1,0 +1,146 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+var _ queryservice.SessionSummaryFinder = (*Datasource)(nil)
+
+// ListSessionSummaries returns aggregated session information.
+func (d *Datasource) ListSessionSummaries(
+	ctx context.Context,
+	dbPath string,
+	input queryservice.ListSessionsInput,
+) ([]*queryservice.SessionSummary, error) {
+	db, err := d.openDB(ctx, dbPath)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for session list: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	fromValue := ""
+	if input.From != "" {
+		fromValue = input.From + "T00:00:00Z"
+	}
+	toValue := ""
+	if input.To != "" {
+		toValue = input.To + "T23:59:59Z"
+	}
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT
+		   e.session_id,
+		   MAX(e.repo) AS repo,
+		   MIN(e.created_at) AS started_at,
+		   MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END) AS ended_at,
+		   COUNT(*) AS total_events,
+		   SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+		   GROUP_CONCAT(DISTINCT e.agent) AS agents
+		 FROM events e
+		 WHERE (? = '' OR e.repo = ?)
+		   AND (? = '' OR e.agent = ?)
+		   AND (? = '' OR e.created_at >= ?)
+		   AND (? = '' OR e.created_at <= ?)
+		 GROUP BY e.session_id
+		 ORDER BY started_at DESC
+		 LIMIT ? OFFSET ?`,
+		input.Repo, input.Repo,
+		input.Agent, input.Agent,
+		fromValue, fromValue,
+		toValue, toValue,
+		input.Limit, input.Offset,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query session summaries: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]*queryservice.SessionSummary, 0)
+	for rows.Next() {
+		summary, err := scanSessionSummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan session summary row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate session summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+func scanSessionSummary(row interface {
+	Scan(dest ...any) error
+}) (*queryservice.SessionSummary, error) {
+	var (
+		sessionID    string
+		repo         string
+		startedAtStr string
+		endedAtStr   sql.NullString
+		totalEvents  int
+		commandCount int
+		agentsStr    string
+	)
+
+	if err := row.Scan(
+		&sessionID,
+		&repo,
+		&startedAtStr,
+		&endedAtStr,
+		&totalEvents,
+		&commandCount,
+		&agentsStr,
+	); err != nil {
+		return nil, xerrors.Errorf("failed to scan session summary: %w", err)
+	}
+
+	startedAt, err := time.Parse(time.RFC3339Nano, startedAtStr)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse started_at: %w", err)
+	}
+
+	var endedAt *time.Time
+	status := "active"
+	if endedAtStr.Valid {
+		t, err := time.Parse(time.RFC3339Nano, endedAtStr.String)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse ended_at: %w", err)
+		}
+		endedAt = &t
+		status = "ended"
+	}
+
+	var agents []string
+	if agentsStr != "" {
+		agents = strings.Split(agentsStr, ",")
+	}
+
+	return &queryservice.SessionSummary{
+		SessionID:    sessionID,
+		Repo:         repo,
+		StartedAt:    startedAt,
+		EndedAt:      endedAt,
+		Status:       status,
+		TotalEvents:  totalEvents,
+		CommandCount: commandCount,
+		Agents:       agents,
+	}, nil
+}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -1,0 +1,168 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func listSessionsTestMigrations() fstest.MapFS {
+	return fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0
+);`),
+		},
+	}
+}
+
+func TestDatasource_ListSessionSummaries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("セッションサマリーを取得できる", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		events := []struct {
+			id        string
+			kind      types.EventKind
+			agent     string
+			sessionID string
+			body      string
+		}{
+			{"e1", types.EventKindSessionStarted, "claude", "s1", "session started"},
+			{"e2", types.EventKindCommandExecuted, "claude", "s1", "go test ./..."},
+			{"e3", types.EventKindCommandExecuted, "claude", "s1", "go build ./..."},
+			{"e4", types.EventKindSessionEnded, "claude", "s1", "session ended"},
+			{"e5", types.EventKindSessionStarted, "codex", "s2", "session started"},
+			{"e6", types.EventKindCommandExecuted, "codex", "s2", "git status"},
+		}
+
+		for _, e := range events {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf(e.agent)
+			sid, _ := types.SessionIDOf(e.sessionID)
+			event, _ := model.NewEvent(eid, e.kind, "hook", agent, sid, "duck8823/traceary", e.body)
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 2 {
+			t.Fatalf("got %d summaries, want 2", len(summaries))
+		}
+
+		// s2 is newer (last inserted), should be first? Actually s1 has earlier started_at...
+		// Both sessions have same created_at base (close in time), but order is by started_at DESC
+		// s2's events are inserted after s1's, so s2.started_at > s1.started_at
+		latest := summaries[0]
+		if latest.SessionID != "s2" {
+			t.Fatalf("first session = %q, want s2", latest.SessionID)
+		}
+		if latest.TotalEvents != 2 {
+			t.Fatalf("s2 total_events = %d, want 2", latest.TotalEvents)
+		}
+		if latest.CommandCount != 1 {
+			t.Fatalf("s2 command_count = %d, want 1", latest.CommandCount)
+		}
+		if latest.Status != "active" {
+			t.Fatalf("s2 status = %q, want active", latest.Status)
+		}
+
+		older := summaries[1]
+		if older.SessionID != "s1" {
+			t.Fatalf("second session = %q, want s1", older.SessionID)
+		}
+		if older.TotalEvents != 4 {
+			t.Fatalf("s1 total_events = %d, want 4", older.TotalEvents)
+		}
+		if older.CommandCount != 2 {
+			t.Fatalf("s1 command_count = %d, want 2", older.CommandCount)
+		}
+		if older.Status != "ended" {
+			t.Fatalf("s1 status = %q, want ended", older.Status)
+		}
+		if older.EndedAt == nil {
+			t.Fatalf("s1 ended_at should not be nil")
+		}
+	})
+
+	t.Run("agent フィルタが機能する", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		for _, e := range []struct {
+			id, agent, sid string
+		}{
+			{"e1", "claude", "s1"},
+			{"e2", "codex", "s2"},
+		} {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf(e.agent)
+			sid, _ := types.SessionIDOf(e.sid)
+			event, _ := model.NewEvent(eid, types.EventKindSessionStarted, "hook", agent, sid, "repo", "start")
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+			Agent: "claude",
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].SessionID != "s1" {
+			t.Fatalf("session = %q, want s1", summaries[0].SessionID)
+		}
+	})
+}

--- a/integrations/claude-plugin/scripts/common.sh
+++ b/integrations/claude-plugin/scripts/common.sh
@@ -86,6 +86,17 @@ traceary_resolve_bin() {
   return 1
 }
 
+traceary_resolve_agent() {
+  local client="$1"
+  local agent_type
+  agent_type="$(traceary_json_get 'agent_type')"
+  if [[ -n "$agent_type" ]]; then
+    printf '%s/%s' "$client" "$agent_type"
+  else
+    printf '%s' "$client"
+  fi
+}
+
 traceary_session_state_path() {
   local client="$1"
   local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"

--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -41,7 +41,9 @@ if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
 fi
 
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
+COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/integrations/claude-plugin/scripts/traceary-session.sh
+++ b/integrations/claude-plugin/scripts/traceary-session.sh
@@ -31,9 +31,11 @@ if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
 fi
 COMMON_ARGS+=("${ACTION/start/start}")
 
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
 case "$ACTION" in
   start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$CLIENT")
+    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -63,7 +65,7 @@ case "$ACTION" in
       exit 0
     fi
 
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi

--- a/integrations/gemini-extension/scripts/common.sh
+++ b/integrations/gemini-extension/scripts/common.sh
@@ -86,6 +86,17 @@ traceary_resolve_bin() {
   return 1
 }
 
+traceary_resolve_agent() {
+  local client="$1"
+  local agent_type
+  agent_type="$(traceary_json_get 'agent_type')"
+  if [[ -n "$agent_type" ]]; then
+    printf '%s/%s' "$client" "$agent_type"
+  else
+    printf '%s' "$client"
+  fi
+}
+
 traceary_session_state_path() {
   local client="$1"
   local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -41,7 +41,9 @@ if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
 fi
 
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
+COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/integrations/gemini-extension/scripts/traceary-session.sh
+++ b/integrations/gemini-extension/scripts/traceary-session.sh
@@ -31,9 +31,11 @@ if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
 fi
 COMMON_ARGS+=("${ACTION/start/start}")
 
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
 case "$ACTION" in
   start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$CLIENT")
+    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -63,7 +65,7 @@ case "$ACTION" in
       exit 0
     fi
 
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi

--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func run() error {
 	getContextQueryService := queryservice.NewGetContextQueryService(datasource)
 	getEventDetailsQueryService := queryservice.NewGetEventDetailsQueryService(datasource)
 	findLatestSessionQueryService := queryservice.NewFindLatestSessionQueryService(datasource)
+	listSessionsQueryService := queryservice.NewListSessionsQueryService(datasource)
 	mcpServer, err := mcpserver.NewServer(
 		metadata.version,
 		initializeStoreUsecase,
@@ -192,6 +193,7 @@ func run() error {
 		GetContextQueryService:        getContextQueryService,
 		GetEventDetailsQueryService:   getEventDetailsQueryService,
 		FindLatestSessionQueryService: findLatestSessionQueryService,
+		ListSessionsQueryService:      listSessionsQueryService,
 		MCPServerRunner:               mcpServer,
 	}).Command()
 	rootCmd.Version = versionString()

--- a/plugins/traceary/scripts/common.sh
+++ b/plugins/traceary/scripts/common.sh
@@ -86,6 +86,17 @@ traceary_resolve_bin() {
   return 1
 }
 
+traceary_resolve_agent() {
+  local client="$1"
+  local agent_type
+  agent_type="$(traceary_json_get 'agent_type')"
+  if [[ -n "$agent_type" ]]; then
+    printf '%s/%s' "$client" "$agent_type"
+  else
+    printf '%s' "$client"
+  fi
+}
+
 traceary_session_state_path() {
   local client="$1"
   local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -41,7 +41,9 @@ if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
 fi
 
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
+COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/plugins/traceary/scripts/traceary-session.sh
+++ b/plugins/traceary/scripts/traceary-session.sh
@@ -31,9 +31,11 @@ if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
 fi
 COMMON_ARGS+=("${ACTION/start/start}")
 
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
 case "$ACTION" in
   start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$CLIENT")
+    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -63,7 +65,7 @@ case "$ACTION" in
       exit 0
     fi
 
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi

--- a/presentation/cli/event_output.go
+++ b/presentation/cli/event_output.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
 )
+
+const messageColumnMaxWidth = 80
 
 func writeEventsByFormat(output io.Writer, events []*model.Event, asJSON bool) error {
 	if asJSON {
@@ -39,7 +42,7 @@ func writeEvents(output io.Writer, events []*model.Event) error {
 			event.Agent(),
 			event.SessionID(),
 			formatOptionalColumn(event.Repo()),
-			event.Body(),
+			truncateMessage(event.Body()),
 		); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print event row", "イベント一覧行の出力に失敗しました"), err)
 		}
@@ -54,6 +57,14 @@ func writeEventDetailsByFormat(output io.Writer, eventDetails *queryservice.Even
 	}
 
 	return writeEventDetails(output, eventDetails)
+}
+
+func truncateMessage(s string) string {
+	normalized := strings.Join(strings.Fields(s), " ")
+	if len([]rune(normalized)) <= messageColumnMaxWidth {
+		return normalized
+	}
+	return string([]rune(normalized)[:messageColumnMaxWidth]) + "…"
 }
 
 func formatOptionalColumn(value string) string {

--- a/presentation/cli/event_output_test.go
+++ b/presentation/cli/event_output_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "短いメッセージはそのまま返す",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "改行をスペースに正規化する",
+			in:   "line1\nline2\nline3",
+			want: "line1 line2 line3",
+		},
+		{
+			name: "連続空白を1つに正規化する",
+			in:   "hello   \t  world",
+			want: "hello world",
+		},
+		{
+			name: "80文字を超えるメッセージを切り詰める",
+			in:   strings.Repeat("a", 100),
+			want: strings.Repeat("a", 80) + "…",
+		},
+		{
+			name: "ちょうど80文字はそのまま返す",
+			in:   strings.Repeat("b", 80),
+			want: strings.Repeat("b", 80),
+		},
+		{
+			name: "マルチバイト文字をルーン単位で切り詰める",
+			in:   strings.Repeat("あ", 100),
+			want: strings.Repeat("あ", 80) + "…",
+		},
+		{
+			name: "空文字列はそのまま返す",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncateMessage(tt.in)
+			if got != tt.want {
+				t.Errorf("truncateMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/presentation/cli/hook_assets.go
+++ b/presentation/cli/hook_assets.go
@@ -106,6 +106,17 @@ traceary_resolve_bin() {
   return 1
 }
 
+traceary_resolve_agent() {
+  local client="$1"
+  local agent_type
+  agent_type="$(traceary_json_get 'agent_type')"
+  if [[ -n "$agent_type" ]]; then
+    printf '%s/%s' "$client" "$agent_type"
+  else
+    printf '%s' "$client"
+  fi
+}
+
 traceary_session_state_path() {
   local client="$1"
   local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"
@@ -215,9 +226,11 @@ if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
 fi
 COMMON_ARGS+=("${ACTION/start/start}")
 
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
 case "$ACTION" in
   start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$CLIENT")
+    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -247,7 +260,7 @@ case "$ACTION" in
       exit 0
     fi
 
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -312,7 +325,9 @@ if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
 fi
 
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
+COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -21,6 +21,7 @@ type RootCLI struct {
 	getContextQueryService        queryservice.GetContextQueryService
 	getEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	findLatestSessionQueryService queryservice.FindLatestSessionQueryService
+	listSessionsQueryService      queryservice.ListSessionsQueryService
 	mcpServerRunner               MCPServerRunner
 }
 
@@ -38,6 +39,7 @@ type RootCLIOptions struct {
 	GetContextQueryService        queryservice.GetContextQueryService
 	GetEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	FindLatestSessionQueryService queryservice.FindLatestSessionQueryService
+	ListSessionsQueryService      queryservice.ListSessionsQueryService
 	MCPServerRunner               MCPServerRunner
 }
 
@@ -56,6 +58,7 @@ func NewRootCLI(options RootCLIOptions) *RootCLI {
 		getContextQueryService:        options.GetContextQueryService,
 		getEventDetailsQueryService:   options.GetEventDetailsQueryService,
 		findLatestSessionQueryService: options.FindLatestSessionQueryService,
+		listSessionsQueryService:      options.ListSessionsQueryService,
 		mcpServerRunner:               options.MCPServerRunner,
 	}
 }

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+func (c *RootCLI) newSessionListCommand() *cobra.Command {
+	var (
+		dbPath string
+		repo   string
+		agent  string
+		from   string
+		to     string
+		limit  int
+		offset int
+		asJSON bool
+	)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: Localize("List session summaries", "セッション一覧を表示する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+
+			if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			if offset < 0 {
+				return xerrors.Errorf("%s", Localize("offset must be >= 0", "offset は 0 以上でなければなりません"))
+			}
+
+			resolvedRepo := resolveRepoValue(ctx, repo)
+
+			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, queryservice.ListSessionsInput{
+				Limit:  limit,
+				Offset: offset,
+				Repo:   resolvedRepo,
+				Agent:  agent,
+				From:   from,
+				To:     to,
+			})
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
+			}
+
+			return writeSessionSummaries(output, summaries, asJSON)
+		},
+	}
+
+	listCmd.Flags().StringVar(&dbPath, "db-path", "", Localize("SQLite DB path (env: TRACEARY_DB_PATH)", "SQLite DB パス (env: TRACEARY_DB_PATH)"))
+	listCmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
+	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD)", "開始日 (YYYY-MM-DD)"))
+	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD)", "終了日 (YYYY-MM-DD)"))
+	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of sessions", "最大表示セッション数"))
+	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of sessions to skip", "スキップするセッション数"))
+	listCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+
+	return listCmd
+}
+
+func writeSessionSummaries(output io.Writer, summaries []*queryservice.SessionSummary, asJSON bool) error {
+	if asJSON {
+		return writeSessionSummariesJSON(output, summaries)
+	}
+
+	if len(summaries) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
+			return xerrors.Errorf("failed to print empty message: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintln(output, "STARTED_AT\tSTATUS\tDURATION\tSESSION_ID\tREPO\tEVENTS\tCMDS\tAGENTS"); err != nil {
+		return xerrors.Errorf("failed to print header: %w", err)
+	}
+	for _, s := range summaries {
+		duration := "-"
+		if s.EndedAt != nil {
+			duration = formatDuration(s.EndedAt.Sub(s.StartedAt))
+		}
+
+		agentSummary := strings.Join(s.Agents, ", ")
+
+		if _, err := fmt.Fprintf(
+			output,
+			"%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+			s.StartedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			s.Status,
+			duration,
+			s.SessionID,
+			formatOptionalColumn(s.Repo),
+			s.TotalEvents,
+			s.CommandCount,
+			agentSummary,
+		); err != nil {
+			return xerrors.Errorf("failed to print session row: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func writeSessionSummariesJSON(output io.Writer, summaries []*queryservice.SessionSummary) error {
+	type jsonSummary struct {
+		SessionID    string   `json:"session_id"`
+		Repo         string   `json:"repo,omitempty"`
+		StartedAt    string   `json:"started_at"`
+		EndedAt      *string  `json:"ended_at,omitempty"`
+		Status       string   `json:"status"`
+		DurationSec  *float64 `json:"duration_sec,omitempty"`
+		TotalEvents  int      `json:"total_events"`
+		CommandCount int      `json:"command_count"`
+		Agents       []string `json:"agents"`
+	}
+
+	items := make([]jsonSummary, 0, len(summaries))
+	for _, s := range summaries {
+		item := jsonSummary{
+			SessionID:    s.SessionID,
+			Repo:         s.Repo,
+			StartedAt:    s.StartedAt.UTC().Format(time.RFC3339),
+			Status:       s.Status,
+			TotalEvents:  s.TotalEvents,
+			CommandCount: s.CommandCount,
+			Agents:       s.Agents,
+		}
+		if s.EndedAt != nil {
+			endStr := s.EndedAt.UTC().Format(time.RFC3339)
+			item.EndedAt = &endStr
+			dur := s.EndedAt.Sub(s.StartedAt).Seconds()
+			item.DurationSec = &dur
+		}
+		items = append(items, item)
+	}
+
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(items); err != nil {
+		return xerrors.Errorf("failed to encode JSON: %w", err)
+	}
+
+	return nil
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+}

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -1,0 +1,151 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+type listSessionsQueryServiceStub struct {
+	receivedPath  string
+	receivedInput queryservice.ListSessionsInput
+	called        bool
+	summaries     []*queryservice.SessionSummary
+	err           error
+}
+
+func (s *listSessionsQueryServiceStub) Run(
+	_ context.Context,
+	dbPath string,
+	input queryservice.ListSessionsInput,
+) ([]*queryservice.SessionSummary, error) {
+	s.called = true
+	s.receivedPath = dbPath
+	s.receivedInput = input
+	return s.summaries, s.err
+}
+
+var _ queryservice.ListSessionsQueryService = (*listSessionsQueryServiceStub)(nil)
+
+func TestRootCLI_SessionListCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("セッション一覧を表示できる", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2026, 4, 9, 13, 30, 0, 0, time.UTC)
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*queryservice.SessionSummary{
+				{
+					SessionID:    "session-1",
+					Repo:         "duck8823/traceary",
+					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					EndedAt:      &endedAt,
+					Status:       "ended",
+					TotalEvents:  42,
+					CommandCount: 30,
+					Agents:       []string{"claude", "codex"},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   initStub,
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"session", "list",
+			"--db-path", dbPath,
+			"--repo", "duck8823/traceary",
+			"--agent", "claude",
+			"--limit", "10",
+		})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !listStub.called {
+			t.Fatalf("ListSessionsQueryService.Run() was not called")
+		}
+		output := stdout.String()
+		if !strings.Contains(output, "session-1") {
+			t.Fatalf("output should contain session-1, got: %s", output)
+		}
+		if !strings.Contains(output, "1h30m") {
+			t.Fatalf("output should contain duration 1h30m, got: %s", output)
+		}
+		if !strings.Contains(output, "claude, codex") {
+			t.Fatalf("output should contain agents, got: %s", output)
+		}
+	})
+
+	t.Run("セッションがない場合はメッセージを表示する", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: &listSessionsQueryServiceStub{},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if stdout.String() != "No sessions found.\n" {
+			t.Fatalf("stdout = %q, want empty message", stdout.String())
+		}
+	})
+
+	t.Run("JSON 形式で出力できる", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2026, 4, 9, 12, 5, 0, 0, time.UTC)
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*queryservice.SessionSummary{
+				{
+					SessionID:    "session-json",
+					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					EndedAt:      &endedAt,
+					Status:       "ended",
+					TotalEvents:  5,
+					CommandCount: 3,
+					Agents:       []string{"claude"},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath, "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		output := stdout.String()
+		if !strings.Contains(output, `"session_id": "session-json"`) {
+			t.Fatalf("JSON output should contain session_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"duration_sec"`) {
+			t.Fatalf("JSON output should contain duration_sec, got: %s", output)
+		}
+	})
+}

--- a/scripts/hooks/common.sh
+++ b/scripts/hooks/common.sh
@@ -86,6 +86,17 @@ traceary_resolve_bin() {
   return 1
 }
 
+traceary_resolve_agent() {
+  local client="$1"
+  local agent_type
+  agent_type="$(traceary_json_get 'agent_type')"
+  if [[ -n "$agent_type" ]]; then
+    printf '%s/%s' "$client" "$agent_type"
+  else
+    printf '%s' "$client"
+  fi
+}
+
 traceary_session_state_path() {
   local client="$1"
   local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"

--- a/scripts/hooks/traceary-audit.sh
+++ b/scripts/hooks/traceary-audit.sh
@@ -41,7 +41,9 @@ if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
 fi
 
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
+COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/scripts/hooks/traceary-session.sh
+++ b/scripts/hooks/traceary-session.sh
@@ -31,9 +31,11 @@ if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
 fi
 COMMON_ARGS+=("${ACTION/start/start}")
 
+AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
+
 case "$ACTION" in
   start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$CLIENT")
+    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
@@ -63,7 +65,7 @@ case "$ACTION" in
       exit 0
     fi
 
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi


### PR DESCRIPTION
## Summary

- Truncate MESSAGE column in list/search table output to 80 chars with newline normalization
- Add `session list` command showing aggregated session summaries (status, duration, event/command counts, agent breakdown)
- Resolve sub-agent type from Claude Code hook payload (`agent_type` → `claude/Explore` etc.)
- Tolerate permission errors on chmod during DB initialization for read-only environments

## Sub-issues

Closes #185
Closes #186
Closes #187
Closes #188

Part of #184

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] `python3 scripts/verify_integrations.py` passes
- [x] `traceary session list` outputs correct table and JSON
- [x] `traceary list` truncates long messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)