### PR TITLE
test: guard tail boundary dedupe at From==cursor.timestamp

### DIFF
--- a/application/types/event_list_criteria.go
+++ b/application/types/event_list_criteria.go
@@ -8,6 +8,13 @@ import (
 
 // EventListCriteria holds filter parameters for event listing.
 // Zero-value fields are ignored (no filter applied).
+//
+// Time range semantics (documented here so callers can reason about cursor
+// advancement without reading the SQL): From is inclusive and To is
+// exclusive. i.e. events with created_at == From are returned, events with
+// created_at == To are not. Tail-style cursors that poll repeatedly with
+// From set to the last seen timestamp must therefore dedupe returned
+// events against an already-seen set at the boundary.
 type EventListCriteria struct {
 	limit        int
 	offset       int

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -616,3 +616,79 @@ CREATE TABLE command_audits (
 		t.Fatalf("got[0].EventID() = %q, want event-inside", got[0].EventID().String())
 	}
 }
+
+func TestDatasource_ListWindow_RespectsFromLowerBoundInclusive(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_events_created_at
+    ON events(created_at DESC, id DESC);`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	// This test pins the `From` inclusivity contract at the query layer so a
+	// future refactor that flips it to exclusive is caught here, not by
+	// deprecation in tail.go's cursor-based dedupe. Three events: one before
+	// From (must be excluded), one exactly at From (must be INcluded), one
+	// strictly after (must be included).
+	boundary := time.Date(2026, 4, 13, 18, 0, 0, 0, time.UTC)
+	before := newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "ws", "before", boundary.Add(-time.Second))
+	at := newEventForSQLiteTest(t, "event-at-boundary", "cli", "codex", "session-1", "ws", "at", boundary)
+	after := newEventForSQLiteTest(t, "event-after", "cli", "codex", "session-1", "ws", "after", boundary.Add(time.Second))
+	for _, event := range []*model.Event{before, at, after} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID().String(), err)
+		}
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(10).
+		From(boundary).
+		To(boundary.Add(10 * time.Second)).
+		Build()
+
+	got, err := sut.ListWindow(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListWindow() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(events) = %d, want 2 (From must include boundary, exclude before)", len(got))
+	}
+	// DESC order: got[0] = after, got[1] = at
+	if got[0].EventID().String() != "event-after" || got[1].EventID().String() != "event-at-boundary" {
+		t.Fatalf("got = %q/%q, want event-after/event-at-boundary", got[0].EventID(), got[1].EventID())
+	}
+}

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -267,6 +267,85 @@ func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
 	}
 }
 
+func TestRunTail_DoesNotReEmitBoundaryEventWhenFromEqualsInitialTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// Regression for #491: EventListCriteria.From() is inclusive, so the
+	// follow-mode poll that runs after the initial fetch re-queries the same
+	// timestamp as the last initial event. The tail cursor must rely on its
+	// seenIDs set to drop that boundary event; otherwise the event gets
+	// re-emitted every tick. This test forces that exact scenario end-to-end
+	// through runTail, not just pollTailEvents in isolation, so a future
+	// refactor that drops the seenIDs filter or flips From to exclusive on
+	// one side of the stack is still caught.
+
+	startTime := time.Date(2026, 4, 13, 19, 0, 0, 0, time.UTC)
+	boundaryTime := time.Date(2026, 4, 13, 18, 5, 0, 0, time.UTC)
+	ticker := newFakeTailTicker()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialEvent := mustTailEvent(t, "event-boundary", "cli", "codex", "session-1", "duck8823/traceary", "boundary", boundaryTime)
+
+	firstListDone := make(chan struct{})
+	eventStub := &tailEventUsecaseStub{
+		listResponses: [][]*model.Event{
+			{initialEvent},
+		},
+		onList: func(callIndex int, _ apptypes.EventListCriteria) {
+			if callIndex == 0 {
+				close(firstListDone)
+			}
+		},
+		// Simulate the query service honouring From() inclusively: it returns
+		// the very same initialEvent plus a nothing-else payload, mirroring
+		// what a real backend would yield when From==boundaryTime.
+		listWindowResponses: [][]*model.Event{
+			{initialEvent},
+		},
+		onListWindow: func(_ int, criteria apptypes.EventListCriteria) {
+			cancel()
+			if got := criteria.From(); !got.Equal(boundaryTime) {
+				t.Fatalf("criteria.From() = %v, want %v", got, boundaryTime)
+			}
+		},
+	}
+
+	stdout := &bytes.Buffer{}
+	sut := NewRootCLI(
+		WithStoreManagement(tailStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+			dbPath:        "/tmp/test-traceary.db",
+			limit:         1,
+			client:        "cli",
+			agent:         "codex",
+			sessionID:     "session-1",
+			repo:          "duck8823/traceary",
+			nowFunc:       func() time.Time { return startTime },
+			tickerFactory: func(time.Duration) tailTicker { return ticker },
+		})
+	}()
+
+	<-firstListDone
+	ticker.ch <- time.Now()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("runTail() error = %v", err)
+	}
+
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
+		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tboundary\n"
+	if stdout.String() != want {
+		t.Fatalf("stdout = %q, want %q (event must appear exactly once despite From()==cursor.timestamp)", stdout.String(), want)
+	}
+}
+
 func TestPollTailEvents_DeduplicatesSeenIDsAtSameTimestamp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Add \`TestRunTail_DoesNotReEmitBoundaryEventWhenFromEqualsInitialTimestamp\` — an end-to-end \`runTail\` regression for #491. The scenario: initial fetch returns a single event at time T, follow poll uses \`From=T\`. Because \`EventListCriteria.From\` is inclusive, the query service re-returns the same event, and only the cursor's \`seenIDs\` dedupe keeps it from being emitted twice per tick.

Also lifts the From/To inclusivity contract into \`EventListCriteria\`'s struct-level doc comment.

## Stacking

Based on \`fix/tail-pagination-snapshot-consistency\` (PR #492) because the new test exercises \`runTail\` + \`pollTailEvents\`, which that PR introduces. Merge #492 first.

## Test plan

- [x] \`go test ./...\` — new test PASS
- [x] \`go tool golangci-lint run\` — 0 issues

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)