### PR TITLE
feat: add work timeline with gap-based block detection

### DIFF
--- a/application/queryservice/list_timeline_blocks.go
+++ b/application/queryservice/list_timeline_blocks.go
@@ -1,0 +1,47 @@
+package queryservice
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
+)
+
+// ListTimelineBlocksQueryService returns timeline blocks based on gap detection.
+type ListTimelineBlocksQueryService interface {
+	// Run executes the timeline block query.
+	Run(ctx context.Context, input port.ListTimelineBlocksInput) ([]*port.TimelineBlock, error)
+}
+
+type listTimelineBlocksQueryService struct {
+	finder port.TimelineBlockFinder
+}
+
+// NewListTimelineBlocksQueryService creates a ListTimelineBlocksQueryService.
+func NewListTimelineBlocksQueryService(finder port.TimelineBlockFinder) ListTimelineBlocksQueryService {
+	return &listTimelineBlocksQueryService{finder: finder}
+}
+
+// Run executes the timeline block query.
+func (s *listTimelineBlocksQueryService) Run(
+	ctx context.Context,
+	input port.ListTimelineBlocksInput,
+) ([]*port.TimelineBlock, error) {
+	if s.finder == nil {
+		return nil, xerrors.Errorf("timeline block finder is not configured")
+	}
+	if input.GapSeconds <= 0 {
+		return nil, xerrors.Errorf("gap must be greater than 0")
+	}
+	if input.Limit <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+
+	blocks, err := s.finder.ListTimelineBlocks(ctx, input)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list timeline blocks: %w", err)
+	}
+
+	return blocks, nil
+}

--- a/application/usecase/criteria.go
+++ b/application/usecase/criteria.go
@@ -70,3 +70,13 @@ type SessionLookupCriteria struct {
 	Workspace  types.Workspace
 	ActiveOnly bool
 }
+
+// TimelineCriteria holds filter parameters for work timeline block listing.
+// Zero-value fields are ignored (no filter applied).
+type TimelineCriteria struct {
+	Workspace  types.Workspace
+	From       time.Time
+	To         time.Time
+	GapSeconds int
+	Limit      int
+}

--- a/application/usecase/dto.go
+++ b/application/usecase/dto.go
@@ -59,3 +59,13 @@ type HandoffSummary struct {
 	Summary        string
 	RecentCommands []string
 }
+
+// TimelineBlock represents a contiguous work block separated by an idle gap.
+type TimelineBlock struct {
+	BlockStart time.Time
+	BlockEnd   time.Time
+	EventCount int
+	Workspaces []string
+	Agents     []string
+	KindCounts map[string]int
+}

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -35,4 +35,7 @@ type EventUsecase interface {
 
 	// Context returns recent events for the given context.
 	Context(ctx context.Context, criteria EventContextCriteria) ([]*model.Event, error)
+
+	// Timeline returns work blocks separated by idle gaps.
+	Timeline(ctx context.Context, criteria TimelineCriteria) ([]*TimelineBlock, error)
 }

--- a/application/usecase/event_usecase_adapter.go
+++ b/application/usecase/event_usecase_adapter.go
@@ -18,6 +18,7 @@ type eventUsecaseAdapter struct {
 	searchEvents    queryservice.SearchEventsQueryService
 	getEventDetails queryservice.GetEventDetailsQueryService
 	getContext      queryservice.GetContextQueryService
+	listTimeline    queryservice.ListTimelineBlocksQueryService
 }
 
 // NewEventUsecaseAdapter creates an EventUsecase that delegates to existing usecases and queryservices.
@@ -28,6 +29,7 @@ func NewEventUsecaseAdapter(
 	searchEvents queryservice.SearchEventsQueryService,
 	getEventDetails queryservice.GetEventDetailsQueryService,
 	getContext queryservice.GetContextQueryService,
+	listTimeline queryservice.ListTimelineBlocksQueryService,
 ) EventUsecase {
 	return &eventUsecaseAdapter{
 		recordLog:       recordLog,
@@ -36,6 +38,7 @@ func NewEventUsecaseAdapter(
 		searchEvents:    searchEvents,
 		getEventDetails: getEventDetails,
 		getContext:      getContext,
+		listTimeline:    listTimeline,
 	}
 }
 
@@ -132,4 +135,34 @@ func (a *eventUsecaseAdapter) Context(ctx context.Context, criteria EventContext
 		return nil, xerrors.Errorf("failed to get context events: %w", err)
 	}
 	return events, nil
+}
+
+func (a *eventUsecaseAdapter) Timeline(ctx context.Context, criteria TimelineCriteria) ([]*TimelineBlock, error) {
+	portBlocks, err := a.listTimeline.Run(ctx, port.ListTimelineBlocksInput{
+		Workspace:  criteria.Workspace.String(),
+		From:       criteria.From,
+		To:         criteria.To,
+		GapSeconds: criteria.GapSeconds,
+		Limit:      criteria.Limit,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list timeline blocks: %w", err)
+	}
+
+	blocks := make([]*TimelineBlock, 0, len(portBlocks))
+	for _, pb := range portBlocks {
+		kindCounts := make(map[string]int)
+		for _, k := range pb.Kinds {
+			kindCounts[k]++
+		}
+		blocks = append(blocks, &TimelineBlock{
+			BlockStart: pb.BlockStart,
+			BlockEnd:   pb.BlockEnd,
+			EventCount: pb.EventCount,
+			Workspaces: pb.Workspaces,
+			Agents:     pb.Agents,
+			KindCounts: kindCounts,
+		})
+	}
+	return blocks, nil
 }

--- a/domain/port/query.go
+++ b/domain/port/query.go
@@ -161,3 +161,30 @@ type ListSessionsInput struct {
 type SessionSummaryFinder interface {
 	ListSessionSummaries(ctx context.Context, input ListSessionsInput) ([]*SessionSummary, error)
 }
+
+// --- Timeline Blocks ---
+
+// TimelineBlock represents a contiguous work block separated by idle gaps.
+type TimelineBlock struct {
+	BlockNum   int
+	BlockStart time.Time
+	BlockEnd   time.Time
+	EventCount int
+	Workspaces []string
+	Agents     []string
+	Kinds      []string
+}
+
+// ListTimelineBlocksInput is the input for timeline block listing.
+type ListTimelineBlocksInput struct {
+	Workspace  string
+	From       time.Time
+	To         time.Time
+	GapSeconds int
+	Limit      int
+}
+
+// TimelineBlockFinder provides timeline block lookup.
+type TimelineBlockFinder interface {
+	ListTimelineBlocks(ctx context.Context, input ListTimelineBlocksInput) ([]*TimelineBlock, error)
+}

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -1,0 +1,37 @@
+WITH ordered_events AS (
+  SELECT
+    e.id,
+    e.kind,
+    e.client,
+    e.agent,
+    e.workspace,
+    e.body,
+    e.created_at,
+    LAG(e.created_at) OVER (ORDER BY e.created_at, e.id) AS prev_created_at
+  FROM events e
+  WHERE (? = '' OR e.workspace = ?)
+    AND (? = '' OR e.created_at >= ?)
+    AND (? = '' OR e.created_at < ?)
+),
+blocks AS (
+  SELECT
+    *,
+    SUM(CASE
+      WHEN prev_created_at IS NULL THEN 1
+      WHEN (julianday(created_at) - julianday(prev_created_at)) * 86400 > ? THEN 1
+      ELSE 0
+    END) OVER (ORDER BY created_at, id) AS block_num
+  FROM ordered_events
+)
+SELECT
+  block_num,
+  MIN(created_at) AS block_start,
+  MAX(created_at) AS block_end,
+  COUNT(*) AS event_count,
+  GROUP_CONCAT(DISTINCT workspace) AS workspaces,
+  GROUP_CONCAT(DISTINCT agent) AS agents,
+  GROUP_CONCAT(kind, '|') AS kinds
+FROM blocks
+GROUP BY block_num
+ORDER BY block_start DESC
+LIMIT ?

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -1,3 +1,7 @@
+-- Gap-based work block detection.
+-- When workspace is filtered, LAG operates only on matching rows (correct).
+-- When workspace is empty (all workspaces), cross-workspace gaps are treated
+-- as continuous work, which is the intended behavior for overview timelines.
 WITH ordered_events AS (
   SELECT
     e.id,

--- a/infrastructure/sqlite/timeline_store.go
+++ b/infrastructure/sqlite/timeline_store.go
@@ -1,0 +1,114 @@
+package sqlite
+
+import (
+	"context"
+	_ "embed"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/port"
+)
+
+//go:embed sql/list_timeline_blocks.sql
+var listTimelineBlocksQuery string
+
+// ListTimelineBlocks returns work blocks separated by idle gaps.
+func (d *Datasource) ListTimelineBlocks(
+	ctx context.Context,
+	input port.ListTimelineBlocksInput,
+) ([]*port.TimelineBlock, error) {
+	db, err := d.openDB(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for timeline listing: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	fromValue := ""
+	if !input.From.IsZero() {
+		fromValue = formatTimestamp(input.From)
+	}
+	toValue := ""
+	if !input.To.IsZero() {
+		toValue = formatTimestamp(input.To)
+	}
+
+	rows, err := db.QueryContext(
+		ctx,
+		listTimelineBlocksQuery,
+		input.Workspace, input.Workspace,
+		fromValue, fromValue,
+		toValue, toValue,
+		input.GapSeconds,
+		input.Limit,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query timeline blocks: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close rows", "error", err)
+		}
+	}()
+
+	var blocks []*port.TimelineBlock
+	for rows.Next() {
+		var (
+			blockNum   int
+			blockStart string
+			blockEnd   string
+			eventCount int
+			workspaces string
+			agents     string
+			kinds      string
+		)
+		if err := rows.Scan(&blockNum, &blockStart, &blockEnd, &eventCount, &workspaces, &agents, &kinds); err != nil {
+			return nil, xerrors.Errorf("failed to scan timeline block: %w", err)
+		}
+
+		parsedStart, err := time.Parse(time.RFC3339Nano, blockStart)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse block start: %w", err)
+		}
+		parsedEnd, err := time.Parse(time.RFC3339Nano, blockEnd)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse block end: %w", err)
+		}
+
+		blocks = append(blocks, &port.TimelineBlock{
+			BlockNum:   blockNum,
+			BlockStart: parsedStart,
+			BlockEnd:   parsedEnd,
+			EventCount: eventCount,
+			Workspaces: splitNonEmpty(workspaces, ","),
+			Agents:     splitNonEmpty(agents, ","),
+			Kinds:      splitNonEmpty(kinds, "|"),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate timeline blocks: %w", err)
+	}
+
+	return blocks, nil
+}
+
+func splitNonEmpty(s string, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/main.go
+++ b/main.go
@@ -172,10 +172,12 @@ func run() error {
 	getDetails := queryservice.NewGetEventDetailsQueryService(ds)
 	findLatest := queryservice.NewFindLatestSessionQueryService(ds)
 	listSessions := queryservice.NewListSessionsQueryService(ds)
+	listTimeline := queryservice.NewListTimelineBlocksQueryService(ds)
 
 	eventUsecase := usecase.NewEventUsecaseAdapter(
 		recordLog, recordAudit,
 		listRecent, searchEvents, getDetails, getContext,
+		listTimeline,
 	)
 	sessionUsecase := usecase.NewSessionUsecaseAdapter(
 		recordBoundary, updateLabel,

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -51,6 +51,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newShowCommand())
 	rootCmd.AddCommand(c.newSessionCommand())
 	rootCmd.AddCommand(c.newCompactSummaryCommand())
+	rootCmd.AddCommand(c.newTimelineCommand())
 	rootCmd.AddCommand(c.newCompletionCommand(rootCmd))
 	rootCmd.AddCommand(c.newHooksCommand())
 	rootCmd.AddCommand(c.newDoctorCommand())

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const defaultGapMinutes = 15
+
+func (c *RootCLI) newTimelineCommand() *cobra.Command {
+	var (
+		dbPath    string
+		workspace string
+		from      string
+		to        string
+		gap       int
+		limit     int
+		asJSON    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "timeline",
+		Short: Localize("Show work timeline with gap-based block detection", "ギャップ検出による作業タイムラインを表示する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runTimeline(cmd.Context(), cmd.OutOrStdout(), timelineCommandInput{
+				dbPath:    dbPath,
+				workspace: workspace,
+				from:      from,
+				to:        to,
+				gap:       gap,
+				limit:     limit,
+				asJSON:    asJSON,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&workspace, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
+	cmd.Flags().StringVar(&from, "from", "", Localize("start date (YYYY-MM-DD or RFC3339)", "開始日 (YYYY-MM-DD または RFC3339)"))
+	cmd.Flags().StringVar(&to, "to", "", Localize("end date (YYYY-MM-DD or RFC3339)", "終了日 (YYYY-MM-DD または RFC3339)"))
+	cmd.Flags().IntVar(&gap, "gap", defaultGapMinutes, Localize("idle gap threshold in minutes", "アイドル判定の閾値（分）"))
+	cmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of blocks to display", "表示するブロック数の上限"))
+	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+
+	return cmd
+}
+
+type timelineCommandInput struct {
+	dbPath    string
+	workspace string
+	from      string
+	to        string
+	gap       int
+	limit     int
+	asJSON    bool
+}
+
+func (c *RootCLI) runTimeline(ctx context.Context, output io.Writer, input timelineCommandInput) error {
+	if c.event == nil {
+		return xerrors.Errorf(Localize("event usecase is not configured", "イベントユースケースが設定されていません"))
+	}
+
+	if _, err := resolveDBPath(input.dbPath); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+	}
+	if err := c.storeMaintenance.Initialize(ctx); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+	}
+
+	fromTime, err := parseDateFlag(input.from)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("invalid --from value", "--from の値が不正です"), err)
+	}
+	toTime, err := parseDateFlag(input.to)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("invalid --to value", "--to の値が不正です"), err)
+	}
+
+	blocks, err := c.event.Timeline(ctx, usecase.TimelineCriteria{
+		Workspace:  types.Workspace(strings.TrimSpace(input.workspace)),
+		From:       fromTime,
+		To:         toTime,
+		GapSeconds: input.gap * 60,
+		Limit:      input.limit,
+	})
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to list timeline blocks", "タイムラインブロックの取得に失敗しました"), err)
+	}
+
+	if input.asJSON {
+		return writeTimelineJSON(output, blocks)
+	}
+
+	return writeTimelineText(output, blocks)
+}
+
+func writeTimelineText(output io.Writer, blocks []*usecase.TimelineBlock) error {
+	if len(blocks) == 0 {
+		if _, err := fmt.Fprintln(output, "No work blocks found."); err != nil {
+			return xerrors.Errorf("failed to print timeline: %w", err)
+		}
+		return nil
+	}
+
+	for _, b := range blocks {
+		duration := b.BlockEnd.Sub(b.BlockStart)
+		durationStr := formatDuration(duration)
+		ws := strings.Join(b.Workspaces, ", ")
+
+		if _, err := fmt.Fprintf(output, "%s - %s (%s) %s\n",
+			b.BlockStart.Local().Format("2006-01-02 15:04"),
+			b.BlockEnd.Local().Format("15:04"),
+			durationStr,
+			ws,
+		); err != nil {
+			return xerrors.Errorf("failed to print timeline block: %w", err)
+		}
+
+		// Print kind counts as command frequency
+		kindLine := formatKindCounts(b.KindCounts)
+		if kindLine != "" {
+			if _, err := fmt.Fprintf(output, "  %s\n", kindLine); err != nil {
+				return xerrors.Errorf("failed to print timeline block details: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func formatKindCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return ""
+	}
+	type kv struct {
+		key   string
+		count int
+	}
+	var sorted []kv
+	for k, v := range counts {
+		sorted = append(sorted, kv{k, v})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].count > sorted[j].count
+	})
+
+	var parts []string
+	for _, s := range sorted {
+		parts = append(parts, fmt.Sprintf("%s: %d", s.key, s.count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func writeTimelineJSON(output io.Writer, blocks []*usecase.TimelineBlock) error {
+	type jsonBlock struct {
+		Start      string         `json:"start"`
+		End        string         `json:"end"`
+		Duration   string         `json:"duration"`
+		EventCount int            `json:"event_count"`
+		Workspaces []string       `json:"workspaces"`
+		Agents     []string       `json:"agents"`
+		KindCounts map[string]int `json:"kind_counts"`
+	}
+
+	result := make([]jsonBlock, 0, len(blocks))
+	for _, b := range blocks {
+		result = append(result, jsonBlock{
+			Start:      b.BlockStart.Format(time.RFC3339),
+			End:        b.BlockEnd.Format(time.RFC3339),
+			Duration:   formatDuration(b.BlockEnd.Sub(b.BlockStart)),
+			EventCount: b.EventCount,
+			Workspaces: b.Workspaces,
+			Agents:     b.Agents,
+			KindCounts: b.KindCounts,
+		})
+	}
+
+	encoded, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to marshal timeline JSON: %w", err)
+	}
+	if _, err := fmt.Fprintln(output, string(encoded)); err != nil {
+		return xerrors.Errorf("failed to print timeline JSON: %w", err)
+	}
+	return nil
+}
+
+func parseDateFlag(value string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02", trimmed); err == nil {
+		return t, nil
+	}
+	return time.Time{}, xerrors.Errorf("unsupported date format: %s (use YYYY-MM-DD or RFC3339)", trimmed)
+}

--- a/presentation/cli/timeline_test.go
+++ b/presentation/cli/timeline_test.go
@@ -1,0 +1,128 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_TimelineCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("displays work blocks in text format", func(t *testing.T) {
+		t.Parallel()
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event: &eventUsecaseStub{
+				timelineBlocks: []*usecase.TimelineBlock{
+					{
+						BlockStart: time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+						BlockEnd:   time.Date(2026, 4, 10, 12, 30, 0, 0, time.UTC),
+						EventCount: 42,
+						Workspaces: []string{"github.com/duck8823/traceary"},
+						Agents:     []string{"claude"},
+						KindCounts: map[string]int{"command_executed": 30, "note": 10, "prompt": 2},
+					},
+				},
+			},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "2026-04-10"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, "3h30m") {
+			t.Errorf("output missing duration, got: %s", output)
+		}
+		if !strings.Contains(output, "github.com/duck8823/traceary") {
+			t.Errorf("output missing workspace, got: %s", output)
+		}
+		if !strings.Contains(output, "command_executed: 30") {
+			t.Errorf("output missing kind counts, got: %s", output)
+		}
+	})
+
+	t.Run("displays empty message when no blocks", func(t *testing.T) {
+		t.Parallel()
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event:            &eventUsecaseStub{},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if !strings.Contains(stdout.String(), "No work blocks found.") {
+			t.Errorf("output missing empty message, got: %s", stdout.String())
+		}
+	})
+
+	t.Run("outputs JSON format", func(t *testing.T) {
+		t.Parallel()
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event: &eventUsecaseStub{
+				timelineBlocks: []*usecase.TimelineBlock{
+					{
+						BlockStart: time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+						BlockEnd:   time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
+						EventCount: 5,
+						Workspaces: []string{"ws"},
+						Agents:     []string{"claude"},
+						KindCounts: map[string]int{"note": 5},
+					},
+				},
+			},
+		}).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, `"event_count": 5`) {
+			t.Errorf("output missing event_count, got: %s", output)
+		}
+		if !strings.Contains(output, `"duration": "1h0m"`) {
+			t.Errorf("output missing duration, got: %s", output)
+		}
+	})
+
+	t.Run("rejects invalid --from value", func(t *testing.T) {
+		t.Parallel()
+
+		rootCmd := cli.NewRootCLI(cli.RootCLIOptions{
+			StoreMaintenance: &storeMaintenanceUsecaseStub{},
+			Event:            &eventUsecaseStub{},
+		}).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "not-a-date"})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("Execute() error = nil, want error for invalid date")
+		}
+	})
+}

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -24,6 +24,8 @@ type eventUsecaseStub struct {
 	showErr        error
 	contextEvents  []*model.Event
 	contextErr     error
+	timelineBlocks []*usecase.TimelineBlock
+	timelineErr    error
 }
 
 func (s *eventUsecaseStub) Log(_ context.Context, _ string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace) (*model.Event, error) {
@@ -43,6 +45,9 @@ func (s *eventUsecaseStub) Show(_ context.Context, _ types.EventID) (*usecase.Ev
 }
 func (s *eventUsecaseStub) Context(_ context.Context, _ usecase.EventContextCriteria) ([]*model.Event, error) {
 	return s.contextEvents, s.contextErr
+}
+func (s *eventUsecaseStub) Timeline(_ context.Context, _ usecase.TimelineCriteria) ([]*usecase.TimelineBlock, error) {
+	return s.timelineBlocks, s.timelineErr
 }
 
 // sessionUsecaseStub implements usecase.SessionUsecase for testing.

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -311,9 +311,11 @@ CREATE TABLE command_audits (
 	findLatest := queryservice.NewFindLatestSessionQueryService(datasource)
 	listSessions := queryservice.NewListSessionsQueryService(datasource)
 
+	listTimeline := queryservice.NewListTimelineBlocksQueryService(datasource)
 	eventUsecase := usecase.NewEventUsecaseAdapter(
 		recordLog, recordAudit,
 		listRecent, searchEvents, getDetails, getContext,
+		listTimeline,
 	)
 	sessionUsecase := usecase.NewSessionUsecaseAdapter(
 		recordBoundary, nil,

--- a/schema/sqlite/migrations/000007_add_events_workspace_created_at_index.sql
+++ b/schema/sqlite/migrations/000007_add_events_workspace_created_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_events_workspace_created_at ON events(workspace, created_at);


### PR DESCRIPTION
## Summary
- Add `traceary timeline` CLI command with gap-based work block detection
- SQL CTE with `LAG()` window function groups events into contiguous blocks
- Configurable idle gap threshold (`--gap`, default: 15 minutes)
- Text and JSON output formats
- Full-stack: port → queryservice → SQLite infra → adapter → CLI
- MCP `list_timeline_blocks` tool to be added in follow-up

Closes #427

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` passes
- [ ] CI green
- [ ] Manual: `traceary timeline --from 2026-04-09 --gap 15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)