### PR TITLE
Consolidate date validation into queryservice layer

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -25,8 +25,8 @@ type ListSessionsInput struct {
 	Offset int
 	Repo   string
 	Agent  string
-	From   string
-	To     string
+	From   *time.Time
+	To     *time.Time
 }
 
 // SessionSummaryFinder provides session summary lookup.

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -31,19 +31,12 @@ func (d *Datasource) ListSessionSummaries(
 	}()
 
 	fromValue := ""
-	if input.From != "" {
-		if _, err := time.Parse("2006-01-02", input.From); err != nil {
-			return nil, xerrors.Errorf("invalid from date %q: %w", input.From, err)
-		}
-		fromValue = input.From + "T00:00:00Z"
+	if input.From != nil {
+		fromValue = formatTimestamp(*input.From)
 	}
 	toValue := ""
-	if input.To != "" {
-		parsed, err := time.Parse("2006-01-02", input.To)
-		if err != nil {
-			return nil, xerrors.Errorf("invalid to date %q: %w", input.To, err)
-		}
-		toValue = formatTimestamp(parsed.AddDate(0, 0, 1))
+	if input.To != nil {
+		toValue = formatTimestamp(input.To.AddDate(0, 0, 1))
 	}
 
 	rows, err := db.QueryContext(

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -196,9 +196,10 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			}
 		}
 
+		fromDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
 		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
 			Limit: 10,
-			From:  "2026-04-05",
+			From:  &fromDate,
 		})
 		if err != nil {
 			t.Fatalf("ListSessionSummaries() error = %v", err)
@@ -239,9 +240,10 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			}
 		}
 
+		toDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
 		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
 			Limit: 10,
-			To:    "2026-04-05",
+			To:    &toDate,
 		})
 		if err != nil {
 			t.Fatalf("ListSessionSummaries() error = %v", err)
@@ -254,23 +256,4 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
-	t.Run("不正な from 日付でエラーを返す", func(t *testing.T) {
-		t.Parallel()
-
-		dbPath := filepath.Join(t.TempDir(), "traceary.db")
-		ds := infra.NewDatasource(listSessionsTestMigrations())
-		ctx := context.Background()
-
-		if err := ds.Initialize(ctx, dbPath); err != nil {
-			t.Fatalf("Initialize() error = %v", err)
-		}
-
-		_, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
-			Limit: 10,
-			From:  "invalid",
-		})
-		if err == nil {
-			t.Fatalf("ListSessionSummaries() error = nil, want error")
-		}
-	})
 }

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -46,15 +46,20 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				return xerrors.Errorf("%s", Localize("offset must be >= 0", "offset は 0 以上でなければなりません"))
 			}
 
+			var fromTime, toTime *time.Time
 			if from != "" {
-				if _, err := time.Parse("2006-01-02", from); err != nil {
+				t, err := time.Parse("2006-01-02", from)
+				if err != nil {
 					return xerrors.Errorf("%s: %w", Localize("--from must be YYYY-MM-DD", "--from は YYYY-MM-DD 形式でなければなりません"), err)
 				}
+				fromTime = &t
 			}
 			if to != "" {
-				if _, err := time.Parse("2006-01-02", to); err != nil {
+				t, err := time.Parse("2006-01-02", to)
+				if err != nil {
 					return xerrors.Errorf("%s: %w", Localize("--to must be YYYY-MM-DD", "--to は YYYY-MM-DD 形式でなければなりません"), err)
 				}
+				toTime = &t
 			}
 
 			resolvedRepo := resolveRepoValue(ctx, repo)
@@ -64,8 +69,8 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				Offset: offset,
 				Repo:   resolvedRepo,
 				Agent:  agent,
-				From:   from,
-				To:     to,
+				From:   fromTime,
+				To:     toTime,
 			})
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)


### PR DESCRIPTION
## Summary

- Change `ListSessionsInput.From`/`To` from `string` to `*time.Time`
- CLI layer parses date strings and passes validated `time.Time` values
- Infra layer receives pre-validated values, no longer needs its own validation
- Removes redundant `time.Parse` calls from SQLite implementation

Closes #196
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)