### PR TITLE
docs: define Optional API migration policy

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -7,6 +7,7 @@
 ## まず読むページ
 
 - [アーキテクチャ原則](./architecture/README.ja.md): 4 層、runtime 境界、`scripts/` の役割、`internal/` の方針
+- [Optional API 移行方針](./architecture/optional-api.ja.md): Optional[T] の差分、目標 API、段階移行の方針
 - [Durable memory ガイド](./memory/README.ja.md): 3 層モデル、memory のライフサイクル、ref の意味、memory コマンドの関係
 - [CLI リファレンス](./cli/README.ja.md): コマンドごとの挙動、主要フラグ、出力仕様
 - [Hook contract](./hooks/contract.ja.md): ホストごとの自動記録範囲と共通動作

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 ## Start here
 
 - [Architecture principles](./architecture/README.md): layering rules, runtime boundaries, the role of `scripts/`, and the current `internal/` stance
+- [Optional API migration policy](./architecture/optional-api.md): current Optional[T] gap, target convention API, and staged rollout
 - [Durable memory guide](./memory/README.md): the three-layer model, memory lifecycle, refs, and how memory commands relate
 - [CLI reference](./cli/README.md): command-by-command behavior, flags, and output contracts
 - [Hook contract](./hooks/contract.md): automatic-capture coverage and shared hook semantics across hosts

--- a/docs/architecture/README.ja.md
+++ b/docs/architecture/README.ja.md
@@ -131,6 +131,7 @@ Traceary では、`internal/` を既定では要求しません。
 ## 関連文書
 
 - [ドキュメント索引](../README.ja.md)
+- [Optional API 移行方針](./optional-api.ja.md)
 - [Hook contract](../hooks/contract.ja.md)
 - [イベントライフサイクル](../lifecycle.ja.md)
 - [ネイティブ連携ガイド](../integrations/README.ja.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -126,6 +126,7 @@ If the answer to any of these is "no", document the exception explicitly before 
 ## Related docs
 
 - [Documentation index](../README.md)
+- [Optional API migration policy](./optional-api.md)
 - [Hook contract](../hooks/contract.md)
 - [Event lifecycle](../lifecycle.md)
 - [Native integrations guide](../integrations/README.md)

--- a/docs/architecture/optional-api.ja.md
+++ b/docs/architecture/optional-api.ja.md
@@ -1,0 +1,105 @@
+# Optional[T] API の移行方針
+
+[English](./optional-api.md)
+
+Traceary では、`duck8823/dotfiles/conventions/go/type-system.md` にある Go 規約より前から使っている独自の `Optional[T]` API が残っています。
+この文書では、その差分、目標 API、そして unrelated な機能変更に repo-wide refactor を混ぜずに移行する方針を整理します。
+
+## 現在の Traceary の状態
+
+`domain/types.Optional[T]` は現在、次を公開しています。
+
+- `types.Of(...)`
+- `types.Empty[T]()`
+- `IsPresent()`
+- `Get()`
+- `OrElse(...)`
+
+この API は domain / application / infrastructure / presentation / test に広く使われています。
+この方針を書いた時点でも、legacy 名の参照は repository 全体で数百件規模あり、一括 rename の PR はノイズもリスクも大きすぎます。
+
+## 規約上の target API
+
+この repository が参照している Go 規約では、次を推奨しています。
+
+- `types.Some(...)`
+- `types.None[T]()`
+- `Value()`
+
+Traceary の方針は、この規約 API へ寄せることです。
+つまり、恒久的なローカル例外にするのではなく、移行を選びます。
+
+## 方針
+
+Traceary は、段階的に規約 API へ移行します。
+
+### 目指す最終形
+
+新しいコードは、次の形で読める状態を目指します。
+
+```go
+opt := types.Some(value)
+none := types.None[string]()
+value, ok := opt.Value()
+```
+
+### 過渡期の扱い
+
+unrelated な作業を止めないために、移行には明示的な compatibility window を設けます。
+
+1. まず規約 API (`Some`, `None`, `Value`) を追加する
+2. call site は review しやすい単位で順に移す
+3. repository 内の移行が終わった段階で、legacy 名を削除するか、互換 alias として残すかを明示的に決める
+
+## 推奨 rollout
+
+### Phase 1: compatibility surface を足す
+
+まず、意味を変えずに次を追加します。
+
+- `Some`
+- `None`
+- `Value`
+
+この段階では、call site を全部まとめて変えません。
+
+### Phase 2: repository 内の call site を順に移す
+
+移行は、たとえば次のような単位で分けます。
+
+- `domain/` と `application/`
+- `infrastructure/`
+- `presentation/`
+- test / helper
+
+粒度は調整してよいですが、各 PR は review 可能な大きさに保ちます。
+
+### Phase 3: legacy 名の扱いを確定する
+
+repository 側の移行が終わったら、次を明示的に決めます。
+
+- `Of`, `Empty`, `IsPresent`, `Get` を削除する
+- もしくは、ローカル互換 alias として残す
+
+ここは曖昧にしません。repo 全体が半端に混在した状態を放置しないためです。
+
+## 移行中の新規コードに対するルール
+
+移行が終わるまでの間は、次をルールにします。
+
+- 規約 API が入った後の新規コードでは、原則 `Some`, `None`, `Value` を使う
+- ただし、まだ移行していないファイルを小さく直すだけの PR では、その場の一貫性を優先して legacy 名を維持してもよい
+- Optional API cleanup を、対象外の bug fix や feature PR に混ぜない
+
+## 非対象
+
+この方針は、次を意味しません。
+
+- Optional の意味自体を変えること
+- `Optional[T]` を pointer に全面置換すること
+- 1 本の巨大 PR で repo 全体を rename し切ること
+
+## 関連文書
+
+- [アーキテクチャ原則](./README.ja.md)
+- [ドキュメント索引](../README.ja.md)

--- a/docs/architecture/optional-api.md
+++ b/docs/architecture/optional-api.md
@@ -1,0 +1,106 @@
+# Optional[T] API migration policy
+
+[日本語](./optional-api.ja.md)
+
+Traceary currently uses a local `Optional[T]` API that predates the Go conventions documented in `duck8823/dotfiles/conventions/go/type-system.md`.
+This guide records the gap, the chosen target API, and the rollout policy for closing it without mixing a repo-wide refactor into unrelated features.
+
+## Current state in Traceary
+
+`domain/types.Optional[T]` currently exposes:
+
+- `types.Of(...)`
+- `types.Empty[T]()`
+- `IsPresent()`
+- `Get()`
+- `OrElse(...)`
+
+That API is used broadly across domain, application, infrastructure, presentation, and tests.
+At the time this policy was written, the repository had roughly a few hundred references to the legacy names, so a direct big-bang rename would create a noisy and risky PR.
+
+## Convention target
+
+The Go conventions tracked for this repository prefer:
+
+- `types.Some(...)`
+- `types.None[T]()`
+- `Value()`
+
+The target is to align Traceary with that convention.
+This document chooses migration, not a permanent local exception.
+
+## Policy decision
+
+Traceary will migrate to the convention API in stages.
+
+### Desired end state
+
+New code should read naturally as:
+
+```go
+opt := types.Some(value)
+none := types.None[string]()
+value, ok := opt.Value()
+```
+
+### Transitional rule
+
+To avoid blocking unrelated work, the migration should use an explicit compatibility window:
+
+1. add the convention entrypoints (`Some`, `None`, `Value`) alongside the legacy ones
+2. migrate call sites incrementally in reviewable slices
+3. remove the legacy names only after repository call sites have been converted, or explicitly re-scope that cleanup if the repository decides to keep the aliases longer
+
+## Rollout order
+
+### Phase 1: compatibility surface
+
+Add:
+
+- `Some`
+- `None`
+- `Value`
+
+without changing semantics.
+During this phase, do **not** change every call site in one PR.
+
+### Phase 2: repository call-site migration
+
+Migrate the repository in focused batches, for example:
+
+- `domain/` and `application/`
+- `infrastructure/`
+- `presentation/`
+- tests and helpers
+
+The exact batching can be adjusted, but each PR should stay reviewable.
+
+### Phase 3: legacy-name decision
+
+After the repository is migrated, make an explicit decision:
+
+- remove `Of`, `Empty`, `IsPresent`, and `Get`
+- or keep them as compatibility aliases with clear local documentation
+
+That final step must be intentional. The repository should not drift into a half-migrated state with no documented policy.
+
+## Rules for new code during the migration
+
+Until the migration is finished:
+
+- prefer `Some`, `None`, and `Value` in new code once they exist
+- avoid introducing new uses of `Of`, `Empty`, `IsPresent`, and `Get` unless the touched file has not yet been migrated and consistency in that small patch is more important
+- do not mix Optional API cleanup into unrelated bug fixes unless the issue explicitly includes that scope
+
+## Non-goals
+
+This policy does **not** mean:
+
+- changing Optional semantics
+- replacing `Optional[T]` with pointers everywhere
+- blocking runtime or feature work on a single repo-wide rename PR
+
+## Related docs
+
+- [Architecture principles](./README.md)
+- [Documentation index](../README.md)


### PR DESCRIPTION
## Summary
- add a dedicated docs pair for the Optional[T] API gap and staged migration policy
- choose migration to `Some` / `None` / `Value` instead of keeping the current API as an undocumented local exception
- link the policy from the architecture/docs entry points and record the implementation follow-up

## Testing
- python3 scripts/verify_docs_i18n.py
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run

Closes #459
