### PR TITLE
docs: update documentation for workspace terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Use the [CLI reference](./docs/cli/README.md) for the full command surface.
 
 ## Defaults worth knowing
 
-- `traceary log` and `traceary audit` reuse the latest non-stale active session for the resolved repo/work context when `--session-id` is omitted; when `remote.origin.url` is missing inside a git worktree, Traceary falls back to the worktree root path
+- `traceary log` and `traceary audit` reuse the latest non-stale active session for the resolved workspace when `--session-id` is omitted; when `remote.origin.url` is missing inside a git worktree, Traceary falls back to the worktree root path
 - `traceary session active` treats sessions older than `24h` as stale unless you pass `--allow-stale`
 - `traceary session start` prints a session ID; `traceary session end` prints the recorded event ID
 - `traceary session list --json` includes `label`, `summary`, and `parent_session_id` when present

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -20,7 +20,7 @@ note event を追記します。
 
 既定値:
 
-- `--client` / `--agent` / `--repo`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_REPO` → `cli` / `manual` / 検出した repo
+- `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / 検出した workspace
 - `--session-id`: flag → `TRACEARY_SESSION_ID` → 解決した repo の最新 non-stale active session → `default`
 
 主な flag:
@@ -28,7 +28,7 @@ note event を追記します。
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--id-only`
 - `--json`
 
@@ -59,7 +59,7 @@ session 解決ルール:
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--id-only`
 - `--json`
 - `--allow-secrets`
@@ -84,7 +84,7 @@ session 解決ルールは `traceary log` と同じです。
 - `--json`
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--session-id`
 
 ### `traceary search [<query>]`
@@ -96,7 +96,7 @@ session 解決ルールは `traceary log` と同じです。
 - `--kind`
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--session-id`
 - `--since`
 - `--until`
@@ -123,7 +123,7 @@ alias:
 主な flag:
 
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--limit`
 - `--json`
 
@@ -135,7 +135,7 @@ session start 境界を記録し、session ID を出力します。
 
 既定値:
 
-- `--client` / `--agent` / `--repo`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_REPO` → `cli` / `manual` / 検出した repo
+- `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / 検出した workspace
 - `--session-id`: 省略時は新しい ID を採番
 
 主な flag:
@@ -143,7 +143,7 @@ session start 境界を記録し、session ID を出力します。
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--parent-session-id`
 - `--id-only`
 - `--json`
@@ -155,14 +155,14 @@ session end 境界を記録し、生成された event ID を出力します。
 既定値:
 
 - `--session-id`: flag → `TRACEARY_SESSION_ID`
-- `--client` / `--agent` / `--repo` の不足分は、対応する `session start` から補完できる場合は補完
+- `--client` / `--agent` / `--workspace` の不足分は、対応する `session start` から補完できる場合は補完
 
 主な flag:
 
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--summary`
 - `--id-only`
 - `--json`
@@ -175,7 +175,7 @@ session の一覧サマリーを表示します。
 
 主な flag:
 
-- `--repo`
+- `--workspace`
 - `--agent`
 - `--label`
 - `--from`
@@ -207,7 +207,7 @@ session の label を設定または更新します。
 
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--json`
 
 ### `traceary session active`
@@ -218,7 +218,7 @@ session の label を設定または更新します。
 
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--stale-after`
 - `--allow-stale`
 - `--json`

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -20,7 +20,7 @@ Append a note event.
 
 Defaults:
 
-- `--client` / `--agent` / `--repo`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_REPO` → `cli` / `manual` / detected repo
+- `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / detected workspace
 - `--session-id`: flag → `TRACEARY_SESSION_ID` → latest non-stale active session for the resolved repo → `default`
 
 Useful flags:
@@ -28,7 +28,7 @@ Useful flags:
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--id-only`
 - `--json`
 
@@ -59,7 +59,7 @@ Useful flags:
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--id-only`
 - `--json`
 - `--allow-secrets`
@@ -84,7 +84,7 @@ Useful flags:
 - `--json`
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--session-id`
 
 ### `traceary search [<query>]`
@@ -96,7 +96,7 @@ Useful flags:
 - `--kind`
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--session-id`
 - `--since`
 - `--until`
@@ -123,7 +123,7 @@ Alias:
 Useful flags:
 
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--limit`
 - `--json`
 
@@ -135,7 +135,7 @@ Record a session start boundary and print the session ID.
 
 Defaults:
 
-- `--client` / `--agent` / `--repo`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_REPO` → `cli` / `manual` / detected repo
+- `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / detected workspace
 - `--session-id`: generate a new ID when omitted
 
 Useful flags:
@@ -143,7 +143,7 @@ Useful flags:
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--parent-session-id`
 - `--id-only`
 - `--json`
@@ -155,14 +155,14 @@ Record a session end boundary and print the resulting event ID.
 Defaults:
 
 - `--session-id`: flag → `TRACEARY_SESSION_ID`
-- missing `--client` / `--agent` / `--repo` values are backfilled from the matching `session start` when available
+- missing `--client` / `--agent` / `--workspace` values are backfilled from the matching `session start` when available
 
 Useful flags:
 
 - `--client`
 - `--agent`
 - `--session-id`
-- `--repo`
+- `--workspace`
 - `--summary`
 - `--id-only`
 - `--json`
@@ -175,7 +175,7 @@ The session list view surfaces session metadata such as `label`, `summary`, and 
 
 Useful flags:
 
-- `--repo`
+- `--workspace`
 - `--agent`
 - `--label`
 - `--from`
@@ -207,7 +207,7 @@ Useful flags:
 
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--json`
 
 ### `traceary session active`
@@ -218,7 +218,7 @@ Useful flags:
 
 - `--client`
 - `--agent`
-- `--repo`
+- `--workspace`
 - `--stale-after`
 - `--allow-stale`
 - `--json`


### PR DESCRIPTION
## Summary
- Update CLI docs (en/ja): --repo → --workspace, TRACEARY_REPO → TRACEARY_WORKSPACE
- Update MCP docs (en/ja): "repo" → "workspace" in JSON examples
- Update AGENTS.md, GEMINI.md: environment variable references
- Update README.md: workspace terminology

Closes #396

## Test plan
- [x] Documentation review (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)