### PR TITLE
fix: remove remaining repo references found by release audit

### DIFF
--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -21,7 +21,6 @@ type SessionUsecase interface {
 	Label(ctx context.Context, sessionID types.SessionID, label string) error
 
 	// List returns session summaries matching the criteria.
-	// SessionSummary.Workspace maps to the existing Repo field in infrastructure.
 	List(ctx context.Context, criteria SessionListCriteria) ([]*SessionSummary, error)
 
 	// Tree returns session summaries as a hierarchy for the given workspace.

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -47,7 +47,7 @@ func (c *RootCLI) newCompactSummaryCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	cmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID", "セッション ID"))
-	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	cmd.Flags().IntVar(&limit, "recent", 3, Localize("number of recent commands to show", "表示する直近コマンド数"))
 
 	return cmd

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -167,8 +167,8 @@ func writeContextText(output io.Writer, sessionID string, repo string, events []
 	if _, err := fmt.Fprintf(output, "SESSION_ID: %s\n", formatOptionalColumn(sessionID)); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print session ID", "session ID の出力に失敗しました"), err)
 	}
-	if _, err := fmt.Fprintf(output, "REPO: %s\n", formatOptionalColumn(repo)); err != nil {
-		return xerrors.Errorf("%s: %w", Localize("failed to print repo", "repo の出力に失敗しました"), err)
+	if _, err := fmt.Fprintf(output, "WORKSPACE: %s\n", formatOptionalColumn(repo)); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print workspace", "workspace の出力に失敗しました"), err)
 	}
 	if _, err := fmt.Fprintln(output, "EVENTS:"); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print context events heading", "文脈イベント見出しの出力に失敗しました"), err)

--- a/presentation/cli/context_command_test.go
+++ b/presentation/cli/context_command_test.go
@@ -116,7 +116,7 @@ func TestRootCLI_ContextCommand(t *testing.T) {
 		want := "" +
 			"TRACEARY CONTEXT\n" +
 			"SESSION_ID: session-1\n" +
-			"REPO: github.com/duck8823/traceary\n" +
+			"WORKSPACE: github.com/duck8823/traceary\n" +
 			"EVENTS:\n" +
 			"- 2026-04-08T12:00:00Z [note] event-1 cli/codex README を更新した 次に release note を確認する\n"
 		if stdout.String() != want {

--- a/presentation/cli/event_output.go
+++ b/presentation/cli/event_output.go
@@ -29,7 +29,7 @@ func writeEvents(output io.Writer, events []*model.Event) error {
 		return nil
 	}
 
-	if _, err := fmt.Fprintln(output, "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tREPO\tMESSAGE"); err != nil {
+	if _, err := fmt.Fprintln(output, "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE"); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print list header", "一覧ヘッダーの出力に失敗しました"), err)
 	}
 	for _, event := range events {

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -69,7 +69,7 @@ func TestRootCLI_ListCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tREPO\tMESSAGE\n" +
+		want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
 			"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\thello\n"
 		if stdout.String() != want {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)

--- a/presentation/cli/session_handoff.go
+++ b/presentation/cli/session_handoff.go
@@ -43,7 +43,7 @@ func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	cmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID", "セッション ID"))
-	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	cmd.Flags().IntVar(&recent, "recent", 5, Localize("number of recent commands to show", "表示する直近コマンド数"))
 
 	return cmd

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -93,7 +93,7 @@ func (c *RootCLI) newSessionListCommand() *cobra.Command {
 	}
 
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", Localize("SQLite DB path (env: TRACEARY_DB_PATH)", "SQLite DB パス (env: TRACEARY_DB_PATH)"))
-	listCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	listCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路でフィルタ"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "エージェントでフィルタ"))
 	listCmd.Flags().StringVar(&label, "label", "", Localize("filter by label", "ラベルでフィルタ"))
@@ -122,7 +122,7 @@ func writeSessionSummaries(output io.Writer, summaries []*usecase.SessionSummary
 
 	if _, err := fmt.Fprintln(
 		output,
-		"STARTED_AT\tSTATUS\tDURATION\tSESSION_ID\tREPO\tLABEL\tSUMMARY\tPARENT_SESSION_ID\tEVENTS\tCMDS\tAGENTS",
+		"STARTED_AT\tSTATUS\tDURATION\tSESSION_ID\tWORKSPACE\tLABEL\tSUMMARY\tPARENT_SESSION_ID\tEVENTS\tCMDS\tAGENTS",
 	); err != nil {
 		return xerrors.Errorf("failed to print header: %w", err)
 	}

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -53,7 +53,7 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by repo", "リポジトリでフィルタ"))
+	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	cmd.Flags().IntVar(&limit, "limit", 50, Localize("maximum number of sessions to load", "読み込む最大セッション数"))
 	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 
@@ -113,7 +113,7 @@ func writeSessionTree(output io.Writer, summaries []*usecase.SessionSummary, asJ
 
 type jsonTreeNode struct {
 	SessionID    string          `json:"session_id"`
-	Workspace string          `json:"repo,omitempty"`
+	Workspace string          `json:"workspace,omitempty"`
 	Label        string          `json:"label,omitempty"`
 	Summary      string          `json:"summary,omitempty"`
 	StartedAt    string          `json:"started_at"`

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -69,7 +69,7 @@ func writeEventDetails(output io.Writer, eventDetails *usecase.EventDetails) err
 	event := eventDetails.Event()
 	if _, err := fmt.Fprintf(
 		output,
-		"EVENT_ID: %s\nKIND: %s\nCLIENT: %s\nAGENT: %s\nSESSION_ID: %s\nREPO: %s\nCREATED_AT: %s\nMESSAGE: %s\n",
+		"EVENT_ID: %s\nKIND: %s\nCLIENT: %s\nAGENT: %s\nSESSION_ID: %s\nWORKSPACE: %s\nCREATED_AT: %s\nMESSAGE: %s\n",
 		event.EventID(),
 		event.Kind(),
 		formatOptionalColumn(event.Client()),

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -73,7 +73,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 			"CLIENT: cli\n" +
 			"AGENT: codex\n" +
 			"SESSION_ID: session-1\n" +
-			"REPO: duck8823/traceary\n" +
+			"WORKSPACE: duck8823/traceary\n" +
 			"CREATED_AT: 2026-04-08T12:00:00Z\n" +
 			"MESSAGE: go test ./...\n" +
 			"\n" +


### PR DESCRIPTION
## Summary
Fix repo→workspace rename leftovers found by multi-AI release audit:
- JSON tags, text output labels, tabular headers, CLI help strings, stale comments

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)