### PR TITLE
fix: include exit_code in show command output

### DIFF
--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -27,6 +27,7 @@ type commandAuditJSON struct {
 	Output          string `json:"output"`
 	InputTruncated  bool   `json:"input_truncated"`
 	OutputTruncated bool   `json:"output_truncated"`
+	ExitCode        *int   `json:"exit_code,omitempty"`
 }
 
 type eventDetailsJSON struct {
@@ -90,6 +91,7 @@ func newCommandAuditJSON(commandAudit *model.CommandAudit) *commandAuditJSON {
 		Output:          commandAudit.Output(),
 		InputTruncated:  commandAudit.InputTruncated(),
 		OutputTruncated: commandAudit.OutputTruncated(),
+		ExitCode:        commandAudit.ExitCode(),
 	}
 }
 

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -85,10 +85,16 @@ func writeEventDetails(output io.Writer, eventDetails *queryservice.EventDetails
 		return nil
 	}
 
+	exitCodeDisplay := "-"
+	if commandAudit.ExitCode() != nil {
+		exitCodeDisplay = fmt.Sprintf("%d", *commandAudit.ExitCode())
+	}
+
 	if _, err := fmt.Fprintf(
 		output,
-		"\nCOMMAND: %s\nINPUT_TRUNCATED: %t\nINPUT:\n%s\nOUTPUT_TRUNCATED: %t\nOUTPUT:\n%s\n",
+		"\nCOMMAND: %s\nEXIT_CODE: %s\nINPUT_TRUNCATED: %t\nINPUT:\n%s\nOUTPUT_TRUNCATED: %t\nOUTPUT:\n%s\n",
 		commandAudit.Command(),
+		exitCodeDisplay,
 		commandAudit.InputTruncated(),
 		commandAudit.Input(),
 		commandAudit.OutputTruncated(),

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -116,6 +116,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 			"MESSAGE: go test ./...\n" +
 			"\n" +
 			"COMMAND: go test ./...\n" +
+			"EXIT_CODE: -\n" +
 			"INPUT_TRUNCATED: true\n" +
 			"INPUT:\n" +
 			"stdin\n" +
@@ -232,5 +233,79 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		if stdout.String() != want {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
+	})
+
+	t.Run("exit_code is included in JSON and text output when present", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		exitCode := 1
+		eventDetails, err := queryservice.NewEventDetails(
+			model.EventOf(
+				eventID,
+				types.EventKindCommandExecuted,
+				"cli",
+				agent,
+				sessionID,
+				"duck8823/traceary",
+				"go test ./...",
+				time.Date(2026, 4, 8, 13, 0, 0, 0, time.UTC),
+			),
+			model.CommandAuditOf(
+				eventID,
+				"go test ./...",
+				"stdin",
+				"stderr",
+				false,
+				false,
+				&exitCode,
+			),
+		)
+		if err != nil {
+			t.Fatalf("NewEventDetails() error = %v", err)
+		}
+
+		t.Run("text format", func(t *testing.T) {
+			t.Parallel()
+
+			showStub := &getEventDetailsQueryServiceStub{eventDetails: eventDetails}
+			stdout := &bytes.Buffer{}
+			rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+				InitializeStoreUsecase:      initStub,
+				GetEventDetailsQueryService: showStub,
+			}).Command()
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs([]string{"show", "--db-path", dbPath, "event-1"})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if !bytes.Contains(stdout.Bytes(), []byte("EXIT_CODE: 1\n")) {
+				t.Fatalf("expected EXIT_CODE: 1 in output, got %q", stdout.String())
+			}
+		})
+
+		t.Run("json format", func(t *testing.T) {
+			t.Parallel()
+
+			showStub := &getEventDetailsQueryServiceStub{eventDetails: eventDetails}
+			stdout := &bytes.Buffer{}
+			rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+				InitializeStoreUsecase:      initStub,
+				GetEventDetailsQueryService: showStub,
+			}).Command()
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs([]string{"show", "--db-path", dbPath, "--json", "event-1"})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if !bytes.Contains(stdout.Bytes(), []byte(`"exit_code": 1`)) {
+				t.Fatalf("expected exit_code in JSON output, got %q", stdout.String())
+			}
+		})
 	})
 }


### PR DESCRIPTION
## Summary
- Add `exit_code` field to `commandAuditJSON` struct in `event_json.go`
- Populate from `CommandAudit.ExitCode()` in `newCommandAuditJSON()`
- Add `EXIT_CODE` line to plain-text show output (shows `-` when nil)
- JSON uses `omitempty` so nil exit_code is not included

Closes #300

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] New tests for exit_code in both text and JSON formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)