### PR TITLE
Normalize repo field by persisting session-start repo to state

### DIFF
--- a/integrations/claude-plugin/scripts/common.sh
+++ b/integrations/claude-plugin/scripts/common.sh
@@ -128,6 +128,31 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
+traceary_write_repo_state() {
+  local client="$1"
+  local repo="$2"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  printf '%s' "$repo" > "$state_file"
+}
+
+traceary_read_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  if [[ ! -f "$state_file" ]]; then
+    return 0
+  fi
+  cat "$state_file"
+}
+
+traceary_clear_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  rm -f "$state_file"
+}
+
 traceary_read_state() {
   local client="$1"
   local state_file

--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -33,8 +33,12 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-HOOK_CWD="$(traceary_json_get 'cwd')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+# Prefer repo from session state (set at session start) over CWD-based detection
+REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
+if [[ -z "$REPO_VALUE" ]]; then
+  HOOK_CWD="$(traceary_json_get 'cwd')"
+  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+fi
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then

--- a/integrations/claude-plugin/scripts/traceary-session.sh
+++ b/integrations/claude-plugin/scripts/traceary-session.sh
@@ -50,6 +50,9 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
+      if [[ -n "$REPO_VALUE" ]]; then
+        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      fi
     fi
     ;;
   end|stop)
@@ -74,6 +77,7 @@ case "$ACTION" in
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"
+    traceary_clear_repo_state "$CLIENT"
     traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
     ;;
   *)

--- a/integrations/claude-plugin/scripts/traceary-session.sh
+++ b/integrations/claude-plugin/scripts/traceary-session.sh
@@ -65,7 +65,14 @@ case "$ACTION" in
 
     if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
       traceary_clear_state "$CLIENT"
+      traceary_clear_repo_state "$CLIENT"
       exit 0
+    fi
+
+    # Use repo from session state if available (prevents CWD drift)
+    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    if [[ -n "$REPO_STATE" ]]; then
+      REPO_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")

--- a/integrations/gemini-extension/scripts/common.sh
+++ b/integrations/gemini-extension/scripts/common.sh
@@ -128,6 +128,31 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
+traceary_write_repo_state() {
+  local client="$1"
+  local repo="$2"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  printf '%s' "$repo" > "$state_file"
+}
+
+traceary_read_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  if [[ ! -f "$state_file" ]]; then
+    return 0
+  fi
+  cat "$state_file"
+}
+
+traceary_clear_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  rm -f "$state_file"
+}
+
 traceary_read_state() {
   local client="$1"
   local state_file

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -33,8 +33,12 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-HOOK_CWD="$(traceary_json_get 'cwd')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+# Prefer repo from session state (set at session start) over CWD-based detection
+REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
+if [[ -z "$REPO_VALUE" ]]; then
+  HOOK_CWD="$(traceary_json_get 'cwd')"
+  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+fi
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then

--- a/integrations/gemini-extension/scripts/traceary-session.sh
+++ b/integrations/gemini-extension/scripts/traceary-session.sh
@@ -50,6 +50,9 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
+      if [[ -n "$REPO_VALUE" ]]; then
+        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      fi
     fi
     ;;
   end|stop)
@@ -74,6 +77,7 @@ case "$ACTION" in
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"
+    traceary_clear_repo_state "$CLIENT"
     traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
     ;;
   *)

--- a/integrations/gemini-extension/scripts/traceary-session.sh
+++ b/integrations/gemini-extension/scripts/traceary-session.sh
@@ -65,7 +65,14 @@ case "$ACTION" in
 
     if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
       traceary_clear_state "$CLIENT"
+      traceary_clear_repo_state "$CLIENT"
       exit 0
+    fi
+
+    # Use repo from session state if available (prevents CWD drift)
+    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    if [[ -n "$REPO_STATE" ]]; then
+      REPO_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")

--- a/plugins/traceary/scripts/common.sh
+++ b/plugins/traceary/scripts/common.sh
@@ -128,6 +128,31 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
+traceary_write_repo_state() {
+  local client="$1"
+  local repo="$2"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  printf '%s' "$repo" > "$state_file"
+}
+
+traceary_read_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  if [[ ! -f "$state_file" ]]; then
+    return 0
+  fi
+  cat "$state_file"
+}
+
+traceary_clear_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  rm -f "$state_file"
+}
+
 traceary_read_state() {
   local client="$1"
   local state_file

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -33,8 +33,12 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-HOOK_CWD="$(traceary_json_get 'cwd')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+# Prefer repo from session state (set at session start) over CWD-based detection
+REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
+if [[ -z "$REPO_VALUE" ]]; then
+  HOOK_CWD="$(traceary_json_get 'cwd')"
+  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+fi
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then

--- a/plugins/traceary/scripts/traceary-session.sh
+++ b/plugins/traceary/scripts/traceary-session.sh
@@ -50,6 +50,9 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
+      if [[ -n "$REPO_VALUE" ]]; then
+        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      fi
     fi
     ;;
   end|stop)
@@ -74,6 +77,7 @@ case "$ACTION" in
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"
+    traceary_clear_repo_state "$CLIENT"
     traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
     ;;
   *)

--- a/plugins/traceary/scripts/traceary-session.sh
+++ b/plugins/traceary/scripts/traceary-session.sh
@@ -65,7 +65,14 @@ case "$ACTION" in
 
     if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
       traceary_clear_state "$CLIENT"
+      traceary_clear_repo_state "$CLIENT"
       exit 0
+    fi
+
+    # Use repo from session state if available (prevents CWD drift)
+    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    if [[ -n "$REPO_STATE" ]]; then
+      REPO_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")

--- a/presentation/cli/hook_assets.go
+++ b/presentation/cli/hook_assets.go
@@ -285,7 +285,14 @@ case "$ACTION" in
 
     if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
       traceary_clear_state "$CLIENT"
+      traceary_clear_repo_state "$CLIENT"
       exit 0
+    fi
+
+    # Use repo from session state if available (prevents CWD drift)
+    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    if [[ -n "$REPO_STATE" ]]; then
+      REPO_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")

--- a/presentation/cli/hook_assets.go
+++ b/presentation/cli/hook_assets.go
@@ -148,6 +148,31 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
+traceary_write_repo_state() {
+  local client="$1"
+  local repo="$2"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  printf '%s' "$repo" > "$state_file"
+}
+
+traceary_read_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  if [[ ! -f "$state_file" ]]; then
+    return 0
+  fi
+  cat "$state_file"
+}
+
+traceary_clear_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  rm -f "$state_file"
+}
+
 traceary_read_state() {
   local client="$1"
   local state_file
@@ -245,6 +270,9 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
+      if [[ -n "$REPO_VALUE" ]]; then
+        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      fi
     fi
     ;;
   end|stop)
@@ -269,6 +297,7 @@ case "$ACTION" in
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"
+    traceary_clear_repo_state "$CLIENT"
     traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
     ;;
   *)
@@ -317,8 +346,12 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-HOOK_CWD="$(traceary_json_get 'cwd')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+# Prefer repo from session state (set at session start) over CWD-based detection
+REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
+if [[ -z "$REPO_VALUE" ]]; then
+  HOOK_CWD="$(traceary_json_get 'cwd')"
+  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+fi
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then

--- a/scripts/hooks/common.sh
+++ b/scripts/hooks/common.sh
@@ -128,6 +128,31 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
+traceary_write_repo_state() {
+  local client="$1"
+  local repo="$2"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  printf '%s' "$repo" > "$state_file"
+}
+
+traceary_read_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  if [[ ! -f "$state_file" ]]; then
+    return 0
+  fi
+  cat "$state_file"
+}
+
+traceary_clear_repo_state() {
+  local client="$1"
+  local state_file
+  state_file="$(traceary_session_state_path "$client")-repo"
+  rm -f "$state_file"
+}
+
 traceary_read_state() {
   local client="$1"
   local state_file

--- a/scripts/hooks/scripts_test.go
+++ b/scripts/hooks/scripts_test.go
@@ -238,6 +238,64 @@ func TestTracearyAuditScript_UsesHookPayloadAndSessionState(t *testing.T) {
 	}
 }
 
+func TestTracearyAuditScript_UsesRepoFromSessionState(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fakeLogPath := filepath.Join(tempDir, "traceary.log")
+	fakeTracearyPath := filepath.Join(tempDir, "traceary")
+	writeFakeTraceary(t, fakeTracearyPath)
+
+	homeDir := filepath.Join(tempDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	env := append(os.Environ(),
+		"TRACEARY_BIN="+fakeTracearyPath,
+		"TRACEARY_FAKE_LOG="+fakeLogPath,
+		"TRACEARY_REPO=session-repo",
+		"HOME="+homeDir,
+	)
+
+	// Start session — repo "session-repo" is saved to state
+	if err := runHookScript(t, filepath.Join(".", "traceary-session.sh"), env, `{"cwd":"/tmp/project"}`, "claude", "start"); err != nil {
+		t.Fatalf("runHookScript(start) error = %v", err)
+	}
+
+	// Run audit WITHOUT TRACEARY_REPO — should use repo from session state
+	auditEnv := append(os.Environ(),
+		"TRACEARY_BIN="+fakeTracearyPath,
+		"TRACEARY_FAKE_LOG="+fakeLogPath,
+		"HOME="+homeDir,
+	)
+	auditInput := `{"cwd":"/tmp/other-dir","tool_input":{"command":"ls"},"tool_response":{"exitCode":0,"stderr":"","stdout":"files"}}`
+	if err := runHookScript(t, filepath.Join(".", "traceary-audit.sh"), auditEnv, auditInput, "claude"); err != nil {
+		t.Fatalf("runHookScript(audit) error = %v", err)
+	}
+
+	calls := readLoggedCalls(t, fakeLogPath)
+	if len(calls) != 2 {
+		t.Fatalf("len(calls) = %d, want 2", len(calls))
+	}
+
+	// Verify audit used session-repo, not CWD-based detection
+	auditCall := calls[1]
+	repoIdx := -1
+	for i, arg := range auditCall {
+		if arg == "--repo" && i+1 < len(auditCall) {
+			repoIdx = i + 1
+			break
+		}
+	}
+	if repoIdx == -1 {
+		t.Fatalf("audit call missing --repo flag: %#v", auditCall)
+	}
+	if auditCall[repoIdx] != "session-repo" {
+		t.Fatalf("audit --repo = %q, want %q", auditCall[repoIdx], "session-repo")
+	}
+}
+
 func TestTracearyAuditScript_UsesFailurePayloadWhenToolResponseIsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/hooks/scripts_test.go
+++ b/scripts/hooks/scripts_test.go
@@ -141,6 +141,12 @@ func TestTracearySessionScript_StopIsIdempotentForDuplicateSessionEnd(t *testing
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("logged calls = %#v, want %#v", calls, want)
 	}
+
+	// Verify repo state file is cleaned up after duplicate stop
+	repoStatePath := filepath.Join(homeDir, ".config", "traceary", "hooks", "gemini-"+pidString()+"-repo")
+	if _, err := os.Stat(repoStatePath); !os.IsNotExist(err) {
+		t.Fatalf("repo state file should not exist after stop, got: %v", err)
+	}
 }
 
 func TestTracearySessionScript_UsesGitRootForLocalOnlyRepositories(t *testing.T) {

--- a/scripts/hooks/traceary-audit.sh
+++ b/scripts/hooks/traceary-audit.sh
@@ -33,8 +33,12 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-HOOK_CWD="$(traceary_json_get 'cwd')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+# Prefer repo from session state (set at session start) over CWD-based detection
+REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
+if [[ -z "$REPO_VALUE" ]]; then
+  HOOK_CWD="$(traceary_json_get 'cwd')"
+  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
+fi
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then

--- a/scripts/hooks/traceary-session.sh
+++ b/scripts/hooks/traceary-session.sh
@@ -50,6 +50,9 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
+      if [[ -n "$REPO_VALUE" ]]; then
+        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      fi
     fi
     ;;
   end|stop)
@@ -74,6 +77,7 @@ case "$ACTION" in
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"
+    traceary_clear_repo_state "$CLIENT"
     traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
     ;;
   *)

--- a/scripts/hooks/traceary-session.sh
+++ b/scripts/hooks/traceary-session.sh
@@ -65,7 +65,14 @@ case "$ACTION" in
 
     if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
       traceary_clear_state "$CLIENT"
+      traceary_clear_repo_state "$CLIENT"
       exit 0
+    fi
+
+    # Use repo from session state if available (prevents CWD drift)
+    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    if [[ -n "$REPO_STATE" ]]; then
+      REPO_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")


### PR DESCRIPTION
## Summary

- Save resolved repo to a state file at session start
- Audit hooks read repo from session state first, falling back to CWD-based detection
- Session end clears the repo state file
- Prevents repo drift when subagents run in different directories

Closes #203
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] `python3 scripts/verify_integrations.py` passes
- [x] New test: audit uses repo from session state even without TRACEARY_REPO env

🤖 Generated with [Claude Code](https://claude.com/claude-code)