### PR TITLE
fix: validate date range before applying endExclusive offset in list

### DIFF
--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -113,16 +113,22 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 	if err != nil {
 		return err
 	}
-	fromTime, err := parseFlexibleTime(fromValue, false)
+	// Validate raw dates before applying endExclusive offset.
+	fromRaw, err := parseFlexibleTime(fromValue, false)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve --from", "from の解決に失敗しました"), err)
 	}
-	toTime, err := parseFlexibleTime(toValue, true)
+	toRaw, err := parseFlexibleTime(toValue, false)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 	}
-	if !fromTime.IsZero() && !toTime.IsZero() && fromTime.After(toTime) {
+	if !fromRaw.IsZero() && !toRaw.IsZero() && fromRaw.After(toRaw) {
 		return xerrors.Errorf(Localize("--from must be earlier than --to", "from は to より前である必要があります"))
+	}
+	fromTime := fromRaw
+	toTime, err := parseFlexibleTime(toValue, true)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve --to", "to の解決に失敗しました"), err)
 	}
 
 	resolvedPath, err := resolveDBPath(input.dbPath)


### PR DESCRIPTION
## Summary
- Check --from/--to range using raw dates before applying the +1 day endExclusive shift
- Inverted ranges (e.g., --from 2026-04-10 --to 2026-04-09) are now consistently rejected in both `list` and `session list`

Closes #346

## Test plan
- [x] `go test ./presentation/cli/...` passes
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)