### PR TITLE
Record MCP tool calls via PostToolUse hooks

### DIFF
--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -32,11 +32,29 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-audit.sh\" claude"
           }
         ]
+      },
+      {
+        "matcher": "mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-audit.sh\" claude"
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [
       {
         "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-audit.sh\" claude"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -20,7 +20,11 @@ if [[ -z "$TRACEARY_CMD" ]]; then
   exit 0
 fi
 
+# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
 COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
+if [[ -z "$COMMAND_VALUE" ]]; then
+  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
+fi
 if [[ -z "$COMMAND_VALUE" ]]; then
   exit 0
 fi

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -20,7 +20,11 @@ if [[ -z "$TRACEARY_CMD" ]]; then
   exit 0
 fi
 
+# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
 COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
+if [[ -z "$COMMAND_VALUE" ]]; then
+  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
+fi
 if [[ -z "$COMMAND_VALUE" ]]; then
   exit 0
 fi

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -20,7 +20,11 @@ if [[ -z "$TRACEARY_CMD" ]]; then
   exit 0
 fi
 
+# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
 COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
+if [[ -z "$COMMAND_VALUE" ]]; then
+  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
+fi
 if [[ -z "$COMMAND_VALUE" ]]; then
   exit 0
 fi

--- a/presentation/cli/hook_assets.go
+++ b/presentation/cli/hook_assets.go
@@ -340,7 +340,11 @@ if [[ -z "$TRACEARY_CMD" ]]; then
   exit 0
 fi
 
+# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
 COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
+if [[ -z "$COMMAND_VALUE" ]]; then
+  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
+fi
 if [[ -z "$COMMAND_VALUE" ]]; then
   exit 0
 fi

--- a/scripts/hooks/scripts_test.go
+++ b/scripts/hooks/scripts_test.go
@@ -302,6 +302,52 @@ func TestTracearyAuditScript_UsesRepoFromSessionState(t *testing.T) {
 	}
 }
 
+func TestTracearyAuditScript_UsesToolNameForMCPTools(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fakeLogPath := filepath.Join(tempDir, "traceary.log")
+	fakeTracearyPath := filepath.Join(tempDir, "traceary")
+	writeFakeTraceary(t, fakeTracearyPath)
+
+	homeDir := filepath.Join(tempDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	env := append(os.Environ(),
+		"TRACEARY_BIN="+fakeTracearyPath,
+		"TRACEARY_FAKE_LOG="+fakeLogPath,
+		"TRACEARY_REPO=work-context",
+		"HOME="+homeDir,
+	)
+
+	// Start session first
+	if err := runHookScript(t, filepath.Join(".", "traceary-session.sh"), env, `{"cwd":"/tmp/project"}`, "claude", "start"); err != nil {
+		t.Fatalf("runHookScript(start) error = %v", err)
+	}
+
+	// MCP tool call — no tool_input.command, but has tool_name
+	mcpInput := `{"cwd":"/tmp/project","tool_name":"mcp__atlassian__getPage","tool_input":{"pageId":"12345"},"tool_response":{"content":"page content"}}`
+	if err := runHookScript(t, filepath.Join(".", "traceary-audit.sh"), env, mcpInput, "claude"); err != nil {
+		t.Fatalf("runHookScript(mcp audit) error = %v", err)
+	}
+
+	calls := readLoggedCalls(t, fakeLogPath)
+	if len(calls) != 2 {
+		t.Fatalf("len(calls) = %d, want 2", len(calls))
+	}
+
+	auditCall := calls[1]
+	// First positional arg to "audit" should be the tool_name
+	if auditCall[0] != "audit" {
+		t.Fatalf("call[0] = %q, want audit", auditCall[0])
+	}
+	if auditCall[1] != "mcp__atlassian__getPage" {
+		t.Fatalf("audit command = %q, want mcp__atlassian__getPage", auditCall[1])
+	}
+}
+
 func TestTracearyAuditScript_UsesFailurePayloadWhenToolResponseIsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/hooks/traceary-audit.sh
+++ b/scripts/hooks/traceary-audit.sh
@@ -20,7 +20,11 @@ if [[ -z "$TRACEARY_CMD" ]]; then
   exit 0
 fi
 
+# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
 COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
+if [[ -z "$COMMAND_VALUE" ]]; then
+  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
+fi
 if [[ -z "$COMMAND_VALUE" ]]; then
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Add `mcp__.*` matcher to Claude Code PostToolUse/PostToolUseFailure hooks
- Audit script falls back to `tool_name` when `tool_input.command` is absent
- MCP tool calls (Confluence, Jira, GitHub MCP, etc.) are now recorded in session history

Closes #200
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] `python3 scripts/verify_integrations.py` passes
- [x] New test: MCP tool_name is used as audit command

🤖 Generated with [Claude Code](https://claude.com/claude-code)