### PR TITLE
fix: scan tail windows under a stable read snapshot

### DIFF
--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -13,6 +13,11 @@ import (
 type EventQueryService interface {
 	// ListRecent returns events in descending time order.
 	ListRecent(ctx context.Context, limit, offset int, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, failuresOnly bool, from, to time.Time) ([]*model.Event, error)
+	// ListWindow returns every event matching the criteria whose created_at
+	// falls in [From, To) under a single read snapshot so concurrent writers
+	// cannot cause the scan to drop events. Callers supply the batch size via
+	// criteria.Limit(); offset is ignored.
+	ListWindow(ctx context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error)
 	// Search performs full-text search across events.
 	Search(ctx context.Context, query string, workspace types.Workspace, sessionID types.SessionID, client types.Client, agent types.Agent, kind types.EventKind, from, to time.Time, limit, offset int, failuresOnly bool) ([]*model.Event, error)
 	// GetContext returns recent events for context retrieval.

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -22,6 +22,12 @@ type EventUsecase interface {
 	// List returns events in descending time order.
 	List(ctx context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error)
 
+	// ListWindow returns every event matching the criteria whose created_at
+	// falls in [From, To) under a single read snapshot, so concurrent writers
+	// cannot cause the paged scan to drop events. criteria.Limit() controls
+	// the per-page size for the internal scan; criteria.Offset() is ignored.
+	ListWindow(ctx context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error)
+
 	// Show returns the details for a single event.
 	Show(ctx context.Context, eventID types.EventID) (apptypes.EventDetails, error)
 

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -193,6 +193,21 @@ func (u *eventUsecase) List(ctx context.Context, criteria apptypes.EventListCrit
 	return events, nil
 }
 
+func (u *eventUsecase) ListWindow(ctx context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+
+	events, err := u.eventQuery.ListWindow(ctx, criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list event window: %w", err)
+	}
+	return events, nil
+}
+
 func (u *eventUsecase) Show(ctx context.Context, eventID types.EventID) (apptypes.EventDetails, error) {
 	details, err := u.eventQuery.GetDetails(ctx, eventID)
 	if err != nil {

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -197,6 +197,9 @@ func (u *eventUsecase) ListWindow(ctx context.Context, criteria apptypes.EventLi
 	if criteria.Limit() <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
 	}
+	if criteria.Offset() != 0 {
+		return nil, xerrors.Errorf("offset must be zero for ListWindow (paging is handled internally)")
+	}
 	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
 		return nil, xerrors.Errorf("from must be earlier than to")
 	}

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -164,6 +164,13 @@ func (s *eventQueryServiceStub) GetDetails(
 	return apptypes.EventDetails{}, nil
 }
 
+func (s *eventQueryServiceStub) ListWindow(
+	_ context.Context,
+	_ apptypes.EventListCriteria,
+) ([]*model.Event, error) {
+	return nil, nil
+}
+
 func (s *eventQueryServiceStub) ListTimelineBlocks(
 	_ context.Context,
 	_ types.Workspace,

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -41,7 +41,8 @@ var listTimelineBlocksQuery string
 // EventDatasource is the SQLite-backed implementation of the event
 // repository and event query service.
 type EventDatasource struct {
-	db *Database
+	db                *Database
+	onListWindowBatch func(batchIndex, batchSize int)
 }
 
 // NewEventDatasource creates a new EventDatasource bound to the given
@@ -249,6 +250,9 @@ func (d *EventDatasource) ListWindow(
 	if batch <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
 	}
+	if criteria.Offset() != 0 {
+		return nil, xerrors.Errorf("offset must be zero for ListWindow (paging is handled internally)")
+	}
 	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
 		return nil, xerrors.Errorf("from must be earlier than to")
 	}
@@ -332,6 +336,9 @@ func (d *EventDatasource) ListWindow(
 			slog.Debug("failed to close resource", "error", err)
 		}
 
+		if d.onListWindowBatch != nil {
+			d.onListWindowBatch(offset/batch, pageCount)
+		}
 		if pageCount < batch {
 			break
 		}

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -235,6 +235,112 @@ func (d *EventDatasource) ListRecent(
 	return events, nil
 }
 
+// ListWindow returns every event matching the criteria whose created_at falls
+// in [From, To). The entire paged scan runs inside a single read transaction
+// so SQLite snapshot isolation protects it from concurrent writers shifting
+// later pages — which would otherwise cause OFFSET-based pagination to drop
+// rows. Callers provide the per-page size via criteria.Limit(); offset is
+// ignored.
+func (d *EventDatasource) ListWindow(
+	ctx context.Context,
+	criteria apptypes.EventListCriteria,
+) ([]*model.Event, error) {
+	batch := criteria.Limit()
+	if batch <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event window listing: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin event window read transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	fromValue := ""
+	if !criteria.From().IsZero() {
+		fromValue = formatTimestamp(criteria.From())
+	}
+	toValue := ""
+	if !criteria.To().IsZero() {
+		toValue = formatTimestamp(criteria.To())
+	}
+
+	kind := criteria.Kind()
+	client := criteria.Client()
+	agent := criteria.Agent()
+	sessionID := criteria.SessionID()
+	workspace := criteria.Workspace()
+	failuresFlag := boolToInt(criteria.FailuresOnly())
+
+	events := make([]*model.Event, 0, batch)
+	offset := 0
+	for {
+		rows, err := tx.QueryContext(
+			ctx,
+			selectRecentEventsQuery,
+			kind.String(), kind.String(),
+			client.String(), client.String(),
+			agent.String(), agent.String(),
+			sessionID.String(), sessionID.String(),
+			workspace.String(), workspace.String(),
+			failuresFlag,
+			fromValue, fromValue,
+			toValue, toValue,
+			batch,
+			offset,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to query event window page: %w", err)
+		}
+
+		pageCount := 0
+		for rows.Next() {
+			event, err := scanEvent(rows)
+			if err != nil {
+				if closeErr := rows.Close(); closeErr != nil {
+					slog.Debug("failed to close resource", "error", closeErr)
+				}
+				return nil, xerrors.Errorf("failed to restore event window row: %w", err)
+			}
+			events = append(events, event)
+			pageCount++
+		}
+		if err := rows.Err(); err != nil {
+			if closeErr := rows.Close(); closeErr != nil {
+				slog.Debug("failed to close resource", "error", closeErr)
+			}
+			return nil, xerrors.Errorf("failed to iterate event window rows: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+
+		if pageCount < batch {
+			break
+		}
+		offset += pageCount
+	}
+
+	return events, nil
+}
+
 // Search returns matching events in descending time order.
 func (d *EventDatasource) Search(
 	ctx context.Context,

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -460,6 +460,11 @@ CREATE TABLE command_audits (
 		}
 	}
 
+	var batchSizes []int
+	sut.SetListWindowBatchHookForTest(func(_ int, batchSize int) {
+		batchSizes = append(batchSizes, batchSize)
+	})
+
 	criteria := apptypes.NewEventListCriteriaBuilder(100).
 		From(windowStart).
 		To(windowStart.Add(time.Duration(totalEvents+1) * time.Second)).
@@ -471,6 +476,10 @@ CREATE TABLE command_audits (
 	}
 	if len(got) != totalEvents {
 		t.Fatalf("len(events) = %d, want %d", len(got), totalEvents)
+	}
+	// 250 rows at batch=100 must fan out into three tx-internal reads: 100, 100, 50.
+	if diff := cmp.Diff([]int{100, 100, 50}, batchSizes); diff != "" {
+		t.Fatalf("batch size sequence mismatch (-want +got):\n%s", diff)
 	}
 	// DESC order: events[0] is newest.
 	if got[0].EventID().String() != "event-"+strconv.Itoa(totalEvents-1) {
@@ -486,6 +495,54 @@ CREATE TABLE command_audits (
 			t.Fatalf("duplicate event in window result: %s", id)
 		}
 		seen[id] = struct{}{}
+	}
+}
+
+func TestDatasource_ListWindow_RejectsNonZeroOffset(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_events_created_at
+    ON events(created_at DESC, id DESC);`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(10).Offset(5).Build()
+	if _, err := sut.ListWindow(context.Background(), criteria); err == nil {
+		t.Fatal("ListWindow() with non-zero offset returned nil error, want error")
 	}
 }
 

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -3,12 +3,14 @@ package sqlite_test
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"testing/fstest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
@@ -389,4 +391,171 @@ func newEventForSQLiteTest(
 		body,
 		createdAt,
 	)
+}
+
+func TestDatasource_ListWindow_ReturnsAllEventsAcrossBatches(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_events_created_at
+    ON events(created_at DESC, id DESC);`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	windowStart := time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC)
+	// Insert 250 events so the paged scan has to issue at least three batches
+	// when criteria.Limit() is 100. Before the ListWindow fix, the tail poller
+	// used OFFSET-based pagination across separate connections and would drop
+	// rows when a concurrent writer interleaved inserts between pages; this
+	// test guards the fixed, transaction-scoped loop against regressions in
+	// page assembly for large windows.
+	totalEvents := 250
+	for i := range totalEvents {
+		event := newEventForSQLiteTest(
+			t,
+			"event-"+strconv.Itoa(i),
+			"cli",
+			"codex",
+			"session-1",
+			"duck8823/traceary",
+			"body",
+			windowStart.Add(time.Duration(i)*time.Second),
+		)
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(event-%d) error = %v", i, err)
+		}
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(100).
+		From(windowStart).
+		To(windowStart.Add(time.Duration(totalEvents+1) * time.Second)).
+		Build()
+
+	got, err := sut.ListWindow(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListWindow() error = %v", err)
+	}
+	if len(got) != totalEvents {
+		t.Fatalf("len(events) = %d, want %d", len(got), totalEvents)
+	}
+	// DESC order: events[0] is newest.
+	if got[0].EventID().String() != "event-"+strconv.Itoa(totalEvents-1) {
+		t.Fatalf("got[0].EventID() = %q, want %q", got[0].EventID().String(), "event-"+strconv.Itoa(totalEvents-1))
+	}
+	if got[totalEvents-1].EventID().String() != "event-0" {
+		t.Fatalf("got[last].EventID() = %q, want event-0", got[totalEvents-1].EventID().String())
+	}
+	seen := make(map[string]struct{}, totalEvents)
+	for _, event := range got {
+		id := event.EventID().String()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate event in window result: %s", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestDatasource_ListWindow_RespectsToUpperBoundExclusive(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_events_created_at
+    ON events(created_at DESC, id DESC);`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC)
+	inside := newEventForSQLiteTest(t, "event-inside", "cli", "codex", "session-1", "ws", "in", base)
+	boundary := newEventForSQLiteTest(t, "event-boundary", "cli", "codex", "session-1", "ws", "edge", base.Add(5*time.Second))
+	if err := sut.Save(context.Background(), inside); err != nil {
+		t.Fatalf("Save(inside) error = %v", err)
+	}
+	if err := sut.Save(context.Background(), boundary); err != nil {
+		t.Fatalf("Save(boundary) error = %v", err)
+	}
+
+	// To is exclusive: an event whose created_at equals To must be excluded.
+	criteria := apptypes.NewEventListCriteriaBuilder(10).
+		From(base).
+		To(base.Add(5 * time.Second)).
+		Build()
+
+	got, err := sut.ListWindow(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListWindow() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(events) = %d, want 1 (boundary event must be excluded)", len(got))
+	}
+	if got[0].EventID().String() != "event-inside" {
+		t.Fatalf("got[0].EventID() = %q, want event-inside", got[0].EventID().String())
+	}
 }

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 )
 
+// SetListWindowBatchHookForTest installs a hook that fires once per internal
+// paged read performed by ListWindow. Tests use it to assert the scan loop
+// actually issues multiple batches rather than returning all rows in a single
+// query. Pass nil to clear.
+func (d *EventDatasource) SetListWindowBatchHookForTest(hook func(batchIndex, batchSize int)) {
+	d.onListWindowBatch = hook
+}
+
 // SaveSessionBoundaryForTest exposes saveSessionBoundary so tests can seed
 // the sessions table (insert + optional end update) without going through
 // SaveBoundary. SaveBoundary would also append a session_started or

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -284,7 +284,7 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 			return nil
 		case <-ticker.C():
 			pollSnapshotTo := input.resolvedNowFunc()().UTC()
-			newEvents, err := c.listTailEventsSince(ctx, baseCriteria.Build(), cursor, pollSnapshotTo)
+			newEvents, err := c.pollTailEvents(ctx, baseCriteria.Build(), cursor, pollSnapshotTo)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to poll tail events", "tail イベントのポーリングに失敗しました"), err)
 			}
@@ -299,46 +299,43 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 	}
 }
 
-func (c *RootCLI) listTailEventsSince(
+// pollTailEvents fetches every event in [cursor.timestamp, snapshotTo) via a
+// single ListWindow call so the paged scan runs under the query service's
+// stable read snapshot. Events already emitted at the From boundary are
+// filtered out via the cursor's seenIDs set, and the result is reversed into
+// oldest-first order for tail output.
+func (c *RootCLI) pollTailEvents(
 	ctx context.Context,
 	base apptypes.EventListCriteria,
 	cursor tailCursor,
 	snapshotTo time.Time,
 ) ([]*model.Event, error) {
-	filtered := make([]*model.Event, 0, defaultTailBatchSize)
-	offset := 0
 	if snapshotTo.IsZero() {
 		snapshotTo = time.Now().UTC()
 	}
 
-	for {
-		criteria := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).
-			Offset(offset).
-			Kind(base.Kind()).
-			Client(base.Client()).
-			Agent(base.Agent()).
-			SessionID(base.SessionID()).
-			Workspace(base.Workspace()).
-			FailuresOnly(base.FailuresOnly()).
-			From(cursor.timestamp).
-			To(snapshotTo).
-			Build()
+	criteria := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).
+		Kind(base.Kind()).
+		Client(base.Client()).
+		Agent(base.Agent()).
+		SessionID(base.SessionID()).
+		Workspace(base.Workspace()).
+		FailuresOnly(base.FailuresOnly()).
+		From(cursor.timestamp).
+		To(snapshotTo).
+		Build()
 
-		page, err := c.event.List(ctx, criteria)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to list tail page: %w", err)
-		}
-		for _, event := range page {
-			if cursor.isNew(event) {
-				filtered = append(filtered, event)
-			}
-		}
-		if len(page) < defaultTailBatchSize {
-			break
-		}
-		offset += len(page)
+	events, err := c.event.ListWindow(ctx, criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list tail window: %w", err)
 	}
 
+	filtered := make([]*model.Event, 0, len(events))
+	for _, event := range events {
+		if cursor.isNew(event) {
+			filtered = append(filtered, event)
+		}
+	}
 	slices.Reverse(filtered)
 	return filtered, nil
 }

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 type tailEventUsecaseStub struct {
-	listResponses [][]*model.Event
-	listErrs      []error
-	listCalls     []apptypes.EventListCriteria
-	onList        func(callIndex int, criteria apptypes.EventListCriteria)
+	listResponses       [][]*model.Event
+	listErrs            []error
+	listCalls           []apptypes.EventListCriteria
+	onList              func(callIndex int, criteria apptypes.EventListCriteria)
+	listWindowResponses [][]*model.Event
+	listWindowErrs      []error
+	listWindowCalls     []apptypes.EventListCriteria
+	onListWindow        func(callIndex int, criteria apptypes.EventListCriteria)
 }
 
 func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace) (*model.Event, error) {
@@ -42,6 +46,21 @@ func (s *tailEventUsecaseStub) List(_ context.Context, criteria apptypes.EventLi
 	}
 	if callIndex < len(s.listResponses) {
 		return s.listResponses[callIndex], nil
+	}
+	return nil, nil
+}
+
+func (s *tailEventUsecaseStub) ListWindow(_ context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
+	callIndex := len(s.listWindowCalls)
+	s.listWindowCalls = append(s.listWindowCalls, criteria)
+	if s.onListWindow != nil {
+		s.onListWindow(callIndex, criteria)
+	}
+	if callIndex < len(s.listWindowErrs) && s.listWindowErrs[callIndex] != nil {
+		return nil, s.listWindowErrs[callIndex]
+	}
+	if callIndex < len(s.listWindowResponses) {
+		return s.listWindowResponses[callIndex], nil
 	}
 	return nil, nil
 }
@@ -102,17 +121,19 @@ func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 	eventStub := &tailEventUsecaseStub{
 		listResponses: [][]*model.Event{
 			{initialNewer, initialOlder},
+		},
+		onList: func(callIndex int, _ apptypes.EventListCriteria) {
+			if callIndex == 0 {
+				close(firstListDone)
+			}
+		},
+		listWindowResponses: [][]*model.Event{
 			{followup, initialNewer},
 		},
-		onList: func(callIndex int, criteria apptypes.EventListCriteria) {
-			switch callIndex {
-			case 0:
-				close(firstListDone)
-			case 1:
-				cancel()
-				if got := criteria.From(); !got.Equal(initialNewer.CreatedAt()) {
-					t.Fatalf("criteria.From() = %v, want %v", got, initialNewer.CreatedAt())
-				}
+		onListWindow: func(_ int, criteria apptypes.EventListCriteria) {
+			cancel()
+			if got := criteria.From(); !got.Equal(initialNewer.CreatedAt()) {
+				t.Fatalf("criteria.From() = %v, want %v", got, initialNewer.CreatedAt())
 			}
 		},
 	}
@@ -167,10 +188,10 @@ func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 
 	firstPoll := make(chan struct{})
 	eventStub := &tailEventUsecaseStub{
-		listResponses: [][]*model.Event{
+		listWindowResponses: [][]*model.Event{
 			{newer, older},
 		},
-		onList: func(callIndex int, _ apptypes.EventListCriteria) {
+		onListWindow: func(callIndex int, _ apptypes.EventListCriteria) {
 			if callIndex == 0 {
 				close(firstPoll)
 				cancel()
@@ -246,7 +267,7 @@ func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
 	}
 }
 
-func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
+func TestPollTailEvents_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	t.Parallel()
 
 	timestamp := time.Date(2026, 4, 13, 18, 5, 0, 0, time.UTC)
@@ -254,7 +275,7 @@ func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	fresh := mustTailEvent(t, "event-fresh", "cli", "codex", "session-1", "duck8823/traceary", "fresh", timestamp)
 
 	eventStub := &tailEventUsecaseStub{
-		listResponses: [][]*model.Event{
+		listWindowResponses: [][]*model.Event{
 			{fresh, seen},
 		},
 	}
@@ -266,14 +287,14 @@ func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	cursor := newTailCursor(timestamp)
 	cursor.seenIDs[seen.EventID().String()] = struct{}{}
 
-	events, err := sut.listTailEventsSince(
+	events, err := sut.pollTailEvents(
 		context.Background(),
 		apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(),
 		cursor,
 		timestamp.Add(time.Minute),
 	)
 	if err != nil {
-		t.Fatalf("listTailEventsSince() error = %v", err)
+		t.Fatalf("pollTailEvents() error = %v", err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("len(events) = %d, want 1", len(events))
@@ -283,49 +304,40 @@ func TestListTailEventsSince_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	}
 }
 
-func TestListTailEventsSince_UsesStableSnapshotAcrossPages(t *testing.T) {
+func TestPollTailEvents_DelegatesPagingToWindowQuery(t *testing.T) {
 	t.Parallel()
 
 	cursorTime := time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC)
 	snapshotTo := time.Date(2026, 4, 13, 18, 10, 0, 0, time.UTC)
 
-	firstPage := make([]*model.Event, 0, defaultTailBatchSize)
-	secondPage := make([]*model.Event, 0, defaultTailBatchSize)
-	for i := range defaultTailBatchSize {
-		firstPage = append(firstPage, mustTailEvent(
+	// ListWindow now returns the whole window in a single call. Feeding it a
+	// multi-batch-sized payload verifies tail.go no longer performs its own
+	// offset pagination and simply trusts the query service's stable snapshot.
+	events := make([]*model.Event, 0, defaultTailBatchSize*2+1)
+	for i := range defaultTailBatchSize*2 + 1 {
+		events = append(events, mustTailEvent(
 			t,
-			"event-first-"+strconv.Itoa(i),
+			"event-"+strconv.Itoa(i),
 			"cli",
 			"codex",
 			"session-1",
 			"duck8823/traceary",
-			"first",
-			cursorTime.Add(time.Duration(defaultTailBatchSize-i)*time.Second),
+			"body",
+			cursorTime.Add(time.Duration(i+1)*time.Second),
 		))
-		secondPage = append(secondPage, mustTailEvent(
-			t,
-			"event-second-"+strconv.Itoa(i),
-			"cli",
-			"codex",
-			"session-1",
-			"duck8823/traceary",
-			"second",
-			cursorTime.Add(time.Duration(defaultTailBatchSize*2-i)*time.Second),
-		))
-	}
-	lastPage := []*model.Event{
-		mustTailEvent(t, "event-last", "cli", "codex", "session-1", "duck8823/traceary", "last", cursorTime.Add(5*time.Minute)),
 	}
 
 	eventStub := &tailEventUsecaseStub{
-		listResponses: [][]*model.Event{firstPage, secondPage, lastPage},
-		onList: func(callIndex int, criteria apptypes.EventListCriteria) {
+		listWindowResponses: [][]*model.Event{events},
+		onListWindow: func(_ int, criteria apptypes.EventListCriteria) {
 			if !criteria.To().Equal(snapshotTo) {
-				t.Fatalf("call %d criteria.To() = %v, want %v", callIndex, criteria.To(), snapshotTo)
+				t.Fatalf("criteria.To() = %v, want %v", criteria.To(), snapshotTo)
 			}
-			wantOffset := callIndex * defaultTailBatchSize
-			if criteria.Offset() != wantOffset {
-				t.Fatalf("call %d criteria.Offset() = %d, want %d", callIndex, criteria.Offset(), wantOffset)
+			if !criteria.From().Equal(cursorTime) {
+				t.Fatalf("criteria.From() = %v, want %v", criteria.From(), cursorTime)
+			}
+			if criteria.Offset() != 0 {
+				t.Fatalf("criteria.Offset() = %d, want 0", criteria.Offset())
 			}
 		},
 	}
@@ -334,20 +346,20 @@ func TestListTailEventsSince_UsesStableSnapshotAcrossPages(t *testing.T) {
 		WithEvent(eventStub),
 	)
 
-	events, err := sut.listTailEventsSince(
+	got, err := sut.pollTailEvents(
 		context.Background(),
 		apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build(),
 		newTailCursor(cursorTime),
 		snapshotTo,
 	)
 	if err != nil {
-		t.Fatalf("listTailEventsSince() error = %v", err)
+		t.Fatalf("pollTailEvents() error = %v", err)
 	}
-	if len(events) != defaultTailBatchSize*2+1 {
-		t.Fatalf("len(events) = %d, want %d", len(events), defaultTailBatchSize*2+1)
+	if len(got) != len(events) {
+		t.Fatalf("len(got) = %d, want %d", len(got), len(events))
 	}
-	if len(eventStub.listCalls) != 3 {
-		t.Fatalf("len(listCalls) = %d, want 3", len(eventStub.listCalls))
+	if len(eventStub.listWindowCalls) != 1 {
+		t.Fatalf("len(listWindowCalls) = %d, want 1", len(eventStub.listWindowCalls))
 	}
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -40,6 +40,9 @@ func (s *eventUsecaseStub) Search(_ context.Context, _ apptypes.EventSearchCrite
 func (s *eventUsecaseStub) List(_ context.Context, _ apptypes.EventListCriteria) ([]*model.Event, error) {
 	return s.listEvents, s.listErr
 }
+func (s *eventUsecaseStub) ListWindow(_ context.Context, _ apptypes.EventListCriteria) ([]*model.Event, error) {
+	return s.listEvents, s.listErr
+}
 func (s *eventUsecaseStub) Show(_ context.Context, _ types.EventID) (apptypes.EventDetails, error) {
 	return s.showDetails, s.showErr
 }


### PR DESCRIPTION
## Summary

- Fix Codex-reported data-loss bug: `traceary tail` follow mode was paginating its poll window with OFFSET across independent queries, allowing a concurrent writer to shift later pages and cause silently dropped events.
- New `EventQueryService.ListWindow` runs the paged scan inside a single SQLite read transaction so snapshot isolation keeps the page sequence stable.
- Exposes the method on `EventUsecase` and collapses `presentation/cli/tail.go`'s former `listTailEventsSince` loop into one `ListWindow` call, also moving the paging orchestration out of the CLI layer.

## Test plan

- [x] \`go test ./...\`
- [x] \`go tool golangci-lint run\`
- [x] New \`TestDatasource_ListWindow_ReturnsAllEventsAcrossBatches\` verifies a 250-event scan returns every row in order with no duplicates across three internal batches.
- [x] New \`TestDatasource_ListWindow_RespectsToUpperBoundExclusive\` guards the \`To\` boundary contract.
- [x] Updated \`TestPollTailEvents_*\` confirm the CLI layer issues one \`ListWindow\` call per poll.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)