### PR TITLE
refactor: remove unused BlockNum from port.TimelineBlock

### DIFF
--- a/domain/port/query.go
+++ b/domain/port/query.go
@@ -166,7 +166,6 @@ type SessionSummaryFinder interface {
 
 // TimelineBlock represents a contiguous work block separated by idle gaps.
 type TimelineBlock struct {
-	BlockNum   int
 	BlockStart time.Time
 	BlockEnd   time.Time
 	EventCount int

--- a/infrastructure/sqlite/timeline_store.go
+++ b/infrastructure/sqlite/timeline_store.go
@@ -60,7 +60,7 @@ func (d *Datasource) ListTimelineBlocks(
 	var blocks []*port.TimelineBlock
 	for rows.Next() {
 		var (
-			blockNum   int
+			blockNum   int // scanned but unused (SQL internal grouping key)
 			blockStart string
 			blockEnd   string
 			eventCount int
@@ -82,7 +82,6 @@ func (d *Datasource) ListTimelineBlocks(
 		}
 
 		blocks = append(blocks, &port.TimelineBlock{
-			BlockNum:   blockNum,
 			BlockStart: parsedStart,
 			BlockEnd:   parsedEnd,
 			EventCount: eventCount,


### PR DESCRIPTION
## Summary
- Remove `BlockNum` from `port.TimelineBlock` (internal SQL key, not exposed)
- Align port and usecase TimelineBlock structures

Closes #442

## Test plan
- [x] `go test ./...` ✅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)