### PR TITLE
feat: add durable memory domain model

### DIFF
--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -1,0 +1,210 @@
+package model
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// Memory is the aggregate root for durable memory in Traceary.
+type Memory struct {
+	memoryID     types.MemoryID
+	memoryType   types.MemoryType
+	scope        types.MemoryScope
+	fact         string
+	status       types.MemoryStatus
+	confidence   types.Confidence
+	source       types.MemorySource
+	evidenceRefs []types.EvidenceRef
+	artifactRefs []types.ArtifactRef
+	supersedes   types.Optional[types.MemoryID]
+	expiresAt    types.Optional[time.Time]
+	createdAt    time.Time
+	updatedAt    time.Time
+}
+
+// NewMemoryCandidate creates a candidate memory.
+func NewMemoryCandidate(
+	memoryID types.MemoryID,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+) (*Memory, error) {
+	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusCandidate, types.ConfidenceLow, source, evidenceRefs, artifactRefs, supersedes, types.Empty[time.Time]())
+}
+
+// NewAcceptedMemory creates an accepted memory.
+func NewAcceptedMemory(
+	memoryID types.MemoryID,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	confidence types.Confidence,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+) (*Memory, error) {
+	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusAccepted, confidence, source, evidenceRefs, artifactRefs, supersedes, types.Empty[time.Time]())
+}
+
+func newMemory(
+	memoryID types.MemoryID,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	status types.MemoryStatus,
+	confidence types.Confidence,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+	expiresAt types.Optional[time.Time],
+) (*Memory, error) {
+	trimmedFact := strings.TrimSpace(fact)
+	if trimmedFact == "" {
+		return nil, xerrors.Errorf("memory fact must not be empty")
+	}
+	if scope == nil {
+		return nil, xerrors.Errorf("memory scope must not be nil")
+	}
+
+	now := nowFunc()
+	return &Memory{
+		memoryID:     memoryID,
+		memoryType:   memoryType,
+		scope:        scope,
+		fact:         trimmedFact,
+		status:       status,
+		confidence:   confidence,
+		source:       source,
+		evidenceRefs: slices.Clone(evidenceRefs),
+		artifactRefs: slices.Clone(artifactRefs),
+		supersedes:   supersedes,
+		expiresAt:    expiresAt,
+		createdAt:    now,
+		updatedAt:    now,
+	}, nil
+}
+
+// MemoryOf restores a Memory from persisted values.
+func MemoryOf(
+	memoryID types.MemoryID,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	status types.MemoryStatus,
+	confidence types.Confidence,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+	expiresAt types.Optional[time.Time],
+	createdAt time.Time,
+	updatedAt time.Time,
+) *Memory {
+	return &Memory{
+		memoryID:     memoryID,
+		memoryType:   memoryType,
+		scope:        scope,
+		fact:         fact,
+		status:       status,
+		confidence:   confidence,
+		source:       source,
+		evidenceRefs: slices.Clone(evidenceRefs),
+		artifactRefs: slices.Clone(artifactRefs),
+		supersedes:   supersedes,
+		expiresAt:    expiresAt,
+		createdAt:    createdAt,
+		updatedAt:    updatedAt,
+	}
+}
+
+// MemoryID returns the memory ID.
+func (m *Memory) MemoryID() types.MemoryID { return m.memoryID }
+
+// MemoryType returns the memory type.
+func (m *Memory) MemoryType() types.MemoryType { return m.memoryType }
+
+// Scope returns the memory scope.
+func (m *Memory) Scope() types.MemoryScope { return m.scope }
+
+// Fact returns the distilled fact stored in the memory.
+func (m *Memory) Fact() string { return m.fact }
+
+// Status returns the lifecycle status.
+func (m *Memory) Status() types.MemoryStatus { return m.status }
+
+// Confidence returns the memory confidence.
+func (m *Memory) Confidence() types.Confidence { return m.confidence }
+
+// Source returns the source attribution for the memory.
+func (m *Memory) Source() types.MemorySource { return m.source }
+
+// EvidenceRefs returns the evidence references.
+func (m *Memory) EvidenceRefs() []types.EvidenceRef { return slices.Clone(m.evidenceRefs) }
+
+// ArtifactRefs returns the artifact references.
+func (m *Memory) ArtifactRefs() []types.ArtifactRef { return slices.Clone(m.artifactRefs) }
+
+// Supersedes returns the previous memory ID superseded by this memory, when present.
+func (m *Memory) Supersedes() types.Optional[types.MemoryID] { return m.supersedes }
+
+// ExpiresAt returns the expiry time, if present.
+func (m *Memory) ExpiresAt() types.Optional[time.Time] { return m.expiresAt }
+
+// CreatedAt returns when the memory was created.
+func (m *Memory) CreatedAt() time.Time { return m.createdAt }
+
+// UpdatedAt returns when the memory was last updated.
+func (m *Memory) UpdatedAt() time.Time { return m.updatedAt }
+
+// Accept transitions a candidate memory to accepted.
+func (m *Memory) Accept(confidence types.Confidence) error {
+	if m.status != types.MemoryStatusCandidate {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusAccepted
+	m.confidence = confidence
+	m.updatedAt = nowFunc()
+	return nil
+}
+
+// Reject transitions a candidate memory to rejected.
+func (m *Memory) Reject() error {
+	if m.status != types.MemoryStatusCandidate {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusRejected
+	m.updatedAt = nowFunc()
+	return nil
+}
+
+// MarkSuperseded transitions an accepted memory to superseded.
+func (m *Memory) MarkSuperseded() error {
+	if m.status != types.MemoryStatusAccepted {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusSuperseded
+	m.updatedAt = nowFunc()
+	return nil
+}
+
+// Expire transitions an active memory to expired.
+func (m *Memory) Expire(expiresAt time.Time) error {
+	if m.status != types.MemoryStatusCandidate && m.status != types.MemoryStatusAccepted {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusExpired
+	m.expiresAt = types.Of(expiresAt)
+	m.updatedAt = nowFunc()
+	return nil
+}

--- a/domain/model/memory_errors.go
+++ b/domain/model/memory_errors.go
@@ -1,0 +1,7 @@
+package model
+
+import "golang.org/x/xerrors"
+
+// ErrInvalidMemoryState indicates that an operation cannot be performed
+// because the memory aggregate is in an unexpected lifecycle state.
+var ErrInvalidMemoryState = xerrors.New("invalid memory state")

--- a/domain/model/memory_repository.go
+++ b/domain/model/memory_repository.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryRepository persists Memory aggregates.
+type MemoryRepository interface {
+	// Save persists a memory aggregate.
+	Save(ctx context.Context, memory *Memory) error
+	// FindByID returns the memory for the given ID.
+	// Returns an empty Optional when the memory does not exist.
+	FindByID(ctx context.Context, memoryID types.MemoryID) (types.Optional[*Memory], error)
+}

--- a/domain/model/memory_test.go
+++ b/domain/model/memory_test.go
@@ -1,0 +1,275 @@
+package model_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestNewMemoryCandidate(t *testing.T) {
+	now := time.Date(2026, 4, 13, 9, 0, 0, 0, time.UTC)
+	model.SetNowFunc(func() time.Time { return now })
+	defer model.ResetNowFunc()
+
+	memoryID, _ := types.MemoryIDOf("mem-1")
+	evidence, _ := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-1")
+	artifact, _ := types.ArtifactRefOf(types.ArtifactRefKindURL, "https://example.com/docs")
+	memory, err := model.NewMemoryCandidate(
+		memoryID,
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+		"  Release issues close only after tagged release  ",
+		types.MemorySourceExtracted,
+		[]types.EvidenceRef{evidence},
+		[]types.ArtifactRef{artifact},
+		types.Empty[types.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewMemoryCandidate() error = %v", err)
+	}
+
+	if diff := cmp.Diff(memoryID, memory.MemoryID()); diff != "" {
+		t.Errorf("MemoryID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.MemoryTypeDecision, memory.MemoryType()); diff != "" {
+		t.Errorf("MemoryType() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("Release issues close only after tagged release", memory.Fact()); diff != "" {
+		t.Errorf("Fact() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.MemoryStatusCandidate, memory.Status()); diff != "" {
+		t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.ConfidenceLow, memory.Confidence()); diff != "" {
+		t.Errorf("Confidence() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.MemorySourceExtracted, memory.Source()); diff != "" {
+		t.Errorf("Source() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(now, memory.CreatedAt()); diff != "" {
+		t.Errorf("CreatedAt() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(now, memory.UpdatedAt()); diff != "" {
+		t.Errorf("UpdatedAt() mismatch (-want +got):\n%s", diff)
+	}
+	evidenceRefsGot := memory.EvidenceRefs()
+	if len(evidenceRefsGot) != 1 {
+		t.Fatalf("len(EvidenceRefs()) = %d, want 1", len(evidenceRefsGot))
+	}
+	if evidenceRefsGot[0].Kind() != evidence.Kind() || evidenceRefsGot[0].Value() != evidence.Value() {
+		t.Fatalf("EvidenceRefs()[0] = (%s, %s), want (%s, %s)", evidenceRefsGot[0].Kind(), evidenceRefsGot[0].Value(), evidence.Kind(), evidence.Value())
+	}
+	artifactRefsGot := memory.ArtifactRefs()
+	if len(artifactRefsGot) != 1 {
+		t.Fatalf("len(ArtifactRefs()) = %d, want 1", len(artifactRefsGot))
+	}
+	if artifactRefsGot[0].Kind() != artifact.Kind() || artifactRefsGot[0].Value() != artifact.Value() {
+		t.Fatalf("ArtifactRefs()[0] = (%s, %s), want (%s, %s)", artifactRefsGot[0].Kind(), artifactRefsGot[0].Value(), artifact.Kind(), artifact.Value())
+	}
+}
+
+func TestNewAcceptedMemory(t *testing.T) {
+	t.Parallel()
+
+	memoryID, _ := types.MemoryIDOf("mem-2")
+	previousID, _ := types.MemoryIDOf("mem-1")
+	memory, err := model.NewAcceptedMemory(
+		memoryID,
+		types.MemoryTypePreference,
+		types.AgentScopeOf(types.Agent("codex")),
+		"Use English for CLI output",
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		nil,
+		nil,
+		types.Of(previousID),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+
+	if diff := cmp.Diff(types.MemoryStatusAccepted, memory.Status()); diff != "" {
+		t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.ConfidenceVerified, memory.Confidence()); diff != "" {
+		t.Errorf("Confidence() mismatch (-want +got):\n%s", diff)
+	}
+	if supersedes, ok := memory.Supersedes().Get(); !ok {
+		t.Fatalf("Supersedes() should be present")
+	} else if diff := cmp.Diff(previousID, supersedes); diff != "" {
+		t.Errorf("Supersedes() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemory_StateTransitions(t *testing.T) {
+	t.Parallel()
+
+	newCandidate := func(t *testing.T) *model.Memory {
+		t.Helper()
+		memoryID, _ := types.MemoryIDOf("mem-transition")
+		memory, err := model.NewMemoryCandidate(
+			memoryID,
+			types.MemoryTypeLesson,
+			types.SessionFamilyScopeOf(types.SessionID("session-family-1")),
+			"Remember to rerun lint after hook changes",
+			types.MemorySourceExtracted,
+			nil,
+			nil,
+			types.Empty[types.MemoryID](),
+		)
+		if err != nil {
+			t.Fatalf("NewMemoryCandidate() error = %v", err)
+		}
+		return memory
+	}
+
+	t.Run("accepts candidate memory", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Accept(types.ConfidenceHigh); err != nil {
+			t.Fatalf("Accept() error = %v", err)
+		}
+		if diff := cmp.Diff(types.MemoryStatusAccepted, memory.Status()); diff != "" {
+			t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(types.ConfidenceHigh, memory.Confidence()); diff != "" {
+			t.Errorf("Confidence() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("rejects candidate memory", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Reject(); err != nil {
+			t.Fatalf("Reject() error = %v", err)
+		}
+		if diff := cmp.Diff(types.MemoryStatusRejected, memory.Status()); diff != "" {
+			t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("marks accepted memory as superseded", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Accept(types.ConfidenceMedium); err != nil {
+			t.Fatalf("Accept() error = %v", err)
+		}
+		if err := memory.MarkSuperseded(); err != nil {
+			t.Fatalf("MarkSuperseded() error = %v", err)
+		}
+		if diff := cmp.Diff(types.MemoryStatusSuperseded, memory.Status()); diff != "" {
+			t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("expires accepted memory", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Accept(types.ConfidenceMedium); err != nil {
+			t.Fatalf("Accept() error = %v", err)
+		}
+		expiresAt := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+		if err := memory.Expire(expiresAt); err != nil {
+			t.Fatalf("Expire() error = %v", err)
+		}
+		if diff := cmp.Diff(types.MemoryStatusExpired, memory.Status()); diff != "" {
+			t.Errorf("Status() mismatch (-want +got):\n%s", diff)
+		}
+		if got, ok := memory.ExpiresAt().Get(); !ok {
+			t.Fatalf("ExpiresAt() should be present")
+		} else if diff := cmp.Diff(expiresAt, got); diff != "" {
+			t.Errorf("ExpiresAt() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("rejecting accepted memory returns invalid state", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Accept(types.ConfidenceMedium); err != nil {
+			t.Fatalf("Accept() error = %v", err)
+		}
+		err := memory.Reject()
+		if !errors.Is(err, model.ErrInvalidMemoryState) {
+			t.Fatalf("Reject() error = %v, want ErrInvalidMemoryState", err)
+		}
+	})
+
+	t.Run("accepting rejected memory returns invalid state", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Reject(); err != nil {
+			t.Fatalf("Reject() error = %v", err)
+		}
+		err := memory.Accept(types.ConfidenceHigh)
+		if !errors.Is(err, model.ErrInvalidMemoryState) {
+			t.Fatalf("Accept() error = %v, want ErrInvalidMemoryState", err)
+		}
+	})
+
+	t.Run("superseding candidate memory returns invalid state", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		err := memory.MarkSuperseded()
+		if !errors.Is(err, model.ErrInvalidMemoryState) {
+			t.Fatalf("MarkSuperseded() error = %v, want ErrInvalidMemoryState", err)
+		}
+	})
+
+	t.Run("expiring rejected memory returns invalid state", func(t *testing.T) {
+		t.Parallel()
+		memory := newCandidate(t)
+		if err := memory.Reject(); err != nil {
+			t.Fatalf("Reject() error = %v", err)
+		}
+		err := memory.Expire(time.Date(2026, 4, 14, 15, 0, 0, 0, time.UTC))
+		if !errors.Is(err, model.ErrInvalidMemoryState) {
+			t.Fatalf("Expire() error = %v, want ErrInvalidMemoryState", err)
+		}
+	})
+}
+
+func TestNewMemoryCandidate_ClonesSlices(t *testing.T) {
+	t.Parallel()
+
+	memoryID, _ := types.MemoryIDOf("mem-clone")
+	evidence, _ := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-9")
+	artifact, _ := types.ArtifactRefOf(types.ArtifactRefKindFile, "docs/spec.md")
+	evidenceRefs := []types.EvidenceRef{evidence}
+	artifactRefs := []types.ArtifactRef{artifact}
+	memory, err := model.NewMemoryCandidate(
+		memoryID,
+		types.MemoryTypeConstraint,
+		types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+		"Keep CLI messages in English",
+		types.MemorySourceManual,
+		evidenceRefs,
+		artifactRefs,
+		types.Empty[types.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewMemoryCandidate() error = %v", err)
+	}
+
+	evidenceRefs[0] = types.EvidenceRef{}
+	artifactRefs[0] = types.ArtifactRef{}
+
+	evidenceRefsGot := memory.EvidenceRefs()
+	if len(evidenceRefsGot) != 1 {
+		t.Fatalf("len(EvidenceRefs()) = %d, want 1", len(evidenceRefsGot))
+	}
+	if evidenceRefsGot[0].Kind() != evidence.Kind() || evidenceRefsGot[0].Value() != evidence.Value() {
+		t.Fatalf("EvidenceRefs()[0] = (%s, %s), want (%s, %s)", evidenceRefsGot[0].Kind(), evidenceRefsGot[0].Value(), evidence.Kind(), evidence.Value())
+	}
+	artifactRefsGot := memory.ArtifactRefs()
+	if len(artifactRefsGot) != 1 {
+		t.Fatalf("len(ArtifactRefs()) = %d, want 1", len(artifactRefsGot))
+	}
+	if artifactRefsGot[0].Kind() != artifact.Kind() || artifactRefsGot[0].Value() != artifact.Value() {
+		t.Fatalf("ArtifactRefs()[0] = (%s, %s), want (%s, %s)", artifactRefsGot[0].Kind(), artifactRefsGot[0].Value(), artifact.Kind(), artifact.Value())
+	}
+}

--- a/domain/types/artifact_ref.go
+++ b/domain/types/artifact_ref.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// ArtifactRefKind classifies artifact references.
+type ArtifactRefKind string
+
+const (
+	// ArtifactRefKindURL references a URL.
+	ArtifactRefKindURL ArtifactRefKind = "url"
+	// ArtifactRefKindFile references a file.
+	ArtifactRefKindFile ArtifactRefKind = "file"
+	// ArtifactRefKindIssue references an issue.
+	ArtifactRefKindIssue ArtifactRefKind = "issue"
+	// ArtifactRefKindPR references a pull request.
+	ArtifactRefKindPR ArtifactRefKind = "pr"
+)
+
+var knownArtifactRefKinds = []ArtifactRefKind{
+	ArtifactRefKindURL,
+	ArtifactRefKindFile,
+	ArtifactRefKindIssue,
+	ArtifactRefKindPR,
+}
+
+// ArtifactRef stores a reference to an artifact related to a memory.
+type ArtifactRef struct {
+	kind  ArtifactRefKind
+	value string
+}
+
+// ArtifactRefKindOf creates an ArtifactRefKind from a string.
+func ArtifactRefKindOf(value string) (ArtifactRefKind, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return ArtifactRefKind(""), xerrors.Errorf("artifact ref kind must not be empty")
+	}
+	if slices.Contains(knownArtifactRefKinds, ArtifactRefKind(trimmedValue)) {
+		return ArtifactRefKind(trimmedValue), nil
+	}
+	return ArtifactRefKind(""), xerrors.Errorf("unknown artifact ref kind: %s", trimmedValue)
+}
+
+// ArtifactRefOf creates an ArtifactRef.
+func ArtifactRefOf(kind ArtifactRefKind, value string) (ArtifactRef, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return ArtifactRef{}, xerrors.Errorf("artifact ref value must not be empty")
+	}
+	if _, err := ArtifactRefKindOf(kind.String()); err != nil {
+		return ArtifactRef{}, err
+	}
+	return ArtifactRef{kind: kind, value: trimmedValue}, nil
+}
+
+// Kind returns the artifact ref kind.
+func (a ArtifactRef) Kind() ArtifactRefKind { return a.kind }
+
+// Value returns the artifact ref value.
+func (a ArtifactRef) Value() string { return a.value }
+
+// String returns the string representation.
+func (a ArtifactRefKind) String() string { return string(a) }

--- a/domain/types/artifact_ref_test.go
+++ b/domain/types/artifact_ref_test.go
@@ -1,0 +1,33 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestArtifactRefOf(t *testing.T) {
+	t.Parallel()
+
+	ref, err := types.ArtifactRefOf(types.ArtifactRefKindFile, "docs/spec.md")
+	if err != nil {
+		t.Fatalf("ArtifactRefOf() error = %v", err)
+	}
+	if ref.Kind() != types.ArtifactRefKindFile {
+		t.Fatalf("Kind() = %v, want %v", ref.Kind(), types.ArtifactRefKindFile)
+	}
+	if ref.Value() != "docs/spec.md" {
+		t.Fatalf("Value() = %q, want %q", ref.Value(), "docs/spec.md")
+	}
+}
+
+func TestArtifactRefOf_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	if _, err := types.ArtifactRefOf(types.ArtifactRefKind(""), "value"); err == nil {
+		t.Fatalf("ArtifactRefOf() error = nil, want error for empty kind")
+	}
+	if _, err := types.ArtifactRefOf(types.ArtifactRefKindFile, " "); err == nil {
+		t.Fatalf("ArtifactRefOf() error = nil, want error for empty value")
+	}
+}

--- a/domain/types/confidence.go
+++ b/domain/types/confidence.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// Confidence represents confidence in a durable memory.
+type Confidence string
+
+const (
+	// ConfidenceLow indicates weak confidence.
+	ConfidenceLow Confidence = "low"
+	// ConfidenceMedium indicates moderate confidence.
+	ConfidenceMedium Confidence = "medium"
+	// ConfidenceHigh indicates strong confidence.
+	ConfidenceHigh Confidence = "high"
+	// ConfidenceVerified indicates externally or manually verified confidence.
+	ConfidenceVerified Confidence = "verified"
+)
+
+var knownConfidenceLevels = []Confidence{
+	ConfidenceLow,
+	ConfidenceMedium,
+	ConfidenceHigh,
+	ConfidenceVerified,
+}
+
+// ConfidenceOf creates a Confidence from a string.
+func ConfidenceOf(value string) (Confidence, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return Confidence(""), xerrors.Errorf("confidence must not be empty")
+	}
+	if slices.Contains(knownConfidenceLevels, Confidence(trimmedValue)) {
+		return Confidence(trimmedValue), nil
+	}
+	return Confidence(""), xerrors.Errorf("unknown confidence: %s", trimmedValue)
+}
+
+// String returns the string representation.
+func (c Confidence) String() string { return string(c) }

--- a/domain/types/confidence_test.go
+++ b/domain/types/confidence_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestConfidenceOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    types.Confidence
+		wantErr bool
+	}{
+		{name: "low", input: "low", want: types.ConfidenceLow},
+		{name: "verified", input: "verified", want: types.ConfidenceVerified},
+		{name: "rejects empty", input: " ", wantErr: true},
+		{name: "rejects unknown", input: "certain", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.ConfidenceOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ConfidenceOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("ConfidenceOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/domain/types/evidence_ref.go
+++ b/domain/types/evidence_ref.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// EvidenceRefKind classifies evidence references.
+type EvidenceRefKind string
+
+const (
+	// EvidenceRefKindEvent references an event.
+	EvidenceRefKindEvent EvidenceRefKind = "event"
+	// EvidenceRefKindSession references a session.
+	EvidenceRefKindSession EvidenceRefKind = "session"
+	// EvidenceRefKindURL references a URL.
+	EvidenceRefKindURL EvidenceRefKind = "url"
+	// EvidenceRefKindFile references a file.
+	EvidenceRefKindFile EvidenceRefKind = "file"
+	// EvidenceRefKindIssue references an issue.
+	EvidenceRefKindIssue EvidenceRefKind = "issue"
+	// EvidenceRefKindPR references a pull request.
+	EvidenceRefKindPR EvidenceRefKind = "pr"
+)
+
+var knownEvidenceRefKinds = []EvidenceRefKind{
+	EvidenceRefKindEvent,
+	EvidenceRefKindSession,
+	EvidenceRefKindURL,
+	EvidenceRefKindFile,
+	EvidenceRefKindIssue,
+	EvidenceRefKindPR,
+}
+
+// EvidenceRef stores a reference that supports a durable memory.
+type EvidenceRef struct {
+	kind  EvidenceRefKind
+	value string
+}
+
+// EvidenceRefKindOf creates an EvidenceRefKind from a string.
+func EvidenceRefKindOf(value string) (EvidenceRefKind, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return EvidenceRefKind(""), xerrors.Errorf("evidence ref kind must not be empty")
+	}
+	if slices.Contains(knownEvidenceRefKinds, EvidenceRefKind(trimmedValue)) {
+		return EvidenceRefKind(trimmedValue), nil
+	}
+	return EvidenceRefKind(""), xerrors.Errorf("unknown evidence ref kind: %s", trimmedValue)
+}
+
+// EvidenceRefOf creates an EvidenceRef.
+func EvidenceRefOf(kind EvidenceRefKind, value string) (EvidenceRef, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return EvidenceRef{}, xerrors.Errorf("evidence ref value must not be empty")
+	}
+	if _, err := EvidenceRefKindOf(kind.String()); err != nil {
+		return EvidenceRef{}, err
+	}
+	return EvidenceRef{kind: kind, value: trimmedValue}, nil
+}
+
+// Kind returns the evidence ref kind.
+func (e EvidenceRef) Kind() EvidenceRefKind { return e.kind }
+
+// Value returns the evidence ref value.
+func (e EvidenceRef) Value() string { return e.value }
+
+// String returns the string representation.
+func (e EvidenceRefKind) String() string { return string(e) }

--- a/domain/types/evidence_ref_test.go
+++ b/domain/types/evidence_ref_test.go
@@ -1,0 +1,33 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestEvidenceRefOf(t *testing.T) {
+	t.Parallel()
+
+	ref, err := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-123")
+	if err != nil {
+		t.Fatalf("EvidenceRefOf() error = %v", err)
+	}
+	if ref.Kind() != types.EvidenceRefKindEvent {
+		t.Fatalf("Kind() = %v, want %v", ref.Kind(), types.EvidenceRefKindEvent)
+	}
+	if ref.Value() != "event-123" {
+		t.Fatalf("Value() = %q, want %q", ref.Value(), "event-123")
+	}
+}
+
+func TestEvidenceRefOf_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	if _, err := types.EvidenceRefOf(types.EvidenceRefKind(""), "value"); err == nil {
+		t.Fatalf("EvidenceRefOf() error = nil, want error for empty kind")
+	}
+	if _, err := types.EvidenceRefOf(types.EvidenceRefKindEvent, " "); err == nil {
+		t.Fatalf("EvidenceRefOf() error = nil, want error for empty value")
+	}
+}

--- a/domain/types/memory_id.go
+++ b/domain/types/memory_id.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// MemoryID identifies a durable memory.
+type MemoryID string
+
+// MemoryIDOf creates a MemoryID from a string.
+func MemoryIDOf(value string) (MemoryID, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return MemoryID(""), xerrors.Errorf("memory ID must not be empty")
+	}
+	return MemoryID(trimmedValue), nil
+}
+
+// String returns the string representation.
+func (m MemoryID) String() string { return string(m) }

--- a/domain/types/memory_id_test.go
+++ b/domain/types/memory_id_test.go
@@ -1,0 +1,36 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryIDOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "accepts non-empty", input: "mem-1", want: "mem-1"},
+		{name: "trims whitespace", input: "  mem-2  ", want: "mem-2"},
+		{name: "rejects empty", input: " ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemoryIDOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryIDOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Fatalf("MemoryIDOf().String() = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}

--- a/domain/types/memory_scope.go
+++ b/domain/types/memory_scope.go
@@ -1,0 +1,142 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// MemoryScopeKind classifies typed memory scopes.
+type MemoryScopeKind string
+
+const (
+	// MemoryScopeKindWorkspace scopes memory to a workspace.
+	MemoryScopeKindWorkspace MemoryScopeKind = "workspace"
+	// MemoryScopeKindAgent scopes memory to an agent.
+	MemoryScopeKindAgent MemoryScopeKind = "agent"
+	// MemoryScopeKindSessionFamily scopes memory to a session family.
+	MemoryScopeKindSessionFamily MemoryScopeKind = "session_family"
+)
+
+var knownMemoryScopeKinds = []MemoryScopeKind{
+	MemoryScopeKindWorkspace,
+	MemoryScopeKindAgent,
+	MemoryScopeKindSessionFamily,
+}
+
+// MemoryScope is a sealed interface for durable memory scope values.
+type MemoryScope interface {
+	mustEmbedMemoryScope()
+	Kind() MemoryScopeKind
+	Key() string
+}
+
+// MemoryScopeKindOf creates a MemoryScopeKind from a string.
+func MemoryScopeKindOf(value string) (MemoryScopeKind, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return MemoryScopeKind(""), xerrors.Errorf("memory scope kind must not be empty")
+	}
+	if slices.Contains(knownMemoryScopeKinds, MemoryScopeKind(trimmedValue)) {
+		return MemoryScopeKind(trimmedValue), nil
+	}
+	return MemoryScopeKind(""), xerrors.Errorf("unknown memory scope kind: %s", trimmedValue)
+}
+
+// String returns the string representation.
+func (m MemoryScopeKind) String() string { return string(m) }
+
+// WorkspaceScope constrains memory to a workspace.
+type WorkspaceScope struct {
+	workspace Workspace
+}
+
+// WorkspaceScopeOf creates a WorkspaceScope.
+func WorkspaceScopeOf(workspace Workspace) WorkspaceScope {
+	return WorkspaceScope{workspace: workspace}
+}
+
+func (WorkspaceScope) mustEmbedMemoryScope() {}
+
+// Kind returns the scope kind.
+func (s WorkspaceScope) Kind() MemoryScopeKind { return MemoryScopeKindWorkspace }
+
+// Key returns the flattened key representation.
+func (s WorkspaceScope) Key() string { return s.workspace.String() }
+
+// Workspace returns the workspace value.
+func (s WorkspaceScope) Workspace() Workspace { return s.workspace }
+
+// AgentScope constrains memory to an agent.
+type AgentScope struct {
+	agent Agent
+}
+
+// AgentScopeOf creates an AgentScope.
+func AgentScopeOf(agent Agent) AgentScope {
+	return AgentScope{agent: agent}
+}
+
+func (AgentScope) mustEmbedMemoryScope() {}
+
+// Kind returns the scope kind.
+func (s AgentScope) Kind() MemoryScopeKind { return MemoryScopeKindAgent }
+
+// Key returns the flattened key representation.
+func (s AgentScope) Key() string { return s.agent.String() }
+
+// Agent returns the agent value.
+func (s AgentScope) Agent() Agent { return s.agent }
+
+// SessionFamilyScope constrains memory to a session family.
+type SessionFamilyScope struct {
+	sessionID SessionID
+}
+
+// SessionFamilyScopeOf creates a SessionFamilyScope.
+func SessionFamilyScopeOf(sessionID SessionID) SessionFamilyScope {
+	return SessionFamilyScope{sessionID: sessionID}
+}
+
+func (SessionFamilyScope) mustEmbedMemoryScope() {}
+
+// Kind returns the scope kind.
+func (s SessionFamilyScope) Kind() MemoryScopeKind { return MemoryScopeKindSessionFamily }
+
+// Key returns the flattened key representation.
+func (s SessionFamilyScope) Key() string { return s.sessionID.String() }
+
+// SessionID returns the session family identifier.
+func (s SessionFamilyScope) SessionID() SessionID { return s.sessionID }
+
+// MemoryScopeFrom restores a typed MemoryScope from persisted values.
+func MemoryScopeFrom(kind string, value string) (MemoryScope, error) {
+	resolvedKind, err := MemoryScopeKindOf(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resolvedKind {
+	case MemoryScopeKindWorkspace:
+		workspace, err := WorkspaceOf(value)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid workspace scope: %w", err)
+		}
+		return WorkspaceScopeOf(workspace), nil
+	case MemoryScopeKindAgent:
+		agent, err := AgentOf(value)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid agent scope: %w", err)
+		}
+		return AgentScopeOf(agent), nil
+	case MemoryScopeKindSessionFamily:
+		sessionID, err := SessionIDOf(value)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid session family scope: %w", err)
+		}
+		return SessionFamilyScopeOf(sessionID), nil
+	default:
+		return nil, xerrors.Errorf("unsupported memory scope kind: %s", resolvedKind)
+	}
+}

--- a/domain/types/memory_scope_test.go
+++ b/domain/types/memory_scope_test.go
@@ -1,0 +1,78 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryScopeKindOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    types.MemoryScopeKind
+		wantErr bool
+	}{
+		{name: "workspace", input: "workspace", want: types.MemoryScopeKindWorkspace},
+		{name: "agent", input: "agent", want: types.MemoryScopeKindAgent},
+		{name: "rejects empty", input: "", wantErr: true},
+		{name: "rejects unknown", input: "user", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemoryScopeKindOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryScopeKindOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("MemoryScopeKindOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemoryScopeFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		kind     string
+		value    string
+		wantKind types.MemoryScopeKind
+		wantKey  string
+		wantErr  bool
+	}{
+		{name: "workspace scope", kind: "workspace", value: "github.com/duck8823/traceary", wantKind: types.MemoryScopeKindWorkspace, wantKey: "github.com/duck8823/traceary"},
+		{name: "agent scope", kind: "agent", value: "codex", wantKind: types.MemoryScopeKindAgent, wantKey: "codex"},
+		{name: "session family scope", kind: "session_family", value: "session-123", wantKind: types.MemoryScopeKindSessionFamily, wantKey: "session-123"},
+		{name: "rejects unknown kind", kind: "user", value: "abc", wantErr: true},
+		{name: "rejects invalid value", kind: "workspace", value: " ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemoryScopeFrom(tt.kind, tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryScopeFrom() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tt.wantKind, got.Kind()); diff != "" {
+				t.Fatalf("Kind() mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantKey, got.Key()); diff != "" {
+				t.Fatalf("Key() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/domain/types/memory_source.go
+++ b/domain/types/memory_source.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// MemorySource describes how a durable memory was produced.
+type MemorySource string
+
+const (
+	// MemorySourceManual indicates a manually entered memory.
+	MemorySourceManual MemorySource = "manual"
+	// MemorySourceExtracted indicates a memory extracted from existing signals.
+	MemorySourceExtracted MemorySource = "extracted"
+	// MemorySourceImported indicates a memory imported from another source.
+	MemorySourceImported MemorySource = "imported"
+)
+
+var knownMemorySources = []MemorySource{
+	MemorySourceManual,
+	MemorySourceExtracted,
+	MemorySourceImported,
+}
+
+// MemorySourceOf creates a MemorySource from a string.
+func MemorySourceOf(value string) (MemorySource, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return MemorySource(""), xerrors.Errorf("memory source must not be empty")
+	}
+	if slices.Contains(knownMemorySources, MemorySource(trimmedValue)) {
+		return MemorySource(trimmedValue), nil
+	}
+	return MemorySource(""), xerrors.Errorf("unknown memory source: %s", trimmedValue)
+}
+
+// String returns the string representation.
+func (m MemorySource) String() string { return string(m) }

--- a/domain/types/memory_source_test.go
+++ b/domain/types/memory_source_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemorySourceOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    types.MemorySource
+		wantErr bool
+	}{
+		{name: "manual", input: "manual", want: types.MemorySourceManual},
+		{name: "imported", input: "imported", want: types.MemorySourceImported},
+		{name: "rejects empty", input: "", wantErr: true},
+		{name: "rejects unknown", input: "generated", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemorySourceOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemorySourceOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("MemorySourceOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/domain/types/memory_status.go
+++ b/domain/types/memory_status.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// MemoryStatus represents the lifecycle status of a memory.
+type MemoryStatus string
+
+const (
+	// MemoryStatusCandidate indicates review is still required.
+	MemoryStatusCandidate MemoryStatus = "candidate"
+	// MemoryStatusAccepted indicates the memory is active.
+	MemoryStatusAccepted MemoryStatus = "accepted"
+	// MemoryStatusRejected indicates the memory was rejected.
+	MemoryStatusRejected MemoryStatus = "rejected"
+	// MemoryStatusSuperseded indicates the memory was replaced.
+	MemoryStatusSuperseded MemoryStatus = "superseded"
+	// MemoryStatusExpired indicates the memory is no longer active due to expiry.
+	MemoryStatusExpired MemoryStatus = "expired"
+)
+
+var knownMemoryStatuses = []MemoryStatus{
+	MemoryStatusCandidate,
+	MemoryStatusAccepted,
+	MemoryStatusRejected,
+	MemoryStatusSuperseded,
+	MemoryStatusExpired,
+}
+
+// MemoryStatusOf creates a MemoryStatus from a string.
+func MemoryStatusOf(value string) (MemoryStatus, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return MemoryStatus(""), xerrors.Errorf("memory status must not be empty")
+	}
+	if slices.Contains(knownMemoryStatuses, MemoryStatus(trimmedValue)) {
+		return MemoryStatus(trimmedValue), nil
+	}
+	return MemoryStatus(""), xerrors.Errorf("unknown memory status: %s", trimmedValue)
+}
+
+// String returns the string representation.
+func (m MemoryStatus) String() string { return string(m) }

--- a/domain/types/memory_status_test.go
+++ b/domain/types/memory_status_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryStatusOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    types.MemoryStatus
+		wantErr bool
+	}{
+		{name: "candidate", input: "candidate", want: types.MemoryStatusCandidate},
+		{name: "expired", input: "expired", want: types.MemoryStatusExpired},
+		{name: "rejects empty", input: "", wantErr: true},
+		{name: "rejects unknown", input: "future", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemoryStatusOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryStatusOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("MemoryStatusOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/domain/types/memory_type.go
+++ b/domain/types/memory_type.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"slices"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// MemoryType classifies durable memory.
+type MemoryType string
+
+const (
+	// MemoryTypePreference stores stable preferences.
+	MemoryTypePreference MemoryType = "preference"
+	// MemoryTypeDecision stores important decisions.
+	MemoryTypeDecision MemoryType = "decision"
+	// MemoryTypeConstraint stores constraints.
+	MemoryTypeConstraint MemoryType = "constraint"
+	// MemoryTypeLesson stores lessons learned.
+	MemoryTypeLesson MemoryType = "lesson"
+	// MemoryTypeArtifact stores durable artifact pointers.
+	MemoryTypeArtifact MemoryType = "artifact"
+)
+
+var knownMemoryTypes = []MemoryType{
+	MemoryTypePreference,
+	MemoryTypeDecision,
+	MemoryTypeConstraint,
+	MemoryTypeLesson,
+	MemoryTypeArtifact,
+}
+
+// MemoryTypeOf creates a MemoryType from a string.
+func MemoryTypeOf(value string) (MemoryType, error) {
+	trimmedValue := strings.TrimSpace(value)
+	if trimmedValue == "" {
+		return MemoryType(""), xerrors.Errorf("memory type must not be empty")
+	}
+	if slices.Contains(knownMemoryTypes, MemoryType(trimmedValue)) {
+		return MemoryType(trimmedValue), nil
+	}
+	return MemoryType(""), xerrors.Errorf("unknown memory type: %s", trimmedValue)
+}
+
+// String returns the string representation.
+func (m MemoryType) String() string { return string(m) }

--- a/domain/types/memory_type_test.go
+++ b/domain/types/memory_type_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryTypeOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    types.MemoryType
+		wantErr bool
+	}{
+		{name: "preference", input: "preference", want: types.MemoryTypePreference},
+		{name: "artifact", input: "artifact", want: types.MemoryTypeArtifact},
+		{name: "rejects empty", input: " ", wantErr: true},
+		{name: "rejects unknown", input: "unknown", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := types.MemoryTypeOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryTypeOf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("MemoryTypeOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Introduce the first-class durable memory domain model required by #460 without coupling it to persistence or presentation concerns.

## What changed

- added `model.Memory` as a separate aggregate root with lifecycle transitions
- added `model.MemoryRepository`
- added typed memory value objects under `domain/types/`
  - `MemoryID`
  - `MemoryType`
  - `MemoryStatus`
  - `Confidence`
  - `MemorySource`
  - `MemoryScope` (`workspace`, `agent`, `session_family`)
  - `EvidenceRef`
  - `ArtifactRef`
- added domain tests for constructors, invariants, allowed transitions, and prohibited transitions

## Validation

- `go test ./...`
- `go tool golangci-lint run`

Closes #460
