### PR TITLE
Fix goreleaser formula generation and add auto-merge for Homebrew PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,15 @@ jobs:
           existing_pr="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')"
           if [[ -n "${existing_pr}" ]]; then
             gh pr edit "${existing_pr}" --title "${title}" --body "${body}"
+            pr_number="${existing_pr}"
           else
-            gh pr create --base main --head "${branch}" --title "${title}" --body "${body}"
+            pr_url="$(gh pr create --base main --head "${branch}" --title "${title}" --body "${body}")"
+            pr_number="$(echo "${pr_url}" | grep -oE '[0-9]+$')"
+          fi
+
+          # Enable auto-merge so the PR merges after CI passes
+          if [[ -n "${pr_number}" ]]; then
+            gh pr merge "${pr_number}" --auto --merge || true
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,11 +41,11 @@ brews:
   - ids:
       - binaries
     directory: Formula
+    skip_upload: true
     repository:
       owner: duck8823
       name: traceary
       branch: main
-      disable: true
     homepage: https://github.com/duck8823/traceary
     description: Local-first CLI and MCP server for AI agent work history
     license: MIT


### PR DESCRIPTION
## Summary

- Replace unsupported `repository.disable: true` with `skip_upload: true` in goreleaser config
- Add `gh pr merge --auto --merge` to release workflow for Homebrew formula PR
- Enable repository auto-merge setting

## Root cause analysis

| Release | Failure | Root cause |
|---|---|---|
| v0.1.17 | Asset upload race condition | Fixed: `replace_existing_artifacts: true` |
| v0.1.18 | `enforce_admins` blocked push | Fixed: `enforce_admins: false` |
| v0.1.19 | Manual workflow_dispatch | Workaround, not fix |
| v0.2.0 | `brew.repository.name is not set` | Fixed: restored repository config |
| v0.2.0 (2nd) | `disable: true` not valid | **Fixed here**: `skip_upload: true` |
| All | Homebrew PR requires manual merge | **Fixed here**: auto-merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)