### PR TITLE
Fix session handoff and compact-summary to respect --session-id flag

### DIFF
--- a/domain/port/query.go
+++ b/domain/port/query.go
@@ -147,14 +147,15 @@ type SessionSummary struct {
 
 // ListSessionsInput is the input for session listing.
 type ListSessionsInput struct {
-	Limit  int
-	Offset int
-	Repo   string
-	Client string
-	Agent  string
-	Label  string
-	From   *time.Time
-	To     *time.Time
+	Limit     int
+	Offset    int
+	SessionID string
+	Repo      string
+	Client    string
+	Agent     string
+	Label     string
+	From      *time.Time
+	To        *time.Time
 }
 
 // SessionSummaryFinder provides session summary lookup.

--- a/infrastructure/sqlite/list_sessions.go
+++ b/infrastructure/sqlite/list_sessions.go
@@ -46,6 +46,7 @@ func (d *Datasource) ListSessionSummaries(
 	rows, err := db.QueryContext(
 		ctx,
 		listSessionsQuery,
+		input.SessionID, input.SessionID,
 		input.Repo, input.Repo,
 		input.Client, input.Client,
 		input.Agent, input.Agent,

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -261,6 +261,51 @@ func TestDatasource_ListSessionSummaries(t *testing.T) {
 		}
 	})
 
+	t.Run("session_id filter returns only the matching session", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		ds := infra.NewDatasource(listSessionsTestMigrations())
+		ctx := context.Background()
+
+		if err := ds.Initialize(ctx, dbPath); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		for _, e := range []struct {
+			id, agent, sid string
+		}{
+			{"e1", "claude", "s1"},
+			{"e2", "claude", "s2"},
+		} {
+			eid, _ := types.EventIDOf(e.id)
+			agent, _ := types.AgentOf(e.agent)
+			sid, _ := types.SessionIDOf(e.sid)
+			event, _ := model.NewEvent(eid, types.EventKindSessionStarted, "hook", agent, sid, "repo", "start")
+			if err := ds.Save(ctx, dbPath, event); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+		}
+
+		now := time.Now().UTC()
+		saveTestSession(ctx, t, ds, dbPath, "s1", now, nil, "claude", "repo")
+		saveTestSession(ctx, t, ds, dbPath, "s2", now.Add(time.Second), nil, "claude", "repo")
+
+		summaries, err := ds.ListSessionSummaries(ctx, dbPath, port.ListSessionsInput{
+			Limit:     10,
+			SessionID: "s1",
+		})
+		if err != nil {
+			t.Fatalf("ListSessionSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if summaries[0].SessionID != "s1" {
+			t.Fatalf("session = %q, want s1", summaries[0].SessionID)
+		}
+	})
+
 	t.Run("to filter excludes out-of-range sessions", func(t *testing.T) {
 		t.Parallel()
 

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -19,7 +19,8 @@ LEFT JOIN (
   FROM events e
   GROUP BY e.session_id
 ) agg ON agg.session_id = s.session_id
-WHERE (? = '' OR s.repo = ?)
+WHERE (? = '' OR s.session_id = ?)
+  AND (? = '' OR s.repo = ?)
   AND (? = '' OR s.client = ?)
   AND (? = '' OR s.agent = ?)
   AND (? = '' OR s.label = ?)

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -72,8 +72,9 @@ func (c *RootCLI) printCompactSummary(
 
 	// Get session info
 	sessions, err := c.listSessionsQueryService.Run(ctx, dbPath, port.ListSessionsInput{
-		Limit: 1,
-		Repo:  repo,
+		Limit:     1,
+		SessionID: sessionID,
+		Repo:      repo,
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to list sessions: %w", err)

--- a/presentation/cli/compact_summary_test.go
+++ b/presentation/cli/compact_summary_test.go
@@ -100,6 +100,44 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("--session-id flag is passed to session query service", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		listEventsStub := &listEventsQueryServiceStub{}
+		listSessionsStub := &listSessionsQueryServiceStub{
+			summaries: []*port.SessionSummary{
+				{
+					SessionID: "target-session",
+					Repo:      "duck8823/traceary",
+					StartedAt: time.Now().Add(-time.Hour),
+				},
+			},
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   initStub,
+			ListEventsQueryService:   listEventsStub,
+			ListSessionsQueryService: listSessionsStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"compact-summary", "--db-path", dbPath, "--session-id", "target-session"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if listSessionsStub.receivedInput.SessionID != "target-session" {
+			t.Errorf("session query received SessionID = %q, want %q", listSessionsStub.receivedInput.SessionID, "target-session")
+		}
+		if !strings.Contains(stdout.String(), "target-session") {
+			t.Errorf("output missing session ID, got: %s", stdout.String())
+		}
+	})
+
 	t.Run("output stays within token limit", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add `SessionID` field to `port.ListSessionsInput` struct
- Update `list_sessions.sql` with a `WHERE` clause for `session_id` filtering
- Wire `SessionID` through `infrastructure/sqlite/list_sessions.go` query parameters
- Pass `sessionID` from `printCompactSummary` to `listSessionsQueryService.Run()`
- Add tests at both infrastructure and CLI layers to verify the fix

## Problem

The `session handoff` and `compact-summary` commands accepted `--session-id` but ignored it when querying session metadata. They always returned the latest session regardless of the specified session ID.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new tests)
- [x] `go tool golangci-lint run` reports 0 issues
- [x] New infrastructure test verifies `SessionID` filter returns only the matching session
- [x] New CLI test verifies `--session-id` flag value is forwarded to the query service

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)