### PR TITLE
fix: use single %w in xerrors.Errorf for migration rollback error

### DIFF
--- a/infrastructure/sqlite/migrate.go
+++ b/infrastructure/sqlite/migrate.go
@@ -142,7 +142,7 @@ func applyMigration(ctx context.Context, db *sql.DB, version int64, name string,
 	defer func() {
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				err = xerrors.Errorf("failed to roll back migration transaction: %w: %w", rollbackErr, err)
+				err = xerrors.Errorf("failed to roll back migration transaction: %w (original error: %v)", rollbackErr, err)
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary
- Replace `%w: %w` with `%w (original error: %v)` in `migrate.go:145`
- Avoids broken unwrap behavior from double `%w` in `xerrors.Errorf`

Closes #343

## Test plan
- [x] `go test ./infrastructure/sqlite/...` passes
- [x] `go tool golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)