### PR TITLE
fix: reject session end for nonexistent session

### DIFF
--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -59,7 +59,7 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 			return xerrors.Errorf("failed to check rows affected: %w", err)
 		}
 		if rowsAffected == 0 {
-			slog.Debug("session not found for ended_at update, skipping", "session_id", session.SessionID().String())
+			return xerrors.Errorf("session not found: %s", session.SessionID().String())
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Return error from `SaveSession` when ending a session that doesn't exist (rowsAffected == 0)
- Prevents orphan `session_ended` events from being created
- Previously silently skipped with debug log

Closes #338

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)