### PR TITLE
Add session handoff command for context resumption

### DIFF
--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -29,6 +29,7 @@ func (c *RootCLI) newSessionCommand() *cobra.Command {
 	sessionCmd.AddCommand(c.newSessionActiveCommand())
 	sessionCmd.AddCommand(c.newSessionListCommand())
 	sessionCmd.AddCommand(c.newSessionLabelCommand())
+	sessionCmd.AddCommand(c.newSessionHandoffCommand())
 
 	return sessionCmd
 }

--- a/presentation/cli/session_handoff.go
+++ b/presentation/cli/session_handoff.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
+	var (
+		dbPath    string
+		sessionID string
+		repo      string
+		recent    int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "handoff",
+		Short: Localize("Print a concise session summary for handoff", "引き継ぎ用の簡潔なセッションサマリーを出力する"),
+		Long: Localize(
+			"Print a concise summary of the current session state, suitable for\nhandoff to another agent or context resumption after compact/clear.",
+			"現在のセッション状態の簡潔なサマリーを出力します。\n別エージェントへの引き継ぎや compact/clear 後の再開に使えます。",
+		),
+		Aliases: []string{"context"},
+		Args:    noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+			if err := c.initializeStoreUsecase.Run(ctx, resolvedDBPath); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			resolvedRepo := resolveRepoValue(ctx, repo)
+			resolvedSessionID := resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", "")
+
+			return c.printCompactSummary(ctx, output, resolvedDBPath, resolvedSessionID, resolvedRepo, recent)
+		},
+	}
+
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID", "セッション ID"))
+	cmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	cmd.Flags().IntVar(&recent, "recent", 5, Localize("number of recent commands to show", "表示する直近コマンド数"))
+
+	return cmd
+}


### PR DESCRIPTION
## Summary

- `traceary session handoff` (alias: `session context`)
- Concise session summary with recent commands
- Reuses compact-summary logic

Closes #237
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)