### PR TITLE
feat(hooks): expand Claude PostToolUse matcher to built-in tools (Read/Edit/Write/Grep/Glob/Agent/...)

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -14,7 +14,8 @@
 | SessionEnd | `*` | セッション終了を記録 |
 | PostToolUse | `Bash` | シェルコマンド監査を exit code 付きで記録 |
 | PostToolUse | `mcp__.*` | MCP ツール監査を記録 |
-| PostToolUseFailure | `Bash`, `mcp__.*` | 失敗したツール実行を記録 |
+| PostToolUse | `Read\|Edit\|Write\|MultiEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|NotebookEdit` | Claude Code 組み込みツール（ファイル I/O・検索・agent・web）の呼び出しを記録（v0.8-6 で追加） |
+| PostToolUseFailure | `Bash`, `mcp__.*`, 組み込みツール | 失敗したツール実行を記録 |
 | PostCompact | `*` | compact サマリーを記録 |
 | UserPromptSubmit | `*` | ユーザーの指示テキストを記録 |
 | Stop | `*` | `transcript_path` から最後の assistant メッセージを読み取り `transcript` event として記録（既知 secret の redaction を適用） |

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -14,7 +14,8 @@ This document defines the hook capability tiers across AI agent clients.
 | SessionEnd | `*` | Record session end |
 | PostToolUse | `Bash` | Record shell command audit with exit code |
 | PostToolUse | `mcp__.*` | Record MCP tool audit |
-| PostToolUseFailure | `Bash`, `mcp__.*` | Record failed tool execution |
+| PostToolUse | `Read\|Edit\|Write\|MultiEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|NotebookEdit` | Record built-in Claude Code tool invocations (file I/O, search, agent, web). Added in v0.8-6 |
+| PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | Record failed tool execution |
 | PostCompact | `*` | Record compact summary |
 | UserPromptSubmit | `*` | Record user prompt text |
 | Stop | `*` | Record last assistant message from `transcript_path` as a `transcript` event (built-in secret redaction applied) |

--- a/infrastructure/filesystem/claude_hooks_handler.go
+++ b/infrastructure/filesystem/claude_hooks_handler.go
@@ -7,6 +7,15 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
+// claudeBuiltinToolsMatcher is the regular expression Claude Code
+// evaluates as the PostToolUse matcher for Traceary's coverage of
+// built-in tools (the ones that do not match `Bash` or `mcp__.*`).
+// Read / Edit / Write / Grep / Glob / Agent / TodoWrite / WebFetch /
+// WebSearch / NotebookEdit are the core surfaces operators use for
+// real work — capturing them is what actually makes tail / timeline
+// reflect day-to-day activity instead of just shell + MCP traffic.
+const claudeBuiltinToolsMatcher = "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+
 // ClaudeHooksHandler installs Traceary hooks for the Claude Code client.
 type ClaudeHooksHandler struct{}
 
@@ -63,12 +72,18 @@ func (h *ClaudeHooksHandler) Build(tracearyBin string) model.Hooks {
 			model.HookEntryOf(types.Some("mcp__.*"), []model.HookCommand{
 				model.HookCommandOf("traceary-audit", "command", auditCommand, types.None[int](), "", managedKeyOf("traceary-audit.sh", "claude")),
 			}),
+			model.HookEntryOf(types.Some(claudeBuiltinToolsMatcher), []model.HookCommand{
+				model.HookCommandOf("traceary-audit", "command", auditCommand, types.None[int](), "", managedKeyOf("traceary-audit.sh", "claude")),
+			}),
 		},
 		"PostToolUseFailure": {
 			model.HookEntryOf(types.Some("Bash"), []model.HookCommand{
 				model.HookCommandOf("traceary-audit", "command", auditCommand, types.None[int](), "", managedKeyOf("traceary-audit.sh", "claude")),
 			}),
 			model.HookEntryOf(types.Some("mcp__.*"), []model.HookCommand{
+				model.HookCommandOf("traceary-audit", "command", auditCommand, types.None[int](), "", managedKeyOf("traceary-audit.sh", "claude")),
+			}),
+			model.HookEntryOf(types.Some(claudeBuiltinToolsMatcher), []model.HookCommand{
 				model.HookCommandOf("traceary-audit", "command", auditCommand, types.None[int](), "", managedKeyOf("traceary-audit.sh", "claude")),
 			}),
 		},

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -116,6 +116,28 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		}
 	})
 
+	t.Run("PostToolUseFailure mirrors PostToolUse matcher set", func(t *testing.T) {
+		t.Parallel()
+
+		entries := hooks.Entries("PostToolUseFailure")
+		if diff := cmp.Diff(3, len(entries)); diff != "" {
+			t.Fatalf("len(PostToolUseFailure entries) mismatch (-want +got):\n%s", diff)
+		}
+		firstMatcher, _ := entries[0].Matcher().Value()
+		if diff := cmp.Diff("Bash", firstMatcher); diff != "" {
+			t.Fatalf("PostToolUseFailure[0] matcher mismatch (-want +got):\n%s", diff)
+		}
+		secondMatcher, _ := entries[1].Matcher().Value()
+		if diff := cmp.Diff("mcp__.*", secondMatcher); diff != "" {
+			t.Fatalf("PostToolUseFailure[1] matcher mismatch (-want +got):\n%s", diff)
+		}
+		thirdMatcher, _ := entries[2].Matcher().Value()
+		wantBuiltin := "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+		if diff := cmp.Diff(wantBuiltin, thirdMatcher); diff != "" {
+			t.Fatalf("PostToolUseFailure[2] matcher mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("UserPromptSubmit references prompt script", func(t *testing.T) {
 		t.Parallel()
 

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -85,11 +85,11 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		}
 	})
 
-	t.Run("PostToolUse covers Bash and mcp", func(t *testing.T) {
+	t.Run("PostToolUse covers Bash, mcp, and built-in tools", func(t *testing.T) {
 		t.Parallel()
 
 		entries := hooks.Entries("PostToolUse")
-		if diff := cmp.Diff(2, len(entries)); diff != "" {
+		if diff := cmp.Diff(3, len(entries)); diff != "" {
 			t.Fatalf("len(PostToolUse entries) mismatch (-want +got):\n%s", diff)
 		}
 		firstMatcher, _ := entries[0].Matcher().Value()
@@ -100,11 +100,19 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		if diff := cmp.Diff("mcp__.*", secondMatcher); diff != "" {
 			t.Fatalf("PostToolUse[1] matcher mismatch (-want +got):\n%s", diff)
 		}
+		thirdMatcher, _ := entries[2].Matcher().Value()
+		wantBuiltin := "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+		if diff := cmp.Diff(wantBuiltin, thirdMatcher); diff != "" {
+			t.Fatalf("PostToolUse[2] matcher mismatch (-want +got):\n%s", diff)
+		}
 		if diff := cmp.Diff("traceary-audit.sh:claude", entries[0].Commands()[0].ManagedKey()); diff != "" {
 			t.Fatalf("PostToolUse[0] managed key mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff("traceary-audit", entries[0].Commands()[0].Name()); diff != "" {
 			t.Fatalf("PostToolUse[0] name mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("traceary-audit.sh:claude", entries[2].Commands()[0].ManagedKey()); diff != "" {
+			t.Fatalf("PostToolUse[2] managed key mismatch (-want +got):\n%s", diff)
 		}
 	})
 

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -61,6 +61,15 @@
             "command": "'traceary' 'hook' 'audit' 'claude'"
           }
         ]
+      },
+      {
+        "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
+          }
+        ]
       }
     ],
     "PostCompact": [

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -112,6 +112,15 @@
             "command": "'traceary' 'hook' 'audit' 'claude'"
           }
         ]
+      },
+      {
+        "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
+          }
+        ]
       }
     ]
   }

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -123,6 +123,21 @@ def check_claude() -> None:
     require('PostCompact' in hooks['hooks'], 'Claude hooks must include PostCompact')
     require("'hook' 'session' 'claude'" in json.dumps(hooks['hooks']), 'Claude packaged hooks must invoke traceary hook session directly')
     require("'hook' 'audit' 'claude'" in json.dumps(hooks['hooks']), 'Claude packaged hooks must invoke traceary hook audit directly')
+
+    # v0.8-6: both PostToolUse and PostToolUseFailure must register
+    # three matchers (Bash / mcp__.* / built-in tool list) so Traceary
+    # captures the real working surface, not just shell + MCP traffic.
+    for event_name in ('PostToolUse', 'PostToolUseFailure'):
+        entries = hooks['hooks'].get(event_name, [])
+        matchers = [entry.get('matcher') for entry in entries]
+        require(
+            matchers[:2] == ['Bash', 'mcp__.*'],
+            f'Claude {event_name} must register Bash and mcp__.* as the first two matchers, got {matchers!r}',
+        )
+        require(
+            len(matchers) >= 3 and matchers[2] and 'Read' in matchers[2] and 'Edit' in matchers[2] and 'Write' in matchers[2],
+            f'Claude {event_name} must include the built-in tool matcher (Read|Edit|Write|...), got {matchers!r}',
+        )
     require((ROOT / 'integrations' / 'claude-plugin' / 'scripts' / 'traceary-compact.sh').exists(), 'missing Claude compact hook script')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-help' / 'SKILL.md').exists(), 'missing Claude traceary-help skill')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Claude traceary-session-history skill')


### PR DESCRIPTION
Closes #605

## Summary

Adds a third PostToolUse + PostToolUseFailure matcher to the Claude plugin covering the built-in tool surface:

```
Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit
```

Until now only `Bash` and `mcp__.*` were captured, so the tools operators actually spend most of their time in were invisible to `traceary tail` / `list` / timeline. That made working-hours and effort measurement dramatically under-report reality.

## Scope boundaries

- **Default-on**: adds the new matcher unconditionally. Users who want only Bash/mcp__ can remove the third entry from their settings.json.
- **`--matcher` preset flag deferred**: the issue mentioned `--matcher minimal|default|all` — that is a separate generator-config surface change and is not required to ship the coverage. Tracked as future work if demand shows up.
- **Codex / Gemini unchanged**: Codex is already effectively all-tools (empty matcher); Gemini's AfterTool hook has different semantics. Parity drift between Gemini's packaged hooks.json and its generator is a separate concern and not touched here.

## Prerequisite

v0.7.2-1 WAL mode (#607, merged) is the prerequisite — without it the higher write volume could trigger SQLITE_BUSY.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` green (existing generator test updated for the new third entry)
- [x] `go tool golangci-lint run` — 0 issues
- [x] `python3 scripts/verify_integrations.py` — ok

Parent umbrella: #562 (v0.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)