### PR TITLE
fix(mcp/add_log): redact transcript-kind bodies to match Stop-hook policy

### DIFF
--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -39,7 +39,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 
 | キー | 型 | 用途 |
 | --- | --- | --- |
-| `redact.extra_patterns` | 文字列配列 | 監査および transcript リダクション用の追加正規表現パターン。各エントリは Go の `regexp` パターンとしてコンパイルされ、マッチした内容が `[REDACTED]` に置換されます。CLI（`traceary audit`、Claude Stop-hook の transcript capture）と MCP サーバー（`add_audit`）の両方で、組み込みルールの後に適用されます。 |
+| `redact.extra_patterns` | 文字列配列 | 監査および transcript リダクション用の追加正規表現パターン。各エントリは Go の `regexp` パターンとしてコンパイルされ、マッチした内容が `[REDACTED]` に置換されます。CLI（`traceary audit`、`traceary log --kind transcript`、Claude Stop-hook の transcript capture）と MCP サーバー（`add_audit`、`kind=transcript` を指定した `add_log`）の両方で、組み込みルールの後に適用されます。 |
 | `read.fields` | 文字列配列 | `traceary tail` / `list` / `search` のテキスト出力で `--fields` が指定されなかった場合に使用されるコンパクトカラムのデフォルト順。利用可能なフィールド名: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`。未知・空・重複エントリはコマンド実行時に拒否されます。`--fields` フラグが指定された場合は常にこの設定を上書きします。`--wide` や `--json` 出力には影響しません。 |
 | `read.presets` | object | `traceary tail` / `list` / `search` 向けの保存済みビュー。`--preset <name>` で適用します。各 entry は `fields`（`read.fields` と同じ registry）と `filters`（`kind`, `failures`, `workspace`, `session_id`, `client`, `agent`）を持てます。明示した CLI フラグは常に preset を上書きします。built-in preset（`failures`, `prompts-only`, `compact-summaries`）と同名のエントリは built-in を上書きしますが、実行時に stderr へ `[WARN]` を出します。 |
 | `read.color` | string | `traceary tail` / `list` / `search` のコンパクトテキスト出力に対する `--color` の既定値。許容値: `auto`, `always`, `never`。`auto` は stdout が TTY のときだけ色を付けます。`NO_COLOR` 環境変数や明示の `--color=never` は常にこの設定より優先されます。`--wide` / `--json` 出力には色は付きません。 |
@@ -84,6 +84,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 - Traceary 自身の backend へ telemetry を送信しません
 - `traceary audit` の payload は、redaction / truncation がかからない限り、ローカル SQLite store に保存されます
 - `prompt` イベント（`UserPromptSubmit` hook 経由）と `compact_summary` イベント（`PostCompact` hook 経由）は、redaction / truncation なしでそのまま保存されます — ユーザーの意図を記録することが Traceary の目的であるため、これは設計上の選択です
+- `transcript` イベント（Claude `Stop` hook、`traceary log --kind transcript`、MCP `add_log` の `kind=transcript` 経由）は、`audit` と同じ方式で redaction されます（組み込み redactor + `redact.extra_patterns`）。assistant の transcript は shell 出力やファイル内容を再掲することが多く、secret を含む可能性が高いためです
 - secret redaction はベストエフォートであり、完全な DLP ではありません
 
 ## 関連ドキュメント

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -39,7 +39,7 @@ Traceary reads an optional JSON configuration file from `~/.config/traceary/conf
 
 | Key | Type | Purpose |
 | --- | --- | --- |
-| `redact.extra_patterns` | string array | Extra regex patterns for audit and transcript redaction. Each entry is compiled as a Go `regexp` pattern and matched content is replaced with `[REDACTED]`. Applied after the built-in redaction rules in both the CLI (`traceary audit`, Claude Stop-hook transcript capture) and MCP server (`add_audit`). |
+| `redact.extra_patterns` | string array | Extra regex patterns for audit and transcript redaction. Each entry is compiled as a Go `regexp` pattern and matched content is replaced with `[REDACTED]`. Applied after the built-in redaction rules in both the CLI (`traceary audit`, `traceary log --kind transcript`, Claude Stop-hook transcript capture) and MCP server (`add_audit`, `add_log` with `kind=transcript`). |
 | `read.fields` | string array | Default compact column order for `traceary tail` / `list` / `search` text output when `--fields` is omitted. Accepted field names: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`. Unknown / empty / duplicate entries are rejected at command runtime; the `--fields` flag always overrides this setting. Does not affect `--wide` or `--json` output. |
 | `read.presets` | object | Named saved views for `traceary tail` / `list` / `search`, applied via `--preset <name>`. Each entry can set `fields` (same registry as `read.fields`) and `filters` (any of `kind`, `failures`, `workspace`, `session_id`, `client`, `agent`). Explicit CLI flags always override preset values. Entries whose name collides with a built-in preset (`failures`, `prompts-only`, `compact-summaries`) win over the built-in but emit a `[WARN]` line on stderr. |
 | `read.color` | string | Default `--color` mode for `traceary tail` / `list` / `search` compact text output. Accepted values: `auto`, `always`, `never`. `auto` colorizes only when stdout is a TTY. `NO_COLOR` env and explicit `--color=never` always win over the config. `--wide` and `--json` output are always uncolored regardless of this setting. |
@@ -84,6 +84,7 @@ If the file exists but is unreadable or invalid JSON, Traceary falls back to the
 - Traceary does not send telemetry to a Traceary-owned backend
 - when you run `traceary audit`, payloads are written to your local SQLite store unless redaction or truncation changes them first
 - `prompt` events (from `UserPromptSubmit` hooks) and `compact_summary` events (from `PostCompact` hooks) are stored as-is without redaction or truncation — this is by design, as recording the user's intent is a core purpose of Traceary
+- `transcript` events (from Claude `Stop` hook, `traceary log --kind transcript`, or MCP `add_log` with `kind=transcript`) are redacted in the same way as `audit` events (built-in redactors plus `redact.extra_patterns`) because assistant transcripts routinely re-state shell output and file contents that include secrets
 - secret redaction is best effort, not a complete data-loss-prevention system
 
 ## Related docs

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/redaction"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -110,7 +111,20 @@ func (c *RootCLI) runLog(ctx context.Context, output io.Writer, input logCommand
 	sessionID, _ := types.SessionIDOf(sessionResolution.sessionID)
 	workspace := types.Workspace(resolvedRepo)
 	kind := types.EventKind(strings.TrimSpace(input.kind))
-	event, err := c.event.Log(ctx, input.message, kind, client, agent, sessionID, workspace)
+	message := input.message
+	// Match the Stop-hook transcript capture policy (#626) and the MCP
+	// add_log path (#648): when the caller records a transcript event
+	// through the CLI, run the same redactor chain before persistence.
+	// Prompt / compact_summary bodies are left verbatim on purpose —
+	// operator intent is documented in docs/environment/README.md.
+	if kind == types.EventKindTranscript {
+		extraRedactors, compileErr := redaction.CompileExtraPatterns(c.extraRedactPatterns)
+		if compileErr != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to compile extra redaction patterns for transcript", "transcript 用の extra redaction pattern の compile に失敗しました"), compileErr)
+		}
+		message, _ = redaction.Apply(message, extraRedactors)
+	}
+	event, err := c.event.Log(ctx, message, kind, client, agent, sessionID, workspace)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record log", "ログ記録に失敗しました"), err)
 	}

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/redaction"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
@@ -243,9 +244,26 @@ func (s *Server) Run(ctx context.Context) error {
 
 func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input addLogInput) (*mcp.CallToolResult, addLogOutput, error) {
+		kind := types.EventKind(strings.TrimSpace(input.Kind))
+		message := input.Message
+		// v0.8 dogfooding finding (#648): `kind=transcript` bodies
+		// come from the same sensitive surface as the Stop-hook
+		// transcript capture path, so apply the built-in + operator-
+		// supplied extra redactors before persistence. Prompt and
+		// compact_summary remain uncut by design because those kinds
+		// intentionally preserve operator intent (documented in
+		// docs/environment/README.md).
+		if kind == types.EventKindTranscript {
+			extras, err := redaction.CompileExtraPatterns(s.extraRedactPatterns)
+			if err != nil {
+				return nil, addLogOutput{}, xerrors.Errorf("failed to compile extra redaction patterns for transcript: %w", err)
+			}
+			message, _ = redaction.Apply(message, extras)
+		}
+
 		event, err := s.event.Log(ctx,
-			input.Message,
-			types.EventKind(strings.TrimSpace(input.Kind)),
+			message,
+			kind,
 			types.Client(resolveValue(input.Client, defaultClientValue)),
 			types.Agent(resolveValue(input.Agent, defaultAgentValue)),
 			types.SessionID(resolveValue(input.SessionID, defaultSessionValue)),

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -254,11 +254,11 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 		// intentionally preserve operator intent (documented in
 		// docs/environment/README.md).
 		if kind == types.EventKindTranscript {
-			extras, err := redaction.CompileExtraPatterns(s.extraRedactPatterns)
+			extraRedactors, err := redaction.CompileExtraPatterns(s.extraRedactPatterns)
 			if err != nil {
 				return nil, addLogOutput{}, xerrors.Errorf("failed to compile extra redaction patterns for transcript: %w", err)
 			}
-			message, _ = redaction.Apply(message, extras)
+			message, _ = redaction.Apply(message, extraRedactors)
 		}
 
 		event, err := s.event.Log(ctx,

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -686,6 +686,55 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("add_log redacts transcript kind body using built-in redactors", func(t *testing.T) {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_log",
+			Arguments: map[string]any{
+				"message":    "assistant echoed back: Authorization: Bearer abc.def.ghi-should-not-leak",
+				"kind":       "transcript",
+				"agent":      "claude",
+				"session_id": "session-transcript-mcp",
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_log transcript) error = %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("CallTool(add_log transcript) returned tool error")
+		}
+		body := extractJSONStringValue(t, result, "body")
+		if strings.Contains(body, "abc.def.ghi-should-not-leak") {
+			t.Errorf("transcript body leaked bearer token: %q", body)
+		}
+		if !strings.Contains(body, "[REDACTED]") {
+			t.Errorf("transcript body missing [REDACTED] placeholder: %q", body)
+		}
+	})
+
+	t.Run("add_log preserves prompt body verbatim (no redaction by design)", func(t *testing.T) {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "add_log",
+			Arguments: map[string]any{
+				"message":    "user prompt with password=intent: preserved-by-design",
+				"kind":       "prompt",
+				"agent":      "claude",
+				"session_id": "session-prompt-mcp",
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_log prompt) error = %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("CallTool(add_log prompt) returned tool error")
+		}
+		body := extractJSONStringValue(t, result, "body")
+		if !strings.Contains(body, "preserved-by-design") {
+			t.Errorf("prompt body should preserve operator intent verbatim, got: %q", body)
+		}
+	})
+
 	t.Run("set_memory_validity accepts bounds and clear_valid_to separately", func(t *testing.T) {
 		rememberResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "remember_memory",


### PR DESCRIPTION
## Summary

#648 (surfaced during #646 review): MCP `add_log` accepted `kind=transcript` and stored the body verbatim, while the Claude Stop-hook path now runs built-in + operator-configured extra redactors on transcript capture (#626). An agent writing a transcript via MCP therefore bypassed the protection the hook path provides.

## Changes

- `presentation/mcpserver/server.go` `addLog`: when `kind == transcript`, compile `s.extraRedactPatterns` via `redaction.CompileExtraPatterns` and run `redaction.Apply(message, extras)` before persisting. Other kinds (prompt / compact_summary / note) stay unmodified because those kinds intentionally preserve operator intent (see `docs/environment/README.md`).
- `presentation/mcpserver/server_test.go` `TestServer_BuildAndTools`: two new subtests — `add_log_redacts_transcript_kind_body_using_built-in_redactors` and `add_log_preserves_prompt_body_verbatim_(no_redaction_by_design)` — cover both sides of the kind gate.

## Acceptance

- [x] MCP transcript bodies receive the same built-in redactor pass as CLI Stop-hook transcripts.
- [x] Prompt / compact_summary bodies still store operator text verbatim.
- [x] `go build ./...` / `go test ./...` / `go tool golangci-lint run` green.

Closes #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)