### PR TITLE
fix(mcp/memory): unify JSON null shape with CLI memory output

### DIFF
--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -100,6 +100,7 @@ type memorySummaryOutput struct {
 	Status     string  `json:"status" jsonschema:"lifecycle status"`
 	Confidence string  `json:"confidence" jsonschema:"confidence level"`
 	Source     string  `json:"source" jsonschema:"memory source"`
+	Supersedes *string `json:"supersedes,omitempty" jsonschema:"superseded memory identifier; null or omitted when this memory does not supersede another"`
 	ExpiresAt  *string `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano); null or omitted when unset"`
 	ValidFrom  string  `json:"valid_from" jsonschema:"start of content validity window (RFC3339Nano)"`
 	ValidTo    *string `json:"valid_to,omitempty" jsonschema:"end of content validity window (RFC3339Nano); null or omitted means open-ended"`

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -85,23 +85,33 @@ type memoriesOutput struct {
 }
 
 // memorySummaryOutput is the compact durable-memory shape used inside context packs.
+//
+// Optional timestamps are rendered as `*string` + `omitempty`: an absent
+// bound produces JSON `null` / an omitted key rather than an empty
+// string. This matches the CLI shape (presentation/cli/output.go
+// memorySummaryOutput) so consumers of memory_pack and `memory list
+// --json` can share the same TypeScript / JSON Schema shape.
 type memorySummaryOutput struct {
-	MemoryID   string `json:"memory_id" jsonschema:"durable memory identifier"`
-	Type       string `json:"type" jsonschema:"memory type"`
-	ScopeKind  string `json:"scope_kind" jsonschema:"scope kind"`
-	ScopeValue string `json:"scope_value" jsonschema:"scope value"`
-	Fact       string `json:"fact" jsonschema:"distilled memory fact"`
-	Status     string `json:"status" jsonschema:"lifecycle status"`
-	Confidence string `json:"confidence" jsonschema:"confidence level"`
-	Source     string `json:"source" jsonschema:"memory source"`
-	ExpiresAt  string `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano)"`
-	ValidFrom  string `json:"valid_from,omitempty" jsonschema:"start of content validity window (RFC3339Nano)"`
-	ValidTo    string `json:"valid_to,omitempty" jsonschema:"end of content validity window (RFC3339Nano); empty means open-ended"`
-	CreatedAt  string `json:"created_at" jsonschema:"creation timestamp (RFC3339Nano)"`
-	UpdatedAt  string `json:"updated_at" jsonschema:"update timestamp (RFC3339Nano)"`
+	MemoryID   string  `json:"memory_id" jsonschema:"durable memory identifier"`
+	Type       string  `json:"type" jsonschema:"memory type"`
+	ScopeKind  string  `json:"scope_kind" jsonschema:"scope kind"`
+	ScopeValue string  `json:"scope_value" jsonschema:"scope value"`
+	Fact       string  `json:"fact" jsonschema:"distilled memory fact"`
+	Status     string  `json:"status" jsonschema:"lifecycle status"`
+	Confidence string  `json:"confidence" jsonschema:"confidence level"`
+	Source     string  `json:"source" jsonschema:"memory source"`
+	ExpiresAt  *string `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano); null or omitted when unset"`
+	ValidFrom  string  `json:"valid_from" jsonschema:"start of content validity window (RFC3339Nano)"`
+	ValidTo    *string `json:"valid_to,omitempty" jsonschema:"end of content validity window (RFC3339Nano); null or omitted means open-ended"`
+	CreatedAt  string  `json:"created_at" jsonschema:"creation timestamp (RFC3339Nano)"`
+	UpdatedAt  string  `json:"updated_at" jsonschema:"update timestamp (RFC3339Nano)"`
 }
 
-// memoryOutput is the full durable-memory shape returned by MCP memory tools.
+// memoryOutput is the full durable-memory shape returned by MCP memory
+// tools. Shape matches presentation/cli/output.go memorySummaryOutput
+// so a consumer can share a single JSON / TypeScript definition for
+// both `memory list --json` and the MCP retrieve_memories tool — see
+// #628.
 type memoryOutput struct {
 	MemoryID     string            `json:"memory_id" jsonschema:"durable memory identifier"`
 	Type         string            `json:"type" jsonschema:"memory type"`
@@ -111,10 +121,10 @@ type memoryOutput struct {
 	Status       string            `json:"status" jsonschema:"lifecycle status"`
 	Confidence   string            `json:"confidence" jsonschema:"confidence level"`
 	Source       string            `json:"source" jsonschema:"memory source"`
-	Supersedes   string            `json:"supersedes,omitempty" jsonschema:"superseded memory identifier"`
-	ExpiresAt    string            `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano)"`
-	ValidFrom    string            `json:"valid_from,omitempty" jsonschema:"start of content validity window (RFC3339Nano)"`
-	ValidTo      string            `json:"valid_to,omitempty" jsonschema:"end of content validity window (RFC3339Nano); empty means open-ended"`
+	Supersedes   *string           `json:"supersedes,omitempty" jsonschema:"superseded memory identifier; null or omitted when this memory does not supersede another"`
+	ExpiresAt    *string           `json:"expires_at,omitempty" jsonschema:"expiry timestamp (RFC3339Nano); null or omitted when unset"`
+	ValidFrom    string            `json:"valid_from" jsonschema:"start of content validity window (RFC3339Nano)"`
+	ValidTo      *string           `json:"valid_to,omitempty" jsonschema:"end of content validity window (RFC3339Nano); null or omitted means open-ended"`
 	CreatedAt    string            `json:"created_at" jsonschema:"creation timestamp (RFC3339Nano)"`
 	UpdatedAt    string            `json:"updated_at" jsonschema:"update timestamp (RFC3339Nano)"`
 	EvidenceRefs []memoryRefOutput `json:"evidence_refs,omitempty" jsonschema:"supporting evidence refs"`

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1039,6 +1039,7 @@ func convertMemorySummaries(memories []apptypes.MemorySummary) []memorySummaryOu
 			Status:     summary.Status().String(),
 			Confidence: summary.Confidence().String(),
 			Source:     summary.Source().String(),
+			Supersedes: formatOptionalMemoryIDPtr(summary.Supersedes()),
 			ExpiresAt:  formatOptionalTimePtr(summary.ExpiresAt()),
 			ValidFrom:  summary.ValidFrom().UTC().Format(time.RFC3339Nano),
 			ValidTo:    formatOptionalTimePtr(summary.ValidTo()),

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1039,9 +1039,9 @@ func convertMemorySummaries(memories []apptypes.MemorySummary) []memorySummaryOu
 			Status:     summary.Status().String(),
 			Confidence: summary.Confidence().String(),
 			Source:     summary.Source().String(),
-			ExpiresAt:  formatOptionalTime(summary.ExpiresAt()),
+			ExpiresAt:  formatOptionalTimePtr(summary.ExpiresAt()),
 			ValidFrom:  summary.ValidFrom().UTC().Format(time.RFC3339Nano),
-			ValidTo:    formatOptionalTime(summary.ValidTo()),
+			ValidTo:    formatOptionalTimePtr(summary.ValidTo()),
 			CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339Nano),
 			UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
 		})
@@ -1051,10 +1051,6 @@ func convertMemorySummaries(memories []apptypes.MemorySummary) []memorySummaryOu
 
 func newMemoryOutput(details apptypes.MemoryDetails) memoryOutput {
 	summary := details.Summary()
-	supersedes := ""
-	if value, ok := summary.Supersedes().Value(); ok {
-		supersedes = value.String()
-	}
 
 	return memoryOutput{
 		MemoryID:     summary.MemoryID().String(),
@@ -1065,10 +1061,10 @@ func newMemoryOutput(details apptypes.MemoryDetails) memoryOutput {
 		Status:       summary.Status().String(),
 		Confidence:   summary.Confidence().String(),
 		Source:       summary.Source().String(),
-		Supersedes:   supersedes,
-		ExpiresAt:    formatOptionalTime(summary.ExpiresAt()),
+		Supersedes:   formatOptionalMemoryIDPtr(summary.Supersedes()),
+		ExpiresAt:    formatOptionalTimePtr(summary.ExpiresAt()),
 		ValidFrom:    summary.ValidFrom().UTC().Format(time.RFC3339Nano),
-		ValidTo:      formatOptionalTime(summary.ValidTo()),
+		ValidTo:      formatOptionalTimePtr(summary.ValidTo()),
 		CreatedAt:    summary.CreatedAt().UTC().Format(time.RFC3339Nano),
 		UpdatedAt:    summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
 		EvidenceRefs: convertEvidenceRefs(details.EvidenceRefs()),
@@ -1077,11 +1073,6 @@ func newMemoryOutput(details apptypes.MemoryDetails) memoryOutput {
 }
 
 func newMemoryOutputFromSummary(summary apptypes.MemorySummary) memoryOutput {
-	supersedes := ""
-	if memoryID, ok := summary.Supersedes().Value(); ok {
-		supersedes = memoryID.String()
-	}
-
 	return memoryOutput{
 		MemoryID:   summary.MemoryID().String(),
 		Type:       summary.MemoryType().String(),
@@ -1091,10 +1082,10 @@ func newMemoryOutputFromSummary(summary apptypes.MemorySummary) memoryOutput {
 		Status:     summary.Status().String(),
 		Confidence: summary.Confidence().String(),
 		Source:     summary.Source().String(),
-		Supersedes: supersedes,
-		ExpiresAt:  formatOptionalTime(summary.ExpiresAt()),
+		Supersedes: formatOptionalMemoryIDPtr(summary.Supersedes()),
+		ExpiresAt:  formatOptionalTimePtr(summary.ExpiresAt()),
 		ValidFrom:  summary.ValidFrom().UTC().Format(time.RFC3339Nano),
-		ValidTo:    formatOptionalTime(summary.ValidTo()),
+		ValidTo:    formatOptionalTimePtr(summary.ValidTo()),
 		CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339Nano),
 		UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339Nano),
 	}
@@ -1116,11 +1107,29 @@ func convertArtifactRefs(refs []types.ArtifactRef) []memoryRefOutput {
 	return outputs
 }
 
-func formatOptionalTime(value types.Optional[time.Time]) string {
-	if timeValue, ok := value.Value(); ok {
-		return timeValue.UTC().Format(time.RFC3339Nano)
+// formatOptionalTimePtr renders an Optional[time.Time] as `*string`:
+// nil when absent, otherwise RFC3339Nano UTC. This lets MCP memory
+// outputs carry JSON `null` for unset bounds — matching the CLI
+// memorySummaryOutput shape (#628).
+func formatOptionalTimePtr(value types.Optional[time.Time]) *string {
+	timeValue, ok := value.Value()
+	if !ok {
+		return nil
 	}
-	return ""
+	formatted := timeValue.UTC().Format(time.RFC3339Nano)
+	return &formatted
+}
+
+// formatOptionalMemoryIDPtr renders an Optional[MemoryID] as
+// `*string` so absent values emit `null` / are omitted rather than
+// surfacing as an empty string distinguishable from "no predecessor".
+func formatOptionalMemoryIDPtr(value types.Optional[types.MemoryID]) *string {
+	memoryID, ok := value.Value()
+	if !ok {
+		return nil
+	}
+	id := memoryID.String()
+	return &id
 }
 
 func parseMemoryScopes(workspace string, agent string, sessionFamily string) ([]types.MemoryScope, error) {


### PR DESCRIPTION
## Summary

v0.8 quality-phase Claude designer HIGH: CLI `memory list --json` and MCP `retrieve_memories` render optional memory fields with different JSON shapes. A consumer pulling from both surfaces hits silent `null` vs `""` divergence.

## Changes

- `presentation/mcpserver/output.go`:
  - `memoryOutput.Supersedes`, `ExpiresAt`, `ValidTo` → `*string` + `omitempty` (null / absent when unset)
  - `memoryOutput.ValidFrom` → `string` (always present, no omitempty)
  - Same changes on `memorySummaryOutput` (context-pack nested shape)
  - `jsonschema` tags describe the new null/absent semantics
- `presentation/mcpserver/server.go`:
  - New `formatOptionalTimePtr` and `formatOptionalMemoryIDPtr` helpers returning `*string`
  - `newMemoryOutput` / `newMemoryOutputFromSummary` / `convertMemorySummaries` switched over
  - Old string-returning `formatOptionalTime` helper removed (no remaining callers)

The CLI memory output shape (`*string` + `omitempty`) is the canonical choice because it lets consumers tell apart "not set" (null / omitted) from "empty string" without inferring.

## Acceptance

- [x] Same memory returns the same JSON shape via `memory list --json` and `retrieve_memories` (Supersedes / ExpiresAt / ValidFrom / ValidTo semantics).
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)