### PR TITLE
refactor: extract close-stale-sessions usecase from session gc command

### DIFF
--- a/application/usecase/close_stale_sessions.go
+++ b/application/usecase/close_stale_sessions.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
+)
+
+// CloseStaleSessionsInput is the input for closing stale sessions.
+type CloseStaleSessionsInput struct {
+	DBPath     string
+	StaleAfter time.Duration
+	DryRun     bool
+}
+
+// CloseStaleSessionsResult is the result of a stale-session cleanup.
+type CloseStaleSessionsResult struct {
+	ClosedCount int
+}
+
+// CloseStaleSessionsUsecase closes sessions that have been active beyond a threshold.
+type CloseStaleSessionsUsecase interface {
+	Run(ctx context.Context, input CloseStaleSessionsInput) (*CloseStaleSessionsResult, error)
+}
+
+type closeStaleSessionsUsecase struct {
+	staleSessionCloser port.StaleSessionCloser
+}
+
+// NewCloseStaleSessionsUsecase creates a CloseStaleSessionsUsecase.
+func NewCloseStaleSessionsUsecase(staleSessionCloser port.StaleSessionCloser) CloseStaleSessionsUsecase {
+	return &closeStaleSessionsUsecase{staleSessionCloser: staleSessionCloser}
+}
+
+// Run executes stale session cleanup or a dry run.
+func (u *closeStaleSessionsUsecase) Run(
+	ctx context.Context,
+	input CloseStaleSessionsInput,
+) (*CloseStaleSessionsResult, error) {
+	if u.staleSessionCloser == nil {
+		return nil, xerrors.Errorf("stale session closer is not configured")
+	}
+	if strings.TrimSpace(input.DBPath) == "" {
+		return nil, xerrors.Errorf("DB path must not be empty")
+	}
+
+	result, err := u.staleSessionCloser.CloseStaleSessions(
+		ctx,
+		strings.TrimSpace(input.DBPath),
+		port.StaleSessionCloserInput{
+			StaleAfter: input.StaleAfter,
+			DryRun:     input.DryRun,
+		},
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to close stale sessions: %w", err)
+	}
+
+	return &CloseStaleSessionsResult{
+		ClosedCount: result.ClosedCount,
+	}, nil
+}

--- a/domain/port/store.go
+++ b/domain/port/store.go
@@ -59,3 +59,19 @@ type StoreBackupRestorer interface {
 type GarbageCollector interface {
 	CollectGarbage(ctx context.Context, dbPath string, before time.Time, dryRun bool) (int, error)
 }
+
+// StaleSessionCloserInput defines the criteria for closing stale sessions.
+type StaleSessionCloserInput struct {
+	StaleAfter time.Duration
+	DryRun     bool
+}
+
+// StaleSessionCloserResult contains the count of closed sessions.
+type StaleSessionCloserResult struct {
+	ClosedCount int
+}
+
+// StaleSessionCloser closes sessions that have been active beyond a threshold.
+type StaleSessionCloser interface {
+	CloseStaleSessions(ctx context.Context, dbPath string, input StaleSessionCloserInput) (*StaleSessionCloserResult, error)
+}

--- a/infrastructure/sqlite/close_stale_sessions.go
+++ b/infrastructure/sqlite/close_stale_sessions.go
@@ -6,25 +6,18 @@ import (
 	"time"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
 )
 
-// CloseStaleSessionsInput defines the criteria for closing stale sessions.
-type CloseStaleSessionsInput struct {
-	StaleAfter time.Duration
-	DryRun     bool
-}
-
-// CloseStaleSessionsResult contains the count of closed sessions.
-type CloseStaleSessionsResult struct {
-	ClosedCount int
-}
+var _ port.StaleSessionCloser = (*Datasource)(nil)
 
 // CloseStaleSessions closes active sessions that have no recent events.
 func (d *Datasource) CloseStaleSessions(
 	ctx context.Context,
 	dbPath string,
-	input CloseStaleSessionsInput,
-) (*CloseStaleSessionsResult, error) {
+	input port.StaleSessionCloserInput,
+) (*port.StaleSessionCloserResult, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB: %w", err)
@@ -46,7 +39,7 @@ func (d *Datasource) CloseStaleSessions(
 		).Scan(&count); err != nil {
 			return nil, xerrors.Errorf("failed to count stale sessions: %w", err)
 		}
-		return &CloseStaleSessionsResult{ClosedCount: count}, nil
+		return &port.StaleSessionCloserResult{ClosedCount: count}, nil
 	}
 
 	now := formatTimestamp(time.Now())
@@ -64,5 +57,5 @@ func (d *Datasource) CloseStaleSessions(
 		return nil, xerrors.Errorf("failed to check rows affected: %w", err)
 	}
 
-	return &CloseStaleSessionsResult{ClosedCount: int(rowsAffected)}, nil
+	return &port.StaleSessionCloserResult{ClosedCount: int(rowsAffected)}, nil
 }

--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func run() error {
 	recordSessionBoundaryUsecase := usecase.NewRecordSessionBoundaryUsecase(datasource, datasource, datasource)
 	recordCommandAuditUsecase := usecase.NewRecordCommandAuditUsecase(datasource)
 	collectGarbageUsecase := usecase.NewCollectGarbageUsecase(datasource)
+	closeStaleSessionsUsecase := usecase.NewCloseStaleSessionsUsecase(datasource)
 	searchEventsQueryService := queryservice.NewSearchEventsQueryService(datasource)
 	listRecentEventsQueryService := queryservice.NewListRecentEventsQueryService(datasource)
 	getContextQueryService := queryservice.NewGetContextQueryService(datasource)
@@ -190,6 +191,7 @@ func run() error {
 		RecordSessionBoundaryUsecase:  recordSessionBoundaryUsecase,
 		RecordCommandAuditUsecase:     recordCommandAuditUsecase,
 		CollectGarbageUsecase:         collectGarbageUsecase,
+		CloseStaleSessionsUsecase:     closeStaleSessionsUsecase,
 		SearchEventsQueryService:      searchEventsQueryService,
 		ListEventsQueryService:        listRecentEventsQueryService,
 		GetContextQueryService:        getContextQueryService,

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -16,6 +16,7 @@ type RootCLI struct {
 	recordSessionBoundaryUsecase  usecase.RecordSessionBoundaryUsecase
 	recordCommandAuditUsecase     usecase.RecordCommandAuditUsecase
 	collectGarbageUsecase         usecase.CollectGarbageUsecase
+	closeStaleSessionsUsecase     usecase.CloseStaleSessionsUsecase
 	searchEventsQueryService      queryservice.SearchEventsQueryService
 	listEventsQueryService        queryservice.ListRecentEventsQueryService
 	getContextQueryService        queryservice.GetContextQueryService
@@ -35,6 +36,7 @@ type RootCLIOptions struct {
 	RecordSessionBoundaryUsecase  usecase.RecordSessionBoundaryUsecase
 	RecordCommandAuditUsecase     usecase.RecordCommandAuditUsecase
 	CollectGarbageUsecase         usecase.CollectGarbageUsecase
+	CloseStaleSessionsUsecase     usecase.CloseStaleSessionsUsecase
 	SearchEventsQueryService      queryservice.SearchEventsQueryService
 	ListEventsQueryService        queryservice.ListRecentEventsQueryService
 	GetContextQueryService        queryservice.GetContextQueryService
@@ -55,6 +57,7 @@ func NewRootCLI(options RootCLIOptions) *RootCLI {
 		recordSessionBoundaryUsecase:  options.RecordSessionBoundaryUsecase,
 		recordCommandAuditUsecase:     options.RecordCommandAuditUsecase,
 		collectGarbageUsecase:         options.CollectGarbageUsecase,
+		closeStaleSessionsUsecase:     options.CloseStaleSessionsUsecase,
 		searchEventsQueryService:      options.SearchEventsQueryService,
 		listEventsQueryService:        options.ListEventsQueryService,
 		getContextQueryService:        options.GetContextQueryService,

--- a/presentation/cli/session_gc.go
+++ b/presentation/cli/session_gc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+	"github.com/duck8823/traceary/application/usecase"
 )
 
 func (c *RootCLI) newSessionGCCommand() *cobra.Command {
@@ -33,8 +33,8 @@ func (c *RootCLI) newSessionGCCommand() *cobra.Command {
 				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 			}
 
-			ds := infra.NewDatasource(nil)
-			result, err := ds.CloseStaleSessions(ctx, resolvedDBPath, infra.CloseStaleSessionsInput{
+			result, err := c.closeStaleSessionsUsecase.Run(ctx, usecase.CloseStaleSessionsInput{
+				DBPath:     resolvedDBPath,
 				StaleAfter: staleAfter,
 				DryRun:     dryRun,
 			})


### PR DESCRIPTION
## Summary
- Remove direct `infrastructure/sqlite` import from `presentation/cli/session_gc.go`
- Add `StaleSessionCloser` port interface to `domain/port/store.go`
- Create `CloseStaleSessionsUsecase` in `application/usecase/`
- Update `infrastructure/sqlite/close_stale_sessions.go` to implement the port interface
- Wire through `RootCLI` and `main.go`

This was the only CLI command that bypassed the DI container and directly instantiated infrastructure. All commands now follow the same usecase/queryservice injection pattern.

Closes #336

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go tool golangci-lint run` — 0 issues
- [ ] `traceary session gc --stale-after 24h --dry-run` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)