### PR TITLE
docs: refresh storage and interactive guides

### DIFF
--- a/docs/interactive/README.ja.md
+++ b/docs/interactive/README.ja.md
@@ -2,14 +2,70 @@
 
 [English](./README.md)
 
-この文書は、Traceary を対話的に使うときの使い勝手を整理するためのメモです。
-`v0.1.9` で直接改善したものと、あえて後続リリースに回したものを分けて記録します。
+この文書では、現在の Traceary CLI を使って対話的に履歴を確認する方法を整理します。
+書き込みの自動化よりも、人が参照系コマンドをどう使い分けるかに焦点を当てています。
 
-## `v0.1.9` で入れたもの
+## 最近変わったこと
 
-### Shell completion
+現在の Traceary には、インタラクティブ利用を支える基本機能として次の 2 つがあります。
 
-Traceary は built-in の completion generator を持つようになりました。
+- shell completion
+- `traceary tail` による live follow
+
+そのため、参照系は `list` や `search` のような単発の snapshot だけではありません。
+
+## いまの推奨フロー
+
+確認したい内容に応じて、次のように使い分けるのがおすすめです。
+
+### 1. 「今なにが起きたか」をざっと見たい → `traceary list`
+
+最近の履歴を素早く見たいときや、workspace / client などの構造 filter がすでに決まっているときは `list` を使います。
+
+```sh
+traceary list --limit 20
+traceary list --workspace github.com/duck8823/traceary --client codex
+```
+
+### 2. 「今まさに書き込まれているか」を追いたい → `traceary tail`
+
+新しい event が入る様子をリアルタイムで追いたいときは `tail` を使います。hook が発火しているか、想定した workspace に書き込まれているか、失敗 event が流れてきているかを確認するのに向いています。
+
+```sh
+traceary tail
+traceary tail --workspace github.com/duck8823/traceary --failures
+traceary tail --json
+```
+
+### 3. 「特定のエラーやコマンドを探したい」 → `traceary search`
+
+テキスト検索と期間・workspace 条件を組み合わせたいときは `search` を使います。
+
+```sh
+traceary search panic --workspace github.com/duck8823/traceary
+traceary search --since 2026-04-01 --kind command_executed lint
+```
+
+### 4. 「構造化された詳細を見たい」 → `traceary show`
+
+event ID が分かっていて、対応する event や audit payload を構造化して見たいときは `show` を使います。
+
+```sh
+traceary show evt_123 --json
+```
+
+### 5. 「次に持ち越す文脈だけをまとめたい」 → `traceary handoff`
+
+生の event stream ではなく、再開や引き継ぎに使う working-memory pack を見たいときは `handoff` を使います。別エージェントへ渡す前提の要約を見るなら、まずここです。
+
+```sh
+traceary handoff --workspace github.com/duck8823/traceary
+traceary session handoff --session-id sess_123 --json
+```
+
+## Shell completion
+
+Traceary には built-in の completion generator があります。
 
 ```sh
 traceary completion bash
@@ -18,30 +74,18 @@ traceary completion fish
 traceary completion powershell
 ```
 
-これは、event model や read-path semantics を増やしすぎずに、日常の interactive 利用を改善できる最小の変更です。
+`tail` が入った後でも、CLI 全体の発見しやすさを上げる意味で completion を有効にする価値はあります。
 
-## まだ後続送りにしているもの
+## 今後の改善候補
 
-次の案は有効ですが、`v0.1.9` には含めていません。
+初期の `v0.1.x` より interactive 利用はだいぶ良くなりましたが、次の改善余地はまだあります。
 
-- `tail` / `watch` 的な live follow view
 - `show` / `context` の人間向け整形強化
 - pager-aware な output flow
 - `list` / `search` の上に乗る、より opinionated な interactive filter
-
-これらは小さな `v0.1.x` polish というより、`v0.2` の UX pass に近いと判断しています。
-
-## 現時点の推奨
-
-より豊かな interactive mode が入るまでは、次の使い分けを推奨します。
-
-1. 最近の feed は `traceary list --limit ... --offset ...`
-2. 条件付き lookup は `traceary search ... --json`
-3. 構造化された詳細確認は `traceary show <event-id> --json`
-4. command discovery は shell completion を有効化して補う
 
 ## 関連文書
 
 - CLI reference: [`../cli/README.ja.md`](../cli/README.ja.md)
 - MCP guide: [`../mcp/README.ja.md`](../mcp/README.ja.md)
-
+- イベントライフサイクル: [`../lifecycle.ja.md`](../lifecycle.ja.md)

--- a/docs/interactive/README.ja.md
+++ b/docs/interactive/README.ja.md
@@ -60,7 +60,7 @@ traceary show evt_123 --json
 
 ```sh
 traceary handoff --workspace github.com/duck8823/traceary
-traceary session handoff --session-id sess_123 --json
+traceary session handoff --session-id sess_123
 ```
 
 ## Shell completion

--- a/docs/interactive/README.md
+++ b/docs/interactive/README.md
@@ -62,7 +62,7 @@ This is the operator-facing summary view for resuming work or handing context to
 
 ```sh
 traceary handoff --workspace github.com/duck8823/traceary
-traceary session handoff --session-id sess_123 --json
+traceary session handoff --session-id sess_123
 ```
 
 ## Shell completion

--- a/docs/interactive/README.md
+++ b/docs/interactive/README.md
@@ -2,14 +2,72 @@
 
 [日本語](./README.ja.md)
 
-This note tracks the current state of Traceary's interactive inspection UX.
-It records what `v0.1.9` improved directly and what remains intentionally deferred to a later release line.
+This note explains how to inspect Traceary interactively with the CLI that ships today.
+It focuses on read-side workflows for humans rather than on the write-side hook automation.
 
-## Landed in `v0.1.9`
+## What changed recently
 
-### Shell completion
+Traceary now ships two baseline interactive conveniences:
 
-Traceary now exposes a built-in completion generator:
+- shell completion
+- `traceary tail` for live-follow inspection
+
+That means the interactive read path is no longer limited to one-shot snapshots such as `list` and `search`.
+
+## Recommended interactive workflow
+
+Use the commands below according to the question you are trying to answer.
+
+### 1. "What just happened?" → `traceary list`
+
+Use `list` when you want a quick recent feed and already know the structured filters you care about.
+
+```sh
+traceary list --limit 20
+traceary list --workspace github.com/duck8823/traceary --client codex
+```
+
+### 2. "Is the system writing events right now?" → `traceary tail`
+
+Use `tail` when you want to watch new events arrive in real time.
+This is the best command for confirming that hooks are firing, that the expected workspace is receiving writes, or that failures are visible as they happen.
+
+```sh
+traceary tail
+traceary tail --workspace github.com/duck8823/traceary --failures
+traceary tail --json
+```
+
+### 3. "Find a specific error / command / note" → `traceary search`
+
+Use `search` for text lookup combined with time or workspace filters.
+
+```sh
+traceary search panic --workspace github.com/duck8823/traceary
+traceary search --since 2026-04-01 --kind command_executed lint
+```
+
+### 4. "Show me the full structured record" → `traceary show`
+
+Use `show` when you already have an event ID and want the structured event or audit payload.
+
+```sh
+traceary show evt_123 --json
+```
+
+### 5. "What context should I carry into the next session?" → `traceary handoff`
+
+Use `handoff` when you want a concise working-memory pack instead of the raw event stream.
+This is the operator-facing summary view for resuming work or handing context to another agent.
+
+```sh
+traceary handoff --workspace github.com/duck8823/traceary
+traceary session handoff --session-id sess_123 --json
+```
+
+## Shell completion
+
+Traceary exposes a built-in completion generator:
 
 ```sh
 traceary completion bash
@@ -18,30 +76,18 @@ traceary completion fish
 traceary completion powershell
 ```
 
-This is the smallest practical improvement that helps daily interactive use without changing the event model or read-path semantics.
+Completion is still worth enabling even after `tail` landed, because it reduces command discovery friction for the broader CLI surface.
 
-## Still deferred
+## Still future-facing
 
-The following ideas remain valid, but they are intentionally not part of `v0.1.9`:
+Interactive work is better than it was in early `v0.1.x`, but some improvements still belong to future UX passes:
 
-- `tail` / `watch` style live-follow views
 - richer human-readable formatting for `show` / `context`
 - pager-aware output flows
 - more opinionated interactive filters layered on top of `list` / `search`
-
-These are closer to a `v0.2` UX pass than to a small `v0.1.x` polish change.
-
-## Current recommendation
-
-Until a richer interactive mode lands:
-
-1. use `traceary list --limit ... --offset ...` for a recent feed
-2. use `traceary search ... --json` for filtered lookup
-3. use `traceary show <event-id> --json` when you need structured detail
-4. enable shell completion so command discovery does not depend only on memory
 
 ## Related docs
 
 - CLI reference: [`../cli/README.md`](../cli/README.md)
 - MCP guide: [`../mcp/README.md`](../mcp/README.md)
-
+- Event lifecycle: [`../lifecycle.md`](../lifecycle.md)

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -37,7 +37,7 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
-- `idx_events_workspace_created_at` on `(workspace, created_at DESC, id DESC)`
+- `idx_events_workspace_created_at` on `(workspace, created_at)`
 
 ### `command_audits`
 
@@ -74,7 +74,7 @@ start/end event から導かれ、session 系コマンドでも更新される s
 主な index:
 
 - `idx_sessions_started_at`
-- `idx_sessions_workspace_started_at`
+- `idx_sessions_repo_started_at`
 - `idx_sessions_parent`
 
 ### `memories`

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -3,9 +3,9 @@
 [English](./README.md)
 
 Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存します。
-このガイドでは、何がどこに保存されるのか、schema がどう構成されているのか、現在の `gc` / backup の既定動作が何かを説明します。
+このガイドでは、何がどこに保存されるのか、現在の schema がどう構成されているのか、`gc` / backup の既定動作が実際に何を意味するのかを整理します。
 
-## local-first な配置
+## ローカルファーストの配置
 
 - 既定の DB path: `~/.config/traceary/traceary.db`
 - 上書き方法: `--db-path` または `TRACEARY_DB_PATH`
@@ -20,29 +20,30 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 
 ### `events`
 
-追記専用の event stream です。note、session 境界、review record、command audit はすべてここから始まります。
+追記専用の event stream です。note、session 境界、review、prompt、compact summary、command audit の元イベントはすべてここに入ります。
 
-column:
+主な column:
 
 - `id`: event identifier
-- `kind`: `note`、`command_executed`、`session_started`、`session_ended` などの event kind
+- `kind`: `note`、`command_executed`、`session_started`、`session_ended`、`prompt`、`compact_summary` などの event kind
 - `agent`: `codex`、`claude`、`gemini`、`manual` などの論理的な actor
 - `session_id`: session grouping identifier
-- `body`: event の人間向けメッセージ
+- `body`: 人が読むための event メッセージ
 - `created_at`: RFC3339 timestamp
-- `client`: `cli`、`claude`、`codex`、`gemini` などの ingestion path
-- `repo`: 利用可能な場合の current repository / workspace identifier
+- `client`: `cli`、`claude`、`codex`、`gemini`、`mcp` などの ingestion path
+- `workspace`: 利用可能な場合の補助的な work-context identifier
 
 主な index:
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
+- `idx_events_workspace_created_at` on `(workspace, created_at DESC, id DESC)`
 
 ### `command_audits`
 
 `command_executed` event に紐づく構造化 audit detail です。
 
-column:
+主な column:
 
 - `event_id`: primary key かつ `events.id` への foreign key
 - `command_text`: 記録した command line
@@ -50,8 +51,76 @@ column:
 - `output_text`: 保存した command output payload
 - `input_truncated`: input を切り詰めたかどうか
 - `output_truncated`: output を切り詰めたかどうか
+- `exit_code`: 取得できた場合の終了コード
 
-`command_audits.event_id` は `ON DELETE CASCADE` なので、`gc` によって event を削除すると対応する audit payload も同時に消えます。
+`command_audits.event_id` は `ON DELETE CASCADE` なので、`gc` で event を削除すると対応する audit payload も同時に消えます。
+
+### `sessions`
+
+start/end event から導かれ、session 系コマンドでも更新される session 集約です。
+
+主な column:
+
+- `session_id`: session identifier
+- `started_at`: session 開始時刻
+- `ended_at`: session が終了済みならその時刻
+- `client`: session の client attribution
+- `agent`: session の agent attribution
+- `workspace`: 補助的な work-context identifier
+- `label`: 任意の運用ラベル
+- `summary`: 任意の session summary
+- `parent_session_id`: 任意の親 session link
+
+主な index:
+
+- `idx_sessions_started_at`
+- `idx_sessions_workspace_started_at`
+- `idx_sessions_parent`
+
+### `memories`
+
+`v0.5.0` で導入した durable memory の集約です。
+
+主な column:
+
+- `id`: durable memory identifier
+- `type`: `decision`、`constraint`、`preference`、`lesson`、`artifact` などの taxonomy
+- `scope_kind` / `scope_value`: persistence 用に平坦化した typed scope（`workspace`、`agent`、`session_family`）
+- `fact`: 抽出・保持する durable-memory の本文
+- `status`: `candidate`、`accepted`、`rejected`、`superseded`、`expired` などの lifecycle status
+- `confidence`: `low`、`medium`、`high`、`verified` などの confidence
+- `source`: `manual` や `extracted` などの source attribution
+- `supersedes_memory_id`: 置き換え元 memory がある場合の参照
+- `expires_at`: expiry timestamp
+- `created_at` / `updated_at`: lifecycle timestamp
+
+主な index:
+
+- `idx_memories_scope_status_updated`
+- `idx_memories_type_status_updated`
+- `idx_memories_supersedes_memory_id`
+
+### `memory_evidence_refs`
+
+Durable memory に紐づく evidence ref です。
+
+主な column:
+
+- `memory_id`: `memories.id` への foreign key
+- `ordinal`: memory 内での安定した順序
+- `ref_kind`: `event`、`session`、`url`、`file`、`issue`、`pr` などの参照種別
+- `ref_value`: 参照先の値
+
+### `memory_artifact_refs`
+
+Durable memory に紐づく artifact ref です。
+
+主な column:
+
+- `memory_id`: `memories.id` への foreign key
+- `ordinal`: memory 内での安定した順序
+- `ref_kind`: `file`、`url`、`command` などの artifact 種別
+- `ref_value`: artifact の値
 
 ## Traceary が保存しないもの
 
@@ -72,18 +141,19 @@ column:
 
 ## `gc` の既定動作
 
-`traceary gc` は、古い event を retention ベースで掃除するコマンドです。
+`traceary gc` は、古い event 履歴を retention ベースで掃除するコマンドです。
 
 - 既定 retention: `90` 日 (`--keep-days 90`)
-- 選択条件: `created_at < cutoff` の row を削除
+- 選択条件: `events.created_at < cutoff` の row を削除
 - `--dry-run`: 削除候補件数だけ表示
 - 削除後に `VACUUM` を実行
 
 実務上の意味:
 
 - `gc` は opt-in であり、Traceary が background で自動削除することはありません
-- `gc` を実行すると、該当 event と紐づく `command_audits` も削除されます
-- 長期履歴を残したい場合は、強めの cleanup の前に backup を取ってください
+- `gc` を実行すると、該当する `events` と紐づく `command_audits` は削除されます
+- 現在の `gc` は `sessions` や durable memory (`memories`, `memory_evidence_refs`, `memory_artifact_refs`) を削除しません
+- 長期の監査履歴を残したい場合は、強めの cleanup の前に backup を取ってください
 
 ## backup の既定動作
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -37,7 +37,7 @@ Important indexes:
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
-- `idx_events_workspace_created_at` on `(workspace, created_at DESC, id DESC)`
+- `idx_events_workspace_created_at` on `(workspace, created_at)`
 
 ### `command_audits`
 
@@ -74,7 +74,7 @@ Key columns:
 Important indexes:
 
 - `idx_sessions_started_at`
-- `idx_sessions_workspace_started_at`
+- `idx_sessions_repo_started_at`
 - `idx_sessions_parent`
 
 ### `memories`

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -3,7 +3,7 @@
 [日本語](./README.ja.md)
 
 Traceary stores its local state in a single SQLite database file.
-This guide explains what gets written there, how the schema is organized, and what the current `gc` / backup defaults mean.
+This guide explains what gets written there, how the schema is organized today, and what the current `gc` / backup defaults mean in practice.
 
 ## Local-first layout
 
@@ -20,29 +20,30 @@ Traceary currently creates these tables:
 
 ### `events`
 
-The append-only event stream. Every note, session boundary, review record, and command audit starts here.
+The append-only event stream. Notes, session boundaries, reviews, prompts, compact summaries, and command-audit wrapper events all start here.
 
-Columns:
+Key columns:
 
 - `id`: event identifier
-- `kind`: event kind such as `note`, `command_executed`, `session_started`, `session_ended`
+- `kind`: event kind such as `note`, `command_executed`, `session_started`, `session_ended`, `prompt`, `compact_summary`
 - `agent`: logical actor such as `codex`, `claude`, `gemini`, or `manual`
 - `session_id`: session grouping identifier
-- `body`: human-facing message for the event
+- `body`: human-facing event message
 - `created_at`: RFC3339 timestamp
-- `client`: ingestion path such as `cli`, `claude`, `codex`, `gemini`
-- `repo`: current repository / workspace identifier when available
+- `client`: ingestion path such as `cli`, `claude`, `codex`, `gemini`, or `mcp`
+- `workspace`: auxiliary work-context identifier when available
 
 Important indexes:
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
+- `idx_events_workspace_created_at` on `(workspace, created_at DESC, id DESC)`
 
 ### `command_audits`
 
 Structured audit details for `command_executed` events.
 
-Columns:
+Key columns:
 
 - `event_id`: primary key and foreign key to `events.id`
 - `command_text`: captured command line
@@ -50,8 +51,76 @@ Columns:
 - `output_text`: stored command output payload
 - `input_truncated`: whether Traceary truncated the stored input
 - `output_truncated`: whether Traceary truncated the stored output
+- `exit_code`: captured exit code when available
 
 Because `command_audits.event_id` uses `ON DELETE CASCADE`, deleting an event through `gc` also deletes its audit payload.
+
+### `sessions`
+
+Session-level aggregates derived from start/end events and updated directly by session-oriented commands.
+
+Key columns:
+
+- `session_id`: session identifier
+- `started_at`: session start time
+- `ended_at`: session end time when the session has been closed
+- `client`: client attribution for the session
+- `agent`: agent attribution for the session
+- `workspace`: auxiliary work-context identifier
+- `label`: optional operator-facing label
+- `summary`: optional session summary text
+- `parent_session_id`: optional parent session link
+
+Important indexes:
+
+- `idx_sessions_started_at`
+- `idx_sessions_workspace_started_at`
+- `idx_sessions_parent`
+
+### `memories`
+
+Durable-memory aggregates introduced in `v0.5.0`.
+
+Key columns:
+
+- `id`: durable memory identifier
+- `type`: memory taxonomy such as `decision`, `constraint`, `preference`, `lesson`, `artifact`
+- `scope_kind` / `scope_value`: typed scope flattened for persistence (`workspace`, `agent`, `session_family`)
+- `fact`: distilled durable-memory text
+- `status`: lifecycle status such as `candidate`, `accepted`, `rejected`, `superseded`, `expired`
+- `confidence`: confidence value such as `low`, `medium`, `high`, `verified`
+- `source`: source attribution such as `manual` or `extracted`
+- `supersedes_memory_id`: previous memory replaced by this record, when present
+- `expires_at`: expiry timestamp when present
+- `created_at` / `updated_at`: lifecycle timestamps
+
+Important indexes:
+
+- `idx_memories_scope_status_updated`
+- `idx_memories_type_status_updated`
+- `idx_memories_supersedes_memory_id`
+
+### `memory_evidence_refs`
+
+Evidence references attached to a durable memory.
+
+Key columns:
+
+- `memory_id`: foreign key to `memories.id`
+- `ordinal`: stable ordering within the memory
+- `ref_kind`: reference type such as `event`, `session`, `url`, `file`, `issue`, `pr`
+- `ref_value`: reference payload
+
+### `memory_artifact_refs`
+
+Artifact references attached to a durable memory.
+
+Key columns:
+
+- `memory_id`: foreign key to `memories.id`
+- `ordinal`: stable ordering within the memory
+- `ref_kind`: artifact type such as `file`, `url`, or `command`
+- `ref_value`: artifact payload
 
 ## What Traceary does not store
 
@@ -65,7 +134,7 @@ Current non-goals:
 ## Migrations and compatibility
 
 - migrations are embedded in the binary from `schema/sqlite/migrations`
-- the store is initialized before normal command execution, so upgrades apply migrations automatically
+- store initialization runs before normal command execution, so upgrades apply migrations automatically
 - backup restore copies the SQLite file first and then reruns store initialization so newer migrations can be applied
 
 Traceary does not promise backward compatibility for arbitrary manual schema edits.
@@ -73,18 +142,19 @@ If you need a portable copy, use `traceary backup create` instead of editing the
 
 ## `gc` defaults
 
-`traceary gc` is retention-based cleanup for old events.
+`traceary gc` is retention-based cleanup for old event history.
 
 - default retention: `90` days (`--keep-days 90`)
-- selection rule: delete rows where `created_at < cutoff`
+- selection rule: delete rows where `events.created_at < cutoff`
 - `--dry-run`: print only the candidate count
 - after deletion, Traceary runs `VACUUM`
 
 Practical implications:
 
 - `gc` is opt-in; Traceary does not delete history automatically in the background
-- a `gc` run removes matching events and their linked `command_audits`
-- if you care about long-term history, take a backup before an aggressive cleanup
+- a `gc` run removes matching `events` rows and linked `command_audits`
+- the current `gc` implementation does **not** delete `sessions` or durable-memory rows from `memories`, `memory_evidence_refs`, or `memory_artifact_refs`
+- if you care about long-term audit history, take a backup before an aggressive cleanup
 
 ## Backup defaults
 
@@ -104,4 +174,3 @@ When you need to understand what Traceary is doing locally:
 1. run `traceary doctor` to confirm the resolved DB path and writeability
 2. inspect `schema/sqlite/migrations/` if you need the exact SQL
 3. use `traceary backup create` before manual investigation or risky cleanup
-


### PR DESCRIPTION
## Summary
- refresh the storage guide so it matches the current SQLite schema and gc semantics
- rewrite the interactive guide around shipped read-side workflows such as tail and handoff
- align the Japanese paired docs with the same behavior and terminology

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #500