### PR TITLE
Extract inline SQL to embedded files (list_sessions)

### DIFF
--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"log/slog"
 	"strings"
 	"time"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 )
+
+//go:embed sql/list_sessions.sql
+var listSessionsQuery string
 
 var _ queryservice.SessionSummaryFinder = (*Datasource)(nil)
 
@@ -41,34 +45,7 @@ func (d *Datasource) ListSessionSummaries(
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT
-		   s.session_id,
-		   s.repo,
-		   s.started_at,
-		   s.ended_at,
-		   COALESCE(agg.total_events, 0) AS total_events,
-		   COALESCE(agg.command_count, 0) AS command_count,
-		   COALESCE(agg.agents, '') AS agents,
-		   s.label,
-		   s.summary,
-		   COALESCE(s.parent_session_id, '') AS parent_session_id
-		 FROM sessions s
-		 LEFT JOIN (
-		   SELECT
-		     e.session_id,
-		     COUNT(*) AS total_events,
-		     SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-		     GROUP_CONCAT(DISTINCT e.agent) AS agents
-		   FROM events e
-		   GROUP BY e.session_id
-		 ) agg ON agg.session_id = s.session_id
-		 WHERE (? = '' OR s.repo = ?)
-		   AND (? = '' OR s.agent = ?)
-		   AND (? = '' OR s.label = ?)
-		   AND (? = '' OR s.started_at >= ?)
-		   AND (? = '' OR s.started_at < ?)
-		 ORDER BY s.started_at DESC
-		 LIMIT ? OFFSET ?`,
+		listSessionsQuery,
 		input.Repo, input.Repo,
 		input.Agent, input.Agent,
 		input.Label, input.Label,

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -1,0 +1,28 @@
+SELECT
+  s.session_id,
+  s.repo,
+  s.started_at,
+  s.ended_at,
+  COALESCE(agg.total_events, 0) AS total_events,
+  COALESCE(agg.command_count, 0) AS command_count,
+  COALESCE(agg.agents, '') AS agents,
+  s.label,
+  s.summary,
+  COALESCE(s.parent_session_id, '') AS parent_session_id
+FROM sessions s
+LEFT JOIN (
+  SELECT
+    e.session_id,
+    COUNT(*) AS total_events,
+    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+    GROUP_CONCAT(DISTINCT e.agent) AS agents
+  FROM events e
+  GROUP BY e.session_id
+) agg ON agg.session_id = s.session_id
+WHERE (? = '' OR s.repo = ?)
+  AND (? = '' OR s.agent = ?)
+  AND (? = '' OR s.label = ?)
+  AND (? = '' OR s.started_at >= ?)
+  AND (? = '' OR s.started_at < ?)
+ORDER BY s.started_at DESC
+LIMIT ? OFFSET ?


### PR DESCRIPTION
## Summary

- Extract list_sessions query to sql/list_sessions.sql with go:embed
- First step of SQL externalization per Go convention

Closes #252
Part of #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)