### PR TITLE
docs: document prompt/compact_summary raw storage in privacy posture

### DIFF
--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -69,6 +69,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 - Traceary はホスト型サービスを前提にしていません
 - Traceary 自身の backend へ telemetry を送信しません
 - `traceary audit` の payload は、redaction / truncation がかからない限り、ローカル SQLite store に保存されます
+- `prompt` イベント（`UserPromptSubmit` hook 経由）と `compact_summary` イベント（`PostCompact` hook 経由）は、redaction / truncation なしでそのまま保存されます — ユーザーの意図を記録することが Traceary の目的であるため、これは設計上の選択です
 - secret redaction はベストエフォートであり、完全な DLP ではありません
 
 ## 関連ドキュメント

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -69,6 +69,7 @@ If the file exists but is unreadable or invalid JSON, Traceary falls back to the
 - Traceary has no hosted service requirement
 - Traceary does not send telemetry to a Traceary-owned backend
 - when you run `traceary audit`, payloads are written to your local SQLite store unless redaction or truncation changes them first
+- `prompt` events (from `UserPromptSubmit` hooks) and `compact_summary` events (from `PostCompact` hooks) are stored as-is without redaction or truncation — this is by design, as recording the user's intent is a core purpose of Traceary
 - secret redaction is best effort, not a complete data-loss-prevention system
 
 ## Related docs


### PR DESCRIPTION
## Summary
- Add prompt/compact_summary raw storage clarification to Privacy posture section
- Bilingual update (en + ja)

Closes #443

## Test plan
- [x] `scripts/verify_docs_i18n.py` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)