### PR TITLE
test: align repository tests with shared conventions

### DIFF
--- a/application/types/memory_details_test.go
+++ b/application/types/memory_details_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
@@ -36,13 +38,13 @@ func TestMemoryDetailsFrom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemoryDetailsFrom() error = %v", err)
 	}
-	if got := details.Summary().MemoryID(); got != memoryID {
-		t.Fatalf("Summary().MemoryID() = %s, want %s", got, memoryID)
+	if diff := cmp.Diff(memoryID, details.Summary().MemoryID()); diff != "" {
+		t.Fatalf("Summary().MemoryID() mismatch (-want +got):\n%s", diff)
 	}
-	if got := len(details.EvidenceRefs()); got != 1 {
-		t.Fatalf("len(EvidenceRefs()) = %d, want 1", got)
+	if diff := cmp.Diff(1, len(details.EvidenceRefs())); diff != "" {
+		t.Fatalf("len(EvidenceRefs()) mismatch (-want +got):\n%s", diff)
 	}
-	if got := len(details.ArtifactRefs()); got != 1 {
-		t.Fatalf("len(ArtifactRefs()) = %d, want 1", got)
+	if diff := cmp.Diff(1, len(details.ArtifactRefs())); diff != "" {
+		t.Fatalf("len(ArtifactRefs()) mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/application/types/memory_search_criteria_test.go
+++ b/application/types/memory_search_criteria_test.go
@@ -3,6 +3,8 @@ package types_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
@@ -19,19 +21,19 @@ func TestMemorySearchCriteriaBuilder(t *testing.T) {
 		MemoryType(domtypes.MemoryTypeLesson).
 		Build()
 
-	if got := criteria.Query(); got != "release" {
-		t.Fatalf("Query() = %q, want %q", got, "release")
+	if diff := cmp.Diff("release", criteria.Query()); diff != "" {
+		t.Fatalf("Query() mismatch (-want +got):\n%s", diff)
 	}
-	if got := criteria.Offset(); got != 2 {
-		t.Fatalf("Offset() = %d, want 2", got)
+	if diff := cmp.Diff(2, criteria.Offset()); diff != "" {
+		t.Fatalf("Offset() mismatch (-want +got):\n%s", diff)
 	}
-	if got := len(criteria.Scopes()); got != 1 {
-		t.Fatalf("len(Scopes()) = %d, want 1", got)
+	if diff := cmp.Diff(1, len(criteria.Scopes())); diff != "" {
+		t.Fatalf("len(Scopes()) mismatch (-want +got):\n%s", diff)
 	}
-	if got := len(criteria.Statuses()); got != 1 {
-		t.Fatalf("len(Statuses()) = %d, want 1", got)
+	if diff := cmp.Diff(1, len(criteria.Statuses())); diff != "" {
+		t.Fatalf("len(Statuses()) mismatch (-want +got):\n%s", diff)
 	}
-	if got := len(criteria.MemoryTypes()); got != 1 {
-		t.Fatalf("len(MemoryTypes()) = %d, want 1", got)
+	if diff := cmp.Diff(1, len(criteria.MemoryTypes())); diff != "" {
+		t.Fatalf("len(MemoryTypes()) mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/application/types/memory_summary_test.go
+++ b/application/types/memory_summary_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
@@ -35,11 +37,15 @@ func TestMemorySummaryOf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryOf() error = %v", err)
 	}
-	if got := summary.Fact(); got != "Release issues close only after tagged release" {
-		t.Fatalf("Fact() = %q", got)
+	if diff := cmp.Diff("Release issues close only after tagged release", summary.Fact()); diff != "" {
+		t.Fatalf("Fact() mismatch (-want +got):\n%s", diff)
 	}
-	if got, ok := summary.ExpiresAt().Value(); !ok || !got.Equal(expiresAt) {
-		t.Fatalf("ExpiresAt() = (%v, %v), want (%v, true)", got, ok, expiresAt)
+	gotExpiresAt, ok := summary.ExpiresAt().Value()
+	if diff := cmp.Diff(true, ok); diff != "" {
+		t.Fatalf("ExpiresAt() presence mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(expiresAt, gotExpiresAt); diff != "" {
+		t.Fatalf("ExpiresAt() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -68,7 +74,7 @@ func TestMemorySummaryFrom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryFrom() error = %v", err)
 	}
-	if got := summary.MemoryID(); got != memoryID {
-		t.Fatalf("MemoryID() = %s, want %s", got, memoryID)
+	if diff := cmp.Diff(memoryID, summary.MemoryID()); diff != "" {
+		t.Fatalf("MemoryID() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/infrastructure/filesystem/hooks_marshal_test.go
+++ b/infrastructure/filesystem/hooks_marshal_test.go
@@ -44,11 +44,14 @@ func TestMarshalHooks_RendersCanonicalDocument(t *testing.T) {
 	if !ok {
 		t.Fatalf("SessionStart not found in decoded output")
 	}
-	if got, want := len(sessionStart), 1; got != want {
-		t.Fatalf("len(SessionStart) = %d, want %d", got, want)
+	if diff := cmp.Diff(1, len(sessionStart)); diff != "" {
+		t.Fatalf("len(SessionStart) mismatch (-want +got):\n%s", diff)
 	}
-	if sessionStart[0].Matcher == nil || *sessionStart[0].Matcher != "*" {
-		t.Fatalf("SessionStart matcher = %v, want %q", sessionStart[0].Matcher, "*")
+	if sessionStart[0].Matcher == nil {
+		t.Fatalf("SessionStart matcher = nil, want non-nil")
+	}
+	if diff := cmp.Diff("*", *sessionStart[0].Matcher); diff != "" {
+		t.Fatalf("SessionStart matcher mismatch (-want +got):\n%s", diff)
 	}
 	gotCommand := sessionStart[0].Hooks[0]
 	wantCommand := hookCommandDocument{

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWriteCLIError(t *testing.T) {
@@ -17,8 +19,8 @@ func TestWriteCLIError(t *testing.T) {
 		if err := writeCLIError(buffer, testError("boom")); err != nil {
 			t.Fatalf("writeCLIError() error = %v", err)
 		}
-		if buffer.String() != "Error: boom\n" {
-			t.Fatalf("buffer = %q, want %q", buffer.String(), "Error: boom\n")
+		if diff := cmp.Diff("Error: boom\n", buffer.String()); diff != "" {
+			t.Fatalf("buffer mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -29,8 +31,8 @@ func TestWriteCLIError(t *testing.T) {
 		if err := writeCLIError(buffer, nil); err != nil {
 			t.Fatalf("writeCLIError() error = %v", err)
 		}
-		if buffer.Len() != 0 {
-			t.Fatalf("buffer = %q, want empty", buffer.String())
+		if diff := cmp.Diff("", buffer.String()); diff != "" {
+			t.Fatalf("buffer mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -107,14 +109,14 @@ func TestResolveBuildMetadata(t *testing.T) {
 			}, true
 		})
 
-		if gotVersion != "v0.1.7" {
-			t.Fatalf("version = %q, want %q", gotVersion, "v0.1.7")
+		if diff := cmp.Diff("v0.1.7", gotVersion); diff != "" {
+			t.Fatalf("version mismatch (-want +got):\n%s", diff)
 		}
-		if gotCommit != "abcdef123456" {
-			t.Fatalf("commit = %q, want %q", gotCommit, "abcdef123456")
+		if diff := cmp.Diff("abcdef123456", gotCommit); diff != "" {
+			t.Fatalf("commit mismatch (-want +got):\n%s", diff)
 		}
-		if gotDate != "2026-04-08T03:00:00Z" {
-			t.Fatalf("date = %q, want %q", gotDate, "2026-04-08T03:00:00Z")
+		if diff := cmp.Diff("2026-04-08T03:00:00Z", gotDate); diff != "" {
+			t.Fatalf("date mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -124,8 +126,8 @@ func TestResolveBuildMetadata(t *testing.T) {
 		gotVersion, gotCommit, gotDate := resolveBuildMetadata("dev", "none", "unknown", func() (*debug.BuildInfo, bool) {
 			return nil, false
 		})
-		if gotVersion != "dev" || gotCommit != "none" || gotDate != "unknown" {
-			t.Fatalf("resolveBuildMetadata() = (%q, %q, %q)", gotVersion, gotCommit, gotDate)
+		if diff := cmp.Diff([]string{"dev", "none", "unknown"}, []string{gotVersion, gotCommit, gotDate}); diff != "" {
+			t.Fatalf("resolveBuildMetadata() mismatch (-want +got):\n%s", diff)
 		}
 	})
 }

--- a/presentation/cli/audit_test.go
+++ b/presentation/cli/audit_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
@@ -71,8 +73,8 @@ func TestRootCLI_AuditCommand(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if stdout.String() != "Recorded: event-1\n" {
-		t.Fatalf("stdout = %q, want %q", stdout.String(), "Recorded: event-1\n")
+	if diff := cmp.Diff("Recorded: event-1\n", stdout.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -151,8 +153,8 @@ func TestRootCLI_AuditCommand_FallsBackFromStaleActiveSession(t *testing.T) {
 	want := "" +
 		"Active session session-stale is stale; using default session ID\n" +
 		"Recorded: event-stale-audit\n"
-	if stdout.String() != want {
-		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	if diff := cmp.Diff(want, stdout.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -226,8 +228,8 @@ func TestRootCLI_AuditCommand_IdOnly(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if stdout.String() != "event-id-only\n" {
-		t.Fatalf("stdout = %q, want %q", stdout.String(), "event-id-only\n")
+	if diff := cmp.Diff("event-id-only\n", stdout.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/presentation/cli/context_internal_test.go
+++ b/presentation/cli/context_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestDetectRepoContextFromDir(t *testing.T) {
@@ -17,8 +19,8 @@ func TestDetectRepoContextFromDir(t *testing.T) {
 		if err != nil {
 			t.Fatalf("detectRepoContextFromDir() error = %v", err)
 		}
-		if want := "github.com/duck8823/traceary"; got != want {
-			t.Fatalf("detectRepoContextFromDir() = %q, want %q", got, want)
+		if diff := cmp.Diff("github.com/duck8823/traceary", got); diff != "" {
+			t.Fatalf("detectRepoContextFromDir() mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -34,8 +36,8 @@ func TestDetectRepoContextFromDir(t *testing.T) {
 			t.Fatalf("detectRepoContextFromDir() error = %v", err)
 		}
 		want := normalizeLocalWorkContextPath(gitCommandOutputForContextTest(t, repoDir, "rev-parse", "--show-toplevel"))
-		if got != want {
-			t.Fatalf("detectRepoContextFromDir() = %q, want %q", got, want)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("detectRepoContextFromDir() mismatch (-want +got):\n%s", diff)
 		}
 	})
 }

--- a/presentation/cli/hook_runtime_internal_test.go
+++ b/presentation/cli/hook_runtime_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestResolveHookStateKey_UsesGrandparentProcessIdentity(t *testing.T) {
@@ -20,8 +22,8 @@ func TestResolveHookStateKey_UsesGrandparentProcessIdentity(t *testing.T) {
 		hookParentProcessLookup = originalLookup
 	})
 
-	if got, want := resolveHookStateKey(), "4242"; got != want {
-		t.Fatalf("resolveHookStateKey() = %q, want %q", got, want)
+	if diff := cmp.Diff("4242", resolveHookStateKey()); diff != "" {
+		t.Fatalf("resolveHookStateKey() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -39,7 +41,7 @@ func TestResolveHookStateKey_UsesParentIdentityForNonShellParents(t *testing.T) 
 		hookParentProcessLookup = originalLookup
 	})
 
-	if got, want := resolveHookStateKey(), sanitizeHookStateKey(strconv.Itoa(os.Getppid())); got != want {
-		t.Fatalf("resolveHookStateKey() = %q, want %q", got, want)
+	if diff := cmp.Diff(sanitizeHookStateKey(strconv.Itoa(os.Getppid())), resolveHookStateKey()); diff != "" {
+		t.Fatalf("resolveHookStateKey() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/presentation/cli/hooks_guide_test.go
+++ b/presentation/cli/hooks_guide_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -32,14 +34,15 @@ func TestRootCLI_HooksGuideCommand(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "traceary hooks install --client gemini") {
-		t.Fatalf("stdout = %q, want install step", stdout.String())
+	output := stdout.String()
+	if !strings.Contains(output, "traceary hooks install --client gemini") {
+		t.Fatalf("stdout = %q, want install step", output)
 	}
-	if !strings.Contains(stdout.String(), "traceary doctor --client gemini") {
-		t.Fatalf("stdout = %q, want doctor step", stdout.String())
+	if !strings.Contains(output, "traceary doctor --client gemini") {
+		t.Fatalf("stdout = %q, want doctor step", output)
 	}
-	if !strings.Contains(stdout.String(), "hooksConfig.enabled=true") {
-		t.Fatalf("stdout = %q, want Gemini note", stdout.String())
+	if !strings.Contains(output, "hooksConfig.enabled=true") {
+		t.Fatalf("stdout = %q, want Gemini note", output)
 	}
 }
 
@@ -55,7 +58,7 @@ func TestRootCLI_HooksGuideCommand_MissingClientReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Execute() error = nil, want error")
 	}
-	if err.Error() != `required flag(s) "client" not set` {
-		t.Fatalf("Execute() error = %q, want required client flag error", err.Error())
+	if diff := cmp.Diff(`required flag(s) "client" not set`, err.Error()); diff != "" {
+		t.Fatalf("Execute() error mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/presentation/cli/hooks_helper_test.go
+++ b/presentation/cli/hooks_helper_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestRootCLI_HooksHelperCommand(t *testing.T) {
@@ -18,8 +20,8 @@ func TestRootCLI_HooksHelperCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if got, want := stdout.String(), "go test ./..."; got != want {
-			t.Fatalf("stdout = %q, want %q", got, want)
+		if diff := cmp.Diff("go test ./...", stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -34,8 +36,8 @@ func TestRootCLI_HooksHelperCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if got, want := stdout.String(), `{"error":"boom","is_interrupt":false}`; got != want {
-			t.Fatalf("stdout = %q, want %q", got, want)
+		if diff := cmp.Diff(`{"error":"boom","is_interrupt":false}`, stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -49,8 +51,8 @@ func TestRootCLI_HooksHelperCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if got, want := stdout.String(), "github.com/duck8823/traceary"; got != want {
-			t.Fatalf("stdout = %q, want %q", got, want)
+		if diff := cmp.Diff("github.com/duck8823/traceary", stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 }

--- a/presentation/cli/init_test.go
+++ b/presentation/cli/init_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -28,8 +30,8 @@ func TestRootCLI_InitCommand(t *testing.T) {
 		t.Fatalf("Run() was not called")
 	}
 	wantOutput := "Initialized: " + dbPath + "\n"
-	if stdout.String() != wantOutput {
-		t.Fatalf("stdout = %q, want %q", stdout.String(), wantOutput)
+	if diff := cmp.Diff(wantOutput, stdout.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -104,8 +106,8 @@ func TestRootCLI_InitCommand_UsesTracearyDBPathEnv(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	wantOutput := "Initialized: " + dbPath + "\n"
-	if stdout.String() != wantOutput {
-		t.Fatalf("stdout = %q, want %q", stdout.String(), wantOutput)
+	if diff := cmp.Diff(wantOutput, stdout.String()); diff != "" {
+		t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
@@ -62,8 +64,8 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if stdout.String() != "Recorded: event-1\n" {
-			t.Fatalf("stdout = %q, want %q", stdout.String(), "Recorded: event-1\n")
+		if diff := cmp.Diff("Recorded: event-1\n", stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -101,8 +103,8 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if stdout.String() != "Recorded: event-1\n" {
-			t.Fatalf("stdout = %q, want %q", stdout.String(), "Recorded: event-1\n")
+		if diff := cmp.Diff("Recorded: event-1\n", stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -162,8 +164,8 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		if stdout.String() != "event-1\n" {
-			t.Fatalf("stdout = %q, want %q", stdout.String(), "event-1\n")
+		if diff := cmp.Diff("event-1\n", stdout.String()); diff != "" {
+			t.Fatalf("stdout mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -195,11 +197,11 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		}
 
 		payload := decodeJSONMap(t, stdout.String())
-		if got, want := payload["event_id"], "event-1"; got != want {
-			t.Fatalf("event_id = %v, want %q", got, want)
+		if diff := cmp.Diff("event-1", payload["event_id"]); diff != "" {
+			t.Fatalf("event_id mismatch (-want +got):\n%s", diff)
 		}
-		if got, want := payload["message"], "hello"; got != want {
-			t.Fatalf("message = %v, want %q", got, want)
+		if diff := cmp.Diff("hello", payload["message"]); diff != "" {
+			t.Fatalf("message mismatch (-want +got):\n%s", diff)
 		}
 	})
 

--- a/presentation/mcpserver/helpers_test.go
+++ b/presentation/mcpserver/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/presentation/mcpserver"
 )
 
@@ -58,8 +60,11 @@ func TestParseFlexibleTime(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("parseFlexibleTime(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
 			}
-			if !tt.wantErr && !got.Equal(tt.want) {
-				t.Errorf("parseFlexibleTime(%q) = %v, want %v", tt.value, got, tt.want)
+			if tt.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParseFlexibleTime(%q) mismatch (-want +got):\n%s", tt.value, diff)
 			}
 		})
 	}
@@ -68,27 +73,27 @@ func TestParseFlexibleTime(t *testing.T) {
 func TestResolveLimit(t *testing.T) {
 	t.Parallel()
 
-	if got := mcpserver.ResolveLimit(5, 10); got != 5 {
-		t.Errorf("ResolveLimit(5, 10) = %d, want 5", got)
+	if diff := cmp.Diff(5, mcpserver.ResolveLimit(5, 10)); diff != "" {
+		t.Errorf("ResolveLimit(5, 10) mismatch (-want +got):\n%s", diff)
 	}
-	if got := mcpserver.ResolveLimit(0, 10); got != 10 {
-		t.Errorf("ResolveLimit(0, 10) = %d, want 10", got)
+	if diff := cmp.Diff(10, mcpserver.ResolveLimit(0, 10)); diff != "" {
+		t.Errorf("ResolveLimit(0, 10) mismatch (-want +got):\n%s", diff)
 	}
-	if got := mcpserver.ResolveLimit(-1, 10); got != 10 {
-		t.Errorf("ResolveLimit(-1, 10) = %d, want 10", got)
+	if diff := cmp.Diff(10, mcpserver.ResolveLimit(-1, 10)); diff != "" {
+		t.Errorf("ResolveLimit(-1, 10) mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestResolveOffset(t *testing.T) {
 	t.Parallel()
 
-	if got := mcpserver.ResolveOffset(5); got != 5 {
-		t.Errorf("ResolveOffset(5) = %d, want 5", got)
+	if diff := cmp.Diff(5, mcpserver.ResolveOffset(5)); diff != "" {
+		t.Errorf("ResolveOffset(5) mismatch (-want +got):\n%s", diff)
 	}
-	if got := mcpserver.ResolveOffset(0); got != 0 {
-		t.Errorf("ResolveOffset(0) = %d, want 0", got)
+	if diff := cmp.Diff(0, mcpserver.ResolveOffset(0)); diff != "" {
+		t.Errorf("ResolveOffset(0) mismatch (-want +got):\n%s", diff)
 	}
-	if got := mcpserver.ResolveOffset(-1); got != 0 {
-		t.Errorf("ResolveOffset(-1) = %d, want 0", got)
+	if diff := cmp.Diff(0, mcpserver.ResolveOffset(-1)); diff != "" {
+		t.Errorf("ResolveOffset(-1) mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- replace repeated scalar and output assertions with `cmp.Diff` in representative test surfaces
- update touched tests to use the convention Optional API while keeping assertions inline
- keep same-package tests only where they still exercise unexported behavior directly

Closes #527

## Testing
- `GOCACHE=$(pwd)/.cache/go-build go test ./...`
- `GOCACHE=$(pwd)/.cache/go-build go build ./...`
- `GOCACHE=$(pwd)/.cache/go-build GOLANGCI_LINT_CACHE=$(pwd)/.cache/golangci go tool golangci-lint run ./...`
