### PR TITLE
feat: include tool_name in MCP audit input when tool_input is empty

### DIFF
--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -36,6 +36,13 @@ fi
 
 REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
+# For MCP tools, ensure tool_input includes at least the tool name when empty
+if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
+  TOOL_NAME="$(traceary_json_get 'tool_name')"
+  if [[ -n "$TOOL_NAME" ]]; then
+    AUDIT_INPUT="{\"tool_name\":\"$TOOL_NAME\"}"
+  fi
+fi
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -36,6 +36,13 @@ fi
 
 REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
+# For MCP tools, ensure tool_input includes at least the tool name when empty
+if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
+  TOOL_NAME="$(traceary_json_get 'tool_name')"
+  if [[ -n "$TOOL_NAME" ]]; then
+    AUDIT_INPUT="{\"tool_name\":\"$TOOL_NAME\"}"
+  fi
+fi
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -36,6 +36,13 @@ fi
 
 REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
+# For MCP tools, ensure tool_input includes at least the tool name when empty
+if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
+  TOOL_NAME="$(traceary_json_get 'tool_name')"
+  if [[ -n "$TOOL_NAME" ]]; then
+    AUDIT_INPUT="{\"tool_name\":\"$TOOL_NAME\"}"
+  fi
+fi
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"

--- a/scripts/hooks/traceary-audit.sh
+++ b/scripts/hooks/traceary-audit.sh
@@ -36,6 +36,13 @@ fi
 
 REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
+# For MCP tools, ensure tool_input includes at least the tool name when empty
+if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
+  TOOL_NAME="$(traceary_json_get 'tool_name')"
+  if [[ -n "$TOOL_NAME" ]]; then
+    AUDIT_INPUT="{\"tool_name\":\"$TOOL_NAME\"}"
+  fi
+fi
 AUDIT_OUTPUT="$(traceary_json_get 'tool_response')"
 if [[ -z "$AUDIT_OUTPUT" ]]; then
   AUDIT_OUTPUT="$(traceary_build_failure_output || true)"


### PR DESCRIPTION
## Summary
- When MCP tool calls have empty \`tool_input\`, build fallback input with \`tool_name\`
- Updated hook script in all 3 integration packages

Closes #299

## Test plan
- [x] \`go test ./...\` passes (including hook script tests)
- [x] \`python3 scripts/verify_integrations.py\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)