### PR TITLE
fix: add missing SessionStart(compact) and mcp matchers to generated hooks

### DIFF
--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -374,6 +374,7 @@ func buildClaudeHooksSettings(scriptsDir string, tracearyBin string) *hooksSetti
 	endCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-session.sh", "claude", "end")
 	auditCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-audit.sh", "claude")
 	compactCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-compact.sh", "claude", "post-compact")
+	compactResumeCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-compact.sh", "claude", "session-start-compact")
 	promptCommand := buildHookScriptCommand(scriptsDir, tracearyBin, "traceary-prompt.sh", "claude")
 
 	return &hooksSettings{
@@ -382,6 +383,10 @@ func buildClaudeHooksSettings(scriptsDir string, tracearyBin string) *hooksSetti
 				newHookMatcher("*", hookCommand{
 					Type:    "command",
 					Command: startCommand,
+				}),
+				newHookMatcher("compact", hookCommand{
+					Type:    "command",
+					Command: compactResumeCommand,
 				}),
 			},
 			"SessionEnd": {
@@ -395,9 +400,17 @@ func buildClaudeHooksSettings(scriptsDir string, tracearyBin string) *hooksSetti
 					Type:    "command",
 					Command: auditCommand,
 				}),
+				newHookMatcher("mcp__.*", hookCommand{
+					Type:    "command",
+					Command: auditCommand,
+				}),
 			},
 			"PostToolUseFailure": {
 				newHookMatcher("Bash", hookCommand{
+					Type:    "command",
+					Command: auditCommand,
+				}),
+				newHookMatcher("mcp__.*", hookCommand{
 					Type:    "command",
 					Command: auditCommand,
 				}),

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -42,9 +42,22 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 			`TRACEARY_BIN='/tmp/traceary bin/traceary' bash '`+filepath.Join(scriptsDir, "traceary-session.sh")+`' 'claude' 'start'`; got != want {
 			t.Fatalf("SessionStart command = %q, want %q", got, want)
 		}
+		if got, want := *settings.Hooks["SessionStart"][1].Matcher, "compact"; got != want {
+			t.Fatalf("SessionStart[1] matcher = %q, want %q", got, want)
+		}
+		if got, want := settings.Hooks["SessionStart"][1].Hooks[0].Command,
+			`TRACEARY_BIN='/tmp/traceary bin/traceary' bash '`+filepath.Join(scriptsDir, "traceary-compact.sh")+`' 'claude' 'session-start-compact'`; got != want {
+			t.Fatalf("SessionStart[1] command = %q, want %q", got, want)
+		}
+		if got, want := *settings.Hooks["PostToolUse"][1].Matcher, "mcp__.*"; got != want {
+			t.Fatalf("PostToolUse[1] matcher = %q, want %q", got, want)
+		}
 		if got, want := settings.Hooks["PostToolUseFailure"][0].Hooks[0].Command,
 			`TRACEARY_BIN='/tmp/traceary bin/traceary' bash '`+filepath.Join(scriptsDir, "traceary-audit.sh")+`' 'claude'`; got != want {
 			t.Fatalf("PostToolUseFailure command = %q, want %q", got, want)
+		}
+		if got, want := *settings.Hooks["PostToolUseFailure"][1].Matcher, "mcp__.*"; got != want {
+			t.Fatalf("PostToolUseFailure[1] matcher = %q, want %q", got, want)
 		}
 		if got, want := *settings.Hooks["PostCompact"][0].Matcher, "*"; got != want {
 			t.Fatalf("PostCompact matcher = %q, want %q", got, want)


### PR DESCRIPTION
## Summary
- Add `SessionStart` compact matcher for context resume after compact
- Add `PostToolUse` and `PostToolUseFailure` `mcp__.*` matchers for MCP tool audit
- Aligns `traceary hooks print --client claude` with plugin `hooks.json` and `contract.md`

Closes #437

## Test plan
- [x] `go test ./...` ✅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)