### PR TITLE
fix: accept RFC3339 format in CLI --from/--to date flags

### DIFF
--- a/presentation/cli/date_parse.go
+++ b/presentation/cli/date_parse.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// parseFlexibleTime parses a date/time string in either RFC3339 or YYYY-MM-DD format.
+// When endExclusive is true and the input is a date-only string, the returned
+// time is advanced by one day so that the caller can use a strict less-than
+// comparison for the upper bound.
+func parseFlexibleTime(value string, endExclusive bool) (time.Time, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return time.Time{}, nil
+	}
+
+	if parsedTime, err := time.Parse(time.RFC3339, trimmedValue); err == nil {
+		return parsedTime.UTC(), nil
+	}
+
+	parsedDate, err := time.Parse("2006-01-02", trimmedValue)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf(
+			"%s: %w",
+			Localize("time must be RFC3339 or YYYY-MM-DD", "日時は RFC3339 または YYYY-MM-DD 形式で指定してください"),
+			err,
+		)
+	}
+	if endExclusive {
+		return parsedDate.AddDate(0, 0, 1), nil
+	}
+
+	return parsedDate, nil
+}
+
+// parseFlexibleTimePtr parses a date/time string into a *time.Time pointer.
+// Returns nil when the input is empty. Used by commands that pass optional
+// date pointers to query services (e.g. session list).
+func parseFlexibleTimePtr(value string, endExclusive bool) (*time.Time, error) {
+	t, err := parseFlexibleTime(value, endExclusive)
+	if err != nil {
+		return nil, err
+	}
+	if t.IsZero() {
+		return nil, nil
+	}
+	return &t, nil
+}

--- a/presentation/cli/date_parse_test.go
+++ b/presentation/cli/date_parse_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFlexibleTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		value        string
+		endExclusive bool
+		wantTime     time.Time
+		wantErr      bool
+	}{
+		{
+			name:     "empty string returns zero time",
+			value:    "",
+			wantTime: time.Time{},
+		},
+		{
+			name:     "whitespace-only returns zero time",
+			value:    "  ",
+			wantTime: time.Time{},
+		},
+		{
+			name:     "YYYY-MM-DD returns midnight UTC",
+			value:    "2026-04-11",
+			wantTime: time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "YYYY-MM-DD with endExclusive adds one day",
+			value:        "2026-04-11",
+			endExclusive: true,
+			wantTime:     time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "RFC3339 is parsed and converted to UTC",
+			value:    "2026-04-11T15:30:00Z",
+			wantTime: time.Date(2026, 4, 11, 15, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "RFC3339 with timezone offset is normalized to UTC",
+			value:    "2026-04-11T15:30:00+09:00",
+			wantTime: time.Date(2026, 4, 11, 6, 30, 0, 0, time.UTC),
+		},
+		{
+			name:         "RFC3339 with endExclusive does not add one day",
+			value:        "2026-04-11T15:30:00Z",
+			endExclusive: true,
+			wantTime:     time.Date(2026, 4, 11, 15, 30, 0, 0, time.UTC),
+		},
+		{
+			name:    "invalid format returns error",
+			value:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:    "invalid month returns error",
+			value:   "2026-13-01",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseFlexibleTime(tt.value, tt.endExclusive)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.wantTime) {
+				t.Errorf("got %v, want %v", got, tt.wantTime)
+			}
+		})
+	}
+}
+
+func TestParseFlexibleTimePtr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseFlexibleTimePtr("", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("valid date returns non-nil pointer", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseFlexibleTimePtr("2026-04-11", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		want := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", *got, want)
+		}
+	})
+
+	t.Run("invalid value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseFlexibleTimePtr("bad", false)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -72,10 +72,10 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 			"絞り込む kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)",
 		),
 	)
-	searchCmd.Flags().StringVar(&from, "from", "", Localize("start date (`YYYY-MM-DD`)", "開始日 (`YYYY-MM-DD`)"))
-	searchCmd.Flags().StringVar(&since, "since", "", Localize("start date (`YYYY-MM-DD`) (alias for `--from`)", "開始日 (`YYYY-MM-DD`) (`--from` の別名)"))
-	searchCmd.Flags().StringVar(&to, "to", "", Localize("end date (`YYYY-MM-DD`)", "終了日 (`YYYY-MM-DD`)"))
-	searchCmd.Flags().StringVar(&until, "until", "", Localize("end date (`YYYY-MM-DD`) (alias for `--to`)", "終了日 (`YYYY-MM-DD`) (`--to` の別名)"))
+	searchCmd.Flags().StringVar(&from, "from", "", Localize("start date (`YYYY-MM-DD` or RFC3339)", "開始日 (`YYYY-MM-DD` または RFC3339)"))
+	searchCmd.Flags().StringVar(&since, "since", "", Localize("start date (`YYYY-MM-DD` or RFC3339) (alias for `--from`)", "開始日 (`YYYY-MM-DD` または RFC3339) (`--from` の別名)"))
+	searchCmd.Flags().StringVar(&to, "to", "", Localize("end date (`YYYY-MM-DD` or RFC3339)", "終了日 (`YYYY-MM-DD` または RFC3339)"))
+	searchCmd.Flags().StringVar(&until, "until", "", Localize("end date (`YYYY-MM-DD` or RFC3339) (alias for `--to`)", "終了日 (`YYYY-MM-DD` または RFC3339) (`--to` の別名)"))
 	searchCmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of results", "表示件数"))
 	searchCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of matching events to skip before returning results", "結果を返す前にスキップする件数"))
 	searchCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
@@ -176,21 +176,10 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 	return nil
 }
 
+// parseSearchDate delegates to parseFlexibleTime, which accepts both
+// RFC3339 and YYYY-MM-DD formats.
 func parseSearchDate(value string, endExclusive bool) (time.Time, error) {
-	trimmedValue := strings.TrimSpace(value)
-	if trimmedValue == "" {
-		return time.Time{}, nil
-	}
-
-	parsedTime, err := time.Parse("2006-01-02", trimmedValue)
-	if err != nil {
-		return time.Time{}, xerrors.Errorf("%s: %w", Localize("date must use YYYY-MM-DD format", "日付は YYYY-MM-DD 形式で指定してください"), err)
-	}
-	if endExclusive {
-		return parsedTime.AddDate(0, 0, 1), nil
-	}
-
-	return parsedTime, nil
+	return parseFlexibleTime(value, endExclusive)
 }
 
 func resolveSearchDateValue(primary string, alias string, primaryName string, aliasName string) (string, error) {

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -47,20 +47,13 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				return xerrors.Errorf("%s", Localize("offset must be >= 0", "offset は 0 以上でなければなりません"))
 			}
 
-			var fromTime, toTime *time.Time
-			if from != "" {
-				t, err := time.Parse("2006-01-02", from)
-				if err != nil {
-					return xerrors.Errorf("%s: %w", Localize("--from must be YYYY-MM-DD", "--from は YYYY-MM-DD 形式でなければなりません"), err)
-				}
-				fromTime = &t
+			fromTime, err := parseFlexibleTimePtr(from, false)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve --from", "from の解決に失敗しました"), err)
 			}
-			if to != "" {
-				t, err := time.Parse("2006-01-02", to)
-				if err != nil {
-					return xerrors.Errorf("%s: %w", Localize("--to must be YYYY-MM-DD", "--to は YYYY-MM-DD 形式でなければなりません"), err)
-				}
-				toTime = &t
+			toTime, err := parseFlexibleTimePtr(to, true)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 			}
 
 			resolvedRepo := resolveRepoValue(ctx, repo)
@@ -86,8 +79,8 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
 	listCmd.Flags().StringVar(&label, "label", "", Localize("filter by label", "ラベルでフィルタ"))
-	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD)", "開始日 (YYYY-MM-DD)"))
-	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD)", "終了日 (YYYY-MM-DD)"))
+	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD or RFC3339)", "開始日 (YYYY-MM-DD または RFC3339)"))
+	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD or RFC3339)", "終了日 (YYYY-MM-DD または RFC3339)"))
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of sessions", "最大表示セッション数"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of sessions to skip", "スキップするセッション数"))
 	listCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -51,7 +51,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to resolve --from", "from の解決に失敗しました"), err)
 			}
-			toTime, err := parseFlexibleTimePtr(to, true)
+			toTime, err := parseFlexibleTimePtr(to, false)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 			}


### PR DESCRIPTION
## Summary
- Extract shared `parseFlexibleTime()` to `presentation/cli/date_parse.go`
- Accept both RFC3339 (`2026-04-11T15:30:00Z`) and YYYY-MM-DD (`2026-04-11`) in `--from`/`--to` flags
- Replace `parseSearchDate()` in search and inline parsing in session list with the shared parser
- Update flag help strings to document accepted formats

Closes #304

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] `traceary search --from 2026-04-11T00:00:00Z --json` succeeds
- [ ] `traceary session list --from 2026-04-11T00:00:00Z --json` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)