### PR TITLE
feat: add live tailing for event streams

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -87,6 +87,25 @@ session 解決ルールは `traceary log` と同じです。
 - `--workspace`
 - `--session-id`
 
+### `traceary tail`
+
+新しい event を追跡表示します。
+
+`tail` は live observation 用のコマンドです。最初に最近の backlog を表示し、その後はローカルストアに追加される一致 event を継続的に追跡します。hook が正しく発火しているか、期待した session / workspace に書き込まれているか、失敗がリアルタイムで見えているかを確認したいときに使います。`list` と違って 1 回の snapshot で終了せず、`search` と違ってキーワード検索は行いません。`handoff` と違って working memory を組み立てず、raw event stream をそのまま表示します。
+
+テキスト出力は `list` と同じ表形式です。`--json` は改行区切り JSON (1 行 1 event) を出すので、パイプラインが逐次処理できます。
+
+主な flag:
+
+- `--kind`
+- `--limit`
+- `--json`
+- `--client`
+- `--agent`
+- `--workspace`
+- `--session-id`
+- `--failures`
+
 ### `traceary search [<query>]`
 
 全文検索と構造フィルタで event を検索します。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -87,6 +87,25 @@ Useful flags:
 - `--workspace`
 - `--session-id`
 
+### `traceary tail`
+
+Follow new events as they arrive.
+
+`tail` is the live observation view. It prints a recent backlog first and then keeps following new matching events from the local store. Use it when you want to confirm that hooks are firing, that the expected session/workspace is receiving writes, or that failures are surfacing in real time. Unlike `list`, it does not exit after one snapshot. Unlike `search`, it does not perform keyword matching. Unlike `handoff`, it stays at the raw event-stream layer rather than assembling working memory.
+
+Text output uses the same tabular row shape as `list`. `--json` emits newline-delimited JSON objects (one event per line) so pipelines can consume the stream incrementally.
+
+Useful flags:
+
+- `--kind`
+- `--limit`
+- `--json`
+- `--client`
+- `--agent`
+- `--workspace`
+- `--session-id`
+- `--failures`
+
 ### `traceary search [<query>]`
 
 Search events by text and structured filters.

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -192,15 +192,17 @@ type timelineCommandInput struct {
 
 // tailCommandInput is the resolved input to the `traceary tail` command.
 type tailCommandInput struct {
-	dbPath       string
-	limit        int
-	kind         string
-	client       string
-	agent        string
-	sessionID    string
-	repo         string
-	failuresOnly bool
-	asJSON       bool
+	dbPath        string
+	limit         int
+	kind          string
+	client        string
+	agent         string
+	sessionID     string
+	repo          string
+	failuresOnly  bool
+	asJSON        bool
+	nowFunc       func() time.Time
+	tickerFactory func(time.Duration) tailTicker
 }
 
 // memoryListCommandInput is the resolved input to `traceary memory list`.

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -190,6 +190,19 @@ type timelineCommandInput struct {
 	asJSON    bool
 }
 
+// tailCommandInput is the resolved input to the `traceary tail` command.
+type tailCommandInput struct {
+	dbPath       string
+	limit        int
+	kind         string
+	client       string
+	agent        string
+	sessionID    string
+	repo         string
+	failuresOnly bool
+	asJSON       bool
+}
+
 // memoryListCommandInput is the resolved input to `traceary memory list`.
 type memoryListCommandInput struct {
 	dbPath        string

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -138,6 +138,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newAuditCommand())
 	rootCmd.AddCommand(c.newGCCommand())
 	rootCmd.AddCommand(c.newSearchCommand())
+	rootCmd.AddCommand(c.newTailCommand())
 	rootCmd.AddCommand(c.newContextCommand())
 	rootCmd.AddCommand(c.newHandoffCommand())
 	rootCmd.AddCommand(c.newListCommand())

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -23,11 +23,6 @@ const (
 	defaultTailPollInterval = time.Second
 )
 
-var (
-	tailNowFunc     = time.Now
-	newTailTickerFn = newRealTailTicker
-)
-
 type tailTicker interface {
 	C() <-chan time.Time
 	Stop()
@@ -47,6 +42,20 @@ func (t realTailTicker) C() <-chan time.Time {
 
 func (t realTailTicker) Stop() {
 	t.ticker.Stop()
+}
+
+func (i tailCommandInput) resolvedNowFunc() func() time.Time {
+	if i.nowFunc != nil {
+		return i.nowFunc
+	}
+	return time.Now
+}
+
+func (i tailCommandInput) resolvedTickerFactory() func(time.Duration) tailTicker {
+	if i.tickerFactory != nil {
+		return i.tickerFactory
+	}
+	return newRealTailTicker
 }
 
 type tailCursor struct {
@@ -240,7 +249,7 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 		FailuresOnly(input.failuresOnly)
 
 	writer := newTailEventWriter(output, input.asJSON)
-	cursor := newTailCursor(tailNowFunc().UTC())
+	cursor := newTailCursor(input.resolvedNowFunc()().UTC())
 	if input.limit > 0 {
 		initialCriteria := apptypes.NewEventListCriteriaBuilder(input.limit).
 			Kind(baseCriteria.Build().Kind()).
@@ -266,7 +275,7 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 		return err
 	}
 
-	ticker := newTailTickerFn(defaultTailPollInterval)
+	ticker := input.resolvedTickerFactory()(defaultTailPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	defaultTailInitialLimit = 20
+	defaultTailBatchSize    = 100
+	defaultTailPollInterval = time.Second
+)
+
+var (
+	tailNowFunc     = time.Now
+	newTailTickerFn = newRealTailTicker
+)
+
+type tailTicker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type realTailTicker struct {
+	ticker *time.Ticker
+}
+
+func newRealTailTicker(interval time.Duration) tailTicker {
+	return realTailTicker{ticker: time.NewTicker(interval)}
+}
+
+func (t realTailTicker) C() <-chan time.Time {
+	return t.ticker.C
+}
+
+func (t realTailTicker) Stop() {
+	t.ticker.Stop()
+}
+
+type tailCursor struct {
+	timestamp time.Time
+	seenIDs   map[string]struct{}
+}
+
+func newTailCursor(start time.Time) tailCursor {
+	return tailCursor{
+		timestamp: start,
+		seenIDs:   make(map[string]struct{}),
+	}
+}
+
+func (c *tailCursor) isNew(event *model.Event) bool {
+	if event == nil {
+		return false
+	}
+	if event.CreatedAt().After(c.timestamp) {
+		return true
+	}
+	if !event.CreatedAt().Equal(c.timestamp) {
+		return false
+	}
+	_, seen := c.seenIDs[event.EventID().String()]
+	return !seen
+}
+
+func (c *tailCursor) Advance(events []*model.Event) {
+	if len(events) == 0 {
+		return
+	}
+
+	maxTimestamp := c.timestamp
+	for _, event := range events {
+		if event != nil && event.CreatedAt().After(maxTimestamp) {
+			maxTimestamp = event.CreatedAt()
+		}
+	}
+
+	if maxTimestamp.After(c.timestamp) {
+		c.timestamp = maxTimestamp
+		c.seenIDs = make(map[string]struct{})
+	}
+
+	for _, event := range events {
+		if event != nil && event.CreatedAt().Equal(c.timestamp) {
+			c.seenIDs[event.EventID().String()] = struct{}{}
+		}
+	}
+}
+
+type tailEventWriter struct {
+	output      io.Writer
+	asJSON      bool
+	headerWrote bool
+}
+
+func newTailEventWriter(output io.Writer, asJSON bool) *tailEventWriter {
+	return &tailEventWriter{
+		output: output,
+		asJSON: asJSON,
+	}
+}
+
+func (w *tailEventWriter) EnsureReady() error {
+	if w.asJSON || w.headerWrote {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w.output, "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print list header", "一覧ヘッダーの出力に失敗しました"), err)
+	}
+	w.headerWrote = true
+	return nil
+}
+
+func (w *tailEventWriter) Write(events []*model.Event) error {
+	if err := w.EnsureReady(); err != nil {
+		return err
+	}
+	for _, event := range events {
+		if w.asJSON {
+			if err := writeEventNDJSON(w.output, event); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(
+			w.output,
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			event.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
+			event.Kind(),
+			formatOptionalColumn(event.Client().String()),
+			event.Agent(),
+			event.SessionID(),
+			formatOptionalColumn(event.Workspace().String()),
+			truncateMessage(event.Body()),
+		); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print event row", "イベント一覧行の出力に失敗しました"), err)
+		}
+	}
+
+	return nil
+}
+
+func writeEventNDJSON(output io.Writer, event *model.Event) error {
+	encoded, err := json.Marshal(newEventOutput(event))
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to encode JSON", "JSON 変換に失敗しました"), err)
+	}
+	if _, err := output.Write(append(encoded, '\n')); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to write JSON", "JSON 出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func (c *RootCLI) newTailCommand() *cobra.Command {
+	var (
+		dbPath       string
+		limit        int
+		kind         string
+		client       string
+		agent        string
+		sessionID    string
+		repo         string
+		failuresOnly bool
+		asJSON       bool
+	)
+
+	tailCmd := &cobra.Command{
+		Use:   "tail",
+		Short: Localize("Follow new events as they arrive", "新しいイベントを追跡表示する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runTail(cmd.Context(), cmd.OutOrStdout(), tailCommandInput{
+				dbPath:       dbPath,
+				limit:        limit,
+				kind:         kind,
+				client:       client,
+				agent:        agent,
+				sessionID:    sessionID,
+				repo:         repo,
+				failuresOnly: failuresOnly,
+				asJSON:       asJSON,
+			})
+		},
+	}
+	tailCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	tailCmd.Flags().IntVar(&limit, "limit", defaultTailInitialLimit, Localize("number of recent events to print before following (0 prints only new events)", "追跡開始前に表示する直近イベント数 (0 の場合は新規イベントのみ表示)"))
+	tailCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)"))
+	tailCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
+	tailCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
+	tailCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))
+	tailCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	tailCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
+	tailCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print NDJSON output", "NDJSON 形式で出力する"))
+
+	return tailCmd
+}
+
+func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.event == nil {
+		return xerrors.Errorf(Localize("list events query service is not configured", "イベント一覧クエリサービスが設定されていません"))
+	}
+	if input.limit < 0 {
+		return xerrors.Errorf(Localize("limit must be greater than or equal to 0", "limit は 0 以上である必要があります"))
+	}
+	resolvedKind, err := resolveListKind(input.kind)
+	if err != nil {
+		return err
+	}
+
+	resolvedDBPath, err := resolveDBPath(input.dbPath)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+	}
+
+	baseCriteria := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).
+		Kind(types.EventKind(resolvedKind)).
+		Client(types.Client(strings.TrimSpace(input.client))).
+		Agent(types.Agent(strings.TrimSpace(input.agent))).
+		SessionID(types.SessionID(strings.TrimSpace(input.sessionID))).
+		Workspace(types.Workspace(resolveWorkspaceValue(ctx, input.repo))).
+		FailuresOnly(input.failuresOnly)
+
+	writer := newTailEventWriter(output, input.asJSON)
+	cursor := newTailCursor(tailNowFunc().UTC())
+	if input.limit > 0 {
+		initialCriteria := apptypes.NewEventListCriteriaBuilder(input.limit).
+			Kind(baseCriteria.Build().Kind()).
+			Client(baseCriteria.Build().Client()).
+			Agent(baseCriteria.Build().Agent()).
+			SessionID(baseCriteria.Build().SessionID()).
+			Workspace(baseCriteria.Build().Workspace()).
+			FailuresOnly(baseCriteria.Build().FailuresOnly()).
+			Build()
+		initialEvents, err := c.event.List(ctx, initialCriteria)
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to list initial tail events", "tail 初期イベントの取得に失敗しました"), err)
+		}
+		slices.Reverse(initialEvents)
+		if err := writer.Write(initialEvents); err != nil {
+			return err
+		}
+		if len(initialEvents) > 0 {
+			cursor = newTailCursor(initialEvents[len(initialEvents)-1].CreatedAt())
+			cursor.Advance(initialEvents)
+		}
+	} else if err := writer.EnsureReady(); err != nil {
+		return err
+	}
+
+	ticker := newTailTickerFn(defaultTailPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			newEvents, err := c.listTailEventsSince(ctx, baseCriteria.Build(), cursor)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to poll tail events", "tail イベントのポーリングに失敗しました"), err)
+			}
+			if len(newEvents) == 0 {
+				continue
+			}
+			if err := writer.Write(newEvents); err != nil {
+				return err
+			}
+			cursor.Advance(newEvents)
+		}
+	}
+}
+
+func (c *RootCLI) listTailEventsSince(ctx context.Context, base apptypes.EventListCriteria, cursor tailCursor) ([]*model.Event, error) {
+	filtered := make([]*model.Event, 0, defaultTailBatchSize)
+	offset := 0
+
+	for {
+		criteria := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).
+			Offset(offset).
+			Kind(base.Kind()).
+			Client(base.Client()).
+			Agent(base.Agent()).
+			SessionID(base.SessionID()).
+			Workspace(base.Workspace()).
+			FailuresOnly(base.FailuresOnly()).
+			From(cursor.timestamp).
+			Build()
+
+		page, err := c.event.List(ctx, criteria)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to list tail page: %w", err)
+		}
+		for _, event := range page {
+			if cursor.isNew(event) {
+				filtered = append(filtered, event)
+			}
+		}
+		if len(page) < defaultTailBatchSize {
+			break
+		}
+		offset += len(page)
+	}
+
+	slices.Reverse(filtered)
+	return filtered, nil
+}

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -283,7 +283,8 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C():
-			newEvents, err := c.listTailEventsSince(ctx, baseCriteria.Build(), cursor)
+			pollSnapshotTo := input.resolvedNowFunc()().UTC()
+			newEvents, err := c.listTailEventsSince(ctx, baseCriteria.Build(), cursor, pollSnapshotTo)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to poll tail events", "tail イベントのポーリングに失敗しました"), err)
 			}
@@ -298,9 +299,17 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 	}
 }
 
-func (c *RootCLI) listTailEventsSince(ctx context.Context, base apptypes.EventListCriteria, cursor tailCursor) ([]*model.Event, error) {
+func (c *RootCLI) listTailEventsSince(
+	ctx context.Context,
+	base apptypes.EventListCriteria,
+	cursor tailCursor,
+	snapshotTo time.Time,
+) ([]*model.Event, error) {
 	filtered := make([]*model.Event, 0, defaultTailBatchSize)
 	offset := 0
+	if snapshotTo.IsZero() {
+		snapshotTo = time.Now().UTC()
+	}
 
 	for {
 		criteria := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).
@@ -312,6 +321,7 @@ func (c *RootCLI) listTailEventsSince(ctx context.Context, base apptypes.EventLi
 			Workspace(base.Workspace()).
 			FailuresOnly(base.FailuresOnly()).
 			From(cursor.timestamp).
+			To(snapshotTo).
 			Build()
 
 		page, err := c.event.List(ctx, criteria)

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -1,0 +1,330 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+type tailEventUsecaseStub struct {
+	listResponses [][]*model.Event
+	listErrs      []error
+	listCalls     []apptypes.EventListCriteria
+	onList        func(callIndex int, criteria apptypes.EventListCriteria)
+}
+
+func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace) (*model.Event, error) {
+	return nil, nil
+}
+
+func (s *tailEventUsecaseStub) Audit(context.Context, string, string, string, types.Client, types.Agent, types.SessionID, types.Workspace, types.Optional[int], apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+	return nil, nil, nil
+}
+
+func (s *tailEventUsecaseStub) Search(context.Context, apptypes.EventSearchCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+
+func (s *tailEventUsecaseStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
+	callIndex := len(s.listCalls)
+	s.listCalls = append(s.listCalls, criteria)
+	if s.onList != nil {
+		s.onList(callIndex, criteria)
+	}
+	if callIndex < len(s.listErrs) && s.listErrs[callIndex] != nil {
+		return nil, s.listErrs[callIndex]
+	}
+	if callIndex < len(s.listResponses) {
+		return s.listResponses[callIndex], nil
+	}
+	return nil, nil
+}
+
+func (s *tailEventUsecaseStub) Show(context.Context, types.EventID) (apptypes.EventDetails, error) {
+	return apptypes.EventDetails{}, nil
+}
+
+func (s *tailEventUsecaseStub) Context(context.Context, apptypes.EventContextCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+
+func (s *tailEventUsecaseStub) Timeline(context.Context, apptypes.TimelineCriteria) ([]apptypes.TimelineBlock, error) {
+	return nil, nil
+}
+
+type tailStoreManagementStub struct{}
+
+func (tailStoreManagementStub) Initialize(context.Context) error { return nil }
+func (tailStoreManagementStub) CreateBackup(context.Context, string, bool) error {
+	return nil
+}
+func (tailStoreManagementStub) RestoreBackup(context.Context, string, bool) error {
+	return nil
+}
+func (tailStoreManagementStub) CollectGarbage(context.Context, time.Time, bool) (apptypes.CollectGarbageResult, error) {
+	return apptypes.CollectGarbageResult{}, nil
+}
+func (tailStoreManagementStub) CloseStaleSessions(context.Context, time.Duration, bool) (apptypes.CloseStaleSessionsResult, error) {
+	return apptypes.CloseStaleSessionsResult{}, nil
+}
+
+type fakeTailTicker struct {
+	ch chan time.Time
+}
+
+func newFakeTailTicker() *fakeTailTicker {
+	return &fakeTailTicker{ch: make(chan time.Time, 4)}
+}
+
+func (t *fakeTailTicker) C() <-chan time.Time { return t.ch }
+func (t *fakeTailTicker) Stop()               {}
+
+func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
+	t.Parallel()
+
+	originalNow := tailNowFunc
+	originalTicker := newTailTickerFn
+	defer func() {
+		tailNowFunc = originalNow
+		newTailTickerFn = originalTicker
+	}()
+
+	startTime := time.Date(2026, 4, 13, 19, 0, 0, 0, time.UTC)
+	tailNowFunc = func() time.Time { return startTime }
+	ticker := newFakeTailTicker()
+	newTailTickerFn = func(time.Duration) tailTicker { return ticker }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialOlder := mustTailEvent(t, "event-1", "cli", "codex", "session-1", "duck8823/traceary", "older", time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC))
+	initialNewer := mustTailEvent(t, "event-2", "cli", "codex", "session-1", "duck8823/traceary", "newer", time.Date(2026, 4, 13, 18, 5, 0, 0, time.UTC))
+	followup := mustTailEvent(t, "event-3", "cli", "codex", "session-1", "duck8823/traceary", "latest", time.Date(2026, 4, 13, 18, 10, 0, 0, time.UTC))
+
+	firstListDone := make(chan struct{})
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{
+			{initialNewer, initialOlder},
+			{followup, initialNewer},
+		},
+		onList: func(callIndex int, criteria apptypes.EventListCriteria) {
+			switch callIndex {
+			case 0:
+				close(firstListDone)
+			case 1:
+				cancel()
+				if got := criteria.From(); !got.Equal(initialNewer.CreatedAt()) {
+					t.Fatalf("criteria.From() = %v, want %v", got, initialNewer.CreatedAt())
+				}
+			}
+		},
+	}
+
+	stdout := &bytes.Buffer{}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+			dbPath:    "/tmp/test-traceary.db",
+			limit:     2,
+			client:    "cli",
+			agent:     "codex",
+			sessionID: "session-1",
+			repo:      "duck8823/traceary",
+		})
+	}()
+
+	<-firstListDone
+	ticker.ch <- time.Now()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("runTail() error = %v", err)
+	}
+
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
+		"2026-04-13T18:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tolder\n" +
+		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tnewer\n" +
+		"2026-04-13T18:10:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tlatest\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
+	t.Parallel()
+
+	originalNow := tailNowFunc
+	originalTicker := newTailTickerFn
+	defer func() {
+		tailNowFunc = originalNow
+		newTailTickerFn = originalTicker
+	}()
+
+	startTime := time.Date(2026, 4, 13, 19, 30, 0, 0, time.UTC)
+	tailNowFunc = func() time.Time { return startTime }
+	ticker := newFakeTailTicker()
+	newTailTickerFn = func(time.Duration) tailTicker { return ticker }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	older := mustTailEvent(t, "event-older", "cli", "codex", "session-1", "duck8823/traceary", "older", time.Date(2026, 4, 13, 19, 0, 0, 0, time.UTC))
+	newer := mustTailEvent(t, "event-newer", "cli", "codex", "session-1", "duck8823/traceary", "new", time.Date(2026, 4, 13, 19, 45, 0, 0, time.UTC))
+
+	firstPoll := make(chan struct{})
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{
+			{newer, older},
+		},
+		onList: func(callIndex int, _ apptypes.EventListCriteria) {
+			if callIndex == 0 {
+				close(firstPoll)
+				cancel()
+			}
+		},
+	}
+	stdout := &bytes.Buffer{}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+			dbPath: "/tmp/test-traceary.db",
+			limit:  0,
+			repo:   "duck8823/traceary",
+		})
+	}()
+
+	ticker.ch <- time.Now()
+	<-firstPoll
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("runTail() error = %v", err)
+	}
+
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
+		"2026-04-13T19:45:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tnew\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
+	t.Parallel()
+
+	originalNow := tailNowFunc
+	originalTicker := newTailTickerFn
+	defer func() {
+		tailNowFunc = originalNow
+		newTailTickerFn = originalTicker
+	}()
+
+	tailNowFunc = func() time.Time {
+		return time.Date(2026, 4, 13, 20, 0, 0, 0, time.UTC)
+	}
+	newTailTickerFn = func(time.Duration) tailTicker { return newFakeTailTicker() }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	event := mustTailEvent(t, "event-json", "cli", "codex", "session-2", "duck8823/traceary", "hello json", time.Date(2026, 4, 13, 19, 55, 0, 0, time.UTC))
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{{event}},
+		onList: func(callIndex int, _ apptypes.EventListCriteria) {
+			if callIndex == 0 {
+				cancel()
+			}
+		},
+	}
+	stdout := &bytes.Buffer{}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	if err := sut.runTail(ctx, stdout, tailCommandInput{
+		dbPath: "/tmp/test-traceary.db",
+		limit:  1,
+		repo:   "duck8823/traceary",
+		asJSON: true,
+	}); err != nil {
+		t.Fatalf("runTail() error = %v", err)
+	}
+
+	want := "{\"event_id\":\"event-json\",\"kind\":\"note\",\"client\":\"cli\",\"agent\":\"codex\",\"session_id\":\"session-2\",\"workspace\":\"duck8823/traceary\",\"message\":\"hello json\",\"created_at\":\"2026-04-13T19:55:00Z\"}\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2026, 4, 13, 18, 5, 0, 0, time.UTC)
+	seen := mustTailEvent(t, "event-seen", "cli", "codex", "session-1", "duck8823/traceary", "seen", timestamp)
+	fresh := mustTailEvent(t, "event-fresh", "cli", "codex", "session-1", "duck8823/traceary", "fresh", timestamp)
+
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{
+			{fresh, seen},
+		},
+	}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	cursor := newTailCursor(timestamp)
+	cursor.seenIDs[seen.EventID().String()] = struct{}{}
+
+	events, err := sut.listTailEventsSince(context.Background(), apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(), cursor)
+	if err != nil {
+		t.Fatalf("listTailEventsSince() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if got := events[0].EventID().String(); got != fresh.EventID().String() {
+		t.Fatalf("EventID() = %q, want %q", got, fresh.EventID().String())
+	}
+}
+
+func mustTailEvent(t *testing.T, eventID string, client string, agent string, sessionID string, workspace string, body string, createdAt time.Time) *model.Event {
+	t.Helper()
+
+	resolvedEventID, err := types.EventIDOf(eventID)
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	resolvedAgent, err := types.AgentOf(agent)
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	resolvedSessionID, err := types.SessionIDOf(sessionID)
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	return model.EventOf(
+		resolvedEventID,
+		types.EventKindNote,
+		types.Client(client),
+		resolvedAgent,
+		resolvedSessionID,
+		types.Workspace(workspace),
+		body,
+		createdAt,
+	)
+}

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -265,7 +266,12 @@ func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	cursor := newTailCursor(timestamp)
 	cursor.seenIDs[seen.EventID().String()] = struct{}{}
 
-	events, err := sut.listTailEventsSince(context.Background(), apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(), cursor)
+	events, err := sut.listTailEventsSince(
+		context.Background(),
+		apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(),
+		cursor,
+		timestamp.Add(time.Minute),
+	)
 	if err != nil {
 		t.Fatalf("listTailEventsSince() error = %v", err)
 	}
@@ -274,6 +280,74 @@ func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	}
 	if got := events[0].EventID().String(); got != fresh.EventID().String() {
 		t.Fatalf("EventID() = %q, want %q", got, fresh.EventID().String())
+	}
+}
+
+func TestListTailEventsSince_UsesStableSnapshotAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	cursorTime := time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC)
+	snapshotTo := time.Date(2026, 4, 13, 18, 10, 0, 0, time.UTC)
+
+	firstPage := make([]*model.Event, 0, defaultTailBatchSize)
+	secondPage := make([]*model.Event, 0, defaultTailBatchSize)
+	for i := range defaultTailBatchSize {
+		firstPage = append(firstPage, mustTailEvent(
+			t,
+			"event-first-"+strconv.Itoa(i),
+			"cli",
+			"codex",
+			"session-1",
+			"duck8823/traceary",
+			"first",
+			cursorTime.Add(time.Duration(defaultTailBatchSize-i)*time.Second),
+		))
+		secondPage = append(secondPage, mustTailEvent(
+			t,
+			"event-second-"+strconv.Itoa(i),
+			"cli",
+			"codex",
+			"session-1",
+			"duck8823/traceary",
+			"second",
+			cursorTime.Add(time.Duration(defaultTailBatchSize*2-i)*time.Second),
+		))
+	}
+	lastPage := []*model.Event{
+		mustTailEvent(t, "event-last", "cli", "codex", "session-1", "duck8823/traceary", "last", cursorTime.Add(5*time.Minute)),
+	}
+
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{firstPage, secondPage, lastPage},
+		onList: func(callIndex int, criteria apptypes.EventListCriteria) {
+			if !criteria.To().Equal(snapshotTo) {
+				t.Fatalf("call %d criteria.To() = %v, want %v", callIndex, criteria.To(), snapshotTo)
+			}
+			wantOffset := callIndex * defaultTailBatchSize
+			if criteria.Offset() != wantOffset {
+				t.Fatalf("call %d criteria.Offset() = %d, want %d", callIndex, criteria.Offset(), wantOffset)
+			}
+		},
+	}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	events, err := sut.listTailEventsSince(
+		context.Background(),
+		apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(),
+		newTailCursor(cursorTime),
+		snapshotTo,
+	)
+	if err != nil {
+		t.Fatalf("listTailEventsSince() error = %v", err)
+	}
+	if len(events) != defaultTailBatchSize*2+1 {
+		t.Fatalf("len(events) = %d, want %d", len(events), defaultTailBatchSize*2+1)
+	}
+	if len(eventStub.listCalls) != 3 {
+		t.Fatalf("len(listCalls) = %d, want 3", len(eventStub.listCalls))
 	}
 }
 

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -87,17 +87,8 @@ func (t *fakeTailTicker) Stop()               {}
 func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 	t.Parallel()
 
-	originalNow := tailNowFunc
-	originalTicker := newTailTickerFn
-	defer func() {
-		tailNowFunc = originalNow
-		newTailTickerFn = originalTicker
-	}()
-
 	startTime := time.Date(2026, 4, 13, 19, 0, 0, 0, time.UTC)
-	tailNowFunc = func() time.Time { return startTime }
 	ticker := newFakeTailTicker()
-	newTailTickerFn = func(time.Duration) tailTicker { return ticker }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -134,12 +125,14 @@ func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
-			dbPath:    "/tmp/test-traceary.db",
-			limit:     2,
-			client:    "cli",
-			agent:     "codex",
-			sessionID: "session-1",
-			repo:      "duck8823/traceary",
+			dbPath:        "/tmp/test-traceary.db",
+			limit:         2,
+			client:        "cli",
+			agent:         "codex",
+			sessionID:     "session-1",
+			repo:          "duck8823/traceary",
+			nowFunc:       func() time.Time { return startTime },
+			tickerFactory: func(time.Duration) tailTicker { return ticker },
 		})
 	}()
 
@@ -162,17 +155,8 @@ func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 	t.Parallel()
 
-	originalNow := tailNowFunc
-	originalTicker := newTailTickerFn
-	defer func() {
-		tailNowFunc = originalNow
-		newTailTickerFn = originalTicker
-	}()
-
 	startTime := time.Date(2026, 4, 13, 19, 30, 0, 0, time.UTC)
-	tailNowFunc = func() time.Time { return startTime }
 	ticker := newFakeTailTicker()
-	newTailTickerFn = func(time.Duration) tailTicker { return ticker }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -201,9 +185,11 @@ func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
-			dbPath: "/tmp/test-traceary.db",
-			limit:  0,
-			repo:   "duck8823/traceary",
+			dbPath:        "/tmp/test-traceary.db",
+			limit:         0,
+			repo:          "duck8823/traceary",
+			nowFunc:       func() time.Time { return startTime },
+			tickerFactory: func(time.Duration) tailTicker { return ticker },
 		})
 	}()
 
@@ -224,18 +210,6 @@ func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
 	t.Parallel()
 
-	originalNow := tailNowFunc
-	originalTicker := newTailTickerFn
-	defer func() {
-		tailNowFunc = originalNow
-		newTailTickerFn = originalTicker
-	}()
-
-	tailNowFunc = func() time.Time {
-		return time.Date(2026, 4, 13, 20, 0, 0, 0, time.UTC)
-	}
-	newTailTickerFn = func(time.Duration) tailTicker { return newFakeTailTicker() }
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -255,10 +229,12 @@ func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
 	)
 
 	if err := sut.runTail(ctx, stdout, tailCommandInput{
-		dbPath: "/tmp/test-traceary.db",
-		limit:  1,
-		repo:   "duck8823/traceary",
-		asJSON: true,
+		dbPath:        "/tmp/test-traceary.db",
+		limit:         1,
+		repo:          "duck8823/traceary",
+		asJSON:        true,
+		nowFunc:       func() time.Time { return time.Date(2026, 4, 13, 20, 0, 0, 0, time.UTC) },
+		tickerFactory: func(time.Duration) tailTicker { return newFakeTailTicker() },
 	}); err != nil {
 		t.Fatalf("runTail() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- add `traceary tail` to follow new events from the local store
- stream tabular rows or NDJSON with the familiar event filters
- document how `tail` differs from `list`, `search`, and `handoff`

## Motivation
- operators need a live observation surface after the v0.5.0 memory rollout
- repeatedly rerunning `list` is clumsy when validating hooks and active session/workspace routing
- `tail` keeps the read side lightweight by staying on raw events instead of assembling working memory

## Verification
- go test ./...
- go build ./...
- go tool golangci-lint run
- python3 scripts/verify_docs_i18n.py

Closes #481
