### PR TITLE
feat: broaden artifact ref extraction

### DIFF
--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -21,7 +21,8 @@ var (
 	urlRefPattern              = regexp.MustCompile(`https?://[^\s)]+`)
 	issueRefPattern            = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
 	prRefPattern               = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
-	fileRefPattern             = regexp.MustCompile(`(?i)\b(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.(?:go|md|json|sh|sql|yaml|yml|toml)\b`)
+	bareFileRefPattern         = regexp.MustCompile(`(?i)\b[A-Za-z0-9_.-]+\.(?:[A-Za-z0-9_-]+\.)*(?:go|md|json|sh|sql|yaml|yml|toml|ts|tsx|js|jsx|py|rb|ini|cfg|conf|proto|tpl)\b`)
+	pathLikeRefPattern         = regexp.MustCompile(`(?:\./|\.\./|/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_-]+)*`)
 )
 
 const memoryExtractionDedupePageSize = 200
@@ -495,10 +496,12 @@ func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {
 		return nil
 	}
 
+	textWithoutURLs := text
 	for _, match := range urlRefPattern.FindAllString(text, -1) {
 		if err := appendRef(domtypes.ArtifactRefKindURL, match); err != nil {
 			return nil, xerrors.Errorf("failed to build URL artifact ref: %w", err)
 		}
+		textWithoutURLs = strings.ReplaceAll(textWithoutURLs, match, " ")
 	}
 	for _, matches := range issueRefPattern.FindAllStringSubmatch(text, -1) {
 		if len(matches) != 2 {
@@ -516,13 +519,63 @@ func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {
 			return nil, xerrors.Errorf("failed to build PR artifact ref: %w", err)
 		}
 	}
-	for _, match := range fileRefPattern.FindAllString(text, -1) {
+	textWithoutPaths := textWithoutURLs
+	for _, match := range pathLikeRefPattern.FindAllString(textWithoutURLs, -1) {
+		normalized := normalizeArtifactPathMatch(match)
+		if !looksPathLikeArtifact(normalized) {
+			continue
+		}
+		if err := appendRef(domtypes.ArtifactRefKindFile, normalized); err != nil {
+			return nil, xerrors.Errorf("failed to build file artifact ref: %w", err)
+		}
+		textWithoutPaths = strings.ReplaceAll(textWithoutPaths, match, " ")
+	}
+	for _, match := range bareFileRefPattern.FindAllString(textWithoutPaths, -1) {
 		if err := appendRef(domtypes.ArtifactRefKindFile, match); err != nil {
 			return nil, xerrors.Errorf("failed to build file artifact ref: %w", err)
 		}
 	}
 
 	return refs, nil
+}
+
+func normalizeArtifactPathMatch(value string) string {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.Trim(trimmed, "`'\"()[]{}<>,:;")
+	return trimmed
+}
+
+func looksPathLikeArtifact(value string) bool {
+	if value == "" {
+		return false
+	}
+	if !strings.Contains(value, "/") {
+		return false
+	}
+	if strings.Contains(value, "://") {
+		return false
+	}
+	hasLetter := false
+	for _, r := range value {
+		if ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') {
+			hasLetter = true
+			break
+		}
+	}
+	if !hasLetter {
+		return false
+	}
+	segments := strings.Split(value, "/")
+	if len(segments) < 2 {
+		return false
+	}
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func memoryCandidateKey(scope domtypes.MemoryScope, memoryType domtypes.MemoryType, fact string) string {

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -51,6 +51,28 @@ var extensionlessArtifactRootSegments = map[string]struct{}{
 	"tests":          {},
 }
 
+var artifactFileExtensions = map[string]struct{}{
+	"go":    {},
+	"md":    {},
+	"json":  {},
+	"sh":    {},
+	"sql":   {},
+	"yaml":  {},
+	"yml":   {},
+	"toml":  {},
+	"ts":    {},
+	"tsx":   {},
+	"js":    {},
+	"jsx":   {},
+	"py":    {},
+	"rb":    {},
+	"ini":   {},
+	"cfg":   {},
+	"conf":  {},
+	"proto": {},
+	"tpl":   {},
+}
+
 const memoryExtractionDedupePageSize = 200
 
 type memoryExtractionUsecase struct {
@@ -613,12 +635,21 @@ func looksPathLikeArtifact(value string) bool {
 		return false
 	}
 	if strings.Contains(lastMeaningful, ".") {
-		return true
+		return hasAllowedArtifactExtension(lastMeaningful)
 	}
 	if hasExplicitPrefix {
 		return true
 	}
 	_, ok := extensionlessArtifactRootSegments[strings.ToLower(firstMeaningful)]
+	return ok
+}
+
+func hasAllowedArtifactExtension(value string) bool {
+	lastDot := strings.LastIndex(value, ".")
+	if lastDot <= 0 || lastDot == len(value)-1 {
+		return false
+	}
+	_, ok := artifactFileExtensions[strings.ToLower(value[lastDot+1:])]
 	return ok
 }
 

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -25,6 +25,32 @@ var (
 	pathLikeRefPattern         = regexp.MustCompile(`(?:\./|\.\./|/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_-]+)*`)
 )
 
+var extensionlessArtifactRootSegments = map[string]struct{}{
+	".github":        {},
+	"application":    {},
+	"bin":            {},
+	"cmd":            {},
+	"config":         {},
+	"configs":        {},
+	"coverage":       {},
+	"dist":           {},
+	"docs":           {},
+	"domain":         {},
+	"fixtures":       {},
+	"formula":        {},
+	"infrastructure": {},
+	"integrations":   {},
+	"internal":       {},
+	"pkg":            {},
+	"plugins":        {},
+	"presentation":   {},
+	"schema":         {},
+	"scripts":        {},
+	"src":            {},
+	"test":           {},
+	"tests":          {},
+}
+
 const memoryExtractionDedupePageSize = 200
 
 type memoryExtractionUsecase struct {
@@ -556,6 +582,8 @@ func looksPathLikeArtifact(value string) bool {
 	if strings.Contains(value, "://") {
 		return false
 	}
+	hasExplicitPrefix := strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") || strings.HasPrefix(value, "/")
+
 	hasLetter := false
 	for _, r := range value {
 		if ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') {
@@ -570,13 +598,28 @@ func looksPathLikeArtifact(value string) bool {
 	if len(segments) < 2 {
 		return false
 	}
+	firstMeaningful := ""
+	lastMeaningful := ""
 	for _, segment := range segments {
 		if segment == "" || segment == "." || segment == ".." {
 			continue
 		}
+		if firstMeaningful == "" {
+			firstMeaningful = segment
+		}
+		lastMeaningful = segment
+	}
+	if firstMeaningful == "" || lastMeaningful == "" {
+		return false
+	}
+	if strings.Contains(lastMeaningful, ".") {
 		return true
 	}
-	return false
+	if hasExplicitPrefix {
+		return true
+	}
+	_, ok := extensionlessArtifactRootSegments[strings.ToLower(firstMeaningful)]
+	return ok
 }
 
 func memoryCandidateKey(scope domtypes.MemoryScope, memoryType domtypes.MemoryType, fact string) string {

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -541,7 +541,8 @@ func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {
 
 func normalizeArtifactPathMatch(value string) string {
 	trimmed := strings.TrimSpace(value)
-	trimmed = strings.Trim(trimmed, "`'\"()[]{}<>,:;")
+	trimmed = strings.TrimLeft(trimmed, "`'\"()[]{}<>,:;")
+	trimmed = strings.TrimRight(trimmed, "`'\"()[]{}<>,:;.!?")
 	return trimmed
 }
 

--- a/application/usecase/memory_extraction_usecase_internal_test.go
+++ b/application/usecase/memory_extraction_usecase_internal_test.go
@@ -53,6 +53,8 @@ func TestLooksPathLikeArtifact_RejectsDateLikePaths(t *testing.T) {
 		{name: "extensionless path", value: "bin/traceary", want: true},
 		{name: "extensionless docs path", value: "docs/release/README", want: true},
 		{name: "relative path", value: "./tmp/output", want: true},
+		{name: "version prose", value: "v1.2/v1.3", want: false},
+		{name: "generic source path", value: "foo/bar.go", want: true},
 	}
 
 	for _, tc := range cases {
@@ -67,7 +69,7 @@ func TestLooksPathLikeArtifact_RejectsDateLikePaths(t *testing.T) {
 func TestInferArtifactRefs_DoesNotTreatSlashSeparatedProseAsFiles(t *testing.T) {
 	t.Parallel()
 
-	refs, err := inferArtifactRefs("Refer to the pros/cons discussion, but keep docs/release/README and bin/traceary in sync.")
+	refs, err := inferArtifactRefs("Refer to the pros/cons discussion and compare v1.2/v1.3, but keep docs/release/README, bin/traceary, and foo/bar.go in sync.")
 	if err != nil {
 		t.Fatalf("inferArtifactRefs() error = %v", err)
 	}
@@ -80,6 +82,7 @@ func TestInferArtifactRefs_DoesNotTreatSlashSeparatedProseAsFiles(t *testing.T) 
 	want := []string{
 		"file:docs/release/README",
 		"file:bin/traceary",
+		"file:foo/bar.go",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("artifact refs mismatch (-want +got):\n%s", diff)

--- a/application/usecase/memory_extraction_usecase_internal_test.go
+++ b/application/usecase/memory_extraction_usecase_internal_test.go
@@ -12,7 +12,7 @@ func TestInferArtifactRefs_BroadensSupportedFilePatterns(t *testing.T) {
 	t.Parallel()
 
 	refs, err := inferArtifactRefs(
-		"Artifact: src/app.tsx scripts/check.py Formula/traceary.rb configs/release.yaml.tpl docs/release/README bin/traceary https://github.com/duck8823/traceary/blob/main/scripts/install.sh 2026/04/13",
+		"Artifact: src/app.tsx. scripts/check.py Formula/traceary.rb configs/release.yaml.tpl docs/release/README. bin/traceary https://github.com/duck8823/traceary/blob/main/scripts/install.sh 2026/04/13",
 	)
 	if err != nil {
 		t.Fatalf("inferArtifactRefs() error = %v", err)

--- a/application/usecase/memory_extraction_usecase_internal_test.go
+++ b/application/usecase/memory_extraction_usecase_internal_test.go
@@ -1,0 +1,76 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestInferArtifactRefs_BroadensSupportedFilePatterns(t *testing.T) {
+	t.Parallel()
+
+	refs, err := inferArtifactRefs(
+		"Artifact: src/app.tsx scripts/check.py Formula/traceary.rb configs/release.yaml.tpl docs/release/README bin/traceary https://github.com/duck8823/traceary/blob/main/scripts/install.sh 2026/04/13",
+	)
+	if err != nil {
+		t.Fatalf("inferArtifactRefs() error = %v", err)
+	}
+
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		got = append(got, ref.Kind().String()+":"+ref.Value())
+	}
+
+	want := []string{
+		"url:https://github.com/duck8823/traceary/blob/main/scripts/install.sh",
+		"file:src/app.tsx",
+		"file:scripts/check.py",
+		"file:Formula/traceary.rb",
+		"file:configs/release.yaml.tpl",
+		"file:docs/release/README",
+		"file:bin/traceary",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("artifact refs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLooksPathLikeArtifact_RejectsDateLikePaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "date like", value: "2026/04/13", want: false},
+		{name: "url path", value: "https://example.com/path", want: false},
+		{name: "source path", value: "src/app.tsx", want: true},
+		{name: "extensionless path", value: "bin/traceary", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksPathLikeArtifact(tc.value); got != tc.want {
+				t.Fatalf("looksPathLikeArtifact(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInferArtifactRefs_ProducesValidArtifactRefs(t *testing.T) {
+	t.Parallel()
+
+	refs, err := inferArtifactRefs("Artifact: scripts/check.py and docs/release/README")
+	if err != nil {
+		t.Fatalf("inferArtifactRefs() error = %v", err)
+	}
+
+	for _, ref := range refs {
+		if _, err := domtypes.ArtifactRefOf(ref.Kind(), ref.Value()); err != nil {
+			t.Fatalf("ArtifactRefOf(%s, %q) error = %v", ref.Kind(), ref.Value(), err)
+		}
+	}
+}

--- a/application/usecase/memory_extraction_usecase_internal_test.go
+++ b/application/usecase/memory_extraction_usecase_internal_test.go
@@ -47,8 +47,12 @@ func TestLooksPathLikeArtifact_RejectsDateLikePaths(t *testing.T) {
 	}{
 		{name: "date like", value: "2026/04/13", want: false},
 		{name: "url path", value: "https://example.com/path", want: false},
+		{name: "slash prose", value: "pros/cons", want: false},
+		{name: "slash prose short", value: "and/or", want: false},
 		{name: "source path", value: "src/app.tsx", want: true},
 		{name: "extensionless path", value: "bin/traceary", want: true},
+		{name: "extensionless docs path", value: "docs/release/README", want: true},
+		{name: "relative path", value: "./tmp/output", want: true},
 	}
 
 	for _, tc := range cases {
@@ -57,6 +61,28 @@ func TestLooksPathLikeArtifact_RejectsDateLikePaths(t *testing.T) {
 				t.Fatalf("looksPathLikeArtifact(%q) = %v, want %v", tc.value, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestInferArtifactRefs_DoesNotTreatSlashSeparatedProseAsFiles(t *testing.T) {
+	t.Parallel()
+
+	refs, err := inferArtifactRefs("Refer to the pros/cons discussion, but keep docs/release/README and bin/traceary in sync.")
+	if err != nil {
+		t.Fatalf("inferArtifactRefs() error = %v", err)
+	}
+
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		got = append(got, ref.Kind().String()+":"+ref.Value())
+	}
+
+	want := []string{
+		"file:docs/release/README",
+		"file:bin/traceary",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("artifact refs mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary

- broaden durable-memory candidate artifact extraction for additional source/config/test paths
- support extensionless but path-like references such as `docs/release/README` and `bin/traceary`
- avoid treating URL fragments or date-like paths as file artifact refs

Closes #473