### PR TITLE
fix(sqlite): enable WAL + busy_timeout to eliminate SQLITE_BUSY under concurrent hook writes

### DIFF
--- a/docs/backup/README.ja.md
+++ b/docs/backup/README.ja.md
@@ -54,6 +54,8 @@ traceary backup restore --input /tmp/traceary-backup.db --force
 - destination を上書きするのは `--force` を渡したときだけです
 - destination DB path の解決順は通常どおり `--db-path` → `TRACEARY_DB_PATH` → `~/.config/traceary/traceary.db` です
 - マシン外に保存したい場合は、その SQLite file を既存の暗号化ディスク / backup tooling で保護してください
+- **`traceary backup create` の出力は単一ファイルとしてそのままコピーして安全** — `VACUUM INTO` で固めているため WAL sidecar は生成されません
+- **稼働中の DB を直接コピーする場合は WAL sidecar も必要** — runtime の DB は `journal_mode=WAL` を使用しており、本体の隣に `<db>-wal` と `<db>-shm` が生成されます。外部のファイルレベル backup ツールで `.db` だけをスナップショットすると不整合なコピーになる恐れがあるため、`traceary backup create` を使うか、sidecar も一緒にコピーしてください
 
 ## この release でやらないこと
 

--- a/docs/backup/README.md
+++ b/docs/backup/README.md
@@ -54,6 +54,8 @@ One practical flow is:
 - restores overwrite the destination only when you pass `--force`
 - the destination DB path still follows the normal resolution order: `--db-path` → `TRACEARY_DB_PATH` → `~/.config/traceary/traceary.db`
 - if you need off-machine storage, use your existing encrypted disk / backup tooling around the SQLite file
+- **`traceary backup create` output is safe to copy as a single file** — it is produced via `VACUUM INTO`, so it has no WAL sidecar to worry about
+- **copying a live DB directly requires the WAL sidecars too** — the runtime DB uses `journal_mode=WAL`, which generates `<db>-wal` and `<db>-shm` files next to the main DB. External file-level tooling that snapshots only the `.db` file can produce an inconsistent copy; prefer `traceary backup create` or include both sidecars in the copy
 
 ## Non-goals for this release
 

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -15,17 +15,26 @@ Traceary は、process 間調停を SQLite 自身に委ねています。
 - write は小さな append 系操作（`events`、`command_audits`、session 境界）が中心
 - file level の write 直列化は SQLite が安全に扱う
 
+Traceary が接続時に適用している設定:
+
+- `journal_mode=WAL` — reader（例: `traceary tail` の poll）と writer が互いをブロックせず並行に処理できる
+- `synchronous=NORMAL` — WAL モードで推奨される durability 設定。fsync は checkpoint 境界でのみ実行される
+- `busy_timeout=5000` — 一時的なロック競合時は最大 5 秒 SQLite が自動で retry し、`SQLITE_BUSY` を即座に返さない
+- `foreign_keys=1` — 外部キー制約を有効化
+
+WAL モードは DB 本体の横に `<db>-wal` と `<db>-shm` の sidecar file を生成します。バックアップ/リストアはこれらを既に扱っていますが、手動で DB をコピーする場合は sidecar も一緒にコピーする必要があります。
+
 現在 Traceary が**追加していない**もの:
 
 - custom background writer や queue
-- 継続的な `database is locked` 圧に対する application-level retry loop
+- SQLite の `busy_timeout` を超える application-level retry loop
 - distributed / multi-host coordination
 
 実務上の見方:
 
 - 1 台のマシンで数本の並列 AI session を回す用途はスコープ内
 - 同じ DB path に対する極端に高い write volume は、現時点で tuning 対象ではない
-- SQLite lock error が繰り返し出る場合は、並列 writer を減らす、作業フローごとに DB path を分ける、競合 process が終わってから再実行する、の順で対処してください
+- 5 秒の busy window を超えて `SQLITE_BUSY` が出る場合は、並列 writer を減らす、作業フローごとに DB path を分ける、で対処してください
 
 ## Hook session state の前提
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -15,17 +15,26 @@ Current assumptions:
 - writes are small append-style operations (`events`, `command_audits`, session boundaries)
 - SQLite serializes those writes safely at the file level
 
+Connection settings applied by Traceary:
+
+- `journal_mode=WAL` — readers (e.g. `traceary tail` polling) and writers can proceed concurrently without blocking each other
+- `synchronous=NORMAL` — the recommended durability setting for WAL mode; fsyncs occur at checkpoint boundaries
+- `busy_timeout=5000` — SQLite auto-retries on transient lock contention for up to 5 seconds before surfacing `SQLITE_BUSY`
+- `foreign_keys=1` — foreign-key constraints are enforced
+
+WAL mode produces two sidecar files next to the main database: `<db>-wal` and `<db>-shm`. Backup and restore already handle these files; manual copies of the DB should include them for a consistent snapshot.
+
 What Traceary does **not** add today:
 
 - no custom background writer or queue
-- no application-level retry loop for sustained `database is locked` pressure
+- no application-level retry loop beyond SQLite's `busy_timeout`
 - no distributed or multi-host coordination
 
 Practical guidance:
 
 - a few parallel AI sessions on one machine are in scope
 - extremely high write volume to the same DB path is not a tuned use case today
-- if you repeatedly hit SQLite lock errors, reduce concurrent writers, split DB paths by workflow, or retry the operation after the short-lived competing process exits
+- if you still hit `SQLITE_BUSY` past the 5-second busy window, reduce concurrent writers or split DB paths by workflow
 
 ## Hook session-state assumptions
 

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/url"
@@ -127,8 +128,22 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string) (err error
 	return nil
 }
 
+// sqliteBusyTimeout is the SQLite busy-wait window in milliseconds
+// applied via the busy_timeout pragma. Five seconds is long enough to
+// absorb routine hook/MCP write contention while still surfacing real
+// deadlocks to the caller.
+const sqliteBusyTimeout = 5000
+
 func sqliteDSN(dbPath string) string {
 	values := url.Values{}
+	// WAL lets readers and writers proceed concurrently so tail polls
+	// are not blocked by short-lived hook writes. synchronous=NORMAL is
+	// the recommended pairing with WAL (fsyncs only on checkpoint).
+	// busy_timeout lets SQLite auto-retry on transient lock contention
+	// instead of failing immediately with SQLITE_BUSY.
+	values.Add("_pragma", "journal_mode(WAL)")
+	values.Add("_pragma", "synchronous(NORMAL)")
+	values.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteBusyTimeout))
 	values.Add("_pragma", "foreign_keys(1)")
 
 	return (&url.URL{

--- a/infrastructure/sqlite/database_concurrency_test.go
+++ b/infrastructure/sqlite/database_concurrency_test.go
@@ -1,0 +1,108 @@
+package sqlite_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// TestDatabase_ConcurrentWritersAndReaders_NoSQLITE_BUSY simulates the
+// tail polling scenario that previously surfaced
+// `database is locked (5) SQLITE_BUSY`: several hook-like goroutines
+// writing events while a tail-like goroutine polls recent events.
+//
+// With WAL + busy_timeout enabled on the DSN, none of the calls should
+// fail with SQLITE_BUSY; the driver retries internally within the
+// configured busy timeout window.
+func TestDatabase_ConcurrentWritersAndReaders_NoSQLITE_BUSY(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	eventDS, _, storeManager := newFullDatasources(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	const writers = 4
+	const writesPerWriter = 40
+	const readers = 2
+	const readsPerReader = 80
+
+	errCh := make(chan error, writers+readers)
+	var wg sync.WaitGroup
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(writer int) {
+			defer wg.Done()
+			for i := 0; i < writesPerWriter; i++ {
+				event := newConcurrencyTestEvent(t,
+					fmt.Sprintf("event-%d-%d", writer, i),
+					fmt.Sprintf("session-%d", writer),
+					time.Now().UTC(),
+				)
+				if err := eventDS.Save(ctx, event); err != nil {
+					errCh <- fmt.Errorf("writer %d iter %d: Save(): %w", writer, i, err)
+					return
+				}
+			}
+		}(w)
+	}
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(reader int) {
+			defer wg.Done()
+			criteria := apptypes.NewEventListCriteriaBuilder(50).Build()
+			for i := 0; i < readsPerReader; i++ {
+				if _, err := eventDS.ListWindow(ctx, criteria); err != nil {
+					errCh <- fmt.Errorf("reader %d iter %d: ListWindow(): %w", reader, i, err)
+					return
+				}
+			}
+		}(r)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+func newConcurrencyTestEvent(t *testing.T, eventIDValue, sessionIDValue string, createdAt time.Time) *model.Event {
+	t.Helper()
+
+	eventID, err := types.EventIDOf(eventIDValue)
+	if err != nil {
+		t.Fatalf("EventIDOf() error = %v", err)
+	}
+	agent, err := types.AgentOf("codex")
+	if err != nil {
+		t.Fatalf("AgentOf() error = %v", err)
+	}
+	sessionID, err := types.SessionIDOf(sessionIDValue)
+	if err != nil {
+		t.Fatalf("SessionIDOf() error = %v", err)
+	}
+
+	return model.EventOf(
+		eventID,
+		types.EventKindCommandExecuted,
+		types.Client("hook"),
+		agent,
+		sessionID,
+		types.Workspace("concurrency-test"),
+		"concurrent write",
+		createdAt,
+	)
+}

--- a/infrastructure/sqlite/database_dsn_test.go
+++ b/infrastructure/sqlite/database_dsn_test.go
@@ -1,0 +1,76 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestSQLiteDSN_IncludesConcurrencyPragmas asserts that sqliteDSN emits
+// the journal_mode, synchronous, busy_timeout, and foreign_keys pragmas
+// so readers and writers can proceed concurrently under hook load.
+func TestSQLiteDSN_IncludesConcurrencyPragmas(t *testing.T) {
+	t.Parallel()
+
+	dsn := sqliteDSN("/tmp/example.db")
+
+	// url.Values URL-encodes parentheses to %28 and %29 when building
+	// the query string.
+	wants := []string{
+		"journal_mode%28WAL%29",
+		"synchronous%28NORMAL%29",
+		"busy_timeout%285000%29",
+		"foreign_keys%281%29",
+	}
+	for _, want := range wants {
+		if !strings.Contains(dsn, want) {
+			t.Errorf("sqliteDSN(%q) = %q; missing pragma %q", "/tmp/example.db", dsn, want)
+		}
+	}
+}
+
+// TestSQLiteDSN_AppliesPragmasOnOpen opens a real SQLite connection via
+// the DSN and verifies that the journal_mode, synchronous, and
+// busy_timeout pragmas actually take effect on the resulting connection.
+func TestSQLiteDSN_AppliesPragmasOnOpen(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("db.Close() error = %v", err)
+		}
+	})
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("PingContext() error = %v", err)
+	}
+
+	tests := []struct {
+		pragma string
+		want   string
+	}{
+		{"journal_mode", "wal"},
+		{"synchronous", "1"}, // NORMAL
+		{"busy_timeout", "5000"},
+		{"foreign_keys", "1"},
+	}
+	for _, tt := range tests {
+		var got string
+		if err := db.QueryRowContext(context.Background(), "PRAGMA "+tt.pragma).Scan(&got); err != nil {
+			t.Errorf("PRAGMA %s error = %v", tt.pragma, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("PRAGMA %s = %q; want %q", tt.pragma, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #607

## Summary

- Adds `journal_mode=WAL`, `synchronous=NORMAL`, and `busy_timeout=5000` to the SQLite DSN so readers (e.g. `traceary tail` polling) no longer block behind short-lived hook writers and transient contention auto-retries within the 5-second busy window instead of surfacing `SQLITE_BUSY` to the caller.
- Covers the change with three tests: a DSN unit test, a real-DB pragma round-trip test, and a concurrency integration test that writes from multiple goroutines while a reader polls.
- Updates `docs/operations/README{,.ja}.md` to describe the new connection settings and drop the stale "no retry loop" note.

## Why this shape

- WAL is the standard SQLite answer to reader/writer contention under short-lived workers; no application-level queue is needed for our scale.
- `synchronous=NORMAL` is the canonical WAL pairing — full fsync on checkpoint only, still durable across process crashes.
- `busy_timeout=5000` is large enough to swallow routine hook bursts while still surfacing real deadlocks to the caller.
- Backup/restore already handles `<db>-wal` / `<db>-shm` sidecars (see `prepareBackupCreateDestination` and the post-restore cleanup in `RestoreBackup`), so no extra changes there.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./infrastructure/sqlite/`
- [x] `go tool golangci-lint run`
- [x] New DSN unit test asserts pragmas appear in DSN string
- [x] New pragma round-trip test opens a real DB and checks effective values via `PRAGMA`
- [x] New concurrency test: 4 writers × 40 ops + 2 readers × 80 ops, no `SQLITE_BUSY`

Parent umbrella: #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)