### PR TITLE
fix: reject zero and negative --stale-after in session gc

### DIFF
--- a/presentation/cli/session_gc.go
+++ b/presentation/cli/session_gc.go
@@ -33,6 +33,10 @@ func (c *RootCLI) newSessionGCCommand() *cobra.Command {
 				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 			}
 
+			if staleAfter <= 0 {
+				return xerrors.Errorf("--stale-after must be greater than 0")
+			}
+
 			result, err := c.closeStaleSessionsUsecase.Run(ctx, usecase.CloseStaleSessionsInput{
 				DBPath:     resolvedDBPath,
 				StaleAfter: staleAfter,


### PR DESCRIPTION
## Summary
- Validate `--stale-after` > 0 before executing session gc
- Previously `--stale-after 0s` closed ALL active sessions without warning
- Negative values were silently accepted

Closes #339

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./presentation/cli/...` passes
- [x] `go tool golangci-lint run` — 0 issues
- [ ] `traceary session gc --stale-after 0s` → error
- [ ] `traceary session gc --stale-after -1s` → error
- [ ] `traceary session gc --stale-after 1h` → works

🤖 Generated with [Claude Code](https://claude.com/claude-code)