### PR TITLE
feat: persist compact_summary in PostCompact hook

### DIFF
--- a/examples/hooks/claude.settings.json
+++ b/examples/hooks/claude.settings.json
@@ -43,6 +43,17 @@
           }
         ]
       }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/traceary-compact.sh\" claude post-compact"
+          }
+        ]
+      }
     ]
   }
 }

--- a/integrations/claude-plugin/scripts/traceary-compact.sh
+++ b/integrations/claude-plugin/scripts/traceary-compact.sh
@@ -28,9 +28,19 @@ fi
 
 case "$ACTION" in
   post-compact)
-    # Record that a compact happened
+    # Record compact summary or fallback note
     if [[ -n "$SESSION_ID" ]]; then
-      COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      COMPACT_SUMMARY="$(traceary_json_get 'compact_summary')"
+      WORKSPACE="$(traceary_resolve_effective_workspace "$CLIENT")"
+
+      if [[ -n "$COMPACT_SUMMARY" ]]; then
+        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      else
+        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      fi
+      if [[ -n "$WORKSPACE" ]]; then
+        COMMAND+=(--workspace "$WORKSPACE")
+      fi
       if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
         COMMAND+=(--db-path "$TRACEARY_DB_PATH")
       fi

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -373,6 +373,7 @@ func buildClaudeHooksSettings(scriptsDir string, tracearyBin string) *hooksSetti
 	startCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-session.sh", "claude", "start")
 	endCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-session.sh", "claude", "end")
 	auditCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-audit.sh", "claude")
+	compactCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-compact.sh", "claude", "post-compact")
 
 	return &hooksSettings{
 		Hooks: map[string][]hookMatcher{
@@ -398,6 +399,12 @@ func buildClaudeHooksSettings(scriptsDir string, tracearyBin string) *hooksSetti
 				newHookMatcher("Bash", hookCommand{
 					Type:    "command",
 					Command: auditCommand,
+				}),
+			},
+			"PostCompact": {
+				newHookMatcher("*", hookCommand{
+					Type:    "command",
+					Command: compactCommand,
 				}),
 			},
 		},

--- a/presentation/cli/hooks_merge.go
+++ b/presentation/cli/hooks_merge.go
@@ -108,5 +108,6 @@ func isTracearyManagedHookCommand(hook hookCommand) bool {
 
 	commandValue := strings.TrimSpace(hook.Command)
 	return strings.Contains(commandValue, "traceary-session.sh") ||
-		strings.Contains(commandValue, "traceary-audit.sh")
+		strings.Contains(commandValue, "traceary-audit.sh") ||
+		strings.Contains(commandValue, "traceary-compact.sh")
 }

--- a/presentation/cli/hooks_merge.go
+++ b/presentation/cli/hooks_merge.go
@@ -109,5 +109,5 @@ func isTracearyManagedHookCommand(hook hookCommand) bool {
 	commandValue := strings.TrimSpace(hook.Command)
 	return strings.Contains(commandValue, "traceary-session.sh") ||
 		strings.Contains(commandValue, "traceary-audit.sh") ||
-		strings.Contains(commandValue, "traceary-compact.sh")
+		(strings.Contains(commandValue, "traceary-compact.sh") && strings.Contains(commandValue, "post-compact"))
 }

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -46,6 +46,13 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 			`TRACEARY_BIN='/tmp/traceary bin/traceary' bash '`+filepath.Join(scriptsDir, "traceary-audit.sh")+`' 'claude'`; got != want {
 			t.Fatalf("PostToolUseFailure command = %q, want %q", got, want)
 		}
+		if got, want := *settings.Hooks["PostCompact"][0].Matcher, "*"; got != want {
+			t.Fatalf("PostCompact matcher = %q, want %q", got, want)
+		}
+		if got, want := settings.Hooks["PostCompact"][0].Hooks[0].Command,
+			`TRACEARY_BIN='/tmp/traceary bin/traceary' bash '`+filepath.Join(scriptsDir, "traceary-compact.sh")+`' 'claude' 'post-compact'`; got != want {
+			t.Fatalf("PostCompact command = %q, want %q", got, want)
+		}
 		assertInstalledHookScripts(t, scriptsDir)
 	})
 
@@ -354,7 +361,7 @@ func TestRootCLI_HooksInstallCommand(t *testing.T) {
 func assertInstalledHookScripts(t *testing.T, scriptsDir string) {
 	t.Helper()
 
-	for _, scriptName := range []string{"common.sh", "traceary-session.sh", "traceary-audit.sh"} {
+	for _, scriptName := range []string{"common.sh", "traceary-session.sh", "traceary-audit.sh", "traceary-compact.sh"} {
 		scriptPath := filepath.Join(scriptsDir, scriptName)
 		info, err := os.Stat(scriptPath)
 		if err != nil {

--- a/scripts/hooks/traceary-compact.sh
+++ b/scripts/hooks/traceary-compact.sh
@@ -28,9 +28,19 @@ fi
 
 case "$ACTION" in
   post-compact)
-    # Record that a compact happened
+    # Record compact summary or fallback note
     if [[ -n "$SESSION_ID" ]]; then
-      COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      COMPACT_SUMMARY="$(traceary_json_get 'compact_summary')"
+      WORKSPACE="$(traceary_resolve_effective_workspace "$CLIENT")"
+
+      if [[ -n "$COMPACT_SUMMARY" ]]; then
+        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      else
+        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+      fi
+      if [[ -n "$WORKSPACE" ]]; then
+        COMMAND+=(--workspace "$WORKSPACE")
+      fi
       if [[ -n "${TRACEARY_DB_PATH:-}" ]]; then
         COMMAND+=(--db-path "$TRACEARY_DB_PATH")
       fi


### PR DESCRIPTION
## Summary
- Update `traceary-compact.sh` to extract `compact_summary` from PostCompact hook stdin and save as `compact_summary` EventKind
- Fallback to `"compact triggered"` note when `compact_summary` field is absent
- Add `PostCompact` hook entry to `buildClaudeHooksSettings` (generated hooks)
- Update hooks merge logic to recognize `traceary-compact.sh` for deduplication
- Add PostCompact to example Claude settings

Closes #425

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] CI green
- [ ] Manual: run `/compact` and verify compact_summary event in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)