### PR TITLE
Prepare v0.1.19 release

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,32 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [v0.1.19] - 2026-04-10
+
+この release では、CLI の可視性を高め、redaction を黙って弱める config 異常を見えるようにし、hook asset の重複管理を解消しました。
+
+### 追加
+- `traceary doctor` が `config.json` の状態を missing / loaded / unreadable / invalid で判別して表示
+- 壊れた config により追加 redaction パターンが無効化されるとき、CLI / MCP の config 読み込みで警告を表示
+- hook script の改行正規化と required flag セットアップ挙動の回帰テスト
+
+### 修正
+- `traceary session list` の text / JSON 出力で `label` / `summary` / `parent_session_id` を一貫して表示
+- `traceary session label` と `session list` の拡張メタデータを CLI docs / top-level docs に反映
+- セッションメタデータの表形式出力で tab / newline を正規化し、ターミナル表示崩れを防止
+- package 化された hook script の改行を install 前に LF へ正規化し、Windows checkout 時の `/bin/bash\r` shebang 退行を防止
+
+### 変更
+- packaged hook asset を重複した文字列リテラルではなく、canonical な `scripts/hooks/*.sh` から生成するよう変更
+- 残っていた Cobra required flag セットアップ時の panic を、required flag の挙動を維持したまま graceful error に置換
+- 統合マニフェストのバージョンを `0.1.19` に更新
+
+### 含まれるイシュー
+- #219 CLI 出力と docs でセッションメタデータを一貫表示
+- #220 config 読み込み失敗をオペレーターに可視化
+- #221 hook script を packaging / test 共通の単一ソースに統一
+- #222 残る CLI setup panic を graceful error に置換
+
 ## [v0.1.18] - 2026-04-10
 
 セッションメタデータの充実とデータ品質の向上を行いました。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+## [v0.1.19] - 2026-04-10
+
+This release improves CLI visibility, makes config failures visible before they silently weaken redaction behavior, and removes drift-prone hook asset duplication.
+
+### Added
+- `traceary doctor` now reports config health states for missing, loaded, unreadable, and invalid `config.json` files
+- CLI and MCP config loading now emit operator-visible warnings when a broken config disables extra redaction patterns
+- regression coverage for embedded hook script line-ending normalization and required-flag setup behavior
+
+### Fixed
+- `traceary session list` text and JSON output now surface `label`, `summary`, and `parent_session_id` consistently
+- CLI docs and top-level docs now document `traceary session label` and the richer `session list` metadata surface
+- tabular session metadata output now normalizes tabs/newlines to avoid terminal layout breakage
+- packaged hook scripts now normalize embedded line endings to LF before installation, avoiding `/bin/bash\r` shebang regressions on Windows checkouts
+
+### Changed
+- packaged hook assets are now derived from the canonical `scripts/hooks/*.sh` sources instead of duplicate handwritten string literals
+- the remaining Cobra required-flag setup panics were replaced with graceful command-construction errors while preserving required-flag semantics
+- updated integration manifests to version `0.1.19`
+
+### Included issues
+- #219 Surface session metadata consistently in CLI output and docs
+- #220 Make config load failures visible to operators
+- #221 Make hook scripts single-source for packaging and tests
+- #222 Replace remaining CLI setup panics with graceful errors
+
 ## [v0.1.18] - 2026-04-10
 
 This release introduces a dedicated sessions table, enriches session metadata with labels, summaries, and parent-child relationships, and improves data quality.

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 特定の release を使いたい場合は、tag を明示します。
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.18
+go install github.com/duck8823/traceary@v0.1.19
 ```
 
 ### Homebrew

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 If you prefer a specific release, pin the tag explicitly.
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.18
+go install github.com/duck8823/traceary@v0.1.19
 ```
 
 ### Homebrew

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "traceary",
   "description": "Local-first Traceary integration for Claude Code with MCP tools and automatic session/audit hooks.",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "author": {
     "name": "Shunsuke Maeda",
     "email": "duck8823@gmail.com"

--- a/integrations/gemini-extension/gemini-extension.json
+++ b/integrations/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Local-first Traceary integration for Gemini CLI with shared MCP tools and automatic session/audit hooks.",
   "mcpServers": {
     "traceary": {

--- a/plugins/traceary/.codex-plugin/plugin.json
+++ b/plugins/traceary/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Local-first Traceary integration for Codex with MCP tools and automatic session/audit hooks.",
   "author": {
     "name": "Shunsuke Maeda",

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     tomllib = None
 
 ROOT = Path(__file__).resolve().parent.parent
-INTEGRATION_VERSION = '0.1.18'
+INTEGRATION_VERSION = '0.1.19'
 HOOK_SOURCES = [
     ROOT / 'scripts' / 'hooks' / 'common.sh',
     ROOT / 'scripts' / 'hooks' / 'traceary-session.sh',


### PR DESCRIPTION
## Motivation

Issue #218 tracks the release-line follow-ups needed after the v0.1.18 feature work merged. The child implementation PRs are done, so the remaining work is to align release-facing metadata, changelogs, and packaged integration versions for v0.1.19 before tagging.

## Summary

- update CHANGELOGs for the v0.1.19 release line
- bump the Claude/Codex/Gemini integration manifest versions to `0.1.19`
- refresh the release guide's pinned `go install` example to `v0.1.19`
- keep `scripts/verify_integrations.py` aligned with the packaged integration version

Closes #218

## Test plan

- [x] `GOCACHE=$(pwd)/.cache/go-build GOMODCACHE=$(pwd)/.cache/go-mod go build ./...`
- [x] `GOCACHE=$(pwd)/.cache/go-build go test ./...`
- [x] `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...`
- [x] `python3 scripts/verify_integrations.py`