### PR TITLE
docs: define the Go repo-tooling migration path

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -27,6 +27,7 @@
 - [バックアップガイド](./backup/README.ja.md): バックアップ、復元、マシン移行の手順
 - [運用上の前提](./operations/README.ja.md): SQLite の同時実行、hook 状態管理、既知の制約
 - [Python 依存の縮小計画](./operations/python-dependencies.ja.md): 現在の Python helper、影響範囲、移行順
+- [repository tooling の方針](./operations/repo-tooling.ja.md): maintainer-only helper をまとめる Go entrypoint の方針
 - [リリースガイド](./release/README.ja.md): リリース手順、GitHub Actions、ローカルでの確認方法
 
 ## リポジトリの基本文書

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 - [Backup guide](./backup/README.md): backup, restore, and machine-migration workflow
 - [Operational assumptions](./operations/README.md): SQLite concurrency, hook-state assumptions, and known limits
 - [Python dependency plan](./operations/python-dependencies.md): current Python-backed helpers, audience impact, and reduction order
+- [Repository tooling plan](./operations/repo-tooling.md): the planned Go entrypoint for maintainer-only repository helpers
 - [Release guide](./release/README.md): release packaging, GitHub Actions, and local snapshot builds
 
 ## Project docs

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -99,3 +99,4 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 - storage model: [`../storage/README.ja.md`](../storage/README.ja.md)
 - backup guide: [`../backup/README.ja.md`](../backup/README.ja.md)
 - Python 依存の縮小計画: [`./python-dependencies.ja.md`](./python-dependencies.ja.md)
+- repository tooling の方針: [`./repo-tooling.ja.md`](./repo-tooling.ja.md)

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -99,3 +99,4 @@ Possible but not actively tuned:
 - storage model: [`../storage/README.md`](../storage/README.md)
 - backup guide: [`../backup/README.md`](../backup/README.md)
 - Python dependency plan: [`./python-dependencies.md`](./python-dependencies.md)
+- Repository tooling plan: [`./repo-tooling.md`](./repo-tooling.md)

--- a/docs/operations/python-dependencies.ja.md
+++ b/docs/operations/python-dependencies.ja.md
@@ -62,8 +62,8 @@ release prep、smoke test、CI のすべてで使っているためです。
 
 推奨方向:
 
-- integration manifest と local package structure を検証できる Go 製 repo verification command を用意する
-- 実装の置き場所は repository-only helper package / subcommand でもよいが、利用者向けの documented entrypoint は 1 つに保つ
+- `go run ./cmd/repo-tooling integrations verify` を最初の移行先にする
+- 以降の verifier も、単発 helper ではなく同じ `cmd/repo-tooling` entrypoint に集約する
 
 ### 3. changelog / docs verifier
 

--- a/docs/operations/python-dependencies.md
+++ b/docs/operations/python-dependencies.md
@@ -60,8 +60,8 @@ Once the public Codex flow is moved, the next best return comes from `scripts/ve
 
 Preferred replacement direction:
 
-- a Go-based repo verification command that can validate integration manifests and local package structure
-- the implementation may live in a repository-only helper package or subcommand, but the repo should still expose a single documented entrypoint
+- `go run ./cmd/repo-tooling integrations verify`
+- additional repository verifiers should share the same `cmd/repo-tooling` entrypoint instead of growing one-off helpers
 
 ### 3. Changelog and docs verifiers
 

--- a/docs/operations/repo-tooling.ja.md
+++ b/docs/operations/repo-tooling.ja.md
@@ -1,0 +1,128 @@
+# repository tooling の入口と移行方針
+
+[English](./repo-tooling.md)
+
+Traceary の user-facing runtime は、配布している Go CLI と MCP server に閉じているべきです。
+一方で、maintainer-only の repository helper は別種の tooling です。runtime の product surface ではありませんが、置き場所と入口は統一する必要があります。
+
+この文書では、その入口、Python helper からの移行順、そして新しい repository automation を増やすときの原則を定義します。
+
+## 決定事項
+
+maintainer-only の repository tooling は、専用の Go entrypoint に寄せます。
+
+- `go run ./cmd/repo-tooling ...`
+
+repository verifier、release preparation helper、repository 内だけで成立する structure check は、この面に集約する方針です。
+
+## なぜ main の `traceary` CLI に入れないのか
+
+main の `traceary` binary は public runtime entrypoint です。
+ここに入るべきものは次です。
+
+- user-facing CLI command
+- support 対象の hook runtime entrypoint
+- MCP server
+
+maintainer-only の repository automation は性質が異なります。
+
+- Git checkout を前提にしてよい
+- repository にしか無い file を検証してよい
+- install 済み product の一部ではなくても、CI や release preparation では必要になる
+
+そのため、runtime behavior と repository maintenance concern を混ぜずに済む `cmd/repo-tooling` を選びます。
+
+## repo tooling に入れるもの
+
+`cmd/repo-tooling` に置く例:
+
+- integration package verification
+- docs i18n pairing check
+- changelog coverage check
+- version bump のような release-prep helper
+
+逆に、ここへ入れないもの:
+
+- `traceary hook ...` runtime subcommand
+- end-user 向け install / uninstall flow
+- MCP server の runtime behavior
+- support 対象外の one-off personal script
+
+## 想定する command 形
+
+最終的には、次のような subcommand に寄せます。
+
+- `go run ./cmd/repo-tooling integrations verify`
+- `go run ./cmd/repo-tooling docs verify-i18n`
+- `go run ./cmd/repo-tooling release verify-changelog`
+- `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+
+実際の package layout は調整してよいですが、documented entrypoint は 1 つに揃えます。
+
+## 移行順
+
+### 1. integration verification
+
+最初の対象:
+
+- `scripts/verify_integrations.py`
+
+これを先にやる理由:
+
+- CI / smoke test / release preparation のすべてで使っている
+- 複数 integration package と managed file をまたいで検証している
+- 検証対象の Go integration logic の近くへ寄せる価値が高い
+
+置き換え先:
+
+- `go run ./cmd/repo-tooling integrations verify`
+
+### 2. docs pairing verification
+
+次の対象:
+
+- `scripts/verify_docs_i18n.py`
+
+置き換え先:
+
+- `go run ./cmd/repo-tooling docs verify-i18n`
+
+### 3. changelog coverage verification
+
+3 番目の対象:
+
+- `scripts/verify_changelog_releases.py`
+
+置き換え先:
+
+- `go run ./cmd/repo-tooling release verify-changelog`
+
+### 4. version bump helper
+
+最後の対象:
+
+- `scripts/bump_version.py`
+
+置き換え先:
+
+- `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+
+## 今後のルール
+
+上の移行が終わるまでは、次を repository rule にします。
+
+1. 新しい maintainer-only Python helper を増やす場合は、issue に「なぜ今 Go ではないのか」を明記する
+2. 単発 script を増やすより、既存 verifier の拡張を優先する
+3. support 対象の maintainer helper は docs index と関連 workflow guide から辿れるようにする
+4. user-facing entrypoint は `traceary` に、repository-only helper は repo tooling に置く
+
+## 現在の状態
+
+現時点では、[`python-dependencies.ja.md`](./python-dependencies.ja.md) にある helper がまだ Python で残っています。
+この文書は、それらをどこへ移すのかを先に固定し、場当たり的な script 増殖を防ぐためのものです。
+
+## 関連文書
+
+- Python 依存の棚卸し: [`./python-dependencies.ja.md`](./python-dependencies.ja.md)
+- release workflow: [`../release/README.ja.md`](../release/README.ja.md)
+- integrations overview: [`../integrations/README.ja.md`](../integrations/README.ja.md)

--- a/docs/operations/repo-tooling.md
+++ b/docs/operations/repo-tooling.md
@@ -1,0 +1,128 @@
+# Repository tooling surface and migration plan
+
+[日本語](./repo-tooling.ja.md)
+
+Traceary's user-facing runtime should stay inside the shipped Go CLI and MCP server.
+Maintainer-only repository helpers are a different class of tooling: they are not part of the runtime product surface, but they still need a coherent home.
+
+This guide defines that home, the migration order away from Python helpers, and the rules for adding new repository automation.
+
+## Decision
+
+Maintainer-only repository tooling should converge on a dedicated Go entrypoint:
+
+- `go run ./cmd/repo-tooling ...`
+
+This is the preferred surface for repository verifiers, release-preparation helpers, and structure checks that are not part of the supported end-user runtime.
+
+## Why this should not live in the main `traceary` CLI
+
+The main `traceary` binary is the public runtime entrypoint.
+It should contain:
+
+- user-facing CLI commands
+- supported hook runtime entrypoints
+- the MCP server
+
+Maintainer-only repository automation has different constraints:
+
+- it may assume a Git checkout
+- it may validate files that only exist in the repository
+- it may be useful in CI or release preparation without being part of the installed product
+
+Keeping those helpers under a separate Go entrypoint avoids mixing runtime behavior with repository maintenance concerns.
+
+## What belongs in repo tooling
+
+Examples that belong under `cmd/repo-tooling`:
+
+- integration package verification
+- docs i18n pairing checks
+- changelog coverage checks
+- release-preparation helpers such as version bumps
+
+Examples that do **not** belong there:
+
+- `traceary hook ...` runtime subcommands
+- end-user installation and uninstall flows
+- MCP server behavior
+- one-off personal scripts that are not part of the supported maintainer workflow
+
+## Planned command shape
+
+The repository should converge on subcommands shaped like these:
+
+- `go run ./cmd/repo-tooling integrations verify`
+- `go run ./cmd/repo-tooling docs verify-i18n`
+- `go run ./cmd/repo-tooling release verify-changelog`
+- `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+
+The exact package layout can evolve, but the documented entrypoint should stay singular.
+
+## Migration order
+
+### 1. Integration verification
+
+First target:
+
+- `scripts/verify_integrations.py`
+
+Why first:
+
+- it is used in CI, smoke tests, and release preparation
+- it already validates multiple integration packages and their managed files
+- it benefits the most from living next to the Go integration logic it verifies
+
+Planned replacement:
+
+- `go run ./cmd/repo-tooling integrations verify`
+
+### 2. Docs pairing verification
+
+Second target:
+
+- `scripts/verify_docs_i18n.py`
+
+Planned replacement:
+
+- `go run ./cmd/repo-tooling docs verify-i18n`
+
+### 3. Changelog coverage verification
+
+Third target:
+
+- `scripts/verify_changelog_releases.py`
+
+Planned replacement:
+
+- `go run ./cmd/repo-tooling release verify-changelog`
+
+### 4. Version bump helper
+
+Final target:
+
+- `scripts/bump_version.py`
+
+Planned replacement:
+
+- `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+
+## Rules for new maintainer automation
+
+Until the migrations above land:
+
+1. do not add new maintainer-only Python helpers unless the issue explicitly records why Go is not being used yet
+2. prefer extending an existing verifier over adding a new one-off script
+3. document every supported maintainer helper from the docs index and the relevant workflow guide
+4. keep user-facing entrypoints in `traceary`; keep repository-only helpers in repo tooling
+
+## Current status
+
+Today the repository still uses Python for the helpers listed in [`python-dependencies.md`](./python-dependencies.md).
+This page defines the agreed Go destination so that future migrations move toward one consistent surface instead of growing more ad-hoc scripts.
+
+## Related docs
+
+- Python dependency inventory: [`./python-dependencies.md`](./python-dependencies.md)
+- release workflow: [`../release/README.md`](../release/README.md)
+- integrations overview: [`../integrations/README.md`](../integrations/README.md)

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -104,7 +104,7 @@ GoReleaser workflow が artifact の公開を自動化しますが、maintainer 
 
 1. **まず両方の changelog を更新する。** `CHANGELOG.md` と `CHANGELOG.ja.md` の双方に `## [vX.Y.Z] - YYYY-MM-DD` セクションを追加します。次のステップの前に両ファイルの release 見出しが一致していないと `scripts/verify_changelog_releases.py` が失敗します。
 2. **manifest を bump する。** `make release/bump VERSION=X.Y.Z` を実行すると、`VERSION` と integration plugin manifest がまとめて更新され、`scripts/verify_integrations.py` も走ります。
-3. **ローカル検証。** `python3 scripts/verify_changelog_releases.py` / `go test ./...` / `go tool golangci-lint run` をすべて通します。
+3. **ローカル検証。** `python3 scripts/verify_changelog_releases.py` / `go test ./...` / `go tool golangci-lint run` をすべて通します。これらの Python entrypoint は現時点の release-prep surface であり、Go への移行先は [`../operations/repo-tooling.ja.md`](../operations/repo-tooling.ja.md) に整理しています。
 4. **release-preparation PR を開く。** `maintenance/release-vX.Y.Z` ブランチを作成し、changelog と bump を commit・push して `main` 向けに PR を開きます。**`Closes #<parent>` は書かない**でください。親 release issue は release workflow が閉じるため、release-prep PR からは閉じません。
 5. **Multi-AI レビュー + merge。** release-prep PR も通常の PR と同じく、最新 head に対する Claude / Gemini のレビューを取り、そのうえで PR 上の Codex app review が返るのを待ってから merge commit でマージします。
 6. **tag を打って push する。** release-prep PR が merge されたら、`git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z` を実行します。`v*` tag が `.github/workflows/release.yml` を起動します。

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -105,7 +105,7 @@ The GoReleaser workflow automates artifact publishing, but a handful of steps st
 
 1. **Update both changelogs first.** Edit `CHANGELOG.md` and `CHANGELOG.ja.md` to add a new `## [vX.Y.Z] - YYYY-MM-DD` section. The section must exist in *both* files with matching release headings before the next step, or `scripts/verify_changelog_releases.py` will fail.
 2. **Bump manifests.** Run `make release/bump VERSION=X.Y.Z` — this updates `VERSION`, all integration plugin manifests, and runs `scripts/verify_integrations.py`.
-3. **Verify locally.** `python3 scripts/verify_changelog_releases.py`, `go test ./...`, and `go tool golangci-lint run` must all pass.
+3. **Verify locally.** `python3 scripts/verify_changelog_releases.py`, `go test ./...`, and `go tool golangci-lint run` must all pass. These Python entrypoints are still the current release-prep surface; the planned Go replacement is tracked in [`../operations/repo-tooling.md`](../operations/repo-tooling.md).
 4. **Open the release-preparation PR.** Create a `maintenance/release-vX.Y.Z` branch, commit the changelog and bump changes, push, and open a PR targeting `main`. Do **not** include `Closes #<parent>` — the parent release issue is auto-closed by the tagged release workflow, not by the release-prep PR.
 5. **Multi-AI review + merge.** The release-prep PR must pass the same review gate as any other PR: obtain fresh Claude and Gemini reviews on the latest head, then wait for the PR-side Codex app review to finish before merging with a merge commit.
 6. **Tag and push.** After the release-prep PR merges, run `git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z`. The `v*` tag triggers `.github/workflows/release.yml`.


### PR DESCRIPTION
## Summary
- define a dedicated `go run ./cmd/repo-tooling ...` surface for maintainer-only repository helpers
- add bilingual docs that map the remaining Python scripts to their planned Go entrypoints and migration order
- update docs indexes and release guidance to point at the repo-tooling plan instead of ad-hoc script growth

## Testing
- GOCACHE=$(pwd)/.cache/go-build go test ./...
- GOCACHE=$(pwd)/.cache/go-build go build ./...
- GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...
- python3 scripts/verify_docs_i18n.py

Closes #523
