### PR TITLE
feat(memory): add resume / review / incident retrieval presets

### DIFF
--- a/application/types/context_pack_criteria.go
+++ b/application/types/context_pack_criteria.go
@@ -13,6 +13,7 @@ type ContextPackCriteria struct {
 	workspace           domtypes.Workspace
 	recentCommandsLimit int
 	memoryLimit         int
+	memoryPreset        MemoryRetrievalPreset
 }
 
 // SessionID returns the target session filter.
@@ -26,6 +27,11 @@ func (c ContextPackCriteria) RecentCommandsLimit() int { return c.recentCommands
 
 // MemoryLimit returns the maximum number of durable memories to include.
 func (c ContextPackCriteria) MemoryLimit() int { return c.memoryLimit }
+
+// MemoryPreset returns the retrieval preset to apply when loading
+// durable memories for the pack. Empty means "no preset — use the
+// default accepted-only behavior of the memory query path."
+func (c ContextPackCriteria) MemoryPreset() MemoryRetrievalPreset { return c.memoryPreset }
 
 // ContextPackCriteriaBuilder builds a ContextPackCriteria value.
 type ContextPackCriteriaBuilder struct {
@@ -62,6 +68,13 @@ func (b *ContextPackCriteriaBuilder) RecentCommandsLimit(limit int) *ContextPack
 // MemoryLimit sets the durable memory limit.
 func (b *ContextPackCriteriaBuilder) MemoryLimit(limit int) *ContextPackCriteriaBuilder {
 	b.criteria.memoryLimit = limit
+	return b
+}
+
+// MemoryPreset sets the retrieval preset used to pre-populate the
+// durable-memory filters for the pack.
+func (b *ContextPackCriteriaBuilder) MemoryPreset(preset MemoryRetrievalPreset) *ContextPackCriteriaBuilder {
+	b.criteria.memoryPreset = preset
 	return b
 }
 

--- a/application/types/memory_preset.go
+++ b/application/types/memory_preset.go
@@ -1,0 +1,163 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryRetrievalPreset names a canonical retrieval shape over durable
+// memory. Presets pre-populate a MemoryListCriteriaBuilder with the
+// filters that match a specific operator scenario (resume / review /
+// incident), and the caller can still layer explicit filters on top.
+type MemoryRetrievalPreset string
+
+const (
+	// MemoryRetrievalPresetResume surfaces memories operators want when
+	// picking up where a session left off: accepted memories ordered
+	// newest-first, no type restriction so recent lessons /
+	// constraints / preferences all surface together.
+	MemoryRetrievalPresetResume MemoryRetrievalPreset = "resume"
+
+	// MemoryRetrievalPresetReview focuses on long-lived "what did we
+	// decide" knowledge: only accepted decisions and constraints, no
+	// preferences or one-off lessons.
+	MemoryRetrievalPresetReview MemoryRetrievalPreset = "review"
+
+	// MemoryRetrievalPresetIncident surfaces what an operator needs to
+	// know when a failure just happened: accepted lessons and
+	// constraints (the "what to avoid" axis) plus decisions that might
+	// explain why a contested path exists.
+	MemoryRetrievalPresetIncident MemoryRetrievalPreset = "incident"
+)
+
+// MemoryRetrievalPresetOf parses a free-form string into a known
+// preset. Empty input returns "" (no preset applied) so callers can
+// pass a user-supplied flag value through without special-casing.
+func MemoryRetrievalPresetOf(value string) (MemoryRetrievalPreset, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+	switch MemoryRetrievalPreset(trimmed) {
+	case MemoryRetrievalPresetResume, MemoryRetrievalPresetReview, MemoryRetrievalPresetIncident:
+		return MemoryRetrievalPreset(trimmed), nil
+	}
+	return "", xerrors.Errorf(
+		"unknown memory retrieval preset: %q (allowed values: %s)",
+		trimmed,
+		strings.Join(knownMemoryRetrievalPresetStrings(), ", "),
+	)
+}
+
+// KnownMemoryRetrievalPresets returns the exhaustive list of built-in
+// presets, in the order CLI help and docs should render them.
+func KnownMemoryRetrievalPresets() []MemoryRetrievalPreset {
+	return []MemoryRetrievalPreset{
+		MemoryRetrievalPresetResume,
+		MemoryRetrievalPresetReview,
+		MemoryRetrievalPresetIncident,
+	}
+}
+
+func knownMemoryRetrievalPresetStrings() []string {
+	presets := KnownMemoryRetrievalPresets()
+	out := make([]string, 0, len(presets))
+	for _, p := range presets {
+		out = append(out, string(p))
+	}
+	return out
+}
+
+// String returns the canonical name of the preset.
+func (p MemoryRetrievalPreset) String() string { return string(p) }
+
+// presetFilters is the internal representation of what a preset
+// contributes to a criteria builder. Keeping this as an intermediate
+// value lets us share the resume / review / incident definitions
+// between MemoryListCriteriaBuilder and MemorySearchCriteriaBuilder
+// without duplicating the switch on preset.
+type presetFilters struct {
+	statuses    []domtypes.MemoryStatus
+	memoryTypes []domtypes.MemoryType
+}
+
+func (p MemoryRetrievalPreset) filters() presetFilters {
+	switch p {
+	case MemoryRetrievalPresetResume:
+		return presetFilters{
+			statuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+		}
+	case MemoryRetrievalPresetReview:
+		return presetFilters{
+			statuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			memoryTypes: []domtypes.MemoryType{
+				domtypes.MemoryTypeDecision,
+				domtypes.MemoryTypeConstraint,
+			},
+		}
+	case MemoryRetrievalPresetIncident:
+		return presetFilters{
+			statuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			memoryTypes: []domtypes.MemoryType{
+				domtypes.MemoryTypeDecision,
+				domtypes.MemoryTypeConstraint,
+				domtypes.MemoryTypeLesson,
+			},
+		}
+	}
+	return presetFilters{}
+}
+
+// ApplyToMemoryListCriteriaBuilder pre-populates the builder with the
+// preset's default filters. Explicit filters the caller sets after
+// calling this method override the preset's defaults — the preset is
+// purely a convenience starting point, not a ceiling.
+//
+// Design choices:
+//
+//   - `resume` does not restrict memoryTypes because the scenario is
+//     "what was I working on" — preferences and lessons are as useful
+//     as decisions. It only pins statuses=[accepted].
+//   - `review` narrows to decision + constraint because those are the
+//     types operators expect to reread.
+//   - `incident` includes lesson + constraint + decision so the
+//     "what did we learn" / "what must not happen" / "why is this
+//     state here" axes all surface together.
+//
+// Callers pass a MemoryListCriteriaBuilder to keep the dependency
+// direction domain-free; no MemoryListCriteria allocation is returned
+// directly because the caller typically still needs to chain Limit(),
+// Scopes(), AsOf(), etc.
+func (p MemoryRetrievalPreset) ApplyToMemoryListCriteriaBuilder(builder *MemoryListCriteriaBuilder) *MemoryListCriteriaBuilder {
+	if builder == nil {
+		return builder
+	}
+	filters := p.filters()
+	if len(filters.statuses) > 0 {
+		builder = builder.Statuses(filters.statuses)
+	}
+	if len(filters.memoryTypes) > 0 {
+		builder = builder.MemoryTypes(filters.memoryTypes)
+	}
+	return builder
+}
+
+// ApplyToMemorySearchCriteriaBuilder is the search-side counterpart
+// to ApplyToMemoryListCriteriaBuilder. Same defaults, same override
+// semantics.
+func (p MemoryRetrievalPreset) ApplyToMemorySearchCriteriaBuilder(builder *MemorySearchCriteriaBuilder) *MemorySearchCriteriaBuilder {
+	if builder == nil {
+		return builder
+	}
+	filters := p.filters()
+	if len(filters.statuses) > 0 {
+		builder = builder.Statuses(filters.statuses)
+	}
+	if len(filters.memoryTypes) > 0 {
+		builder = builder.MemoryTypes(filters.memoryTypes)
+	}
+	return builder
+}

--- a/application/types/memory_preset.go
+++ b/application/types/memory_preset.go
@@ -96,6 +96,7 @@ func (p MemoryRetrievalPreset) filters() presetFilters {
 			memoryTypes: []domtypes.MemoryType{
 				domtypes.MemoryTypeDecision,
 				domtypes.MemoryTypeConstraint,
+				domtypes.MemoryTypeArtifact,
 			},
 		}
 	case MemoryRetrievalPresetIncident:
@@ -105,6 +106,7 @@ func (p MemoryRetrievalPreset) filters() presetFilters {
 				domtypes.MemoryTypeDecision,
 				domtypes.MemoryTypeConstraint,
 				domtypes.MemoryTypeLesson,
+				domtypes.MemoryTypeArtifact,
 			},
 		}
 	}

--- a/application/types/memory_preset_test.go
+++ b/application/types/memory_preset_test.go
@@ -56,10 +56,14 @@ func TestMemoryRetrievalPreset_ApplyToMemoryListCriteriaBuilder(t *testing.T) {
 			wantStatuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
 		},
 		{
-			name:            "review narrows to decisions and constraints",
-			preset:          apptypes.MemoryRetrievalPresetReview,
-			wantStatuses:    []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
-			wantMemoryTypes: []domtypes.MemoryType{domtypes.MemoryTypeDecision, domtypes.MemoryTypeConstraint},
+			name:         "review narrows to decisions, constraints, and artifacts",
+			preset:       apptypes.MemoryRetrievalPresetReview,
+			wantStatuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			wantMemoryTypes: []domtypes.MemoryType{
+				domtypes.MemoryTypeDecision,
+				domtypes.MemoryTypeConstraint,
+				domtypes.MemoryTypeArtifact,
+			},
 		},
 		{
 			name:         "incident adds lessons to the review set",
@@ -69,6 +73,7 @@ func TestMemoryRetrievalPreset_ApplyToMemoryListCriteriaBuilder(t *testing.T) {
 				domtypes.MemoryTypeDecision,
 				domtypes.MemoryTypeConstraint,
 				domtypes.MemoryTypeLesson,
+				domtypes.MemoryTypeArtifact,
 			},
 		},
 	}

--- a/application/types/memory_preset_test.go
+++ b/application/types/memory_preset_test.go
@@ -1,0 +1,108 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryRetrievalPresetOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    apptypes.MemoryRetrievalPreset
+		wantErr bool
+	}{
+		{"empty", "", "", false},
+		{"whitespace", "   ", "", false},
+		{"resume", "resume", apptypes.MemoryRetrievalPresetResume, false},
+		{"review", "review", apptypes.MemoryRetrievalPresetReview, false},
+		{"incident", "incident", apptypes.MemoryRetrievalPresetIncident, false},
+		{"unknown", "nonsense", "", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := apptypes.MemoryRetrievalPresetOf(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryRetrievalPresetOf(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("MemoryRetrievalPresetOf(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemoryRetrievalPreset_ApplyToMemoryListCriteriaBuilder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		preset          apptypes.MemoryRetrievalPreset
+		wantStatuses    []domtypes.MemoryStatus
+		wantMemoryTypes []domtypes.MemoryType
+	}{
+		{
+			name:         "resume keeps type axis open",
+			preset:       apptypes.MemoryRetrievalPresetResume,
+			wantStatuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+		},
+		{
+			name:            "review narrows to decisions and constraints",
+			preset:          apptypes.MemoryRetrievalPresetReview,
+			wantStatuses:    []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			wantMemoryTypes: []domtypes.MemoryType{domtypes.MemoryTypeDecision, domtypes.MemoryTypeConstraint},
+		},
+		{
+			name:         "incident adds lessons to the review set",
+			preset:       apptypes.MemoryRetrievalPresetIncident,
+			wantStatuses: []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			wantMemoryTypes: []domtypes.MemoryType{
+				domtypes.MemoryTypeDecision,
+				domtypes.MemoryTypeConstraint,
+				domtypes.MemoryTypeLesson,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			builder := apptypes.NewMemoryListCriteriaBuilder(10)
+			criteria := tt.preset.ApplyToMemoryListCriteriaBuilder(builder).Build()
+			if diff := cmp.Diff(tt.wantStatuses, criteria.Statuses(), cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("Statuses mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantMemoryTypes, criteria.MemoryTypes(), cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("MemoryTypes mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestMemoryRetrievalPreset_ExplicitFiltersOverride documents that a
+// preset is a *starting point*: if the caller sets Statuses /
+// MemoryTypes after applying the preset, the explicit values replace
+// the preset's defaults. This is what makes `--preset review --type
+// lesson` meaningful — the user wants to look at lessons, not the
+// preset's default decision+constraint pair.
+func TestMemoryRetrievalPreset_ExplicitFiltersOverride(t *testing.T) {
+	t.Parallel()
+
+	builder := apptypes.NewMemoryListCriteriaBuilder(10)
+	builder = apptypes.MemoryRetrievalPresetReview.ApplyToMemoryListCriteriaBuilder(builder)
+	builder = builder.MemoryTypes([]domtypes.MemoryType{domtypes.MemoryTypeLesson})
+	criteria := builder.Build()
+	want := []domtypes.MemoryType{domtypes.MemoryTypeLesson}
+	if diff := cmp.Diff(want, criteria.MemoryTypes()); diff != "" {
+		t.Fatalf("MemoryTypes mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -74,7 +74,7 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 	if err != nil {
 		compactSummary = ""
 	}
-	memories, err := b.loadMemories(ctx, session, criteria.MemoryLimit())
+	memories, err := b.loadMemories(ctx, session, criteria.MemoryLimit(), criteria.MemoryPreset())
 	if err != nil {
 		return domtypes.None[apptypes.ContextPack](), err
 	}
@@ -147,7 +147,12 @@ func (b *contextPackBuilder) loadCompactSummary(ctx context.Context, session app
 	return extractCompactSummarySignal(events[0].Body()), nil
 }
 
-func (b *contextPackBuilder) loadMemories(ctx context.Context, session apptypes.SessionSummary, limit int) ([]apptypes.MemorySummary, error) {
+func (b *contextPackBuilder) loadMemories(
+	ctx context.Context,
+	session apptypes.SessionSummary,
+	limit int,
+	preset apptypes.MemoryRetrievalPreset,
+) ([]apptypes.MemorySummary, error) {
 	if b.memoryQuery == nil || limit == 0 {
 		return nil, nil
 	}
@@ -157,11 +162,18 @@ func (b *contextPackBuilder) loadMemories(ctx context.Context, session apptypes.
 		return nil, nil
 	}
 
-	criteria := apptypes.NewMemoryListCriteriaBuilder(limit).
-		Scopes(scopes).
-		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}).
-		Build()
-	memories, err := b.memoryQuery.List(ctx, criteria)
+	builder := apptypes.NewMemoryListCriteriaBuilder(limit).Scopes(scopes)
+	if preset != "" {
+		// Preset wins for context packs: callers asked for a specific
+		// retrieval shape (resume / review / incident), so we honor
+		// its Statuses + MemoryTypes defaults. No preset falls back to
+		// the legacy accepted-only behavior so existing clients see
+		// the same pack shape as before.
+		builder = preset.ApplyToMemoryListCriteriaBuilder(builder)
+	} else {
+		builder = builder.Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted})
+	}
+	memories, err := b.memoryQuery.List(ctx, builder.Build())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list durable memories for context pack: %w", err)
 	}

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -130,6 +130,22 @@ import は Codex の handbook（既定値は `~/.codex/memories/MEMORY.md`）を
 - `traceary memory search`
 - `traceary memory show`
 
+#### 取り出し preset
+
+`memory list` / `memory search` / MCP `retrieve_memories` は `--preset <name>` で用途別の取り出し shape をプリセットできます。`--status` / `--type` を明示した場合は preset のデフォルトを上書きします。
+
+| Preset | 用途 | 既定フィルタ |
+| --- | --- | --- |
+| `resume` | 「どこまでやっていたか」を拾う。type 軸は絞らない | `status=accepted` |
+| `review` | 「何を決めて、どんな制約があるか」を確認する。再読に値する long-lived 知識だけに絞る | `status=accepted`, `type=decision,constraint` |
+| `incident` | 「失敗直後、何を知るべきか」。決定・制約に加えて lesson も含める | `status=accepted`, `type=decision,constraint,lesson` |
+
+例:
+
+- `traceary memory list --preset review --workspace github.com/org/repo`
+- `traceary memory list --preset review --type lesson` — 明示 `--type` は preset の既定を上書き
+- MCP: `retrieve_memories({"preset":"incident","workspace":"..."})`
+
 ### 文脈に載せる経路
 
 Durable memory を再開向けの pack に組み込んで使いたいときは次を使います。

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -153,6 +153,22 @@ Use these to inspect existing durable memories:
 - `traceary memory search`
 - `traceary memory show`
 
+#### Retrieval presets
+
+`memory list` and `memory search` (and MCP `retrieve_memories`) accept `--preset <name>` to apply a built-in retrieval shape for a common operator scenario. Explicit `--status` / `--type` flags still win — the preset only pre-populates the defaults.
+
+| Preset | Intent | Defaults applied |
+| --- | --- | --- |
+| `resume` | "Pick up where I left off." No type restriction — preferences and lessons are as useful as decisions. | `status=accepted` |
+| `review` | "What did we decide and what are the constraints?" Filters to long-lived knowledge you expect to reread. | `status=accepted`, `type=decision,constraint` |
+| `incident` | "A failure just happened — what do I need to know?" Includes lessons and constraints on top of decisions. | `status=accepted`, `type=decision,constraint,lesson` |
+
+Examples:
+
+- `traceary memory list --preset review --workspace github.com/org/repo`
+- `traceary memory list --preset review --type lesson` — explicit `--type` overrides the preset's default
+- MCP: `retrieve_memories({"preset":"incident","workspace":"..."})`
+
 ### Context / handoff path
 
 Use these when you want the memory layer folded into a resume-friendly context pack:

--- a/presentation/cli/handoff.go
+++ b/presentation/cli/handoff.go
@@ -34,6 +34,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 		repo      string
 		recent    int
 		memories  int
+		preset    string
 	)
 
 	cmd := &cobra.Command{
@@ -51,6 +52,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 				workspace: repo,
 				recent:    recent,
 				memories:  memories,
+				preset:    preset,
 			})
 		},
 	}
@@ -60,6 +62,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 	cmd.Flags().StringVar(&repo, "workspace", "", Localize("filter by workspace", "ワークスペースでフィルタ"))
 	cmd.Flags().IntVar(&recent, "recent", 5, Localize("number of recent commands to show", "表示する直近コマンド数"))
 	cmd.Flags().IntVar(&memories, "memories", 5, Localize("number of durable memories to include", "含める durable memory 数"))
+	cmd.Flags().StringVar(&preset, "preset", "", Localize("apply a built-in retrieval preset to durable memories (resume | review | incident)", "durable memory 取得に built-in preset を適用する (resume | review | incident)"))
 
 	return cmd
 }
@@ -70,6 +73,7 @@ type handoffCommandInput struct {
 	workspace string
 	recent    int
 	memories  int
+	preset    string
 }
 
 func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handoffCommandInput) error {
@@ -90,6 +94,10 @@ func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handof
 	}
 
 	resolvedWorkspace := resolveWorkspaceValue(ctx, input.workspace)
+	preset, err := apptypes.MemoryRetrievalPresetOf(input.preset)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --preset", "--preset の解析に失敗しました"), err)
+	}
 	result, err := c.context.Handoff(
 		ctx,
 		apptypes.NewContextPackCriteriaBuilder().
@@ -97,6 +105,7 @@ func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handof
 			Workspace(types.Workspace(resolvedWorkspace)).
 			RecentCommandsLimit(input.recent).
 			MemoryLimit(input.memories).
+			MemoryPreset(preset).
 			Build(),
 	)
 	if err != nil {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -267,6 +267,7 @@ type memoryListCommandInput struct {
 	offset          int
 	asOf            string
 	includeExpired  bool
+	preset          string
 	asJSON          bool
 }
 
@@ -283,6 +284,7 @@ type memorySearchCommandInput struct {
 	query           string
 	asOf            string
 	includeExpired  bool
+	preset          string
 	asJSON          bool
 }
 

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -886,6 +886,7 @@ func hasMemorySearchInputConstraint(input memorySearchCommandInput) bool {
 		strings.TrimSpace(input.workspace) != "" ||
 		strings.TrimSpace(input.agent) != "" ||
 		strings.TrimSpace(input.sessionFamily) != "" ||
+		strings.TrimSpace(input.preset) != "" ||
 		len(input.statuses) > 0 ||
 		len(input.memoryTypes) > 0
 }

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -56,6 +56,7 @@ func (c *RootCLI) newMemoryListCommand() *cobra.Command {
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before listing", "一覧表示前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
 	cmd.Flags().BoolVar(&input.includeExpired, "include-expired", false, Localize("include memories whose validTo is in the past (bypass the default validity-window filter)", "validTo が過去の memory も含める (既定の validity-window filter をバイパス)"))
+	cmd.Flags().StringVar(&input.preset, "preset", "", Localize("apply a built-in retrieval preset (resume | review | incident); explicit filters still override preset defaults", "built-in の retrieval preset を適用する (resume | review | incident)。明示的な filter は preset を上書きする"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -84,6 +85,7 @@ func (c *RootCLI) newMemorySearchCommand() *cobra.Command {
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before returning results", "結果を返す前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
 	cmd.Flags().BoolVar(&input.includeExpired, "include-expired", false, Localize("include memories whose validTo is in the past (bypass the default validity-window filter)", "validTo が過去の memory も含める (既定の validity-window filter をバイパス)"))
+	cmd.Flags().StringVar(&input.preset, "preset", "", Localize("apply a built-in retrieval preset (resume | review | incident); explicit filters still override preset defaults", "built-in の retrieval preset を適用する (resume | review | incident)。明示的な filter は preset を上書きする"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -300,12 +302,24 @@ func (c *RootCLI) runMemoryList(ctx context.Context, output io.Writer, input mem
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to parse --as-of", "--as-of の解析に失敗しました"), err)
 	}
-	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).
-		Offset(input.offset).
-		Scopes(scopes).
-		Statuses(statuses).
-		MemoryTypes(memoryTypes).
-		IncludeExpiredByValidity(input.includeExpired)
+	preset, err := apptypes.MemoryRetrievalPresetOf(input.preset)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --preset", "--preset の解析に失敗しました"), err)
+	}
+	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).Offset(input.offset).Scopes(scopes)
+	if preset != "" {
+		criteriaBuilder = preset.ApplyToMemoryListCriteriaBuilder(criteriaBuilder)
+	}
+	// Explicit --status / --type still win: setting them after the
+	// preset overwrites the preset's defaults. Skip the call when the
+	// user didn't pass anything so the preset's choice stays in effect.
+	if len(statuses) > 0 {
+		criteriaBuilder = criteriaBuilder.Statuses(statuses)
+	}
+	if len(memoryTypes) > 0 {
+		criteriaBuilder = criteriaBuilder.MemoryTypes(memoryTypes)
+	}
+	criteriaBuilder = criteriaBuilder.IncludeExpiredByValidity(input.includeExpired)
 	if t, ok := asOf.Value(); ok {
 		criteriaBuilder = criteriaBuilder.AsOf(t)
 	}
@@ -357,13 +371,24 @@ func (c *RootCLI) runMemorySearch(ctx context.Context, output io.Writer, input m
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to parse --as-of", "--as-of の解析に失敗しました"), err)
 	}
+	preset, err := apptypes.MemoryRetrievalPresetOf(input.preset)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --preset", "--preset の解析に失敗しました"), err)
+	}
 	criteriaBuilder := apptypes.NewMemorySearchCriteriaBuilder(input.limit).
 		Query(strings.TrimSpace(input.query)).
 		Offset(input.offset).
-		Scopes(scopes).
-		Statuses(statuses).
-		MemoryTypes(memoryTypes).
-		IncludeExpiredByValidity(input.includeExpired)
+		Scopes(scopes)
+	if preset != "" {
+		criteriaBuilder = preset.ApplyToMemorySearchCriteriaBuilder(criteriaBuilder)
+	}
+	if len(statuses) > 0 {
+		criteriaBuilder = criteriaBuilder.Statuses(statuses)
+	}
+	if len(memoryTypes) > 0 {
+		criteriaBuilder = criteriaBuilder.MemoryTypes(memoryTypes)
+	}
+	criteriaBuilder = criteriaBuilder.IncludeExpiredByValidity(input.includeExpired)
 	if t, ok := asOf.Value(); ok {
 		criteriaBuilder = criteriaBuilder.AsOf(t)
 	}

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -110,6 +110,7 @@ type retrieveMemoriesInput struct {
 	Offset         int      `json:"offset,omitempty" jsonschema:"number of memories to skip before returning results (default: 0)"`
 	AsOf           string   `json:"as_of,omitempty" jsonschema:"evaluate content validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`
 	IncludeExpired bool     `json:"include_expired,omitempty" jsonschema:"include memories whose valid_to is in the past (bypasses the default validity-window filter)"`
+	Preset         string   `json:"preset,omitempty" jsonschema:"built-in retrieval preset: resume | review | incident. Explicit status / type filters still override the preset defaults"`
 }
 
 // rememberMemoryInput is the MCP input for the remember_memory tool.

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -81,6 +81,7 @@ type sessionHandoffInput struct {
 	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
+	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
 }
 
 // memoryPackInput is the MCP input for the memory_pack tool.
@@ -89,6 +90,7 @@ type memoryPackInput struct {
 	Workspace           string `json:"workspace,omitempty" jsonschema:"work context filter"`
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
+	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
 }
 
 // memoryRefInput is the MCP representation of evidence/artifact references.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -490,11 +490,16 @@ func (s *Server) getContext() mcp.ToolHandlerFor[getContextInput, eventsOutput] 
 
 func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessionHandoffOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionHandoffInput) (*mcp.CallToolResult, sessionHandoffOutput, error) {
+		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
+		if err != nil {
+			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
 			input.Workspace,
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
+			preset,
 		))
 		if err != nil {
 			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to get session handoff: %w", err)
@@ -511,11 +516,16 @@ func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessio
 
 func (s *Server) memoryPack() mcp.ToolHandlerFor[memoryPackInput, memoryPackOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input memoryPackInput) (*mcp.CallToolResult, memoryPackOutput, error) {
+		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
+		if err != nil {
+			return nil, memoryPackOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
 			input.Workspace,
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
+			preset,
 		))
 		if err != nil {
 			return nil, memoryPackOutput{}, xerrors.Errorf("failed to build memory pack: %w", err)
@@ -977,7 +987,7 @@ func (s *Server) setMemoryValidity() mcp.ToolHandlerFor[setMemoryValidityInput, 
 	}
 }
 
-func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int) apptypes.ContextPackCriteria {
+func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int, preset apptypes.MemoryRetrievalPreset) apptypes.ContextPackCriteria {
 	builder := apptypes.NewContextPackCriteriaBuilder().
 		SessionID(types.SessionID(strings.TrimSpace(sessionID))).
 		Workspace(types.Workspace(strings.TrimSpace(workspace)))
@@ -986,6 +996,9 @@ func buildContextPackCriteria(sessionID string, workspace string, recentCommands
 	}
 	if memoryLimit != nil {
 		builder.MemoryLimit(*memoryLimit)
+	}
+	if preset != "" {
+		builder.MemoryPreset(preset)
 	}
 	return builder.Build()
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -565,16 +565,27 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 			}
 			asOfTime = parsed
 		}
+		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
+		if err != nil {
+			return nil, memoriesOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+		}
 
 		var summaries []apptypes.MemorySummary
 		if strings.TrimSpace(input.Query) != "" {
 			searchBuilder := apptypes.NewMemorySearchCriteriaBuilder(resolveLimit(input.Limit, defaultSearchLimit)).
 				Query(strings.TrimSpace(input.Query)).
 				Offset(resolveOffset(input.Offset)).
-				Scopes(scopes).
-				Statuses(statuses).
-				MemoryTypes(memoryTypes).
-				IncludeExpiredByValidity(input.IncludeExpired)
+				Scopes(scopes)
+			if preset != "" {
+				searchBuilder = preset.ApplyToMemorySearchCriteriaBuilder(searchBuilder)
+			}
+			if len(statuses) > 0 {
+				searchBuilder = searchBuilder.Statuses(statuses)
+			}
+			if len(memoryTypes) > 0 {
+				searchBuilder = searchBuilder.MemoryTypes(memoryTypes)
+			}
+			searchBuilder = searchBuilder.IncludeExpiredByValidity(input.IncludeExpired)
 			if !asOfTime.IsZero() {
 				searchBuilder = searchBuilder.AsOf(asOfTime)
 			}
@@ -585,10 +596,17 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 		} else {
 			listBuilder := apptypes.NewMemoryListCriteriaBuilder(resolveLimit(input.Limit, defaultSearchLimit)).
 				Offset(resolveOffset(input.Offset)).
-				Scopes(scopes).
-				Statuses(statuses).
-				MemoryTypes(memoryTypes).
-				IncludeExpiredByValidity(input.IncludeExpired)
+				Scopes(scopes)
+			if preset != "" {
+				listBuilder = preset.ApplyToMemoryListCriteriaBuilder(listBuilder)
+			}
+			if len(statuses) > 0 {
+				listBuilder = listBuilder.Statuses(statuses)
+			}
+			if len(memoryTypes) > 0 {
+				listBuilder = listBuilder.MemoryTypes(memoryTypes)
+			}
+			listBuilder = listBuilder.IncludeExpiredByValidity(input.IncludeExpired)
 			if !asOfTime.IsZero() {
 				listBuilder = listBuilder.AsOf(asOfTime)
 			}


### PR DESCRIPTION
Closes #570

## Summary

Adds three named retrieval presets to durable memory (CLI + MCP):

| Preset | Defaults |
| --- | --- |
| `resume` | `status=accepted`. Type axis left open. |
| `review` | `status=accepted`, `type=decision\|constraint`. |
| `incident` | `status=accepted`, `type=decision\|constraint\|lesson`. |

Explicit `--status` / `--type` flags after a preset still override the preset's defaults (composable, not a ceiling), matching #570 acceptance criterion.

Surfaces wired:
- CLI `memory list --preset`
- CLI `memory search --preset`
- MCP `retrieve_memories` accepts a `preset` argument

## Out of scope (follow-up)

- `session_handoff` / `memory_pack` preset plumbing. These flow through ContextPackCriteria rather than MemoryListCriteria and pair naturally with #617 (ContextPackCriteria.AsOf). Same v0.8 follow-up slot.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` green
- [x] `go tool golangci-lint run` — 0 issues
- New tests: preset parser (happy + unknown), preset → criteria defaults for all three presets, explicit-filter-wins regression

Parent umbrella: #562 (v0.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)