### PR TITLE
feat: propagate parent session ID via TRACEARY_PARENT_SESSION_ID env var

### DIFF
--- a/integrations/claude-plugin/scripts/traceary-session.sh
+++ b/integrations/claude-plugin/scripts/traceary-session.sh
@@ -45,6 +45,10 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
     fi
+    PARENT_SESSION_ID="${TRACEARY_PARENT_SESSION_ID:-}"
+    if [[ -n "$PARENT_SESSION_ID" ]]; then
+      COMMAND+=(--parent-session-id "$PARENT_SESSION_ID")
+    fi
 
     ACTUAL_SESSION_ID="$("${COMMAND[@]}" 2>/dev/null | tail -n 1 | tr -d '\r' || true)"
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then

--- a/integrations/gemini-extension/scripts/traceary-session.sh
+++ b/integrations/gemini-extension/scripts/traceary-session.sh
@@ -45,6 +45,10 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
     fi
+    PARENT_SESSION_ID="${TRACEARY_PARENT_SESSION_ID:-}"
+    if [[ -n "$PARENT_SESSION_ID" ]]; then
+      COMMAND+=(--parent-session-id "$PARENT_SESSION_ID")
+    fi
 
     ACTUAL_SESSION_ID="$("${COMMAND[@]}" 2>/dev/null | tail -n 1 | tr -d '\r' || true)"
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then

--- a/plugins/traceary/scripts/traceary-session.sh
+++ b/plugins/traceary/scripts/traceary-session.sh
@@ -45,6 +45,10 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
     fi
+    PARENT_SESSION_ID="${TRACEARY_PARENT_SESSION_ID:-}"
+    if [[ -n "$PARENT_SESSION_ID" ]]; then
+      COMMAND+=(--parent-session-id "$PARENT_SESSION_ID")
+    fi
 
     ACTUAL_SESSION_ID="$("${COMMAND[@]}" 2>/dev/null | tail -n 1 | tr -d '\r' || true)"
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then

--- a/scripts/hooks/traceary-session.sh
+++ b/scripts/hooks/traceary-session.sh
@@ -45,6 +45,10 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
     fi
+    PARENT_SESSION_ID="${TRACEARY_PARENT_SESSION_ID:-}"
+    if [[ -n "$PARENT_SESSION_ID" ]]; then
+      COMMAND+=(--parent-session-id "$PARENT_SESSION_ID")
+    fi
 
     ACTUAL_SESSION_ID="$("${COMMAND[@]}" 2>/dev/null | tail -n 1 | tr -d '\r' || true)"
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then


### PR DESCRIPTION
## Summary
- Read `TRACEARY_PARENT_SESSION_ID` environment variable in session start hook
- Pass it as `--parent-session-id` to the traceary CLI
- Enables parent-child session tracking across AI client boundaries (Claude → Codex, Codex → Claude, etc.)
- Updated hook script in all 3 integration packages (Claude, Codex, Gemini)

Closes #333

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` — 0 issues
- [x] `python3 scripts/verify_integrations.py` — consistent
- [ ] Manual: set `TRACEARY_PARENT_SESSION_ID=<id>` and verify child session links

🤖 Generated with [Claude Code](https://claude.com/claude-code)