### PR TITLE
feat: enhance compact-summary CLI with stored compact_summary

### DIFF
--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -118,10 +118,79 @@ func (c *RootCLI) printCompactSummary(
 		sb.WriteString("\n")
 	}
 
+	// Retrieve the latest compact_summary event for richer context
+	compactSummaryEvents, err := c.event.List(ctx, usecase.EventListCriteria{
+		Limit:     1,
+		SessionID: types.SessionID(sessionID),
+		Workspace: types.Workspace(repo),
+		Kind:      types.EventKindCompactSummary,
+	})
+	if err == nil && len(compactSummaryEvents) > 0 {
+		body := compactSummaryEvents[0].Body()
+		summary := extractCompactSummarySections(body)
+		if summary != "" {
+			sb.WriteString("  summary: ")
+			sb.WriteString(summary)
+			sb.WriteString("\n")
+		}
+	}
+
 	sb.WriteString("  Run list_events for full history.\n")
 
 	if _, err := fmt.Fprint(output, sb.String()); err != nil {
 		return xerrors.Errorf("failed to print compact summary: %w", err)
 	}
 	return nil
+}
+
+const maxCompactSummaryLen = 500
+
+// extractCompactSummarySections extracts "Current Work" and "Pending Tasks"
+// sections from a compact_summary body. Returns a truncated single-line string.
+func extractCompactSummarySections(body string) string {
+	sections := []string{"Current Work", "Pending Tasks"}
+	var parts []string
+
+	for _, section := range sections {
+		header := fmt.Sprintf("%s:", section)
+		idx := strings.Index(body, header)
+		if idx < 0 {
+			// Try numbered section format (e.g., "8. Current Work:")
+			for i := 1; i <= 9; i++ {
+				alt := fmt.Sprintf("%d. %s:", i, section)
+				idx = strings.Index(body, alt)
+				if idx >= 0 {
+					idx += len(alt)
+					break
+				}
+			}
+			if idx < 0 {
+				continue
+			}
+		} else {
+			idx += len(header)
+		}
+
+		// Extract content until next section header or end
+		rest := body[idx:]
+		endIdx := len(rest)
+		for i := 1; i <= 9; i++ {
+			nextHeader := fmt.Sprintf("\n%d. ", i)
+			if pos := strings.Index(rest, nextHeader); pos > 0 && pos < endIdx {
+				endIdx = pos
+			}
+		}
+		content := strings.TrimSpace(rest[:endIdx])
+		// Collapse to single line
+		content = strings.Join(strings.Fields(content), " ")
+		if content != "" {
+			parts = append(parts, content)
+		}
+	}
+
+	result := strings.Join(parts, " | ")
+	if len([]rune(result)) > maxCompactSummaryLen {
+		result = string([]rune(result)[:maxCompactSummaryLen]) + "…"
+	}
+	return result
 }

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -118,7 +118,9 @@ func (c *RootCLI) printCompactSummary(
 		sb.WriteString("\n")
 	}
 
-	// Retrieve the latest compact_summary event for richer context
+	// Retrieve the latest compact_summary event for richer context.
+	// Errors are intentionally ignored: this output is injected into hook stdout
+	// and must not fail even if the compact_summary query encounters a DB issue.
 	compactSummaryEvents, err := c.event.List(ctx, usecase.EventListCriteria{
 		Limit:     1,
 		SessionID: types.SessionID(sessionID),
@@ -176,7 +178,17 @@ func extractCompactSummarySections(body string) string {
 		endIdx := len(rest)
 		for i := 1; i <= 9; i++ {
 			nextHeader := fmt.Sprintf("\n%d. ", i)
-			if pos := strings.Index(rest, nextHeader); pos > 0 && pos < endIdx {
+			if pos := strings.Index(rest, nextHeader); pos >= 0 && pos < endIdx {
+				endIdx = pos
+			}
+		}
+		// Also check for plain (unnumbered) section headers
+		for _, otherSection := range sections {
+			if otherSection == section {
+				continue
+			}
+			plainHeader := "\n" + otherSection + ":"
+			if pos := strings.Index(rest, plainHeader); pos >= 0 && pos < endIdx {
 				endIdx = pos
 			}
 		}

--- a/presentation/cli/compact_summary_test.go
+++ b/presentation/cli/compact_summary_test.go
@@ -132,6 +132,50 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("includes summary from compact_summary event", func(t *testing.T) {
+		t.Parallel()
+
+		eventID, _ := types.EventIDOf("e1")
+		agent, _ := types.AgentOf("claude")
+		sessionID, _ := types.SessionIDOf("session-abc")
+
+		dbPath := filepath.Join(t.TempDir(), "traceary.db")
+		eventStub := &eventUsecaseStub{
+			listEvents: []*model.Event{
+				model.EventOf(eventID, types.EventKindCompactSummary, "hook", agent, sessionID, "duck8823/traceary",
+					"<summary>\n8. Current Work:\n   Implementing feature X\n9. Optional Next Step:\n   Deploy\n</summary>",
+					time.Now()),
+			},
+		}
+		sessionStub := &sessionUsecaseStub{
+			listResult: []*usecase.SessionSummary{
+				{SessionID: "session-abc", Workspace: "duck8823/traceary", StartedAt: time.Now()},
+			},
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event:            eventStub,
+			Session:          sessionStub,
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"compact-summary", "--db-path", dbPath})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, "summary:") {
+			t.Errorf("output missing summary section, got: %s", output)
+		}
+		if !strings.Contains(output, "Implementing feature X") {
+			t.Errorf("output missing current work content, got: %s", output)
+		}
+	})
+
 	t.Run("output stays within token limit", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- Retrieve latest `compact_summary` event from DB in `printCompactSummary`
- Extract "Current Work" and "Pending Tasks" sections from compact summary body
- Truncate extracted summary to 500 chars to limit context consumption
- Falls back gracefully when no compact_summary event exists
- Shared by both `compact-summary` and `session handoff` commands

Closes #426

## Test plan
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)