### PR TITLE
feat: add --json flag to session tree command

### DIFF
--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -15,6 +17,7 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 		dbPath string
 		repo   string
 		limit  int
+		asJSON bool
 	)
 
 	cmd := &cobra.Command{
@@ -43,13 +46,14 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
 			}
 
-			return writeSessionTree(output, summaries)
+			return writeSessionTree(output, summaries, asJSON)
 		},
 	}
 
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	cmd.Flags().StringVar(&repo, "repo", "", Localize("filter by repo", "リポジトリでフィルタ"))
 	cmd.Flags().IntVar(&limit, "limit", 50, Localize("maximum number of sessions to load", "読み込む最大セッション数"))
+	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 
 	return cmd
 }
@@ -59,8 +63,14 @@ type sessionNode struct {
 	children []*sessionNode
 }
 
-func writeSessionTree(output io.Writer, summaries []*port.SessionSummary) error {
+func writeSessionTree(output io.Writer, summaries []*port.SessionSummary, asJSON bool) error {
 	if len(summaries) == 0 {
+		if asJSON {
+			if _, err := fmt.Fprintln(output, "[]"); err != nil {
+				return xerrors.Errorf("failed to print empty JSON array: %w", err)
+			}
+			return nil
+		}
 		if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
 			return xerrors.Errorf("failed to print empty message: %w", err)
 		}
@@ -86,12 +96,70 @@ func writeSessionTree(output io.Writer, summaries []*port.SessionSummary) error 
 		roots = append(roots, node)
 	}
 
+	if asJSON {
+		return writeSessionTreeJSON(output, roots)
+	}
+
 	for _, root := range roots {
 		if err := printNode(output, root, "", true); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+type jsonTreeNode struct {
+	SessionID    string          `json:"session_id"`
+	Repo         string          `json:"repo,omitempty"`
+	Label        string          `json:"label,omitempty"`
+	Summary      string          `json:"summary,omitempty"`
+	StartedAt    string          `json:"started_at"`
+	EndedAt      *string         `json:"ended_at,omitempty"`
+	Status       string          `json:"status"`
+	DurationSec  *float64        `json:"duration_sec,omitempty"`
+	TotalEvents  int             `json:"total_events"`
+	CommandCount int             `json:"command_count"`
+	Agents       []string        `json:"agents"`
+	Children     []*jsonTreeNode `json:"children"`
+}
+
+func sessionNodeToJSON(node *sessionNode) *jsonTreeNode {
+	s := node.summary
+	jn := &jsonTreeNode{
+		SessionID:    s.SessionID,
+		Repo:         s.Repo,
+		Label:        s.Label,
+		Summary:      s.Summary,
+		StartedAt:    s.StartedAt.UTC().Format(time.RFC3339),
+		Status:       s.Status,
+		TotalEvents:  s.TotalEvents,
+		CommandCount: s.CommandCount,
+		Agents:       s.Agents,
+		Children:     make([]*jsonTreeNode, 0, len(node.children)),
+	}
+	if s.EndedAt != nil {
+		endStr := s.EndedAt.UTC().Format(time.RFC3339)
+		jn.EndedAt = &endStr
+		dur := s.EndedAt.Sub(s.StartedAt).Seconds()
+		jn.DurationSec = &dur
+	}
+	for _, child := range node.children {
+		jn.Children = append(jn.Children, sessionNodeToJSON(child))
+	}
+	return jn
+}
+
+func writeSessionTreeJSON(output io.Writer, roots []*sessionNode) error {
+	items := make([]*jsonTreeNode, 0, len(roots))
+	for _, root := range roots {
+		items = append(items, sessionNodeToJSON(root))
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(items); err != nil {
+		return xerrors.Errorf("failed to encode JSON: %w", err)
+	}
 	return nil
 }
 

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -1,0 +1,160 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/port"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_SessionTreeCommand_JSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("outputs nested JSON tree", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2026, 4, 9, 13, 30, 0, 0, time.UTC)
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		initStub := &initializeStoreUsecaseStub{}
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*port.SessionSummary{
+				{
+					SessionID:   "root-session",
+					Repo:        "duck8823/traceary",
+					Label:       "sprint",
+					StartedAt:   time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					EndedAt:     &endedAt,
+					Status:      "ended",
+					TotalEvents: 10,
+					CommandCount: 5,
+					Agents:      []string{"claude"},
+				},
+				{
+					SessionID:       "child-session",
+					Repo:            "duck8823/traceary",
+					ParentSessionID: "root-session",
+					StartedAt:       time.Date(2026, 4, 9, 12, 30, 0, 0, time.UTC),
+					Status:          "active",
+					TotalEvents:     3,
+					CommandCount:    2,
+					Agents:          []string{"codex"},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   initStub,
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"session", "tree",
+			"--db-path", dbPath,
+			"--json",
+		})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		output := stdout.String()
+
+		// Verify it's valid JSON
+		var tree []json.RawMessage
+		if err := json.Unmarshal([]byte(output), &tree); err != nil {
+			t.Fatalf("output is not valid JSON array: %v\noutput: %s", err, output)
+		}
+		if len(tree) != 1 {
+			t.Fatalf("expected 1 root node, got %d", len(tree))
+		}
+
+		// Verify root node fields
+		if !strings.Contains(output, `"session_id": "root-session"`) {
+			t.Fatalf("JSON output should contain root session_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"status": "ended"`) {
+			t.Fatalf("JSON output should contain status, got: %s", output)
+		}
+		if !strings.Contains(output, `"duration_sec"`) {
+			t.Fatalf("JSON output should contain duration_sec for ended session, got: %s", output)
+		}
+		if !strings.Contains(output, `"label": "sprint"`) {
+			t.Fatalf("JSON output should contain label, got: %s", output)
+		}
+
+		// Verify nested children
+		if !strings.Contains(output, `"session_id": "child-session"`) {
+			t.Fatalf("JSON output should contain child session_id, got: %s", output)
+		}
+		// Child has no ended_at so no duration_sec — just verify it's nested in children
+		if !strings.Contains(output, `"children"`) {
+			t.Fatalf("JSON output should contain children field, got: %s", output)
+		}
+	})
+
+	t.Run("outputs empty JSON array when no sessions", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: &listSessionsQueryServiceStub{},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "tree", "--db-path", dbPath, "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if strings.TrimSpace(stdout.String()) != "[]" {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), "[]\n")
+		}
+	})
+
+	t.Run("text output is unchanged without --json", func(t *testing.T) {
+		t.Parallel()
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		listStub := &listSessionsQueryServiceStub{
+			summaries: []*port.SessionSummary{
+				{
+					SessionID:   "text-session",
+					Repo:        "duck8823/traceary",
+					StartedAt:   time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+					Status:      "active",
+					TotalEvents: 1,
+					CommandCount: 0,
+					Agents:      []string{},
+				},
+			},
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			InitializeStoreUsecase:   &initializeStoreUsecaseStub{},
+			ListSessionsQueryService: listStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "tree", "--db-path", dbPath})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		output := stdout.String()
+		if !strings.Contains(output, "text-session") {
+			t.Fatalf("text output should contain session id, got: %s", output)
+		}
+		// Text output should NOT be JSON
+		if strings.HasPrefix(strings.TrimSpace(output), "[") {
+			t.Fatalf("text output should not be JSON, got: %s", output)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `--json` flag to `session tree` command for machine-readable output
- JSON output preserves the parent-child hierarchy via nested `children` arrays
- Follows the existing JSON output pattern from `session list` (`writeSessionSummariesJSON`)
- Empty result set outputs `[]` instead of text message

Closes #344

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests in `session_tree_test.go`)
- [x] `go tool golangci-lint run` passes with 0 issues
- [ ] Manual verification: `traceary session tree --json` outputs valid nested JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)