### PR TITLE
refactor: remove remaining CLI setup panics

### DIFF
--- a/presentation/cli/backup.go
+++ b/presentation/cli/backup.go
@@ -61,12 +61,16 @@ func (c *RootCLI) newBackupCreateCommand() *cobra.Command {
 		outputPath string
 		force      bool
 	)
+	var commandSetupErr error
 
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: Localize("Create a compact SQLite backup file", "コンパクトな SQLite バックアップファイルを作成する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if commandSetupErr != nil {
+				return commandSetupErr
+			}
 			return c.runBackupCreate(cmd.Context(), cmd.OutOrStdout(), backupCreateCommandInput{
 				dbPath:     dbPath,
 				outputPath: outputPath,
@@ -77,6 +81,7 @@ func (c *RootCLI) newBackupCreateCommand() *cobra.Command {
 	createCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	createCmd.Flags().StringVar(&outputPath, "output", "", Localize("backup output path", "バックアップ出力先パス"))
 	createCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the backup file if it already exists", "既存のバックアップファイルがあれば上書きする"))
+	commandSetupErr = configureRequiredFlag(createCmd, "output")
 
 	return createCmd
 }
@@ -88,12 +93,16 @@ func (c *RootCLI) newBackupRestoreCommand() *cobra.Command {
 		force     bool
 		assumeYes bool
 	)
+	var commandSetupErr error
 
 	restoreCmd := &cobra.Command{
 		Use:   "restore",
 		Short: Localize("Restore the SQLite store from a backup file", "バックアップファイルから SQLite ストアを復元する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if commandSetupErr != nil {
+				return commandSetupErr
+			}
 			return c.runBackupRestore(cmd.Context(), cmd.OutOrStdout(), backupRestoreCommandInput{
 				dbPath:    dbPath,
 				inputPath: inputPath,
@@ -106,6 +115,7 @@ func (c *RootCLI) newBackupRestoreCommand() *cobra.Command {
 	restoreCmd.Flags().StringVar(&inputPath, "input", "", Localize("backup input path", "バックアップ入力パス"))
 	restoreCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the destination DB if it already exists", "復元先 DB が既に存在する場合は上書きする"))
 	restoreCmd.Flags().BoolVar(&assumeYes, "yes", false, Localize("skip the interactive confirmation prompt when overwriting an existing destination DB", "既存 DB を上書きするときの対話確認を省略する"))
+	commandSetupErr = configureRequiredFlag(restoreCmd, "input")
 	restoreCmd.Long = Localize(
 		"Restore a Traceary SQLite backup into the destination DB path.\n\nIf the destination DB already exists, you must pass --force. On an interactive terminal, Traceary asks for confirmation before the destructive overwrite unless you also pass --yes.",
 		"Traceary の SQLite バックアップを復元先 DB path へ戻します。\n\n復元先 DB が既に存在する場合は --force が必要です。対話端末では、破壊的な上書きを行う前に Traceary が確認を求めます。--yes を付けると確認を省略します。",

--- a/presentation/cli/backup.go
+++ b/presentation/cli/backup.go
@@ -77,9 +77,6 @@ func (c *RootCLI) newBackupCreateCommand() *cobra.Command {
 	createCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	createCmd.Flags().StringVar(&outputPath, "output", "", Localize("backup output path", "バックアップ出力先パス"))
 	createCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the backup file if it already exists", "既存のバックアップファイルがあれば上書きする"))
-	if err := createCmd.MarkFlagRequired("output"); err != nil {
-		panic(err)
-	}
 
 	return createCmd
 }
@@ -109,9 +106,6 @@ func (c *RootCLI) newBackupRestoreCommand() *cobra.Command {
 	restoreCmd.Flags().StringVar(&inputPath, "input", "", Localize("backup input path", "バックアップ入力パス"))
 	restoreCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the destination DB if it already exists", "復元先 DB が既に存在する場合は上書きする"))
 	restoreCmd.Flags().BoolVar(&assumeYes, "yes", false, Localize("skip the interactive confirmation prompt when overwriting an existing destination DB", "既存 DB を上書きするときの対話確認を省略する"))
-	if err := restoreCmd.MarkFlagRequired("input"); err != nil {
-		panic(err)
-	}
 	restoreCmd.Long = Localize(
 		"Restore a Traceary SQLite backup into the destination DB path.\n\nIf the destination DB already exists, you must pass --force. On an interactive terminal, Traceary asks for confirmation before the destructive overwrite unless you also pass --yes.",
 		"Traceary の SQLite バックアップを復元先 DB path へ戻します。\n\n復元先 DB が既に存在する場合は --force が必要です。対話端末では、破壊的な上書きを行う前に Traceary が確認を求めます。--yes を付けると確認を省略します。",

--- a/presentation/cli/backup_test.go
+++ b/presentation/cli/backup_test.go
@@ -86,8 +86,12 @@ func TestRootCLI_BackupCreateCommand_MissingOutputReturnsError(t *testing.T) {
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{"backup", "create"})
 
-	if err := rootCmd.Execute(); err == nil {
+	err := rootCmd.Execute()
+	if err == nil {
 		t.Fatal("Execute() error = nil, want error")
+	}
+	if err.Error() != `required flag(s) "output" not set` {
+		t.Fatalf("Execute() error = %q, want required output flag error", err.Error())
 	}
 }
 
@@ -141,8 +145,12 @@ func TestRootCLI_BackupRestoreCommand_MissingInputReturnsError(t *testing.T) {
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{"backup", "restore"})
 
-	if err := rootCmd.Execute(); err == nil {
+	err := rootCmd.Execute()
+	if err == nil {
 		t.Fatal("Execute() error = nil, want error")
+	}
+	if err.Error() != `required flag(s) "input" not set` {
+		t.Fatalf("Execute() error = %q, want required input flag error", err.Error())
 	}
 }
 

--- a/presentation/cli/backup_test.go
+++ b/presentation/cli/backup_test.go
@@ -76,6 +76,21 @@ func TestRootCLI_BackupCreateCommand(t *testing.T) {
 	}
 }
 
+func TestRootCLI_BackupCreateCommand_MissingOutputReturnsError(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		CreateStoreBackupUsecase: &createStoreBackupUsecaseStub{},
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"backup", "create"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+}
+
 func TestRootCLI_BackupRestoreCommand(t *testing.T) {
 	t.Parallel()
 
@@ -113,6 +128,21 @@ func TestRootCLI_BackupRestoreCommand(t *testing.T) {
 	}
 	if stdout.String() != "Restored backup to: "+dbPath+"\n" {
 		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRootCLI_BackupRestoreCommand_MissingInputReturnsError(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		RestoreStoreBackupUsecase: &restoreStoreBackupUsecaseStub{},
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"backup", "restore"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want error")
 	}
 }
 

--- a/presentation/cli/cobra_required_flag.go
+++ b/presentation/cli/cobra_required_flag.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func configureRequiredFlag(cmd *cobra.Command, flagName string) error {
+	if err := cmd.MarkFlagRequired(flagName); err != nil {
+		return xerrors.Errorf(
+			"%s: %w",
+			localizef(
+				"failed to configure required flag %q",
+				"必須 flag %q の設定に失敗しました",
+				"--"+strings.TrimSpace(flagName),
+			),
+			err,
+		)
+	}
+
+	return nil
+}

--- a/presentation/cli/hooks_guide.go
+++ b/presentation/cli/hooks_guide.go
@@ -38,9 +38,6 @@ func (c *RootCLI) newHooksGuideCommand() *cobra.Command {
 	guideCmd.Flags().StringVar(&client, "client", "", hooksClientFlagUsage)
 	guideCmd.Flags().StringVar(&projectDir, "project-dir", "", Localize("project directory used for project-local client configs", "project-local client config に使う project directory"))
 	guideCmd.Flags().StringVar(&outputPath, "output", "", Localize("override the expected config file path", "想定 config file path を上書きする"))
-	if err := guideCmd.MarkFlagRequired("client"); err != nil {
-		panic(err)
-	}
 
 	return guideCmd
 }
@@ -50,6 +47,9 @@ func (c *RootCLI) runHooksGuide(
 	output io.Writer,
 	input hooksGuideCommandInput,
 ) error {
+	if err := requireHooksClient(input.client); err != nil {
+		return err
+	}
 	resolvedProjectDir, err := resolveHooksProjectDir(input.projectDir)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve project directory", "project directory の解決に失敗しました"), err)

--- a/presentation/cli/hooks_guide.go
+++ b/presentation/cli/hooks_guide.go
@@ -22,12 +22,16 @@ func (c *RootCLI) newHooksGuideCommand() *cobra.Command {
 		projectDir string
 		outputPath string
 	)
+	var commandSetupErr error
 
 	guideCmd := &cobra.Command{
 		Use:   "guide",
 		Short: Localize("Print guided setup steps for a supported client", "対応 client 向けの guided setup 手順を出力する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if commandSetupErr != nil {
+				return commandSetupErr
+			}
 			return c.runHooksGuide(cmd.Context(), cmd.OutOrStdout(), hooksGuideCommandInput{
 				client:     client,
 				projectDir: projectDir,
@@ -38,6 +42,7 @@ func (c *RootCLI) newHooksGuideCommand() *cobra.Command {
 	guideCmd.Flags().StringVar(&client, "client", "", hooksClientFlagUsage)
 	guideCmd.Flags().StringVar(&projectDir, "project-dir", "", Localize("project directory used for project-local client configs", "project-local client config に使う project directory"))
 	guideCmd.Flags().StringVar(&outputPath, "output", "", Localize("override the expected config file path", "想定 config file path を上書きする"))
+	commandSetupErr = configureRequiredFlag(guideCmd, "client")
 
 	return guideCmd
 }

--- a/presentation/cli/hooks_guide_test.go
+++ b/presentation/cli/hooks_guide_test.go
@@ -51,7 +51,11 @@ func TestRootCLI_HooksGuideCommand_MissingClientReturnsError(t *testing.T) {
 	rootCmd.SetErr(&bytes.Buffer{})
 	rootCmd.SetArgs([]string{"hooks", "guide"})
 
-	if err := rootCmd.Execute(); err == nil {
+	err := rootCmd.Execute()
+	if err == nil {
 		t.Fatal("Execute() error = nil, want error")
+	}
+	if err.Error() != `required flag(s) "client" not set` {
+		t.Fatalf("Execute() error = %q, want required client flag error", err.Error())
 	}
 }

--- a/presentation/cli/hooks_guide_test.go
+++ b/presentation/cli/hooks_guide_test.go
@@ -42,3 +42,16 @@ func TestRootCLI_HooksGuideCommand(t *testing.T) {
 		t.Fatalf("stdout = %q, want Gemini note", stdout.String())
 	}
 }
+
+func TestRootCLI_HooksGuideCommand_MissingClientReturnsError(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"hooks", "guide"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Motivation

Issue #222 tracks the last Cobra setup paths in the CLI that still used `panic(...)` when command-construction helpers failed. Those paths are unlikely, but they still violate the runtime-path rule for this repository.

## Summary

- remove the remaining `MarkFlagRequired(...)/panic(...)` command-construction paths from `backup` and `hooks guide`
- rely on normal runtime validation instead of panic-based setup failure handling
- add CLI tests covering the missing-flag error paths for the affected commands

Closes #222

## Test plan

- [x] `GOCACHE=$(pwd)/.cache/go-build go test ./presentation/cli ./...`
- [x] `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...`