### PR TITLE
docs: align workspace terminology across docs and CLI help

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -136,7 +136,7 @@ traceary session end --session-id "$sid" --id-only
 
 ## 先に知っておくと楽なこと
 
-- `traceary log` / `traceary audit` で `--session-id` を省くと、解決できた repo / work context に対応する最新の non-stale アクティブセッションを優先して使います。`remote.origin.url` が無い Git worktree では、worktree ルートパスを代わりに使います
+- `traceary log` / `traceary audit` で `--session-id` を省くと、解決できた workspace に対応する最新の non-stale アクティブセッションを優先して使います。`remote.origin.url` が無い Git worktree では、worktree ルートパスを代わりに使います
 - `traceary session active` は既定で 24 時間を超えたセッションを stale とみなします。必要なら `--allow-stale` を付けてください
 - `traceary session start` はセッション ID を出力し、`traceary session end` は記録したイベント ID を出力します
 - `traceary session list --json` では、値がある場合に `label` / `summary` / `parent_session_id` も確認できます

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -21,7 +21,7 @@ note event を追記します。
 既定値:
 
 - `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / 検出した workspace
-- `--session-id`: flag → `TRACEARY_SESSION_ID` → 解決した repo の最新 non-stale active session → `default`
+- `--session-id`: flag → `TRACEARY_SESSION_ID` → 解決した workspace の最新 non-stale active session → `default`
 
 主な flag:
 
@@ -35,9 +35,9 @@ note event を追記します。
 session 解決ルール:
 
 - 明示 `--session-id` または `TRACEARY_SESSION_ID` を最優先
-- それ以外では、解決できた repo / work context に対応する最新の non-stale active session を再利用
+- それ以外では、解決できた workspace に対応する最新の non-stale active session を再利用
 - `remote.origin.url` が無い Git worktree でも、work-context key として worktree ルートパスを使います
-- repo / work context が無い、または一致する active session が無い場合は、従来どおり `default` session ID を使います
+- workspace を解決できない、または一致する active session が無い場合は、従来どおり `default` session ID を使います
 
 > **注意:** `log` と `audit` は `--session-id` の値をそのまま受け入れ、存在確認は行いません。これは意図的な設計です。hook では高頻度にイベントを書き込むため、毎回 DB ルックアップを挟むとオーバーヘッドが大きくなります。存在しない session ID を渡した場合でもイベント自体は記録されますが、session 単位のクエリには現れません。
 
@@ -74,7 +74,7 @@ session 解決ルールは `traceary log` と同じです。
 
 最近の event を一覧表示します。
 
-`list` は直近履歴を素早く絞るためのコマンドです。kind / client / agent / session / repo が決まっているときはこちらを使い、キーワード検索や期間条件が必要なときは `search` を使います。
+`list` は直近履歴を素早く絞るためのコマンドです。kind / client / agent / session / workspace が決まっているときはこちらを使い、キーワード検索や期間条件が必要なときは `search` を使います。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -21,7 +21,7 @@ Append a note event.
 Defaults:
 
 - `--client` / `--agent` / `--workspace`: flag → `TRACEARY_CLIENT` / `TRACEARY_AGENT` / `TRACEARY_WORKSPACE` → `cli` / `manual` / detected workspace
-- `--session-id`: flag → `TRACEARY_SESSION_ID` → latest non-stale active session for the resolved repo → `default`
+- `--session-id`: flag → `TRACEARY_SESSION_ID` → latest non-stale active session for the resolved workspace → `default`
 
 Useful flags:
 
@@ -35,9 +35,9 @@ Useful flags:
 Session resolution rules:
 
 - explicit `--session-id` or `TRACEARY_SESSION_ID` wins
-- otherwise Traceary reuses the latest non-stale active session for the resolved repo/work context
+- otherwise Traceary reuses the latest non-stale active session for the resolved workspace
 - when `remote.origin.url` is unavailable but the current directory is still inside a git worktree, Traceary falls back to the worktree root path as the work-context key
-- if no repo/work context or no matching active session is found, Traceary falls back to the historical `default` session ID
+- if no workspace could be resolved or no matching active session is found, Traceary falls back to the historical `default` session ID
 
 > **Note:** `log` and `audit` accept any `--session-id` value without validating whether the session actually exists. This is by design — hooks record events at high frequency and the extra DB lookup per write would add unacceptable overhead. If you pass a nonexistent session ID, the event is still recorded; it will simply not appear in session-scoped queries.
 
@@ -74,7 +74,7 @@ Session resolution follows the same rules as `traceary log`.
 
 List recent events.
 
-`list` is the fast recent-history view. Use it when you already know the event kind / client / agent / session / repo filters you want. Switch to `search` when you need keyword matching or date-range filtering.
+`list` is the fast recent-history view. Use it when you already know the event kind / client / agent / session / workspace filters you want. Switch to `search` when you need keyword matching or date-range filtering.
 
 Useful flags:
 

--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -42,7 +42,7 @@
 ## 共通動作
 
 全レベル共通:
-- セッション開始時に repo を state ファイルに永続化し、audit は state から読み取る
+- セッション開始時に解決した workspace を state ファイルに保存し、audit はそこから workspace を読み取る
 - エージェントタイプ解決: `agent_type` フィールド → 階層的エージェント名（Claude のみ）
 - `tool_response.exitCode` から exit code を抽出（利用可能時）
 - MCP ツール名 fallback: `tool_input.command` → `tool_name`

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -42,7 +42,7 @@ This document defines the hook capability tiers across AI agent clients.
 ## Shared Behavior
 
 All tiers:
-- Session start persists repo to state file; audit reads repo from state
+- Session start persists the resolved workspace to the state file; audit reads the workspace from state
 - Agent type resolution: `agent_type` field → hierarchical agent name (Claude only)
 - Exit code extraction from `tool_response.exitCode` when available
 - MCP tool name fallback: `tool_input.command` → `tool_name`

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -41,8 +41,8 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 		Use:   "audit <command> [<input>] [<output>]",
 		Short: Localize("Record a command execution audit event", "コマンド実行の監査ログを記録する"),
 		Long: Localize(
-			"Record a shell-command audit.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected repo\n- session ID: --session-id -> TRACEARY_SESSION_ID -> latest non-stale active session for the resolved repo -> default\n- input / output: optional; omit them when you only need the command text\n- secret policy: --allow-secrets or TRACEARY_ALLOW_SECRETS disables best-effort redaction",
-			"shell command の監査ログを記録します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した repo\n- session ID: --session-id -> TRACEARY_SESSION_ID -> 解決した repo の最新 non-stale active session -> default\n- input / output: 任意。command 文字列だけを記録したい場合は省略できます\n- secret policy: --allow-secrets または TRACEARY_ALLOW_SECRETS で best-effort redaction を無効化します",
+			"Record a shell-command audit.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected workspace\n- session ID: --session-id -> TRACEARY_SESSION_ID -> latest non-stale active session for the resolved workspace -> default\n- input / output: optional; omit them when you only need the command text\n- secret policy: --allow-secrets or TRACEARY_ALLOW_SECRETS disables best-effort redaction",
+			"shell command の監査ログを記録します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した workspace\n- session ID: --session-id -> TRACEARY_SESSION_ID -> 解決した workspace の最新 non-stale active session -> default\n- input / output: 任意。command 文字列だけを記録したい場合は省略できます\n- secret policy: --allow-secrets または TRACEARY_ALLOW_SECRETS で best-effort redaction を無効化します",
 		),
 		Example: strings.Join([]string{
 			"  traceary audit \"go test ./...\"",
@@ -99,7 +99,7 @@ func (c *RootCLI) newAuditCommand() *cobra.Command {
 			"セッション ID (env: TRACEARY_SESSION_ID。未指定時は active session、なければ既定値)",
 		),
 	)
-	auditCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary work context identifier (env: TRACEARY_WORKSPACE)", "補助的なコンテキスト識別子 (env: TRACEARY_WORKSPACE)"))
+	auditCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary workspace identifier (env: TRACEARY_WORKSPACE)", "補助的な workspace 識別子 (env: TRACEARY_WORKSPACE)"))
 	auditCmd.Flags().StringVar(&command, "command", "", Localize("command text to record", "記録する command 文字列"))
 	auditCmd.Flags().StringVar(&auditInput, "input", "", Localize("optional command input payload", "任意の command input"))
 	auditCmd.Flags().StringVar(&auditOutput, "output", "", Localize("optional command output payload", "任意の command output"))

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -102,7 +102,7 @@ func buildCompactSummaryText(result types.Optional[apptypes.ContextPack]) (strin
 	pack, _ := result.Get()
 	fmt.Fprintf(&sb, "Session %s resumed after compact\n", pack.SessionID())
 	if pack.Workspace().String() != "" {
-		fmt.Fprintf(&sb, "  repo: %s\n", pack.Workspace())
+		fmt.Fprintf(&sb, "  workspace: %s\n", pack.Workspace())
 	}
 	if pack.Label() != "" {
 		fmt.Fprintf(&sb, "  label: %s\n", pack.Label())

--- a/presentation/cli/compact_summary_test.go
+++ b/presentation/cli/compact_summary_test.go
@@ -57,7 +57,7 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 			t.Errorf("output missing session ID")
 		}
 		if !strings.Contains(output, "duck8823/traceary") {
-			t.Errorf("output missing repo")
+			t.Errorf("output missing workspace")
 		}
 		if !strings.Contains(output, "v0.2.1 sprint") {
 			t.Errorf("output missing label")

--- a/presentation/cli/context.go
+++ b/presentation/cli/context.go
@@ -69,12 +69,12 @@ func detectRepoContextFromDir(ctx context.Context, cwd string) (string, error) {
 	if remoteErr != nil && repoRootErr != nil {
 		return "", xerrors.Errorf(
 			"%s: %w",
-			Localize("failed to detect git work context", "git work context の検出に失敗しました"),
+			Localize("failed to detect workspace from git context", "git コンテキストから workspace を検出できませんでした"),
 			repoRootErr,
 		)
 	}
 
-	return "", xerrors.Errorf(Localize("git work context could not be resolved", "git work context を解決できませんでした"))
+	return "", xerrors.Errorf(Localize("workspace could not be resolved from git context", "git コンテキストから workspace を解決できませんでした"))
 }
 
 func gitOutput(ctx context.Context, cwd string, args ...string) (string, error) {

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -46,7 +46,7 @@ func (c *RootCLI) newContextCommand() *cobra.Command {
 	contextCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("target session ID", "対象の session ID"))
 	contextCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "作業主体の入口で絞り込む"))
 	contextCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
-	contextCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	contextCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary workspace identifier", "補助的な workspace 識別子で絞り込む"))
 	contextCmd.Flags().IntVar(&limit, "limit", 10, Localize("maximum number of events to include", "表示件数"))
 	contextCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 

--- a/presentation/cli/hooks_helper.go
+++ b/presentation/cli/hooks_helper.go
@@ -62,7 +62,7 @@ func (c *RootCLI) newHooksHelperBuildFailureOutputCommand() *cobra.Command {
 func (c *RootCLI) newHooksHelperNormalizeGitRemoteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "normalize-git-remote [raw]",
-		Short:  "Normalize a git remote URL to Traceary repo format",
+		Short:  "Normalize a git remote URL to a Traceary workspace identifier",
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -60,7 +60,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	listCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))
-	listCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	listCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary workspace identifier", "補助的な workspace 識別子で絞り込む"))
 	listCmd.Flags().StringVar(&from, "from", "", Localize("start date (`YYYY-MM-DD` or RFC3339)", "開始日 (`YYYY-MM-DD` または RFC3339)"))
 	listCmd.Flags().StringVar(&since, "since", "", Localize("start date (`YYYY-MM-DD` or RFC3339) (alias for `--from`)", "開始日 (`YYYY-MM-DD` または RFC3339) (`--from` の別名)"))
 	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (`YYYY-MM-DD` or RFC3339)", "終了日 (`YYYY-MM-DD` または RFC3339)"))

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -35,8 +35,8 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 		Use:   "log <message>",
 		Short: Localize("Append a session note", "セッションログを追記する"),
 		Long: Localize(
-			"Append a note to Traceary.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected repo\n- session ID: --session-id -> TRACEARY_SESSION_ID -> latest non-stale active session for the resolved repo -> default",
-			"Traceary にメモを追記します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / repo: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した repo\n- session ID: --session-id -> TRACEARY_SESSION_ID -> 解決した repo の最新 non-stale active session -> default",
+			"Append a note to Traceary.\n\nDefaults:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / detected workspace\n- session ID: --session-id -> TRACEARY_SESSION_ID -> latest non-stale active session for the resolved workspace -> default",
+			"Traceary にメモを追記します。\n\n既定値の解決順:\n- DB path: --db-path -> TRACEARY_DB_PATH -> ~/.config/traceary/traceary.db\n- client / agent / workspace: flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE -> cli / manual / 検出した workspace\n- session ID: --session-id -> TRACEARY_SESSION_ID -> 解決した workspace の最新 non-stale active session -> default",
 		),
 		Example: strings.Join([]string{
 			"  traceary log \"investigate retry behavior\"",
@@ -70,7 +70,7 @@ func (c *RootCLI) newLogCommand() *cobra.Command {
 			"セッション ID (env: TRACEARY_SESSION_ID。未指定時は active session、なければ既定値)",
 		),
 	)
-	logCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary work context identifier (env: TRACEARY_WORKSPACE)", "補助的なコンテキスト識別子 (env: TRACEARY_WORKSPACE)"))
+	logCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary workspace identifier (env: TRACEARY_WORKSPACE)", "補助的な workspace 識別子 (env: TRACEARY_WORKSPACE)"))
 	logCmd.Flags().BoolVar(&idOnly, "id-only", false, Localize("print only the recorded event ID", "記録した event ID だけを出力する"))
 	logCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	logCmd.MarkFlagsMutuallyExclusive("id-only", "json")

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -262,7 +262,7 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to default session when work context is missing", func(t *testing.T) {
+	t.Run("falls back to default session when workspace is missing", func(t *testing.T) {
 		t.Setenv("TRACEARY_SESSION_ID", "")
 		cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
 			return "", errors.New("no git remote")
@@ -294,7 +294,7 @@ func TestRootCLI_LogCommand(t *testing.T) {
 			t.Fatalf("Execute() error = %v", err)
 		}
 		want := "" +
-			"No work context was detected; using default session ID\n" +
+			"No workspace was detected; using default session ID\n" +
 			"Recorded: event-1\n"
 		if stdout.String() != want {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -15,16 +15,16 @@ import (
 
 func (c *RootCLI) newSearchCommand() *cobra.Command {
 	var (
-		dbPath    string
-		repo      string
-		sessionID string
-		client    string
-		agent     string
-		kind      string
-		from      string
-		since     string
-		to        string
-		until     string
+		dbPath       string
+		repo         string
+		sessionID    string
+		client       string
+		agent        string
+		kind         string
+		from         string
+		since        string
+		to           string
+		until        string
 		limit        int
 		offset       int
 		failuresOnly bool
@@ -60,7 +60,7 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 		},
 	}
 	searchCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
-	searchCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by work context (env: TRACEARY_WORKSPACE / current git remote)", "絞り込む work context (env: TRACEARY_WORKSPACE / current git remote)"))
+	searchCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace (env: TRACEARY_WORKSPACE / current git remote)", "絞り込む workspace (env: TRACEARY_WORKSPACE / current git remote)"))
 	searchCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "絞り込む session ID"))
 	searchCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "絞り込む client"))
 	searchCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "絞り込む agent"))

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -48,8 +48,8 @@ func (c *RootCLI) newSessionLatestCommand() *cobra.Command {
 		Use:   "latest",
 		Short: Localize("Print the latest session ID", "直近のセッション ID を表示する"),
 		Long: Localize(
-			"Print the latest matching session ID.\n\n\"latest\" means the session whose most recent lifecycle boundary (start or end) is newest among the matches.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected work context when omitted.",
-			"条件に一致する直近の session ID を表示します。\n\nここでの「直近」は、一致した session のうち最新の lifecycle boundary (start または end) が最も新しいものを意味します。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した work context を使います。",
+			"Print the latest matching session ID.\n\n\"latest\" means the session whose most recent lifecycle boundary (start or end) is newest among the matches.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected workspace when omitted.",
+			"条件に一致する直近の session ID を表示します。\n\nここでの「直近」は、一致した session のうち最新の lifecycle boundary (start または end) が最も新しいものを意味します。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した workspace を使います。",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -65,7 +65,7 @@ func (c *RootCLI) newSessionLatestCommand() *cobra.Command {
 	latestCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	latestCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	latestCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
-	latestCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	latestCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary workspace identifier", "補助的な workspace 識別子で絞り込む"))
 	latestCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 
 	return latestCmd
@@ -109,7 +109,7 @@ func (c *RootCLI) newSessionStartCommand() *cobra.Command {
 	startCmd.Flags().StringVar(&client, "client", "", Localize("recording channel (env: TRACEARY_CLIENT)", "記録経路 (env: TRACEARY_CLIENT)"))
 	startCmd.Flags().StringVar(&agent, "agent", "", Localize("actor name (env: TRACEARY_AGENT)", "作業主体 (env: TRACEARY_AGENT)"))
 	startCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID to start", "開始するセッション ID"))
-	startCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary work context identifier (env: TRACEARY_WORKSPACE)", "補助的なコンテキスト識別子 (env: TRACEARY_WORKSPACE)"))
+	startCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary workspace identifier (env: TRACEARY_WORKSPACE)", "補助的な workspace 識別子 (env: TRACEARY_WORKSPACE)"))
 	startCmd.Flags().StringVar(&parentSessionID, "parent-session-id", "", Localize("parent session ID for sub-agent sessions", "サブエージェントセッションの親セッション ID"))
 	startCmd.Flags().BoolVar(&idOnly, "id-only", false, Localize("print only the resulting identifier", "結果の識別子だけを出力する"))
 	startCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
@@ -156,7 +156,7 @@ func (c *RootCLI) newSessionEndCommand() *cobra.Command {
 	endCmd.Flags().StringVar(&client, "client", "", Localize("recording channel (env: TRACEARY_CLIENT)", "記録経路 (env: TRACEARY_CLIENT)"))
 	endCmd.Flags().StringVar(&agent, "agent", "", Localize("actor name (env: TRACEARY_AGENT)", "作業主体 (env: TRACEARY_AGENT)"))
 	endCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("session ID to end (env: TRACEARY_SESSION_ID)", "終了するセッション ID (env: TRACEARY_SESSION_ID)"))
-	endCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary work context identifier (env: TRACEARY_WORKSPACE)", "補助的なコンテキスト識別子 (env: TRACEARY_WORKSPACE)"))
+	endCmd.Flags().StringVar(&repo, "workspace", "", Localize("auxiliary workspace identifier (env: TRACEARY_WORKSPACE)", "補助的な workspace 識別子 (env: TRACEARY_WORKSPACE)"))
 	endCmd.Flags().StringVar(&summary, "summary", "", Localize("session summary text", "セッションサマリーテキスト"))
 	endCmd.Flags().BoolVar(&idOnly, "id-only", false, Localize("print only the resulting identifier", "結果の識別子だけを出力する"))
 	endCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
@@ -180,8 +180,8 @@ func (c *RootCLI) newSessionActiveCommand() *cobra.Command {
 		Use:   "active",
 		Short: Localize("Print the active session ID (stale sessions older than 24h are excluded by default)", "現在アクティブな session ID を表示する (既定では 24h 超の stale を除外)"),
 		Long: Localize(
-			"Print the active matching session ID.\n\nUnlike session latest, this only returns non-ended sessions. By default, sessions older than 24h are treated as stale unless --allow-stale is set.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected work context when omitted.",
-			"条件に一致する active session ID を表示します。\n\nsession latest と違って、未終了の session だけを返します。既定では 24h を超える session は --allow-stale を指定しない限り stale とみなします。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した work context を使います。",
+			"Print the active matching session ID.\n\nUnlike session latest, this only returns non-ended sessions. By default, sessions older than 24h are treated as stale unless --allow-stale is set.\nFilters resolve as flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE, and --workspace falls back to the detected workspace when omitted.",
+			"条件に一致する active session ID を表示します。\n\nsession latest と違って、未終了の session だけを返します。既定では 24h を超える session は --allow-stale を指定しない限り stale とみなします。\nfilter は flag -> TRACEARY_CLIENT / TRACEARY_AGENT / TRACEARY_WORKSPACE の順に解決し、--workspace 省略時は検出した workspace を使います。",
 		),
 		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -200,7 +200,7 @@ func (c *RootCLI) newSessionActiveCommand() *cobra.Command {
 	activeCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	activeCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	activeCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
-	activeCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	activeCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary workspace identifier", "補助的な workspace 識別子で絞り込む"))
 	activeCmd.Flags().DurationVar(
 		&staleAfter,
 		"stale-after",

--- a/presentation/cli/session_resolution.go
+++ b/presentation/cli/session_resolution.go
@@ -31,12 +31,12 @@ func (c *RootCLI) resolveManualSessionID(
 
 	trimmedRepo := strings.TrimSpace(repo)
 	if trimmedRepo == "" || c.session == nil {
-		slog.Debug("no work context or query service, using default session", "workspace", trimmedRepo, "has_query_service", c.session != nil)
+		slog.Debug("no workspace or query service, using default session", "workspace", trimmedRepo, "has_query_service", c.session != nil)
 		return &manualSessionResolution{
 			sessionID: defaultSessionIDValue,
 			notice: Localize(
-				"No work context was detected; using default session ID",
-				"作業コンテキストを検出できなかったため、既定の session ID を使います",
+				"No workspace was detected; using default session ID",
+				"workspace を検出できなかったため、既定の session ID を使います",
 			),
 		}, nil
 	}

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -209,7 +209,7 @@ func (c *RootCLI) newTailCommand() *cobra.Command {
 	tailCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	tailCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	tailCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))
-	tailCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary work context identifier", "補助的なコンテキスト識別子で絞り込む"))
+	tailCmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by auxiliary workspace identifier", "補助的な workspace 識別子で絞り込む"))
 	tailCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
 	tailCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print NDJSON output", "NDJSON 形式で出力する"))
 


### PR DESCRIPTION
## Summary
- replace remaining public repo/work-context wording with workspace terminology
- update operator-facing CLI help and compact-summary output to match the public model
- refresh the paired docs and tests that cover the user-facing messages

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #501