### PR TITLE
feat: add Client and Workspace value objects

### DIFF
--- a/domain/types/client.go
+++ b/domain/types/client.go
@@ -6,7 +6,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Client is a value object representing the recording channel (e.g. cli, hook, mcp).
+// Client is a value object representing the recording channel.
+// Values are not restricted to a fixed set; new channels may be introduced
+// by additional integrations (e.g. cli, hook, mcp).
 type Client string
 
 // ClientOf creates a Client from a string.

--- a/domain/types/client.go
+++ b/domain/types/client.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// Client is a value object representing the recording channel (e.g. cli, hook, mcp).
+type Client string
+
+// ClientOf creates a Client from a string.
+func ClientOf(value string) (Client, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return Client(""), xerrors.Errorf("client must not be empty")
+	}
+	return Client(trimmedValue), nil
+}
+
+// String returns the string representation.
+func (c Client) String() string { return string(c) }

--- a/domain/types/client_test.go
+++ b/domain/types/client_test.go
@@ -1,0 +1,38 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestClientOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid client", input: "cli", want: "cli"},
+		{name: "hook client", input: "hook", want: "hook"},
+		{name: "mcp client", input: "mcp", want: "mcp"},
+		{name: "trims whitespace", input: "  cli  ", want: "cli"},
+		{name: "empty string returns error", input: "", wantErr: true},
+		{name: "whitespace-only returns error", input: "   ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.ClientOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ClientOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("ClientOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+			}
+		})
+	}
+}

--- a/domain/types/client_test.go
+++ b/domain/types/client_test.go
@@ -19,6 +19,7 @@ func TestClientOf(t *testing.T) {
 		{name: "hook client", input: "hook", want: "hook"},
 		{name: "mcp client", input: "mcp", want: "mcp"},
 		{name: "trims whitespace", input: "  cli  ", want: "cli"},
+		{name: "accepts arbitrary channel name", input: "custom-plugin", want: "custom-plugin"},
 		{name: "empty string returns error", input: "", wantErr: true},
 		{name: "whitespace-only returns error", input: "   ", wantErr: true},
 	}

--- a/domain/types/workspace.go
+++ b/domain/types/workspace.go
@@ -6,7 +6,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Workspace is a value object representing the work context (e.g. github.com/org/repo, /abs/path).
+// Workspace is a value object representing the work context.
+// The format is not restricted; typical values include GitHub repository
+// paths (github.com/org/repo) and absolute filesystem paths.
 type Workspace string
 
 // WorkspaceOf creates a Workspace from a string.

--- a/domain/types/workspace.go
+++ b/domain/types/workspace.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// Workspace is a value object representing the work context (e.g. github.com/org/repo, /abs/path).
+type Workspace string
+
+// WorkspaceOf creates a Workspace from a string.
+func WorkspaceOf(value string) (Workspace, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return Workspace(""), xerrors.Errorf("workspace must not be empty")
+	}
+	return Workspace(trimmedValue), nil
+}
+
+// String returns the string representation.
+func (w Workspace) String() string { return string(w) }

--- a/domain/types/workspace_test.go
+++ b/domain/types/workspace_test.go
@@ -18,6 +18,7 @@ func TestWorkspaceOf(t *testing.T) {
 		{name: "github repo path", input: "github.com/duck8823/traceary", want: "github.com/duck8823/traceary"},
 		{name: "absolute path", input: "/home/user/project", want: "/home/user/project"},
 		{name: "trims whitespace", input: "  github.com/org/repo  ", want: "github.com/org/repo"},
+		{name: "accepts any non-empty string", input: "my-workspace", want: "my-workspace"},
 		{name: "empty string returns error", input: "", wantErr: true},
 		{name: "whitespace-only returns error", input: "   ", wantErr: true},
 	}

--- a/domain/types/workspace_test.go
+++ b/domain/types/workspace_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestWorkspaceOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "github repo path", input: "github.com/duck8823/traceary", want: "github.com/duck8823/traceary"},
+		{name: "absolute path", input: "/home/user/project", want: "/home/user/project"},
+		{name: "trims whitespace", input: "  github.com/org/repo  ", want: "github.com/org/repo"},
+		{name: "empty string returns error", input: "", wantErr: true},
+		{name: "whitespace-only returns error", input: "   ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.WorkspaceOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("WorkspaceOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("WorkspaceOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `types.Client` value object for recording channel (cli, hook, mcp)
- Add `types.Workspace` value object for work context (github repo path or absolute path)
- Follow existing `Agent`/`SessionID` pattern with constructor validation and String() method
- Table-driven tests for both types

Closes #389

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./domain/types/...` passes
- [x] `go vet ./domain/types/...` passes
- [x] `golangci-lint run ./domain/types/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)