### PR TITLE
Update Homebrew formula for v0.1.17 and fix goreleaser race condition

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,7 @@ release:
   github:
     owner: duck8823
     name: traceary
+  replace_existing_artifacts: true
 
 changelog:
   sort: asc

--- a/Formula/traceary.rb
+++ b/Formula/traceary.rb
@@ -5,21 +5,21 @@
 class Traceary < Formula
   desc "Local-first CLI and MCP server for AI agent work history"
   homepage "https://github.com/duck8823/traceary"
-  version "0.1.16"
+  version "0.1.17"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/duck8823/traceary/releases/download/v0.1.16/traceary_0.1.16_darwin_amd64.tar.gz"
-      sha256 "8c0d246a255ec74536ba5f2107946880eb62abb419b7974366cc7c5906a71d39"
+      url "https://github.com/duck8823/traceary/releases/download/v0.1.17/traceary_0.1.17_darwin_amd64.tar.gz"
+      sha256 "a3c6144ec5dec7a2eaf77f641084421a341010066f0743cd2d4d3cbf75b57e28"
 
       define_method(:install) do
         bin.install "traceary"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/duck8823/traceary/releases/download/v0.1.16/traceary_0.1.16_darwin_arm64.tar.gz"
-      sha256 "44b976d69051c25c2b1c37b1b6146130e80a3299cbc97bff0b8e7673eb79489a"
+      url "https://github.com/duck8823/traceary/releases/download/v0.1.17/traceary_0.1.17_darwin_arm64.tar.gz"
+      sha256 "30b71ee4e618bf77658fae93479d2168c860b6279f5cdf988fda370f2ddd087b"
 
       define_method(:install) do
         bin.install "traceary"
@@ -29,15 +29,15 @@ class Traceary < Formula
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/duck8823/traceary/releases/download/v0.1.16/traceary_0.1.16_linux_amd64.tar.gz"
-      sha256 "85f0d3b518a72f8eb7b2ff879e6dba1510bcc3e7d14ef2c9b081cb58a611c07d"
+      url "https://github.com/duck8823/traceary/releases/download/v0.1.17/traceary_0.1.17_linux_amd64.tar.gz"
+      sha256 "e1a14709d4100fbc1373e595a20c35ae21f2148434a740d6cae9631ea6341f22"
       define_method(:install) do
         bin.install "traceary"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/duck8823/traceary/releases/download/v0.1.16/traceary_0.1.16_linux_arm64.tar.gz"
-      sha256 "c20634a5f1f1a3977fa1b9a939fa136b71764cde9cd74843f03adeb3b568b3e0"
+      url "https://github.com/duck8823/traceary/releases/download/v0.1.17/traceary_0.1.17_linux_arm64.tar.gz"
+      sha256 "97799afcb31f6ad20b3a26a835d777442d09aeaa70e5738f97b3ea345bbc55a5"
       define_method(:install) do
         bin.install "traceary"
       end


### PR DESCRIPTION
## Summary

- Update Formula/traceary.rb with v0.1.17 checksums (goreleaser failed to push this due to asset upload race condition)
- Add `replace_existing_artifacts: true` to `.goreleaser.yml` to prevent future upload failures

## Test plan

- [x] Checksums match release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)