### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,33 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [v0.2.0] - 2026-04-11
+
+コンテキスト保全と本番運用対応のリリースです。
+
+### 追加
+- compact/clear 後の自動コンテキスト保全（PostCompact + SessionStart hooks）
+- `traceary compact-summary` コマンド（LLM不要のコンテキストポインタ生成）
+- `traceary session handoff` コマンド（簡潔なセッション状態サマリー）
+- `traceary session tree` コマンド（親子セッション階層の可視化）
+- `traceary list --failures` フラグ（失敗コマンドのフィルタ表示）
+- `exit_code` カラム追加（マイグレーション 000005）
+- `traceary doctor` のバージョンチェック
+- Hook contract ドキュメント（Claude/Codex/Gemini の能力ティア定義）
+- 統合 contract テスト、マイグレーション回帰テスト
+
+### 変更
+- Gemini CLI の AfterTool を全ツール対応に拡張
+- 24h 超の active セッションを stale として表示
+- README を CLI ファーストのインストールフローに再構成
+- Makefile を英語化 + ターゲット追加
+- テスト名を全て日本語から英語に移行
+- リポジトリインターフェースを `domain/port` に移動
+- `list_sessions` の SQL を go:embed ファイルに外出し
+
+### 含まれるイシュー
+#236-#254（20件、#255 は合理的にクローズ）
+
 ## [v0.1.19] - 2026-04-10
 
 この release では、CLI の可視性を高め、redaction を黙って弱める config 異常を見えるようにし、hook asset の重複管理を解消しました。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+## [v0.2.0] - 2026-04-11
+
+Context preservation and production readiness release.
+
+### Added
+- Automatic context preservation: PostCompact and SessionStart(compact) hooks inject lightweight context pointer after compact/clear
+- `traceary compact-summary` command for LLM-free context pointer generation
+- `traceary session handoff` command for concise session state summary
+- `traceary session tree` command for parent-child session visualization
+- `traceary list --failures` flag for failure-first view (filter by non-zero exit code)
+- `exit_code` column in command_audits for failure tracking (migration 000005)
+- Version check in `traceary doctor` via GitHub API with 3s timeout
+- Hook contract documentation defining capability tiers across Claude, Codex, Gemini
+- Integration contract tests verifying hooks.json structure for all 3 clients
+- Migration regression tests (empty DB, idempotency, backfill accuracy)
+
+### Changed
+- Gemini CLI AfterTool expanded from `run_shell_command` to all tools
+- Stale session detection: active sessions >24h marked as "stale" in session list
+- README restructured as CLI-first install flow (Step 1: CLI, Step 2: Plugin)
+- Makefile translated to English with `code/build` and `code/cover` targets added
+- All test names migrated from Japanese to English for OSS contributors
+- Repository interfaces moved to `domain/port` package (fixing infrastructure → application dependency)
+- `list_sessions` SQL extracted to embedded file via go:embed
+
+### Improved
+- domain/model coverage: 48.8% → 97.6%, domain/types: 42.3% → 100%
+- scripts/hooks coverage: 14.3% → 78.6%
+- mcpserver coverage: 66.7% → 73.8%
+
+### Included issues
+- #236 Automatic context preservation across compact/clear
+- #237 Session handoff command
+- #238 Session tree visualization
+- #239 Failure-first view in list
+- #240 Gemini full tool audit
+- #241 Codex SessionEnd reliability (stale detection)
+- #242 Unified hook contract across clients
+- #243 scripts/hooks test coverage
+- #244 domain model/types test coverage
+- #245 main/mcpserver test coverage
+- #246 Hook payload normalization (exit_code)
+- #247 Integration contract tests
+- #248 Migration regression tests
+- #249 Version check in doctor
+- #250 README CLI-first restructure
+- #251 Repository interfaces to domain/port
+- #252 SQL extraction to go:embed
+- #253 Test names English migration
+- #254 Makefile improvements
+
 ## [v0.1.19] - 2026-04-10
 
 This release improves CLI visibility, makes config failures visible before they silently weaken redaction behavior, and removes drift-prone hook asset duplication.

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 特定の release を使いたい場合は、tag を明示します。
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.19
+go install github.com/duck8823/traceary@v0.2.0
 ```
 
 ### Homebrew

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 If you prefer a specific release, pin the tag explicitly.
 
 ```sh
-go install github.com/duck8823/traceary@v0.1.19
+go install github.com/duck8823/traceary@v0.2.0
 ```
 
 ### Homebrew

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "traceary",
   "description": "Local-first Traceary integration for Claude Code with MCP tools and automatic session/audit hooks.",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "author": {
     "name": "Shunsuke Maeda",
     "email": "duck8823@gmail.com"

--- a/integrations/gemini-extension/gemini-extension.json
+++ b/integrations/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Local-first Traceary integration for Gemini CLI with shared MCP tools and automatic session/audit hooks.",
   "mcpServers": {
     "traceary": {

--- a/plugins/traceary/.codex-plugin/plugin.json
+++ b/plugins/traceary/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.1.19",
+  "version": "0.2.0",
   "description": "Local-first Traceary integration for Codex with MCP tools and automatic session/audit hooks.",
   "author": {
     "name": "Shunsuke Maeda",

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     tomllib = None
 
 ROOT = Path(__file__).resolve().parent.parent
-INTEGRATION_VERSION = '0.1.19'
+INTEGRATION_VERSION = '0.2.0'
 HOOK_SOURCES = [
     ROOT / 'scripts' / 'hooks' / 'common.sh',
     ROOT / 'scripts' / 'hooks' / 'traceary-session.sh',


### PR DESCRIPTION
## Summary

Update integration manifests, CHANGELOGs, and release docs to v0.2.0.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)