### PR TITLE
Introduce sessions table and session metadata model

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -9,14 +9,17 @@ import (
 
 // SessionSummary holds aggregated information about a single session.
 type SessionSummary struct {
-	SessionID    string
-	Repo         string
-	StartedAt    time.Time
-	EndedAt      *time.Time
-	Status       string
-	TotalEvents  int
-	CommandCount int
-	Agents       []string
+	SessionID       string
+	Repo            string
+	StartedAt       time.Time
+	EndedAt         *time.Time
+	Status          string
+	TotalEvents     int
+	CommandCount    int
+	Agents          []string
+	Label           string
+	Summary         string
+	ParentSessionID string
 }
 
 // ListSessionsInput is the input for session listing.

--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -27,6 +27,12 @@ type RecordSessionBoundaryInput struct {
 // ErrSessionStartedEventNotFound indicates the target session has no start event.
 var ErrSessionStartedEventNotFound = xerrors.New("session_started event was not found for the target session")
 
+// SessionSaver persists session metadata.
+type SessionSaver interface {
+	// SaveSession creates or updates a session record.
+	SaveSession(ctx context.Context, dbPath string, session *model.Session) error
+}
+
 // SessionStartedEventFinder provides lookup for session_started events.
 type SessionStartedEventFinder interface {
 	// FindSessionStartedEvent returns the latest session_started event for the target session.
@@ -45,6 +51,7 @@ type RecordSessionBoundaryUsecase interface {
 
 type recordSessionBoundaryUsecase struct {
 	eventSaver                EventSaver
+	sessionSaver              SessionSaver
 	sessionStartedEventFinder SessionStartedEventFinder
 }
 
@@ -52,9 +59,15 @@ type recordSessionBoundaryUsecase struct {
 func NewRecordSessionBoundaryUsecase(
 	eventSaver EventSaver,
 	sessionStartedEventFinder SessionStartedEventFinder,
+	sessionSavers ...SessionSaver,
 ) RecordSessionBoundaryUsecase {
+	var sessionSaver SessionSaver
+	if len(sessionSavers) > 0 {
+		sessionSaver = sessionSavers[0]
+	}
 	return &recordSessionBoundaryUsecase{
 		eventSaver:                eventSaver,
+		sessionSaver:              sessionSaver,
 		sessionStartedEventFinder: sessionStartedEventFinder,
 	}
 }
@@ -110,7 +123,38 @@ func (u *recordSessionBoundaryUsecase) Run(
 		return nil, xerrors.Errorf("failed to save session boundary event: %w", err)
 	}
 
+	if u.sessionSaver != nil {
+		session := buildSessionFromBoundary(event, input.Kind)
+		if err := u.sessionSaver.SaveSession(ctx, trimmedDBPath, session); err != nil {
+			return nil, xerrors.Errorf("failed to save session metadata: %w", err)
+		}
+	}
+
 	return event, nil
+}
+
+func buildSessionFromBoundary(event *model.Event, kind types.EventKind) *model.Session {
+	switch kind {
+	case types.EventKindSessionStarted:
+		return model.NewSession(
+			event.SessionID(),
+			event.CreatedAt(),
+			event.Client(),
+			event.Agent(),
+			event.Repo(),
+		)
+	default:
+		endedAt := event.CreatedAt()
+		return model.SessionOf(
+			event.SessionID(),
+			event.CreatedAt(),
+			&endedAt,
+			event.Client(),
+			event.Agent(),
+			event.Repo(),
+			"", "", "",
+		)
+	}
 }
 
 func (u *recordSessionBoundaryUsecase) resolveSessionBoundaryAttribution(

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// Session represents a recorded agent work session.
+type Session struct {
+	sessionID       types.SessionID
+	startedAt       time.Time
+	endedAt         *time.Time
+	client          string
+	agent           types.Agent
+	repo            string
+	label           string
+	summary         string
+	parentSessionID string
+}
+
+// NewSession creates a new Session for session start.
+func NewSession(
+	sessionID types.SessionID,
+	startedAt time.Time,
+	client string,
+	agent types.Agent,
+	repo string,
+) *Session {
+	return &Session{
+		sessionID: sessionID,
+		startedAt: startedAt,
+		client:    client,
+		agent:     agent,
+		repo:      repo,
+	}
+}
+
+// SessionOf restores a Session from persisted data.
+func SessionOf(
+	sessionID types.SessionID,
+	startedAt time.Time,
+	endedAt *time.Time,
+	client string,
+	agent types.Agent,
+	repo string,
+	label string,
+	summary string,
+	parentSessionID string,
+) *Session {
+	return &Session{
+		sessionID:       sessionID,
+		startedAt:       startedAt,
+		endedAt:         endedAt,
+		client:          client,
+		agent:           agent,
+		repo:            repo,
+		label:           label,
+		summary:         summary,
+		parentSessionID: parentSessionID,
+	}
+}
+
+// SessionID returns the session ID.
+func (s *Session) SessionID() types.SessionID { return s.sessionID }
+
+// StartedAt returns when the session started.
+func (s *Session) StartedAt() time.Time { return s.startedAt }
+
+// EndedAt returns when the session ended, or nil if still active.
+func (s *Session) EndedAt() *time.Time { return s.endedAt }
+
+// Client returns the client that created the session.
+func (s *Session) Client() string { return s.client }
+
+// Agent returns the agent that ran the session.
+func (s *Session) Agent() types.Agent { return s.agent }
+
+// Repo returns the work context repository.
+func (s *Session) Repo() string { return s.repo }
+
+// Label returns the user-assigned label.
+func (s *Session) Label() string { return s.label }
+
+// Summary returns the session summary text.
+func (s *Session) Summary() string { return s.summary }
+
+// ParentSessionID returns the parent session ID, or empty if top-level.
+func (s *Session) ParentSessionID() string { return s.parentSessionID }

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -42,20 +42,31 @@ func (d *Datasource) ListSessionSummaries(
 	rows, err := db.QueryContext(
 		ctx,
 		`SELECT
-		   e.session_id,
-		   MAX(e.repo) AS repo,
-		   MIN(e.created_at) AS started_at,
-		   MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END) AS ended_at,
-		   COUNT(*) AS total_events,
-		   SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-		   GROUP_CONCAT(DISTINCT e.agent) AS agents
-		 FROM events e
-		 WHERE (? = '' OR e.repo = ?)
-		   AND (? = '' OR e.agent = ?)
-		   AND (? = '' OR e.created_at >= ?)
-		   AND (? = '' OR e.created_at < ?)
-		 GROUP BY e.session_id
-		 ORDER BY started_at DESC
+		   s.session_id,
+		   s.repo,
+		   s.started_at,
+		   s.ended_at,
+		   COALESCE(agg.total_events, 0) AS total_events,
+		   COALESCE(agg.command_count, 0) AS command_count,
+		   COALESCE(agg.agents, '') AS agents,
+		   s.label,
+		   s.summary,
+		   COALESCE(s.parent_session_id, '') AS parent_session_id
+		 FROM sessions s
+		 LEFT JOIN (
+		   SELECT
+		     e.session_id,
+		     COUNT(*) AS total_events,
+		     SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+		     GROUP_CONCAT(DISTINCT e.agent) AS agents
+		   FROM events e
+		   GROUP BY e.session_id
+		 ) agg ON agg.session_id = s.session_id
+		 WHERE (? = '' OR s.repo = ?)
+		   AND (? = '' OR s.agent = ?)
+		   AND (? = '' OR s.started_at >= ?)
+		   AND (? = '' OR s.started_at < ?)
+		 ORDER BY s.started_at DESC
 		 LIMIT ? OFFSET ?`,
 		input.Repo, input.Repo,
 		input.Agent, input.Agent,
@@ -91,13 +102,16 @@ func scanSessionSummary(row interface {
 	Scan(dest ...any) error
 }) (*queryservice.SessionSummary, error) {
 	var (
-		sessionID    string
-		repo         string
-		startedAtStr string
-		endedAtStr   sql.NullString
-		totalEvents  int
-		commandCount int
-		agentsStr    sql.NullString
+		sessionID       string
+		repo            string
+		startedAtStr    string
+		endedAtStr      sql.NullString
+		totalEvents     int
+		commandCount    int
+		agentsStr       sql.NullString
+		label           string
+		summary         string
+		parentSessionID string
 	)
 
 	if err := row.Scan(
@@ -108,6 +122,9 @@ func scanSessionSummary(row interface {
 		&totalEvents,
 		&commandCount,
 		&agentsStr,
+		&label,
+		&summary,
+		&parentSessionID,
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan session summary: %w", err)
 	}
@@ -134,13 +151,16 @@ func scanSessionSummary(row interface {
 	}
 
 	return &queryservice.SessionSummary{
-		SessionID:    sessionID,
-		Repo:         repo,
-		StartedAt:    startedAt,
-		EndedAt:      endedAt,
-		Status:       status,
-		TotalEvents:  totalEvents,
-		CommandCount: commandCount,
-		Agents:       agents,
+		SessionID:       sessionID,
+		Repo:            repo,
+		StartedAt:       startedAt,
+		EndedAt:         endedAt,
+		Status:          status,
+		TotalEvents:     totalEvents,
+		CommandCount:    commandCount,
+		Agents:          agents,
+		Label:           label,
+		Summary:         summary,
+		ParentSessionID: parentSessionID,
 	}, nil
 }

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -39,6 +39,45 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
     output_truncated INTEGER NOT NULL DEFAULT 0
 );`),
 		},
+		"000004_create_sessions.sql": {
+			Data: []byte(`CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    client TEXT NOT NULL DEFAULT '',
+    agent TEXT NOT NULL DEFAULT '',
+    repo TEXT NOT NULL DEFAULT '',
+    label TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT REFERENCES sessions(session_id)
+);
+INSERT OR IGNORE INTO sessions (session_id, started_at, ended_at, client, agent, repo)
+SELECT
+    e.session_id,
+    MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at ELSE e.created_at END),
+    MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END),
+    COALESCE(MAX(CASE WHEN e.kind = 'session_started' THEN e.client END), MAX(e.client)),
+    COALESCE(MAX(CASE WHEN e.kind = 'session_started' THEN e.agent END), MAX(e.agent)),
+    COALESCE(MAX(CASE WHEN e.kind = 'session_started' THEN e.repo END), MAX(e.repo))
+FROM events e
+GROUP BY e.session_id;`),
+		},
+	}
+}
+
+func saveTestSession(ctx context.Context, t *testing.T, ds *infra.Datasource, dbPath string, sessionID string, startedAt time.Time, endedAt *time.Time, agent string, repo string) {
+	t.Helper()
+	ag, _ := types.AgentOf(agent)
+	sid, _ := types.SessionIDOf(sessionID)
+	session := model.NewSession(sid, startedAt, "hook", ag, repo)
+	if err := ds.SaveSession(ctx, dbPath, session); err != nil {
+		t.Fatalf("SaveSession(start) error = %v", err)
+	}
+	if endedAt != nil {
+		endSession := model.SessionOf(sid, startedAt, endedAt, "hook", ag, repo, "", "", "")
+		if err := ds.SaveSession(ctx, dbPath, endSession); err != nil {
+			t.Fatalf("SaveSession(end) error = %v", err)
+		}
 	}
 }
 
@@ -80,6 +119,11 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 				t.Fatalf("Save() error = %v", err)
 			}
 		}
+
+		// Save session metadata
+		s1End := time.Now().UTC()
+		saveTestSession(ctx, t, ds, dbPath, "s1", time.Now().Add(-time.Hour).UTC(), &s1End, "claude", "duck8823/traceary")
+		saveTestSession(ctx, t, ds, dbPath, "s2", time.Now().UTC(), nil, "codex", "duck8823/traceary")
 
 		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
 			Limit: 10,
@@ -152,6 +196,10 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			}
 		}
 
+		now := time.Now().UTC()
+		saveTestSession(ctx, t, ds, dbPath, "s1", now, nil, "claude", "repo")
+		saveTestSession(ctx, t, ds, dbPath, "s2", now.Add(time.Second), nil, "codex", "repo")
+
 		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
 			Limit: 10,
 			Agent: "claude",
@@ -178,7 +226,6 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// Insert two sessions on different dates using EventOf with explicit timestamps
 		for _, e := range []struct {
 			id, sid  string
 			dayOfMon int
@@ -194,6 +241,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			if err := ds.Save(ctx, dbPath, event); err != nil {
 				t.Fatalf("Save() error = %v", err)
 			}
+			saveTestSession(ctx, t, ds, dbPath, e.sid, ts, nil, "claude", "repo")
 		}
 
 		fromDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
@@ -238,6 +286,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 			if err := ds.Save(ctx, dbPath, event); err != nil {
 				t.Fatalf("Save() error = %v", err)
 			}
+			saveTestSession(ctx, t, ds, dbPath, e.sid, ts, nil, "claude", "repo")
 		}
 
 		toDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -1,0 +1,58 @@
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+)
+
+var _ usecase.SessionSaver = (*Datasource)(nil)
+
+// SaveSession creates or updates a session record.
+// On session start, a new row is inserted.
+// On session end, the existing row is updated with ended_at.
+func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *model.Session) error {
+	db, err := d.openDB(ctx, dbPath)
+	if err != nil {
+		return xerrors.Errorf("failed to open DB for session save: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	if session.EndedAt() != nil {
+		// Session end: update ended_at
+		_, err := db.ExecContext(
+			ctx,
+			`UPDATE sessions SET ended_at = ? WHERE session_id = ?`,
+			formatTimestamp(*session.EndedAt()),
+			session.SessionID().String(),
+		)
+		if err != nil {
+			return xerrors.Errorf("failed to update session ended_at: %w", err)
+		}
+		return nil
+	}
+
+	// Session start: insert new row
+	_, err = db.ExecContext(
+		ctx,
+		`INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, repo) VALUES (?, ?, ?, ?, ?)`,
+		session.SessionID().String(),
+		formatTimestamp(session.StartedAt()),
+		session.Client(),
+		session.Agent().String(),
+		session.Repo(),
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to insert session: %w", err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func run() error {
 	createStoreBackupUsecase := usecase.NewCreateStoreBackupUsecase(datasource)
 	restoreStoreBackupUsecase := usecase.NewRestoreStoreBackupUsecase(datasource)
 	recordLogUsecase := usecase.NewRecordLogUsecase(datasource)
-	recordSessionBoundaryUsecase := usecase.NewRecordSessionBoundaryUsecase(datasource, datasource)
+	recordSessionBoundaryUsecase := usecase.NewRecordSessionBoundaryUsecase(datasource, datasource, datasource)
 	recordCommandAuditUsecase := usecase.NewRecordCommandAuditUsecase(datasource)
 	collectGarbageUsecase := usecase.NewCollectGarbageUsecase(datasource)
 	searchEventsQueryService := queryservice.NewSearchEventsQueryService(datasource)

--- a/schema/sqlite/migrations/000004_create_sessions.sql
+++ b/schema/sqlite/migrations/000004_create_sessions.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    client TEXT NOT NULL DEFAULT '',
+    agent TEXT NOT NULL DEFAULT '',
+    repo TEXT NOT NULL DEFAULT '',
+    label TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT REFERENCES sessions(session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_started_at
+    ON sessions(started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_repo_started_at
+    ON sessions(repo, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+    ON sessions(parent_session_id);
+
+-- Backfill from existing session_started/session_ended events
+INSERT OR IGNORE INTO sessions (session_id, started_at, ended_at, client, agent, repo)
+SELECT
+    e.session_id,
+    MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at ELSE e.created_at END) AS started_at,
+    MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END) AS ended_at,
+    COALESCE(
+        MAX(CASE WHEN e.kind = 'session_started' THEN e.client END),
+        MAX(e.client)
+    ) AS client,
+    COALESCE(
+        MAX(CASE WHEN e.kind = 'session_started' THEN e.agent END),
+        MAX(e.agent)
+    ) AS agent,
+    COALESCE(
+        MAX(CASE WHEN e.kind = 'session_started' THEN e.repo END),
+        MAX(e.repo)
+    ) AS repo
+FROM events e
+GROUP BY e.session_id;


### PR DESCRIPTION
## Summary

- New `sessions` table with `label`, `summary`, `parent_session_id` columns
- Migration 000004 with backfill from existing events
- Domain `Session` model (separate from `Event` aggregate)
- `SessionSaver` interface wired into `RecordSessionBoundaryUsecase`
- `session list` query rewritten to use sessions table with events JOIN
- Foundation for #201 (labels), #204 (summaries), #202 (parent-child)

Closes #206
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] Existing session list tests updated for sessions table

🤖 Generated with [Claude Code](https://claude.com/claude-code)