### PR TITLE
Improve mcpserver test coverage and fix remaining Japanese test names

### DIFF
--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -170,7 +170,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
-	t.Run("agent フィルタが機能する", func(t *testing.T) {
+	t.Run("agent filter works", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -215,7 +215,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
-	t.Run("from フィルタで対象外セッションが除外される", func(t *testing.T) {
+	t.Run("from filter excludes out-of-range sessions", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -260,7 +260,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
-	t.Run("to フィルタで対象外セッションが除外される", func(t *testing.T) {
+	t.Run("to filter excludes out-of-range sessions", func(t *testing.T) {
 		t.Parallel()
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")

--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,7 @@ import (
 func TestWriteCLIError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("plain text で user-facing error を出力する", func(t *testing.T) {
+	t.Run("prints user-facing error as plain text", func(t *testing.T) {
 		t.Parallel()
 
 		buffer := &bytes.Buffer{}
@@ -23,7 +23,7 @@ func TestWriteCLIError(t *testing.T) {
 		}
 	})
 
-	t.Run("nil error なら何も出力しない", func(t *testing.T) {
+	t.Run("prints nothing for nil error", func(t *testing.T) {
 		t.Parallel()
 
 		buffer := &bytes.Buffer{}
@@ -71,7 +71,7 @@ func TestSetupLogger(t *testing.T) {
 		}
 	})
 
-	t.Run("LOG_LEVEL 未設定はエラーなし", func(t *testing.T) {
+	t.Run("no error when LOG_LEVEL is unset", func(t *testing.T) {
 		if err := os.Unsetenv("LOG_LEVEL"); err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +80,7 @@ func TestSetupLogger(t *testing.T) {
 		}
 	})
 
-	t.Run("LOG_OPTION=development はエラーなし", func(t *testing.T) {
+	t.Run("no error when LOG_OPTION=development", func(t *testing.T) {
 		t.Setenv("LOG_OPTION", "development")
 		if err := setupLogger(); err != nil {
 			t.Fatalf("setupLogger() with LOG_OPTION=development returned error: %v", err)
@@ -109,7 +109,7 @@ func TestResolveBuildMetadata(t *testing.T) {
 		}
 	})
 
-	t.Run("dev build は build info を使って埋める", func(t *testing.T) {
+	t.Run("dev build fills from build info", func(t *testing.T) {
 		t.Parallel()
 
 		got := resolveBuildMetadata("dev", "none", "unknown", func() (*debug.BuildInfo, bool) {

--- a/presentation/mcpserver/export_test.go
+++ b/presentation/mcpserver/export_test.go
@@ -1,0 +1,14 @@
+package mcpserver
+
+import "time"
+
+// ParseFlexibleTime exposes parseFlexibleTime for testing.
+var ParseFlexibleTime = func(value string, endExclusive bool) (time.Time, error) {
+	return parseFlexibleTime(value, endExclusive)
+}
+
+// ResolveLimit exposes resolveLimit for testing.
+var ResolveLimit = resolveLimit
+
+// ResolveOffset exposes resolveOffset for testing.
+var ResolveOffset = resolveOffset

--- a/presentation/mcpserver/helpers_test.go
+++ b/presentation/mcpserver/helpers_test.go
@@ -1,0 +1,94 @@
+package mcpserver_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/presentation/mcpserver"
+)
+
+func TestParseFlexibleTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		value        string
+		endExclusive bool
+		want         time.Time
+		wantErr      bool
+	}{
+		{
+			name:  "empty string returns zero time",
+			value: "",
+			want:  time.Time{},
+		},
+		{
+			name:  "RFC3339 format parsed correctly",
+			value: "2026-04-10T12:00:00Z",
+			want:  time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "YYYY-MM-DD format parsed as start of day",
+			value: "2026-04-10",
+			want:  time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "YYYY-MM-DD with endExclusive returns next day",
+			value:        "2026-04-10",
+			endExclusive: true,
+			want:         time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "invalid format returns error",
+			value:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:  "whitespace is trimmed",
+			value: "  2026-04-10  ",
+			want:  time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := mcpserver.ParseFlexibleTime(tt.value, tt.endExclusive)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseFlexibleTime(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if !tt.wantErr && !got.Equal(tt.want) {
+				t.Errorf("parseFlexibleTime(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveLimit(t *testing.T) {
+	t.Parallel()
+
+	if got := mcpserver.ResolveLimit(5, 10); got != 5 {
+		t.Errorf("ResolveLimit(5, 10) = %d, want 5", got)
+	}
+	if got := mcpserver.ResolveLimit(0, 10); got != 10 {
+		t.Errorf("ResolveLimit(0, 10) = %d, want 10", got)
+	}
+	if got := mcpserver.ResolveLimit(-1, 10); got != 10 {
+		t.Errorf("ResolveLimit(-1, 10) = %d, want 10", got)
+	}
+}
+
+func TestResolveOffset(t *testing.T) {
+	t.Parallel()
+
+	if got := mcpserver.ResolveOffset(5); got != 5 {
+		t.Errorf("ResolveOffset(5) = %d, want 5", got)
+	}
+	if got := mcpserver.ResolveOffset(0); got != 0 {
+		t.Errorf("ResolveOffset(0) = %d, want 0", got)
+	}
+	if got := mcpserver.ResolveOffset(-1); got != 0 {
+		t.Errorf("ResolveOffset(-1) = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add parseFlexibleTime, resolveLimit, resolveOffset tests via export_test.go pattern
- Fix remaining Japanese test names in main_test.go and list_sessions_test.go
- mcpserver: 66.7% → 73.8%, overall: 72.7% → 74.3%
- 80%+ target for mcpserver requires handler error path tests (follow-up)

Closes #245
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)