### PR TITLE
Automatic context preservation across compact/clear

### DIFF
--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -10,6 +10,15 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-session.sh\" claude start"
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-compact.sh\" claude session-start-compact"
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -39,6 +48,17 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-audit.sh\" claude"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/traceary-compact.sh\" claude post-compact"
           }
         ]
       }

--- a/integrations/claude-plugin/scripts/traceary-compact.sh
+++ b/integrations/claude-plugin/scripts/traceary-compact.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT="${1:-}"
+ACTION="${2:-}"
+
+if [[ -z "$CLIENT" || -z "$ACTION" ]]; then
+  echo "usage: traceary-compact.sh <client> <post-compact|session-start-compact>" >&2
+  exit 64
+fi
+
+traceary_read_hook_input
+
+TRACEARY_CMD="$(traceary_resolve_bin 2>/dev/null || true)"
+if [[ -z "$TRACEARY_CMD" ]]; then
+  exit 0
+fi
+
+SESSION_ID="$(traceary_json_get 'session_id')"
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$(traceary_read_state "$CLIENT")"
+fi
+
+case "$ACTION" in
+  post-compact)
+    # Record that a compact happened
+    if [[ -n "$SESSION_ID" ]]; then
+      COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
+        COMMAND+=(--db-path "$TRACEARY_DB_PATH")
+      fi
+      "${COMMAND[@]}" >/dev/null 2>&1 || true
+    fi
+    ;;
+  session-start-compact)
+    # Output context pointer to stdout for injection into new context
+    COMMAND=("$TRACEARY_CMD" compact-summary)
+    if [[ -n "$SESSION_ID" ]]; then
+      COMMAND+=(--session-id "$SESSION_ID")
+    fi
+    if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
+      COMMAND+=(--db-path "$TRACEARY_DB_PATH")
+    fi
+    "${COMMAND[@]}" 2>/dev/null || true
+    ;;
+  *)
+    echo "unsupported action: $ACTION" >&2
+    exit 64
+    ;;
+esac
+
+exit 0

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+)
+
+func (c *RootCLI) newCompactSummaryCommand() *cobra.Command {
+	var (
+		dbPath    string
+		sessionID string
+		repo      string
+		limit     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "compact-summary",
+		Short: Localize("Generate a compact context pointer for session resumption", "compact 後のセッション再開用コンテキストポインタを生成する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+			if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			resolvedRepo := resolveRepoValue(ctx, repo)
+			resolvedSessionID := resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", "")
+
+			return c.printCompactSummary(ctx, output, resolvedDBPath, resolvedSessionID, resolvedRepo, limit)
+		},
+	}
+
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID", "セッション ID"))
+	cmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	cmd.Flags().IntVar(&limit, "recent", 3, Localize("number of recent commands to show", "表示する直近コマンド数"))
+
+	return cmd
+}
+
+func (c *RootCLI) printCompactSummary(
+	ctx context.Context,
+	output io.Writer,
+	dbPath string,
+	sessionID string,
+	repo string,
+	recentCount int,
+) error {
+	// Get recent events for context
+	events, err := c.listEventsQueryService.Run(ctx, dbPath, queryservice.ListRecentEventsInput{
+		Limit:     recentCount + 5, // fetch extra to find commands
+		SessionID: sessionID,
+		Repo:      repo,
+		Kind:      "command_executed",
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to list events: %w", err)
+	}
+
+	// Get session info
+	sessions, err := c.listSessionsQueryService.Run(ctx, dbPath, queryservice.ListSessionsInput{
+		Limit: 1,
+		Repo:  repo,
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to list sessions: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[Traceary] ")
+
+	if len(sessions) > 0 {
+		s := sessions[0]
+		fmt.Fprintf(&sb, "Session %s resumed after compact\n", s.SessionID)
+		if s.Repo != "" {
+			fmt.Fprintf(&sb, "  repo: %s\n", s.Repo)
+		}
+		if s.Label != "" {
+			fmt.Fprintf(&sb, "  label: %s\n", s.Label)
+		}
+	} else {
+		sb.WriteString("No active session\n")
+	}
+
+	if len(events) > 0 {
+		sb.WriteString("  recent: ")
+		shown := 0
+		for _, e := range events {
+			if shown >= recentCount {
+				break
+			}
+			if shown > 0 {
+				sb.WriteString(" → ")
+			}
+			cmd := truncateMessage(e.Body())
+			if len([]rune(cmd)) > 40 {
+				cmd = string([]rune(cmd)[:40]) + "…"
+			}
+			sb.WriteString(cmd)
+			shown++
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("  Run list_events for full history.\n")
+
+	if _, err := fmt.Fprint(output, sb.String()); err != nil {
+		return xerrors.Errorf("failed to print compact summary: %w", err)
+	}
+	return nil
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -84,6 +84,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newListCommand())
 	rootCmd.AddCommand(c.newShowCommand())
 	rootCmd.AddCommand(c.newSessionCommand())
+	rootCmd.AddCommand(c.newCompactSummaryCommand())
 	rootCmd.AddCommand(c.newCompletionCommand(rootCmd))
 	rootCmd.AddCommand(c.newHooksCommand())
 	rootCmd.AddCommand(c.newDoctorCommand())

--- a/scripts/hooks/traceary-compact.sh
+++ b/scripts/hooks/traceary-compact.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT="${1:-}"
+ACTION="${2:-}"
+
+if [[ -z "$CLIENT" || -z "$ACTION" ]]; then
+  echo "usage: traceary-compact.sh <client> <post-compact|session-start-compact>" >&2
+  exit 64
+fi
+
+traceary_read_hook_input
+
+TRACEARY_CMD="$(traceary_resolve_bin 2>/dev/null || true)"
+if [[ -z "$TRACEARY_CMD" ]]; then
+  exit 0
+fi
+
+SESSION_ID="$(traceary_json_get 'session_id')"
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$(traceary_read_state "$CLIENT")"
+fi
+
+case "$ACTION" in
+  post-compact)
+    # Record that a compact happened
+    if [[ -n "$SESSION_ID" ]]; then
+      COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
+        COMMAND+=(--db-path "$TRACEARY_DB_PATH")
+      fi
+      "${COMMAND[@]}" >/dev/null 2>&1 || true
+    fi
+    ;;
+  session-start-compact)
+    # Output context pointer to stdout for injection into new context
+    COMMAND=("$TRACEARY_CMD" compact-summary)
+    if [[ -n "$SESSION_ID" ]]; then
+      COMMAND+=(--session-id "$SESSION_ID")
+    fi
+    if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
+      COMMAND+=(--db-path "$TRACEARY_DB_PATH")
+    fi
+    "${COMMAND[@]}" 2>/dev/null || true
+    ;;
+  *)
+    echo "unsupported action: $ACTION" >&2
+    exit 64
+    ;;
+esac
+
+exit 0

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -115,6 +115,8 @@ def check_claude() -> None:
     require('SessionStart' in hooks['hooks'], 'Claude hooks must include SessionStart')
     require('SessionEnd' in hooks['hooks'], 'Claude hooks must include SessionEnd')
     require('PostToolUse' in hooks['hooks'], 'Claude hooks must include PostToolUse')
+    require('PostCompact' in hooks['hooks'], 'Claude hooks must include PostCompact')
+    require((ROOT / 'integrations' / 'claude-plugin' / 'scripts' / 'traceary-compact.sh').exists(), 'missing Claude compact hook script')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-help' / 'SKILL.md').exists(), 'missing Claude traceary-help skill')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Claude traceary-session-history skill')
 


### PR DESCRIPTION
## Summary

- `traceary compact-summary` command for lightweight context pointer
- `traceary-compact.sh` hook script
- Claude plugin PostCompact + SessionStart(compact) hooks
- Automatic context injection after compact

Closes #236
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)