### PR TITLE
feat(hooks): capture assistant transcript as transcript events on Claude Stop hook

### DIFF
--- a/application/usecase/audit_redaction.go
+++ b/application/usecase/audit_redaction.go
@@ -51,6 +51,19 @@ type auditPayloadRedactor struct {
 	replacement string
 }
 
+// RedactWellKnownSecrets applies only the built-in audit redactors
+// (private keys, auth headers, token / secret / password shaped
+// assignments) to a free-form text payload. It does not consult any
+// user-configured `extra_redact_patterns`, which is intentional for
+// callers — like transcript capture — that run outside the usecase's
+// TracearyConfig plumbing. Returns the sanitized string; whether any
+// redaction fired is not surfaced because callers currently treat
+// redaction as silent best-effort.
+func RedactWellKnownSecrets(value string) string {
+	sanitized, _ := redactAuditPayload(value, nil)
+	return sanitized
+}
+
 func redactAuditPayload(value string, extraRedactors []auditPayloadRedactor) (string, bool) {
 	redacted := false
 	normalizedValue := value

--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -17,6 +17,7 @@
 | PostToolUseFailure | `Bash`, `mcp__.*` | 失敗したツール実行を記録 |
 | PostCompact | `*` | compact サマリーを記録 |
 | UserPromptSubmit | `*` | ユーザーの指示テキストを記録 |
+| Stop | `*` | `transcript_path` から最後の assistant メッセージを読み取り `transcript` event として記録（既知 secret の redaction を適用） |
 | SessionStart (compact) (予定) | `compact` | stdout 経由でコンテキストポインタを注入 |
 
 ### Tier 2: 部分対応 (Codex)

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -17,6 +17,7 @@ This document defines the hook capability tiers across AI agent clients.
 | PostToolUseFailure | `Bash`, `mcp__.*` | Record failed tool execution |
 | PostCompact | `*` | Record compact summary |
 | UserPromptSubmit | `*` | Record user prompt text |
+| Stop | `*` | Record last assistant message from `transcript_path` as a `transcript` event (built-in secret redaction applied) |
 | SessionStart (compact) (planned) | `compact` | Inject context pointer via stdout |
 
 ### Tier 2: Partial (Codex)

--- a/docs/lifecycle.ja.md
+++ b/docs/lifecycle.ja.md
@@ -21,6 +21,7 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | PostToolUse | `mcp__.*` | `command_executed` | MCP ツール呼び出し |
 | PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | 失敗したツール実行（`failures_only` でフィルタ可能） |
 | PostCompact | `*` | `compact_summary` | コンテキスト圧縮時の構造化サマリー |
+| Stop | `*` | `transcript` | stop-hook の `transcript_path` から読み取った最後の assistant 発話（reasoning 等） |
 | SessionEnd | `*` | `session_ended` | セッション終了 |
 
 ### Codex CLI (Tier 2: 部分対応)
@@ -63,6 +64,7 @@ SessionStart → [AfterTool]* → SessionEnd
 | `session_ended` | セッション終了境界 | SessionEnd / Stop hooks |
 | `compact_summary` | コンテキスト圧縮時の構造化サマリー | PostCompact hook |
 | `prompt` | ユーザーの指示テキスト | UserPromptSubmit hook |
+| `transcript` | 最後の assistant メッセージの text ブロック（reasoning / 説明）。tool_use ブロックは `command_executed` に寄せるため除外する | Stop hook (Claude Code) |
 
 ## データフロー
 
@@ -92,4 +94,5 @@ AI クライアント (Claude Code / Codex CLI / Gemini CLI)
 | `traceary hook audit <client>` | コマンド・ツール監査の記録 | 全クライアント |
 | `traceary hook compact <client> <post-compact|session-start-compact>` | compact サマリーの記録 / compact resume 出力 | Claude Code |
 | `traceary hook prompt <client>` | ユーザー prompt の記録 | Claude Code |
+| `traceary hook transcript <client>` | assistant 発話の transcript 記録（Stop hook 経由） | Claude Code |
 | `scripts/hooks/` 配下の shell wrapper | `traceary hook ...` へ転送する互換レイヤー | packaged integration / 既存導入環境 |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -21,6 +21,7 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | PostToolUse | `mcp__.*` | `command_executed` | MCP tool invocation |
 | PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | Failed tool execution (filterable via `failures_only`) |
 | PostCompact | `*` | `compact_summary` | Structured summary on context compression |
+| Stop | `*` | `transcript` | Last assistant text blocks (reasoning) from the stop-hook `transcript_path` |
 | SessionEnd | `*` | `session_ended` | Session end |
 
 ### Codex CLI (Tier 2: Partial)
@@ -63,6 +64,7 @@ SessionStart → [AfterTool]* → SessionEnd
 | `session_ended` | Session end boundary | SessionEnd / Stop hooks |
 | `compact_summary` | Structured summary from context compression | PostCompact hook |
 | `prompt` | User instruction text | UserPromptSubmit hook |
+| `transcript` | Last assistant-message text blocks (reasoning / explanation). Tool-use blocks are excluded — those are captured by `command_executed`. | Stop hook (Claude Code) |
 
 ## Data Flow
 
@@ -92,4 +94,5 @@ AI Client (Claude Code / Codex CLI / Gemini CLI)
 | `traceary hook audit <client>` | Command/tool audit | All |
 | `traceary hook compact <client> <post-compact|session-start-compact>` | Compact summary recording / compact resume output | Claude Code |
 | `traceary hook prompt <client>` | User prompt recording | Claude Code |
+| `traceary hook transcript <client>` | Assistant-message transcript recording (Stop hook) | Claude Code |
 | packaged shell wrappers under `scripts/hooks/` | Compatibility layer that forwards into `traceary hook ...` | Packaged integrations / legacy installs |

--- a/domain/types/event_kind.go
+++ b/domain/types/event_kind.go
@@ -22,6 +22,10 @@ const (
 	EventKindCompactSummary EventKind = "compact_summary"
 	// EventKindPrompt represents user prompt events.
 	EventKindPrompt EventKind = "prompt"
+	// EventKindTranscript represents a captured assistant-message turn
+	// (reasoning / explanation / proposals), distinct from prompt (user
+	// input) and command_executed (tool invocation).
+	EventKindTranscript EventKind = "transcript"
 )
 
 // EventKind is a value object that represents an event kind.
@@ -35,6 +39,7 @@ var knownEventKinds = []EventKind{
 	EventKindSessionEnded,
 	EventKindCompactSummary,
 	EventKindPrompt,
+	EventKindTranscript,
 }
 
 // EventKindOf builds EventKind from a string value.

--- a/domain/types/event_kind_test.go
+++ b/domain/types/event_kind_test.go
@@ -57,7 +57,7 @@ func TestEventKindOf(t *testing.T) {
 			}
 			if tt.wantErr {
 				if tt.name == "returns error for unknown event kind" &&
-					!strings.Contains(err.Error(), "allowed values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt") {
+					!strings.Contains(err.Error(), "allowed values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript") {
 					t.Fatalf("error = %q, want valid kind list", err.Error())
 				}
 				return

--- a/infrastructure/filesystem/claude_hooks_handler.go
+++ b/infrastructure/filesystem/claude_hooks_handler.go
@@ -26,10 +26,12 @@ func (h *ClaudeHooksHandler) Build(tracearyBin string) model.Hooks {
 	compactCommand := newHookRuntimeCommand(tracearyBin, "hook", "compact", "claude", "post-compact")
 	compactResumeCommand := newHookRuntimeCommand(tracearyBin, "hook", "compact", "claude", "session-start-compact")
 	promptCommand := newHookRuntimeCommand(tracearyBin, "hook", "prompt", "claude")
+	transcriptCommand := newHookRuntimeCommand(tracearyBin, "hook", "transcript", "claude")
 
 	eventOrder := []string{
 		"SessionStart",
 		"SessionEnd",
+		"Stop",
 		"PostToolUse",
 		"PostToolUseFailure",
 		"PostCompact",
@@ -47,6 +49,11 @@ func (h *ClaudeHooksHandler) Build(tracearyBin string) model.Hooks {
 		"SessionEnd": {
 			model.HookEntryOf(types.Some("*"), []model.HookCommand{
 				model.HookCommandOf("traceary-session-end", "command", sessionEndCommand, types.None[int](), "", managedKeyOf("traceary-session.sh", "claude", "end")),
+			}),
+		},
+		"Stop": {
+			model.HookEntryOf(types.Some("*"), []model.HookCommand{
+				model.HookCommandOf("traceary-transcript", "command", transcriptCommand, types.None[int](), "", managedKeyOf("traceary-transcript.sh", "claude")),
 			}),
 		},
 		"PostToolUse": {

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -20,6 +20,7 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 	wantEventOrder := []string{
 		"SessionStart",
 		"SessionEnd",
+		"Stop",
 		"PostToolUse",
 		"PostToolUseFailure",
 		"PostCompact",

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -32,6 +32,17 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'claude'"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -509,6 +510,12 @@ func (c *RootCLI) runHookTranscript(
 	if !ok || strings.TrimSpace(transcriptText) == "" {
 		return nil
 	}
+	// Transcript text routinely carries things the assistant re-stated
+	// from files or shell output — API keys from .env files, Bearer
+	// tokens from header dumps, private keys pasted into chat. Apply
+	// the built-in audit redactors before persisting so
+	// `traceary tail` cannot leak them back later.
+	transcriptText = usecase.RedactWellKnownSecrets(transcriptText)
 
 	sessionID, err := resolveHookSessionID(payload, client)
 	if err != nil {

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -541,13 +542,27 @@ func (c *RootCLI) runHookTranscript(
 
 // readLastAssistantTranscriptEntry reads the JSONL transcript file at
 // path and returns the concatenated text content of the LAST
-// `assistant`-role message. Each line is expected to be a JSON object
-// with `role` and a `content` array of blocks; only blocks with
-// `type == "text"` contribute to the output. Returns ok=false for any
-// IO or parse error so callers can silently skip.
+// assistant turn.
+//
+// Real Claude Code transcripts use an envelope shape:
+//
+//	{"type":"assistant", "message":{"role":"assistant","content":[...]}}
+//	{"type":"user",      "message":{"role":"user",     "content":"..."}}
+//	{"type":"file-history-snapshot", ...}
+//
+// Each assistant turn's `message.content` is an array of blocks — we
+// keep `type=text` and `type=thinking` blocks (reasoning and extended
+// thinking) and drop `type=tool_use` / `type=tool_result` because
+// those are already captured by `command_executed` audits.
+//
+// Returns ok=false for IO / parse failure so callers can silently
+// skip; slog.Debug lines preserve the underlying cause for
+// TRACEARY_HOOK_DEBUG-style troubleshooting without aborting the
+// host's Stop hook.
 func readLastAssistantTranscriptEntry(path string) (string, bool) {
 	file, err := os.Open(path) // #nosec G304 -- path supplied by the host Stop hook
 	if err != nil {
+		slog.Debug("failed to open transcript file", "path", path, "error", err)
 		return "", false
 	}
 	defer func() { _ = file.Close() }()
@@ -558,28 +573,47 @@ func readLastAssistantTranscriptEntry(path string) (string, bool) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
 	var lastAssistantText string
+	var parseErrors int
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
 			continue
 		}
-		var message transcriptMessage
-		if err := json.Unmarshal(line, &message); err != nil {
+		var entry transcriptLine
+		if err := json.Unmarshal(line, &entry); err != nil {
+			parseErrors++
 			continue
 		}
-		if message.Role != "assistant" {
+		// Only assistant turns contribute. The envelope carries its
+		// own type field; we also verify the inner message.role to
+		// avoid mismatched snapshots.
+		if entry.Type != "assistant" && entry.Message.Role != "assistant" {
 			continue
 		}
-		text := extractAssistantText(message.Content)
+		text := extractAssistantText(entry.Message.Content)
 		if text == "" {
 			continue
 		}
 		lastAssistantText = text
 	}
 	if err := scanner.Err(); err != nil {
+		slog.Debug("failed while scanning transcript file", "path", path, "error", err)
+		return "", false
+	}
+	if parseErrors > 0 && lastAssistantText == "" {
+		slog.Debug("transcript file had no parseable assistant entries", "path", path, "parse_errors", parseErrors)
 		return "", false
 	}
 	return lastAssistantText, lastAssistantText != ""
+}
+
+// transcriptLine is one row in Claude Code's JSONL transcript. Only
+// the envelope `type` and the nested `message` matter for this
+// feature; everything else (timestamps, message-id, snapshots) is
+// deliberately ignored.
+type transcriptLine struct {
+	Type    string            `json:"type"`
+	Message transcriptMessage `json:"message"`
 }
 
 type transcriptMessage struct {
@@ -587,9 +621,13 @@ type transcriptMessage struct {
 	Content []transcriptContent `json:"content"`
 }
 
+// transcriptContent covers both `text` blocks (normal assistant
+// reasoning) and `thinking` blocks (extended thinking). Tool-use /
+// tool-result blocks are ignored by the extractor.
 type transcriptContent struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Thinking string `json:"thinking"`
 }
 
 func extractAssistantText(blocks []transcriptContent) string {
@@ -598,10 +636,15 @@ func extractAssistantText(blocks []transcriptContent) string {
 	}
 	var builder strings.Builder
 	for _, block := range blocks {
-		if block.Type != "text" {
+		var trimmed string
+		switch block.Type {
+		case "text":
+			trimmed = strings.TrimSpace(block.Text)
+		case "thinking":
+			trimmed = strings.TrimSpace(block.Thinking)
+		default:
 			continue
 		}
-		trimmed := strings.TrimSpace(block.Text)
 		if trimmed == "" {
 			continue
 		}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -37,6 +39,7 @@ func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd.AddCommand(c.newHookAuditCommand())
 	hookCmd.AddCommand(c.newHookCompactCommand())
 	hookCmd.AddCommand(c.newHookPromptCommand())
+	hookCmd.AddCommand(c.newHookTranscriptCommand())
 
 	return hookCmd
 }
@@ -109,6 +112,25 @@ func (c *RootCLI) newHookPromptCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runHookBestEffort("prompt", func() error {
 				return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) newHookTranscriptCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "transcript <client>",
+		Short:  "Record the last assistant message from a Stop-hook transcript_path",
+		Hidden: true,
+		Args:   exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHookBestEffort("transcript", func() error {
+				return c.runHookTranscript(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
 			})
 		},
 	}
@@ -449,6 +471,146 @@ func (c *RootCLI) runHookPrompt(
 	}
 
 	return nil
+}
+
+// runHookTranscript records the last assistant-message turn as a
+// `transcript` event. It reads Stop-hook stdin to find
+// `transcript_path` (a JSONL file maintained by Claude Code that
+// contains one message per line) and extracts the last assistant
+// message's text blocks. Tool-use blocks are excluded because they
+// are already captured by `command_executed` audits, which keeps
+// transcript events focused on "what the AI was thinking" rather
+// than duplicating the tool call log. If `transcript_path` is
+// missing or unreadable we fail soft — transcript capture is a
+// nice-to-have, not a requirement for sessions to close cleanly.
+func (c *RootCLI) runHookTranscript(
+	ctx context.Context,
+	input io.Reader,
+	client string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.event == nil {
+		return xerrors.Errorf("record log usecase is not configured")
+	}
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	transcriptPath := hookPayloadString(payload, "transcript_path", "")
+	if transcriptPath == "" {
+		return nil
+	}
+	transcriptText, ok := readLastAssistantTranscriptEntry(transcriptPath)
+	if !ok || strings.TrimSpace(transcriptText) == "" {
+		return nil
+	}
+
+	sessionID, err := resolveHookSessionID(payload, client)
+	if err != nil {
+		return err
+	}
+	if sessionID == "" {
+		return nil
+	}
+	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+	if err != nil {
+		return err
+	}
+	agent, err := resolveHookAgent(client, payload)
+	if err != nil {
+		return err
+	}
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+	if _, err := c.event.Log(ctx, transcriptText, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace); err != nil {
+		return xerrors.Errorf("failed to record hook transcript: %w", err)
+	}
+
+	return nil
+}
+
+// readLastAssistantTranscriptEntry reads the JSONL transcript file at
+// path and returns the concatenated text content of the LAST
+// `assistant`-role message. Each line is expected to be a JSON object
+// with `role` and a `content` array of blocks; only blocks with
+// `type == "text"` contribute to the output. Returns ok=false for any
+// IO or parse error so callers can silently skip.
+func readLastAssistantTranscriptEntry(path string) (string, bool) {
+	file, err := os.Open(path) // #nosec G304 -- path supplied by the host Stop hook
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	// Transcript entries can carry multi-KB reasoning payloads; lift
+	// the default 64KB line limit so long turns don't truncate.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var lastAssistantText string
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var message transcriptMessage
+		if err := json.Unmarshal(line, &message); err != nil {
+			continue
+		}
+		if message.Role != "assistant" {
+			continue
+		}
+		text := extractAssistantText(message.Content)
+		if text == "" {
+			continue
+		}
+		lastAssistantText = text
+	}
+	if err := scanner.Err(); err != nil {
+		return "", false
+	}
+	return lastAssistantText, lastAssistantText != ""
+}
+
+type transcriptMessage struct {
+	Role    string              `json:"role"`
+	Content []transcriptContent `json:"content"`
+}
+
+type transcriptContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func extractAssistantText(blocks []transcriptContent) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	for _, block := range blocks {
+		if block.Type != "text" {
+			continue
+		}
+		trimmed := strings.TrimSpace(block.Text)
+		if trimmed == "" {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteString("\n\n")
+		}
+		builder.WriteString(trimmed)
+	}
+	return builder.String()
 }
 
 func resolveHookAgent(client string, payload []byte) (types.Agent, error) {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -465,6 +465,100 @@ func TestRootCLI_HookPromptCommand_UsesPromptPayload(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-transcript")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-transcript"), []byte("transcript-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-transcript-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	// Two turns: older assistant message then newer assistant message
+	// (plus an unrelated user line). Tool-use blocks must not leak into
+	// the captured text.
+	transcriptLines := []string{
+		`{"role":"user","content":[{"type":"text","text":"initial question"}]}`,
+		`{"role":"assistant","content":[{"type":"text","text":"older reasoning"},{"type":"tool_use","name":"Read"}]}`,
+		`{"role":"user","content":[{"type":"text","text":"follow-up"}]}`,
+		`{"role":"assistant","content":[{"type":"text","text":"newer reasoning"},{"type":"text","text":"with two blocks"}]}`,
+	}
+	if err := os.WriteFile(transcriptPath, []byte(strings.Join(transcriptLines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(transcript) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-transcript"),
+			types.EventKindTranscript,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("transcript-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"newer reasoning\n\nwith two blocks",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	payload := `{"transcript_path":"` + transcriptPath + `"}`
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"hook", "transcript", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := eventStub.logCall.kind, types.EventKindTranscript; got != want {
+		t.Fatalf("transcript log kind = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.message, "newer reasoning\n\nwith two blocks"; got != want {
+		t.Fatalf("transcript log message = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookTranscriptCommand_SkipsWhenTranscriptPathMissing(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{}`))
+	rootCmd.SetArgs([]string{"hook", "transcript", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	// No transcript_path → no event recorded, no failure.
+	if eventStub.logCall.message != "" {
+		t.Fatalf("logCall.message = %q, want empty when transcript_path missing", eventStub.logCall.message)
+	}
+}
+
 func TestRootCLI_HookPromptCommand_PrefersPersistedWorkspaceOverEnvOverride(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 	t.Setenv("TRACEARY_WORKSPACE", "env/workspace")

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -484,14 +484,17 @@ func TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage(t *testing.T)
 	}
 
 	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
-	// Two turns: older assistant message then newer assistant message
-	// (plus an unrelated user line). Tool-use blocks must not leak into
-	// the captured text.
+	// Real Claude Code JSONL envelope: top-level `type=assistant` with
+	// nested `message.role` / `message.content`. We also drop an
+	// envelope-only snapshot line, a tool_use block (captured by
+	// command_executed audits), and interleave a `thinking` block on
+	// the last turn to verify extended-thinking is included.
 	transcriptLines := []string{
-		`{"role":"user","content":[{"type":"text","text":"initial question"}]}`,
-		`{"role":"assistant","content":[{"type":"text","text":"older reasoning"},{"type":"tool_use","name":"Read"}]}`,
-		`{"role":"user","content":[{"type":"text","text":"follow-up"}]}`,
-		`{"role":"assistant","content":[{"type":"text","text":"newer reasoning"},{"type":"text","text":"with two blocks"}]}`,
+		`{"type":"file-history-snapshot","messageId":"x","snapshot":{},"isSnapshotUpdate":false}`,
+		`{"type":"user","message":{"role":"user","content":"initial question"}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"older reasoning"},{"type":"tool_use","name":"Read"}]}}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"x","content":"ok"}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"first-block thinking","signature":"sig"},{"type":"text","text":"newer reasoning"},{"type":"text","text":"with two blocks"}]}}`,
 	}
 	if err := os.WriteFile(transcriptPath, []byte(strings.Join(transcriptLines, "\n")+"\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(transcript) error = %v", err)
@@ -506,7 +509,7 @@ func TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage(t *testing.T)
 			types.Agent("claude"),
 			types.SessionID("transcript-session"),
 			types.Workspace("github.com/duck8823/traceary"),
-			"newer reasoning\n\nwith two blocks",
+			"first-block thinking\n\nnewer reasoning\n\nwith two blocks",
 			time.Now(),
 		),
 	}
@@ -528,7 +531,71 @@ func TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage(t *testing.T)
 	if got, want := eventStub.logCall.kind, types.EventKindTranscript; got != want {
 		t.Fatalf("transcript log kind = %q, want %q", got, want)
 	}
-	if got, want := eventStub.logCall.message, "newer reasoning\n\nwith two blocks"; got != want {
+	if got, want := eventStub.logCall.message, "first-block thinking\n\nnewer reasoning\n\nwith two blocks"; got != want {
+		t.Fatalf("transcript log message = %q, want %q", got, want)
+	}
+}
+
+// TestRootCLI_HookTranscriptCommand_HandlesMalformedTranscript asserts
+// that lines which fail to parse are skipped rather than aborting the
+// whole Stop hook. Structural drift in the JSONL format (e.g. future
+// Claude Code revisions adding a new envelope type) must not mask the
+// last good assistant message when one is present.
+func TestRootCLI_HookTranscriptCommand_HandlesMalformedTranscript(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-transcript-mal")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-transcript-mal"), []byte("mal-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-transcript-mal-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	transcriptPath := filepath.Join(t.TempDir(), "mixed.jsonl")
+	transcriptLines := []string{
+		`{not-json`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"valid assistant reply"}]}}`,
+		`{"type":"user","message":{"role":"user","content":"noise"}}`,
+	}
+	if err := os.WriteFile(transcriptPath, []byte(strings.Join(transcriptLines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(transcript) error = %v", err)
+	}
+
+	storeStub := &storeManagementUsecaseStub{}
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-mal"),
+			types.EventKindTranscript,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("mal-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"valid assistant reply",
+			time.Now(),
+		),
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"transcript_path":"` + transcriptPath + `"}`))
+	rootCmd.SetArgs([]string{"hook", "transcript", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := eventStub.logCall.message, "valid assistant reply"; got != want {
 		t.Fatalf("transcript log message = %q, want %q", got, want)
 	}
 }

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -75,7 +75,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display", "表示件数"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of events to skip before listing", "一覧表示前にスキップする件数"))
-	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)"))
+	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)"))
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	listCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -88,8 +88,8 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 		"kind",
 		"",
 		Localize(
-			"filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
-			"絞り込む kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
+			"filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)",
+			"絞り込む kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)",
 		),
 	)
 	searchCmd.Flags().StringVar(&from, "from", "", Localize("start date (`YYYY-MM-DD` or RFC3339)", "開始日 (`YYYY-MM-DD` または RFC3339)"))

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -270,6 +270,7 @@ func validateSearchKind(value string) (string, error) {
 		"session_ended":    "session_ended",
 		"compact_summary":  "compact_summary",
 		"prompt":           "prompt",
+		"transcript":       "transcript",
 		"audit":            "command_executed",
 	}
 	if resolvedKind, ok := validKinds[trimmedValue]; ok {
@@ -277,7 +278,7 @@ func validateSearchKind(value string) (string, error) {
 	}
 
 	return "", xerrors.Errorf(Localize(
-		"unsupported kind: %s (valid values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
-		"未対応の kind です: %s (有効値: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)",
+		"unsupported kind: %s (valid values: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)",
+		"未対応の kind です: %s (有効値: note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)",
 	), trimmedValue)
 }

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -236,7 +236,7 @@ func (c *RootCLI) newTailCommand() *cobra.Command {
 	}
 	tailCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	tailCmd.Flags().IntVar(&limit, "limit", defaultTailInitialLimit, Localize("number of recent events to print before following (0 prints only new events)", "追跡開始前に表示する直近イベント数 (0 の場合は新規イベントのみ表示)"))
-	tailCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt; alias: audit)"))
+	tailCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)"))
 	tailCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	tailCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
 	tailCmd.Flags().StringVar(&sessionID, "session-id", "", Localize("filter by session ID", "session ID で絞り込む"))


### PR DESCRIPTION
Closes #606

## Summary

Introduces the `transcript` EventKind and a Claude `Stop`-hook entrypoint that records the last assistant-message text blocks from `transcript_path`. Tool-use blocks are excluded (already in `command_executed`), so `transcript` captures "what the AI was thinking" without duplicating the tool log.

## Design decisions locked in

- **Separate EventKind `transcript`** (not `note` overload) — clean filter axis alongside `prompt` / `command_executed`
- **Last assistant message per Stop event** — matches Stop hook contract; linear write volume
- **Text blocks only** joined with blank lines — tool_use excluded on purpose
- **Fail-soft** — missing/unreadable transcript_path silently returns; never blocks Stop
- **Claude only this PR** — Codex / Gemini have different Stop-hook semantics; defer to follow-up
- **Opt-in/out default**: not yet plumbed as a dedicated flag. If agents want the Stop hook wired but not the capture, they can remove just the Stop entry from settings.json. Explicit `--disable-transcript` plumbed through install flags is tracked as a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` green
- [x] `go tool golangci-lint run` — 0 issues
- [x] `python3 scripts/verify_integrations.py` — ok
- New tests in `presentation/cli/hook_runtime_test.go`:
  - `TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage` — multiple turns, mixed text+tool_use blocks, asserts the last assistant message's text blocks are captured joined by blank line
  - `TestRootCLI_HookTranscriptCommand_SkipsWhenTranscriptPathMissing` — fail-soft path
- Existing generator test updated for the new `Stop` event entry in the EventOrder

Parent umbrella: #562 (v0.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)