### PR TITLE
feat: consolidate into EventUsecase, SessionUsecase, StoreMaintenanceUsecase

### DIFF
--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -38,6 +38,7 @@ type EventUsecase interface {
 	List(ctx context.Context, criteria EventListCriteria) ([]*model.Event, error)
 
 	// Show returns the details for a single event.
+	// Returns usecase.EventDetails; port.EventDetails will be removed in Phase C.
 	Show(ctx context.Context, eventID types.EventID) (*EventDetails, error)
 
 	// Context returns recent events for the given context.

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// AuditParams holds parameters for recording a command audit event.
+type AuditParams struct {
+	Command             string
+	Input               string
+	Output              string
+	Client              types.Client
+	Agent               types.Agent
+	SessionID           types.SessionID
+	Workspace           types.Workspace
+	ExitCode            *int
+	AllowSecrets        bool
+	MaxInputBytes       int
+	MaxOutputBytes      int
+	ExtraRedactPatterns []string
+}
+
+// EventUsecase consolidates event recording and query operations.
+type EventUsecase interface {
+	// Log records a note event.
+	Log(ctx context.Context, message string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error)
+
+	// Audit records a command execution audit event.
+	Audit(ctx context.Context, params AuditParams) (*model.Event, *model.CommandAudit, error)
+
+	// Search performs full-text search across events.
+	Search(ctx context.Context, criteria EventSearchCriteria) ([]*model.Event, error)
+
+	// List returns events in descending time order.
+	List(ctx context.Context, criteria EventListCriteria) ([]*model.Event, error)
+
+	// Show returns the details for a single event.
+	Show(ctx context.Context, eventID types.EventID) (*EventDetails, error)
+
+	// Context returns recent events for the given context.
+	Context(ctx context.Context, criteria EventContextCriteria) ([]*model.Event, error)
+}

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EndSessionParams holds parameters for ending a session.
+// Zero-value Client/Agent/Workspace falls back to the session start values.
+type EndSessionParams struct {
+	Client    types.Client
+	Agent     types.Agent
+	SessionID types.SessionID
+	Workspace types.Workspace
+	Summary   string
+}
+
+// SessionUsecase consolidates session lifecycle and query operations.
+type SessionUsecase interface {
+	// Start begins a new session. If sessionID is zero, a new ID is generated.
+	Start(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error)
+
+	// End closes an existing session. Zero-value fields in params fall back
+	// to values from the corresponding session_started event.
+	End(ctx context.Context, params EndSessionParams) (*model.Event, error)
+
+	// Label updates the label on an existing session.
+	Label(ctx context.Context, sessionID types.SessionID, label string) error
+
+	// List returns session summaries matching the criteria.
+	List(ctx context.Context, criteria SessionListCriteria) ([]*SessionSummary, error)
+
+	// Tree returns session summaries as a hierarchy for the given workspace.
+	Tree(ctx context.Context, workspace types.Workspace, limit int) ([]*SessionSummary, error)
+
+	// Active returns the session_started event for the active session matching the criteria.
+	Active(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error)
+
+	// Latest returns the session_started event for the latest session matching the criteria.
+	Latest(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error)
+
+	// Handoff returns a concise summary for session context transfer between agents.
+	Handoff(ctx context.Context, sessionID types.SessionID, workspace types.Workspace, recent int) (*HandoffSummary, error)
+}

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -20,6 +20,7 @@ type EndSessionParams struct {
 // SessionUsecase consolidates session lifecycle and query operations.
 type SessionUsecase interface {
 	// Start begins a new session. If sessionID is zero, a new ID is generated.
+	// Zero-value parentSessionID means no parent (top-level session).
 	Start(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error)
 
 	// End closes an existing session. Zero-value fields in params fall back
@@ -30,17 +31,22 @@ type SessionUsecase interface {
 	Label(ctx context.Context, sessionID types.SessionID, label string) error
 
 	// List returns session summaries matching the criteria.
+	// SessionSummary.Workspace maps to the existing Repo field in infrastructure.
 	List(ctx context.Context, criteria SessionListCriteria) ([]*SessionSummary, error)
 
 	// Tree returns session summaries as a hierarchy for the given workspace.
+	// Zero-value workspace returns sessions across all workspaces.
 	Tree(ctx context.Context, workspace types.Workspace, limit int) ([]*SessionSummary, error)
 
 	// Active returns the session_started event for the active session matching the criteria.
+	// ActiveOnly in criteria is ignored; this method always filters for active sessions.
 	Active(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error)
 
 	// Latest returns the session_started event for the latest session matching the criteria.
+	// ActiveOnly in criteria is ignored; this method returns the latest session regardless of status.
 	Latest(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error)
 
 	// Handoff returns a concise summary for session context transfer between agents.
+	// Zero-value workspace means no workspace filter.
 	Handoff(ctx context.Context, sessionID types.SessionID, workspace types.Workspace, recent int) (*HandoffSummary, error)
 }

--- a/application/usecase/store_maintenance_usecase.go
+++ b/application/usecase/store_maintenance_usecase.go
@@ -1,0 +1,24 @@
+package usecase
+
+import (
+	"context"
+	"time"
+)
+
+// StoreMaintenanceUsecase consolidates store lifecycle operations.
+type StoreMaintenanceUsecase interface {
+	// Initialize creates the store and applies migrations.
+	Initialize(ctx context.Context) error
+
+	// CreateBackup creates a backup of the store.
+	CreateBackup(ctx context.Context, outputPath string, overwrite bool) error
+
+	// RestoreBackup restores a backup into the store.
+	RestoreBackup(ctx context.Context, inputPath string, overwrite bool) error
+
+	// CollectGarbage removes events older than the given time.
+	CollectGarbage(ctx context.Context, before time.Time, dryRun bool) (*CollectGarbageResult, error)
+
+	// CloseStaleSession closes sessions active beyond the given duration.
+	CloseStaleSession(ctx context.Context, staleAfter time.Duration, dryRun bool) (*CloseStaleSessionsResult, error)
+}

--- a/application/usecase/store_maintenance_usecase.go
+++ b/application/usecase/store_maintenance_usecase.go
@@ -19,6 +19,6 @@ type StoreMaintenanceUsecase interface {
 	// CollectGarbage removes events older than the given time.
 	CollectGarbage(ctx context.Context, before time.Time, dryRun bool) (*CollectGarbageResult, error)
 
-	// CloseStaleSession closes sessions active beyond the given duration.
-	CloseStaleSession(ctx context.Context, staleAfter time.Duration, dryRun bool) (*CloseStaleSessionsResult, error)
+	// CloseStaleSessions closes sessions active beyond the given duration.
+	CloseStaleSessions(ctx context.Context, staleAfter time.Duration, dryRun bool) (*CloseStaleSessionsResult, error)
 }


### PR DESCRIPTION
## Summary
- Add 3 aggregate-based usecase interfaces consolidating 16 port interfaces + 9 usecases + 6 queryservices:
  - `EventUsecase`: Log, Audit, Search, List, Show, Context (6 methods)
  - `SessionUsecase`: Start, End, Label, List, Tree, Active, Latest, Handoff (8 methods)
  - `StoreMaintenanceUsecase`: Initialize, CreateBackup, RestoreBackup, CollectGarbage, CloseStaleSession (5 methods)
- Add `AuditParams` and `EndSessionParams` parameter structs for complex methods
- Method signatures use value object types and A3 criteria/DTOs
- No dbPath in method signatures (constructor-injected in B2)
- Reuse existing `CollectGarbageResult` and `CloseStaleSessionsResult` types
- Coexists with old code until Phase C cleanup

Closes #392

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests unaffected)
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)