### PR TITLE
refactor: remove GetSessionStartedEvent from EventRepository

### DIFF
--- a/domain/model/event_repository.go
+++ b/domain/model/event_repository.go
@@ -1,23 +1,10 @@
 package model
 
-import (
-	"context"
-
-	"golang.org/x/xerrors"
-
-	"github.com/duck8823/traceary/domain/types"
-)
-
-// ErrSessionStartedEventNotFound indicates no session_started event exists for the given session.
-var ErrSessionStartedEventNotFound = xerrors.New("session_started event was not found for the target session")
+import "context"
 
 // EventRepository defines persistence operations for the Event aggregate.
 type EventRepository interface {
 	// Save persists an Event. If the event includes a CommandAudit,
 	// both are saved as part of the same aggregate.
 	Save(ctx context.Context, event *Event) error
-
-	// GetSessionStartedEvent retrieves the session_started event for the given session.
-	// Returns ErrSessionStartedEventNotFound when no matching event exists.
-	GetSessionStartedEvent(ctx context.Context, sessionID types.SessionID) (*Event, error)
 }


### PR DESCRIPTION
## Summary
- Remove `GetSessionStartedEvent` and `ErrSessionStartedEventNotFound` from `domain/model/event_repository.go`
- This was a query operation (find by foreign key + filter), not a repository concern
- Session-started event lookup remains via `port.SessionStartedEventFinder` / QueryService

Closes #403

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)