### PR TITLE
feat: add --client filter to session list command

### DIFF
--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -27,6 +27,7 @@ type ListSessionsInput struct {
 	Limit  int
 	Offset int
 	Repo   string
+	Client string
 	Agent  string
 	Label  string
 	From   *time.Time

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -47,6 +47,7 @@ func (d *Datasource) ListSessionSummaries(
 		ctx,
 		listSessionsQuery,
 		input.Repo, input.Repo,
+		input.Client, input.Client,
 		input.Agent, input.Agent,
 		input.Label, input.Label,
 		fromValue, fromValue,

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -20,6 +20,7 @@ LEFT JOIN (
   GROUP BY e.session_id
 ) agg ON agg.session_id = s.session_id
 WHERE (? = '' OR s.repo = ?)
+  AND (? = '' OR s.client = ?)
   AND (? = '' OR s.agent = ?)
   AND (? = '' OR s.label = ?)
   AND (? = '' OR s.started_at >= ?)

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -17,6 +17,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 	var (
 		dbPath string
 		repo   string
+		client string
 		agent  string
 		label  string
 		from   string
@@ -69,6 +70,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 				Limit:  limit,
 				Offset: offset,
 				Repo:   resolvedRepo,
+				Client: client,
 				Agent:  agent,
 				Label:  label,
 				From:   fromTime,
@@ -84,6 +86,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", Localize("SQLite DB path (env: TRACEARY_DB_PATH)", "SQLite DB パス (env: TRACEARY_DB_PATH)"))
 	listCmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路でフィルタ"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
 	listCmd.Flags().StringVar(&label, "label", "", Localize("filter by label", "ラベルでフィルタ"))
 	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD)", "開始日 (YYYY-MM-DD)"))


### PR DESCRIPTION
## Summary
- Add `Client` field to `ListSessionsInput`
- Add `AND (? = '' OR s.client = ?)` clause to `list_sessions.sql`
- Add `--client` flag to `traceary session list`

Closes #305

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] `traceary session list --client hook --json` returns filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)