### PR TITLE
refactor: make hook scripts single-source

### DIFF
--- a/presentation/cli/hook_assets.go
+++ b/presentation/cli/hook_assets.go
@@ -6,384 +6,23 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
+
+	hookscripts "github.com/duck8823/traceary/scripts/hooks"
 )
 
 const hooksScriptsDirEnvKey = "TRACEARY_HOOK_SCRIPTS_DIR"
 
-type hookScriptAsset struct {
-	name    string
-	content string
-}
+type hookScriptAsset = hookscripts.ScriptAsset
 
-var hookScriptAssets = []hookScriptAsset{
-	{
-		name: "common.sh",
-		content: `#!/bin/bash
+var hookScriptAssets = mustHookScriptAssets()
 
-set -euo pipefail
+func mustHookScriptAssets() []hookScriptAsset {
+	assets, err := hookscripts.Assets()
+	if err != nil {
+		panic(err)
+	}
 
-traceary_read_hook_input() {
-  if [[ -n "${TRACEARY_HOOK_INPUT:-}" ]]; then
-    export TRACEARY_HOOK_INPUT
-    return 0
-  fi
-
-  TRACEARY_HOOK_INPUT="$(cat 2>/dev/null || true)"
-  export TRACEARY_HOOK_INPUT
-}
-
-traceary_helper_command() {
-  local helper_name="${1:-}"
-  shift || true
-
-  local traceary_cmd="${TRACEARY_CMD:-}"
-  if [[ -z "$traceary_cmd" ]]; then
-    traceary_cmd="$(traceary_resolve_bin 2>/dev/null || true)"
-  fi
-  if [[ -z "$traceary_cmd" ]]; then
-    return 1
-  fi
-
-  TRACEARY_HOOK_INPUT="${TRACEARY_HOOK_INPUT:-}" "$traceary_cmd" hooks helper "$helper_name" "$@" 2>/dev/null
-}
-
-traceary_json_get() {
-  local path="${1:-}"
-  local default_value="${2:-}"
-
-  traceary_helper_command json-get "$path" "$default_value" || printf '%s' "$default_value"
-}
-
-traceary_build_failure_output() {
-  traceary_helper_command build-failure-output || true
-}
-
-traceary_normalize_git_remote() {
-  local raw="${1:-}"
-
-  traceary_helper_command normalize-git-remote "$raw" || true
-}
-
-traceary_resolve_repo() {
-  local cwd="${1:-}"
-
-  if [[ -n "${TRACEARY_REPO:-}" ]]; then
-    printf '%s' "$TRACEARY_REPO"
-    return 0
-  fi
-  if [[ -z "$cwd" ]]; then
-    return 0
-  fi
-  if command -v git >/dev/null 2>&1; then
-    local remote
-    remote="$(git -C "$cwd" config --get remote.origin.url 2>/dev/null || true)"
-    if [[ -n "$remote" ]]; then
-      traceary_normalize_git_remote "$remote"
-      return 0
-    fi
-
-    local repo_root
-    repo_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$repo_root" ]]; then
-      printf '%s' "$repo_root"
-      return 0
-    fi
-  fi
-
-  printf '%s' "$cwd"
-}
-
-traceary_resolve_bin() {
-  if [[ -n "${TRACEARY_BIN:-}" ]]; then
-    printf '%s' "$TRACEARY_BIN"
-    return 0
-  fi
-  if command -v traceary >/dev/null 2>&1; then
-    command -v traceary
-    return 0
-  fi
-
-  return 1
-}
-
-traceary_resolve_agent() {
-  local client="$1"
-  local agent_type
-  agent_type="$(traceary_json_get 'agent_type')"
-  if [[ -n "$agent_type" ]]; then
-    printf '%s/%s' "$client" "$agent_type"
-  else
-    printf '%s' "$client"
-  fi
-}
-
-traceary_session_state_path() {
-  local client="$1"
-  local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"
-  mkdir -p "$state_dir"
-  printf '%s/%s-%s' "$state_dir" "$client" "${TRACEARY_HOOK_STATE_KEY:-${PPID:-$$}}"
-}
-
-traceary_sanitize_state_key() {
-  local value="${1:-}"
-
-  printf '%s' "$value" | tr -cs 'A-Za-z0-9._-' '_'
-}
-
-traceary_session_end_marker_path() {
-  local client="$1"
-  local session_id="$2"
-  local state_dir="${TRACEARY_HOOK_STATE_DIR:-${HOME}/.config/traceary/hooks}"
-  local sanitized_session_id
-  sanitized_session_id="$(traceary_sanitize_state_key "$session_id")"
-  mkdir -p "$state_dir/ended"
-  printf '%s/ended/%s-%s' "$state_dir" "$client" "$sanitized_session_id"
-}
-
-traceary_write_state() {
-  local client="$1"
-  local session_id="$2"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")"
-  printf '%s' "$session_id" > "$state_file"
-}
-
-traceary_write_repo_state() {
-  local client="$1"
-  local repo="$2"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")-repo"
-  printf '%s' "$repo" > "$state_file"
-}
-
-traceary_read_repo_state() {
-  local client="$1"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")-repo"
-  if [[ ! -f "$state_file" ]]; then
-    return 0
-  fi
-  cat "$state_file"
-}
-
-traceary_clear_repo_state() {
-  local client="$1"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")-repo"
-  rm -f "$state_file"
-}
-
-traceary_read_state() {
-  local client="$1"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")"
-  if [[ ! -f "$state_file" ]]; then
-    return 0
-  fi
-
-  cat "$state_file"
-}
-
-traceary_clear_state() {
-  local client="$1"
-  local state_file
-  state_file="$(traceary_session_state_path "$client")"
-  rm -f "$state_file"
-}
-
-traceary_mark_session_ended() {
-  local client="$1"
-  local session_id="$2"
-  local marker_file
-  marker_file="$(traceary_session_end_marker_path "$client" "$session_id")"
-  : > "$marker_file"
-}
-
-traceary_session_end_already_recorded() {
-  local client="$1"
-  local session_id="$2"
-  local marker_file
-  marker_file="$(traceary_session_end_marker_path "$client" "$session_id")"
-  [[ -f "$marker_file" ]]
-}
-
-traceary_clear_session_end_marker() {
-  local client="$1"
-  local session_id="$2"
-  local marker_file
-  marker_file="$(traceary_session_end_marker_path "$client" "$session_id")"
-  rm -f "$marker_file"
-}
-`,
-	},
-	{
-		name: "traceary-session.sh",
-		content: `#!/bin/bash
-
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=common.sh
-source "$SCRIPT_DIR/common.sh"
-
-CLIENT="${1:-}"
-ACTION="${2:-}"
-
-if [[ -z "$CLIENT" || -z "$ACTION" ]]; then
-  echo "usage: traceary-session.sh <client> <start|end|stop>" >&2
-  exit 64
-fi
-
-traceary_read_hook_input
-
-TRACEARY_CMD="$(traceary_resolve_bin 2>/dev/null || true)"
-if [[ -z "$TRACEARY_CMD" ]]; then
-  exit 0
-fi
-
-HOOK_CWD="$(traceary_json_get 'cwd')"
-SESSION_ID="$(traceary_json_get 'session_id')"
-REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
-
-COMMON_ARGS=(session)
-if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
-  COMMON_ARGS+=(--db-path "$TRACEARY_DB_PATH")
-fi
-COMMON_ARGS+=("${ACTION/start/start}")
-
-AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
-
-case "$ACTION" in
-  start)
-    COMMAND=("$TRACEARY_CMD" session start --client hook --agent "$AGENT_VALUE")
-    if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
-      COMMAND+=(--db-path "$TRACEARY_DB_PATH")
-    fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--repo "$REPO_VALUE")
-    fi
-    if [[ -n "$SESSION_ID" ]]; then
-      COMMAND+=(--session-id "$SESSION_ID")
-    fi
-
-    ACTUAL_SESSION_ID="$("${COMMAND[@]}" 2>/dev/null | tail -n 1 | tr -d '\r' || true)"
-    if [[ -n "$ACTUAL_SESSION_ID" ]]; then
-      traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
-      traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
-      if [[ -n "$REPO_VALUE" ]]; then
-        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
-      fi
-    fi
-    ;;
-  end|stop)
-    if [[ -z "$SESSION_ID" ]]; then
-      SESSION_ID="$(traceary_read_state "$CLIENT")"
-    fi
-    if [[ -z "$SESSION_ID" ]]; then
-      exit 0
-    fi
-
-    if traceary_session_end_already_recorded "$CLIENT" "$SESSION_ID"; then
-      traceary_clear_state "$CLIENT"
-      traceary_clear_repo_state "$CLIENT"
-      exit 0
-    fi
-
-    # Use repo from session state if available (prevents CWD drift)
-    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
-    if [[ -n "$REPO_STATE" ]]; then
-      REPO_VALUE="$REPO_STATE"
-    fi
-
-    COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
-    if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
-      COMMAND+=(--db-path "$TRACEARY_DB_PATH")
-    fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--repo "$REPO_VALUE")
-    fi
-    "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
-    traceary_clear_state "$CLIENT"
-    traceary_clear_repo_state "$CLIENT"
-    traceary_mark_session_ended "$CLIENT" "$SESSION_ID"
-    ;;
-  *)
-    echo "unsupported action: $ACTION" >&2
-    exit 64
-    ;;
-esac
-
-exit 0
-`,
-	},
-	{
-		name: "traceary-audit.sh",
-		content: `#!/bin/bash
-
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=common.sh
-source "$SCRIPT_DIR/common.sh"
-
-CLIENT="${1:-}"
-
-if [[ -z "$CLIENT" ]]; then
-  echo "usage: traceary-audit.sh <client>" >&2
-  exit 64
-fi
-
-traceary_read_hook_input
-
-TRACEARY_CMD="$(traceary_resolve_bin 2>/dev/null || true)"
-if [[ -z "$TRACEARY_CMD" ]]; then
-  exit 0
-fi
-
-# For Bash tools, use tool_input.command; for MCP/other tools, use tool_name
-COMMAND_VALUE="$(traceary_json_get 'tool_input.command')"
-if [[ -z "$COMMAND_VALUE" ]]; then
-  COMMAND_VALUE="$(traceary_json_get 'tool_name')"
-fi
-if [[ -z "$COMMAND_VALUE" ]]; then
-  exit 0
-fi
-
-SESSION_ID="$(traceary_json_get 'session_id')"
-if [[ -z "$SESSION_ID" ]]; then
-  SESSION_ID="$(traceary_read_state "$CLIENT")"
-fi
-if [[ -z "$SESSION_ID" ]]; then
-  exit 0
-fi
-
-# Prefer repo from session state (set at session start) over CWD-based detection
-REPO_VALUE="$(traceary_read_repo_state "$CLIENT")"
-if [[ -z "$REPO_VALUE" ]]; then
-  HOOK_CWD="$(traceary_json_get 'cwd')"
-  REPO_VALUE="$(traceary_resolve_repo "$HOOK_CWD")"
-fi
-AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
-AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
-if [[ -z "$AUDIT_OUTPUT" ]]; then
-  AUDIT_OUTPUT="$(traceary_build_failure_output || true)"
-fi
-
-AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
-
-COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
-if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
-  COMMAND+=(--db-path "$TRACEARY_DB_PATH")
-fi
-if [[ -n "$REPO_VALUE" ]]; then
-  COMMAND+=(--repo "$REPO_VALUE")
-fi
-
-"${COMMAND[@]}" >/dev/null 2>&1 || exit 0
-
-exit 0
-`,
-	},
+	return assets
 }
 
 func ensureHookScriptsInstalled() (string, error) {
@@ -396,9 +35,9 @@ func ensureHookScriptsInstalled() (string, error) {
 	}
 
 	for _, asset := range hookScriptAssets {
-		outputPath := filepath.Join(scriptsDir, asset.name)
+		outputPath := filepath.Join(scriptsDir, asset.Name)
 		currentContent, err := os.ReadFile(outputPath)
-		if err == nil && string(currentContent) == asset.content {
+		if err == nil && string(currentContent) == asset.Content {
 			if chmodErr := os.Chmod(outputPath, 0o755); chmodErr != nil {
 				return "", xerrors.Errorf("%s: %w", Localize("failed to chmod hook script", "hook script の chmod に失敗しました"), chmodErr)
 			}
@@ -407,7 +46,7 @@ func ensureHookScriptsInstalled() (string, error) {
 		if err != nil && !os.IsNotExist(err) {
 			return "", xerrors.Errorf("%s: %w", Localize("failed to inspect installed hook script", "既存 hook script の確認に失敗しました"), err)
 		}
-		if err := os.WriteFile(outputPath, []byte(asset.content), 0o755); err != nil {
+		if err := os.WriteFile(outputPath, []byte(asset.Content), 0o755); err != nil {
 			return "", xerrors.Errorf("%s: %w", Localize("failed to write hook script", "hook script の書き出しに失敗しました"), err)
 		}
 	}

--- a/presentation/cli/hook_assets_test.go
+++ b/presentation/cli/hook_assets_test.go
@@ -6,18 +6,42 @@ import (
 	"testing"
 )
 
-func TestHookScriptAssetsStayInSyncWithCanonicalScripts(t *testing.T) {
+func TestEnsureHookScriptsInstalled_MaterializesCanonicalScripts(t *testing.T) {
 	t.Parallel()
+
+	homeDir := t.TempDir()
+	SetUserHomeDirFunc(func() (string, error) {
+		return homeDir, nil
+	})
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	scriptsDir, err := ensureHookScriptsInstalled()
+	if err != nil {
+		t.Fatalf("ensureHookScriptsInstalled() error = %v", err)
+	}
+
+	if got, want := scriptsDir, filepath.Join(homeDir, ".config", "traceary", "hook-scripts"); got != want {
+		t.Fatalf("scriptsDir = %q, want %q", got, want)
+	}
 
 	repoRoot := filepath.Join("..", "..")
 	for _, asset := range hookScriptAssets {
-		canonicalPath := filepath.Join(repoRoot, "scripts", "hooks", asset.name)
+		outputPath := filepath.Join(scriptsDir, asset.Name)
+		gotContent, err := os.ReadFile(outputPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", outputPath, err)
+		}
+		if got, want := string(gotContent), asset.Content; got != want {
+			t.Fatalf("installed asset %q mismatch", asset.Name)
+		}
+
+		canonicalPath := filepath.Join(repoRoot, "scripts", "hooks", asset.Name)
 		canonicalContent, err := os.ReadFile(canonicalPath)
 		if err != nil {
 			t.Fatalf("ReadFile(%q) error = %v", canonicalPath, err)
 		}
-		if got, want := asset.content, string(canonicalContent); got != want {
-			t.Fatalf("asset %q drifted from canonical script", asset.name)
+		if got, want := asset.Content, string(canonicalContent); got != want {
+			t.Fatalf("asset %q drifted from canonical script", asset.Name)
 		}
 	}
 }

--- a/presentation/cli/hook_assets_test.go
+++ b/presentation/cli/hook_assets_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestEnsureHookScriptsInstalled_MaterializesCanonicalScripts(t *testing.T) {
-	t.Parallel()
-
 	homeDir := t.TempDir()
 	SetUserHomeDirFunc(func() (string, error) {
 		return homeDir, nil

--- a/scripts/hooks/assets.go
+++ b/scripts/hooks/assets.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"embed"
 	"io/fs"
+	"strings"
 
 	"golang.org/x/xerrors"
 )
@@ -35,9 +36,14 @@ func Assets() ([]ScriptAsset, error) {
 		}
 		assets = append(assets, ScriptAsset{
 			Name:    entry.Name(),
-			Content: string(content),
+			Content: normalizeScriptContent(string(content)),
 		})
 	}
 
 	return assets, nil
+}
+
+func normalizeScriptContent(content string) string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	return strings.ReplaceAll(normalized, "\r", "\n")
 }

--- a/scripts/hooks/assets.go
+++ b/scripts/hooks/assets.go
@@ -1,0 +1,43 @@
+package hooks
+
+import (
+	"embed"
+	"io/fs"
+
+	"golang.org/x/xerrors"
+)
+
+// ScriptAsset describes one packaged hook script.
+type ScriptAsset struct {
+	Name    string
+	Content string
+}
+
+//go:embed *.sh
+var scriptAssetsFS embed.FS
+
+// Assets returns the canonical hook scripts bundled with Traceary.
+func Assets() ([]ScriptAsset, error) {
+	entries, err := fs.ReadDir(scriptAssetsFS, ".")
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read embedded hook scripts: %w", err)
+	}
+
+	assets := make([]ScriptAsset, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		content, err := scriptAssetsFS.ReadFile(entry.Name())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read embedded hook script %s: %w", entry.Name(), err)
+		}
+		assets = append(assets, ScriptAsset{
+			Name:    entry.Name(),
+			Content: string(content),
+		})
+	}
+
+	return assets, nil
+}

--- a/scripts/hooks/assets_test.go
+++ b/scripts/hooks/assets_test.go
@@ -1,0 +1,13 @@
+package hooks
+
+import "testing"
+
+func TestNormalizeScriptContent_CRLFIsConvertedToLF(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeScriptContent("#!/bin/bash\r\necho hi\r\n")
+	want := "#!/bin/bash\necho hi\n"
+	if got != want {
+		t.Fatalf("normalizeScriptContent() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Motivation

Issue #221 aims to remove the manual duplication between the canonical shell scripts under `scripts/hooks/` and the packaged hook assets used by `traceary hooks install/print`. Keeping two handwritten copies makes drift likely and weakens the script tests.

## Summary

- embed the canonical `scripts/hooks/*.sh` files in the `scripts/hooks` package
- derive packaged hook assets from those embedded canonical scripts instead of maintaining separate string literals in the CLI package
- update hook asset tests to verify the installer materializes the canonical scripts
- keep the existing installed script behavior unchanged while removing the duplicate maintenance path

Closes #221

## Test plan

- [x] `GOCACHE=$(pwd)/.cache/go-build go test ./presentation/cli ./scripts/hooks ./...`
- [x] `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...`