### PR TITLE
Migrate all test names from Japanese to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,5 +70,5 @@ go tool golangci-lint run
 
 - `go tool golangci-lint run` must pass before committing
 - `go test ./...` must pass before committing
-- Test names use Japanese descriptions (table-driven with subtests)
+- Test names use English descriptions (table-driven with subtests)
 - No `panic()` in runtime paths — reserved only for programming errors in init-time assertions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,5 +71,5 @@ go tool golangci-lint run
 
 - `go tool golangci-lint run` must pass before committing
 - `go test ./...` must pass before committing
-- Test names use Japanese descriptions (table-driven with subtests)
+- Test names use English descriptions (table-driven with subtests)
 - No `panic()` in runtime paths — reserved only for programming errors in init-time assertions

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -70,5 +70,5 @@ go tool golangci-lint run
 
 - `go tool golangci-lint run` must pass before committing
 - `go test ./...` must pass before committing
-- Test names use Japanese descriptions (table-driven with subtests)
+- Test names use English descriptions (table-driven with subtests)
 - No `panic()` in runtime paths — reserved only for programming errors in init-time assertions

--- a/application/queryservice/find_latest_session_test.go
+++ b/application/queryservice/find_latest_session_test.go
@@ -44,7 +44,7 @@ func TestFindLatestSessionQueryService_Run(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("直近セッションイベントを返す", func(t *testing.T) {
+	t.Run("returns latest session event", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &latestSessionFinderStub{

--- a/application/queryservice/get_context_test.go
+++ b/application/queryservice/get_context_test.go
@@ -43,7 +43,7 @@ func TestGetContextQueryService_Run(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("文脈イベントを返す", func(t *testing.T) {
+	t.Run("returns context events", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &contextEventFinderStub{

--- a/application/queryservice/get_event_details_test.go
+++ b/application/queryservice/get_event_details_test.go
@@ -43,7 +43,7 @@ func TestGetEventDetailsQueryService_Run(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("イベント詳細を返す", func(t *testing.T) {
+	t.Run("returns event details", func(t *testing.T) {
 		t.Parallel()
 
 		eventDetails, err := queryservice.NewEventDetails(

--- a/application/queryservice/list_recent_events_test.go
+++ b/application/queryservice/list_recent_events_test.go
@@ -43,7 +43,7 @@ func TestListRecentEventsQueryService_Run(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("イベント一覧を返す", func(t *testing.T) {
+	t.Run("returns event list", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &recentEventFinderStub{

--- a/application/queryservice/list_sessions_test.go
+++ b/application/queryservice/list_sessions_test.go
@@ -28,7 +28,7 @@ func (s *sessionSummaryFinderStub) ListSessionSummaries(
 func TestListSessionsQueryService_Run(t *testing.T) {
 	t.Parallel()
 
-	t.Run("セッションサマリーを返す", func(t *testing.T) {
+	t.Run("returns session summaries", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &sessionSummaryFinderStub{

--- a/application/queryservice/search_events_test.go
+++ b/application/queryservice/search_events_test.go
@@ -43,7 +43,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("検索結果を返す", func(t *testing.T) {
+	t.Run("returns search results", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventSearcherStub{
@@ -92,7 +92,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("検索語が空でも構造フィルタがあれば検索できる", func(t *testing.T) {
+	t.Run("searches with structural filters when query is empty", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventSearcherStub{}
@@ -110,7 +110,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("検索条件が空ならエラー", func(t *testing.T) {
+	t.Run("returns error when all search conditions are empty", func(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
@@ -124,7 +124,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("未知の kind ならエラー", func(t *testing.T) {
+	t.Run("returns error for unknown kind", func(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})

--- a/application/usecase/collect_garbage_test.go
+++ b/application/usecase/collect_garbage_test.go
@@ -61,7 +61,7 @@ func TestCollectGarbageUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("基準時刻がない場合はエラー", func(t *testing.T) {
+	t.Run("returns error when cutoff time is missing", func(t *testing.T) {
 		t.Parallel()
 
 		sut := usecase.NewCollectGarbageUsecase(&garbageCollectorStub{})

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -31,7 +31,7 @@ func (s *commandAuditSaverStub) SaveCommandAudit(
 func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 	t.Parallel()
 
-	t.Run("監査イベントを保存できる", func(t *testing.T) {
+	t.Run("saves audit event successfully", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -70,7 +70,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("長い input/output は切り詰めて保存する", func(t *testing.T) {
+	t.Run("truncates long input/output before saving", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -104,7 +104,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("明示した上限で input/output を切り詰める", func(t *testing.T) {
+	t.Run("truncates input/output at explicit limit", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -135,7 +135,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("一般的な secret は既定で伏せ字にする", func(t *testing.T) {
+	t.Run("redacts common secrets by default", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -207,7 +207,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("追加リダクションパターンでカスタムフィールドを伏せ字にする", func(t *testing.T) {
+	t.Run("redacts custom fields with extra patterns", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -237,7 +237,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("不正な追加リダクションパターンはエラーを返す", func(t *testing.T) {
+	t.Run("returns error for invalid extra redaction pattern", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}
@@ -258,7 +258,7 @@ func TestRecordCommandAuditUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("負の上限はエラー", func(t *testing.T) {
+	t.Run("returns error for negative limit", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &commandAuditSaverStub{}

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -23,7 +23,7 @@ func (s *eventRepositoryStub) Save(_ context.Context, dbPath string, event *mode
 func TestRecordLogUsecase_Run(t *testing.T) {
 	t.Parallel()
 
-	t.Run("イベントを保存できる", func(t *testing.T) {
+	t.Run("saves event successfully", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventRepositoryStub{}
@@ -72,7 +72,7 @@ func TestRecordLogUsecase_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("必須項目が不正な場合はエラー", func(t *testing.T) {
+	t.Run("returns error for invalid required fields", func(t *testing.T) {
 		t.Parallel()
 
 		stub := &eventRepositoryStub{}

--- a/domain/model/command_audit_test.go
+++ b/domain/model/command_audit_test.go
@@ -15,7 +15,7 @@ func TestNewCommandAudit(t *testing.T) {
 		t.Fatalf("EventIDOf() error = %v", err)
 	}
 
-	t.Run("コマンド監査情報を生成できる", func(t *testing.T) {
+	t.Run("creates command audit successfully", func(t *testing.T) {
 		t.Parallel()
 
 		got, err := model.NewCommandAudit(
@@ -47,7 +47,7 @@ func TestNewCommandAudit(t *testing.T) {
 		}
 	})
 
-	t.Run("空コマンドはエラー", func(t *testing.T) {
+	t.Run("returns error for empty command", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := model.NewCommandAudit(eventID, "   ", "", "", false, false)

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -106,7 +106,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		t.Fatalf("Save(finished end) error = %v", err)
 	}
 
-	t.Run("直近の session_started を返す", func(t *testing.T) {
+	t.Run("returns latest session_started", func(t *testing.T) {
 		got, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
@@ -124,7 +124,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
-	t.Run("終了境界が最後の session も latest として選ばれる", func(t *testing.T) {
+	t.Run("session with end boundary as last event is selected as latest", func(t *testing.T) {
 		laterStartEvent := newFindLatestSessionEventFixture(
 			t,
 			"event-6",
@@ -187,7 +187,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
-	t.Run("同じ session_id に複数の start があれば最新 start を返す", func(t *testing.T) {
+	t.Run("returns newest start when multiple starts exist for same session_id", func(t *testing.T) {
 		repeatedStartEvent := newFindLatestSessionEventFixture(
 			t,
 			"event-8",
@@ -218,7 +218,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
-	t.Run("一致する session がなければエラー", func(t *testing.T) {
+	t.Run("returns error when no matching session exists", func(t *testing.T) {
 		_, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
@@ -232,7 +232,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
-	t.Run("一致する active session がなければエラー", func(t *testing.T) {
+	t.Run("returns error when no matching active session exists", func(t *testing.T) {
 		_, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,

--- a/infrastructure/sqlite/find_session_started_event_test.go
+++ b/infrastructure/sqlite/find_session_started_event_test.go
@@ -92,7 +92,7 @@ CREATE INDEX idx_events_created_at
 		}
 	}
 
-	t.Run("対象 session の直近 session_started を返す", func(t *testing.T) {
+	t.Run("returns latest session_started for target session", func(t *testing.T) {
 		t.Parallel()
 
 		sessionID, err := types.SessionIDOf("session-1")
@@ -118,7 +118,7 @@ CREATE INDEX idx_events_created_at
 		}
 	})
 
-	t.Run("見つからない場合は not found を返す", func(t *testing.T) {
+	t.Run("returns not found when no match exists", func(t *testing.T) {
 		t.Parallel()
 
 		sessionID, err := types.SessionIDOf("session-missing")

--- a/infrastructure/sqlite/get_event_details_test.go
+++ b/infrastructure/sqlite/get_event_details_test.go
@@ -76,7 +76,7 @@ CREATE TABLE command_audits (
 		}
 	})
 
-	t.Run("存在しない event ID ならエラー", func(t *testing.T) {
+	t.Run("returns error for nonexistent event ID", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := sut.GetEventDetails(context.Background(), dbPath, "missing")

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -84,7 +84,7 @@ func saveTestSession(ctx context.Context, t *testing.T, ds *infra.Datasource, db
 func TestDatasource_ListSessionSummaries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("セッションサマリーを取得できる", func(t *testing.T) {
+	t.Run("retrieves session summaries", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -90,7 +90,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("EventID() = %q, want %q", got[0].EventID(), "event-audit")
 	}
 
-	t.Run("構造フィルタだけで検索できる", func(t *testing.T) {
+	t.Run("searches with structural filters only", func(t *testing.T) {
 		t.Parallel()
 
 		filtered, err := sut.SearchEvents(context.Background(), dbPath, queryservice.SearchEventsInput{

--- a/main_test.go
+++ b/main_test.go
@@ -55,7 +55,7 @@ type testError string
 func (e testError) Error() string { return string(e) }
 
 func TestSetupLogger(t *testing.T) {
-	t.Run("有効な LOG_LEVEL はエラーなく設定される", func(t *testing.T) {
+	t.Run("valid LOG_LEVEL is set without error", func(t *testing.T) {
 		for _, level := range []string{"debug", "info", "warn", "warning", "error", "DEBUG", "Info"} {
 			t.Setenv("LOG_LEVEL", level)
 			if err := setupLogger(); err != nil {
@@ -64,7 +64,7 @@ func TestSetupLogger(t *testing.T) {
 		}
 	})
 
-	t.Run("不正な LOG_LEVEL はエラーを返す", func(t *testing.T) {
+	t.Run("invalid LOG_LEVEL returns error", func(t *testing.T) {
 		t.Setenv("LOG_LEVEL", "invalid")
 		if err := setupLogger(); err == nil {
 			t.Fatal("setupLogger() with LOG_LEVEL=invalid returned nil, want error")
@@ -91,7 +91,7 @@ func TestSetupLogger(t *testing.T) {
 func TestResolveBuildMetadata(t *testing.T) {
 	t.Parallel()
 
-	t.Run("明示値がある場合は build info より優先する", func(t *testing.T) {
+	t.Run("explicit values take precedence over build info", func(t *testing.T) {
 		t.Parallel()
 
 		got := resolveBuildMetadata("v1.2.3", "commit-explicit", "2026-04-08T00:00:00Z", func() (*debug.BuildInfo, bool) {

--- a/presentation/cli/context_command_test.go
+++ b/presentation/cli/context_command_test.go
@@ -75,7 +75,7 @@ func TestRootCLI_ContextCommand(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("直近 session を解決して文脈を表示できる", func(t *testing.T) {
+	t.Run("resolves latest session and displays context", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -199,7 +199,7 @@ func TestRootCLI_ContextCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("直近 session がなくても repo 文脈へフォールバックできる", func(t *testing.T) {
+	t.Run("falls back to repo context when no latest session exists", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")

--- a/presentation/cli/gc_test.go
+++ b/presentation/cli/gc_test.go
@@ -65,7 +65,7 @@ func TestRootCLI_GCCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("削除件数を表示できる", func(t *testing.T) {
+	t.Run("displays deletion count", func(t *testing.T) {
 		stub := &collectGarbageUsecaseStub{
 			result: &usecase.CollectGarbageResult{DeletedCount: 2, DryRun: false},
 		}

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -37,7 +37,7 @@ var _ queryservice.ListRecentEventsQueryService = (*listEventsQueryServiceStub)(
 func TestRootCLI_ListCommand(t *testing.T) {
 	t.Parallel()
 
-	t.Run("イベント一覧を表示できる", func(t *testing.T) {
+	t.Run("displays event list", func(t *testing.T) {
 		t.Parallel()
 
 		eventID, err := types.EventIDOf("event-1")
@@ -182,7 +182,7 @@ func TestRootCLI_ListCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("イベントがない場合はメッセージを表示する", func(t *testing.T) {
+	t.Run("displays message when no events exist", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -43,7 +43,7 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("フラグ値でログを記録できる", func(t *testing.T) {
+	t.Run("records log with flag values", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := t.TempDir() + "/traceary.db"
@@ -101,7 +101,7 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("環境変数デフォルトを利用できる", func(t *testing.T) {
+	t.Run("uses environment variable defaults", func(t *testing.T) {
 		t.Setenv("TRACEARY_AGENT", "claude")
 		t.Setenv("TRACEARY_SESSION_ID", "session-env")
 		t.Setenv("TRACEARY_CLIENT", "hook")

--- a/presentation/cli/mcp_server_test.go
+++ b/presentation/cli/mcp_server_test.go
@@ -43,7 +43,7 @@ func TestRootCLI_MCPServer(t *testing.T) {
 		}
 	})
 
-	t.Run("ランナー未設定ならエラー", func(t *testing.T) {
+	t.Run("returns error when runner is not configured", func(t *testing.T) {
 		t.Parallel()
 
 		sut := cli.NewRootCLI(cli.RootCLIOptions{})

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -36,7 +36,7 @@ var _ queryservice.ListSessionsQueryService = (*listSessionsQueryServiceStub)(ni
 func TestRootCLI_SessionListCommand(t *testing.T) {
 	t.Parallel()
 
-	t.Run("セッション一覧を表示できる", func(t *testing.T) {
+	t.Run("displays session list", func(t *testing.T) {
 		t.Parallel()
 
 		endedAt := time.Date(2026, 4, 9, 13, 30, 0, 0, time.UTC)
@@ -101,7 +101,7 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("セッションがない場合はメッセージを表示する", func(t *testing.T) {
+	t.Run("displays message when no sessions exist", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -50,7 +50,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		t.Fatalf("SessionIDOf() error = %v", err)
 	}
 
-	t.Run("イベント詳細を表示できる", func(t *testing.T) {
+	t.Run("displays event details", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")


### PR DESCRIPTION
## Summary

- Rename 45 Japanese test descriptions to English across 23 test files
- Update CLAUDE.md, AGENTS.md, GEMINI.md: "Japanese descriptions" → "English descriptions"
- No behavior changes, only test names

Closes #253
Part of #235

## Test plan

- [x] `go test ./...` passes
- [x] No Japanese test names remain (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)