### PR TITLE
docs: document session ID acceptance behavior in log/audit

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -39,6 +39,8 @@ session 解決ルール:
 - `remote.origin.url` が無くても Git worktree 内であれば、work-context key として worktree ルートパスを使います
 - repo / work context が無い、または一致する active session が無い場合は、従来どおり `default` session ID に fallback
 
+> **注意:** `log` と `audit` は `--session-id` の値を検証せずにそのまま受け入れます。これは設計上の意図です — hook は高頻度でイベントを記録するため、書き込みごとに DB ルックアップを追加するとオーバーヘッドが無視できません。存在しないセッション ID を渡してもイベントは記録されますが、セッション単位のクエリには表示されません。
+
 ### `traceary audit <command> [<input>] [<output>]`
 
 コマンド実行の監査イベントを記録します。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -39,6 +39,8 @@ Session resolution rules:
 - when `remote.origin.url` is unavailable but the current directory is still inside a git worktree, Traceary falls back to the worktree root path as the work-context key
 - if no repo/work context or no matching active session is found, Traceary falls back to the historical `default` session ID
 
+> **Note:** `log` and `audit` accept any `--session-id` value without validating whether the session actually exists. This is by design — hooks record events at high frequency and the extra DB lookup per write would add unacceptable overhead. If you pass a nonexistent session ID, the event is still recorded; it will simply not appear in session-scoped queries.
+
 ### `traceary audit <command> [<input>] [<output>]`
 
 Record a command execution audit event.


### PR DESCRIPTION
## Summary
- Document that `log` and `audit` accept any `--session-id` without validation
- Explain the design rationale (hook performance)
- Both English and Japanese docs updated

Closes #310

## Test plan
- [x] Documentation review only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)