### PR TITLE
feat: add Go hook runtime subcommands

### DIFF
--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -1,0 +1,756 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const hookStateDirEnvKey = "TRACEARY_HOOK_STATE_DIR"
+
+func (c *RootCLI) newHookCommand() *cobra.Command {
+	hookCmd := &cobra.Command{
+		Use:    "hook",
+		Short:  "Runtime entrypoints used by packaged Traceary hooks",
+		Hidden: true,
+	}
+	hookCmd.AddCommand(c.newHookSessionCommand())
+	hookCmd.AddCommand(c.newHookAuditCommand())
+	hookCmd.AddCommand(c.newHookCompactCommand())
+	hookCmd.AddCommand(c.newHookPromptCommand())
+
+	return hookCmd
+}
+
+func (c *RootCLI) newHookSessionCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "session <client> <start|end|stop>",
+		Short:  "Record hook-driven session lifecycle events",
+		Hidden: true,
+		Args:   exactArgsLocalized(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) newHookAuditCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "audit <client>",
+		Short:  "Record hook-driven command audits",
+		Hidden: true,
+		Args:   exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runHookAudit(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) newHookCompactCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "compact <client> <post-compact|session-start-compact>",
+		Short:  "Record or emit compact hook state",
+		Hidden: true,
+		Args:   exactArgsLocalized(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) newHookPromptCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "prompt <client>",
+		Short:  "Record hook-driven prompt capture",
+		Hidden: true,
+		Args:   exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) runHookSession(
+	ctx context.Context,
+	output io.Writer,
+	input io.Reader,
+	client string,
+	action string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.session == nil {
+		return xerrors.Errorf("record session boundary usecase is not configured")
+	}
+
+	if action != "start" && action != "end" && action != "stop" {
+		return xerrors.Errorf("unsupported hook session action: %s", action)
+	}
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+
+	agent, err := resolveHookAgent(client, payload)
+	if err != nil {
+		return err
+	}
+
+	switch action {
+	case "start":
+		workspace, err := resolveHookWorkspace(ctx, payload, client, false)
+		if err != nil {
+			return err
+		}
+		sessionID := types.SessionID(hookPayloadString(payload, "session_id", ""))
+		parentSessionID := types.SessionID(strings.TrimSpace(os.Getenv("TRACEARY_PARENT_SESSION_ID")))
+		event, err := c.session.Start(ctx, types.Client("hook"), agent, sessionID, workspace, parentSessionID)
+		if err != nil {
+			return xerrors.Errorf("failed to record hook session start: %w", err)
+		}
+		if err := writeHookSessionState(client, event.SessionID()); err != nil {
+			return err
+		}
+		if err := clearHookSessionEndMarker(client, event.SessionID()); err != nil {
+			return err
+		}
+		if workspace != "" {
+			if err := writeHookWorkspaceState(client, workspace); err != nil {
+				return err
+			}
+		}
+		if output != nil {
+			if _, err := fmt.Fprintln(output, event.SessionID()); err != nil {
+				return xerrors.Errorf("failed to print session ID: %w", err)
+			}
+		}
+		return nil
+	case "end", "stop":
+		sessionID := types.SessionID(hookPayloadString(payload, "session_id", ""))
+		if sessionID == "" {
+			sessionID, err = readHookSessionState(client)
+			if err != nil {
+				return err
+			}
+		}
+		if sessionID == "" {
+			return nil
+		}
+		if alreadyEnded, err := hookSessionEndAlreadyRecorded(client, sessionID); err == nil && alreadyEnded {
+			if clearErr := clearHookSessionState(client); clearErr != nil {
+				return clearErr
+			}
+			if clearErr := clearHookWorkspaceState(client); clearErr != nil {
+				return clearErr
+			}
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+		if err != nil {
+			return err
+		}
+		if _, err := c.session.End(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
+			return xerrors.Errorf("failed to record hook session end: %w", err)
+		}
+		if err := clearHookSessionState(client); err != nil {
+			return err
+		}
+		if err := clearHookWorkspaceState(client); err != nil {
+			return err
+		}
+		if err := markHookSessionEnded(client, sessionID); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return xerrors.Errorf("unsupported hook session action: %s", action)
+	}
+}
+
+func (c *RootCLI) runHookAudit(
+	ctx context.Context,
+	input io.Reader,
+	client string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.event == nil {
+		return xerrors.Errorf("record command audit usecase is not configured")
+	}
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	command := hookPayloadString(payload, "tool_input.command", "")
+	if command == "" {
+		command = hookPayloadString(payload, "tool_name", "")
+	}
+	if command == "" {
+		return nil
+	}
+
+	sessionID, err := resolveHookSessionID(payload, client)
+	if err != nil {
+		return err
+	}
+	if sessionID == "" {
+		return nil
+	}
+	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+	if err != nil {
+		return err
+	}
+	agent, err := resolveHookAgent(client, payload)
+	if err != nil {
+		return err
+	}
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+
+	auditInput := hookPayloadString(payload, "tool_input", "{}")
+	if auditInput == "" || auditInput == "{}" {
+		toolName := hookPayloadString(payload, "tool_name", "")
+		if toolName != "" {
+			encodedValue, err := marshalStableJSON(map[string]any{"tool_name": toolName})
+			if err != nil {
+				return err
+			}
+			auditInput = string(encodedValue)
+		}
+	}
+	auditOutput := hookPayloadString(payload, "tool_response", "")
+	if auditOutput == "" {
+		auditOutput, err = buildHookFailureOutput(payload)
+		if err != nil {
+			return err
+		}
+	}
+
+	redaction := apptypes.NewAuditRedactionBuilder().
+		ExtraRedactPatterns(c.extraRedactPatterns).
+		Build()
+	_, _, err = c.event.Audit(
+		ctx,
+		command,
+		auditInput,
+		auditOutput,
+		types.Client("hook"),
+		agent,
+		sessionID,
+		workspace,
+		hookPayloadExitCode(payload),
+		redaction,
+	)
+
+	if err != nil {
+		return xerrors.Errorf("failed to record hook audit: %w", err)
+	}
+
+	return nil
+}
+
+func (c *RootCLI) runHookCompact(
+	ctx context.Context,
+	output io.Writer,
+	input io.Reader,
+	client string,
+	action string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+
+	sessionID, err := resolveHookSessionID(payload, client)
+	if err != nil {
+		return err
+	}
+
+	switch action {
+	case "post-compact":
+		if c.event == nil || sessionID == "" {
+			return nil
+		}
+		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+		if err != nil {
+			return err
+		}
+		agent, err := resolveHookAgent(client, payload)
+		if err != nil {
+			return err
+		}
+		compactSummary := hookPayloadString(payload, "compact_summary", "")
+		body := compactSummary
+		kind := types.EventKindCompactSummary
+		if body == "" {
+			body = "compact triggered"
+			kind = types.EventKind("")
+		}
+		_, err = c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace)
+		if err != nil {
+			return xerrors.Errorf("failed to record compact hook event: %w", err)
+		}
+
+		return nil
+	case "session-start-compact":
+		if output == nil {
+			return nil
+		}
+		return c.printCompactSummary(ctx, output, resolvedDBPath, sessionID.String(), "", 3)
+	default:
+		return xerrors.Errorf("unsupported hook compact action: %s", action)
+	}
+}
+
+func (c *RootCLI) runHookPrompt(
+	ctx context.Context,
+	input io.Reader,
+	client string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.event == nil {
+		return xerrors.Errorf("record log usecase is not configured")
+	}
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	promptText := hookPayloadString(payload, "prompt", "")
+	if promptText == "" {
+		return nil
+	}
+	sessionID, err := resolveHookSessionID(payload, client)
+	if err != nil {
+		return err
+	}
+	if sessionID == "" {
+		return nil
+	}
+	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+	if err != nil {
+		return err
+	}
+	agent, err := resolveHookAgent(client, payload)
+	if err != nil {
+		return err
+	}
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+	_, err = c.event.Log(ctx, promptText, types.EventKindPrompt, types.Client("hook"), agent, sessionID, workspace)
+
+	if err != nil {
+		return xerrors.Errorf("failed to record hook prompt: %w", err)
+	}
+
+	return nil
+}
+
+func resolveHookAgent(client string, payload []byte) (types.Agent, error) {
+	agentType := hookPayloadString(payload, "agent_type", "")
+	agentValue := strings.TrimSpace(client)
+	if agentType != "" {
+		agentValue += "/" + agentType
+	}
+
+	agent, err := types.AgentOf(agentValue)
+	if err != nil {
+		return "", xerrors.Errorf("failed to resolve hook agent: %w", err)
+	}
+
+	return agent, nil
+}
+
+func resolveHookSessionID(payload []byte, client string) (types.SessionID, error) {
+	sessionID := types.SessionID(hookPayloadString(payload, "session_id", ""))
+	if sessionID != "" {
+		return sessionID, nil
+	}
+
+	return readHookSessionState(client)
+}
+
+func resolveHookWorkspace(ctx context.Context, payload []byte, client string, preferState bool) (types.Workspace, error) {
+	if explicit := strings.TrimSpace(os.Getenv("TRACEARY_WORKSPACE")); explicit != "" {
+		return types.Workspace(explicit), nil
+	}
+	if preferState {
+		workspace, err := readHookWorkspaceState(client)
+		if err != nil {
+			return "", err
+		}
+		if workspace != "" {
+			return workspace, nil
+		}
+	}
+
+	cwd := hookPayloadString(payload, "cwd", "")
+	if cwd == "" {
+		return "", nil
+	}
+
+	workspace, err := detectRepoContextFromDir(ctx, cwd)
+	if err == nil {
+		return types.Workspace(workspace), nil
+	}
+
+	return types.Workspace(normalizeLocalWorkContextPath(cwd)), nil
+}
+
+func hookPayloadString(payload []byte, path string, defaultValue string) string {
+	if len(payload) == 0 {
+		return defaultValue
+	}
+	value, ok := lookupHookPayloadValue(payload, path)
+	if !ok || value == nil {
+		return defaultValue
+	}
+	renderedValue, err := renderHookHelperValue(value)
+	if err != nil {
+		return defaultValue
+	}
+
+	return renderedValue
+}
+
+func hookPayloadExitCode(payload []byte) types.Optional[int] {
+	if len(payload) == 0 {
+		return types.Empty[int]()
+	}
+	value, ok := lookupHookPayloadValue(payload, "tool_response.exitCode")
+	if !ok || value == nil {
+		return types.Empty[int]()
+	}
+	switch typedValue := value.(type) {
+	case float64:
+		return types.Of(int(typedValue))
+	case int:
+		return types.Of(typedValue)
+	case int64:
+		return types.Of(int(typedValue))
+	case json.Number:
+		parsed, err := typedValue.Int64()
+		if err != nil {
+			return types.Empty[int]()
+		}
+		return types.Of(int(parsed))
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typedValue))
+		if err != nil {
+			return types.Empty[int]()
+		}
+		return types.Of(parsed)
+	default:
+		return types.Empty[int]()
+	}
+}
+
+func buildHookFailureOutput(payload []byte) (string, error) {
+	if len(payload) == 0 {
+		return "", nil
+	}
+	result := map[string]any{}
+	if errorValue := hookPayloadString(payload, "error", ""); errorValue != "" {
+		result["error"] = errorValue
+	}
+	if interruptValue, ok := lookupHookPayloadValue(payload, "is_interrupt"); ok {
+		result["is_interrupt"] = interruptValue
+	}
+	if len(result) == 0 {
+		return "", nil
+	}
+	encodedValue, err := marshalStableJSON(result)
+	if err != nil {
+		return "", xerrors.Errorf("failed to marshal failure payload: %w", err)
+	}
+
+	return string(encodedValue), nil
+}
+
+func resolveHookStateDir() (string, error) {
+	if envValue := strings.TrimSpace(os.Getenv(hookStateDirEnvKey)); envValue != "" {
+		resolvedPath, err := filepath.Abs(envValue)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve hook state directory: %w", err)
+		}
+
+		return resolvedPath, nil
+	}
+
+	homeDir, err := userHomeDirFunc()
+	if err != nil {
+		return "", xerrors.Errorf("failed to get user home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".config", "traceary", "hooks"), nil
+}
+
+func resolveHookStateKey() string {
+	if explicit := strings.TrimSpace(os.Getenv("TRACEARY_HOOK_STATE_KEY")); explicit != "" {
+		return sanitizeHookStateKey(explicit)
+	}
+	if parentPID := os.Getppid(); parentPID > 0 {
+		return sanitizeHookStateKey(strconv.Itoa(parentPID))
+	}
+
+	return sanitizeHookStateKey(strconv.Itoa(os.Getpid()))
+}
+
+func sanitizeHookStateKey(value string) string {
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			builder.WriteRune(r)
+		case r >= 'a' && r <= 'z':
+			builder.WriteRune(r)
+		case r >= '0' && r <= '9':
+			builder.WriteRune(r)
+		case r == '.' || r == '_' || r == '-':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('_')
+		}
+	}
+	if builder.Len() == 0 {
+		return "default"
+	}
+
+	return builder.String()
+}
+
+func hookSessionStatePath(client string) (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(stateDir, client+"-"+resolveHookStateKey()), nil
+}
+
+func hookWorkspaceStatePath(client string) (string, error) {
+	statePath, err := hookSessionStatePath(client)
+	if err != nil {
+		return "", err
+	}
+
+	return statePath + "-repo", nil
+}
+
+func hookSessionEndMarkerPath(client string, sessionID types.SessionID) (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	sanitizedSessionID := sanitizeHookStateKey(sessionID.String())
+
+	return filepath.Join(stateDir, "ended", client+"-"+sanitizedSessionID), nil
+}
+
+func writeHookSessionState(client string, sessionID types.SessionID) error {
+	statePath, err := hookSessionStatePath(client)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return xerrors.Errorf("failed to create hook state directory: %w", err)
+	}
+
+	if err := os.WriteFile(statePath, []byte(sessionID), 0o600); err != nil {
+		return xerrors.Errorf("failed to write hook session state: %w", err)
+	}
+
+	return nil
+}
+
+func readHookSessionState(client string) (types.SessionID, error) {
+	statePath, err := hookSessionStatePath(client)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", xerrors.Errorf("failed to read hook session state: %w", err)
+	}
+
+	return types.SessionID(strings.TrimSpace(string(data))), nil
+}
+
+func clearHookSessionState(client string) error {
+	statePath, err := hookSessionStatePath(client)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear hook session state: %w", err)
+	}
+
+	return nil
+}
+
+func writeHookWorkspaceState(client string, workspace types.Workspace) error {
+	statePath, err := hookWorkspaceStatePath(client)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return xerrors.Errorf("failed to create hook state directory: %w", err)
+	}
+
+	if err := os.WriteFile(statePath, []byte(workspace), 0o600); err != nil {
+		return xerrors.Errorf("failed to write hook workspace state: %w", err)
+	}
+
+	return nil
+}
+
+func readHookWorkspaceState(client string) (types.Workspace, error) {
+	statePath, err := hookWorkspaceStatePath(client)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", xerrors.Errorf("failed to read hook workspace state: %w", err)
+	}
+
+	return types.Workspace(strings.TrimSpace(string(data))), nil
+}
+
+func clearHookWorkspaceState(client string) error {
+	statePath, err := hookWorkspaceStatePath(client)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear hook workspace state: %w", err)
+	}
+
+	return nil
+}
+
+func hookSessionEndAlreadyRecorded(client string, sessionID types.SessionID) (bool, error) {
+	markerPath, err := hookSessionEndMarkerPath(client, sessionID)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(markerPath)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, xerrors.Errorf("failed to inspect hook end marker: %w", err)
+}
+
+func markHookSessionEnded(client string, sessionID types.SessionID) error {
+	markerPath, err := hookSessionEndMarkerPath(client, sessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		return xerrors.Errorf("failed to create hook end-marker directory: %w", err)
+	}
+
+	if err := os.WriteFile(markerPath, []byte{}, 0o600); err != nil {
+		return xerrors.Errorf("failed to write hook end marker: %w", err)
+	}
+
+	return nil
+}
+
+func clearHookSessionEndMarker(client string, sessionID types.SessionID) error {
+	markerPath, err := hookSessionEndMarkerPath(client, sessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear hook end marker: %w", err)
+	}
+
+	return nil
+}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -140,22 +140,21 @@ func (c *RootCLI) runHookSession(
 	if err != nil {
 		return err
 	}
-	resolvedDBPath, err := resolveDBPath(dbPath)
-	if err != nil {
-		return err
-	}
-	c.applyDatabasePath(resolvedDBPath)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return xerrors.Errorf("failed to initialize store: %w", err)
-	}
-
-	agent, err := resolveHookAgent(client, payload)
-	if err != nil {
-		return err
-	}
 
 	switch action {
 	case "start":
+		resolvedDBPath, err := resolveDBPath(dbPath)
+		if err != nil {
+			return err
+		}
+		c.applyDatabasePath(resolvedDBPath)
+		if err := c.storeManagement.Initialize(ctx); err != nil {
+			return xerrors.Errorf("failed to initialize store: %w", err)
+		}
+		agent, err := resolveHookAgent(client, payload)
+		if err != nil {
+			return err
+		}
 		workspace, err := resolveHookWorkspace(ctx, payload, client, false)
 		if err != nil {
 			return err
@@ -186,6 +185,10 @@ func (c *RootCLI) runHookSession(
 		}
 		return nil
 	case "end", "stop":
+		agent, err := resolveHookAgent(client, payload)
+		if err != nil {
+			return err
+		}
 		sessionID := types.SessionID(hookPayloadString(payload, "session_id", ""))
 		if sessionID == "" {
 			sessionID, err = readHookSessionState(client)
@@ -208,6 +211,14 @@ func (c *RootCLI) runHookSession(
 			return err
 		}
 
+		resolvedDBPath, err := resolveDBPath(dbPath)
+		if err != nil {
+			return err
+		}
+		c.applyDatabasePath(resolvedDBPath)
+		if err := c.storeManagement.Initialize(ctx); err != nil {
+			return xerrors.Errorf("failed to initialize store: %w", err)
+		}
 		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
 		if err != nil {
 			return err

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -20,7 +20,12 @@ import (
 
 const hookStateDirEnvKey = "TRACEARY_HOOK_STATE_DIR"
 
-var hookParentPIDLookup = defaultHookParentPIDLookup
+type hookParentProcessInfo struct {
+	parentPID int
+	command   string
+}
+
+var hookParentProcessLookup = defaultHookParentProcessLookup
 
 func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd := &cobra.Command{
@@ -45,7 +50,7 @@ func (c *RootCLI) newHookSessionCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort(func() error {
+			return runHookBestEffort("session", func() error {
 				return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
 			})
 		},
@@ -64,7 +69,7 @@ func (c *RootCLI) newHookAuditCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort(func() error {
+			return runHookBestEffort("audit", func() error {
 				return c.runHookAudit(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
 			})
 		},
@@ -83,7 +88,7 @@ func (c *RootCLI) newHookCompactCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort(func() error {
+			return runHookBestEffort("compact", func() error {
 				return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
 			})
 		},
@@ -102,7 +107,7 @@ func (c *RootCLI) newHookPromptCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort(func() error {
+			return runHookBestEffort("prompt", func() error {
 				return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
 			})
 		},
@@ -461,6 +466,9 @@ func resolveHookSessionID(payload []byte, client string) (types.SessionID, error
 
 func resolveHookWorkspace(ctx context.Context, payload []byte, client string, preferState bool) (types.Workspace, error) {
 	if preferState {
+		// Once a session has started, subsequent hook events should stay bound to
+		// the persisted workspace so audit/prompt/end events do not drift when the
+		// current cwd or explicit override changes mid-session.
 		workspace, err := readHookWorkspaceState(client)
 		if err != nil {
 			return "", err
@@ -579,8 +587,10 @@ func resolveHookStateKey() string {
 		return sanitizeHookStateKey(explicit)
 	}
 	if parentPID := os.Getppid(); parentPID > 0 {
-		if grandParentPID, err := hookParentPIDLookup(parentPID); err == nil && grandParentPID > 0 {
-			return sanitizeHookStateKey(strconv.Itoa(grandParentPID))
+		if processInfo, err := hookParentProcessLookup(parentPID); err == nil {
+			if processInfo.parentPID > 0 && looksLikeHookWrapperProcess(processInfo.command) {
+				return sanitizeHookStateKey(strconv.Itoa(processInfo.parentPID))
+			}
 		}
 		return sanitizeHookStateKey(strconv.Itoa(parentPID))
 	}
@@ -588,24 +598,41 @@ func resolveHookStateKey() string {
 	return sanitizeHookStateKey(strconv.Itoa(os.Getpid()))
 }
 
-func defaultHookParentPIDLookup(pid int) (int, error) {
-	output, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+func defaultHookParentProcessLookup(pid int) (hookParentProcessInfo, error) {
+	output, err := exec.Command("ps", "-o", "ppid=,comm=", "-p", strconv.Itoa(pid)).Output()
 	if err != nil {
-		return 0, xerrors.Errorf("failed to resolve hook parent process: %w", err)
+		return hookParentProcessInfo{}, xerrors.Errorf("failed to resolve hook parent process: %w", err)
 	}
-	trimmed := strings.TrimSpace(string(output))
-	if trimmed == "" {
-		return 0, nil
+	fields := strings.Fields(strings.TrimSpace(string(output)))
+	if len(fields) == 0 {
+		return hookParentProcessInfo{}, nil
 	}
-	parentPID, err := strconv.Atoi(trimmed)
+	parentPID, err := strconv.Atoi(fields[0])
 	if err != nil {
-		return 0, xerrors.Errorf("failed to parse hook parent process ID: %w", err)
+		return hookParentProcessInfo{}, xerrors.Errorf("failed to parse hook parent process ID: %w", err)
 	}
-	return parentPID, nil
+	command := ""
+	if len(fields) > 1 {
+		command = fields[1]
+	}
+	return hookParentProcessInfo{parentPID: parentPID, command: command}, nil
 }
 
-func runHookBestEffort(run func() error) error {
+func looksLikeHookWrapperProcess(command string) bool {
+	baseName := filepath.Base(strings.TrimSpace(command))
+	switch baseName {
+	case "sh", "bash", "zsh", "dash":
+		return true
+	default:
+		return false
+	}
+}
+
+func runHookBestEffort(commandName string, run func() error) error {
 	if err := run(); err != nil {
+		if debugEnabled := strings.TrimSpace(os.Getenv("TRACEARY_HOOK_DEBUG")); debugEnabled != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "traceary hook %s suppressed error: %v\n", commandName, err)
+		}
 		return nil
 	}
 	return nil

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -18,6 +19,8 @@ import (
 )
 
 const hookStateDirEnvKey = "TRACEARY_HOOK_STATE_DIR"
+
+var hookParentPIDLookup = defaultHookParentPIDLookup
 
 func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd := &cobra.Command{
@@ -42,7 +45,9 @@ func (c *RootCLI) newHookSessionCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			return runHookBestEffort(func() error {
+				return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			})
 		},
 	}
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
@@ -59,7 +64,9 @@ func (c *RootCLI) newHookAuditCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.runHookAudit(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return runHookBestEffort(func() error {
+				return c.runHookAudit(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			})
 		},
 	}
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
@@ -76,7 +83,9 @@ func (c *RootCLI) newHookCompactCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			return runHookBestEffort(func() error {
+				return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			})
 		},
 	}
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
@@ -93,7 +102,9 @@ func (c *RootCLI) newHookPromptCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return runHookBestEffort(func() error {
+				return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			})
 		},
 	}
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
@@ -160,6 +171,8 @@ func (c *RootCLI) runHookSession(
 			if err := writeHookWorkspaceState(client, workspace); err != nil {
 				return err
 			}
+		} else if err := clearHookWorkspaceState(client); err != nil {
+			return err
 		}
 		if output != nil {
 			if _, err := fmt.Fprintln(output, event.SessionID()); err != nil {
@@ -447,9 +460,6 @@ func resolveHookSessionID(payload []byte, client string) (types.SessionID, error
 }
 
 func resolveHookWorkspace(ctx context.Context, payload []byte, client string, preferState bool) (types.Workspace, error) {
-	if explicit := strings.TrimSpace(os.Getenv("TRACEARY_WORKSPACE")); explicit != "" {
-		return types.Workspace(explicit), nil
-	}
 	if preferState {
 		workspace, err := readHookWorkspaceState(client)
 		if err != nil {
@@ -458,6 +468,9 @@ func resolveHookWorkspace(ctx context.Context, payload []byte, client string, pr
 		if workspace != "" {
 			return workspace, nil
 		}
+	}
+	if explicit := strings.TrimSpace(os.Getenv("TRACEARY_WORKSPACE")); explicit != "" {
+		return types.Workspace(explicit), nil
 	}
 
 	cwd := hookPayloadString(payload, "cwd", "")
@@ -566,10 +579,36 @@ func resolveHookStateKey() string {
 		return sanitizeHookStateKey(explicit)
 	}
 	if parentPID := os.Getppid(); parentPID > 0 {
+		if grandParentPID, err := hookParentPIDLookup(parentPID); err == nil && grandParentPID > 0 {
+			return sanitizeHookStateKey(strconv.Itoa(grandParentPID))
+		}
 		return sanitizeHookStateKey(strconv.Itoa(parentPID))
 	}
 
 	return sanitizeHookStateKey(strconv.Itoa(os.Getpid()))
+}
+
+func defaultHookParentPIDLookup(pid int) (int, error) {
+	output, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, xerrors.Errorf("failed to resolve hook parent process: %w", err)
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return 0, nil
+	}
+	parentPID, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to parse hook parent process ID: %w", err)
+	}
+	return parentPID, nil
+}
+
+func runHookBestEffort(run func() error) error {
+	if err := run(); err != nil {
+		return nil
+	}
+	return nil
 }
 
 func sanitizeHookStateKey(value string) string {

--- a/presentation/cli/hook_runtime_internal_test.go
+++ b/presentation/cli/hook_runtime_internal_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import "testing"
+
+func TestResolveHookStateKey_UsesGrandparentProcessIdentity(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "")
+
+	originalLookup := hookParentPIDLookup
+	hookParentPIDLookup = func(pid int) (int, error) {
+		if pid <= 0 {
+			t.Fatalf("pid = %d, want > 0", pid)
+		}
+		return 4242, nil
+	}
+	t.Cleanup(func() {
+		hookParentPIDLookup = originalLookup
+	})
+
+	if got, want := resolveHookStateKey(), "4242"; got != want {
+		t.Fatalf("resolveHookStateKey() = %q, want %q", got, want)
+	}
+}

--- a/presentation/cli/hook_runtime_internal_test.go
+++ b/presentation/cli/hook_runtime_internal_test.go
@@ -1,22 +1,45 @@
 package cli
 
-import "testing"
+import (
+	"os"
+	"strconv"
+	"testing"
+)
 
 func TestResolveHookStateKey_UsesGrandparentProcessIdentity(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "")
 
-	originalLookup := hookParentPIDLookup
-	hookParentPIDLookup = func(pid int) (int, error) {
+	originalLookup := hookParentProcessLookup
+	hookParentProcessLookup = func(pid int) (hookParentProcessInfo, error) {
 		if pid <= 0 {
 			t.Fatalf("pid = %d, want > 0", pid)
 		}
-		return 4242, nil
+		return hookParentProcessInfo{parentPID: 4242, command: "/bin/bash"}, nil
 	}
 	t.Cleanup(func() {
-		hookParentPIDLookup = originalLookup
+		hookParentProcessLookup = originalLookup
 	})
 
 	if got, want := resolveHookStateKey(), "4242"; got != want {
+		t.Fatalf("resolveHookStateKey() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHookStateKey_UsesParentIdentityForNonShellParents(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "")
+
+	originalLookup := hookParentProcessLookup
+	hookParentProcessLookup = func(pid int) (hookParentProcessInfo, error) {
+		if pid <= 0 {
+			t.Fatalf("pid = %d, want > 0", pid)
+		}
+		return hookParentProcessInfo{parentPID: 4242, command: "/usr/bin/codex"}, nil
+	}
+	t.Cleanup(func() {
+		hookParentProcessLookup = originalLookup
+	})
+
+	if got, want := resolveHookStateKey(), sanitizeHookStateKey(strconv.Itoa(os.Getppid())); got != want {
 		t.Fatalf("resolveHookStateKey() = %q, want %q", got, want)
 	}
 }

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,6 +151,53 @@ func TestRootCLI_HookSessionCommand_StopUsesStateAndCreatesEndMarker(t *testing.
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "ended", "claude-claude-session")); err != nil {
 		t.Fatalf("Stat(end marker) error = %v", err)
+	}
+}
+
+func TestRootCLI_HookSessionCommand_StartClearsStaleWorkspaceStateWhenWorkspaceMissing(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	workspaceStatePath := filepath.Join(stateDir, "claude-test-key-repo")
+	if err := os.WriteFile(workspaceStatePath, []byte("stale/workspace"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	sessionStub := &sessionUsecaseStub{
+		startEvent: model.EventOf(
+			types.EventID("evt-start"),
+			types.EventKindSessionStarted,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("generated-session"),
+			types.Workspace(""),
+			"session started",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "start"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Stat(workspaceStatePath); !os.IsNotExist(err) {
+		t.Fatalf("workspace state still exists: %v", err)
 	}
 }
 
@@ -364,5 +412,76 @@ func TestRootCLI_HookPromptCommand_UsesPromptPayload(t *testing.T) {
 	}
 	if got, want := eventStub.logCall.agent, types.Agent("claude/planner"); got != want {
 		t.Fatalf("prompt log agent = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookPromptCommand_PrefersPersistedWorkspaceOverEnvOverride(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+	t.Setenv("TRACEARY_WORKSPACE", "env/workspace")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("prompt-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("state/workspace"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-prompt"),
+			types.EventKindPrompt,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("prompt-session"),
+			types.Workspace("state/workspace"),
+			"Fix the flaky test",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"prompt":"Fix the flaky test"}`))
+	rootCmd.SetArgs([]string{"hook", "prompt", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := eventStub.logCall.workspace, types.Workspace("state/workspace"); got != want {
+		t.Fatalf("prompt log workspace = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookCommand_SwallowsOperationalErrors(t *testing.T) {
+	storeStub := &storeManagementUsecaseStub{initErr: errors.New("boom")}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "start"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v, want nil for best-effort hook command", err)
+	}
+	if !storeStub.initCalled {
+		t.Fatal("store Initialize() was not called")
 	}
 }

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -154,6 +154,56 @@ func TestRootCLI_HookSessionCommand_StopUsesStateAndCreatesEndMarker(t *testing.
 	}
 }
 
+func TestRootCLI_HookSessionCommand_StopClearsDuplicateEndStateBeforeStoreInitialization(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(filepath.Join(stateDir, "ended"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("claude-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "ended", "claude-claude-session"), []byte("done"), 0o600); err != nil {
+		t.Fatalf("WriteFile(end marker) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{initErr: errors.New("boom")}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"agent_type":"planner"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "stop"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if storeStub.initCalled {
+		t.Fatal("store Initialize() was called for duplicate end cleanup")
+	}
+	if got := sessionStub.endCall.sessionID; got != "" {
+		t.Fatalf("session end call sessionID = %q, want empty for duplicate cleanup", got)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claude-test-key")); !os.IsNotExist(err) {
+		t.Fatalf("session state still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claude-test-key-repo")); !os.IsNotExist(err) {
+		t.Fatalf("workspace state still exists: %v", err)
+	}
+}
+
 func TestRootCLI_HookSessionCommand_StartClearsStaleWorkspaceStateWhenWorkspaceMissing(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -1,0 +1,368 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_HookSessionCommand_StartRecordsSessionAndState(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	t.Setenv("TRACEARY_PARENT_SESSION_ID", "parent-session")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	storeStub := &storeManagementUsecaseStub{}
+	sessionStub := &sessionUsecaseStub{
+		startEvent: model.EventOf(
+			types.EventID("evt-start"),
+			types.EventKindSessionStarted,
+			types.Client("hook"),
+			types.Agent("claude/planner"),
+			types.SessionID("generated-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"session started",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"cwd":"/tmp/project","agent_type":"planner"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "start"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := stdout.String(), "generated-session\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if !storeStub.initCalled {
+		t.Fatal("store Initialize() was not called")
+	}
+	if got, want := sessionStub.startCall.client, types.Client("hook"); got != want {
+		t.Fatalf("start client = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startCall.agent, types.Agent("claude/planner"); got != want {
+		t.Fatalf("start agent = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startCall.workspace, types.Workspace("github.com/duck8823/traceary"); got != want {
+		t.Fatalf("start workspace = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startCall.parentSessionID, types.SessionID("parent-session"); got != want {
+		t.Fatalf("start parentSessionID = %q, want %q", got, want)
+	}
+
+	statePath := filepath.Join(homeDir, ".config", "traceary", "hooks", "claude-test-key")
+	stateValue, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(state) error = %v", err)
+	}
+	if got, want := strings.TrimSpace(string(stateValue)), "generated-session"; got != want {
+		t.Fatalf("state session ID = %q, want %q", got, want)
+	}
+	workspaceStatePath := statePath + "-repo"
+	workspaceValue, err := os.ReadFile(workspaceStatePath)
+	if err != nil {
+		t.Fatalf("ReadFile(workspace state) error = %v", err)
+	}
+	if got, want := strings.TrimSpace(string(workspaceValue)), "github.com/duck8823/traceary"; got != want {
+		t.Fatalf("workspace state = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSessionCommand_StopUsesStateAndCreatesEndMarker(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("claude-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	sessionStub := &sessionUsecaseStub{
+		endEvent: model.EventOf(
+			types.EventID("evt-end"),
+			types.EventKindSessionEnded,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("claude-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"session ended",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"agent_type":"planner"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "stop"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := sessionStub.endCall.sessionID, types.SessionID("claude-session"); got != want {
+		t.Fatalf("end session ID = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.endCall.workspace, types.Workspace("github.com/duck8823/traceary"); got != want {
+		t.Fatalf("end workspace = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.endCall.agent, types.Agent("claude/planner"); got != want {
+		t.Fatalf("end agent = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claude-test-key")); !os.IsNotExist(err) {
+		t.Fatalf("session state still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claude-test-key-repo")); !os.IsNotExist(err) {
+		t.Fatalf("workspace state still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "ended", "claude-claude-session")); err != nil {
+		t.Fatalf("Stat(end marker) error = %v", err)
+	}
+}
+
+func TestRootCLI_HookAuditCommand_UsesSessionStateAndToolPayload(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-test-key"), []byte("generated-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		auditEvent: model.EventOf(
+			types.EventID("evt-audit"),
+			types.EventKindCommandExecuted,
+			types.Client("hook"),
+			types.Agent("codex"),
+			types.SessionID("generated-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"command executed",
+			time.Now(),
+		),
+		auditAudit: model.CommandAuditOf(
+			types.EventID("evt-audit"),
+			"go test ./...",
+			`{"command":"go test ./..."}`,
+			`{"exitCode":0}`,
+			false,
+			false,
+			types.Of(0),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"tool_input":{"command":"go test ./...","description":"Run tests"},"tool_response":{"exitCode":0,"stdout":"ok","stderr":""}}`))
+	rootCmd.SetArgs([]string{"hook", "audit", "codex"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := eventStub.auditCall.command, "go test ./..."; got != want {
+		t.Fatalf("audit command = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.input, `{"command":"go test ./...","description":"Run tests"}`; got != want {
+		t.Fatalf("audit input = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.output, `{"exitCode":0,"stderr":"","stdout":"ok"}`; got != want {
+		t.Fatalf("audit output = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.sessionID, types.SessionID("generated-session"); got != want {
+		t.Fatalf("audit sessionID = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.workspace, types.Workspace("github.com/duck8823/traceary"); got != want {
+		t.Fatalf("audit workspace = %q, want %q", got, want)
+	}
+	if got, ok := eventStub.auditCall.exitCode.Get(); !ok || got != 0 {
+		t.Fatalf("audit exitCode = (%d, %t), want (0, true)", got, ok)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_SupportsPostCompactAndResume(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("compact-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-compact"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("compact-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"summary",
+			time.Now(),
+		),
+	}
+	contextStub := &contextUsecaseStub{
+		handoff: types.Of(apptypes.ContextPackOf(
+			types.SessionID("compact-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"",
+			"active",
+			4,
+			1,
+			[]string{"claude"},
+			apptypes.WorkingStateOf("Investigating flaky tests", "Remember the failing shard"),
+			[]string{"go test ./..."},
+			nil,
+		)),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+		cli.WithContext(contextStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"compact_summary":"Remember the failing shard"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "post-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(post-compact) error = %v", err)
+	}
+	if got, want := eventStub.logCall.kind, types.EventKindCompactSummary; got != want {
+		t.Fatalf("post-compact log kind = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.message, "Remember the failing shard"; got != want {
+		t.Fatalf("post-compact log message = %q, want %q", got, want)
+	}
+
+	resumeCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithContext(contextStub),
+	).Command()
+	stdout := &bytes.Buffer{}
+	resumeCmd.SetOut(stdout)
+	resumeCmd.SetErr(&bytes.Buffer{})
+	resumeCmd.SetIn(strings.NewReader(`{}`))
+	resumeCmd.SetArgs([]string{"hook", "compact", "claude", "session-start-compact"})
+
+	if err := resumeCmd.Execute(); err != nil {
+		t.Fatalf("Execute(session-start-compact) error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Session compact-session resumed after compact") {
+		t.Fatalf("resume stdout = %q, want compact summary text", got)
+	}
+}
+
+func TestRootCLI_HookPromptCommand_UsesPromptPayload(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("prompt-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-prompt"),
+			types.EventKindPrompt,
+			types.Client("hook"),
+			types.Agent("claude/planner"),
+			types.SessionID("prompt-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"Fix the flaky test",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"prompt":"Fix the flaky test","agent_type":"planner"}`))
+	rootCmd.SetArgs([]string{"hook", "prompt", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := eventStub.logCall.kind, types.EventKindPrompt; got != want {
+		t.Fatalf("prompt log kind = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.message, "Fix the flaky test"; got != want {
+		t.Fatalf("prompt log message = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.agent, types.Agent("claude/planner"); got != want {
+		t.Fatalf("prompt log agent = %q, want %q", got, want)
+	}
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -143,6 +143,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newHandoffCommand())
 	rootCmd.AddCommand(c.newListCommand())
 	rootCmd.AddCommand(c.newShowCommand())
+	rootCmd.AddCommand(c.newHookCommand())
 	rootCmd.AddCommand(c.newSessionCommand())
 	rootCmd.AddCommand(c.newMemoryCommand())
 	rootCmd.AddCommand(c.newCompactSummaryCommand())

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -26,12 +26,47 @@ type eventUsecaseStub struct {
 	contextErr     error
 	timelineBlocks []apptypes.TimelineBlock
 	timelineErr    error
+
+	logCall struct {
+		message   string
+		kind      types.EventKind
+		client    types.Client
+		agent     types.Agent
+		sessionID types.SessionID
+		workspace types.Workspace
+	}
+	auditCall struct {
+		command   string
+		input     string
+		output    string
+		client    types.Client
+		agent     types.Agent
+		sessionID types.SessionID
+		workspace types.Workspace
+		exitCode  types.Optional[int]
+		redaction apptypes.AuditRedaction
+	}
 }
 
-func (s *eventUsecaseStub) Log(_ context.Context, _ string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace) (*model.Event, error) {
+func (s *eventUsecaseStub) Log(_ context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
+	s.logCall.message = message
+	s.logCall.kind = kind
+	s.logCall.client = client
+	s.logCall.agent = agent
+	s.logCall.sessionID = sessionID
+	s.logCall.workspace = workspace
 	return s.logEvent, s.logErr
 }
-func (s *eventUsecaseStub) Audit(_ context.Context, _ string, _ string, _ string, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ types.Optional[int], _ apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], redaction apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+	s.auditCall.command = command
+	s.auditCall.input = input
+	s.auditCall.output = output
+	s.auditCall.client = client
+	s.auditCall.agent = agent
+	s.auditCall.sessionID = sessionID
+	s.auditCall.workspace = workspace
+	s.auditCall.exitCode = exitCode
+	s.auditCall.redaction = redaction
 	return s.auditEvent, s.auditAudit, s.auditErr
 }
 func (s *eventUsecaseStub) Search(_ context.Context, _ apptypes.EventSearchCriteria) ([]*model.Event, error) {
@@ -72,12 +107,37 @@ type sessionUsecaseStub struct {
 	latestCriteria apptypes.SessionLookupCriteria
 	handoff        types.Optional[apptypes.HandoffSummary]
 	handoffErr     error
+
+	startCall struct {
+		client          types.Client
+		agent           types.Agent
+		sessionID       types.SessionID
+		workspace       types.Workspace
+		parentSessionID types.SessionID
+	}
+	endCall struct {
+		client    types.Client
+		agent     types.Agent
+		sessionID types.SessionID
+		workspace types.Workspace
+		summary   string
+	}
 }
 
-func (s *sessionUsecaseStub) Start(_ context.Context, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ types.SessionID) (*model.Event, error) {
+func (s *sessionUsecaseStub) Start(_ context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error) {
+	s.startCall.client = client
+	s.startCall.agent = agent
+	s.startCall.sessionID = sessionID
+	s.startCall.workspace = workspace
+	s.startCall.parentSessionID = parentSessionID
 	return s.startEvent, s.startErr
 }
-func (s *sessionUsecaseStub) End(_ context.Context, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ string) (*model.Event, error) {
+func (s *sessionUsecaseStub) End(_ context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error) {
+	s.endCall.client = client
+	s.endCall.agent = agent
+	s.endCall.sessionID = sessionID
+	s.endCall.workspace = workspace
+	s.endCall.summary = summary
 	return s.endEvent, s.endErr
 }
 func (s *sessionUsecaseStub) Label(_ context.Context, _ types.SessionID, _ string) error {


### PR DESCRIPTION
## Summary
- add hidden `traceary hook ...` Go subcommands for session, audit, compact, and prompt hook runtime paths
- keep host payload parsing and session/workspace normalization inside `presentation/cli`
- cover the new hook entrypoints with CLI-focused tests while preserving the existing packaged shell compatibility path for follow-up migration work

## Testing
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build go build ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #507
