### PR TITLE
Enforce 1-issue-1-PR rule in project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ go tool golangci-lint run
 
 ### Git workflow
 
+- **1 issue = 1 branch = 1 PR (no exceptions)**
+  - Create a dedicated branch for each issue before starting implementation
+  - A single PR must close exactly one sub-issue
+  - Never bundle multiple issues into one branch or PR
 - Branch naming: `feature/`, `fix/`, `maintenance/` prefixes
 - Commits: conventional-style (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
 - PRs: merge (not squash), draft first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ go tool golangci-lint run
 
 ### Git workflow
 
+- **1 issue = 1 branch = 1 PR (no exceptions)**
+  - Create a dedicated branch for each issue before starting implementation
+  - A single PR must close exactly one sub-issue
+  - Never bundle multiple issues into one branch or PR
+  - At sprint start, create all branches upfront before coding
 - Branch naming: `feature/`, `fix/`, `maintenance/` prefixes
 - Commits: conventional-style (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
 - PRs: merge (not squash), draft first

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,6 +51,10 @@ go tool golangci-lint run
 
 ### Git workflow
 
+- **1 issue = 1 branch = 1 PR (no exceptions)**
+  - Create a dedicated branch for each issue before starting implementation
+  - A single PR must close exactly one sub-issue
+  - Never bundle multiple issues into one branch or PR
 - Branch naming: `feature/`, `fix/`, `maintenance/` prefixes
 - Commits: conventional-style (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
 - PRs: merge (not squash), draft first


### PR DESCRIPTION
## Summary

- Add explicit "1 issue = 1 branch = 1 PR (no exceptions)" rule to CLAUDE.md, AGENTS.md, GEMINI.md
- Include sub-rules: create branches upfront, single Closes per PR, never bundle

Closes #194
Part of #184

## Test plan

- [x] `go test ./...` passes
- [x] `python3 scripts/verify_integrations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)