### PR TITLE
feat: add repository interfaces and Session.SetLabel

### DIFF
--- a/domain/model/event_repository.go
+++ b/domain/model/event_repository.go
@@ -3,8 +3,13 @@ package model
 import (
 	"context"
 
+	"golang.org/x/xerrors"
+
 	"github.com/duck8823/traceary/domain/types"
 )
+
+// ErrSessionStartedEventNotFound indicates no session_started event exists for the given session.
+var ErrSessionStartedEventNotFound = xerrors.New("session_started event was not found for the target session")
 
 // EventRepository defines persistence operations for the Event aggregate.
 type EventRepository interface {
@@ -12,6 +17,7 @@ type EventRepository interface {
 	// both are saved as part of the same aggregate.
 	Save(ctx context.Context, event *Event) error
 
-	// GetBySessionID retrieves the session_started event for the given session.
-	GetBySessionID(ctx context.Context, sessionID types.SessionID) (*Event, error)
+	// GetSessionStartedEvent retrieves the session_started event for the given session.
+	// Returns ErrSessionStartedEventNotFound when no matching event exists.
+	GetSessionStartedEvent(ctx context.Context, sessionID types.SessionID) (*Event, error)
 }

--- a/domain/model/event_repository.go
+++ b/domain/model/event_repository.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EventRepository defines persistence operations for the Event aggregate.
+type EventRepository interface {
+	// Save persists an Event. If the event includes a CommandAudit,
+	// both are saved as part of the same aggregate.
+	Save(ctx context.Context, event *Event) error
+
+	// GetBySessionID retrieves the session_started event for the given session.
+	GetBySessionID(ctx context.Context, sessionID types.SessionID) (*Event, error)
+}

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -82,7 +82,7 @@ func (s *Session) Repo() string { return s.repo }
 // Label returns the user-assigned label.
 func (s *Session) Label() string { return s.label }
 
-// SetLabel updates the session label.
+// SetLabel updates the session label. An empty string clears the label.
 func (s *Session) SetLabel(label string) { s.label = label }
 
 // Summary returns the session summary text.

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -82,6 +82,9 @@ func (s *Session) Repo() string { return s.repo }
 // Label returns the user-assigned label.
 func (s *Session) Label() string { return s.label }
 
+// SetLabel updates the session label.
+func (s *Session) SetLabel(label string) { s.label = label }
+
 // Summary returns the session summary text.
 func (s *Session) Summary() string { return s.summary }
 

--- a/domain/model/session_repository.go
+++ b/domain/model/session_repository.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// SessionRepository defines persistence operations for the Session aggregate.
+type SessionRepository interface {
+	// Save persists a Session (insert or update).
+	Save(ctx context.Context, session *Session) error
+
+	// GetByID retrieves a Session by its session ID.
+	GetByID(ctx context.Context, sessionID types.SessionID) (*Session, error)
+}

--- a/domain/model/session_test.go
+++ b/domain/model/session_test.go
@@ -78,3 +78,27 @@ func TestSessionOf(t *testing.T) {
 		t.Errorf("ParentSessionID() = %q, want %q", session.ParentSessionID(), "parent-123")
 	}
 }
+
+func TestSession_SetLabel(t *testing.T) {
+	t.Parallel()
+
+	agent, _ := types.AgentOf("claude")
+	sid, _ := types.SessionIDOf("session-3")
+	now := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	session := model.NewSession(sid, now, "cli", agent, "duck8823/traceary")
+
+	if session.Label() != "" {
+		t.Fatalf("Label() = %q, want empty before SetLabel", session.Label())
+	}
+
+	session.SetLabel("sprint-1")
+	if session.Label() != "sprint-1" {
+		t.Errorf("Label() = %q, want %q after SetLabel", session.Label(), "sprint-1")
+	}
+
+	session.SetLabel("updated-label")
+	if session.Label() != "updated-label" {
+		t.Errorf("Label() = %q, want %q after second SetLabel", session.Label(), "updated-label")
+	}
+}

--- a/domain/model/session_test.go
+++ b/domain/model/session_test.go
@@ -101,4 +101,9 @@ func TestSession_SetLabel(t *testing.T) {
 	if session.Label() != "updated-label" {
 		t.Errorf("Label() = %q, want %q after second SetLabel", session.Label(), "updated-label")
 	}
+
+	session.SetLabel("")
+	if session.Label() != "" {
+		t.Errorf("Label() = %q, want empty after clearing with SetLabel", session.Label())
+	}
 }


### PR DESCRIPTION
## Summary
- Add `EventRepository` interface to `domain/model/` with `Save` and `GetBySessionID` methods
- Add `SessionRepository` interface to `domain/model/` with `Save` and `GetByID` methods
- Add `Session.SetLabel()` method for in-place label mutation before persistence
- Repository interfaces follow dotfiles Go conventions: no `dbPath` in method signatures (injected via constructor in B2)

Closes #390

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./domain/model/...` passes (includes SetLabel test)
- [x] `go vet ./domain/model/...` passes
- [x] `golangci-lint run ./domain/model/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)