### PR TITLE
feat(list,search): compact output with local TZ, --wide and --utc flags

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -76,12 +76,16 @@ session 解決ルールは `traceary log` と同じです。
 
 `list` は直近履歴を素早く絞るためのコマンドです。kind / client / agent / session / workspace が決まっているときはこちらを使い、キーワード検索や期間条件が必要なときは `search` を使います。
 
+デフォルトのテキスト出力は `tail` と同じコンパクトな 1 行形式 (`HH:MM:SS  kind  sess=<先頭8文字>  ws=<basename>  message`、ヘッダ無し、現地時刻) です。`--wide` で従来の 7 カラム tab 区切り表、`--utc` でテキスト出力を UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。
+
 主な flag:
 
 - `--kind`
 - `--limit`
 - `--offset`
 - `--json`
+- `--wide`
+- `--utc`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -114,6 +118,8 @@ session 解決ルールは `traceary log` と同じです。
 
 全文検索と構造フィルタで event を検索します。
 
+テキスト出力は `list` / `tail` と同じコンパクト 1 行形式 (デフォルトで現地時刻) です。`--wide` で従来の 7 カラム表、`--utc` で UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。
+
 主な flag:
 
 - `--kind`
@@ -126,6 +132,8 @@ session 解決ルールは `traceary log` と同じです。
 - `--limit`
 - `--offset`
 - `--json`
+- `--wide`
+- `--utc`
 
 ### `traceary show <event-id>`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -76,12 +76,16 @@ List recent events.
 
 `list` is the fast recent-history view. Use it when you already know the event kind / client / agent / session / workspace filters you want. Switch to `search` when you need keyword matching or date-range filtering.
 
+Default text output is the same compact single-line shape as `tail` (`HH:MM:SS  kind  sess=<first-8>  ws=<basename>  message`, local time, no header). Pass `--wide` for the legacy tab-separated seven-column format, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged.
+
 Useful flags:
 
 - `--kind`
 - `--limit`
 - `--offset`
 - `--json`
+- `--wide`
+- `--utc`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -114,6 +118,8 @@ Useful flags:
 
 Search events by text and structured filters.
 
+Text results use the same compact single-line format as `list` / `tail` (local time by default). Pass `--wide` for the legacy seven-column table, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged.
+
 Useful flags:
 
 - `--kind`
@@ -126,6 +132,8 @@ Useful flags:
 - `--limit`
 - `--offset`
 - `--json`
+- `--wide`
+- `--utc`
 
 ### `traceary show <event-id>`
 

--- a/presentation/cli/event_output.go
+++ b/presentation/cli/event_output.go
@@ -13,15 +13,15 @@ import (
 
 const messageColumnMaxWidth = 80
 
-func writeEventsByFormat(output io.Writer, events []*model.Event, asJSON bool) error {
+func writeEventsByFormat(output io.Writer, events []*model.Event, asJSON bool, textOpts eventTextFormatOptions) error {
 	if asJSON {
 		return writeEventsJSON(output, events)
 	}
 
-	return writeEvents(output, events)
+	return writeEvents(output, events, textOpts)
 }
 
-func writeEvents(output io.Writer, events []*model.Event) error {
+func writeEvents(output io.Writer, events []*model.Event, textOpts eventTextFormatOptions) error {
 	if len(events) == 0 {
 		if _, err := fmt.Fprintln(output, Localize("No matching records.", "一致する記録はありません")); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print empty list message", "空一覧メッセージの出力に失敗しました"), err)
@@ -29,19 +29,23 @@ func writeEvents(output io.Writer, events []*model.Event) error {
 		return nil
 	}
 
-	// list/search continue to emit the UTC wide format; #541 will switch
-	// the default to local-compact. Keeping behaviour unchanged here lets
-	// #538 land without touching list/search output.
-	wideOpts := eventTextFormatOptions{wide: true, utc: true}
-	if _, err := fmt.Fprintln(output, formatEventWideHeader()); err != nil {
-		return xerrors.Errorf("%s: %w", Localize("failed to print list header", "一覧ヘッダーの出力に失敗しました"), err)
+	if textOpts.wide {
+		if _, err := fmt.Fprintln(output, formatEventWideHeader()); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print list header", "一覧ヘッダーの出力に失敗しました"), err)
+		}
+		for _, event := range events {
+			if _, err := fmt.Fprintln(output, formatEventWideRow(event, textOpts)); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to print event row", "イベント一覧行の出力に失敗しました"), err)
+			}
+		}
+		return nil
 	}
+
 	for _, event := range events {
-		if _, err := fmt.Fprintln(output, formatEventWideRow(event, wideOpts)); err != nil {
+		if _, err := fmt.Fprintln(output, formatEventCompactRow(event, textOpts)); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print event row", "イベント一覧行の出力に失敗しました"), err)
 		}
 	}
-
 	return nil
 }
 

--- a/presentation/cli/event_text_formatter_test.go
+++ b/presentation/cli/event_text_formatter_test.go
@@ -159,6 +159,64 @@ func TestFormatEventWideRow_UTCMatchesLegacyFormat(t *testing.T) {
 	}
 }
 
+func TestWriteEvents_CompactDefaultOmitsHeader(t *testing.T) {
+	t.Parallel()
+
+	event := mustTailEvent(
+		t,
+		"abcdef1234567890",
+		"cli",
+		"codex",
+		"session-compact-9999",
+		"duck8823/traceary",
+		"hello list compact",
+		time.Date(2026, 4, 15, 9, 30, 0, 0, time.UTC),
+	)
+
+	var buf bytes.Buffer
+	if err := writeEvents(&buf, []*model.Event{event}, eventTextFormatOptions{utc: true}); err != nil {
+		t.Fatalf("writeEvents() error = %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "CREATED_AT\t") {
+		t.Fatalf("compact mode emitted wide header: %q", got)
+	}
+	if !strings.HasPrefix(got, "09:30:00 ") {
+		t.Fatalf("expected HH:MM:SS UTC prefix, got %q", got)
+	}
+	if !strings.Contains(got, "sess=session-") {
+		t.Fatalf("expected compact session prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("expected trailing newline, got %q", got)
+	}
+}
+
+func TestWriteEvents_WideUTCMatchesLegacyTable(t *testing.T) {
+	t.Parallel()
+
+	event := mustTailEvent(
+		t,
+		"event-wide-list",
+		"cli",
+		"codex",
+		"session-1",
+		"duck8823/traceary",
+		"hello",
+		time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC),
+	)
+
+	var buf bytes.Buffer
+	if err := writeEvents(&buf, []*model.Event{event}, eventTextFormatOptions{wide: true, utc: true}); err != nil {
+		t.Fatalf("writeEvents() error = %v", err)
+	}
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
+		"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\thello\n"
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Fatalf("writeEvents() wide+utc mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestRunTail_DefaultCompactUsesInjectedLocation(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -117,6 +117,9 @@ type listCommandInput struct {
 	until        string
 	failuresOnly bool
 	asJSON       bool
+	wide         bool
+	utc          bool
+	location     *time.Location
 }
 
 // logCommandInput is the resolved input to the `traceary log` command.
@@ -149,6 +152,9 @@ type searchCommandInput struct {
 	query        string
 	failuresOnly bool
 	asJSON       bool
+	wide         bool
+	utc          bool
+	location     *time.Location
 }
 
 // sessionBoundaryCommandInput is the resolved input to

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -28,6 +28,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		until        string
 		failuresOnly bool
 		asJSON       bool
+		wide         bool
+		utc          bool
 	)
 
 	listCmd := &cobra.Command{
@@ -50,6 +52,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 				until:        until,
 				failuresOnly: failuresOnly,
 				asJSON:       asJSON,
+				wide:         wide,
+				utc:          utc,
 			})
 		},
 	}
@@ -67,6 +71,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&until, "until", "", Localize("end date (`YYYY-MM-DD` or RFC3339) (alias for `--to`)", "終了日 (`YYYY-MM-DD` または RFC3339) (`--to` の別名)"))
 	listCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
 	listCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	listCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
+	listCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 
 	return listCmd
 }
@@ -139,7 +145,12 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to list events", "イベント一覧の取得に失敗しました"), err)
 	}
-	if err := writeEventsByFormat(output, events, input.asJSON); err != nil {
+	textOpts := eventTextFormatOptions{
+		wide:     input.wide,
+		utc:      input.utc,
+		location: input.location,
+	}
+	if err := writeEventsByFormat(output, events, input.asJSON, textOpts); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print event list", "一覧出力に失敗しました"), err)
 	}
 

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -62,6 +62,8 @@ func TestRootCLI_ListCommand(t *testing.T) {
 			"--agent", "codex",
 			"--session-id", "session-1",
 			"--workspace", "duck8823/traceary",
+			"--wide",
+			"--utc",
 		})
 
 		if err := rootCmd.Execute(); err != nil {

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -29,6 +29,8 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 		offset       int
 		failuresOnly bool
 		asJSON       bool
+		wide         bool
+		utc          bool
 	)
 
 	searchCmd := &cobra.Command{
@@ -56,6 +58,8 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 				query:        query,
 				failuresOnly: failuresOnly,
 				asJSON:       asJSON,
+				wide:         wide,
+				utc:          utc,
 			})
 		},
 	}
@@ -81,6 +85,8 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 	searchCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of matching events to skip before returning results", "結果を返す前にスキップする件数"))
 	searchCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
 	searchCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	searchCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
+	searchCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 
 	return searchCmd
 }
@@ -153,7 +159,12 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 		return xerrors.Errorf("%s: %w", Localize("failed to search events", "検索に失敗しました"), err)
 	}
 
-	if err := writeEventsByFormat(output, events, input.asJSON); err != nil {
+	textOpts := eventTextFormatOptions{
+		wide:     input.wide,
+		utc:      input.utc,
+		location: input.location,
+	}
+	if err := writeEventsByFormat(output, events, input.asJSON, textOpts); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print search results", "検索結果の出力に失敗しました"), err)
 	}
 


### PR DESCRIPTION
## Summary

- Default `traceary list` and text-mode `traceary search` text output now share the compact single-line shape introduced for `tail` in #538 (`HH:MM:SS  kind  sess=<first-8>  ws=<basename>  message`, local time, no header).
- New flags `--wide` (legacy tab-separated seven-column table with header) and `--utc` (force UTC text timestamps). `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte for scripts that parse stdout.
- `writeEventsByFormat` / `writeEvents` now thread `eventTextFormatOptions` so future callers can opt into either mode without reintroducing duplicate formatters.
- JSON output (`--json`) is unchanged.
- Docs (`docs/cli/README.md` + `.ja.md`) updated for both `list` and `search` sections.

Closes #541

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go tool golangci-lint run` (0 issues)
- [x] `TestRootCLI_ListCommand/displays_event_list` updated to `--wide --utc`, still byte-compatible
- [x] `TestWriteEvents_CompactDefaultOmitsHeader` — compact path yields HH:MM:SS prefix, no header
- [x] `TestWriteEvents_WideUTCMatchesLegacyTable` — wide+utc still byte-matches the pre-v0.6.1 layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)