### PR TITLE
docs: add lifecycle and event kind documentation

### DIFF
--- a/docs/lifecycle.ja.md
+++ b/docs/lifecycle.ja.md
@@ -1,0 +1,96 @@
+# イベントライフサイクル
+
+[English](./lifecycle.md)
+
+Traceary が各 AI エージェントクライアントでイベントを記録する仕組みを説明します。
+
+## クライアント別ライフサイクル
+
+### Claude Code (Tier 1: フル対応)
+
+```
+SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCompact →)* → SessionEnd
+```
+
+| Hook イベント | Matcher | Traceary イベント種別 | 説明 |
+|---|---|---|---|
+| SessionStart | `*` | `session_started` | セッション開始（workspace 解決を含む） |
+| SessionStart | `compact` | — | compact-summary を新しいコンテキストに注入（stdout 経由） |
+| UserPromptSubmit | `*` | `prompt` | ユーザーの指示テキスト |
+| PostToolUse | `Bash` | `command_executed` | シェルコマンド（入出力・終了コード付き） |
+| PostToolUse | `mcp__.*` | `command_executed` | MCP ツール呼び出し |
+| PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | 失敗したツール実行（`failures_only` でフィルタ可能） |
+| PostCompact | `*` | `compact_summary` | コンテキスト圧縮時の構造化サマリー |
+| SessionEnd | `*` | `session_ended` | セッション終了 |
+
+### Codex CLI (Tier 2: 部分対応)
+
+```
+SessionStart → [PostToolUse]* → Stop
+```
+
+| Hook イベント | Traceary イベント種別 | 説明 |
+|---|---|---|
+| SessionStart | `session_started` | セッション開始 |
+| PostToolUse | `command_executed` | ツール実行 |
+| Stop | `session_ended` | セッション終了（SessionEnd ではなく Stop を使用） |
+
+**制限**: `compact` hooks なし、`prompt` 記録なし、failure 専用イベントなし。
+
+### Gemini CLI (Tier 3: 基本対応)
+
+```
+SessionStart → [AfterTool]* → SessionEnd
+```
+
+| Hook イベント | Traceary イベント種別 | 説明 |
+|---|---|---|
+| SessionStart | `session_started` | セッション開始 |
+| AfterTool | `command_executed` | ツール実行 |
+| SessionEnd | `session_ended` | セッション終了 |
+
+**制限**: `compact` hooks なし、`prompt` 記録なし、failure 専用イベントなし。
+
+## イベント種別
+
+| 種別 | 説明 | ソース |
+|------|------|--------|
+| `note` | 自由テキストログ | CLI `traceary log` / MCP `add_log` |
+| `command_executed` | コマンド・ツール実行記録 | PostToolUse hooks |
+| `reviewed` | レビュー結果 | CLI / MCP |
+| `session_started` | セッション開始境界 | SessionStart hooks |
+| `session_ended` | セッション終了境界 | SessionEnd / Stop hooks |
+| `compact_summary` | コンテキスト圧縮時の構造化サマリー | PostCompact hook |
+| `prompt` | ユーザーの指示テキスト | UserPromptSubmit hook |
+
+## データフロー
+
+```
+AI クライアント (Claude Code / Codex CLI / Gemini CLI)
+  │
+  ├─ Hook / Extension イベント
+  │    │
+  │    ▼
+  │  traceary-*.sh (bash スクリプト: ~/.config/traceary/hook-scripts/)
+  │    │
+  │    ▼
+  │  traceary CLI (log / audit / session start|end)
+  │    │
+  │    ▼
+  │  SQLite (~/.config/traceary/traceary.db)
+  │
+  └─ MCP server (stdio トランスポート)
+       │
+       ▼
+     traceary mcp-server → SQLite
+```
+
+## Hook スクリプトマッピング
+
+| スクリプト | 用途 | 対応クライアント |
+|------------|------|------------------|
+| `traceary-session.sh` | セッション開始・終了 | 全クライアント |
+| `traceary-audit.sh` | コマンド・ツール監査 | 全クライアント |
+| `traceary-compact.sh` | compact サマリー記録 | Claude Code |
+| `traceary-prompt.sh` | ユーザー prompt 記録 | Claude Code |
+| `common.sh` | 共通ヘルパー関数 | 全クライアント |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,96 @@
+# Event Lifecycle
+
+[日本語](./lifecycle.ja.md)
+
+This document describes how Traceary records events across different AI agent clients.
+
+## Client Lifecycles
+
+### Claude Code (Tier 1: Full)
+
+```
+SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCompact →)* → SessionEnd
+```
+
+| Hook Event | Matcher | Traceary Event Kind | Description |
+|---|---|---|---|
+| SessionStart | `*` | `session_started` | Session start with workspace resolution |
+| SessionStart | `compact` | — | Inject compact-summary into new context (stdout) |
+| UserPromptSubmit | `*` | `prompt` | User instruction text |
+| PostToolUse | `Bash` | `command_executed` | Shell command with input/output/exit code |
+| PostToolUse | `mcp__.*` | `command_executed` | MCP tool invocation |
+| PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | Failed tool execution (filterable via `failures_only`) |
+| PostCompact | `*` | `compact_summary` | Structured summary on context compression |
+| SessionEnd | `*` | `session_ended` | Session end |
+
+### Codex CLI (Tier 2: Partial)
+
+```
+SessionStart → [PostToolUse]* → Stop
+```
+
+| Hook Event | Traceary Event Kind | Description |
+|---|---|---|
+| SessionStart | `session_started` | Session start |
+| PostToolUse | `command_executed` | Tool execution |
+| Stop | `session_ended` | Session end (uses Stop instead of SessionEnd) |
+
+**Limitations**: No `compact` hooks, no `prompt` recording, no failure-specific events.
+
+### Gemini CLI (Tier 3: Basic)
+
+```
+SessionStart → [AfterTool]* → SessionEnd
+```
+
+| Hook Event | Traceary Event Kind | Description |
+|---|---|---|
+| SessionStart | `session_started` | Session start |
+| AfterTool | `command_executed` | Tool execution |
+| SessionEnd | `session_ended` | Session end |
+
+**Limitations**: No `compact` hooks, no `prompt` recording, no failure-specific events.
+
+## Event Kinds
+
+| Kind | Description | Source |
+|------|-------------|--------|
+| `note` | Free-text log entry | CLI `traceary log` / MCP `add_log` |
+| `command_executed` | Command or tool execution record | PostToolUse hooks |
+| `reviewed` | Review result | CLI / MCP |
+| `session_started` | Session start boundary | SessionStart hooks |
+| `session_ended` | Session end boundary | SessionEnd / Stop hooks |
+| `compact_summary` | Structured summary from context compression | PostCompact hook |
+| `prompt` | User instruction text | UserPromptSubmit hook |
+
+## Data Flow
+
+```
+AI Client (Claude Code / Codex CLI / Gemini CLI)
+  │
+  ├─ Hook / Extension event
+  │    │
+  │    ▼
+  │  traceary-*.sh (bash scripts in ~/.config/traceary/hook-scripts/)
+  │    │
+  │    ▼
+  │  traceary CLI (log / audit / session start|end)
+  │    │
+  │    ▼
+  │  SQLite (~/.config/traceary/traceary.db)
+  │
+  └─ MCP server (stdio transport)
+       │
+       ▼
+     traceary mcp-server → SQLite
+```
+
+## Hook Script Mapping
+
+| Script | Purpose | Clients |
+|--------|---------|---------|
+| `traceary-session.sh` | Session start/end | All |
+| `traceary-audit.sh` | Command/tool audit | All |
+| `traceary-compact.sh` | Compact summary recording | Claude Code |
+| `traceary-prompt.sh` | User prompt recording | Claude Code |
+| `common.sh` | Shared helper functions | All |


### PR DESCRIPTION
## Summary
- Add `docs/lifecycle.md` and `docs/lifecycle.ja.md` (bilingual pair)
- Document AI client lifecycles: Claude Code (Tier 1), Codex CLI (Tier 2), Gemini CLI (Tier 3)
- Event kind reference table with all 7 kinds
- Data flow diagram: AI Client → hooks → CLI → SQLite
- Hook script mapping table

Closes #429

## Test plan
- [x] `python3 scripts/verify_docs_i18n.py` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)