### PR TITLE
fix: reject inverted date range in session list

### DIFF
--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -56,6 +56,9 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 			}
+			if fromTime != nil && toTime != nil && fromTime.After(*toTime) {
+				return xerrors.Errorf(Localize("--from must be earlier than --to", "from は to より前である必要があります"))
+			}
 
 			resolvedRepo := resolveRepoValue(ctx, repo)
 


### PR DESCRIPTION
## Summary
- Add `fromTime.After(*toTime)` check to session list, matching search command behavior

Closes #311

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)