### PR TITLE
fix: surface config load failures to operators

### DIFF
--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -53,6 +53,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 ```
 
 ファイルが存在しない場合、Traceary は組み込みのリダクションパターンのみを使用します。
+ファイルが存在しても unreadable または不正な JSON の場合、Traceary は組み込みのリダクションパターンへ fallback し、config ベースの redaction が必要な場面では operator 向け warning を出し、`traceary doctor` でもその壊れた状態を報告します。
 
 ## Runtime 前提
 

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -53,6 +53,7 @@ Example:
 ```
 
 If the file does not exist, Traceary uses the built-in redaction patterns only.
+If the file exists but is unreadable or invalid JSON, Traceary falls back to the built-in redaction patterns, emits an operator-visible warning when config-backed redaction would have been used, and reports the broken state in `traceary doctor`.
 
 ## Runtime assumptions
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/presentation"
 )
 
 const (
@@ -114,6 +116,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Message: localizef("resolved DB path: %s", "解決した DB パス: %s", resolvedDBPath),
 	})
 
+	report.Checks = append(report.Checks, inspectDoctorConfig())
+
 	if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
 		report.Checks = append(report.Checks, doctorCheck{
 			Name:    "db-write",
@@ -200,6 +204,48 @@ func resolveDoctorClients(client string) ([]string, error) {
 	}
 
 	return []string{resolvedClient}, nil
+}
+
+func inspectDoctorConfig() doctorCheck {
+	configResult := presentation.InspectConfig()
+	switch configResult.Status {
+	case presentation.ConfigLoadStatusLoaded:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusPass,
+			Message: localizef("loaded config file: %s", "設定ファイルを読み込みました: %s", configResult.Path),
+		}
+	case presentation.ConfigLoadStatusMissing:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusPass,
+			Message: localizef("optional config file is not present yet; built-in redaction defaults remain active: %s", "オプション設定ファイルはまだありません。組み込みの redaction 既定値を使います: %s", configResult.Path),
+		}
+	case presentation.ConfigLoadStatusInvalid:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusFail,
+			Message: localizef("config file is invalid JSON, so extra redaction patterns are disabled: %s (%v)", "設定ファイルの JSON が不正なため、追加 redaction pattern は無効です: %s (%v)", configResult.Path, configResult.Err),
+		}
+	case presentation.ConfigLoadStatusUnreadable:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusFail,
+			Message: localizef("config file could not be read, so extra redaction patterns are disabled: %s (%v)", "設定ファイルを読み込めないため、追加 redaction pattern は無効です: %s (%v)", configResult.Path, configResult.Err),
+		}
+	case presentation.ConfigLoadStatusHomeDirFailure:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusFail,
+			Message: localizef("failed to resolve the config path, so extra redaction patterns are disabled: %v", "設定ファイルのパスを解決できないため、追加 redaction pattern は無効です: %v", configResult.Err),
+		}
+	default:
+		return doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusFail,
+			Message: localizef("config state is unknown", "設定ファイルの状態を判定できません"),
+		}
+	}
 }
 
 func inspectDoctorConfigFile(client string, outputPath string) doctorCheck {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -39,6 +39,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 	homeDir := t.TempDir()
 	scriptsDir := filepath.Join(t.TempDir(), "hook-scripts")
 	t.Setenv("TRACEARY_HOOK_SCRIPTS_DIR", scriptsDir)
+	t.Setenv("HOME", homeDir)
 	cli.SetUserHomeDirFunc(func() (string, error) {
 		return homeDir, nil
 	})
@@ -72,6 +73,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if len(initializeStore.paths) != 1 {
 			t.Fatalf("len(initializeStore.paths) = %d, want 1", len(initializeStore.paths))
 		}
+		assertDoctorCheckStatus(t, report.Checks, "config", "pass")
 		assertDoctorCheckStatus(t, report.Checks, "claude-config", "warn")
 		assertDoctorCheckStatus(t, report.Checks, "codex-config", "warn")
 		assertDoctorCheckStatus(t, report.Checks, "gemini-config", "warn")
@@ -100,6 +102,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if unmarshalErr := json.Unmarshal(stdout.Bytes(), &report); unmarshalErr != nil {
 			t.Fatalf("json.Unmarshal() error = %v", unmarshalErr)
 		}
+		assertDoctorCheckStatus(t, report.Checks, "config", "pass")
 		assertDoctorCheckStatus(t, report.Checks, "claude-config", "warn")
 	})
 
@@ -132,10 +135,18 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatalf("json.Unmarshal() error = %v", err)
 		}
+		assertDoctorCheckStatus(t, report.Checks, "config", "pass")
 		assertDoctorCheckStatus(t, report.Checks, "hook-scripts", "warn")
 	})
 
 	t.Run("existing Traceary config passes", func(t *testing.T) {
+		configDir := filepath.Join(homeDir, ".config", "traceary")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"redact":{"extra_patterns":["internal_token"]}}`), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
 		settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
 		if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 			t.Fatalf("MkdirAll() error = %v", err)
@@ -181,10 +192,46 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatalf("json.Unmarshal() error = %v", err)
 		}
+		assertDoctorCheckStatus(t, report.Checks, "config", "pass")
 		assertDoctorCheckStatus(t, report.Checks, "claude-config", "pass")
 		if report.HookScriptsDir == "" {
 			t.Fatalf("HookScriptsDir = empty, want non-empty")
 		}
+	})
+
+	t.Run("invalid Traceary config fails doctor", func(t *testing.T) {
+		configDir := filepath.Join(homeDir, ".config", "traceary")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{invalid}"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		initializeStore := &doctorInitializeStoreUsecaseStub{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: initializeStore,
+		}).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"doctor",
+			"--client", "claude",
+			"--project-dir", projectDir,
+			"--json",
+		})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("Execute() error = nil, want non-nil")
+		}
+
+		var report doctorReportJSON
+		if unmarshalErr := json.Unmarshal(stdout.Bytes(), &report); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal() error = %v", unmarshalErr)
+		}
+		assertDoctorCheckStatus(t, report.Checks, "config", "fail")
 	})
 }
 

--- a/presentation/config.go
+++ b/presentation/config.go
@@ -2,6 +2,7 @@ package presentation
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -17,29 +18,100 @@ type RedactConfig struct {
 	ExtraPatterns []string `json:"extra_patterns"`
 }
 
-// LoadConfig reads the Traceary config from ~/.config/traceary/config.json.
-// Returns a zero-value Config if the file does not exist or cannot be parsed.
-func LoadConfig() Config {
+// ConfigLoadStatus describes the result of attempting to load the optional
+// operator config file.
+type ConfigLoadStatus string
+
+const (
+	// ConfigLoadStatusLoaded indicates that config.json was read successfully.
+	ConfigLoadStatusLoaded         ConfigLoadStatus = "loaded"
+	// ConfigLoadStatusMissing indicates that config.json is not present.
+	ConfigLoadStatusMissing        ConfigLoadStatus = "missing"
+	// ConfigLoadStatusInvalid indicates that config.json exists but is invalid.
+	ConfigLoadStatusInvalid        ConfigLoadStatus = "invalid"
+	// ConfigLoadStatusUnreadable indicates that config.json exists but could not be read.
+	ConfigLoadStatusUnreadable     ConfigLoadStatus = "unreadable"
+	// ConfigLoadStatusHomeDirFailure indicates that the config path could not be resolved.
+	ConfigLoadStatusHomeDirFailure ConfigLoadStatus = "home_dir_failure"
+)
+
+// ConfigLoadResult describes the outcome of reading the optional config file.
+type ConfigLoadResult struct {
+	Config Config
+	Path   string
+	Status ConfigLoadStatus
+	Err    error
+}
+
+// InspectConfig reads the Traceary config from ~/.config/traceary/config.json
+// without emitting operator-facing log output.
+func InspectConfig() ConfigLoadResult {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		slog.Debug("failed to get home directory for config", "error", err)
-		return Config{}
+		return ConfigLoadResult{
+			Status: ConfigLoadStatusHomeDirFailure,
+			Err:    err,
+		}
 	}
 
 	configPath := filepath.Join(homeDir, ".config", "traceary", "config.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			slog.Debug("failed to read config file", "path", configPath, "error", err)
+		if os.IsNotExist(err) {
+			return ConfigLoadResult{
+				Path:   configPath,
+				Status: ConfigLoadStatusMissing,
+			}
 		}
-		return Config{}
+		return ConfigLoadResult{
+			Path:   configPath,
+			Status: ConfigLoadStatusUnreadable,
+			Err:    err,
+		}
 	}
 
 	var config Config
 	if err := json.Unmarshal(data, &config); err != nil {
-		slog.Debug("failed to parse config file", "path", configPath, "error", err)
-		return Config{}
+		return ConfigLoadResult{
+			Path:   configPath,
+			Status: ConfigLoadStatusInvalid,
+			Err:    err,
+		}
 	}
 
-	return config
+	return ConfigLoadResult{
+		Config: config,
+		Path:   configPath,
+		Status: ConfigLoadStatusLoaded,
+	}
+}
+
+func (r ConfigLoadResult) warningMessage() string {
+	switch r.Status {
+	case ConfigLoadStatusInvalid:
+		return fmt.Sprintf(
+			"Traceary config is invalid; extra audit redaction patterns are disabled until the file is fixed: %s",
+			r.Path,
+		)
+	case ConfigLoadStatusUnreadable:
+		return fmt.Sprintf(
+			"Traceary config could not be read; extra audit redaction patterns are disabled until the file is readable: %s",
+			r.Path,
+		)
+	case ConfigLoadStatusHomeDirFailure:
+		return "Traceary config path could not be resolved; extra audit redaction patterns are disabled"
+	default:
+		return ""
+	}
+}
+
+// LoadConfig reads the Traceary config from ~/.config/traceary/config.json.
+// Returns a zero-value Config when the optional config cannot be used.
+func LoadConfig() Config {
+	result := InspectConfig()
+	if warningMessage := result.warningMessage(); warningMessage != "" {
+		slog.Warn(warningMessage, "error", result.Err)
+	}
+
+	return result.Config
 }

--- a/presentation/config_test.go
+++ b/presentation/config_test.go
@@ -1,8 +1,11 @@
 package presentation_test
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/duck8823/traceary/presentation"
@@ -15,6 +18,11 @@ func TestLoadConfig_ファイルが存在しない場合はゼロ値を返す(t 
 
 	if len(config.Redact.ExtraPatterns) != 0 {
 		t.Errorf("expected empty extra patterns, got %v", config.Redact.ExtraPatterns)
+	}
+
+	result := presentation.InspectConfig()
+	if result.Status != presentation.ConfigLoadStatusMissing {
+		t.Fatalf("InspectConfig().Status = %q, want %q", result.Status, presentation.ConfigLoadStatusMissing)
 	}
 }
 
@@ -34,6 +42,11 @@ func TestLoadConfig_不正なJSONの場合はゼロ値を返す(t *testing.T) {
 
 	if len(config.Redact.ExtraPatterns) != 0 {
 		t.Errorf("expected empty extra patterns, got %v", config.Redact.ExtraPatterns)
+	}
+
+	result := presentation.InspectConfig()
+	if result.Status != presentation.ConfigLoadStatusInvalid {
+		t.Fatalf("InspectConfig().Status = %q, want %q", result.Status, presentation.ConfigLoadStatusInvalid)
 	}
 }
 
@@ -60,5 +73,36 @@ func TestLoadConfig_正常なconfig_jsonからパターンを読み込める(t *
 	}
 	if config.Redact.ExtraPatterns[1] != "internal_token" {
 		t.Errorf("expected second pattern 'internal_token', got %q", config.Redact.ExtraPatterns[1])
+	}
+
+	result := presentation.InspectConfig()
+	if result.Status != presentation.ConfigLoadStatusLoaded {
+		t.Fatalf("InspectConfig().Status = %q, want %q", result.Status, presentation.ConfigLoadStatusLoaded)
+	}
+}
+
+func TestLoadConfig_不正なJSONは警告ログを出す(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{invalid}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logBuffer := &bytes.Buffer{}
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(logBuffer, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	_ = presentation.LoadConfig()
+
+	if !strings.Contains(logBuffer.String(), "Traceary config is invalid") {
+		t.Fatalf("expected warning log about invalid config, got: %s", logBuffer.String())
 	}
 }


### PR DESCRIPTION
## Motivation

Issue #220 covers the operational safety gap around `~/.config/traceary/config.json`. When that file was unreadable or invalid, Traceary silently dropped back to built-in redaction defaults, which made it easy to miss that custom redaction patterns were no longer active.

## Summary

- add structured config inspection states so the CLI can distinguish missing, loaded, unreadable, and invalid config
- emit operator-visible warnings when config-backed redaction is disabled during CLI/MCP config loading
- surface config health in `traceary doctor` and fail doctor on broken config states
- add tests for config status inspection, warning behavior, and doctor reporting
- document the new warning/doctor behavior in the environment reference

Closes #220

## Test plan

- [x] `GOCACHE=$(pwd)/.cache/go-build go test ./presentation/... ./...`
- [x] `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...`