### PR TITLE
Add hook contract defining capability tiers across clients

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -1,0 +1,55 @@
+# Hook 契約
+
+[English](./contract.md)
+
+AI エージェントクライアント間の hook 能力を定義するドキュメントです。
+
+## 能力ティア
+
+### Tier 1: フル対応 (Claude Code)
+
+| Hook イベント | Matcher | 動作 |
+|---|---|---|
+| SessionStart | `*` | セッション開始を記録 |
+| SessionEnd | `*` | セッション終了を記録 |
+| PostToolUse | `Bash` | シェルコマンド監査を exit code 付きで記録 |
+| PostToolUse | `mcp__.*` | MCP ツール監査を記録 |
+| PostToolUseFailure | `Bash`, `mcp__.*` | 失敗したツール実行を記録 |
+| PostCompact (予定) | `*` | compact イベントを記録 |
+| SessionStart (compact) (予定) | `compact` | stdout 経由でコンテキストポインタを注入 |
+
+### Tier 2: 部分対応 (Codex)
+
+| Hook イベント | Matcher | 動作 |
+|---|---|---|
+| SessionStart | (全て) | セッション開始を記録 |
+| Stop | (全て) | セッション終了を記録 |
+| PostToolUse | (全て) | ツール監査を記録 |
+
+**制限**: SessionEnd なし（Stop を使用）、compact hooks なし、failure 専用イベントなし。
+
+### Tier 3: 基本対応 (Gemini CLI)
+
+| Hook イベント | Matcher | 動作 |
+|---|---|---|
+| SessionStart | `*` | セッション開始を記録 |
+| SessionEnd | `*` | セッション終了を記録 |
+| AfterTool | `*` | ツール監査を記録 |
+
+**制限**: compact hooks なし、failure 専用イベントなし。
+
+## 共通動作
+
+全ティア共通:
+- セッション開始時に repo を state ファイルに永続化し、audit は state から読み取る
+- エージェントタイプ解決: `agent_type` フィールド → 階層的エージェント名（Claude のみ）
+- `tool_response.exitCode` から exit code を抽出（利用可能時）
+- MCP ツール名 fallback: `tool_input.command` → `tool_name`
+
+## 欠落機能のフォールバック
+
+| 欠落機能 | フォールバック |
+|---|---|
+| Compact hooks | MCP `get_context` / `session_handoff` でオンデマンド取得 |
+| Failure イベント | audit スクリプトで tool_response の exit code を解析 |
+| エージェントタイプ | クライアント名のみ使用（例: `codex`, `gemini`） |

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -1,0 +1,55 @@
+# Hook Contract
+
+[日本語](./contract.ja.md)
+
+This document defines the hook capability tiers across AI agent clients.
+
+## Capability Tiers
+
+### Tier 1: Full (Claude Code)
+
+| Hook Event | Matcher | Behavior |
+|---|---|---|
+| SessionStart | `*` | Record session start |
+| SessionEnd | `*` | Record session end |
+| PostToolUse | `Bash` | Record shell command audit with exit code |
+| PostToolUse | `mcp__.*` | Record MCP tool audit |
+| PostToolUseFailure | `Bash`, `mcp__.*` | Record failed tool execution |
+| PostCompact (planned) | `*` | Record compact event |
+| SessionStart (compact) (planned) | `compact` | Inject context pointer via stdout |
+
+### Tier 2: Partial (Codex)
+
+| Hook Event | Matcher | Behavior |
+|---|---|---|
+| SessionStart | (all) | Record session start |
+| Stop | (all) | Record session end |
+| PostToolUse | (all) | Record tool audit |
+
+**Limitations**: No SessionEnd (uses Stop instead), no compact hooks, no failure-specific event.
+
+### Tier 3: Basic (Gemini CLI)
+
+| Hook Event | Matcher | Behavior |
+|---|---|---|
+| SessionStart | `*` | Record session start |
+| SessionEnd | `*` | Record session end |
+| AfterTool | `*` | Record tool audit |
+
+**Limitations**: No compact hooks, no failure-specific event, no PostCompact/SessionStart(compact).
+
+## Shared Behavior
+
+All tiers:
+- Session start persists repo to state file; audit reads repo from state
+- Agent type resolution: `agent_type` field → hierarchical agent name (Claude only)
+- Exit code extraction from `tool_response.exitCode` when available
+- MCP tool name fallback: `tool_input.command` → `tool_name`
+
+## Fallback for Missing Capabilities
+
+| Missing Capability | Fallback |
+|---|---|
+| Compact hooks | MCP `get_context` / `session_handoff` on demand |
+| Failure event | Parse exit code from tool_response in audit script |
+| Agent type | Use client name only (e.g., `codex`, `gemini`) |


### PR DESCRIPTION
## Summary

- Document Tier 1/2/3 capabilities for Claude, Codex, Gemini
- Shared behaviors and fallback strategies
- Bilingual (EN + JA)

Closes #242
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)