### PR TITLE
test: cover custom redact pattern in memory dedupe test

### DIFF
--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -460,12 +460,19 @@ func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingFactsAfterSanitizat
 			// This sub-case exercises the core guarantee of the dedupe fix:
 			// two facts whose raw values differ must collapse to the same key
 			// *after* a caller-supplied redaction pattern normalizes them.
-			// `internalCode=...` is outside the built-in redactor set, so the
-			// custom pattern is the only thing that can make these equal.
+			// Both facts start with "Please" so inferMemoryTypeFromText
+			// actually produces a MemoryTypePreference candidate — an earlier
+			// iteration used "Remember ..." which matches no heuristic
+			// prefix, making the extractor emit nothing and the test pass
+			// for the wrong reason (caught by the Codex verifier). The
+			// `internalCode=` token is outside the built-in redactor
+			// alternation (password|secret|token|...), so only the
+			// caller-supplied pattern below can normalize the two values to
+			// the same key.
 			name:                "custom extra redact pattern",
 			extraRedactPatterns: []string{`internalCode=\S+`},
-			existingFact:        "Remember the deploy secret internalCode=alpha-one for next release.",
-			promptFact:          "Remember the deploy secret internalCode=beta-two for next release.",
+			existingFact:        "Please keep internalCode=alpha-one out of rendered templates.",
+			promptFact:          "Please keep internalCode=beta-two out of rendered templates.",
 		},
 	}
 

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -440,61 +440,96 @@ func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingFactsAfterSanitizat
 		"",
 		domtypes.SessionID(""),
 	)
-	promptEvent := mustExtractionEvent(
-		t,
-		"event-prompt",
-		domtypes.EventKindPrompt,
-		"Please keep password=secret-two out of generated examples.",
-	)
 
-	existingSummary, err := apptypes.MemorySummaryOf(
-		mustMemoryID(t, "memory-existing-sanitized"),
-		domtypes.MemoryTypePreference,
-		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
-		"Please keep password=secret-one out of generated examples.",
-		domtypes.MemoryStatusCandidate,
-		domtypes.ConfidenceVerified,
-		domtypes.MemorySourceExtracted,
-		domtypes.Empty[domtypes.MemoryID](),
-		domtypes.Empty[time.Time](),
-		time.Now(),
-		time.Now(),
-	)
-	if err != nil {
-		t.Fatalf("MemorySummaryOf() error = %v", err)
-	}
-
-	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
-		listResult: []apptypes.MemorySummary{existingSummary},
-	}
-	sut := usecase.NewMemoryExtractionUsecase(
-		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
-		&eventQueryServiceStub{
-			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
-				domtypes.EventKindPrompt: {promptEvent},
-			},
+	testCases := []struct {
+		name                string
+		extraRedactPatterns []string
+		existingFact        string
+		promptFact          string
+	}{
+		{
+			// Built-in redactors already catch `password=<value>`, so this
+			// sub-case exercises the dedupe path driven by the default
+			// sanitizer — the original coverage.
+			name:                "built-in password redactor",
+			extraRedactPatterns: nil,
+			existingFact:        "Please keep password=secret-one out of generated examples.",
+			promptFact:          "Please keep password=secret-two out of generated examples.",
 		},
-		memoryUsecase,
-		nil,
-	)
+		{
+			// This sub-case exercises the core guarantee of the dedupe fix:
+			// two facts whose raw values differ must collapse to the same key
+			// *after* a caller-supplied redaction pattern normalizes them.
+			// `internalCode=...` is outside the built-in redactor set, so the
+			// custom pattern is the only thing that can make these equal.
+			name:                "custom extra redact pattern",
+			extraRedactPatterns: []string{`internalCode=\S+`},
+			existingFact:        "Remember the deploy secret internalCode=alpha-one for next release.",
+			promptFact:          "Remember the deploy secret internalCode=beta-two for next release.",
+		},
+	}
 
-	got, err := sut.Extract(
-		context.Background(),
-		apptypes.NewMemoryExtractionCriteriaBuilder().
-			SessionID(domtypes.SessionID("session-1")).
-			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
-			EventLimit(5).
-			CandidateLimit(10).
-			Build(),
-	)
-	if err != nil {
-		t.Fatalf("Extract() error = %v", err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("len(Extract()) = %d, want 0", len(got))
-	}
-	if len(memoryUsecase.proposeCalls) != 0 {
-		t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			promptEvent := mustExtractionEvent(
+				t,
+				"event-prompt",
+				domtypes.EventKindPrompt,
+				tc.promptFact,
+			)
+
+			existingSummary, err := apptypes.MemorySummaryOf(
+				mustMemoryID(t, "memory-existing-sanitized"),
+				domtypes.MemoryTypePreference,
+				domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+				tc.existingFact,
+				domtypes.MemoryStatusCandidate,
+				domtypes.ConfidenceVerified,
+				domtypes.MemorySourceExtracted,
+				domtypes.Empty[domtypes.MemoryID](),
+				domtypes.Empty[time.Time](),
+				time.Now(),
+				time.Now(),
+			)
+			if err != nil {
+				t.Fatalf("MemorySummaryOf() error = %v", err)
+			}
+
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+				listResult: []apptypes.MemorySummary{existingSummary},
+			}
+			sut := usecase.NewMemoryExtractionUsecase(
+				&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+				&eventQueryServiceStub{
+					listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+						domtypes.EventKindPrompt: {promptEvent},
+					},
+				},
+				memoryUsecase,
+				tc.extraRedactPatterns,
+			)
+
+			got, err := sut.Extract(
+				context.Background(),
+				apptypes.NewMemoryExtractionCriteriaBuilder().
+					SessionID(domtypes.SessionID("session-1")).
+					Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+					EventLimit(5).
+					CandidateLimit(10).
+					Build(),
+			)
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("len(Extract()) = %d, want 0", len(got))
+			}
+			if len(memoryUsecase.proposeCalls) != 0 {
+				t.Fatalf("Propose() call count = %d, want 0", len(memoryUsecase.proposeCalls))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Strengthen \`TestMemoryExtractionUsecase_Extract_DeduplicatesExistingFactsAfterSanitization\` so it actually exercises the core guarantee of the v0.5.1 dedupe fix (#474 / 421b2181e): that two facts whose raw values differ collapse to the same key *after* a caller-supplied redaction pattern normalizes them.

Previously the test passed \`extraRedactPatterns=nil\`, so it only verified the dedupe path driven by built-in redactors.

## Test plan

- [x] Table-driven restructure with two sub-cases (built-in + custom).
- [x] Custom sub-case uses \`internalCode=\\S+\` — outside the built-in redactor set, so the custom pattern is the only thing that can make the two facts collide after sanitization.
- [x] \`go test ./...\`
- [x] \`go tool golangci-lint run\`

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)