### PR TITLE
refactor: move queryservice consumer interfaces to domain/port

### DIFF
--- a/application/queryservice/find_latest_session.go
+++ b/application/queryservice/find_latest_session.go
@@ -8,45 +8,21 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
-
-// FindLatestSessionInput is the input for latest-session lookup.
-type FindLatestSessionInput struct {
-	Client     string
-	Agent      string
-	Repo       string
-	ActiveOnly bool
-}
-
-var (
-	// ErrSessionNotFound indicates that no session matches the filters.
-	ErrSessionNotFound = xerrors.New("no matching session found")
-	// ErrActiveSessionNotFound indicates that no active session matches the filters.
-	ErrActiveSessionNotFound = xerrors.New("no matching active session found")
-)
-
-// LatestSessionFinder provides access to the latest matching session start event.
-type LatestSessionFinder interface {
-	// FindLatestSessionStartedEvent returns the session_started event for the latest matching session.
-	FindLatestSessionStartedEvent(
-		ctx context.Context,
-		dbPath string,
-		input FindLatestSessionInput,
-	) (*model.Event, error)
-}
 
 // FindLatestSessionQueryService returns the latest session.
 type FindLatestSessionQueryService interface {
 	// Run executes the latest-session query.
-	Run(ctx context.Context, dbPath string, input FindLatestSessionInput) (*model.Event, error)
+	Run(ctx context.Context, dbPath string, input port.FindLatestSessionInput) (*model.Event, error)
 }
 
 type findLatestSessionQueryService struct {
-	latestSessionFinder LatestSessionFinder
+	latestSessionFinder port.LatestSessionFinder
 }
 
 // NewFindLatestSessionQueryService creates a FindLatestSessionQueryService.
-func NewFindLatestSessionQueryService(latestSessionFinder LatestSessionFinder) FindLatestSessionQueryService {
+func NewFindLatestSessionQueryService(latestSessionFinder port.LatestSessionFinder) FindLatestSessionQueryService {
 	return &findLatestSessionQueryService{latestSessionFinder: latestSessionFinder}
 }
 
@@ -54,7 +30,7 @@ func NewFindLatestSessionQueryService(latestSessionFinder LatestSessionFinder) F
 func (s *findLatestSessionQueryService) Run(
 	ctx context.Context,
 	dbPath string,
-	input FindLatestSessionInput,
+	input port.FindLatestSessionInput,
 ) (*model.Event, error) {
 	if s.latestSessionFinder == nil {
 		return nil, xerrors.Errorf("latest session finder is not configured")
@@ -65,7 +41,7 @@ func (s *findLatestSessionQueryService) Run(
 
 	event, err := s.latestSessionFinder.FindLatestSessionStartedEvent(ctx, dbPath, input)
 	if err != nil {
-		if errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrActiveSessionNotFound) {
+		if errors.Is(err, port.ErrSessionNotFound) || errors.Is(err, port.ErrActiveSessionNotFound) {
 			//nolint:wrapcheck // Preserve the user-facing not-found message.
 			return nil, err
 		}
@@ -77,5 +53,5 @@ func (s *findLatestSessionQueryService) Run(
 
 // IsSessionLookupNotFound reports whether err is a session-lookup not-found error.
 func IsSessionLookupNotFound(err error) bool {
-	return errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrActiveSessionNotFound)
+	return errors.Is(err, port.ErrSessionNotFound) || errors.Is(err, port.ErrActiveSessionNotFound)
 }

--- a/application/queryservice/find_latest_session_test.go
+++ b/application/queryservice/find_latest_session_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 type latestSessionFinderStub struct {
 	receivedPath  string
-	receivedInput queryservice.FindLatestSessionInput
+	receivedInput port.FindLatestSessionInput
 	event         *model.Event
 	err           error
 }
@@ -21,7 +22,7 @@ type latestSessionFinderStub struct {
 func (s *latestSessionFinderStub) FindLatestSessionStartedEvent(
 	_ context.Context,
 	dbPath string,
-	input queryservice.FindLatestSessionInput,
+	input port.FindLatestSessionInput,
 ) (*model.Event, error) {
 	s.receivedPath = dbPath
 	s.receivedInput = input
@@ -61,7 +62,7 @@ func TestFindLatestSessionQueryService_Run(t *testing.T) {
 		}
 		sut := queryservice.NewFindLatestSessionQueryService(stub)
 
-		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.FindLatestSessionInput{
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", port.FindLatestSessionInput{
 			Client:     "cli",
 			Agent:      "codex",
 			Repo:       "github.com/duck8823/traceary",
@@ -88,18 +89,18 @@ func TestFindLatestSessionQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		stub := &latestSessionFinderStub{
-			err: queryservice.ErrActiveSessionNotFound,
+			err: port.ErrActiveSessionNotFound,
 		}
 		sut := queryservice.NewFindLatestSessionQueryService(stub)
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.FindLatestSessionInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.FindLatestSessionInput{
 			ActiveOnly: true,
 		})
-		if !errors.Is(err, queryservice.ErrActiveSessionNotFound) {
+		if !errors.Is(err, port.ErrActiveSessionNotFound) {
 			t.Fatalf("Run() error = %v, want ErrActiveSessionNotFound", err)
 		}
-		if err.Error() != queryservice.ErrActiveSessionNotFound.Error() {
-			t.Fatalf("error = %q, want %q", err.Error(), queryservice.ErrActiveSessionNotFound.Error())
+		if err.Error() != port.ErrActiveSessionNotFound.Error() {
+			t.Fatalf("error = %q, want %q", err.Error(), port.ErrActiveSessionNotFound.Error())
 		}
 	})
 }

--- a/application/queryservice/get_context.go
+++ b/application/queryservice/get_context.go
@@ -7,33 +7,21 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
-
-// GetContextInput is the input for context retrieval.
-type GetContextInput struct {
-	Repo      string
-	SessionID string
-	Limit     int
-}
-
-// ContextEventFinder provides contextual event lookup.
-type ContextEventFinder interface {
-	// GetContextEvents returns matching events in descending time order.
-	GetContextEvents(ctx context.Context, dbPath string, input GetContextInput) ([]*model.Event, error)
-}
 
 // GetContextQueryService returns contextual events.
 type GetContextQueryService interface {
 	// Run executes the context query.
-	Run(ctx context.Context, dbPath string, input GetContextInput) ([]*model.Event, error)
+	Run(ctx context.Context, dbPath string, input port.GetContextInput) ([]*model.Event, error)
 }
 
 type getContextQueryService struct {
-	contextEventFinder ContextEventFinder
+	contextEventFinder port.ContextEventFinder
 }
 
 // NewGetContextQueryService creates a GetContextQueryService.
-func NewGetContextQueryService(contextEventFinder ContextEventFinder) GetContextQueryService {
+func NewGetContextQueryService(contextEventFinder port.ContextEventFinder) GetContextQueryService {
 	return &getContextQueryService{contextEventFinder: contextEventFinder}
 }
 
@@ -41,7 +29,7 @@ func NewGetContextQueryService(contextEventFinder ContextEventFinder) GetContext
 func (s *getContextQueryService) Run(
 	ctx context.Context,
 	dbPath string,
-	input GetContextInput,
+	input port.GetContextInput,
 ) ([]*model.Event, error) {
 	if s.contextEventFinder == nil {
 		return nil, xerrors.Errorf("context event finder is not configured")

--- a/application/queryservice/get_context_test.go
+++ b/application/queryservice/get_context_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 type contextEventFinderStub struct {
 	receivedPath  string
-	receivedInput queryservice.GetContextInput
+	receivedInput port.GetContextInput
 	events        []*model.Event
 	err           error
 }
@@ -20,7 +21,7 @@ type contextEventFinderStub struct {
 func (s *contextEventFinderStub) GetContextEvents(
 	_ context.Context,
 	dbPath string,
-	input queryservice.GetContextInput,
+	input port.GetContextInput,
 ) ([]*model.Event, error) {
 	s.receivedPath = dbPath
 	s.receivedInput = input
@@ -62,7 +63,7 @@ func TestGetContextQueryService_Run(t *testing.T) {
 		}
 		sut := queryservice.NewGetContextQueryService(stub)
 
-		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.GetContextInput{
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", port.GetContextInput{
 			Repo:      "github.com/duck8823/traceary",
 			SessionID: "session-1",
 			Limit:     10,
@@ -86,7 +87,7 @@ func TestGetContextQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewGetContextQueryService(&contextEventFinderStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.GetContextInput{Limit: 0})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.GetContextInput{Limit: 0})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}

--- a/application/queryservice/get_event_details.go
+++ b/application/queryservice/get_event_details.go
@@ -6,51 +6,21 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
-
-// EventDetails represents the details for a single event.
-type EventDetails struct {
-	event        *model.Event
-	commandAudit *model.CommandAudit
-}
-
-// NewEventDetails creates an EventDetails value.
-func NewEventDetails(event *model.Event, commandAudit *model.CommandAudit) (*EventDetails, error) {
-	if event == nil {
-		return nil, xerrors.Errorf("event must not be nil")
-	}
-
-	return &EventDetails{
-		event:        event,
-		commandAudit: commandAudit,
-	}, nil
-}
-
-// Event returns the event.
-func (d *EventDetails) Event() *model.Event { return d.event }
-
-// CommandAudit returns the linked command audit.
-func (d *EventDetails) CommandAudit() *model.CommandAudit { return d.commandAudit }
-
-// EventDetailsFinder provides event-details lookup.
-type EventDetailsFinder interface {
-	// GetEventDetails returns the details for the given event ID.
-	GetEventDetails(ctx context.Context, dbPath string, eventID string) (*EventDetails, error)
-}
 
 // GetEventDetailsQueryService returns event details.
 type GetEventDetailsQueryService interface {
 	// Run executes the event-details query.
-	Run(ctx context.Context, dbPath string, eventID string) (*EventDetails, error)
+	Run(ctx context.Context, dbPath string, eventID string) (*port.EventDetails, error)
 }
 
 type getEventDetailsQueryService struct {
-	eventDetailsFinder EventDetailsFinder
+	eventDetailsFinder port.EventDetailsFinder
 }
 
 // NewGetEventDetailsQueryService creates a GetEventDetailsQueryService.
-func NewGetEventDetailsQueryService(eventDetailsFinder EventDetailsFinder) GetEventDetailsQueryService {
+func NewGetEventDetailsQueryService(eventDetailsFinder port.EventDetailsFinder) GetEventDetailsQueryService {
 	return &getEventDetailsQueryService{eventDetailsFinder: eventDetailsFinder}
 }
 
@@ -59,7 +29,7 @@ func (s *getEventDetailsQueryService) Run(
 	ctx context.Context,
 	dbPath string,
 	eventID string,
-) (*EventDetails, error) {
+) (*port.EventDetails, error) {
 	if s.eventDetailsFinder == nil {
 		return nil, xerrors.Errorf("event details finder is not configured")
 	}

--- a/application/queryservice/get_event_details_test.go
+++ b/application/queryservice/get_event_details_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 type eventDetailsFinderStub struct {
 	receivedPath    string
 	receivedEventID string
-	eventDetails    *queryservice.EventDetails
+	eventDetails    *port.EventDetails
 	err             error
 }
 
@@ -21,7 +22,7 @@ func (s *eventDetailsFinderStub) GetEventDetails(
 	_ context.Context,
 	dbPath string,
 	eventID string,
-) (*queryservice.EventDetails, error) {
+) (*port.EventDetails, error) {
 	s.receivedPath = dbPath
 	s.receivedEventID = eventID
 	return s.eventDetails, s.err
@@ -46,7 +47,7 @@ func TestGetEventDetailsQueryService_Run(t *testing.T) {
 	t.Run("returns event details", func(t *testing.T) {
 		t.Parallel()
 
-		eventDetails, err := queryservice.NewEventDetails(
+		eventDetails, err := port.NewEventDetails(
 			model.EventOf(
 				eventID,
 				types.EventKindCommandExecuted,

--- a/application/queryservice/list_recent_events.go
+++ b/application/queryservice/list_recent_events.go
@@ -2,45 +2,25 @@ package queryservice
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
-
-// ListRecentEventsInput is the input for recent event listing.
-type ListRecentEventsInput struct {
-	Limit        int
-	Offset       int
-	Kind         string
-	Client       string
-	Agent        string
-	SessionID    string
-	Repo         string
-	FailuresOnly bool
-	From         time.Time
-	To           time.Time
-}
-
-// RecentEventFinder provides recent event lookup.
-type RecentEventFinder interface {
-	// ListRecent returns events in descending time order.
-	ListRecent(ctx context.Context, dbPath string, input ListRecentEventsInput) ([]*model.Event, error)
-}
 
 // ListRecentEventsQueryService returns recent events.
 type ListRecentEventsQueryService interface {
 	// Run executes the recent event query.
-	Run(ctx context.Context, dbPath string, input ListRecentEventsInput) ([]*model.Event, error)
+	Run(ctx context.Context, dbPath string, input port.ListRecentEventsInput) ([]*model.Event, error)
 }
 
 type listRecentEventsQueryService struct {
-	recentEventFinder RecentEventFinder
+	recentEventFinder port.RecentEventFinder
 }
 
 // NewListRecentEventsQueryService creates a ListRecentEventsQueryService.
-func NewListRecentEventsQueryService(recentEventFinder RecentEventFinder) ListRecentEventsQueryService {
+func NewListRecentEventsQueryService(recentEventFinder port.RecentEventFinder) ListRecentEventsQueryService {
 	return &listRecentEventsQueryService{recentEventFinder: recentEventFinder}
 }
 
@@ -48,7 +28,7 @@ func NewListRecentEventsQueryService(recentEventFinder RecentEventFinder) ListRe
 func (s *listRecentEventsQueryService) Run(
 	ctx context.Context,
 	dbPath string,
-	input ListRecentEventsInput,
+	input port.ListRecentEventsInput,
 ) ([]*model.Event, error) {
 	if s.recentEventFinder == nil {
 		return nil, xerrors.Errorf("recent event finder is not configured")

--- a/application/queryservice/list_recent_events_test.go
+++ b/application/queryservice/list_recent_events_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 type recentEventFinderStub struct {
 	receivedPath  string
-	receivedInput queryservice.ListRecentEventsInput
+	receivedInput port.ListRecentEventsInput
 	events        []*model.Event
 	err           error
 }
@@ -20,7 +21,7 @@ type recentEventFinderStub struct {
 func (s *recentEventFinderStub) ListRecent(
 	_ context.Context,
 	dbPath string,
-	input queryservice.ListRecentEventsInput,
+	input port.ListRecentEventsInput,
 ) ([]*model.Event, error) {
 	s.receivedPath = dbPath
 	s.receivedInput = input
@@ -62,7 +63,7 @@ func TestListRecentEventsQueryService_Run(t *testing.T) {
 		}
 		sut := queryservice.NewListRecentEventsQueryService(stub)
 
-		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListRecentEventsInput{
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListRecentEventsInput{
 			Limit:     5,
 			Offset:    2,
 			Kind:      "note",
@@ -102,7 +103,7 @@ func TestListRecentEventsQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewListRecentEventsQueryService(&recentEventFinderStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListRecentEventsInput{})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListRecentEventsInput{})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}
@@ -113,7 +114,7 @@ func TestListRecentEventsQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewListRecentEventsQueryService(&recentEventFinderStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListRecentEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListRecentEventsInput{
 			Limit:  10,
 			Offset: -1,
 		})

--- a/application/queryservice/list_sessions.go
+++ b/application/queryservice/list_sessions.go
@@ -2,62 +2,31 @@ package queryservice
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
 )
-
-// SessionSummary holds aggregated information about a single session.
-type SessionSummary struct {
-	SessionID       string
-	Repo            string
-	StartedAt       time.Time
-	EndedAt         *time.Time
-	Status          string
-	TotalEvents     int
-	CommandCount    int
-	Agents          []string
-	Label           string
-	Summary         string
-	ParentSessionID string
-}
-
-// ListSessionsInput is the input for session listing.
-type ListSessionsInput struct {
-	Limit  int
-	Offset int
-	Repo   string
-	Client string
-	Agent  string
-	Label  string
-	From   *time.Time
-	To     *time.Time
-}
-
-// SessionSummaryFinder provides session summary lookup.
-type SessionSummaryFinder interface {
-	ListSessionSummaries(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
-}
 
 // ListSessionsQueryService returns session summaries.
 type ListSessionsQueryService interface {
-	Run(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+	Run(ctx context.Context, dbPath string, input port.ListSessionsInput) ([]*port.SessionSummary, error)
 }
 
 type listSessionsQueryService struct {
-	finder SessionSummaryFinder
+	finder port.SessionSummaryFinder
 }
 
 // NewListSessionsQueryService creates a ListSessionsQueryService.
-func NewListSessionsQueryService(finder SessionSummaryFinder) ListSessionsQueryService {
+func NewListSessionsQueryService(finder port.SessionSummaryFinder) ListSessionsQueryService {
 	return &listSessionsQueryService{finder: finder}
 }
 
 func (s *listSessionsQueryService) Run(
 	ctx context.Context,
 	dbPath string,
-	input ListSessionsInput,
-) ([]*SessionSummary, error) {
+	input port.ListSessionsInput,
+) ([]*port.SessionSummary, error) {
 	if s.finder == nil {
 		return nil, xerrors.Errorf("session summary finder is not configured")
 	}

--- a/application/queryservice/list_sessions_test.go
+++ b/application/queryservice/list_sessions_test.go
@@ -6,20 +6,21 @@ import (
 	"time"
 
 	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 type sessionSummaryFinderStub struct {
 	receivedPath  string
-	receivedInput queryservice.ListSessionsInput
-	summaries     []*queryservice.SessionSummary
+	receivedInput port.ListSessionsInput
+	summaries     []*port.SessionSummary
 	err           error
 }
 
 func (s *sessionSummaryFinderStub) ListSessionSummaries(
 	_ context.Context,
 	dbPath string,
-	input queryservice.ListSessionsInput,
-) ([]*queryservice.SessionSummary, error) {
+	input port.ListSessionsInput,
+) ([]*port.SessionSummary, error) {
 	s.receivedPath = dbPath
 	s.receivedInput = input
 	return s.summaries, s.err
@@ -32,7 +33,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		stub := &sessionSummaryFinderStub{
-			summaries: []*queryservice.SessionSummary{
+			summaries: []*port.SessionSummary{
 				{
 					SessionID:    "s1",
 					StartedAt:    time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
@@ -44,7 +45,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		}
 		sut := queryservice.NewListSessionsQueryService(stub)
 
-		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListSessionsInput{
 			Limit: 10,
 			Repo:  "duck8823/traceary",
 		})
@@ -66,7 +67,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewListSessionsQueryService(nil)
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 10})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListSessionsInput{Limit: 10})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}
@@ -76,7 +77,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
-		_, err := sut.Run(context.Background(), "", queryservice.ListSessionsInput{Limit: 10})
+		_, err := sut.Run(context.Background(), "", port.ListSessionsInput{Limit: 10})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}
@@ -86,7 +87,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 0})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListSessionsInput{Limit: 0})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}
@@ -96,7 +97,7 @@ func TestListSessionsQueryService_Run(t *testing.T) {
 		t.Parallel()
 
 		sut := queryservice.NewListSessionsQueryService(&sessionSummaryFinderStub{})
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.ListSessionsInput{Limit: 10, Offset: -1})
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.ListSessionsInput{Limit: 10, Offset: -1})
 		if err == nil {
 			t.Fatalf("Run() error = nil, want error")
 		}

--- a/application/queryservice/search_events.go
+++ b/application/queryservice/search_events.go
@@ -4,47 +4,26 @@ import (
 	"context"
 	"slices"
 	"strings"
-	"time"
 
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
-
-// SearchEventsInput is the input for event search.
-type SearchEventsInput struct {
-	Query        string
-	Repo         string
-	SessionID    string
-	Client       string
-	Agent        string
-	Kind         string
-	From         time.Time
-	To           time.Time
-	Limit        int
-	Offset       int
-	FailuresOnly bool
-}
-
-// EventSearcher provides event search.
-type EventSearcher interface {
-	// SearchEvents returns matching events in descending time order.
-	SearchEvents(ctx context.Context, dbPath string, input SearchEventsInput) ([]*model.Event, error)
-}
 
 // SearchEventsQueryService searches events.
 type SearchEventsQueryService interface {
 	// Run executes the event search query.
-	Run(ctx context.Context, dbPath string, input SearchEventsInput) ([]*model.Event, error)
+	Run(ctx context.Context, dbPath string, input port.SearchEventsInput) ([]*model.Event, error)
 }
 
 type searchEventsQueryService struct {
-	eventSearcher EventSearcher
+	eventSearcher port.EventSearcher
 }
 
 // NewSearchEventsQueryService creates a SearchEventsQueryService.
-func NewSearchEventsQueryService(eventSearcher EventSearcher) SearchEventsQueryService {
+func NewSearchEventsQueryService(eventSearcher port.EventSearcher) SearchEventsQueryService {
 	return &searchEventsQueryService{eventSearcher: eventSearcher}
 }
 
@@ -52,7 +31,7 @@ func NewSearchEventsQueryService(eventSearcher EventSearcher) SearchEventsQueryS
 func (s *searchEventsQueryService) Run(
 	ctx context.Context,
 	dbPath string,
-	input SearchEventsInput,
+	input port.SearchEventsInput,
 ) ([]*model.Event, error) {
 	if s.eventSearcher == nil {
 		return nil, xerrors.Errorf("event searcher is not configured")
@@ -92,7 +71,7 @@ func (s *searchEventsQueryService) Run(
 	return events, nil
 }
 
-func hasSearchConstraint(input SearchEventsInput) bool {
+func hasSearchConstraint(input port.SearchEventsInput) bool {
 	return strings.TrimSpace(input.Query) != "" ||
 		strings.TrimSpace(input.Repo) != "" ||
 		strings.TrimSpace(input.SessionID) != "" ||

--- a/application/queryservice/search_events_test.go
+++ b/application/queryservice/search_events_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 type eventSearcherStub struct {
 	receivedPath  string
-	receivedInput queryservice.SearchEventsInput
+	receivedInput port.SearchEventsInput
 	events        []*model.Event
 	err           error
 }
@@ -20,7 +21,7 @@ type eventSearcherStub struct {
 func (s *eventSearcherStub) SearchEvents(
 	_ context.Context,
 	dbPath string,
-	input queryservice.SearchEventsInput,
+	input port.SearchEventsInput,
 ) ([]*model.Event, error) {
 	s.receivedPath = dbPath
 	s.receivedInput = input
@@ -62,7 +63,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		}
 		sut := queryservice.NewSearchEventsQueryService(stub)
 
-		got, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		got, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			Query:     "traceary",
 			Repo:      "github.com/duck8823/traceary",
 			SessionID: "session-1",
@@ -98,7 +99,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		stub := &eventSearcherStub{}
 		sut := queryservice.NewSearchEventsQueryService(stub)
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			SessionID: "session-1",
 			Limit:     10,
 		})
@@ -115,7 +116,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			Query: "   ",
 			Limit: 10,
 		})
@@ -129,7 +130,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			Query: "traceary",
 			Kind:  "unknown",
 			Limit: 10,
@@ -144,7 +145,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 
 		sut := queryservice.NewSearchEventsQueryService(&eventSearcherStub{})
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			Query:  "traceary",
 			Limit:  10,
 			Offset: -1,
@@ -160,7 +161,7 @@ func TestSearchEventsQueryService_Run(t *testing.T) {
 		stub := &eventSearcherStub{}
 		sut := queryservice.NewSearchEventsQueryService(stub)
 
-		_, err := sut.Run(context.Background(), "/tmp/traceary.db", queryservice.SearchEventsInput{
+		_, err := sut.Run(context.Background(), "/tmp/traceary.db", port.SearchEventsInput{
 			Query: "go test",
 			Kind:  "audit",
 			Limit: 10,

--- a/domain/port/query.go
+++ b/domain/port/query.go
@@ -1,0 +1,163 @@
+package port
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+)
+
+// --- List Recent Events ---
+
+// ListRecentEventsInput is the input for recent event listing.
+type ListRecentEventsInput struct {
+	Limit        int
+	Offset       int
+	Kind         string
+	Client       string
+	Agent        string
+	SessionID    string
+	Repo         string
+	FailuresOnly bool
+	From         time.Time
+	To           time.Time
+}
+
+// RecentEventFinder provides recent event lookup.
+type RecentEventFinder interface {
+	// ListRecent returns events in descending time order.
+	ListRecent(ctx context.Context, dbPath string, input ListRecentEventsInput) ([]*model.Event, error)
+}
+
+// --- Search Events ---
+
+// SearchEventsInput is the input for event search.
+type SearchEventsInput struct {
+	Query        string
+	Repo         string
+	SessionID    string
+	Client       string
+	Agent        string
+	Kind         string
+	From         time.Time
+	To           time.Time
+	Limit        int
+	Offset       int
+	FailuresOnly bool
+}
+
+// EventSearcher provides event search.
+type EventSearcher interface {
+	// SearchEvents returns matching events in descending time order.
+	SearchEvents(ctx context.Context, dbPath string, input SearchEventsInput) ([]*model.Event, error)
+}
+
+// --- Get Context ---
+
+// GetContextInput is the input for context retrieval.
+type GetContextInput struct {
+	Repo      string
+	SessionID string
+	Limit     int
+}
+
+// ContextEventFinder provides contextual event lookup.
+type ContextEventFinder interface {
+	// GetContextEvents returns matching events in descending time order.
+	GetContextEvents(ctx context.Context, dbPath string, input GetContextInput) ([]*model.Event, error)
+}
+
+// --- Get Event Details ---
+
+// EventDetails represents the details for a single event.
+type EventDetails struct {
+	event        *model.Event
+	commandAudit *model.CommandAudit
+}
+
+// NewEventDetails creates an EventDetails value.
+func NewEventDetails(event *model.Event, commandAudit *model.CommandAudit) (*EventDetails, error) {
+	if event == nil {
+		return nil, xerrors.Errorf("event must not be nil")
+	}
+
+	return &EventDetails{
+		event:        event,
+		commandAudit: commandAudit,
+	}, nil
+}
+
+// Event returns the event.
+func (d *EventDetails) Event() *model.Event { return d.event }
+
+// CommandAudit returns the linked command audit.
+func (d *EventDetails) CommandAudit() *model.CommandAudit { return d.commandAudit }
+
+// EventDetailsFinder provides event-details lookup.
+type EventDetailsFinder interface {
+	// GetEventDetails returns the details for the given event ID.
+	GetEventDetails(ctx context.Context, dbPath string, eventID string) (*EventDetails, error)
+}
+
+// --- Find Latest Session ---
+
+// FindLatestSessionInput is the input for latest-session lookup.
+type FindLatestSessionInput struct {
+	Client     string
+	Agent      string
+	Repo       string
+	ActiveOnly bool
+}
+
+var (
+	// ErrSessionNotFound indicates that no session matches the filters.
+	ErrSessionNotFound = xerrors.New("no matching session found")
+	// ErrActiveSessionNotFound indicates that no active session matches the filters.
+	ErrActiveSessionNotFound = xerrors.New("no matching active session found")
+)
+
+// LatestSessionFinder provides access to the latest matching session start event.
+type LatestSessionFinder interface {
+	// FindLatestSessionStartedEvent returns the session_started event for the latest matching session.
+	FindLatestSessionStartedEvent(
+		ctx context.Context,
+		dbPath string,
+		input FindLatestSessionInput,
+	) (*model.Event, error)
+}
+
+// --- List Sessions ---
+
+// SessionSummary holds aggregated information about a single session.
+type SessionSummary struct {
+	SessionID       string
+	Repo            string
+	StartedAt       time.Time
+	EndedAt         *time.Time
+	Status          string
+	TotalEvents     int
+	CommandCount    int
+	Agents          []string
+	Label           string
+	Summary         string
+	ParentSessionID string
+}
+
+// ListSessionsInput is the input for session listing.
+type ListSessionsInput struct {
+	Limit  int
+	Offset int
+	Repo   string
+	Client string
+	Agent  string
+	Label  string
+	From   *time.Time
+	To     *time.Time
+}
+
+// SessionSummaryFinder provides session summary lookup.
+type SessionSummaryFinder interface {
+	ListSessionSummaries(ctx context.Context, dbPath string, input ListSessionsInput) ([]*SessionSummary, error)
+}

--- a/infrastructure/sqlite/event_store.go
+++ b/infrastructure/sqlite/event_store.go
@@ -8,12 +8,12 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
-var _ queryservice.RecentEventFinder = (*Datasource)(nil)
+var _ port.RecentEventFinder = (*Datasource)(nil)
 
 // Save persists an event.
 func (d *Datasource) Save(ctx context.Context, dbPath string, event *model.Event) error {
@@ -54,7 +54,7 @@ func (d *Datasource) Save(ctx context.Context, dbPath string, event *model.Event
 func (d *Datasource) ListRecent(
 	ctx context.Context,
 	dbPath string,
-	input queryservice.ListRecentEventsInput,
+	input port.ListRecentEventsInput,
 ) ([]*model.Event, error) {
 	if input.Limit <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
@@ -84,7 +84,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("Save(newer) error = %v", err)
 	}
 
-	got, err := sut.ListRecent(context.Background(), dbPath, queryservice.ListRecentEventsInput{
+	got, err := sut.ListRecent(context.Background(), dbPath, port.ListRecentEventsInput{
 		Limit: 10,
 	})
 	if err != nil {
@@ -166,7 +166,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("Save() error = %v", err)
 	}
 
-	got, err := sut.ListRecent(context.Background(), dbPath, queryservice.ListRecentEventsInput{
+	got, err := sut.ListRecent(context.Background(), dbPath, port.ListRecentEventsInput{
 		Limit: 1,
 	})
 	if err != nil {
@@ -239,7 +239,7 @@ CREATE TABLE command_audits (
 		}
 	}
 
-	got, err := sut.ListRecent(context.Background(), dbPath, queryservice.ListRecentEventsInput{
+	got, err := sut.ListRecent(context.Background(), dbPath, port.ListRecentEventsInput{
 		Limit:  1,
 		Offset: 1,
 	})
@@ -314,7 +314,7 @@ CREATE TABLE command_audits (
 		}
 	}
 
-	got, err := sut.ListRecent(context.Background(), dbPath, queryservice.ListRecentEventsInput{
+	got, err := sut.ListRecent(context.Background(), dbPath, port.ListRecentEventsInput{
 		Limit:     10,
 		Kind:      types.EventKindNote.String(),
 		Client:    "cli",

--- a/infrastructure/sqlite/find_latest_session.go
+++ b/infrastructure/sqlite/find_latest_session.go
@@ -8,18 +8,18 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
-var _ queryservice.LatestSessionFinder = (*Datasource)(nil)
+var _ port.LatestSessionFinder = (*Datasource)(nil)
 
 // FindLatestSessionStartedEvent returns the latest session_started event.
 func (d *Datasource) FindLatestSessionStartedEvent(
 	ctx context.Context,
 	dbPath string,
-	input queryservice.FindLatestSessionInput,
+	input port.FindLatestSessionInput,
 ) (*model.Event, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {
@@ -129,9 +129,9 @@ func (d *Datasource) FindLatestSessionStartedEvent(
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			if input.ActiveOnly {
-				return nil, queryservice.ErrActiveSessionNotFound
+				return nil, port.ErrActiveSessionNotFound
 			}
-			return nil, queryservice.ErrSessionNotFound
+			return nil, port.ErrSessionNotFound
 		}
 		return nil, xerrors.Errorf("failed to restore latest session event: %w", err)
 	}

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -8,7 +8,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
@@ -110,7 +110,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		got, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{
+			port.FindLatestSessionInput{
 				Client: "cli",
 				Agent:  "codex",
 				Repo:   "github.com/duck8823/traceary",
@@ -154,7 +154,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		got, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{
+			port.FindLatestSessionInput{
 				Client: "cli",
 				Agent:  "codex",
 				Repo:   "github.com/duck8823/traceary",
@@ -172,7 +172,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		got, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{
+			port.FindLatestSessionInput{
 				Client:     "cli",
 				Agent:      "codex",
 				Repo:       "github.com/duck8823/traceary",
@@ -204,7 +204,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		got, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{
+			port.FindLatestSessionInput{
 				Client: "cli",
 				Agent:  "codex",
 				Repo:   "github.com/duck8823/traceary",
@@ -222,12 +222,12 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		_, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{Agent: "claude"},
+			port.FindLatestSessionInput{Agent: "claude"},
 		)
 		if err == nil {
 			t.Fatalf("FindLatestSessionStartedEvent() error = nil, want error")
 		}
-		if !errors.Is(err, queryservice.ErrSessionNotFound) {
+		if !errors.Is(err, port.ErrSessionNotFound) {
 			t.Fatalf("error = %v, want ErrSessionNotFound", err)
 		}
 	})
@@ -236,7 +236,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		_, err := sut.FindLatestSessionStartedEvent(
 			context.Background(),
 			dbPath,
-			queryservice.FindLatestSessionInput{
+			port.FindLatestSessionInput{
 				Agent:      "claude",
 				ActiveOnly: true,
 			},
@@ -244,7 +244,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		if err == nil {
 			t.Fatalf("FindLatestSessionStartedEvent() error = nil, want error")
 		}
-		if !errors.Is(err, queryservice.ErrActiveSessionNotFound) {
+		if !errors.Is(err, port.ErrActiveSessionNotFound) {
 			t.Fatalf("error = %v, want ErrActiveSessionNotFound", err)
 		}
 	})
@@ -319,7 +319,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 	got, err := sut.FindLatestSessionStartedEvent(
 		context.Background(),
 		dbPath,
-		queryservice.FindLatestSessionInput{
+		port.FindLatestSessionInput{
 			Client: "cli",
 			Agent:  "codex",
 			Repo:   "github.com/duck8823/traceary",
@@ -389,7 +389,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 	got, err := sut.FindLatestSessionStartedEvent(
 		context.Background(),
 		dbPath,
-		queryservice.FindLatestSessionInput{
+		port.FindLatestSessionInput{
 			Client:     "cli",
 			Agent:      "codex",
 			Repo:       "github.com/duck8823/traceary",

--- a/infrastructure/sqlite/get_context_events.go
+++ b/infrastructure/sqlite/get_context_events.go
@@ -7,17 +7,17 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
 
-var _ queryservice.ContextEventFinder = (*Datasource)(nil)
+var _ port.ContextEventFinder = (*Datasource)(nil)
 
 // GetContextEvents returns events matching the requested context in descending time order.
 func (d *Datasource) GetContextEvents(
 	ctx context.Context,
 	dbPath string,
-	input queryservice.GetContextInput,
+	input port.GetContextInput,
 ) ([]*model.Event, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {

--- a/infrastructure/sqlite/get_context_events_test.go
+++ b/infrastructure/sqlite/get_context_events_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
@@ -75,7 +75,7 @@ ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT '';`),
 		t.Fatalf("Save(third) error = %v", err)
 	}
 
-	got, err := sut.GetContextEvents(context.Background(), dbPath, queryservice.GetContextInput{
+	got, err := sut.GetContextEvents(context.Background(), dbPath, port.GetContextInput{
 		Repo:      " github.com/duck8823/traceary ",
 		SessionID: "session-1",
 		Limit:     10,

--- a/infrastructure/sqlite/get_event_details.go
+++ b/infrastructure/sqlite/get_event_details.go
@@ -8,19 +8,19 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
 
-var _ queryservice.EventDetailsFinder = (*Datasource)(nil)
+var _ port.EventDetailsFinder = (*Datasource)(nil)
 
 // GetEventDetails returns the details for the given event ID.
 func (d *Datasource) GetEventDetails(
 	ctx context.Context,
 	dbPath string,
 	eventID string,
-) (*queryservice.EventDetails, error) {
+) (*port.EventDetails, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event details lookup: %w", err)
@@ -89,7 +89,7 @@ func (d *Datasource) GetEventDetails(
 		)
 	}
 
-	eventDetails, err := queryservice.NewEventDetails(event, commandAudit)
+	eventDetails, err := port.NewEventDetails(event, commandAudit)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to build event details: %w", err)
 	}

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -10,20 +10,20 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 //go:embed sql/list_sessions.sql
 var listSessionsQuery string
 
-var _ queryservice.SessionSummaryFinder = (*Datasource)(nil)
+var _ port.SessionSummaryFinder = (*Datasource)(nil)
 
 // ListSessionSummaries returns aggregated session information.
 func (d *Datasource) ListSessionSummaries(
 	ctx context.Context,
 	dbPath string,
-	input queryservice.ListSessionsInput,
-) ([]*queryservice.SessionSummary, error) {
+	input port.ListSessionsInput,
+) ([]*port.SessionSummary, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for session list: %w", err)
@@ -63,7 +63,7 @@ func (d *Datasource) ListSessionSummaries(
 		}
 	}()
 
-	summaries := make([]*queryservice.SessionSummary, 0)
+	summaries := make([]*port.SessionSummary, 0)
 	for rows.Next() {
 		summary, err := scanSessionSummary(rows)
 		if err != nil {
@@ -80,7 +80,7 @@ func (d *Datasource) ListSessionSummaries(
 
 func scanSessionSummary(row interface {
 	Scan(dest ...any) error
-}) (*queryservice.SessionSummary, error) {
+}) (*port.SessionSummary, error) {
 	var (
 		sessionID       string
 		repo            string
@@ -132,7 +132,7 @@ func scanSessionSummary(row interface {
 		agents = strings.Split(agentsStr.String, ",")
 	}
 
-	return &queryservice.SessionSummary{
+	return &port.SessionSummary{
 		SessionID:       sessionID,
 		Repo:            repo,
 		StartedAt:       startedAt,

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
@@ -126,7 +126,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		saveTestSession(ctx, t, ds, dbPath, "s1", time.Now().Add(-time.Hour).UTC(), &s1End, "claude", "duck8823/traceary")
 		saveTestSession(ctx, t, ds, dbPath, "s2", time.Now().UTC(), nil, "codex", "duck8823/traceary")
 
-		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, port.ListSessionsInput{
 			Limit: 10,
 		})
 		if err != nil {
@@ -201,7 +201,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		saveTestSession(ctx, t, ds, dbPath, "s1", now, nil, "claude", "repo")
 		saveTestSession(ctx, t, ds, dbPath, "s2", now.Add(time.Second), nil, "codex", "repo")
 
-		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, port.ListSessionsInput{
 			Limit: 10,
 			Agent: "claude",
 		})
@@ -246,7 +246,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 
 		fromDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
-		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, port.ListSessionsInput{
 			Limit: 10,
 			From:  &fromDate,
 		})
@@ -291,7 +291,7 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 
 		toDate := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
-		summaries, err := ds.ListSessionSummaries(ctx, dbPath, queryservice.ListSessionsInput{
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, port.ListSessionsInput{
 			Limit: 10,
 			To:    &toDate,
 		})

--- a/infrastructure/sqlite/search_events.go
+++ b/infrastructure/sqlite/search_events.go
@@ -8,20 +8,20 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 //go:embed sql/search_events.sql
 var searchEventsQuery string
 
-var _ queryservice.EventSearcher = (*Datasource)(nil)
+var _ port.EventSearcher = (*Datasource)(nil)
 
 // SearchEvents returns matching events in descending time order.
 func (d *Datasource) SearchEvents(
 	ctx context.Context,
 	dbPath string,
-	input queryservice.SearchEventsInput,
+	input port.SearchEventsInput,
 ) ([]*model.Event, error) {
 	db, err := d.openDB(ctx, dbPath)
 	if err != nil {

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
@@ -74,7 +74,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("SaveCommandAudit() error = %v", err)
 	}
 
-	got, err := sut.SearchEvents(context.Background(), dbPath, queryservice.SearchEventsInput{
+	got, err := sut.SearchEvents(context.Background(), dbPath, port.SearchEventsInput{
 		Query: "stdout",
 		Repo:  "github.com/duck8823/traceary",
 		From:  time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
@@ -94,7 +94,7 @@ CREATE TABLE command_audits (
 	t.Run("searches with structural filters only", func(t *testing.T) {
 		t.Parallel()
 
-		filtered, err := sut.SearchEvents(context.Background(), dbPath, queryservice.SearchEventsInput{
+		filtered, err := sut.SearchEvents(context.Background(), dbPath, port.SearchEventsInput{
 			Repo:      "github.com/duck8823/traceary",
 			SessionID: "session-1",
 			Client:    "cli",
@@ -116,7 +116,7 @@ CREATE TABLE command_audits (
 	t.Run("offset で 2 ページ目を取得できる", func(t *testing.T) {
 		t.Parallel()
 
-		filtered, err := sut.SearchEvents(context.Background(), dbPath, queryservice.SearchEventsInput{
+		filtered, err := sut.SearchEvents(context.Background(), dbPath, port.SearchEventsInput{
 			Repo:   "github.com/duck8823/traceary",
 			Limit:  1,
 			Offset: 1,

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/presentation"
 )
 
@@ -224,7 +224,7 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		return xerrors.Errorf("%s: %w", Localize("failed to record command audit", "監査ログ記録に失敗しました"), err)
 	}
 	if input.asJSON {
-		eventDetails, err := queryservice.NewEventDetails(event, commandAudit)
+		eventDetails, err := port.NewEventDetails(event, commandAudit)
 		if err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to build audit result", "監査ログ結果の構築に失敗しました"), err)
 		}

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newCompactSummaryCommand() *cobra.Command {
@@ -60,7 +60,7 @@ func (c *RootCLI) printCompactSummary(
 	recentCount int,
 ) error {
 	// Get recent events for context
-	events, err := c.listEventsQueryService.Run(ctx, dbPath, queryservice.ListRecentEventsInput{
+	events, err := c.listEventsQueryService.Run(ctx, dbPath, port.ListRecentEventsInput{
 		Limit:     recentCount + 5, // fetch extra to find commands
 		SessionID: sessionID,
 		Repo:      repo,
@@ -71,7 +71,7 @@ func (c *RootCLI) printCompactSummary(
 	}
 
 	// Get session info
-	sessions, err := c.listSessionsQueryService.Run(ctx, dbPath, queryservice.ListSessionsInput{
+	sessions, err := c.listSessionsQueryService.Run(ctx, dbPath, port.ListSessionsInput{
 		Limit: 1,
 		Repo:  repo,
 	})

--- a/presentation/cli/compact_summary_test.go
+++ b/presentation/cli/compact_summary_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
@@ -31,7 +31,7 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 			},
 		}
 		listSessionsStub := &listSessionsQueryServiceStub{
-			summaries: []*queryservice.SessionSummary{
+			summaries: []*port.SessionSummary{
 				{
 					SessionID: "session-abc",
 					Repo:      "duck8823/traceary",
@@ -118,7 +118,7 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 			InitializeStoreUsecase: &initializeStoreUsecaseStub{},
 			ListEventsQueryService: &listEventsQueryServiceStub{events: events},
 			ListSessionsQueryService: &listSessionsQueryServiceStub{
-				summaries: []*queryservice.SessionSummary{{SessionID: "s1", Repo: "repo"}},
+				summaries: []*port.SessionSummary{{SessionID: "s1", Repo: "repo"}},
 			},
 		}).Command()
 		rootCmd.SetOut(stdout)

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newContextCommand() *cobra.Command {
@@ -99,7 +100,7 @@ func (c *RootCLI) runContext(ctx context.Context, output io.Writer, input contex
 		return err
 	}
 
-	events, err := c.getContextQueryService.Run(ctx, resolvedPath, queryservice.GetContextInput{
+	events, err := c.getContextQueryService.Run(ctx, resolvedPath, port.GetContextInput{
 		Repo:      resolvedRepo,
 		SessionID: resolvedSessionID,
 		Limit:     input.limit,
@@ -129,7 +130,7 @@ func (c *RootCLI) resolveContextSessionID(
 		return "", nil
 	}
 
-	event, err := c.findLatestSessionQueryService.Run(ctx, dbPath, queryservice.FindLatestSessionInput{
+	event, err := c.findLatestSessionQueryService.Run(ctx, dbPath, port.FindLatestSessionInput{
 		Client: strings.TrimSpace(input.client),
 		Agent:  strings.TrimSpace(input.agent),
 		Repo:   strings.TrimSpace(input.repo),

--- a/presentation/cli/context_command_test.go
+++ b/presentation/cli/context_command_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
 type getContextQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.GetContextInput
+	receivedInput port.GetContextInput
 	called        bool
 	events        []*model.Event
 	err           error
@@ -24,7 +25,7 @@ type getContextQueryServiceStub struct {
 func (s *getContextQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.GetContextInput,
+	input port.GetContextInput,
 ) ([]*model.Event, error) {
 	s.called = true
 	s.receivedPath = dbPath
@@ -36,7 +37,7 @@ var _ queryservice.GetContextQueryService = (*getContextQueryServiceStub)(nil)
 
 type contextLatestSessionQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.FindLatestSessionInput
+	receivedInput port.FindLatestSessionInput
 	called        bool
 	event         *model.Event
 	err           error
@@ -45,7 +46,7 @@ type contextLatestSessionQueryServiceStub struct {
 func (s *contextLatestSessionQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.FindLatestSessionInput,
+	input port.FindLatestSessionInput,
 ) (*model.Event, error) {
 	s.called = true
 	s.receivedPath = dbPath
@@ -206,7 +207,7 @@ func TestRootCLI_ContextCommand(t *testing.T) {
 		initStub := &initializeStoreUsecaseStub{}
 		contextStub := &getContextQueryServiceStub{}
 		latestStub := &contextLatestSessionQueryServiceStub{
-			err: queryservice.ErrSessionNotFound,
+			err: port.ErrSessionNotFound,
 		}
 
 		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 )
 
@@ -44,7 +44,7 @@ func writeEventsJSON(output io.Writer, events []*model.Event) error {
 	return writeJSON(output, serializedEvents)
 }
 
-func writeEventDetailsJSON(output io.Writer, eventDetails *queryservice.EventDetails) error {
+func writeEventDetailsJSON(output io.Writer, eventDetails *port.EventDetails) error {
 	if eventDetails == nil {
 		return xerrors.Errorf(Localize("event details must not be nil", "イベント詳細は nil にできません"))
 	}

--- a/presentation/cli/event_output.go
+++ b/presentation/cli/event_output.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 )
 
@@ -51,7 +51,7 @@ func writeEvents(output io.Writer, events []*model.Event) error {
 	return nil
 }
 
-func writeEventDetailsByFormat(output io.Writer, eventDetails *queryservice.EventDetails, asJSON bool) error {
+func writeEventDetailsByFormat(output io.Writer, eventDetails *port.EventDetails, asJSON bool) error {
 	if asJSON {
 		return writeEventDetailsJSON(output, eventDetails)
 	}

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newListCommand() *cobra.Command {
@@ -133,7 +133,7 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 
-	events, err := c.listEventsQueryService.Run(ctx, resolvedPath, queryservice.ListRecentEventsInput{
+	events, err := c.listEventsQueryService.Run(ctx, resolvedPath, port.ListRecentEventsInput{
 		Limit:        input.limit,
 		Offset:       input.offset,
 		Kind:         resolvedKind,

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
 type listEventsQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.ListRecentEventsInput
+	receivedInput port.ListRecentEventsInput
 	called        bool
 	events        []*model.Event
 	err           error
@@ -24,7 +25,7 @@ type listEventsQueryServiceStub struct {
 func (s *listEventsQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.ListRecentEventsInput,
+	input port.ListRecentEventsInput,
 ) ([]*model.Event, error) {
 	s.called = true
 	s.receivedPath = dbPath

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
@@ -277,7 +277,7 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		if !queryStub.called {
 			t.Fatal("FindLatestSessionQueryService.Run() was not called")
 		}
-		if queryStub.receivedInput != (queryservice.FindLatestSessionInput{
+		if queryStub.receivedInput != (port.FindLatestSessionInput{
 			Repo:       "github.com/duck8823/traceary",
 			ActiveOnly: true,
 		}) {

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newSearchCommand() *cobra.Command {
@@ -152,7 +152,7 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 		return err
 	}
 
-	events, err := c.searchEventsQueryService.Run(ctx, resolvedPath, queryservice.SearchEventsInput{
+	events, err := c.searchEventsQueryService.Run(ctx, resolvedPath, port.SearchEventsInput{
 		Query:        input.query,
 		Repo:         resolveRepoValue(ctx, input.repo),
 		SessionID:    input.sessionID,

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
 type searchEventsQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.SearchEventsInput
+	receivedInput port.SearchEventsInput
 	called        bool
 	events        []*model.Event
 	err           error
@@ -23,7 +24,7 @@ type searchEventsQueryServiceStub struct {
 func (s *searchEventsQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.SearchEventsInput,
+	input port.SearchEventsInput,
 ) ([]*model.Event, error) {
 	s.called = true
 	s.receivedPath = dbPath

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -345,7 +346,7 @@ func (c *RootCLI) runSessionLatest(
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 
-	event, err := c.findLatestSessionQueryService.Run(ctx, resolvedPath, queryservice.FindLatestSessionInput{
+	event, err := c.findLatestSessionQueryService.Run(ctx, resolvedPath, port.FindLatestSessionInput{
 		Client:     resolveOptionalValue(input.client, "TRACEARY_CLIENT", ""),
 		Agent:      resolveOptionalValue(input.agent, "TRACEARY_AGENT", ""),
 		Repo:       resolveRepoValue(ctx, input.repo),

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newSessionListCommand() *cobra.Command {
@@ -62,7 +62,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 
 			resolvedRepo := resolveRepoValue(ctx, repo)
 
-			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, queryservice.ListSessionsInput{
+			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, port.ListSessionsInput{
 				Limit:  limit,
 				Offset: offset,
 				Repo:   resolvedRepo,
@@ -94,7 +94,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 	return listCmd
 }
 
-func writeSessionSummaries(output io.Writer, summaries []*queryservice.SessionSummary, asJSON bool) error {
+func writeSessionSummaries(output io.Writer, summaries []*port.SessionSummary, asJSON bool) error {
 	if asJSON {
 		return writeSessionSummariesJSON(output, summaries)
 	}
@@ -142,7 +142,7 @@ func writeSessionSummaries(output io.Writer, summaries []*queryservice.SessionSu
 	return nil
 }
 
-func writeSessionSummariesJSON(output io.Writer, summaries []*queryservice.SessionSummary) error {
+func writeSessionSummariesJSON(output io.Writer, summaries []*port.SessionSummary) error {
 	type jsonSummary struct {
 		SessionID       string   `json:"session_id"`
 		Repo            string   `json:"repo,omitempty"`

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -9,22 +9,23 @@ import (
 	"time"
 
 	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
 type listSessionsQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.ListSessionsInput
+	receivedInput port.ListSessionsInput
 	called        bool
-	summaries     []*queryservice.SessionSummary
+	summaries     []*port.SessionSummary
 	err           error
 }
 
 func (s *listSessionsQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.ListSessionsInput,
-) ([]*queryservice.SessionSummary, error) {
+	input port.ListSessionsInput,
+) ([]*port.SessionSummary, error) {
 	s.called = true
 	s.receivedPath = dbPath
 	s.receivedInput = input
@@ -43,7 +44,7 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		initStub := &initializeStoreUsecaseStub{}
 		listStub := &listSessionsQueryServiceStub{
-			summaries: []*queryservice.SessionSummary{
+			summaries: []*port.SessionSummary{
 				{
 					SessionID:       "session-1",
 					Repo:            "duck8823/traceary",
@@ -128,7 +129,7 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 		endedAt := time.Date(2026, 4, 9, 12, 5, 0, 0, time.UTC)
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		listStub := &listSessionsQueryServiceStub{
-			summaries: []*queryservice.SessionSummary{
+			summaries: []*port.SessionSummary{
 				{
 					SessionID:       "session-json",
 					Label:           "release",
@@ -178,7 +179,7 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		listStub := &listSessionsQueryServiceStub{
-			summaries: []*queryservice.SessionSummary{
+			summaries: []*port.SessionSummary{
 				{
 					SessionID:       "session-sanitized",
 					Label:           "release\tcandidate",

--- a/presentation/cli/session_resolution.go
+++ b/presentation/cli/session_resolution.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 type manualSessionResolution struct {
@@ -41,7 +42,7 @@ func (c *RootCLI) resolveManualSessionID(
 		}, nil
 	}
 
-	event, err := c.findLatestSessionQueryService.Run(ctx, dbPath, queryservice.FindLatestSessionInput{
+	event, err := c.findLatestSessionQueryService.Run(ctx, dbPath, port.FindLatestSessionInput{
 		Repo:       trimmedRepo,
 		ActiveOnly: true,
 	})

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
@@ -36,7 +37,7 @@ var _ usecase.RecordSessionBoundaryUsecase = (*recordSessionBoundaryUsecaseStub)
 
 type findLatestSessionQueryServiceStub struct {
 	receivedPath  string
-	receivedInput queryservice.FindLatestSessionInput
+	receivedInput port.FindLatestSessionInput
 	called        bool
 	event         *model.Event
 	err           error
@@ -45,7 +46,7 @@ type findLatestSessionQueryServiceStub struct {
 func (s *findLatestSessionQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
-	input queryservice.FindLatestSessionInput,
+	input port.FindLatestSessionInput,
 ) (*model.Event, error) {
 	s.called = true
 	s.receivedPath = dbPath
@@ -696,7 +697,7 @@ func TestRootCLI_SessionLatestCommand_NotFoundError(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
 	initStub := &initializeStoreUsecaseStub{}
 	latestStub := &findLatestSessionQueryServiceStub{
-		err: queryservice.ErrSessionNotFound,
+		err: port.ErrSessionNotFound,
 	}
 	rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
 		InitializeStoreUsecase:        initStub,

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
@@ -35,7 +35,7 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 
 			resolvedRepo := resolveRepoValue(ctx, repo)
 
-			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, queryservice.ListSessionsInput{
+			summaries, err := c.listSessionsQueryService.Run(ctx, resolvedDBPath, port.ListSessionsInput{
 				Limit: limit,
 				Repo:  resolvedRepo,
 			})
@@ -55,11 +55,11 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 }
 
 type sessionNode struct {
-	summary  *queryservice.SessionSummary
+	summary  *port.SessionSummary
 	children []*sessionNode
 }
 
-func writeSessionTree(output io.Writer, summaries []*queryservice.SessionSummary) error {
+func writeSessionTree(output io.Writer, summaries []*port.SessionSummary) error {
 	if len(summaries) == 0 {
 		if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
 			return xerrors.Errorf("failed to print empty message: %w", err)

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/port"
 )
 
 func (c *RootCLI) newShowCommand() *cobra.Command {
@@ -59,7 +59,7 @@ func (c *RootCLI) runShow(ctx context.Context, output io.Writer, dbPath string, 
 	return nil
 }
 
-func writeEventDetails(output io.Writer, eventDetails *queryservice.EventDetails) error {
+func writeEventDetails(output io.Writer, eventDetails *port.EventDetails) error {
 	if eventDetails == nil {
 		return xerrors.Errorf(Localize("event details must not be nil", "イベント詳細は nil にできません"))
 	}

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
@@ -17,7 +18,7 @@ type getEventDetailsQueryServiceStub struct {
 	receivedPath    string
 	receivedEventID string
 	called          bool
-	eventDetails    *queryservice.EventDetails
+	eventDetails    *port.EventDetails
 	err             error
 }
 
@@ -25,7 +26,7 @@ func (s *getEventDetailsQueryServiceStub) Run(
 	_ context.Context,
 	dbPath string,
 	eventID string,
-) (*queryservice.EventDetails, error) {
+) (*port.EventDetails, error) {
 	s.called = true
 	s.receivedPath = dbPath
 	s.receivedEventID = eventID
@@ -55,7 +56,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		initStub := &initializeStoreUsecaseStub{}
-		eventDetails, err := queryservice.NewEventDetails(
+		eventDetails, err := port.NewEventDetails(
 			model.EventOf(
 				eventID,
 				types.EventKindCommandExecuted,
@@ -133,7 +134,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		initStub := &initializeStoreUsecaseStub{}
-		eventDetails, err := queryservice.NewEventDetails(
+		eventDetails, err := port.NewEventDetails(
 			model.EventOf(
 				eventID,
 				types.EventKindNote,
@@ -172,7 +173,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		initStub := &initializeStoreUsecaseStub{}
-		eventDetails, err := queryservice.NewEventDetails(
+		eventDetails, err := port.NewEventDetails(
 			model.EventOf(
 				eventID,
 				types.EventKindCommandExecuted,
@@ -241,7 +242,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		initStub := &initializeStoreUsecaseStub{}
 		exitCode := 1
-		eventDetails, err := queryservice.NewEventDetails(
+		eventDetails, err := port.NewEventDetails(
 			model.EventOf(
 				eventID,
 				types.EventKindCommandExecuted,

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation"
@@ -370,13 +371,13 @@ func (s *Server) endSession(dbPath string) mcp.ToolHandlerFor[sessionBoundaryInp
 
 func (s *Server) latestSession(dbPath string) mcp.ToolHandlerFor[sessionLookupInput, sessionEventOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionLookupInput) (*mcp.CallToolResult, sessionEventOutput, error) {
-		event, err := s.findLatestSessionQueryService.Run(ctx, dbPath, queryservice.FindLatestSessionInput{
+		event, err := s.findLatestSessionQueryService.Run(ctx, dbPath, port.FindLatestSessionInput{
 			Client: strings.TrimSpace(input.Client),
 			Agent:  strings.TrimSpace(input.Agent),
 			Repo:   strings.TrimSpace(input.Repo),
 		})
 		if err != nil {
-			if errors.Is(err, queryservice.ErrSessionNotFound) {
+			if errors.Is(err, port.ErrSessionNotFound) {
 				return nil, sessionEventOutput{}, xerrors.Errorf("no matching session found")
 			}
 			return nil, sessionEventOutput{}, xerrors.Errorf("failed to get latest session: %w", err)
@@ -388,14 +389,14 @@ func (s *Server) latestSession(dbPath string) mcp.ToolHandlerFor[sessionLookupIn
 
 func (s *Server) activeSession(dbPath string) mcp.ToolHandlerFor[sessionLookupInput, sessionEventOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionLookupInput) (*mcp.CallToolResult, sessionEventOutput, error) {
-		event, err := s.findLatestSessionQueryService.Run(ctx, dbPath, queryservice.FindLatestSessionInput{
+		event, err := s.findLatestSessionQueryService.Run(ctx, dbPath, port.FindLatestSessionInput{
 			Client:     strings.TrimSpace(input.Client),
 			Agent:      strings.TrimSpace(input.Agent),
 			Repo:       strings.TrimSpace(input.Repo),
 			ActiveOnly: true,
 		})
 		if err != nil {
-			if errors.Is(err, queryservice.ErrActiveSessionNotFound) {
+			if errors.Is(err, port.ErrActiveSessionNotFound) {
 				return nil, sessionEventOutput{}, xerrors.Errorf("no matching active session found")
 			}
 			return nil, sessionEventOutput{}, xerrors.Errorf("failed to get active session: %w", err)
@@ -451,7 +452,7 @@ func (s *Server) listEvents(dbPath string) mcp.ToolHandlerFor[listEventsInput, e
 			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve to: %w", err)
 		}
 
-		events, err := s.listEventsQueryService.Run(ctx, dbPath, queryservice.ListRecentEventsInput{
+		events, err := s.listEventsQueryService.Run(ctx, dbPath, port.ListRecentEventsInput{
 			Limit:     resolveLimit(input.Limit, defaultSearchLimit),
 			Offset:    resolveOffset(input.Offset),
 			Kind:      strings.TrimSpace(input.Kind),
@@ -513,7 +514,7 @@ func (s *Server) search(dbPath string) mcp.ToolHandlerFor[searchInput, eventsOut
 			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve to: %w", err)
 		}
 		limit := resolveLimit(input.Limit, defaultSearchLimit)
-		events, err := s.searchEventsQueryService.Run(ctx, dbPath, queryservice.SearchEventsInput{
+		events, err := s.searchEventsQueryService.Run(ctx, dbPath, port.SearchEventsInput{
 			Query: strings.TrimSpace(input.Query),
 			Repo:  strings.TrimSpace(input.Repo),
 			From:  from,
@@ -530,7 +531,7 @@ func (s *Server) search(dbPath string) mcp.ToolHandlerFor[searchInput, eventsOut
 
 func (s *Server) getContext(dbPath string) mcp.ToolHandlerFor[getContextInput, eventsOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input getContextInput) (*mcp.CallToolResult, eventsOutput, error) {
-		events, err := s.getContextQueryService.Run(ctx, dbPath, queryservice.GetContextInput{
+		events, err := s.getContextQueryService.Run(ctx, dbPath, port.GetContextInput{
 			Repo:      strings.TrimSpace(input.Repo),
 			SessionID: strings.TrimSpace(input.SessionID),
 			Limit:     resolveLimit(input.Limit, defaultContextLimit),
@@ -562,7 +563,7 @@ type sessionHandoffOutput struct {
 
 func (s *Server) sessionHandoff(dbPath string) mcp.ToolHandlerFor[sessionHandoffInput, sessionHandoffOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionHandoffInput) (*mcp.CallToolResult, sessionHandoffOutput, error) {
-		sessions, err := s.listSessionsQueryService.Run(ctx, dbPath, queryservice.ListSessionsInput{
+		sessions, err := s.listSessionsQueryService.Run(ctx, dbPath, port.ListSessionsInput{
 			Limit: 1,
 			Repo:  strings.TrimSpace(input.Repo),
 		})
@@ -575,7 +576,7 @@ func (s *Server) sessionHandoff(dbPath string) mcp.ToolHandlerFor[sessionHandoff
 		}
 
 		session := sessions[0]
-		events, err := s.listEventsQueryService.Run(ctx, dbPath, queryservice.ListRecentEventsInput{
+		events, err := s.listEventsQueryService.Run(ctx, dbPath, port.ListRecentEventsInput{
 			Limit:     5,
 			SessionID: session.SessionID,
 			Kind:      "command_executed",


### PR DESCRIPTION
## Summary
- Move 6 read-side consumer interfaces and their Input/Output types from `application/queryservice/` to `domain/port/query.go`
- Fix dependency inversion: `infrastructure/sqlite` no longer imports `application/queryservice`
- All layers now depend on `domain/port` for both read and write interfaces

### Moved to `domain/port/query.go`
- `RecentEventFinder` + `ListRecentEventsInput`
- `EventSearcher` + `SearchEventsInput`
- `ContextEventFinder` + `GetContextInput`
- `EventDetailsFinder` + `EventDetails` + `NewEventDetails()`
- `LatestSessionFinder` + `FindLatestSessionInput` + error sentinels
- `SessionSummaryFinder` + `SessionSummary` + `ListSessionsInput`

### Files changed
45 files across `application/queryservice/`, `infrastructure/sqlite/`, `presentation/cli/`, `presentation/mcpserver/`

Closes #335

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)