### PR TITLE
docs(readme): add tail and timeline inspection examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,6 +135,43 @@ traceary memory remember \
 traceary handoff --workspace github.com/duck8823/traceary
 ```
 
+## 直近の動きを確認する
+
+Traceary は 4 つの補完的なビューを用意していて、「いま何が起きているか」と「ある期間に何が起きたか」をターミナルから切り替えて確認できます。
+
+| 目的 | コマンド | 使いどころ |
+|---|---|---|
+| いま動いているものを追う | `traceary tail` | hook が発火しているか / 失敗がリアルタイムで見えているかを確認 |
+| ある期間の流れを俯瞰する | `traceary timeline` | アイドルギャップ区切りの作業ブロックを workspace 別のアクティビティ要約付きで表示 |
+| 生 event を直接掘る | `traceary list` / `traceary search` | kind / session / query をピンポイントで指定 |
+| 引き継ぎコンテキストで再開する | `traceary handoff` | 整形済みの working memory を次のセッションへ |
+
+### `traceary tail`
+
+```text
+$ traceary tail --limit 3
+07:06:44  command_executed  sess=4a70c526  ws=traceary  ls ~/.traceary 2>&1; find ~ -name "traceary…
+07:06:47  command_executed  sess=4a70c526  ws=traceary  ./traceary timeline --db-path /Users/duck88…
+07:06:52  command_executed  sess=4a70c526  ws=traceary  timeout 1 ./traceary tail --db-path /Users/…
+```
+
+デフォルトは 1 行コンパクト形式（現地時刻）で約 100 カラムに収まります。`--wide --utc` で v0.6.1 以前の tab 区切り 7 カラムをバイト単位で再現でき、`--json` を使えば NDJSON でパイプに流せます。
+
+### `traceary timeline`
+
+```text
+$ traceary timeline --limit 2
+2026-04-15 06:37 - 07:06 (29m21s) total events: 165
+  github.com/duck8823/traceary (153) — 自律的に進めてください。
+  github.com/duck8823/dotfiles  ( 12) — rust インストールしました
+2026-04-15 05:39 - 06:10 (31m1s) total events: 136
+  github.com/duck8823/traceary (136) — <analysis> This conversation is a resumption after compaction. …
+```
+
+各ブロックは workspace ごとの 1 行サブロウで表示され、アクティビティ要約は **`compact_summary` → 最初の `prompt` → kind counts** のフォールバック順で選ばれるため、どの workspace で何が行われていたかを一目で把握できます。`--utc` でタイムスタンプを UTC に切り替え、`--json` を使うと既存フィールドに加えて `workspace_breakdown` 配列が返ります。
+
+詳細なフラグリファレンスと追加例は [`docs/cli/README.ja.md`](./docs/cli/README.ja.md) を参照してください。
+
 ## ホスト別の自動記録マトリクス
 
 問い合わせ面は共通です。Traceary を入れれば、どのホストからでも同じ CLI / MCP の memory・context 機能を使えます。差が出るのは、hook でどこまで自動記録できるかです。

--- a/README.md
+++ b/README.md
@@ -136,6 +136,43 @@ traceary memory remember \
 traceary handoff --workspace github.com/duck8823/traceary
 ```
 
+## Inspect recent and live activity
+
+Traceary ships four complementary inspection views so you can switch between "what's happening now" and "what happened across a span" without leaving the terminal:
+
+| When | Command | Use it to |
+|---|---|---|
+| Following what is happening now | `traceary tail` | confirm hooks are firing, watch failures in real time |
+| Understanding what happened across a span | `traceary timeline` | see gap-separated work blocks with a per-workspace activity summary |
+| Inspecting raw events directly | `traceary list` / `traceary search` | jump to an exact kind / session / query |
+| Resuming with assembled working memory | `traceary handoff` | start a follow-up session with curated context |
+
+### `traceary tail`
+
+```text
+$ traceary tail --limit 3
+07:06:44  command_executed  sess=4a70c526  ws=traceary  ls ~/.traceary 2>&1; find ~ -name "traceary…
+07:06:47  command_executed  sess=4a70c526  ws=traceary  ./traceary timeline --db-path /Users/duck88…
+07:06:52  command_executed  sess=4a70c526  ws=traceary  timeout 1 ./traceary tail --db-path /Users/…
+```
+
+Compact single-line rows (local time by default) fit inside ~100 columns. Add `--wide --utc` to restore the pre-v0.6.1 tab-separated seven-column layout byte-for-byte, or `--json` for NDJSON when piping into tooling.
+
+### `traceary timeline`
+
+```text
+$ traceary timeline --limit 2
+2026-04-15 06:37 - 07:06 (29m21s) total events: 165
+  github.com/duck8823/traceary (153) — 自律的に進めてください。
+  github.com/duck8823/dotfiles  ( 12) — rust インストールしました
+2026-04-15 05:39 - 06:10 (31m1s) total events: 136
+  github.com/duck8823/traceary (136) — <analysis> This conversation is a resumption after compaction. …
+```
+
+Each block shows one sub-row per workspace with an activity summary picked from the fallback chain **`compact_summary` → first `prompt` → kind counts**, so you can see *what was being done* in each workspace instead of just a comma-joined list. Pass `--utc` to switch text timestamps to UTC; `--json` adds a `workspace_breakdown` array alongside the existing block fields.
+
+See [`docs/cli/README.md`](./docs/cli/README.md) for the full flag reference and more examples.
+
 ## Host capture matrix
 
 The query surface is shared: once Traceary is installed, every host can use the same CLI and MCP memory/context commands. What differs is how much context each host can capture automatically via hooks.


### PR DESCRIPTION
## Summary

- Add an **"Inspect recent and live activity"** section to both `README.md` and `README.ja.md` that shows what `tail` and `timeline` look like after the v0.6.1 UX work.
- The tail example uses the new compact single-line format (local time, `sess=<8-char>`, `ws=<basename>`) and mentions `--wide --utc` for byte-compatible legacy output.
- The timeline example shows the per-workspace breakdown with the `compact_summary → prompt → kind_counts` fallback in action (pulled from real output against my local DB so the example is not a stale shape).
- A short decision table covers when to reach for `tail` / `timeline` / `list` / `search` / `handoff` so new users can pick the right view from the top-level README.

Closes #540

## Test plan

- [x] `python3 scripts/verify_docs_i18n.py` — i18n check passes
- [x] `go test ./...`
- [x] README examples rendered against a real local DB via `./traceary tail` / `./traceary timeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)