### PR TITLE
Normalize hook payload: add exit_code tracking to command audits

### DIFF
--- a/application/queryservice/get_event_details_test.go
+++ b/application/queryservice/get_event_details_test.go
@@ -64,6 +64,7 @@ func TestGetEventDetailsQueryService_Run(t *testing.T) {
 				"stdout",
 				false,
 				false,
+				nil,
 			),
 		)
 		if err != nil {

--- a/application/usecase/record_command_audit.go
+++ b/application/usecase/record_command_audit.go
@@ -41,6 +41,7 @@ type RecordCommandAuditInput struct {
 	MaxInputBytes       int
 	MaxOutputBytes      int
 	ExtraRedactPatterns []string
+	ExitCode            *int
 }
 
 // RecordCommandAuditUsecase persists command-audit events.
@@ -122,6 +123,7 @@ func (u *recordCommandAuditUsecase) Run(
 		return nil, nil, xerrors.Errorf("failed to build command audit: %w", err)
 	}
 	commandAudit.SetRedaction(inputRedacted, outputRedacted)
+	commandAudit.SetExitCode(input.ExitCode)
 
 	event, err := model.NewEvent(
 		eventID,

--- a/domain/model/command_audit.go
+++ b/domain/model/command_audit.go
@@ -18,6 +18,7 @@ type CommandAudit struct {
 	outputTruncated bool
 	inputRedacted   bool
 	outputRedacted  bool
+	exitCode        *int
 }
 
 // NewCommandAudit creates a new CommandAudit.
@@ -52,6 +53,7 @@ func CommandAuditOf(
 	output string,
 	inputTruncated bool,
 	outputTruncated bool,
+	exitCode *int,
 ) *CommandAudit {
 	return &CommandAudit{
 		eventID:         eventID,
@@ -60,6 +62,7 @@ func CommandAuditOf(
 		output:          output,
 		inputTruncated:  inputTruncated,
 		outputTruncated: outputTruncated,
+		exitCode:        exitCode,
 	}
 }
 
@@ -96,3 +99,14 @@ func (a *CommandAudit) InputRedacted() bool { return a.inputRedacted }
 
 // OutputRedacted reports whether output redaction was applied.
 func (a *CommandAudit) OutputRedacted() bool { return a.outputRedacted }
+
+// ExitCode returns the exit code, or nil if not captured.
+func (a *CommandAudit) ExitCode() *int { return a.exitCode }
+
+// SetExitCode sets the exit code for the command.
+func (a *CommandAudit) SetExitCode(code *int) {
+	if a == nil {
+		return
+	}
+	a.exitCode = code
+}

--- a/domain/model/command_audit_test.go
+++ b/domain/model/command_audit_test.go
@@ -62,7 +62,7 @@ func TestCommandAuditOf(t *testing.T) {
 
 	eventID, _ := types.EventIDOf("event-2")
 
-	audit := model.CommandAuditOf(eventID, "go build", "input-data", "output-data", false, true)
+	audit := model.CommandAuditOf(eventID, "go build", "input-data", "output-data", false, true, nil)
 
 	if audit.EventID() != eventID {
 		t.Errorf("EventID() = %v, want %v", audit.EventID(), eventID)

--- a/infrastructure/sqlite/command_audit_store.go
+++ b/infrastructure/sqlite/command_audit_store.go
@@ -64,14 +64,15 @@ func (d *Datasource) SaveCommandAudit(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		commandAudit.EventID().String(),
 		commandAudit.Command(),
 		commandAudit.Input(),
 		commandAudit.Output(),
 		commandAudit.InputTruncated(),
 		commandAudit.OutputTruncated(),
+		commandAudit.ExitCode(),
 	); err != nil {
 		return xerrors.Errorf("failed to insert command audit: %w", err)
 	}

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -43,7 +43,8 @@ CREATE TABLE command_audits (
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 	}

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -92,7 +92,8 @@ CREATE TABLE command_audits (
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 	}

--- a/infrastructure/sqlite/get_event_details.go
+++ b/infrastructure/sqlite/get_event_details.go
@@ -34,7 +34,7 @@ func (d *Datasource) GetEventDetails(
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at,
-		        ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated
+		        ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code
 		   FROM events AS e
 		   LEFT JOIN command_audits AS ca
 		     ON ca.event_id = e.id
@@ -48,6 +48,7 @@ func (d *Datasource) GetEventDetails(
 		outputTextValue      sql.NullString
 		inputTruncatedValue  sql.NullBool
 		outputTruncatedValue sql.NullBool
+		exitCodeValue        sql.NullInt64
 	)
 
 	event, err := d.scanEventWithAudit(
@@ -57,6 +58,7 @@ func (d *Datasource) GetEventDetails(
 		&outputTextValue,
 		&inputTruncatedValue,
 		&outputTruncatedValue,
+		&exitCodeValue,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -71,6 +73,11 @@ func (d *Datasource) GetEventDetails(
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore event ID: %w", err)
 		}
+		var exitCode *int
+		if exitCodeValue.Valid {
+			v := int(exitCodeValue.Int64)
+			exitCode = &v
+		}
 		commandAudit = model.CommandAuditOf(
 			eventIDValue,
 			commandTextValue.String,
@@ -78,6 +85,7 @@ func (d *Datasource) GetEventDetails(
 			outputTextValue.String,
 			inputTruncatedValue.Bool,
 			outputTruncatedValue.Bool,
+			exitCode,
 		)
 	}
 
@@ -98,6 +106,7 @@ func (d *Datasource) scanEventWithAudit(
 	outputTextValue *sql.NullString,
 	inputTruncatedValue *sql.NullBool,
 	outputTruncatedValue *sql.NullBool,
+	exitCodeValue *sql.NullInt64,
 ) (*model.Event, error) {
 	var (
 		eventIDValue   string
@@ -124,6 +133,7 @@ func (d *Datasource) scanEventWithAudit(
 		outputTextValue,
 		inputTruncatedValue,
 		outputTruncatedValue,
+		exitCodeValue,
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event details row: %w", err)
 	}

--- a/infrastructure/sqlite/get_event_details_test.go
+++ b/infrastructure/sqlite/get_event_details_test.go
@@ -38,7 +38,8 @@ CREATE TABLE command_audits (
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 	}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -36,7 +36,8 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 		"000004_create_sessions.sql": {

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -41,7 +41,8 @@ CREATE TABLE command_audits (
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 	}

--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -51,7 +51,13 @@ fi
 
 AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
 
+# Extract exit code from tool_response if available
+EXIT_CODE="$(traceary_json_get 'tool_response.exitCode')"
+
 COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
+if [[ -n "$EXIT_CODE" ]]; then
+  COMMAND+=(--exit-code "$EXIT_CODE")
+fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -51,7 +51,13 @@ fi
 
 AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
 
+# Extract exit code from tool_response if available
+EXIT_CODE="$(traceary_json_get 'tool_response.exitCode')"
+
 COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
+if [[ -n "$EXIT_CODE" ]]; then
+  COMMAND+=(--exit-code "$EXIT_CODE")
+fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -51,7 +51,13 @@ fi
 
 AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
 
+# Extract exit code from tool_response if available
+EXIT_CODE="$(traceary_json_get 'tool_response.exitCode')"
+
 COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
+if [[ -n "$EXIT_CODE" ]]; then
+  COMMAND+=(--exit-code "$EXIT_CODE")
+fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -29,6 +29,8 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 		inputFlagSet   bool
 		auditOutput    string
 		outputFlagSet  bool
+		exitCode       int
+		exitCodeSet    bool
 		idOnly         bool
 		asJSON         bool
 		allowSecrets   bool
@@ -63,6 +65,11 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 				return err
 			}
 
+			var exitCodePtr *int
+			if exitCodeSet {
+				exitCodePtr = &exitCode
+			}
+
 			return c.runAudit(cmd.Context(), cmd.OutOrStdout(), auditCommandInput{
 				dbPath:         dbPath,
 				command:        commandValue,
@@ -72,6 +79,7 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 				agent:          agent,
 				sessionID:      sessionID,
 				repo:           repo,
+				exitCode:       exitCodePtr,
 				idOnly:         idOnly,
 				asJSON:         asJSON,
 				allowSecrets:   allowSecrets,
@@ -116,10 +124,12 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 		0,
 		Localize("maximum stored output bytes (env: TRACEARY_MAX_AUDIT_OUTPUT_BYTES, 0 uses default)", "出力保存サイズ上限 (env: TRACEARY_MAX_AUDIT_OUTPUT_BYTES, 0 なら既定値)"),
 	)
+	auditCmd.Flags().IntVar(&exitCode, "exit-code", 0, Localize("command exit code", "コマンド終了コード"))
 	auditCmd.PreRun = func(cmd *cobra.Command, _ []string) {
 		commandFlagSet = cmd.Flags().Changed("command")
 		inputFlagSet = cmd.Flags().Changed("input")
 		outputFlagSet = cmd.Flags().Changed("output")
+		exitCodeSet = cmd.Flags().Changed("exit-code")
 	}
 	auditCmd.MarkFlagsMutuallyExclusive("id-only", "json")
 
@@ -145,6 +155,7 @@ type auditCommandInput struct {
 	agent          string
 	sessionID      string
 	repo           string
+	exitCode       *int
 	idOnly         bool
 	asJSON         bool
 	allowSecrets   bool
@@ -207,6 +218,7 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		MaxInputBytes:       maxInputBytes,
 		MaxOutputBytes:      maxOutputBytes,
 		ExtraRedactPatterns: config.Redact.ExtraPatterns,
+		ExitCode:            input.exitCode,
 	})
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record command audit", "監査ログ記録に失敗しました"), err)

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -73,6 +73,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 				"stdout",
 				true,
 				false,
+				nil,
 			),
 		)
 		if err != nil {
@@ -188,6 +189,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 				"stdout",
 				true,
 				false,
+				nil,
 			),
 		)
 		if err != nil {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -271,7 +271,8 @@ CREATE TABLE command_audits (
     input_text TEXT NOT NULL,
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
-    output_truncated INTEGER NOT NULL DEFAULT 0
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
 );`),
 		},
 	}

--- a/schema/sqlite/migrations/000005_add_exit_code.sql
+++ b/schema/sqlite/migrations/000005_add_exit_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE command_audits ADD COLUMN exit_code INTEGER;

--- a/scripts/hooks/scripts_test.go
+++ b/scripts/hooks/scripts_test.go
@@ -237,6 +237,7 @@ func TestTracearyAuditScript_UsesHookPayloadAndSessionState(t *testing.T) {
 		"--client", "hook",
 		"--agent", "codex",
 		"--session-id", "generated-session",
+		"--exit-code", "0",
 		"--repo", "work-context",
 	}
 	if !reflect.DeepEqual(calls[1], wantAudit) {
@@ -516,6 +517,7 @@ func TestTracearyAuditScript_UsesAgentTypeFromPayload(t *testing.T) {
 		"--client", "hook",
 		"--agent", "claude/Explore",
 		"--session-id", "generated-session",
+		"--exit-code", "0",
 		"--repo", "work-context",
 	}
 	if !reflect.DeepEqual(calls[1], wantAudit) {

--- a/scripts/hooks/traceary-audit.sh
+++ b/scripts/hooks/traceary-audit.sh
@@ -51,7 +51,13 @@ fi
 
 AGENT_VALUE="$(traceary_resolve_agent "$CLIENT")"
 
+# Extract exit code from tool_response if available
+EXIT_CODE="$(traceary_json_get 'tool_response.exitCode')"
+
 COMMAND=("$TRACEARY_CMD" audit "$COMMAND_VALUE" "$AUDIT_INPUT" "$AUDIT_OUTPUT" --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
+if [[ -n "$EXIT_CODE" ]]; then
+  COMMAND+=(--exit-code "$EXIT_CODE")
+fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi


### PR DESCRIPTION
## Summary

- Migration 000005: add `exit_code` column to `command_audits`
- Domain: `ExitCode()` / `SetExitCode()` on CommandAudit
- Hook script: parse `tool_response.exitCode` and pass `--exit-code` flag
- CLI: `traceary audit --exit-code` flag
- Foundation for failure-first view (#239)

Closes #246
Part of #235

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] `python3 scripts/verify_integrations.py` passes
- [x] Hook tests updated for --exit-code in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)