### PR TITLE
feat(session-tree): subagent lineage + --root / --ongoing-only

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -402,6 +402,18 @@ session の一覧サマリーを表示します。
 - `--offset`
 - `--json`
 
+### `traceary session tree`
+
+読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: `claude:explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / `duration_ms` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
+
+主な flag:
+
+- `--workspace`
+- `--limit`
+- `--root <session-id>` — 指定 session を root とするサブツリーのみ表示
+- `--ongoing-only` — active session を含む lineage だけを残す
+- `--json`
+
 ### `traceary session label <label-text>`
 
 session の label を設定または更新します。

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -404,7 +404,7 @@ session の一覧サマリーを表示します。
 
 ### `traceary session tree`
 
-読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: `claude:explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / `duration_ms` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
+読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: Claude Code の subagent なら `claude/Explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / `duration_ms` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -404,7 +404,7 @@ Useful flags:
 
 ### `traceary session tree`
 
-Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude:explore`), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, `duration_ms`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
+Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude/Explore` for Claude Code subagents), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, `duration_ms`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
 
 Useful flags:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -402,6 +402,18 @@ Useful flags:
 - `--offset`
 - `--json`
 
+### `traceary session tree`
+
+Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude:explore`), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, `duration_ms`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
+
+Useful flags:
+
+- `--workspace`
+- `--limit`
+- `--root <session-id>` — focus on the subtree rooted at the given session
+- `--ongoing-only` — keep only lineages that still contain an active session
+- `--json`
+
 ### `traceary session label <label-text>`
 
 Set or update a session label.

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -37,18 +37,22 @@ type contextOutput struct {
 
 // sessionTreeNode is the JSON shape of a single session in the tree output.
 type sessionTreeNode struct {
-	SessionID    string             `json:"session_id"`
-	Workspace    string             `json:"workspace,omitempty"`
-	Label        string             `json:"label,omitempty"`
-	Summary      string             `json:"summary,omitempty"`
-	StartedAt    string             `json:"started_at"`
-	EndedAt      *string            `json:"ended_at,omitempty"`
-	Status       string             `json:"status"`
-	DurationSec  *float64           `json:"duration_sec,omitempty"`
-	TotalEvents  int                `json:"total_events"`
-	CommandCount int                `json:"command_count"`
-	Agents       []string           `json:"agents"`
-	Children     []*sessionTreeNode `json:"children"`
+	SessionID       string             `json:"session_id"`
+	ParentSessionID string             `json:"parent_session_id,omitempty"`
+	Depth           int                `json:"depth"`
+	Workspace       string             `json:"workspace,omitempty"`
+	Label           string             `json:"label,omitempty"`
+	Summary         string             `json:"summary,omitempty"`
+	StartedAt       string             `json:"started_at"`
+	EndedAt         *string            `json:"ended_at,omitempty"`
+	Status          string             `json:"status"`
+	DurationSec     *float64           `json:"duration_sec,omitempty"`
+	DurationMs      *int64             `json:"duration_ms,omitempty"`
+	TotalEvents     int                `json:"total_events"`
+	CommandCount    int                `json:"command_count"`
+	Agents          []string           `json:"agents"`
+	SubagentType    string             `json:"subagent_type,omitempty"`
+	Children        []*sessionTreeNode `json:"children"`
 }
 
 // memorySummaryOutput is the JSON shape of a durable memory summary in CLI output.

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -169,12 +169,13 @@ func pruneEndedLineages(node *sessionNode) bool {
 	return len(node.children) > 0
 }
 
+// isSessionActive treats only sessions with status=active as live. A
+// session that has not received an end event but has aged past the store
+// timeout is already marked status=stale by the SQLite datasource, and
+// --ongoing-only explicitly promises "at least one active session" — so
+// stale lineages must not resurface as ongoing work.
 func isSessionActive(summary apptypes.SessionSummary) bool {
-	if summary.Status() == "active" {
-		return true
-	}
-	_, ended := summary.EndedAt().Value()
-	return !ended
+	return summary.Status() == "active"
 }
 
 func writeSessionTreeEmpty(output io.Writer, asJSON bool) error {
@@ -223,18 +224,18 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 }
 
 // extractSubagentType returns the most specific subagent role the session
-// participated in. The captured agents slice stores values like "claude" or
-// "claude:explore"; tree consumers want a single string to colour or filter
-// on, so the helper picks the first entry that carries a `:role` suffix
-// and falls back to the first agent when none do. The helper always
-// returns an empty string for no-agent sessions so the JSON field is
-// omitted via `omitempty`.
+// participated in. Hook capture writes hierarchical agent names as
+// `<client>/<role>` (for example `claude/Explore` or `claude/planner`), so
+// tree consumers want a single string to colour or filter on; the helper
+// picks the first entry that carries a `/role` suffix and falls back to
+// the first agent when none do. The helper always returns an empty string
+// for no-agent sessions so the JSON field is omitted via `omitempty`.
 func extractSubagentType(agents []string) string {
 	if len(agents) == 0 {
 		return ""
 	}
 	for _, agent := range agents {
-		if strings.Contains(agent, ":") {
+		if strings.Contains(agent, "/") {
 			return agent
 		}
 	}

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,10 +16,12 @@ import (
 
 func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 	var (
-		dbPath string
-		repo   string
-		limit  int
-		asJSON bool
+		dbPath       string
+		repo         string
+		limit        int
+		asJSON       bool
+		rootID       string
+		ongoingOnly  bool
 	)
 
 	cmd := &cobra.Command{
@@ -48,7 +51,11 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
 			}
 
-			return writeSessionTree(output, summaries, asJSON)
+			return writeSessionTreeFiltered(output, summaries, sessionTreeFilter{
+				root:        rootID,
+				ongoingOnly: ongoingOnly,
+				asJSON:      asJSON,
+			})
 		},
 	}
 
@@ -56,8 +63,22 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	cmd.Flags().IntVar(&limit, "limit", 50, Localize("maximum number of sessions to load", "読み込む最大セッション数"))
 	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	cmd.Flags().StringVar(&rootID, "root", "", Localize(
+		"focus on the subtree rooted at the given session id (printed as the tree root when provided)",
+		"指定 session id を root とするサブツリーだけを表示する",
+	))
+	cmd.Flags().BoolVar(&ongoingOnly, "ongoing-only", false, Localize(
+		"keep only lineages that contain at least one active session",
+		"active session を少なくとも1つ含む lineage だけに絞る",
+	))
 
 	return cmd
+}
+
+type sessionTreeFilter struct {
+	root        string
+	ongoingOnly bool
+	asJSON      bool
 }
 
 type sessionNode struct {
@@ -65,18 +86,9 @@ type sessionNode struct {
 	children []*sessionNode
 }
 
-func writeSessionTree(output io.Writer, summaries []apptypes.SessionSummary, asJSON bool) error {
+func writeSessionTreeFiltered(output io.Writer, summaries []apptypes.SessionSummary, filter sessionTreeFilter) error {
 	if len(summaries) == 0 {
-		if asJSON {
-			if _, err := fmt.Fprintln(output, "[]"); err != nil {
-				return xerrors.Errorf("failed to print empty JSON array: %w", err)
-			}
-			return nil
-		}
-		if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
-			return xerrors.Errorf("failed to print empty message: %w", err)
-		}
-		return nil
+		return writeSessionTreeEmpty(output, filter.asJSON)
 	}
 
 	// Build tree
@@ -99,7 +111,24 @@ func writeSessionTree(output io.Writer, summaries []apptypes.SessionSummary, asJ
 		roots = append(roots, node)
 	}
 
-	if asJSON {
+	if filter.root != "" {
+		if rootNode, ok := nodeMap[filter.root]; ok {
+			roots = []*sessionNode{rootNode}
+		} else {
+			// Requested root not in the loaded window; treat as empty
+			// result rather than silently printing every root.
+			return writeSessionTreeEmpty(output, filter.asJSON)
+		}
+	}
+
+	if filter.ongoingOnly {
+		roots = keepOngoingLineages(roots)
+		if len(roots) == 0 {
+			return writeSessionTreeEmpty(output, filter.asJSON)
+		}
+	}
+
+	if filter.asJSON {
 		return writeSessionTreeJSON(output, roots)
 	}
 
@@ -112,36 +141,110 @@ func writeSessionTree(output io.Writer, summaries []apptypes.SessionSummary, asJ
 	return nil
 }
 
-func sessionNodeToOutput(node *sessionNode) *sessionTreeNode {
+// keepOngoingLineages prunes every subtree whose sessions are all ended so
+// --ongoing-only surfaces active work without hiding the static lineage
+// around it. A parent is retained when either the parent itself is active
+// or any descendant is.
+func keepOngoingLineages(roots []*sessionNode) []*sessionNode {
+	filtered := make([]*sessionNode, 0, len(roots))
+	for _, root := range roots {
+		if pruneEndedLineages(root) {
+			filtered = append(filtered, root)
+		}
+	}
+	return filtered
+}
+
+func pruneEndedLineages(node *sessionNode) bool {
+	keptChildren := node.children[:0]
+	for _, child := range node.children {
+		if pruneEndedLineages(child) {
+			keptChildren = append(keptChildren, child)
+		}
+	}
+	node.children = keptChildren
+	if isSessionActive(node.summary) {
+		return true
+	}
+	return len(node.children) > 0
+}
+
+func isSessionActive(summary apptypes.SessionSummary) bool {
+	if summary.Status() == "active" {
+		return true
+	}
+	_, ended := summary.EndedAt().Value()
+	return !ended
+}
+
+func writeSessionTreeEmpty(output io.Writer, asJSON bool) error {
+	if asJSON {
+		if _, err := fmt.Fprintln(output, "[]"); err != nil {
+			return xerrors.Errorf("failed to print empty JSON array: %w", err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintln(output, Localize("No sessions found.", "セッションが見つかりません")); err != nil {
+		return xerrors.Errorf("failed to print empty message: %w", err)
+	}
+	return nil
+}
+
+func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 	s := node.summary
 	jn := &sessionTreeNode{
-		SessionID:    string(s.SessionID()),
-		Workspace:    string(s.Workspace()),
-		Label:        s.Label(),
-		Summary:      s.Summary(),
-		StartedAt:    s.StartedAt().UTC().Format(time.RFC3339),
-		Status:       s.Status(),
-		TotalEvents:  s.TotalEvents(),
-		CommandCount: s.CommandCount(),
-		Agents:       s.Agents(),
-		Children:     make([]*sessionTreeNode, 0, len(node.children)),
+		SessionID:       string(s.SessionID()),
+		ParentSessionID: s.ParentSessionID().String(),
+		Depth:           depth,
+		Workspace:       string(s.Workspace()),
+		Label:           s.Label(),
+		Summary:         s.Summary(),
+		StartedAt:       s.StartedAt().UTC().Format(time.RFC3339),
+		Status:          s.Status(),
+		TotalEvents:     s.TotalEvents(),
+		CommandCount:    s.CommandCount(),
+		Agents:          s.Agents(),
+		SubagentType:    extractSubagentType(s.Agents()),
+		Children:        make([]*sessionTreeNode, 0, len(node.children)),
 	}
 	if endedAt, ok := s.EndedAt().Value(); ok {
 		endStr := endedAt.UTC().Format(time.RFC3339)
 		jn.EndedAt = &endStr
-		dur := endedAt.Sub(s.StartedAt()).Seconds()
-		jn.DurationSec = &dur
+		dur := endedAt.Sub(s.StartedAt())
+		secs := dur.Seconds()
+		ms := dur.Milliseconds()
+		jn.DurationSec = &secs
+		jn.DurationMs = &ms
 	}
 	for _, child := range node.children {
-		jn.Children = append(jn.Children, sessionNodeToOutput(child))
+		jn.Children = append(jn.Children, sessionNodeToOutput(child, depth+1))
 	}
 	return jn
+}
+
+// extractSubagentType returns the most specific subagent role the session
+// participated in. The captured agents slice stores values like "claude" or
+// "claude:explore"; tree consumers want a single string to colour or filter
+// on, so the helper picks the first entry that carries a `:role` suffix
+// and falls back to the first agent when none do. The helper always
+// returns an empty string for no-agent sessions so the JSON field is
+// omitted via `omitempty`.
+func extractSubagentType(agents []string) string {
+	if len(agents) == 0 {
+		return ""
+	}
+	for _, agent := range agents {
+		if strings.Contains(agent, ":") {
+			return agent
+		}
+	}
+	return agents[0]
 }
 
 func writeSessionTreeJSON(output io.Writer, roots []*sessionNode) error {
 	items := make([]*sessionTreeNode, 0, len(roots))
 	for _, root := range roots {
-		items = append(items, sessionNodeToOutput(root))
+		items = append(items, sessionNodeToOutput(root, 0))
 	}
 	encoder := json.NewEncoder(output)
 	encoder.SetIndent("", "  ")
@@ -172,13 +275,21 @@ func printNode(output io.Writer, node *sessionNode, prefix string, isLast bool) 
 		label = fmt.Sprintf(" [%s]", s.Label())
 	}
 
-	line := fmt.Sprintf("%s%s%s [%s] %s (%s, %d cmds)%s\n",
+	subagent := extractSubagentType(s.Agents())
+	subagentFragment := ""
+	if subagent != "" {
+		subagentFragment = " " + subagent
+	}
+
+	line := fmt.Sprintf("%s%s%s [%s]%s %s (%s, %d cmds/%d events)%s\n",
 		prefix, connector,
 		s.SessionID(),
 		s.Status(),
+		subagentFragment,
 		formatOptionalColumn(s.Workspace().String()),
 		duration,
 		s.CommandCount(),
+		s.TotalEvents(),
 		label,
 	)
 

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -197,7 +197,7 @@ func TestRootCLI_SessionTreeCommand_LineageFields(t *testing.T) {
 				"ended",
 				4,
 				3,
-				[]string{"claude:explore"},
+				[]string{"claude/explore"},
 				"",
 				"",
 				types.SessionID("parent-session"),
@@ -253,7 +253,7 @@ func TestRootCLI_SessionTreeCommand_LineageFields(t *testing.T) {
 		t.Fatalf("unexpected children: %+v", root.Children)
 	}
 	child := root.Children[0]
-	if child.Depth != 1 || child.ParentSessionID != "parent-session" || child.SubagentType != "claude:explore" {
+	if child.Depth != 1 || child.ParentSessionID != "parent-session" || child.SubagentType != "claude/explore" {
 		t.Fatalf("unexpected child: %+v", child)
 	}
 }
@@ -281,7 +281,7 @@ func TestRootCLI_SessionTreeCommand_RootFilter(t *testing.T) {
 				types.SessionID("child-of-b"),
 				types.Workspace("ws"),
 				started, types.Some(ended),
-				"ended", 1, 1, []string{"codex:explore"}, "", "", types.SessionID("root-b"),
+				"ended", 1, 1, []string{"codex/explore"}, "", "", types.SessionID("root-b"),
 			),
 		},
 	}
@@ -333,6 +333,15 @@ func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
 				started, types.Some(ended),
 				"ended", 1, 1, []string{"codex"}, "", "", types.SessionID("dead-root"),
 			),
+			// Stale (status=stale, no end event) sessions must not leak into
+			// --ongoing-only output — once the datasource has promoted them
+			// to stale, they are no longer the live work the flag promises.
+			apptypes.SessionSummaryOf(
+				types.SessionID("stale-root"),
+				types.Workspace("ws"),
+				started, types.None[time.Time](),
+				"stale", 1, 0, []string{"claude"}, "", "", types.SessionID(""),
+			),
 		},
 	}
 	stdout := &bytes.Buffer{}
@@ -352,5 +361,8 @@ func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
 	}
 	if strings.Contains(out, "dead-root") || strings.Contains(out, "dead-child") {
 		t.Fatalf("--ongoing-only should prune dead lineage, got %q", out)
+	}
+	if strings.Contains(out, "stale-root") {
+		t.Fatalf("--ongoing-only should prune stale sessions, got %q", out)
 	}
 }

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -168,3 +168,189 @@ func TestRootCLI_SessionTreeCommand_JSON(t *testing.T) {
 		}
 	})
 }
+
+func TestRootCLI_SessionTreeCommand_LineageFields(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	ended := started.Add(90 * time.Second)
+	listStub := &sessionUsecaseStub{
+		listResult: []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(
+				types.SessionID("parent-session"),
+				types.Workspace("duck8823/traceary"),
+				started,
+				types.Some(ended),
+				"ended",
+				12,
+				8,
+				[]string{"claude"},
+				"",
+				"",
+				types.SessionID(""),
+			),
+			apptypes.SessionSummaryOf(
+				types.SessionID("child-session"),
+				types.Workspace("duck8823/traceary"),
+				started.Add(5*time.Second),
+				types.Some(ended),
+				"ended",
+				4,
+				3,
+				[]string{"claude:explore"},
+				"",
+				"",
+				types.SessionID("parent-session"),
+			),
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(listStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "tree", "--db-path", "/tmp/test-traceary.db", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var trees []struct {
+		SessionID       string  `json:"session_id"`
+		ParentSessionID string  `json:"parent_session_id"`
+		Depth           int     `json:"depth"`
+		DurationMs      *int64  `json:"duration_ms"`
+		DurationSec     *float64 `json:"duration_sec"`
+		SubagentType    string  `json:"subagent_type"`
+		Children        []struct {
+			SessionID       string `json:"session_id"`
+			ParentSessionID string `json:"parent_session_id"`
+			Depth           int    `json:"depth"`
+			SubagentType    string `json:"subagent_type"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &trees); err != nil {
+		t.Fatalf("json.Unmarshal: %v (body=%s)", err, stdout.String())
+	}
+	if len(trees) != 1 || trees[0].SessionID != "parent-session" {
+		t.Fatalf("unexpected tree shape: %+v", trees)
+	}
+	root := trees[0]
+	if root.Depth != 0 {
+		t.Fatalf("root depth = %d, want 0", root.Depth)
+	}
+	if root.ParentSessionID != "" {
+		t.Fatalf("root parent_session_id = %q, want empty", root.ParentSessionID)
+	}
+	if root.DurationMs == nil || *root.DurationMs != 90_000 {
+		t.Fatalf("root duration_ms = %v, want 90000", root.DurationMs)
+	}
+	if root.SubagentType != "claude" {
+		t.Fatalf("root subagent_type = %q, want claude", root.SubagentType)
+	}
+	if len(root.Children) != 1 || root.Children[0].SessionID != "child-session" {
+		t.Fatalf("unexpected children: %+v", root.Children)
+	}
+	child := root.Children[0]
+	if child.Depth != 1 || child.ParentSessionID != "parent-session" || child.SubagentType != "claude:explore" {
+		t.Fatalf("unexpected child: %+v", child)
+	}
+}
+
+func TestRootCLI_SessionTreeCommand_RootFilter(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	ended := started.Add(time.Minute)
+	listStub := &sessionUsecaseStub{
+		listResult: []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(
+				types.SessionID("root-a"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 3, 2, []string{"claude"}, "", "", types.SessionID(""),
+			),
+			apptypes.SessionSummaryOf(
+				types.SessionID("root-b"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 3, 2, []string{"codex"}, "", "", types.SessionID(""),
+			),
+			apptypes.SessionSummaryOf(
+				types.SessionID("child-of-b"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 1, 1, []string{"codex:explore"}, "", "", types.SessionID("root-b"),
+			),
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(listStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "tree", "--db-path", "/tmp/test-traceary.db", "--root", "root-b"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "root-b") {
+		t.Fatalf("--root root-b should keep root-b, got %q", out)
+	}
+	if strings.Contains(out, "root-a") {
+		t.Fatalf("--root root-b should hide root-a, got %q", out)
+	}
+	if !strings.Contains(out, "child-of-b") {
+		t.Fatalf("--root root-b should keep its descendant, got %q", out)
+	}
+}
+
+func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	ended := started.Add(time.Minute)
+	listStub := &sessionUsecaseStub{
+		listResult: []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(
+				types.SessionID("live-root"),
+				types.Workspace("ws"),
+				started, types.None[time.Time](),
+				"active", 1, 0, []string{"claude"}, "", "", types.SessionID(""),
+			),
+			apptypes.SessionSummaryOf(
+				types.SessionID("dead-root"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 3, 2, []string{"codex"}, "", "", types.SessionID(""),
+			),
+			apptypes.SessionSummaryOf(
+				types.SessionID("dead-child"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 1, 1, []string{"codex"}, "", "", types.SessionID("dead-root"),
+			),
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(listStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "tree", "--db-path", "/tmp/test-traceary.db", "--ongoing-only"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "live-root") {
+		t.Fatalf("--ongoing-only should keep live-root, got %q", out)
+	}
+	if strings.Contains(out, "dead-root") || strings.Contains(out, "dead-child") {
+		t.Fatalf("--ongoing-only should prune dead lineage, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `parent_session_id`, `depth`, `duration_ms`, and `subagent_type` to `session tree --json` nodes for external tooling.
- Surface subagent role (e.g. `claude:explore`) and `N cmds / M events` breakdown in the text output.
- Add `--root <session-id>` and `--ongoing-only` filters for focused views.
- Presentation-layer only — no schema changes (reuses existing `agents` and `parent_session_id` columns).

Closes #561.

## Test plan

- [x] `go test ./...` (3 new lineage/filter/extractor tests)
- [x] `go vet ./...`
- [x] `go tool golangci-lint run` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)