### PR TITLE
release: v0.2.2

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "traceary",
   "description": "Local-first Traceary integration for Claude Code with MCP tools and automatic session/audit hooks.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Shunsuke Maeda",
     "email": "duck8823@gmail.com"

--- a/integrations/gemini-extension/gemini-extension.json
+++ b/integrations/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Local-first Traceary integration for Gemini CLI with shared MCP tools and automatic session/audit hooks.",
   "mcpServers": {
     "traceary": {

--- a/plugins/traceary/.codex-plugin/plugin.json
+++ b/plugins/traceary/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "traceary",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Local-first Traceary integration for Codex with MCP tools and automatic session/audit hooks.",
   "author": {
     "name": "Shunsuke Maeda",


### PR DESCRIPTION
## Summary
Bump plugin/extension versions to 0.2.2.

## v0.2.2 Changes (10 PRs)

### Bug fixes
- #312: CLI --from/--to accept RFC3339 format (#304)
- #313: show --json includes exit_code (#300)
- #314: search --failures counts as constraint (#301)
- #315: list --kind accepts audit alias (#309)
- #319: session list rejects inverted date range (#311)

### Enhancements
- #316: session list --client filter (#305)
- #317: backup create positional argument (#307)
- #320: list --from/--to date filters (#302)
- #321: MCP list_events filters (#303)

### Documentation
- #318: document session ID acceptance behavior (#310)

### Deferred to v0.2.3
- #299: MCP tool call parameter recording
- #306: doctor plugin detection
- #308: double session end warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)