### PR TITLE
fix: filter release badge by push event

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 </p>
 
 [![CI](https://github.com/duck8823/traceary/actions/workflows/ci.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/ci.yml)
-[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
+[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
 
 Traceary は、AI エージェントの作業ログ、セッション境界、シェルコマンド監査をローカルの SQLite に残して検索できる CLI / MCP サーバーです。
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 [![CI](https://github.com/duck8823/traceary/actions/workflows/ci.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/ci.yml)
-[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
+[![Release](https://github.com/duck8823/traceary/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/duck8823/traceary/actions/workflows/release.yml)
 
 Traceary is a local-first CLI and MCP server for recording and searching AI agent work logs, session boundaries, and shell command audits.
 


### PR DESCRIPTION
## Summary
- Add `?event=push` filter to Release badge URL in both README.md and README.ja.md
- Excludes stale `workflow_dispatch` run that caused "failing" badge

Closes #351

## Test plan
- [x] Badge URL renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)