### PR TITLE
chore: add dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml`
- Weekly Go module + GitHub Actions updates (Saturday 09:00 JST)
- Updates grouped per ecosystem, labeled `dependencies`

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)