### PR TITLE
feat: inject dbPath at construction via ServiceFactory

### DIFF
--- a/application/usecase/event_usecase_adapter.go
+++ b/application/usecase/event_usecase_adapter.go
@@ -1,0 +1,139 @@
+package usecase
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+type eventUsecaseAdapter struct {
+	dbPath          string
+	recordLog       RecordLogUsecase
+	recordAudit     RecordCommandAuditUsecase
+	listRecent      queryservice.ListRecentEventsQueryService
+	searchEvents    queryservice.SearchEventsQueryService
+	getEventDetails queryservice.GetEventDetailsQueryService
+	getContext      queryservice.GetContextQueryService
+}
+
+// NewEventUsecaseAdapter creates an EventUsecase that delegates to existing usecases and queryservices.
+func NewEventUsecaseAdapter(
+	dbPath string,
+	recordLog RecordLogUsecase,
+	recordAudit RecordCommandAuditUsecase,
+	listRecent queryservice.ListRecentEventsQueryService,
+	searchEvents queryservice.SearchEventsQueryService,
+	getEventDetails queryservice.GetEventDetailsQueryService,
+	getContext queryservice.GetContextQueryService,
+) EventUsecase {
+	return &eventUsecaseAdapter{
+		dbPath:          dbPath,
+		recordLog:       recordLog,
+		recordAudit:     recordAudit,
+		listRecent:      listRecent,
+		searchEvents:    searchEvents,
+		getEventDetails: getEventDetails,
+		getContext:      getContext,
+	}
+}
+
+func (a *eventUsecaseAdapter) Log(ctx context.Context, message string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
+	event, err := a.recordLog.Run(ctx, RecordLogInput{
+		DBPath:    a.dbPath,
+		Message:   message,
+		Client:    client.String(),
+		Agent:     agent.String(),
+		SessionID: sessionID.String(),
+		Repo:      workspace.String(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to record log: %w", err)
+	}
+	return event, nil
+}
+
+func (a *eventUsecaseAdapter) Audit(ctx context.Context, params AuditParams) (*model.Event, *model.CommandAudit, error) {
+	event, audit, err := a.recordAudit.Run(ctx, RecordCommandAuditInput{
+		DBPath:              a.dbPath,
+		Command:             params.Command,
+		Input:               params.Input,
+		Output:              params.Output,
+		Client:              params.Client.String(),
+		Agent:               params.Agent.String(),
+		SessionID:           params.SessionID.String(),
+		Repo:                params.Workspace.String(),
+		ExitCode:            params.ExitCode,
+		AllowSecrets:        params.AllowSecrets,
+		MaxInputBytes:       params.MaxInputBytes,
+		MaxOutputBytes:      params.MaxOutputBytes,
+		ExtraRedactPatterns: params.ExtraRedactPatterns,
+	})
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to record audit: %w", err)
+	}
+	return event, audit, nil
+}
+
+func (a *eventUsecaseAdapter) Search(ctx context.Context, criteria EventSearchCriteria) ([]*model.Event, error) {
+	events, err := a.searchEvents.Run(ctx, a.dbPath, port.SearchEventsInput{
+		Query:        criteria.Query,
+		Repo:         criteria.Workspace.String(),
+		SessionID:    criteria.SessionID.String(),
+		Client:       criteria.Client.String(),
+		Agent:        criteria.Agent.String(),
+		Kind:         criteria.Kind.String(),
+		From:         criteria.From,
+		To:           criteria.To,
+		Limit:        criteria.Limit,
+		Offset:       criteria.Offset,
+		FailuresOnly: criteria.FailuresOnly,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to search events: %w", err)
+	}
+	return events, nil
+}
+
+func (a *eventUsecaseAdapter) List(ctx context.Context, criteria EventListCriteria) ([]*model.Event, error) {
+	events, err := a.listRecent.Run(ctx, a.dbPath, port.ListRecentEventsInput{
+		Limit:        criteria.Limit,
+		Offset:       criteria.Offset,
+		Kind:         criteria.Kind.String(),
+		Client:       criteria.Client.String(),
+		Agent:        criteria.Agent.String(),
+		SessionID:    criteria.SessionID.String(),
+		Repo:         criteria.Workspace.String(),
+		FailuresOnly: criteria.FailuresOnly,
+		From:         criteria.From,
+		To:           criteria.To,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list events: %w", err)
+	}
+	return events, nil
+}
+
+func (a *eventUsecaseAdapter) Show(ctx context.Context, eventID types.EventID) (*EventDetails, error) {
+	portDetails, err := a.getEventDetails.Run(ctx, a.dbPath, eventID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get event details: %w", err)
+	}
+	return NewEventDetails(portDetails.Event(), portDetails.CommandAudit())
+}
+
+func (a *eventUsecaseAdapter) Context(ctx context.Context, criteria EventContextCriteria) ([]*model.Event, error) {
+	events, err := a.getContext.Run(ctx, a.dbPath, port.GetContextInput{
+		Repo:      criteria.Workspace.String(),
+		SessionID: criteria.SessionID.String(),
+		Limit:     criteria.Limit,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get context events: %w", err)
+	}
+	return events, nil
+}

--- a/application/usecase/service_factory.go
+++ b/application/usecase/service_factory.go
@@ -1,0 +1,16 @@
+package usecase
+
+import "context"
+
+// Services holds the consolidated usecase instances.
+type Services struct {
+	Event            EventUsecase
+	Session          SessionUsecase
+	StoreMaintenance StoreMaintenanceUsecase
+}
+
+// ServiceFactory builds Services for a given database path.
+type ServiceFactory interface {
+	// Build creates all usecase instances bound to the given dbPath.
+	Build(ctx context.Context, dbPath string) (*Services, error)
+}

--- a/application/usecase/session_usecase_adapter.go
+++ b/application/usecase/session_usecase_adapter.go
@@ -163,14 +163,14 @@ func (a *sessionUsecaseAdapter) Handoff(ctx context.Context, sessionID types.Ses
 	recentCommands := make([]string, 0, len(events))
 	for _, event := range events {
 		cmd := event.Body()
-		if len(cmd) > 60 {
-			cmd = cmd[:57] + "..."
+		if runes := []rune(cmd); len(runes) > 60 {
+			cmd = string(runes[:60]) + "…"
 		}
 		recentCommands = append(recentCommands, cmd)
 	}
 
-	sid, _ := types.SessionIDOf(session.SessionID)
-	ws, _ := types.WorkspaceOf(session.Repo)
+	sid := types.SessionID(session.SessionID)
+	ws := types.Workspace(session.Repo)
 
 	return &HandoffSummary{
 		SessionID:      sid,
@@ -188,15 +188,9 @@ func (a *sessionUsecaseAdapter) Handoff(ctx context.Context, sessionID types.Ses
 func convertSessionSummaries(portSummaries []*port.SessionSummary) []*SessionSummary {
 	summaries := make([]*SessionSummary, 0, len(portSummaries))
 	for _, ps := range portSummaries {
-		sid, _ := types.SessionIDOf(ps.SessionID)
-		ws, _ := types.WorkspaceOf(ps.Repo)
-		var parentSID types.SessionID
-		if ps.ParentSessionID != "" {
-			parentSID, _ = types.SessionIDOf(ps.ParentSessionID)
-		}
 		summaries = append(summaries, &SessionSummary{
-			SessionID:       sid,
-			Workspace:       ws,
+			SessionID:       types.SessionID(ps.SessionID),
+			Workspace:       types.Workspace(ps.Repo),
 			StartedAt:       ps.StartedAt,
 			EndedAt:         ps.EndedAt,
 			Status:          ps.Status,
@@ -205,7 +199,7 @@ func convertSessionSummaries(portSummaries []*port.SessionSummary) []*SessionSum
 			Agents:          ps.Agents,
 			Label:           ps.Label,
 			Summary:         ps.Summary,
-			ParentSessionID: parentSID,
+			ParentSessionID: types.SessionID(ps.ParentSessionID),
 		})
 	}
 	return summaries

--- a/application/usecase/session_usecase_adapter.go
+++ b/application/usecase/session_usecase_adapter.go
@@ -1,0 +1,212 @@
+package usecase
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/port"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+type sessionUsecaseAdapter struct {
+	dbPath            string
+	recordBoundary    RecordSessionBoundaryUsecase
+	updateLabel       UpdateSessionLabelUsecase
+	findLatestSession queryservice.FindLatestSessionQueryService
+	listSessions      queryservice.ListSessionsQueryService
+	listRecentEvents  queryservice.ListRecentEventsQueryService
+}
+
+// NewSessionUsecaseAdapter creates a SessionUsecase that delegates to existing usecases and queryservices.
+func NewSessionUsecaseAdapter(
+	dbPath string,
+	recordBoundary RecordSessionBoundaryUsecase,
+	updateLabel UpdateSessionLabelUsecase,
+	findLatestSession queryservice.FindLatestSessionQueryService,
+	listSessions queryservice.ListSessionsQueryService,
+	listRecentEvents queryservice.ListRecentEventsQueryService,
+) SessionUsecase {
+	return &sessionUsecaseAdapter{
+		dbPath:            dbPath,
+		recordBoundary:    recordBoundary,
+		updateLabel:       updateLabel,
+		findLatestSession: findLatestSession,
+		listSessions:      listSessions,
+		listRecentEvents:  listRecentEvents,
+	}
+}
+
+func (a *sessionUsecaseAdapter) Start(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error) {
+	event, err := a.recordBoundary.Run(ctx, RecordSessionBoundaryInput{
+		DBPath:          a.dbPath,
+		Client:          client.String(),
+		Agent:           agent.String(),
+		SessionID:       sessionID.String(),
+		Repo:            workspace.String(),
+		Kind:            types.EventKindSessionStarted,
+		ParentSessionID: parentSessionID.String(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start session: %w", err)
+	}
+	return event, nil
+}
+
+func (a *sessionUsecaseAdapter) End(ctx context.Context, params EndSessionParams) (*model.Event, error) {
+	event, err := a.recordBoundary.Run(ctx, RecordSessionBoundaryInput{
+		DBPath:    a.dbPath,
+		Client:    params.Client.String(),
+		Agent:     params.Agent.String(),
+		SessionID: params.SessionID.String(),
+		Repo:      params.Workspace.String(),
+		Kind:      types.EventKindSessionEnded,
+		Summary:   params.Summary,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to end session: %w", err)
+	}
+	return event, nil
+}
+
+func (a *sessionUsecaseAdapter) Label(ctx context.Context, sessionID types.SessionID, label string) error {
+	if err := a.updateLabel.Run(ctx, UpdateSessionLabelInput{
+		DBPath:    a.dbPath,
+		SessionID: sessionID.String(),
+		Label:     label,
+	}); err != nil {
+		return xerrors.Errorf("failed to update session label: %w", err)
+	}
+	return nil
+}
+
+func (a *sessionUsecaseAdapter) List(ctx context.Context, criteria SessionListCriteria) ([]*SessionSummary, error) {
+	portSummaries, err := a.listSessions.Run(ctx, a.dbPath, port.ListSessionsInput{
+		Limit:     criteria.Limit,
+		Offset:    criteria.Offset,
+		SessionID: criteria.SessionID.String(),
+		Repo:      criteria.Workspace.String(),
+		Client:    criteria.Client.String(),
+		Agent:     criteria.Agent.String(),
+		Label:     criteria.Label,
+		From:      criteria.From,
+		To:        criteria.To,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list sessions: %w", err)
+	}
+	return convertSessionSummaries(portSummaries), nil
+}
+
+func (a *sessionUsecaseAdapter) Tree(ctx context.Context, workspace types.Workspace, limit int) ([]*SessionSummary, error) {
+	portSummaries, err := a.listSessions.Run(ctx, a.dbPath, port.ListSessionsInput{
+		Limit: limit,
+		Repo:  workspace.String(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list sessions for tree: %w", err)
+	}
+	return convertSessionSummaries(portSummaries), nil
+}
+
+func (a *sessionUsecaseAdapter) Active(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error) {
+	event, err := a.findLatestSession.Run(ctx, a.dbPath, port.FindLatestSessionInput{
+		Client:     criteria.Client.String(),
+		Agent:      criteria.Agent.String(),
+		Repo:       criteria.Workspace.String(),
+		ActiveOnly: true,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to find active session: %w", err)
+	}
+	return event, nil
+}
+
+func (a *sessionUsecaseAdapter) Latest(ctx context.Context, criteria SessionLookupCriteria) (*model.Event, error) {
+	event, err := a.findLatestSession.Run(ctx, a.dbPath, port.FindLatestSessionInput{
+		Client:     criteria.Client.String(),
+		Agent:      criteria.Agent.String(),
+		Repo:       criteria.Workspace.String(),
+		ActiveOnly: false,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to find latest session: %w", err)
+	}
+	return event, nil
+}
+
+func (a *sessionUsecaseAdapter) Handoff(ctx context.Context, sessionID types.SessionID, workspace types.Workspace, recent int) (*HandoffSummary, error) {
+	sessions, err := a.listSessions.Run(ctx, a.dbPath, port.ListSessionsInput{
+		Limit:     1,
+		SessionID: sessionID.String(),
+		Repo:      workspace.String(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list sessions for handoff: %w", err)
+	}
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+
+	session := sessions[0]
+	events, err := a.listRecentEvents.Run(ctx, a.dbPath, port.ListRecentEventsInput{
+		Limit:     recent,
+		SessionID: session.SessionID,
+		Kind:      types.EventKindCommandExecuted.String(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list recent events for handoff: %w", err)
+	}
+
+	recentCommands := make([]string, 0, len(events))
+	for _, event := range events {
+		cmd := event.Body()
+		if len(cmd) > 60 {
+			cmd = cmd[:57] + "..."
+		}
+		recentCommands = append(recentCommands, cmd)
+	}
+
+	sid, _ := types.SessionIDOf(session.SessionID)
+	ws, _ := types.WorkspaceOf(session.Repo)
+
+	return &HandoffSummary{
+		SessionID:      sid,
+		Workspace:      ws,
+		Label:          session.Label,
+		Status:         session.Status,
+		TotalEvents:    session.TotalEvents,
+		CommandCount:   session.CommandCount,
+		Agents:         session.Agents,
+		Summary:        session.Summary,
+		RecentCommands: recentCommands,
+	}, nil
+}
+
+func convertSessionSummaries(portSummaries []*port.SessionSummary) []*SessionSummary {
+	summaries := make([]*SessionSummary, 0, len(portSummaries))
+	for _, ps := range portSummaries {
+		sid, _ := types.SessionIDOf(ps.SessionID)
+		ws, _ := types.WorkspaceOf(ps.Repo)
+		var parentSID types.SessionID
+		if ps.ParentSessionID != "" {
+			parentSID, _ = types.SessionIDOf(ps.ParentSessionID)
+		}
+		summaries = append(summaries, &SessionSummary{
+			SessionID:       sid,
+			Workspace:       ws,
+			StartedAt:       ps.StartedAt,
+			EndedAt:         ps.EndedAt,
+			Status:          ps.Status,
+			TotalEvents:     ps.TotalEvents,
+			CommandCount:    ps.CommandCount,
+			Agents:          ps.Agents,
+			Label:           ps.Label,
+			Summary:         ps.Summary,
+			ParentSessionID: parentSID,
+		})
+	}
+	return summaries
+}

--- a/application/usecase/store_maintenance_usecase_adapter.go
+++ b/application/usecase/store_maintenance_usecase_adapter.go
@@ -1,0 +1,89 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+type storeMaintenanceUsecaseAdapter struct {
+	dbPath             string
+	initializeStore    InitializeStoreUsecase
+	createBackup       CreateStoreBackupUsecase
+	restoreBackup      RestoreStoreBackupUsecase
+	collectGarbage     CollectGarbageUsecase
+	closeStaleSessions CloseStaleSessionsUsecase
+}
+
+// NewStoreMaintenanceUsecaseAdapter creates a StoreMaintenanceUsecase that delegates to existing usecases.
+func NewStoreMaintenanceUsecaseAdapter(
+	dbPath string,
+	initializeStore InitializeStoreUsecase,
+	createBackup CreateStoreBackupUsecase,
+	restoreBackup RestoreStoreBackupUsecase,
+	collectGarbage CollectGarbageUsecase,
+	closeStaleSessions CloseStaleSessionsUsecase,
+) StoreMaintenanceUsecase {
+	return &storeMaintenanceUsecaseAdapter{
+		dbPath:             dbPath,
+		initializeStore:    initializeStore,
+		createBackup:       createBackup,
+		restoreBackup:      restoreBackup,
+		collectGarbage:     collectGarbage,
+		closeStaleSessions: closeStaleSessions,
+	}
+}
+
+func (a *storeMaintenanceUsecaseAdapter) Initialize(ctx context.Context) error {
+	if err := a.initializeStore.Run(ctx, a.dbPath); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+	return nil
+}
+
+func (a *storeMaintenanceUsecaseAdapter) CreateBackup(ctx context.Context, outputPath string, overwrite bool) error {
+	if err := a.createBackup.Run(ctx, CreateStoreBackupInput{
+		DBPath:     a.dbPath,
+		OutputPath: outputPath,
+		Overwrite:  overwrite,
+	}); err != nil {
+		return xerrors.Errorf("failed to create backup: %w", err)
+	}
+	return nil
+}
+
+func (a *storeMaintenanceUsecaseAdapter) RestoreBackup(ctx context.Context, inputPath string, overwrite bool) error {
+	if err := a.restoreBackup.Run(ctx, RestoreStoreBackupInput{
+		DBPath:    a.dbPath,
+		InputPath: inputPath,
+		Overwrite: overwrite,
+	}); err != nil {
+		return xerrors.Errorf("failed to restore backup: %w", err)
+	}
+	return nil
+}
+
+func (a *storeMaintenanceUsecaseAdapter) CollectGarbage(ctx context.Context, before time.Time, dryRun bool) (*CollectGarbageResult, error) {
+	result, err := a.collectGarbage.Run(ctx, CollectGarbageInput{
+		DBPath: a.dbPath,
+		Before: before,
+		DryRun: dryRun,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to collect garbage: %w", err)
+	}
+	return result, nil
+}
+
+func (a *storeMaintenanceUsecaseAdapter) CloseStaleSessions(ctx context.Context, staleAfter time.Duration, dryRun bool) (*CloseStaleSessionsResult, error) {
+	result, err := a.closeStaleSessions.Run(ctx, CloseStaleSessionsInput{
+		DBPath:     a.dbPath,
+		StaleAfter: staleAfter,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to close stale sessions: %w", err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- Add `ServiceFactory` interface and `Services` struct for constructing consolidated usecases with dbPath bound at creation time
- Add 3 adapter implementations that delegate to existing usecases/queryservices:
  - `eventUsecaseAdapter`: wraps RecordLogUsecase, RecordCommandAuditUsecase, and 4 queryservices
  - `sessionUsecaseAdapter`: wraps RecordSessionBoundaryUsecase, UpdateSessionLabelUsecase, and 3 queryservices
  - `storeMaintenanceUsecaseAdapter`: wraps 5 existing usecases
- Adapters translate between new value-object typed signatures and old string-based signatures
- dbPath is stored once and injected into every delegated call
- No changes to existing code — old and new coexist until Phase C

Closes #393

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests unaffected)
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)