### PR TITLE
feat: extract durable memory candidates from session signals

### DIFF
--- a/application/types/memory_extraction_criteria.go
+++ b/application/types/memory_extraction_criteria.go
@@ -1,0 +1,72 @@
+package types
+
+import domtypes "github.com/duck8823/traceary/domain/types"
+
+const (
+	defaultMemoryExtractionEventLimit     = 5
+	defaultMemoryExtractionCandidateLimit = 10
+)
+
+// MemoryExtractionCriteria describes how to extract candidate durable memories
+// from existing session/history signals.
+type MemoryExtractionCriteria struct {
+	sessionID      domtypes.SessionID
+	workspace      domtypes.Workspace
+	eventLimit     int
+	candidateLimit int
+}
+
+// SessionID returns the target session ID.
+func (c MemoryExtractionCriteria) SessionID() domtypes.SessionID { return c.sessionID }
+
+// Workspace returns the target workspace.
+func (c MemoryExtractionCriteria) Workspace() domtypes.Workspace { return c.workspace }
+
+// EventLimit returns the maximum number of recent events to inspect per kind.
+func (c MemoryExtractionCriteria) EventLimit() int { return c.eventLimit }
+
+// CandidateLimit returns the maximum number of candidates to persist.
+func (c MemoryExtractionCriteria) CandidateLimit() int { return c.candidateLimit }
+
+// MemoryExtractionCriteriaBuilder builds MemoryExtractionCriteria values.
+type MemoryExtractionCriteriaBuilder struct {
+	criteria MemoryExtractionCriteria
+}
+
+// NewMemoryExtractionCriteriaBuilder starts a criteria builder with sensible
+// defaults.
+func NewMemoryExtractionCriteriaBuilder() *MemoryExtractionCriteriaBuilder {
+	return &MemoryExtractionCriteriaBuilder{criteria: MemoryExtractionCriteria{
+		eventLimit:     defaultMemoryExtractionEventLimit,
+		candidateLimit: defaultMemoryExtractionCandidateLimit,
+	}}
+}
+
+// SessionID sets the target session ID.
+func (b *MemoryExtractionCriteriaBuilder) SessionID(sessionID domtypes.SessionID) *MemoryExtractionCriteriaBuilder {
+	b.criteria.sessionID = sessionID
+	return b
+}
+
+// Workspace sets the target workspace.
+func (b *MemoryExtractionCriteriaBuilder) Workspace(workspace domtypes.Workspace) *MemoryExtractionCriteriaBuilder {
+	b.criteria.workspace = workspace
+	return b
+}
+
+// EventLimit sets the per-kind event inspection limit.
+func (b *MemoryExtractionCriteriaBuilder) EventLimit(limit int) *MemoryExtractionCriteriaBuilder {
+	b.criteria.eventLimit = limit
+	return b
+}
+
+// CandidateLimit sets the maximum number of extracted candidates.
+func (b *MemoryExtractionCriteriaBuilder) CandidateLimit(limit int) *MemoryExtractionCriteriaBuilder {
+	b.criteria.candidateLimit = limit
+	return b
+}
+
+// Build finalizes the criteria.
+func (b *MemoryExtractionCriteriaBuilder) Build() MemoryExtractionCriteria {
+	return b.criteria
+}

--- a/application/usecase/memory_extraction_usecase.go
+++ b/application/usecase/memory_extraction_usecase.go
@@ -1,0 +1,15 @@
+package usecase
+
+import (
+	"context"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// MemoryExtractionUsecase extracts candidate durable memories from existing
+// session/history signals.
+type MemoryExtractionUsecase interface {
+	// Extract proposes candidate memories from the target session and returns the
+	// created candidate details.
+	Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error)
+}

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -27,9 +27,10 @@ var (
 const memoryExtractionDedupePageSize = 200
 
 type memoryExtractionUsecase struct {
-	sessionQuery queryservice.SessionQueryService
-	eventQuery   queryservice.EventQueryService
-	memory       MemoryUsecase
+	sessionQuery        queryservice.SessionQueryService
+	eventQuery          queryservice.EventQueryService
+	memory              MemoryUsecase
+	extraRedactPatterns []string
 }
 
 // NewMemoryExtractionUsecase creates a MemoryExtractionUsecase.
@@ -37,11 +38,13 @@ func NewMemoryExtractionUsecase(
 	sessionQuery queryservice.SessionQueryService,
 	eventQuery queryservice.EventQueryService,
 	memory MemoryUsecase,
+	extraRedactPatterns []string,
 ) MemoryExtractionUsecase {
 	return &memoryExtractionUsecase{
-		sessionQuery: sessionQuery,
-		eventQuery:   eventQuery,
-		memory:       memory,
+		sessionQuery:        sessionQuery,
+		eventQuery:          eventQuery,
+		memory:              memory,
+		extraRedactPatterns: slices.Clone(extraRedactPatterns),
 	}
 }
 
@@ -78,6 +81,10 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 	if err != nil {
 		return nil, err
 	}
+	extraRedactors, err := compileExtraRedactPatterns(u.extraRedactPatterns)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to compile extraction redaction patterns: %w", err)
+	}
 
 	specs, err := u.collectCandidateSpecs(ctx, session, criteria.EventLimit())
 	if err != nil {
@@ -87,7 +94,7 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 	results := make([]apptypes.MemoryDetails, 0, min(criteria.CandidateLimit(), len(specs)))
 	seenKeys := make(map[string]struct{}, len(specs))
 	for _, spec := range specs {
-		key := memoryCandidateKey(scope, spec.memoryType, spec.fact)
+		key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
 		if _, exists := seenKeys[key]; exists {
 			continue
 		}
@@ -361,6 +368,11 @@ func normalizeCandidateFact(value string) string {
 	trimmed = strings.Trim(trimmed, "`")
 	trimmed = strings.Trim(trimmed, "[]")
 	return strings.Join(strings.Fields(trimmed), " ")
+}
+
+func sanitizeCandidateFact(value string, extraRedactors []auditPayloadRedactor) string {
+	sanitized, _ := redactAuditPayload(strings.TrimSpace(value), extraRedactors)
+	return strings.Join(strings.Fields(sanitized), " ")
 }
 
 func memoryTypeFromLabel(label string) (domtypes.MemoryType, error) {

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -1,0 +1,509 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+var (
+	explicitMemoryLabelPattern = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
+	urlRefPattern              = regexp.MustCompile(`https?://[^\s)]+`)
+	issueRefPattern            = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
+	prRefPattern               = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
+	fileRefPattern             = regexp.MustCompile(`(?i)\b(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.(?:go|md|json|sh|sql|yaml|yml|toml)\b`)
+)
+
+type memoryExtractionUsecase struct {
+	sessionQuery queryservice.SessionQueryService
+	eventQuery   queryservice.EventQueryService
+	memory       MemoryUsecase
+}
+
+// NewMemoryExtractionUsecase creates a MemoryExtractionUsecase.
+func NewMemoryExtractionUsecase(
+	sessionQuery queryservice.SessionQueryService,
+	eventQuery queryservice.EventQueryService,
+	memory MemoryUsecase,
+) MemoryExtractionUsecase {
+	return &memoryExtractionUsecase{
+		sessionQuery: sessionQuery,
+		eventQuery:   eventQuery,
+		memory:       memory,
+	}
+}
+
+func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
+	if u.sessionQuery == nil {
+		return nil, xerrors.Errorf("session query service is not configured")
+	}
+	if u.eventQuery == nil {
+		return nil, xerrors.Errorf("event query service is not configured")
+	}
+	if u.memory == nil {
+		return nil, xerrors.Errorf("memory usecase is not configured")
+	}
+	if criteria.SessionID().String() == "" {
+		return nil, xerrors.Errorf("session ID must not be empty")
+	}
+	if criteria.EventLimit() < 0 {
+		return nil, xerrors.Errorf("event limit must be greater than or equal to 0")
+	}
+	if criteria.CandidateLimit() <= 0 {
+		return nil, xerrors.Errorf("candidate limit must be greater than or equal to 1")
+	}
+
+	session, ok, err := u.findTargetSession(ctx, criteria)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	scope := extractedMemoryScope(session)
+	existingKeys, err := u.loadExistingCandidateKeys(ctx, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	specs, err := u.collectCandidateSpecs(ctx, session, criteria.EventLimit())
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]apptypes.MemoryDetails, 0, min(criteria.CandidateLimit(), len(specs)))
+	seenKeys := make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		key := memoryCandidateKey(scope, spec.memoryType, spec.fact)
+		if _, exists := seenKeys[key]; exists {
+			continue
+		}
+		if _, exists := existingKeys[key]; exists {
+			continue
+		}
+
+		details, err := u.memory.Propose(
+			ctx,
+			spec.memoryType,
+			scope,
+			spec.fact,
+			domtypes.MemorySourceExtracted,
+			spec.evidenceRefs,
+			spec.artifactRefs,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to propose extracted memory candidate: %w", err)
+		}
+		results = append(results, details)
+		seenKeys[key] = struct{}{}
+		if len(results) >= criteria.CandidateLimit() {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+func (u *memoryExtractionUsecase) findTargetSession(
+	ctx context.Context,
+	criteria apptypes.MemoryExtractionCriteria,
+) (apptypes.SessionSummary, bool, error) {
+	summaries, err := u.sessionQuery.ListSummaries(
+		ctx,
+		1,
+		0,
+		criteria.SessionID(),
+		criteria.Workspace(),
+		domtypes.Client(""),
+		domtypes.Agent(""),
+		"",
+		domtypes.Empty[time.Time](),
+		domtypes.Empty[time.Time](),
+	)
+	if err != nil {
+		return apptypes.SessionSummary{}, false, xerrors.Errorf("failed to list sessions for memory extraction: %w", err)
+	}
+	if len(summaries) == 0 {
+		return apptypes.SessionSummary{}, false, nil
+	}
+	return summaries[0], true, nil
+}
+
+func extractedMemoryScope(session apptypes.SessionSummary) domtypes.MemoryScope {
+	if workspace := session.Workspace(); workspace.String() != "" {
+		return domtypes.WorkspaceScopeOf(workspace)
+	}
+	return domtypes.SessionFamilyScopeOf(session.SessionID())
+}
+
+func (u *memoryExtractionUsecase) loadExistingCandidateKeys(ctx context.Context, scope domtypes.MemoryScope) (map[string]struct{}, error) {
+	summaries, err := u.memory.List(
+		ctx,
+		apptypes.NewMemoryListCriteriaBuilder(200).
+			Scopes([]domtypes.MemoryScope{scope}).
+			Statuses([]domtypes.MemoryStatus{
+				domtypes.MemoryStatusCandidate,
+				domtypes.MemoryStatusAccepted,
+			}).
+			Build(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list existing memories for extraction dedupe: %w", err)
+	}
+
+	keys := make(map[string]struct{}, len(summaries))
+	for _, summary := range summaries {
+		keys[memoryCandidateKey(summary.Scope(), summary.MemoryType(), summary.Fact())] = struct{}{}
+	}
+	return keys, nil
+}
+
+type extractionSignal struct {
+	text            string
+	event           *model.Event
+	heuristics      bool
+	allowStructured bool
+}
+
+func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]memoryCandidateSpec, error) {
+	signals := make([]extractionSignal, 0, 1+4*max(eventLimit, 1))
+	if summary := strings.TrimSpace(session.Summary()); summary != "" {
+		signals = append(signals, extractionSignal{
+			text:            summary,
+			heuristics:      true,
+			allowStructured: true,
+		})
+	}
+
+	appendKindSignals := func(kind domtypes.EventKind, heuristics bool, allowStructured bool) error {
+		if eventLimit == 0 {
+			return nil
+		}
+		events, err := u.eventQuery.ListRecent(
+			ctx,
+			eventLimit,
+			0,
+			kind,
+			domtypes.Client(""),
+			domtypes.Agent(""),
+			session.SessionID(),
+			domtypes.Workspace(""),
+			false,
+			time.Time{},
+			time.Time{},
+		)
+		if err != nil {
+			return xerrors.Errorf("failed to list %s events for extraction: %w", kind, err)
+		}
+		for _, event := range events {
+			signals = append(signals, extractionSignal{
+				text:            event.Body(),
+				event:           event,
+				heuristics:      heuristics,
+				allowStructured: allowStructured,
+			})
+		}
+		return nil
+	}
+
+	if err := appendKindSignals(domtypes.EventKindPrompt, true, true); err != nil {
+		return nil, err
+	}
+	if err := appendKindSignals(domtypes.EventKindReviewed, true, true); err != nil {
+		return nil, err
+	}
+	if err := appendKindSignals(domtypes.EventKindNote, true, true); err != nil {
+		return nil, err
+	}
+	if err := appendKindSignals(domtypes.EventKindCompactSummary, false, true); err != nil {
+		return nil, err
+	}
+
+	specs := make([]memoryCandidateSpec, 0, len(signals))
+	for _, signal := range signals {
+		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
+		if err != nil {
+			return nil, err
+		}
+		signalSpecs, err := extractMemoryCandidatesFromSignal(signal, evidenceRefs)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, signalSpecs...)
+	}
+
+	return specs, nil
+}
+
+type memoryCandidateSpec struct {
+	memoryType   domtypes.MemoryType
+	fact         string
+	evidenceRefs []domtypes.EvidenceRef
+	artifactRefs []domtypes.ArtifactRef
+}
+
+func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []domtypes.EvidenceRef) ([]memoryCandidateSpec, error) {
+	segments := candidateSegments(signal.text)
+	specs := make([]memoryCandidateSpec, 0, len(segments))
+	for _, segment := range segments {
+		if signal.allowStructured {
+			spec, ok, err := structuredCandidateSpec(segment, evidenceRefs)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				specs = append(specs, spec)
+				continue
+			}
+		}
+
+		if signal.heuristics {
+			spec, ok, err := heuristicCandidateSpec(segment, evidenceRefs)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				specs = append(specs, spec)
+			}
+		}
+	}
+	return specs, nil
+}
+
+func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
+	matches := explicitMemoryLabelPattern.FindStringSubmatch(segment)
+	if len(matches) != 3 {
+		return memoryCandidateSpec{}, false, nil
+	}
+
+	memoryType, err := memoryTypeFromLabel(matches[1])
+	if err != nil {
+		return memoryCandidateSpec{}, false, err
+	}
+	fact := normalizeCandidateFact(matches[2])
+	if fact == "" {
+		return memoryCandidateSpec{}, false, nil
+	}
+
+	artifactRefs, err := inferArtifactRefs(fact)
+	if err != nil {
+		return memoryCandidateSpec{}, false, err
+	}
+	return memoryCandidateSpec{
+		memoryType:   memoryType,
+		fact:         fact,
+		evidenceRefs: slices.Clone(evidenceRefs),
+		artifactRefs: artifactRefs,
+	}, true, nil
+}
+
+func heuristicCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
+	fact := normalizeCandidateFact(segment)
+	if fact == "" {
+		return memoryCandidateSpec{}, false, nil
+	}
+
+	memoryType, ok := inferMemoryTypeFromText(fact)
+	if !ok {
+		return memoryCandidateSpec{}, false, nil
+	}
+
+	artifactRefs, err := inferArtifactRefs(fact)
+	if err != nil {
+		return memoryCandidateSpec{}, false, err
+	}
+	return memoryCandidateSpec{
+		memoryType:   memoryType,
+		fact:         fact,
+		evidenceRefs: slices.Clone(evidenceRefs),
+		artifactRefs: artifactRefs,
+	}, true, nil
+}
+
+func candidateSegments(text string) []string {
+	lines := strings.Split(text, "\n")
+	segments := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := normalizeCandidateFact(line)
+		if trimmed == "" {
+			continue
+		}
+		segments = append(segments, trimmed)
+	}
+	return segments
+}
+
+func normalizeCandidateFact(value string) string {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.TrimPrefix(trimmed, "- ")
+	trimmed = strings.TrimPrefix(trimmed, "* ")
+	trimmed = strings.TrimPrefix(trimmed, "> ")
+	trimmed = strings.Trim(trimmed, "`")
+	trimmed = strings.Trim(trimmed, "[]")
+	return strings.Join(strings.Fields(trimmed), " ")
+}
+
+func memoryTypeFromLabel(label string) (domtypes.MemoryType, error) {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "preference", "feedback", "correction":
+		return domtypes.MemoryTypePreference, nil
+	case "decision":
+		return domtypes.MemoryTypeDecision, nil
+	case "constraint":
+		return domtypes.MemoryTypeConstraint, nil
+	case "lesson":
+		return domtypes.MemoryTypeLesson, nil
+	case "artifact":
+		return domtypes.MemoryTypeArtifact, nil
+	default:
+		return domtypes.MemoryType(""), xerrors.Errorf("unsupported memory label: %s", label)
+	}
+}
+
+func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
+	lower := strings.ToLower(text)
+
+	switch {
+	case containsAny(lower,
+		"prefer ",
+		"please ",
+		"always ",
+		"never ",
+		"do not ",
+		"don't ",
+		"respond in",
+		"call it ",
+		"use english",
+		"use japanese",
+		"correction:",
+		"feedback:",
+	):
+		return domtypes.MemoryTypePreference, true
+	case containsAny(lower,
+		"must ",
+		"must not",
+		"required",
+		"cannot ",
+		"can't ",
+		"only ",
+		"forbidden",
+		"out of scope",
+	):
+		return domtypes.MemoryTypeConstraint, true
+	case containsAny(lower,
+		"decision:",
+		"decided ",
+		"we chose",
+		"chosen ",
+		"agreed ",
+	):
+		return domtypes.MemoryTypeDecision, true
+	case containsAny(lower,
+		"lesson:",
+		"learned ",
+		"next time",
+		"remember to",
+		"mistake",
+	):
+		return domtypes.MemoryTypeLesson, true
+	default:
+		if inferredArtifactRefs, err := inferArtifactRefs(text); err == nil && len(inferredArtifactRefs) > 0 && containsAny(lower, "see ", "reference ", "refer to", "artifact:") {
+			return domtypes.MemoryTypeArtifact, true
+		}
+		return domtypes.MemoryType(""), false
+	}
+}
+
+func containsAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildSignalEvidenceRefs(sessionID domtypes.SessionID, event *model.Event) ([]domtypes.EvidenceRef, error) {
+	evidenceRefs := make([]domtypes.EvidenceRef, 0, 2)
+	if sessionID.String() != "" {
+		ref, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindSession, sessionID.String())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to build session evidence ref: %w", err)
+		}
+		evidenceRefs = append(evidenceRefs, ref)
+	}
+	if event != nil {
+		ref, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindEvent, event.EventID().String())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to build event evidence ref: %w", err)
+		}
+		evidenceRefs = append(evidenceRefs, ref)
+	}
+	return evidenceRefs, nil
+}
+
+func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {
+	refs := make([]domtypes.ArtifactRef, 0)
+	seen := make(map[string]struct{})
+	appendRef := func(kind domtypes.ArtifactRefKind, value string) error {
+		key := fmt.Sprintf("%s:%s", kind, value)
+		if _, exists := seen[key]; exists {
+			return nil
+		}
+		ref, err := domtypes.ArtifactRefOf(kind, value)
+		if err != nil {
+			return xerrors.Errorf("invalid artifact ref %s:%s: %w", kind, value, err)
+		}
+		refs = append(refs, ref)
+		seen[key] = struct{}{}
+		return nil
+	}
+
+	for _, match := range urlRefPattern.FindAllString(text, -1) {
+		if err := appendRef(domtypes.ArtifactRefKindURL, match); err != nil {
+			return nil, xerrors.Errorf("failed to build URL artifact ref: %w", err)
+		}
+	}
+	for _, matches := range issueRefPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) != 2 {
+			continue
+		}
+		if err := appendRef(domtypes.ArtifactRefKindIssue, "#"+matches[1]); err != nil {
+			return nil, xerrors.Errorf("failed to build issue artifact ref: %w", err)
+		}
+	}
+	for _, matches := range prRefPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) != 2 {
+			continue
+		}
+		if err := appendRef(domtypes.ArtifactRefKindPR, "#"+matches[1]); err != nil {
+			return nil, xerrors.Errorf("failed to build PR artifact ref: %w", err)
+		}
+	}
+	for _, match := range fileRefPattern.FindAllString(text, -1) {
+		if err := appendRef(domtypes.ArtifactRefKindFile, match); err != nil {
+			return nil, xerrors.Errorf("failed to build file artifact ref: %w", err)
+		}
+	}
+
+	return refs, nil
+}
+
+func memoryCandidateKey(scope domtypes.MemoryScope, memoryType domtypes.MemoryType, fact string) string {
+	scopeKey := ""
+	if scope != nil {
+		scopeKey = fmt.Sprintf("%s:%s", scope.Kind(), scope.Key())
+	}
+	return fmt.Sprintf("%s|%s|%s", scopeKey, memoryType, strings.ToLower(strings.TrimSpace(fact)))
+}

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -24,6 +24,8 @@ var (
 	fileRefPattern             = regexp.MustCompile(`(?i)\b(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.(?:go|md|json|sh|sql|yaml|yml|toml)\b`)
 )
 
+const memoryExtractionDedupePageSize = 200
+
 type memoryExtractionUsecase struct {
 	sessionQuery queryservice.SessionQueryService
 	eventQuery   queryservice.EventQueryService
@@ -148,23 +150,30 @@ func extractedMemoryScope(session apptypes.SessionSummary) domtypes.MemoryScope 
 }
 
 func (u *memoryExtractionUsecase) loadExistingCandidateKeys(ctx context.Context, scope domtypes.MemoryScope) (map[string]struct{}, error) {
-	summaries, err := u.memory.List(
-		ctx,
-		apptypes.NewMemoryListCriteriaBuilder(200).
-			Scopes([]domtypes.MemoryScope{scope}).
-			Statuses([]domtypes.MemoryStatus{
-				domtypes.MemoryStatusCandidate,
-				domtypes.MemoryStatusAccepted,
-			}).
-			Build(),
-	)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to list existing memories for extraction dedupe: %w", err)
-	}
-
-	keys := make(map[string]struct{}, len(summaries))
-	for _, summary := range summaries {
-		keys[memoryCandidateKey(summary.Scope(), summary.MemoryType(), summary.Fact())] = struct{}{}
+	keys := make(map[string]struct{})
+	offset := 0
+	for {
+		summaries, err := u.memory.List(
+			ctx,
+			apptypes.NewMemoryListCriteriaBuilder(memoryExtractionDedupePageSize).
+				Offset(offset).
+				Scopes([]domtypes.MemoryScope{scope}).
+				Statuses([]domtypes.MemoryStatus{
+					domtypes.MemoryStatusCandidate,
+					domtypes.MemoryStatusAccepted,
+				}).
+				Build(),
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to list existing memories for extraction dedupe: %w", err)
+		}
+		for _, summary := range summaries {
+			keys[memoryCandidateKey(summary.Scope(), summary.MemoryType(), summary.Fact())] = struct{}{}
+		}
+		if len(summaries) < memoryExtractionDedupePageSize {
+			break
+		}
+		offset += len(summaries)
 	}
 	return keys, nil
 }

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -146,6 +146,7 @@ func TestMemoryExtractionUsecase_Extract(t *testing.T) {
 			},
 		},
 		memoryUsecase,
+		nil,
 	)
 
 	got, err := sut.Extract(
@@ -245,6 +246,7 @@ func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingAndGracefullyHandle
 		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
 		&eventQueryServiceStub{},
 		memoryUsecase,
+		nil,
 	)
 
 	got, err := sut.Extract(
@@ -327,6 +329,7 @@ func TestMemoryExtractionUsecase_Extract_PaginatesExistingMemoryDedupe(t *testin
 		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
 		&eventQueryServiceStub{},
 		memoryUsecase,
+		nil,
 	)
 
 	got, err := sut.Extract(
@@ -355,6 +358,69 @@ func TestMemoryExtractionUsecase_Extract_PaginatesExistingMemoryDedupe(t *testin
 	}
 	if got := memoryUsecase.listCalls[1].Offset(); got != 200 {
 		t.Fatalf("second List().Offset() = %d, want 200", got)
+	}
+}
+
+func TestMemoryExtractionUsecase_Extract_DeduplicatesSanitizedFacts(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.Empty[time.Time](),
+		"ended",
+		4,
+		0,
+		[]string{"codex"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	promptEvent := mustExtractionEvent(
+		t,
+		"event-prompt",
+		domtypes.EventKindPrompt,
+		"Please keep password=secret-one out of generated examples.\nPlease keep password=secret-two out of generated examples.",
+	)
+
+	details := mustMemoryDetailsFromSummary(
+		t,
+		"memory-candidate-sanitized",
+		domtypes.MemoryTypePreference,
+		"Please keep password=[REDACTED] out of generated examples.",
+	)
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details},
+	}
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{
+			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+				domtypes.EventKindPrompt: {promptEvent},
+			},
+		},
+		memoryUsecase,
+		nil,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-1")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(5).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(Extract()) = %d, want 1", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("Propose() call count = %d, want 1", len(memoryUsecase.proposeCalls))
 	}
 }
 

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -1,0 +1,294 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+type memoryExtractionMemoryUsecaseStub struct {
+	listResult    []apptypes.MemorySummary
+	listErr       error
+	proposeResult []apptypes.MemoryDetails
+	proposeErr    error
+	proposeCalls  []memoryExtractionProposeCall
+}
+
+type memoryExtractionProposeCall struct {
+	memoryType   domtypes.MemoryType
+	scope        domtypes.MemoryScope
+	fact         string
+	source       domtypes.MemorySource
+	evidenceRefs []domtypes.EvidenceRef
+	artifactRefs []domtypes.ArtifactRef
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Remember(context.Context, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Propose(_ context.Context, memoryType domtypes.MemoryType, scope domtypes.MemoryScope, fact string, source domtypes.MemorySource, evidenceRefs []domtypes.EvidenceRef, artifactRefs []domtypes.ArtifactRef) (apptypes.MemoryDetails, error) {
+	s.proposeCalls = append(s.proposeCalls, memoryExtractionProposeCall{
+		memoryType:   memoryType,
+		scope:        scope,
+		fact:         fact,
+		source:       source,
+		evidenceRefs: append([]domtypes.EvidenceRef(nil), evidenceRefs...),
+		artifactRefs: append([]domtypes.ArtifactRef(nil), artifactRefs...),
+	})
+	if s.proposeErr != nil {
+		return apptypes.MemoryDetails{}, s.proposeErr
+	}
+	if len(s.proposeResult) >= len(s.proposeCalls) {
+		return s.proposeResult[len(s.proposeCalls)-1], nil
+	}
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Accept(context.Context, domtypes.MemoryID, domtypes.Optional[domtypes.Confidence]) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Reject(context.Context, domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Supersede(context.Context, domtypes.MemoryID, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Expire(context.Context, domtypes.MemoryID, domtypes.Optional[time.Time]) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) List(_ context.Context, _ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	return s.listResult, s.listErr
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Search(context.Context, apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	return nil, nil
+}
+
+func (s *memoryExtractionMemoryUsecaseStub) Show(context.Context, domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+func TestMemoryExtractionUsecase_Extract(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.Empty[time.Time](),
+		"active",
+		12,
+		4,
+		[]string{"claude"},
+		"",
+		"Decision: Use ContextUsecase for handoff output",
+		domtypes.SessionID(""),
+	)
+	promptEvent := mustExtractionEvent(t,
+		"event-prompt",
+		domtypes.EventKindPrompt,
+		"Please answer in Japanese and never merge before Codex review.",
+	)
+	noteEvent := mustExtractionEvent(t,
+		"event-note",
+		domtypes.EventKindNote,
+		"Constraint: Keep get_context as raw event retrieval.",
+	)
+	compactEvent := mustExtractionEvent(t,
+		"event-compact",
+		domtypes.EventKindCompactSummary,
+		"<summary>\nLesson: Extracted candidates should remain review-only.\nArtifact: docs/cli/README.md\n</summary>",
+	)
+
+	details1 := mustMemoryDetailsFromSummary(t, "memory-candidate-1", domtypes.MemoryTypeDecision, "Use ContextUsecase for handoff output")
+	details2 := mustMemoryDetailsFromSummary(t, "memory-candidate-2", domtypes.MemoryTypePreference, "Please answer in Japanese and never merge before Codex review.")
+	details3 := mustMemoryDetailsFromSummary(t, "memory-candidate-3", domtypes.MemoryTypeConstraint, "Keep get_context as raw event retrieval.")
+	details4 := mustMemoryDetailsFromSummary(t, "memory-candidate-4", domtypes.MemoryTypeLesson, "Extracted candidates should remain review-only.")
+	details5 := mustMemoryDetailsFromSummary(t, "memory-candidate-5", domtypes.MemoryTypeArtifact, "docs/cli/README.md")
+
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details1, details2, details3, details4, details5},
+	}
+
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{
+			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+				domtypes.EventKindPrompt:         {promptEvent},
+				domtypes.EventKindNote:           {noteEvent},
+				domtypes.EventKindCompactSummary: {compactEvent},
+			},
+		},
+		memoryUsecase,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-1")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(3).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("len(Extract()) = %d, want 5", len(got))
+	}
+
+	gotTypes := make([]domtypes.MemoryType, 0, len(memoryUsecase.proposeCalls))
+	gotFacts := make([]string, 0, len(memoryUsecase.proposeCalls))
+	for _, call := range memoryUsecase.proposeCalls {
+		gotTypes = append(gotTypes, call.memoryType)
+		gotFacts = append(gotFacts, call.fact)
+		if diff := cmp.Diff(domtypes.MemorySourceExtracted, call.source); diff != "" {
+			t.Fatalf("source mismatch (-want +got):\n%s", diff)
+		}
+		if call.scope == nil || call.scope.Kind() != domtypes.MemoryScopeKindWorkspace || call.scope.Key() != "github.com/duck8823/traceary" {
+			t.Fatalf("scope = %v, want workspace scope", call.scope)
+		}
+		if len(call.evidenceRefs) == 0 {
+			t.Fatalf("evidenceRefs = empty, want session/event evidence")
+		}
+	}
+	if diff := cmp.Diff(
+		[]domtypes.MemoryType{
+			domtypes.MemoryTypeDecision,
+			domtypes.MemoryTypePreference,
+			domtypes.MemoryTypeConstraint,
+			domtypes.MemoryTypeLesson,
+			domtypes.MemoryTypeArtifact,
+		},
+		gotTypes,
+	); diff != "" {
+		t.Fatalf("memory types mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(
+		[]string{
+			"Use ContextUsecase for handoff output",
+			"Please answer in Japanese and never merge before Codex review.",
+			"Keep get_context as raw event retrieval.",
+			"Extracted candidates should remain review-only.",
+			"docs/cli/README.md",
+		},
+		gotFacts,
+	); diff != "" {
+		t.Fatalf("facts mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingAndGracefullyHandlesMissingPrompts(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.Empty[time.Time](),
+		"ended",
+		4,
+		0,
+		[]string{"codex"},
+		"",
+		"Lesson: Wait for explicit review completion before merge",
+		domtypes.SessionID(""),
+	)
+	existingSummary, err := apptypes.MemorySummaryOf(
+		mustMemoryID(t, "memory-existing"),
+		domtypes.MemoryTypeLesson,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"Wait for explicit review completion before merge",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceExtracted,
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Now(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{existingSummary},
+	}
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{},
+		memoryUsecase,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-1")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(0).
+			CandidateLimit(5).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(Extract()) = %d, want 0", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+	}
+}
+
+func mustExtractionEvent(t *testing.T, eventID string, kind domtypes.EventKind, body string) *model.Event {
+	t.Helper()
+
+	event, err := model.NewEvent(
+		domtypes.EventID(eventID),
+		kind,
+		domtypes.Client("cli"),
+		domtypes.Agent("claude"),
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		body,
+	)
+	if err != nil {
+		t.Fatalf("NewEvent() error = %v", err)
+	}
+	return event
+}
+
+func mustMemoryDetailsFromSummary(t *testing.T, memoryID string, memoryType domtypes.MemoryType, fact string) apptypes.MemoryDetails {
+	t.Helper()
+
+	summary, err := apptypes.MemorySummaryOf(
+		mustMemoryID(t, memoryID),
+		memoryType,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		fact,
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceExtracted,
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Now(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+	return apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindSession, "session-1")}, nil)
+}

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -2,6 +2,7 @@ package usecase_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 type memoryExtractionMemoryUsecaseStub struct {
 	listResult    []apptypes.MemorySummary
 	listErr       error
+	listCalls     []apptypes.MemoryListCriteria
 	proposeResult []apptypes.MemoryDetails
 	proposeErr    error
 	proposeCalls  []memoryExtractionProposeCall
@@ -68,8 +70,20 @@ func (s *memoryExtractionMemoryUsecaseStub) Expire(context.Context, domtypes.Mem
 	return apptypes.MemoryDetails{}, nil
 }
 
-func (s *memoryExtractionMemoryUsecaseStub) List(_ context.Context, _ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
-	return s.listResult, s.listErr
+func (s *memoryExtractionMemoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	s.listCalls = append(s.listCalls, criteria)
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	start := criteria.Offset()
+	if start >= len(s.listResult) {
+		return nil, nil
+	}
+	end := start + criteria.Limit()
+	if end > len(s.listResult) {
+		end = len(s.listResult)
+	}
+	return append([]apptypes.MemorySummary(nil), s.listResult[start:end]...), nil
 }
 
 func (s *memoryExtractionMemoryUsecaseStub) Search(context.Context, apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
@@ -250,6 +264,97 @@ func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingAndGracefullyHandle
 	}
 	if len(memoryUsecase.proposeCalls) != 0 {
 		t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+	}
+}
+
+func TestMemoryExtractionUsecase_Extract_PaginatesExistingMemoryDedupe(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.Empty[time.Time](),
+		"ended",
+		4,
+		0,
+		[]string{"codex"},
+		"",
+		"Decision: Keep get_context raw",
+		domtypes.SessionID(""),
+	)
+
+	listResult := make([]apptypes.MemorySummary, 0, 201)
+	for idx := 0; idx < 200; idx++ {
+		summary, err := apptypes.MemorySummaryOf(
+			mustMemoryID(t, fmt.Sprintf("memory-existing-%03d", idx)),
+			domtypes.MemoryTypeLesson,
+			domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+			fmt.Sprintf("Existing lesson %03d", idx),
+			domtypes.MemoryStatusCandidate,
+			domtypes.ConfidenceVerified,
+			domtypes.MemorySourceExtracted,
+			domtypes.Empty[domtypes.MemoryID](),
+			domtypes.Empty[time.Time](),
+			time.Now(),
+			time.Now(),
+		)
+		if err != nil {
+			t.Fatalf("MemorySummaryOf() error = %v", err)
+		}
+		listResult = append(listResult, summary)
+	}
+	duplicateSummary, err := apptypes.MemorySummaryOf(
+		mustMemoryID(t, "memory-existing-duplicate"),
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"Keep get_context raw",
+		domtypes.MemoryStatusAccepted,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Now(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+	listResult = append(listResult, duplicateSummary)
+
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{listResult: listResult}
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{},
+		memoryUsecase,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-1")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(0).
+			CandidateLimit(5).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(Extract()) = %d, want 0", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+	}
+	if len(memoryUsecase.listCalls) != 2 {
+		t.Fatalf("List() call count = %d, want 2", len(memoryUsecase.listCalls))
+	}
+	if got := memoryUsecase.listCalls[0].Offset(); got != 0 {
+		t.Fatalf("first List().Offset() = %d, want 0", got)
+	}
+	if got := memoryUsecase.listCalls[1].Offset(); got != 200 {
+		t.Fatalf("second List().Offset() = %d, want 200", got)
 	}
 }
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -217,6 +217,18 @@ candidate な durable memory を記録します。後で review できます。
 
 主な flag は `memory remember` と同じですが、`--confidence` は使われません。
 
+### `traceary memory extract`
+
+対象 session の session summary、compact summary、prompt event、note/review signal から candidate durable memory を抽出します。抽出結果は candidate のみで、Traceary が auto-accept することはありません。prompt event は任意で、prompt や compact-summary event がなくても利用可能な signal の範囲で劣化動作します。`Feedback:` / `Correction:` ラベルは、現在の最小 durable-memory taxonomy の中で `preference` candidate として保持されます。保存される candidate は、他の durable memory 書き込みと同じ sanitization/redaction 経路を通ってから永続化されます。
+
+主な flag:
+
+- `--session-id`
+- `--workspace`
+- `--event-limit`
+- `--candidate-limit`
+- `--json`
+
 ### `traceary memory accept <memory-id>`
 
 candidate durable memory を accept します。

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -219,7 +219,7 @@ candidate な durable memory を記録します。後で review できます。
 
 ### `traceary memory extract`
 
-対象 session の session summary、compact summary、prompt event、note/review signal から candidate durable memory を抽出します。抽出結果は candidate のみで、Traceary が auto-accept することはありません。prompt event は任意で、prompt や compact-summary event がなくても利用可能な signal の範囲で劣化動作します。`Feedback:` / `Correction:` ラベルは、現在の最小 durable-memory taxonomy の中で `preference` candidate として保持されます。保存される candidate は、他の durable memory 書き込みと同じ sanitization/redaction 経路を通ってから永続化されます。
+対象 session の session summary、compact summary、prompt event、note/review signal から candidate durable memory を抽出します。抽出結果は candidate のみで、Traceary が auto-accept することはありません。prompt event は任意で、prompt や compact-summary event がなくても利用可能な signal の範囲で劣化動作します。`--session-id` を省略した場合は、まず active session を解決し、見つからなければ workspace 内の latest session にフォールバックします。`Feedback:` / `Correction:` ラベルは、現在の最小 durable-memory taxonomy の中で `preference` candidate として保持されます。保存される candidate は、他の durable memory 書き込みと同じ sanitization/redaction 経路を通ってから永続化されます。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -217,6 +217,18 @@ Record a candidate durable memory that still needs review.
 
 Useful flags are the same as `memory remember`, except `--confidence` is ignored.
 
+### `traceary memory extract`
+
+Extract candidate durable memories from a target session using session summaries, compact summaries, prompt events, and note/review signals. Extraction is candidate-only: Traceary never auto-accepts the extracted memories. Prompt events are optional; missing prompt or compact-summary events simply reduce the available signals. `Feedback:` / `Correction:` labels are preserved by mapping them into the current minimal durable-memory taxonomy as `preference` candidates. Persisted candidates go through the same sanitization/redaction path as other durable-memory writes before they are stored.
+
+Useful flags:
+
+- `--session-id`
+- `--workspace`
+- `--event-limit`
+- `--candidate-limit`
+- `--json`
+
 ### `traceary memory accept <memory-id>`
 
 Accept a candidate durable memory.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -219,7 +219,7 @@ Useful flags are the same as `memory remember`, except `--confidence` is ignored
 
 ### `traceary memory extract`
 
-Extract candidate durable memories from a target session using session summaries, compact summaries, prompt events, and note/review signals. Extraction is candidate-only: Traceary never auto-accepts the extracted memories. Prompt events are optional; missing prompt or compact-summary events simply reduce the available signals. `Feedback:` / `Correction:` labels are preserved by mapping them into the current minimal durable-memory taxonomy as `preference` candidates. Persisted candidates go through the same sanitization/redaction path as other durable-memory writes before they are stored.
+Extract candidate durable memories from a target session using session summaries, compact summaries, prompt events, and note/review signals. Extraction is candidate-only: Traceary never auto-accepts the extracted memories. Prompt events are optional; missing prompt or compact-summary events simply reduce the available signals. When `--session-id` is omitted, Traceary resolves the active session first and then falls back to the latest matching session in the workspace. `Feedback:` / `Correction:` labels are preserved by mapping them into the current minimal durable-memory taxonomy as `preference` candidates. Persisted candidates go through the same sanitization/redaction path as other durable-memory writes before they are stored.
 
 Useful flags:
 

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func run() error {
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
 	memoryUsecase := usecase.NewMemoryUsecase(memoryDatasource, memoryDatasource, extraRedactPatterns)
-	memoryExtractionUsecase := usecase.NewMemoryExtractionUsecase(sessionDatasource, eventDatasource, memoryUsecase)
+	memoryExtractionUsecase := usecase.NewMemoryExtractionUsecase(sessionDatasource, eventDatasource, memoryUsecase, extraRedactPatterns)
 	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
 

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func run() error {
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
 	memoryUsecase := usecase.NewMemoryUsecase(memoryDatasource, memoryDatasource, extraRedactPatterns)
+	memoryExtractionUsecase := usecase.NewMemoryExtractionUsecase(sessionDatasource, eventDatasource, memoryUsecase)
 	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
 
@@ -177,6 +178,7 @@ func run() error {
 		cli.WithEvent(eventUsecase),
 		cli.WithSession(sessionUsecase),
 		cli.WithMemory(memoryUsecase),
+		cli.WithMemoryExtraction(memoryExtractionUsecase),
 		cli.WithContext(contextUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),
 		cli.WithMCPServerRunner(mcpServer),

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -259,3 +259,13 @@ type memorySupersedeCommandInput struct {
 	idOnly        bool
 	asJSON        bool
 }
+
+// memoryExtractCommandInput is the resolved input to `traceary memory extract`.
+type memoryExtractCommandInput struct {
+	dbPath         string
+	sessionID      string
+	workspace      string
+	eventLimit     int
+	candidateLimit int
+	asJSON         bool
+}

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -23,6 +23,7 @@ func (c *RootCLI) newMemoryCommand() *cobra.Command {
 	memoryCmd.AddCommand(c.newMemoryShowCommand())
 	memoryCmd.AddCommand(c.newMemoryRememberCommand())
 	memoryCmd.AddCommand(c.newMemoryProposeCommand())
+	memoryCmd.AddCommand(c.newMemoryExtractCommand())
 	memoryCmd.AddCommand(c.newMemoryAcceptCommand())
 	memoryCmd.AddCommand(c.newMemoryRejectCommand())
 	memoryCmd.AddCommand(c.newMemorySupersedeCommand())

--- a/presentation/cli/memory_extract.go
+++ b/presentation/cli/memory_extract.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func (c *RootCLI) newMemoryExtractCommand() *cobra.Command {
+	input := memoryExtractCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "extract",
+		Short: Localize("Extract candidate durable memories from an existing session", "既存 session から candidate durable memory を抽出する"),
+		Long: Localize(
+			"Extract candidate durable memories from session summaries, compact summaries, prompt events, and note/review signals without auto-accepting them.",
+			"session summary、compact summary、prompt event、note/review signal から candidate durable memory を抽出します。auto-accept は行いません。",
+		),
+		Args: noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryExtract(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.sessionID, "session-id", "", Localize("target session ID (defaults to the active/latest session for the workspace)", "対象 session ID (省略時は workspace の active/latest session)"))
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace used to resolve the target session", "対象 session 解決に使う workspace"))
+	cmd.Flags().IntVar(&input.eventLimit, "event-limit", 5, Localize("maximum number of recent events to inspect per signal kind", "signal kind ごとに調べる recent event 数"))
+	cmd.Flags().IntVar(&input.candidateLimit, "candidate-limit", 10, Localize("maximum number of candidates to create", "作成する candidate 数の上限"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	return cmd
+}
+
+func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input memoryExtractCommandInput) error {
+	if c.memoryExtraction == nil {
+		return xerrors.Errorf(Localize("memory extraction usecase is not configured", "memory extraction ユースケースが設定されていません"))
+	}
+	if input.eventLimit < 0 {
+		return xerrors.Errorf(Localize("event-limit must be greater than or equal to 0", "event-limit は 0 以上である必要があります"))
+	}
+	if input.candidateLimit <= 0 {
+		return xerrors.Errorf(Localize("candidate-limit must be greater than or equal to 1", "candidate-limit は 1 以上である必要があります"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+
+	resolvedWorkspace := resolveWorkspaceValue(ctx, input.workspace)
+	resolvedSessionID, err := c.resolveContextSessionID(ctx, contextCommandInput{
+		sessionID: input.sessionID,
+		repo:      resolvedWorkspace,
+	})
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(resolvedSessionID) == "" {
+		return xerrors.Errorf(Localize("failed to resolve a target session for memory extraction", "memory extraction 対象の session を解決できませんでした"))
+	}
+
+	details, err := c.memoryExtraction.Extract(
+		ctx,
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(types.SessionID(resolvedSessionID)).
+			Workspace(types.Workspace(resolvedWorkspace)).
+			EventLimit(input.eventLimit).
+			CandidateLimit(input.candidateLimit).
+			Build(),
+	)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to extract durable-memory candidates", "durable memory candidate の抽出に失敗しました"), err)
+	}
+	if err := writeExtractedMemoryCandidatesByFormat(output, details, input.asJSON); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print extracted durable-memory candidates", "抽出した durable memory candidate の出力に失敗しました"), err)
+	}
+	return nil
+}

--- a/presentation/cli/memory_extract.go
+++ b/presentation/cli/memory_extract.go
@@ -36,6 +36,9 @@ func (c *RootCLI) newMemoryExtractCommand() *cobra.Command {
 }
 
 func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input memoryExtractCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
 	if c.memoryExtraction == nil {
 		return xerrors.Errorf(Localize("memory extraction usecase is not configured", "memory extraction ユースケースが設定されていません"))
 	}

--- a/presentation/cli/memory_extract.go
+++ b/presentation/cli/memory_extract.go
@@ -50,10 +50,7 @@ func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input 
 	}
 
 	resolvedWorkspace := resolveWorkspaceValue(ctx, input.workspace)
-	resolvedSessionID, err := c.resolveContextSessionID(ctx, contextCommandInput{
-		sessionID: input.sessionID,
-		repo:      resolvedWorkspace,
-	})
+	resolvedSessionID, resolvedLookupWorkspace, err := c.resolveMemoryExtractTargetSession(ctx, input.sessionID, resolvedWorkspace)
 	if err != nil {
 		return err
 	}
@@ -65,7 +62,7 @@ func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input 
 		ctx,
 		apptypes.NewMemoryExtractionCriteriaBuilder().
 			SessionID(types.SessionID(resolvedSessionID)).
-			Workspace(types.Workspace(resolvedWorkspace)).
+			Workspace(types.Workspace(resolvedLookupWorkspace)).
 			EventLimit(input.eventLimit).
 			CandidateLimit(input.candidateLimit).
 			Build(),
@@ -77,4 +74,35 @@ func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input 
 		return xerrors.Errorf("%s: %w", Localize("failed to print extracted durable-memory candidates", "抽出した durable memory candidate の出力に失敗しました"), err)
 	}
 	return nil
+}
+
+func (c *RootCLI) resolveMemoryExtractTargetSession(ctx context.Context, sessionID string, workspace string) (string, string, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID != "" {
+		return trimmedSessionID, "", nil
+	}
+	if c.session == nil {
+		return "", workspace, nil
+	}
+
+	lookupCriteria := apptypes.NewSessionLookupCriteriaBuilder().
+		Workspace(types.Workspace(strings.TrimSpace(workspace))).
+		Build()
+	active, err := c.session.Active(ctx, lookupCriteria)
+	if err != nil {
+		return "", workspace, xerrors.Errorf("%s: %w", Localize("failed to resolve active session for memory extraction", "memory extraction 用の active session 解決に失敗しました"), err)
+	}
+	if event, ok := active.Get(); ok && event != nil {
+		return event.SessionID().String(), workspace, nil
+	}
+
+	latest, err := c.session.Latest(ctx, lookupCriteria)
+	if err != nil {
+		return "", workspace, xerrors.Errorf("%s: %w", Localize("failed to resolve latest session for memory extraction", "memory extraction 用の latest session 解決に失敗しました"), err)
+	}
+	if event, ok := latest.Get(); ok && event != nil {
+		return event.SessionID().String(), workspace, nil
+	}
+
+	return "", workspace, nil
 }

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -42,6 +42,29 @@ func writeMemoryMutationResult(output io.Writer, details apptypes.MemoryDetails,
 	return writeMemoryDetailsByFormat(output, details, asJSON)
 }
 
+func writeExtractedMemoryCandidatesByFormat(output io.Writer, details []apptypes.MemoryDetails, asJSON bool) error {
+	if asJSON {
+		serialized := make([]memoryDetailsOutput, 0, len(details))
+		for _, detail := range details {
+			serialized = append(serialized, newMemoryDetailsOutput(detail))
+		}
+		return writeJSON(output, serialized)
+	}
+
+	if len(details) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No extractable durable-memory candidates were found.", "抽出可能な durable memory candidate は見つかりませんでした")); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty extraction message", "空の抽出結果メッセージの出力に失敗しました"), err)
+		}
+		return nil
+	}
+
+	summaries := make([]apptypes.MemorySummary, 0, len(details))
+	for _, detail := range details {
+		summaries = append(summaries, detail.Summary())
+	}
+	return writeMemorySummaries(output, summaries)
+}
+
 func writeMemorySummaries(output io.Writer, summaries []apptypes.MemorySummary) error {
 	if len(summaries) == 0 {
 		if _, err := fmt.Fprintln(output, Localize("No matching durable memories.", "一致する durable memory はありません")); err != nil {

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -284,6 +284,92 @@ func TestRootCLI_MemoryExtractCommand_UsesResolvedSession(t *testing.T) {
 	}
 }
 
+func TestRootCLI_MemoryExtractCommand_FallsBackToLatestSession(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	latestEvent, err := model.NewEvent(
+		types.EventID("event-latest"),
+		types.EventKindSessionStarted,
+		types.Client("cli"),
+		types.Agent("codex"),
+		types.SessionID("session-latest"),
+		types.Workspace("github.com/duck8823/traceary"),
+		"session started",
+	)
+	if err != nil {
+		t.Fatalf("NewEvent() error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{latestEvent: latestEvent}
+	extractionStub := &memoryExtractionUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithMemoryExtraction(extractionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "extract",
+		"--db-path", "/tmp/test-traceary.db",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := extractionStub.criteria.SessionID().String(); got != "session-latest" {
+		t.Fatalf("SessionID() = %q, want session-latest", got)
+	}
+	if got := extractionStub.criteria.Workspace().String(); got != "github.com/duck8823/traceary" {
+		t.Fatalf("Workspace() = %q, want github.com/duck8823/traceary", got)
+	}
+	if got := sessionStub.latestCriteria.Workspace().String(); got != "github.com/duck8823/traceary" {
+		t.Fatalf("Latest().Workspace() = %q, want github.com/duck8823/traceary", got)
+	}
+}
+
+func TestRootCLI_MemoryExtractCommand_ExplicitSessionIDSkipsWorkspaceFilter(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	sessionStub := &sessionUsecaseStub{}
+	extractionStub := &memoryExtractionUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithMemoryExtraction(extractionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "extract",
+		"--db-path", "/tmp/test-traceary.db",
+		"--session-id", "session-explicit",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := extractionStub.criteria.SessionID().String(); got != "session-explicit" {
+		t.Fatalf("SessionID() = %q, want session-explicit", got)
+	}
+	if got := extractionStub.criteria.Workspace().String(); got != "" {
+		t.Fatalf("Workspace() = %q, want empty when session-id is explicit", got)
+	}
+	if sessionStub.activeCriteria.Workspace().String() != "" || sessionStub.latestCriteria.Workspace().String() != "" {
+		t.Fatalf("session lookup should be skipped when --session-id is explicit")
+	}
+}
+
 func mustMemorySummary(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemorySummary {
 	t.Helper()
 

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -222,6 +222,68 @@ func TestRootCLI_MemoryProposeCommand_IgnoresConfidenceFlagValidation(t *testing
 	}
 }
 
+func TestRootCLI_MemoryExtractCommand_UsesResolvedSession(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	activeEvent, err := model.NewEvent(
+		types.EventID("event-active"),
+		types.EventKindSessionStarted,
+		types.Client("cli"),
+		types.Agent("claude"),
+		types.SessionID("session-42"),
+		types.Workspace("github.com/duck8823/traceary"),
+		"session started",
+	)
+	if err != nil {
+		t.Fatalf("NewEvent() error = %v", err)
+	}
+
+	extractionStub := &memoryExtractionUsecaseStub{
+		details: []apptypes.MemoryDetails{
+			mustMemoryDetails(t, "memory-extracted-1", "Always wait for Codex review before merge", types.MemoryStatusCandidate),
+			mustMemoryDetails(t, "memory-extracted-2", "Decision: keep get_context raw", types.MemoryStatusCandidate),
+		},
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{activeEvent: activeEvent}),
+		cli.WithMemoryExtraction(extractionStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "extract",
+		"--db-path", "/tmp/test-traceary.db",
+		"--event-limit", "3",
+		"--candidate-limit", "2",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := extractionStub.criteria.SessionID().String(); got != "session-42" {
+		t.Fatalf("SessionID() = %q, want session-42", got)
+	}
+	if got := extractionStub.criteria.Workspace().String(); got != "github.com/duck8823/traceary" {
+		t.Fatalf("Workspace() = %q, want github.com/duck8823/traceary", got)
+	}
+	if got := extractionStub.criteria.EventLimit(); got != 3 {
+		t.Fatalf("EventLimit() = %d, want 3", got)
+	}
+	if got := extractionStub.criteria.CandidateLimit(); got != 2 {
+		t.Fatalf("CandidateLimit() = %d, want 2", got)
+	}
+	if !strings.Contains(stdout.String(), "memory-extracted-1") || !strings.Contains(stdout.String(), "memory-extracted-2") {
+		t.Fatalf("stdout = %q, want extracted candidate IDs", stdout.String())
+	}
+}
+
 func mustMemorySummary(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemorySummary {
 	t.Helper()
 

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -370,6 +370,29 @@ func TestRootCLI_MemoryExtractCommand_ExplicitSessionIDSkipsWorkspaceFilter(t *t
 	}
 }
 
+func TestRootCLI_MemoryExtractCommand_RequiresStoreManagement(t *testing.T) {
+	extractionStub := &memoryExtractionUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithMemoryExtraction(extractionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "extract",
+		"--db-path", "/tmp/test-traceary.db",
+		"--session-id", "session-explicit",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want configuration error")
+	}
+	if !strings.Contains(err.Error(), "initialize store usecase is not configured") {
+		t.Fatalf("Execute() error = %v, want store-management configuration error", err)
+	}
+}
+
 func mustMemorySummary(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemorySummary {
 	t.Helper()
 

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -12,6 +12,7 @@ type RootCLI struct {
 	event                usecase.EventUsecase
 	session              usecase.SessionUsecase
 	memory               usecase.MemoryUsecase
+	memoryExtraction     usecase.MemoryExtractionUsecase
 	context              usecase.ContextUsecase
 	storeManagement      usecase.StoreManagementUsecase
 	mcpServerRunner      MCPServerRunner
@@ -43,6 +44,12 @@ func WithSession(session usecase.SessionUsecase) RootCLIOption {
 // WithMemory injects the MemoryUsecase used by durable-memory commands.
 func WithMemory(memory usecase.MemoryUsecase) RootCLIOption {
 	return func(c *RootCLI) { c.memory = memory }
+}
+
+// WithMemoryExtraction injects the MemoryExtractionUsecase used by candidate
+// extraction commands.
+func WithMemoryExtraction(memoryExtraction usecase.MemoryExtractionUsecase) RootCLIOption {
+	return func(c *RootCLI) { c.memoryExtraction = memoryExtraction }
 }
 
 // WithContext injects the ContextUsecase used by structured handoff commands.

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -52,21 +52,23 @@ func (s *eventUsecaseStub) Timeline(_ context.Context, _ apptypes.TimelineCriter
 
 // sessionUsecaseStub implements usecase.SessionUsecase for testing.
 type sessionUsecaseStub struct {
-	startEvent  *model.Event
-	startErr    error
-	endEvent    *model.Event
-	endErr      error
-	labelErr    error
-	listResult  []apptypes.SessionSummary
-	listErr     error
-	treeResult  []apptypes.SessionSummary
-	treeErr     error
-	activeEvent *model.Event
-	activeErr   error
-	latestEvent *model.Event
-	latestErr   error
-	handoff     types.Optional[apptypes.HandoffSummary]
-	handoffErr  error
+	startEvent     *model.Event
+	startErr       error
+	endEvent       *model.Event
+	endErr         error
+	labelErr       error
+	listResult     []apptypes.SessionSummary
+	listErr        error
+	treeResult     []apptypes.SessionSummary
+	treeErr        error
+	activeEvent    *model.Event
+	activeErr      error
+	activeCriteria apptypes.SessionLookupCriteria
+	latestEvent    *model.Event
+	latestErr      error
+	latestCriteria apptypes.SessionLookupCriteria
+	handoff        types.Optional[apptypes.HandoffSummary]
+	handoffErr     error
 }
 
 func (s *sessionUsecaseStub) Start(_ context.Context, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ types.SessionID) (*model.Event, error) {
@@ -84,7 +86,8 @@ func (s *sessionUsecaseStub) List(_ context.Context, _ apptypes.SessionListCrite
 func (s *sessionUsecaseStub) Tree(_ context.Context, _ types.Workspace, _ int) ([]apptypes.SessionSummary, error) {
 	return s.treeResult, s.treeErr
 }
-func (s *sessionUsecaseStub) Active(_ context.Context, _ apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
+func (s *sessionUsecaseStub) Active(_ context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
+	s.activeCriteria = criteria
 	if s.activeEvent == nil && s.activeErr == nil {
 		return types.Empty[*model.Event](), nil
 	}
@@ -93,7 +96,8 @@ func (s *sessionUsecaseStub) Active(_ context.Context, _ apptypes.SessionLookupC
 	}
 	return types.Of(s.activeEvent), nil
 }
-func (s *sessionUsecaseStub) Latest(_ context.Context, _ apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
+func (s *sessionUsecaseStub) Latest(_ context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
+	s.latestCriteria = criteria
 	if s.latestEvent == nil && s.latestErr == nil {
 		return types.Empty[*model.Event](), nil
 	}

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -115,6 +115,17 @@ func (s *contextUsecaseStub) Handoff(_ context.Context, _ apptypes.ContextPackCr
 	return s.handoff, s.handoffErr
 }
 
+type memoryExtractionUsecaseStub struct {
+	details  []apptypes.MemoryDetails
+	err      error
+	criteria apptypes.MemoryExtractionCriteria
+}
+
+func (s *memoryExtractionUsecaseStub) Extract(_ context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
+	s.criteria = criteria
+	return s.details, s.err
+}
+
 type memoryUsecaseStub struct {
 	listResult       []apptypes.MemorySummary
 	listErr          error


### PR DESCRIPTION
## Motivation
- durable memory already supports manual lifecycle operations, but Traceary still requires operators to restate obvious lessons, preferences, and decisions by hand after a session ends
- v0.5.0's stretch goal is to promote high-value session signals into reviewable memory candidates without auto-accepting them
- parent issue feedback emphasized a minimal taxonomy, preserving feedback/correction-like signals, and keeping extraction candidate-only

## What changed
- add `MemoryExtractionUsecase` and extraction criteria for candidate durable memories
- extract candidates from session summaries plus recent prompt / note / review / compact-summary signals with explicit evidence refs and artifact inference
- dedupe against existing candidate/accepted memories in the same scope
- add `traceary memory extract` CLI command and output formatting
- document the new command and its candidate-only / sanitized behavior

## Verification
- `GOCACHE=$(pwd)/.cache/go-build go test ./...`
- `GOCACHE=$(pwd)/.cache/go-build go build ./...`
- `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run`
- `python3 scripts/verify_docs_i18n.py`

Closes #465
