### PR TITLE
fix: count --failures as a valid search constraint

### DIFF
--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -141,7 +141,7 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 	}
-	if !hasSearchConstraint(input.query, input.repo, input.sessionID, input.client, input.agent, input.kind, fromTime, toTime) {
+	if !hasSearchConstraint(input.query, input.repo, input.sessionID, input.client, input.agent, input.kind, fromTime, toTime, input.failuresOnly) {
 		return xerrors.Errorf(Localize("at least one search filter is required", "検索条件は1つ以上必要です"))
 	}
 	if !fromTime.IsZero() && !toTime.IsZero() && fromTime.After(toTime) {
@@ -218,6 +218,7 @@ func hasSearchConstraint(
 	kind string,
 	from time.Time,
 	to time.Time,
+	failuresOnly bool,
 ) bool {
 	return strings.TrimSpace(query) != "" ||
 		strings.TrimSpace(repo) != "" ||
@@ -226,7 +227,8 @@ func hasSearchConstraint(
 		strings.TrimSpace(agent) != "" ||
 		strings.TrimSpace(kind) != "" ||
 		!from.IsZero() ||
-		!to.IsZero()
+		!to.IsZero() ||
+		failuresOnly
 }
 
 func validateSearchKind(value string) (string, error) {

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -253,3 +253,35 @@ func TestRootCLI_SearchCommand_NegativeOffset(t *testing.T) {
 		t.Fatalf("Execute() error = nil, want error")
 	}
 }
+
+func TestRootCLI_SearchCommand_FailuresOnlyAsConstraint(t *testing.T) {
+	t.Setenv("TRACEARY_REPO", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	initStub := &initializeStoreUsecaseStub{}
+	searchStub := &searchEventsQueryServiceStub{}
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:   initStub,
+		SearchEventsQueryService: searchStub,
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"search",
+		"--db-path", "/tmp/traceary.db",
+		"--failures",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v; --failures alone should count as a valid search constraint", err)
+	}
+	if !searchStub.called {
+		t.Fatalf("SearchEventsQueryService.Run() was not called")
+	}
+	if !searchStub.receivedInput.FailuresOnly {
+		t.Fatalf("FailuresOnly = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `failuresOnly` parameter to `hasSearchConstraint()` in `search.go`
- `traceary search --failures` alone now works without requiring additional filters

Closes #301

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [x] New test: `--failures` alone succeeds and passes `FailuresOnly=true` to query service

🤖 Generated with [Claude Code](https://claude.com/claude-code)