### PR TITLE
Support --summary flag on session end

### DIFF
--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -23,6 +23,7 @@ type RecordSessionBoundaryInput struct {
 	Repo          string
 	DefaultRepo   string
 	Kind          types.EventKind
+	Summary       string
 }
 
 // ErrSessionStartedEventNotFound indicates the target session has no start event.
@@ -125,7 +126,7 @@ func (u *recordSessionBoundaryUsecase) Run(
 	}
 
 	if u.sessionSaver != nil {
-		session := buildSessionFromBoundary(event, input.Kind)
+		session := buildSessionFromBoundary(event, input.Kind, input.Summary)
 		if err := u.sessionSaver.SaveSession(ctx, trimmedDBPath, session); err != nil {
 			return nil, xerrors.Errorf("failed to save session metadata: %w", err)
 		}
@@ -134,7 +135,7 @@ func (u *recordSessionBoundaryUsecase) Run(
 	return event, nil
 }
 
-func buildSessionFromBoundary(event *model.Event, kind types.EventKind) *model.Session {
+func buildSessionFromBoundary(event *model.Event, kind types.EventKind, summary string) *model.Session {
 	switch kind {
 	case types.EventKindSessionStarted:
 		return model.NewSession(
@@ -155,7 +156,7 @@ func buildSessionFromBoundary(event *model.Event, kind types.EventKind) *model.S
 			event.Client(),
 			event.Agent(),
 			event.Repo(),
-			"", "", "",
+			"", summary, "",
 		)
 	}
 }

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -30,8 +30,10 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 		// Session end: update ended_at
 		result, err := db.ExecContext(
 			ctx,
-			`UPDATE sessions SET ended_at = ? WHERE session_id = ?`,
+			`UPDATE sessions SET ended_at = ?, summary = CASE WHEN ? != '' THEN ? ELSE summary END WHERE session_id = ?`,
 			formatTimestamp(*session.EndedAt()),
+			session.Summary(),
+			session.Summary(),
 			session.SessionID().String(),
 		)
 		if err != nil {

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -120,6 +120,7 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 		agent     string
 		sessionID string
 		repo      string
+		summary   string
 		idOnly    bool
 		asJSON    bool
 	)
@@ -139,6 +140,7 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 				agent:     agent,
 				sessionID: resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", ""),
 				repo:      repo,
+				summary:   summary,
 				kind:      types.EventKindSessionEnded,
 				idOnly:    idOnly,
 				asJSON:    asJSON,
@@ -150,6 +152,7 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 	endCmd.Flags().StringVar(&agent, "agent", "", Localize("actor name (env: TRACEARY_AGENT)", "作業主体 (env: TRACEARY_AGENT)"))
 	endCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID to end (env: TRACEARY_SESSION_ID)", "終了するセッション ID (env: TRACEARY_SESSION_ID)"))
 	endCmd.Flags().StringVar(&repo, "repo", "", Localize("auxiliary work context identifier (env: TRACEARY_REPO)", "補助的なコンテキスト識別子 (env: TRACEARY_REPO)"))
+	endCmd.Flags().StringVar(&summary, "summary", "", Localize("session summary text", "セッションサマリーテキスト"))
 	endCmd.Flags().BoolVar(&idOnly, "id-only", false, Localize("print only the resulting identifier", "結果の識別子だけを出力する"))
 	endCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	endCmd.MarkFlagsMutuallyExclusive("id-only", "json")
@@ -163,6 +166,7 @@ type sessionBoundaryCommandInput struct {
 	agent     string
 	sessionID string
 	repo      string
+	summary   string
 	kind      types.EventKind
 	idOnly    bool
 	asJSON    bool
@@ -257,6 +261,7 @@ func (c *RootCLI) runSessionBoundary(
 		Repo:          resolveSessionBoundaryRepo(input),
 		DefaultRepo:   resolveRepoValue(ctx, input.repo),
 		Kind:          input.kind,
+		Summary:       input.summary,
 	})
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record session boundary", "session 境界の記録に失敗しました"), err)


### PR DESCRIPTION
## Summary

- Add `--summary` flag to `traceary session end`
- Summary is stored in the sessions table via SaveSession UPDATE
- When empty, preserves existing summary value

Closes #204
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)