### PR TITLE
feat(context-pack): add as_of to handoff / memory_pack

### DIFF
--- a/application/types/context_pack_criteria.go
+++ b/application/types/context_pack_criteria.go
@@ -1,6 +1,10 @@
 package types
 
-import domtypes "github.com/duck8823/traceary/domain/types"
+import (
+	"time"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
 
 const (
 	defaultContextPackRecentCommandsLimit = 5
@@ -14,6 +18,7 @@ type ContextPackCriteria struct {
 	recentCommandsLimit int
 	memoryLimit         int
 	memoryPreset        MemoryRetrievalPreset
+	memoryAsOf          domtypes.Optional[time.Time]
 }
 
 // SessionID returns the target session filter.
@@ -32,6 +37,13 @@ func (c ContextPackCriteria) MemoryLimit() int { return c.memoryLimit }
 // durable memories for the pack. Empty means "no preset — use the
 // default accepted-only behavior of the memory query path."
 func (c ContextPackCriteria) MemoryPreset() MemoryRetrievalPreset { return c.memoryPreset }
+
+// MemoryAsOf returns the point-in-time at which content validity should
+// be evaluated when loading durable memories for the pack. A present
+// value lets an operator time-travel handoff / memory_pack to "what
+// was valid at time T" instead of "what is valid now". None (the
+// default) evaluates validity against the current time.
+func (c ContextPackCriteria) MemoryAsOf() domtypes.Optional[time.Time] { return c.memoryAsOf }
 
 // ContextPackCriteriaBuilder builds a ContextPackCriteria value.
 type ContextPackCriteriaBuilder struct {
@@ -75,6 +87,14 @@ func (b *ContextPackCriteriaBuilder) MemoryLimit(limit int) *ContextPackCriteria
 // durable-memory filters for the pack.
 func (b *ContextPackCriteriaBuilder) MemoryPreset(preset MemoryRetrievalPreset) *ContextPackCriteriaBuilder {
 	b.criteria.memoryPreset = preset
+	return b
+}
+
+// MemoryAsOf sets the as-of timestamp used when filtering memory
+// validity windows. Callers pass domtypes.None[time.Time]() to clear
+// any previously-set value and evaluate validity against "now".
+func (b *ContextPackCriteriaBuilder) MemoryAsOf(asOf domtypes.Optional[time.Time]) *ContextPackCriteriaBuilder {
+	b.criteria.memoryAsOf = asOf
 	return b
 }
 

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -74,7 +74,7 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 	if err != nil {
 		compactSummary = ""
 	}
-	memories, err := b.loadMemories(ctx, session, criteria.MemoryLimit(), criteria.MemoryPreset())
+	memories, err := b.loadMemories(ctx, session, criteria.MemoryLimit(), criteria.MemoryPreset(), criteria.MemoryAsOf())
 	if err != nil {
 		return domtypes.None[apptypes.ContextPack](), err
 	}
@@ -152,6 +152,7 @@ func (b *contextPackBuilder) loadMemories(
 	session apptypes.SessionSummary,
 	limit int,
 	preset apptypes.MemoryRetrievalPreset,
+	asOf domtypes.Optional[time.Time],
 ) ([]apptypes.MemorySummary, error) {
 	if b.memoryQuery == nil || limit == 0 {
 		return nil, nil
@@ -172,6 +173,9 @@ func (b *contextPackBuilder) loadMemories(
 		builder = preset.ApplyToMemoryListCriteriaBuilder(builder)
 	} else {
 		builder = builder.Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted})
+	}
+	if asOfValue, ok := asOf.Value(); ok {
+		builder = builder.AsOf(asOfValue)
 	}
 	memories, err := b.memoryQuery.List(ctx, builder.Build())
 	if err != nil {

--- a/application/usecase/context_usecase_impl_test.go
+++ b/application/usecase/context_usecase_impl_test.go
@@ -278,4 +278,89 @@ func TestContextUsecase_Handoff(t *testing.T) {
 			t.Fatalf("RecentCommands() mismatch (-want +got):\n%s", diff)
 		}
 	})
+
+	t.Run("propagates MemoryAsOf from ContextPackCriteria to the memory query builder", func(t *testing.T) {
+		t.Parallel()
+
+		asOf := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		session := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-asof"),
+			domtypes.Workspace("duck8823/traceary"),
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+
+		memoryQuery := &memoryQueryStub{}
+		sut := usecase.NewContextUsecase(
+			&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+			&eventQueryServiceStub{},
+			memoryQuery,
+		)
+
+		criteria := apptypes.NewContextPackCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-asof")).
+			Workspace(domtypes.Workspace("duck8823/traceary")).
+			MemoryLimit(5).
+			MemoryAsOf(domtypes.Some(asOf)).
+			Build()
+
+		if _, err := sut.Handoff(context.Background(), criteria); err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+
+		gotAsOf, ok := memoryQuery.listCriteria.AsOf().Value()
+		if !ok {
+			t.Fatalf("memory list AsOf = None, want Some(%v)", asOf)
+		}
+		if !gotAsOf.Equal(asOf) {
+			t.Errorf("memory list AsOf = %v, want %v", gotAsOf, asOf)
+		}
+	})
+
+	t.Run("omits MemoryAsOf when ContextPackCriteria does not set it", func(t *testing.T) {
+		t.Parallel()
+
+		session := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-noasof"),
+			domtypes.Workspace("duck8823/traceary"),
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+
+		memoryQuery := &memoryQueryStub{}
+		sut := usecase.NewContextUsecase(
+			&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+			&eventQueryServiceStub{},
+			memoryQuery,
+		)
+
+		criteria := apptypes.NewContextPackCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-noasof")).
+			Workspace(domtypes.Workspace("duck8823/traceary")).
+			MemoryLimit(5).
+			Build()
+
+		if _, err := sut.Handoff(context.Background(), criteria); err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+
+		if _, ok := memoryQuery.listCriteria.AsOf().Value(); ok {
+			t.Errorf("memory list AsOf = Some(...), want None when criteria omits as-of")
+		}
+	})
 }

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -66,13 +66,15 @@ func (s *memoryRepositoryStub) FindByID(_ context.Context, memoryID domtypes.Mem
 type memoryQueryStub struct {
 	listResult   []apptypes.MemorySummary
 	listErr      error
+	listCriteria apptypes.MemoryListCriteria
 	searchResult []apptypes.MemorySummary
 	searchErr    error
 	details      apptypes.MemoryDetails
 	detailsErr   error
 }
 
-func (s *memoryQueryStub) List(_ context.Context, _ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+func (s *memoryQueryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	s.listCriteria = criteria
 	return s.listResult, s.listErr
 }
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -205,6 +205,8 @@ session metadata、recent commands、compact summary、accepted durable memories
 - `--workspace`
 - `--recent`
 - `--memories`
+- `--preset` (任意): durable memory に built-in preset (`resume` / `review` / `incident`) を適用
+- `--as-of` (任意): durable memory の validity を指定時刻 (YYYY-MM-DD または RFC3339) で評価する。既定は「現在」
 
 ### `traceary session handoff`
 
@@ -216,6 +218,8 @@ session metadata、recent commands、compact summary、accepted durable memories
 - `--workspace`
 - `--recent`
 - `--memories`
+- `--preset`
+- `--as-of`
 
 ### `traceary compact-summary`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -205,6 +205,8 @@ Useful flags:
 - `--workspace`
 - `--recent`
 - `--memories`
+- `--preset` (optional): apply a built-in retrieval preset (`resume` / `review` / `incident`) to durable memory filters
+- `--as-of` (optional): evaluate durable memory validity at the given timestamp (YYYY-MM-DD or RFC3339); defaults to "now"
 
 ### `traceary session handoff`
 
@@ -216,6 +218,8 @@ Useful flags:
 - `--workspace`
 - `--recent`
 - `--memories`
+- `--preset`
+- `--as-of`
 
 ### `traceary compact-summary`
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -209,6 +209,8 @@ Inputs:
 - `session_id`
 - `recent_commands_limit`（既定: `5`。明示的に `0` を渡すと recent commands を無効化）
 - `memory_limit`（既定: `5`。明示的に `0` を渡すと durable memories を無効化）
+- `preset`（任意）: durable memory に built-in preset (`resume` / `review` / `incident`) を適用
+- `as_of`（任意）: durable memory の validity を指定時刻 (YYYY-MM-DD または RFC3339) で評価する。既定は「現在」
 
 ### `retrieve_memories`
 
@@ -314,6 +316,8 @@ Inputs:
 - `session_id`
 - `recent_commands_limit`（既定: `5`。明示的に `0` を渡すと recent commands を無効化）
 - `memory_limit`（既定: `5`。明示的に `0` を渡すと durable memories を無効化）
+- `preset`（任意）: durable memory に built-in preset (`resume` / `review` / `incident`) を適用
+- `as_of`（任意）: durable memory の validity を指定時刻 (YYYY-MM-DD または RFC3339) で評価する。既定は「現在」
 
 ## 実用的なクライアント設定例
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -211,6 +211,8 @@ Inputs:
 - `session_id`
 - `recent_commands_limit` (default: `5`; explicit `0` disables recent commands)
 - `memory_limit` (default: `5`; explicit `0` disables durable memories)
+- `preset` (optional): apply a built-in retrieval preset to durable memories (`resume` | `review` | `incident`)
+- `as_of` (optional): evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to "now"
 
 ### `retrieve_memories`
 
@@ -316,6 +318,8 @@ Inputs:
 - `session_id`
 - `recent_commands_limit` (default: `5`; explicit `0` disables recent commands)
 - `memory_limit` (default: `5`; explicit `0` disables durable memories)
+- `preset` (optional): apply a built-in retrieval preset to durable memories (`resume` | `review` | `incident`)
+- `as_of` (optional): evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to "now"
 
 ## Practical client example
 

--- a/presentation/cli/handoff.go
+++ b/presentation/cli/handoff.go
@@ -35,6 +35,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 		recent    int
 		memories  int
 		preset    string
+		asOf      string
 	)
 
 	cmd := &cobra.Command{
@@ -53,6 +54,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 				recent:    recent,
 				memories:  memories,
 				preset:    preset,
+				asOf:      asOf,
 			})
 		},
 	}
@@ -63,6 +65,7 @@ func (c *RootCLI) newHandoffCommandWithUse(use string, short string) *cobra.Comm
 	cmd.Flags().IntVar(&recent, "recent", 5, Localize("number of recent commands to show", "表示する直近コマンド数"))
 	cmd.Flags().IntVar(&memories, "memories", 5, Localize("number of durable memories to include", "含める durable memory 数"))
 	cmd.Flags().StringVar(&preset, "preset", "", Localize("apply a built-in retrieval preset to durable memories (resume | review | incident)", "durable memory 取得に built-in preset を適用する (resume | review | incident)"))
+	cmd.Flags().StringVar(&asOf, "as-of", "", Localize("evaluate durable memory validity at the given timestamp (RFC3339 or YYYY-MM-DD)", "指定時刻 (RFC3339 または YYYY-MM-DD) の時点で durable memory の validity を評価する"))
 
 	return cmd
 }
@@ -74,6 +77,7 @@ type handoffCommandInput struct {
 	recent    int
 	memories  int
 	preset    string
+	asOf      string
 }
 
 func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handoffCommandInput) error {
@@ -98,6 +102,10 @@ func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handof
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to parse --preset", "--preset の解析に失敗しました"), err)
 	}
+	asOf, err := parseOptionalValidityTime(input.asOf)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --as-of", "--as-of の解析に失敗しました"), err)
+	}
 	result, err := c.context.Handoff(
 		ctx,
 		apptypes.NewContextPackCriteriaBuilder().
@@ -106,6 +114,7 @@ func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handof
 			RecentCommandsLimit(input.recent).
 			MemoryLimit(input.memories).
 			MemoryPreset(preset).
+			MemoryAsOf(asOf).
 			Build(),
 	)
 	if err != nil {

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -82,6 +82,7 @@ type sessionHandoffInput struct {
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
+	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`
 }
 
 // memoryPackInput is the MCP input for the memory_pack tool.
@@ -91,6 +92,7 @@ type memoryPackInput struct {
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
+	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`
 }
 
 // memoryRefInput is the MCP representation of evidence/artifact references.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -494,12 +494,17 @@ func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessio
 		if err != nil {
 			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to parse preset: %w", err)
 		}
+		asOf, err := parseFlexibleTimeOptional(input.AsOf)
+		if err != nil {
+			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to parse as_of: %w", err)
+		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
 			input.Workspace,
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
 			preset,
+			asOf,
 		))
 		if err != nil {
 			return nil, sessionHandoffOutput{}, xerrors.Errorf("failed to get session handoff: %w", err)
@@ -520,12 +525,17 @@ func (s *Server) memoryPack() mcp.ToolHandlerFor[memoryPackInput, memoryPackOutp
 		if err != nil {
 			return nil, memoryPackOutput{}, xerrors.Errorf("failed to parse preset: %w", err)
 		}
+		asOf, err := parseFlexibleTimeOptional(input.AsOf)
+		if err != nil {
+			return nil, memoryPackOutput{}, xerrors.Errorf("failed to parse as_of: %w", err)
+		}
 		result, err := s.context.Handoff(ctx, buildContextPackCriteria(
 			input.SessionID,
 			input.Workspace,
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
 			preset,
+			asOf,
 		))
 		if err != nil {
 			return nil, memoryPackOutput{}, xerrors.Errorf("failed to build memory pack: %w", err)
@@ -987,7 +997,7 @@ func (s *Server) setMemoryValidity() mcp.ToolHandlerFor[setMemoryValidityInput, 
 	}
 }
 
-func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int, preset apptypes.MemoryRetrievalPreset) apptypes.ContextPackCriteria {
+func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int, preset apptypes.MemoryRetrievalPreset, asOf types.Optional[time.Time]) apptypes.ContextPackCriteria {
 	builder := apptypes.NewContextPackCriteriaBuilder().
 		SessionID(types.SessionID(strings.TrimSpace(sessionID))).
 		Workspace(types.Workspace(strings.TrimSpace(workspace)))
@@ -999,6 +1009,9 @@ func buildContextPackCriteria(sessionID string, workspace string, recentCommands
 	}
 	if preset != "" {
 		builder.MemoryPreset(preset)
+	}
+	if _, ok := asOf.Value(); ok {
+		builder.MemoryAsOf(asOf)
 	}
 	return builder.Build()
 }
@@ -1409,6 +1422,21 @@ func parseFlexibleTime(value string, endExclusive bool) (time.Time, error) {
 	}
 
 	return parsedDate, nil
+}
+
+// parseFlexibleTimeOptional returns None when the input is empty and
+// Some(time) otherwise, surfacing parse failures as errors. Callers
+// that want to distinguish "not supplied" from "unset" use this over
+// parseFlexibleTime, which returns a zero time.Time in either case.
+func parseFlexibleTimeOptional(value string) (types.Optional[time.Time], error) {
+	if strings.TrimSpace(value) == "" {
+		return types.None[time.Time](), nil
+	}
+	parsed, err := parseFlexibleTime(value, false)
+	if err != nil {
+		return types.None[time.Time](), err
+	}
+	return types.Some(parsed), nil
 }
 
 func convertEvents(events []*model.Event) []eventOutput {


### PR DESCRIPTION
## Summary

#617: `MemoryListCriteria` already accepts `as_of`, but `ContextPackCriteria` did not carry it through, so CLI `traceary handoff` and MCP `session_handoff` / `memory_pack` always evaluated durable-memory validity at "now". There was no way to reconstruct the memory set that was valid at an earlier timestamp.

**Scope confirmed during plan**: stay inside the existing handoff / memory_pack surface instead of adding a brand-new `traceary memory pack` CLI. Keeps the feature minimal while still closing the gap.

## Changes

- `application/types/context_pack_criteria.go`: new `memoryAsOf` Optional field + `MemoryAsOf` accessor and builder method.
- `application/usecase/context_pack_builder.go`: `loadMemories` takes the criteria's as-of and plumbs it into `MemoryListCriteria` when set; empty / None leaves the default "as of now" behavior intact.
- `presentation/cli/handoff.go`: new `--as-of` flag on `traceary handoff` mirroring the memory list / search parser, wired through a new `asOf` field on the command input.
- `presentation/mcpserver/input.go`: new `AsOf` field on both `sessionHandoffInput` and `memoryPackInput` with matching `jsonschema` description.
- `presentation/mcpserver/server.go`: `sessionHandoff` + `memoryPack` parse the input via the new `parseFlexibleTimeOptional` helper (None vs parse-error vs Some) and `buildContextPackCriteria` accepts the Optional, forwarding it to the builder.

## Acceptance

- [x] `traceary handoff --as-of <timestamp>` evaluates memory validity at the given time.
- [x] MCP `session_handoff({as_of: "..."})` and `memory_pack({as_of: "..."})` do the same.
- [x] Omitting the flag / field keeps previous behavior (validity "as of now").
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.

Closes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)