### PR TITLE
fix: accept 'audit' alias in list --kind flag

### DIFF
--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application/queryservice"
-	"github.com/duck8823/traceary/domain/types"
 )
 
 func (c *RootCLI) newListCommand() *cobra.Command {
@@ -48,7 +47,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display", "表示件数"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of events to skip before listing", "一覧表示前にスキップする件数"))
-	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind", "イベント種別で絞り込む"))
+	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended; alias: audit)"))
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	listCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))
@@ -118,16 +117,8 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 	return nil
 }
 
+// resolveListKind delegates to validateSearchKind so that both list and
+// search accept the same kind values and aliases (e.g. "audit").
 func resolveListKind(value string) (string, error) {
-	trimmedValue := strings.TrimSpace(value)
-	if trimmedValue == "" {
-		return "", nil
-	}
-
-	kind, err := types.EventKindOf(trimmedValue)
-	if err != nil {
-		return "", xerrors.Errorf("%s: %w", Localize("invalid event kind", "不正なイベント種別です"), err)
-	}
-
-	return kind.String(), nil
+	return validateSearchKind(value)
 }


### PR DESCRIPTION
## Summary
- Delegate `resolveListKind()` to `validateSearchKind()` so both `list` and `search` accept the `audit` alias
- Update `--kind` flag help to list valid values and aliases

Closes #309

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] `traceary list --kind audit --json` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)