### PR TITLE
fix: use traceary_resolve_agent in compact hook

### DIFF
--- a/integrations/claude-plugin/scripts/traceary-compact.sh
+++ b/integrations/claude-plugin/scripts/traceary-compact.sh
@@ -32,11 +32,12 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMPACT_SUMMARY="$(traceary_json_get 'compact_summary')"
       WORKSPACE="$(traceary_resolve_effective_workspace "$CLIENT")"
+      AGENT="$(traceary_resolve_agent "$CLIENT")"
 
       if [[ -n "$COMPACT_SUMMARY" ]]; then
-        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$AGENT" --session-id "$SESSION_ID")
       else
-        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$AGENT" --session-id "$SESSION_ID")
       fi
       if [[ -n "$WORKSPACE" ]]; then
         COMMAND+=(--workspace "$WORKSPACE")

--- a/scripts/hooks/traceary-compact.sh
+++ b/scripts/hooks/traceary-compact.sh
@@ -32,11 +32,12 @@ case "$ACTION" in
     if [[ -n "$SESSION_ID" ]]; then
       COMPACT_SUMMARY="$(traceary_json_get 'compact_summary')"
       WORKSPACE="$(traceary_resolve_effective_workspace "$CLIENT")"
+      AGENT="$(traceary_resolve_agent "$CLIENT")"
 
       if [[ -n "$COMPACT_SUMMARY" ]]; then
-        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+        COMMAND=("$TRACEARY_CMD" log "$COMPACT_SUMMARY" --kind compact_summary --client hook --agent "$AGENT" --session-id "$SESSION_ID")
       else
-        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$CLIENT" --session-id "$SESSION_ID")
+        COMMAND=("$TRACEARY_CMD" log "compact triggered" --client hook --agent "$AGENT" --session-id "$SESSION_ID")
       fi
       if [[ -n "$WORKSPACE" ]]; then
         COMMAND+=(--workspace "$WORKSPACE")


### PR DESCRIPTION
## Summary
- Use `traceary_resolve_agent` instead of raw `$CLIENT` in `traceary-compact.sh`

Closes #436

## Test plan
- [x] `go test ./...` ✅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)