### PR TITLE
feat(memory): ingest transcript events into extraction + refresh MCP tool descriptions

### DIFF
--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -290,6 +290,9 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 	if err := appendKindSignals(domtypes.EventKindPrompt, true, true); err != nil {
 		return nil, err
 	}
+	if err := appendKindSignals(domtypes.EventKindTranscript, true, true); err != nil {
+		return nil, err
+	}
 	if err := appendKindSignals(domtypes.EventKindReviewed, true, true); err != nil {
 		return nil, err
 	}

--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -210,6 +210,68 @@ func TestMemoryExtractionUsecase_Extract(t *testing.T) {
 	}
 }
 
+func TestMemoryExtractionUsecase_Extract_IncludesTranscriptEvents(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-transcript"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"active",
+		1,
+		0,
+		[]string{"claude"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	transcriptEvent := mustExtractionEvent(t,
+		"event-transcript",
+		domtypes.EventKindTranscript,
+		"Decision: adopt the application/redaction leaf package.",
+	)
+
+	details := mustMemoryDetailsFromSummary(t, "memory-transcript-1", domtypes.MemoryTypeDecision, "adopt the application/redaction leaf package.")
+
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details},
+	}
+
+	sut := usecase.NewMemoryExtractionUsecase(
+		&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+		&eventQueryServiceStub{
+			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+				domtypes.EventKindTranscript: {transcriptEvent},
+			},
+		},
+		memoryUsecase,
+		nil,
+	)
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-transcript")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(1).
+			CandidateLimit(5).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(Extract()) = %d, want 1 transcript-derived candidate", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
+	}
+	if memoryUsecase.proposeCalls[0].memoryType != domtypes.MemoryTypeDecision {
+		t.Errorf("memoryType = %v, want Decision", memoryUsecase.proposeCalls[0].memoryType)
+	}
+}
+
 func TestMemoryExtractionUsecase_Extract_DeduplicatesExistingAndGracefullyHandlesMissingPrompts(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -106,7 +106,7 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "add_log",
-		Description: "Add a log event, note, prompt, or compact summary.",
+		Description: "Add a log event, note, prompt, transcript, or compact summary.",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)},
 	}, s.addLog())
 	mcp.AddTool(server, &mcp.Tool{
@@ -131,7 +131,7 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 	}, s.activeSession())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_events",
-		Description: "List recent events, logs, audits, prompts, and summaries.",
+		Description: "List recent events, logs, audits, prompts, transcripts, and summaries.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.listEvents())
 	mcp.AddTool(server, &mcp.Tool{
@@ -141,12 +141,12 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 	}, s.addAudit())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "search",
-		Description: "Search events, logs, audits, prompts, and summaries by text, time, or workspace.",
+		Description: "Search events, logs, audits, prompts, transcripts, and summaries by text, time, or workspace.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.search())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_context",
-		Description: "Get recent context events, logs, audits, prompts, and summaries for a session or workspace.",
+		Description: "Get recent context events, logs, audits, prompts, transcripts, and summaries for a session or workspace.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.getContext())
 	mcp.AddTool(server, &mcp.Tool{

--- a/presentation/mcpserver/tool_metadata_test.go
+++ b/presentation/mcpserver/tool_metadata_test.go
@@ -56,7 +56,7 @@ func TestServer_ToolMetadata(t *testing.T) {
 		{
 			name: "add_log",
 			want: toolMetadataExpectation{
-				description:      "Add a log event, note, prompt, or compact summary.",
+				description:      "Add a log event, note, prompt, transcript, or compact summary.",
 				destructiveFalse: true,
 			},
 		},
@@ -91,7 +91,7 @@ func TestServer_ToolMetadata(t *testing.T) {
 		{
 			name: "list_events",
 			want: toolMetadataExpectation{
-				description: "List recent events, logs, audits, prompts, and summaries.",
+				description: "List recent events, logs, audits, prompts, transcripts, and summaries.",
 				readOnly:    true,
 			},
 		},
@@ -105,14 +105,14 @@ func TestServer_ToolMetadata(t *testing.T) {
 		{
 			name: "search",
 			want: toolMetadataExpectation{
-				description: "Search events, logs, audits, prompts, and summaries by text, time, or workspace.",
+				description: "Search events, logs, audits, prompts, transcripts, and summaries by text, time, or workspace.",
 				readOnly:    true,
 			},
 		},
 		{
 			name: "get_context",
 			want: toolMetadataExpectation{
-				description: "Get recent context events, logs, audits, prompts, and summaries for a session or workspace.",
+				description: "Get recent context events, logs, audits, prompts, transcripts, and summaries for a session or workspace.",
 				readOnly:    true,
 			},
 		},


### PR DESCRIPTION
## Summary

- `memory_extraction_usecase_impl.go` now appends `EventKindTranscript` to the signal table with the same `(heuristics=true, allowStructured=true)` defaults as `EventKindPrompt`. Assistant-reasoning transcripts routinely surface explicit `Decision:` / `Constraint:` / `Lesson:` labels, so they deserve the same extraction treatment.
- MCP tool `Description` strings for `add_log`, `list_events`, `search`, and `get_context` now mention `transcript`, helping MCP Tool Search and host UIs discover the kind added in #606.

## Tests

- New unit test `TestMemoryExtractionUsecase_Extract_IncludesTranscriptEvents` asserting a transcript-only session yields a candidate.
- Existing `TestServer_ToolMetadata` expectations updated for the four refreshed descriptions.

## Acceptance

- [x] Memory extraction considers transcript events (test added).
- [x] MCP tool listings include `transcript` in their description text.
- [x] `go test ./...` / `go tool golangci-lint run` green.

Closes #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)