### PR TITLE
fix: address review findings for v0.2.2

### DIFF
--- a/presentation/cli/backup.go
+++ b/presentation/cli/backup.go
@@ -67,7 +67,13 @@ func (c *RootCLI) newBackupCreateCommand() *cobra.Command {
 		Args:  maximumNArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedOutput := outputPath
-			if len(args) == 1 && resolvedOutput == "" {
+			if len(args) == 1 && resolvedOutput != "" {
+				return xerrors.Errorf(Localize(
+					"output path specified twice: positional argument and --output flag",
+					"出力先パスが二重に指定されています（位置引数と --output フラグ）",
+				))
+			}
+			if len(args) == 1 {
 				resolvedOutput = args[0]
 			}
 			if resolvedOutput == "" {

--- a/presentation/cli/backup_test.go
+++ b/presentation/cli/backup_test.go
@@ -92,6 +92,46 @@ func TestRootCLI_BackupCreateCommand_MissingOutputReturnsError(t *testing.T) {
 	}
 }
 
+func TestRootCLI_BackupCreateCommand_PositionalArgument(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	outputPath := filepath.Join(t.TempDir(), "traceary-backup.db")
+	createBackup := &createStoreBackupUsecaseStub{}
+	initStub := &initializeStoreUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		InitializeStoreUsecase:   initStub,
+		CreateStoreBackupUsecase: createBackup,
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"backup", "create", "--db-path", dbPath, outputPath})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if createBackup.input.OutputPath != outputPath {
+		t.Fatalf("output = %q, want %q", createBackup.input.OutputPath, outputPath)
+	}
+}
+
+func TestRootCLI_BackupCreateCommand_DuplicateOutputReturnsError(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+		CreateStoreBackupUsecase: &createStoreBackupUsecaseStub{},
+	}).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"backup", "create", "--output", "/tmp/a.db", "/tmp/b.db"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error for duplicate output path")
+	}
+}
+
 func TestRootCLI_BackupRestoreCommand(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -238,4 +238,28 @@ func TestRootCLI_ListCommand(t *testing.T) {
 			t.Fatalf("Execute() error = nil, want error")
 		}
 	})
+
+	t.Run("--kind audit resolves to command_executed", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		listStub := &listEventsQueryServiceStub{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase: &initializeStoreUsecaseStub{},
+			ListEventsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"list", "--db-path", dbPath, "--kind", "audit"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !listStub.called {
+			t.Fatal("ListRecentEventsQueryService.Run() was not called")
+		}
+		if listStub.receivedInput.Kind != "command_executed" {
+			t.Fatalf("Kind = %q, want %q", listStub.receivedInput.Kind, "command_executed")
+		}
+	})
 }

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -249,4 +249,28 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 			t.Fatalf("Execute() error = nil, want error")
 		}
 	})
+
+	t.Run("--client filter is passed to query service", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		listStub := &listSessionsQueryServiceStub{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "list", "--db-path", dbPath, "--client", "hook"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !listStub.called {
+			t.Fatal("ListSessionsQueryService.Run() was not called")
+		}
+		if listStub.receivedInput.Client != "hook" {
+			t.Fatalf("Client = %q, want %q", listStub.receivedInput.Client, "hook")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
Address 5 HIGH findings from Claude reviewer:

1. **backup create**: Reject ambiguous input when both positional arg and --output are provided
2. **backup_test**: Add positional argument happy-path test
3. **backup_test**: Add duplicate output path error test
4. **session_list_test**: Add --client filter propagation test
5. **list_test**: Add --kind audit alias resolution test

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)