### PR TITLE
refactor: extract inline SQL to embedded .sql files

### DIFF
--- a/infrastructure/sqlite/close_stale_sessions.go
+++ b/infrastructure/sqlite/close_stale_sessions.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	_ "embed"
 	"log/slog"
 	"time"
 
@@ -9,6 +10,12 @@ import (
 
 	"github.com/duck8823/traceary/domain/port"
 )
+
+//go:embed sql/count_stale_sessions.sql
+var countStaleSessionsQuery string
+
+//go:embed sql/update_stale_sessions.sql
+var updateStaleSessionsQuery string
 
 var _ port.StaleSessionCloser = (*Datasource)(nil)
 
@@ -34,7 +41,7 @@ func (d *Datasource) CloseStaleSessions(
 		var count int
 		if err := db.QueryRowContext(
 			ctx,
-			`SELECT COUNT(*) FROM sessions WHERE ended_at IS NULL AND started_at < ?`,
+			countStaleSessionsQuery,
 			cutoff,
 		).Scan(&count); err != nil {
 			return nil, xerrors.Errorf("failed to count stale sessions: %w", err)
@@ -45,7 +52,7 @@ func (d *Datasource) CloseStaleSessions(
 	now := formatTimestamp(time.Now())
 	result, err := db.ExecContext(
 		ctx,
-		`UPDATE sessions SET ended_at = ? WHERE ended_at IS NULL AND started_at < ?`,
+		updateStaleSessionsQuery,
 		now, cutoff,
 	)
 	if err != nil {

--- a/infrastructure/sqlite/command_audit_store.go
+++ b/infrastructure/sqlite/command_audit_store.go
@@ -2,13 +2,17 @@ package sqlite
 
 import (
 	"context"
+	_ "embed"
 	"log/slog"
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 )
+
+//go:embed sql/insert_command_audit.sql
+var insertCommandAuditQuery string
 
 var _ port.CommandAuditSaver = (*Datasource)(nil)
 
@@ -48,8 +52,7 @@ func (d *Datasource) SaveCommandAudit(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO events(id, kind, client, agent, session_id, repo, body, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		insertEventQuery,
 		event.EventID().String(),
 		event.Kind().String(),
 		event.Client(),
@@ -64,8 +67,7 @@ func (d *Datasource) SaveCommandAudit(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		insertCommandAuditQuery,
 		commandAudit.EventID().String(),
 		commandAudit.Command(),
 		commandAudit.Input(),

--- a/infrastructure/sqlite/event_store.go
+++ b/infrastructure/sqlite/event_store.go
@@ -2,8 +2,9 @@ package sqlite
 
 import (
 	"context"
-	"log/slog"
 	"database/sql"
+	_ "embed"
+	"log/slog"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -12,6 +13,12 @@ import (
 	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+//go:embed sql/insert_event.sql
+var insertEventQuery string
+
+//go:embed sql/select_recent_events.sql
+var selectRecentEventsQuery string
 
 var _ port.RecentEventFinder = (*Datasource)(nil)
 
@@ -33,8 +40,7 @@ func (d *Datasource) Save(ctx context.Context, dbPath string, event *model.Event
 
 	if _, err := db.ExecContext(
 		ctx,
-		`INSERT INTO events(id, kind, client, agent, session_id, repo, body, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		insertEventQuery,
 		event.EventID().String(),
 		event.Kind().String(),
 		event.Client(),
@@ -84,19 +90,7 @@ func (d *Datasource) ListRecent(
 
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at
-		   FROM events e
-		   LEFT JOIN command_audits ca ON ca.event_id = e.id
-		  WHERE (? = '' OR e.kind = ?)
-		    AND (? = '' OR e.client = ?)
-		    AND (? = '' OR e.agent = ?)
-		    AND (? = '' OR e.session_id = ?)
-		    AND (? = '' OR e.repo = ?)
-		    AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-		    AND (? = '' OR e.created_at >= ?)
-		    AND (? = '' OR e.created_at < ?)
-		  ORDER BY e.created_at DESC, e.id DESC
-		  LIMIT ? OFFSET ?`,
+		selectRecentEventsQuery,
 		input.Kind, input.Kind,
 		input.Client, input.Client,
 		input.Agent, input.Agent,

--- a/infrastructure/sqlite/find_latest_session.go
+++ b/infrastructure/sqlite/find_latest_session.go
@@ -2,9 +2,10 @@ package sqlite
 
 import (
 	"context"
-	"log/slog"
 	"database/sql"
+	_ "embed"
 	"errors"
+	"log/slog"
 
 	"golang.org/x/xerrors"
 
@@ -12,6 +13,9 @@ import (
 	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+//go:embed sql/find_latest_session.sql
+var findLatestSessionQuery string
 
 var _ port.LatestSessionFinder = (*Datasource)(nil)
 
@@ -33,83 +37,7 @@ func (d *Datasource) FindLatestSessionStartedEvent(
 
 	row := db.QueryRowContext(
 		ctx,
-		`WITH candidate_sessions AS (
-		     SELECT started.id,
-		            started.kind,
-		            started.client,
-		            started.agent,
-		            started.session_id,
-		            started.repo,
-		            started.body,
-		            started.created_at,
-		            (
-		              SELECT boundary.created_at
-		                FROM events boundary
-		               WHERE boundary.session_id = started.session_id
-		                 AND boundary.client = started.client
-		                 AND boundary.agent = started.agent
-		                 AND boundary.repo = started.repo
-		                 AND boundary.kind IN (?, ?)
-		               ORDER BY boundary.created_at DESC, boundary.id DESC
-		               LIMIT 1
-		            ) AS latest_boundary_created_at,
-		            (
-		              SELECT boundary.id
-		                FROM events boundary
-		               WHERE boundary.session_id = started.session_id
-		                 AND boundary.client = started.client
-		                 AND boundary.agent = started.agent
-		                 AND boundary.repo = started.repo
-		                 AND boundary.kind IN (?, ?)
-		               ORDER BY boundary.created_at DESC, boundary.id DESC
-		               LIMIT 1
-		            ) AS latest_boundary_id
-		       FROM events started
-		      WHERE started.kind = ?
-		        AND (? = '' OR started.client = ?)
-		        AND (? = '' OR started.agent = ?)
-		        AND (? = '' OR started.repo = ?)
-		        AND NOT EXISTS (
-		             SELECT 1
-		               FROM events newer_started
-		              WHERE newer_started.kind = ?
-		                AND newer_started.session_id = started.session_id
-		                AND newer_started.client = started.client
-		                AND newer_started.agent = started.agent
-		                AND newer_started.repo = started.repo
-		                AND (
-		                     newer_started.created_at > started.created_at OR
-		                     (newer_started.created_at = started.created_at AND newer_started.id > started.id)
-		                )
-		        )
-		        AND (
-		             ? = 0 OR NOT EXISTS (
-		                 SELECT 1
-		                   FROM events ended
-		                  WHERE ended.kind = ?
-		                    AND ended.session_id = started.session_id
-		                    AND ended.client = started.client
-		                    AND ended.agent = started.agent
-		                    AND ended.repo = started.repo
-		                    AND (
-		                         ended.created_at > started.created_at OR
-		                         (ended.created_at = started.created_at AND ended.id > started.id)
-		                    )
-		             )
-		        )
-		)
-		SELECT id,
-		       kind,
-		       client,
-		       agent,
-		       session_id,
-		       repo,
-		       body,
-		       created_at
-		  FROM candidate_sessions
-		 ORDER BY CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END DESC,
-		          CASE WHEN ? THEN id ELSE latest_boundary_id END DESC
-		 LIMIT 1`,
+		findLatestSessionQuery,
 		types.EventKindSessionStarted.String(),
 		types.EventKindSessionEnded.String(),
 		types.EventKindSessionStarted.String(),

--- a/infrastructure/sqlite/find_session_started_event.go
+++ b/infrastructure/sqlite/find_session_started_event.go
@@ -2,16 +2,20 @@ package sqlite
 
 import (
 	"context"
-	"log/slog"
 	"database/sql"
+	_ "embed"
 	"errors"
+	"log/slog"
 
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+//go:embed sql/find_session_started_event.sql
+var findSessionStartedEventQuery string
 
 var _ port.SessionStartedEventFinder = (*Datasource)(nil)
 
@@ -33,12 +37,7 @@ func (d *Datasource) FindSessionStartedEvent(
 
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT id, kind, client, agent, session_id, repo, body, created_at
-		   FROM events
-		  WHERE kind = ?
-		    AND session_id = ?
-		  ORDER BY created_at DESC, id DESC
-		  LIMIT 1`,
+		findSessionStartedEventQuery,
 		types.EventKindSessionStarted.String(),
 		sessionID.String(),
 	)

--- a/infrastructure/sqlite/gc_store.go
+++ b/infrastructure/sqlite/gc_store.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	_ "embed"
 	"log/slog"
 	"time"
 
@@ -9,6 +10,12 @@ import (
 
 	"github.com/duck8823/traceary/domain/port"
 )
+
+//go:embed sql/count_deletable_events.sql
+var countDeletableEventsQuery string
+
+//go:embed sql/delete_old_events.sql
+var deleteOldEventsQuery string
 
 var _ port.GarbageCollector = (*Datasource)(nil)
 
@@ -34,7 +41,7 @@ func (d *Datasource) CollectGarbage(
 	var deleteCount int
 	if err := db.QueryRowContext(
 		ctx,
-		`SELECT COUNT(*) FROM events WHERE created_at < ?`,
+		countDeletableEventsQuery,
 		beforeValue,
 	).Scan(&deleteCount); err != nil {
 		return 0, xerrors.Errorf("failed to count deletable events: %w", err)
@@ -56,7 +63,7 @@ func (d *Datasource) CollectGarbage(
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`DELETE FROM events WHERE created_at < ?`,
+		deleteOldEventsQuery,
 		beforeValue,
 	); err != nil {
 		return 0, xerrors.Errorf("failed to delete old events: %w", err)

--- a/infrastructure/sqlite/get_context_events.go
+++ b/infrastructure/sqlite/get_context_events.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	_ "embed"
 	"log/slog"
 	"strings"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/port"
 )
+
+//go:embed sql/get_context_events.sql
+var getContextEventsQuery string
 
 var _ port.ContextEventFinder = (*Datasource)(nil)
 
@@ -33,12 +37,7 @@ func (d *Datasource) GetContextEvents(
 	trimmedSessionID := strings.TrimSpace(input.SessionID)
 	rows, err := db.QueryContext(
 		ctx,
-		`SELECT id, kind, client, agent, session_id, repo, body, created_at
-		   FROM events
-		  WHERE (? = '' OR repo = ?)
-		    AND (? = '' OR session_id = ?)
-		  ORDER BY created_at DESC, id DESC
-		  LIMIT ?`,
+		getContextEventsQuery,
 		trimmedRepo,
 		trimmedRepo,
 		trimmedSessionID,

--- a/infrastructure/sqlite/get_event_details.go
+++ b/infrastructure/sqlite/get_event_details.go
@@ -2,9 +2,10 @@ package sqlite
 
 import (
 	"context"
-	"log/slog"
 	"database/sql"
+	_ "embed"
 	"errors"
+	"log/slog"
 
 	"golang.org/x/xerrors"
 
@@ -12,6 +13,9 @@ import (
 	"github.com/duck8823/traceary/domain/port"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+//go:embed sql/get_event_details.sql
+var getEventDetailsQuery string
 
 var _ port.EventDetailsFinder = (*Datasource)(nil)
 
@@ -33,12 +37,7 @@ func (d *Datasource) GetEventDetails(
 
 	row := db.QueryRowContext(
 		ctx,
-		`SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at,
-		        ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code
-		   FROM events AS e
-		   LEFT JOIN command_audits AS ca
-		     ON ca.event_id = e.id
-		  WHERE e.id = ?`,
+		getEventDetailsQuery,
 		eventID,
 	)
 

--- a/infrastructure/sqlite/session_store.go
+++ b/infrastructure/sqlite/session_store.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"log/slog"
 	"strings"
 
@@ -11,6 +12,15 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/port"
 )
+
+//go:embed sql/select_session_ended_at.sql
+var selectSessionEndedAtQuery string
+
+//go:embed sql/update_session_ended_at.sql
+var updateSessionEndedAtQuery string
+
+//go:embed sql/insert_session.sql
+var insertSessionQuery string
 
 var _ port.SessionSaver = (*Datasource)(nil)
 
@@ -33,7 +43,7 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 		var existingEndedAt sql.NullString
 		_ = db.QueryRowContext(
 			ctx,
-			`SELECT ended_at FROM sessions WHERE session_id = ?`,
+			selectSessionEndedAtQuery,
 			session.SessionID().String(),
 		).Scan(&existingEndedAt)
 		if existingEndedAt.Valid {
@@ -46,7 +56,7 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 		// Session end: update ended_at
 		result, err := db.ExecContext(
 			ctx,
-			`UPDATE sessions SET ended_at = ?, summary = CASE WHEN ? != '' THEN ? ELSE summary END WHERE session_id = ?`,
+			updateSessionEndedAtQuery,
 			formatTimestamp(*session.EndedAt()),
 			session.Summary(),
 			session.Summary(),
@@ -73,7 +83,7 @@ func (d *Datasource) SaveSession(ctx context.Context, dbPath string, session *mo
 	}
 	result, err := db.ExecContext(
 		ctx,
-		`INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, repo, parent_session_id) VALUES (?, ?, ?, ?, ?, ?)`,
+		insertSessionQuery,
 		session.SessionID().String(),
 		formatTimestamp(session.StartedAt()),
 		session.Client(),

--- a/infrastructure/sqlite/sql/count_deletable_events.sql
+++ b/infrastructure/sqlite/sql/count_deletable_events.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) FROM events WHERE created_at < ?

--- a/infrastructure/sqlite/sql/count_stale_sessions.sql
+++ b/infrastructure/sqlite/sql/count_stale_sessions.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) FROM sessions WHERE ended_at IS NULL AND started_at < ?

--- a/infrastructure/sqlite/sql/delete_old_events.sql
+++ b/infrastructure/sqlite/sql/delete_old_events.sql
@@ -1,0 +1,1 @@
+DELETE FROM events WHERE created_at < ?

--- a/infrastructure/sqlite/sql/find_latest_session.sql
+++ b/infrastructure/sqlite/sql/find_latest_session.sql
@@ -1,0 +1,77 @@
+WITH candidate_sessions AS (
+     SELECT started.id,
+            started.kind,
+            started.client,
+            started.agent,
+            started.session_id,
+            started.repo,
+            started.body,
+            started.created_at,
+            (
+              SELECT boundary.created_at
+                FROM events boundary
+               WHERE boundary.session_id = started.session_id
+                 AND boundary.client = started.client
+                 AND boundary.agent = started.agent
+                 AND boundary.repo = started.repo
+                 AND boundary.kind IN (?, ?)
+               ORDER BY boundary.created_at DESC, boundary.id DESC
+               LIMIT 1
+            ) AS latest_boundary_created_at,
+            (
+              SELECT boundary.id
+                FROM events boundary
+               WHERE boundary.session_id = started.session_id
+                 AND boundary.client = started.client
+                 AND boundary.agent = started.agent
+                 AND boundary.repo = started.repo
+                 AND boundary.kind IN (?, ?)
+               ORDER BY boundary.created_at DESC, boundary.id DESC
+               LIMIT 1
+            ) AS latest_boundary_id
+       FROM events started
+      WHERE started.kind = ?
+        AND (? = '' OR started.client = ?)
+        AND (? = '' OR started.agent = ?)
+        AND (? = '' OR started.repo = ?)
+        AND NOT EXISTS (
+             SELECT 1
+               FROM events newer_started
+              WHERE newer_started.kind = ?
+                AND newer_started.session_id = started.session_id
+                AND newer_started.client = started.client
+                AND newer_started.agent = started.agent
+                AND newer_started.repo = started.repo
+                AND (
+                     newer_started.created_at > started.created_at OR
+                     (newer_started.created_at = started.created_at AND newer_started.id > started.id)
+                )
+        )
+        AND (
+             ? = 0 OR NOT EXISTS (
+                 SELECT 1
+                   FROM events ended
+                  WHERE ended.kind = ?
+                    AND ended.session_id = started.session_id
+                    AND ended.client = started.client
+                    AND ended.agent = started.agent
+                    AND ended.repo = started.repo
+                    AND (
+                         ended.created_at > started.created_at OR
+                         (ended.created_at = started.created_at AND ended.id > started.id)
+                    )
+             )
+        )
+)
+SELECT id,
+       kind,
+       client,
+       agent,
+       session_id,
+       repo,
+       body,
+       created_at
+  FROM candidate_sessions
+ ORDER BY CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END DESC,
+          CASE WHEN ? THEN id ELSE latest_boundary_id END DESC
+ LIMIT 1

--- a/infrastructure/sqlite/sql/find_session_started_event.sql
+++ b/infrastructure/sqlite/sql/find_session_started_event.sql
@@ -1,0 +1,6 @@
+SELECT id, kind, client, agent, session_id, repo, body, created_at
+  FROM events
+ WHERE kind = ?
+   AND session_id = ?
+ ORDER BY created_at DESC, id DESC
+ LIMIT 1

--- a/infrastructure/sqlite/sql/get_context_events.sql
+++ b/infrastructure/sqlite/sql/get_context_events.sql
@@ -1,0 +1,6 @@
+SELECT id, kind, client, agent, session_id, repo, body, created_at
+  FROM events
+ WHERE (? = '' OR repo = ?)
+   AND (? = '' OR session_id = ?)
+ ORDER BY created_at DESC, id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/get_event_details.sql
+++ b/infrastructure/sqlite/sql/get_event_details.sql
@@ -1,0 +1,6 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at,
+       ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code
+  FROM events AS e
+  LEFT JOIN command_audits AS ca
+    ON ca.event_id = e.id
+ WHERE e.id = ?

--- a/infrastructure/sqlite/sql/insert_command_audit.sql
+++ b/infrastructure/sqlite/sql/insert_command_audit.sql
@@ -1,0 +1,2 @@
+INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
+VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/insert_event.sql
+++ b/infrastructure/sqlite/sql/insert_event.sql
@@ -1,0 +1,2 @@
+INSERT INTO events(id, kind, client, agent, session_id, repo, body, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/insert_session.sql
+++ b/infrastructure/sqlite/sql/insert_session.sql
@@ -1,0 +1,1 @@
+INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, repo, parent_session_id) VALUES (?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/select_recent_events.sql
+++ b/infrastructure/sqlite/sql/select_recent_events.sql
@@ -1,0 +1,13 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.repo, e.body, e.created_at
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.repo = ?)
+   AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR e.created_at >= ?)
+   AND (? = '' OR e.created_at < ?)
+ ORDER BY e.created_at DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_session_ended_at.sql
+++ b/infrastructure/sqlite/sql/select_session_ended_at.sql
@@ -1,0 +1,1 @@
+SELECT ended_at FROM sessions WHERE session_id = ?

--- a/infrastructure/sqlite/sql/update_session_ended_at.sql
+++ b/infrastructure/sqlite/sql/update_session_ended_at.sql
@@ -1,0 +1,1 @@
+UPDATE sessions SET ended_at = ?, summary = CASE WHEN ? != '' THEN ? ELSE summary END WHERE session_id = ?

--- a/infrastructure/sqlite/sql/update_session_label.sql
+++ b/infrastructure/sqlite/sql/update_session_label.sql
@@ -1,0 +1,1 @@
+UPDATE sessions SET label = ? WHERE session_id = ?

--- a/infrastructure/sqlite/sql/update_stale_sessions.sql
+++ b/infrastructure/sqlite/sql/update_stale_sessions.sql
@@ -1,0 +1,1 @@
+UPDATE sessions SET ended_at = ? WHERE ended_at IS NULL AND started_at < ?

--- a/infrastructure/sqlite/update_session_label.go
+++ b/infrastructure/sqlite/update_session_label.go
@@ -2,12 +2,16 @@ package sqlite
 
 import (
 	"context"
+	_ "embed"
 	"log/slog"
 
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/types"
 )
+
+//go:embed sql/update_session_label.sql
+var updateSessionLabelQuery string
 
 // UpdateSessionLabel sets the label for a session.
 func (d *Datasource) UpdateSessionLabel(ctx context.Context, dbPath string, sessionID types.SessionID, label string) error {
@@ -23,7 +27,7 @@ func (d *Datasource) UpdateSessionLabel(ctx context.Context, dbPath string, sess
 
 	result, err := db.ExecContext(
 		ctx,
-		`UPDATE sessions SET label = ? WHERE session_id = ?`,
+		updateSessionLabelQuery,
 		label,
 		sessionID.String(),
 	)


### PR DESCRIPTION
## Summary
- Extract inline SQL queries from 10 `infrastructure/sqlite/` files into 15 separate `.sql` files under `infrastructure/sqlite/sql/`
- Use `//go:embed` to load SQL at compile time, matching the pattern already established by `search_events.go` and `list_sessions.go`
- `migrate.go` and test files are intentionally untouched

## Files changed
**15 new SQL files** in `infrastructure/sqlite/sql/`:
`insert_event.sql`, `select_recent_events.sql`, `insert_command_audit.sql`, `select_session_ended_at.sql`, `update_session_ended_at.sql`, `insert_session.sql`, `find_session_started_event.sql`, `find_latest_session.sql`, `count_deletable_events.sql`, `delete_old_events.sql`, `get_context_events.sql`, `get_event_details.sql`, `update_session_label.sql`, `count_stale_sessions.sql`, `update_stale_sessions.sql`

**10 Go files** updated to use `//go:embed` + `_ "embed"` import:
`event_store.go`, `command_audit_store.go`, `session_store.go`, `find_session_started_event.go`, `find_latest_session.go`, `gc_store.go`, `get_context_events.go`, `get_event_details.go`, `update_session_label.go`, `close_stale_sessions.go`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` reports 0 issues

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)