### PR TITLE
Harden session metadata SQL and add missing usecase tests

### DIFF
--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -144,10 +145,12 @@ func buildSessionFromBoundary(event *model.Event, kind types.EventKind) *model.S
 			event.Repo(),
 		)
 	default:
+		// For session end, started_at is not available from the event.
+		// Use zero value since SaveSession only updates ended_at.
 		endedAt := event.CreatedAt()
 		return model.SessionOf(
 			event.SessionID(),
-			event.CreatedAt(),
+			time.Time{},
 			&endedAt,
 			event.Client(),
 			event.Agent(),

--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -262,3 +262,89 @@ func mustTime(t *testing.T) time.Time {
 
 	return time.Date(2026, 4, 8, 13, 0, 0, 0, time.UTC)
 }
+
+type sessionSaverStub struct {
+	called  bool
+	session *model.Session
+	err     error
+}
+
+func (s *sessionSaverStub) SaveSession(_ context.Context, _ string, session *model.Session) error {
+	s.called = true
+	s.session = session
+	return s.err
+}
+
+func TestRecordSessionBoundaryUsecase_Run_SessionSaver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("session start で SessionSaver が呼ばれる", func(t *testing.T) {
+		t.Parallel()
+
+		eventStub := &eventRepositoryStub{}
+		sessionStub := &sessionSaverStub{}
+		sut := usecase.NewRecordSessionBoundaryUsecase(eventStub, nil, sessionStub)
+
+		_, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath: "/tmp/traceary.db",
+			Client: "cli",
+			Agent:  "claude",
+			Repo:   "duck8823/traceary",
+			Kind:   types.EventKindSessionStarted,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !sessionStub.called {
+			t.Fatalf("SessionSaver.SaveSession() was not called")
+		}
+		if sessionStub.session.EndedAt() != nil {
+			t.Fatalf("session.EndedAt() should be nil for start")
+		}
+	})
+
+	t.Run("session end で SessionSaver が呼ばれる", func(t *testing.T) {
+		t.Parallel()
+
+		eventStub := &eventRepositoryStub{}
+		sessionStub := &sessionSaverStub{}
+		sut := usecase.NewRecordSessionBoundaryUsecase(eventStub, nil, sessionStub)
+
+		_, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath:    "/tmp/traceary.db",
+			Client:    "cli",
+			Agent:     "claude",
+			Repo:      "duck8823/traceary",
+			SessionID: "test-session",
+			Kind:      types.EventKindSessionEnded,
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !sessionStub.called {
+			t.Fatalf("SessionSaver.SaveSession() was not called")
+		}
+		if sessionStub.session.EndedAt() == nil {
+			t.Fatalf("session.EndedAt() should not be nil for end")
+		}
+	})
+
+	t.Run("SessionSaver がエラーを返したら Run もエラーを返す", func(t *testing.T) {
+		t.Parallel()
+
+		eventStub := &eventRepositoryStub{}
+		sessionStub := &sessionSaverStub{err: errors.New("save failed")}
+		sut := usecase.NewRecordSessionBoundaryUsecase(eventStub, nil, sessionStub)
+
+		_, err := sut.Run(context.Background(), usecase.RecordSessionBoundaryInput{
+			DBPath: "/tmp/traceary.db",
+			Client: "cli",
+			Agent:  "claude",
+			Repo:   "duck8823/traceary",
+			Kind:   types.EventKindSessionStarted,
+		})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error")
+		}
+	})
+}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -54,7 +54,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 INSERT OR IGNORE INTO sessions (session_id, started_at, ended_at, client, agent, repo)
 SELECT
     e.session_id,
-    MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at ELSE e.created_at END),
+    COALESCE(MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at END), MIN(e.created_at)),
     MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END),
     COALESCE(MAX(CASE WHEN e.kind = 'session_started' THEN e.client END), MAX(e.client)),
     COALESCE(MAX(CASE WHEN e.kind = 'session_started' THEN e.agent END), MAX(e.agent)),

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -28,7 +28,7 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 
 	if session.EndedAt() != nil {
 		// Session end: update ended_at
-		_, err := db.ExecContext(
+		result, err := db.ExecContext(
 			ctx,
 			`UPDATE sessions SET ended_at = ? WHERE session_id = ?`,
 			formatTimestamp(*session.EndedAt()),
@@ -36,6 +36,13 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 		)
 		if err != nil {
 			return xerrors.Errorf("failed to update session ended_at: %w", err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return xerrors.Errorf("failed to check rows affected: %w", err)
+		}
+		if rowsAffected == 0 {
+			slog.Debug("session not found for ended_at update, skipping", "session_id", session.SessionID().String())
 		}
 		return nil
 	}

--- a/schema/sqlite/migrations/000004_create_sessions.sql
+++ b/schema/sqlite/migrations/000004_create_sessions.sql
@@ -23,7 +23,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent
 INSERT OR IGNORE INTO sessions (session_id, started_at, ended_at, client, agent, repo)
 SELECT
     e.session_id,
-    MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at ELSE e.created_at END) AS started_at,
+    COALESCE(MIN(CASE WHEN e.kind = 'session_started' THEN e.created_at END), MIN(e.created_at)) AS started_at,
     MAX(CASE WHEN e.kind = 'session_ended' THEN e.created_at END) AS ended_at,
     COALESCE(
         MAX(CASE WHEN e.kind = 'session_started' THEN e.client END),


### PR DESCRIPTION
## Summary

Review fixes for #211 that were lost during merge race condition:
- Use COALESCE for backfill started_at in migration SQL
- Add RowsAffected check on session end UPDATE
- Use zero time for started_at in session end path
- Add 3 SessionSaver usecase tests

Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)