### PR TITLE
docs: refresh release and support guidance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -158,5 +158,5 @@ traceary session end --session-id "$sid" --id-only
 ## コントリビュートとサポート
 
 - バグ報告や改善提案は GitHub Issues へお願いします
-- 脆弱性の連絡先は [CONTRIBUTING.ja.md](./CONTRIBUTING.ja.md) を参照してください
+- 脆弱性の報告方法は [SECURITY.ja.md](./SECURITY.ja.md) を参照してください
 - まだ `v0.x` の OSS なので、自動化に組み込む前には [変更履歴](./CHANGELOG.ja.md) を確認してください

--- a/README.md
+++ b/README.md
@@ -160,5 +160,5 @@ The most common next pages are:
 ## Contributing and support
 
 - bug reports and feature requests belong in GitHub Issues
-- security reports should follow the private contact path in [CONTRIBUTING.md](./CONTRIBUTING.md)
+- security reports should follow [SECURITY.md](./SECURITY.md)
 - this is an actively evolving `v0.x` OSS tool, so check the [changelog](./CHANGELOG.md) before upgrading automation around it

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 特定の release を使いたい場合は tag を明示します。
 
 ```sh
-go install github.com/duck8823/traceary@v0.5.0
+go install github.com/duck8823/traceary@vX.Y.Z
 ```
 
 ### Homebrew
@@ -106,7 +106,7 @@ GoReleaser workflow が artifact の公開を自動化しますが、maintainer 
 2. **manifest を bump する。** `make release/bump VERSION=X.Y.Z` を実行すると、`VERSION` と integration plugin manifest がまとめて更新され、`scripts/verify_integrations.py` も走ります。
 3. **ローカル検証。** `python3 scripts/verify_changelog_releases.py` / `go test ./...` / `go tool golangci-lint run` をすべて通します。
 4. **release-preparation PR を開く。** `maintenance/release-vX.Y.Z` ブランチを作成し、changelog と bump を commit・push して `main` 向けに PR を開きます。**`Closes #<parent>` は書かない**でください。親 release issue は release workflow が閉じるため、release-prep PR からは閉じません。
-5. **Multi-AI レビュー + merge。** release-prep PR も通常の PR と同じく Multi-AI レビューゲート（Claude + Codex または Gemini scout）を通し、merge commit でマージします。
+5. **Multi-AI レビュー + merge。** release-prep PR も通常の PR と同じく、最新 head に対する Claude / Gemini のレビューを取り、そのうえで PR 上の Codex app review が返るのを待ってから merge commit でマージします。
 6. **tag を打って push する。** release-prep PR が merge されたら、`git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z` を実行します。`v*` tag が `.github/workflows/release.yml` を起動します。
 7. **release workflow を監視する。** tag run に対して `gh run watch` を実行し、成功後に `gh release view vX.Y.Z` で公開を確認します。
 8. **Homebrew formula PR を確認する。** release workflow が `maintenance/homebrew-vX.Y.Z` PR を開いて auto-merge を有効化します。実際に merge されたか確認し、`brew update && brew upgrade traceary && traceary -v` で新バージョンを確かめます。

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -17,7 +17,7 @@ go install github.com/duck8823/traceary@latest
 If you prefer a specific release, pin the tag explicitly.
 
 ```sh
-go install github.com/duck8823/traceary@v0.5.0
+go install github.com/duck8823/traceary@vX.Y.Z
 ```
 
 ### Homebrew
@@ -107,7 +107,7 @@ The GoReleaser workflow automates artifact publishing, but a handful of steps st
 2. **Bump manifests.** Run `make release/bump VERSION=X.Y.Z` — this updates `VERSION`, all integration plugin manifests, and runs `scripts/verify_integrations.py`.
 3. **Verify locally.** `python3 scripts/verify_changelog_releases.py`, `go test ./...`, and `go tool golangci-lint run` must all pass.
 4. **Open the release-preparation PR.** Create a `maintenance/release-vX.Y.Z` branch, commit the changelog and bump changes, push, and open a PR targeting `main`. Do **not** include `Closes #<parent>` — the parent release issue is auto-closed by the tagged release workflow, not by the release-prep PR.
-5. **Multi-AI review + merge.** The release-prep PR must pass the same Multi-AI review gate as any other PR (Claude + Codex or Gemini scout). Merge with a merge commit.
+5. **Multi-AI review + merge.** The release-prep PR must pass the same review gate as any other PR: obtain fresh Claude and Gemini reviews on the latest head, then wait for the PR-side Codex app review to finish before merging with a merge commit.
 6. **Tag and push.** After the release-prep PR merges, run `git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z`. The `v*` tag triggers `.github/workflows/release.yml`.
 7. **Watch the release workflow.** `gh run watch` against the tag run. On success, verify with `gh release view vX.Y.Z`.
 8. **Confirm the Homebrew formula PR.** The release workflow opens `maintenance/homebrew-vX.Y.Z` and enables auto-merge, but confirm it actually merged. `brew update && brew upgrade traceary && traceary -v` should report the new version.


### PR DESCRIPTION
## Summary
- replace stale release version examples with reusable placeholders
- update the maintainer review steps to match the current Claude/Gemini + Codex app flow
- point README security-reporting guidance directly at SECURITY.md / SECURITY.ja.md

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #503