### PR TITLE
fix: strip build metadata from version comparison in doctor

### DIFF
--- a/presentation/cli/doctor_version.go
+++ b/presentation/cli/doctor_version.go
@@ -48,6 +48,10 @@ func checkLatestVersion(currentVersion string) doctorCheck {
 
 	latestVersion := strings.TrimPrefix(release.TagName, "v")
 	normalizedCurrent := strings.TrimPrefix(currentVersion, "v")
+	// Strip build metadata: "0.2.4 (commit=..., date=..., go=...)" → "0.2.4"
+	if idx := strings.IndexAny(normalizedCurrent, " +"); idx >= 0 {
+		normalizedCurrent = normalizedCurrent[:idx]
+	}
 
 	if normalizedCurrent == latestVersion {
 		return doctorCheck{


### PR DESCRIPTION
## Summary
- Strip build metadata (space/+ separated suffix) from current version before comparing with latest release
- Fixes false "update available" warning when running the latest version

Closes #337

## Test plan
- [x] `go test ./presentation/cli/...` passes
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)