### PR TITLE
fix: sync plugin hook scripts after workspace rename

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,46 @@
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-audit.sh' 'gemini'",
+            "timeout": 5000,
+            "description": "Record shell command audits in Traceary"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-session-end",
+            "type": "command",
+            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-session.sh' 'gemini' 'end'",
+            "timeout": 5000,
+            "description": "Finish a Traceary session"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-session-start",
+            "type": "command",
+            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-session.sh' 'gemini' 'start'",
+            "timeout": 5000,
+            "description": "Start a Traceary session"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/claude-plugin/scripts/common.sh
+++ b/integrations/claude-plugin/scripts/common.sh
@@ -62,10 +62,10 @@ traceary_resolve_workspace() {
       return 0
     fi
 
-    local repo_root
-    repo_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$repo_root" ]]; then
-      printf '%s' "$repo_root"
+    local workspace_root
+    workspace_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$workspace_root" ]]; then
+      printf '%s' "$workspace_root"
       return 0
     fi
   fi
@@ -96,16 +96,16 @@ traceary_resolve_session_id() {
   printf '%s' "$session_id"
 }
 
-traceary_resolve_effective_repo() {
+traceary_resolve_effective_workspace() {
   local client="$1"
-  local repo
-  repo="$(traceary_read_repo_state "$client")"
-  if [[ -z "$repo" ]]; then
+  local ws
+  ws="$(traceary_read_workspace_state "$client")"
+  if [[ -z "$ws" ]]; then
     local cwd
     cwd="$(traceary_json_get 'cwd')"
-    repo="$(traceary_resolve_workspace "$cwd")"
+    ws="$(traceary_resolve_workspace "$cwd")"
   fi
-  printf '%s' "$repo"
+  printf '%s' "$ws"
 }
 
 traceary_resolve_agent() {
@@ -150,15 +150,15 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
-traceary_write_repo_state() {
+traceary_write_workspace_state() {
   local client="$1"
-  local repo="$2"
+  local ws="$2"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"
-  printf '%s' "$repo" > "$state_file"
+  printf '%s' "$ws" > "$state_file"
 }
 
-traceary_read_repo_state() {
+traceary_read_workspace_state() {
   local client="$1"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"

--- a/integrations/claude-plugin/scripts/traceary-audit.sh
+++ b/integrations/claude-plugin/scripts/traceary-audit.sh
@@ -34,7 +34,7 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
+WORKSPACE_VALUE="$(traceary_resolve_effective_workspace "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 # For MCP tools, ensure tool_input includes at least the tool name when empty
 if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
@@ -60,8 +60,8 @@ fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi
-if [[ -n "$REPO_VALUE" ]]; then
-  COMMAND+=(--workspace "$REPO_VALUE")
+if [[ -n "$WORKSPACE_VALUE" ]]; then
+  COMMAND+=(--workspace "$WORKSPACE_VALUE")
 fi
 
 "${COMMAND[@]}" >/dev/null 2>&1 || exit 0

--- a/integrations/claude-plugin/scripts/traceary-session.sh
+++ b/integrations/claude-plugin/scripts/traceary-session.sh
@@ -23,7 +23,7 @@ fi
 
 HOOK_CWD="$(traceary_json_get 'cwd')"
 SESSION_ID="$(traceary_json_get 'session_id')"
-REPO_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
+WORKSPACE_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
 
 COMMON_ARGS=(session)
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
@@ -39,8 +39,8 @@ case "$ACTION" in
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
@@ -54,8 +54,8 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
-      if [[ -n "$REPO_VALUE" ]]; then
-        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      if [[ -n "$WORKSPACE_VALUE" ]]; then
+        traceary_write_workspace_state "$CLIENT" "$WORKSPACE_VALUE"
       fi
     fi
     ;;
@@ -74,17 +74,17 @@ case "$ACTION" in
     fi
 
     # Use repo from session state if available (prevents CWD drift)
-    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    REPO_STATE="$(traceary_read_workspace_state "$CLIENT")"
     if [[ -n "$REPO_STATE" ]]; then
-      REPO_VALUE="$REPO_STATE"
+      WORKSPACE_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"

--- a/integrations/gemini-extension/scripts/common.sh
+++ b/integrations/gemini-extension/scripts/common.sh
@@ -62,10 +62,10 @@ traceary_resolve_workspace() {
       return 0
     fi
 
-    local repo_root
-    repo_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$repo_root" ]]; then
-      printf '%s' "$repo_root"
+    local workspace_root
+    workspace_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$workspace_root" ]]; then
+      printf '%s' "$workspace_root"
       return 0
     fi
   fi
@@ -96,16 +96,16 @@ traceary_resolve_session_id() {
   printf '%s' "$session_id"
 }
 
-traceary_resolve_effective_repo() {
+traceary_resolve_effective_workspace() {
   local client="$1"
-  local repo
-  repo="$(traceary_read_repo_state "$client")"
-  if [[ -z "$repo" ]]; then
+  local ws
+  ws="$(traceary_read_workspace_state "$client")"
+  if [[ -z "$ws" ]]; then
     local cwd
     cwd="$(traceary_json_get 'cwd')"
-    repo="$(traceary_resolve_workspace "$cwd")"
+    ws="$(traceary_resolve_workspace "$cwd")"
   fi
-  printf '%s' "$repo"
+  printf '%s' "$ws"
 }
 
 traceary_resolve_agent() {
@@ -150,15 +150,15 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
-traceary_write_repo_state() {
+traceary_write_workspace_state() {
   local client="$1"
-  local repo="$2"
+  local ws="$2"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"
-  printf '%s' "$repo" > "$state_file"
+  printf '%s' "$ws" > "$state_file"
 }
 
-traceary_read_repo_state() {
+traceary_read_workspace_state() {
   local client="$1"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"

--- a/integrations/gemini-extension/scripts/traceary-audit.sh
+++ b/integrations/gemini-extension/scripts/traceary-audit.sh
@@ -34,7 +34,7 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
+WORKSPACE_VALUE="$(traceary_resolve_effective_workspace "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 # For MCP tools, ensure tool_input includes at least the tool name when empty
 if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
@@ -60,8 +60,8 @@ fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi
-if [[ -n "$REPO_VALUE" ]]; then
-  COMMAND+=(--workspace "$REPO_VALUE")
+if [[ -n "$WORKSPACE_VALUE" ]]; then
+  COMMAND+=(--workspace "$WORKSPACE_VALUE")
 fi
 
 "${COMMAND[@]}" >/dev/null 2>&1 || exit 0

--- a/integrations/gemini-extension/scripts/traceary-session.sh
+++ b/integrations/gemini-extension/scripts/traceary-session.sh
@@ -23,7 +23,7 @@ fi
 
 HOOK_CWD="$(traceary_json_get 'cwd')"
 SESSION_ID="$(traceary_json_get 'session_id')"
-REPO_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
+WORKSPACE_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
 
 COMMON_ARGS=(session)
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
@@ -39,8 +39,8 @@ case "$ACTION" in
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
@@ -54,8 +54,8 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
-      if [[ -n "$REPO_VALUE" ]]; then
-        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      if [[ -n "$WORKSPACE_VALUE" ]]; then
+        traceary_write_workspace_state "$CLIENT" "$WORKSPACE_VALUE"
       fi
     fi
     ;;
@@ -74,17 +74,17 @@ case "$ACTION" in
     fi
 
     # Use repo from session state if available (prevents CWD drift)
-    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    REPO_STATE="$(traceary_read_workspace_state "$CLIENT")"
     if [[ -n "$REPO_STATE" ]]; then
-      REPO_VALUE="$REPO_STATE"
+      WORKSPACE_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"

--- a/plugins/traceary/scripts/common.sh
+++ b/plugins/traceary/scripts/common.sh
@@ -62,10 +62,10 @@ traceary_resolve_workspace() {
       return 0
     fi
 
-    local repo_root
-    repo_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [[ -n "$repo_root" ]]; then
-      printf '%s' "$repo_root"
+    local workspace_root
+    workspace_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "$workspace_root" ]]; then
+      printf '%s' "$workspace_root"
       return 0
     fi
   fi
@@ -96,16 +96,16 @@ traceary_resolve_session_id() {
   printf '%s' "$session_id"
 }
 
-traceary_resolve_effective_repo() {
+traceary_resolve_effective_workspace() {
   local client="$1"
-  local repo
-  repo="$(traceary_read_repo_state "$client")"
-  if [[ -z "$repo" ]]; then
+  local ws
+  ws="$(traceary_read_workspace_state "$client")"
+  if [[ -z "$ws" ]]; then
     local cwd
     cwd="$(traceary_json_get 'cwd')"
-    repo="$(traceary_resolve_workspace "$cwd")"
+    ws="$(traceary_resolve_workspace "$cwd")"
   fi
-  printf '%s' "$repo"
+  printf '%s' "$ws"
 }
 
 traceary_resolve_agent() {
@@ -150,15 +150,15 @@ traceary_write_state() {
   printf '%s' "$session_id" > "$state_file"
 }
 
-traceary_write_repo_state() {
+traceary_write_workspace_state() {
   local client="$1"
-  local repo="$2"
+  local ws="$2"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"
-  printf '%s' "$repo" > "$state_file"
+  printf '%s' "$ws" > "$state_file"
 }
 
-traceary_read_repo_state() {
+traceary_read_workspace_state() {
   local client="$1"
   local state_file
   state_file="$(traceary_session_state_path "$client")-repo"

--- a/plugins/traceary/scripts/traceary-audit.sh
+++ b/plugins/traceary/scripts/traceary-audit.sh
@@ -34,7 +34,7 @@ if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
 
-REPO_VALUE="$(traceary_resolve_effective_repo "$CLIENT")"
+WORKSPACE_VALUE="$(traceary_resolve_effective_workspace "$CLIENT")"
 AUDIT_INPUT="$(traceary_json_get 'tool_input' '{}')"
 # For MCP tools, ensure tool_input includes at least the tool name when empty
 if [[ "$AUDIT_INPUT" == "{}" || -z "$AUDIT_INPUT" ]]; then
@@ -60,8 +60,8 @@ fi
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
   COMMAND+=(--db-path "$TRACEARY_DB_PATH")
 fi
-if [[ -n "$REPO_VALUE" ]]; then
-  COMMAND+=(--workspace "$REPO_VALUE")
+if [[ -n "$WORKSPACE_VALUE" ]]; then
+  COMMAND+=(--workspace "$WORKSPACE_VALUE")
 fi
 
 "${COMMAND[@]}" >/dev/null 2>&1 || exit 0

--- a/plugins/traceary/scripts/traceary-session.sh
+++ b/plugins/traceary/scripts/traceary-session.sh
@@ -23,7 +23,7 @@ fi
 
 HOOK_CWD="$(traceary_json_get 'cwd')"
 SESSION_ID="$(traceary_json_get 'session_id')"
-REPO_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
+WORKSPACE_VALUE="$(traceary_resolve_workspace "$HOOK_CWD")"
 
 COMMON_ARGS=(session)
 if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
@@ -39,8 +39,8 @@ case "$ACTION" in
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     if [[ -n "$SESSION_ID" ]]; then
       COMMAND+=(--session-id "$SESSION_ID")
@@ -54,8 +54,8 @@ case "$ACTION" in
     if [[ -n "$ACTUAL_SESSION_ID" ]]; then
       traceary_write_state "$CLIENT" "$ACTUAL_SESSION_ID"
       traceary_clear_session_end_marker "$CLIENT" "$ACTUAL_SESSION_ID"
-      if [[ -n "$REPO_VALUE" ]]; then
-        traceary_write_repo_state "$CLIENT" "$REPO_VALUE"
+      if [[ -n "$WORKSPACE_VALUE" ]]; then
+        traceary_write_workspace_state "$CLIENT" "$WORKSPACE_VALUE"
       fi
     fi
     ;;
@@ -74,17 +74,17 @@ case "$ACTION" in
     fi
 
     # Use repo from session state if available (prevents CWD drift)
-    REPO_STATE="$(traceary_read_repo_state "$CLIENT")"
+    REPO_STATE="$(traceary_read_workspace_state "$CLIENT")"
     if [[ -n "$REPO_STATE" ]]; then
-      REPO_VALUE="$REPO_STATE"
+      WORKSPACE_VALUE="$REPO_STATE"
     fi
 
     COMMAND=("$TRACEARY_CMD" session end --client hook --agent "$AGENT_VALUE" --session-id "$SESSION_ID")
     if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
       COMMAND+=(--db-path "$TRACEARY_DB_PATH")
     fi
-    if [[ -n "$REPO_VALUE" ]]; then
-      COMMAND+=(--workspace "$REPO_VALUE")
+    if [[ -n "$WORKSPACE_VALUE" ]]; then
+      COMMAND+=(--workspace "$WORKSPACE_VALUE")
     fi
     "${COMMAND[@]}" >/dev/null 2>&1 || exit 0
     traceary_clear_state "$CLIENT"


### PR DESCRIPTION
## Summary
The repo→workspace rename (#409) updated `scripts/hooks/` but did not copy the changes to plugin packages. This fixes CI failure caused by drifted hook scripts.

## Test plan
- [x] `python3 scripts/verify_integrations.py` passes
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)