### PR TITLE
chore: ignore local Claude workspace state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .DS_Store
 dist/
 .cache/
+.claude/
 .ai-logs/


### PR DESCRIPTION
## Summary
- ignore `.claude/` local workspace state

## Motivation
`.claude/` only contains machine-local Claude tooling state such as lock files, local settings, and temporary worktree metadata. It should not appear as untracked repository content.

Closes #518
