### PR TITLE
refactor: replace AuditParams/EndSessionParams with individual arguments

### DIFF
--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -7,16 +7,8 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// AuditParams holds parameters for recording a command audit event.
-type AuditParams struct {
-	Command             string
-	Input               string
-	Output              string
-	Client              types.Client
-	Agent               types.Agent
-	SessionID           types.SessionID
-	Workspace           types.Workspace
-	ExitCode            *int
+// AuditRedaction holds redaction and truncation settings for command audit recording.
+type AuditRedaction struct {
 	AllowSecrets        bool
 	MaxInputBytes       int
 	MaxOutputBytes      int
@@ -29,7 +21,7 @@ type EventUsecase interface {
 	Log(ctx context.Context, message string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error)
 
 	// Audit records a command execution audit event.
-	Audit(ctx context.Context, params AuditParams) (*model.Event, *model.CommandAudit, error)
+	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode *int, redaction AuditRedaction) (*model.Event, *model.CommandAudit, error)
 
 	// Search performs full-text search across events.
 	Search(ctx context.Context, criteria EventSearchCriteria) ([]*model.Event, error)

--- a/application/usecase/event_usecase_adapter.go
+++ b/application/usecase/event_usecase_adapter.go
@@ -57,21 +57,21 @@ func (a *eventUsecaseAdapter) Log(ctx context.Context, message string, client ty
 	return event, nil
 }
 
-func (a *eventUsecaseAdapter) Audit(ctx context.Context, params AuditParams) (*model.Event, *model.CommandAudit, error) {
+func (a *eventUsecaseAdapter) Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode *int, redaction AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	event, audit, err := a.recordAudit.Run(ctx, RecordCommandAuditInput{
 		DBPath:              a.dbPath,
-		Command:             params.Command,
-		Input:               params.Input,
-		Output:              params.Output,
-		Client:              params.Client.String(),
-		Agent:               params.Agent.String(),
-		SessionID:           params.SessionID.String(),
-		Repo:                params.Workspace.String(),
-		ExitCode:            params.ExitCode,
-		AllowSecrets:        params.AllowSecrets,
-		MaxInputBytes:       params.MaxInputBytes,
-		MaxOutputBytes:      params.MaxOutputBytes,
-		ExtraRedactPatterns: params.ExtraRedactPatterns,
+		Command:             command,
+		Input:               input,
+		Output:              output,
+		Client:              client.String(),
+		Agent:               agent.String(),
+		SessionID:           sessionID.String(),
+		Repo:                workspace.String(),
+		ExitCode:            exitCode,
+		AllowSecrets:        redaction.AllowSecrets,
+		MaxInputBytes:       redaction.MaxInputBytes,
+		MaxOutputBytes:      redaction.MaxOutputBytes,
+		ExtraRedactPatterns: redaction.ExtraRedactPatterns,
 	})
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to record audit: %w", err)

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -7,25 +7,15 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// EndSessionParams holds parameters for ending a session.
-// Zero-value Client/Agent/Workspace falls back to the session start values.
-type EndSessionParams struct {
-	Client    types.Client
-	Agent     types.Agent
-	SessionID types.SessionID
-	Workspace types.Workspace
-	Summary   string
-}
-
 // SessionUsecase consolidates session lifecycle and query operations.
 type SessionUsecase interface {
 	// Start begins a new session. If sessionID is zero, a new ID is generated.
 	// Zero-value parentSessionID means no parent (top-level session).
 	Start(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error)
 
-	// End closes an existing session. Zero-value fields in params fall back
-	// to values from the corresponding session_started event.
-	End(ctx context.Context, params EndSessionParams) (*model.Event, error)
+	// End closes an existing session. Zero-value client/agent/workspace
+	// falls back to values from the corresponding session_started event.
+	End(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error)
 
 	// Label updates the label on an existing session.
 	Label(ctx context.Context, sessionID types.SessionID, label string) error

--- a/application/usecase/session_usecase_adapter.go
+++ b/application/usecase/session_usecase_adapter.go
@@ -55,15 +55,15 @@ func (a *sessionUsecaseAdapter) Start(ctx context.Context, client types.Client, 
 	return event, nil
 }
 
-func (a *sessionUsecaseAdapter) End(ctx context.Context, params EndSessionParams) (*model.Event, error) {
+func (a *sessionUsecaseAdapter) End(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error) {
 	event, err := a.recordBoundary.Run(ctx, RecordSessionBoundaryInput{
 		DBPath:    a.dbPath,
-		Client:    params.Client.String(),
-		Agent:     params.Agent.String(),
-		SessionID: params.SessionID.String(),
-		Repo:      params.Workspace.String(),
+		Client:    client.String(),
+		Agent:     agent.String(),
+		SessionID: sessionID.String(),
+		Repo:      workspace.String(),
 		Kind:      types.EventKindSessionEnded,
-		Summary:   params.Summary,
+		Summary:   summary,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to end session: %w", err)


### PR DESCRIPTION
## Summary
- Remove `AuditParams` struct — expand to individual domain arguments on `EventUsecase.Audit`
- Remove `EndSessionParams` struct — expand to individual arguments on `SessionUsecase.End`
- Add `AuditRedaction` struct (domain-meaningful: redaction/truncation config)
- Update adapter implementations

Closes #404

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)