### PR TITLE
Prepare v0.1.18 release

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,40 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [v0.1.18] - 2026-04-10
+
+セッションメタデータの充実とデータ品質の向上を行いました。
+
+### 追加
+- `sessions` テーブル新設 + 既存 events からのバックフィルマイグレーション
+- `traceary session label <text> --session-id <id>` コマンド — セッションにラベルを付与
+- `session list --label` フィルタ
+- `traceary session end --summary` フラグ — セッション終了時にサマリーを記録
+- `traceary session start --parent-session-id` フラグ — サブエージェントの親子関係を記録
+- Claude Code hooks で MCP ツール呼び出し（`mcp__.*`）を記録
+- Gemini CLI ワンコマンドインストールスクリプト
+
+### 修正
+- audit hooks でセッション開始時の repo を永続化し、CWD ベースの repo drift を防止
+- MCP ツール呼び出し時に `tool_name` へ fallback するよう audit スクリプトを改善
+- 日付バリデーションを queryservice 層に集約（infra 層の冗長なバリデーションを除去）
+- doctor 設定チェックの `localizef` 引数過剰を修正
+
+### 変更
+- `session list` クエリを sessions テーブル主体に書き換え（events JOIN で集計）
+- `SessionSummary` DTO に `label`/`summary`/`parent_session_id` を追加
+- 統合マニフェストのバージョンを `0.1.18` に更新
+
+### 含まれるイシュー
+- #196 日付バリデーションの queryservice 層集約
+- #200 hooks による MCP ツール呼び出し記録
+- #201 セッションにラベル/タスク名を付与
+- #202 セッション間の親子関係を記録
+- #203 repo フィールドの正規化
+- #204 セッション終了時にサマリーを記録
+- #206 セッションメタデータモデルの導入
+- #207 Gemini CLI インストール体験の改善
+
 ## [v0.1.17] - 2026-04-09
 
 マルチエージェントワークフローの改善と CLI の使い勝手向上を行いました。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+## [v0.1.18] - 2026-04-10
+
+This release introduces a dedicated sessions table, enriches session metadata with labels, summaries, and parent-child relationships, and improves data quality.
+
+### Added
+- `sessions` table with migration and backfill from existing events
+- `traceary session label <text> --session-id <id>` command to tag sessions
+- `--label` filter for `session list` command
+- `--summary` flag on `traceary session end` to record session summaries
+- `--parent-session-id` flag on `traceary session start` for sub-agent hierarchy
+- MCP tool call recording via `mcp__.*` matcher in Claude Code hooks
+- Gemini CLI one-command install script (`scripts/install-gemini-extension.sh`)
+
+### Fixed
+- Audit hooks now persist repo from session start and reuse it, preventing CWD-based repo drift in sub-agents
+- Audit script falls back to `tool_name` when `tool_input.command` is absent (MCP tools)
+- Consolidated date validation into queryservice layer (removed redundant infra-layer validation)
+- Fixed excess `localizef` arguments in doctor config checks
+
+### Changed
+- `session list` query rewritten to use sessions table with events JOIN for aggregated counts
+- `SessionSummary` DTO now includes `label`, `summary`, `parent_session_id`
+- Updated integration manifests to version `0.1.18`
+
+### Included issues
+- #196 Consolidate date validation into queryservice layer
+- #200 Record MCP tool calls via hooks
+- #201 Add searchable labels/task names to sessions
+- #202 Record parent-child relationships between agent sessions
+- #203 Normalize repo field to prevent CWD-based drift
+- #204 Record session summary on session end
+- #206 Introduce session metadata model
+- #207 Improve Gemini CLI installation experience
+
 ## [v0.1.17] - 2026-04-09
 
 This release focuses on multi-agent workflow improvements and CLI ergonomics.

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 特定の release を使いたい場合は、tag を明示します。
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.17
+go install github.com/duck8823/traceary@v0.1.18
 ```
 
 ### Homebrew

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 If you prefer a specific release, pin the tag explicitly.
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.17
+go install github.com/duck8823/traceary@v0.1.18
 ```
 
 ### Homebrew

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "traceary",
   "description": "Local-first Traceary integration for Claude Code with MCP tools and automatic session/audit hooks.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "author": {
     "name": "Shunsuke Maeda",
     "email": "duck8823@gmail.com"

--- a/integrations/gemini-extension/gemini-extension.json
+++ b/integrations/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Local-first Traceary integration for Gemini CLI with shared MCP tools and automatic session/audit hooks.",
   "mcpServers": {
     "traceary": {

--- a/plugins/traceary/.codex-plugin/plugin.json
+++ b/plugins/traceary/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Local-first Traceary integration for Codex with MCP tools and automatic session/audit hooks.",
   "author": {
     "name": "Shunsuke Maeda",

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     tomllib = None
 
 ROOT = Path(__file__).resolve().parent.parent
-INTEGRATION_VERSION = '0.1.17'
+INTEGRATION_VERSION = '0.1.18'
 HOOK_SOURCES = [
     ROOT / 'scripts' / 'hooks' / 'common.sh',
     ROOT / 'scripts' / 'hooks' / 'traceary-session.sh',


### PR DESCRIPTION
## Summary

- Update integration manifests, CHANGELOGs, and release docs to v0.1.18

Closes #205

## Test plan

- [x] `go test ./...` passes
- [x] `python3 scripts/verify_integrations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)