### PR TITLE
Add session label command and --label filter

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -28,6 +28,7 @@ type ListSessionsInput struct {
 	Offset int
 	Repo   string
 	Agent  string
+	Label  string
 	From   *time.Time
 	To     *time.Time
 }

--- a/application/usecase/update_session_label.go
+++ b/application/usecase/update_session_label.go
@@ -1,0 +1,61 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// SessionLabelUpdater updates a session label.
+type SessionLabelUpdater interface {
+	UpdateSessionLabel(ctx context.Context, dbPath string, sessionID types.SessionID, label string) error
+}
+
+// UpdateSessionLabelInput is the input for updating a session label.
+type UpdateSessionLabelInput struct {
+	DBPath    string
+	SessionID string
+	Label     string
+}
+
+// UpdateSessionLabelUsecase updates a session's label.
+type UpdateSessionLabelUsecase interface {
+	Run(ctx context.Context, input UpdateSessionLabelInput) error
+}
+
+type updateSessionLabelUsecase struct {
+	updater SessionLabelUpdater
+}
+
+// NewUpdateSessionLabelUsecase creates an UpdateSessionLabelUsecase.
+func NewUpdateSessionLabelUsecase(updater SessionLabelUpdater) UpdateSessionLabelUsecase {
+	return &updateSessionLabelUsecase{updater: updater}
+}
+
+func (u *updateSessionLabelUsecase) Run(ctx context.Context, input UpdateSessionLabelInput) error {
+	if u.updater == nil {
+		return xerrors.Errorf("session label updater is not configured")
+	}
+	trimmedDBPath := strings.TrimSpace(input.DBPath)
+	if trimmedDBPath == "" {
+		return xerrors.Errorf("DB path must not be empty")
+	}
+	trimmedSessionID := strings.TrimSpace(input.SessionID)
+	if trimmedSessionID == "" {
+		return xerrors.Errorf("session ID must not be empty")
+	}
+
+	sessionID, err := types.SessionIDOf(trimmedSessionID)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve session ID: %w", err)
+	}
+
+	if err := u.updater.UpdateSessionLabel(ctx, trimmedDBPath, sessionID, input.Label); err != nil {
+		return xerrors.Errorf("failed to update session label: %w", err)
+	}
+
+	return nil
+}

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -64,12 +64,14 @@ func (d *Datasource) ListSessionSummaries(
 		 ) agg ON agg.session_id = s.session_id
 		 WHERE (? = '' OR s.repo = ?)
 		   AND (? = '' OR s.agent = ?)
+		   AND (? = '' OR s.label = ?)
 		   AND (? = '' OR s.started_at >= ?)
 		   AND (? = '' OR s.started_at < ?)
 		 ORDER BY s.started_at DESC
 		 LIMIT ? OFFSET ?`,
 		input.Repo, input.Repo,
 		input.Agent, input.Agent,
+		input.Label, input.Label,
 		fromValue, fromValue,
 		toValue, toValue,
 		input.Limit, input.Offset,

--- a/infrastructure/sqlite/update_session_label.go
+++ b/infrastructure/sqlite/update_session_label.go
@@ -1,0 +1,43 @@
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// UpdateSessionLabel sets the label for a session.
+func (d *Datasource) UpdateSessionLabel(ctx context.Context, dbPath string, sessionID types.SessionID, label string) error {
+	db, err := d.openDB(ctx, dbPath)
+	if err != nil {
+		return xerrors.Errorf("failed to open DB: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	result, err := db.ExecContext(
+		ctx,
+		`UPDATE sessions SET label = ? WHERE session_id = ?`,
+		label,
+		sessionID.String(),
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to update session label: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to check rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return xerrors.Errorf("session not found: %s", sessionID)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func run() error {
 	getEventDetailsQueryService := queryservice.NewGetEventDetailsQueryService(datasource)
 	findLatestSessionQueryService := queryservice.NewFindLatestSessionQueryService(datasource)
 	listSessionsQueryService := queryservice.NewListSessionsQueryService(datasource)
+	updateSessionLabelUsecase := usecase.NewUpdateSessionLabelUsecase(datasource)
 	mcpServer, err := mcpserver.NewServer(
 		metadata.version,
 		initializeStoreUsecase,
@@ -194,6 +195,7 @@ func run() error {
 		GetEventDetailsQueryService:   getEventDetailsQueryService,
 		FindLatestSessionQueryService: findLatestSessionQueryService,
 		ListSessionsQueryService:      listSessionsQueryService,
+		UpdateSessionLabelUsecase:     updateSessionLabelUsecase,
 		MCPServerRunner:               mcpServer,
 	}).Command()
 	rootCmd.Version = versionString()

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -22,6 +22,7 @@ type RootCLI struct {
 	getEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	findLatestSessionQueryService queryservice.FindLatestSessionQueryService
 	listSessionsQueryService      queryservice.ListSessionsQueryService
+	updateSessionLabelUsecase     usecase.UpdateSessionLabelUsecase
 	mcpServerRunner               MCPServerRunner
 }
 
@@ -40,6 +41,7 @@ type RootCLIOptions struct {
 	GetEventDetailsQueryService   queryservice.GetEventDetailsQueryService
 	FindLatestSessionQueryService queryservice.FindLatestSessionQueryService
 	ListSessionsQueryService      queryservice.ListSessionsQueryService
+	UpdateSessionLabelUsecase     usecase.UpdateSessionLabelUsecase
 	MCPServerRunner               MCPServerRunner
 }
 
@@ -59,6 +61,7 @@ func NewRootCLI(options RootCLIOptions) *RootCLI {
 		getEventDetailsQueryService:   options.GetEventDetailsQueryService,
 		findLatestSessionQueryService: options.FindLatestSessionQueryService,
 		listSessionsQueryService:      options.ListSessionsQueryService,
+		updateSessionLabelUsecase:     options.UpdateSessionLabelUsecase,
 		mcpServerRunner:               options.MCPServerRunner,
 	}
 }

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -28,6 +28,7 @@ func (c *RootCLI) newSessionCommand() *cobra.Command {
 	sessionCmd.AddCommand(c.newSessionLatestCommand())
 	sessionCmd.AddCommand(c.newSessionActiveCommand())
 	sessionCmd.AddCommand(c.newSessionListCommand())
+	sessionCmd.AddCommand(c.newSessionLabelCommand())
 
 	return sessionCmd
 }

--- a/presentation/cli/session_label.go
+++ b/presentation/cli/session_label.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+func (c *RootCLI) newSessionLabelCommand() *cobra.Command {
+	var (
+		dbPath    string
+		sessionID string
+	)
+
+	labelCmd := &cobra.Command{
+		Use:   "label [label-text]",
+		Short: Localize("Set a label on a session", "セッションにラベルを設定する"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+
+			if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			resolvedSessionID := resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", "")
+			if resolvedSessionID == "" {
+				return xerrors.Errorf("%s", Localize("--session-id is required", "--session-id は必須です"))
+			}
+
+			if err := c.updateSessionLabelUsecase.Run(ctx, usecase.UpdateSessionLabelInput{
+				DBPath:    resolvedDBPath,
+				SessionID: resolvedSessionID,
+				Label:     args[0],
+			}); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to update session label", "セッションラベルの更新に失敗しました"), err)
+			}
+
+			return printSessionLabelResult(output, resolvedSessionID, args[0])
+		},
+	}
+
+	labelCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	labelCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID to label", "ラベルを設定するセッション ID"))
+
+	return labelCmd
+}
+
+func printSessionLabelResult(output io.Writer, sessionID string, label string) error {
+	if _, err := fmt.Fprintf(output, "%s: %s -> %s\n",
+		Localize("Label set", "ラベルを設定しました"),
+		sessionID,
+		label,
+	); err != nil {
+		return xerrors.Errorf("failed to print result: %w", err)
+	}
+	return nil
+}

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -18,6 +18,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 		dbPath string
 		repo   string
 		agent  string
+		label  string
 		from   string
 		to     string
 		limit  int
@@ -69,6 +70,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				Offset: offset,
 				Repo:   resolvedRepo,
 				Agent:  agent,
+				Label:  label,
 				From:   fromTime,
 				To:     toTime,
 			})
@@ -83,6 +85,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", Localize("SQLite DB path (env: TRACEARY_DB_PATH)", "SQLite DB パス (env: TRACEARY_DB_PATH)"))
 	listCmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
+	listCmd.Flags().StringVar(&label, "label", "", Localize("filter by label", "ラベルでフィルタ"))
 	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD)", "開始日 (YYYY-MM-DD)"))
 	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD)", "終了日 (YYYY-MM-DD)"))
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of sessions", "最大表示セッション数"))


### PR DESCRIPTION
## Summary

- New `traceary session label <text> --session-id <id>` command to tag sessions
- `UpdateSessionLabelUsecase` + SQLite `UpdateSessionLabel` implementation
- `session list --label <text>` filter to find labeled sessions
- Full layer wiring (CLI -> usecase -> infra)

Closes #201
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)