### PR TITLE
fix: remove remaining repo references in docs and CLI descriptions

### DIFF
--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -13,7 +13,7 @@
 | `TRACEARY_CLIENT` | `log` / `audit` / session command の既定 `client` attribution |
 | `TRACEARY_AGENT` | `log` / `audit` / session command の既定 `agent` attribution |
 | `TRACEARY_SESSION_ID` | `log` / `audit` / `session end` の既定 session ID |
-| `TRACEARY_REPO` | 補助的な work-context identifier を上書きする |
+| `TRACEARY_WORKSPACE` | 補助的な work-context identifier を上書きする |
 | `TRACEARY_ALLOW_SECRETS` | `traceary audit` の best-effort secret redaction を無効化する |
 | `TRACEARY_MAX_AUDIT_INPUT_BYTES` | `traceary audit` の input 保存サイズ上限の既定値 |
 | `TRACEARY_MAX_AUDIT_OUTPUT_BYTES` | `traceary audit` の output 保存サイズ上限の既定値 |

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -13,7 +13,7 @@ This page centralizes Traceary's environment variables, runtime assumptions, and
 | `TRACEARY_CLIENT` | Default `client` attribution for `log`, `audit`, and session commands |
 | `TRACEARY_AGENT` | Default `agent` attribution for `log`, `audit`, and session commands |
 | `TRACEARY_SESSION_ID` | Default session ID for `log`, `audit`, and `session end` |
-| `TRACEARY_REPO` | Override the auxiliary work-context identifier |
+| `TRACEARY_WORKSPACE` | Override the auxiliary work-context identifier |
 | `TRACEARY_ALLOW_SECRETS` | Disable best-effort secret redaction for `traceary audit` |
 | `TRACEARY_MAX_AUDIT_INPUT_BYTES` | Default stored input size limit for `traceary audit` |
 | `TRACEARY_MAX_AUDIT_OUTPUT_BYTES` | Default stored output size limit for `traceary audit` |

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -31,7 +31,7 @@ host ごとの native package を使いたい場合は、まず [ネイティブ
 
 - `TRACEARY_BIN`: `traceary` binary の絶対 path
 - `TRACEARY_DB_PATH`: 既定の `~/.config/traceary/traceary.db` ではなく明示的な SQLite path を使いたいときに指定
-- `TRACEARY_REPO`: 明示的な work-context 文字列。auto-detection を上書きしたいときに使う
+- `TRACEARY_WORKSPACE`: 明示的な work-context 文字列。auto-detection を上書きしたいときに使う
 - `TRACEARY_HOOK_SCRIPTS_DIR`: `traceary hooks print/install` が portable hook script を書き出す先を上書き
 - `TRACEARY_HOOK_STATE_DIR`: 一時 session state の保存先を上書き
 - `TRACEARY_HOOK_STATE_KEY`: 既定の `PPID` ベース key が合わないときに process ごとの state key を上書き

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -31,7 +31,7 @@ If you want host-native packages instead of manual hook wiring, start with the [
 
 - `TRACEARY_BIN`: absolute path to the `traceary` binary
 - `TRACEARY_DB_PATH`: explicit SQLite path when you do not want the default `~/.config/traceary/traceary.db`
-- `TRACEARY_REPO`: explicit work-context string. Use this to override auto-detection.
+- `TRACEARY_WORKSPACE`: explicit work-context string. Use this to override auto-detection.
 - `TRACEARY_HOOK_SCRIPTS_DIR`: override where `traceary hooks print/install` materializes portable hook scripts
 - `TRACEARY_HOOK_STATE_DIR`: override where temporary session state is stored
 - `TRACEARY_HOOK_STATE_KEY`: override the per-process state key when the default `PPID`-based key is not suitable

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -49,8 +49,8 @@ func (c *RootCLI) newSessionLatestCommand() *cobra.Command {
 		Use:   "latest",
 		Short: Localize("Print the latest session ID", "直近のセッション ID を表示する"),
 		Long: Localize(
-			"Print the latest matching session ID.\n\n\"latest\" means the session whose most recent lifecycle boundary (start or end) is newest among the matches.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --repo falls back to the detected work context when omitted.",
-			"条件に一致する直近の session ID を表示します。\n\nここでの「直近」は、一致した session のうち最新の lifecycle boundary (start または end) が最も新しいものを意味します。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--repo 省略時は検出した work context を使います。",
+			"Print the latest matching session ID.\n\n\"latest\" means the session whose most recent lifecycle boundary (start or end) is newest among the matches.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected work context when omitted.",
+			"条件に一致する直近の session ID を表示します。\n\nここでの「直近」は、一致した session のうち最新の lifecycle boundary (start または end) が最も新しいものを意味します。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した work context を使います。",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -88,8 +88,8 @@ func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: Localize("Record session start", "セッション開始を記録する"),
 		Long: Localize(
-			"Record a session-start boundary.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected repo\n- session ID: generate a new ID when --session-id is omitted",
-			"session 開始境界を記録します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した repo\n- session ID: --session-id を省略した場合は新しく採番します",
+			"Record a session-start boundary.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected workspace\n- session ID: generate a new ID when --session-id is omitted",
+			"session 開始境界を記録します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した workspace\n- session ID: --session-id を省略した場合は新しく採番します",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -135,8 +135,8 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 		Use:   "end",
 		Short: Localize("Record session end", "セッション終了を記録する"),
 		Long: Localize(
-			"Record a session-end boundary.\n\nDefaults:\n- session ID: --session-id -> TRACEARY_SESSION_ID\n- client / agent / repo: use explicit flags first, then backfill from the matching session start when possible",
-			"session 終了境界を記録します。\n\n既定値の解決順:\n- session ID: --session-id -> TRACEARY_SESSION_ID\n- client / agent / repo: 明示 flag を優先し、足りない値は対応する session start から補完します",
+			"Record a session-end boundary.\n\nDefaults:\n- session ID: --session-id -> TRACEARY_SESSION_ID\n- client / agent / workspace: use explicit flags first, then backfill from the matching session start when possible",
+			"session 終了境界を記録します。\n\n既定値の解決順:\n- session ID: --session-id -> TRACEARY_SESSION_ID\n- client / agent / workspace: 明示 flag を優先し、足りない値は対応する session start から補完します",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -205,8 +205,8 @@ func (c *RootCLI) newSessionActiveCommand() *cobra.Command {
 		Use:   "active",
 		Short: Localize("Print the active session ID (stale sessions older than 24h are excluded by default)", "現在アクティブな session ID を表示する (既定では 24h 超の stale を除外)"),
 		Long: Localize(
-			"Print the active matching session ID.\n\nUnlike session latest, this only returns non-ended sessions. By default, sessions older than 24h are treated as stale unless --allow-stale is set.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --repo falls back to the detected work context when omitted.",
-			"条件に一致する active session ID を表示します。\n\nsession latest と違って、未終了の session だけを返します。既定では 24h を超える session は --allow-stale を指定しない限り stale とみなします。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--repo 省略時は検出した work context を使います。",
+			"Print the active matching session ID.\n\nUnlike session latest, this only returns non-ended sessions. By default, sessions older than 24h are treated as stale unless --allow-stale is set.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected work context when omitted.",
+			"条件に一致する active session ID を表示します。\n\nsession latest と違って、未終了の session だけを返します。既定では 24h を超える session は --allow-stale を指定しない限り stale とみなします。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した work context を使います。",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/scripts/hooks/scripts_test.go
+++ b/scripts/hooks/scripts_test.go
@@ -261,11 +261,11 @@ func TestTracearyAuditScript_UsesRepoFromSessionState(t *testing.T) {
 	env := append(os.Environ(),
 		"TRACEARY_BIN="+fakeTracearyPath,
 		"TRACEARY_FAKE_LOG="+fakeLogPath,
-		"TRACEARY_WORKSPACE=session-repo",
+		"TRACEARY_WORKSPACE=session-workspace",
 		"HOME="+homeDir,
 	)
 
-	// Start session — repo "session-repo" is saved to state
+	// Start session — repo "session-workspace" is saved to state
 	if err := runHookScript(t, filepath.Join(".", "traceary-session.sh"), env, `{"cwd":"/tmp/project"}`, "claude", "start"); err != nil {
 		t.Fatalf("runHookScript(start) error = %v", err)
 	}
@@ -286,20 +286,20 @@ func TestTracearyAuditScript_UsesRepoFromSessionState(t *testing.T) {
 		t.Fatalf("len(calls) = %d, want 2", len(calls))
 	}
 
-	// Verify audit used session-repo, not CWD-based detection
+	// Verify audit used session-workspace, not CWD-based detection
 	auditCall := calls[1]
-	repoIdx := -1
+	wsIdx := -1
 	for i, arg := range auditCall {
 		if arg == "--workspace" && i+1 < len(auditCall) {
-			repoIdx = i + 1
+			wsIdx = i + 1
 			break
 		}
 	}
-	if repoIdx == -1 {
-		t.Fatalf("audit call missing --repo flag: %#v", auditCall)
+	if wsIdx == -1 {
+		t.Fatalf("audit call missing --workspace flag: %#v", auditCall)
 	}
-	if auditCall[repoIdx] != "session-repo" {
-		t.Fatalf("audit --repo = %q, want %q", auditCall[repoIdx], "session-repo")
+	if auditCall[wsIdx] != "session-workspace" {
+		t.Fatalf("audit --workspace = %q, want %q", auditCall[wsIdx], "session-workspace")
 	}
 }
 


### PR DESCRIPTION
## Summary
Additional repo→workspace rename leftovers from Codex verifier audit:
- docs/environment, docs/hooks: TRACEARY_REPO → TRACEARY_WORKSPACE
- session.go Long descriptions
- scripts_test.go error messages

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)