### PR TITLE
feat: add manual durable memory lifecycle CLI

### DIFF
--- a/application/usecase/id_generator.go
+++ b/application/usecase/id_generator.go
@@ -23,6 +23,19 @@ func newEventID() (types.EventID, error) {
 	return eventID, nil
 }
 
+func newMemoryID() (types.MemoryID, error) {
+	value, err := newRandomHexString(16)
+	if err != nil {
+		return types.MemoryID(""), xerrors.Errorf("failed to generate memory ID: %w", err)
+	}
+
+	memoryID, err := types.MemoryIDOf("memory-" + value)
+	if err != nil {
+		return types.MemoryID(""), xerrors.Errorf("failed to convert memory ID: %w", err)
+	}
+
+	return memoryID, nil
+}
 func newSessionID() (types.SessionID, error) {
 	value, err := newRandomHexString(16)
 	if err != nil {

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryUsecase consolidates durable-memory lifecycle and query operations.
+type MemoryUsecase interface {
+	// Remember records an accepted memory directly.
+	Remember(
+		ctx context.Context,
+		memoryType domtypes.MemoryType,
+		scope domtypes.MemoryScope,
+		fact string,
+		confidence domtypes.Optional[domtypes.Confidence],
+		source domtypes.MemorySource,
+		evidenceRefs []domtypes.EvidenceRef,
+		artifactRefs []domtypes.ArtifactRef,
+	) (apptypes.MemoryDetails, error)
+
+	// Propose records a candidate memory that still requires review.
+	Propose(
+		ctx context.Context,
+		memoryType domtypes.MemoryType,
+		scope domtypes.MemoryScope,
+		fact string,
+		source domtypes.MemorySource,
+		evidenceRefs []domtypes.EvidenceRef,
+		artifactRefs []domtypes.ArtifactRef,
+	) (apptypes.MemoryDetails, error)
+
+	// Accept accepts an existing candidate memory.
+	Accept(ctx context.Context, memoryID domtypes.MemoryID, confidence domtypes.Optional[domtypes.Confidence]) (apptypes.MemoryDetails, error)
+
+	// Reject rejects an existing candidate memory.
+	Reject(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error)
+
+	// Supersede replaces an accepted memory with a new accepted memory.
+	Supersede(
+		ctx context.Context,
+		memoryID domtypes.MemoryID,
+		memoryType domtypes.MemoryType,
+		scope domtypes.MemoryScope,
+		fact string,
+		confidence domtypes.Optional[domtypes.Confidence],
+		source domtypes.MemorySource,
+		evidenceRefs []domtypes.EvidenceRef,
+		artifactRefs []domtypes.ArtifactRef,
+	) (apptypes.MemoryDetails, error)
+
+	// Expire expires an active memory at the given time. Empty expiry means now.
+	Expire(ctx context.Context, memoryID domtypes.MemoryID, expiresAt domtypes.Optional[time.Time]) (apptypes.MemoryDetails, error)
+
+	// List returns memory summaries matching the criteria.
+	List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error)
+
+	// Search searches durable memories.
+	Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error)
+
+	// Show returns the details for a single durable memory.
+	Show(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error)
+}

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -273,15 +273,11 @@ func (u *memoryUsecase) Supersede(
 	if err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build replacement memory: %w", err)
 	}
-	if err := u.memoryRepo.Save(ctx, memory); err != nil {
-		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save replacement memory: %w", err)
-	}
-
 	if err := existing.MarkSuperseded(); err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to supersede existing memory: %w", err)
 	}
-	if err := u.memoryRepo.Save(ctx, existing); err != nil {
-		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save superseded memory state: %w", err)
+	if err := u.memoryRepo.SaveSupersession(ctx, existing, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save supersession: %w", err)
 	}
 
 	details, err := apptypes.MemoryDetailsFrom(memory)

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -1,0 +1,518 @@
+package usecase
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+type memoryUsecase struct {
+	memoryRepo          model.MemoryRepository
+	memoryQuery         queryservice.MemoryQueryService
+	extraRedactPatterns []string
+}
+
+// NewMemoryUsecase creates a MemoryUsecase.
+func NewMemoryUsecase(
+	memoryRepo model.MemoryRepository,
+	memoryQuery queryservice.MemoryQueryService,
+	extraRedactPatterns []string,
+) MemoryUsecase {
+	return &memoryUsecase{
+		memoryRepo:          memoryRepo,
+		memoryQuery:         memoryQuery,
+		extraRedactPatterns: slices.Clone(extraRedactPatterns),
+	}
+}
+
+func (u *memoryUsecase) Remember(
+	ctx context.Context,
+	memoryType domtypes.MemoryType,
+	scope domtypes.MemoryScope,
+	fact string,
+	confidence domtypes.Optional[domtypes.Confidence],
+	source domtypes.MemorySource,
+	evidenceRefs []domtypes.EvidenceRef,
+	artifactRefs []domtypes.ArtifactRef,
+) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	resolvedType, err := resolveRequiredMemoryType(memoryType)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedScope, err := resolveRequiredMemoryScope(scope)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedSource, err := resolveMemorySource(source)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedConfidence, err := resolveAcceptedConfidence(confidence)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	fact, evidenceRefs, artifactRefs, err = u.sanitizeMemoryPayload(fact, evidenceRefs, artifactRefs)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := requireAcceptedEvidenceRefs(evidenceRefs); err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+
+	memoryID, err := newMemoryID()
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to generate memory ID: %w", err)
+	}
+	memory, err := model.NewAcceptedMemory(
+		memoryID,
+		resolvedType,
+		resolvedScope,
+		fact,
+		resolvedConfidence,
+		resolvedSource,
+		evidenceRefs,
+		artifactRefs,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build accepted memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save accepted memory: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) Propose(
+	ctx context.Context,
+	memoryType domtypes.MemoryType,
+	scope domtypes.MemoryScope,
+	fact string,
+	source domtypes.MemorySource,
+	evidenceRefs []domtypes.EvidenceRef,
+	artifactRefs []domtypes.ArtifactRef,
+) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	resolvedType, err := resolveRequiredMemoryType(memoryType)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedScope, err := resolveRequiredMemoryScope(scope)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedSource, err := resolveMemorySource(source)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	fact, evidenceRefs, artifactRefs, err = u.sanitizeMemoryPayload(fact, evidenceRefs, artifactRefs)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+
+	memoryID, err := newMemoryID()
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to generate memory ID: %w", err)
+	}
+	memory, err := model.NewMemoryCandidate(
+		memoryID,
+		resolvedType,
+		resolvedScope,
+		fact,
+		resolvedSource,
+		evidenceRefs,
+		artifactRefs,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build candidate memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save candidate memory: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) Accept(ctx context.Context, memoryID domtypes.MemoryID, confidence domtypes.Optional[domtypes.Confidence]) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	memory, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := requireAcceptedEvidenceRefs(memory.EvidenceRefs()); err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedConfidence, err := resolveAcceptedConfidence(confidence)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := memory.Accept(resolvedConfidence); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to accept memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save accepted memory: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) Reject(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	memory, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := memory.Reject(); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to reject memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save rejected memory: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) Supersede(
+	ctx context.Context,
+	memoryID domtypes.MemoryID,
+	memoryType domtypes.MemoryType,
+	scope domtypes.MemoryScope,
+	fact string,
+	confidence domtypes.Optional[domtypes.Confidence],
+	source domtypes.MemorySource,
+	evidenceRefs []domtypes.EvidenceRef,
+	artifactRefs []domtypes.ArtifactRef,
+) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	existing, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+
+	resolvedType, err := inheritOrResolveMemoryType(memoryType, existing.MemoryType())
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedScope, err := inheritOrResolveMemoryScope(scope, existing.Scope())
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedSource, err := resolveMemorySource(source)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedConfidence, err := resolveAcceptedConfidence(confidence)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	fact, evidenceRefs, artifactRefs, err = u.sanitizeMemoryPayload(fact, evidenceRefs, artifactRefs)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := requireAcceptedEvidenceRefs(evidenceRefs); err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+
+	newMemoryID, err := newMemoryID()
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to generate replacement memory ID: %w", err)
+	}
+	memory, err := model.NewAcceptedMemory(
+		newMemoryID,
+		resolvedType,
+		resolvedScope,
+		fact,
+		resolvedConfidence,
+		resolvedSource,
+		evidenceRefs,
+		artifactRefs,
+		domtypes.Of(existing.MemoryID()),
+	)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build replacement memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save replacement memory: %w", err)
+	}
+
+	if err := existing.MarkSuperseded(); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to supersede existing memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, existing); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save superseded memory state: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) Expire(ctx context.Context, memoryID domtypes.MemoryID, expiresAt domtypes.Optional[time.Time]) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	memory, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	resolvedExpiresAt, err := resolveExpiresAt(expiresAt)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := memory.Expire(resolvedExpiresAt); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to expire memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save expired memory: %w", err)
+	}
+
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	if u.memoryQuery == nil {
+		return nil, xerrors.Errorf("memory query service is not configured")
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	summaries, err := u.memoryQuery.List(ctx, criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list durable memories: %w", err)
+	}
+	return summaries, nil
+}
+
+func (u *memoryUsecase) Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	if u.memoryQuery == nil {
+		return nil, xerrors.Errorf("memory query service is not configured")
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !hasMemorySearchConstraint(criteria) {
+		return nil, xerrors.Errorf("at least one search filter is required")
+	}
+
+	summaries, err := u.memoryQuery.Search(ctx, criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to search durable memories: %w", err)
+	}
+	return summaries, nil
+}
+
+func (u *memoryUsecase) Show(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	if u.memoryQuery == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory query service is not configured")
+	}
+	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID.String())
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to resolve memory ID: %w", err)
+	}
+
+	details, err := u.memoryQuery.GetDetails(ctx, resolvedMemoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to get memory details: %w", err)
+	}
+	return details, nil
+}
+
+func (u *memoryUsecase) findMemoryByID(ctx context.Context, memoryID domtypes.MemoryID) (*model.Memory, error) {
+	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to resolve memory ID: %w", err)
+	}
+
+	result, err := u.memoryRepo.FindByID(ctx, resolvedMemoryID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to find memory: %w", err)
+	}
+	memory, ok := result.Get()
+	if !ok {
+		return nil, xerrors.Errorf("memory not found: %s", resolvedMemoryID)
+	}
+	return memory, nil
+}
+
+func (u *memoryUsecase) sanitizeMemoryPayload(
+	fact string,
+	evidenceRefs []domtypes.EvidenceRef,
+	artifactRefs []domtypes.ArtifactRef,
+) (string, []domtypes.EvidenceRef, []domtypes.ArtifactRef, error) {
+	extraRedactors, err := compileExtraRedactPatterns(u.extraRedactPatterns)
+	if err != nil {
+		return "", nil, nil, xerrors.Errorf("failed to compile extra redaction patterns: %w", err)
+	}
+
+	sanitizedFact, _ := redactAuditPayload(strings.TrimSpace(fact), extraRedactors)
+	sanitizedEvidenceRefs, err := sanitizeEvidenceRefs(evidenceRefs, extraRedactors)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	sanitizedArtifactRefs, err := sanitizeArtifactRefs(artifactRefs, extraRedactors)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	return sanitizedFact, sanitizedEvidenceRefs, sanitizedArtifactRefs, nil
+}
+
+func sanitizeEvidenceRefs(refs []domtypes.EvidenceRef, extraRedactors []auditPayloadRedactor) ([]domtypes.EvidenceRef, error) {
+	sanitized := make([]domtypes.EvidenceRef, 0, len(refs))
+	for _, ref := range refs {
+		value, _ := redactAuditPayload(ref.Value(), extraRedactors)
+		resolvedRef, err := domtypes.EvidenceRefOf(ref.Kind(), value)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to sanitize evidence ref: %w", err)
+		}
+		sanitized = append(sanitized, resolvedRef)
+	}
+	return sanitized, nil
+}
+
+func sanitizeArtifactRefs(refs []domtypes.ArtifactRef, extraRedactors []auditPayloadRedactor) ([]domtypes.ArtifactRef, error) {
+	sanitized := make([]domtypes.ArtifactRef, 0, len(refs))
+	for _, ref := range refs {
+		value, _ := redactAuditPayload(ref.Value(), extraRedactors)
+		resolvedRef, err := domtypes.ArtifactRefOf(ref.Kind(), value)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to sanitize artifact ref: %w", err)
+		}
+		sanitized = append(sanitized, resolvedRef)
+	}
+	return sanitized, nil
+}
+
+func resolveRequiredMemoryType(memoryType domtypes.MemoryType) (domtypes.MemoryType, error) {
+	resolved, err := domtypes.MemoryTypeOf(memoryType.String())
+	if err != nil {
+		return domtypes.MemoryType(""), xerrors.Errorf("failed to resolve memory type: %w", err)
+	}
+	return resolved, nil
+}
+
+func inheritOrResolveMemoryType(memoryType domtypes.MemoryType, fallback domtypes.MemoryType) (domtypes.MemoryType, error) {
+	if strings.TrimSpace(memoryType.String()) == "" {
+		return resolveRequiredMemoryType(fallback)
+	}
+	return resolveRequiredMemoryType(memoryType)
+}
+
+func resolveRequiredMemoryScope(scope domtypes.MemoryScope) (domtypes.MemoryScope, error) {
+	if scope == nil {
+		return nil, xerrors.Errorf("memory scope must not be nil")
+	}
+	if _, err := domtypes.MemoryScopeFrom(scope.Kind().String(), scope.Key()); err != nil {
+		return nil, xerrors.Errorf("failed to resolve memory scope: %w", err)
+	}
+	return scope, nil
+}
+
+func inheritOrResolveMemoryScope(scope domtypes.MemoryScope, fallback domtypes.MemoryScope) (domtypes.MemoryScope, error) {
+	if scope == nil {
+		return resolveRequiredMemoryScope(fallback)
+	}
+	return resolveRequiredMemoryScope(scope)
+}
+
+func resolveMemorySource(source domtypes.MemorySource) (domtypes.MemorySource, error) {
+	if strings.TrimSpace(source.String()) == "" {
+		return domtypes.MemorySourceManual, nil
+	}
+	resolved, err := domtypes.MemorySourceOf(source.String())
+	if err != nil {
+		return domtypes.MemorySource(""), xerrors.Errorf("failed to resolve memory source: %w", err)
+	}
+	return resolved, nil
+}
+
+func resolveAcceptedConfidence(confidence domtypes.Optional[domtypes.Confidence]) (domtypes.Confidence, error) {
+	if value, ok := confidence.Get(); ok {
+		resolved, err := domtypes.ConfidenceOf(value.String())
+		if err != nil {
+			return domtypes.Confidence(""), xerrors.Errorf("failed to resolve confidence: %w", err)
+		}
+		return resolved, nil
+	}
+	return domtypes.ConfidenceVerified, nil
+}
+
+func requireAcceptedEvidenceRefs(evidenceRefs []domtypes.EvidenceRef) error {
+	if len(evidenceRefs) == 0 {
+		return xerrors.Errorf("accepted memory requires at least one evidence ref")
+	}
+	return nil
+}
+
+func resolveExpiresAt(expiresAt domtypes.Optional[time.Time]) (time.Time, error) {
+	if value, ok := expiresAt.Get(); ok {
+		if value.IsZero() {
+			return time.Time{}, xerrors.Errorf("expiry timestamp must not be zero")
+		}
+		return value, nil
+	}
+	return time.Now(), nil
+}
+
+func hasMemorySearchConstraint(criteria apptypes.MemorySearchCriteria) bool {
+	return strings.TrimSpace(criteria.Query()) != "" ||
+		len(criteria.Scopes()) > 0 ||
+		len(criteria.Statuses()) > 0 ||
+		len(criteria.MemoryTypes()) > 0
+}

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type memoryRepositoryStub struct {
-	byID      map[string]*model.Memory
-	saveCalls []*model.Memory
-	saveErr   error
-	findErr   error
+	byID              map[string]*model.Memory
+	saveCalls         []*model.Memory
+	supersessionCalls []memorySupersessionCall
+	saveErr           error
+	findErr           error
 }
 
 func (s *memoryRepositoryStub) Save(_ context.Context, memory *model.Memory) error {
@@ -27,6 +28,24 @@ func (s *memoryRepositoryStub) Save(_ context.Context, memory *model.Memory) err
 	}
 	s.saveCalls = append(s.saveCalls, memory)
 	s.byID[memory.MemoryID().String()] = memory
+	return s.saveErr
+}
+
+type memorySupersessionCall struct {
+	superseded  *model.Memory
+	replacement *model.Memory
+}
+
+func (s *memoryRepositoryStub) SaveSupersession(_ context.Context, superseded *model.Memory, replacement *model.Memory) error {
+	if s.byID == nil {
+		s.byID = make(map[string]*model.Memory)
+	}
+	s.supersessionCalls = append(s.supersessionCalls, memorySupersessionCall{
+		superseded:  superseded,
+		replacement: replacement,
+	})
+	s.byID[superseded.MemoryID().String()] = superseded
+	s.byID[replacement.MemoryID().String()] = replacement
 	return s.saveErr
 }
 
@@ -247,8 +266,8 @@ func TestMemoryUsecase_Supersede(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Supersede() error = %v", err)
 	}
-	if len(repo.saveCalls) != 2 {
-		t.Fatalf("Save() call count = %d, want 2", len(repo.saveCalls))
+	if len(repo.supersessionCalls) != 1 {
+		t.Fatalf("SaveSupersession() call count = %d, want 1", len(repo.supersessionCalls))
 	}
 	if diff := cmp.Diff(domtypes.MemoryStatusSuperseded, repo.byID[originalID.String()].Status()); diff != "" {
 		t.Fatalf("original status mismatch (-want +got):\n%s", diff)

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -1,0 +1,380 @@
+package usecase_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+type memoryRepositoryStub struct {
+	byID      map[string]*model.Memory
+	saveCalls []*model.Memory
+	saveErr   error
+	findErr   error
+}
+
+func (s *memoryRepositoryStub) Save(_ context.Context, memory *model.Memory) error {
+	if s.byID == nil {
+		s.byID = make(map[string]*model.Memory)
+	}
+	s.saveCalls = append(s.saveCalls, memory)
+	s.byID[memory.MemoryID().String()] = memory
+	return s.saveErr
+}
+
+func (s *memoryRepositoryStub) FindByID(_ context.Context, memoryID domtypes.MemoryID) (domtypes.Optional[*model.Memory], error) {
+	if s.findErr != nil {
+		return domtypes.Empty[*model.Memory](), s.findErr
+	}
+	if s.byID == nil {
+		return domtypes.Empty[*model.Memory](), nil
+	}
+	memory, ok := s.byID[memoryID.String()]
+	if !ok {
+		return domtypes.Empty[*model.Memory](), nil
+	}
+	return domtypes.Of(memory), nil
+}
+
+type memoryQueryStub struct {
+	listResult   []apptypes.MemorySummary
+	listErr      error
+	searchResult []apptypes.MemorySummary
+	searchErr    error
+	details      apptypes.MemoryDetails
+	detailsErr   error
+}
+
+func (s *memoryQueryStub) List(_ context.Context, _ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	return s.listResult, s.listErr
+}
+
+func (s *memoryQueryStub) Search(_ context.Context, _ apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	return s.searchResult, s.searchErr
+}
+
+func (s *memoryQueryStub) GetDetails(_ context.Context, _ domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	return s.details, s.detailsErr
+}
+
+func TestMemoryUsecase_Remember(t *testing.T) {
+	t.Parallel()
+
+	repo := &memoryRepositoryStub{}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	scope := domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary"))
+	evidenceRef := mustEvidenceRef(t, domtypes.EvidenceRefKindURL, "https://example.com?token=secret-token")
+	artifactRef := mustArtifactRef(t, domtypes.ArtifactRefKindIssue, "#454")
+
+	details, err := sut.Remember(
+		context.Background(),
+		domtypes.MemoryTypeDecision,
+		scope,
+		`keep {"api_key":"super-secret"} out of releases`,
+		domtypes.Empty[domtypes.Confidence](),
+		domtypes.MemorySource(""),
+		[]domtypes.EvidenceRef{evidenceRef},
+		[]domtypes.ArtifactRef{artifactRef},
+	)
+	if err != nil {
+		t.Fatalf("Remember() error = %v", err)
+	}
+	if len(repo.saveCalls) != 1 {
+		t.Fatalf("Save() call count = %d, want 1", len(repo.saveCalls))
+	}
+
+	saved := repo.saveCalls[0]
+	if saved.Status() != domtypes.MemoryStatusAccepted {
+		t.Fatalf("Status() = %s, want accepted", saved.Status())
+	}
+	if saved.Confidence() != domtypes.ConfidenceVerified {
+		t.Fatalf("Confidence() = %s, want verified", saved.Confidence())
+	}
+	if saved.Source() != domtypes.MemorySourceManual {
+		t.Fatalf("Source() = %s, want manual", saved.Source())
+	}
+	if !strings.Contains(saved.Fact(), "[REDACTED]") {
+		t.Fatalf("Fact() = %q, want redacted placeholder", saved.Fact())
+	}
+	if got := saved.EvidenceRefs()[0].Value(); !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("EvidenceRef.Value() = %q, want redacted placeholder", got)
+	}
+	if details.Summary().MemoryID().String() == "" {
+		t.Fatalf("Summary().MemoryID() is empty")
+	}
+}
+
+func TestMemoryUsecase_Propose(t *testing.T) {
+	t.Parallel()
+
+	repo := &memoryRepositoryStub{}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	details, err := sut.Propose(
+		context.Background(),
+		domtypes.MemoryTypeLesson,
+		domtypes.AgentScopeOf(domtypes.Agent("codex")),
+		"wait for codex review before merge",
+		domtypes.MemorySourceExtracted,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Propose() error = %v", err)
+	}
+
+	saved := repo.saveCalls[0]
+	if diff := cmp.Diff(domtypes.MemoryStatusCandidate, saved.Status()); diff != "" {
+		t.Fatalf("Status() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.ConfidenceLow, saved.Confidence()); diff != "" {
+		t.Fatalf("Confidence() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.MemorySourceExtracted, saved.Source()); diff != "" {
+		t.Fatalf("Source() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(saved.MemoryID(), details.Summary().MemoryID()); diff != "" {
+		t.Fatalf("MemoryID() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryUsecase_AcceptRequiresEvidence(t *testing.T) {
+	t.Parallel()
+
+	memoryID := mustMemoryID(t, "memory-candidate-no-evidence")
+	candidate, err := model.NewMemoryCandidate(
+		memoryID,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"candidate without evidence",
+		domtypes.MemorySourceManual,
+		nil,
+		nil,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewMemoryCandidate() error = %v", err)
+	}
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{memoryID.String(): candidate}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	if _, err := sut.Accept(context.Background(), memoryID, domtypes.Empty[domtypes.Confidence]()); err == nil {
+		t.Fatal("Accept() error = nil, want error")
+	}
+}
+
+func TestMemoryUsecase_Accept(t *testing.T) {
+	t.Parallel()
+
+	memoryID := mustMemoryID(t, "memory-candidate")
+	candidate, err := model.NewMemoryCandidate(
+		memoryID,
+		domtypes.MemoryTypeConstraint,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"candidate with evidence",
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#462")},
+		nil,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewMemoryCandidate() error = %v", err)
+	}
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{memoryID.String(): candidate}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	details, err := sut.Accept(context.Background(), memoryID, domtypes.Of(domtypes.ConfidenceHigh))
+	if err != nil {
+		t.Fatalf("Accept() error = %v", err)
+	}
+
+	saved := repo.byID[memoryID.String()]
+	if diff := cmp.Diff(domtypes.MemoryStatusAccepted, saved.Status()); diff != "" {
+		t.Fatalf("Status() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.ConfidenceHigh, saved.Confidence()); diff != "" {
+		t.Fatalf("Confidence() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.MemoryStatusAccepted, details.Summary().Status()); diff != "" {
+		t.Fatalf("Summary().Status() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryUsecase_Supersede(t *testing.T) {
+	t.Parallel()
+
+	originalID := mustMemoryID(t, "memory-original")
+	original, err := model.NewAcceptedMemory(
+		originalID,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"old fact",
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#453")},
+		nil,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{originalID.String(): original}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	details, err := sut.Supersede(
+		context.Background(),
+		originalID,
+		domtypes.MemoryType(""),
+		nil,
+		"new fact",
+		domtypes.Empty[domtypes.Confidence](),
+		domtypes.MemorySource(""),
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindPR, "#467")},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Supersede() error = %v", err)
+	}
+	if len(repo.saveCalls) != 2 {
+		t.Fatalf("Save() call count = %d, want 2", len(repo.saveCalls))
+	}
+	if diff := cmp.Diff(domtypes.MemoryStatusSuperseded, repo.byID[originalID.String()].Status()); diff != "" {
+		t.Fatalf("original status mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(originalID.String(), mustMemoryIDString(t, details.Summary().Supersedes())); diff != "" {
+		t.Fatalf("Supersedes() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.MemoryStatusAccepted, details.Summary().Status()); diff != "" {
+		t.Fatalf("replacement status mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryUsecase_Expire(t *testing.T) {
+	t.Parallel()
+
+	memoryID := mustMemoryID(t, "memory-expire")
+	memory, err := model.NewAcceptedMemory(
+		memoryID,
+		domtypes.MemoryTypeConstraint,
+		domtypes.AgentScopeOf(domtypes.Agent("codex")),
+		"expires later",
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#462")},
+		nil,
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+	when := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{memoryID.String(): memory}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	details, err := sut.Expire(context.Background(), memoryID, domtypes.Of(when))
+	if err != nil {
+		t.Fatalf("Expire() error = %v", err)
+	}
+	if diff := cmp.Diff(domtypes.MemoryStatusExpired, repo.byID[memoryID.String()].Status()); diff != "" {
+		t.Fatalf("Status() mismatch (-want +got):\n%s", diff)
+	}
+	expiresAt, ok := details.Summary().ExpiresAt().Get()
+	if !ok {
+		t.Fatal("ExpiresAt() missing, want value")
+	}
+	if diff := cmp.Diff(when, expiresAt); diff != "" {
+		t.Fatalf("ExpiresAt() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryUsecase_Show(t *testing.T) {
+	t.Parallel()
+
+	memory := mustAcceptedMemory(t, "memory-show", "shown fact")
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		t.Fatalf("MemoryDetailsFrom() error = %v", err)
+	}
+
+	sut := usecase.NewMemoryUsecase(nil, &memoryQueryStub{details: details}, nil)
+	got, err := sut.Show(context.Background(), memory.MemoryID())
+	if err != nil {
+		t.Fatalf("Show() error = %v", err)
+	}
+	if diff := cmp.Diff(details.Summary().MemoryID(), got.Summary().MemoryID()); diff != "" {
+		t.Fatalf("MemoryID() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func mustMemoryID(t *testing.T, value string) domtypes.MemoryID {
+	t.Helper()
+
+	memoryID, err := domtypes.MemoryIDOf(value)
+	if err != nil {
+		t.Fatalf("MemoryIDOf() error = %v", err)
+	}
+	return memoryID
+}
+
+func mustEvidenceRef(t *testing.T, kind domtypes.EvidenceRefKind, value string) domtypes.EvidenceRef {
+	t.Helper()
+
+	ref, err := domtypes.EvidenceRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("EvidenceRefOf() error = %v", err)
+	}
+	return ref
+}
+
+func mustArtifactRef(t *testing.T, kind domtypes.ArtifactRefKind, value string) domtypes.ArtifactRef {
+	t.Helper()
+
+	ref, err := domtypes.ArtifactRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("ArtifactRefOf() error = %v", err)
+	}
+	return ref
+}
+
+func mustAcceptedMemory(t *testing.T, memoryIDValue string, fact string) *model.Memory {
+	t.Helper()
+
+	memory, err := model.NewAcceptedMemory(
+		mustMemoryID(t, memoryIDValue),
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		fact,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#454")},
+		[]domtypes.ArtifactRef{mustArtifactRef(t, domtypes.ArtifactRefKindPR, "#467")},
+		domtypes.Empty[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+	return memory
+}
+
+func mustMemoryIDString(t *testing.T, value domtypes.Optional[domtypes.MemoryID]) string {
+	t.Helper()
+
+	memoryID, ok := value.Get()
+	if !ok {
+		t.Fatal("Optional.Get() = empty, want value")
+	}
+	return memoryID.String()
+}

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -127,6 +127,113 @@ alias:
 - `--limit`
 - `--json`
 
+## Durable memory コマンド
+
+### `traceary memory list`
+
+Durable memory を一覧表示します。scope flag を明示しない場合、`memory list` は解決した workspace scope を既定で使います。
+
+主な flag:
+
+- `--workspace`
+- `--agent`
+- `--session-family`
+- `--status`
+- `--type`
+- `--limit`
+- `--offset`
+- `--json`
+
+### `traceary memory search [<query>]`
+
+全文検索と構造フィルタで durable memory を検索します。query または filter のいずれか 1 つ以上が必要です。
+
+主な flag:
+
+- `--workspace`
+- `--agent`
+- `--session-family`
+- `--status`
+- `--type`
+- `--limit`
+- `--offset`
+- `--json`
+
+### `traceary memory show <memory-id>`
+
+1 件の durable memory を詳細表示します。evidence ref と artifact ref も含みます。
+
+主な flag:
+
+- `--json`
+
+### `traceary memory remember`
+
+accepted な durable memory を直接記録します。
+
+主な flag:
+
+- `--type`
+- `--fact`
+- `--workspace` / `--agent` / `--session-family`
+- `--confidence`
+- `--source`
+- `--evidence`
+- `--artifact`
+- `--id-only`
+- `--json`
+
+### `traceary memory propose`
+
+candidate な durable memory を記録します。後で review できます。
+
+主な flag は `memory remember` と同じですが、`--confidence` は使われません。
+
+### `traceary memory accept <memory-id>`
+
+candidate durable memory を accept します。
+
+主な flag:
+
+- `--confidence`
+- `--id-only`
+- `--json`
+
+### `traceary memory reject <memory-id>`
+
+candidate durable memory を reject します。
+
+主な flag:
+
+- `--id-only`
+- `--json`
+
+### `traceary memory supersede <memory-id>`
+
+accepted durable memory を新しい accepted memory で置き換えます。`--type` と scope flag を省略すると現在の memory を継承します。
+
+主な flag:
+
+- `--type`
+- `--fact`
+- `--workspace` / `--agent` / `--session-family`
+- `--confidence`
+- `--source`
+- `--evidence`
+- `--artifact`
+- `--id-only`
+- `--json`
+
+### `traceary memory expire <memory-id>`
+
+active な durable memory を expire します。
+
+主な flag:
+
+- `--at`
+- `--id-only`
+- `--json`
+
 ## Session コマンド
 
 ### `traceary session start`

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -127,6 +127,113 @@ Useful flags:
 - `--limit`
 - `--json`
 
+## Durable memory commands
+
+### `traceary memory list`
+
+List durable memories. When no explicit scope flag is set, `memory list` defaults to the resolved workspace scope.
+
+Useful flags:
+
+- `--workspace`
+- `--agent`
+- `--session-family`
+- `--status`
+- `--type`
+- `--limit`
+- `--offset`
+- `--json`
+
+### `traceary memory search [<query>]`
+
+Search durable memories by text and structured filters. At least one query or filter is required.
+
+Useful flags:
+
+- `--workspace`
+- `--agent`
+- `--session-family`
+- `--status`
+- `--type`
+- `--limit`
+- `--offset`
+- `--json`
+
+### `traceary memory show <memory-id>`
+
+Show one durable memory in detail, including evidence and artifact references.
+
+Useful flags:
+
+- `--json`
+
+### `traceary memory remember`
+
+Record an accepted durable memory directly.
+
+Useful flags:
+
+- `--type`
+- `--fact`
+- `--workspace` / `--agent` / `--session-family`
+- `--confidence`
+- `--source`
+- `--evidence`
+- `--artifact`
+- `--id-only`
+- `--json`
+
+### `traceary memory propose`
+
+Record a candidate durable memory that still needs review.
+
+Useful flags are the same as `memory remember`, except `--confidence` is ignored.
+
+### `traceary memory accept <memory-id>`
+
+Accept a candidate durable memory.
+
+Useful flags:
+
+- `--confidence`
+- `--id-only`
+- `--json`
+
+### `traceary memory reject <memory-id>`
+
+Reject a candidate durable memory.
+
+Useful flags:
+
+- `--id-only`
+- `--json`
+
+### `traceary memory supersede <memory-id>`
+
+Replace an accepted durable memory with a new accepted memory. Omitted `--type` and scope flags inherit from the current memory.
+
+Useful flags:
+
+- `--type`
+- `--fact`
+- `--workspace` / `--agent` / `--session-family`
+- `--confidence`
+- `--source`
+- `--evidence`
+- `--artifact`
+- `--id-only`
+- `--json`
+
+### `traceary memory expire <memory-id>`
+
+Expire an active durable memory.
+
+Useful flags:
+
+- `--at`
+- `--id-only`
+- `--json`
+
 ## Session commands
 
 ### `traceary session start`

--- a/domain/model/memory_repository.go
+++ b/domain/model/memory_repository.go
@@ -10,6 +10,9 @@ import (
 type MemoryRepository interface {
 	// Save persists a memory aggregate.
 	Save(ctx context.Context, memory *Memory) error
+	// SaveSupersession persists a superseded memory state and its replacement
+	// atomically.
+	SaveSupersession(ctx context.Context, superseded *Memory, replacement *Memory) error
 	// FindByID returns the memory for the given ID.
 	// Returns an empty Optional when the memory does not exist.
 	FindByID(ctx context.Context, memoryID types.MemoryID) (types.Optional[*Memory], error)

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -80,6 +80,36 @@ func (d *MemoryDatasource) Save(ctx context.Context, memory *model.Memory) error
 		return xerrors.Errorf("memory must not be nil")
 	}
 
+	return d.runMemoryWriteTx(ctx, func(tx *sql.Tx) error {
+		if err := persistMemoryTx(ctx, tx, memory); err != nil {
+			return xerrors.Errorf("failed to persist memory: %w", err)
+		}
+		return nil
+	})
+}
+
+// SaveSupersession persists a superseded memory state and its replacement in a
+// single transaction.
+func (d *MemoryDatasource) SaveSupersession(ctx context.Context, superseded *model.Memory, replacement *model.Memory) error {
+	if superseded == nil {
+		return xerrors.Errorf("superseded memory must not be nil")
+	}
+	if replacement == nil {
+		return xerrors.Errorf("replacement memory must not be nil")
+	}
+
+	return d.runMemoryWriteTx(ctx, func(tx *sql.Tx) error {
+		if err := persistMemoryTx(ctx, tx, superseded); err != nil {
+			return xerrors.Errorf("failed to persist superseded memory: %w", err)
+		}
+		if err := persistMemoryTx(ctx, tx, replacement); err != nil {
+			return xerrors.Errorf("failed to persist replacement memory: %w", err)
+		}
+		return nil
+	})
+}
+
+func (d *MemoryDatasource) runMemoryWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
 	db, err := d.db.open(ctx)
 	if err != nil {
 		return xerrors.Errorf("failed to open DB for memory save: %w", err)
@@ -100,6 +130,18 @@ func (d *MemoryDatasource) Save(ctx context.Context, memory *model.Memory) error
 		}
 	}()
 
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit memory save transaction: %w", err)
+	}
+
+	return nil
+}
+
+func persistMemoryTx(ctx context.Context, tx *sql.Tx, memory *model.Memory) error {
 	var supersedesValue *string
 	if supersedes, ok := memory.Supersedes().Get(); ok {
 		value := supersedes.String()
@@ -161,10 +203,6 @@ func (d *MemoryDatasource) Save(ctx context.Context, memory *model.Memory) error
 		); err != nil {
 			return xerrors.Errorf("failed to insert memory artifact ref: %w", err)
 		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return xerrors.Errorf("failed to commit memory save transaction: %w", err)
 	}
 
 	return nil

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -125,6 +125,15 @@ func mustArtifactRef(t *testing.T, kind types.ArtifactRefKind, value string) typ
 	return ref
 }
 
+func mustMemoryIDFromOptional(t *testing.T, value types.Optional[types.MemoryID]) types.MemoryID {
+	t.Helper()
+	memoryID, ok := value.Get()
+	if !ok {
+		t.Fatal("Optional.Get() ok = false, want true")
+	}
+	return memoryID
+}
+
 func memoryOf(
 	t *testing.T,
 	memoryID string,
@@ -268,6 +277,88 @@ func TestMemoryDatasource_SaveAndFindByID(t *testing.T) {
 	}
 	if gotExpiresAt, ok := got.ExpiresAt().Get(); !ok || !gotExpiresAt.Equal(expiresAt) {
 		t.Fatalf("ExpiresAt() = (%v, %v), want (%v, true)", gotExpiresAt, ok, expiresAt)
+	}
+}
+
+func TestMemoryDatasource_SaveSupersession(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	original := memoryOf(
+		t,
+		"mem-original",
+		types.MemoryTypeDecision,
+		mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+		"Original release memory",
+		types.MemoryStatusAccepted,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindIssue, "#454")},
+		nil,
+		types.Empty[types.MemoryID](),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 9, 30, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, original); err != nil {
+		t.Fatalf("Save(original) error = %v", err)
+	}
+	if err := original.MarkSuperseded(); err != nil {
+		t.Fatalf("MarkSuperseded() error = %v", err)
+	}
+
+	replacement := memoryOf(
+		t,
+		"mem-replacement",
+		types.MemoryTypeDecision,
+		mustWorkspaceScope(t, "github.com/duck8823/traceary"),
+		"Replacement release memory",
+		types.MemoryStatusAccepted,
+		types.ConfidenceHigh,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindPR, "#468")},
+		[]types.ArtifactRef{mustArtifactRef(t, types.ArtifactRefKindFile, "presentation/cli/memory.go")},
+		types.Of(original.MemoryID()),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 12, 10, 15, 0, 0, time.UTC),
+	)
+	if err := sut.SaveSupersession(ctx, original, replacement); err != nil {
+		t.Fatalf("SaveSupersession() error = %v", err)
+	}
+
+	gotOriginalOpt, err := sut.FindByID(ctx, original.MemoryID())
+	if err != nil {
+		t.Fatalf("FindByID(original) error = %v", err)
+	}
+	gotOriginal, ok := gotOriginalOpt.Get()
+	if !ok {
+		t.Fatal("FindByID(original) returned empty result")
+	}
+	if diff := cmp.Diff(types.MemoryStatusSuperseded, gotOriginal.Status()); diff != "" {
+		t.Fatalf("original status mismatch (-want +got):\n%s", diff)
+	}
+
+	gotReplacementOpt, err := sut.FindByID(ctx, replacement.MemoryID())
+	if err != nil {
+		t.Fatalf("FindByID(replacement) error = %v", err)
+	}
+	gotReplacement, ok := gotReplacementOpt.Get()
+	if !ok {
+		t.Fatal("FindByID(replacement) returned empty result")
+	}
+	if diff := cmp.Diff(types.MemoryStatusAccepted, gotReplacement.Status()); diff != "" {
+		t.Fatalf("replacement status mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(original.MemoryID(), mustMemoryIDFromOptional(t, gotReplacement.Supersedes())); diff != "" {
+		t.Fatalf("replacement supersedes mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -141,13 +141,15 @@ func run() error {
 	db := sqlite.NewDatabase(dbPath, migrationsSubFS)
 	eventDatasource := sqlite.NewEventDatasource(db)
 	sessionDatasource := sqlite.NewSessionDatasource(db)
+	memoryDatasource := sqlite.NewMemoryDatasource(db)
 	storeManagementDatasource := sqlite.NewStoreManagementDatasource(db)
+
+	extraRedactPatterns := presentation.LoadExtraRedactPatterns()
 
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
+	memoryUsecase := usecase.NewMemoryUsecase(memoryDatasource, memoryDatasource, extraRedactPatterns)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
-
-	extraRedactPatterns := presentation.LoadExtraRedactPatterns()
 
 	mcpServer, err := mcpserver.NewServer(
 		resolvedVersion,
@@ -171,6 +173,7 @@ func run() error {
 	rootCmd := cli.NewRootCLI(
 		cli.WithEvent(eventUsecase),
 		cli.WithSession(sessionUsecase),
+		cli.WithMemory(memoryUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),
 		cli.WithMCPServerRunner(mcpServer),
 		cli.WithHooksOrchestrator(hooksOrchestrator),

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -189,3 +189,73 @@ type timelineCommandInput struct {
 	limit     int
 	asJSON    bool
 }
+
+// memoryListCommandInput is the resolved input to `traceary memory list`.
+type memoryListCommandInput struct {
+	dbPath        string
+	workspace     string
+	agent         string
+	sessionFamily string
+	statuses      []string
+	memoryTypes   []string
+	limit         int
+	offset        int
+	asJSON        bool
+}
+
+// memorySearchCommandInput is the resolved input to `traceary memory search`.
+type memorySearchCommandInput struct {
+	dbPath        string
+	workspace     string
+	agent         string
+	sessionFamily string
+	statuses      []string
+	memoryTypes   []string
+	limit         int
+	offset        int
+	query         string
+	asJSON        bool
+}
+
+// memoryWriteCommandInput is the resolved input to memory write commands.
+type memoryWriteCommandInput struct {
+	dbPath        string
+	workspace     string
+	agent         string
+	sessionFamily string
+	memoryType    string
+	fact          string
+	confidence    string
+	source        string
+	evidenceRefs  []string
+	artifactRefs  []string
+	idOnly        bool
+	asJSON        bool
+}
+
+// memoryMutationCommandInput is the resolved input to memory status commands.
+type memoryMutationCommandInput struct {
+	dbPath     string
+	memoryID   string
+	confidence string
+	expiresAt  string
+	idOnly     bool
+	asJSON     bool
+}
+
+// memorySupersedeCommandInput is the resolved input to `traceary memory supersede`.
+type memorySupersedeCommandInput struct {
+	dbPath        string
+	memoryID      string
+	workspace     string
+	agent         string
+	sessionFamily string
+	memoryType    string
+	fact          string
+	confidence    string
+	source        string
+	evidenceRefs  []string
+	artifactRefs  []string
+	idOnly        bool
+	asJSON        bool
+}

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -1,0 +1,768 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func (c *RootCLI) newMemoryCommand() *cobra.Command {
+	memoryCmd := &cobra.Command{
+		Use:   "memory",
+		Short: Localize("Manage durable memories", "durable memory を管理する"),
+	}
+	memoryCmd.AddCommand(c.newMemoryListCommand())
+	memoryCmd.AddCommand(c.newMemorySearchCommand())
+	memoryCmd.AddCommand(c.newMemoryShowCommand())
+	memoryCmd.AddCommand(c.newMemoryRememberCommand())
+	memoryCmd.AddCommand(c.newMemoryProposeCommand())
+	memoryCmd.AddCommand(c.newMemoryAcceptCommand())
+	memoryCmd.AddCommand(c.newMemoryRejectCommand())
+	memoryCmd.AddCommand(c.newMemorySupersedeCommand())
+	memoryCmd.AddCommand(c.newMemoryExpireCommand())
+	return memoryCmd
+}
+
+func (c *RootCLI) newMemoryListCommand() *cobra.Command {
+	input := memoryListCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: Localize("List durable memories", "durable memory を一覧表示する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryList(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("filter by workspace scope (defaults to env/detected workspace when no other scope filter is set)", "workspace scope で絞り込む (他の scope filter がない場合は env/検出 workspace を使用)"))
+	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("filter by agent scope", "agent scope で絞り込む"))
+	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
+	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
+	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before listing", "一覧表示前にスキップする件数"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	return cmd
+}
+
+func (c *RootCLI) newMemorySearchCommand() *cobra.Command {
+	input := memorySearchCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: Localize("Search durable memories", "durable memory を検索する"),
+		Args:  maximumNArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				input.query = args[0]
+			}
+			return c.runMemorySearch(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("filter by workspace scope", "workspace scope で絞り込む"))
+	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("filter by agent scope", "agent scope で絞り込む"))
+	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
+	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
+	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before returning results", "結果を返す前にスキップする件数"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	return cmd
+}
+
+func (c *RootCLI) newMemoryShowCommand() *cobra.Command {
+	var (
+		dbPath string
+		asJSON bool
+	)
+	cmd := &cobra.Command{
+		Use:   "show <memory-id>",
+		Short: Localize("Show durable memory details", "durable memory の詳細を表示する"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runMemoryShow(cmd.Context(), cmd.OutOrStdout(), dbPath, args[0], asJSON)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	return cmd
+}
+
+func (c *RootCLI) newMemoryRememberCommand() *cobra.Command {
+	input := memoryWriteCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "remember",
+		Short: Localize("Record an accepted durable memory", "accepted な durable memory を記録する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryRemember(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	configureMemoryWriteFlags(cmd, &input)
+	return cmd
+}
+
+func (c *RootCLI) newMemoryProposeCommand() *cobra.Command {
+	input := memoryWriteCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "propose",
+		Short: Localize("Record a candidate durable memory", "candidate な durable memory を記録する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryPropose(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	configureMemoryWriteFlags(cmd, &input)
+	return cmd
+}
+
+func (c *RootCLI) newMemoryAcceptCommand() *cobra.Command {
+	input := memoryMutationCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "accept <memory-id>",
+		Short: Localize("Accept a candidate durable memory", "candidate durable memory を accept する"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input.memoryID = args[0]
+			return c.runMemoryAccept(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.confidence, "confidence", "", Localize("accepted confidence (defaults to verified)", "accepted 時の confidence (既定値は verified)"))
+	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	return cmd
+}
+
+func (c *RootCLI) newMemoryRejectCommand() *cobra.Command {
+	input := memoryMutationCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "reject <memory-id>",
+		Short: Localize("Reject a candidate durable memory", "candidate durable memory を reject する"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input.memoryID = args[0]
+			return c.runMemoryReject(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	return cmd
+}
+
+func (c *RootCLI) newMemorySupersedeCommand() *cobra.Command {
+	input := memorySupersedeCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "supersede <memory-id>",
+		Short: Localize("Replace an accepted durable memory", "accepted durable memory を置き換える"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input.memoryID = args[0]
+			return c.runMemorySupersede(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("replacement workspace scope (inherits the current memory scope when omitted)", "置換後の workspace scope (未指定時は現在の memory scope を継承)"))
+	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("replacement agent scope", "置換後の agent scope"))
+	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("replacement session-family scope", "置換後の session-family scope"))
+	cmd.Flags().StringVar(&input.memoryType, "type", "", Localize("replacement memory type (inherits when omitted)", "置換後の memory type (未指定時は継承)"))
+	cmd.Flags().StringVar(&input.fact, "fact", "", Localize("distilled memory fact", "記録する memory fact"))
+	cmd.Flags().StringVar(&input.confidence, "confidence", "", Localize("replacement confidence (defaults to verified)", "置換後の confidence (既定値は verified)"))
+	cmd.Flags().StringVar(&input.source, "source", "", Localize("memory source (defaults to manual)", "memory source (既定値は manual)"))
+	cmd.Flags().StringArrayVar(&input.evidenceRefs, "evidence", nil, Localize("evidence ref as kind:value (repeatable)", "kind:value 形式の evidence ref (複数指定可)"))
+	cmd.Flags().StringArrayVar(&input.artifactRefs, "artifact", nil, Localize("artifact ref as kind:value (repeatable)", "kind:value 形式の artifact ref (複数指定可)"))
+	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	cmd.MarkFlagsMutuallyExclusive("workspace", "agent", "session-family")
+	return cmd
+}
+
+func (c *RootCLI) newMemoryExpireCommand() *cobra.Command {
+	input := memoryMutationCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "expire <memory-id>",
+		Short: Localize("Expire an active durable memory", "active な durable memory を expire する"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input.memoryID = args[0]
+			return c.runMemoryExpire(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.expiresAt, "at", "", Localize("expiry time (`YYYY-MM-DD` or RFC3339, defaults to now)", "expiry time (`YYYY-MM-DD` または RFC3339。既定値は now)"))
+	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	return cmd
+}
+
+func configureMemoryWriteFlags(cmd *cobra.Command, input *memoryWriteCommandInput) {
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace scope (defaults to env/detected workspace when no other scope is set)", "workspace scope (他の scope がない場合は env/検出 workspace を使用)"))
+	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("agent scope", "agent scope"))
+	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("session-family scope", "session-family scope"))
+	cmd.Flags().StringVar(&input.memoryType, "type", "", Localize("memory type", "memory type"))
+	cmd.Flags().StringVar(&input.fact, "fact", "", Localize("distilled memory fact", "記録する memory fact"))
+	cmd.Flags().StringVar(&input.confidence, "confidence", "", Localize("accepted confidence (defaults to verified for remember)", "accepted 時の confidence (remember の既定値は verified)"))
+	cmd.Flags().StringVar(&input.source, "source", "", Localize("memory source (defaults to manual)", "memory source (既定値は manual)"))
+	cmd.Flags().StringArrayVar(&input.evidenceRefs, "evidence", nil, Localize("evidence ref as kind:value (repeatable)", "kind:value 形式の evidence ref (複数指定可)"))
+	cmd.Flags().StringArrayVar(&input.artifactRefs, "artifact", nil, Localize("artifact ref as kind:value (repeatable)", "kind:value 形式の artifact ref (複数指定可)"))
+	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	cmd.MarkFlagsMutuallyExclusive("workspace", "agent", "session-family")
+}
+
+func (c *RootCLI) runMemoryList(ctx context.Context, output io.Writer, input memoryListCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if input.limit <= 0 {
+		return xerrors.Errorf(Localize("limit must be greater than or equal to 1", "limit は 1 以上である必要があります"))
+	}
+	if input.offset < 0 {
+		return xerrors.Errorf(Localize("offset must be greater than or equal to 0", "offset は 0 以上である必要があります"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+
+	scopes, err := resolveMemoryFilterScopes(ctx, input.workspace, input.agent, input.sessionFamily, true)
+	if err != nil {
+		return err
+	}
+	statuses, err := parseMemoryStatuses(input.statuses)
+	if err != nil {
+		return err
+	}
+	memoryTypes, err := parseMemoryTypes(input.memoryTypes)
+	if err != nil {
+		return err
+	}
+
+	criteria := apptypes.NewMemoryListCriteriaBuilder(input.limit).
+		Offset(input.offset).
+		Scopes(scopes).
+		Statuses(statuses).
+		MemoryTypes(memoryTypes).
+		Build()
+	summaries, err := c.memory.List(ctx, criteria)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to list durable memories", "durable memory の一覧取得に失敗しました"), err)
+	}
+	if err := writeMemorySummariesByFormat(output, summaries, input.asJSON); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory list", "durable memory 一覧の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func (c *RootCLI) runMemorySearch(ctx context.Context, output io.Writer, input memorySearchCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if input.limit <= 0 {
+		return xerrors.Errorf(Localize("limit must be greater than or equal to 1", "limit は 1 以上である必要があります"))
+	}
+	if input.offset < 0 {
+		return xerrors.Errorf(Localize("offset must be greater than or equal to 0", "offset は 0 以上である必要があります"))
+	}
+	if !hasMemorySearchInputConstraint(input) {
+		return xerrors.Errorf(Localize("at least one search filter is required", "検索条件は1つ以上必要です"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+
+	scopes, err := resolveMemoryFilterScopes(ctx, input.workspace, input.agent, input.sessionFamily, false)
+	if err != nil {
+		return err
+	}
+	statuses, err := parseMemoryStatuses(input.statuses)
+	if err != nil {
+		return err
+	}
+	memoryTypes, err := parseMemoryTypes(input.memoryTypes)
+	if err != nil {
+		return err
+	}
+
+	criteria := apptypes.NewMemorySearchCriteriaBuilder(input.limit).
+		Query(strings.TrimSpace(input.query)).
+		Offset(input.offset).
+		Scopes(scopes).
+		Statuses(statuses).
+		MemoryTypes(memoryTypes).
+		Build()
+	summaries, err := c.memory.Search(ctx, criteria)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to search durable memories", "durable memory の検索に失敗しました"), err)
+	}
+	if err := writeMemorySummariesByFormat(output, summaries, input.asJSON); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory search results", "durable memory 検索結果の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func (c *RootCLI) runMemoryShow(ctx context.Context, output io.Writer, dbPath string, memoryID string, asJSON bool) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if err := c.initializeStore(ctx, dbPath); err != nil {
+		return err
+	}
+	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
+	}
+	details, err := c.memory.Show(ctx, resolvedMemoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to get memory details", "durable memory 詳細の取得に失敗しました"), err)
+	}
+	if err := writeMemoryDetailsByFormat(output, details, asJSON); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory details", "durable memory 詳細の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func (c *RootCLI) runMemoryRemember(ctx context.Context, output io.Writer, input memoryWriteCommandInput) error {
+	if err := validateMemoryWriteInput(input); err != nil {
+		return err
+	}
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryType, scope, confidence, source, evidenceRefs, artifactRefs, err := c.resolveMemoryWriteParameters(ctx, input)
+	if err != nil {
+		return err
+	}
+	details, err := c.memory.Remember(ctx, memoryType, scope, input.fact, confidence, source, evidenceRefs, artifactRefs)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to record durable memory", "durable memory の記録に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryPropose(ctx context.Context, output io.Writer, input memoryWriteCommandInput) error {
+	if err := validateMemoryWriteInput(input); err != nil {
+		return err
+	}
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryType, scope, _, source, evidenceRefs, artifactRefs, err := c.resolveMemoryWriteParameters(ctx, input)
+	if err != nil {
+		return err
+	}
+	details, err := c.memory.Propose(ctx, memoryType, scope, input.fact, source, evidenceRefs, artifactRefs)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to record candidate durable memory", "candidate durable memory の記録に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryAccept(ctx context.Context, output io.Writer, input memoryMutationCommandInput) error {
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
+	}
+	confidence, err := parseOptionalConfidence(input.confidence)
+	if err != nil {
+		return err
+	}
+	details, err := c.memory.Accept(ctx, memoryID, confidence)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to accept durable memory", "durable memory の accept に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryReject(ctx context.Context, output io.Writer, input memoryMutationCommandInput) error {
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
+	}
+	details, err := c.memory.Reject(ctx, memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to reject durable memory", "durable memory の reject に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) runMemorySupersede(ctx context.Context, output io.Writer, input memorySupersedeCommandInput) error {
+	if strings.TrimSpace(input.fact) == "" {
+		return xerrors.Errorf(Localize("fact must not be empty", "fact は空にできません"))
+	}
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
+	}
+	memoryType, err := parseOptionalMemoryType(input.memoryType)
+	if err != nil {
+		return err
+	}
+	scope, err := resolveOptionalMemoryScope(input.workspace, input.agent, input.sessionFamily)
+	if err != nil {
+		return err
+	}
+	confidence, err := parseOptionalConfidence(input.confidence)
+	if err != nil {
+		return err
+	}
+	source, err := parseMemorySource(input.source)
+	if err != nil {
+		return err
+	}
+	evidenceRefs, err := parseEvidenceRefs(input.evidenceRefs)
+	if err != nil {
+		return err
+	}
+	artifactRefs, err := parseArtifactRefs(input.artifactRefs)
+	if err != nil {
+		return err
+	}
+	details, err := c.memory.Supersede(ctx, memoryID, memoryType, scope, input.fact, confidence, source, evidenceRefs, artifactRefs)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to supersede durable memory", "durable memory の置換に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryExpire(ctx context.Context, output io.Writer, input memoryMutationCommandInput) error {
+	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
+	}
+	expiresAt, err := parseOptionalExpiryTime(input.expiresAt)
+	if err != nil {
+		return err
+	}
+	details, err := c.memory.Expire(ctx, memoryID, expiresAt)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to expire durable memory", "durable memory の expire に失敗しました"), err)
+	}
+	return writeMemoryMutationResult(output, details, input.idOnly, input.asJSON)
+}
+
+func (c *RootCLI) initializeMemoryStore(ctx context.Context, dbPath string) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	return c.initializeStore(ctx, dbPath)
+}
+
+func (c *RootCLI) initializeStore(ctx context.Context, dbPath string) error {
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+	}
+	return nil
+}
+
+func (c *RootCLI) resolveMemoryWriteParameters(ctx context.Context, input memoryWriteCommandInput) (
+	domtypes.MemoryType,
+	domtypes.MemoryScope,
+	domtypes.Optional[domtypes.Confidence],
+	domtypes.MemorySource,
+	[]domtypes.EvidenceRef,
+	[]domtypes.ArtifactRef,
+	error,
+) {
+	memoryType, err := parseRequiredMemoryType(input.memoryType)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	scope, err := resolveMemoryWriteScope(ctx, input.workspace, input.agent, input.sessionFamily)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	confidence, err := parseOptionalConfidence(input.confidence)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	source, err := parseMemorySource(input.source)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	evidenceRefs, err := parseEvidenceRefs(input.evidenceRefs)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	artifactRefs, err := parseArtifactRefs(input.artifactRefs)
+	if err != nil {
+		return domtypes.MemoryType(""), nil, domtypes.Empty[domtypes.Confidence](), domtypes.MemorySource(""), nil, nil, err
+	}
+	return memoryType, scope, confidence, source, evidenceRefs, artifactRefs, nil
+}
+
+func validateMemoryWriteInput(input memoryWriteCommandInput) error {
+	if strings.TrimSpace(input.memoryType) == "" {
+		return xerrors.Errorf(Localize("memory type must not be empty", "memory type は空にできません"))
+	}
+	if strings.TrimSpace(input.fact) == "" {
+		return xerrors.Errorf(Localize("fact must not be empty", "fact は空にできません"))
+	}
+	return nil
+}
+
+func parseRequiredMemoryType(value string) (domtypes.MemoryType, error) {
+	resolved, err := domtypes.MemoryTypeOf(value)
+	if err != nil {
+		return domtypes.MemoryType(""), xerrors.Errorf("%s: %w", Localize("failed to resolve memory type", "memory type の解決に失敗しました"), err)
+	}
+	return resolved, nil
+}
+
+func parseOptionalMemoryType(value string) (domtypes.MemoryType, error) {
+	if strings.TrimSpace(value) == "" {
+		return domtypes.MemoryType(""), nil
+	}
+	return parseRequiredMemoryType(value)
+}
+
+func parseOptionalConfidence(value string) (domtypes.Optional[domtypes.Confidence], error) {
+	if strings.TrimSpace(value) == "" {
+		return domtypes.Empty[domtypes.Confidence](), nil
+	}
+	confidence, err := domtypes.ConfidenceOf(value)
+	if err != nil {
+		return domtypes.Empty[domtypes.Confidence](), xerrors.Errorf("%s: %w", Localize("failed to resolve confidence", "confidence の解決に失敗しました"), err)
+	}
+	return domtypes.Of(confidence), nil
+}
+
+func parseMemorySource(value string) (domtypes.MemorySource, error) {
+	if strings.TrimSpace(value) == "" {
+		return domtypes.MemorySource(""), nil
+	}
+	source, err := domtypes.MemorySourceOf(value)
+	if err != nil {
+		return domtypes.MemorySource(""), xerrors.Errorf("%s: %w", Localize("failed to resolve memory source", "memory source の解決に失敗しました"), err)
+	}
+	return source, nil
+}
+
+func parseMemoryStatuses(values []string) ([]domtypes.MemoryStatus, error) {
+	statuses := make([]domtypes.MemoryStatus, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		status, err := domtypes.MemoryStatusOf(value)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve memory status", "memory status の解決に失敗しました"), err)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
+func parseMemoryTypes(values []string) ([]domtypes.MemoryType, error) {
+	memoryTypes := make([]domtypes.MemoryType, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		memoryType, err := domtypes.MemoryTypeOf(value)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve memory type", "memory type の解決に失敗しました"), err)
+		}
+		memoryTypes = append(memoryTypes, memoryType)
+	}
+	return memoryTypes, nil
+}
+
+func parseEvidenceRefs(values []string) ([]domtypes.EvidenceRef, error) {
+	refs := make([]domtypes.EvidenceRef, 0, len(values))
+	for _, value := range values {
+		kind, rawValue, err := parseKindValueToken(value)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to parse evidence ref", "evidence ref の解析に失敗しました"), err)
+		}
+		resolvedKind, err := domtypes.EvidenceRefKindOf(kind)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve evidence ref kind", "evidence ref kind の解決に失敗しました"), err)
+		}
+		ref, err := domtypes.EvidenceRefOf(resolvedKind, rawValue)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve evidence ref", "evidence ref の解決に失敗しました"), err)
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+func parseArtifactRefs(values []string) ([]domtypes.ArtifactRef, error) {
+	refs := make([]domtypes.ArtifactRef, 0, len(values))
+	for _, value := range values {
+		kind, rawValue, err := parseKindValueToken(value)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to parse artifact ref", "artifact ref の解析に失敗しました"), err)
+		}
+		resolvedKind, err := domtypes.ArtifactRefKindOf(kind)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve artifact ref kind", "artifact ref kind の解決に失敗しました"), err)
+		}
+		ref, err := domtypes.ArtifactRefOf(resolvedKind, rawValue)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve artifact ref", "artifact ref の解決に失敗しました"), err)
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+func parseKindValueToken(value string) (string, string, error) {
+	trimmed := strings.TrimSpace(value)
+	separator := strings.Index(trimmed, ":")
+	if separator <= 0 || separator == len(trimmed)-1 {
+		return "", "", xerrors.Errorf(Localize("references must use kind:value format", "参照は kind:value 形式で指定する必要があります"))
+	}
+	return trimmed[:separator], trimmed[separator+1:], nil
+}
+
+func resolveMemoryWriteScope(ctx context.Context, workspace string, agent string, sessionFamily string) (domtypes.MemoryScope, error) {
+	if strings.TrimSpace(agent) != "" {
+		resolvedAgent, err := domtypes.AgentOf(agent)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
+		}
+		return domtypes.AgentScopeOf(resolvedAgent), nil
+	}
+	if strings.TrimSpace(sessionFamily) != "" {
+		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
+		}
+		return domtypes.SessionFamilyScopeOf(resolvedSessionID), nil
+	}
+	resolvedWorkspace := resolveWorkspaceValue(ctx, workspace)
+	if strings.TrimSpace(resolvedWorkspace) == "" {
+		return nil, xerrors.Errorf(Localize("workspace scope could not be resolved", "workspace scope を解決できませんでした"))
+	}
+	workspaceValue, err := domtypes.WorkspaceOf(resolvedWorkspace)
+	if err != nil {
+		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
+	}
+	return domtypes.WorkspaceScopeOf(workspaceValue), nil
+}
+
+func resolveOptionalMemoryScope(workspace string, agent string, sessionFamily string) (domtypes.MemoryScope, error) {
+	if strings.TrimSpace(agent) != "" {
+		resolvedAgent, err := domtypes.AgentOf(agent)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
+		}
+		return domtypes.AgentScopeOf(resolvedAgent), nil
+	}
+	if strings.TrimSpace(sessionFamily) != "" {
+		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
+		}
+		return domtypes.SessionFamilyScopeOf(resolvedSessionID), nil
+	}
+	if strings.TrimSpace(workspace) == "" {
+		return nil, nil
+	}
+	workspaceValue, err := domtypes.WorkspaceOf(workspace)
+	if err != nil {
+		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
+	}
+	return domtypes.WorkspaceScopeOf(workspaceValue), nil
+}
+
+func resolveMemoryFilterScopes(ctx context.Context, workspace string, agent string, sessionFamily string, defaultWorkspace bool) ([]domtypes.MemoryScope, error) {
+	scopes := make([]domtypes.MemoryScope, 0, 3)
+	if strings.TrimSpace(workspace) != "" {
+		workspaceValue, err := domtypes.WorkspaceOf(workspace)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
+		}
+		scopes = append(scopes, domtypes.WorkspaceScopeOf(workspaceValue))
+	}
+	if strings.TrimSpace(agent) != "" {
+		resolvedAgent, err := domtypes.AgentOf(agent)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
+		}
+		scopes = append(scopes, domtypes.AgentScopeOf(resolvedAgent))
+	}
+	if strings.TrimSpace(sessionFamily) != "" {
+		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		if err != nil {
+			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
+		}
+		scopes = append(scopes, domtypes.SessionFamilyScopeOf(resolvedSessionID))
+	}
+	if len(scopes) > 0 || !defaultWorkspace {
+		return scopes, nil
+	}
+	resolvedWorkspace := resolveWorkspaceValue(ctx, workspace)
+	if strings.TrimSpace(resolvedWorkspace) == "" {
+		return nil, nil
+	}
+	workspaceValue, err := domtypes.WorkspaceOf(resolvedWorkspace)
+	if err != nil {
+		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
+	}
+	return []domtypes.MemoryScope{domtypes.WorkspaceScopeOf(workspaceValue)}, nil
+}
+
+func parseOptionalExpiryTime(value string) (domtypes.Optional[time.Time], error) {
+	if strings.TrimSpace(value) == "" {
+		return domtypes.Empty[time.Time](), nil
+	}
+	resolved, err := parseFlexibleTime(value, false)
+	if err != nil {
+		return domtypes.Empty[time.Time](), xerrors.Errorf("%s: %w", Localize("failed to resolve expiry time", "expiry time の解決に失敗しました"), err)
+	}
+	return domtypes.Of(resolved), nil
+}
+
+func hasMemorySearchInputConstraint(input memorySearchCommandInput) bool {
+	return strings.TrimSpace(input.query) != "" ||
+		strings.TrimSpace(input.workspace) != "" ||
+		strings.TrimSpace(input.agent) != "" ||
+		strings.TrimSpace(input.sessionFamily) != "" ||
+		len(input.statuses) > 0 ||
+		len(input.memoryTypes) > 0
+}

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -59,6 +59,7 @@ func (c *RootCLI) newMemorySearchCommand() *cobra.Command {
 		Short: Localize("Search durable memories", "durable memory を検索する"),
 		Args:  maximumNArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			input.query = ""
 			if len(args) == 1 {
 				input.query = args[0]
 			}
@@ -369,6 +370,7 @@ func (c *RootCLI) runMemoryPropose(ctx context.Context, output io.Writer, input 
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
+	input.confidence = ""
 	memoryType, scope, _, source, evidenceRefs, artifactRefs, err := c.resolveMemoryWriteParameters(ctx, input)
 	if err != nil {
 		return err

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func writeMemorySummariesByFormat(output io.Writer, summaries []apptypes.MemorySummary, asJSON bool) error {
+	if asJSON {
+		serialized := make([]memorySummaryOutput, 0, len(summaries))
+		for _, summary := range summaries {
+			serialized = append(serialized, newMemorySummaryOutput(summary))
+		}
+		return writeJSON(output, serialized)
+	}
+
+	return writeMemorySummaries(output, summaries)
+}
+
+func writeMemoryDetailsByFormat(output io.Writer, details apptypes.MemoryDetails, asJSON bool) error {
+	if asJSON {
+		return writeJSON(output, newMemoryDetailsOutput(details))
+	}
+
+	return writeMemoryDetails(output, details)
+}
+
+func writeMemoryMutationResult(output io.Writer, details apptypes.MemoryDetails, idOnly bool, asJSON bool) error {
+	if idOnly {
+		if _, err := fmt.Fprintln(output, details.Summary().MemoryID()); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory ID", "memory ID の出力に失敗しました"), err)
+		}
+		return nil
+	}
+
+	return writeMemoryDetailsByFormat(output, details, asJSON)
+}
+
+func writeMemorySummaries(output io.Writer, summaries []apptypes.MemorySummary) error {
+	if len(summaries) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No matching durable memories.", "一致する durable memory はありません")); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty memory list message", "空の durable memory 一覧メッセージの出力に失敗しました"), err)
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintln(output, "UPDATED_AT\tMEMORY_ID\tTYPE\tSCOPE\tSTATUS\tCONFIDENCE\tSOURCE\tFACT"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory list header", "durable memory 一覧ヘッダーの出力に失敗しました"), err)
+	}
+	for _, summary := range summaries {
+		if _, err := fmt.Fprintf(
+			output,
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			summary.UpdatedAt().UTC().Format(time.RFC3339),
+			summary.MemoryID(),
+			summary.MemoryType(),
+			formatMemoryScope(summary.Scope()),
+			summary.Status(),
+			summary.Confidence(),
+			summary.Source(),
+			truncateMessage(summary.Fact()),
+		); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory summary row", "durable memory 一覧行の出力に失敗しました"), err)
+		}
+	}
+
+	return nil
+}
+
+func writeMemoryDetails(output io.Writer, details apptypes.MemoryDetails) error {
+	summary := details.Summary()
+	if _, err := fmt.Fprintf(
+		output,
+		"MEMORY_ID: %s\nTYPE: %s\nSCOPE: %s\nSTATUS: %s\nCONFIDENCE: %s\nSOURCE: %s\nSUPERSEDES: %s\nEXPIRES_AT: %s\nCREATED_AT: %s\nUPDATED_AT: %s\nFACT: %s\n",
+		summary.MemoryID(),
+		summary.MemoryType(),
+		formatMemoryScope(summary.Scope()),
+		summary.Status(),
+		summary.Confidence(),
+		summary.Source(),
+		formatOptionalMemoryID(summary.Supersedes()),
+		formatOptionalTime(summary.ExpiresAt()),
+		summary.CreatedAt().UTC().Format(time.RFC3339),
+		summary.UpdatedAt().UTC().Format(time.RFC3339),
+		summary.Fact(),
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory fields", "durable memory 共通項目の出力に失敗しました"), err)
+	}
+
+	if err := writeEvidenceRefSection(output, details.EvidenceRefs()); err != nil {
+		return err
+	}
+	if err := writeArtifactRefSection(output, details.ArtifactRefs()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeEvidenceRefSection(output io.Writer, refs []domtypes.EvidenceRef) error {
+	if _, err := fmt.Fprintln(output, "\nEVIDENCE_REFS:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print evidence refs heading", "evidence refs 見出しの出力に失敗しました"), err)
+	}
+	if len(refs) == 0 {
+		if _, err := fmt.Fprintln(output, "- -"); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty evidence refs", "空の evidence refs の出力に失敗しました"), err)
+		}
+		return nil
+	}
+	for _, ref := range refs {
+		if _, err := fmt.Fprintf(output, "- %s:%s\n", ref.Kind(), ref.Value()); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print evidence ref", "evidence ref の出力に失敗しました"), err)
+		}
+	}
+
+	return nil
+}
+
+func writeArtifactRefSection(output io.Writer, refs []domtypes.ArtifactRef) error {
+	if _, err := fmt.Fprintln(output, "\nARTIFACT_REFS:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print artifact refs heading", "artifact refs 見出しの出力に失敗しました"), err)
+	}
+	if len(refs) == 0 {
+		if _, err := fmt.Fprintln(output, "- -"); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty artifact refs", "空の artifact refs の出力に失敗しました"), err)
+		}
+		return nil
+	}
+	for _, ref := range refs {
+		if _, err := fmt.Fprintf(output, "- %s:%s\n", ref.Kind(), ref.Value()); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print artifact ref", "artifact ref の出力に失敗しました"), err)
+		}
+	}
+
+	return nil
+}
+
+func newMemorySummaryOutput(summary apptypes.MemorySummary) memorySummaryOutput {
+	var supersedes *string
+	if value, ok := summary.Supersedes().Get(); ok {
+		resolved := value.String()
+		supersedes = &resolved
+	}
+
+	var expiresAt *string
+	if value, ok := summary.ExpiresAt().Get(); ok {
+		resolved := value.UTC().Format(time.RFC3339)
+		expiresAt = &resolved
+	}
+
+	return memorySummaryOutput{
+		MemoryID:   summary.MemoryID().String(),
+		Type:       summary.MemoryType().String(),
+		ScopeKind:  summary.Scope().Kind().String(),
+		ScopeValue: summary.Scope().Key(),
+		Fact:       summary.Fact(),
+		Status:     summary.Status().String(),
+		Confidence: summary.Confidence().String(),
+		Source:     summary.Source().String(),
+		Supersedes: supersedes,
+		ExpiresAt:  expiresAt,
+		CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339),
+		UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339),
+	}
+}
+
+func newMemoryDetailsOutput(details apptypes.MemoryDetails) memoryDetailsOutput {
+	evidenceRefs := make([]string, 0, len(details.EvidenceRefs()))
+	for _, ref := range details.EvidenceRefs() {
+		evidenceRefs = append(evidenceRefs, fmt.Sprintf("%s:%s", ref.Kind(), ref.Value()))
+	}
+
+	artifactRefs := make([]string, 0, len(details.ArtifactRefs()))
+	for _, ref := range details.ArtifactRefs() {
+		artifactRefs = append(artifactRefs, fmt.Sprintf("%s:%s", ref.Kind(), ref.Value()))
+	}
+
+	return memoryDetailsOutput{
+		Summary:      newMemorySummaryOutput(details.Summary()),
+		EvidenceRefs: evidenceRefs,
+		ArtifactRefs: artifactRefs,
+	}
+}
+
+func formatMemoryScope(scope domtypes.MemoryScope) string {
+	if scope == nil {
+		return "-"
+	}
+
+	return fmt.Sprintf("%s:%s", scope.Kind(), scope.Key())
+}
+
+func formatOptionalMemoryID(value domtypes.Optional[domtypes.MemoryID]) string {
+	if memoryID, ok := value.Get(); ok {
+		return memoryID.String()
+	}
+
+	return "-"
+}
+
+func formatOptionalTime(value domtypes.Optional[time.Time]) string {
+	if resolved, ok := value.Get(); ok {
+		return resolved.UTC().Format(time.RFC3339)
+	}
+
+	return "-"
+}

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -1,0 +1,239 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_MemoryRememberCommand(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	stub := &memoryUsecaseStub{
+		rememberDetails: mustMemoryDetails(t, "memory-remembered", "Remember release discipline", types.MemoryStatusAccepted),
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "remember",
+		"--db-path", "/tmp/test-traceary.db",
+		"--type", "decision",
+		"--fact", "Remember release discipline",
+		"--evidence", "issue:#462",
+		"--artifact", "pr:#468",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if stub.rememberCall.memoryType != types.MemoryTypeDecision {
+		t.Fatalf("memoryType = %s, want decision", stub.rememberCall.memoryType)
+	}
+	workspaceScope, ok := stub.rememberCall.scope.(types.WorkspaceScope)
+	if !ok {
+		t.Fatalf("scope type = %T, want WorkspaceScope", stub.rememberCall.scope)
+	}
+	if workspaceScope.Workspace().String() != "github.com/duck8823/traceary" {
+		t.Fatalf("workspace = %q, want detected repo workspace", workspaceScope.Workspace().String())
+	}
+	if len(stub.rememberCall.evidenceRefs) != 1 || stub.rememberCall.evidenceRefs[0].Kind() != types.EvidenceRefKindIssue || stub.rememberCall.evidenceRefs[0].Value() != "#462" {
+		t.Fatalf("evidenceRefs = %#v, want issue:#462", stub.rememberCall.evidenceRefs)
+	}
+	if len(stub.rememberCall.artifactRefs) != 1 || stub.rememberCall.artifactRefs[0].Kind() != types.ArtifactRefKindPR || stub.rememberCall.artifactRefs[0].Value() != "#468" {
+		t.Fatalf("artifactRefs = %#v, want pr:#468", stub.rememberCall.artifactRefs)
+	}
+	if !strings.Contains(stdout.String(), "EVIDENCE_REFS:") || !strings.Contains(stdout.String(), "ARTIFACT_REFS:") {
+		t.Fatalf("stdout = %q, want evidence/artifact sections", stdout.String())
+	}
+}
+
+func TestRootCLI_MemoryListCommand_DefaultWorkspaceScope(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	stub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{mustMemorySummary(t, "memory-listed", "Listed memory", types.MemoryStatusAccepted)},
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "list", "--db-path", "/tmp/test-traceary.db", "--json"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := stub.listCriteria.Scopes(); len(got) != 1 {
+		t.Fatalf("len(scopes) = %d, want 1", len(got))
+	} else if got[0].Kind() != types.MemoryScopeKindWorkspace || got[0].Key() != "github.com/duck8823/traceary" {
+		t.Fatalf("scope = %s:%s, want workspace:github.com/duck8823/traceary", got[0].Kind(), got[0].Key())
+	}
+	if !strings.Contains(stdout.String(), `"memory_id": "memory-listed"`) {
+		t.Fatalf("stdout = %q, want JSON summary", stdout.String())
+	}
+}
+
+func TestRootCLI_MemorySearchCommand_RequiresConstraint(t *testing.T) {
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "search", "--db-path", "/tmp/test-traceary.db"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+}
+
+func TestRootCLI_MemoryShowCommand(t *testing.T) {
+	details := mustMemoryDetails(t, "memory-shown", "Shown memory", types.MemoryStatusAccepted)
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{showDetails: details}),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "show", "--db-path", "/tmp/test-traceary.db", "memory-shown"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "MEMORY_ID: memory-shown") {
+		t.Fatalf("stdout = %q, want memory header", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "- issue:#462") || !strings.Contains(stdout.String(), "- pr:#468") {
+		t.Fatalf("stdout = %q, want evidence/artifact refs", stdout.String())
+	}
+}
+
+func TestRootCLI_MemoryAcceptCommand_PassesConfidence(t *testing.T) {
+	stub := &memoryUsecaseStub{
+		acceptDetails: mustMemoryDetails(t, "memory-accepted", "Accepted memory", types.MemoryStatusAccepted),
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "accept", "--db-path", "/tmp/test-traceary.db", "--confidence", "high", "--id-only", "memory-candidate"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stub.acceptCall.memoryID.String() != "memory-candidate" {
+		t.Fatalf("memoryID = %q, want memory-candidate", stub.acceptCall.memoryID.String())
+	}
+	confidence, ok := stub.acceptCall.confidence.Get()
+	if !ok || confidence != types.ConfidenceHigh {
+		t.Fatalf("confidence = %v, %t, want high/true", confidence, ok)
+	}
+	if stdout.String() != "memory-accepted\n" {
+		t.Fatalf("stdout = %q, want memory ID only", stdout.String())
+	}
+}
+
+func mustMemorySummary(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemorySummary {
+	t.Helper()
+
+	summary, err := apptypes.MemorySummaryOf(
+		mustMemoryIDForCLI(t, memoryIDValue),
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+		fact,
+		status,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		types.Empty[types.MemoryID](),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 13, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+	return summary
+}
+
+func mustMemoryDetails(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemoryDetails {
+	t.Helper()
+
+	memory := model.MemoryOf(
+		mustMemoryIDForCLI(t, memoryIDValue),
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+		fact,
+		status,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRefForCLI(t, types.EvidenceRefKindIssue, "#462")},
+		[]types.ArtifactRef{mustArtifactRefForCLI(t, types.ArtifactRefKindPR, "#468")},
+		types.Empty[types.MemoryID](),
+		types.Empty[time.Time](),
+		time.Date(2026, 4, 13, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC),
+	)
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		t.Fatalf("MemoryDetailsFrom() error = %v", err)
+	}
+	return details
+}
+
+func mustMemoryIDForCLI(t *testing.T, value string) types.MemoryID {
+	t.Helper()
+	memoryID, err := types.MemoryIDOf(value)
+	if err != nil {
+		t.Fatalf("MemoryIDOf() error = %v", err)
+	}
+	return memoryID
+}
+
+func mustEvidenceRefForCLI(t *testing.T, kind types.EvidenceRefKind, value string) types.EvidenceRef {
+	t.Helper()
+	ref, err := types.EvidenceRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("EvidenceRefOf() error = %v", err)
+	}
+	return ref
+}
+
+func mustArtifactRefForCLI(t *testing.T, kind types.ArtifactRefKind, value string) types.ArtifactRef {
+	t.Helper()
+	ref, err := types.ArtifactRefOf(kind, value)
+	if err != nil {
+		t.Fatalf("ArtifactRefOf() error = %v", err)
+	}
+	return ref
+}

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -112,6 +112,35 @@ func TestRootCLI_MemorySearchCommand_RequiresConstraint(t *testing.T) {
 	}
 }
 
+func TestRootCLI_MemorySearchCommand_DoesNotLeakPositionalQuery(t *testing.T) {
+	stub := &memoryUsecaseStub{
+		searchResult: []apptypes.MemorySummary{mustMemorySummary(t, "memory-search", "Search memory", types.MemoryStatusAccepted)},
+	}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+
+	rootCmd.SetArgs([]string{"memory", "search", "--db-path", "/tmp/test-traceary.db", "release"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+	if got := stub.searchCriteria.Query(); got != "release" {
+		t.Fatalf("first query = %q, want release", got)
+	}
+
+	rootCmd.SetArgs([]string{"memory", "search", "--db-path", "/tmp/test-traceary.db", "--status", "accepted"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+	if got := stub.searchCriteria.Query(); got != "" {
+		t.Fatalf("second query = %q, want empty", got)
+	}
+}
+
 func TestRootCLI_MemoryShowCommand(t *testing.T) {
 	details := mustMemoryDetails(t, "memory-shown", "Shown memory", types.MemoryStatusAccepted)
 
@@ -161,6 +190,35 @@ func TestRootCLI_MemoryAcceptCommand_PassesConfidence(t *testing.T) {
 	}
 	if stdout.String() != "memory-accepted\n" {
 		t.Fatalf("stdout = %q, want memory ID only", stdout.String())
+	}
+}
+
+func TestRootCLI_MemoryProposeCommand_IgnoresConfidenceFlagValidation(t *testing.T) {
+	stub := &memoryUsecaseStub{
+		proposeDetails: mustMemoryDetails(t, "memory-proposed", "Candidate memory", types.MemoryStatusCandidate),
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "propose",
+		"--db-path", "/tmp/test-traceary.db",
+		"--type", "lesson",
+		"--fact", "Wait for codex review before merge",
+		"--confidence", "definitely-not-valid",
+		"--workspace", "github.com/duck8823/traceary",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "memory-proposed") {
+		t.Fatalf("stdout = %q, want proposed memory output", stdout.String())
 	}
 }
 

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -50,3 +50,26 @@ type sessionTreeNode struct {
 	Agents       []string           `json:"agents"`
 	Children     []*sessionTreeNode `json:"children"`
 }
+
+// memorySummaryOutput is the JSON shape of a durable memory summary in CLI output.
+type memorySummaryOutput struct {
+	MemoryID   string  `json:"memory_id"`
+	Type       string  `json:"type"`
+	ScopeKind  string  `json:"scope_kind"`
+	ScopeValue string  `json:"scope_value"`
+	Fact       string  `json:"fact"`
+	Status     string  `json:"status"`
+	Confidence string  `json:"confidence"`
+	Source     string  `json:"source"`
+	Supersedes *string `json:"supersedes,omitempty"`
+	ExpiresAt  *string `json:"expires_at,omitempty"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
+}
+
+// memoryDetailsOutput is the JSON shape of a durable memory with refs.
+type memoryDetailsOutput struct {
+	Summary      memorySummaryOutput `json:"summary"`
+	EvidenceRefs []string            `json:"evidence_refs"`
+	ArtifactRefs []string            `json:"artifact_refs"`
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -11,6 +11,7 @@ import (
 type RootCLI struct {
 	event                usecase.EventUsecase
 	session              usecase.SessionUsecase
+	memory               usecase.MemoryUsecase
 	storeManagement      usecase.StoreManagementUsecase
 	mcpServerRunner      MCPServerRunner
 	hooksOrchestrator    application.HooksOrchestrator
@@ -36,6 +37,11 @@ func WithEvent(event usecase.EventUsecase) RootCLIOption {
 // WithSession injects the SessionUsecase used by session-related commands.
 func WithSession(session usecase.SessionUsecase) RootCLIOption {
 	return func(c *RootCLI) { c.session = session }
+}
+
+// WithMemory injects the MemoryUsecase used by durable-memory commands.
+func WithMemory(memory usecase.MemoryUsecase) RootCLIOption {
+	return func(c *RootCLI) { c.memory = memory }
 }
 
 // WithStoreManagement injects the StoreManagementUsecase used by init,
@@ -123,6 +129,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newListCommand())
 	rootCmd.AddCommand(c.newShowCommand())
 	rootCmd.AddCommand(c.newSessionCommand())
+	rootCmd.AddCommand(c.newMemoryCommand())
 	rootCmd.AddCommand(c.newCompactSummaryCommand())
 	rootCmd.AddCommand(c.newTimelineCommand())
 	rootCmd.AddCommand(c.newCompletionCommand(rootCmd))

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -106,6 +106,92 @@ func (s *sessionUsecaseStub) Handoff(_ context.Context, _ types.SessionID, _ typ
 	return s.handoff, s.handoffErr
 }
 
+type memoryUsecaseStub struct {
+	listResult       []apptypes.MemorySummary
+	listErr          error
+	searchResult     []apptypes.MemorySummary
+	searchErr        error
+	showDetails      apptypes.MemoryDetails
+	showErr          error
+	rememberDetails  apptypes.MemoryDetails
+	rememberErr      error
+	proposeDetails   apptypes.MemoryDetails
+	proposeErr       error
+	acceptDetails    apptypes.MemoryDetails
+	acceptErr        error
+	rejectDetails    apptypes.MemoryDetails
+	rejectErr        error
+	supersedeDetails apptypes.MemoryDetails
+	supersedeErr     error
+	expireDetails    apptypes.MemoryDetails
+	expireErr        error
+
+	rememberCall struct {
+		memoryType   types.MemoryType
+		scope        types.MemoryScope
+		fact         string
+		confidence   types.Optional[types.Confidence]
+		source       types.MemorySource
+		evidenceRefs []types.EvidenceRef
+		artifactRefs []types.ArtifactRef
+	}
+	listCriteria   apptypes.MemoryListCriteria
+	searchCriteria apptypes.MemorySearchCriteria
+	showMemoryID   types.MemoryID
+	acceptCall     struct {
+		memoryID   types.MemoryID
+		confidence types.Optional[types.Confidence]
+	}
+}
+
+func (s *memoryUsecaseStub) Remember(_ context.Context, memoryType types.MemoryType, scope types.MemoryScope, fact string, confidence types.Optional[types.Confidence], source types.MemorySource, evidenceRefs []types.EvidenceRef, artifactRefs []types.ArtifactRef) (apptypes.MemoryDetails, error) {
+	s.rememberCall.memoryType = memoryType
+	s.rememberCall.scope = scope
+	s.rememberCall.fact = fact
+	s.rememberCall.confidence = confidence
+	s.rememberCall.source = source
+	s.rememberCall.evidenceRefs = append([]types.EvidenceRef(nil), evidenceRefs...)
+	s.rememberCall.artifactRefs = append([]types.ArtifactRef(nil), artifactRefs...)
+	return s.rememberDetails, s.rememberErr
+}
+
+func (s *memoryUsecaseStub) Propose(_ context.Context, _ types.MemoryType, _ types.MemoryScope, _ string, _ types.MemorySource, _ []types.EvidenceRef, _ []types.ArtifactRef) (apptypes.MemoryDetails, error) {
+	return s.proposeDetails, s.proposeErr
+}
+
+func (s *memoryUsecaseStub) Accept(_ context.Context, memoryID types.MemoryID, confidence types.Optional[types.Confidence]) (apptypes.MemoryDetails, error) {
+	s.acceptCall.memoryID = memoryID
+	s.acceptCall.confidence = confidence
+	return s.acceptDetails, s.acceptErr
+}
+
+func (s *memoryUsecaseStub) Reject(_ context.Context, _ types.MemoryID) (apptypes.MemoryDetails, error) {
+	return s.rejectDetails, s.rejectErr
+}
+
+func (s *memoryUsecaseStub) Supersede(_ context.Context, _ types.MemoryID, _ types.MemoryType, _ types.MemoryScope, _ string, _ types.Optional[types.Confidence], _ types.MemorySource, _ []types.EvidenceRef, _ []types.ArtifactRef) (apptypes.MemoryDetails, error) {
+	return s.supersedeDetails, s.supersedeErr
+}
+
+func (s *memoryUsecaseStub) Expire(_ context.Context, _ types.MemoryID, _ types.Optional[time.Time]) (apptypes.MemoryDetails, error) {
+	return s.expireDetails, s.expireErr
+}
+
+func (s *memoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	s.listCriteria = criteria
+	return s.listResult, s.listErr
+}
+
+func (s *memoryUsecaseStub) Search(_ context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	s.searchCriteria = criteria
+	return s.searchResult, s.searchErr
+}
+
+func (s *memoryUsecaseStub) Show(_ context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error) {
+	s.showMemoryID = memoryID
+	return s.showDetails, s.showErr
+}
+
 // storeManagementUsecaseStub implements usecase.StoreManagementUsecase for testing.
 type storeManagementUsecaseStub struct {
 	initCalled      bool


### PR DESCRIPTION
## Summary
- add the manual durable-memory lifecycle usecase for remember/propose/accept/reject/supersede/expire
- add the `traceary memory ...` CLI namespace with text/JSON output for summaries and details
- document the new durable-memory CLI commands in the English and Japanese CLI references

## Motivation
- operators need a first-class way to manage durable memories directly from the CLI before MCP and automatic extraction arrive
- durable memory writes must be sanitized consistently before persistence while preserving evidence and artifact traceability in read paths
- v0.5.0 needs the manual lifecycle and CLI surface in place before handoff/context can become memory-aware

## Testing
- python3 scripts/verify_docs_i18n.py
- go test ./...
- go build ./...
- go tool golangci-lint run

Closes #462
