### PR TITLE
feat(hooks/claude): expand PostToolUse matcher to 2026-Q2 built-in tools

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -42,7 +42,7 @@ host ごとのネイティブ連携パッケージを使いたい場合は、ま
 
 | Client | Settings file | Session start | Session end | Audit hook | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Claude Code | `.claude/settings.json` or `~/.claude/settings.json` | `SessionStart` | `SessionEnd` | `PostToolUse` + `PostToolUseFailure` with `matcher: "Bash"` と `matcher: "mcp__.*"` | 現行 Anthropic docs では `Stop` は session-end hook ではなく per-response hook と定義されています |
+| Claude Code | `.claude/settings.json` or `~/.claude/settings.json` | `SessionStart` | `SessionEnd` | `PostToolUse` + `PostToolUseFailure` with `matcher: "Bash"` / `matcher: "mcp__.*"` / 組み込み tool matcher (`Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode`) | 現行 Anthropic docs では `Stop` は session-end hook ではなく per-response hook と定義されています |
 | Codex CLI (`codex-cli 0.118.0`) | `~/.codex/hooks.json` | `SessionStart` | `Stop` (best effort) | `PostToolUse` | ローカルの Codex build では `SessionEnd` が見つからず、`Stop` を best-effort で使います |
 | Gemini CLI (`gemini-cli 0.36.0`) | `.gemini/settings.json` or `~/.gemini/settings.json` | `SessionStart` | `SessionEnd` | `AfterTool` with `matcher: "run_shell_command"` | hook payload は JSON-over-stdin / JSON-over-stdout。`SessionEnd` は best-effort です |
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -42,7 +42,7 @@ Traceary no longer installs portable hook-script copies under `~/.config/tracear
 
 | Client | Settings file | Session start | Session end | Audit hook | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Claude Code | `.claude/settings.json` or `~/.claude/settings.json` | `SessionStart` | `SessionEnd` | `PostToolUse` + `PostToolUseFailure` with `matcher: "Bash"` and `matcher: "mcp__.*"` | Anthropic's current docs define `Stop` as a per-response hook, not a session-end hook. |
+| Claude Code | `.claude/settings.json` or `~/.claude/settings.json` | `SessionStart` | `SessionEnd` | `PostToolUse` + `PostToolUseFailure` with `matcher: "Bash"`, `matcher: "mcp__.*"`, and the built-in tool matcher (`Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode`) | Anthropic's current docs define `Stop` as a per-response hook, not a session-end hook. |
 | Codex CLI (`codex-cli 0.118.0`) | `~/.codex/hooks.json` | `SessionStart` | `Stop` (best effort) | `PostToolUse` | The installed Codex build exposes `SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionDenied`, `UserPromptSubmit`, and `Elicitation` in local binary strings. A dedicated `SessionEnd` hook was not found locally. |
 | Gemini CLI (`gemini-cli 0.36.0`) | `.gemini/settings.json` or `~/.gemini/settings.json` | `SessionStart` | `SessionEnd` | `AfterTool` with `matcher: "run_shell_command"` | Hooks are JSON-over-stdin / JSON-over-stdout and `SessionEnd` is best effort. |
 

--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -14,7 +14,7 @@
 | SessionEnd | `*` | セッション終了を記録 |
 | PostToolUse | `Bash` | シェルコマンド監査を exit code 付きで記録 |
 | PostToolUse | `mcp__.*` | MCP ツール監査を記録 |
-| PostToolUse | `Read\|Edit\|Write\|MultiEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|NotebookEdit` | Claude Code 組み込みツール（ファイル I/O・検索・agent・web）の呼び出しを記録（v0.8-6 で追加） |
+| PostToolUse | `Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode` | Claude Code 組み込みツール（ファイル I/O・検索・agent・web・plan モード終了）の呼び出しを記録（v0.8-6 で追加、v0.8-6b で `NotebookRead` と `ExitPlanMode` を追加） |
 | PostToolUseFailure | `Bash`, `mcp__.*`, 組み込みツール | 失敗したツール実行を記録 |
 | PostCompact | `*` | compact サマリーを記録 |
 | UserPromptSubmit | `*` | ユーザーの指示テキストを記録 |

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -14,7 +14,7 @@ This document defines the hook capability tiers across AI agent clients.
 | SessionEnd | `*` | Record session end |
 | PostToolUse | `Bash` | Record shell command audit with exit code |
 | PostToolUse | `mcp__.*` | Record MCP tool audit |
-| PostToolUse | `Read\|Edit\|Write\|MultiEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|NotebookEdit` | Record built-in Claude Code tool invocations (file I/O, search, agent, web). Added in v0.8-6 |
+| PostToolUse | `Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode` | Record built-in Claude Code tool invocations (file I/O, search, agent, web, plan-mode exit). Added in v0.8-6; expanded to include `NotebookRead` and `ExitPlanMode` in v0.8-6b |
 | PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | Record failed tool execution |
 | PostCompact | `*` | Record compact summary |
 | UserPromptSubmit | `*` | Record user prompt text |

--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -8,7 +8,7 @@ Claude 向け package は `integrations/claude-plugin/` にあり、repository r
 
 - `traceary mcp-server` を使う `traceary` MCP server
 - `SessionStart` / `SessionEnd` hook
-- Bash 向けの `PostToolUse` / `PostToolUseFailure` audit hook
+- `Bash` / `mcp__.*` / 組み込み tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`) 向けの `PostToolUse` / `PostToolUseFailure` audit hook
 - slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-capture` skill（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `propose_memory` を能動的に呼ぶよう誘導します）
 
 ## Install

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -8,7 +8,7 @@ The Claude package lives under `integrations/claude-plugin/` and is published th
 
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart` / `SessionEnd` hooks
-- `PostToolUse` / `PostToolUseFailure` shell-audit hooks for Bash
+- `PostToolUse` / `PostToolUseFailure` audit hooks for `Bash`, `mcp__.*`, and the built-in tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)
 - slash-style skills: `/traceary-help` plus the contextual `traceary-session-history` and `traceary-memory-capture` skills (the latter prompts the agent to proactively call `propose_memory` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
 
 ## Install

--- a/docs/lifecycle.ja.md
+++ b/docs/lifecycle.ja.md
@@ -19,7 +19,8 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | UserPromptSubmit | `*` | `prompt` | ユーザーが送った指示テキスト |
 | PostToolUse | `Bash` | `command_executed` | シェルコマンド（入出力・終了コード付き） |
 | PostToolUse | `mcp__.*` | `command_executed` | MCP ツール呼び出し |
-| PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | 失敗したツール実行（`failures_only` でフィルタ可能） |
+| PostToolUse | 組み込み tools | `command_executed` | ファイル I/O・検索・agent・web・plan モード終了 (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)。v0.8-6 で追加、v0.8-6b で拡張。 |
+| PostToolUseFailure | `Bash`, `mcp__.*`, 組み込み tools | `command_executed` | 失敗したツール実行（`failures_only` でフィルタ可能） |
 | PostCompact | `*` | `compact_summary` | コンテキスト圧縮時の構造化サマリー |
 | Stop | `*` | `transcript` | stop-hook の `transcript_path` から読み取った最後の assistant 発話（reasoning 等） |
 | SessionEnd | `*` | `session_ended` | セッション終了 |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -19,7 +19,8 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | UserPromptSubmit | `*` | `prompt` | User instruction text |
 | PostToolUse | `Bash` | `command_executed` | Shell command with input/output/exit code |
 | PostToolUse | `mcp__.*` | `command_executed` | MCP tool invocation |
-| PostToolUseFailure | `Bash`, `mcp__.*` | `command_executed` | Failed tool execution (filterable via `failures_only`) |
+| PostToolUse | built-in tools | `command_executed` | File I/O / search / agent / web / plan-mode exit (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`). Added in v0.8-6; expanded in v0.8-6b. |
+| PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | `command_executed` | Failed tool execution (filterable via `failures_only`) |
 | PostCompact | `*` | `compact_summary` | Structured summary on context compression |
 | Stop | `*` | `transcript` | Last assistant text blocks (reasoning) from the stop-hook `transcript_path` |
 | SessionEnd | `*` | `session_ended` | Session end |

--- a/infrastructure/filesystem/claude_hooks_handler.go
+++ b/infrastructure/filesystem/claude_hooks_handler.go
@@ -10,11 +10,20 @@ import (
 // claudeBuiltinToolsMatcher is the regular expression Claude Code
 // evaluates as the PostToolUse matcher for Traceary's coverage of
 // built-in tools (the ones that do not match `Bash` or `mcp__.*`).
-// Read / Edit / Write / Grep / Glob / Agent / TodoWrite / WebFetch /
-// WebSearch / NotebookEdit are the core surfaces operators use for
-// real work — capturing them is what actually makes tail / timeline
-// reflect day-to-day activity instead of just shell + MCP traffic.
-const claudeBuiltinToolsMatcher = "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+//
+// Coverage set (v0.8-6b, refreshed 2026-Q2):
+//   - file I/O: Read, NotebookRead, Edit, MultiEdit, Write, NotebookEdit
+//   - search: Grep, Glob
+//   - agent / task: Agent, Task, TodoWrite
+//   - web: WebFetch, WebSearch
+//   - control flow: ExitPlanMode
+//
+// The default is an exhaustive list rather than `.*` so Traceary does
+// not accidentally tail operator-irrelevant tool categories (for
+// example, future per-plugin tools). The preset expansion that opts
+// into `.*` lives in `traceary hooks install --matcher` (#632), which
+// preserves this default.
+const claudeBuiltinToolsMatcher = "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|ExitPlanMode"
 
 // ClaudeHooksHandler installs Traceary hooks for the Claude Code client.
 type ClaudeHooksHandler struct{}

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -101,7 +101,7 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 			t.Fatalf("PostToolUse[1] matcher mismatch (-want +got):\n%s", diff)
 		}
 		thirdMatcher, _ := entries[2].Matcher().Value()
-		wantBuiltin := "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+		wantBuiltin := "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|ExitPlanMode"
 		if diff := cmp.Diff(wantBuiltin, thirdMatcher); diff != "" {
 			t.Fatalf("PostToolUse[2] matcher mismatch (-want +got):\n%s", diff)
 		}
@@ -132,7 +132,7 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 			t.Fatalf("PostToolUseFailure[1] matcher mismatch (-want +got):\n%s", diff)
 		}
 		thirdMatcher, _ := entries[2].Matcher().Value()
-		wantBuiltin := "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit"
+		wantBuiltin := "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|ExitPlanMode"
 		if diff := cmp.Diff(wantBuiltin, thirdMatcher); diff != "" {
 			t.Fatalf("PostToolUseFailure[2] matcher mismatch (-want +got):\n%s", diff)
 		}

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -63,7 +63,7 @@
         ]
       },
       {
-        "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit",
+        "matcher": "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|ExitPlanMode",
         "hooks": [
           {
             "type": "command",
@@ -114,7 +114,7 @@
         ]
       },
       {
-        "matcher": "Read|Edit|Write|MultiEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|NotebookEdit",
+        "matcher": "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|Grep|Glob|Agent|Task|TodoWrite|WebFetch|WebSearch|ExitPlanMode",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

#621: refresh Claude Code's built-in `PostToolUse` / `PostToolUseFailure` matcher to the 2026-Q2 surface.

Coverage added on top of the v0.8-6 set:

- `NotebookRead` (pair with the existing `NotebookEdit` coverage)
- `ExitPlanMode` (plan-mode exit signal)

Removed / rearranged nothing — all 12 v0.8-6 tools still covered.

## Default stays exhaustive

Keeps `.*` out of the default matcher on purpose. The preset-driven opt-in to a wildcard matcher lives in `traceary hooks install --matcher` (#632), so the default install never spams `tail` / `timeline` with plugin- or project-specific tool categories the operator does not care about.

## Changes

- `infrastructure/filesystem/claude_hooks_handler.go`: constant updated with a grouped comment naming each category.
- `infrastructure/filesystem/claude_hooks_handler_test.go`: regression tests updated to the new regex.
- `integrations/claude-plugin/hooks/hooks.json`: packaged plugin matcher bumped in both `PostToolUse` and `PostToolUseFailure` blocks.
- `docs/hooks/contract{,.ja}.md`: matcher list refreshed with a v0.8-6b expansion note.

## Acceptance

- [x] Default matcher covers the 2026-Q2 built-in tools that actually matter for operator auditing (file I/O + search + agent + web + plan-mode exit).
- [x] Default stays an exhaustive list (not `.*`); `.*` remains reserved for the `--matcher all` preset from #632.
- [x] `go test ./...` / `go tool golangci-lint run` / `python3 scripts/verify_integrations.py` green.

Closes #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)