### PR TITLE
Expand Gemini AfterTool to capture all tool types

### DIFF
--- a/integrations/gemini-extension/hooks/hooks.json
+++ b/integrations/gemini-extension/hooks/hooks.json
@@ -30,14 +30,14 @@
     ],
     "AfterTool": [
       {
-        "matcher": "run_shell_command",
+        "matcher": "*",
         "hooks": [
           {
             "name": "traceary-audit",
             "type": "command",
             "command": "bash \"${extensionPath}/scripts/traceary-audit.sh\" gemini",
             "timeout": 5000,
-            "description": "Record shell command audits in Traceary"
+            "description": "Record tool execution audits in Traceary"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Change AfterTool matcher from `run_shell_command` to `*`
- All tool types (MCP, file ops, etc.) now recorded

Closes #240
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)