### PR TITLE
fix: pass session_id to session lookup in MCP session_handoff

### DIFF
--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -571,8 +571,9 @@ type sessionHandoffOutput struct {
 func (s *Server) sessionHandoff(dbPath string) mcp.ToolHandlerFor[sessionHandoffInput, sessionHandoffOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionHandoffInput) (*mcp.CallToolResult, sessionHandoffOutput, error) {
 		sessions, err := s.listSessionsQueryService.Run(ctx, dbPath, port.ListSessionsInput{
-			Limit: 1,
-			Repo:  strings.TrimSpace(input.Repo),
+			Limit:     1,
+			SessionID: strings.TrimSpace(input.SessionID),
+			Repo:      strings.TrimSpace(input.Repo),
 		})
 		if err != nil {
 			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to list sessions: %w", err)


### PR DESCRIPTION
## Summary
- Pass `input.SessionID` to `ListSessionsInput.SessionID` in the MCP `session_handoff` handler
- Previously the tool accepted `session_id` but silently ignored it

Closes #386

## Test plan
- [x] `go build ./...` / `go test ./...` / `golangci-lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)