### PR TITLE
feat: add compact_summary and prompt EventKind variants

### DIFF
--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -17,8 +17,8 @@ type AuditRedaction struct {
 
 // EventUsecase consolidates event recording and query operations.
 type EventUsecase interface {
-	// Log records a note event.
-	Log(ctx context.Context, message string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error)
+	// Log records a log event. Zero-value kind defaults to note.
+	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error)
 
 	// Audit records a command execution audit event.
 	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode *int, redaction AuditRedaction) (*model.Event, *model.CommandAudit, error)

--- a/application/usecase/event_usecase_adapter.go
+++ b/application/usecase/event_usecase_adapter.go
@@ -39,9 +39,10 @@ func NewEventUsecaseAdapter(
 	}
 }
 
-func (a *eventUsecaseAdapter) Log(ctx context.Context, message string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
+func (a *eventUsecaseAdapter) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
 	event, err := a.recordLog.Run(ctx, RecordLogInput{
 		Message:   message,
+		Kind:      kind.String(),
 		Client:    client.String(),
 		Agent:     agent.String(),
 		SessionID: sessionID.String(),

--- a/application/usecase/record_log.go
+++ b/application/usecase/record_log.go
@@ -18,6 +18,7 @@ type EventSaver = port.EventSaver
 // RecordLogInput is the input for traceary log recording.
 type RecordLogInput struct {
 	Message   string
+	Kind      string
 	Client    string
 	Agent     string
 	SessionID string
@@ -52,6 +53,14 @@ func (u *recordLogUsecase) Run(ctx context.Context, input RecordLogInput) (*mode
 	if err != nil {
 		return nil, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
+	kind := types.EventKindNote
+	if strings.TrimSpace(input.Kind) != "" {
+		kind, err = types.EventKindOf(input.Kind)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve event kind: %w", err)
+		}
+	}
+
 	eventID, err := newEventID()
 	if err != nil {
 		return nil, xerrors.Errorf("failed to generate event ID: %w", err)
@@ -59,7 +68,7 @@ func (u *recordLogUsecase) Run(ctx context.Context, input RecordLogInput) (*mode
 
 	event, err := model.NewEvent(
 		eventID,
-		types.EventKindNote,
+		kind,
 		strings.TrimSpace(input.Client),
 		agent,
 		sessionID,

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -66,6 +66,66 @@ func TestRecordLogUsecase_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("saves event with specified kind", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewRecordLogUsecase(stub)
+
+		got, err := sut.Run(context.Background(), usecase.RecordLogInput{
+			Message:   "compact summary text",
+			Kind:      "compact_summary",
+			Client:    "hook",
+			Agent:     "claude",
+			SessionID: "session-1",
+			Workspace: "duck8823/traceary",
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got.Kind().String() != "compact_summary" {
+			t.Fatalf("Kind() = %q, want %q", got.Kind(), "compact_summary")
+		}
+	})
+
+	t.Run("defaults to note when kind is empty", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewRecordLogUsecase(stub)
+
+		got, err := sut.Run(context.Background(), usecase.RecordLogInput{
+			Message:   "hello",
+			Client:    "cli",
+			Agent:     "manual",
+			SessionID: "session-1",
+		})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if got.Kind().String() != "note" {
+			t.Fatalf("Kind() = %q, want %q", got.Kind(), "note")
+		}
+	})
+
+	t.Run("returns error for invalid kind", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewRecordLogUsecase(stub)
+
+		_, err := sut.Run(context.Background(), usecase.RecordLogInput{
+			Message:   "hello",
+			Kind:      "invalid_kind",
+			Client:    "cli",
+			Agent:     "manual",
+			SessionID: "session-1",
+		})
+		if err == nil {
+			t.Fatalf("Run() error = nil, want error for invalid kind")
+		}
+	})
+
 	t.Run("returns error for invalid required fields", func(t *testing.T) {
 		t.Parallel()
 

--- a/domain/types/event_kind.go
+++ b/domain/types/event_kind.go
@@ -18,6 +18,10 @@ const (
 	EventKindSessionStarted EventKind = "session_started"
 	// EventKindSessionEnded represents session end events.
 	EventKindSessionEnded EventKind = "session_ended"
+	// EventKindCompactSummary represents compact summary events.
+	EventKindCompactSummary EventKind = "compact_summary"
+	// EventKindPrompt represents user prompt events.
+	EventKindPrompt EventKind = "prompt"
 )
 
 // EventKind is a value object that represents an event kind.
@@ -29,6 +33,8 @@ var knownEventKinds = []EventKind{
 	EventKindReviewed,
 	EventKindSessionStarted,
 	EventKindSessionEnded,
+	EventKindCompactSummary,
+	EventKindPrompt,
 }
 
 // EventKindOf builds EventKind from a string value.

--- a/domain/types/event_kind_test.go
+++ b/domain/types/event_kind_test.go
@@ -23,6 +23,18 @@ func TestEventKindOf(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "accepts compact_summary kind",
+			value:   "compact_summary",
+			want:    types.EventKindCompactSummary,
+			wantErr: false,
+		},
+		{
+			name:    "accepts prompt kind",
+			value:   "prompt",
+			want:    types.EventKindPrompt,
+			wantErr: false,
+		},
+		{
 			name:    "returns error for unknown event kind",
 			value:   "unknown",
 			wantErr: true,
@@ -45,7 +57,7 @@ func TestEventKindOf(t *testing.T) {
 			}
 			if tt.wantErr {
 				if tt.name == "returns error for unknown event kind" &&
-					!strings.Contains(err.Error(), "allowed values: note, command_executed, reviewed, session_started, session_ended") {
+					!strings.Contains(err.Error(), "allowed values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt") {
 					t.Fatalf("error = %q, want valid kind list", err.Error())
 				}
 				return

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -57,7 +57,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display", "表示件数"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of events to skip before listing", "一覧表示前にスキップする件数"))
-	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended; alias: audit)"))
+	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)"))
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	listCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -22,6 +22,7 @@ const (
 func (c *RootCLI) newLogCommand() *cobra.Command {
 	var (
 		dbPath    string
+		kind      string
 		client    string
 		agent     string
 		sessionID string
@@ -46,6 +47,7 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 			return c.runLog(cmd.Context(), cmd.OutOrStdout(), logCommandInput{
 				dbPath:    dbPath,
 				message:   args[0],
+				kind:      kind,
 				client:    client,
 				agent:     agent,
 				sessionID: sessionID,
@@ -56,6 +58,7 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 		},
 	}
 	logCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	logCmd.Flags().StringVar(&kind, "kind", "", Localize("event kind (default: note)", "イベント種別 (既定: note)"))
 	logCmd.Flags().StringVar(&client, "client", "", Localize("recording channel (env: TRACEARY_CLIENT)", "記録経路 (env: TRACEARY_CLIENT)"))
 	logCmd.Flags().StringVar(&agent, "agent", "", Localize("actor name (env: TRACEARY_AGENT)", "作業主体 (env: TRACEARY_AGENT)"))
 	logCmd.Flags().StringVar(
@@ -78,6 +81,7 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 type logCommandInput struct {
 	dbPath    string
 	message   string
+	kind      string
 	client    string
 	agent     string
 	sessionID string
@@ -116,7 +120,8 @@ func (c *RootCLI) runLog(ctx context.Context, output io.Writer, input logCommand
 	agent, _ := types.AgentOf(resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue))
 	sessionID, _ := types.SessionIDOf(sessionResolution.sessionID)
 	workspace := types.Workspace(resolvedRepo)
-	event, err := c.event.Log(ctx, input.message, client, agent, sessionID, workspace)
+	kind := types.EventKind(strings.TrimSpace(input.kind))
+	event, err := c.event.Log(ctx, input.message, kind, client, agent, sessionID, workspace)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record log", "ログ記録に失敗しました"), err)
 	}

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -67,6 +67,45 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("records log with specified kind", func(t *testing.T) {
+		t.Parallel()
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event: &eventUsecaseStub{
+				logEvent: model.EventOf(
+					eventID,
+					types.EventKindCompactSummary,
+					"hook",
+					agent,
+					sessionID,
+					"duck8823/traceary",
+					"summary text",
+					fixedLogTime(),
+				),
+			},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{
+			"log",
+			"--db-path", "/tmp/test-traceary.db",
+			"--kind", "compact_summary",
+			"--client", "hook",
+			"--agent", "codex",
+			"--session-id", "session-1",
+			"summary text",
+		})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if stdout.String() != "Recorded: event-1\n" {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), "Recorded: event-1\n")
+		}
+	})
+
 	t.Run("uses environment variable defaults", func(t *testing.T) {
 		t.Setenv("TRACEARY_AGENT", "claude")
 		t.Setenv("TRACEARY_SESSION_ID", "session-env")

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -70,8 +70,8 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 		"kind",
 		"",
 		Localize(
-			"filter by event kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)",
-			"絞り込む kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)",
+			"filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
+			"絞り込む kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
 		),
 	)
 	searchCmd.Flags().StringVar(&from, "from", "", Localize("start date (`YYYY-MM-DD` or RFC3339)", "開始日 (`YYYY-MM-DD` または RFC3339)"))
@@ -234,6 +234,8 @@ func validateSearchKind(value string) (string, error) {
 		"reviewed":         "reviewed",
 		"session_started":  "session_started",
 		"session_ended":    "session_ended",
+		"compact_summary":  "compact_summary",
+		"prompt":           "prompt",
 		"audit":            "command_executed",
 	}
 	if resolvedKind, ok := validKinds[trimmedValue]; ok {
@@ -241,7 +243,7 @@ func validateSearchKind(value string) (string, error) {
 	}
 
 	return "", xerrors.Errorf(Localize(
-		"unsupported kind: %s (valid values: note, command_executed, reviewed, session_started, session_ended; alias: audit)",
-		"未対応の kind です: %s (有効値: note, command_executed, reviewed, session_started, session_ended; alias: audit)",
+		"unsupported kind: %s (valid values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
+		"未対応の kind です: %s (有効値: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
 	), trimmedValue)
 }

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -26,7 +26,7 @@ type eventUsecaseStub struct {
 	contextErr     error
 }
 
-func (s *eventUsecaseStub) Log(_ context.Context, _ string, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace) (*model.Event, error) {
+func (s *eventUsecaseStub) Log(_ context.Context, _ string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace) (*model.Event, error) {
 	return s.logEvent, s.logErr
 }
 func (s *eventUsecaseStub) Audit(_ context.Context, _ string, _ string, _ string, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ *int, _ usecase.AuditRedaction) (*model.Event, *model.CommandAudit, error) {

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -153,6 +153,7 @@ func (s *Server) Run(ctx context.Context, dbPath string) error {
 
 type addLogInput struct {
 	Message   string `json:"message" jsonschema:"log body to record"`
+	Kind      string `json:"kind,omitempty" jsonschema:"event kind (default: note; allowed: note, compact_summary, prompt)"`
 	Client    string `json:"client,omitempty" jsonschema:"recording channel (default: mcp)"`
 	Agent     string `json:"agent,omitempty" jsonschema:"actor name (default: manual)"`
 	SessionID string `json:"session_id,omitempty" jsonschema:"session ID (default: default)"`
@@ -228,7 +229,7 @@ type addAuditOutput struct {
 type listEventsInput struct {
 	Limit     int    `json:"limit,omitempty" jsonschema:"result limit (default: 20)"`
 	Offset    int    `json:"offset,omitempty" jsonschema:"offset from the newest result (default: 0)"`
-	Kind      string `json:"kind,omitempty" jsonschema:"filter by event kind (note, command_executed, reviewed, session_started, session_ended; alias: audit)"`
+	Kind      string `json:"kind,omitempty" jsonschema:"filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)"`
 	Client    string `json:"client,omitempty" jsonschema:"filter by client"`
 	Agent     string `json:"agent,omitempty" jsonschema:"filter by agent"`
 	SessionID string `json:"session_id,omitempty" jsonschema:"filter by session ID"`
@@ -270,6 +271,7 @@ func (s *Server) addLog(_ string) mcp.ToolHandlerFor[addLogInput, addLogOutput] 
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input addLogInput) (*mcp.CallToolResult, addLogOutput, error) {
 		event, err := s.event.Log(ctx,
 			input.Message,
+			types.EventKind(strings.TrimSpace(input.Kind)),
 			types.Client(resolveValue(input.Client, defaultClientValue)),
 			types.Agent(resolveValue(input.Agent, defaultAgentValue)),
 			types.SessionID(resolveValue(input.SessionID, defaultSessionValue)),

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -91,6 +91,27 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("add_log with kind saves event with specified kind", func(t *testing.T) {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_log",
+			Arguments: map[string]any{
+				"message":    "compact summary text",
+				"kind":       "compact_summary",
+				"agent":      "claude",
+				"session_id": "session-1",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_log) error = %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("CallTool(add_log) returned tool error")
+		}
+		if got := extractJSONStringValue(t, result, "kind"); got != "compact_summary" {
+			t.Fatalf("kind = %q, want %q", got, "compact_summary")
+		}
+	})
+
 	t.Run("add_audit と get_context が動作する", func(t *testing.T) {
 		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "add_audit",


### PR DESCRIPTION
## Summary
- Add `compact_summary` and `prompt` EventKind constants to domain layer
- Update `RecordLogUsecase` to accept optional `Kind` field (defaults to `note`)
- Add `--kind` flag to `traceary log` CLI command
- Add `kind` parameter to MCP `add_log` tool
- Update kind filter descriptions to include new values

Closes #424

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)