### PR TITLE
refactor: move IsSessionLookupNotFound to usecase package

### DIFF
--- a/application/usecase/session_errors.go
+++ b/application/usecase/session_errors.go
@@ -1,0 +1,12 @@
+package usecase
+
+import (
+	"errors"
+
+	"github.com/duck8823/traceary/domain/port"
+)
+
+// IsSessionLookupNotFound reports whether err is a session-lookup not-found error.
+func IsSessionLookupNotFound(err error) bool {
+	return errors.Is(err, port.ErrSessionNotFound) || errors.Is(err, port.ErrActiveSessionNotFound)
+}

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/duck8823/traceary/domain/types"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
 )
 
@@ -137,7 +136,7 @@ func (c *RootCLI) resolveContextSessionID(
 		Workspace: types.Workspace(strings.TrimSpace(input.repo)),
 	})
 	if err != nil {
-		if queryservice.IsSessionLookupNotFound(err) {
+		if usecase.IsSessionLookupNotFound(err) {
 			slog.Debug("no session found for context, using empty session", "client", input.client, "agent", input.agent, "workspace", input.repo)
 			return "", nil
 		}

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
@@ -368,7 +367,7 @@ func (c *RootCLI) runSessionLatest(
 		event, err = c.session.Latest(ctx, criteria)
 	}
 	if err != nil {
-		if queryservice.IsSessionLookupNotFound(err) {
+		if usecase.IsSessionLookupNotFound(err) {
 			if input.activeOnly {
 				return xerrors.Errorf(Localize("no matching active session found", "条件に一致する active session は存在しません"))
 			}

--- a/presentation/cli/session_resolution.go
+++ b/presentation/cli/session_resolution.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/duck8823/traceary/domain/types"
 
-	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/domain/model"
 )
 
@@ -47,7 +46,7 @@ func (c *RootCLI) resolveManualSessionID(
 		Workspace: types.Workspace(trimmedRepo),
 	})
 	if err != nil {
-		if queryservice.IsSessionLookupNotFound(err) {
+		if usecase.IsSessionLookupNotFound(err) {
 			slog.Debug("no active session found for repo, using default", "workspace", trimmedRepo)
 			return &manualSessionResolution{
 				sessionID: defaultSessionIDValue,


### PR DESCRIPTION
## Summary
Move `IsSessionLookupNotFound` from `application/queryservice` to `application/usecase`.
Eliminates layer violation where presentation imported queryservice.

Closes #418

## Test plan
- [x] All tests pass
- [x] lint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)