### PR TITLE
feat(timeline): per-workspace breakdown with activity summary

### DIFF
--- a/application/types/timeline_block.go
+++ b/application/types/timeline_block.go
@@ -5,14 +5,76 @@ import (
 	"time"
 )
 
+// TimelineWorkspaceBreakdownSummarySource identifies which event kind the
+// workspace activity summary was derived from. Consumers can disambiguate
+// between user-intent (prompt), agent-report (compact_summary), and the
+// kind-count fallback.
+type TimelineWorkspaceBreakdownSummarySource string
+
+const (
+	// TimelineSummarySourceCompactSummary means the summary came from a
+	// compact_summary event body recorded for this workspace in the block.
+	TimelineSummarySourceCompactSummary TimelineWorkspaceBreakdownSummarySource = "compact_summary"
+	// TimelineSummarySourcePrompt means the summary came from the first
+	// prompt event body recorded for this workspace in the block.
+	TimelineSummarySourcePrompt TimelineWorkspaceBreakdownSummarySource = "prompt"
+	// TimelineSummarySourceKindCounts means no summary event was available
+	// and the renderer should fall back to the kind-count line.
+	TimelineSummarySourceKindCounts TimelineWorkspaceBreakdownSummarySource = "kind_counts"
+)
+
+// TimelineWorkspaceBreakdown captures per-workspace activity inside a
+// timeline block. It is always nested under a TimelineBlock.
+type TimelineWorkspaceBreakdown struct {
+	workspace     string
+	eventCount    int
+	kinds         []string
+	summary       string
+	summarySource TimelineWorkspaceBreakdownSummarySource
+}
+
+// TimelineWorkspaceBreakdownOf creates a TimelineWorkspaceBreakdown.
+func TimelineWorkspaceBreakdownOf(
+	workspace string,
+	eventCount int,
+	kinds []string,
+	summary string,
+	summarySource TimelineWorkspaceBreakdownSummarySource,
+) TimelineWorkspaceBreakdown {
+	return TimelineWorkspaceBreakdown{
+		workspace:     workspace,
+		eventCount:    eventCount,
+		kinds:         slices.Clone(kinds),
+		summary:       summary,
+		summarySource: summarySource,
+	}
+}
+
+// Workspace returns the workspace identifier.
+func (b TimelineWorkspaceBreakdown) Workspace() string { return b.workspace }
+
+// EventCount returns the number of events attributed to this workspace.
+func (b TimelineWorkspaceBreakdown) EventCount() int { return b.eventCount }
+
+// Kinds returns the kinds observed for this workspace inside the block.
+func (b TimelineWorkspaceBreakdown) Kinds() []string { return slices.Clone(b.kinds) }
+
+// Summary returns the short activity summary for this workspace.
+func (b TimelineWorkspaceBreakdown) Summary() string { return b.summary }
+
+// SummarySource returns which event kind the summary was derived from.
+func (b TimelineWorkspaceBreakdown) SummarySource() TimelineWorkspaceBreakdownSummarySource {
+	return b.summarySource
+}
+
 // TimelineBlock represents a contiguous work block separated by idle gaps.
+// It holds block-level aggregates plus a per-workspace breakdown.
 type TimelineBlock struct {
-	blockStart time.Time
-	blockEnd   time.Time
-	eventCount int
-	workspaces []string
-	agents     []string
-	kinds      []string
+	blockStart         time.Time
+	blockEnd           time.Time
+	eventCount         int
+	agents             []string
+	workspaceBreakdown []TimelineWorkspaceBreakdown
 }
 
 // TimelineBlockOf creates a TimelineBlock.
@@ -20,17 +82,15 @@ func TimelineBlockOf(
 	blockStart time.Time,
 	blockEnd time.Time,
 	eventCount int,
-	workspaces []string,
 	agents []string,
-	kinds []string,
+	workspaceBreakdown []TimelineWorkspaceBreakdown,
 ) TimelineBlock {
 	return TimelineBlock{
-		blockStart: blockStart,
-		blockEnd:   blockEnd,
-		eventCount: eventCount,
-		workspaces: slices.Clone(workspaces),
-		agents:     slices.Clone(agents),
-		kinds:      slices.Clone(kinds),
+		blockStart:         blockStart,
+		blockEnd:           blockEnd,
+		eventCount:         eventCount,
+		agents:             slices.Clone(agents),
+		workspaceBreakdown: slices.Clone(workspaceBreakdown),
 	}
 }
 
@@ -43,11 +103,31 @@ func (b TimelineBlock) BlockEnd() time.Time { return b.blockEnd }
 // EventCount returns the number of events in the block.
 func (b TimelineBlock) EventCount() int { return b.eventCount }
 
-// Workspaces returns the workspaces involved.
-func (b TimelineBlock) Workspaces() []string { return slices.Clone(b.workspaces) }
-
 // Agents returns the agents involved.
 func (b TimelineBlock) Agents() []string { return slices.Clone(b.agents) }
 
-// Kinds returns the event kinds in the block.
-func (b TimelineBlock) Kinds() []string { return slices.Clone(b.kinds) }
+// WorkspaceBreakdown returns per-workspace activity inside the block.
+func (b TimelineBlock) WorkspaceBreakdown() []TimelineWorkspaceBreakdown {
+	return slices.Clone(b.workspaceBreakdown)
+}
+
+// Workspaces returns the distinct workspaces involved in the block, derived
+// from the workspace breakdown for backward compatibility with callers that
+// only need the workspace list.
+func (b TimelineBlock) Workspaces() []string {
+	out := make([]string, 0, len(b.workspaceBreakdown))
+	for _, ws := range b.workspaceBreakdown {
+		out = append(out, ws.workspace)
+	}
+	return out
+}
+
+// Kinds returns the union of kinds seen across every workspace in the
+// block, preserving each workspace's kind ordering.
+func (b TimelineBlock) Kinds() []string {
+	var out []string
+	for _, ws := range b.workspaceBreakdown {
+		out = append(out, ws.kinds...)
+	}
+	return out
+}

--- a/application/types/timeline_block_test.go
+++ b/application/types/timeline_block_test.go
@@ -14,11 +14,25 @@ func TestTimelineBlockOf_Getters(t *testing.T) {
 
 	blockStart := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 	blockEnd := blockStart.Add(30 * time.Minute)
-	workspaces := []string{"github.com/org/repo-a", "github.com/org/repo-b"}
 	agents := []string{"claude", "codex"}
-	kinds := []string{"note", "command_executed"}
+	breakdown := []apptypes.TimelineWorkspaceBreakdown{
+		apptypes.TimelineWorkspaceBreakdownOf(
+			"github.com/org/repo-a",
+			3,
+			[]string{"note", "command_executed"},
+			"fix the thing",
+			apptypes.TimelineSummarySourcePrompt,
+		),
+		apptypes.TimelineWorkspaceBreakdownOf(
+			"github.com/org/repo-b",
+			2,
+			[]string{"command_executed"},
+			"",
+			apptypes.TimelineSummarySourceKindCounts,
+		),
+	}
 
-	block := apptypes.TimelineBlockOf(blockStart, blockEnd, 5, workspaces, agents, kinds)
+	block := apptypes.TimelineBlockOf(blockStart, blockEnd, 5, agents, breakdown)
 
 	if !block.BlockStart().Equal(blockStart) {
 		t.Errorf("BlockStart() = %v, want %v", block.BlockStart(), blockStart)
@@ -29,63 +43,74 @@ func TestTimelineBlockOf_Getters(t *testing.T) {
 	if diff := cmp.Diff(5, block.EventCount()); diff != "" {
 		t.Errorf("EventCount() mismatch (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(workspaces, block.Workspaces()); diff != "" {
+	if diff := cmp.Diff([]string{"github.com/org/repo-a", "github.com/org/repo-b"}, block.Workspaces()); diff != "" {
 		t.Errorf("Workspaces() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(agents, block.Agents()); diff != "" {
 		t.Errorf("Agents() mismatch (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(kinds, block.Kinds()); diff != "" {
+	if diff := cmp.Diff([]string{"note", "command_executed", "command_executed"}, block.Kinds()); diff != "" {
 		t.Errorf("Kinds() mismatch (-want +got):\n%s", diff)
+	}
+
+	returnedBreakdown := block.WorkspaceBreakdown()
+	if len(returnedBreakdown) != 2 {
+		t.Fatalf("WorkspaceBreakdown() len = %d, want 2", len(returnedBreakdown))
+	}
+	if got := returnedBreakdown[0].Summary(); got != "fix the thing" {
+		t.Errorf("breakdown[0].Summary() = %q, want %q", got, "fix the thing")
+	}
+	if got := returnedBreakdown[0].SummarySource(); got != apptypes.TimelineSummarySourcePrompt {
+		t.Errorf("breakdown[0].SummarySource() = %q, want %q", got, apptypes.TimelineSummarySourcePrompt)
+	}
+	if got := returnedBreakdown[1].SummarySource(); got != apptypes.TimelineSummarySourceKindCounts {
+		t.Errorf("breakdown[1].SummarySource() = %q, want %q", got, apptypes.TimelineSummarySourceKindCounts)
 	}
 }
 
 func TestTimelineBlock_DefensiveCopy(t *testing.T) {
 	t.Parallel()
 
-	workspaces := []string{"ws-a", "ws-b"}
 	agents := []string{"claude", "codex"}
-	kinds := []string{"note", "command_executed"}
+	breakdown := []apptypes.TimelineWorkspaceBreakdown{
+		apptypes.TimelineWorkspaceBreakdownOf(
+			"ws-a",
+			2,
+			[]string{"note"},
+			"",
+			apptypes.TimelineSummarySourceKindCounts,
+		),
+	}
 
 	block := apptypes.TimelineBlockOf(
 		time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC),
 		time.Date(2024, time.January, 2, 4, 4, 5, 0, time.UTC),
-		3,
-		workspaces,
+		2,
 		agents,
-		kinds,
+		breakdown,
 	)
 
 	// Mutate source slices after construction.
-	workspaces[0] = "mutated-source-ws"
 	agents[0] = "mutated-source-agent"
-	kinds[0] = "mutated-source-kind"
+	breakdown[0] = apptypes.TimelineWorkspaceBreakdownOf("mutated", 99, nil, "", apptypes.TimelineSummarySourceKindCounts)
 
-	if diff := cmp.Diff([]string{"ws-a", "ws-b"}, block.Workspaces()); diff != "" {
-		t.Errorf("Workspaces source slice leaked (-want +got):\n%s", diff)
-	}
 	if diff := cmp.Diff([]string{"claude", "codex"}, block.Agents()); diff != "" {
 		t.Errorf("Agents source slice leaked (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff([]string{"note", "command_executed"}, block.Kinds()); diff != "" {
-		t.Errorf("Kinds source slice leaked (-want +got):\n%s", diff)
+	if diff := cmp.Diff([]string{"ws-a"}, block.Workspaces()); diff != "" {
+		t.Errorf("Workspaces derived slice leaked (-want +got):\n%s", diff)
 	}
 
 	// Mutate returned slices from getters.
-	retWorkspaces := block.Workspaces()
-	retWorkspaces[0] = "mutated-return-ws"
 	retAgents := block.Agents()
 	retAgents[0] = "mutated-return-agent"
-	retKinds := block.Kinds()
-	retKinds[0] = "mutated-return-kind"
+	retBreakdown := block.WorkspaceBreakdown()
+	retBreakdown[0] = apptypes.TimelineWorkspaceBreakdownOf("mutated", 99, nil, "", apptypes.TimelineSummarySourceKindCounts)
 
-	if diff := cmp.Diff([]string{"ws-a", "ws-b"}, block.Workspaces()); diff != "" {
-		t.Errorf("Workspaces() is not a defensive copy (-want +got):\n%s", diff)
-	}
 	if diff := cmp.Diff([]string{"claude", "codex"}, block.Agents()); diff != "" {
 		t.Errorf("Agents() is not a defensive copy (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff([]string{"note", "command_executed"}, block.Kinds()); diff != "" {
-		t.Errorf("Kinds() is not a defensive copy (-want +got):\n%s", diff)
+	if diff := cmp.Diff([]string{"ws-a"}, block.Workspaces()); diff != "" {
+		t.Errorf("WorkspaceBreakdown() is not a defensive copy (-want +got):\n%s", diff)
 	}
 }

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -135,6 +135,22 @@ session 解決ルールは `traceary log` と同じです。
 - `--wide`
 - `--utc`
 
+### `traceary timeline`
+
+ギャップ検出による作業タイムラインを、ワークスペース単位のアクティビティ要約付きで表示します。
+
+`timeline` は直近のイベントをアイドルギャップ（デフォルト 15 分）で区切って連続する作業ブロックに分け、各ブロック内で workspace ごとに整列された 1 行を表示します。ワークスペース単位のアクティビティ要約は **`compact_summary` → 最初の `prompt` → kind counts** のフォールバック順で選ばれ、そのブロック内でそのワークスペースに存在するシグナルが 1 行に展開されます。デフォルトのテキスト出力は現地時刻 (local time) で、`--utc` で UTC に切り替えられます。`--json` はブロックスキーマに `workspace_breakdown` 配列 (`{workspace, event_count, kind_counts, summary, summary_source}`) を追加します（既存フィールドは維持され後方互換）。
+
+主な flag:
+
+- `--workspace`
+- `--from`
+- `--to`
+- `--gap` (アイドルギャップ閾値/分)
+- `--limit`
+- `--json`
+- `--utc`
+
 ### `traceary show <event-id>`
 
 1 件の event を詳細表示します。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -135,6 +135,22 @@ Useful flags:
 - `--wide`
 - `--utc`
 
+### `traceary timeline`
+
+Show work timeline with gap-based block detection and per-workspace activity summaries.
+
+`timeline` groups recent events into contiguous work blocks separated by idle gaps (default: 15 minutes) and prints one aligned sub-row per workspace inside each block. The per-workspace activity summary is picked using the fallback chain **`compact_summary` → first `prompt` → kind counts**, so whichever signal exists for that workspace in the block lights up the line. Default text output uses local time; pass `--utc` for UTC. `--json` extends the block schema with a `workspace_breakdown` array (`{workspace, event_count, kind_counts, summary, summary_source}`) — existing consumers keep working unchanged.
+
+Useful flags:
+
+- `--workspace`
+- `--from`
+- `--to`
+- `--gap` (idle gap threshold in minutes)
+- `--limit`
+- `--json`
+- `--utc`
+
 ### `traceary show <event-id>`
 
 Show one event in detail.

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -688,14 +688,15 @@ func (d *EventDatasource) ListTimelineBlocks(
 }
 
 // resolveWorkspaceSummary applies the fallback chain
-// compact_summary → prompt → kind_counts. The caller still has to render
-// the kind-count fallback from the kinds slice when summary is empty; the
-// returned source reflects that decision.
+// compact_summary → prompt → kind_counts. Whitespace-only candidates are
+// treated as absent so blank rows cannot override a later non-blank
+// candidate (SQLite TRIM only strips spaces, not tabs/newlines, so this
+// defense is enforced in Go rather than in SQL).
 func resolveWorkspaceSummary(compactSummaryBody, firstPromptBody string) (string, apptypes.TimelineWorkspaceBreakdownSummarySource) {
-	if compactSummaryBody != "" {
+	if strings.TrimSpace(compactSummaryBody) != "" {
 		return compactSummaryBody, apptypes.TimelineSummarySourceCompactSummary
 	}
-	if firstPromptBody != "" {
+	if strings.TrimSpace(firstPromptBody) != "" {
 		return firstPromptBody, apptypes.TimelineSummarySourcePrompt
 	}
 	return "", apptypes.TimelineSummarySourceKindCounts

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -595,44 +595,110 @@ func (d *EventDatasource) ListTimelineBlocks(
 		}
 	}()
 
-	var blocks []apptypes.TimelineBlock
+	// The query returns one row per (block, workspace). We preserve the
+	// insertion order of both block_num values (ordered DESC by block_start
+	// in SQL) and their per-workspace rows (ordered DESC by ws_event_count,
+	// then by workspace name) so the Go slice mirrors the SQL ORDER BY.
+	type blockAccumulator struct {
+		blockStart time.Time
+		blockEnd   time.Time
+		eventCount int
+		agents     []string
+		breakdown  []apptypes.TimelineWorkspaceBreakdown
+	}
+
+	var blockOrder []int
+	blockMap := make(map[int]*blockAccumulator)
+
 	for rows.Next() {
 		var (
-			blockNum   int // scanned but unused (SQL internal grouping key)
-			blockStart string
-			blockEnd   string
-			eventCount int
-			workspaces string
-			agents     string
-			kinds      string
+			blockNum             int
+			blockStart           string
+			blockEnd             string
+			blockEventCount      int
+			agents               string
+			workspace            string
+			wsEventCount         int
+			kinds                string
+			firstPromptBody      string
+			compactSummaryBody   string
 		)
-		if err := rows.Scan(&blockNum, &blockStart, &blockEnd, &eventCount, &workspaces, &agents, &kinds); err != nil {
+		if err := rows.Scan(
+			&blockNum,
+			&blockStart,
+			&blockEnd,
+			&blockEventCount,
+			&agents,
+			&workspace,
+			&wsEventCount,
+			&kinds,
+			&firstPromptBody,
+			&compactSummaryBody,
+		); err != nil {
 			return nil, xerrors.Errorf("failed to scan timeline block: %w", err)
 		}
 
-		parsedStart, err := time.Parse(time.RFC3339Nano, blockStart)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to parse block start: %w", err)
-		}
-		parsedEnd, err := time.Parse(time.RFC3339Nano, blockEnd)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to parse block end: %w", err)
+		accum, ok := blockMap[blockNum]
+		if !ok {
+			parsedStart, err := time.Parse(time.RFC3339Nano, blockStart)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse block start: %w", err)
+			}
+			parsedEnd, err := time.Parse(time.RFC3339Nano, blockEnd)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse block end: %w", err)
+			}
+			accum = &blockAccumulator{
+				blockStart: parsedStart,
+				blockEnd:   parsedEnd,
+				eventCount: blockEventCount,
+				agents:     splitNonEmpty(agents, ","),
+			}
+			blockMap[blockNum] = accum
+			blockOrder = append(blockOrder, blockNum)
 		}
 
-		blocks = append(blocks, apptypes.TimelineBlockOf(
-			parsedStart,
-			parsedEnd,
-			eventCount,
-			splitNonEmpty(workspaces, ","),
-			splitNonEmpty(agents, ","),
-			splitNonEmpty(kinds, "|"),
+		kindList := splitNonEmpty(kinds, "|")
+		summary, source := resolveWorkspaceSummary(compactSummaryBody, firstPromptBody)
+		accum.breakdown = append(accum.breakdown, apptypes.TimelineWorkspaceBreakdownOf(
+			workspace,
+			wsEventCount,
+			kindList,
+			summary,
+			source,
 		))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("failed to iterate timeline blocks: %w", err)
 	}
 
+	blocks := make([]apptypes.TimelineBlock, 0, len(blockOrder))
+	for _, num := range blockOrder {
+		accum := blockMap[num]
+		blocks = append(blocks, apptypes.TimelineBlockOf(
+			accum.blockStart,
+			accum.blockEnd,
+			accum.eventCount,
+			accum.agents,
+			accum.breakdown,
+		))
+	}
+
 	return blocks, nil
+}
+
+// resolveWorkspaceSummary applies the fallback chain
+// compact_summary → prompt → kind_counts. The caller still has to render
+// the kind-count fallback from the kinds slice when summary is empty; the
+// returned source reflects that decision.
+func resolveWorkspaceSummary(compactSummaryBody, firstPromptBody string) (string, apptypes.TimelineWorkspaceBreakdownSummarySource) {
+	if compactSummaryBody != "" {
+		return compactSummaryBody, apptypes.TimelineSummarySourceCompactSummary
+	}
+	if firstPromptBody != "" {
+		return firstPromptBody, apptypes.TimelineSummarySourcePrompt
+	}
+	return "", apptypes.TimelineSummarySourceKindCounts
 }
 
 // scanEvent reads a single event row into a model.Event.

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -64,6 +64,7 @@ prompt_ranked AS (
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at, id) AS rn
   FROM blocks
   WHERE kind = 'prompt'
+    AND TRIM(body) != ''
 ),
 first_prompt AS (
   SELECT block_num, workspace, body AS first_prompt_body
@@ -78,6 +79,7 @@ compact_ranked AS (
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at DESC, id DESC) AS rn
   FROM blocks
   WHERE kind = 'compact_summary'
+    AND TRIM(body) != ''
 ),
 last_compact AS (
   SELECT block_num, workspace, body AS compact_summary_body
@@ -98,6 +100,7 @@ ws_rows AS (
   LEFT JOIN last_compact lc
     ON lc.block_num = b.block_num AND lc.workspace = b.workspace
   WHERE b.block_num IN (SELECT block_num FROM top_blocks)
+    AND b.workspace != ''
   GROUP BY b.block_num, b.workspace
 )
 SELECT

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -1,4 +1,18 @@
--- Gap-based work block detection.
+-- Gap-based work block detection with per-workspace breakdown.
+--
+-- The CTE chain:
+--   ordered_events : filter + LAG over created_at
+--   blocks         : assign block_num using gap threshold
+--   block_summary  : one row per block with aggregates
+--   top_blocks    : block_summary ordered DESC + LIMIT N
+--   first_prompt   : first prompt body per (block, workspace)
+--   last_compact   : last compact_summary body per (block, workspace)
+--   ws_rows        : one row per (block, workspace) with counts / kinds /
+--                    joined summary candidates
+--
+-- The final SELECT returns one row per (block, workspace) for the top N
+-- blocks; Go assembles per-block breakdown by grouping on block_num.
+--
 -- When workspace is filtered, LAG operates only on matching rows (correct).
 -- When workspace is empty (all workspaces), cross-workspace gaps are treated
 -- as continuous work, which is the intended behavior for overview timelines.
@@ -6,7 +20,6 @@ WITH ordered_events AS (
   SELECT
     e.id,
     e.kind,
-    e.client,
     e.agent,
     e.workspace,
     e.body,
@@ -26,16 +39,78 @@ blocks AS (
       ELSE 0
     END) OVER (ORDER BY created_at, id) AS block_num
   FROM ordered_events
+),
+block_summary AS (
+  SELECT
+    block_num,
+    MIN(created_at) AS block_start,
+    MAX(created_at) AS block_end,
+    COUNT(*) AS block_event_count,
+    GROUP_CONCAT(DISTINCT agent) AS agents
+  FROM blocks
+  GROUP BY block_num
+),
+top_blocks AS (
+  SELECT *
+  FROM block_summary
+  ORDER BY block_start DESC
+  LIMIT ?
+),
+prompt_ranked AS (
+  SELECT
+    block_num,
+    workspace,
+    body,
+    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at, id) AS rn
+  FROM blocks
+  WHERE kind = 'prompt'
+),
+first_prompt AS (
+  SELECT block_num, workspace, body AS first_prompt_body
+  FROM prompt_ranked
+  WHERE rn = 1
+),
+compact_ranked AS (
+  SELECT
+    block_num,
+    workspace,
+    body,
+    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at DESC, id DESC) AS rn
+  FROM blocks
+  WHERE kind = 'compact_summary'
+),
+last_compact AS (
+  SELECT block_num, workspace, body AS compact_summary_body
+  FROM compact_ranked
+  WHERE rn = 1
+),
+ws_rows AS (
+  SELECT
+    b.block_num,
+    b.workspace,
+    COUNT(*) AS ws_event_count,
+    GROUP_CONCAT(b.kind, '|') AS kinds,
+    MAX(fp.first_prompt_body) AS first_prompt_body,
+    MAX(lc.compact_summary_body) AS compact_summary_body
+  FROM blocks b
+  LEFT JOIN first_prompt fp
+    ON fp.block_num = b.block_num AND fp.workspace = b.workspace
+  LEFT JOIN last_compact lc
+    ON lc.block_num = b.block_num AND lc.workspace = b.workspace
+  WHERE b.block_num IN (SELECT block_num FROM top_blocks)
+  GROUP BY b.block_num, b.workspace
 )
 SELECT
-  block_num,
-  MIN(created_at) AS block_start,
-  MAX(created_at) AS block_end,
-  COUNT(*) AS event_count,
-  GROUP_CONCAT(DISTINCT workspace) AS workspaces,
-  GROUP_CONCAT(DISTINCT agent) AS agents,
-  GROUP_CONCAT(kind, '|') AS kinds
-FROM blocks
-GROUP BY block_num
-ORDER BY block_start DESC
-LIMIT ?
+  tb.block_num,
+  tb.block_start,
+  tb.block_end,
+  tb.block_event_count,
+  COALESCE(tb.agents, '') AS agents,
+  wr.workspace,
+  wr.ws_event_count,
+  wr.kinds,
+  COALESCE(wr.first_prompt_body, '') AS first_prompt_body,
+  COALESCE(wr.compact_summary_body, '') AS compact_summary_body
+FROM top_blocks tb
+JOIN ws_rows wr ON wr.block_num = tb.block_num
+ORDER BY tb.block_start DESC, wr.ws_event_count DESC, wr.workspace

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -201,6 +201,76 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
+	t.Run("filters empty workspace rows out of breakdown", func(t *testing.T) {
+		t.Parallel()
+		ds := newDatasource(t)
+
+		// Mix a legacy empty-workspace row with a normal one in the same block.
+		saveEvent(t, ds, "e1", "", time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC))
+		saveEvent(t, ds, "e2", "ws-real", time.Date(2026, 4, 10, 9, 1, 0, 0, time.UTC))
+		saveEvent(t, ds, "e3", "ws-real", time.Date(2026, 4, 10, 9, 2, 0, 0, time.UTC))
+
+		blocks, err := ds.ListTimelineBlocks(context.Background(), types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+		if err != nil {
+			t.Fatalf("ListTimelineBlocks() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+		}
+		breakdown := blocks[0].WorkspaceBreakdown()
+		if len(breakdown) != 1 {
+			t.Fatalf("breakdown len = %d, want 1 (empty workspace must not leak)", len(breakdown))
+		}
+		if got := breakdown[0].Workspace(); got != "ws-real" {
+			t.Errorf("breakdown[0].Workspace() = %q, want %q", got, "ws-real")
+		}
+		if got := blocks[0].EventCount(); got != 3 {
+			t.Errorf("block event count = %d, want 3 (still counts empty-workspace event)", got)
+		}
+	})
+
+	t.Run("blank summary body is skipped in favor of a later non-blank candidate", func(t *testing.T) {
+		t.Parallel()
+		ds := newDatasource(t)
+
+		// First prompt is whitespace-only, second is real content.
+		saveEventKind(t, ds, "e1", "ws-prompt", types.EventKindPrompt, "   ", time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC))
+		saveEventKind(t, ds, "e2", "ws-prompt", types.EventKindPrompt, "fix the real thing", time.Date(2026, 4, 10, 10, 1, 0, 0, time.UTC))
+		// Blank compact_summary must not override a real prompt fallback.
+		saveEventKind(t, ds, "e3", "ws-compact", types.EventKindCompactSummary, "\t\n", time.Date(2026, 4, 10, 10, 2, 0, 0, time.UTC))
+		saveEventKind(t, ds, "e4", "ws-compact", types.EventKindPrompt, "user intent", time.Date(2026, 4, 10, 10, 3, 0, 0, time.UTC))
+
+		blocks, err := ds.ListTimelineBlocks(context.Background(), types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+		if err != nil {
+			t.Fatalf("ListTimelineBlocks() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+		}
+		byWs := make(map[string]int, len(blocks[0].WorkspaceBreakdown()))
+		breakdown := blocks[0].WorkspaceBreakdown()
+		for i, ws := range breakdown {
+			byWs[ws.Workspace()] = i
+		}
+		promptIdx, ok := byWs["ws-prompt"]
+		if !ok {
+			t.Fatalf("breakdown missing ws-prompt: %+v", breakdown)
+		}
+		if got := breakdown[promptIdx].Summary(); got != "fix the real thing" {
+			t.Errorf("ws-prompt summary = %q, want 'fix the real thing' (blank prompt must be skipped)", got)
+		}
+		compactIdx, ok := byWs["ws-compact"]
+		if !ok {
+			t.Fatalf("breakdown missing ws-compact: %+v", breakdown)
+		}
+		if got := breakdown[compactIdx].Summary(); got != "user intent" {
+			t.Errorf("ws-compact summary = %q, want 'user intent' (blank compact_summary must fall through to prompt)", got)
+		}
+		if got := breakdown[compactIdx].SummarySource(); got != "prompt" {
+			t.Errorf("ws-compact source = %q, want 'prompt'", got)
+		}
+	})
+
 	t.Run("respects limit", func(t *testing.T) {
 		t.Parallel()
 		ds := newDatasource(t)

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -119,6 +119,88 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 		}
 	})
 
+	saveEventKind := func(t *testing.T, ds *sqlite.EventDatasource, id string, workspace string, kind types.EventKind, body string, createdAt time.Time) {
+		t.Helper()
+		eventID, _ := types.EventIDOf(id)
+		agent, _ := types.AgentOf("claude")
+		sessionID, _ := types.SessionIDOf("session-1")
+		event := model.EventOf(eventID, kind, types.Client("hook"), agent, sessionID, types.Workspace(workspace), body, createdAt)
+		if err := ds.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+
+	t.Run("provides per-workspace breakdown with compact_summary fallback", func(t *testing.T) {
+		t.Parallel()
+		ds := newDatasource(t)
+
+		// Single block spanning two workspaces.
+		saveEvent(t, ds, "e1", "ws-a", time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC))
+		saveEventKind(t, ds, "e2", "ws-a", types.EventKindPrompt, "user wanted feature X", time.Date(2026, 4, 10, 9, 1, 0, 0, time.UTC))
+		saveEventKind(t, ds, "e3", "ws-a", types.EventKindCompactSummary, "shipped feature X via PR #1", time.Date(2026, 4, 10, 9, 8, 0, 0, time.UTC))
+		saveEvent(t, ds, "e4", "ws-b", time.Date(2026, 4, 10, 9, 5, 0, 0, time.UTC))
+		saveEventKind(t, ds, "e5", "ws-b", types.EventKindPrompt, "triage bug Y", time.Date(2026, 4, 10, 9, 6, 0, 0, time.UTC))
+
+		blocks, err := ds.ListTimelineBlocks(context.Background(), types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+		if err != nil {
+			t.Fatalf("ListTimelineBlocks() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+		}
+		breakdown := blocks[0].WorkspaceBreakdown()
+		byWs := make(map[string]int, len(breakdown))
+		for i, ws := range breakdown {
+			byWs[ws.Workspace()] = i
+		}
+		wsA, ok := byWs["ws-a"]
+		if !ok {
+			t.Fatalf("breakdown missing ws-a: %+v", breakdown)
+		}
+		if got := breakdown[wsA].Summary(); got != "shipped feature X via PR #1" {
+			t.Errorf("ws-a summary = %q, want compact_summary body", got)
+		}
+		if got := breakdown[wsA].SummarySource(); got != "compact_summary" {
+			t.Errorf("ws-a source = %q, want compact_summary", got)
+		}
+		wsB, ok := byWs["ws-b"]
+		if !ok {
+			t.Fatalf("breakdown missing ws-b: %+v", breakdown)
+		}
+		if got := breakdown[wsB].Summary(); got != "triage bug Y" {
+			t.Errorf("ws-b summary = %q, want first prompt body", got)
+		}
+		if got := breakdown[wsB].SummarySource(); got != "prompt" {
+			t.Errorf("ws-b source = %q, want prompt", got)
+		}
+	})
+
+	t.Run("falls back to kind_counts when no summary candidate", func(t *testing.T) {
+		t.Parallel()
+		ds := newDatasource(t)
+
+		saveEvent(t, ds, "e1", "ws-only-commands", time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC))
+		saveEvent(t, ds, "e2", "ws-only-commands", time.Date(2026, 4, 10, 9, 1, 0, 0, time.UTC))
+
+		blocks, err := ds.ListTimelineBlocks(context.Background(), types.Workspace(""), time.Time{}, time.Time{}, 900, 10)
+		if err != nil {
+			t.Fatalf("ListTimelineBlocks() error = %v", err)
+		}
+		if len(blocks) != 1 {
+			t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+		}
+		breakdown := blocks[0].WorkspaceBreakdown()
+		if len(breakdown) != 1 {
+			t.Fatalf("breakdown len = %d, want 1", len(breakdown))
+		}
+		if got := breakdown[0].Summary(); got != "" {
+			t.Errorf("summary = %q, want empty string", got)
+		}
+		if got := breakdown[0].SummarySource(); got != "kind_counts" {
+			t.Errorf("source = %q, want kind_counts", got)
+		}
+	})
+
 	t.Run("respects limit", func(t *testing.T) {
 		t.Parallel()
 		ds := newDatasource(t)

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -194,6 +194,8 @@ type timelineCommandInput struct {
 	gap       int
 	limit     int
 	asJSON    bool
+	utc       bool
+	location  *time.Location
 }
 
 // tailCommandInput is the resolved input to the `traceary tail` command.

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -16,7 +16,10 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-const defaultGapMinutes = 15
+const (
+	defaultGapMinutes      = 15
+	timelineSummaryMaxRune = 72
+)
 
 func (c *RootCLI) newTimelineCommand() *cobra.Command {
 	var (
@@ -27,6 +30,7 @@ func (c *RootCLI) newTimelineCommand() *cobra.Command {
 		gap       int
 		limit     int
 		asJSON    bool
+		utc       bool
 	)
 
 	cmd := &cobra.Command{
@@ -42,6 +46,7 @@ func (c *RootCLI) newTimelineCommand() *cobra.Command {
 				gap:       gap,
 				limit:     limit,
 				asJSON:    asJSON,
+				utc:       utc,
 			})
 		},
 	}
@@ -53,6 +58,7 @@ func (c *RootCLI) newTimelineCommand() *cobra.Command {
 	cmd.Flags().IntVar(&gap, "gap", defaultGapMinutes, Localize("idle gap threshold in minutes", "アイドル判定の閾値（分）"))
 	cmd.Flags().IntVar(&limit, "limit", 20, Localize("maximum number of blocks to display", "表示するブロック数の上限"))
 	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 
 	return cmd
 }
@@ -95,7 +101,8 @@ func (c *RootCLI) runTimeline(ctx context.Context, output io.Writer, input timel
 		return writeTimelineJSON(output, blocks)
 	}
 
-	return writeTimelineText(output, blocks)
+	textOpts := eventTextFormatOptions{utc: input.utc, location: input.location}
+	return writeTimelineText(output, blocks, textOpts)
 }
 
 func computeKindCounts(kinds []string) map[string]int {
@@ -106,7 +113,7 @@ func computeKindCounts(kinds []string) map[string]int {
 	return counts
 }
 
-func writeTimelineText(output io.Writer, blocks []apptypes.TimelineBlock) error {
+func writeTimelineText(output io.Writer, blocks []apptypes.TimelineBlock, opts eventTextFormatOptions) error {
 	if len(blocks) == 0 {
 		if _, err := fmt.Fprintln(output, "No work blocks found."); err != nil {
 			return xerrors.Errorf("failed to print timeline: %w", err)
@@ -117,27 +124,89 @@ func writeTimelineText(output io.Writer, blocks []apptypes.TimelineBlock) error 
 	for _, b := range blocks {
 		duration := b.BlockEnd().Sub(b.BlockStart())
 		durationStr := formatDuration(duration)
-		ws := strings.Join(b.Workspaces(), ", ")
 
-		if _, err := fmt.Fprintf(output, "%s - %s (%s) %s\n",
-			b.BlockStart().Local().Format("2006-01-02 15:04"),
-			b.BlockEnd().Local().Format("15:04"),
+		header := fmt.Sprintf(
+			"%s - %s (%s) total events: %d",
+			formatTextTimestamp(b.BlockStart(), opts, "2006-01-02 15:04"),
+			formatTextTimestamp(b.BlockEnd(), opts, "15:04"),
 			durationStr,
-			ws,
-		); err != nil {
+			b.EventCount(),
+		)
+		if _, err := fmt.Fprintln(output, header); err != nil {
 			return xerrors.Errorf("failed to print timeline block: %w", err)
 		}
 
-		// Print kind counts as command frequency
-		kindCounts := computeKindCounts(b.Kinds())
-		kindLine := formatKindCounts(kindCounts)
-		if kindLine != "" {
-			if _, err := fmt.Fprintf(output, "  %s\n", kindLine); err != nil {
-				return xerrors.Errorf("failed to print timeline block details: %w", err)
+		breakdown := b.WorkspaceBreakdown()
+		if len(breakdown) == 0 {
+			continue
+		}
+
+		maxCountWidth := 0
+		for _, ws := range breakdown {
+			if w := countWidth(ws.EventCount()); w > maxCountWidth {
+				maxCountWidth = w
+			}
+		}
+		maxWorkspaceWidth := 0
+		for _, ws := range breakdown {
+			if w := runeLen(ws.Workspace()); w > maxWorkspaceWidth {
+				maxWorkspaceWidth = w
+			}
+		}
+
+		for _, ws := range breakdown {
+			summary := workspaceActivityText(ws)
+			line := fmt.Sprintf(
+				"  %s (%s) — %s",
+				padRight(ws.Workspace(), maxWorkspaceWidth),
+				padLeft(fmt.Sprintf("%d", ws.EventCount()), maxCountWidth),
+				summary,
+			)
+			if _, err := fmt.Fprintln(output, line); err != nil {
+				return xerrors.Errorf("failed to print timeline block workspace row: %w", err)
 			}
 		}
 	}
 	return nil
+}
+
+// workspaceActivityText renders the per-workspace activity summary using
+// the compact_summary → prompt → kind-counts fallback chain.
+func workspaceActivityText(ws apptypes.TimelineWorkspaceBreakdown) string {
+	switch ws.SummarySource() {
+	case apptypes.TimelineSummarySourceCompactSummary, apptypes.TimelineSummarySourcePrompt:
+		return truncateNormalized(ws.Summary(), timelineSummaryMaxRune)
+	default:
+		return formatKindCounts(computeKindCounts(ws.Kinds()))
+	}
+}
+
+func countWidth(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	w := 0
+	for n > 0 {
+		w++
+		n /= 10
+	}
+	return w
+}
+
+func padRight(s string, width int) string {
+	diff := width - runeLen(s)
+	if diff <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", diff)
+}
+
+func padLeft(s string, width int) string {
+	diff := width - runeLen(s)
+	if diff <= 0 {
+		return s
+	}
+	return strings.Repeat(" ", diff) + s
 }
 
 func formatKindCounts(counts map[string]int) string {
@@ -153,7 +222,10 @@ func formatKindCounts(counts map[string]int) string {
 		sorted = append(sorted, kv{k, v})
 	}
 	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].count > sorted[j].count
+		if sorted[i].count != sorted[j].count {
+			return sorted[i].count > sorted[j].count
+		}
+		return sorted[i].key < sorted[j].key
 	})
 
 	var parts []string
@@ -164,26 +236,46 @@ func formatKindCounts(counts map[string]int) string {
 }
 
 func writeTimelineJSON(output io.Writer, blocks []apptypes.TimelineBlock) error {
+	type jsonWorkspaceBreakdown struct {
+		Workspace     string         `json:"workspace"`
+		EventCount    int            `json:"event_count"`
+		KindCounts    map[string]int `json:"kind_counts"`
+		Summary       string         `json:"summary"`
+		SummarySource string         `json:"summary_source"`
+	}
 	type jsonBlock struct {
-		Start      string         `json:"start"`
-		End        string         `json:"end"`
-		Duration   string         `json:"duration"`
-		EventCount int            `json:"event_count"`
-		Workspaces []string       `json:"workspaces"`
-		Agents     []string       `json:"agents"`
-		KindCounts map[string]int `json:"kind_counts"`
+		Start              string                   `json:"start"`
+		End                string                   `json:"end"`
+		Duration           string                   `json:"duration"`
+		EventCount         int                      `json:"event_count"`
+		Workspaces         []string                 `json:"workspaces"`
+		Agents             []string                 `json:"agents"`
+		KindCounts         map[string]int           `json:"kind_counts"`
+		WorkspaceBreakdown []jsonWorkspaceBreakdown `json:"workspace_breakdown"`
 	}
 
 	result := make([]jsonBlock, 0, len(blocks))
 	for _, b := range blocks {
+		breakdown := b.WorkspaceBreakdown()
+		wsOut := make([]jsonWorkspaceBreakdown, 0, len(breakdown))
+		for _, ws := range breakdown {
+			wsOut = append(wsOut, jsonWorkspaceBreakdown{
+				Workspace:     ws.Workspace(),
+				EventCount:    ws.EventCount(),
+				KindCounts:    computeKindCounts(ws.Kinds()),
+				Summary:       ws.Summary(),
+				SummarySource: string(ws.SummarySource()),
+			})
+		}
 		result = append(result, jsonBlock{
-			Start:      b.BlockStart().Format(time.RFC3339),
-			End:        b.BlockEnd().Format(time.RFC3339),
-			Duration:   formatDuration(b.BlockEnd().Sub(b.BlockStart())),
-			EventCount: b.EventCount(),
-			Workspaces: b.Workspaces(),
-			Agents:     b.Agents(),
-			KindCounts: computeKindCounts(b.Kinds()),
+			Start:              b.BlockStart().Format(time.RFC3339),
+			End:                b.BlockEnd().Format(time.RFC3339),
+			Duration:           formatDuration(b.BlockEnd().Sub(b.BlockStart())),
+			EventCount:         b.EventCount(),
+			Workspaces:         b.Workspaces(),
+			Agents:             b.Agents(),
+			KindCounts:         computeKindCounts(b.Kinds()),
+			WorkspaceBreakdown: wsOut,
 		})
 	}
 

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -115,7 +115,7 @@ func computeKindCounts(kinds []string) map[string]int {
 
 func writeTimelineText(output io.Writer, blocks []apptypes.TimelineBlock, opts eventTextFormatOptions) error {
 	if len(blocks) == 0 {
-		if _, err := fmt.Fprintln(output, "No work blocks found."); err != nil {
+		if _, err := fmt.Fprintln(output, Localize("No work blocks found.", "作業ブロックが見つかりませんでした。")); err != nil {
 			return xerrors.Errorf("failed to print timeline: %w", err)
 		}
 		return nil
@@ -126,10 +126,11 @@ func writeTimelineText(output io.Writer, blocks []apptypes.TimelineBlock, opts e
 		durationStr := formatDuration(duration)
 
 		header := fmt.Sprintf(
-			"%s - %s (%s) total events: %d",
+			"%s - %s (%s) %s: %d",
 			formatTextTimestamp(b.BlockStart(), opts, "2006-01-02 15:04"),
 			formatTextTimestamp(b.BlockEnd(), opts, "15:04"),
 			durationStr,
+			Localize("total events", "総イベント数"),
 			b.EventCount(),
 		)
 		if _, err := fmt.Fprintln(output, header); err != nil {

--- a/presentation/cli/timeline_test.go
+++ b/presentation/cli/timeline_test.go
@@ -16,7 +16,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 	t.Run("displays work blocks in text format", func(t *testing.T) {
 		t.Parallel()
 
-		// Build Kinds slice that produces the same KindCounts: command_executed:30, note:10, prompt:2
+		// Kinds for the single workspace: command_executed:30, note:10, prompt:2
 		var kinds []string
 		for i := 0; i < 30; i++ {
 			kinds = append(kinds, "command_executed")
@@ -26,6 +26,15 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		}
 		for i := 0; i < 2; i++ {
 			kinds = append(kinds, "prompt")
+		}
+		breakdown := []apptypes.TimelineWorkspaceBreakdown{
+			apptypes.TimelineWorkspaceBreakdownOf(
+				"github.com/duck8823/traceary",
+				42,
+				kinds,
+				"",
+				apptypes.TimelineSummarySourceKindCounts,
+			),
 		}
 
 		stdout := &bytes.Buffer{}
@@ -37,16 +46,15 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 						time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
 						time.Date(2026, 4, 10, 12, 30, 0, 0, time.UTC),
 						42,
-						[]string{"github.com/duck8823/traceary"},
 						[]string{"claude"},
-						kinds,
+						breakdown,
 					),
 				},
 			}),
 		).Command()
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(&bytes.Buffer{})
-		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "2026-04-10"})
+		rootCmd.SetArgs([]string{"timeline", "--db-path", "/tmp/test.db", "--from", "2026-04-10", "--utc"})
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -61,6 +69,9 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		}
 		if !strings.Contains(output, "command_executed: 30") {
 			t.Errorf("output missing kind counts, got: %s", output)
+		}
+		if !strings.Contains(output, "total events: 42") {
+			t.Errorf("output missing total event count, got: %s", output)
 		}
 	})
 
@@ -88,9 +99,14 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 	t.Run("outputs JSON format", func(t *testing.T) {
 		t.Parallel()
 
-		var kinds []string
-		for i := 0; i < 5; i++ {
-			kinds = append(kinds, "note")
+		breakdown := []apptypes.TimelineWorkspaceBreakdown{
+			apptypes.TimelineWorkspaceBreakdownOf(
+				"ws",
+				5,
+				[]string{"note", "note", "note", "note", "note"},
+				"",
+				apptypes.TimelineSummarySourceKindCounts,
+			),
 		}
 
 		stdout := &bytes.Buffer{}
@@ -102,9 +118,8 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 						time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
 						time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
 						5,
-						[]string{"ws"},
 						[]string{"claude"},
-						kinds,
+						breakdown,
 					),
 				},
 			}),


### PR DESCRIPTION
## Summary

- `traceary timeline` now renders one header per block followed by per-workspace sub-rows that show "what was being done" in each workspace, not just a comma-joined list.
- The per-workspace activity summary uses the fallback chain **`compact_summary` → first `prompt` → `kind_counts`** so whichever signal is available for that workspace in the block lights up the line.
- `TimelineBlock` DTO is reshaped to carry a `TimelineWorkspaceBreakdown` list. Legacy `Workspaces()` / `Kinds()` accessors are preserved and derived from the breakdown for backward compatibility.
- `infrastructure/sqlite/sql/list_timeline_blocks.sql` is rewritten to return one row per `(block, workspace)` via window-function CTEs (`first_prompt`, `last_compact`, `ws_rows`). Go assembles blocks from those rows.
- JSON output gains an additive `workspace_breakdown` array: `{workspace, event_count, kind_counts, summary, summary_source}` — existing consumers keep working.
- New `--utc` flag for parity with `tail` / `list` / `search`; local time remains the default. Timestamps go through the shared `formatTextTimestamp` helper.

Closes #539

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go tool golangci-lint run` (0 issues)
- [x] New `infrastructure/sqlite/timeline_store_test.go` cases:
  - `provides per-workspace breakdown with compact_summary fallback` — verifies compact_summary wins for ws-a and first prompt wins for ws-b within the same block
  - `falls back to kind_counts when no summary candidate` — verifies empty summary + `kind_counts` source
- [x] `application/types/timeline_block_test.go` updated for the new constructor + breakdown getter
- [x] `presentation/cli/timeline_test.go` updated to use the new constructor, asserts the new `total events:` header line

## Out of scope
- README documentation for timeline (handled by #540).
- Changing block segmentation logic.
- LLM-based summarization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)