### PR TITLE
docs: add Python dependency reduction plan

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,6 +25,7 @@
 
 - [バックアップガイド](./backup/README.ja.md): バックアップ、復元、マシン移行の手順
 - [運用上の前提](./operations/README.ja.md): SQLite の同時実行、hook 状態管理、既知の制約
+- [Python 依存の縮小計画](./operations/python-dependencies.ja.md): 現在の Python helper、影響範囲、移行順
 - [リリースガイド](./release/README.ja.md): リリース手順、GitHub Actions、ローカルでの確認方法
 
 ## リポジトリの基本文書

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 
 - [Backup guide](./backup/README.md): backup, restore, and machine-migration workflow
 - [Operational assumptions](./operations/README.md): SQLite concurrency, hook-state assumptions, and known limits
+- [Python dependency plan](./operations/python-dependencies.md): current Python-backed helpers, audience impact, and reduction order
 - [Release guide](./release/README.md): release packaging, GitHub Actions, and local snapshot builds
 
 ## Project docs

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -98,4 +98,4 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 - hooks integration: [`../hooks/README.ja.md`](../hooks/README.ja.md)
 - storage model: [`../storage/README.ja.md`](../storage/README.ja.md)
 - backup guide: [`../backup/README.ja.md`](../backup/README.ja.md)
-
+- Python 依存の縮小計画: [`./python-dependencies.ja.md`](./python-dependencies.ja.md)

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -98,4 +98,4 @@ Possible but not actively tuned:
 - hooks integration: [`../hooks/README.md`](../hooks/README.md)
 - storage model: [`../storage/README.md`](../storage/README.md)
 - backup guide: [`../backup/README.md`](../backup/README.md)
-
+- Python dependency plan: [`./python-dependencies.md`](./python-dependencies.md)

--- a/docs/operations/python-dependencies.ja.md
+++ b/docs/operations/python-dependencies.ja.md
@@ -1,0 +1,98 @@
+# Python 依存の棚卸しと縮小計画
+
+[English](./python-dependencies.md)
+
+Traceary の core runtime は Go ですが、いくつかの repository workflow では今も `python3` を使っています。
+この文書では、その依存がどこに残っているのか、誰に影響するのか、そして次にどこから減らすべきかを整理します。
+
+## 現在の方針
+
+- `traceary` CLI と MCP server は、Python なしで動く状態を維持する
+- user-facing な install / runtime workflow に Python 前提を増やす場合は、明示的な設計判断を必須にする
+- maintainer-only の Python helper は当面許容するが、所有者と移行先を文書で明示する
+
+## 現在 Python に依存している面
+
+### user-facing
+
+| 対象 | 現在の entrypoint | いま Python を使っている理由 | 今後の方向 |
+| --- | --- | --- | --- |
+| Codex local plugin install | `python3 scripts/codex/install_plugin.py` | plugin file / config / hook wiring を 1 つの helper でまとめている | first-class な Go entrypoint に置き換える |
+| Codex local plugin uninstall | `python3 scripts/codex/uninstall_plugin.py` | plugin cache / config / Traceary 管理下 hook をまとめて外している | 対になる Go entrypoint に置き換える |
+
+### maintainer-only
+
+| 対象 | 現在の entrypoint | 利用箇所 | 今後の方向 |
+| --- | --- | --- | --- |
+| docs pairing verification | `python3 scripts/verify_docs_i18n.py` | ローカル検証、CI docs job | 当面維持。将来的には Go 製 repo verifier に統合 |
+| integration package verification | `python3 scripts/verify_integrations.py` | release prep、smoke test、CI | Codex install 経路の移行後に Go へ移す |
+| changelog coverage verification | `python3 scripts/verify_changelog_releases.py` | release prep、CI docs/release jobs | 共通の Go verifier ができた段階で統合する |
+| version bump helper | `python3 scripts/bump_version.py` | release prep | user 影響が低いので最後に移す |
+
+## この issue の対象外
+
+次は、この issue が扱う Python 依存の話とは分けます。
+
+- `scripts/hooks/` 配下の shell wrapper
+  - これは hook runtime cleanup の別 issue で扱う
+- support 対象外の one-off local developer script
+- Traceary が配布していない third-party client tooling
+
+## 推奨する移行順
+
+### 1. Codex install / uninstall helper
+
+最優先はここです。理由は、公開 docs に載っている user-facing な導線であり、現在も local Codex integration の完全な利用手順で Python を要求しているためです。
+
+置き換え先の第一候補:
+
+- `traceary integration codex install`
+- `traceary integration codex uninstall`
+
+これを先にやる理由:
+
+- user-facing な前提条件から Python を外せる
+- install behavior を通常の Go CLI surface に戻せる
+- 将来の docs が repository-local helper ではなく `traceary` 自体を案内できる
+
+### 2. integration verification
+
+public Codex flow を移したあとは、`scripts/verify_integrations.py` の移行が一番効果的です。
+release prep、smoke test、CI のすべてで使っているためです。
+
+推奨方向:
+
+- integration manifest と local package structure を検証できる Go 製 repo verification command を用意する
+- 実装の置き場所は repository-only helper package / subcommand でもよいが、利用者向けの documented entrypoint は 1 つに保つ
+
+### 3. changelog / docs verifier
+
+その次に移す対象:
+
+- `scripts/verify_changelog_releases.py`
+- `scripts/verify_docs_i18n.py`
+
+これらは maintainer-only なので、優先度より correctness を重視します。
+共通の Go verifier ができたなら、別々の tool を増やさずそこへ統合します。
+
+### 4. version bump helper
+
+`scripts/bump_version.py` は便利ですが優先度は低めです。
+上の高優先度項目が固まってから移せば十分です。
+
+## 今後の repository rule
+
+上の移行が終わるまでは、次をルールにします。
+
+1. 新しい user-facing Python helper command は追加しない
+2. maintainer-only の Python helper をどうしても追加する場合は、少なくとも次を文書化する
+   - なぜ今 Go を使わないのか
+   - どこから呼ばれるのか
+   - 将来どこへ移すのか
+3. 単発 script を増やすより、既存 verifier の拡張を優先する
+
+## 関連文書
+
+- architecture principles: [`../architecture/README.ja.md`](../architecture/README.ja.md)
+- Codex integration: [`../integrations/codex-plugin.ja.md`](../integrations/codex-plugin.ja.md)
+- release workflow: [`../release/README.ja.md`](../release/README.ja.md)

--- a/docs/operations/python-dependencies.md
+++ b/docs/operations/python-dependencies.md
@@ -1,0 +1,96 @@
+# Python dependency inventory and reduction plan
+
+[日本語](./python-dependencies.ja.md)
+
+Traceary's core runtime is Go, but a small set of repository workflows still rely on `python3`.
+This guide records where that dependency still exists, which audience it affects, and which migration targets should move first.
+
+## Current policy
+
+- the `traceary` CLI and MCP server should keep working without Python
+- no new user-facing install or runtime workflow should introduce a Python prerequisite without an explicit design decision
+- maintainer-only Python helpers are still allowed for now, but they should have a documented owner and migration target
+
+## Python-backed surfaces today
+
+### User-facing
+
+| Surface | Current entrypoint | Why it uses Python today | Planned direction |
+| --- | --- | --- | --- |
+| Codex local plugin install | `python3 scripts/codex/install_plugin.py` | merges plugin files, config, and hook wiring in one helper | replace with a first-class Go entrypoint |
+| Codex local plugin uninstall | `python3 scripts/codex/uninstall_plugin.py` | removes plugin cache, config, and Traceary-managed hooks | replace with the matching Go entrypoint |
+
+### Maintainer-only
+
+| Surface | Current entrypoint | Used by | Planned direction |
+| --- | --- | --- | --- |
+| docs pairing verification | `python3 scripts/verify_docs_i18n.py` | local checks, CI docs job | keep short-term; fold into a Go-based repo verifier later |
+| integration package verification | `python3 scripts/verify_integrations.py` | release prep, smoke tests, CI | migrate after the Codex install path |
+| changelog coverage verification | `python3 scripts/verify_changelog_releases.py` | release prep, CI docs/release jobs | migrate after integration verification if a shared Go verifier exists |
+| version bump helper | `python3 scripts/bump_version.py` | release prep | migrate last; low user impact |
+
+## What is intentionally out of scope
+
+These are *not* part of the Python dependency story this issue is addressing:
+
+- shell wrappers under `scripts/hooks/` — those are tracked separately as hook-runtime cleanup work
+- one-off local developer scripts outside the supported maintainer workflow
+- third-party client tooling that Traceary does not ship
+
+## Preferred migration order
+
+### 1. Codex install and uninstall helpers
+
+This is the highest-priority removal target because it is public, documented, and currently required for the full local Codex integration flow.
+
+Preferred replacement surface:
+
+- `traceary integration codex install`
+- `traceary integration codex uninstall`
+
+Why this is first:
+
+- it removes Python from the main user-facing prerequisite path
+- it keeps installation behavior inside the normal Go CLI surface
+- it lets future docs point to `traceary` itself instead of repository-local helpers
+
+### 2. Integration verification
+
+Once the public Codex flow is moved, the next best return comes from `scripts/verify_integrations.py` because it is used in release preparation, smoke tests, and CI.
+
+Preferred replacement direction:
+
+- a Go-based repo verification command that can validate integration manifests and local package structure
+- the implementation may live in a repository-only helper package or subcommand, but the repo should still expose a single documented entrypoint
+
+### 3. Changelog and docs verifiers
+
+After integration verification, migrate:
+
+- `scripts/verify_changelog_releases.py`
+- `scripts/verify_docs_i18n.py`
+
+These remain maintainer-only, so correctness matters more than urgency.
+If a shared Go verifier exists by then, they should join it rather than becoming separate tools again.
+
+### 4. Version bump helper
+
+`scripts/bump_version.py` is useful but low priority.
+It should move only after the higher-impact checks above have settled.
+
+## Repository rules going forward
+
+Until the migrations above land:
+
+1. do not add new user-facing Python helper commands
+2. if a new maintainer-only Python helper is truly necessary, document:
+   - why Go is not being used yet
+   - where the helper is called from
+   - what the eventual migration target is
+3. prefer expanding an existing verifier over adding another one-off script
+
+## Related docs
+
+- architecture principles: [`../architecture/README.md`](../architecture/README.md)
+- Codex integration: [`../integrations/codex-plugin.md`](../integrations/codex-plugin.md)
+- release workflow: [`../release/README.md`](../release/README.md)


### PR DESCRIPTION
## Summary
- add a dedicated docs pair for Python dependency inventory and reduction order
- classify current Python-backed surfaces into user-facing vs maintainer-only flows
- choose the next migration target explicitly and link the operations/docs indexes to the plan

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #509
