### PR TITLE
docs: document architecture principles and runtime boundaries

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,6 +160,7 @@ traceary handoff --workspace github.com/duck8823/traceary
 詳しい一覧は [ドキュメント索引](./docs/README.ja.md) にまとめています。最初によく使うのは次のページです。
 
 - [ネイティブ連携ガイド](./docs/integrations/README.ja.md)
+- [アーキテクチャ原則](./docs/architecture/README.ja.md)
 - [Durable memory ガイド](./docs/memory/README.ja.md)
 - [CLI リファレンス](./docs/cli/README.ja.md)
 - [Hooks ガイド](./docs/hooks/README.ja.md)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Use the [documentation index](./docs/README.md) for the full map.
 The most common next pages are:
 
 - [Native integrations](./docs/integrations/README.md)
+- [Architecture principles](./docs/architecture/README.md)
 - [Durable memory guide](./docs/memory/README.md)
 - [CLI reference](./docs/cli/README.md)
 - [Hooks guide](./docs/hooks/README.md)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -6,6 +6,7 @@
 
 ## まず読むページ
 
+- [アーキテクチャ原則](./architecture/README.ja.md): 4 層、runtime 境界、`scripts/` の役割、`internal/` の方針
 - [Durable memory ガイド](./memory/README.ja.md): 3 層モデル、memory のライフサイクル、ref の意味、memory コマンドの関係
 - [CLI リファレンス](./cli/README.ja.md): コマンドごとの挙動、主要フラグ、出力仕様
 - [Hook contract](./hooks/contract.ja.md): ホストごとの自動記録範囲と共通動作

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 
 ## Start here
 
+- [Architecture principles](./architecture/README.md): layering rules, runtime boundaries, the role of `scripts/`, and the current `internal/` stance
 - [Durable memory guide](./memory/README.md): the three-layer model, memory lifecycle, refs, and how memory commands relate
 - [CLI reference](./cli/README.md): command-by-command behavior, flags, and output contracts
 - [Hook contract](./hooks/contract.md): automatic-capture coverage and shared hook semantics across hosts

--- a/docs/architecture/README.ja.md
+++ b/docs/architecture/README.ja.md
@@ -1,0 +1,137 @@
+# アーキテクチャ原則
+
+[English](./README.md)
+
+この文書は、Traceary のソフトウェアアーキテクチャについて守るべき原則を整理したものです。とくに hook runtime のような構造変更を進めるときに、「なんとなくそうしていた」ではなく、明文化された境界に沿ってレビューできるようにすることを目的としています。
+
+## この文書が必要な理由
+
+Traceary はすでに 4 層構造を採っていますが、runtime の振る舞いと補助スクリプトの境界が一部で曖昧です。もっとも分かりやすい例が、現在の hook 配布方式です。`scripts/hooks/` の shell script をバイナリへ埋め込み、利用者環境に展開していますが、Traceary の主 runtime はあくまで Go です。
+
+この方式は今のところ機能しています。ただし、将来にわたって維持したい理想形ではありません。この文書では、その理想形を定義します。
+
+## 4 層構造
+
+Traceary では、次の 4 層を前提にします。
+
+```text
+presentation -> application -> domain <- infrastructure
+```
+
+| 層 | 置くもの | 置かないもの |
+| --- | --- | --- |
+| `presentation/` | CLI コマンドの配線、MCP server の handler、hook ホスト固有の payload 解釈、利用者向けの表示整形、transport ごとの入力検証 | domain ルール、永続化の実装、長期的な業務状態 |
+| `application/` | write-side use case、read-side query service の契約、domain object をまたぐオーケストレーション、共有の read model / DTO | SQL、filesystem の細かな操作、transport 固有の payload 解釈 |
+| `domain/` | entity、value object、repository 契約、不変条件、業務エラー | Cobra、SQLite、JSON transport の扱い、shell 連携の都合 |
+| `infrastructure/` | SQLite 実装、filesystem adapter、プラットフォーム固有の file handling、外部依存の adapter | domain/application に置くべき業務判断、その場しのぎの CLI 制御 |
+
+### 依存方向
+
+- `presentation` は `application` と `domain/types` に依存してよい
+- `application` は `domain` に依存してよい
+- `domain` は他の層に依存してはいけない
+- `infrastructure` は `application` の契約と `domain` に依存してよいが、内側の層から `infrastructure` を参照してはいけない
+
+ここで目指しているのは、何でも抽象化することではありません。業務ルールと runtime entrypoint の置き場所を、誰が見ても分かるようにすることです。
+
+## runtime の振る舞いはどこに置くか
+
+runtime の本体ロジックは、明示的な例外がない限り、通常の Go package に置きます。場当たり的な helper script を primary な実装にしてはいけません。
+
+### 推奨する runtime entrypoint
+
+利用者やホストから直接呼ばれる entrypoint は `presentation/` に置きます。
+
+例:
+- `traceary` CLI コマンド
+- `traceary mcp-server`
+- 今後追加する `traceary hook ...` サブコマンド
+
+これらの entrypoint では、ホスト固有の payload やユーザー入力を受け取り、正規化したうえで application の use case へ渡します。
+
+### hook ホスト adapter
+
+hook ホスト adapter は、ホスト固有の runtime payload を解釈する限り、presentation 層の責務です。
+
+つまり、次は presentation に置きます。
+
+- Claude / Codex / Gemini ごとの event 名や payload 形式の差
+- hook invocation の stdin / env / JSON の解釈
+- それらを application 入力へ正規化する処理
+
+逆に、host ごとの shell 振る舞いを runtime 本体として抱え続けるべきではありません。
+
+### 外向きの integration asset
+
+hook 設定ファイルや互換用 shell wrapper のように、利用者環境へ配布・展開する asset は残る場合があります。これらは runtime の正本ではなく、配布・導入の都合として扱います。したがって、責務としては `infrastructure/` 側です。
+
+判断に迷ったら、次の 2 問で分けます。
+
+- **「ユーザーが Traceary を呼び出したとき、何が起きるべきか」** → `presentation` / `application`
+- **「ホストが Traceary を呼べるように、どうファイルを配置・生成するか」** → `infrastructure`
+
+## `scripts/` の役割
+
+`scripts/` は、開発・運用・リリース補助のための置き場です。
+
+典型例:
+- 検証スクリプト
+- リリース準備用ユーティリティ
+- packaging / install の補助
+- CI 向けの保守スクリプト
+
+`scripts/` は、長く残る production runtime logic の本体置き場ではありません。
+
+もし runtime 時にも必要な script が残るなら、それは一時的な互換レイヤーとして扱い、最低限次を明記します。
+
+- なぜまだ必要なのか
+- 本来の Go entrypoint は何か、または何になる予定か
+- その縮小・削除を追跡している issue はどれか
+
+## 現在の例外: hook 用 shell asset
+
+現状では、`scripts/hooks/` 配下の shell asset を埋め込み、各 integration 向けに展開しています。これは明示的な一時例外です。
+
+進めたい方向は次の通りです。
+
+1. hook runtime の本体を Go サブコマンド（`traceary hook ...`）へ移す
+2. shell asset が必要なら、薄い互換 wrapper だけに縮小する
+3. 最終的に `scripts/hooks/` を runtime 実装の正本とみなさない状態へ移る
+
+この移行が終わるまでは、`scripts/hooks/` は互換用 infrastructure とみなし、新しい業務ロジックや runtime の主実装をそこへ足さないのが原則です。
+
+## `internal/` についての方針
+
+`internal/` は可視性を制御するための仕組みであって、アーキテクチャそのものではありません。
+
+Traceary では、`internal/` を既定では要求しません。
+
+使うのは、次のような場合だけです。
+
+- その package が実装詳細であり、外から import されると明確に害がある
+- 可視性を制限した方が public package surface を実質的に単純化できる
+- その制約が、既存の層名・package 名よりも明快である
+
+単に見た目をきれいにするためだけに `internal/` を増やしてはいけません。境界が曖昧なら、まず境界を直します。
+
+## 新しい設計を足すときの確認項目
+
+新機能や refactor を入れるときは、少なくとも次を確認します。
+
+1. runtime の本体ロジックは helper script ではなく Go package にあるか
+2. transport / host 固有の解釈は `presentation/` に留まっているか
+3. オーケストレーションは `application/` にあるか
+4. domain から SQLite / CLI / MCP の都合が見えていないか
+5. `infrastructure/` は契約を実装しているだけで、業務判断を作っていないか
+6. script が残る場合、それは helper か一時的な互換レイヤーだと明示されているか
+7. `internal/` を提案するなら、好みではなく具体的な可視性上の理由があるか
+
+どれかが満たせない場合は、例外を明文化してからマージします。
+
+## 関連文書
+
+- [ドキュメント索引](../README.ja.md)
+- [Hook contract](../hooks/contract.ja.md)
+- [イベントライフサイクル](../lifecycle.ja.md)
+- [ネイティブ連携ガイド](../integrations/README.ja.md)
+- [Durable memory ガイド](../memory/README.ja.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,132 @@
+# Architecture principles
+
+[日本語](./README.ja.md)
+
+This document records the software architecture rules that Traceary should keep as the repository evolves. It exists so future refactors — especially around hook runtime behavior — can be reviewed against explicit boundaries instead of convention by memory.
+
+## Why this document exists
+
+Traceary already follows a four-layer structure, but the repository still has a few places where runtime behavior and helper assets blur together. The most visible example is the current hook packaging model: shell scripts under `scripts/hooks/` are embedded into the binary and materialized for users even though Traceary's primary runtime is Go.
+
+That packaging model works today, but it should be treated as a transitional compatibility path, not as the architectural target. This document defines the target.
+
+## The four layers
+
+Traceary uses four named layers:
+
+```text
+presentation -> application -> domain <- infrastructure
+```
+
+| Layer | What belongs here | What does not belong here |
+| --- | --- | --- |
+| `presentation/` | CLI command wiring, MCP server handlers, hook-host payload parsing, operator-facing formatting, transport-specific validation | domain rules, persistence logic, long-lived business state |
+| `application/` | write-side use cases, read-side query-service contracts, orchestration across domain objects, shared read models/DTOs | SQL, filesystem mutation details, transport-specific payload parsing |
+| `domain/` | entities, value objects, repository contracts, invariants, business errors | Cobra, SQLite, JSON transport handling, shell integration details |
+| `infrastructure/` | SQLite implementations, filesystem adapters, platform-specific file handling, external dependency adapters | business decisions that should live in domain/application, ad-hoc CLI flow control |
+
+### Dependency direction
+
+- `presentation` may depend on `application` and `domain/types`.
+- `application` may depend on `domain`.
+- `domain` must not depend on the other layers.
+- `infrastructure` may depend on `application` contracts and `domain`, but the inner layers must not depend on `infrastructure`.
+
+The goal is not to make every file abstract. The goal is to keep business rules and runtime entrypoints in predictable places.
+
+## Where runtime behavior belongs
+
+Runtime behavior should live in normal Go packages, not in ad-hoc helper scripts, unless there is an explicit and documented exception.
+
+### Preferred runtime entrypoints
+
+First-class runtime entrypoints belong in `presentation/`.
+
+Examples:
+- `traceary` CLI commands
+- `traceary mcp-server`
+- future `traceary hook ...` subcommands
+
+These entrypoints may parse host-specific payloads or user input, then hand normalized data to application use cases.
+
+### Hook-host adapters
+
+Hook-host adapters are part of the presentation layer when they interpret host-specific runtime payloads.
+
+That means:
+- Claude / Codex / Gemini event names and payload shapes are presentation concerns
+- stdin/env/JSON parsing for hook invocations is a presentation concern
+- mapping those payloads into normalized application inputs is a presentation concern
+
+What should *not* happen is embedding host-specific shell behavior as the primary home of Traceary's runtime logic.
+
+### Outbound integration assets
+
+Some integration assets are still generated or installed from outside `presentation/`, for example hook config files and compatibility shell wrappers. Those belong to infrastructure as delivery/install concerns, not as the canonical implementation of runtime behavior.
+
+A useful rule of thumb:
+- **"What should happen when the user invokes Traceary?"** -> `presentation` / `application`
+- **"How do we install or materialize files so a host can invoke Traceary?"** -> `infrastructure`
+
+## The role of `scripts/`
+
+`scripts/` is for developer and release helpers.
+
+Typical examples:
+- verification helpers
+- release-preparation utilities
+- packaging/install convenience scripts
+- CI-oriented maintenance helpers
+
+`scripts/` is **not** the preferred long-lived home for production runtime logic.
+
+If a script is required at runtime, treat it as a temporary compatibility asset and document:
+- why it still exists
+- what the intended Go entrypoint is or will be
+- what issue tracks its removal or narrowing
+
+## Current exception: packaged hook shell assets
+
+Today the repository still embeds shell assets from `scripts/hooks/` and materializes them for packaged integrations. That is an explicit temporary exception.
+
+The intended direction is:
+1. move hook runtime behavior into Go subcommands (`traceary hook ...`)
+2. reduce shell assets to thin compatibility wrappers only when still needed
+3. eventually stop treating `scripts/hooks/` as the canonical runtime implementation
+
+Until that migration lands, reviews should treat `scripts/hooks/` as compatibility infrastructure, not as the place to introduce new business/runtime behavior by default.
+
+## `internal/` policy
+
+`internal/` is a visibility tool, not a substitute for architecture.
+
+Traceary does **not** require an `internal/` tree by default.
+
+Use `internal/` only when one of these is true:
+- a package is implementation detail that would be actively harmful to import from sibling modules
+- visibility restriction materially simplifies the public package surface
+- the restriction is clearer than the existing layer/package naming
+
+Do **not** add `internal/` just to make a design look cleaner on paper. If the layer boundaries are unclear, fix the boundaries first.
+
+## Design checklist for new work
+
+When adding or refactoring functionality, check these questions:
+
+1. Is the primary runtime behavior implemented in Go packages rather than helper scripts?
+2. Does transport/host-specific parsing stay in `presentation/`?
+3. Does orchestration stay in `application/`?
+4. Do domain rules remain free from SQLite/CLI/MCP details?
+5. Is `infrastructure/` implementing contracts instead of inventing business behavior?
+6. If a script still exists, is it clearly a helper or a temporary compatibility layer?
+7. If `internal/` is proposed, is there a concrete visibility reason beyond taste?
+
+If the answer to any of these is "no", document the exception explicitly before merging.
+
+## Related docs
+
+- [Documentation index](../README.md)
+- [Hook contract](../hooks/contract.md)
+- [Event lifecycle](../lifecycle.md)
+- [Native integrations guide](../integrations/README.md)
+- [Durable memory guide](../memory/README.md)


### PR DESCRIPTION
## Summary
- add a dedicated architecture principles guide in English and Japanese
- document Traceary's four-layer model, runtime boundaries, the role of `scripts/`, and the `internal/` stance
- link the new guide from the docs index and top-level README docs section

## Motivation
- establish an explicit architecture baseline before the hook-runtime migration work under v0.6.0 continues
- make the current `scripts/hooks` shell packaging model an intentional documented exception instead of an implicit norm
- give future runtime refactors a stable review checklist for layer placement and boundary decisions

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build go build ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #506
