### PR TITLE
Add version check to doctor command

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -18,6 +18,7 @@ const (
 	doctorStatusPass = "pass"
 	doctorStatusWarn = "warn"
 	doctorStatusFail = "fail"
+	doctorStatusSkip = "skip"
 )
 
 type doctorCheck struct {
@@ -48,10 +49,11 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 		Args:    noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runDoctor(cmd.Context(), cmd.OutOrStdout(), doctorCommandInput{
-				dbPath:     dbPath,
-				client:     client,
-				projectDir: projectDir,
-				asJSON:     asJSON,
+				dbPath:         dbPath,
+				client:         client,
+				projectDir:     projectDir,
+				currentVersion: cmd.Root().Version,
+				asJSON:         asJSON,
 			})
 		},
 	}
@@ -64,10 +66,11 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 }
 
 type doctorCommandInput struct {
-	dbPath     string
-	client     string
-	projectDir string
-	asJSON     bool
+	dbPath         string
+	client         string
+	projectDir     string
+	currentVersion string
+	asJSON         bool
 }
 
 func (c *RootCLI) runDoctor(ctx context.Context, output io.Writer, input doctorCommandInput) error {
@@ -189,6 +192,8 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 
 		report.Checks = append(report.Checks, inspectDoctorConfigFile(targetClient, outputPath))
 	}
+
+	report.Checks = append(report.Checks, checkLatestVersion(input.currentVersion))
 
 	return report, nil
 }

--- a/presentation/cli/doctor_version.go
+++ b/presentation/cli/doctor_version.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func checkLatestVersion(currentVersion string) doctorCheck {
+	if currentVersion == "" {
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusSkip,
+			Message: Localize("version check skipped: current version unknown", "バージョンチェックをスキップ: 現在のバージョンが不明"),
+		}
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/duck8823/traceary/releases/latest")
+	if err != nil {
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusSkip,
+			Message: Localize("version check skipped: network unavailable", "バージョンチェックをスキップ: ネットワーク不通"),
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusSkip,
+			Message: Localize("version check skipped: GitHub API unavailable", "バージョンチェックをスキップ: GitHub API 不通"),
+		}
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusSkip,
+			Message: Localize("version check skipped: failed to parse response", "バージョンチェックをスキップ: レスポンス解析失敗"),
+		}
+	}
+
+	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	normalizedCurrent := strings.TrimPrefix(currentVersion, "v")
+
+	if normalizedCurrent == latestVersion {
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusPass,
+			Message: localizef("traceary is up to date: %s", "traceary は最新です: %s", normalizedCurrent),
+		}
+	}
+
+	return doctorCheck{
+		Name:   "version",
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"update available: %s → %s (run: brew upgrade traceary)",
+			"更新があります: %s → %s (実行: brew upgrade traceary)",
+			normalizedCurrent, latestVersion,
+		),
+	}
+}


### PR DESCRIPTION
## Summary

- `traceary doctor` now checks for updates via GitHub API
- 3s timeout, graceful skip on network failure
- Shows WARN with upgrade command when outdated

Closes #249
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)