### PR TITLE
feat: add filter criteria structs and application DTOs

### DIFF
--- a/application/usecase/criteria.go
+++ b/application/usecase/criteria.go
@@ -65,7 +65,8 @@ type SessionListCriteria struct {
 // (active session, latest session).
 // Zero-value fields are ignored (no filter applied).
 type SessionLookupCriteria struct {
-	Client    types.Client
-	Agent     types.Agent
-	Workspace types.Workspace
+	Client     types.Client
+	Agent      types.Agent
+	Workspace  types.Workspace
+	ActiveOnly bool
 }

--- a/application/usecase/criteria.go
+++ b/application/usecase/criteria.go
@@ -1,0 +1,71 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EventSearchCriteria holds filter parameters for full-text event search.
+// Zero-value fields are ignored (no filter applied).
+type EventSearchCriteria struct {
+	Query        string
+	Workspace    types.Workspace
+	SessionID    types.SessionID
+	Client       types.Client
+	Agent        types.Agent
+	Kind         types.EventKind
+	From         time.Time
+	To           time.Time
+	Limit        int
+	Offset       int
+	FailuresOnly bool
+}
+
+// EventListCriteria holds filter parameters for event listing.
+// Zero-value fields are ignored (no filter applied).
+type EventListCriteria struct {
+	Limit        int
+	Offset       int
+	Kind         types.EventKind
+	Client       types.Client
+	Agent        types.Agent
+	SessionID    types.SessionID
+	Workspace    types.Workspace
+	FailuresOnly bool
+	From         time.Time
+	To           time.Time
+}
+
+// EventContextCriteria holds filter parameters for context event retrieval.
+// Zero-value fields are ignored (no filter applied).
+type EventContextCriteria struct {
+	Workspace types.Workspace
+	SessionID types.SessionID
+	Client    types.Client
+	Agent     types.Agent
+	Limit     int
+}
+
+// SessionListCriteria holds filter parameters for session listing.
+// Zero-value fields are ignored (no filter applied).
+type SessionListCriteria struct {
+	Limit     int
+	Offset    int
+	SessionID types.SessionID
+	Workspace types.Workspace
+	Client    types.Client
+	Agent     types.Agent
+	Label     string
+	From      *time.Time
+	To        *time.Time
+}
+
+// SessionLookupCriteria holds filter parameters for single-session lookup
+// (active session, latest session).
+// Zero-value fields are ignored (no filter applied).
+type SessionLookupCriteria struct {
+	Client    types.Client
+	Agent     types.Agent
+	Workspace types.Workspace
+}

--- a/application/usecase/dto.go
+++ b/application/usecase/dto.go
@@ -44,7 +44,7 @@ type SessionSummary struct {
 	Agents          []string
 	Label           string
 	Summary         string
-	ParentSessionID string
+	ParentSessionID types.SessionID
 }
 
 // HandoffSummary holds information for session handoff between agents.

--- a/application/usecase/dto.go
+++ b/application/usecase/dto.go
@@ -1,0 +1,61 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+
+	"golang.org/x/xerrors"
+)
+
+// EventDetails pairs an Event with its optional CommandAudit.
+type EventDetails struct {
+	event        *model.Event
+	commandAudit *model.CommandAudit
+}
+
+// NewEventDetails creates an EventDetails value.
+func NewEventDetails(event *model.Event, commandAudit *model.CommandAudit) (*EventDetails, error) {
+	if event == nil {
+		return nil, xerrors.Errorf("event must not be nil")
+	}
+	return &EventDetails{
+		event:        event,
+		commandAudit: commandAudit,
+	}, nil
+}
+
+// Event returns the event.
+func (d *EventDetails) Event() *model.Event { return d.event }
+
+// CommandAudit returns the linked command audit, or nil.
+func (d *EventDetails) CommandAudit() *model.CommandAudit { return d.commandAudit }
+
+// SessionSummary holds aggregated information about a single session.
+type SessionSummary struct {
+	SessionID       types.SessionID
+	Workspace       types.Workspace
+	StartedAt       time.Time
+	EndedAt         *time.Time
+	Status          string
+	TotalEvents     int
+	CommandCount    int
+	Agents          []string
+	Label           string
+	Summary         string
+	ParentSessionID string
+}
+
+// HandoffSummary holds information for session handoff between agents.
+type HandoffSummary struct {
+	SessionID      types.SessionID
+	Workspace      types.Workspace
+	Label          string
+	Status         string
+	TotalEvents    int
+	CommandCount   int
+	Agents         []string
+	Summary        string
+	RecentCommands []string
+}

--- a/application/usecase/dto_test.go
+++ b/application/usecase/dto_test.go
@@ -1,0 +1,107 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestNewEventDetails(t *testing.T) {
+	t.Parallel()
+
+	eventID, _ := types.EventIDOf("evt-1")
+	kind, _ := types.EventKindOf("note")
+	agent, _ := types.AgentOf("claude")
+	sid, _ := types.SessionIDOf("session-1")
+
+	event, err := model.NewEvent(eventID, kind, "cli", agent, sid, "repo", "test body")
+	if err != nil {
+		t.Fatalf("NewEvent() error = %v", err)
+	}
+
+	t.Run("with event only", func(t *testing.T) {
+		t.Parallel()
+		details, err := usecase.NewEventDetails(event, nil)
+		if err != nil {
+			t.Fatalf("NewEventDetails() error = %v", err)
+		}
+		if details.Event() != event {
+			t.Errorf("Event() mismatch")
+		}
+		if details.CommandAudit() != nil {
+			t.Errorf("CommandAudit() = %v, want nil", details.CommandAudit())
+		}
+	})
+
+	t.Run("with event and command audit", func(t *testing.T) {
+		t.Parallel()
+		audit, _ := model.NewCommandAudit(eventID, "ls -la", "", "", false, false)
+		details, err := usecase.NewEventDetails(event, audit)
+		if err != nil {
+			t.Fatalf("NewEventDetails() error = %v", err)
+		}
+		if details.CommandAudit() != audit {
+			t.Errorf("CommandAudit() mismatch")
+		}
+	})
+
+	t.Run("nil event returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := usecase.NewEventDetails(nil, nil)
+		if err == nil {
+			t.Fatal("NewEventDetails(nil, nil) should return error")
+		}
+	})
+}
+
+func TestSessionSummary_fields(t *testing.T) {
+	t.Parallel()
+
+	sid, _ := types.SessionIDOf("session-1")
+	ws, _ := types.WorkspaceOf("github.com/duck8823/traceary")
+	now := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+
+	summary := usecase.SessionSummary{
+		SessionID:   sid,
+		Workspace:   ws,
+		StartedAt:   now,
+		Status:      "active",
+		TotalEvents: 5,
+		Label:       "sprint-1",
+	}
+
+	if summary.SessionID != sid {
+		t.Errorf("SessionID = %v, want %v", summary.SessionID, sid)
+	}
+	if summary.Workspace != ws {
+		t.Errorf("Workspace = %v, want %v", summary.Workspace, ws)
+	}
+	if summary.Status != "active" {
+		t.Errorf("Status = %q, want %q", summary.Status, "active")
+	}
+}
+
+func TestHandoffSummary_fields(t *testing.T) {
+	t.Parallel()
+
+	sid, _ := types.SessionIDOf("session-1")
+	ws, _ := types.WorkspaceOf("github.com/duck8823/traceary")
+
+	handoff := usecase.HandoffSummary{
+		SessionID:      sid,
+		Workspace:      ws,
+		Label:          "sprint-1",
+		Status:         "active",
+		RecentCommands: []string{"git status", "go test ./..."},
+	}
+
+	if handoff.SessionID != sid {
+		t.Errorf("SessionID = %v, want %v", handoff.SessionID, sid)
+	}
+	if len(handoff.RecentCommands) != 2 {
+		t.Errorf("RecentCommands length = %d, want 2", len(handoff.RecentCommands))
+	}
+}

--- a/application/usecase/dto_test.go
+++ b/application/usecase/dto_test.go
@@ -38,7 +38,10 @@ func TestNewEventDetails(t *testing.T) {
 
 	t.Run("with event and command audit", func(t *testing.T) {
 		t.Parallel()
-		audit, _ := model.NewCommandAudit(eventID, "ls -la", "", "", false, false)
+		audit, err := model.NewCommandAudit(eventID, "ls -la", "", "", false, false)
+		if err != nil {
+			t.Fatalf("NewCommandAudit() error = %v", err)
+		}
 		details, err := usecase.NewEventDetails(event, audit)
 		if err != nil {
 			t.Fatalf("NewEventDetails() error = %v", err)


### PR DESCRIPTION
## Summary
- Add 5 filter criteria structs with value object typed fields (zero value = no filter):
  - `EventSearchCriteria`, `EventListCriteria`, `EventContextCriteria`
  - `SessionListCriteria`, `SessionLookupCriteria`
- Add 3 application DTOs with typed fields replacing raw strings:
  - `EventDetails` (event + optional command audit)
  - `SessionSummary` (aggregated session info)
  - `HandoffSummary` (session handoff between agents)
- Tests for EventDetails constructor and DTO field access

Closes #391

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./application/usecase/...` passes
- [x] `go vet ./application/usecase/...` passes
- [x] `golangci-lint run ./application/usecase/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)