### PR TITLE
feat: add durable memory persistence and query support

### DIFF
--- a/application/queryservice/memory_query.go
+++ b/application/queryservice/memory_query.go
@@ -1,0 +1,18 @@
+package queryservice
+
+import (
+	"context"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryQueryService provides read-side operations for durable memories.
+type MemoryQueryService interface {
+	// List returns memory summaries matching the provided criteria.
+	List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error)
+	// Search performs text search across durable memories and their refs.
+	Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error)
+	// GetDetails returns the details for a single memory.
+	GetDetails(ctx context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error)
+}

--- a/application/types/memory_details.go
+++ b/application/types/memory_details.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"slices"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryDetails holds a MemorySummary plus traceable refs.
+type MemoryDetails struct {
+	summary      MemorySummary
+	evidenceRefs []domtypes.EvidenceRef
+	artifactRefs []domtypes.ArtifactRef
+}
+
+// MemoryDetailsOf creates MemoryDetails from a summary and refs.
+func MemoryDetailsOf(summary MemorySummary, evidenceRefs []domtypes.EvidenceRef, artifactRefs []domtypes.ArtifactRef) MemoryDetails {
+	return MemoryDetails{
+		summary:      summary,
+		evidenceRefs: slices.Clone(evidenceRefs),
+		artifactRefs: slices.Clone(artifactRefs),
+	}
+}
+
+// MemoryDetailsFrom creates MemoryDetails from a Memory aggregate.
+func MemoryDetailsFrom(memory *model.Memory) (MemoryDetails, error) {
+	summary, err := MemorySummaryFrom(memory)
+	if err != nil {
+		return MemoryDetails{}, xerrors.Errorf("failed to build memory summary: %w", err)
+	}
+	return MemoryDetailsOf(summary, memory.EvidenceRefs(), memory.ArtifactRefs()), nil
+}
+
+// Summary returns the memory summary.
+func (d MemoryDetails) Summary() MemorySummary { return d.summary }
+
+// EvidenceRefs returns the supporting evidence refs.
+func (d MemoryDetails) EvidenceRefs() []domtypes.EvidenceRef { return slices.Clone(d.evidenceRefs) }
+
+// ArtifactRefs returns the related artifact refs.
+func (d MemoryDetails) ArtifactRefs() []domtypes.ArtifactRef { return slices.Clone(d.artifactRefs) }

--- a/application/types/memory_details_test.go
+++ b/application/types/memory_details_test.go
@@ -1,0 +1,48 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryDetailsFrom(t *testing.T) {
+	t.Parallel()
+
+	memoryID, _ := domtypes.MemoryIDOf("mem-details")
+	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
+	evidenceRef, _ := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindIssue, "454")
+	artifactRef, _ := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindPR, "466")
+	memory := model.MemoryOf(
+		memoryID,
+		domtypes.MemoryTypeArtifact,
+		domtypes.WorkspaceScopeOf(workspace),
+		"Implementation PRs close sub-issues only",
+		domtypes.MemoryStatusAccepted,
+		domtypes.ConfidenceHigh,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{evidenceRef},
+		[]domtypes.ArtifactRef{artifactRef},
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 8, 15, 0, 0, time.UTC),
+	)
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		t.Fatalf("MemoryDetailsFrom() error = %v", err)
+	}
+	if got := details.Summary().MemoryID(); got != memoryID {
+		t.Fatalf("Summary().MemoryID() = %s, want %s", got, memoryID)
+	}
+	if got := len(details.EvidenceRefs()); got != 1 {
+		t.Fatalf("len(EvidenceRefs()) = %d, want 1", got)
+	}
+	if got := len(details.ArtifactRefs()); got != 1 {
+		t.Fatalf("len(ArtifactRefs()) = %d, want 1", got)
+	}
+}

--- a/application/types/memory_list_criteria.go
+++ b/application/types/memory_list_criteria.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"slices"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+var defaultActiveMemoryStatuses = []domtypes.MemoryStatus{
+	domtypes.MemoryStatusCandidate,
+	domtypes.MemoryStatusAccepted,
+}
+
+// DefaultActiveMemoryStatuses returns the statuses included in read paths
+// when callers do not request explicit memory statuses.
+func DefaultActiveMemoryStatuses() []domtypes.MemoryStatus {
+	return slices.Clone(defaultActiveMemoryStatuses)
+}
+
+// MemoryListCriteria holds filter parameters for memory listing.
+// Zero-value fields are ignored unless documented otherwise.
+type MemoryListCriteria struct {
+	limit       int
+	offset      int
+	scopes      []domtypes.MemoryScope
+	statuses    []domtypes.MemoryStatus
+	memoryTypes []domtypes.MemoryType
+}
+
+// Limit returns the maximum number of results.
+func (c MemoryListCriteria) Limit() int { return c.limit }
+
+// Offset returns the result offset.
+func (c MemoryListCriteria) Offset() int { return c.offset }
+
+// Scopes returns the typed scope filters.
+func (c MemoryListCriteria) Scopes() []domtypes.MemoryScope { return slices.Clone(c.scopes) }
+
+// Statuses returns the lifecycle status filters.
+func (c MemoryListCriteria) Statuses() []domtypes.MemoryStatus { return slices.Clone(c.statuses) }
+
+// MemoryTypes returns the memory type filters.
+func (c MemoryListCriteria) MemoryTypes() []domtypes.MemoryType { return slices.Clone(c.memoryTypes) }
+
+// MemoryListCriteriaBuilder builds a MemoryListCriteria value.
+type MemoryListCriteriaBuilder struct {
+	criteria MemoryListCriteria
+}
+
+// NewMemoryListCriteriaBuilder starts building with the given limit.
+func NewMemoryListCriteriaBuilder(limit int) *MemoryListCriteriaBuilder {
+	return &MemoryListCriteriaBuilder{criteria: MemoryListCriteria{limit: limit}}
+}
+
+// Offset sets the number of results to skip.
+func (b *MemoryListCriteriaBuilder) Offset(offset int) *MemoryListCriteriaBuilder {
+	b.criteria.offset = offset
+	return b
+}
+
+// Scope appends a typed scope filter.
+func (b *MemoryListCriteriaBuilder) Scope(scope domtypes.MemoryScope) *MemoryListCriteriaBuilder {
+	if scope != nil {
+		b.criteria.scopes = append(b.criteria.scopes, scope)
+	}
+	return b
+}
+
+// Scopes replaces the typed scope filters.
+func (b *MemoryListCriteriaBuilder) Scopes(scopes []domtypes.MemoryScope) *MemoryListCriteriaBuilder {
+	b.criteria.scopes = slices.Clone(scopes)
+	return b
+}
+
+// Status appends a lifecycle status filter.
+func (b *MemoryListCriteriaBuilder) Status(status domtypes.MemoryStatus) *MemoryListCriteriaBuilder {
+	if status != "" {
+		b.criteria.statuses = append(b.criteria.statuses, status)
+	}
+	return b
+}
+
+// Statuses replaces the lifecycle status filters.
+func (b *MemoryListCriteriaBuilder) Statuses(statuses []domtypes.MemoryStatus) *MemoryListCriteriaBuilder {
+	b.criteria.statuses = slices.Clone(statuses)
+	return b
+}
+
+// MemoryType appends a memory type filter.
+func (b *MemoryListCriteriaBuilder) MemoryType(memoryType domtypes.MemoryType) *MemoryListCriteriaBuilder {
+	if memoryType != "" {
+		b.criteria.memoryTypes = append(b.criteria.memoryTypes, memoryType)
+	}
+	return b
+}
+
+// MemoryTypes replaces the memory type filters.
+func (b *MemoryListCriteriaBuilder) MemoryTypes(memoryTypes []domtypes.MemoryType) *MemoryListCriteriaBuilder {
+	b.criteria.memoryTypes = slices.Clone(memoryTypes)
+	return b
+}
+
+// Build finalizes and returns the MemoryListCriteria.
+func (b *MemoryListCriteriaBuilder) Build() MemoryListCriteria {
+	return b.criteria
+}

--- a/application/types/memory_list_criteria_test.go
+++ b/application/types/memory_list_criteria_test.go
@@ -1,0 +1,48 @@
+package types_test
+
+import (
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestDefaultActiveMemoryStatuses(t *testing.T) {
+	t.Parallel()
+
+	got := apptypes.DefaultActiveMemoryStatuses()
+	if len(got) != 2 {
+		t.Fatalf("len(DefaultActiveMemoryStatuses()) = %d, want 2", len(got))
+	}
+	if got[0] != domtypes.MemoryStatusCandidate || got[1] != domtypes.MemoryStatusAccepted {
+		t.Fatalf("DefaultActiveMemoryStatuses() = %v", got)
+	}
+}
+
+func TestMemoryListCriteriaBuilder(t *testing.T) {
+	t.Parallel()
+
+	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
+	criteria := apptypes.NewMemoryListCriteriaBuilder(20).
+		Offset(5).
+		Scope(domtypes.WorkspaceScopeOf(workspace)).
+		Status(domtypes.MemoryStatusAccepted).
+		MemoryType(domtypes.MemoryTypeDecision).
+		Build()
+
+	if got := criteria.Limit(); got != 20 {
+		t.Fatalf("Limit() = %d, want 20", got)
+	}
+	if got := criteria.Offset(); got != 5 {
+		t.Fatalf("Offset() = %d, want 5", got)
+	}
+	if got := len(criteria.Scopes()); got != 1 {
+		t.Fatalf("len(Scopes()) = %d, want 1", got)
+	}
+	if got := len(criteria.Statuses()); got != 1 {
+		t.Fatalf("len(Statuses()) = %d, want 1", got)
+	}
+	if got := len(criteria.MemoryTypes()); got != 1 {
+		t.Fatalf("len(MemoryTypes()) = %d, want 1", got)
+	}
+}

--- a/application/types/memory_search_criteria.go
+++ b/application/types/memory_search_criteria.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"slices"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemorySearchCriteria holds filter parameters for full-text memory search.
+type MemorySearchCriteria struct {
+	query       string
+	limit       int
+	offset      int
+	scopes      []domtypes.MemoryScope
+	statuses    []domtypes.MemoryStatus
+	memoryTypes []domtypes.MemoryType
+}
+
+// Query returns the search query.
+func (c MemorySearchCriteria) Query() string { return c.query }
+
+// Limit returns the maximum number of results.
+func (c MemorySearchCriteria) Limit() int { return c.limit }
+
+// Offset returns the result offset.
+func (c MemorySearchCriteria) Offset() int { return c.offset }
+
+// Scopes returns the typed scope filters.
+func (c MemorySearchCriteria) Scopes() []domtypes.MemoryScope { return slices.Clone(c.scopes) }
+
+// Statuses returns the lifecycle status filters.
+func (c MemorySearchCriteria) Statuses() []domtypes.MemoryStatus { return slices.Clone(c.statuses) }
+
+// MemoryTypes returns the memory type filters.
+func (c MemorySearchCriteria) MemoryTypes() []domtypes.MemoryType { return slices.Clone(c.memoryTypes) }
+
+// MemorySearchCriteriaBuilder builds a MemorySearchCriteria value.
+type MemorySearchCriteriaBuilder struct {
+	criteria MemorySearchCriteria
+}
+
+// NewMemorySearchCriteriaBuilder starts building with the given limit.
+func NewMemorySearchCriteriaBuilder(limit int) *MemorySearchCriteriaBuilder {
+	return &MemorySearchCriteriaBuilder{criteria: MemorySearchCriteria{limit: limit}}
+}
+
+// Query sets the search query string.
+func (b *MemorySearchCriteriaBuilder) Query(query string) *MemorySearchCriteriaBuilder {
+	b.criteria.query = query
+	return b
+}
+
+// Offset sets the result offset.
+func (b *MemorySearchCriteriaBuilder) Offset(offset int) *MemorySearchCriteriaBuilder {
+	b.criteria.offset = offset
+	return b
+}
+
+// Scope appends a typed scope filter.
+func (b *MemorySearchCriteriaBuilder) Scope(scope domtypes.MemoryScope) *MemorySearchCriteriaBuilder {
+	if scope != nil {
+		b.criteria.scopes = append(b.criteria.scopes, scope)
+	}
+	return b
+}
+
+// Scopes replaces the typed scope filters.
+func (b *MemorySearchCriteriaBuilder) Scopes(scopes []domtypes.MemoryScope) *MemorySearchCriteriaBuilder {
+	b.criteria.scopes = slices.Clone(scopes)
+	return b
+}
+
+// Status appends a lifecycle status filter.
+func (b *MemorySearchCriteriaBuilder) Status(status domtypes.MemoryStatus) *MemorySearchCriteriaBuilder {
+	if status != "" {
+		b.criteria.statuses = append(b.criteria.statuses, status)
+	}
+	return b
+}
+
+// Statuses replaces the lifecycle status filters.
+func (b *MemorySearchCriteriaBuilder) Statuses(statuses []domtypes.MemoryStatus) *MemorySearchCriteriaBuilder {
+	b.criteria.statuses = slices.Clone(statuses)
+	return b
+}
+
+// MemoryType appends a memory type filter.
+func (b *MemorySearchCriteriaBuilder) MemoryType(memoryType domtypes.MemoryType) *MemorySearchCriteriaBuilder {
+	if memoryType != "" {
+		b.criteria.memoryTypes = append(b.criteria.memoryTypes, memoryType)
+	}
+	return b
+}
+
+// MemoryTypes replaces the memory type filters.
+func (b *MemorySearchCriteriaBuilder) MemoryTypes(memoryTypes []domtypes.MemoryType) *MemorySearchCriteriaBuilder {
+	b.criteria.memoryTypes = slices.Clone(memoryTypes)
+	return b
+}
+
+// Build finalizes and returns the MemorySearchCriteria.
+func (b *MemorySearchCriteriaBuilder) Build() MemorySearchCriteria {
+	return b.criteria
+}

--- a/application/types/memory_search_criteria_test.go
+++ b/application/types/memory_search_criteria_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemorySearchCriteriaBuilder(t *testing.T) {
+	t.Parallel()
+
+	agent, _ := domtypes.AgentOf("codex")
+	criteria := apptypes.NewMemorySearchCriteriaBuilder(10).
+		Query("release").
+		Offset(2).
+		Scope(domtypes.AgentScopeOf(agent)).
+		Status(domtypes.MemoryStatusCandidate).
+		MemoryType(domtypes.MemoryTypeLesson).
+		Build()
+
+	if got := criteria.Query(); got != "release" {
+		t.Fatalf("Query() = %q, want %q", got, "release")
+	}
+	if got := criteria.Offset(); got != 2 {
+		t.Fatalf("Offset() = %d, want 2", got)
+	}
+	if got := len(criteria.Scopes()); got != 1 {
+		t.Fatalf("len(Scopes()) = %d, want 1", got)
+	}
+	if got := len(criteria.Statuses()); got != 1 {
+		t.Fatalf("len(Statuses()) = %d, want 1", got)
+	}
+	if got := len(criteria.MemoryTypes()); got != 1 {
+		t.Fatalf("len(MemoryTypes()) = %d, want 1", got)
+	}
+}

--- a/application/types/memory_summary.go
+++ b/application/types/memory_summary.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemorySummary holds read-side information about a single durable memory.
+type MemorySummary struct {
+	memoryID   domtypes.MemoryID
+	memoryType domtypes.MemoryType
+	scope      domtypes.MemoryScope
+	fact       string
+	status     domtypes.MemoryStatus
+	confidence domtypes.Confidence
+	source     domtypes.MemorySource
+	supersedes domtypes.Optional[domtypes.MemoryID]
+	expiresAt  domtypes.Optional[time.Time]
+	createdAt  time.Time
+	updatedAt  time.Time
+}
+
+// MemorySummaryOf creates a MemorySummary.
+func MemorySummaryOf(
+	memoryID domtypes.MemoryID,
+	memoryType domtypes.MemoryType,
+	scope domtypes.MemoryScope,
+	fact string,
+	status domtypes.MemoryStatus,
+	confidence domtypes.Confidence,
+	source domtypes.MemorySource,
+	supersedes domtypes.Optional[domtypes.MemoryID],
+	expiresAt domtypes.Optional[time.Time],
+	createdAt time.Time,
+	updatedAt time.Time,
+) (MemorySummary, error) {
+	trimmedFact := strings.TrimSpace(fact)
+	if trimmedFact == "" {
+		return MemorySummary{}, xerrors.Errorf("memory fact must not be empty")
+	}
+	if scope == nil {
+		return MemorySummary{}, xerrors.Errorf("memory scope must not be nil")
+	}
+
+	return MemorySummary{
+		memoryID:   memoryID,
+		memoryType: memoryType,
+		scope:      scope,
+		fact:       trimmedFact,
+		status:     status,
+		confidence: confidence,
+		source:     source,
+		supersedes: supersedes,
+		expiresAt:  expiresAt,
+		createdAt:  createdAt,
+		updatedAt:  updatedAt,
+	}, nil
+}
+
+// MemorySummaryFrom creates a MemorySummary from a Memory aggregate.
+func MemorySummaryFrom(memory *model.Memory) (MemorySummary, error) {
+	if memory == nil {
+		return MemorySummary{}, xerrors.Errorf("memory must not be nil")
+	}
+	return MemorySummaryOf(
+		memory.MemoryID(),
+		memory.MemoryType(),
+		memory.Scope(),
+		memory.Fact(),
+		memory.Status(),
+		memory.Confidence(),
+		memory.Source(),
+		memory.Supersedes(),
+		memory.ExpiresAt(),
+		memory.CreatedAt(),
+		memory.UpdatedAt(),
+	)
+}
+
+// MemoryID returns the memory ID.
+func (s MemorySummary) MemoryID() domtypes.MemoryID { return s.memoryID }
+
+// MemoryType returns the memory type.
+func (s MemorySummary) MemoryType() domtypes.MemoryType { return s.memoryType }
+
+// Scope returns the memory scope.
+func (s MemorySummary) Scope() domtypes.MemoryScope { return s.scope }
+
+// Fact returns the distilled fact.
+func (s MemorySummary) Fact() string { return s.fact }
+
+// Status returns the memory lifecycle status.
+func (s MemorySummary) Status() domtypes.MemoryStatus { return s.status }
+
+// Confidence returns the memory confidence.
+func (s MemorySummary) Confidence() domtypes.Confidence { return s.confidence }
+
+// Source returns the memory source attribution.
+func (s MemorySummary) Source() domtypes.MemorySource { return s.source }
+
+// Supersedes returns the superseded memory ID, when present.
+func (s MemorySummary) Supersedes() domtypes.Optional[domtypes.MemoryID] { return s.supersedes }
+
+// ExpiresAt returns the expiry timestamp, when present.
+func (s MemorySummary) ExpiresAt() domtypes.Optional[time.Time] { return s.expiresAt }
+
+// CreatedAt returns when the memory was created.
+func (s MemorySummary) CreatedAt() time.Time { return s.createdAt }
+
+// UpdatedAt returns when the memory was last updated.
+func (s MemorySummary) UpdatedAt() time.Time { return s.updatedAt }

--- a/application/types/memory_summary_test.go
+++ b/application/types/memory_summary_test.go
@@ -1,0 +1,74 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemorySummaryOf(t *testing.T) {
+	t.Parallel()
+
+	memoryID, _ := domtypes.MemoryIDOf("mem-1")
+	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
+	supersedes, _ := domtypes.MemoryIDOf("mem-0")
+	expiresAt := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC)
+
+	summary, err := apptypes.MemorySummaryOf(
+		memoryID,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(workspace),
+		"  Release issues close only after tagged release  ",
+		domtypes.MemoryStatusAccepted,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		domtypes.Of(supersedes),
+		domtypes.Of(expiresAt),
+		createdAt,
+		updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+	if got := summary.Fact(); got != "Release issues close only after tagged release" {
+		t.Fatalf("Fact() = %q", got)
+	}
+	if got, ok := summary.ExpiresAt().Get(); !ok || !got.Equal(expiresAt) {
+		t.Fatalf("ExpiresAt() = (%v, %v), want (%v, true)", got, ok, expiresAt)
+	}
+}
+
+func TestMemorySummaryFrom(t *testing.T) {
+	t.Parallel()
+
+	memoryID, _ := domtypes.MemoryIDOf("mem-2")
+	agent, _ := domtypes.AgentOf("codex")
+	memory := model.MemoryOf(
+		memoryID,
+		domtypes.MemoryTypeLesson,
+		domtypes.AgentScopeOf(agent),
+		"Codex prompt capture is optional",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceLow,
+		domtypes.MemorySourceExtracted,
+		nil,
+		nil,
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 9, 30, 0, 0, time.UTC),
+	)
+
+	summary, err := apptypes.MemorySummaryFrom(memory)
+	if err != nil {
+		t.Fatalf("MemorySummaryFrom() error = %v", err)
+	}
+	if got := summary.MemoryID(); got != memoryID {
+		t.Fatalf("MemoryID() = %s, want %s", got, memoryID)
+	}
+}

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -52,8 +52,8 @@ func NewEventDatasource(db *Database) *EventDatasource {
 
 // Compile-time interface assertions.
 var (
-	_ model.EventRepository           = (*EventDatasource)(nil)
-	_ queryservice.EventQueryService  = (*EventDatasource)(nil)
+	_ model.EventRepository          = (*EventDatasource)(nil)
+	_ queryservice.EventQueryService = (*EventDatasource)(nil)
 )
 
 // Save persists an event.
@@ -662,7 +662,7 @@ func restoreEvent(
 
 func escapeLikeQuery(query string) string {
 	replacer := strings.NewReplacer(
-		`\\`, `\\\\`,
+		`\`, `\\`,
 		`%`, `\%`,
 		`_`, `\_`,
 	)

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -1,0 +1,654 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+//go:embed sql/upsert_memory.sql
+var upsertMemoryQuery string
+
+//go:embed sql/delete_memory_evidence_refs.sql
+var deleteMemoryEvidenceRefsQuery string
+
+//go:embed sql/delete_memory_artifact_refs.sql
+var deleteMemoryArtifactRefsQuery string
+
+//go:embed sql/insert_memory_evidence_ref.sql
+var insertMemoryEvidenceRefQuery string
+
+//go:embed sql/insert_memory_artifact_ref.sql
+var insertMemoryArtifactRefQuery string
+
+//go:embed sql/select_memory_row_by_id.sql
+var selectMemoryRowByIDQuery string
+
+//go:embed sql/select_memory_evidence_refs.sql
+var selectMemoryEvidenceRefsQuery string
+
+//go:embed sql/select_memory_artifact_refs.sql
+var selectMemoryArtifactRefsQuery string
+
+const selectMemorySummaryColumnsQuery = `
+SELECT
+    m.id,
+    m.type,
+    m.scope_kind,
+    m.scope_value,
+    m.fact,
+    m.status,
+    m.confidence,
+    m.source,
+    m.supersedes_memory_id,
+    m.expires_at,
+    m.created_at,
+    m.updated_at
+FROM memories m
+WHERE 1 = 1`
+
+// MemoryDatasource is the SQLite-backed implementation of the memory
+// repository and memory query service.
+type MemoryDatasource struct {
+	db *Database
+}
+
+// NewMemoryDatasource creates a new MemoryDatasource bound to the given database.
+func NewMemoryDatasource(db *Database) *MemoryDatasource {
+	return &MemoryDatasource{db: db}
+}
+
+var (
+	_ model.MemoryRepository          = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryQueryService = (*MemoryDatasource)(nil)
+)
+
+// Save persists a memory aggregate together with its refs.
+func (d *MemoryDatasource) Save(ctx context.Context, memory *model.Memory) error {
+	if memory == nil {
+		return xerrors.Errorf("memory must not be nil")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to open DB for memory save: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return xerrors.Errorf("failed to begin memory save transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	var supersedesValue *string
+	if supersedes, ok := memory.Supersedes().Get(); ok {
+		value := supersedes.String()
+		supersedesValue = &value
+	}
+	var expiresAtValue *string
+	if expiresAt, ok := memory.ExpiresAt().Get(); ok {
+		formatted := formatTimestamp(expiresAt)
+		expiresAtValue = &formatted
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		upsertMemoryQuery,
+		memory.MemoryID().String(),
+		memory.MemoryType().String(),
+		memory.Scope().Kind().String(),
+		memory.Scope().Key(),
+		memory.Fact(),
+		memory.Status().String(),
+		memory.Confidence().String(),
+		memory.Source().String(),
+		supersedesValue,
+		expiresAtValue,
+		formatTimestamp(memory.CreatedAt()),
+		formatTimestamp(memory.UpdatedAt()),
+	); err != nil {
+		return xerrors.Errorf("failed to upsert memory: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, deleteMemoryEvidenceRefsQuery, memory.MemoryID().String()); err != nil {
+		return xerrors.Errorf("failed to delete existing memory evidence refs: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, deleteMemoryArtifactRefsQuery, memory.MemoryID().String()); err != nil {
+		return xerrors.Errorf("failed to delete existing memory artifact refs: %w", err)
+	}
+
+	for index, evidenceRef := range memory.EvidenceRefs() {
+		if _, err := tx.ExecContext(
+			ctx,
+			insertMemoryEvidenceRefQuery,
+			memory.MemoryID().String(),
+			index,
+			evidenceRef.Kind().String(),
+			evidenceRef.Value(),
+		); err != nil {
+			return xerrors.Errorf("failed to insert memory evidence ref: %w", err)
+		}
+	}
+
+	for index, artifactRef := range memory.ArtifactRefs() {
+		if _, err := tx.ExecContext(
+			ctx,
+			insertMemoryArtifactRefQuery,
+			memory.MemoryID().String(),
+			index,
+			artifactRef.Kind().String(),
+			artifactRef.Value(),
+		); err != nil {
+			return xerrors.Errorf("failed to insert memory artifact ref: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit memory save transaction: %w", err)
+	}
+
+	return nil
+}
+
+// FindByID returns the memory for the given ID.
+func (d *MemoryDatasource) FindByID(ctx context.Context, memoryID types.MemoryID) (types.Optional[*model.Memory], error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return types.Empty[*model.Memory](), xerrors.Errorf("failed to open DB for memory lookup: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	memory, err := findMemoryByID(ctx, db, memoryID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return types.Empty[*model.Memory](), nil
+		}
+		return types.Empty[*model.Memory](), xerrors.Errorf("failed to restore memory: %w", err)
+	}
+
+	return types.Of(memory), nil
+}
+
+// GetDetails returns the details for a single memory.
+func (d *MemoryDatasource) GetDetails(ctx context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to open DB for memory details lookup: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	memory, err := findMemoryByID(ctx, db, memoryID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apptypes.MemoryDetails{}, xerrors.Errorf("memory not found: %s", memoryID)
+		}
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to restore memory details: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+
+	return details, nil
+}
+
+// List returns memory summaries matching the provided criteria.
+func (d *MemoryDatasource) List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for memory list: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	query, args, err := buildMemoryListQuery(criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to build memory list query: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memories: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]apptypes.MemorySummary, 0, criteria.Limit())
+	for rows.Next() {
+		summary, err := scanMemorySummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan memory summary row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+// Search performs text search across durable memories and their refs.
+func (d *MemoryDatasource) Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for memory search: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	query, args, err := buildMemorySearchQuery(criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to build memory search query: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memory search results: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]apptypes.MemorySummary, 0, criteria.Limit())
+	for rows.Next() {
+		summary, err := scanMemorySummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan memory search row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory search rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+type memoryRow struct {
+	memoryID   string
+	memoryType string
+	scopeKind  string
+	scopeValue string
+	fact       string
+	status     string
+	confidence string
+	source     string
+	supersedes sql.NullString
+	expiresAt  sql.NullString
+	createdAt  string
+	updatedAt  string
+}
+
+func scanMemoryRow(rowScanner interface {
+	Scan(dest ...any) error
+}) (memoryRow, error) {
+	var row memoryRow
+	if err := rowScanner.Scan(
+		&row.memoryID,
+		&row.memoryType,
+		&row.scopeKind,
+		&row.scopeValue,
+		&row.fact,
+		&row.status,
+		&row.confidence,
+		&row.source,
+		&row.supersedes,
+		&row.expiresAt,
+		&row.createdAt,
+		&row.updatedAt,
+	); err != nil {
+		return memoryRow{}, xerrors.Errorf("failed to scan memory row: %w", err)
+	}
+	return row, nil
+}
+
+func scanMemorySummary(rowScanner interface {
+	Scan(dest ...any) error
+}) (apptypes.MemorySummary, error) {
+	row, err := scanMemoryRow(rowScanner)
+	if err != nil {
+		return apptypes.MemorySummary{}, err
+	}
+	return restoreMemorySummary(row)
+}
+
+func restoreMemorySummary(row memoryRow) (apptypes.MemorySummary, error) {
+	memoryID, err := types.MemoryIDOf(row.memoryID)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory ID: %w", err)
+	}
+	memoryType, err := types.MemoryTypeOf(row.memoryType)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory type: %w", err)
+	}
+	scope, err := types.MemoryScopeFrom(row.scopeKind, row.scopeValue)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory scope: %w", err)
+	}
+	status, err := types.MemoryStatusOf(row.status)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory status: %w", err)
+	}
+	confidence, err := types.ConfidenceOf(row.confidence)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory confidence: %w", err)
+	}
+	source, err := types.MemorySourceOf(row.source)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory source: %w", err)
+	}
+	supersedes := types.Empty[types.MemoryID]()
+	if row.supersedes.Valid {
+		memoryIDValue, err := types.MemoryIDOf(row.supersedes.String)
+		if err != nil {
+			return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore superseded memory ID: %w", err)
+		}
+		supersedes = types.Of(memoryIDValue)
+	}
+	expiresAt := types.Empty[time.Time]()
+	if row.expiresAt.Valid {
+		expiresAtValue, err := time.Parse(time.RFC3339Nano, row.expiresAt.String)
+		if err != nil {
+			return apptypes.MemorySummary{}, xerrors.Errorf("failed to parse memory expires_at: %w", err)
+		}
+		expiresAt = types.Of(expiresAtValue)
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, row.createdAt)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to parse memory created_at: %w", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, row.updatedAt)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to parse memory updated_at: %w", err)
+	}
+
+	summary, err := apptypes.MemorySummaryOf(
+		memoryID,
+		memoryType,
+		scope,
+		row.fact,
+		status,
+		confidence,
+		source,
+		supersedes,
+		expiresAt,
+		createdAt,
+		updatedAt,
+	)
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to build memory summary: %w", err)
+	}
+	return summary, nil
+}
+
+func restoreMemoryAggregate(row memoryRow, evidenceRefs []types.EvidenceRef, artifactRefs []types.ArtifactRef) (*model.Memory, error) {
+	summary, err := restoreMemorySummary(row)
+	if err != nil {
+		return nil, err
+	}
+	return model.MemoryOf(
+		summary.MemoryID(),
+		summary.MemoryType(),
+		summary.Scope(),
+		summary.Fact(),
+		summary.Status(),
+		summary.Confidence(),
+		summary.Source(),
+		evidenceRefs,
+		artifactRefs,
+		summary.Supersedes(),
+		summary.ExpiresAt(),
+		summary.CreatedAt(),
+		summary.UpdatedAt(),
+	), nil
+}
+
+func findMemoryByID(ctx context.Context, db *sql.DB, memoryID types.MemoryID) (*model.Memory, error) {
+	row := db.QueryRowContext(ctx, selectMemoryRowByIDQuery, memoryID.String())
+	memoryRowValue, err := scanMemoryRow(row)
+	if err != nil {
+		return nil, err
+	}
+
+	evidenceRefs, err := loadMemoryEvidenceRefs(ctx, db, memoryID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load memory evidence refs: %w", err)
+	}
+	artifactRefs, err := loadMemoryArtifactRefs(ctx, db, memoryID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load memory artifact refs: %w", err)
+	}
+
+	memory, err := restoreMemoryAggregate(memoryRowValue, evidenceRefs, artifactRefs)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore memory aggregate: %w", err)
+	}
+
+	return memory, nil
+}
+
+func loadMemoryEvidenceRefs(ctx context.Context, db *sql.DB, memoryID types.MemoryID) ([]types.EvidenceRef, error) {
+	rows, err := db.QueryContext(ctx, selectMemoryEvidenceRefsQuery, memoryID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memory evidence refs: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	evidenceRefs := make([]types.EvidenceRef, 0)
+	for rows.Next() {
+		var kindValue, refValue string
+		if err := rows.Scan(&kindValue, &refValue); err != nil {
+			return nil, xerrors.Errorf("failed to scan memory evidence ref row: %w", err)
+		}
+		kind, err := types.EvidenceRefKindOf(kindValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore evidence ref kind: %w", err)
+		}
+		evidenceRef, err := types.EvidenceRefOf(kind, refValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore evidence ref: %w", err)
+		}
+		evidenceRefs = append(evidenceRefs, evidenceRef)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory evidence refs: %w", err)
+	}
+
+	return evidenceRefs, nil
+}
+
+func loadMemoryArtifactRefs(ctx context.Context, db *sql.DB, memoryID types.MemoryID) ([]types.ArtifactRef, error) {
+	rows, err := db.QueryContext(ctx, selectMemoryArtifactRefsQuery, memoryID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memory artifact refs: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	artifactRefs := make([]types.ArtifactRef, 0)
+	for rows.Next() {
+		var kindValue, refValue string
+		if err := rows.Scan(&kindValue, &refValue); err != nil {
+			return nil, xerrors.Errorf("failed to scan memory artifact ref row: %w", err)
+		}
+		kind, err := types.ArtifactRefKindOf(kindValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore artifact ref kind: %w", err)
+		}
+		artifactRef, err := types.ArtifactRefOf(kind, refValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore artifact ref: %w", err)
+		}
+		artifactRefs = append(artifactRefs, artifactRef)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory artifact refs: %w", err)
+	}
+
+	return artifactRefs, nil
+}
+
+func buildMemoryListQuery(criteria apptypes.MemoryListCriteria) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString(selectMemorySummaryColumnsQuery)
+	args, err := appendMemoryFilters(&builder, nil, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes())
+	if err != nil {
+		return "", nil, err
+	}
+	builder.WriteString(" ORDER BY m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return builder.String(), args, nil
+}
+
+func buildMemorySearchQuery(criteria apptypes.MemorySearchCriteria) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString(selectMemorySummaryColumnsQuery)
+	args := make([]any, 0)
+
+	trimmedQuery := strings.TrimSpace(criteria.Query())
+	if trimmedQuery != "" {
+		likeQuery := "%" + escapeLikeQuery(trimmedQuery) + "%"
+		builder.WriteString(`
+  AND (
+      m.fact LIKE ? ESCAPE '\'
+      OR EXISTS (
+          SELECT 1
+          FROM memory_evidence_refs mer
+          WHERE mer.memory_id = m.id
+            AND mer.ref_value LIKE ? ESCAPE '\'
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM memory_artifact_refs mar
+          WHERE mar.memory_id = m.id
+            AND mar.ref_value LIKE ? ESCAPE '\'
+      )
+  )`)
+		args = append(args, likeQuery, likeQuery, likeQuery)
+	}
+
+	args, err := appendMemoryFilters(&builder, args, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes())
+	if err != nil {
+		return "", nil, err
+	}
+	builder.WriteString(" ORDER BY m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return builder.String(), args, nil
+}
+
+func appendMemoryFilters(
+	builder *strings.Builder,
+	args []any,
+	scopes []types.MemoryScope,
+	statuses []types.MemoryStatus,
+	memoryTypes []types.MemoryType,
+) ([]any, error) {
+	normalizedStatuses := normalizeMemoryStatuses(statuses)
+	builder.WriteString(" AND m.status IN (")
+	for index, status := range normalizedStatuses {
+		if index > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString("?")
+		args = append(args, status.String())
+	}
+	builder.WriteString(")")
+
+	if len(scopes) > 0 {
+		builder.WriteString(" AND (")
+		for index, scope := range scopes {
+			if scope == nil {
+				return nil, xerrors.Errorf("memory scope must not be nil")
+			}
+			if index > 0 {
+				builder.WriteString(" OR ")
+			}
+			builder.WriteString("(m.scope_kind = ? AND m.scope_value = ?)")
+			args = append(args, scope.Kind().String(), scope.Key())
+		}
+		builder.WriteString(")")
+	}
+
+	if len(memoryTypes) > 0 {
+		builder.WriteString(" AND m.type IN (")
+		for index, memoryType := range memoryTypes {
+			if index > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString("?")
+			args = append(args, memoryType.String())
+		}
+		builder.WriteString(")")
+	}
+
+	return args, nil
+}
+
+func normalizeMemoryStatuses(statuses []types.MemoryStatus) []types.MemoryStatus {
+	if len(statuses) == 0 {
+		return apptypes.DefaultActiveMemoryStatuses()
+	}
+	return append([]types.MemoryStatus(nil), statuses...)
+}

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -1,0 +1,473 @@
+package sqlite_test
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func newMemoryDatasource(
+	t *testing.T,
+	dbPath string,
+	migrations fs.FS,
+) (*infra.MemoryDatasource, *infra.StoreManagementDatasource) {
+	t.Helper()
+	db := infra.NewDatabase(dbPath, migrations)
+	return infra.NewMemoryDatasource(db), infra.NewStoreManagementDatasource(db)
+}
+
+func memoryDatasourceTestMigrations() fstest.MapFS {
+	return fstest.MapFS{
+		"000008_create_memories.sql": {
+			Data: []byte(`CREATE TABLE memories (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    scope_kind TEXT NOT NULL,
+    scope_value TEXT NOT NULL,
+    fact TEXT NOT NULL,
+    status TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    source TEXT NOT NULL,
+    supersedes_memory_id TEXT REFERENCES memories(id),
+    expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX idx_memories_scope_status_updated
+    ON memories(scope_kind, scope_value, status, updated_at DESC, id DESC);
+CREATE INDEX idx_memories_type_status_updated
+    ON memories(type, status, updated_at DESC, id DESC);
+CREATE INDEX idx_memories_supersedes_memory_id
+    ON memories(supersedes_memory_id);
+CREATE TABLE memory_evidence_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);
+CREATE TABLE memory_artifact_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);`),
+		},
+	}
+}
+
+func mustMemoryID(t *testing.T, value string) types.MemoryID {
+	t.Helper()
+	memoryID, err := types.MemoryIDOf(value)
+	if err != nil {
+		t.Fatalf("MemoryIDOf() error = %v", err)
+	}
+	return memoryID
+}
+
+func mustWorkspaceScope(t *testing.T, value string) types.MemoryScope {
+	t.Helper()
+	workspace, err := types.WorkspaceOf(value)
+	if err != nil {
+		t.Fatalf("WorkspaceOf() error = %v", err)
+	}
+	return types.WorkspaceScopeOf(workspace)
+}
+
+func mustAgentScope(t *testing.T, value string) types.MemoryScope {
+	t.Helper()
+	agent, err := types.AgentOf(value)
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	return types.AgentScopeOf(agent)
+}
+
+func mustSessionFamilyScope(t *testing.T, value string) types.MemoryScope {
+	t.Helper()
+	sessionID, err := types.SessionIDOf(value)
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+	return types.SessionFamilyScopeOf(sessionID)
+}
+
+func mustEvidenceRef(t *testing.T, kind types.EvidenceRefKind, value string) types.EvidenceRef {
+	t.Helper()
+	ref, err := types.EvidenceRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("EvidenceRefOf() error = %v", err)
+	}
+	return ref
+}
+
+func mustArtifactRef(t *testing.T, kind types.ArtifactRefKind, value string) types.ArtifactRef {
+	t.Helper()
+	ref, err := types.ArtifactRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("ArtifactRefOf() error = %v", err)
+	}
+	return ref
+}
+
+func memoryOf(
+	t *testing.T,
+	memoryID string,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	status types.MemoryStatus,
+	confidence types.Confidence,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+	expiresAt types.Optional[time.Time],
+	createdAt time.Time,
+	updatedAt time.Time,
+) *model.Memory {
+	t.Helper()
+	return model.MemoryOf(
+		mustMemoryID(t, memoryID),
+		memoryType,
+		scope,
+		fact,
+		status,
+		confidence,
+		source,
+		evidenceRefs,
+		artifactRefs,
+		supersedes,
+		expiresAt,
+		createdAt,
+		updatedAt,
+	)
+}
+
+func memoryScopeToken(scope types.MemoryScope) string {
+	if scope == nil {
+		return "<nil>"
+	}
+	return scope.Kind().String() + ":" + scope.Key()
+}
+
+func evidenceRefTokens(refs []types.EvidenceRef) []string {
+	result := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		result = append(result, ref.Kind().String()+":"+ref.Value())
+	}
+	return result
+}
+
+func artifactRefTokens(refs []types.ArtifactRef) []string {
+	result := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		result = append(result, ref.Kind().String()+":"+ref.Value())
+	}
+	return result
+}
+
+func TestMemoryDatasource_SaveAndFindByID(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	baseMemory := memoryOf(
+		t,
+		"mem-base",
+		types.MemoryTypeDecision,
+		mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+		"Release issues close only after tagged release",
+		types.MemoryStatusAccepted,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindIssue, "454")},
+		nil,
+		types.Empty[types.MemoryID](),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 10, 15, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, baseMemory); err != nil {
+		t.Fatalf("Save(baseMemory) error = %v", err)
+	}
+
+	expiresAt := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	memory := memoryOf(
+		t,
+		"mem-1",
+		types.MemoryTypeLesson,
+		mustAgentScope(t, "codex"),
+		"Use issue-specific branches for memory work",
+		types.MemoryStatusExpired,
+		types.ConfidenceHigh,
+		types.MemorySourceExtracted,
+		[]types.EvidenceRef{
+			mustEvidenceRef(t, types.EvidenceRefKindIssue, "460"),
+			mustEvidenceRef(t, types.EvidenceRefKindPR, "466"),
+		},
+		[]types.ArtifactRef{
+			mustArtifactRef(t, types.ArtifactRefKindFile, "domain/model/memory.go"),
+		},
+		types.Of(baseMemory.MemoryID()),
+		types.Of(expiresAt),
+		time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 11, 30, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, memory); err != nil {
+		t.Fatalf("Save(memory) error = %v", err)
+	}
+
+	gotOpt, err := sut.FindByID(ctx, memory.MemoryID())
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	got, ok := gotOpt.Get()
+	if !ok {
+		t.Fatalf("FindByID().Get() ok = false, want true")
+	}
+
+	if diff := cmp.Diff(memory.MemoryID(), got.MemoryID()); diff != "" {
+		t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(memory.Status(), got.Status()); diff != "" {
+		t.Fatalf("Status mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(memoryScopeToken(memory.Scope()), memoryScopeToken(got.Scope())); diff != "" {
+		t.Fatalf("Scope mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(evidenceRefTokens(memory.EvidenceRefs()), evidenceRefTokens(got.EvidenceRefs())); diff != "" {
+		t.Fatalf("EvidenceRefs mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(artifactRefTokens(memory.ArtifactRefs()), artifactRefTokens(got.ArtifactRefs())); diff != "" {
+		t.Fatalf("ArtifactRefs mismatch (-want +got):\n%s", diff)
+	}
+	if gotSupersedes, ok := got.Supersedes().Get(); !ok || gotSupersedes != baseMemory.MemoryID() {
+		t.Fatalf("Supersedes() = (%v, %v), want (%v, true)", gotSupersedes, ok, baseMemory.MemoryID())
+	}
+	if gotExpiresAt, ok := got.ExpiresAt().Get(); !ok || !gotExpiresAt.Equal(expiresAt) {
+		t.Fatalf("ExpiresAt() = (%v, %v), want (%v, true)", gotExpiresAt, ok, expiresAt)
+	}
+}
+
+func TestMemoryDatasource_GetDetails(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	memory := memoryOf(
+		t,
+		"mem-details",
+		types.MemoryTypeArtifact,
+		mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+		"Release metadata PR prepares docs only",
+		types.MemoryStatusAccepted,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindIssue, "218")},
+		[]types.ArtifactRef{mustArtifactRef(t, types.ArtifactRefKindPR, "227")},
+		types.Empty[types.MemoryID](),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 9, 10, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, memory); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	details, err := sut.GetDetails(ctx, memory.MemoryID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if diff := cmp.Diff(memory.MemoryID(), details.Summary().MemoryID()); diff != "" {
+		t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(evidenceRefTokens(memory.EvidenceRefs()), evidenceRefTokens(details.EvidenceRefs())); diff != "" {
+		t.Fatalf("EvidenceRefs mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(artifactRefTokens(memory.ArtifactRefs()), artifactRefTokens(details.ArtifactRefs())); diff != "" {
+		t.Fatalf("ArtifactRefs mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = sut.GetDetails(ctx, mustMemoryID(t, "missing"))
+	if err == nil {
+		t.Fatalf("GetDetails(missing) error = nil, want error")
+	}
+}
+
+func TestMemoryDatasource_List(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	fixtureMemories := []*model.Memory{
+		memoryOf(t, "mem-accepted", types.MemoryTypeDecision, mustWorkspaceScope(t, "github.com/duck8823/traceary"), "Accepted memory", types.MemoryStatusAccepted, types.ConfidenceHigh, types.MemorySourceManual, nil, nil, types.Empty[types.MemoryID](), types.Empty[time.Time](), time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 8, 30, 0, 0, time.UTC)),
+		memoryOf(t, "mem-candidate", types.MemoryTypeLesson, mustAgentScope(t, "codex"), "Candidate memory", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.Empty[types.MemoryID](), types.Empty[time.Time](), time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 9, 30, 0, 0, time.UTC)),
+		memoryOf(t, "mem-rejected", types.MemoryTypeConstraint, mustWorkspaceScope(t, "github.com/duck8823/traceary"), "Rejected memory", types.MemoryStatusRejected, types.ConfidenceMedium, types.MemorySourceManual, nil, nil, types.Empty[types.MemoryID](), types.Empty[time.Time](), time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 10, 30, 0, 0, time.UTC)),
+		memoryOf(t, "mem-superseded", types.MemoryTypeDecision, mustWorkspaceScope(t, "github.com/duck8823/traceary"), "Superseded memory", types.MemoryStatusSuperseded, types.ConfidenceHigh, types.MemorySourceManual, nil, nil, types.Empty[types.MemoryID](), types.Empty[time.Time](), time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 11, 30, 0, 0, time.UTC)),
+		memoryOf(t, "mem-expired", types.MemoryTypeArtifact, mustSessionFamilyScope(t, "session-root"), "Expired memory", types.MemoryStatusExpired, types.ConfidenceHigh, types.MemorySourceImported, nil, nil, types.Empty[types.MemoryID](), types.Of(time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)), time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 12, 30, 0, 0, time.UTC)),
+	}
+	for _, memory := range fixtureMemories {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+
+	t.Run("default active list excludes terminal statuses", func(t *testing.T) {
+		t.Parallel()
+
+		criteria := apptypes.NewMemoryListCriteriaBuilder(10).Build()
+		summaries, err := sut.List(ctx, criteria)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if got := len(summaries); got != 2 {
+			t.Fatalf("len(List()) = %d, want 2", got)
+		}
+		if diff := cmp.Diff([]string{"mem-candidate", "mem-accepted"}, []string{summaries[0].MemoryID().String(), summaries[1].MemoryID().String()}); diff != "" {
+			t.Fatalf("IDs mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("explicit rejected status is queryable", func(t *testing.T) {
+		t.Parallel()
+
+		criteria := apptypes.NewMemoryListCriteriaBuilder(10).
+			Status(types.MemoryStatusRejected).
+			Build()
+		summaries, err := sut.List(ctx, criteria)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if got := len(summaries); got != 1 {
+			t.Fatalf("len(List()) = %d, want 1", got)
+		}
+		if diff := cmp.Diff("mem-rejected", summaries[0].MemoryID().String()); diff != "" {
+			t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("typed session-family scope is queryable", func(t *testing.T) {
+		t.Parallel()
+
+		criteria := apptypes.NewMemoryListCriteriaBuilder(10).
+			Scope(mustSessionFamilyScope(t, "session-root")).
+			Statuses([]types.MemoryStatus{types.MemoryStatusExpired}).
+			Build()
+		summaries, err := sut.List(ctx, criteria)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if got := len(summaries); got != 1 {
+			t.Fatalf("len(List()) = %d, want 1", got)
+		}
+		if diff := cmp.Diff("mem-expired", summaries[0].MemoryID().String()); diff != "" {
+			t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMemoryDatasource_Search(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	memories := []*model.Memory{
+		memoryOf(
+			t,
+			"mem-fact",
+			types.MemoryTypeDecision,
+			mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+			"Release issues close only after tagged release",
+			types.MemoryStatusAccepted,
+			types.ConfidenceVerified,
+			types.MemorySourceManual,
+			[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindIssue, "454")},
+			nil,
+			types.Empty[types.MemoryID](),
+			types.Empty[time.Time](),
+			time.Date(2026, 4, 12, 7, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 12, 7, 10, 0, 0, time.UTC),
+		),
+		memoryOf(
+			t,
+			"mem-artifact",
+			types.MemoryTypeArtifact,
+			mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+			"Homebrew formula update PR",
+			types.MemoryStatusAccepted,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			[]types.ArtifactRef{mustArtifactRef(t, types.ArtifactRefKindPR, "458")},
+			types.Empty[types.MemoryID](),
+			types.Empty[time.Time](),
+			time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 12, 8, 10, 0, 0, time.UTC),
+		),
+	}
+	for _, memory := range memories {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+
+	searchByFact := apptypes.NewMemorySearchCriteriaBuilder(10).Query("tagged release").Build()
+	factResults, err := sut.Search(ctx, searchByFact)
+	if err != nil {
+		t.Fatalf("Search(fact) error = %v", err)
+	}
+	if got := len(factResults); got != 1 {
+		t.Fatalf("len(Search(fact)) = %d, want 1", got)
+	}
+	if diff := cmp.Diff("mem-fact", factResults[0].MemoryID().String()); diff != "" {
+		t.Fatalf("fact result mismatch (-want +got):\n%s", diff)
+	}
+
+	searchByArtifact := apptypes.NewMemorySearchCriteriaBuilder(10).Query("458").Build()
+	artifactResults, err := sut.Search(ctx, searchByArtifact)
+	if err != nil {
+		t.Fatalf("Search(artifact) error = %v", err)
+	}
+	if got := len(artifactResults); got != 1 {
+		t.Fatalf("len(Search(artifact)) = %d, want 1", got)
+	}
+	if diff := cmp.Diff("mem-artifact", artifactResults[0].MemoryID().String()); diff != "" {
+		t.Fatalf("artifact result mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -56,13 +56,17 @@ CREATE TABLE memory_evidence_refs (
     ref_value TEXT NOT NULL,
     PRIMARY KEY (memory_id, ordinal)
 );
+CREATE INDEX idx_memory_evidence_refs_lookup
+    ON memory_evidence_refs(ref_kind, ref_value);
 CREATE TABLE memory_artifact_refs (
     memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
     ordinal INTEGER NOT NULL,
     ref_kind TEXT NOT NULL,
     ref_value TEXT NOT NULL,
     PRIMARY KEY (memory_id, ordinal)
-);`),
+);
+CREATE INDEX idx_memory_artifact_refs_lookup
+    ON memory_artifact_refs(ref_kind, ref_value);`),
 		},
 	}
 }
@@ -440,6 +444,22 @@ func TestMemoryDatasource_Search(t *testing.T) {
 			time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC),
 			time.Date(2026, 4, 12, 8, 10, 0, 0, time.UTC),
 		),
+		memoryOf(
+			t,
+			"mem-path",
+			types.MemoryTypeLesson,
+			mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+			`Windows path C:\traceary\memory.db`,
+			types.MemoryStatusAccepted,
+			types.ConfidenceMedium,
+			types.MemorySourceImported,
+			nil,
+			nil,
+			types.Empty[types.MemoryID](),
+			types.Empty[time.Time](),
+			time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 12, 9, 10, 0, 0, time.UTC),
+		),
 	}
 	for _, memory := range memories {
 		if err := sut.Save(ctx, memory); err != nil {
@@ -469,5 +489,17 @@ func TestMemoryDatasource_Search(t *testing.T) {
 	}
 	if diff := cmp.Diff("mem-artifact", artifactResults[0].MemoryID().String()); diff != "" {
 		t.Fatalf("artifact result mismatch (-want +got):\n%s", diff)
+	}
+
+	searchByPath := apptypes.NewMemorySearchCriteriaBuilder(10).Query(`C:\traceary\memory.db`).Build()
+	pathResults, err := sut.Search(ctx, searchByPath)
+	if err != nil {
+		t.Fatalf("Search(path) error = %v", err)
+	}
+	if got := len(pathResults); got != 1 {
+		t.Fatalf("len(Search(path)) = %d, want 1", got)
+	}
+	if diff := cmp.Diff("mem-path", pathResults[0].MemoryID().String()); diff != "" {
+		t.Fatalf("path result mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -74,6 +74,23 @@ CREATE TABLE command_audits (
 		t.Fatalf("SaveWithAudit() error = %v", err)
 	}
 
+	pathEventID, _ := types.EventIDOf("event-path")
+	pathAgent, _ := types.AgentOf("codex")
+	pathSessionID, _ := types.SessionIDOf("session-path")
+	pathEvent := model.EventOf(
+		pathEventID,
+		types.EventKindNote,
+		types.Client("cli"),
+		pathAgent,
+		pathSessionID,
+		types.Workspace("github.com/duck8823/traceary"),
+		`Windows path C:\traceary\logs`,
+		time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), pathEvent); err != nil {
+		t.Fatalf("Save(pathEvent) error = %v", err)
+	}
+
 	got, err := sut.Search(context.Background(), "stdout", types.Workspace("github.com/duck8823/traceary"), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC), time.Date(2026, 4, 9, 0, 0, 0, 0, time.UTC), 10, 0, false)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
@@ -111,6 +128,21 @@ CREATE TABLE command_audits (
 			t.Fatalf("len(filtered) = %d, want 1", len(filtered))
 		}
 		if diff := cmp.Diff("event-note", filtered[0].EventID().String()); diff != "" {
+			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("matches literal backslashes in search queries", func(t *testing.T) {
+		t.Parallel()
+
+		filtered, err := sut.Search(context.Background(), `C:\traceary\logs`, types.Workspace("github.com/duck8823/traceary"), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Time{}, time.Time{}, 10, 0, false)
+		if err != nil {
+			t.Fatalf("Search() error = %v", err)
+		}
+		if len(filtered) != 1 {
+			t.Fatalf("len(filtered) = %d, want 1", len(filtered))
+		}
+		if diff := cmp.Diff("event-path", filtered[0].EventID().String()); diff != "" {
 			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/infrastructure/sqlite/sql/delete_memory_artifact_refs.sql
+++ b/infrastructure/sqlite/sql/delete_memory_artifact_refs.sql
@@ -1,0 +1,1 @@
+DELETE FROM memory_artifact_refs WHERE memory_id = ?;

--- a/infrastructure/sqlite/sql/delete_memory_evidence_refs.sql
+++ b/infrastructure/sqlite/sql/delete_memory_evidence_refs.sql
@@ -1,0 +1,1 @@
+DELETE FROM memory_evidence_refs WHERE memory_id = ?;

--- a/infrastructure/sqlite/sql/insert_memory_artifact_ref.sql
+++ b/infrastructure/sqlite/sql/insert_memory_artifact_ref.sql
@@ -1,0 +1,6 @@
+INSERT INTO memory_artifact_refs (
+    memory_id,
+    ordinal,
+    ref_kind,
+    ref_value
+) VALUES (?, ?, ?, ?);

--- a/infrastructure/sqlite/sql/insert_memory_evidence_ref.sql
+++ b/infrastructure/sqlite/sql/insert_memory_evidence_ref.sql
@@ -1,0 +1,6 @@
+INSERT INTO memory_evidence_refs (
+    memory_id,
+    ordinal,
+    ref_kind,
+    ref_value
+) VALUES (?, ?, ?, ?);

--- a/infrastructure/sqlite/sql/select_memory_artifact_refs.sql
+++ b/infrastructure/sqlite/sql/select_memory_artifact_refs.sql
@@ -1,0 +1,6 @@
+SELECT
+    ref_kind,
+    ref_value
+FROM memory_artifact_refs
+WHERE memory_id = ?
+ORDER BY ordinal ASC;

--- a/infrastructure/sqlite/sql/select_memory_evidence_refs.sql
+++ b/infrastructure/sqlite/sql/select_memory_evidence_refs.sql
@@ -1,0 +1,6 @@
+SELECT
+    ref_kind,
+    ref_value
+FROM memory_evidence_refs
+WHERE memory_id = ?
+ORDER BY ordinal ASC;

--- a/infrastructure/sqlite/sql/select_memory_row_by_id.sql
+++ b/infrastructure/sqlite/sql/select_memory_row_by_id.sql
@@ -1,0 +1,15 @@
+SELECT
+    id,
+    type,
+    scope_kind,
+    scope_value,
+    fact,
+    status,
+    confidence,
+    source,
+    supersedes_memory_id,
+    expires_at,
+    created_at,
+    updated_at
+FROM memories
+WHERE id = ?;

--- a/infrastructure/sqlite/sql/upsert_memory.sql
+++ b/infrastructure/sqlite/sql/upsert_memory.sql
@@ -1,0 +1,26 @@
+INSERT INTO memories (
+    id,
+    type,
+    scope_kind,
+    scope_value,
+    fact,
+    status,
+    confidence,
+    source,
+    supersedes_memory_id,
+    expires_at,
+    created_at,
+    updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    type = excluded.type,
+    scope_kind = excluded.scope_kind,
+    scope_value = excluded.scope_value,
+    fact = excluded.fact,
+    status = excluded.status,
+    confidence = excluded.confidence,
+    source = excluded.source,
+    supersedes_memory_id = excluded.supersedes_memory_id,
+    expires_at = excluded.expires_at,
+    created_at = excluded.created_at,
+    updated_at = excluded.updated_at;

--- a/schema/sqlite/migrations/000008_create_memories.sql
+++ b/schema/sqlite/migrations/000008_create_memories.sql
@@ -1,0 +1,45 @@
+CREATE TABLE memories (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    scope_kind TEXT NOT NULL,
+    scope_value TEXT NOT NULL,
+    fact TEXT NOT NULL,
+    status TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    source TEXT NOT NULL,
+    supersedes_memory_id TEXT REFERENCES memories(id),
+    expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_memories_scope_status_updated
+    ON memories(scope_kind, scope_value, status, updated_at DESC, id DESC);
+
+CREATE INDEX idx_memories_type_status_updated
+    ON memories(type, status, updated_at DESC, id DESC);
+
+CREATE INDEX idx_memories_supersedes_memory_id
+    ON memories(supersedes_memory_id);
+
+CREATE TABLE memory_evidence_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);
+
+CREATE INDEX idx_memory_evidence_refs_lookup
+    ON memory_evidence_refs(ref_kind, ref_value);
+
+CREATE TABLE memory_artifact_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);
+
+CREATE INDEX idx_memory_artifact_refs_lookup
+    ON memory_artifact_refs(ref_kind, ref_value);


### PR DESCRIPTION
## Motivation
- durable memory needs persistent storage before CLI / MCP surfaces can use it
- v0.5.0 requires typed scope-aware read/query support for manual lifecycle and later context assembly
- active memory lookup should exclude terminal states by default while still allowing explicit status queries

## What changed
- add SQLite migration for `memories`, `memory_evidence_refs`, and `memory_artifact_refs`
- add `MemoryQueryService` plus memory read-side types and criteria builders
- implement `MemoryDatasource` as both `MemoryRepository` and `MemoryQueryService`
- add datasource and application-type tests for round-trip persistence, active filtering, and search semantics

## Validation
- `go test ./...`
- `go build ./...`
- `go tool golangci-lint run`

Closes #461
