### PR TITLE
feat: add MCP durable memory tools

### DIFF
--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -64,7 +64,7 @@ Flags:
 
 ## 公開されるツール
 
-現在の Traceary MCP サーバーは 9 つのツールを公開します。
+現在の Traceary MCP サーバーは 18 個のツールを公開します。
 
 ### `start_session`
 
@@ -75,7 +75,7 @@ Inputs:
 - `client`（既定: `mcp`）
 - `agent`（既定: `manual`）
 - `session_id`（任意。省略時は Traceary が生成）
-- `repo`（任意の work-context 文字列）
+- `workspace`（任意の work-context 文字列）
 
 ### `end_session`
 
@@ -86,7 +86,7 @@ Inputs:
 - `session_id`（必須）
 - `client`（任意。省略時は対応する `session_started` から attribution を優先）
 - `agent`（任意。省略時は対応する `session_started` から attribution を優先）
-- `repo`（任意の work-context 文字列）
+- `workspace`（任意の work-context 文字列）
 
 ### `latest_session`
 
@@ -96,7 +96,7 @@ Inputs:
 
 - `client`
 - `agent`
-- `repo`
+- `workspace`
 
 ### `active_session`
 
@@ -106,7 +106,7 @@ Inputs:
 
 - `client`
 - `agent`
-- `repo`
+- `workspace`
 - `allow_stale`（既定: `false`）
 - `stale_after_seconds`（`0` または省略時は既定の `86400`）
 
@@ -120,7 +120,7 @@ Inputs:
 - `offset`（既定: `0`）
 
 client から `traceary list` 相当の「最近の feed」を見たいときは `list_events` を使います。
-`repo` や `session_id`、全文検索などの structured filter が必要なときは `search` を使ってください。
+`workspace` や `session_id`、全文検索などの structured filter が必要なときは `search` を使ってください。
 
 ### `add_log`
 
@@ -132,7 +132,7 @@ Inputs:
 - `client`（既定: `mcp`）
 - `agent`（既定: `manual`）
 - `session_id`（既定: `default`）
-- `repo`（任意の work-context 文字列）
+- `workspace`（任意の work-context 文字列）
 
 ### `add_audit`
 
@@ -148,7 +148,7 @@ Inputs:
 - `client`（既定: `mcp`）
 - `agent`（既定: `manual`）
 - `session_id`（既定: `default`）
-- `repo`（任意の work-context 文字列）
+- `workspace`（任意の work-context 文字列）
 
 ### `search`
 
@@ -157,20 +157,134 @@ Inputs:
 Inputs:
 
 - `query`（必須）
-- `repo`
+- `workspace`
 - `from`（`YYYY-MM-DD` または RFC3339）
 - `to`（`YYYY-MM-DD` または RFC3339）
 - `limit`（既定: `20`）
 
 ### `get_context`
 
-handoff 用の最近イベント群を返します。
+raw な最近イベント群を返します。
 
 Inputs:
 
-- `repo`
+- `workspace`
 - `session_id`
 - `limit`（既定: `20`）
+
+### `session_handoff`
+
+CLI の `traceary handoff` と揃えた、構造化 working-memory handoff pack を返します。
+
+Inputs:
+
+- `workspace`
+- `session_id`
+- `recent_commands_limit`（既定: `5`）
+- `memory_limit`（既定: `5`）
+
+### `retrieve_memories`
+
+ID 指定、全文検索、scope filter で durable memory を取得します。
+
+Inputs:
+
+- `memory_id`
+- `query`
+- `workspace`
+- `agent`
+- `session_family`
+- `status`
+- `type`
+- `limit`（既定: `20`）
+- `offset`（既定: `0`）
+
+`memory_id` を指定した場合は evidence / artifact refs 付きの単一 memory を返します。
+`query` を指定した場合は全文検索を行います。
+どちらも指定しない場合は、scope / status / type で絞り込んだ active memory 一覧を返します。
+
+### `remember_memory`
+
+accepted な durable memory を記録します。
+
+Inputs:
+
+- `type`（必須）
+- `workspace` / `agent` / `session_family` のいずれか 1 つ（必須、相互排他）
+- `fact`（必須）
+- `confidence`
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+accepted memory には少なくとも 1 件の evidence ref が必要です。
+
+### `propose_memory`
+
+レビュー待ちの candidate durable memory を記録します。
+
+Inputs:
+
+- `type`（必須）
+- `workspace` / `agent` / `session_family` のいずれか 1 つ（必須、相互排他）
+- `fact`（必須）
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+### `accept_memory`
+
+candidate durable memory を accept します。
+
+Inputs:
+
+- `memory_id`（必須）
+- `confidence`
+
+### `reject_memory`
+
+candidate durable memory を reject します。
+
+Inputs:
+
+- `memory_id`（必須）
+
+### `supersede_memory`
+
+accepted な durable memory を superseded にし、置き換え用の accepted memory を保存します。
+
+Inputs:
+
+- `memory_id`（必須）
+- `fact`（必須）
+- 置き換え先の `type`
+- 置き換え先の `workspace` / `agent` / `session_family`
+- `confidence`
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+置き換え先の `type` / scope は、省略時は現在の memory から継承します。
+
+### `expire_memory`
+
+durable memory を expire します。
+
+Inputs:
+
+- `memory_id`（必須）
+- `expires_at`（`YYYY-MM-DD` または RFC3339。既定は now）
+
+### `memory_pack`
+
+prompt injection や agent automation 向けの memory-aware context pack を構築します。
+
+Inputs:
+
+- `workspace`
+- `session_id`
+- `recent_commands_limit`（既定: `5`）
+- `memory_limit`（既定: `5`）
 
 ## 実用的なクライアント設定例
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -176,6 +176,8 @@ Inputs:
 
 CLI の `traceary handoff` と揃えた、構造化 working-memory handoff pack を返します。
 
+トップレベルの `summary` は後方互換のために残してあり、`working_state.combined_summary` をそのまま返します。
+
 Inputs:
 
 - `workspace`
@@ -277,7 +279,7 @@ Inputs:
 
 ### `memory_pack`
 
-prompt injection や agent automation 向けの memory-aware context pack を構築します。
+prompt 向けの context enrichment や agent automation 向けの memory-aware context pack を構築します。
 
 Inputs:
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -205,6 +205,8 @@ Inputs:
 `query` を指定した場合は全文検索を行います。
 どちらも指定しない場合は、scope / status / type で絞り込んだ active memory 一覧を返します。
 
+durable memory の payload は保存済みの内容をそのまま返します。機微情報は、永続化前に既存の memory sanitization / redaction 経路で処理されている前提です。
+
 ### `remember_memory`
 
 accepted な durable memory を記録します。

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -182,8 +182,8 @@ Inputs:
 
 - `workspace`
 - `session_id`
-- `recent_commands_limit`（既定: `5`）
-- `memory_limit`（既定: `5`）
+- `recent_commands_limit`（既定: `5`。明示的に `0` を渡すと recent commands を無効化）
+- `memory_limit`（既定: `5`。明示的に `0` を渡すと durable memories を無効化）
 
 ### `retrieve_memories`
 
@@ -285,8 +285,8 @@ Inputs:
 
 - `workspace`
 - `session_id`
-- `recent_commands_limit`（既定: `5`）
-- `memory_limit`（既定: `5`）
+- `recent_commands_limit`（既定: `5`。明示的に `0` を渡すと recent commands を無効化）
+- `memory_limit`（既定: `5`。明示的に `0` を渡すと durable memories を無効化）
 
 ## 実用的なクライアント設定例
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -182,8 +182,8 @@ Inputs:
 
 - `workspace`
 - `session_id`
-- `recent_commands_limit` (default: `5`)
-- `memory_limit` (default: `5`)
+- `recent_commands_limit` (default: `5`; explicit `0` disables recent commands)
+- `memory_limit` (default: `5`; explicit `0` disables durable memories)
 
 ### `retrieve_memories`
 
@@ -285,8 +285,8 @@ Inputs:
 
 - `workspace`
 - `session_id`
-- `recent_commands_limit` (default: `5`)
-- `memory_limit` (default: `5`)
+- `recent_commands_limit` (default: `5`; explicit `0` disables recent commands)
+- `memory_limit` (default: `5`; explicit `0` disables durable memories)
 
 ## Practical client example
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -64,7 +64,7 @@ Flags:
 
 ## Exposed tools
 
-Traceary currently exposes nine MCP tools.
+Traceary currently exposes eighteen MCP tools.
 
 ### `start_session`
 
@@ -75,7 +75,7 @@ Inputs:
 - `client` (default: `mcp`)
 - `agent` (default: `manual`)
 - `session_id` (optional; Traceary generates one when omitted)
-- `repo` (optional work-context string)
+- `workspace` (optional work-context string)
 
 ### `end_session`
 
@@ -86,7 +86,7 @@ Inputs:
 - `session_id` (required)
 - `client` (optional; when omitted, Traceary prefers attribution from the matching `session_started` event)
 - `agent` (optional; when omitted, Traceary prefers attribution from the matching `session_started` event)
-- `repo` (optional work-context string)
+- `workspace` (optional work-context string)
 
 ### `latest_session`
 
@@ -96,7 +96,7 @@ Inputs:
 
 - `client`
 - `agent`
-- `repo`
+- `workspace`
 
 ### `active_session`
 
@@ -106,7 +106,7 @@ Inputs:
 
 - `client`
 - `agent`
-- `repo`
+- `workspace`
 - `allow_stale` (default: `false`)
 - `stale_after_seconds` (`0` or omitted uses the default `86400`)
 
@@ -120,7 +120,7 @@ Inputs:
 - `offset` (default: `0`)
 
 Use `list_events` when the client wants the same "recent feed" view as `traceary list`.
-Use `search` when the client needs structured filters such as `repo`, `session_id`, or a text query.
+Use `search` when the client needs structured filters such as `workspace`, `session_id`, or a text query.
 
 ### `add_log`
 
@@ -132,7 +132,7 @@ Inputs:
 - `client` (default: `mcp`)
 - `agent` (default: `manual`)
 - `session_id` (default: `default`)
-- `repo` (optional work-context string)
+- `workspace` (optional work-context string)
 
 ### `add_audit`
 
@@ -148,7 +148,7 @@ Inputs:
 - `client` (default: `mcp`)
 - `agent` (default: `manual`)
 - `session_id` (default: `default`)
-- `repo` (optional work-context string)
+- `workspace` (optional work-context string)
 
 ### `search`
 
@@ -157,20 +157,134 @@ Searches existing events.
 Inputs:
 
 - `query` (required)
-- `repo`
+- `workspace`
 - `from` (`YYYY-MM-DD` or RFC3339)
 - `to` (`YYYY-MM-DD` or RFC3339)
 - `limit` (default: `20`)
 
 ### `get_context`
 
-Returns recent events for context handoff.
+Returns recent raw events for context lookup.
 
 Inputs:
 
-- `repo`
+- `workspace`
 - `session_id`
 - `limit` (default: `20`)
+
+### `session_handoff`
+
+Returns the structured working-memory handoff pack aligned with the CLI `traceary handoff` command.
+
+Inputs:
+
+- `workspace`
+- `session_id`
+- `recent_commands_limit` (default: `5`)
+- `memory_limit` (default: `5`)
+
+### `retrieve_memories`
+
+Returns durable memories by direct ID lookup, full-text query, or scope filters.
+
+Inputs:
+
+- `memory_id`
+- `query`
+- `workspace`
+- `agent`
+- `session_family`
+- `status`
+- `type`
+- `limit` (default: `20`)
+- `offset` (default: `0`)
+
+When `memory_id` is set, Traceary returns that single memory with evidence and artifact refs.
+When `query` is set, Traceary performs full-text search.
+Otherwise it lists active memories, optionally filtered by scope / status / type.
+
+### `remember_memory`
+
+Records an accepted durable memory.
+
+Inputs:
+
+- `type` (required)
+- one of `workspace` / `agent` / `session_family` (required, mutually exclusive)
+- `fact` (required)
+- `confidence`
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+Accepted memories require at least one evidence ref.
+
+### `propose_memory`
+
+Records a candidate durable memory that still needs review.
+
+Inputs:
+
+- `type` (required)
+- one of `workspace` / `agent` / `session_family` (required, mutually exclusive)
+- `fact` (required)
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+### `accept_memory`
+
+Accepts a candidate durable memory.
+
+Inputs:
+
+- `memory_id` (required)
+- `confidence`
+
+### `reject_memory`
+
+Rejects a candidate durable memory.
+
+Inputs:
+
+- `memory_id` (required)
+
+### `supersede_memory`
+
+Marks an accepted durable memory as superseded and stores a replacement accepted memory.
+
+Inputs:
+
+- `memory_id` (required)
+- `fact` (required)
+- replacement `type`
+- replacement `workspace` / `agent` / `session_family`
+- `confidence`
+- `source`
+- `evidence_refs`
+- `artifact_refs`
+
+Replacement `type` / scope inherit from the current memory when omitted.
+
+### `expire_memory`
+
+Expires a durable memory.
+
+Inputs:
+
+- `memory_id` (required)
+- `expires_at` (`YYYY-MM-DD` or RFC3339; defaults to now)
+
+### `memory_pack`
+
+Builds a memory-aware context pack for prompt injection or automation.
+
+Inputs:
+
+- `workspace`
+- `session_id`
+- `recent_commands_limit` (default: `5`)
+- `memory_limit` (default: `5`)
 
 ## Practical client example
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -176,6 +176,8 @@ Inputs:
 
 Returns the structured working-memory handoff pack aligned with the CLI `traceary handoff` command.
 
+The top-level `summary` field is kept for compatibility and mirrors `working_state.combined_summary`.
+
 Inputs:
 
 - `workspace`
@@ -277,7 +279,7 @@ Inputs:
 
 ### `memory_pack`
 
-Builds a memory-aware context pack for prompt injection or automation.
+Builds a memory-aware context pack for prompt-context enrichment or automation.
 
 Inputs:
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -205,6 +205,8 @@ When `memory_id` is set, Traceary returns that single memory with evidence and a
 When `query` is set, Traceary performs full-text search.
 Otherwise it lists active memories, optionally filtered by scope / status / type.
 
+Durable-memory payloads are returned as stored. Sensitive content is expected to be handled at write time through the existing memory sanitization/redaction path before persistence.
+
 ### `remember_memory`
 
 Records an accepted durable memory.

--- a/main.go
+++ b/main.go
@@ -157,6 +157,8 @@ func run() error {
 		extraRedactPatterns,
 		eventUsecase,
 		sessionUsecase,
+		memoryUsecase,
+		contextUsecase,
 		storeManagementUsecase,
 	)
 	if err != nil {

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -79,16 +79,16 @@ type getContextInput struct {
 type sessionHandoffInput struct {
 	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier filter"`
 	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
-	RecentCommandsLimit int    `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5)"`
-	MemoryLimit         int    `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5)"`
+	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
+	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 }
 
 // memoryPackInput is the MCP input for the memory_pack tool.
 type memoryPackInput struct {
 	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier filter"`
 	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
-	RecentCommandsLimit int    `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5)"`
-	MemoryLimit         int    `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5)"`
+	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
+	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 }
 
 // memoryRefInput is the MCP representation of evidence/artifact references.

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -77,6 +77,91 @@ type getContextInput struct {
 
 // sessionHandoffInput is the MCP input for the session_handoff tool.
 type sessionHandoffInput struct {
-	SessionID string `json:"session_id,omitempty"`
-	Workspace string `json:"workspace,omitempty"`
+	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier filter"`
+	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
+	RecentCommandsLimit int    `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5)"`
+	MemoryLimit         int    `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5)"`
+}
+
+// memoryPackInput is the MCP input for the memory_pack tool.
+type memoryPackInput struct {
+	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier filter"`
+	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
+	RecentCommandsLimit int    `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5)"`
+	MemoryLimit         int    `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5)"`
+}
+
+// memoryRefInput is the MCP representation of evidence/artifact references.
+type memoryRefInput struct {
+	Kind  string `json:"kind" jsonschema:"reference kind"`
+	Value string `json:"value" jsonschema:"reference value"`
+}
+
+// retrieveMemoriesInput is the MCP input for the retrieve_memories tool.
+type retrieveMemoriesInput struct {
+	MemoryID      string   `json:"memory_id,omitempty" jsonschema:"durable memory identifier to fetch directly"`
+	Query         string   `json:"query,omitempty" jsonschema:"full-text search query"`
+	Workspace     string   `json:"workspace,omitempty" jsonschema:"workspace scope filter"`
+	Agent         string   `json:"agent,omitempty" jsonschema:"agent scope filter"`
+	SessionFamily string   `json:"session_family,omitempty" jsonschema:"session-family scope filter"`
+	Statuses      []string `json:"status,omitempty" jsonschema:"memory lifecycle status filters"`
+	MemoryTypes   []string `json:"type,omitempty" jsonschema:"memory type filters"`
+	Limit         int      `json:"limit,omitempty" jsonschema:"maximum number of memories to return (default: 20)"`
+	Offset        int      `json:"offset,omitempty" jsonschema:"number of memories to skip before returning results (default: 0)"`
+}
+
+// rememberMemoryInput is the MCP input for the remember_memory tool.
+type rememberMemoryInput struct {
+	MemoryType    string           `json:"type" jsonschema:"memory type"`
+	Workspace     string           `json:"workspace,omitempty" jsonschema:"workspace scope"`
+	Agent         string           `json:"agent,omitempty" jsonschema:"agent scope"`
+	SessionFamily string           `json:"session_family,omitempty" jsonschema:"session-family scope"`
+	Fact          string           `json:"fact" jsonschema:"distilled memory fact"`
+	Confidence    string           `json:"confidence,omitempty" jsonschema:"accepted confidence (default: verified)"`
+	Source        string           `json:"source,omitempty" jsonschema:"memory source (default: manual)"`
+	EvidenceRefs  []memoryRefInput `json:"evidence_refs,omitempty" jsonschema:"supporting evidence refs"`
+	ArtifactRefs  []memoryRefInput `json:"artifact_refs,omitempty" jsonschema:"related artifact refs"`
+}
+
+// proposeMemoryInput is the MCP input for the propose_memory tool.
+type proposeMemoryInput struct {
+	MemoryType    string           `json:"type" jsonschema:"memory type"`
+	Workspace     string           `json:"workspace,omitempty" jsonschema:"workspace scope"`
+	Agent         string           `json:"agent,omitempty" jsonschema:"agent scope"`
+	SessionFamily string           `json:"session_family,omitempty" jsonschema:"session-family scope"`
+	Fact          string           `json:"fact" jsonschema:"distilled memory fact"`
+	Source        string           `json:"source,omitempty" jsonschema:"memory source (default: manual)"`
+	EvidenceRefs  []memoryRefInput `json:"evidence_refs,omitempty" jsonschema:"supporting evidence refs"`
+	ArtifactRefs  []memoryRefInput `json:"artifact_refs,omitempty" jsonschema:"related artifact refs"`
+}
+
+// acceptMemoryInput is the MCP input for the accept_memory tool.
+type acceptMemoryInput struct {
+	MemoryID   string `json:"memory_id" jsonschema:"candidate durable memory identifier"`
+	Confidence string `json:"confidence,omitempty" jsonschema:"accepted confidence (default: verified)"`
+}
+
+// rejectMemoryInput is the MCP input for the reject_memory tool.
+type rejectMemoryInput struct {
+	MemoryID string `json:"memory_id" jsonschema:"candidate durable memory identifier"`
+}
+
+// supersedeMemoryInput is the MCP input for the supersede_memory tool.
+type supersedeMemoryInput struct {
+	MemoryID      string           `json:"memory_id" jsonschema:"accepted durable memory identifier to supersede"`
+	MemoryType    string           `json:"type,omitempty" jsonschema:"replacement memory type (inherits when omitted)"`
+	Workspace     string           `json:"workspace,omitempty" jsonschema:"replacement workspace scope"`
+	Agent         string           `json:"agent,omitempty" jsonschema:"replacement agent scope"`
+	SessionFamily string           `json:"session_family,omitempty" jsonschema:"replacement session-family scope"`
+	Fact          string           `json:"fact" jsonschema:"replacement distilled memory fact"`
+	Confidence    string           `json:"confidence,omitempty" jsonschema:"replacement confidence (default: verified)"`
+	Source        string           `json:"source,omitempty" jsonschema:"replacement memory source (default: manual)"`
+	EvidenceRefs  []memoryRefInput `json:"evidence_refs,omitempty" jsonschema:"replacement evidence refs"`
+	ArtifactRefs  []memoryRefInput `json:"artifact_refs,omitempty" jsonschema:"replacement artifact refs"`
+}
+
+// expireMemoryInput is the MCP input for the expire_memory tool.
+type expireMemoryInput struct {
+	MemoryID  string `json:"memory_id" jsonschema:"durable memory identifier"`
+	ExpiresAt string `json:"expires_at,omitempty" jsonschema:"expiry timestamp (YYYY-MM-DD or RFC3339, defaults to now)"`
 }

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -56,13 +56,69 @@ type eventOutput struct {
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.
 type sessionHandoffOutput struct {
-	SessionID      string   `json:"session_id,omitempty"`
-	Workspace      string   `json:"workspace,omitempty"`
-	Label          string   `json:"label,omitempty"`
-	Status         string   `json:"status,omitempty"`
-	TotalEvents    int      `json:"total_events"`
-	CommandCount   int      `json:"command_count"`
-	Agents         []string `json:"agents,omitempty"`
-	Summary        string   `json:"summary,omitempty"`
-	RecentCommands []string `json:"recent_commands,omitempty"`
+	SessionID      string                `json:"session_id,omitempty"`
+	Workspace      string                `json:"workspace,omitempty"`
+	Label          string                `json:"label,omitempty"`
+	Status         string                `json:"status,omitempty"`
+	TotalEvents    int                   `json:"total_events"`
+	CommandCount   int                   `json:"command_count"`
+	Agents         []string              `json:"agents,omitempty"`
+	Summary        string                `json:"summary,omitempty"`
+	WorkingState   workingStateOutput    `json:"working_state"`
+	RecentCommands []string              `json:"recent_commands,omitempty"`
+	Memories       []memorySummaryOutput `json:"memories,omitempty"`
+}
+
+// memoryPackOutput is the MCP output for the memory_pack tool.
+type memoryPackOutput = sessionHandoffOutput
+
+// workingStateOutput represents structured working-memory signals.
+type workingStateOutput struct {
+	SessionSummary  string `json:"session_summary,omitempty"`
+	CompactSummary  string `json:"compact_summary,omitempty"`
+	CombinedSummary string `json:"combined_summary,omitempty"`
+}
+
+// memoriesOutput is the MCP output for retrieve_memories.
+type memoriesOutput struct {
+	Memories []memoryOutput `json:"memories" jsonschema:"durable memories matching the request"`
+}
+
+// memorySummaryOutput is the compact durable-memory shape used inside context packs.
+type memorySummaryOutput struct {
+	MemoryID   string `json:"memory_id" jsonschema:"durable memory identifier"`
+	Type       string `json:"type" jsonschema:"memory type"`
+	ScopeKind  string `json:"scope_kind" jsonschema:"scope kind"`
+	ScopeValue string `json:"scope_value" jsonschema:"scope value"`
+	Fact       string `json:"fact" jsonschema:"distilled memory fact"`
+	Status     string `json:"status" jsonschema:"lifecycle status"`
+	Confidence string `json:"confidence" jsonschema:"confidence level"`
+	Source     string `json:"source" jsonschema:"memory source"`
+	ExpiresAt  string `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano)"`
+	CreatedAt  string `json:"created_at" jsonschema:"creation timestamp (RFC3339Nano)"`
+	UpdatedAt  string `json:"updated_at" jsonschema:"update timestamp (RFC3339Nano)"`
+}
+
+// memoryOutput is the full durable-memory shape returned by MCP memory tools.
+type memoryOutput struct {
+	MemoryID     string            `json:"memory_id" jsonschema:"durable memory identifier"`
+	Type         string            `json:"type" jsonschema:"memory type"`
+	ScopeKind    string            `json:"scope_kind" jsonschema:"scope kind"`
+	ScopeValue   string            `json:"scope_value" jsonschema:"scope value"`
+	Fact         string            `json:"fact" jsonschema:"distilled memory fact"`
+	Status       string            `json:"status" jsonschema:"lifecycle status"`
+	Confidence   string            `json:"confidence" jsonschema:"confidence level"`
+	Source       string            `json:"source" jsonschema:"memory source"`
+	Supersedes   string            `json:"supersedes,omitempty" jsonschema:"superseded memory identifier"`
+	ExpiresAt    string            `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano)"`
+	CreatedAt    string            `json:"created_at" jsonschema:"creation timestamp (RFC3339Nano)"`
+	UpdatedAt    string            `json:"updated_at" jsonschema:"update timestamp (RFC3339Nano)"`
+	EvidenceRefs []memoryRefOutput `json:"evidence_refs,omitempty" jsonschema:"supporting evidence refs"`
+	ArtifactRefs []memoryRefOutput `json:"artifact_refs,omitempty" jsonschema:"related artifact refs"`
+}
+
+// memoryRefOutput is a reference rendered in MCP responses.
+type memoryRefOutput struct {
+	Kind  string `json:"kind" jsonschema:"reference kind"`
+	Value string `json:"value" jsonschema:"reference value"`
 }

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -63,7 +63,7 @@ type sessionHandoffOutput struct {
 	TotalEvents    int                   `json:"total_events"`
 	CommandCount   int                   `json:"command_count"`
 	Agents         []string              `json:"agents,omitempty"`
-	Summary        string                `json:"summary,omitempty"`
+	Summary        string                `json:"summary,omitempty" jsonschema:"legacy compatibility mirror of working_state.combined_summary"`
 	WorkingState   workingStateOutput    `json:"working_state"`
 	RecentCommands []string              `json:"recent_commands,omitempty"`
 	Memories       []memorySummaryOutput `json:"memories,omitempty"`

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -678,13 +678,17 @@ func (s *Server) expireMemory() mcp.ToolHandlerFor[expireMemoryInput, memoryOutp
 	}
 }
 
-func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit int, memoryLimit int) apptypes.ContextPackCriteria {
-	return apptypes.NewContextPackCriteriaBuilder().
+func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int) apptypes.ContextPackCriteria {
+	builder := apptypes.NewContextPackCriteriaBuilder().
 		SessionID(types.SessionID(strings.TrimSpace(sessionID))).
-		Workspace(types.Workspace(strings.TrimSpace(workspace))).
-		RecentCommandsLimit(resolveLimit(recentCommandsLimit, 5)).
-		MemoryLimit(resolveLimit(memoryLimit, 5)).
-		Build()
+		Workspace(types.Workspace(strings.TrimSpace(workspace)))
+	if recentCommandsLimit != nil {
+		builder.RecentCommandsLimit(*recentCommandsLimit)
+	}
+	if memoryLimit != nil {
+		builder.MemoryLimit(*memoryLimit)
+	}
+	return builder.Build()
 }
 
 func newContextPackOutput(pack apptypes.ContextPack) sessionHandoffOutput {

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -182,7 +182,7 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 	}, s.expireMemory())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "memory_pack",
-		Description: "Build a memory-aware context pack for prompt injection or automation",
+		Description: "Build a memory-aware context pack for prompt-context enrichment or automation",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.memoryPack())
 
@@ -546,11 +546,7 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 
 		memories := make([]memoryOutput, 0, len(summaries))
 		for _, summary := range summaries {
-			details, err := s.memory.Show(ctx, summary.MemoryID())
-			if err != nil {
-				return nil, memoriesOutput{}, xerrors.Errorf("failed to load memory details for %s: %w", summary.MemoryID(), err)
-			}
-			memories = append(memories, newMemoryOutput(details))
+			memories = append(memories, newMemoryOutputFromSummary(summary))
 		}
 		return nil, memoriesOutput{Memories: memories}, nil
 	}
@@ -757,6 +753,28 @@ func newMemoryOutput(details apptypes.MemoryDetails) memoryOutput {
 		UpdatedAt:    summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
 		EvidenceRefs: convertEvidenceRefs(details.EvidenceRefs()),
 		ArtifactRefs: convertArtifactRefs(details.ArtifactRefs()),
+	}
+}
+
+func newMemoryOutputFromSummary(summary apptypes.MemorySummary) memoryOutput {
+	supersedes := ""
+	if memoryID, ok := summary.Supersedes().Get(); ok {
+		supersedes = memoryID.String()
+	}
+
+	return memoryOutput{
+		MemoryID:   summary.MemoryID().String(),
+		Type:       summary.MemoryType().String(),
+		ScopeKind:  summary.Scope().Kind().String(),
+		ScopeValue: summary.Scope().Key(),
+		Fact:       summary.Fact(),
+		Status:     summary.Status().String(),
+		Confidence: summary.Confidence().String(),
+		Source:     summary.Source().String(),
+		Supersedes: supersedes,
+		ExpiresAt:  formatOptionalTime(summary.ExpiresAt()),
+		CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339Nano),
+		UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
 	}
 }
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -32,6 +32,8 @@ type Server struct {
 	extraRedactPatterns []string
 	event               usecase.EventUsecase
 	session             usecase.SessionUsecase
+	memory              usecase.MemoryUsecase
+	context             usecase.ContextUsecase
 	storeManagement     usecase.StoreManagementUsecase
 }
 
@@ -41,6 +43,8 @@ func NewServer(
 	extraRedactPatterns []string,
 	event usecase.EventUsecase,
 	session usecase.SessionUsecase,
+	memory usecase.MemoryUsecase,
+	contextUsecase usecase.ContextUsecase,
 	storeManagement usecase.StoreManagementUsecase,
 ) (*Server, error) {
 	if event == nil {
@@ -48,6 +52,12 @@ func NewServer(
 	}
 	if session == nil {
 		return nil, xerrors.Errorf("session usecase is not configured")
+	}
+	if memory == nil {
+		return nil, xerrors.Errorf("memory usecase is not configured")
+	}
+	if contextUsecase == nil {
+		return nil, xerrors.Errorf("context usecase is not configured")
 	}
 	if storeManagement == nil {
 		return nil, xerrors.Errorf("store management usecase is not configured")
@@ -64,6 +74,8 @@ func NewServer(
 		extraRedactPatterns: extraRedactPatterns,
 		event:               event,
 		session:             session,
+		memory:              memory,
+		context:             contextUsecase,
 		storeManagement:     storeManagement,
 	}, nil
 }
@@ -133,6 +145,46 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 		Description: "Get a concise session summary for handoff or context resumption",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.sessionHandoff())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "retrieve_memories",
+		Description: "Retrieve durable memories by ID, query, or scope filters",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, s.retrieveMemories())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "remember_memory",
+		Description: "Record an accepted durable memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.rememberMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "propose_memory",
+		Description: "Record a candidate durable memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.proposeMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "accept_memory",
+		Description: "Accept a candidate durable memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.acceptMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "reject_memory",
+		Description: "Reject a candidate durable memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.rejectMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "supersede_memory",
+		Description: "Replace an accepted durable memory with a new accepted memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.supersedeMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "expire_memory",
+		Description: "Expire a durable memory",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
+	}, s.expireMemory())
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "memory_pack",
+		Description: "Build a memory-aware context pack for prompt injection or automation",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, s.memoryPack())
 
 	return server, nil
 }
@@ -399,11 +451,12 @@ func (s *Server) getContext() mcp.ToolHandlerFor[getContextInput, eventsOutput] 
 
 func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessionHandoffOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionHandoffInput) (*mcp.CallToolResult, sessionHandoffOutput, error) {
-		result, err := s.session.Handoff(ctx,
-			types.SessionID(strings.TrimSpace(input.SessionID)),
-			types.Workspace(strings.TrimSpace(input.Workspace)),
-			5,
-		)
+		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
+			input.SessionID,
+			input.Workspace,
+			input.RecentCommandsLimit,
+			input.MemoryLimit,
+		))
 		if err != nil {
 			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to get session handoff: %w", err)
 		}
@@ -412,19 +465,554 @@ func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessio
 			return nil, sessionHandoffOutput{}, nil
 		}
 
-		summary, _ := result.Get()
-		return nil, sessionHandoffOutput{
-			SessionID:      summary.SessionID().String(),
-			Workspace:      summary.Workspace().String(),
-			Label:          summary.Label(),
-			Status:         summary.Status(),
-			TotalEvents:    summary.TotalEvents(),
-			CommandCount:   summary.CommandCount(),
-			Agents:         summary.Agents(),
-			Summary:        summary.Summary(),
-			RecentCommands: summary.RecentCommands(),
-		}, nil
+		pack, _ := result.Get()
+		return nil, newContextPackOutput(pack), nil
 	}
+}
+
+func (s *Server) memoryPack() mcp.ToolHandlerFor[memoryPackInput, memoryPackOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input memoryPackInput) (*mcp.CallToolResult, memoryPackOutput, error) {
+		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
+			input.SessionID,
+			input.Workspace,
+			input.RecentCommandsLimit,
+			input.MemoryLimit,
+		))
+		if err != nil {
+			return nil, memoryPackOutput{}, xerrors.Errorf("failed to build memory pack: %w", err)
+		}
+		if !result.IsPresent() {
+			return nil, memoryPackOutput{}, nil
+		}
+
+		pack, _ := result.Get()
+		return nil, newContextPackOutput(pack), nil
+	}
+}
+
+func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, memoriesOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input retrieveMemoriesInput) (*mcp.CallToolResult, memoriesOutput, error) {
+		memoryIDValue := strings.TrimSpace(input.MemoryID)
+		if memoryIDValue != "" {
+			memoryID, err := types.MemoryIDOf(memoryIDValue)
+			if err != nil {
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
+			}
+			details, err := s.memory.Show(ctx, memoryID)
+			if err != nil {
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to retrieve memory: %w", err)
+			}
+			return nil, memoriesOutput{Memories: []memoryOutput{newMemoryOutput(details)}}, nil
+		}
+
+		scopes, err := parseMemoryScopes(input.Workspace, input.Agent, input.SessionFamily)
+		if err != nil {
+			return nil, memoriesOutput{}, err
+		}
+		statuses, err := parseMemoryStatuses(input.Statuses)
+		if err != nil {
+			return nil, memoriesOutput{}, err
+		}
+		memoryTypes, err := parseMemoryTypes(input.MemoryTypes)
+		if err != nil {
+			return nil, memoriesOutput{}, err
+		}
+
+		var summaries []apptypes.MemorySummary
+		if strings.TrimSpace(input.Query) != "" {
+			criteria := apptypes.NewMemorySearchCriteriaBuilder(resolveLimit(input.Limit, defaultSearchLimit)).
+				Query(strings.TrimSpace(input.Query)).
+				Offset(resolveOffset(input.Offset)).
+				Scopes(scopes).
+				Statuses(statuses).
+				MemoryTypes(memoryTypes).
+				Build()
+			summaries, err = s.memory.Search(ctx, criteria)
+			if err != nil {
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to search memories: %w", err)
+			}
+		} else {
+			criteria := apptypes.NewMemoryListCriteriaBuilder(resolveLimit(input.Limit, defaultSearchLimit)).
+				Offset(resolveOffset(input.Offset)).
+				Scopes(scopes).
+				Statuses(statuses).
+				MemoryTypes(memoryTypes).
+				Build()
+			summaries, err = s.memory.List(ctx, criteria)
+			if err != nil {
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to list memories: %w", err)
+			}
+		}
+
+		memories := make([]memoryOutput, 0, len(summaries))
+		for _, summary := range summaries {
+			details, err := s.memory.Show(ctx, summary.MemoryID())
+			if err != nil {
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to load memory details for %s: %w", summary.MemoryID(), err)
+			}
+			memories = append(memories, newMemoryOutput(details))
+		}
+		return nil, memoriesOutput{Memories: memories}, nil
+	}
+}
+
+func (s *Server) rememberMemory() mcp.ToolHandlerFor[rememberMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input rememberMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryType, scope, confidence, source, evidenceRefs, artifactRefs, err := parseMemoryWriteInput(
+			input.MemoryType,
+			input.Workspace,
+			input.Agent,
+			input.SessionFamily,
+			input.Confidence,
+			input.Source,
+			input.EvidenceRefs,
+			input.ArtifactRefs,
+		)
+		if err != nil {
+			return nil, memoryOutput{}, err
+		}
+		details, err := s.memory.Remember(ctx, memoryType, scope, input.Fact, confidence, source, evidenceRefs, artifactRefs)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to remember memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func (s *Server) proposeMemory() mcp.ToolHandlerFor[proposeMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input proposeMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryType, scope, source, evidenceRefs, artifactRefs, err := parseMemoryProposalInput(
+			input.MemoryType,
+			input.Workspace,
+			input.Agent,
+			input.SessionFamily,
+			input.Source,
+			input.EvidenceRefs,
+			input.ArtifactRefs,
+		)
+		if err != nil {
+			return nil, memoryOutput{}, err
+		}
+		details, err := s.memory.Propose(ctx, memoryType, scope, input.Fact, source, evidenceRefs, artifactRefs)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to propose memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func (s *Server) acceptMemory() mcp.ToolHandlerFor[acceptMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input acceptMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
+		}
+		confidence, err := parseOptionalConfidence(input.Confidence)
+		if err != nil {
+			return nil, memoryOutput{}, err
+		}
+		details, err := s.memory.Accept(ctx, memoryID, confidence)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to accept memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func (s *Server) rejectMemory() mcp.ToolHandlerFor[rejectMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input rejectMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
+		}
+		details, err := s.memory.Reject(ctx, memoryID)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to reject memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func (s *Server) supersedeMemory() mcp.ToolHandlerFor[supersedeMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input supersedeMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
+		}
+		memoryType, scope, confidence, source, evidenceRefs, artifactRefs, err := parseOptionalMemoryWriteInput(
+			input.MemoryType,
+			input.Workspace,
+			input.Agent,
+			input.SessionFamily,
+			input.Confidence,
+			input.Source,
+			input.EvidenceRefs,
+			input.ArtifactRefs,
+		)
+		if err != nil {
+			return nil, memoryOutput{}, err
+		}
+		details, err := s.memory.Supersede(ctx, memoryID, memoryType, scope, input.Fact, confidence, source, evidenceRefs, artifactRefs)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to supersede memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func (s *Server) expireMemory() mcp.ToolHandlerFor[expireMemoryInput, memoryOutput] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, input expireMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
+		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
+		}
+		expiresAt, err := parseFlexibleTime(input.ExpiresAt, false)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve expires_at: %w", err)
+		}
+		expiresAtOptional := types.Empty[time.Time]()
+		if !expiresAt.IsZero() {
+			expiresAtOptional = types.Of(expiresAt)
+		}
+		details, err := s.memory.Expire(ctx, memoryID, expiresAtOptional)
+		if err != nil {
+			return nil, memoryOutput{}, xerrors.Errorf("failed to expire memory: %w", err)
+		}
+		return nil, newMemoryOutput(details), nil
+	}
+}
+
+func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit int, memoryLimit int) apptypes.ContextPackCriteria {
+	return apptypes.NewContextPackCriteriaBuilder().
+		SessionID(types.SessionID(strings.TrimSpace(sessionID))).
+		Workspace(types.Workspace(strings.TrimSpace(workspace))).
+		RecentCommandsLimit(resolveLimit(recentCommandsLimit, 5)).
+		MemoryLimit(resolveLimit(memoryLimit, 5)).
+		Build()
+}
+
+func newContextPackOutput(pack apptypes.ContextPack) sessionHandoffOutput {
+	return sessionHandoffOutput{
+		SessionID:      pack.SessionID().String(),
+		Workspace:      pack.Workspace().String(),
+		Label:          pack.Label(),
+		Status:         pack.Status(),
+		TotalEvents:    pack.TotalEvents(),
+		CommandCount:   pack.CommandCount(),
+		Agents:         pack.Agents(),
+		Summary:        pack.WorkingState().CombinedSummary(),
+		WorkingState:   newWorkingStateOutput(pack.WorkingState()),
+		RecentCommands: pack.RecentCommands(),
+		Memories:       convertMemorySummaries(pack.Memories()),
+	}
+}
+
+func newWorkingStateOutput(state apptypes.WorkingState) workingStateOutput {
+	return workingStateOutput{
+		SessionSummary:  state.SessionSummary(),
+		CompactSummary:  state.CompactSummary(),
+		CombinedSummary: state.CombinedSummary(),
+	}
+}
+
+func convertMemorySummaries(memories []apptypes.MemorySummary) []memorySummaryOutput {
+	outputs := make([]memorySummaryOutput, 0, len(memories))
+	for _, summary := range memories {
+		outputs = append(outputs, memorySummaryOutput{
+			MemoryID:   summary.MemoryID().String(),
+			Type:       summary.MemoryType().String(),
+			ScopeKind:  summary.Scope().Kind().String(),
+			ScopeValue: summary.Scope().Key(),
+			Fact:       summary.Fact(),
+			Status:     summary.Status().String(),
+			Confidence: summary.Confidence().String(),
+			Source:     summary.Source().String(),
+			ExpiresAt:  formatOptionalTime(summary.ExpiresAt()),
+			CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339Nano),
+			UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
+		})
+	}
+	return outputs
+}
+
+func newMemoryOutput(details apptypes.MemoryDetails) memoryOutput {
+	summary := details.Summary()
+	supersedes := ""
+	if value, ok := summary.Supersedes().Get(); ok {
+		supersedes = value.String()
+	}
+
+	return memoryOutput{
+		MemoryID:     summary.MemoryID().String(),
+		Type:         summary.MemoryType().String(),
+		ScopeKind:    summary.Scope().Kind().String(),
+		ScopeValue:   summary.Scope().Key(),
+		Fact:         summary.Fact(),
+		Status:       summary.Status().String(),
+		Confidence:   summary.Confidence().String(),
+		Source:       summary.Source().String(),
+		Supersedes:   supersedes,
+		ExpiresAt:    formatOptionalTime(summary.ExpiresAt()),
+		CreatedAt:    summary.CreatedAt().UTC().Format(time.RFC3339Nano),
+		UpdatedAt:    summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
+		EvidenceRefs: convertEvidenceRefs(details.EvidenceRefs()),
+		ArtifactRefs: convertArtifactRefs(details.ArtifactRefs()),
+	}
+}
+
+func convertEvidenceRefs(refs []types.EvidenceRef) []memoryRefOutput {
+	outputs := make([]memoryRefOutput, 0, len(refs))
+	for _, ref := range refs {
+		outputs = append(outputs, memoryRefOutput{Kind: ref.Kind().String(), Value: ref.Value()})
+	}
+	return outputs
+}
+
+func convertArtifactRefs(refs []types.ArtifactRef) []memoryRefOutput {
+	outputs := make([]memoryRefOutput, 0, len(refs))
+	for _, ref := range refs {
+		outputs = append(outputs, memoryRefOutput{Kind: ref.Kind().String(), Value: ref.Value()})
+	}
+	return outputs
+}
+
+func formatOptionalTime(value types.Optional[time.Time]) string {
+	if timeValue, ok := value.Get(); ok {
+		return timeValue.UTC().Format(time.RFC3339Nano)
+	}
+	return ""
+}
+
+func parseMemoryScopes(workspace string, agent string, sessionFamily string) ([]types.MemoryScope, error) {
+	scopes := make([]types.MemoryScope, 0, 3)
+	if trimmedWorkspace := strings.TrimSpace(workspace); trimmedWorkspace != "" {
+		resolvedWorkspace, err := types.WorkspaceOf(trimmedWorkspace)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve workspace scope: %w", err)
+		}
+		scopes = append(scopes, types.WorkspaceScopeOf(resolvedWorkspace))
+	}
+	if trimmedAgent := strings.TrimSpace(agent); trimmedAgent != "" {
+		resolvedAgent, err := types.AgentOf(trimmedAgent)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve agent scope: %w", err)
+		}
+		scopes = append(scopes, types.AgentScopeOf(resolvedAgent))
+	}
+	if trimmedSessionFamily := strings.TrimSpace(sessionFamily); trimmedSessionFamily != "" {
+		resolvedSessionID, err := types.SessionIDOf(trimmedSessionFamily)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve session_family scope: %w", err)
+		}
+		scopes = append(scopes, types.SessionFamilyScopeOf(resolvedSessionID))
+	}
+	return scopes, nil
+}
+
+func parseSingleMemoryScope(workspace string, agent string, sessionFamily string) (types.MemoryScope, error) {
+	scopes, err := parseMemoryScopes(workspace, agent, sessionFamily)
+	if err != nil {
+		return nil, err
+	}
+	if len(scopes) == 0 {
+		return nil, xerrors.Errorf("exactly one of workspace, agent, or session_family is required")
+	}
+	if len(scopes) > 1 {
+		return nil, xerrors.Errorf("workspace, agent, and session_family are mutually exclusive")
+	}
+	return scopes[0], nil
+}
+
+func parseOptionalMemoryScope(workspace string, agent string, sessionFamily string) (types.MemoryScope, error) {
+	scopes, err := parseMemoryScopes(workspace, agent, sessionFamily)
+	if err != nil {
+		return nil, err
+	}
+	if len(scopes) > 1 {
+		return nil, xerrors.Errorf("workspace, agent, and session_family are mutually exclusive")
+	}
+	if len(scopes) == 0 {
+		return nil, nil
+	}
+	return scopes[0], nil
+}
+
+func parseMemoryStatuses(values []string) ([]types.MemoryStatus, error) {
+	statuses := make([]types.MemoryStatus, 0, len(values))
+	for _, value := range values {
+		resolved, err := types.MemoryStatusOf(strings.TrimSpace(value))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve memory status: %w", err)
+		}
+		statuses = append(statuses, resolved)
+	}
+	return statuses, nil
+}
+
+func parseMemoryTypes(values []string) ([]types.MemoryType, error) {
+	memoryTypes := make([]types.MemoryType, 0, len(values))
+	for _, value := range values {
+		resolved, err := types.MemoryTypeOf(strings.TrimSpace(value))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve memory type: %w", err)
+		}
+		memoryTypes = append(memoryTypes, resolved)
+	}
+	return memoryTypes, nil
+}
+
+func parseOptionalConfidence(value string) (types.Optional[types.Confidence], error) {
+	if strings.TrimSpace(value) == "" {
+		return types.Empty[types.Confidence](), nil
+	}
+	resolved, err := types.ConfidenceOf(strings.TrimSpace(value))
+	if err != nil {
+		return types.Empty[types.Confidence](), xerrors.Errorf("failed to resolve confidence: %w", err)
+	}
+	return types.Of(resolved), nil
+}
+
+func parseMemorySource(value string) (types.MemorySource, error) {
+	if strings.TrimSpace(value) == "" {
+		return types.MemorySource(""), nil
+	}
+	resolved, err := types.MemorySourceOf(strings.TrimSpace(value))
+	if err != nil {
+		return types.MemorySource(""), xerrors.Errorf("failed to resolve memory source: %w", err)
+	}
+	return resolved, nil
+}
+
+func parseEvidenceRefs(refs []memoryRefInput) ([]types.EvidenceRef, error) {
+	outputs := make([]types.EvidenceRef, 0, len(refs))
+	for _, ref := range refs {
+		kind, err := types.EvidenceRefKindOf(strings.TrimSpace(ref.Kind))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve evidence ref kind: %w", err)
+		}
+		resolved, err := types.EvidenceRefOf(kind, strings.TrimSpace(ref.Value))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve evidence ref: %w", err)
+		}
+		outputs = append(outputs, resolved)
+	}
+	return outputs, nil
+}
+
+func parseArtifactRefs(refs []memoryRefInput) ([]types.ArtifactRef, error) {
+	outputs := make([]types.ArtifactRef, 0, len(refs))
+	for _, ref := range refs {
+		kind, err := types.ArtifactRefKindOf(strings.TrimSpace(ref.Kind))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve artifact ref kind: %w", err)
+		}
+		resolved, err := types.ArtifactRefOf(kind, strings.TrimSpace(ref.Value))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve artifact ref: %w", err)
+		}
+		outputs = append(outputs, resolved)
+	}
+	return outputs, nil
+}
+
+func parseMemoryWriteInput(
+	memoryType string,
+	workspace string,
+	agent string,
+	sessionFamily string,
+	confidence string,
+	source string,
+	evidenceRefs []memoryRefInput,
+	artifactRefs []memoryRefInput,
+) (types.MemoryType, types.MemoryScope, types.Optional[types.Confidence], types.MemorySource, []types.EvidenceRef, []types.ArtifactRef, error) {
+	resolvedType, err := types.MemoryTypeOf(strings.TrimSpace(memoryType))
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, xerrors.Errorf("failed to resolve memory type: %w", err)
+	}
+	scope, err := parseSingleMemoryScope(workspace, agent, sessionFamily)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedConfidence, err := parseOptionalConfidence(confidence)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedSource, err := parseMemorySource(source)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedEvidenceRefs, err := parseEvidenceRefs(evidenceRefs)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedArtifactRefs, err := parseArtifactRefs(artifactRefs)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	return resolvedType, scope, resolvedConfidence, resolvedSource, resolvedEvidenceRefs, resolvedArtifactRefs, nil
+}
+
+func parseMemoryProposalInput(
+	memoryType string,
+	workspace string,
+	agent string,
+	sessionFamily string,
+	source string,
+	evidenceRefs []memoryRefInput,
+	artifactRefs []memoryRefInput,
+) (types.MemoryType, types.MemoryScope, types.MemorySource, []types.EvidenceRef, []types.ArtifactRef, error) {
+	resolvedType, scope, _, resolvedSource, resolvedEvidenceRefs, resolvedArtifactRefs, err := parseMemoryWriteInput(
+		memoryType,
+		workspace,
+		agent,
+		sessionFamily,
+		"",
+		source,
+		evidenceRefs,
+		artifactRefs,
+	)
+	return resolvedType, scope, resolvedSource, resolvedEvidenceRefs, resolvedArtifactRefs, err
+}
+
+func parseOptionalMemoryWriteInput(
+	memoryType string,
+	workspace string,
+	agent string,
+	sessionFamily string,
+	confidence string,
+	source string,
+	evidenceRefs []memoryRefInput,
+	artifactRefs []memoryRefInput,
+) (types.MemoryType, types.MemoryScope, types.Optional[types.Confidence], types.MemorySource, []types.EvidenceRef, []types.ArtifactRef, error) {
+	var resolvedType types.MemoryType
+	if strings.TrimSpace(memoryType) != "" {
+		value, err := types.MemoryTypeOf(strings.TrimSpace(memoryType))
+		if err != nil {
+			return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, xerrors.Errorf("failed to resolve memory type: %w", err)
+		}
+		resolvedType = value
+	}
+	scope, err := parseOptionalMemoryScope(workspace, agent, sessionFamily)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedConfidence, err := parseOptionalConfidence(confidence)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedSource, err := parseMemorySource(source)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedEvidenceRefs, err := parseEvidenceRefs(evidenceRefs)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	resolvedArtifactRefs, err := parseArtifactRefs(artifactRefs)
+	if err != nil {
+		return types.MemoryType(""), nil, types.Empty[types.Confidence](), types.MemorySource(""), nil, nil, err
+	}
+	return resolvedType, scope, resolvedConfidence, resolvedSource, resolvedEvidenceRefs, resolvedArtifactRefs, nil
 }
 
 func resolveValue(value string, defaultValue string) string {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -218,6 +218,264 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("memory tools manage lifecycle and retrieval", func(t *testing.T) {
+		proposeResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "propose_memory",
+			Arguments: map[string]any{
+				"type":      "decision",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Use ContextUsecase for structured handoff output",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#464"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(propose_memory) error = %v", err)
+		}
+		if proposeResult.IsError {
+			t.Fatalf("CallTool(propose_memory) returned tool error")
+		}
+		proposedID := extractJSONStringValue(t, proposeResult, "memory_id")
+		if proposedID == "" {
+			t.Fatalf("proposed memory_id = empty, want non-empty")
+		}
+
+		acceptResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "accept_memory",
+			Arguments: map[string]any{
+				"memory_id": proposedID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(accept_memory) error = %v", err)
+		}
+		if acceptResult.IsError {
+			t.Fatalf("CallTool(accept_memory) returned tool error")
+		}
+		if diff := cmp.Diff("accepted", extractJSONStringValue(t, acceptResult, "status")); diff != "" {
+			t.Fatalf("accepted status mismatch (-want +got):\n%s", diff)
+		}
+
+		retrieveResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "retrieve_memories",
+			Arguments: map[string]any{
+				"query": "ContextUsecase",
+				"limit": 5,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(retrieve_memories) error = %v", err)
+		}
+		if retrieveResult.IsError {
+			t.Fatalf("CallTool(retrieve_memories) returned tool error")
+		}
+		payload := decodeJSONPayload(t, retrieveResult)
+		memories, ok := payload["memories"].([]any)
+		if !ok {
+			t.Fatalf("payload[memories] type = %T, want []any", payload["memories"])
+		}
+		if len(memories) == 0 {
+			t.Fatalf("retrieve_memories returned no memories")
+		}
+		firstMemory, ok := memories[0].(map[string]any)
+		if !ok {
+			t.Fatalf("memories[0] type = %T, want map[string]any", memories[0])
+		}
+		if diff := cmp.Diff(proposedID, firstMemory["memory_id"]); diff != "" {
+			t.Fatalf("retrieved memory_id mismatch (-want +got):\n%s", diff)
+		}
+
+		rejectResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "propose_memory",
+			Arguments: map[string]any{
+				"type":      "lesson",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Candidate memory for rejection",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#464"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(propose_memory) for reject flow error = %v", err)
+		}
+		rejectedID := extractJSONStringValue(t, rejectResult, "memory_id")
+		rejectMutationResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "reject_memory",
+			Arguments: map[string]any{
+				"memory_id": rejectedID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(reject_memory) error = %v", err)
+		}
+		if rejectMutationResult.IsError {
+			t.Fatalf("CallTool(reject_memory) returned tool error")
+		}
+		if diff := cmp.Diff("rejected", extractJSONStringValue(t, rejectMutationResult, "status")); diff != "" {
+			t.Fatalf("rejected status mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("session_handoff and memory_pack expose structured working memory", func(t *testing.T) {
+		startResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "start_session",
+			Arguments: map[string]any{
+				"agent":     "claude",
+				"workspace": "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(start_session) error = %v", err)
+		}
+		sessionID := extractJSONStringValue(t, startResult, "session_id")
+
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_log",
+			Arguments: map[string]any{
+				"message":    "<summary>\n8. Current Work:\n   Wire MCP memory tools\n9. Pending Tasks:\n   Cover MCP server tests\n</summary>",
+				"kind":       "compact_summary",
+				"agent":      "claude",
+				"session_id": sessionID,
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_log compact_summary) error = %v", err)
+		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_audit",
+			Arguments: map[string]any{
+				"command":    "go test ./...",
+				"agent":      "claude",
+				"session_id": sessionID,
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_audit) error = %v", err)
+		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "remember_memory",
+			Arguments: map[string]any{
+				"type":      "decision",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "MCP session_handoff should be backed by ContextUsecase",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#463"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(remember_memory) error = %v", err)
+		}
+
+		handoffResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_handoff",
+			Arguments: map[string]any{
+				"session_id": sessionID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_handoff) error = %v", err)
+		}
+		if handoffResult.IsError {
+			t.Fatalf("CallTool(session_handoff) returned tool error")
+		}
+		handoffPayload := decodeJSONPayload(t, handoffResult)
+		workingState, ok := handoffPayload["working_state"].(map[string]any)
+		if !ok {
+			t.Fatalf("working_state type = %T, want map[string]any", handoffPayload["working_state"])
+		}
+		if diff := cmp.Diff("Wire MCP memory tools | Cover MCP server tests", workingState["compact_summary"]); diff != "" {
+			t.Fatalf("compact_summary mismatch (-want +got):\n%s", diff)
+		}
+		memories, ok := handoffPayload["memories"].([]any)
+		if !ok || len(memories) == 0 {
+			t.Fatalf("handoff memories = %T len=%d, want non-empty []any", handoffPayload["memories"], len(memories))
+		}
+
+		packResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "memory_pack",
+			Arguments: map[string]any{
+				"session_id":             sessionID,
+				"recent_commands_limit":  1,
+				"memory_limit":           1,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(memory_pack) error = %v", err)
+		}
+		if packResult.IsError {
+			t.Fatalf("CallTool(memory_pack) returned tool error")
+		}
+		packPayload := decodeJSONPayload(t, packResult)
+		recentCommands, ok := packPayload["recent_commands"].([]any)
+		if !ok || len(recentCommands) != 1 {
+			t.Fatalf("recent_commands = %T len=%d, want 1", packPayload["recent_commands"], len(recentCommands))
+		}
+	})
+
+	t.Run("supersede and expire memory return updated memory details", func(t *testing.T) {
+		rememberResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "remember_memory",
+			Arguments: map[string]any{
+				"type":      "constraint",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Old memory fact",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#464"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(remember_memory) error = %v", err)
+		}
+		oldID := extractJSONStringValue(t, rememberResult, "memory_id")
+
+		supersedeResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "supersede_memory",
+			Arguments: map[string]any{
+				"memory_id": oldID,
+				"fact":      "Replacement memory fact",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#464"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(supersede_memory) error = %v", err)
+		}
+		if supersedeResult.IsError {
+			t.Fatalf("CallTool(supersede_memory) returned tool error")
+		}
+		newID := extractJSONStringValue(t, supersedeResult, "memory_id")
+		if newID == "" || newID == oldID {
+			t.Fatalf("replacement memory_id = %q, want non-empty and different from %q", newID, oldID)
+		}
+		if diff := cmp.Diff(oldID, extractJSONStringValue(t, supersedeResult, "supersedes")); diff != "" {
+			t.Fatalf("supersedes mismatch (-want +got):\n%s", diff)
+		}
+
+		expireResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "expire_memory",
+			Arguments: map[string]any{
+				"memory_id":  newID,
+				"expires_at": "2026-04-13T00:00:00Z",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(expire_memory) error = %v", err)
+		}
+		if expireResult.IsError {
+			t.Fatalf("CallTool(expire_memory) returned tool error")
+		}
+		if diff := cmp.Diff("expired", extractJSONStringValue(t, expireResult, "status")); diff != "" {
+			t.Fatalf("expired status mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("returns tool error", func(t *testing.T) {
 		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "add_log",
@@ -262,6 +520,25 @@ func extractJSONStringValue(t *testing.T, result *mcp.CallToolResult, key string
 	}
 
 	return stringValue
+}
+
+func decodeJSONPayload(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+
+	if len(result.Content) == 0 {
+		t.Fatalf("tool result content is empty")
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type: %T", result.Content[0])
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal([]byte(textContent.Text), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	return payload
 }
 
 func newTestServer(t *testing.T) *mcpserver.Server {
@@ -310,15 +587,66 @@ CREATE TABLE IF NOT EXISTS sessions (
     parent_session_id TEXT REFERENCES sessions(session_id)
 );`),
 		},
+		"000008_create_memories.sql": {
+			Data: []byte(`
+CREATE TABLE memories (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    scope_kind TEXT NOT NULL,
+    scope_value TEXT NOT NULL,
+    fact TEXT NOT NULL,
+    status TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    source TEXT NOT NULL,
+    supersedes_memory_id TEXT REFERENCES memories(id),
+    expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_memories_scope_status_updated
+    ON memories(scope_kind, scope_value, status, updated_at DESC, id DESC);
+
+CREATE INDEX idx_memories_type_status_updated
+    ON memories(type, status, updated_at DESC, id DESC);
+
+CREATE INDEX idx_memories_supersedes_memory_id
+    ON memories(supersedes_memory_id);
+
+CREATE TABLE memory_evidence_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);
+
+CREATE INDEX idx_memory_evidence_refs_lookup
+    ON memory_evidence_refs(ref_kind, ref_value);
+
+CREATE TABLE memory_artifact_refs (
+    memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    ref_kind TEXT NOT NULL,
+    ref_value TEXT NOT NULL,
+    PRIMARY KEY (memory_id, ordinal)
+);
+
+CREATE INDEX idx_memory_artifact_refs_lookup
+    ON memory_artifact_refs(ref_kind, ref_value);`),
+		},
 	}
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
 	db := sqlite.NewDatabase(dbPath, migrations)
 	eventDatasource := sqlite.NewEventDatasource(db)
 	sessionDatasource := sqlite.NewSessionDatasource(db)
+	memoryDatasource := sqlite.NewMemoryDatasource(db)
 	storeManagementDatasource := sqlite.NewStoreManagementDatasource(db)
 
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
+	memoryUsecase := usecase.NewMemoryUsecase(memoryDatasource, memoryDatasource, nil)
+	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
 
 	server, err := mcpserver.NewServer(
@@ -326,6 +654,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 		nil,
 		eventUsecase,
 		sessionUsecase,
+		memoryUsecase,
+		contextUsecase,
 		storeManagementUsecase,
 	)
 	if err != nil {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -46,7 +46,7 @@ func TestServer_BuildAndTools(t *testing.T) {
 				"message":    "hello from mcp",
 				"agent":      "claude",
 				"session_id": "session-1",
-				"workspace":       "github.com/duck8823/traceary",
+				"workspace":  "github.com/duck8823/traceary",
 			},
 		})
 		if err != nil {
@@ -121,7 +121,7 @@ func TestServer_BuildAndTools(t *testing.T) {
 				"output":     "stdout",
 				"agent":      "codex",
 				"session_id": "session-2",
-				"workspace":       "github.com/duck8823/traceary",
+				"workspace":  "github.com/duck8823/traceary",
 			},
 		})
 		if err != nil {
@@ -153,8 +153,8 @@ func TestServer_BuildAndTools(t *testing.T) {
 		startResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "start_session",
 			Arguments: map[string]any{
-				"agent": "codex",
-				"workspace":  "github.com/duck8823/traceary",
+				"agent":     "codex",
+				"workspace": "github.com/duck8823/traceary",
 			},
 		})
 		if err != nil {
@@ -391,6 +391,12 @@ func TestServer_BuildAndTools(t *testing.T) {
 		if diff := cmp.Diff("Wire MCP memory tools | Cover MCP server tests", workingState["compact_summary"]); diff != "" {
 			t.Fatalf("compact_summary mismatch (-want +got):\n%s", diff)
 		}
+		if diff := cmp.Diff("Wire MCP memory tools | Cover MCP server tests", handoffPayload["summary"]); diff != "" {
+			t.Fatalf("summary mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(workingState["combined_summary"], handoffPayload["summary"]); diff != "" {
+			t.Fatalf("summary compatibility mismatch (-want +got):\n%s", diff)
+		}
 		memories, ok := handoffPayload["memories"].([]any)
 		if !ok || len(memories) == 0 {
 			t.Fatalf("handoff memories = %T len=%d, want non-empty []any", handoffPayload["memories"], len(memories))
@@ -399,9 +405,9 @@ func TestServer_BuildAndTools(t *testing.T) {
 		packResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "memory_pack",
 			Arguments: map[string]any{
-				"session_id":             sessionID,
-				"recent_commands_limit":  1,
-				"memory_limit":           1,
+				"session_id":            sessionID,
+				"recent_commands_limit": 1,
+				"memory_limit":          1,
 			},
 		})
 		if err != nil {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -423,6 +423,89 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("memory_pack preserves explicit zero limits", func(t *testing.T) {
+		startResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "start_session",
+			Arguments: map[string]any{
+				"agent":     "claude",
+				"workspace": "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(start_session) error = %v", err)
+		}
+		sessionID := extractJSONStringValue(t, startResult, "session_id")
+
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_log",
+			Arguments: map[string]any{
+				"message":    "Decision summary",
+				"kind":       "compact_summary",
+				"agent":      "claude",
+				"session_id": sessionID,
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_log compact_summary) error = %v", err)
+		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_audit",
+			Arguments: map[string]any{
+				"command":    "go test ./...",
+				"agent":      "claude",
+				"session_id": sessionID,
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_audit) error = %v", err)
+		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "remember_memory",
+			Arguments: map[string]any{
+				"type":      "decision",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Context packs may disable optional sections",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#464"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(remember_memory) error = %v", err)
+		}
+
+		packResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "memory_pack",
+			Arguments: map[string]any{
+				"session_id":            sessionID,
+				"recent_commands_limit": 0,
+				"memory_limit":          0,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(memory_pack) error = %v", err)
+		}
+		if packResult.IsError {
+			t.Fatalf("CallTool(memory_pack) returned tool error")
+		}
+
+		packPayload := decodeJSONPayload(t, packResult)
+		if recentCommandsValue, exists := packPayload["recent_commands"]; exists {
+			recentCommands, ok := recentCommandsValue.([]any)
+			if !ok || len(recentCommands) != 0 {
+				t.Fatalf("recent_commands = %T len=%d, want omitted or empty []any", recentCommandsValue, len(recentCommands))
+			}
+		}
+		if memoriesValue, exists := packPayload["memories"]; exists {
+			memories, ok := memoriesValue.([]any)
+			if !ok || len(memories) != 0 {
+				t.Fatalf("memories = %T len=%d, want omitted or empty []any", memoriesValue, len(memories))
+			}
+		}
+	})
+
 	t.Run("supersede and expire memory return updated memory details", func(t *testing.T) {
 		rememberResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "remember_memory",


### PR DESCRIPTION
## Summary
- add MCP durable memory tools for read/write lifecycle operations
- expose memory-aware `session_handoff` and `memory_pack` via `ContextUsecase`
- refresh MCP docs for the expanded tool surface

## Motivation
v0.5.0 turns Traceary from a CLI log browser into a reusable memory substrate. The CLI-side memory model and `ContextUsecase` already exist, but MCP clients still cannot manage durable memory or retrieve structured context packs directly. This PR closes that gap so agent runtimes can use the same memory lifecycle and handoff semantics without bypassing domain invariants.

## Testing
- `GOCACHE=$(pwd)/.cache/go-build go test ./...`
- `GOCACHE=$(pwd)/.cache/go-build go build ./...`
- `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run`
- `python3 scripts/verify_docs_i18n.py`

Closes #464
