### PR TITLE
Support parent-child session relationships

### DIFF
--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -22,8 +22,9 @@ type RecordSessionBoundaryInput struct {
 	SessionID     string
 	Repo          string
 	DefaultRepo   string
-	Kind          types.EventKind
-	Summary       string
+	Kind              types.EventKind
+	Summary           string
+	ParentSessionID   string
 }
 
 // ErrSessionStartedEventNotFound indicates the target session has no start event.
@@ -126,7 +127,7 @@ func (u *recordSessionBoundaryUsecase) Run(
 	}
 
 	if u.sessionSaver != nil {
-		session := buildSessionFromBoundary(event, input.Kind, input.Summary)
+		session := buildSessionFromBoundary(event, input.Kind, input.Summary, input.ParentSessionID)
 		if err := u.sessionSaver.SaveSession(ctx, trimmedDBPath, session); err != nil {
 			return nil, xerrors.Errorf("failed to save session metadata: %w", err)
 		}
@@ -135,15 +136,17 @@ func (u *recordSessionBoundaryUsecase) Run(
 	return event, nil
 }
 
-func buildSessionFromBoundary(event *model.Event, kind types.EventKind, summary string) *model.Session {
+func buildSessionFromBoundary(event *model.Event, kind types.EventKind, summary string, parentSessionID string) *model.Session {
 	switch kind {
 	case types.EventKindSessionStarted:
-		return model.NewSession(
+		return model.SessionOf(
 			event.SessionID(),
 			event.CreatedAt(),
+			nil,
 			event.Client(),
 			event.Agent(),
 			event.Repo(),
+			"", "", parentSessionID,
 		)
 	default:
 		// For session end, started_at is not available from the event.

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -50,14 +50,20 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 	}
 
 	// Session start: insert new row
+	var parentSessionID *string
+	if session.ParentSessionID() != "" {
+		v := session.ParentSessionID()
+		parentSessionID = &v
+	}
 	_, err = db.ExecContext(
 		ctx,
-		`INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, repo) VALUES (?, ?, ?, ?, ?)`,
+		`INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, repo, parent_session_id) VALUES (?, ?, ?, ?, ?, ?)`,
 		session.SessionID().String(),
 		formatTimestamp(session.StartedAt()),
 		session.Client(),
 		session.Agent().String(),
 		session.Repo(),
+		parentSessionID,
 	)
 	if err != nil {
 		return xerrors.Errorf("failed to insert session: %w", err)

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -71,13 +71,14 @@ func (c *RootCLI) newSessionLatestCommand() *cobra.Command {
 
 func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 	var (
-		dbPath    string
-		client    string
-		agent     string
-		sessionID string
-		repo      string
-		idOnly    bool
-		asJSON    bool
+		dbPath          string
+		client          string
+		agent           string
+		sessionID       string
+		repo            string
+		parentSessionID string
+		idOnly          bool
+		asJSON          bool
 	)
 
 	startCmd := &cobra.Command{
@@ -90,14 +91,15 @@ func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessionBoundary(cmd.Context(), cmd.OutOrStdout(), sessionBoundaryCommandInput{
-				dbPath:    dbPath,
-				client:    client,
-				agent:     agent,
-				sessionID: strings.TrimSpace(sessionID),
-				repo:      repo,
-				kind:      types.EventKindSessionStarted,
-				idOnly:    idOnly,
-				asJSON:    asJSON,
+				dbPath:          dbPath,
+				client:          client,
+				agent:           agent,
+				sessionID:       strings.TrimSpace(sessionID),
+				repo:            repo,
+				parentSessionID: strings.TrimSpace(parentSessionID),
+				kind:            types.EventKindSessionStarted,
+				idOnly:          idOnly,
+				asJSON:          asJSON,
 			})
 		},
 	}
@@ -106,6 +108,7 @@ func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 	startCmd.Flags().StringVar(&agent, "agent", "", Localize("actor name (env: TRACEARY_AGENT)", "作業主体 (env: TRACEARY_AGENT)"))
 	startCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID to start", "開始するセッション ID"))
 	startCmd.Flags().StringVar(&repo, "repo", "", Localize("auxiliary work context identifier (env: TRACEARY_REPO)", "補助的なコンテキスト識別子 (env: TRACEARY_REPO)"))
+	startCmd.Flags().StringVar(&parentSessionID, "parent-session-id", "", Localize("parent session ID for sub-agent sessions", "サブエージェントセッションの親セッション ID"))
 	startCmd.Flags().BoolVar(&idOnly, "id-only", false, Localize("print only the resulting identifier", "結果の識別子だけを出力する"))
 	startCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	startCmd.MarkFlagsMutuallyExclusive("id-only", "json")
@@ -161,15 +164,16 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 }
 
 type sessionBoundaryCommandInput struct {
-	dbPath    string
-	client    string
-	agent     string
-	sessionID string
-	repo      string
-	summary   string
-	kind      types.EventKind
-	idOnly    bool
-	asJSON    bool
+	dbPath          string
+	client          string
+	agent           string
+	sessionID       string
+	repo            string
+	summary         string
+	parentSessionID string
+	kind            types.EventKind
+	idOnly          bool
+	asJSON          bool
 }
 
 type sessionLatestCommandInput struct {
@@ -260,8 +264,9 @@ func (c *RootCLI) runSessionBoundary(
 		SessionID:     input.sessionID,
 		Repo:          resolveSessionBoundaryRepo(input),
 		DefaultRepo:   resolveRepoValue(ctx, input.repo),
-		Kind:          input.kind,
-		Summary:       input.summary,
+		Kind:              input.kind,
+		Summary:           input.summary,
+		ParentSessionID:   input.parentSessionID,
 	})
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record session boundary", "session 境界の記録に失敗しました"), err)


### PR DESCRIPTION
## Summary

- Add `--parent-session-id` flag to `traceary session start`
- Store parent_session_id in sessions table via INSERT
- Enables tracking which session spawned which sub-agent session

Closes #202
Part of #205

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)