### PR TITLE
Move repository interfaces to domain/port package

### DIFF
--- a/application/usecase/collect_garbage.go
+++ b/application/usecase/collect_garbage.go
@@ -6,13 +6,12 @@ import (
 	"time"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
 )
 
-// GarbageCollector provides old-event deletion.
-type GarbageCollector interface {
-	// CollectGarbage deletes events older than the given time.
-	CollectGarbage(ctx context.Context, dbPath string, before time.Time, dryRun bool) (int, error)
-}
+// GarbageCollector is defined in domain/port.
+type GarbageCollector = port.GarbageCollector
 
 // CollectGarbageInput is the input for garbage collection.
 type CollectGarbageInput struct {

--- a/application/usecase/initialize_store.go
+++ b/application/usecase/initialize_store.go
@@ -5,13 +5,12 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
 )
 
-// StoreInitializer provides store-initialization behavior.
-type StoreInitializer interface {
-	// Initialize initializes a store at the given DB path.
-	Initialize(ctx context.Context, dbPath string) error
-}
+// StoreInitializer is defined in domain/port.
+type StoreInitializer = port.StoreInitializer
 
 // InitializeStoreUsecase initializes the local store.
 type InitializeStoreUsecase interface {

--- a/application/usecase/record_command_audit.go
+++ b/application/usecase/record_command_audit.go
@@ -7,6 +7,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/domain/port"
+
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -16,16 +18,8 @@ const (
 	maxAuditOutputLength = 64 * 1024
 )
 
-// CommandAuditSaver provides persistence for events and command-audit data.
-type CommandAuditSaver interface {
-	// SaveCommandAudit persists an event and command-audit data in one transaction.
-	SaveCommandAudit(
-		ctx context.Context,
-		dbPath string,
-		event *model.Event,
-		commandAudit *model.CommandAudit,
-	) error
-}
+// CommandAuditSaver is defined in domain/port.
+type CommandAuditSaver = port.CommandAuditSaver
 
 // RecordCommandAuditInput is the input for traceary audit recording.
 type RecordCommandAuditInput struct {

--- a/application/usecase/record_log.go
+++ b/application/usecase/record_log.go
@@ -6,15 +6,14 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/domain/port"
+
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// EventSaver provides event persistence.
-type EventSaver interface {
-	// Save persists an event into the target DB.
-	Save(ctx context.Context, dbPath string, event *model.Event) error
-}
+// EventSaver is defined in domain/port.
+type EventSaver = port.EventSaver
 
 // RecordLogInput is the input for traceary log recording.
 type RecordLogInput struct {

--- a/application/usecase/record_session_boundary.go
+++ b/application/usecase/record_session_boundary.go
@@ -8,6 +8,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/domain/port"
+
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -27,24 +29,14 @@ type RecordSessionBoundaryInput struct {
 	ParentSessionID   string
 }
 
-// ErrSessionStartedEventNotFound indicates the target session has no start event.
-var ErrSessionStartedEventNotFound = xerrors.New("session_started event was not found for the target session")
+// ErrSessionStartedEventNotFound is defined in domain/port.
+var ErrSessionStartedEventNotFound = port.ErrSessionStartedEventNotFound
 
-// SessionSaver persists session metadata.
-type SessionSaver interface {
-	// SaveSession creates or updates a session record.
-	SaveSession(ctx context.Context, dbPath string, session *model.Session) error
-}
+// SessionSaver is defined in domain/port.
+type SessionSaver = port.SessionSaver
 
-// SessionStartedEventFinder provides lookup for session_started events.
-type SessionStartedEventFinder interface {
-	// FindSessionStartedEvent returns the latest session_started event for the target session.
-	FindSessionStartedEvent(
-		ctx context.Context,
-		dbPath string,
-		sessionID types.SessionID,
-	) (*model.Event, error)
-}
+// SessionStartedEventFinder is defined in domain/port.
+type SessionStartedEventFinder = port.SessionStartedEventFinder
 
 // RecordSessionBoundaryUsecase records session boundary events.
 type RecordSessionBoundaryUsecase interface {

--- a/application/usecase/store_backup.go
+++ b/application/usecase/store_backup.go
@@ -5,19 +5,15 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
 )
 
-// StoreBackupCreator provides Traceary store backup creation.
-type StoreBackupCreator interface {
-	// CreateBackup creates a backup file from a DB file.
-	CreateBackup(ctx context.Context, dbPath string, outputPath string, overwrite bool) error
-}
+// StoreBackupCreator is defined in domain/port.
+type StoreBackupCreator = port.StoreBackupCreator
 
-// StoreBackupRestorer provides Traceary store restoration.
-type StoreBackupRestorer interface {
-	// RestoreBackup restores a DB file from a backup file.
-	RestoreBackup(ctx context.Context, inputPath string, dbPath string, overwrite bool) error
-}
+// StoreBackupRestorer is defined in domain/port.
+type StoreBackupRestorer = port.StoreBackupRestorer
 
 // CreateStoreBackupInput is the input for backup creation.
 type CreateStoreBackupInput struct {

--- a/application/usecase/update_session_label.go
+++ b/application/usecase/update_session_label.go
@@ -6,13 +6,13 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/domain/port"
+
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// SessionLabelUpdater updates a session label.
-type SessionLabelUpdater interface {
-	UpdateSessionLabel(ctx context.Context, dbPath string, sessionID types.SessionID, label string) error
-}
+// SessionLabelUpdater is defined in domain/port.
+type SessionLabelUpdater = port.SessionLabelUpdater
 
 // UpdateSessionLabelInput is the input for updating a session label.
 type UpdateSessionLabelInput struct {

--- a/domain/port/store.go
+++ b/domain/port/store.go
@@ -1,0 +1,61 @@
+// Package port defines repository and infrastructure interfaces
+// that belong to the domain boundary.
+package port
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// ErrSessionStartedEventNotFound indicates the target session has no start event.
+var ErrSessionStartedEventNotFound = xerrors.New("session_started event was not found for the target session")
+
+// StoreInitializer creates the store and applies migrations.
+type StoreInitializer interface {
+	Initialize(ctx context.Context, dbPath string) error
+}
+
+// EventSaver persists events.
+type EventSaver interface {
+	Save(ctx context.Context, dbPath string, event *model.Event) error
+}
+
+// CommandAuditSaver persists command audit events.
+type CommandAuditSaver interface {
+	SaveCommandAudit(ctx context.Context, dbPath string, event *model.Event, commandAudit *model.CommandAudit) error
+}
+
+// SessionSaver persists session metadata.
+type SessionSaver interface {
+	SaveSession(ctx context.Context, dbPath string, session *model.Session) error
+}
+
+// SessionStartedEventFinder looks up session_started events.
+type SessionStartedEventFinder interface {
+	FindSessionStartedEvent(ctx context.Context, dbPath string, sessionID types.SessionID) (*model.Event, error)
+}
+
+// SessionLabelUpdater updates a session label.
+type SessionLabelUpdater interface {
+	UpdateSessionLabel(ctx context.Context, dbPath string, sessionID types.SessionID, label string) error
+}
+
+// StoreBackupCreator creates a backup of the store.
+type StoreBackupCreator interface {
+	CreateBackup(ctx context.Context, dbPath string, outputPath string, overwrite bool) error
+}
+
+// StoreBackupRestorer restores a backup.
+type StoreBackupRestorer interface {
+	RestoreBackup(ctx context.Context, inputPath string, dbPath string, overwrite bool) error
+}
+
+// GarbageCollector removes old events.
+type GarbageCollector interface {
+	CollectGarbage(ctx context.Context, dbPath string, before time.Time, dryRun bool) (int, error)
+}

--- a/infrastructure/sqlite/backup_store.go
+++ b/infrastructure/sqlite/backup_store.go
@@ -12,11 +12,11 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 )
 
-var _ usecase.StoreBackupCreator = (*Datasource)(nil)
-var _ usecase.StoreBackupRestorer = (*Datasource)(nil)
+var _ port.StoreBackupCreator = (*Datasource)(nil)
+var _ port.StoreBackupRestorer = (*Datasource)(nil)
 
 // CreateBackup creates a backup of the SQLite DB.
 func (d *Datasource) CreateBackup(ctx context.Context, dbPath string, outputPath string, overwrite bool) (err error) {

--- a/infrastructure/sqlite/command_audit_store.go
+++ b/infrastructure/sqlite/command_audit_store.go
@@ -6,11 +6,11 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 )
 
-var _ usecase.CommandAuditSaver = (*Datasource)(nil)
+var _ port.CommandAuditSaver = (*Datasource)(nil)
 
 // SaveCommandAudit persists an event and command-audit data in one transaction.
 func (d *Datasource) SaveCommandAudit(

--- a/infrastructure/sqlite/datasource.go
+++ b/infrastructure/sqlite/datasource.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 // Datasource is a SQLite-backed data source.
@@ -21,7 +21,7 @@ type Datasource struct {
 	migrations fs.FS
 }
 
-var _ usecase.StoreInitializer = (*Datasource)(nil)
+var _ port.StoreInitializer = (*Datasource)(nil)
 
 // NewDatasource creates a new Datasource.
 func NewDatasource(migrations fs.FS) *Datasource {

--- a/infrastructure/sqlite/find_session_started_event.go
+++ b/infrastructure/sqlite/find_session_started_event.go
@@ -8,12 +8,12 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
-var _ usecase.SessionStartedEventFinder = (*Datasource)(nil)
+var _ port.SessionStartedEventFinder = (*Datasource)(nil)
 
 // FindSessionStartedEvent returns the latest session_started event for the target session.
 func (d *Datasource) FindSessionStartedEvent(
@@ -46,7 +46,7 @@ func (d *Datasource) FindSessionStartedEvent(
 	event, err := d.scanEvent(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, usecase.ErrSessionStartedEventNotFound
+			return nil, port.ErrSessionStartedEventNotFound
 		}
 		return nil, xerrors.Errorf("failed to restore session_started event: %w", err)
 	}

--- a/infrastructure/sqlite/gc_store.go
+++ b/infrastructure/sqlite/gc_store.go
@@ -7,10 +7,10 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 )
 
-var _ usecase.GarbageCollector = (*Datasource)(nil)
+var _ port.GarbageCollector = (*Datasource)(nil)
 
 // CollectGarbage deletes events older than the given time.
 func (d *Datasource) CollectGarbage(

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -6,11 +6,11 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 )
 
-var _ usecase.SessionSaver = (*Datasource)(nil)
+var _ port.SessionSaver = (*Datasource)(nil)
 
 // SaveSession creates or updates a session record.
 // On session start, a new row is inserted.


### PR DESCRIPTION
## Summary

- Create domain/port/ with 9 infrastructure interfaces
- Usecase type aliases for backward compatibility
- Infrastructure imports domain/port instead of application/usecase

Closes #251
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)