### PR TITLE
feat(doctor): warn when Claude plugin cache version is older than the marketplace manifest

### DIFF
--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -43,6 +43,8 @@ claude plugins marketplace update traceary-plugins
 claude plugins update traceary@traceary-plugins
 ```
 
+> **重要**: `brew upgrade traceary` は CLI binary を更新しますが、**Claude plugin cache には触れません**。新しい Traceary リリースが hook を追加したとき（例: v0.8 の transcript hook や built-in tool matcher hook）は、Claude Code セッション内で新 hook を有効化するために `claude plugins update traceary@traceary-plugins` も実行する必要があります。`traceary doctor --client claude` は cache が marketplace manifest より古い状態を `claude-plugin-cache` check で警告します。
+
 ## Uninstall
 
 ```sh

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -43,6 +43,8 @@ claude plugins marketplace update traceary-plugins
 claude plugins update traceary@traceary-plugins
 ```
 
+> **Important**: `brew upgrade traceary` refreshes the CLI binary but **does not touch the Claude plugin cache**. When new Traceary releases add hooks (for example the v0.8 transcript and built-in-tool matcher hooks), you must also run `claude plugins update traceary@traceary-plugins` before the newer hooks become active in a running Claude Code session. `traceary doctor --client claude` now surfaces a `claude-plugin-cache` check that warns when the cached version is behind the marketplace manifest.
+
 ## Uninstall
 
 ```sh

--- a/infrastructure/filesystem/claude_plugin_detector.go
+++ b/infrastructure/filesystem/claude_plugin_detector.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/mod/semver"
 )
 
 // ClaudePluginDetection reports whether the Traceary Claude Code plugin
@@ -75,4 +77,90 @@ func DetectClaudeTracearyPluginIn(home string) ClaudePluginDetection {
 	}
 
 	return ClaudePluginDetection{SettingsPath: settingsPath}
+}
+
+// ClaudePluginCacheStatus describes the cached Traceary plugin version
+// alongside the version the marketplace currently advertises. When the
+// two drift (typically because the operator ran `brew upgrade traceary`
+// without `claude plugins update`), the host continues to run an older
+// hook set than the CLI supports — exactly the gotcha v0.8.0 dogfooding
+// surfaced for #606 (transcript hook) and #605 (matcher expansion).
+type ClaudePluginCacheStatus struct {
+	// CachePath is the directory scanned for cached plugin versions.
+	// Empty when detection could not resolve it.
+	CachePath string
+	// CachedVersion is the highest version found under CachePath. Empty
+	// when no versioned directory exists (plugin never cached yet).
+	CachedVersion string
+	// MarketplaceVersion is the plugin.json "version" Claude Code sees
+	// via `~/.claude/plugins/marketplaces/<marketplace>/...`. Empty when
+	// the marketplace clone is missing.
+	MarketplaceVersion string
+	// MarketplacePath is the plugin.json path that was read (empty if
+	// the read failed).
+	MarketplacePath string
+}
+
+// Stale reports whether the cached plugin is at an older semver than
+// the marketplace currently offers. Returns false when either version
+// is unresolved — a missing cache or missing marketplace is surfaced to
+// the caller through the struct fields rather than as "stale".
+func (s ClaudePluginCacheStatus) Stale() bool {
+	if s.CachedVersion == "" || s.MarketplaceVersion == "" {
+		return false
+	}
+	return semver.Compare("v"+s.CachedVersion, "v"+s.MarketplaceVersion) < 0
+}
+
+// DetectClaudePluginCacheStatus resolves the cached plugin version and
+// the marketplace plugin.json version for the given PluginKey (of the
+// form "<plugin>@<marketplace>"). Missing caches and missing marketplace
+// clones are reported via empty fields rather than as errors; only
+// structural IO errors surface. Returns an empty status when pluginKey
+// lacks the expected "plugin@marketplace" shape.
+func DetectClaudePluginCacheStatus(home, pluginKey string) ClaudePluginCacheStatus {
+	parts := strings.SplitN(pluginKey, "@", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ClaudePluginCacheStatus{}
+	}
+	plugin, marketplace := parts[0], parts[1]
+
+	status := ClaudePluginCacheStatus{
+		CachePath: filepath.Join(home, ".claude", "plugins", "cache", marketplace, plugin),
+		MarketplacePath: filepath.Join(
+			home, ".claude", "plugins", "marketplaces", marketplace,
+			"integrations", "claude-plugin", ".claude-plugin", "plugin.json",
+		),
+	}
+
+	if entries, err := os.ReadDir(status.CachePath); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if name == "" || strings.HasPrefix(name, ".") {
+				continue
+			}
+			// Orphaned caches leave a sibling marker file that should
+			// not participate in the "highest cached version" choice.
+			if _, err := os.Stat(filepath.Join(status.CachePath, name, ".orphaned_at")); err == nil {
+				continue
+			}
+			if status.CachedVersion == "" || semver.Compare("v"+name, "v"+status.CachedVersion) > 0 {
+				status.CachedVersion = name
+			}
+		}
+	}
+
+	if content, err := os.ReadFile(status.MarketplacePath); err == nil {
+		var manifest struct {
+			Version string `json:"version"`
+		}
+		if err := json.Unmarshal(content, &manifest); err == nil {
+			status.MarketplaceVersion = strings.TrimSpace(manifest.Version)
+		}
+	}
+
+	return status
 }

--- a/infrastructure/filesystem/claude_plugin_detector_test.go
+++ b/infrastructure/filesystem/claude_plugin_detector_test.go
@@ -124,3 +124,125 @@ func writeClaudeSettings(t *testing.T, home, content string) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 }
+
+func writePluginCache(t *testing.T, home, marketplace, plugin, version string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "plugins", "cache", marketplace, plugin, version)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(cache) error = %v", err)
+	}
+}
+
+func writePluginMarketplaceManifest(t *testing.T, home, marketplace, version string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "plugins", "marketplaces", marketplace, "integrations", "claude-plugin", ".claude-plugin")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(manifest) error = %v", err)
+	}
+	manifest := `{"name":"traceary","version":"` + version + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("WriteFile(manifest) error = %v", err)
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_StaleCache(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.6.0")
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.7.2")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.CachedVersion != "0.6.0" {
+		t.Errorf("CachedVersion = %q, want 0.6.0", got.CachedVersion)
+	}
+	if got.MarketplaceVersion != "0.7.2" {
+		t.Errorf("MarketplaceVersion = %q, want 0.7.2", got.MarketplaceVersion)
+	}
+	if !got.Stale() {
+		t.Errorf("Stale() = false, want true for 0.6.0 vs 0.7.2")
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_UpToDateCache(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.7.2")
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.7.2")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.Stale() {
+		t.Errorf("Stale() = true, want false for equal versions")
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_PicksHighestCachedVersion(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.5.1")
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.7.0")
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.6.1")
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.7.2")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.CachedVersion != "0.7.0" {
+		t.Errorf("CachedVersion = %q, want highest 0.7.0", got.CachedVersion)
+	}
+	if !got.Stale() {
+		t.Errorf("Stale() = false, want true (0.7.0 < 0.7.2)")
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_IgnoresOrphanedCache(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.7.2")
+	// Place a newer but orphaned version alongside.
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.8.0")
+	orphanMarker := filepath.Join(home, ".claude", "plugins", "cache", "traceary-plugins", "traceary", "0.8.0", ".orphaned_at")
+	if err := os.WriteFile(orphanMarker, []byte("2026-04-21"), 0o600); err != nil {
+		t.Fatalf("WriteFile(orphan marker) error = %v", err)
+	}
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.7.2")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.CachedVersion != "0.7.2" {
+		t.Errorf("CachedVersion = %q, want 0.7.2 (orphaned 0.8.0 must be ignored)", got.CachedVersion)
+	}
+	if got.Stale() {
+		t.Errorf("Stale() = true, want false (0.7.2 matches marketplace)")
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_MissingCache(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.7.2")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.CachedVersion != "" {
+		t.Errorf("CachedVersion = %q, want empty", got.CachedVersion)
+	}
+	if got.Stale() {
+		t.Errorf("Stale() = true, want false when cache is absent")
+	}
+}
+
+func TestDetectClaudePluginCacheStatus_MalformedKey(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	got := DetectClaudePluginCacheStatus(home, "no-at-separator")
+	if got.CachePath != "" {
+		t.Errorf("CachePath = %q, want empty for malformed key", got.CachePath)
+	}
+}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -164,6 +164,12 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			report.Checks = append(report.Checks, *globalCheck)
 		}
 
+		if targetClient == "claude" {
+			if cacheCheck := inspectClaudePluginCacheStatus(); cacheCheck != nil {
+				report.Checks = append(report.Checks, *cacheCheck)
+			}
+		}
+
 		if hostCheck := inspectHostCapabilityGaps(targetClient, outputPath); hostCheck != nil {
 			report.Checks = append(report.Checks, *hostCheck)
 		}
@@ -172,6 +178,49 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	report.Checks = append(report.Checks, checkLatestVersion(input.currentVersion))
 
 	return report, nil
+}
+
+// inspectClaudePluginCacheStatus compares the cached Traceary Claude
+// Code plugin version against the marketplace manifest the plugin was
+// registered from. A stale cache is the exact failure mode v0.8.0
+// dogfooding revealed: `brew upgrade traceary` does not refresh the
+// plugin cache, so new hooks (#606 transcript / #605 matcher expansion)
+// stay dark until the operator runs `claude plugins update`. The check
+// returns nil when the plugin is not active or when either side cannot
+// be resolved (reported indirectly by the existing claude-config check).
+func inspectClaudePluginCacheStatus() *doctorCheck {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	detection := filesystem.DetectClaudeTracearyPluginIn(home)
+	if !detection.Active {
+		return nil
+	}
+	status := filesystem.DetectClaudePluginCacheStatus(home, detection.PluginKey)
+	if status.CachedVersion == "" || status.MarketplaceVersion == "" {
+		return nil
+	}
+	if status.Stale() {
+		return &doctorCheck{
+			Name:   "claude-plugin-cache",
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"claude plugin cache %s is older than the marketplace manifest (cached %s, marketplace %s at %s). `brew upgrade traceary` does not refresh the plugin cache; run `claude plugins update %s` to activate the newer hooks",
+				"claude plugin cache %s は marketplace manifest より古いバージョンです (cached %s, marketplace %s at %s)。`brew upgrade traceary` では plugin cache は更新されません。新しい hook を有効にするには `claude plugins update %s` を実行してください",
+				status.CachePath, status.CachedVersion, status.MarketplaceVersion, status.MarketplacePath, detection.PluginKey,
+			),
+		}
+	}
+	return &doctorCheck{
+		Name:   "claude-plugin-cache",
+		Status: doctorStatusPass,
+		Message: localizef(
+			"claude plugin cache matches the marketplace manifest (cached %s, marketplace %s)",
+			"claude plugin cache は marketplace manifest と一致しています (cached %s, marketplace %s)",
+			status.CachedVersion, status.MarketplaceVersion,
+		),
+	}
 }
 
 // inspectHostCapabilityGaps surfaces informational notes about 2026 Q2 host

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -189,12 +189,12 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 // returns nil when the plugin is not active or when either side cannot
 // be resolved (reported indirectly by the existing claude-config check).
 func inspectClaudePluginCacheStatus() *doctorCheck {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	detection := detectClaudeTracearyPluginForCLI()
+	if !detection.Active {
 		return nil
 	}
-	detection := filesystem.DetectClaudeTracearyPluginIn(home)
-	if !detection.Active {
+	home, err := userHomeDirFunc()
+	if err != nil {
 		return nil
 	}
 	status := filesystem.DetectClaudePluginCacheStatus(home, detection.PluginKey)


### PR DESCRIPTION
## Summary

v0.8.0 dogfooding revealed that `brew upgrade traceary` refreshes the CLI binary but does **not** touch the Claude Code plugin cache. When new releases add hooks (v0.8 transcript capture #606 and built-in-tool matcher #605), operators see no effect until they also run `claude plugins update traceary@traceary-plugins`. `doctor` previously reported `claude-config: PASS` as long as the plugin was registered and never surfaced the stale-cache state.

## Changes

- `infrastructure/filesystem/claude_plugin_detector.go`: new `ClaudePluginCacheStatus` struct + `DetectClaudePluginCacheStatus` helper that resolves the highest semver-named directory under `~/.claude/plugins/cache/<marketplace>/<plugin>/` (ignoring orphaned caches) and compares it to the marketplace `plugin.json`.
- `presentation/cli/doctor.go`: new `inspectClaudePluginCacheStatus` check that runs for the Claude client when the plugin is active. Emits `WARN` with the remediation command when the cache is behind, `PASS` when aligned, and is silently skipped when either side cannot be resolved (that state already surfaces through `claude-config`).
- `docs/integrations/claude-plugin{,.ja}.md`: explicit callout that brew upgrade alone is insufficient and that `claude plugins update` is the official refresh path, plus a pointer to the new `claude-plugin-cache` doctor check.

## Acceptance

- [x] `doctor` emits a WARN when the cached plugin version is older than marketplace manifest, with the exact command to run.
- [x] Docs (EN + JA) call out that `brew upgrade traceary` alone is not sufficient.
- [x] Unit tests cover stale, up-to-date, highest-version picking, orphan ignoring, missing cache, and malformed key cases.
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.
- [x] Manual run on the actual dev environment (cache 0.6.0, marketplace 0.7.2) shows the WARN with the expected message.

CHANGELOG update is deferred to v0.8.0 release-preparation (existing project convention).

Closes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)