### PR TITLE
refactor: remove unused EventRepository interface

### DIFF
--- a/domain/model/event_repository.go
+++ b/domain/model/event_repository.go
@@ -1,9 +1,0 @@
-package model
-
-import "context"
-
-// EventRepository defines event persistence.
-type EventRepository interface {
-	// Save persists an event.
-	Save(ctx context.Context, event *Event) error
-}


### PR DESCRIPTION
## Summary
- Delete `domain/model/event_repository.go`
- `EventRepository` was superseded by `port.EventSaver` and had no references

Closes #342

## Test plan
- [x] `go build ./...` / `go test ./...` / `golangci-lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)