### PR TITLE
docs: add durable memory concept guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -122,6 +122,18 @@ traceary audit --id-only --command "go test ./..." --input '{}' --output '{}'
 traceary session end --session-id "$sid" --id-only
 ```
 
+### 4. 再利用したい事実は durable memory に残す
+
+```sh
+traceary memory remember \
+  --type decision \
+  --workspace github.com/duck8823/traceary \
+  --fact "再開時の要約には traceary handoff を使う" \
+  --evidence issue:#502
+
+traceary handoff --workspace github.com/duck8823/traceary
+```
+
 ## ホスト別の自動記録マトリクス
 
 問い合わせ面は共通です。Traceary を入れれば、どのホストからでも同じ CLI / MCP の memory・context 機能を使えます。差が出るのは、hook でどこまで自動記録できるかです。
@@ -136,7 +148,7 @@ traceary session end --session-id "$sid" --id-only
 
 ## 先に知っておくと楽なこと
 
-- `traceary log` / `traceary audit` で `--session-id` を省くと、解決できた repo / work context に対応する最新の non-stale アクティブセッションを優先して使います。`remote.origin.url` が無い Git worktree では、worktree ルートパスを代わりに使います
+- `traceary log` / `traceary audit` で `--session-id` を省くと、解決できた workspace に対応する最新の non-stale アクティブセッションを優先して使います。`remote.origin.url` が無い Git worktree では、worktree ルートパスを代わりに使います
 - `traceary session active` は既定で 24 時間を超えたセッションを stale とみなします。必要なら `--allow-stale` を付けてください
 - `traceary session start` はセッション ID を出力し、`traceary session end` は記録したイベント ID を出力します
 - `traceary session list --json` では、値がある場合に `label` / `summary` / `parent_session_id` も確認できます
@@ -148,7 +160,8 @@ traceary session end --session-id "$sid" --id-only
 詳しい一覧は [ドキュメント索引](./docs/README.ja.md) にまとめています。最初によく使うのは次のページです。
 
 - [ネイティブ連携ガイド](./docs/integrations/README.ja.md)
-- [CLI リファレンス](./docs/cli/README.ja.md) — 手動で CLI を使う場合の詳細はこちら
+- [Durable memory ガイド](./docs/memory/README.ja.md)
+- [CLI リファレンス](./docs/cli/README.ja.md)
 - [Hooks ガイド](./docs/hooks/README.ja.md)
 - [Hook contract と対応レベル](./docs/hooks/contract.ja.md)
 - [イベントライフサイクル](./docs/lifecycle.ja.md)
@@ -158,5 +171,5 @@ traceary session end --session-id "$sid" --id-only
 ## コントリビュートとサポート
 
 - バグ報告や改善提案は GitHub Issues へお願いします
-- 脆弱性の連絡先は [CONTRIBUTING.ja.md](./CONTRIBUTING.ja.md) を参照してください
+- 脆弱性の報告方法は [SECURITY.ja.md](./SECURITY.ja.md) を参照してください
 - まだ `v0.x` の OSS なので、自動化に組み込む前には [変更履歴](./CHANGELOG.ja.md) を確認してください

--- a/README.ja.md
+++ b/README.ja.md
@@ -171,5 +171,5 @@ traceary handoff --workspace github.com/duck8823/traceary
 ## コントリビュートとサポート
 
 - バグ報告や改善提案は GitHub Issues へお願いします
-- 脆弱性の報告方法は [SECURITY.ja.md](./SECURITY.ja.md) を参照してください
+- 脆弱性の連絡先は [CONTRIBUTING.ja.md](./CONTRIBUTING.ja.md) を参照してください
 - まだ `v0.x` の OSS なので、自動化に組み込む前には [変更履歴](./CHANGELOG.ja.md) を確認してください

--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ The most common next pages are:
 ## Contributing and support
 
 - bug reports and feature requests belong in GitHub Issues
-- security reports should follow [SECURITY.md](./SECURITY.md)
+- security reports should follow the private contact path in [CONTRIBUTING.md](./CONTRIBUTING.md)
 - this is an actively evolving `v0.x` OSS tool, so check the [changelog](./CHANGELOG.md) before upgrading automation around it

--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ traceary audit --id-only --command "go test ./..." --input '{}' --output '{}'
 traceary session end --session-id "$sid" --id-only
 ```
 
+### 4. Promote reusable context when it matters
+
+```sh
+traceary memory remember \
+  --type decision \
+  --workspace github.com/duck8823/traceary \
+  --fact "Use traceary handoff for compact resume context" \
+  --evidence issue:#502
+
+traceary handoff --workspace github.com/duck8823/traceary
+```
+
 ## Host capture matrix
 
 The query surface is shared: once Traceary is installed, every host can use the same CLI and MCP memory/context commands. What differs is how much context each host can capture automatically via hooks.
@@ -150,7 +162,8 @@ Use the [documentation index](./docs/README.md) for the full map.
 The most common next pages are:
 
 - [Native integrations](./docs/integrations/README.md)
-- [CLI reference](./docs/cli/README.md) — including manual one-off CLI workflows
+- [Durable memory guide](./docs/memory/README.md)
+- [CLI reference](./docs/cli/README.md)
 - [Hooks guide](./docs/hooks/README.md)
 - [Hook contract and capability tiers](./docs/hooks/contract.md)
 - [Event lifecycle](./docs/lifecycle.md)
@@ -160,5 +173,5 @@ The most common next pages are:
 ## Contributing and support
 
 - bug reports and feature requests belong in GitHub Issues
-- security reports should follow the private contact path in [CONTRIBUTING.md](./CONTRIBUTING.md)
+- security reports should follow [SECURITY.md](./SECURITY.md)
 - this is an actively evolving `v0.x` OSS tool, so check the [changelog](./CHANGELOG.md) before upgrading automation around it

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -6,7 +6,10 @@
 
 ## まず読むページ
 
+- [Durable memory ガイド](./memory/README.ja.md): 3 層モデル、memory のライフサイクル、ref の意味、memory コマンドの関係
 - [CLI リファレンス](./cli/README.ja.md): コマンドごとの挙動、主要フラグ、出力仕様
+- [Hook contract](./hooks/contract.ja.md): ホストごとの自動記録範囲と共通動作
+- [イベントライフサイクル](./lifecycle.ja.md): session 開始、audit、prompt、summary がどう event になるか
 - [環境変数リファレンス](./environment/README.ja.md): 環境変数、実行時の前提、対応プラットフォーム
 - [ストレージモデル](./storage/README.ja.md): SQLite の構造、マイグレーション、GC、保存しないもの
 
@@ -15,7 +18,7 @@
 - [ネイティブ連携ガイド](./integrations/README.ja.md): Claude / Codex / Gemini 向けパッケージ、導入手順、smoke test
 - [Hooks ガイド](./hooks/README.ja.md): Claude Code / Codex / Gemini の hook 設定、導入手順、トラブルシュート
 - [MCP ガイド](./mcp/README.ja.md): `traceary mcp-server` の起動方法、ツール一覧、MCP クライアント連携
-- [インタラクティブ運用メモ](./interactive/README.ja.md): 日常利用で有効だった改善点と、その判断理由
+- [インタラクティブ運用ガイド](./interactive/README.ja.md): `list`、`tail`、`search`、`show`、`handoff` の使い分け
 
 ## 運用
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,10 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 
 ## Start here
 
+- [Durable memory guide](./memory/README.md): the three-layer model, memory lifecycle, refs, and how memory commands relate
 - [CLI reference](./cli/README.md): command-by-command behavior, flags, and output contracts
+- [Hook contract](./hooks/contract.md): automatic-capture coverage and shared hook semantics across hosts
+- [Event lifecycle](./lifecycle.md): how session starts, audits, prompts, and summaries become Traceary events
 - [Environment reference](./environment/README.md): environment variables, runtime assumptions, and platform support
 - [Storage model](./storage/README.md): SQLite layout, migrations, GC behavior, and what Traceary does not store
 
@@ -15,7 +18,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 - [Native integrations](./integrations/README.md): packaged Claude / Codex / Gemini integration bundles, install flows, and smoke tests
 - [Hooks guide](./hooks/README.md): Claude Code / Codex / Gemini hook setup, install flow, and troubleshooting
 - [MCP guide](./mcp/README.md): running `traceary mcp-server`, tool surface, and host-client integration notes
-- [Interactive ergonomics](./interactive/README.md): current CLI ergonomics decisions and follow-up notes from dogfooding
+- [Interactive workflows](./interactive/README.md): how to inspect live and recent activity with `list`, `tail`, `search`, `show`, and `handoff`
 
 ## Operations
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -1,0 +1,107 @@
+# Durable memory ガイド
+
+[English](./README.md)
+
+この文書では、Traceary の durable memory 層が全体のどこに位置づくのかと、memory 関連の CLI / MCP 操作がどうつながるのかを整理します。
+
+## durable memory の位置づけ
+
+Traceary は、エージェントの文脈を 3 層で扱います。
+
+| 層 | 役割 | 代表例 |
+| --- | --- | --- |
+| Audit / Archive | 検索・監査・後追い確認のための元データ | 生の event、session 境界、command audit |
+| Working memory | 再開や handoff のためにその場で組み立てる文脈 | handoff pack、直近コマンド、compact summary |
+| Durable memory | セッションをまたいで残したい事実 | decision、constraint、preference、lesson、artifact ref |
+
+Durable memory は意図的に小さく保ちます。会話全文やログ全文の置き場ではなく、監査ログの代替でもありません。
+
+## memory のライフサイクル
+
+Durable memory には、type・scope・status・confidence・evidence ref・任意の artifact ref があります。
+
+### status
+
+- `candidate`: 抽出または提案されたが、まだレビュー前の memory
+- `accepted`: セッションをまたいで再利用したい active memory
+- `rejected`: 再利用しないと決めた candidate
+- `superseded`: 新しい accepted memory に置き換えられた古い memory
+- `expired`: 期限付きで有効だったが、いまは active ではない memory
+
+既定の active-memory 系の取得では、active な accepted memory だけを対象にします。
+
+## evidence ref と artifact ref の違い
+
+Traceary は、memory に 2 種類の参照を持たせます。
+
+- **evidence ref**: その fact を正当化する根拠
+  - 例: `event:...`, `session:...`, `issue:#462`, `pr:#468`
+- **artifact ref**: 次に人やエージェントが開きたくなる対象
+  - 例: `file:docs/release/README.md`, `url:https://...`, `command:go test ./...`
+
+accepted memory には evidence ref が必須です。artifact ref は任意です。
+
+## memory コマンドの関係
+
+### 手動で書き込む経路
+
+人やエージェントが、残すべき事実を明示的に記録したいときは次を使います。
+
+- `traceary memory remember`
+- `traceary memory propose`
+- `traceary memory accept`
+- `traceary memory reject`
+- `traceary memory supersede`
+- `traceary memory expire`
+
+### 抽出する経路
+
+既存の session signal から candidate memory を起こしたいときは次を使います。
+
+- `traceary memory extract`
+
+extract は candidate-only です。自動で accepted にはしません。
+
+### 参照する経路
+
+既存の durable memory を調べるときは次を使います。
+
+- `traceary memory list`
+- `traceary memory search`
+- `traceary memory show`
+
+### 文脈に載せる経路
+
+Durable memory を再開向けの pack に組み込んで使いたいときは次を使います。
+
+- `traceary handoff`
+- MCP `session_handoff`
+- MCP `memory_pack`
+
+`handoff` は次の session 向けの working-memory 要約です。`memory_pack` は、durable memory を含む構造化 bundle がほしい MCP client 向けの相当物です。
+
+## sanitization / redaction
+
+Durable memory は長く残る文脈なので、抽出または保存する前に既存の sanitization / redaction 経路を通す前提です。
+
+つまり:
+
+- 長期利用の文脈としては、生の shell 出力より安全に扱いやすい
+- ただし、secret を保存してよい場所ではない
+- 残してはいけない情報なら durable memory に昇格させない
+
+## 推奨ワークフロー
+
+1. hooks や CLI で、まず audit layer に生の履歴を残す
+2. `traceary tail`、`traceary list`、`traceary search`、`traceary show` で最近の流れを確認する
+3. すでに信頼できる事実は `traceary memory remember` で明示的に残す
+4. session summary や compact summary から review 用候補を作るときは `traceary memory extract` を使う
+5. 次のエージェントや次回 session に引き継ぐときは `traceary handoff` を使う
+
+## 関連文書
+
+- [README](../../README.ja.md)
+- [CLI リファレンス](../cli/README.ja.md)
+- [MCP ガイド](../mcp/README.ja.md)
+- [Hook contract](../hooks/contract.ja.md)
+- [イベントライフサイクル](../lifecycle.ja.md)

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -1,0 +1,107 @@
+# Durable memory guide
+
+[日本語](./README.ja.md)
+
+This guide explains how Traceary's durable-memory layer fits into the broader product model and how the memory-related CLI / MCP surfaces relate to each other.
+
+## Where durable memory fits
+
+Traceary organizes agent context into three layers:
+
+| Layer | Role | Typical data |
+| --- | --- | --- |
+| Audit / Archive | source-of-truth history for search and inspection | raw events, session boundaries, command audits |
+| Working memory | short-lived context assembled for resume / handoff | handoff packs, recent commands, compact summaries |
+| Durable memory | facts worth carrying across sessions | decisions, constraints, preferences, lessons, artifact refs |
+
+Durable memory is intentionally small. It is not a transcript dump and it is not a replacement for the audit log.
+
+## Memory lifecycle
+
+Every durable memory has a type, scope, status, confidence, evidence refs, and optional artifact refs.
+
+### Statuses
+
+- `candidate`: extracted or proposed memory that still needs review
+- `accepted`: active memory that should be reused across sessions
+- `rejected`: candidate that should not be reused
+- `superseded`: older accepted memory replaced by a newer one
+- `expired`: memory that was valid for a limited period and is no longer active
+
+Only active accepted memories are returned by the default "active memory" paths.
+
+## Evidence refs vs artifact refs
+
+Traceary stores two different kinds of references with a memory:
+
+- **evidence refs** explain why the fact is justified
+  - examples: `event:...`, `session:...`, `issue:#462`, `pr:#468`
+- **artifact refs** point to things an operator or agent may want to open next
+  - examples: `file:docs/release/README.md`, `url:https://...`, `command:go test ./...`
+
+Accepted memories require evidence refs. Artifact refs are optional.
+
+## How the memory commands relate
+
+### Manual write path
+
+Use these when a human or agent wants to record a fact deliberately:
+
+- `traceary memory remember`
+- `traceary memory propose`
+- `traceary memory accept`
+- `traceary memory reject`
+- `traceary memory supersede`
+- `traceary memory expire`
+
+### Extraction path
+
+Use these when Traceary should infer candidate memories from existing session signals:
+
+- `traceary memory extract`
+
+Extraction is candidate-only. It does not auto-accept memories.
+
+### Query path
+
+Use these to inspect existing durable memories:
+
+- `traceary memory list`
+- `traceary memory search`
+- `traceary memory show`
+
+### Context / handoff path
+
+Use these when you want the memory layer folded into a resume-friendly context pack:
+
+- `traceary handoff`
+- MCP `session_handoff`
+- MCP `memory_pack`
+
+`handoff` returns a working-memory summary for the next session. `memory_pack` is the MCP-oriented equivalent when a client wants a structured bundle that already includes durable memories.
+
+## Sanitization and redaction
+
+Traceary treats durable memory as persistent context, so extracted or written memory content should go through the existing sanitization / redaction path before it is stored.
+
+That means:
+
+- durable memory is safer than raw shell output for long-lived reuse
+- but it is still not a place to intentionally store secrets
+- if a fact should stay private, do not promote it into durable memory
+
+## Recommended operator workflow
+
+1. keep raw history in the audit layer through hooks or CLI writes
+2. inspect recent work with `traceary tail`, `traceary list`, `traceary search`, or `traceary show`
+3. use `traceary memory remember` for explicit facts you already trust
+4. use `traceary memory extract` to generate reviewable candidates from session summaries and compact summaries
+5. use `traceary handoff` when the next agent or session should start from a compact context bundle
+
+## Related docs
+
+- [Repository README](../../README.md)
+- [CLI reference](../cli/README.md)
+- [MCP guide](../mcp/README.md)
+- [Hook contract](../hooks/contract.md)
+- [Event lifecycle](../lifecycle.md)


### PR DESCRIPTION
## Summary
- add a dedicated durable-memory concept guide in English and Japanese
- refresh README entry points so the current product shape emphasizes memory, lifecycle, and hooks
- update the docs index to highlight the concept pages maintainers and users should read first

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #502