### PR TITLE
Mark stale sessions in session list for Codex reliability

### DIFF
--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -145,6 +145,8 @@ func scanSessionSummary(row interface {
 		}
 		endedAt = &t
 		status = "ended"
+	} else if time.Since(startedAt) > 24*time.Hour {
+		status = "stale"
 	}
 
 	var agents []string


### PR DESCRIPTION
## Summary

- Sessions active >24h without end event are marked as "stale"
- Helps identify Codex sessions where Stop event did not fire

Closes #241
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)