### PR TITLE
docs: deepen GoDoc architecture comments

### DIFF
--- a/application/package.go
+++ b/application/package.go
@@ -1,3 +1,7 @@
-// Package application provides the application layer, including use cases
-// and query services.
+// Package application defines the orchestration layer between presentation
+// adapters and the domain model.
+//
+// This layer contains write-side use cases, read-side query-service
+// contracts, and shared DTOs used to move structured data across those
+// boundaries without leaking infrastructure concerns into the domain.
 package application

--- a/application/queryservice/package.go
+++ b/application/queryservice/package.go
@@ -1,2 +1,5 @@
-// Package queryservice provides read-only query services.
+// Package queryservice defines read-only application services.
+//
+// Query services answer reporting, search, and inspection requests without
+// exposing persistence details to presentation adapters.
 package queryservice

--- a/application/types/package.go
+++ b/application/types/package.go
@@ -1,2 +1,6 @@
-// Package types defines application-layer DTOs shared by queryservice and usecase interfaces.
+// Package types defines application-layer DTOs, criteria objects, and read
+// models shared by usecase and queryservice boundaries.
+//
+// These types describe structured inputs and outputs for orchestration logic
+// such as session summaries, handoff packs, and durable-memory views.
 package types

--- a/application/usecase/context_usecase.go
+++ b/application/usecase/context_usecase.go
@@ -9,6 +9,10 @@ import (
 
 // ContextUsecase assembles structured working-memory packs for handoff and
 // context resumption.
+//
+// This is the preferred read/write orchestration surface behind
+// operator-facing `traceary handoff` output and MCP tools such as
+// `session_handoff` and `memory_pack`.
 type ContextUsecase interface {
 	// Handoff builds a structured ContextPack. Returns an empty Optional when no
 	// matching session exists.

--- a/application/usecase/memory_extraction_usecase.go
+++ b/application/usecase/memory_extraction_usecase.go
@@ -8,8 +8,14 @@ import (
 
 // MemoryExtractionUsecase extracts candidate durable memories from existing
 // session/history signals.
+//
+// Extraction is intentionally candidate-only. The resulting facts still need
+// review before they become accepted durable memories.
 type MemoryExtractionUsecase interface {
 	// Extract proposes candidate memories from the target session and returns the
 	// created candidate details.
+	//
+	// Stored facts are expected to pass through the existing memory
+	// sanitization/redaction path before persistence.
 	Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error)
 }

--- a/application/usecase/package.go
+++ b/application/usecase/package.go
@@ -1,2 +1,7 @@
-// Package usecase provides Traceary use cases.
+// Package usecase contains Traceary's write-side orchestration interfaces and
+// implementations.
+//
+// Use cases coordinate domain objects, repositories, and query lookups for
+// operator-facing workflows such as session lifecycle management, manual memory
+// updates, and handoff/context assembly.
 package usecase

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -8,7 +8,8 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-// SessionUsecase consolidates session lifecycle and query operations.
+// SessionUsecase consolidates session lifecycle operations plus the legacy
+// session-level query surfaces that remain for compatibility.
 type SessionUsecase interface {
 	// Start begins a new session. If sessionID is zero, a new ID is generated.
 	// Zero-value parentSessionID means no parent (top-level session).
@@ -36,8 +37,11 @@ type SessionUsecase interface {
 	// Returns an empty Optional when no matching session exists.
 	Latest(ctx context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error)
 
-	// Handoff returns a concise summary for session context transfer between agents.
-	// Zero-value workspace means no workspace filter.
-	// Returns an empty Optional when no matching session exists.
+	// Handoff returns the legacy session handoff summary shape used by older CLI
+	// and MCP callers.
+	//
+	// New callers that want the structured working-memory pack should prefer
+	// ContextUsecase.Handoff instead. Zero-value workspace means no workspace
+	// filter. Returns an empty Optional when no matching session exists.
 	Handoff(ctx context.Context, sessionID types.SessionID, workspace types.Workspace, recent int) (types.Optional[apptypes.HandoffSummary], error)
 }

--- a/domain/model/package.go
+++ b/domain/model/package.go
@@ -1,2 +1,6 @@
-// Package model provides Traceary entities and repository interfaces.
+// Package model defines Traceary entities, aggregates, and repository
+// contracts.
+//
+// These types represent the stable business concepts stored by Traceary, such
+// as events, sessions, command audits, and durable memories.
 package model

--- a/domain/package.go
+++ b/domain/package.go
@@ -1,2 +1,5 @@
-// Package domain provides the Traceary domain layer.
+// Package domain holds the Traceary business model.
+//
+// The domain layer stays free of infrastructure dependencies and defines the
+// core concepts that the application layer orchestrates.
 package domain

--- a/domain/types/package.go
+++ b/domain/types/package.go
@@ -1,2 +1,5 @@
-// Package types provides Traceary value objects.
+// Package types provides Traceary value objects and domain-level enums.
+//
+// Value objects in this package encode validated identifiers, taxonomy values,
+// and scope descriptors that are shared across domain models.
 package types

--- a/presentation/package.go
+++ b/presentation/package.go
@@ -1,2 +1,6 @@
-// Package presentation provides external interfaces such as the CLI.
+// Package presentation contains Traceary's external adapters.
+//
+// Today that includes the CLI and MCP server entrypoints, plus the
+// operator-facing formatting and command wiring that sit on top of the
+// application layer.
 package presentation


### PR DESCRIPTION
## Summary
- expand package comments so layer boundaries are discoverable through GoDoc
- clarify the legacy SessionUsecase handoff surface versus ContextUsecase
- document memory extraction semantics around candidate-only creation and sanitization

## Testing
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #504