### PR TITLE
test(memory): cover SetValidity on CLI and MCP presentation paths

### DIFF
--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -393,6 +393,114 @@ func TestRootCLI_MemoryExtractCommand_RequiresStoreManagement(t *testing.T) {
 	}
 }
 
+func TestRootCLI_MemorySetValidityCommand_ParsesFromAndTo(t *testing.T) {
+	stub := &memoryUsecaseStub{
+		setValidityDetails: mustMemoryDetails(t, "memory-validity", "Memory with validity", types.MemoryStatusAccepted),
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "set-validity",
+		"--db-path", "/tmp/test-traceary.db",
+		"--from", "2026-04-20",
+		"--to", "2026-07-01",
+		"--id-only",
+		"memory-validity",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stub.setValidityCallCount != 1 {
+		t.Fatalf("setValidityCallCount = %d, want 1", stub.setValidityCallCount)
+	}
+	if stub.setValidityCall.memoryID.String() != "memory-validity" {
+		t.Errorf("memoryID = %q, want memory-validity", stub.setValidityCall.memoryID.String())
+	}
+	validFrom, ok := stub.setValidityCall.validFrom.Value()
+	if !ok {
+		t.Fatalf("validFrom = None, want Some(2026-04-20)")
+	}
+	if !validFrom.Equal(time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("validFrom = %v, want 2026-04-20 UTC", validFrom)
+	}
+	validTo, ok := stub.setValidityCall.validTo.Value()
+	if !ok {
+		t.Fatalf("validTo = None, want Some(2026-07-01)")
+	}
+	if !validTo.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("validTo = %v, want 2026-07-01 UTC", validTo)
+	}
+	if stub.setValidityCall.clearTo {
+		t.Errorf("clearTo = true, want false")
+	}
+}
+
+func TestRootCLI_MemorySetValidityCommand_ClearToPropagates(t *testing.T) {
+	stub := &memoryUsecaseStub{
+		setValidityDetails: mustMemoryDetails(t, "memory-validity", "Memory with validity cleared", types.MemoryStatusAccepted),
+	}
+
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "set-validity",
+		"--db-path", "/tmp/test-traceary.db",
+		"--clear-to",
+		"memory-validity",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !stub.setValidityCall.clearTo {
+		t.Errorf("clearTo = false, want true")
+	}
+	if _, ok := stub.setValidityCall.validTo.Value(); ok {
+		t.Errorf("validTo set even though only --clear-to supplied")
+	}
+}
+
+func TestRootCLI_MemorySetValidityCommand_RejectsInvalidFrom(t *testing.T) {
+	stub := &memoryUsecaseStub{}
+
+	stderr := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(stderr)
+	rootCmd.SetArgs([]string{
+		"memory", "set-validity",
+		"--db-path", "/tmp/test-traceary.db",
+		"--from", "not-a-timestamp",
+		"memory-validity",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want parse error")
+	}
+	if stub.setValidityCallCount != 0 {
+		t.Errorf("setValidity invoked despite parse error; count = %d", stub.setValidityCallCount)
+	}
+	if !strings.Contains(err.Error(), "--from") {
+		t.Errorf("error = %v, want phrasing that identifies --from", err)
+	}
+}
+
 func mustMemorySummary(t *testing.T, memoryIDValue string, fact string, status types.MemoryStatus) apptypes.MemorySummary {
 	t.Helper()
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -265,6 +265,8 @@ type memoryUsecaseStub struct {
 	supersedeErr     error
 	expireDetails    apptypes.MemoryDetails
 	expireErr        error
+	setValidityDetails apptypes.MemoryDetails
+	setValidityErr     error
 
 	rememberCall struct {
 		memoryType   types.MemoryType
@@ -284,6 +286,14 @@ type memoryUsecaseStub struct {
 	}
 	acceptCallCount int
 	rejectCallCount int
+
+	setValidityCall struct {
+		memoryID  types.MemoryID
+		validFrom types.Optional[time.Time]
+		validTo   types.Optional[time.Time]
+		clearTo   bool
+	}
+	setValidityCallCount int
 }
 
 func (s *memoryUsecaseStub) Remember(_ context.Context, memoryType types.MemoryType, scope types.MemoryScope, fact string, confidence types.Optional[types.Confidence], source types.MemorySource, evidenceRefs []types.EvidenceRef, artifactRefs []types.ArtifactRef) (apptypes.MemoryDetails, error) {
@@ -321,8 +331,13 @@ func (s *memoryUsecaseStub) Expire(_ context.Context, _ types.MemoryID, _ types.
 	return s.expireDetails, s.expireErr
 }
 
-func (s *memoryUsecaseStub) SetValidity(_ context.Context, _ types.MemoryID, _ types.Optional[time.Time], _ types.Optional[time.Time], _ bool) (apptypes.MemoryDetails, error) {
-	return s.expireDetails, s.expireErr
+func (s *memoryUsecaseStub) SetValidity(_ context.Context, memoryID types.MemoryID, validFrom types.Optional[time.Time], validTo types.Optional[time.Time], clearTo bool) (apptypes.MemoryDetails, error) {
+	s.setValidityCall.memoryID = memoryID
+	s.setValidityCall.validFrom = validFrom
+	s.setValidityCall.validTo = validTo
+	s.setValidityCall.clearTo = clearTo
+	s.setValidityCallCount++
+	return s.setValidityDetails, s.setValidityErr
 }
 
 func (s *memoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -686,6 +686,71 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("set_memory_validity accepts bounds and clear_valid_to separately", func(t *testing.T) {
+		rememberResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "remember_memory",
+			Arguments: map[string]any{
+				"type":      "decision",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Memory used for validity plumbing test",
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#629"},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(remember_memory) error = %v", err)
+		}
+		memoryID := extractJSONStringValue(t, rememberResult, "memory_id")
+		if memoryID == "" {
+			t.Fatalf("memory_id = empty")
+		}
+
+		setResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "set_memory_validity",
+			Arguments: map[string]any{
+				"memory_id":  memoryID,
+				"valid_from": "2026-04-20T00:00:00Z",
+				"valid_to":   "2026-07-01T00:00:00Z",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(set_memory_validity) error = %v", err)
+		}
+		if setResult.IsError {
+			t.Fatalf("CallTool(set_memory_validity) IsError = true, want false")
+		}
+
+		clearResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "set_memory_validity",
+			Arguments: map[string]any{
+				"memory_id":      memoryID,
+				"clear_valid_to": true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(set_memory_validity clear) error = %v", err)
+		}
+		if clearResult.IsError {
+			t.Fatalf("CallTool(set_memory_validity clear) IsError = true, want false")
+		}
+
+		conflictResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "set_memory_validity",
+			Arguments: map[string]any{
+				"memory_id":      memoryID,
+				"valid_to":       "2026-12-31T00:00:00Z",
+				"clear_valid_to": true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(set_memory_validity conflict) error = %v", err)
+		}
+		if !conflictResult.IsError {
+			t.Fatalf("CallTool(set_memory_validity conflict) IsError = false, want true")
+		}
+	})
+
 	t.Run("returns tool error", func(t *testing.T) {
 		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "add_log",


### PR DESCRIPTION
## Summary

Fills the presentation-layer test gap flagged in v0.8 quality-phase review (Claude architect HIGH):

- Separate `setValidityDetails` / `setValidityErr` / `setValidityCall` fields on `memoryUsecaseStub` so call recording no longer collides with expire fixtures.
- Three CLI tests in `memory_test.go` for flag parsing (`--from` + `--to`, `--clear-to`, invalid `--from`).
- One MCP integration subtest in `TestServer_BuildAndTools` for `set_memory_validity` (bound setting, clear_valid_to, conflict rejection).

## Acceptance

- [x] `go test ./presentation/cli/` exercises new set-validity paths.
- [x] `go test ./presentation/mcpserver/` exercises new `set_memory_validity` subtest.
- [x] `go test ./...` green.
- [x] `go tool golangci-lint run` clean.

Closes #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)