### PR TITLE
fix(v0.8): quality-phase CRITICAL + HIGH fixes (test flaky + consistency)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist/
 .ai/
 .gocache/
 .golangci-cache/
+.golangci-lint-cache/
 .tmp-review-main/

--- a/docs/architecture/memory-blocks.ja.md
+++ b/docs/architecture/memory-blocks.ja.md
@@ -56,8 +56,8 @@ read 契約 (`application/types/memory_list_criteria.go` の `MemoryListCriteria
 memory blocks が約束する「*open work を resume*」「*過去の決定を review*」「*インシデント関連を一括抽出*」は、**retrieval presets (v0.8-5, #570)** の方がきれいに実現できます:
 
 - **`resume` preset**: session-family scope の `type=decision` / `type=lesson` に加え、audit events から未完了 signal を拾う（新 memory block ではなく event 側で処理）。
-- **`review` preset**: `type=decision` / `type=constraint` を広い時間窓で取る。
-- **`incident` preset**: 時刻範囲を絞って `type=lesson` + 直近失敗 + 関連決定を束ねる複合クエリ。
+- **`review` preset**: `type=decision` / `type=constraint` / `type=artifact` を広い時間窓で取る（決定・制約・そこから派生した runbook/dashboard）。
+- **`incident` preset**: 時刻範囲を絞って `type=lesson` / `type=constraint` / `type=decision` / `type=artifact` を束ねる複合クエリ。「何を避けるべきか」の軸に加えて on-call が参照する ops ツールへのポインタも出す。
 
 これら preset は application 層の拡張で済み、schema 変更不要です。運用フィードバックを受けて柔軟に調整できます。
 

--- a/docs/architecture/memory-blocks.md
+++ b/docs/architecture/memory-blocks.md
@@ -56,8 +56,8 @@ Four of the five proposed blocks reduce to existing `type` + `scope` combination
 The user-visible behavior memory blocks advertise — *resume my open work*, *review what I decided*, *show everything relevant to this incident* — is delivered more cleanly by **retrieval presets** (v0.8-5, #570):
 
 - **`resume` preset**: recent `type=decision` / `type=lesson` in the session-family scope, plus any open-ended signals from audit events (not from a new memory block).
-- **`review` preset**: `type=decision` / `type=constraint` over a wider window.
-- **`incident` preset**: time-boxed retrieval pulling `type=lesson`, recent failures, and related decisions — a composite query, not a block.
+- **`review` preset**: `type=decision` / `type=constraint` / `type=artifact` over a wider window — decisions, the constraints they imply, and the runbooks / dashboards they produced.
+- **`incident` preset**: time-boxed retrieval pulling `type=lesson`, `type=constraint`, `type=decision`, and `type=artifact` — the "what not to do" axis plus pointers to the ops tooling an on-call needs, still a composite query rather than a block.
 
 These presets live in the application layer and do not require schema changes. They can be iterated and tuned per operator feedback without a migration every time.
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -137,8 +137,8 @@ import は Codex の handbook（既定値は `~/.codex/memories/MEMORY.md`）を
 | Preset | 用途 | 既定フィルタ |
 | --- | --- | --- |
 | `resume` | 「どこまでやっていたか」を拾う。type 軸は絞らない | `status=accepted` |
-| `review` | 「何を決めて、どんな制約があるか」を確認する。再読に値する long-lived 知識だけに絞る | `status=accepted`, `type=decision,constraint` |
-| `incident` | 「失敗直後、何を知るべきか」。決定・制約に加えて lesson も含める | `status=accepted`, `type=decision,constraint,lesson` |
+| `review` | 「何を決めて、どんな制約があるか」を確認する。再読に値する long-lived 知識だけに絞る | `status=accepted`, `type=decision,constraint,artifact` |
+| `incident` | 「失敗直後、何を知るべきか」。決定・制約・lesson に加えて artifact（ログ場所・ダッシュボード・runbook 等）も含める | `status=accepted`, `type=decision,constraint,lesson,artifact` |
 
 例:
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -160,8 +160,8 @@ Use these to inspect existing durable memories:
 | Preset | Intent | Defaults applied |
 | --- | --- | --- |
 | `resume` | "Pick up where I left off." No type restriction — preferences and lessons are as useful as decisions. | `status=accepted` |
-| `review` | "What did we decide and what are the constraints?" Filters to long-lived knowledge you expect to reread. | `status=accepted`, `type=decision,constraint` |
-| `incident` | "A failure just happened — what do I need to know?" Includes lessons and constraints on top of decisions. | `status=accepted`, `type=decision,constraint,lesson` |
+| `review` | "What did we decide and what are the constraints?" Filters to long-lived knowledge you expect to reread. | `status=accepted`, `type=decision,constraint,artifact` |
+| `incident` | "A failure just happened — what do I need to know?" Includes lessons and constraints on top of decisions. Artifact memories (log paths, dashboards, runbooks) surface here too because incident reviewers want to jump straight to the tooling. | `status=accepted`, `type=decision,constraint,lesson,artifact` |
 
 Examples:
 

--- a/presentation/cli/replay.go
+++ b/presentation/cli/replay.go
@@ -15,12 +15,20 @@ import (
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
-	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 //go:embed replay_template.html
 var replayTemplateHTML string
+
+// replayTemplateSource is the indirection tests use to inject a
+// malformed template without mutating the package-level
+// `replayTemplateHTML`. Rewriting the package global under
+// `t.Parallel()` made `TestWriteReplayHTML_PreservesExistingOnTemplateError`
+// race with the other replay tests; this var lets the render-error
+// test swap behavior inside a single test goroutine while the other
+// tests keep using the embedded template.
+var replayTemplateSource = func() string { return replayTemplateHTML }
 
 // newReplayCommand builds `traceary replay --out <file>`. The command
 // assembles a single-file HTML replay of recent sessions, events, and
@@ -162,7 +170,7 @@ func (c *RootCLI) gatherReplayData(ctx context.Context, input replayCommandInput
 	sessionCriteria := apptypes.NewSessionListCriteriaBuilder(input.sessions).Build()
 	sessions, err := c.session.List(ctx, sessionCriteria)
 	if err != nil {
-		return replayData{}, xerrors.Errorf("failed to list sessions for replay: %w", err)
+		return replayData{}, xerrors.Errorf("%s: %w", Localize("failed to list sessions for replay", "replay 用のセッション一覧取得に失敗しました"), err)
 	}
 	for _, s := range sessions {
 		events, err := c.eventsForSession(ctx, s.SessionID(), input.eventsPerSession)
@@ -187,7 +195,7 @@ func (c *RootCLI) gatherReplayData(ctx context.Context, input replayCommandInput
 			Build()
 		memories, err := c.memory.List(ctx, memCriteria)
 		if err != nil {
-			return replayData{}, xerrors.Errorf("failed to list memories for replay: %w", err)
+			return replayData{}, xerrors.Errorf("%s: %w", Localize("failed to list memories for replay", "replay 用の durable memory 一覧取得に失敗しました"), err)
 		}
 		for _, m := range memories {
 			data.Memories = append(data.Memories, replayMemory{
@@ -214,7 +222,10 @@ func (c *RootCLI) eventsForSession(ctx context.Context, sessionID types.SessionI
 		Build()
 	events, err := c.event.List(ctx, criteria)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to list events for session %s: %w", sessionID.String(), err)
+		return nil, xerrors.Errorf("%s: %w", Localize(
+			fmt.Sprintf("failed to list events for session %s", sessionID.String()),
+			fmt.Sprintf("session %s の event 一覧取得に失敗しました", sessionID.String()),
+		), err)
 	}
 	result := make([]replayEvent, 0, len(events))
 	for _, e := range events {
@@ -241,10 +252,10 @@ func totalEventCount(sessions []replaySession) int {
 func writeReplayHTML(outputPath string, data replayData) error {
 	absPath, err := filepath.Abs(outputPath)
 	if err != nil {
-		return xerrors.Errorf("failed to resolve output path: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to resolve output path", "出力パスの解決に失敗しました"), err)
 	}
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return xerrors.Errorf("failed to create output directory: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to create output directory", "出力ディレクトリの作成に失敗しました"), err)
 	}
 
 	// Refuse symlink targets — the Stop-hook / CLI input does not have
@@ -253,10 +264,13 @@ func writeReplayHTML(outputPath string, data replayData) error {
 	// intend to touch.
 	if info, err := os.Lstat(absPath); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
-			return xerrors.Errorf("refusing to write replay HTML through a symlink: %s", absPath)
+			return xerrors.Errorf(Localize(
+				"refusing to write replay HTML through a symlink: %s",
+				"symlink 経由の書き込みを拒否しました: %s",
+			), absPath)
 		}
 	} else if !os.IsNotExist(err) {
-		return xerrors.Errorf("failed to inspect replay output path: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to inspect replay output path", "replay 出力パスの確認に失敗しました"), err)
 	}
 
 	tmpl, err := template.New("replay").Funcs(template.FuncMap{
@@ -277,9 +291,9 @@ func writeReplayHTML(outputPath string, data replayData) error {
 			}
 			return string(runes[:n]) + "…"
 		},
-	}).Parse(replayTemplateHTML)
+	}).Parse(replayTemplateSource())
 	if err != nil {
-		return xerrors.Errorf("failed to parse replay template: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to parse replay template", "replay テンプレートの parse に失敗しました"), err)
 	}
 
 	// Write to a sibling temp file and only rename into place on
@@ -287,7 +301,7 @@ func writeReplayHTML(outputPath string, data replayData) error {
 	// partially overwrite an existing replay file.
 	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), ".traceary-replay-*.html.tmp")
 	if err != nil {
-		return xerrors.Errorf("failed to create replay temp file: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to create replay temp file", "replay 一時ファイルの作成に失敗しました"), err)
 	}
 	tmpPath := tmpFile.Name()
 	cleanup := true
@@ -298,19 +312,19 @@ func writeReplayHTML(outputPath string, data replayData) error {
 		}
 	}()
 	if err := tmpl.Execute(tmpFile, data); err != nil {
-		return xerrors.Errorf("failed to render replay template: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to render replay template", "replay テンプレートのレンダリングに失敗しました"), err)
 	}
 	if err := tmpFile.Sync(); err != nil {
-		return xerrors.Errorf("failed to sync replay temp file: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to sync replay temp file", "replay 一時ファイルの fsync に失敗しました"), err)
 	}
 	if err := tmpFile.Close(); err != nil {
-		return xerrors.Errorf("failed to close replay temp file: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to close replay temp file", "replay 一時ファイルの close に失敗しました"), err)
 	}
 	if err := os.Chmod(tmpPath, 0o644); err != nil {
-		return xerrors.Errorf("failed to set replay file permissions: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to set replay file permissions", "replay ファイルの permission 設定に失敗しました"), err)
 	}
 	if err := os.Rename(tmpPath, absPath); err != nil {
-		return xerrors.Errorf("failed to place replay HTML: %w", err)
+		return xerrors.Errorf("%s: %w", Localize("failed to place replay HTML", "replay HTML の配置に失敗しました"), err)
 	}
 	cleanup = false
 	return nil
@@ -324,8 +338,3 @@ func formatOptionalInstant(value types.Optional[time.Time]) string {
 	}
 	return "—"
 }
-
-// _ exists so future additions can reference the interface without
-// a reflow. Keep for readability — the linter's unused-var check
-// does not apply to an `_` identifier.
-var _ = (*model.Event)(nil)

--- a/presentation/cli/replay_template.html
+++ b/presentation/cli/replay_template.html
@@ -130,7 +130,7 @@
 {{end}}
 
 <footer class="meta" style="margin-top:32px; padding-top:12px; border-top:1px solid var(--border);">
-  Traceary v0.8-1 replay export · local-first · no network access required to view this file.
+  Traceary replay export · local-first · no network access required to view this file.
 </footer>
 </body>
 </html>

--- a/presentation/cli/replay_test.go
+++ b/presentation/cli/replay_test.go
@@ -119,16 +119,23 @@ func TestWriteReplayHTML_RefusesSymlinkTarget(t *testing.T) {
 }
 
 func TestWriteReplayHTML_PreservesExistingOnTemplateError(t *testing.T) {
-	t.Parallel()
+	// Intentionally not t.Parallel(): this test mutates the
+	// package-level replayTemplateSource indirection to inject a
+	// malformed template; running in parallel with the other replay
+	// tests would race on that mutation.
 
 	dir := t.TempDir()
 	out := filepath.Join(dir, "replay.html")
 	if err := os.WriteFile(out, []byte("original"), 0o644); err != nil {
 		t.Fatalf("WriteFile(out) error = %v", err)
 	}
-	original := replayTemplateHTML
-	replayTemplateHTML = `{{.DoesNotExist}}`
-	defer func() { replayTemplateHTML = original }()
+	// Swap the template source via the indirection function rather
+	// than the package-level string so concurrent replay tests running
+	// under t.Parallel() do not race on a shared mutation. The
+	// indirection is scoped to this goroutine via a closure capture.
+	original := replayTemplateSource
+	replayTemplateSource = func() string { return `{{.DoesNotExist}}` }
+	defer func() { replayTemplateSource = original }()
 
 	err := writeReplayHTML(out, replayData{GeneratedAt: time.Now().UTC()})
 	if err == nil {

--- a/presentation/cli/replay_test.go
+++ b/presentation/cli/replay_test.go
@@ -129,10 +129,12 @@ func TestWriteReplayHTML_PreservesExistingOnTemplateError(t *testing.T) {
 	if err := os.WriteFile(out, []byte("original"), 0o644); err != nil {
 		t.Fatalf("WriteFile(out) error = %v", err)
 	}
-	// Swap the template source via the indirection function rather
-	// than the package-level string so concurrent replay tests running
-	// under t.Parallel() do not race on a shared mutation. The
-	// indirection is scoped to this goroutine via a closure capture.
+	// Swap the template source via the `replayTemplateSource`
+	// indirection. `replayTemplateSource` is still a package-level
+	// variable — the race avoidance here comes from this test
+	// *not* calling t.Parallel() (see comment above), so go test's
+	// "serial phase before parallel phase" ordering guarantees that
+	// no other replay test runs while this one holds the swap.
 	original := replayTemplateSource
 	replayTemplateSource = func() string { return `{{.DoesNotExist}}` }
 	defer func() { replayTemplateSource = original }()

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -492,7 +492,7 @@ func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessio
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input sessionHandoffInput) (*mcp.CallToolResult, sessionHandoffOutput, error) {
 		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
 		if err != nil {
-			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to parse preset: %w", err)
 		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
@@ -518,7 +518,7 @@ func (s *Server) memoryPack() mcp.ToolHandlerFor[memoryPackInput, memoryPackOutp
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input memoryPackInput) (*mcp.CallToolResult, memoryPackOutput, error) {
 		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
 		if err != nil {
-			return nil, memoryPackOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+			return nil, memoryPackOutput{}, xerrors.Errorf("failed to parse preset: %w", err)
 		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
@@ -571,13 +571,13 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 		if trimmedAsOf := strings.TrimSpace(input.AsOf); trimmedAsOf != "" {
 			parsed, err := parseFlexibleTime(trimmedAsOf, false)
 			if err != nil {
-				return nil, memoriesOutput{}, xerrors.Errorf("failed to resolve as_of: %w", err)
+				return nil, memoriesOutput{}, xerrors.Errorf("failed to parse as_of: %w", err)
 			}
 			asOfTime = parsed
 		}
 		preset, err := apptypes.MemoryRetrievalPresetOf(input.Preset)
 		if err != nil {
-			return nil, memoriesOutput{}, xerrors.Errorf("failed to resolve preset: %w", err)
+			return nil, memoriesOutput{}, xerrors.Errorf("failed to parse preset: %w", err)
 		}
 
 		var summaries []apptypes.MemorySummary

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -389,11 +389,11 @@ func (s *Server) listEvents() mcp.ToolHandlerFor[listEventsInput, eventsOutput] 
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input listEventsInput) (*mcp.CallToolResult, eventsOutput, error) {
 		from, err := parseFlexibleTime(input.From, false)
 		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve from: %w", err)
+			return nil, eventsOutput{}, xerrors.Errorf("failed to parse from: %w", err)
 		}
 		to, err := parseFlexibleTime(input.To, true)
 		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve to: %w", err)
+			return nil, eventsOutput{}, xerrors.Errorf("failed to parse to: %w", err)
 		}
 
 		criteria := apptypes.NewEventListCriteriaBuilder(resolveLimit(input.Limit, defaultSearchLimit)).
@@ -451,11 +451,11 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input searchInput) (*mcp.CallToolResult, eventsOutput, error) {
 		from, err := parseFlexibleTime(input.From, false)
 		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve from: %w", err)
+			return nil, eventsOutput{}, xerrors.Errorf("failed to parse from: %w", err)
 		}
 		to, err := parseFlexibleTime(input.To, true)
 		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to resolve to: %w", err)
+			return nil, eventsOutput{}, xerrors.Errorf("failed to parse to: %w", err)
 		}
 		limit := resolveLimit(input.Limit, defaultSearchLimit)
 		criteria := apptypes.NewEventSearchCriteriaBuilder(limit).
@@ -943,7 +943,7 @@ func (s *Server) expireMemory() mcp.ToolHandlerFor[expireMemoryInput, memoryOutp
 		}
 		expiresAt, err := parseFlexibleTime(input.ExpiresAt, false)
 		if err != nil {
-			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve expires_at: %w", err)
+			return nil, memoryOutput{}, xerrors.Errorf("failed to parse expires_at: %w", err)
 		}
 		expiresAtOptional := types.None[time.Time]()
 		if !expiresAt.IsZero() {
@@ -967,7 +967,7 @@ func (s *Server) setMemoryValidity() mcp.ToolHandlerFor[setMemoryValidityInput, 
 		if strings.TrimSpace(input.ValidFrom) != "" {
 			validFrom, err := parseFlexibleTime(input.ValidFrom, false)
 			if err != nil {
-				return nil, memoryOutput{}, xerrors.Errorf("failed to resolve valid_from: %w", err)
+				return nil, memoryOutput{}, xerrors.Errorf("failed to parse valid_from: %w", err)
 			}
 			validFromOptional = types.Some(validFrom)
 		}
@@ -975,7 +975,7 @@ func (s *Server) setMemoryValidity() mcp.ToolHandlerFor[setMemoryValidityInput, 
 		if strings.TrimSpace(input.ValidTo) != "" {
 			validTo, err := parseFlexibleTime(input.ValidTo, false)
 			if err != nil {
-				return nil, memoryOutput{}, xerrors.Errorf("failed to resolve valid_to: %w", err)
+				return nil, memoryOutput{}, xerrors.Errorf("failed to parse valid_to: %w", err)
 			}
 			validToOptional = types.Some(validTo)
 		}


### PR DESCRIPTION
Umbrella batch of small fixes surfaced by the v0.8 quality phase (Multi-AI review of the full v0.7.2..HEAD diff).

## Scope

**CRITICAL (Codex QA)**
- Replay render-error test raced the other replay tests because it mutated the package-level template string under `t.Parallel()`. Introduce a `replayTemplateSource` func indirection and drop `t.Parallel()` on that case. Verified under `-race -count=3`.

**HIGH (Claude architect)**
- `var _ = (*model.Event)(nil)` dead-code workaround removed from `presentation/cli/replay.go`; stale `domain/model` import dropped.

**HIGH (Codex architect)**
- Preset defaults already included `MemoryTypeArtifact`, but docs still listed the pre-artifact set. Sync `docs/memory/README{,.ja}.md` and `docs/architecture/memory-blocks{,.ja}.md`.

**HIGH (Gemini / Claude designer)**
- `replay.go` had 11 raw-English error sites; wrap them with `Localize(en, ja)` to match the rest of the CLI.
- `replay_template.html` footer hard-coded "v0.8-1"; drop the version suffix.
- MCP `sessionHandoff` / `memoryPack` / `retrieveMemories` emitted "failed to resolve preset" / "failed to resolve as_of" while CLI emits "failed to parse". Unify on "parse".

**chore**
- Ignore `.golangci-lint-cache/` so the local lint cache is never accidentally staged.

## Follow-up issues (not in this PR)

These surfaced during the quality phase but are out of scope for a pre-release polish PR. Each will be filed as a separate `tech-debt` issue:

- `presentation → usecase-impl` direct import (RedactWellKnownSecrets)
- Transcript capture bypasses `extra_redact_patterns`
- Replay cross-aggregate bundle should live in `application/`
- CLI vs MCP JSON null-representation drift
- `SetValidity` CLI/MCP-path tests + dedicated stub fields
- Replay timeline / failure-hotspot sections
- Transcript capture Codex / Gemini host parity
- `hooks install --matcher` preset flag

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` green
- [x] `go test -race -count=3 ./presentation/cli/` green (flaky test gate)
- [x] `go tool golangci-lint run` — 0 issues

Parent umbrella: #562 (v0.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)