### PR TITLE
feat(cli): saved view presets for tail / list / search

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -76,7 +76,7 @@ session 解決ルールは `traceary log` と同じです。
 
 `list` は直近履歴を素早く絞るためのコマンドです。kind / client / agent / session / workspace が決まっているときはこちらを使い、キーワード検索や期間条件が必要なときは `search` を使います。
 
-デフォルトのテキスト出力は `tail` と同じコンパクトな 1 行形式 (`HH:MM:SS  kind  sess=<先頭8文字>  ws=<basename>  message`、ヘッダ無し、現地時刻) です。`--wide` で従来の 7 カラム tab 区切り表、`--utc` でテキスト出力を UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > `~/.config/traceary/config.json` の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールド: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`。
+デフォルトのテキスト出力は `tail` と同じコンパクトな 1 行形式 (`HH:MM:SS  kind  sess=<先頭8文字>  ws=<basename>  message`、ヘッダ無し、現地時刻) です。`--wide` で従来の 7 カラム tab 区切り表、`--utc` でテキスト出力を UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > preset fields > `~/.config/traceary/config.json` の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールド: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`。`--preset <name>` で保存済みビューを適用できます。built-in は `failures` / `prompts-only` / `compact-summaries`、`read.presets` に定義したユーザー preset が同名 built-in を上書きします。明示した `--kind` / `--failures` / `--workspace` などのフラグは常に preset より優先されます。`--wide` / `--json` のときは preset の fields 指定は無視されますが、filter は有効です。
 
 主な flag:
 
@@ -87,6 +87,7 @@ session 解決ルールは `traceary log` と同じです。
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -102,7 +103,7 @@ session 解決ルールは `traceary log` と同じです。
 
 > コンパクト表示の session ID (`sess=<先頭8文字>`) は人間が目視する前提の短縮形です。機械処理には `--wide --utc` または `--json` を利用してください。
 
-`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > config.json の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールドは `traceary list` の説明を参照してください。
+`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > preset fields > config.json の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールドは `traceary list` の説明を参照してください。`--preset <name>` で保存済みビューを適用できます（built-in: `failures` / `prompts-only` / `compact-summaries`、user-defined は `read.presets`）。
 
 主な flag:
 
@@ -112,6 +113,7 @@ session 解決ルールは `traceary log` と同じです。
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -122,7 +124,7 @@ session 解決ルールは `traceary log` と同じです。
 
 全文検索と構造フィルタで event を検索します。
 
-テキスト出力は `list` / `tail` と同じコンパクト 1 行形式 (デフォルトで現地時刻) です。`--wide` で従来の 7 カラム表、`--utc` で UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > config.json の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールドは `traceary list` の説明を参照してください。
+テキスト出力は `list` / `tail` と同じコンパクト 1 行形式 (デフォルトで現地時刻) です。`--wide` で従来の 7 カラム表、`--utc` で UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前の出力を完全再現します。`--json` は従来通りです。`--fields ts,kind,message` でコンパクトカラムの順序を上書きできます (優先順位: `--fields` > preset fields > config.json の `read.fields` > 組み込み既定値)。`--fields` は `--wide` と併用できません。利用可能フィールドは `traceary list` の説明を参照してください。`--preset <name>` で保存済みビューを適用できます。filter を持つ preset なら free-text query なしでも検索条件が揃うので、preset-only な検索も成立します。
 
 主な flag:
 
@@ -139,6 +141,7 @@ session 解決ルールは `traceary log` と同じです。
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 
 ### `traceary timeline`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -76,7 +76,7 @@ List recent events.
 
 `list` is the fast recent-history view. Use it when you already know the event kind / client / agent / session / workspace filters you want. Switch to `search` when you need keyword matching or date-range filtering.
 
-Default text output is the same compact single-line shape as `tail` (`HH:MM:SS  kind  sess=<first-8>  ws=<basename>  message`, local time, no header). Pass `--wide` for the legacy tab-separated seven-column format, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged. Use `--fields ts,kind,message` to pick which compact columns are shown; precedence is `--fields` > `read.fields` in `~/.config/traceary/config.json` > built-in default. `--fields` cannot be combined with `--wide`. Supported fields: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`.
+Default text output is the same compact single-line shape as `tail` (`HH:MM:SS  kind  sess=<first-8>  ws=<basename>  message`, local time, no header). Pass `--wide` for the legacy tab-separated seven-column format, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged. Use `--fields ts,kind,message` to pick which compact columns are shown; precedence is `--fields` > preset fields > `read.fields` in `~/.config/traceary/config.json` > built-in default. `--fields` cannot be combined with `--wide`. Supported fields: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`. Use `--preset <name>` to apply a saved view: built-in presets are `failures`, `prompts-only`, `compact-summaries`; user-defined entries in `read.presets` can override built-in names and explicit filter flags (`--kind`, `--failures`, `--workspace`, etc.) still win over a preset. Presets ignore `--wide` / `--json` for field overrides but still apply filters.
 
 Useful flags:
 
@@ -87,6 +87,7 @@ Useful flags:
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -102,7 +103,7 @@ Default text output is a compact single-line row (`HH:MM:SS  kind  sess=<first-8
 
 > The compact session ID (`sess=<first-8>`) is intended for human scanning only. For machine processing, use `--wide --utc` or `--json`.
 
-Use `--fields ts,kind,message` to override the compact column order (precedence: flag > `read.fields` in config.json > built-in default). `--fields` cannot be combined with `--wide`; see `traceary list` above for the full list of supported fields.
+Use `--fields ts,kind,message` to override the compact column order (precedence: flag > preset fields > `read.fields` in config.json > built-in default). `--fields` cannot be combined with `--wide`; see `traceary list` above for the full list of supported fields. Use `--preset <name>` for saved views (built-in: `failures` / `prompts-only` / `compact-summaries`; user-defined in `read.presets`).
 
 Useful flags:
 
@@ -112,6 +113,7 @@ Useful flags:
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 - `--client`
 - `--agent`
 - `--workspace`
@@ -122,7 +124,7 @@ Useful flags:
 
 Search events by text and structured filters.
 
-Text results use the same compact single-line format as `list` / `tail` (local time by default). Pass `--wide` for the legacy seven-column table, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged. Use `--fields ts,kind,message` to override the compact column order (precedence: flag > `read.fields` in config.json > built-in default); `--fields` cannot be combined with `--wide`, and the supported field list is shown under `traceary list` above.
+Text results use the same compact single-line format as `list` / `tail` (local time by default). Pass `--wide` for the legacy seven-column table, or `--utc` to force UTC timestamps. `--wide --utc` reproduces the pre-v0.6.1 output byte-for-byte. `--json` is unchanged. Use `--fields ts,kind,message` to override the compact column order (precedence: flag > preset fields > `read.fields` in config.json > built-in default); `--fields` cannot be combined with `--wide`, and the supported field list is shown under `traceary list` above. Use `--preset <name>` for saved views; a preset with filters can make a search with no free-text query valid because its filters count as constraints.
 
 Useful flags:
 
@@ -139,6 +141,7 @@ Useful flags:
 - `--wide`
 - `--utc`
 - `--fields`
+- `--preset`
 
 ### `traceary timeline`
 

--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -41,6 +41,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 | --- | --- | --- |
 | `redact.extra_patterns` | 文字列配列 | 監査リダクション用の追加正規表現パターン。各エントリは Go の `regexp` パターンとしてコンパイルされ、マッチした内容が `[REDACTED]` に置換されます。CLI（`traceary audit`）と MCP サーバー（`add_audit`）の両方で、組み込みルールの後に適用されます。 |
 | `read.fields` | 文字列配列 | `traceary tail` / `list` / `search` のテキスト出力で `--fields` が指定されなかった場合に使用されるコンパクトカラムのデフォルト順。利用可能なフィールド名: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`。未知・空・重複エントリはコマンド実行時に拒否されます。`--fields` フラグが指定された場合は常にこの設定を上書きします。`--wide` や `--json` 出力には影響しません。 |
+| `read.presets` | object | `traceary tail` / `list` / `search` 向けの保存済みビュー。`--preset <name>` で適用します。各 entry は `fields`（`read.fields` と同じ registry）と `filters`（`kind`, `failures`, `workspace`, `session_id`, `client`, `agent`）を持てます。明示した CLI フラグは常に preset を上書きします。built-in preset（`failures`, `prompts-only`, `compact-summaries`）と同名のエントリは built-in を上書きしますが、実行時に stderr へ `[WARN]` を出します。 |
 
 例:
 
@@ -50,7 +51,16 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
     "extra_patterns": ["my_custom_secret", "internal_auth_header:\\s*\\S+"]
   },
   "read": {
-    "fields": ["ts", "kind", "session", "ws", "message"]
+    "fields": ["ts", "kind", "session", "ws", "message"],
+    "presets": {
+      "my-view": {
+        "fields": ["ts", "kind", "message"],
+        "filters": {
+          "kind": "prompt",
+          "failures": true
+        }
+      }
+    }
   }
 }
 ```

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -41,6 +41,7 @@ Traceary reads an optional JSON configuration file from `~/.config/traceary/conf
 | --- | --- | --- |
 | `redact.extra_patterns` | string array | Extra regex patterns for audit redaction. Each entry is compiled as a Go `regexp` pattern and matched content is replaced with `[REDACTED]`. Applied after the built-in redaction rules in both the CLI (`traceary audit`) and MCP server (`add_audit`). |
 | `read.fields` | string array | Default compact column order for `traceary tail` / `list` / `search` text output when `--fields` is omitted. Accepted field names: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`. Unknown / empty / duplicate entries are rejected at command runtime; the `--fields` flag always overrides this setting. Does not affect `--wide` or `--json` output. |
+| `read.presets` | object | Named saved views for `traceary tail` / `list` / `search`, applied via `--preset <name>`. Each entry can set `fields` (same registry as `read.fields`) and `filters` (any of `kind`, `failures`, `workspace`, `session_id`, `client`, `agent`). Explicit CLI flags always override preset values. Entries whose name collides with a built-in preset (`failures`, `prompts-only`, `compact-summaries`) win over the built-in but emit a `[WARN]` line on stderr. |
 
 Example:
 
@@ -50,7 +51,16 @@ Example:
     "extra_patterns": ["my_custom_secret", "internal_auth_header:\\s*\\S+"]
   },
   "read": {
-    "fields": ["ts", "kind", "session", "ws", "message"]
+    "fields": ["ts", "kind", "session", "ws", "message"],
+    "presets": {
+      "my-view": {
+        "fields": ["ts", "kind", "message"],
+        "filters": {
+          "kind": "prompt",
+          "failures": true
+        }
+      }
+    }
   }
 }
 ```

--- a/main.go
+++ b/main.go
@@ -147,6 +147,7 @@ func run() error {
 	cfg := presentation.LoadConfig()
 	extraRedactPatterns := cfg.ExtraRedactPatterns
 	defaultReadFields := cfg.ReadFields
+	readPresets := cfg.ReadPresets
 
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
@@ -189,6 +190,7 @@ func run() error {
 		cli.WithHooksInspector(hooksInspector),
 		cli.WithExtraRedactPatterns(extraRedactPatterns),
 		cli.WithDefaultReadFields(defaultReadFields),
+		cli.WithReadPresets(readPresets),
 		cli.WithDatabasePathSetter(db.SetPath),
 	).Command()
 	rootCmd.Version = versionString()

--- a/presentation/cli/event_text_formatter_test.go
+++ b/presentation/cli/event_text_formatter_test.go
@@ -369,7 +369,7 @@ func TestRunTail_DefaultCompactUsesInjectedLocation(t *testing.T) {
 	)
 
 	jst := time.FixedZone("JST", 9*3600)
-	if err := sut.runTail(ctx, stdout, tailCommandInput{
+	if err := sut.runTail(ctx, &bytes.Buffer{}, stdout, tailCommandInput{
 		dbPath:        "/tmp/test-traceary.db",
 		limit:         1,
 		repo:          "duck8823/traceary",

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -122,6 +122,14 @@ type listCommandInput struct {
 	location     *time.Location
 	fields       []string
 	fieldsSet    bool
+	preset          string
+	presetSet       bool
+	kindSet         bool
+	clientSet       bool
+	agentSet        bool
+	sessionIDSet    bool
+	repoSet         bool
+	failuresOnlySet bool
 }
 
 // logCommandInput is the resolved input to the `traceary log` command.
@@ -159,6 +167,14 @@ type searchCommandInput struct {
 	location     *time.Location
 	fields       []string
 	fieldsSet    bool
+	preset          string
+	presetSet       bool
+	kindSet         bool
+	clientSet       bool
+	agentSet        bool
+	sessionIDSet    bool
+	repoSet         bool
+	failuresOnlySet bool
 }
 
 // sessionBoundaryCommandInput is the resolved input to
@@ -218,6 +234,14 @@ type tailCommandInput struct {
 	location      *time.Location
 	fields        []string
 	fieldsSet     bool
+	preset          string
+	presetSet       bool
+	kindSet         bool
+	clientSet       bool
+	agentSet        bool
+	sessionIDSet    bool
+	repoSet         bool
+	failuresOnlySet bool
 	nowFunc       func() time.Time
 	tickerFactory func(time.Duration) tailTicker
 }

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -31,6 +31,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		wide         bool
 		utc          bool
 		fields       []string
+		preset       string
 	)
 
 	listCmd := &cobra.Command{
@@ -38,25 +39,33 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		Short: Localize("List recent events", "直近のログを一覧表示する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return c.runList(cmd.Context(), cmd.OutOrStdout(), listCommandInput{
-				dbPath:       dbPath,
-				limit:        limit,
-				offset:       offset,
-				kind:         kind,
-				client:       client,
-				agent:        agent,
-				sessionID:    sessionID,
-				repo:         repo,
-				from:         from,
-				since:        since,
-				to:           to,
-				until:        until,
-				failuresOnly: failuresOnly,
-				asJSON:       asJSON,
-				wide:         wide,
-				utc:          utc,
-				fields:       fields,
-				fieldsSet:    cmd.Flags().Changed("fields"),
+			return c.runList(cmd.Context(), cmd.ErrOrStderr(), cmd.OutOrStdout(), listCommandInput{
+				dbPath:          dbPath,
+				limit:           limit,
+				offset:          offset,
+				kind:            kind,
+				client:          client,
+				agent:           agent,
+				sessionID:       sessionID,
+				repo:            repo,
+				from:            from,
+				since:           since,
+				to:              to,
+				until:           until,
+				failuresOnly:    failuresOnly,
+				asJSON:          asJSON,
+				wide:            wide,
+				utc:             utc,
+				fields:          fields,
+				fieldsSet:       cmd.Flags().Changed("fields"),
+				preset:          preset,
+				presetSet:       cmd.Flags().Changed("preset"),
+				kindSet:         cmd.Flags().Changed("kind"),
+				clientSet:       cmd.Flags().Changed("client"),
+				agentSet:        cmd.Flags().Changed("agent"),
+				sessionIDSet:    cmd.Flags().Changed("session-id"),
+				repoSet:         cmd.Flags().Changed("workspace"),
+				failuresOnlySet: cmd.Flags().Changed("failures"),
 			})
 		},
 	}
@@ -77,11 +86,12 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
 	listCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 	listCmd.Flags().StringSliceVar(&fields, "fields", nil, readFieldsFlagUsage())
+	listCmd.Flags().StringVar(&preset, "preset", "", readPresetsFlagUsage())
 
 	return listCmd
 }
 
-func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listCommandInput) error {
+func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.Writer, input listCommandInput) error {
 	if c.storeManagement == nil {
 		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
 	}
@@ -94,6 +104,11 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 	if input.offset < 0 {
 		return xerrors.Errorf(Localize("offset must be greater than or equal to 0", "offset は 0 以上である必要があります"))
 	}
+	preset, _, err := resolveReadPreset(input.preset, c.readPresets, warnWriter)
+	if err != nil {
+		return err
+	}
+	applyReadPresetToListInput(&input, preset)
 	resolvedKind, err := resolveListKind(input.kind)
 	if err != nil {
 		return err
@@ -149,7 +164,7 @@ func (c *RootCLI) runList(ctx context.Context, output io.Writer, input listComma
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to list events", "イベント一覧の取得に失敗しました"), err)
 	}
-	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON)
+	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON, preset.fields)
 	if err != nil {
 		return err
 	}

--- a/presentation/cli/read_fields.go
+++ b/presentation/cli/read_fields.go
@@ -152,10 +152,13 @@ func readFieldsFlagUsage() string {
 
 // resolveReadFieldsForCommand applies the precedence rules and enforces the
 // --wide vs --fields mutual exclusion for read commands. When the command is
-// rendering --wide or --json output, the config-backed default is skipped so
-// a broken read.fields entry does not block paths that would not consume it
-// anyway.
-func (c *RootCLI) resolveReadFieldsForCommand(explicit []string, explicitSet bool, wide bool, asJSON bool) ([]readFieldID, error) {
+// rendering --wide or --json output, the config-backed default and the
+// preset fields are skipped so a broken setting does not block paths that
+// would not consume it anyway.
+//
+// Precedence (compact text rendering only): explicit --fields > preset
+// fields > config.read.fields > built-in default.
+func (c *RootCLI) resolveReadFieldsForCommand(explicit []string, explicitSet bool, wide bool, asJSON bool, presetFields []readFieldID) ([]readFieldID, error) {
 	if wide && explicitSet {
 		return nil, xerrors.Errorf(Localize(
 			"--fields cannot be combined with --wide (wide mode keeps the legacy seven-column format)",
@@ -164,6 +167,12 @@ func (c *RootCLI) resolveReadFieldsForCommand(explicit []string, explicitSet boo
 	}
 	if wide || asJSON {
 		return append([]readFieldID(nil), defaultReadFields...), nil
+	}
+	if explicitSet {
+		return parseReadFields(explicit)
+	}
+	if len(presetFields) > 0 {
+		return append([]readFieldID(nil), presetFields...), nil
 	}
 	return resolveReadFields(explicit, explicitSet, c.defaultReadFields)
 }

--- a/presentation/cli/read_fields_test.go
+++ b/presentation/cli/read_fields_test.go
@@ -100,7 +100,7 @@ func TestResolveReadFieldsForCommand_WideConflict(t *testing.T) {
 	t.Parallel()
 
 	cli := NewRootCLI()
-	_, err := cli.resolveReadFieldsForCommand([]string{"ts", "kind"}, true, true, false)
+	_, err := cli.resolveReadFieldsForCommand([]string{"ts", "kind"}, true, true, false, nil)
 	if err == nil {
 		t.Fatalf("resolveReadFieldsForCommand() expected conflict error, got nil")
 	}
@@ -113,7 +113,7 @@ func TestResolveReadFieldsForCommand_WideWithoutExplicitFieldsIsAllowed(t *testi
 	t.Parallel()
 
 	cli := NewRootCLI()
-	got, err := cli.resolveReadFieldsForCommand(nil, false, true, false)
+	got, err := cli.resolveReadFieldsForCommand(nil, false, true, false, nil)
 	if err != nil {
 		t.Fatalf("resolveReadFieldsForCommand() unexpected error = %v", err)
 	}
@@ -129,7 +129,7 @@ func TestResolveReadFieldsForCommand_WideSkipsBrokenConfigDefault(t *testing.T) 
 	t.Parallel()
 
 	cli := NewRootCLI(WithDefaultReadFields([]string{"bogus"}))
-	got, err := cli.resolveReadFieldsForCommand(nil, false, true, false)
+	got, err := cli.resolveReadFieldsForCommand(nil, false, true, false, nil)
 	if err != nil {
 		t.Fatalf("wide mode should bypass config validation, got err = %v", err)
 	}
@@ -142,7 +142,7 @@ func TestResolveReadFieldsForCommand_JSONSkipsBrokenConfigDefault(t *testing.T) 
 	t.Parallel()
 
 	cli := NewRootCLI(WithDefaultReadFields([]string{"bogus"}))
-	got, err := cli.resolveReadFieldsForCommand(nil, false, false, true)
+	got, err := cli.resolveReadFieldsForCommand(nil, false, false, true, nil)
 	if err != nil {
 		t.Fatalf("--json should bypass config validation, got err = %v", err)
 	}

--- a/presentation/cli/read_presets.go
+++ b/presentation/cli/read_presets.go
@@ -104,49 +104,56 @@ func resolveReadPreset(name string, userDefined map[string]presentation.ReadPres
 		return readPreset{}, false, nil
 	}
 
-	merged := builtinReadPresets()
+	builtin := builtinReadPresets()
 
-	// Warn for every user-defined preset that shadows a built-in name so
-	// operators can discover the collision from either a collision-aware
-	// command run or a doctor pass over the config. We collect first and
-	// emit in a stable sorted order to keep the message deterministic.
-	collisions := make([]string, 0)
-	for presetName, user := range userDefined {
-		if _, clash := merged[presetName]; clash {
-			collisions = append(collisions, presetName)
+	// Collision detection walks every user-defined entry but does NOT
+	// validate their payloads. A typo in one preset must not block an
+	// unrelated preset from resolving. The output order is sorted so the
+	// warning sequence stays stable regardless of Go's map iteration.
+	if warnWriter != nil {
+		collisions := make([]string, 0, len(userDefined))
+		for presetName := range userDefined {
+			if _, clash := builtin[presetName]; clash {
+				collisions = append(collisions, presetName)
+			}
 		}
-		converted, err := convertUserPreset(presetName, user)
+		if len(collisions) > 0 {
+			sort.Strings(collisions)
+			for _, collided := range collisions {
+				_, _ = fmt.Fprintf(
+					warnWriter,
+					Localize(
+						"[WARN] user-defined preset %q shadows a built-in preset of the same name\n",
+						"[WARN] ユーザー定義 preset %q が同名の built-in preset を上書きしています\n",
+					),
+					collided,
+				)
+			}
+		}
+	}
+
+	// User-defined entries win over built-ins on collision, so look them up
+	// first and only validate the one the caller asked for. This keeps an
+	// invalid unrelated entry from breaking every other preset.
+	if user, ok := userDefined[trimmed]; ok {
+		converted, err := convertUserPreset(trimmed, user)
 		if err != nil {
 			return readPreset{}, false, err
 		}
-		merged[presetName] = converted
+		return converted, true, nil
 	}
-	if warnWriter != nil && len(collisions) > 0 {
-		sort.Strings(collisions)
-		for _, collided := range collisions {
-			_, _ = fmt.Fprintf(
-				warnWriter,
-				Localize(
-					"[WARN] user-defined preset %q shadows a built-in preset of the same name\n",
-					"[WARN] ユーザー定義 preset %q が同名の built-in preset を上書きしています\n",
-				),
-				collided,
-			)
-		}
+	if preset, ok := builtin[trimmed]; ok {
+		return preset, true, nil
 	}
 
-	preset, ok := merged[trimmed]
-	if !ok {
-		return readPreset{}, false, xerrors.Errorf(
-			Localize(
-				"unknown preset %q (built-in presets: %s)",
-				"preset %q が見つかりません (built-in: %s)",
-			),
-			trimmed,
-			supportedBuiltinPresetsLabel(),
-		)
-	}
-	return preset, true, nil
+	return readPreset{}, false, xerrors.Errorf(
+		Localize(
+			"unknown preset %q (built-in presets: %s)",
+			"preset %q が見つかりません (built-in: %s)",
+		),
+		trimmed,
+		supportedBuiltinPresetsLabel(),
+	)
 }
 
 // convertUserPreset validates a user-defined preset against the closed

--- a/presentation/cli/read_presets.go
+++ b/presentation/cli/read_presets.go
@@ -1,0 +1,291 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/presentation"
+)
+
+// readPreset is the resolved view of either a built-in preset or a
+// user-defined preset from config.json. Both variants flow through the same
+// application pipeline so the CLI caller does not have to branch.
+type readPreset struct {
+	name    string
+	fields  []readFieldID
+	filters readPresetFilters
+	source  readPresetSource
+}
+
+type readPresetSource int
+
+const (
+	readPresetSourceBuiltin readPresetSource = iota
+	readPresetSourceUser
+)
+
+// readPresetFilters holds the filter keys a preset contributes. Zero value
+// means "do not apply" so the explicit-CLI-flag path stays untouched when a
+// preset does not declare a given filter.
+type readPresetFilters struct {
+	kind         string
+	kindSet      bool
+	failures     bool
+	failuresSet  bool
+	workspace    string
+	workspaceSet bool
+	sessionID    string
+	sessionIDSet bool
+	client       string
+	clientSet    bool
+	agent        string
+	agentSet     bool
+}
+
+// builtinReadPresets returns the curated preset catalog every Traceary
+// install ships. The returned map is fresh on every call so callers can
+// safely mutate it when merging user-defined entries.
+func builtinReadPresets() map[string]readPreset {
+	return map[string]readPreset{
+		"failures": {
+			name: "failures",
+			// exit_code is pushed up front so failing command rows carry
+			// their status alongside the timestamp, which is the scanning
+			// order most useful when filtering for failures.
+			fields: []readFieldID{
+				readFieldTS,
+				readFieldKind,
+				readFieldExitCode,
+				readFieldSession,
+				readFieldWorkspace,
+				readFieldMessage,
+			},
+			filters: readPresetFilters{failures: true, failuresSet: true},
+			source:  readPresetSourceBuiltin,
+		},
+		"prompts-only": {
+			name:    "prompts-only",
+			filters: readPresetFilters{kind: "prompt", kindSet: true},
+			source:  readPresetSourceBuiltin,
+		},
+		"compact-summaries": {
+			name:    "compact-summaries",
+			filters: readPresetFilters{kind: "compact_summary", kindSet: true},
+			source:  readPresetSourceBuiltin,
+		},
+	}
+}
+
+// supportedBuiltinPresetsLabel returns the comma-separated list of built-in
+// preset names, used in error messages to help operators discover valid
+// values without grepping through docs.
+func supportedBuiltinPresetsLabel() string {
+	presets := builtinReadPresets()
+	names := make([]string, 0, len(presets))
+	for name := range presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// resolveReadPreset merges the built-in catalog with user-defined presets,
+// logs a collision warning via warnWriter (typically stderr) when a
+// user-defined preset shadows a built-in name, validates the requested
+// preset, and returns the resolved preset. The returned preset is zero-
+// valued when name is empty (no preset requested).
+func resolveReadPreset(name string, userDefined map[string]presentation.ReadPreset, warnWriter io.Writer) (readPreset, bool, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return readPreset{}, false, nil
+	}
+
+	merged := builtinReadPresets()
+
+	// Warn for every user-defined preset that shadows a built-in name so
+	// operators can discover the collision from either a collision-aware
+	// command run or a doctor pass over the config. We collect first and
+	// emit in a stable sorted order to keep the message deterministic.
+	collisions := make([]string, 0)
+	for presetName, user := range userDefined {
+		if _, clash := merged[presetName]; clash {
+			collisions = append(collisions, presetName)
+		}
+		converted, err := convertUserPreset(presetName, user)
+		if err != nil {
+			return readPreset{}, false, err
+		}
+		merged[presetName] = converted
+	}
+	if warnWriter != nil && len(collisions) > 0 {
+		sort.Strings(collisions)
+		for _, collided := range collisions {
+			_, _ = fmt.Fprintf(
+				warnWriter,
+				Localize(
+					"[WARN] user-defined preset %q shadows a built-in preset of the same name\n",
+					"[WARN] ユーザー定義 preset %q が同名の built-in preset を上書きしています\n",
+				),
+				collided,
+			)
+		}
+	}
+
+	preset, ok := merged[trimmed]
+	if !ok {
+		return readPreset{}, false, xerrors.Errorf(
+			Localize(
+				"unknown preset %q (built-in presets: %s)",
+				"preset %q が見つかりません (built-in: %s)",
+			),
+			trimmed,
+			supportedBuiltinPresetsLabel(),
+		)
+	}
+	return preset, true, nil
+}
+
+// convertUserPreset validates a user-defined preset against the closed
+// field / kind registries shared with --fields and --kind.
+func convertUserPreset(name string, user presentation.ReadPreset) (readPreset, error) {
+	result := readPreset{
+		name:   name,
+		source: readPresetSourceUser,
+	}
+
+	if len(user.Fields) > 0 {
+		fields, err := parseReadFields(user.Fields)
+		if err != nil {
+			return readPreset{}, xerrors.Errorf(
+				Localize(
+					"invalid fields in preset %q: %w",
+					"preset %q の fields が不正です: %w",
+				),
+				name,
+				err,
+			)
+		}
+		result.fields = fields
+	}
+
+	filters := readPresetFilters{}
+	if kind := strings.TrimSpace(user.Filters.Kind); kind != "" {
+		if _, err := validateSearchKind(kind); err != nil {
+			return readPreset{}, xerrors.Errorf(
+				Localize(
+					"invalid kind in preset %q: %w",
+					"preset %q の kind が不正です: %w",
+				),
+				name,
+				err,
+			)
+		}
+		filters.kind = kind
+		filters.kindSet = true
+	}
+	if user.Filters.Failures != nil {
+		filters.failures = *user.Filters.Failures
+		filters.failuresSet = true
+	}
+	if ws := strings.TrimSpace(user.Filters.Workspace); ws != "" {
+		filters.workspace = ws
+		filters.workspaceSet = true
+	}
+	if sid := strings.TrimSpace(user.Filters.SessionID); sid != "" {
+		filters.sessionID = sid
+		filters.sessionIDSet = true
+	}
+	if client := strings.TrimSpace(user.Filters.Client); client != "" {
+		filters.client = client
+		filters.clientSet = true
+	}
+	if agent := strings.TrimSpace(user.Filters.Agent); agent != "" {
+		filters.agent = agent
+		filters.agentSet = true
+	}
+	result.filters = filters
+	return result, nil
+}
+
+// applyReadPresetToListInput fills filter fields on listCommandInput from
+// the resolved preset, but only for fields the caller did not already set
+// via an explicit CLI flag. Explicit flags always win.
+func applyReadPresetToListInput(input *listCommandInput, preset readPreset) {
+	if preset.filters.kindSet && !input.kindSet {
+		input.kind = preset.filters.kind
+	}
+	if preset.filters.clientSet && !input.clientSet {
+		input.client = preset.filters.client
+	}
+	if preset.filters.agentSet && !input.agentSet {
+		input.agent = preset.filters.agent
+	}
+	if preset.filters.sessionIDSet && !input.sessionIDSet {
+		input.sessionID = preset.filters.sessionID
+	}
+	if preset.filters.workspaceSet && !input.repoSet {
+		input.repo = preset.filters.workspace
+	}
+	if preset.filters.failuresSet && !input.failuresOnlySet {
+		input.failuresOnly = preset.filters.failures
+	}
+}
+
+// applyReadPresetToSearchInput mirrors applyReadPresetToListInput for the
+// search command. Keeping the two helpers separate avoids tying the two
+// command inputs together just to share filter plumbing.
+func applyReadPresetToSearchInput(input *searchCommandInput, preset readPreset) {
+	if preset.filters.kindSet && !input.kindSet {
+		input.kind = preset.filters.kind
+	}
+	if preset.filters.clientSet && !input.clientSet {
+		input.client = preset.filters.client
+	}
+	if preset.filters.agentSet && !input.agentSet {
+		input.agent = preset.filters.agent
+	}
+	if preset.filters.sessionIDSet && !input.sessionIDSet {
+		input.sessionID = preset.filters.sessionID
+	}
+	if preset.filters.workspaceSet && !input.repoSet {
+		input.repo = preset.filters.workspace
+	}
+	if preset.filters.failuresSet && !input.failuresOnlySet {
+		input.failuresOnly = preset.filters.failures
+	}
+}
+
+// applyReadPresetToTailInput mirrors the helpers above for tail.
+func applyReadPresetToTailInput(input *tailCommandInput, preset readPreset) {
+	if preset.filters.kindSet && !input.kindSet {
+		input.kind = preset.filters.kind
+	}
+	if preset.filters.clientSet && !input.clientSet {
+		input.client = preset.filters.client
+	}
+	if preset.filters.agentSet && !input.agentSet {
+		input.agent = preset.filters.agent
+	}
+	if preset.filters.sessionIDSet && !input.sessionIDSet {
+		input.sessionID = preset.filters.sessionID
+	}
+	if preset.filters.workspaceSet && !input.repoSet {
+		input.repo = preset.filters.workspace
+	}
+	if preset.filters.failuresSet && !input.failuresOnlySet {
+		input.failuresOnly = preset.filters.failures
+	}
+}
+
+// readPresetsFlagUsage returns the shared --preset flag usage string for
+// list / search / tail commands.
+func readPresetsFlagUsage() string {
+	return Localize(
+		"apply a saved view preset (built-in: "+supportedBuiltinPresetsLabel()+"; user-defined entries in read.presets override built-in names)",
+		"保存済みのビュー preset を適用する (built-in: "+supportedBuiltinPresetsLabel()+"; config.json の read.presets は同名の built-in を上書き)",
+	)
+}

--- a/presentation/cli/read_presets_test.go
+++ b/presentation/cli/read_presets_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/presentation"
+)
+
+func TestResolveReadPreset_BuiltinFailures(t *testing.T) {
+	t.Parallel()
+
+	preset, ok, err := resolveReadPreset("failures", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() unexpected error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("resolveReadPreset() ok = false, want true")
+	}
+	if !preset.filters.failuresSet || !preset.filters.failures {
+		t.Fatalf("expected failures filter to be set true, got %+v", preset.filters)
+	}
+	if !readFieldsContain(preset.fields, readFieldExitCode) {
+		t.Fatalf("expected failures preset to include exit_code field, got %v", preset.fields)
+	}
+}
+
+func TestResolveReadPreset_BuiltinPromptsOnly(t *testing.T) {
+	t.Parallel()
+
+	preset, _, err := resolveReadPreset("prompts-only", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() unexpected error = %v", err)
+	}
+	if preset.filters.kind != "prompt" || !preset.filters.kindSet {
+		t.Fatalf("expected kind=prompt, got %+v", preset.filters)
+	}
+	if len(preset.fields) != 0 {
+		t.Fatalf("expected prompts-only to not override fields, got %v", preset.fields)
+	}
+}
+
+func TestResolveReadPreset_UnknownReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := resolveReadPreset("bogus", nil, nil)
+	if err == nil {
+		t.Fatalf("resolveReadPreset() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failures") {
+		t.Fatalf("error should mention built-in preset catalog, got %q", err.Error())
+	}
+}
+
+func TestResolveReadPreset_EmptyReturnsNotOK(t *testing.T) {
+	t.Parallel()
+
+	preset, ok, err := resolveReadPreset("", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() unexpected error = %v", err)
+	}
+	if ok {
+		t.Fatalf("resolveReadPreset() ok = true, want false for empty name")
+	}
+	_ = preset
+}
+
+func TestResolveReadPreset_UserDefinedOverridesBuiltin(t *testing.T) {
+	t.Parallel()
+
+	userFields := []string{"ts", "kind"}
+	userDefined := map[string]presentation.ReadPreset{
+		"failures": {Fields: userFields},
+	}
+	warn := &bytes.Buffer{}
+
+	preset, ok, err := resolveReadPreset("failures", userDefined, warn)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() unexpected error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("resolveReadPreset() ok = false, want true")
+	}
+	if len(preset.fields) != 2 || preset.fields[0] != readFieldTS || preset.fields[1] != readFieldKind {
+		t.Fatalf("user-defined override did not win, got %v", preset.fields)
+	}
+	if !strings.Contains(warn.String(), "[WARN]") {
+		t.Fatalf("expected collision warning on stderr, got %q", warn.String())
+	}
+}
+
+func TestResolveReadPreset_UserDefinedWithInvalidFieldRejected(t *testing.T) {
+	t.Parallel()
+
+	userDefined := map[string]presentation.ReadPreset{
+		"my-view": {Fields: []string{"ts", "bogus"}},
+	}
+	_, _, err := resolveReadPreset("my-view", userDefined, nil)
+	if err == nil {
+		t.Fatalf("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "my-view") {
+		t.Fatalf("error should name the offending preset, got %q", err.Error())
+	}
+}
+
+func TestResolveReadPreset_UserDefinedWithInvalidKindRejected(t *testing.T) {
+	t.Parallel()
+
+	userDefined := map[string]presentation.ReadPreset{
+		"my-view": {Filters: presentation.ReadPresetFilters{Kind: "bogus-kind"}},
+	}
+	_, _, err := resolveReadPreset("my-view", userDefined, nil)
+	if err == nil {
+		t.Fatalf("expected validation error, got nil")
+	}
+}
+
+func TestApplyReadPresetToListInput_RespectsExplicitOverride(t *testing.T) {
+	t.Parallel()
+
+	input := listCommandInput{
+		kind:    "command_executed",
+		kindSet: true,
+	}
+	preset, _, err := resolveReadPreset("prompts-only", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() error = %v", err)
+	}
+	applyReadPresetToListInput(&input, preset)
+	if input.kind != "command_executed" {
+		t.Fatalf("explicit kind was overwritten by preset, got %q", input.kind)
+	}
+}
+
+func TestApplyReadPresetToListInput_FillsUnsetFilters(t *testing.T) {
+	t.Parallel()
+
+	input := listCommandInput{}
+	preset, _, err := resolveReadPreset("failures", nil, nil)
+	if err != nil {
+		t.Fatalf("resolveReadPreset() error = %v", err)
+	}
+	applyReadPresetToListInput(&input, preset)
+	if !input.failuresOnly {
+		t.Fatalf("failures filter not applied, got %+v", input)
+	}
+}
+
+func TestResolveReadFieldsForCommand_PresetFieldsTakePrecedenceOverConfig(t *testing.T) {
+	t.Parallel()
+
+	cli := NewRootCLI(WithDefaultReadFields([]string{"ts", "message"}))
+	presetFields := []readFieldID{readFieldTS, readFieldKind, readFieldExitCode, readFieldMessage}
+
+	got, err := cli.resolveReadFieldsForCommand(nil, false, false, false, presetFields)
+	if err != nil {
+		t.Fatalf("resolveReadFieldsForCommand() error = %v", err)
+	}
+	if len(got) != len(presetFields) || got[2] != readFieldExitCode {
+		t.Fatalf("expected preset fields to take precedence over config default, got %v", got)
+	}
+}
+
+func TestResolveReadFieldsForCommand_ExplicitFieldsOverridePreset(t *testing.T) {
+	t.Parallel()
+
+	cli := NewRootCLI()
+	presetFields := []readFieldID{readFieldTS, readFieldKind, readFieldMessage}
+
+	got, err := cli.resolveReadFieldsForCommand([]string{"id"}, true, false, false, presetFields)
+	if err != nil {
+		t.Fatalf("resolveReadFieldsForCommand() error = %v", err)
+	}
+	if len(got) != 1 || got[0] != readFieldEventID {
+		t.Fatalf("explicit --fields should override preset, got %v", got)
+	}
+}

--- a/presentation/cli/read_presets_test.go
+++ b/presentation/cli/read_presets_test.go
@@ -117,6 +117,43 @@ func TestResolveReadPreset_UserDefinedWithInvalidKindRejected(t *testing.T) {
 	}
 }
 
+// TestResolveReadPreset_InvalidUnrelatedUserPresetDoesNotBlockOthers ensures
+// validation is scoped to the preset the caller asked for. Codex verifier
+// flagged on PR #580 that a single typo in one user-defined preset could
+// otherwise break every other preset.
+func TestResolveReadPreset_InvalidUnrelatedUserPresetDoesNotBlockOthers(t *testing.T) {
+	t.Parallel()
+
+	userDefined := map[string]presentation.ReadPreset{
+		"bad-fields": {Fields: []string{"bogus"}},
+		"good":       {Filters: presentation.ReadPresetFilters{Kind: "prompt"}},
+	}
+
+	preset, ok, err := resolveReadPreset("failures", userDefined, nil)
+	if err != nil {
+		t.Fatalf("built-in resolution should not be affected by an unrelated broken preset, got err = %v", err)
+	}
+	if !ok || preset.name != "failures" {
+		t.Fatalf("expected built-in failures preset, got %+v", preset)
+	}
+
+	preset, ok, err = resolveReadPreset("good", userDefined, nil)
+	if err != nil {
+		t.Fatalf("valid user preset should not be affected by an unrelated broken preset, got err = %v", err)
+	}
+	if !ok || !preset.filters.kindSet || preset.filters.kind != "prompt" {
+		t.Fatalf("expected good preset with kind=prompt, got %+v", preset)
+	}
+
+	_, _, err = resolveReadPreset("bad-fields", userDefined, nil)
+	if err == nil {
+		t.Fatalf("expected validation error for bad-fields, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-fields") {
+		t.Fatalf("error should name the requested preset, got %q", err.Error())
+	}
+}
+
 func TestApplyReadPresetToListInput_RespectsExplicitOverride(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/presentation"
 )
 
 // RootCLI provides the Traceary root command.
@@ -20,7 +21,8 @@ type RootCLI struct {
 	hooksOrchestrator   application.HooksOrchestrator
 	hooksInspector      application.HooksInspector
 	extraRedactPatterns []string
-	defaultReadFields  []string
+	defaultReadFields   []string
+	readPresets         map[string]presentation.ReadPreset
 	// databasePathSetter is invoked by each subcommand's RunE after it
 	// resolves --db-path / TRACEARY_DB_PATH, so the shared Database
 	// instance opens the user-specified path instead of the composition-
@@ -101,6 +103,14 @@ func WithExtraRedactPatterns(patterns []string) RootCLIOption {
 // or empty lists fall back to the built-in default column order.
 func WithDefaultReadFields(columns []string) RootCLIOption {
 	return func(c *RootCLI) { c.defaultReadFields = columns }
+}
+
+// WithReadPresets injects the user-defined read presets loaded from
+// ~/.config/traceary/config.json. The builtin preset catalog is always
+// available; these entries merge on top and override built-in names on
+// collision (with a stderr warning from the resolver).
+func WithReadPresets(presets map[string]presentation.ReadPreset) RootCLIOption {
+	return func(c *RootCLI) { c.readPresets = presets }
 }
 
 // WithDatabasePathSetter injects a callback invoked by every subcommand

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -32,6 +32,7 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 		wide         bool
 		utc          bool
 		fields       []string
+		preset       string
 	)
 
 	searchCmd := &cobra.Command{
@@ -43,26 +44,34 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 			if len(args) == 1 {
 				query = args[0]
 			}
-			return c.runSearch(cmd.Context(), cmd.OutOrStdout(), searchCommandInput{
-				dbPath:       dbPath,
-				repo:         repo,
-				sessionID:    sessionID,
-				client:       client,
-				agent:        agent,
-				kind:         kind,
-				from:         from,
-				since:        since,
-				to:           to,
-				until:        until,
-				limit:        limit,
-				offset:       offset,
-				query:        query,
-				failuresOnly: failuresOnly,
-				asJSON:       asJSON,
-				wide:         wide,
-				utc:          utc,
-				fields:       fields,
-				fieldsSet:    cmd.Flags().Changed("fields"),
+			return c.runSearch(cmd.Context(), cmd.ErrOrStderr(), cmd.OutOrStdout(), searchCommandInput{
+				dbPath:          dbPath,
+				repo:            repo,
+				sessionID:       sessionID,
+				client:          client,
+				agent:           agent,
+				kind:            kind,
+				from:            from,
+				since:           since,
+				to:              to,
+				until:           until,
+				limit:           limit,
+				offset:          offset,
+				query:           query,
+				failuresOnly:    failuresOnly,
+				asJSON:          asJSON,
+				wide:            wide,
+				utc:             utc,
+				fields:          fields,
+				fieldsSet:       cmd.Flags().Changed("fields"),
+				preset:          preset,
+				presetSet:       cmd.Flags().Changed("preset"),
+				kindSet:         cmd.Flags().Changed("kind"),
+				clientSet:       cmd.Flags().Changed("client"),
+				agentSet:        cmd.Flags().Changed("agent"),
+				sessionIDSet:    cmd.Flags().Changed("session-id"),
+				repoSet:         cmd.Flags().Changed("workspace"),
+				failuresOnlySet: cmd.Flags().Changed("failures"),
 			})
 		},
 	}
@@ -91,11 +100,12 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 	searchCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
 	searchCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 	searchCmd.Flags().StringSliceVar(&fields, "fields", nil, readFieldsFlagUsage())
+	searchCmd.Flags().StringVar(&preset, "preset", "", readPresetsFlagUsage())
 
 	return searchCmd
 }
 
-func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchCommandInput) error {
+func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io.Writer, input searchCommandInput) error {
 	if c.storeManagement == nil {
 		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
 	}
@@ -108,6 +118,11 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 	if input.offset < 0 {
 		return xerrors.Errorf(Localize("offset must be greater than or equal to 0", "offset は 0 以上である必要があります"))
 	}
+	preset, _, err := resolveReadPreset(input.preset, c.readPresets, warnWriter)
+	if err != nil {
+		return err
+	}
+	applyReadPresetToSearchInput(&input, preset)
 
 	resolvedDBPath, err := resolveDBPath(input.dbPath)
 	if err != nil {
@@ -163,7 +178,7 @@ func (c *RootCLI) runSearch(ctx context.Context, output io.Writer, input searchC
 		return xerrors.Errorf("%s: %w", Localize("failed to search events", "検索に失敗しました"), err)
 	}
 
-	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON)
+	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON, preset.fields)
 	if err != nil {
 		return err
 	}

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -195,6 +195,7 @@ func (c *RootCLI) newTailCommand() *cobra.Command {
 		wide         bool
 		utc          bool
 		fields       []string
+		preset       string
 	)
 
 	tailCmd := &cobra.Command{
@@ -202,20 +203,28 @@ func (c *RootCLI) newTailCommand() *cobra.Command {
 		Short: Localize("Follow new events as they arrive", "新しいイベントを追跡表示する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return c.runTail(cmd.Context(), cmd.OutOrStdout(), tailCommandInput{
-				dbPath:       dbPath,
-				limit:        limit,
-				kind:         kind,
-				client:       client,
-				agent:        agent,
-				sessionID:    sessionID,
-				repo:         repo,
-				failuresOnly: failuresOnly,
-				asJSON:       asJSON,
-				wide:         wide,
-				utc:          utc,
-				fields:       fields,
-				fieldsSet:    cmd.Flags().Changed("fields"),
+			return c.runTail(cmd.Context(), cmd.ErrOrStderr(), cmd.OutOrStdout(), tailCommandInput{
+				dbPath:          dbPath,
+				limit:           limit,
+				kind:            kind,
+				client:          client,
+				agent:           agent,
+				sessionID:       sessionID,
+				repo:            repo,
+				failuresOnly:    failuresOnly,
+				asJSON:          asJSON,
+				wide:            wide,
+				utc:             utc,
+				fields:          fields,
+				fieldsSet:       cmd.Flags().Changed("fields"),
+				preset:          preset,
+				presetSet:       cmd.Flags().Changed("preset"),
+				kindSet:         cmd.Flags().Changed("kind"),
+				clientSet:       cmd.Flags().Changed("client"),
+				agentSet:        cmd.Flags().Changed("agent"),
+				sessionIDSet:    cmd.Flags().Changed("session-id"),
+				repoSet:         cmd.Flags().Changed("workspace"),
+				failuresOnlySet: cmd.Flags().Changed("failures"),
 			})
 		},
 	}
@@ -231,11 +240,12 @@ func (c *RootCLI) newTailCommand() *cobra.Command {
 	tailCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
 	tailCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
 	tailCmd.Flags().StringSliceVar(&fields, "fields", nil, readFieldsFlagUsage())
+	tailCmd.Flags().StringVar(&preset, "preset", "", readPresetsFlagUsage())
 
 	return tailCmd
 }
 
-func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailCommandInput) error {
+func (c *RootCLI) runTail(ctx context.Context, warnWriter io.Writer, output io.Writer, input tailCommandInput) error {
 	if c.storeManagement == nil {
 		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
 	}
@@ -245,6 +255,11 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 	if input.limit < 0 {
 		return xerrors.Errorf(Localize("limit must be greater than or equal to 0", "limit は 0 以上である必要があります"))
 	}
+	preset, _, err := resolveReadPreset(input.preset, c.readPresets, warnWriter)
+	if err != nil {
+		return err
+	}
+	applyReadPresetToTailInput(&input, preset)
 	resolvedKind, err := resolveListKind(input.kind)
 	if err != nil {
 		return err
@@ -267,7 +282,7 @@ func (c *RootCLI) runTail(ctx context.Context, output io.Writer, input tailComma
 		Workspace(types.Workspace(resolveWorkspaceValue(ctx, input.repo))).
 		FailuresOnly(input.failuresOnly)
 
-	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON)
+	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON, preset.fields)
 	if err != nil {
 		return err
 	}

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -146,7 +146,7 @@ func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+		errCh <- sut.runTail(ctx, &bytes.Buffer{}, stdout, tailCommandInput{
 			dbPath:        "/tmp/test-traceary.db",
 			limit:         2,
 			client:        "cli",
@@ -208,7 +208,7 @@ func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+		errCh <- sut.runTail(ctx, &bytes.Buffer{}, stdout, tailCommandInput{
 			dbPath:        "/tmp/test-traceary.db",
 			limit:         0,
 			repo:          "duck8823/traceary",
@@ -254,7 +254,7 @@ func TestRunTail_JSONOutputsNDJSON(t *testing.T) {
 		WithEvent(eventStub),
 	)
 
-	if err := sut.runTail(ctx, stdout, tailCommandInput{
+	if err := sut.runTail(ctx, &bytes.Buffer{}, stdout, tailCommandInput{
 		dbPath:        "/tmp/test-traceary.db",
 		limit:         1,
 		repo:          "duck8823/traceary",
@@ -324,7 +324,7 @@ func TestRunTail_DoesNotReEmitBoundaryEventWhenFromEqualsInitialTimestamp(t *tes
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- sut.runTail(ctx, stdout, tailCommandInput{
+		errCh <- sut.runTail(ctx, &bytes.Buffer{}, stdout, tailCommandInput{
 			dbPath:        "/tmp/test-traceary.db",
 			limit:         1,
 			client:        "cli",

--- a/presentation/config.go
+++ b/presentation/config.go
@@ -19,7 +19,28 @@ type redactSection struct {
 }
 
 type readSection struct {
-	Fields []string `json:"fields"`
+	Fields  []string                 `json:"fields"`
+	Presets map[string]readPresetDoc `json:"presets"`
+}
+
+// readPresetDoc mirrors a user-defined read preset entry in config.json. The
+// fields are intentionally loose so LoadConfig stays lenient — preset
+// validation (unknown field names, unsupported kinds, etc.) happens when a
+// preset is applied at command runtime.
+type readPresetDoc struct {
+	Fields  []string          `json:"fields"`
+	Filters readPresetFilters `json:"filters"`
+}
+
+// readPresetFilters lists the filter keys a preset can carry. Only filters
+// that every read command (tail / list / search) can consume are included.
+type readPresetFilters struct {
+	Kind      string `json:"kind"`
+	Failures  *bool  `json:"failures"`
+	Workspace string `json:"workspace"`
+	SessionID string `json:"session_id"`
+	Client    string `json:"client"`
+	Agent     string `json:"agent"`
 }
 
 // Config carries the resolved configuration values consumed by the CLI and
@@ -33,6 +54,30 @@ type Config struct {
 	// text output when the user does not pass --fields. Nil / empty means
 	// "fall back to the built-in default column order".
 	ReadFields []string
+	// ReadPresets captures user-defined read presets. The runtime validates
+	// field names, kind values, and other constraints when a preset is
+	// applied; LoadConfig only parses the shape.
+	ReadPresets map[string]ReadPreset
+}
+
+// ReadPreset is the runtime-facing view of a user-defined preset loaded from
+// config.json. It intentionally uses plain fields so callers can apply a
+// preset without importing JSON tag types from this package.
+type ReadPreset struct {
+	Fields  []string
+	Filters ReadPresetFilters
+}
+
+// ReadPresetFilters lists the filter keys a preset can carry. Presence
+// (non-zero value) is what matters to the runtime; the preset applies the
+// filter only when the corresponding key is set.
+type ReadPresetFilters struct {
+	Kind      string
+	Failures  *bool
+	Workspace string
+	SessionID string
+	Client    string
+	Agent     string
 }
 
 // LoadConfig reads the optional Traceary config file and returns a Config.
@@ -47,7 +92,29 @@ func LoadConfig() Config {
 	return Config{
 		ExtraRedactPatterns: file.Redact.ExtraPatterns,
 		ReadFields:          file.Read.Fields,
+		ReadPresets:         toReadPresetMap(file.Read.Presets),
 	}
+}
+
+func toReadPresetMap(raw map[string]readPresetDoc) map[string]ReadPreset {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]ReadPreset, len(raw))
+	for name, doc := range raw {
+		out[name] = ReadPreset{
+			Fields: append([]string(nil), doc.Fields...),
+			Filters: ReadPresetFilters{
+				Kind:      doc.Filters.Kind,
+				Failures:  doc.Filters.Failures,
+				Workspace: doc.Filters.Workspace,
+				SessionID: doc.Filters.SessionID,
+				Client:    doc.Filters.Client,
+				Agent:     doc.Filters.Agent,
+			},
+		}
+	}
+	return out
 }
 
 // LoadExtraRedactPatterns preserves the earlier API so callers that only need


### PR DESCRIPTION
Closes #554.

## Summary

v0.6.1 introduced compact output, #553 added `--fields` + `read.fields`. This PR layers saved view presets on top: `--preset failures` / `--preset prompts-only` / `--preset compact-summaries` for built-in entries, and `read.presets.<name>` in `~/.config/traceary/config.json` for user-defined ones. Explicit filter flags always win over a preset; explicit `--fields` always wins over preset fields; `--wide` / `--json` keep ignoring field overrides so the machine-readable contract from v0.6.1 is preserved.

## Changes

1. **Config** — `presentation/config.go` accepts `read.presets` next to `read.fields`. The loader stays lenient (validation at preset-apply time).
2. **Preset registry** — new `presentation/cli/read_presets.go` with three built-in presets, user-defined merge, closed-registry validation for field names and kind values, a stderr `[WARN]` banner when a user-defined preset shadows a built-in name, and per-command `applyReadPresetTo*Input` helpers.
3. **CLI flags** — `--preset <name>` added to list / search / tail. Input structs track which filter flags were explicitly set so `applyReadPresetTo*Input` only fills unset slots. `runSearch` now accepts preset filters as its constraints when no free-text query is provided.
4. **Field precedence** — `resolveReadFieldsForCommand` grows a `presetFields` argument. The final order is `--fields > preset fields > read.fields > built-in default`. `--wide` / `--json` still short-circuit to the built-in default.
5. **Docs** — `docs/cli/README.md` (+ JA) document `--preset` on all three commands; `docs/environment/README.md` (+ JA) describe `read.presets` alongside the existing `read.fields` entry with an extended JSON example.

## Test plan

- [x] `go test ./...` passes (new `read_presets_test.go` + extended `read_fields_test.go`)
- [x] `go tool golangci-lint run` passes (0 issues)
- [x] Built-in `failures` preset adds `exit_code` to compact output
- [x] User-defined preset overrides a built-in with a `[WARN]` on stderr
- [x] Unknown preset prints a clear error naming the built-in catalog
- [x] Explicit `--kind` / `--failures` / `--workspace` override preset values
- [x] `--wide` / `--json` ignore preset fields but still apply preset filters
- [ ] Manual smoke: `traceary list --preset failures`, `traceary search --preset prompts-only`, `traceary tail --preset compact-summaries --json` (to attach on review)

## Notes for review

- The "failures preset highlights exit_code" requirement from the issue is implemented by field ordering (exit_code right after kind), not ANSI color. That matches the current formatter capabilities; when #555 lands we can flip it to real highlighting.
- `resolveReadPreset` warns for every collision in the user-defined map, not only for the preset the caller requested, so `doctor` could consume the same helper later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)