### PR TITLE
feat(skills): add traceary-memory-capture skill to prompt agents to propose durable memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 .golangci-cache/
 .golangci-lint-cache/
 .tmp-review-main/
+.gopath

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,7 @@ go tool golangci-lint run
 - `go test ./...` must pass before committing
 - Test names use English descriptions (table-driven with subtests)
 - No `panic()` in runtime paths — reserved only for programming errors in init-time assertions
+
+### Durable memory capture (agent guidance)
+
+When working on this repository with a Claude Code agent, proactively call the `propose_memory` MCP tool when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. The candidate lands in Traceary's review inbox — it does not auto-accept. See the packaged `traceary-memory-capture` skill for trigger phrases, the five memory types, and the required input shape (exactly one of `workspace` / `agent` / `session_family`).

--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -9,7 +9,7 @@ Claude 向け package は `integrations/claude-plugin/` にあり、repository r
 - `traceary mcp-server` を使う `traceary` MCP server
 - `SessionStart` / `SessionEnd` hook
 - Bash 向けの `PostToolUse` / `PostToolUseFailure` audit hook
-- slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` skill
+- slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-capture` skill（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `propose_memory` を能動的に呼ぶよう誘導します）
 
 ## Install
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -9,7 +9,7 @@ The Claude package lives under `integrations/claude-plugin/` and is published th
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart` / `SessionEnd` hooks
 - `PostToolUse` / `PostToolUseFailure` shell-audit hooks for Bash
-- slash-style skills: `/traceary-help` plus the contextual `traceary-session-history` skill
+- slash-style skills: `/traceary-help` plus the contextual `traceary-session-history` and `traceary-memory-capture` skills (the latter prompts the agent to proactively call `propose_memory` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
 
 ## Install
 

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -42,7 +42,7 @@ traceary doctor --client codex --json
 - `traceary mcp-server` を呼ぶ `traceary` MCP server
 - `SessionStart`, `UserPromptSubmit`, `Stop`, `PostToolUse` hook（`plugins/traceary/hooks.json` で宣言、manifest から参照）
 - slash command: `/traceary:help`, `/traceary:doctor`
-- 文脈に効く skill: `traceary-session-history`
+- 文脈に効く skill: `traceary-session-history` / `traceary-memory-capture`（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `propose_memory` を能動的に呼ぶよう誘導します）
 
 ## 更新
 

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -42,7 +42,7 @@ traceary doctor --client codex --json
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart`, `UserPromptSubmit`, `Stop`, and `PostToolUse` hooks (declared in `plugins/traceary/hooks.json` and referenced from the plugin manifest)
 - slash commands: `/traceary:help` and `/traceary:doctor`
-- contextual skill: `traceary-session-history`
+- contextual skills: `traceary-session-history` and `traceary-memory-capture` (the latter prompts the agent to proactively call `propose_memory` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
 
 ## Update
 

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -10,7 +10,7 @@ Gemini 向け package は `integrations/gemini-extension/` にあります。Gem
 - `SessionStart` / `SessionEnd` hook
 - `run_shell_command` 向け `AfterTool` audit hook
 - slash command の `/traceary-help` と `/traceary-doctor`
-- 文脈で効く `traceary-session-history` skill
+- 文脈で効く `traceary-session-history` / `traceary-memory-capture` skill（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `propose_memory` を能動的に呼ぶよう誘導します）
 
 ## Install
 

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -10,7 +10,7 @@ The Gemini package lives under `integrations/gemini-extension/`. Gemini CLI expe
 - `SessionStart` / `SessionEnd` hooks
 - `AfterTool` shell-audit hook for `run_shell_command`
 - slash commands: `/traceary-help` and `/traceary-doctor`
-- contextual skill: `traceary-session-history`
+- contextual skills: `traceary-session-history` and `traceary-memory-capture` (the latter prompts the agent to proactively call `propose_memory` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
 
 ## Install
 

--- a/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: traceary-memory-capture
+description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's propose_memory MCP tool so the candidate lands in the review inbox; accept_memory only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
+version: 1.0.0
+---
+
+# Traceary memory capture
+
+Durable memory in Traceary is the cross-session layer: decisions, constraints, lessons, preferences, and artifact pointers that should survive compact / clear / a new session. The MCP `propose_memory` tool records a *candidate* — it does not auto-accept — so using it liberally is safe.
+
+## When to propose
+
+Call `propose_memory` (or `remember_memory` when the user explicitly asks you to remember something now) when you observe any of:
+
+- **decision**: a design / scope / strategy choice the operator just committed to.
+- **constraint**: a rule the operator stated (e.g. "never force-push to main", "always wait for CI before merging").
+- **lesson**: an error / fix pair worth not repeating (e.g. "mock DB tests masked a migration bug — don't do that again").
+- **preference**: an ergonomic choice the operator stated (e.g. "keep PRs under 500 lines").
+- **artifact**: a pointer worth reusing next session (e.g. `file:docs/architecture/redaction.md`, `url:https://grafana.internal/...`).
+
+## How to call it
+
+Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+
+```
+propose_memory({
+  "type": "constraint",
+  "workspace": "github.com/org/repo",
+  "fact": "Release tags require Multi-AI review before push",
+  "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+})
+```
+
+For artifact references, include `artifact_refs` instead of (or in addition to) evidence: `{"kind": "file", "value": "docs/architecture/redaction.md"}`.
+
+## Guardrails
+
+- **Never auto-accept.** `propose_memory` leaves the memory in `status=candidate` for human review. Do not call `accept_memory` unless the user explicitly confirms.
+- **Do not duplicate known memories.** If a `retrieve_memories` call would hit an identical fact, skip proposing again.
+- **Do not propose noise.** Temporary session state, WIP context, and in-progress tasks do not belong in durable memory — they belong in session handoff, not memory.
+- **Do not propose secrets.** Traceary sanitizes on write, but avoid passing secret-shaped payloads.

--- a/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
@@ -20,7 +20,7 @@ Call `propose_memory` (or `remember_memory` when the user explicitly asks you to
 
 ## How to call it
 
-Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+Use the MCP tool with at minimum `type`, a scope field (exactly one of `workspace`, `agent`, or `session_family`), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
 
 ```
 propose_memory({

--- a/integrations/gemini-extension/GEMINI.md
+++ b/integrations/gemini-extension/GEMINI.md
@@ -9,3 +9,5 @@ This extension wires Traceary into Gemini CLI through three shared surfaces:
 Prefer the packaged MCP tools when the user asks about prior sessions, command audits, or what happened earlier in the workspace.
 
 Use `/traceary-doctor` when the user needs setup or troubleshooting guidance.
+
+When the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session, proactively call `propose_memory` so the candidate lands in Traceary's review inbox. See the `traceary-memory-capture` skill for trigger phrases and guardrails (always propose, never auto-accept).

--- a/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: traceary-memory-capture
+description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's propose_memory MCP tool so the candidate lands in the review inbox; accept_memory only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
+version: 1.0.0
+---
+
+# Traceary memory capture
+
+Durable memory in Traceary is the cross-session layer: decisions, constraints, lessons, preferences, and artifact pointers that should survive compact / clear / a new session. The MCP `propose_memory` tool records a *candidate* — it does not auto-accept — so using it liberally is safe.
+
+## When to propose
+
+Call `propose_memory` (or `remember_memory` when the user explicitly asks you to remember something now) when you observe any of:
+
+- **decision**: a design / scope / strategy choice the operator just committed to.
+- **constraint**: a rule the operator stated (e.g. "never force-push to main", "always wait for CI before merging").
+- **lesson**: an error / fix pair worth not repeating (e.g. "mock DB tests masked a migration bug — don't do that again").
+- **preference**: an ergonomic choice the operator stated (e.g. "keep PRs under 500 lines").
+- **artifact**: a pointer worth reusing next session (e.g. `file:docs/architecture/redaction.md`, `url:https://grafana.internal/...`).
+
+## How to call it
+
+Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+
+```
+propose_memory({
+  "type": "constraint",
+  "workspace": "github.com/org/repo",
+  "fact": "Release tags require Multi-AI review before push",
+  "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+})
+```
+
+For artifact references, include `artifact_refs` instead of (or in addition to) evidence: `{"kind": "file", "value": "docs/architecture/redaction.md"}`.
+
+## Guardrails
+
+- **Never auto-accept.** `propose_memory` leaves the memory in `status=candidate` for human review. Do not call `accept_memory` unless the user explicitly confirms.
+- **Do not duplicate known memories.** If a `retrieve_memories` call would hit an identical fact, skip proposing again.
+- **Do not propose noise.** Temporary session state, WIP context, and in-progress tasks do not belong in durable memory — they belong in session handoff, not memory.
+- **Do not propose secrets.** Traceary sanitizes on write, but avoid passing secret-shaped payloads.

--- a/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
@@ -20,7 +20,7 @@ Call `propose_memory` (or `remember_memory` when the user explicitly asks you to
 
 ## How to call it
 
-Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+Use the MCP tool with at minimum `type`, a scope field (exactly one of `workspace`, `agent`, or `session_family`), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
 
 ```
 propose_memory({

--- a/plugins/traceary/skills/traceary-memory-capture/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-capture/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: traceary-memory-capture
+description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's propose_memory MCP tool so the candidate lands in the review inbox; accept_memory only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
+version: 1.0.0
+---
+
+# Traceary memory capture
+
+Durable memory in Traceary is the cross-session layer: decisions, constraints, lessons, preferences, and artifact pointers that should survive compact / clear / a new session. The MCP `propose_memory` tool records a *candidate* — it does not auto-accept — so using it liberally is safe.
+
+## When to propose
+
+Call `propose_memory` (or `remember_memory` when the user explicitly asks you to remember something now) when you observe any of:
+
+- **decision**: a design / scope / strategy choice the operator just committed to.
+- **constraint**: a rule the operator stated (e.g. "never force-push to main", "always wait for CI before merging").
+- **lesson**: an error / fix pair worth not repeating (e.g. "mock DB tests masked a migration bug — don't do that again").
+- **preference**: an ergonomic choice the operator stated (e.g. "keep PRs under 500 lines").
+- **artifact**: a pointer worth reusing next session (e.g. `file:docs/architecture/redaction.md`, `url:https://grafana.internal/...`).
+
+## How to call it
+
+Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+
+```
+propose_memory({
+  "type": "constraint",
+  "workspace": "github.com/org/repo",
+  "fact": "Release tags require Multi-AI review before push",
+  "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+})
+```
+
+For artifact references, include `artifact_refs` instead of (or in addition to) evidence: `{"kind": "file", "value": "docs/architecture/redaction.md"}`.
+
+## Guardrails
+
+- **Never auto-accept.** `propose_memory` leaves the memory in `status=candidate` for human review. Do not call `accept_memory` unless the user explicitly confirms.
+- **Do not duplicate known memories.** If a `retrieve_memories` call would hit an identical fact, skip proposing again.
+- **Do not propose noise.** Temporary session state, WIP context, and in-progress tasks do not belong in durable memory — they belong in session handoff, not memory.
+- **Do not propose secrets.** Traceary sanitizes on write, but avoid passing secret-shaped payloads.

--- a/plugins/traceary/skills/traceary-memory-capture/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-capture/SKILL.md
@@ -20,7 +20,7 @@ Call `propose_memory` (or `remember_memory` when the user explicitly asks you to
 
 ## How to call it
 
-Use the MCP tool with at minimum `type`, `scope` (workspace by default), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
+Use the MCP tool with at minimum `type`, a scope field (exactly one of `workspace`, `agent`, or `session_family`), `fact`, and `evidence_refs` (the conversation turn / event / issue that justifies the claim). Example:
 
 ```
 propose_memory({

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -141,6 +141,7 @@ def check_claude() -> None:
     require((ROOT / 'integrations' / 'claude-plugin' / 'scripts' / 'traceary-compact.sh').exists(), 'missing Claude compact hook script')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-help' / 'SKILL.md').exists(), 'missing Claude traceary-help skill')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Claude traceary-session-history skill')
+    require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Claude traceary-memory-capture skill')
 
 
 def check_codex() -> None:
@@ -171,6 +172,7 @@ def check_codex() -> None:
     require((ROOT / 'plugins' / 'traceary' / 'commands' / 'help.md').exists(), 'missing Codex help command')
     require((ROOT / 'plugins' / 'traceary' / 'commands' / 'doctor.md').exists(), 'missing Codex doctor command')
     require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Codex traceary-session-history skill')
+    require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Codex traceary-memory-capture skill')
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_root = Path(temp_dir)
@@ -346,6 +348,7 @@ def check_gemini() -> None:
     require((ROOT / 'integrations' / 'gemini-extension' / 'commands' / 'traceary-help.toml').exists(), 'missing Gemini help command')
     require((ROOT / 'integrations' / 'gemini-extension' / 'commands' / 'traceary-doctor.toml').exists(), 'missing Gemini doctor command')
     require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Gemini traceary-session-history skill')
+    require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-capture skill')
     require((ROOT / 'integrations' / 'gemini-extension' / 'GEMINI.md').exists(), 'missing Gemini context file')
 
 


### PR DESCRIPTION
## Summary

Minimum-viable implementation of durable-memory write-path enablement surfaced during v0.8.0 dogfooding. Across 10+ real sessions the durable-memory store remained almost empty because no hook or prompt was pushing the agent to write.

- **New skill: `traceary-memory-capture`** added to all three plugin skill directories (Claude plugin, Codex plugin, Gemini extension). It tells the hosted agent when and how to call `propose_memory`, enumerates the five memory types (decision / constraint / lesson / preference / artifact), shows the minimal payload, and enforces the guardrail that candidates go to review rather than auto-accept.
- **Gemini root directive**: `GEMINI.md` now mentions the proactive-propose guidance so it is visible to Gemini outside of skill matcher hits.

## Out of scope (deferred)

Options A-C from #611 remain deferred to later iterations:
- A. Stop hook → keyword-based candidate propose (`#606` extension)
- B. UserPromptSubmit → "remember/always/never" pattern detection
- C. SessionEnd → `memory extract` auto-kick

This PR commits only to the SKILL.md-level guidance as the minimum exercise of the durable-memory write path.

## Acceptance

- [x] Claude / Codex / Gemini plugin skill descriptors prompt `propose_memory` with the appropriate `type` for each of the 5 categories.
- [x] Guardrail text forbids auto-accept, duplicate proposal, noise, and secrets.
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.
- [ ] Dogfooding: a single v0.8.0 session produces ≥3 candidate memories without manual `memory remember`. (To be verified post-plugin-update by operator — tracked in release checklist.)

Closes #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)