### PR TITLE
Add session summary command (`session list`)

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -1,0 +1,75 @@
+package queryservice
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// SessionSummary holds aggregated information about a single session.
+type SessionSummary struct {
+	SessionID    string
+	Repo         string
+	StartedAt    time.Time
+	EndedAt      *time.Time
+	Status       string
+	TotalEvents  int
+	CommandCount int
+	Agents       []string
+}
+
+// ListSessionsInput is the input for session listing.
+type ListSessionsInput struct {
+	Limit  int
+	Offset int
+	Repo   string
+	Agent  string
+	From   string
+	To     string
+}
+
+// SessionSummaryFinder provides session summary lookup.
+type SessionSummaryFinder interface {
+	ListSessionSummaries(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+}
+
+// ListSessionsQueryService returns session summaries.
+type ListSessionsQueryService interface {
+	Run(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+}
+
+type listSessionsQueryService struct {
+	finder SessionSummaryFinder
+}
+
+// NewListSessionsQueryService creates a ListSessionsQueryService.
+func NewListSessionsQueryService(finder SessionSummaryFinder) ListSessionsQueryService {
+	return &listSessionsQueryService{finder: finder}
+}
+
+func (s *listSessionsQueryService) Run(
+	ctx context.Context,
+	dbPath string,
+	input ListSessionsInput,
+) ([]*SessionSummary, error) {
+	if s.finder == nil {
+		return nil, xerrors.Errorf("session summary finder is not configured")
+	}
+	if dbPath == "" {
+		return nil, xerrors.Errorf("DB path must not be empty")
+	}
+	if input.Limit <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if input.Offset < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	summaries, err := s.finder.ListSessionSummaries(ctx, dbPath, input)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list session summaries: %w", err)
+	}
+
+	return summaries, nil
+}

--- a/application/queryservice/list_sessions_test.go
+++ b/application/queryservice/list_sessions_test.go
@@ -1,0 +1,104 @@
+package queryservice_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+type sessionSummaryFinderStub struct {
+	receivedPath  string
+	receivedInput queryservice.ListSessionsInput
+	summaries     []*queryservice.SessionSummary
+	err           error
+}
+
+func (s *sessionSummaryFinderStub) ListSessionSummaries(
+	_ context.Context,
+	dbPath string,
+	input queryservice.ListSessionsInput,
+) ([]*queryservice.SessionSummary, error) {
+	s.receivedPath = dbPath
+	s.receivedInput = input
+	return s.summaries, s.err
+}
+
+func TestListSessionsQueryService_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("セッションサマリーを返す", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &sessionSummaryFinderStub{
+			summaries: []*queryservice.SessionSummary{
+				{
+					SessionID:    "s1",
+					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					TotalEvents:  5,
+					CommandCount: 3,
+					Agents:       []string{"claude"},
+				},
+			},
+		}
+		sut := queryservice.NewListSessionsQueryService(stub)
+
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{
+			Limit: 10,
+			Repo:  "duck8823/traceary",
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("len(got) = %d, want 1", len(got))
+		}
+		if stub.receivedPath != "/tmp/traceary.db" {
+			t.Fatalf("received path = %q, want %q", stub.receivedPath, "/tmp/traceary.db")
+		}
+		if stub.receivedInput.Repo != "duck8823/traceary" {
+			t.Fatalf("received repo = %q, want %q", stub.receivedInput.Repo, "duck8823/traceary")
+		}
+	})
+
+	t.Run("finder が nil ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		sut := queryservice.NewListSessionsQueryService(nil)
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 10})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+
+	t.Run("DB パスが空ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
+		_, err := sut.Run(context.Background(), "", queryservice.ListSessionsInput{Limit: 10})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+
+	t.Run("limit が 0 ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 0})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+
+	t.Run("offset が負ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 10, Offset: -1})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+}

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -97,7 +97,7 @@ func scanSessionSummary(row interface {
 		endedAtStr   sql.NullString
 		totalEvents  int
 		commandCount int
-		agentsStr    string
+		agentsStr    sql.NullString
 	)
 
 	if err := row.Scan(
@@ -129,8 +129,8 @@ func scanSessionSummary(row interface {
 	}
 
 	var agents []string
-	if agentsStr != "" {
-		agents = strings.Split(agentsStr, ",")
+	if agentsStr.Valid && agentsStr.String != "" {
+		agents = strings.Split(agentsStr.String, ",")
 	}
 
 	return &queryservice.SessionSummary{

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -39,10 +39,11 @@ func (d *Datasource) ListSessionSummaries(
 	}
 	toValue := ""
 	if input.To != "" {
-		if _, err := time.Parse("2006-01-02", input.To); err != nil {
+		parsed, err := time.Parse("2006-01-02", input.To)
+		if err != nil {
 			return nil, xerrors.Errorf("invalid to date %q: %w", input.To, err)
 		}
-		toValue = input.To + "T23:59:59Z"
+		toValue = formatTimestamp(parsed.AddDate(0, 0, 1))
 	}
 
 	rows, err := db.QueryContext(
@@ -59,7 +60,7 @@ func (d *Datasource) ListSessionSummaries(
 		 WHERE (? = '' OR e.repo = ?)
 		   AND (? = '' OR e.agent = ?)
 		   AND (? = '' OR e.created_at >= ?)
-		   AND (? = '' OR e.created_at <= ?)
+		   AND (? = '' OR e.created_at < ?)
 		 GROUP BY e.session_id
 		 ORDER BY started_at DESC
 		 LIMIT ? OFFSET ?`,

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -32,10 +32,16 @@ func (d *Datasource) ListSessionSummaries(
 
 	fromValue := ""
 	if input.From != "" {
+		if _, err := time.Parse("2006-01-02", input.From); err != nil {
+			return nil, xerrors.Errorf("invalid from date %q: %w", input.From, err)
+		}
 		fromValue = input.From + "T00:00:00Z"
 	}
 	toValue := ""
 	if input.To != "" {
+		if _, err := time.Parse("2006-01-02", input.To); err != nil {
+			return nil, xerrors.Errorf("invalid to date %q: %w", input.To, err)
+		}
 		toValue = input.To + "T23:59:59Z"
 	}
 

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -1,0 +1,146 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+var _ queryservice.SessionSummaryFinder = (*Datasource)(nil)
+
+// ListSessionSummaries returns aggregated session information.
+func (d *Datasource) ListSessionSummaries(
+	ctx context.Context,
+	dbPath string,
+	input queryservice.ListSessionsInput,
+) ([]*queryservice.SessionSummary, error) {
+	db, err := d.openDB(ctx, dbPath)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for session list: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	fromValue := ""
+	if input.From != "" {
+		fromValue = input.From + "T00:00:00Z"
+	}
+	toValue := ""
+	if input.To != "" {
+		toValue = input.To + "T23:59:59Z"
+	}
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT
+		   e.session_id,
+		   MAX(e.repo) AS repo,
+		   MIN(e.created_at) AS started_at,
+		   MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END) AS ended_at,
+		   COUNT(*) AS total_events,
+		   SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+		   GROUP_CONCAT(DISTINCT e.agent) AS agents
+		 FROM events e
+		 WHERE (? = '' OR e.repo = ?)
+		   AND (? = '' OR e.agent = ?)
+		   AND (? = '' OR e.created_at >= ?)
+		   AND (? = '' OR e.created_at <= ?)
+		 GROUP BY e.session_id
+		 ORDER BY started_at DESC
+		 LIMIT ? OFFSET ?`,
+		input.Repo, input.Repo,
+		input.Agent, input.Agent,
+		fromValue, fromValue,
+		toValue, toValue,
+		input.Limit, input.Offset,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query session summaries: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]*queryservice.SessionSummary, 0)
+	for rows.Next() {
+		summary, err := scanSessionSummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan session summary row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate session summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+func scanSessionSummary(row interface {
+	Scan(dest ...any) error
+}) (*queryservice.SessionSummary, error) {
+	var (
+		sessionID    string
+		repo         string
+		startedAtStr string
+		endedAtStr   sql.NullString
+		totalEvents  int
+		commandCount int
+		agentsStr    string
+	)
+
+	if err := row.Scan(
+		&sessionID,
+		&repo,
+		&startedAtStr,
+		&endedAtStr,
+		&totalEvents,
+		&commandCount,
+		&agentsStr,
+	); err != nil {
+		return nil, xerrors.Errorf("failed to scan session summary: %w", err)
+	}
+
+	startedAt, err := time.Parse(time.RFC3339Nano, startedAtStr)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse started_at: %w", err)
+	}
+
+	var endedAt *time.Time
+	status := "active"
+	if endedAtStr.Valid {
+		t, err := time.Parse(time.RFC3339Nano, endedAtStr.String)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse ended_at: %w", err)
+		}
+		endedAt = &t
+		status = "ended"
+	}
+
+	var agents []string
+	if agentsStr != "" {
+		agents = strings.Split(agentsStr, ",")
+	}
+
+	return &queryservice.SessionSummary{
+		SessionID:    sessionID,
+		Repo:         repo,
+		StartedAt:    startedAt,
+		EndedAt:      endedAt,
+		Status:       status,
+		TotalEvents:  totalEvents,
+		CommandCount: commandCount,
+		Agents:       agents,
+	}, nil
+}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
@@ -163,6 +164,70 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 		if summaries[0].SessionID != "s1" {
 			t.Fatalf("session = %q, want s1", summaries[0].SessionID)
+		}
+	})
+
+	t.Run("from フィルタで対象外セッションが除外される", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// Insert two sessions on different dates using EventOf with explicit timestamps
+		for _, e := range []struct {
+			id, sid  string
+			dayOfMon int
+		}{
+			{"e1", "s-old", 1},
+			{"e2", "s-new", 10},
+		} {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf("claude")
+			sid, _ := types.SessionIDOf(e.sid)
+			ts := time.Date(2026, 4, e.dayOfMon, 12, 0, 0, 0, time.UTC)
+			event := model.EventOf(eid, types.EventKindSessionStarted, "hook", agent, sid, "repo", "start", ts)
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+			From:  "2026-04-05",
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].SessionID != "s-new" {
+			t.Fatalf("session = %q, want s-new", summaries[0].SessionID)
+		}
+	})
+
+	t.Run("不正な from 日付でエラーを返す", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		_, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+			From:  "invalid",
+		})
+		if err == nil {
+			t.Fatalf("ListSessionSummaries() error = nil, want error")
 		}
 	})
 }

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -1,0 +1,168 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func listSessionsTestMigrations() fstest.MapFS {
+	return fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0
+);`),
+		},
+	}
+}
+
+func TestDatasource_ListSessionSummaries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("セッションサマリーを取得できる", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		events := []struct {
+			id        string
+			kind      types.EventKind
+			agent     string
+			sessionID string
+			body      string
+		}{
+			{"e1", types.EventKindSessionStarted, "claude", "s1", "session started"},
+			{"e2", types.EventKindCommandExecuted, "claude", "s1", "go test ./..."},
+			{"e3", types.EventKindCommandExecuted, "claude", "s1", "go build ./..."},
+			{"e4", types.EventKindSessionEnded, "claude", "s1", "session ended"},
+			{"e5", types.EventKindSessionStarted, "codex", "s2", "session started"},
+			{"e6", types.EventKindCommandExecuted, "codex", "s2", "git status"},
+		}
+
+		for _, e := range events {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf(e.agent)
+			sid, _ := types.SessionIDOf(e.sessionID)
+			event, _ := model.NewEvent(eid, e.kind, "hook", agent, sid, "duck8823/traceary", e.body)
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 2 {
+			t.Fatalf("got %d summaries, want 2", len(summaries))
+		}
+
+		// s2 is newer (last inserted), should be first? Actually s1 has earlier started_at...
+		// Both sessions have same created_at base (close in time), but order is by started_at DESC
+		// s2's events are inserted after s1's, so s2.started_at > s1.started_at
+		latest := summaries[0]
+		if latest.SessionID != "s2" {
+			t.Fatalf("first session = %q, want s2", latest.SessionID)
+		}
+		if latest.TotalEvents != 2 {
+			t.Fatalf("s2 total_events = %d, want 2", latest.TotalEvents)
+		}
+		if latest.CommandCount != 1 {
+			t.Fatalf("s2 command_count = %d, want 1", latest.CommandCount)
+		}
+		if latest.Status != "active" {
+			t.Fatalf("s2 status = %q, want active", latest.Status)
+		}
+
+		older := summaries[1]
+		if older.SessionID != "s1" {
+			t.Fatalf("second session = %q, want s1", older.SessionID)
+		}
+		if older.TotalEvents != 4 {
+			t.Fatalf("s1 total_events = %d, want 4", older.TotalEvents)
+		}
+		if older.CommandCount != 2 {
+			t.Fatalf("s1 command_count = %d, want 2", older.CommandCount)
+		}
+		if older.Status != "ended" {
+			t.Fatalf("s1 status = %q, want ended", older.Status)
+		}
+		if older.EndedAt == nil {
+			t.Fatalf("s1 ended_at should not be nil")
+		}
+	})
+
+	t.Run("agent フィルタが機能する", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		for _, e := range []struct {
+			id, agent, sid string
+		}{
+			{"e1", "claude", "s1"},
+			{"e2", "codex", "s2"},
+		} {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf(e.agent)
+			sid, _ := types.SessionIDOf(e.sid)
+			event, _ := model.NewEvent(eid, types.EventKindSessionStarted, "hook", agent, sid, "repo", "start")
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+			Agent: "claude",
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].SessionID != "s1" {
+			t.Fatalf("session = %q, want s1", summaries[0].SessionID)
+		}
+	})
+}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -211,6 +211,49 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
+	t.Run("to フィルタで対象外セッションが除外される", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		for _, e := range []struct {
+			id, sid  string
+			dayOfMon int
+		}{
+			{"e1", "s-old", 1},
+			{"e2", "s-new", 10},
+		} {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf("claude")
+			sid, _ := types.SessionIDOf(e.sid)
+			ts := time.Date(2026, 4, e.dayOfMon, 12, 0, 0, 0, time.UTC)
+			event := model.EventOf(eid, types.EventKindSessionStarted, "hook", agent, sid, "repo", "start", ts)
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+			Limit: 10,
+			To:    "2026-04-05",
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].SessionID != "s-old" {
+			t.Fatalf("session = %q, want s-old", summaries[0].SessionID)
+		}
+	})
+
 	t.Run("不正な from 日付でエラーを返す", func(t *testing.T) {
 		t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func run() error {
 	getContextQueryService := queryservice.NewGetContextQueryService(datasource)
 	getEventDetailsQueryService := queryservice.NewGetEventDetailsQueryService(datasource)
 	findLatestSessionQueryService := queryservice.NewFindLatestSessionQueryService(datasource)
+	listSessionsQueryService := queryservice.NewListSessionsQueryService(datasource)
 	mcpServer, err := mcpserver.NewServer(
 		metadata.version,
 		initializeStoreUsecase,
@@ -192,6 +193,7 @@ func run() error {
 		GetContextQueryService:        getContextQueryService,
 		GetEventDetailsQueryService:   getEventDetailsQueryService,
 		FindLatestSessionQueryService: findLatestSessionQueryService,
+		ListSessionsQueryService:      listSessionsQueryService,
 		MCPServerRunner:               mcpServer,
 	}).Command()
 	rootCmd.Version = versionString()

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -21,6 +21,7 @@ type RootCLI struct {
 	getContextQueryService        queryservice.GetContextQueryService
 	getEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	findLatestSessionQueryService queryservice.FindLatestSessionQueryService
+	listSessionsQueryService      queryservice.ListSessionsQueryService
 	mcpServerRunner               MCPServerRunner
 }
 
@@ -38,6 +39,7 @@ type RootCLIOptions struct {
 	GetContextQueryService        queryservice.GetContextQueryService
 	GetEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	FindLatestSessionQueryService queryservice.FindLatestSessionQueryService
+	ListSessionsQueryService      queryservice.ListSessionsQueryService
 	MCPServerRunner               MCPServerRunner
 }
 
@@ -56,6 +58,7 @@ func NewRootCLI(options RootCLIOptions) *RootCLI {
 		getContextQueryService:        options.GetContextQueryService,
 		getEventDetailsQueryService:   options.GetEventDetailsQueryService,
 		findLatestSessionQueryService: options.FindLatestSessionQueryService,
+		listSessionsQueryService:      options.ListSessionsQueryService,
 		mcpServerRunner:               options.MCPServerRunner,
 	}
 }

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -27,6 +27,7 @@ func (c *RootCLI) newSessionCommand() *cobra.Command {
 	sessionCmd.AddCommand(c.newSessionEndCommand())
 	sessionCmd.AddCommand(c.newSessionLatestCommand())
 	sessionCmd.AddCommand(c.newSessionActiveCommand())
+	sessionCmd.AddCommand(c.newSessionListCommand())
 
 	return sessionCmd
 }

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -46,6 +46,17 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				return xerrors.Errorf("%s", Localize("offset must be >= 0", "offset は 0 以上でなければなりません"))
 			}
 
+			if from != "" {
+				if _, err := time.Parse("2006-01-02", from); err != nil {
+					return xerrors.Errorf("%s: %w", Localize("--from must be YYYY-MM-DD", "--from は YYYY-MM-DD 形式でなければなりません"), err)
+				}
+			}
+			if to != "" {
+				if _, err := time.Parse("2006-01-02", to); err != nil {
+					return xerrors.Errorf("%s: %w", Localize("--to must be YYYY-MM-DD", "--to は YYYY-MM-DD 形式でなければなりません"), err)
+				}
+			}
+
 			resolvedRepo := resolveRepoValue(ctx, repo)
 
 			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, queryservice.ListSessionsInput{

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+func (c *RootCLI) newSessionListCommand() *cobra.Command {
+	var (
+		dbPath string
+		repo   string
+		agent  string
+		from   string
+		to     string
+		limit  int
+		offset int
+		asJSON bool
+	)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: Localize("List session summaries", "セッション一覧を表示する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+
+			if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			if offset < 0 {
+				return xerrors.Errorf("%s", Localize("offset must be >= 0", "offset は 0 以上でなければなりません"))
+			}
+
+			resolvedRepo := resolveRepoValue(ctx, repo)
+
+			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, queryservice.ListSessionsInput{
+				Limit:  limit,
+				Offset: offset,
+				Repo:   resolvedRepo,
+				Agent:  agent,
+				From:   from,
+				To:     to,
+			})
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
+			}
+
+			return writeSessionSummaries(output, summaries, asJSON)
+		},
+	}
+
+	listCmd.Flags().StringVar(&dbPath, "db-path", "", Localize("SQLite DB path (env: TRACEARY_DB_PATH)", "SQLite DB パス (env: TRACEARY_DB_PATH)"))
+	listCmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
+	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD)", "開始日 (YYYY-MM-DD)"))
+	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD)", "終了日 (YYYY-MM-DD)"))
+	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of sessions", "最大表示セッション数"))
+	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of sessions to skip", "スキップするセッション数"))
+	listCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+
+	return listCmd
+}
+
+func writeSessionSummaries(output io.Writer, summaries []*queryservice.SessionSummary, asJSON bool) error {
+	if asJSON {
+		return writeSessionSummariesJSON(output, summaries)
+	}
+
+	if len(summaries) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
+			return xerrors.Errorf("failed to print empty message: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintln(output, "STARTED_AT\tSTATUS\tDURATION\tSESSION_ID\tREPO\tEVENTS\tCMDS\tAGENTS"); err != nil {
+		return xerrors.Errorf("failed to print header: %w", err)
+	}
+	for _, s := range summaries {
+		duration := "-"
+		if s.EndedAt != nil {
+			duration = formatDuration(s.EndedAt.Sub(s.StartedAt))
+		}
+
+		agentSummary := strings.Join(s.Agents, ", ")
+
+		if _, err := fmt.Fprintf(
+			output,
+			"%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+			s.StartedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			s.Status,
+			duration,
+			s.SessionID,
+			formatOptionalColumn(s.Repo),
+			s.TotalEvents,
+			s.CommandCount,
+			agentSummary,
+		); err != nil {
+			return xerrors.Errorf("failed to print session row: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func writeSessionSummariesJSON(output io.Writer, summaries []*queryservice.SessionSummary) error {
+	type jsonSummary struct {
+		SessionID    string   `json:"session_id"`
+		Repo         string   `json:"repo,omitempty"`
+		StartedAt    string   `json:"started_at"`
+		EndedAt      *string  `json:"ended_at,omitempty"`
+		Status       string   `json:"status"`
+		DurationSec  *float64 `json:"duration_sec,omitempty"`
+		TotalEvents  int      `json:"total_events"`
+		CommandCount int      `json:"command_count"`
+		Agents       []string `json:"agents"`
+	}
+
+	items := make([]jsonSummary, 0, len(summaries))
+	for _, s := range summaries {
+		item := jsonSummary{
+			SessionID:    s.SessionID,
+			Repo:         s.Repo,
+			StartedAt:    s.StartedAt.UTC().Format(time.RFC3339),
+			Status:       s.Status,
+			TotalEvents:  s.TotalEvents,
+			CommandCount: s.CommandCount,
+			Agents:       s.Agents,
+		}
+		if s.EndedAt != nil {
+			endStr := s.EndedAt.UTC().Format(time.RFC3339)
+			item.EndedAt = &endStr
+			dur := s.EndedAt.Sub(s.StartedAt).Seconds()
+			item.DurationSec = &dur
+		}
+		items = append(items, item)
+	}
+
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(items); err != nil {
+		return xerrors.Errorf("failed to encode JSON: %w", err)
+	}
+
+	return nil
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+}

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -1,0 +1,151 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+type listSessionsQueryServiceStub struct {
+	receivedPath  string
+	receivedInput queryservice.ListSessionsInput
+	called        bool
+	summaries     []*queryservice.SessionSummary
+	err           error
+}
+
+func (s *listSessionsQueryServiceStub) Run(
+	_ context.Context,
+	dbPath string,
+	input queryservice.ListSessionsInput,
+) ([]*queryservice.SessionSummary, error) {
+	s.called = true
+	s.receivedPath = dbPath
+	s.receivedInput = input
+	return s.summaries, s.err
+}
+
+var _ queryservice.ListSessionsQueryService = (*listSessionsQueryServiceStub)(nil)
+
+func TestRootCLI_SessionListCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("セッション一覧を表示できる", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2026, 4, 9, 13, 30, 0, 0, time.UTC)
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*queryservice.SessionSummary{
+				{
+					SessionID:    "session-1",
+					Repo:         "duck8823/traceary",
+					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					EndedAt:      &endedAt,
+					Status:       "ended",
+					TotalEvents:  42,
+					CommandCount: 30,
+					Agents:       []string{"claude", "codex"},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   initStub,
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"session", "list",
+			"--db-path", dbPath,
+			"--repo", "duck8823/traceary",
+			"--agent", "claude",
+			"--limit", "10",
+		})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !listStub.called {
+			t.Fatalf("ListSessionsQueryService.Run() was not called")
+		}
+		output := stdout.String()
+		if !strings.Contains(output, "session-1") {
+			t.Fatalf("output should contain session-1, got: %s", output)
+		}
+		if !strings.Contains(output, "1h30m") {
+			t.Fatalf("output should contain duration 1h30m, got: %s", output)
+		}
+		if !strings.Contains(output, "claude, codex") {
+			t.Fatalf("output should contain agents, got: %s", output)
+		}
+	})
+
+	t.Run("セッションがない場合はメッセージを表示する", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: &listSessionsQueryServiceStub{},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if stdout.String() != "No sessions found.\n" {
+			t.Fatalf("stdout = %q, want empty message", stdout.String())
+		}
+	})
+
+	t.Run("JSON 形式で出力できる", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2026, 4, 9, 12, 5, 0, 0, time.UTC)
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*queryservice.SessionSummary{
+				{
+					SessionID:    "session-json",
+					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					EndedAt:      &endedAt,
+					Status:       "ended",
+					TotalEvents:  5,
+					CommandCount: 3,
+					Agents:       []string{"claude"},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath, "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		output := stdout.String()
+		if !strings.Contains(output, `"session_id": "session-json"`) {
+			t.Fatalf("JSON output should contain session_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"duration_sec"`) {
+			t.Fatalf("JSON output should contain duration_sec, got: %s", output)
+		}
+	})
+}

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -148,4 +148,38 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 			t.Fatalf("JSON output should contain duration_sec, got: %s", output)
 		}
 	})
+
+	t.Run("--from が不正な形式ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: &listSessionsQueryServiceStub{},
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath, "--from", "invalid"})
+
+		if err := rootCmd.Execute(); err == nil {
+			t.Fatalf("Execute() error = nil, want error")
+		}
+	})
+
+	t.Run("--to が不正な形式ならエラー", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: &listSessionsQueryServiceStub{},
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath, "--to", "not-a-date"})
+
+		if err := rootCmd.Execute(); err == nil {
+			t.Fatalf("Execute() error = nil, want error")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- New `traceary session list` command showing aggregated session info
- Columns: STARTED_AT, STATUS, DURATION, SESSION_ID, REPO, EVENTS, CMDS, AGENTS
- Supports `--repo`, `--agent`, `--from`, `--to`, `--limit`, `--offset` filters
- `--json` output includes `duration_sec` and structured agent list

Closes #186
Part of #184

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] `traceary session list` verified with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)