### PR TITLE
fix: dedupe extracted memories after redaction changes

### DIFF
--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -77,13 +77,13 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 	}
 
 	scope := extractedMemoryScope(session)
-	existingKeys, err := u.loadExistingCandidateKeys(ctx, scope)
-	if err != nil {
-		return nil, err
-	}
 	extraRedactors, err := compileExtraRedactPatterns(u.extraRedactPatterns)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to compile extraction redaction patterns: %w", err)
+	}
+	existingKeys, err := u.loadExistingCandidateKeys(ctx, scope, extraRedactors)
+	if err != nil {
+		return nil, err
 	}
 
 	specs, err := u.collectCandidateSpecs(ctx, session, criteria.EventLimit())
@@ -156,7 +156,11 @@ func extractedMemoryScope(session apptypes.SessionSummary) domtypes.MemoryScope 
 	return domtypes.SessionFamilyScopeOf(session.SessionID())
 }
 
-func (u *memoryExtractionUsecase) loadExistingCandidateKeys(ctx context.Context, scope domtypes.MemoryScope) (map[string]struct{}, error) {
+func (u *memoryExtractionUsecase) loadExistingCandidateKeys(
+	ctx context.Context,
+	scope domtypes.MemoryScope,
+	extraRedactors []auditPayloadRedactor,
+) (map[string]struct{}, error) {
 	keys := make(map[string]struct{})
 	offset := 0
 	for {
@@ -175,7 +179,7 @@ func (u *memoryExtractionUsecase) loadExistingCandidateKeys(ctx context.Context,
 			return nil, xerrors.Errorf("failed to list existing memories for extraction dedupe: %w", err)
 		}
 		for _, summary := range summaries {
-			keys[memoryCandidateKey(summary.Scope(), summary.MemoryType(), summary.Fact())] = struct{}{}
+			keys[memoryCandidateKey(summary.Scope(), summary.MemoryType(), sanitizeCandidateFact(summary.Fact(), extraRedactors))] = struct{}{}
 		}
 		if len(summaries) < memoryExtractionDedupePageSize {
 			break

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -424,6 +424,80 @@ func TestMemoryExtractionUsecase_Extract_DeduplicatesSanitizedFacts(t *testing.T
 	}
 }
 
+func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingFactsAfterSanitization(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.Empty[time.Time](),
+		"ended",
+		4,
+		0,
+		[]string{"codex"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	promptEvent := mustExtractionEvent(
+		t,
+		"event-prompt",
+		domtypes.EventKindPrompt,
+		"Please keep password=secret-two out of generated examples.",
+	)
+
+	existingSummary, err := apptypes.MemorySummaryOf(
+		mustMemoryID(t, "memory-existing-sanitized"),
+		domtypes.MemoryTypePreference,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"Please keep password=secret-one out of generated examples.",
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceExtracted,
+		domtypes.Empty[domtypes.MemoryID](),
+		domtypes.Empty[time.Time](),
+		time.Now(),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{existingSummary},
+	}
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{
+			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+				domtypes.EventKindPrompt: {promptEvent},
+			},
+		},
+		memoryUsecase,
+		nil,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-1")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(5).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(Extract()) = %d, want 0", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+	}
+}
+
 func mustExtractionEvent(t *testing.T, eventID string, kind domtypes.EventKind, body string) *model.Event {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- sanitize existing durable-memory facts with the current redaction pipeline before extraction dedupe
- keep candidate extraction behavior unchanged while removing noisy duplicates after redaction-rule changes
- add regression coverage for historical raw facts that now collapse to the same sanitized candidate

Closes #474