### PR TITLE
fix: show user-friendly error for invalid parent-session-id

### DIFF
--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -81,6 +82,9 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 		parentSessionID,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") && session.ParentSessionID() != "" {
+			return xerrors.Errorf("parent session not found: %s", session.ParentSessionID())
+		}
 		return xerrors.Errorf("failed to insert session: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Catch FK constraint failure when parent_session_id references a nonexistent session
- Return `parent session not found: <id>` instead of raw SQLite error

Closes #340

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)