### PR TITLE
Fix goreleaser formula generation by restoring repository config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,11 @@ brews:
   - ids:
       - binaries
     directory: Formula
+    repository:
+      owner: duck8823
+      name: traceary
+      branch: main
+      disable: true
     homepage: https://github.com/duck8823/traceary
     description: Local-first CLI and MCP server for AI agent work history
     license: MIT


### PR DESCRIPTION
## Summary

GoReleaser skips formula generation when `brews.repository.name` is not set
(removed in c2564a32). Restore with `disable: true` so formula is generated
in dist/ for the workflow step to create a PR.

## Root cause

`pipe skipped or partially skipped — reason=brew.repository.name is not set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)