### PR TITLE
fix(doctor): handle Go pseudo-versions in version check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.34.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	modernc.org/sqlite v1.48.2
@@ -213,7 +214,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
-	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/presentation/cli/doctor_version.go
+++ b/presentation/cli/doctor_version.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 func checkLatestVersion(currentVersion string) doctorCheck {
@@ -53,21 +55,70 @@ func checkLatestVersion(currentVersion string) doctorCheck {
 		normalizedCurrent = normalizedCurrent[:idx]
 	}
 
-	if normalizedCurrent == latestVersion {
+	return compareTracearyVersion(normalizedCurrent, latestVersion)
+}
+
+// compareTracearyVersion compares the running binary's semver-ish
+// version string (which may be a Go pseudo-version such as
+// `0.7.3-0.20260420223154-9a43e0847edd`) against the latest release
+// tag and renders a doctor check. Pseudo-versions for X.Y.Z-0.* sort
+// newer than release X.Y.(Z-1) but older than release X.Y.Z, so a
+// main build whose prefix already exceeds the latest release must be
+// reported as "ahead of the latest release" instead of telling the
+// operator to `brew upgrade` (which would downgrade the binary).
+func compareTracearyVersion(currentVersion, latestVersion string) doctorCheck {
+	currentSemver := "v" + currentVersion
+	latestSemver := "v" + latestVersion
+
+	if !semver.IsValid(currentSemver) || !semver.IsValid(latestSemver) {
+		// Fall back to string equality when either side is not parseable
+		// as semver. This keeps the legacy behaviour for exotic build
+		// strings instead of silently claiming "up to date".
+		if currentVersion == latestVersion {
+			return doctorCheck{
+				Name:    "version",
+				Status:  doctorStatusPass,
+				Message: localizef("traceary is up to date: %s", "traceary は最新です: %s", currentVersion),
+			}
+		}
 		return doctorCheck{
-			Name:    "version",
-			Status:  doctorStatusPass,
-			Message: localizef("traceary is up to date: %s", "traceary は最新です: %s", normalizedCurrent),
+			Name:   "version",
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"update available: %s → %s (run: brew upgrade traceary)",
+				"更新があります: %s → %s (実行: brew upgrade traceary)",
+				currentVersion, latestVersion,
+			),
 		}
 	}
 
-	return doctorCheck{
-		Name:   "version",
-		Status: doctorStatusWarn,
-		Message: localizef(
-			"update available: %s → %s (run: brew upgrade traceary)",
-			"更新があります: %s → %s (実行: brew upgrade traceary)",
-			normalizedCurrent, latestVersion,
-		),
+	comparison := semver.Compare(currentSemver, latestSemver)
+	switch {
+	case comparison > 0:
+		return doctorCheck{
+			Name:   "version",
+			Status: doctorStatusPass,
+			Message: localizef(
+				"traceary is a development build newer than the latest release: %s > %s",
+				"traceary は最新リリースより新しい development build です: %s > %s",
+				currentVersion, latestVersion,
+			),
+		}
+	case comparison == 0:
+		return doctorCheck{
+			Name:    "version",
+			Status:  doctorStatusPass,
+			Message: localizef("traceary is up to date: %s", "traceary は最新です: %s", currentVersion),
+		}
+	default:
+		return doctorCheck{
+			Name:   "version",
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"update available: %s → %s (run: brew upgrade traceary)",
+				"更新があります: %s → %s (実行: brew upgrade traceary)",
+				currentVersion, latestVersion,
+			),
+		}
 	}
 }

--- a/presentation/cli/doctor_version_test.go
+++ b/presentation/cli/doctor_version_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompareTracearyVersion_Equal(t *testing.T) {
+	t.Parallel()
+
+	got := compareTracearyVersion("0.7.2", "0.7.2")
+
+	if got.Status != doctorStatusPass {
+		t.Errorf("Status = %q, want %q", got.Status, doctorStatusPass)
+	}
+	if !strings.Contains(got.Message, "0.7.2") {
+		t.Errorf("Message = %q, want it to include 0.7.2", got.Message)
+	}
+}
+
+func TestCompareTracearyVersion_OlderWarns(t *testing.T) {
+	t.Parallel()
+
+	got := compareTracearyVersion("0.7.1", "0.7.2")
+
+	if got.Status != doctorStatusWarn {
+		t.Errorf("Status = %q, want %q", got.Status, doctorStatusWarn)
+	}
+	if !strings.Contains(got.Message, "→ 0.7.2") {
+		t.Errorf("Message = %q, want upgrade arrow to 0.7.2", got.Message)
+	}
+}
+
+func TestCompareTracearyVersion_PseudoVersionNewerPasses(t *testing.T) {
+	t.Parallel()
+
+	current := "0.7.3-0.20260420223154-9a43e0847edd"
+	got := compareTracearyVersion(current, "0.7.2")
+
+	if got.Status != doctorStatusPass {
+		t.Errorf("Status = %q, want %q (pseudo-version newer than latest release)", got.Status, doctorStatusPass)
+	}
+	if strings.Contains(got.Message, "brew upgrade") {
+		t.Errorf("Message = %q, must not tell the user to downgrade their dev build", got.Message)
+	}
+	if !strings.Contains(got.Message, "development build") && !strings.Contains(got.Message, "development") {
+		t.Errorf("Message = %q, expected a 'development build' hint", got.Message)
+	}
+}
+
+func TestCompareTracearyVersion_PseudoVersionOlderStillWarns(t *testing.T) {
+	t.Parallel()
+
+	// A pseudo-version whose base is older than latest — e.g. a stale
+	// branch built off 0.6.x while latest is 0.7.2 — should still warn.
+	current := "0.6.1-0.20260301000000-deadbeefcafe"
+	got := compareTracearyVersion(current, "0.7.2")
+
+	if got.Status != doctorStatusWarn {
+		t.Errorf("Status = %q, want %q", got.Status, doctorStatusWarn)
+	}
+}
+
+func TestCompareTracearyVersion_InvalidFallsBackToStringCompare(t *testing.T) {
+	t.Parallel()
+
+	// "nightly" is not valid semver on either side — keep legacy string
+	// behavior so we do not silently claim "up to date".
+	got := compareTracearyVersion("nightly", "0.7.2")
+
+	if got.Status != doctorStatusWarn {
+		t.Errorf("Status = %q, want %q (string mismatch must warn)", got.Status, doctorStatusWarn)
+	}
+}


### PR DESCRIPTION
## Summary

v0.8.0 dogfooding revealed that `doctor` reports main-built binaries (Go pseudo-versions like `0.7.3-0.20260420223154-9a43e0847edd`) with a misleading downgrade prompt:

```
[WARN] version: update available: 0.7.3-0.20260420223154-9a43e0847edd → 0.7.2 (run: brew upgrade traceary)
```

The previous implementation only checked string equality; anything not literally equal to the latest release tag was flagged for upgrade, even when the running binary was *ahead* of that tag.

## Changes

- `presentation/cli/doctor_version.go`: extract `compareTracearyVersion` that normalises both sides and uses `golang.org/x/mod/semver` for the comparison. Pseudo-version `X.Y.Z-0.*` sorts above release `X.Y.(Z-1)` and below release `X.Y.Z`, so the check correctly reports equal / older / newer states. Invalid semver on either side falls back to the legacy string compare.
- `presentation/cli/doctor_version_test.go`: new unit tests covering equal, older, pseudo-version-newer, pseudo-version-older, and invalid-fallback cases.

## Acceptance

- [x] Pseudo-version build with main sha: PASS, "development build newer than the latest release".
- [x] Older release installed while newer latest exists: WARN with upgrade arrow.
- [x] Equal version: PASS.
- [x] Invalid semver: falls back to string compare + warn.
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.
- [x] Manual run on dev environment: `[PASS] version: traceary is a development build newer than the latest release: 0.7.3-0.2026... > 0.7.2`.

Related: #337 (previous version-check false-positive fix, did not cover Go pseudo-versions).

Closes #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)