### PR TITLE
feat(hooks/install): add --upgrade flag for non-destructive migrations

### DIFF
--- a/application/hooks_orchestrator.go
+++ b/application/hooks_orchestrator.go
@@ -7,7 +7,7 @@ import (
 )
 
 // HookUpgradeDiff reports which events changed during a non-destructive
-// hook install (merge-only mode). The three slices are disjoint.
+// hook install (merge-only mode). The four slices are disjoint.
 //
 // AddedEvents     : events that had no Traceary-managed commands before
 //                   but now do (new hook coverage).
@@ -17,10 +17,17 @@ import (
 // PreservedEvents : events whose normalized command set matched; the
 //                   merged output is byte-identical for these events,
 //                   which is what makes --upgrade idempotent.
+// RemovedEvents   : events present only in the existing config that held
+//                   Traceary-managed commands for an event the current
+//                   release no longer emits (e.g. a hook retired between
+//                   releases). Those stale commands are stripped during
+//                   the merge so the upgrade leaves the Traceary footprint
+//                   consistent with the running binary.
 type HookUpgradeDiff struct {
 	AddedEvents     []string
 	RefreshedEvents []string
 	PreservedEvents []string
+	RemovedEvents   []string
 }
 
 // HooksOrchestrator is the application-level entrypoint for hook generation

--- a/application/hooks_orchestrator.go
+++ b/application/hooks_orchestrator.go
@@ -6,6 +6,23 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
+// HookUpgradeDiff reports which events changed during a non-destructive
+// hook install (merge-only mode). The three slices are disjoint.
+//
+// AddedEvents     : events that had no Traceary-managed commands before
+//                   but now do (new hook coverage).
+// RefreshedEvents : events whose Traceary-managed commands were replaced
+//                   with the current release's set (upgrade, binary
+//                   rename, or command drift).
+// PreservedEvents : events whose normalized command set matched; the
+//                   merged output is byte-identical for these events,
+//                   which is what makes --upgrade idempotent.
+type HookUpgradeDiff struct {
+	AddedEvents     []string
+	RefreshedEvents []string
+	PreservedEvents []string
+}
+
 // HooksOrchestrator is the application-level entrypoint for hook generation
 // and installation. It resolves the correct HooksClientHandler for a client
 // alias, builds the Hooks aggregate, and renders or writes it to disk.
@@ -49,6 +66,21 @@ type HooksOrchestrator interface {
 		force bool,
 		matcherPreset string,
 	) (string, error)
+
+	// UpgradeWithMatcher applies the current hook configuration for the
+	// given client in merge-only mode (never overwrites) and returns a
+	// HookUpgradeDiff describing which events were added, refreshed, or
+	// preserved. It is the primary entrypoint for non-destructive
+	// migrations from older Traceary releases: the file is left byte
+	// identical when already up to date (idempotent).
+	UpgradeWithMatcher(
+		ctx context.Context,
+		client string,
+		tracearyBin string,
+		projectDir string,
+		outputPath types.Optional[string],
+		matcherPreset string,
+	) (string, HookUpgradeDiff, error)
 
 	// SupportedClients returns the canonical list of supported client
 	// identifiers (e.g. "claude", "codex", "gemini").

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -146,6 +146,23 @@ Claude Code plugin が有効な場合、`hooks install --client claude` は `--m
 
 既存ファイルがある場合、Traceary は上書きせずエラーにします。まず差分を確認し、本当に置き換えてよいときだけ `--force` を使ってください。
 対応している JSON config であれば、`hooks install` は既存設定へ Traceary 管理下の hook entry をマージし、無関係な設定は保持します。`--force` を付けた場合だけ完全上書きします。
+
+### 非破壊マイグレーション (`--upgrade`)
+
+Traceary のリリースで新しい hook event (例: `UserPromptSubmit`) が追加されたとき、ユーザー追加の hook を触らずに新規分だけ反映したい場合は `--upgrade` を使います。
+
+```
+traceary hooks install --client codex --upgrade
+```
+
+`--upgrade` はデフォルト install と同じ merge パスを明示的に実行し、さらに以下を保証します。
+
+- 既存ファイルを決して上書きしない (`--force` とは排他)
+- ユーザー追加の非 Traceary hook はそのまま残す
+- Traceary 管理分のみ最新の定義で置き換える (バイナリパス変更や script 形式 → 直接呼び出し形式へのリライトも対象)
+- イベント単位のサマリを表示 (`追加: UserPromptSubmit`、`更新: ...`、`変更なし: ...`)
+- idempotent — アップグレード後に再実行すると「既に最新」と表示し、ファイルはバイト同一で維持される
+
 `hooks install` の実行後には、そのまま確認に使える `doctor` コマンドも出力します。
 
 **Claude Code plugin との関係**: Traceary の Claude Code plugin が有効な場合（`~/.claude/settings.json` の `enabledPlugins` で検知）、`hooks install --client claude` は settings file への書き込みをスキップして通知を出します。plugin がすでに同じ hook を Claude Code に提供しているため、重ねて install すると audit が 1 ツール呼び出しにつき 2 回記録されてしまいます。両方に登録したい場合（plugin 開発など）のみ `--force` を使ってください。

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -160,7 +160,8 @@ traceary hooks install --client codex --upgrade
 - 既存ファイルを決して上書きしない (`--force` とは排他)
 - ユーザー追加の非 Traceary hook はそのまま残す
 - Traceary 管理分のみ最新の定義で置き換える (バイナリパス変更や script 形式 → 直接呼び出し形式へのリライトも対象)
-- イベント単位のサマリを表示 (`追加: UserPromptSubmit`、`更新: ...`、`変更なし: ...`)
+- 現行リリースで廃止された event に残っている Traceary 管理 entry は削除し、稼働中のバイナリと Traceary フットプリントを一致させる (`削除` として表示)
+- イベント単位のサマリを表示 (`追加: UserPromptSubmit`、`更新: ...`、`削除: ...`、`変更なし: ...`)
 - idempotent — アップグレード後に再実行すると「既に最新」と表示し、ファイルはバイト同一で維持される
 
 `hooks install` の実行後には、そのまま確認に使える `doctor` コマンドも出力します。

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -146,6 +146,23 @@ Use `--global` to write the hooks to the user-level config instead of the per-pr
 
 If the destination already exists, Traceary stops with an error instead of overwriting it. Review the diff first, then rerun with `--force` only when replacing the existing file is intentional.
 For supported JSON config files, `hooks install` first tries to merge Traceary-managed entries into the existing file while preserving unrelated settings. `--force` skips merge and replaces the file completely.
+
+### Non-destructive migration (`--upgrade`)
+
+Use `--upgrade` when a Traceary release adds a new hook event (for example `UserPromptSubmit`) and you want to catch it up without touching user-added hooks:
+
+```
+traceary hooks install --client codex --upgrade
+```
+
+The flag runs the same merge path as the default install but explicitly:
+
+- never overwrites the destination file (mutually exclusive with `--force`),
+- preserves every non-Traceary hook the user added,
+- refreshes only the Traceary-managed entries (binary path changes, script-form → direct-form rewrites),
+- prints a per-event summary (`Added: UserPromptSubmit`, `Refreshed: …`, `Unchanged: …`),
+- is idempotent — re-running after an upgrade reports `already up to date` and leaves the file byte-identical.
+
 After `hooks install`, Traceary prints the matching `doctor` command so you can immediately verify the generated config in the same environment.
 
 **Claude Code plugin interaction.** When the Traceary Claude Code plugin is enabled (detected via `enabledPlugins` in `~/.claude/settings.json`), `hooks install --client claude` skips writing the settings file and prints a notice — the plugin already delivers the same hooks, so installing both would record every audit event twice. Use `--force` only if you deliberately want both registrations (plugin development).

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -160,7 +160,8 @@ The flag runs the same merge path as the default install but explicitly:
 - never overwrites the destination file (mutually exclusive with `--force`),
 - preserves every non-Traceary hook the user added,
 - refreshes only the Traceary-managed entries (binary path changes, script-form → direct-form rewrites),
-- prints a per-event summary (`Added: UserPromptSubmit`, `Refreshed: …`, `Unchanged: …`),
+- strips Traceary-managed entries for events the current release no longer emits, so the Traceary footprint stays consistent with the running binary (reported as `Removed`),
+- prints a per-event summary (`Added: UserPromptSubmit`, `Refreshed: …`, `Removed: …`, `Unchanged: …`),
 - is idempotent — re-running after an upgrade reports `already up to date` and leaves the file byte-identical.
 
 After `hooks install`, Traceary prints the matching `doctor` command so you can immediately verify the generated config in the same environment.

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -11,43 +12,139 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 )
 
-// mergeHooksDocument merges the desired Hooks aggregate with the existing JSON
-// settings bytes, replacing all previously Traceary-managed hooks while
-// preserving user-defined ones and any unrelated top-level fields.
+// hookMergeDiff describes how a non-destructive merge would change the
+// Traceary-managed subset of a hook configuration. The three event slices
+// are disjoint and sorted alphabetically for stable output.
+//
+// AddedEvents     : the event had no Traceary-managed commands in the
+//                   existing config but the desired config includes at
+//                   least one Traceary command for it.
+// RefreshedEvents : the event already had Traceary-managed commands in
+//                   the existing config, but the normalized command set
+//                   is different from the desired set (upgrade, demotion,
+//                   or binary-path rename).
+// PreservedEvents : the normalized Traceary command set is identical, so
+//                   re-running would produce the same bytes.
+type hookMergeDiff struct {
+	AddedEvents     []string
+	RefreshedEvents []string
+	PreservedEvents []string
+}
+
+// mergeHooksDocument is the original merge entry point that discards the
+// diff. Kept for callers that only need the merged bytes.
 func mergeHooksDocument(existingContent []byte, hooks model.Hooks) ([]byte, error) {
+	merged, _, err := mergeHooksDocumentWithDiff(existingContent, hooks)
+	return merged, err
+}
+
+// mergeHooksDocumentWithDiff merges the desired Hooks aggregate with the
+// existing JSON settings bytes (same semantics as mergeHooksDocument) and
+// additionally returns a per-event diff so callers can report what changed.
+func mergeHooksDocumentWithDiff(existingContent []byte, hooks model.Hooks) ([]byte, hookMergeDiff, error) {
+	var diff hookMergeDiff
+
+	desired := hooksDocumentOf(hooks)
+
 	if len(strings.TrimSpace(string(existingContent))) == 0 {
-		return marshalHooks(hooks)
+		for _, event := range hooks.EventOrder() {
+			if hasTracearyManagedCommands(desired.Hooks[event]) {
+				diff.AddedEvents = append(diff.AddedEvents, event)
+			}
+		}
+		sort.Strings(diff.AddedEvents)
+		encoded, err := marshalHooks(hooks)
+		return encoded, diff, err
 	}
 
 	root := map[string]json.RawMessage{}
 	if err := json.Unmarshal(existingContent, &root); err != nil {
-		return nil, xerrors.Errorf("existing settings file must contain a JSON object: %w", err)
+		return nil, diff, xerrors.Errorf("existing settings file must contain a JSON object: %w", err)
 	}
 
 	existingHooks := map[string][]hookMatcherDocument{}
 	if hooksValue, ok := root["hooks"]; ok && len(strings.TrimSpace(string(hooksValue))) > 0 {
 		if err := json.Unmarshal(hooksValue, &existingHooks); err != nil {
-			return nil, xerrors.Errorf("existing hooks field must be a JSON object whose values are hook arrays: %w", err)
+			return nil, diff, xerrors.Errorf("existing hooks field must be a JSON object whose values are hook arrays: %w", err)
 		}
 	}
 
-	desired := hooksDocumentOf(hooks)
+	for _, event := range hooks.EventOrder() {
+		desiredKeys := tracearyManagedKeySet(desired.Hooks[event])
+		if len(desiredKeys) == 0 {
+			continue
+		}
+		existingKeys := tracearyManagedKeySet(existingHooks[event])
+		switch {
+		case len(existingKeys) == 0:
+			diff.AddedEvents = append(diff.AddedEvents, event)
+		case managedKeySetsEqual(existingKeys, desiredKeys):
+			diff.PreservedEvents = append(diff.PreservedEvents, event)
+		default:
+			diff.RefreshedEvents = append(diff.RefreshedEvents, event)
+		}
+	}
+	sort.Strings(diff.AddedEvents)
+	sort.Strings(diff.RefreshedEvents)
+	sort.Strings(diff.PreservedEvents)
+
 	for event, desiredMatchers := range desired.Hooks {
 		existingHooks[event] = mergeHookMatchers(existingHooks[event], desiredMatchers)
 	}
 
 	encodedHooks, err := json.MarshalIndent(existingHooks, "", "  ")
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal merged hooks JSON: %w", err)
+		return nil, diff, xerrors.Errorf("failed to marshal merged hooks JSON: %w", err)
 	}
 	root["hooks"] = encodedHooks
 
 	encodedRoot, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal merged settings JSON: %w", err)
+		return nil, diff, xerrors.Errorf("failed to marshal merged settings JSON: %w", err)
 	}
 
-	return encodedRoot, nil
+	return encodedRoot, diff, nil
+}
+
+// hasTracearyManagedCommands reports whether the matcher list contains at
+// least one command recognized as Traceary-managed (direct hook binary
+// invocation or legacy script form).
+func hasTracearyManagedCommands(matchers []hookMatcherDocument) bool {
+	for _, matcher := range matchers {
+		for _, command := range matcher.Hooks {
+			if extractTracearyManagedKey(command.Command) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tracearyManagedKeySet returns the set of normalized managed keys found in
+// the matcher list. Keys are stable across binary path / script path
+// rewrites, so identical sets imply identical Traceary coverage.
+func tracearyManagedKeySet(matchers []hookMatcherDocument) map[string]struct{} {
+	keys := make(map[string]struct{})
+	for _, matcher := range matchers {
+		for _, command := range matcher.Hooks {
+			if key := extractTracearyManagedKey(command.Command); key != "" {
+				keys[key] = struct{}{}
+			}
+		}
+	}
+	return keys
+}
+
+func managedKeySetsEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key := range a {
+		if _, ok := b[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func mergeHookMatchers(existing []hookMatcherDocument, desired []hookMatcherDocument) []hookMatcherDocument {

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -13,7 +13,7 @@ import (
 )
 
 // hookMergeDiff describes how a non-destructive merge would change the
-// Traceary-managed subset of a hook configuration. The three event slices
+// Traceary-managed subset of a hook configuration. The four event slices
 // are disjoint and sorted alphabetically for stable output.
 //
 // AddedEvents     : the event had no Traceary-managed commands in the
@@ -25,10 +25,16 @@ import (
 //                   or binary-path rename).
 // PreservedEvents : the normalized Traceary command set is identical, so
 //                   re-running would produce the same bytes.
+// RemovedEvents   : the event is only in the existing config (no longer
+//                   emitted by the current release) but held Traceary-
+//                   managed commands; the merge strips those so the
+//                   Traceary footprint on disk stays consistent with the
+//                   running binary.
 type hookMergeDiff struct {
 	AddedEvents     []string
 	RefreshedEvents []string
 	PreservedEvents []string
+	RemovedEvents   []string
 }
 
 // mergeHooksDocument is the original merge entry point that discards the
@@ -69,7 +75,9 @@ func mergeHooksDocumentWithDiff(existingContent []byte, hooks model.Hooks) ([]by
 		}
 	}
 
+	desiredEventSet := make(map[string]struct{}, len(hooks.EventOrder()))
 	for _, event := range hooks.EventOrder() {
+		desiredEventSet[event] = struct{}{}
 		desiredKeys := tracearyManagedKeySet(desired.Hooks[event])
 		if len(desiredKeys) == 0 {
 			continue
@@ -84,12 +92,38 @@ func mergeHooksDocumentWithDiff(existingContent []byte, hooks model.Hooks) ([]by
 			diff.RefreshedEvents = append(diff.RefreshedEvents, event)
 		}
 	}
+	// Obsolete events: existing Traceary-managed entries for events the
+	// current release no longer emits. We strip those commands during
+	// the merge (empty desired matcher list) so upgrades remove hooks
+	// that were retired between releases, and surface them under
+	// RemovedEvents so the CLI summary can explain the change.
+	for event, matchers := range existingHooks {
+		if _, inDesired := desiredEventSet[event]; inDesired {
+			continue
+		}
+		if len(tracearyManagedKeySet(matchers)) == 0 {
+			continue
+		}
+		diff.RemovedEvents = append(diff.RemovedEvents, event)
+	}
 	sort.Strings(diff.AddedEvents)
 	sort.Strings(diff.RefreshedEvents)
 	sort.Strings(diff.PreservedEvents)
+	sort.Strings(diff.RemovedEvents)
 
 	for event, desiredMatchers := range desired.Hooks {
 		existingHooks[event] = mergeHookMatchers(existingHooks[event], desiredMatchers)
+	}
+	for _, event := range diff.RemovedEvents {
+		// Strip Traceary-managed commands for retired events; leave the
+		// event entry behind (empty) if non-Traceary hooks remain, or
+		// drop the key entirely otherwise so the file stays clean.
+		filtered := mergeHookMatchers(existingHooks[event], nil)
+		if len(filtered) == 0 {
+			delete(existingHooks, event)
+		} else {
+			existingHooks[event] = filtered
+		}
 	}
 
 	encodedHooks, err := json.MarshalIndent(existingHooks, "", "  ")

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -154,15 +154,24 @@ func hasTracearyManagedCommands(matchers []hookMatcherDocument) bool {
 	return false
 }
 
-// tracearyManagedKeySet returns the set of normalized managed keys found in
-// the matcher list. Keys are stable across binary path / script path
-// rewrites, so identical sets imply identical Traceary coverage.
+// tracearyManagedKeySet returns the set of normalized (matcher, managed key)
+// pairs found in the matcher list. Keys are stable across binary path /
+// script path rewrites, so identical sets imply identical Traceary
+// coverage. The matcher pattern is part of the key because Claude Code
+// uses the same command with different PostToolUse matchers for different
+// `--matcher` presets — without the matcher column the diff would
+// misreport a matcher-preset change as "unchanged" while the merged
+// bytes actually differ.
 func tracearyManagedKeySet(matchers []hookMatcherDocument) map[string]struct{} {
 	keys := make(map[string]struct{})
 	for _, matcher := range matchers {
+		matcherValue := ""
+		if matcher.Matcher != nil {
+			matcherValue = *matcher.Matcher
+		}
 		for _, command := range matcher.Hooks {
 			if key := extractTracearyManagedKey(command.Command); key != "" {
-				keys[key] = struct{}{}
+				keys[matcherValue+"\x00"+key] = struct{}{}
 			}
 		}
 	}

--- a/infrastructure/filesystem/hooks_merge_test.go
+++ b/infrastructure/filesystem/hooks_merge_test.go
@@ -170,6 +170,136 @@ func TestMergeHooksDocument_InvalidExistingFails(t *testing.T) {
 	}
 }
 
+func TestMergeHooksDocumentWithDiff_EmptyExistingAddsAllEvents(t *testing.T) {
+	t.Parallel()
+
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+	_, diff, err := mergeHooksDocumentWithDiff(nil, desired)
+	if err != nil {
+		t.Fatalf("mergeHooksDocumentWithDiff() error = %v", err)
+	}
+	if len(diff.AddedEvents) == 0 {
+		t.Fatalf("expected all desired events to appear as Added on empty existing, got empty Added")
+	}
+	if len(diff.RefreshedEvents) != 0 || len(diff.PreservedEvents) != 0 {
+		t.Fatalf("expected only Added events on empty existing, got refreshed=%v preserved=%v", diff.RefreshedEvents, diff.PreservedEvents)
+	}
+}
+
+func TestMergeHooksDocumentWithDiff_IdenticalSetsPreserved(t *testing.T) {
+	t.Parallel()
+
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+	initial, _, err := mergeHooksDocumentWithDiff(nil, desired)
+	if err != nil {
+		t.Fatalf("first merge error = %v", err)
+	}
+	merged, diff, err := mergeHooksDocumentWithDiff(initial, desired)
+	if err != nil {
+		t.Fatalf("re-merge error = %v", err)
+	}
+	if len(diff.AddedEvents) != 0 || len(diff.RefreshedEvents) != 0 {
+		t.Fatalf("expected idempotent re-run, got added=%v refreshed=%v", diff.AddedEvents, diff.RefreshedEvents)
+	}
+	if len(diff.PreservedEvents) == 0 {
+		t.Fatalf("expected preserved events on re-run, got empty")
+	}
+	// Byte-level idempotence: the merged output on the second run should
+	// contain the same Traceary entries as the initial output. The outer
+	// JSON may differ by key ordering from json.MarshalIndent of maps, so
+	// we only assert the Traceary command stays intact.
+	if !strings.Contains(string(merged), "'traceary' 'hook' 'session'") {
+		t.Fatalf("merged output lost traceary session hook: %s", merged)
+	}
+}
+
+func TestMergeHooksDocumentWithDiff_DifferentKeysRefreshed(t *testing.T) {
+	t.Parallel()
+
+	existing := []byte(`{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/old/scripts/traceary-session.sh' 'claude' 'start'"
+          }
+        ]
+      }
+    ]
+  }
+}`)
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+
+	_, diff, err := mergeHooksDocumentWithDiff(existing, desired)
+	if err != nil {
+		t.Fatalf("mergeHooksDocumentWithDiff() error = %v", err)
+	}
+	foundRefresh := false
+	for _, event := range diff.RefreshedEvents {
+		if event == "SessionStart" {
+			foundRefresh = true
+			break
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected SessionStart in Refreshed, got refreshed=%v added=%v preserved=%v", diff.RefreshedEvents, diff.AddedEvents, diff.PreservedEvents)
+	}
+}
+
+func TestMergeHooksDocumentWithDiff_MissingEventAdded(t *testing.T) {
+	t.Parallel()
+
+	// existing only has SessionStart entries that match the current desired
+	// set (both the '*' entry and the 'compact' entry), so SessionStart
+	// should be preserved and every other desired event should be Added.
+	existing := []byte(`{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'session' 'claude' 'start'"
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'compact' 'claude' 'session-start-compact'"
+          }
+        ]
+      }
+    ]
+  }
+}`)
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+
+	_, diff, err := mergeHooksDocumentWithDiff(existing, desired)
+	if err != nil {
+		t.Fatalf("mergeHooksDocumentWithDiff() error = %v", err)
+	}
+	foundPreservedSession := false
+	for _, event := range diff.PreservedEvents {
+		if event == "SessionStart" {
+			foundPreservedSession = true
+			break
+		}
+	}
+	if !foundPreservedSession {
+		t.Fatalf("expected SessionStart preserved, got preserved=%v added=%v refreshed=%v", diff.PreservedEvents, diff.AddedEvents, diff.RefreshedEvents)
+	}
+	if len(diff.AddedEvents) == 0 {
+		t.Fatalf("expected at least one Added event for brand-new coverage, got empty")
+	}
+}
+
 func TestExtractTracearyManagedKey(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesystem/hooks_merge_test.go
+++ b/infrastructure/filesystem/hooks_merge_test.go
@@ -300,6 +300,119 @@ func TestMergeHooksDocumentWithDiff_MissingEventAdded(t *testing.T) {
 	}
 }
 
+func TestMergeHooksDocumentWithDiff_StripsObsoleteTracearyEvents(t *testing.T) {
+	t.Parallel()
+
+	// existing holds a Traceary-managed command for a retired event name
+	// (PreToolUseLegacy) that the current release no longer emits. The
+	// merge should strip the stale entry and surface it as Removed.
+	existing := []byte(`{
+  "hooks": {
+    "PreToolUseLegacy": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {"type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'session-start-compact'"}
+        ]
+      }
+    ]
+  }
+}`)
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+
+	merged, diff, err := mergeHooksDocumentWithDiff(existing, desired)
+	if err != nil {
+		t.Fatalf("mergeHooksDocumentWithDiff() error = %v", err)
+	}
+
+	foundRemoved := false
+	for _, event := range diff.RemovedEvents {
+		if event == "PreToolUseLegacy" {
+			foundRemoved = true
+			break
+		}
+	}
+	if !foundRemoved {
+		t.Fatalf("expected PreToolUseLegacy in RemovedEvents, got removed=%v", diff.RemovedEvents)
+	}
+
+	if strings.Contains(string(merged), "PreToolUseLegacy") {
+		t.Fatalf("merged output still references retired event: %s", merged)
+	}
+}
+
+func TestMergeHooksDocumentWithDiff_ObsoleteEventKeepsUserHooks(t *testing.T) {
+	t.Parallel()
+
+	// Retired event with both a Traceary command and a user command.
+	// The Traceary command must be stripped, but the user command
+	// must stay and the event key must survive with only the user hook.
+	existing := []byte(`{
+  "hooks": {
+    "PreToolUseLegacy": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"},
+          {"type": "command", "command": "echo user-pretool"}
+        ]
+      }
+    ]
+  }
+}`)
+	desired := (&ClaudeHooksHandler{}).Build("traceary")
+
+	merged, diff, err := mergeHooksDocumentWithDiff(existing, desired)
+	if err != nil {
+		t.Fatalf("mergeHooksDocumentWithDiff() error = %v", err)
+	}
+
+	foundRemoved := false
+	for _, event := range diff.RemovedEvents {
+		if event == "PreToolUseLegacy" {
+			foundRemoved = true
+			break
+		}
+	}
+	if !foundRemoved {
+		t.Fatalf("expected PreToolUseLegacy in RemovedEvents, got removed=%v", diff.RemovedEvents)
+	}
+
+	if !strings.Contains(string(merged), "echo user-pretool") {
+		t.Fatalf("merged output dropped user hook under retired event: %s", merged)
+	}
+	if strings.Contains(string(merged), "'traceary' 'hook' 'audit' 'claude'") && strings.Count(string(merged), "PreToolUseLegacy") > 0 {
+		// Command appears elsewhere (e.g. PostToolUseFailure) but it
+		// must not appear under the retired PreToolUseLegacy event.
+		// A string-split check is good enough here.
+		if strings.Contains(string(merged), `"PreToolUseLegacy": [`) {
+			// Walk the event's array bounds.
+			start := strings.Index(string(merged), `"PreToolUseLegacy": [`)
+			end := strings.Index(string(merged)[start:], "]")
+			if end > 0 {
+				segment := string(merged)[start : start+end]
+				if strings.Contains(segment, "'traceary' 'hook' 'audit' 'claude'") {
+					t.Fatalf("retired event still lists traceary command: %s", segment)
+				}
+			}
+		}
+	}
+}
+
 func TestExtractTracearyManagedKey(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -83,7 +83,7 @@ func (o *HooksOrchestrator) Install(
 // Clients that do not honor a matcher preset ignore the value — only
 // Claude Code respects it today, via ClaudeHooksHandler.BuildWithMatcher.
 func (o *HooksOrchestrator) InstallWithMatcher(
-	_ context.Context,
+	ctx context.Context,
 	client string,
 	tracearyBin string,
 	projectDir string,
@@ -91,30 +91,71 @@ func (o *HooksOrchestrator) InstallWithMatcher(
 	force bool,
 	matcherPreset string,
 ) (string, error) {
+	path, _, err := o.installWithDiff(ctx, client, tracearyBin, projectDir, outputPath, force, matcherPreset)
+	return path, err
+}
+
+// UpgradeWithMatcher applies the current hook configuration to an existing
+// (or new) config file in merge-only mode and returns a diff describing
+// what changed. Callers should prefer this over InstallWithMatcher when
+// surfacing migration results to the user — the diff identifies which
+// events were added, refreshed, or already up to date. Re-running on an
+// already up-to-date config is a no-op at the byte level.
+func (o *HooksOrchestrator) UpgradeWithMatcher(
+	ctx context.Context,
+	client string,
+	tracearyBin string,
+	projectDir string,
+	outputPath types.Optional[string],
+	matcherPreset string,
+) (string, application.HookUpgradeDiff, error) {
+	path, diff, err := o.installWithDiff(ctx, client, tracearyBin, projectDir, outputPath, false, matcherPreset)
+	if err != nil {
+		return "", application.HookUpgradeDiff{}, err
+	}
+	return path, application.HookUpgradeDiff{
+		AddedEvents:     append([]string(nil), diff.AddedEvents...),
+		RefreshedEvents: append([]string(nil), diff.RefreshedEvents...),
+		PreservedEvents: append([]string(nil), diff.PreservedEvents...),
+	}, nil
+}
+
+// installWithDiff is the shared implementation for InstallWithMatcher and
+// UpgradeWithMatcher. The diff is empty when force overwrites the file
+// (no merge performed) or when no existing file was present.
+func (o *HooksOrchestrator) installWithDiff(
+	_ context.Context,
+	client string,
+	tracearyBin string,
+	projectDir string,
+	outputPath types.Optional[string],
+	force bool,
+	matcherPreset string,
+) (string, hookMergeDiff, error) {
 	handler, err := o.resolveHandler(client)
 	if err != nil {
-		return "", err
+		return "", hookMergeDiff{}, err
 	}
 
 	resolvedOutputPath, err := resolveInstallOutputPath(handler, projectDir, outputPath)
 	if err != nil {
-		return "", err
+		return "", hookMergeDiff{}, err
 	}
 
 	hooks := buildHooksForInstall(handler, tracearyBin, matcherPreset)
-	encoded, err := renderInstallContent(resolvedOutputPath, hooks, force)
+	encoded, diff, err := renderInstallContent(resolvedOutputPath, hooks, force)
 	if err != nil {
-		return "", err
+		return "", hookMergeDiff{}, err
 	}
 
 	if err := safeMkdirAll(filepath.Dir(resolvedOutputPath), 0o755); err != nil {
-		return "", xerrors.Errorf("failed to create output directory: %w", err)
+		return "", hookMergeDiff{}, xerrors.Errorf("failed to create output directory: %w", err)
 	}
 	if err := safeWriteFile(resolvedOutputPath, append(encoded, '\n'), 0o644); err != nil {
-		return "", xerrors.Errorf("failed to write settings file: %w", err)
+		return "", hookMergeDiff{}, xerrors.Errorf("failed to write settings file: %w", err)
 	}
 
-	return resolvedOutputPath, nil
+	return resolvedOutputPath, diff, nil
 }
 
 // matcherPresetHandler is the optional interface client handlers
@@ -224,24 +265,30 @@ func resolveInstallOutputPath(
 	return defaultPath, nil
 }
 
-func renderInstallContent(resolvedOutputPath string, hooks model.Hooks, force bool) ([]byte, error) {
+func renderInstallContent(resolvedOutputPath string, hooks model.Hooks, force bool) ([]byte, hookMergeDiff, error) {
+	var diff hookMergeDiff
 	if force {
-		return marshalHooks(hooks)
+		encoded, err := marshalHooks(hooks)
+		return encoded, diff, err
 	}
 
 	existingContent, err := safeReadFile(resolvedOutputPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return marshalHooks(hooks)
+			encoded, createDiff, merr := mergeHooksDocumentWithDiff(nil, hooks)
+			if merr != nil {
+				return nil, hookMergeDiff{}, xerrors.Errorf("failed to render new hook configuration: %w", merr)
+			}
+			return encoded, createDiff, nil
 		}
 
-		return nil, xerrors.Errorf("failed to read existing settings file: %w", err)
+		return nil, diff, xerrors.Errorf("failed to read existing settings file: %w", err)
 	}
 
-	mergedContent, err := mergeHooksDocument(existingContent, hooks)
+	mergedContent, mergeDiff, err := mergeHooksDocumentWithDiff(existingContent, hooks)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to merge existing hook configuration: %w", err)
+		return nil, hookMergeDiff{}, xerrors.Errorf("failed to merge existing hook configuration: %w", err)
 	}
 
-	return mergedContent, nil
+	return mergedContent, mergeDiff, nil
 }

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -117,6 +117,7 @@ func (o *HooksOrchestrator) UpgradeWithMatcher(
 		AddedEvents:     append([]string(nil), diff.AddedEvents...),
 		RefreshedEvents: append([]string(nil), diff.RefreshedEvents...),
 		PreservedEvents: append([]string(nil), diff.PreservedEvents...),
+		RemovedEvents:   append([]string(nil), diff.RemovedEvents...),
 	}, nil
 }
 

--- a/infrastructure/filesystem/hooks_orchestrator_test.go
+++ b/infrastructure/filesystem/hooks_orchestrator_test.go
@@ -265,6 +265,182 @@ func TestHooksOrchestrator_NormalizeClient(t *testing.T) {
 	}
 }
 
+func TestHooksOrchestrator_UpgradeAddsMissingEventsAndReportsDiff(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+	orchestrator := newTestOrchestrator(homeDir)
+
+	settingsPath := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	// Pre-existing hooks.json missing the UserPromptSubmit event but already
+	// carrying the session start + end entries a previous Traceary release
+	// installed. This simulates the dogfooded finding from the #637 issue.
+	existing := []byte(`{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {"type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'start'"}
+        ]
+      }
+    ]
+  }
+}
+`)
+	if err := os.WriteFile(settingsPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	resolvedPath, diff, err := orchestrator.UpgradeWithMatcher(
+		context.Background(),
+		"codex", "traceary",
+		projectDir,
+		types.None[string](),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("UpgradeWithMatcher() error = %v", err)
+	}
+	if resolvedPath != settingsPath {
+		t.Fatalf("UpgradeWithMatcher() path = %q, want %q", resolvedPath, settingsPath)
+	}
+
+	foundUserPrompt := false
+	for _, event := range diff.AddedEvents {
+		if event == "UserPromptSubmit" {
+			foundUserPrompt = true
+			break
+		}
+	}
+	if !foundUserPrompt {
+		t.Fatalf("expected UserPromptSubmit in AddedEvents, got added=%v", diff.AddedEvents)
+	}
+
+	foundPreservedSession := false
+	for _, event := range diff.PreservedEvents {
+		if event == "SessionStart" {
+			foundPreservedSession = true
+			break
+		}
+	}
+	if !foundPreservedSession {
+		t.Fatalf("expected SessionStart preserved, got preserved=%v refreshed=%v", diff.PreservedEvents, diff.RefreshedEvents)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "UserPromptSubmit") {
+		t.Fatalf("upgraded settings missing UserPromptSubmit: %s", content)
+	}
+}
+
+func TestHooksOrchestrator_UpgradeIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+	orchestrator := newTestOrchestrator(homeDir)
+
+	// First upgrade from empty: should add every event.
+	if _, _, err := orchestrator.UpgradeWithMatcher(
+		context.Background(),
+		"codex", "traceary",
+		projectDir,
+		types.None[string](),
+		"",
+	); err != nil {
+		t.Fatalf("first UpgradeWithMatcher() error = %v", err)
+	}
+	settingsPath := filepath.Join(homeDir, ".codex", "hooks.json")
+	firstContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	// Second upgrade: should be a no-op (all events preserved).
+	_, diff, err := orchestrator.UpgradeWithMatcher(
+		context.Background(),
+		"codex", "traceary",
+		projectDir,
+		types.None[string](),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("second UpgradeWithMatcher() error = %v", err)
+	}
+	if len(diff.AddedEvents) != 0 || len(diff.RefreshedEvents) != 0 {
+		t.Fatalf("expected idempotent re-run, got added=%v refreshed=%v", diff.AddedEvents, diff.RefreshedEvents)
+	}
+	if len(diff.PreservedEvents) == 0 {
+		t.Fatalf("expected PreservedEvents populated on idempotent re-run, got empty")
+	}
+
+	secondContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(firstContent) != string(secondContent) {
+		t.Fatalf("idempotent re-run changed file bytes\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
+	}
+}
+
+func TestHooksOrchestrator_UpgradePreservesUserHooks(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+	orchestrator := newTestOrchestrator(homeDir)
+
+	settingsPath := filepath.Join(projectDir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := []byte(`{
+  "theme": "dark",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "echo custom-start"}
+        ]
+      }
+    ]
+  }
+}
+`)
+	if err := os.WriteFile(settingsPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, _, err := orchestrator.UpgradeWithMatcher(
+		context.Background(),
+		"gemini", "traceary",
+		projectDir,
+		types.None[string](),
+		"",
+	); err != nil {
+		t.Fatalf("UpgradeWithMatcher() error = %v", err)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), `"theme": "dark"`) {
+		t.Fatalf("--upgrade dropped unrelated top-level field: %s", content)
+	}
+	if !strings.Contains(string(content), `"command": "echo custom-start"`) {
+		t.Fatalf("--upgrade dropped user-added hook command: %s", content)
+	}
+}
+
 func TestHooksOrchestrator_ResolveInstallPathHonorsOverride(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -40,6 +41,7 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 		outputPath  string
 		global      bool
 		force       bool
+		upgrade     bool
 		matcher     string
 	)
 
@@ -47,12 +49,13 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 		Use:   "install --client <claude|codex|gemini>",
 		Short: Localize("Write hook configuration examples to the standard config path", "標準の設定パスへ hook 設定例を書き出す"),
 		Long: Localize(
-			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini.\nAliases: claude-code, codex-cli, gemini-cli.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini). Codex hooks are already user-level, so --global is a no-op there.",
-			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini。\nalias: claude-code, codex-cli, gemini-cli。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json)。Codex の hook は元から user-level なため --global は効果ありません。",
+			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini.\nAliases: claude-code, codex-cli, gemini-cli.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini). Codex hooks are already user-level, so --global is a no-op there.\nUse --upgrade for a non-destructive migration: only Traceary-managed entries are replaced, user-added entries are preserved, and a summary of added / refreshed / unchanged events is printed. Re-running --upgrade on an already up-to-date config is a no-op.",
+			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini。\nalias: claude-code, codex-cli, gemini-cli。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json)。Codex の hook は元から user-level なため --global は効果ありません。\n--upgrade を指定すると非破壊マイグレーションになります (Traceary 管理分のみ置換、ユーザー追加の hook は保持、追加 / 更新 / 変更なしの内訳を表示)。既に最新の設定に対して再実行しても no-op です。",
 		),
 		Example: strings.Join([]string{
 			"  traceary hooks install --client claude --project-dir .",
 			"  traceary hooks install --client claude --global",
+			"  traceary hooks install --client codex-cli --upgrade",
 			"  traceary hooks install --client codex-cli --force",
 		}, "\n"),
 		Args: noArgsLocalized(),
@@ -64,6 +67,7 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 				outputPath:  outputPath,
 				global:      global,
 				force:       force,
+				upgrade:     upgrade,
 				matcher:     matcher,
 			})
 		},
@@ -73,7 +77,8 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 	installCmd.Flags().StringVar(&tracearyBin, "traceary-bin", "", Localize("traceary binary path or command name", "traceary バイナリパス"))
 	installCmd.Flags().StringVar(&outputPath, "output", "", Localize("override the output file path", "書き出し先を明示する"))
 	installCmd.Flags().BoolVar(&global, "global", false, Localize("write to the user-level config instead of the project config (mutually exclusive with --output)", "project ではなく user-level 設定へ書き込む (--output とは排他)"))
-	installCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the file if it already exists", "既存ファイルがある場合でも上書きする"))
+	installCmd.Flags().BoolVar(&force, "force", false, Localize("overwrite the file if it already exists (mutually exclusive with --upgrade)", "既存ファイルがある場合でも上書きする (--upgrade とは排他)"))
+	installCmd.Flags().BoolVar(&upgrade, "upgrade", false, Localize("non-destructive migration: merge only Traceary-managed entries and print a summary of added / refreshed / unchanged events (mutually exclusive with --force)", "非破壊マイグレーション: Traceary 管理分のみマージし、追加 / 更新 / 変更なしの内訳を表示 (--force とは排他)"))
 	installCmd.Flags().StringVar(&matcher, "matcher", "", Localize("Claude PostToolUse matcher preset: minimal (Bash + mcp__.*), default (+ built-in tool list), all (+ .*). Ignored for other clients. When the Claude Code plugin is active, install skips writing to settings.json unless --force is also set; otherwise the plugin's own hooks.json stays in control and this flag has no effect.", "Claude PostToolUse matcher preset: minimal (Bash + mcp__.*), default (+ 組み込み tool 列), all (+ .*)。他 client では無視されます。Claude Code plugin が有効な場合、--force を付けない限り install は settings.json 書き込みをスキップするため、plugin 配布の hooks.json が優先されて本フラグは効きません。"))
 
 	return installCmd
@@ -168,6 +173,14 @@ func (c *RootCLI) runHooksInstall(
 			),
 		)
 	}
+	if input.upgrade && input.force {
+		return xerrors.Errorf(
+			Localize(
+				"--upgrade and --force are mutually exclusive (use one or the other)",
+				"--upgrade と --force は同時指定できません (どちらか一方のみ指定してください)",
+			),
+		)
+	}
 	resolvedProjectDir, err := resolveHooksProjectDir(input.projectDir)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve project directory", "project directory の解決に失敗しました"), err)
@@ -254,6 +267,21 @@ func (c *RootCLI) runHooksInstall(
 		}
 	}
 
+	if input.upgrade {
+		resolvedOutputPath, diff, err := c.hooksOrchestrator.UpgradeWithMatcher(
+			ctx,
+			input.client,
+			resolvedTracearyBin,
+			resolvedProjectDir,
+			outputPathOption,
+			matcherPreset,
+		)
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to upgrade hook configuration file", "hook 設定ファイルのアップグレードに失敗しました"), err)
+		}
+		return writeHookUpgradeSummary(c, output, resolvedOutputPath, input, resolvedProjectDir, diff)
+	}
+
 	resolvedOutputPath, err := c.hooksOrchestrator.InstallWithMatcher(
 		ctx,
 		input.client,
@@ -281,6 +309,60 @@ func (c *RootCLI) runHooksInstall(
 	}
 
 	return nil
+}
+
+// writeHookUpgradeSummary renders the `--upgrade` summary to output. When
+// the diff is empty the migration was a no-op (re-run on an up-to-date
+// file), and we say so explicitly instead of inventing a change count so
+// the user can tell idempotent runs from real migrations.
+func writeHookUpgradeSummary(
+	c *RootCLI,
+	output io.Writer,
+	resolvedOutputPath string,
+	input hooksInstallCommandInput,
+	resolvedProjectDir string,
+	diff application.HookUpgradeDiff,
+) error {
+	canonicalClient := normalizeHooksClientForDisplay(c, input.client)
+	if len(diff.AddedEvents) == 0 && len(diff.RefreshedEvents) == 0 {
+		if _, err := fmt.Fprintf(
+			output,
+			Localize(
+				"Upgrade: %s is already up to date. %d event(s) unchanged.\nNext step: traceary doctor --client %s --project-dir %s\n",
+				"アップグレード: %s は既に最新です。%d 件のイベントに変更なし。\n次の確認: traceary doctor --client %s --project-dir %s\n",
+			),
+			resolvedOutputPath,
+			len(diff.PreservedEvents),
+			canonicalClient,
+			shellQuote(resolvedProjectDir),
+		); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print hook upgrade summary", "hook アップグレードサマリーの出力に失敗しました"), err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		Localize(
+			"Upgrade: wrote %s\n  Added %d event(s): %s\n  Refreshed %d event(s): %s\n  Unchanged %d event(s): %s\nNext step: traceary doctor --client %s --project-dir %s\n",
+			"アップグレード: %s に書き出しました\n  追加 %d 件: %s\n  更新 %d 件: %s\n  変更なし %d 件: %s\n次の確認: traceary doctor --client %s --project-dir %s\n",
+		),
+		resolvedOutputPath,
+		len(diff.AddedEvents), formatEventList(diff.AddedEvents),
+		len(diff.RefreshedEvents), formatEventList(diff.RefreshedEvents),
+		len(diff.PreservedEvents), formatEventList(diff.PreservedEvents),
+		canonicalClient,
+		shellQuote(resolvedProjectDir),
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print hook upgrade summary", "hook アップグレードサマリーの出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func formatEventList(events []string) string {
+	if len(events) == 0 {
+		return Localize("(none)", "(なし)")
+	}
+	return strings.Join(events, ", ")
 }
 
 func normalizeHooksClientForDisplay(c *RootCLI, client string) string {

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -197,6 +197,25 @@ func (c *RootCLI) runHooksInstall(
 	canonicalClient := normalizeHooksClientForDisplay(c, input.client)
 	if canonicalClient == "claude" {
 		detection := detectClaudeTracearyPluginForCLI()
+		if detection.Active && input.upgrade {
+			// --upgrade is the non-destructive path, so pointing users
+			// at --force here would be actively wrong: --force clobbers
+			// user hooks, which is the opposite of what --upgrade is
+			// for. Explain that the plugin already owns the migration
+			// instead, and return cleanly.
+			if _, err := fmt.Fprintf(
+				output,
+				Localize(
+					"Skipped upgrade: Traceary plugin %q is already enabled in %s.\nThe plugin's packaged hooks.json is updated with the plugin itself, so no settings.json migration is needed. Upgrade the plugin version to pick up new hook events, or disable the plugin first if you want Traceary to manage settings.json directly.\n",
+					"アップグレードをスキップしました: Traceary plugin %q が %s で既に有効です。\nplugin 配布の hooks.json は plugin 自体のアップデートで最新化されるため、settings.json のマイグレーションは不要です。新しい hook event を取り込むには plugin のバージョンを上げるか、settings.json を Traceary で直接管理したい場合は plugin を一旦無効化してください。\n",
+				),
+				detection.PluginKey,
+				detection.SettingsPath,
+			); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to print plugin upgrade skip notice", "plugin upgrade skip 通知の出力に失敗しました"), err)
+			}
+			return nil
+		}
 		if detection.Active && !input.force {
 			if _, err := fmt.Fprintf(
 				output,
@@ -324,7 +343,7 @@ func writeHookUpgradeSummary(
 	diff application.HookUpgradeDiff,
 ) error {
 	canonicalClient := normalizeHooksClientForDisplay(c, input.client)
-	if len(diff.AddedEvents) == 0 && len(diff.RefreshedEvents) == 0 {
+	if len(diff.AddedEvents) == 0 && len(diff.RefreshedEvents) == 0 && len(diff.RemovedEvents) == 0 {
 		if _, err := fmt.Fprintf(
 			output,
 			Localize(
@@ -343,12 +362,13 @@ func writeHookUpgradeSummary(
 	if _, err := fmt.Fprintf(
 		output,
 		Localize(
-			"Upgrade: wrote %s\n  Added %d event(s): %s\n  Refreshed %d event(s): %s\n  Unchanged %d event(s): %s\nNext step: traceary doctor --client %s --project-dir %s\n",
-			"アップグレード: %s に書き出しました\n  追加 %d 件: %s\n  更新 %d 件: %s\n  変更なし %d 件: %s\n次の確認: traceary doctor --client %s --project-dir %s\n",
+			"Upgrade: wrote %s\n  Added %d event(s): %s\n  Refreshed %d event(s): %s\n  Removed %d event(s): %s\n  Unchanged %d event(s): %s\nNext step: traceary doctor --client %s --project-dir %s\n",
+			"アップグレード: %s に書き出しました\n  追加 %d 件: %s\n  更新 %d 件: %s\n  削除 %d 件: %s\n  変更なし %d 件: %s\n次の確認: traceary doctor --client %s --project-dir %s\n",
 		),
 		resolvedOutputPath,
 		len(diff.AddedEvents), formatEventList(diff.AddedEvents),
 		len(diff.RefreshedEvents), formatEventList(diff.RefreshedEvents),
+		len(diff.RemovedEvents), formatEventList(diff.RemovedEvents),
 		len(diff.PreservedEvents), formatEventList(diff.PreservedEvents),
 		canonicalClient,
 		shellQuote(resolvedProjectDir),

--- a/presentation/cli/hooks_upgrade_test.go
+++ b/presentation/cli/hooks_upgrade_test.go
@@ -1,0 +1,213 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+// TestHooksInstall_UpgradeAddsMissingEventsAndReports asserts that
+// `traceary hooks install --client codex --upgrade` on a config that
+// already carries the SessionStart hook but not the newer
+// UserPromptSubmit event adds the missing coverage and prints an
+// "Added" line for the migrated event. This mirrors the dogfooding
+// scenario that drove #637.
+func TestHooksInstall_UpgradeAddsMissingEventsAndReports(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	codexPath := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := []byte(`{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'start'"}]}
+    ]
+  }
+}
+`)
+	if err := os.WriteFile(codexPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "codex",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "UserPromptSubmit") {
+		t.Errorf("stdout = %q; want mention of UserPromptSubmit in Added summary", output)
+	}
+	if !strings.Contains(output, "Added") && !strings.Contains(output, "追加") {
+		t.Errorf("stdout = %q; want Added/追加 summary line", output)
+	}
+
+	content, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "UserPromptSubmit") {
+		t.Errorf("codex hooks.json = %q; want UserPromptSubmit after --upgrade", content)
+	}
+}
+
+// TestHooksInstall_UpgradeIsIdempotent asserts that re-running
+// `--upgrade` on an already up-to-date config is a no-op that reports
+// zero added / refreshed events and leaves the file byte-identical.
+func TestHooksInstall_UpgradeIsIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// First run: write full hook config.
+	rootCmd := newTestRootCLI().Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "codex",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+
+	codexPath := filepath.Join(homeDir, ".codex", "hooks.json")
+	firstContent, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	// Second run: expect no-op summary.
+	rootCmd = newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "codex",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "up to date") && !strings.Contains(output, "最新") {
+		t.Errorf("stdout = %q; want up-to-date notice on idempotent re-run", output)
+	}
+
+	secondContent, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(firstContent) != string(secondContent) {
+		t.Fatalf("idempotent re-run changed file bytes\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
+	}
+}
+
+// TestHooksInstall_UpgradeRejectsForceCombination ensures --upgrade and
+// --force produce a clear validation error instead of silently mixing
+// semantics.
+func TestHooksInstall_UpgradeRejectsForceCombination(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	rootCmd := newTestRootCLI().Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "codex",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+		"--force",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil; want mutual-exclusion error")
+	}
+	if !strings.Contains(err.Error(), "--upgrade") || !strings.Contains(err.Error(), "--force") {
+		t.Errorf("err = %v; want mention of --upgrade and --force", err)
+	}
+}
+
+// TestHooksInstall_UpgradePreservesUserAddedHooks asserts that user
+// hooks in the target file are left alone while only Traceary-managed
+// entries are refreshed.
+func TestHooksInstall_UpgradePreservesUserAddedHooks(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	settingsPath := filepath.Join(projectDir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := []byte(`{
+  "theme": "dark",
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"type": "command", "command": "echo user-hook"}]}
+    ]
+  }
+}
+`)
+	if err := os.WriteFile(settingsPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI().Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "gemini",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), `"theme": "dark"`) {
+		t.Errorf("merged settings lost unrelated top-level field: %s", content)
+	}
+	if !strings.Contains(string(content), `"command": "echo user-hook"`) {
+		t.Errorf("merged settings lost user-added hook: %s", content)
+	}
+}

--- a/presentation/cli/hooks_upgrade_test.go
+++ b/presentation/cli/hooks_upgrade_test.go
@@ -214,6 +214,75 @@ func TestHooksInstall_UpgradeSkipsWhenClaudePluginActive(t *testing.T) {
 	}
 }
 
+// TestHooksInstall_UpgradeDetectsMatcherPresetChange asserts that a
+// Claude --matcher preset change (minimal → all) is surfaced as a
+// Refreshed event instead of being misreported as "already up to date"
+// while the file bytes still change. Regression guard for the Codex
+// verifier finding on PR #656.
+func TestHooksInstall_UpgradeDetectsMatcherPresetChange(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// First upgrade with --matcher minimal so the file carries the
+	// minimal matcher row set.
+	rootCmd := newTestRootCLI().Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "claude",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+		"--matcher", "minimal",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	minimalContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	// Second upgrade with --matcher all changes Claude matcher rows
+	// even though the managed command keys remain identical. The diff
+	// must classify affected events as Refreshed, not Preserved.
+	rootCmd = newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "claude",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+		"--matcher", "all",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+
+	allContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(minimalContent) == string(allContent) {
+		t.Fatalf("matcher change minimal→all should rewrite file; contents identical")
+	}
+
+	output := stdout.String()
+	if strings.Contains(output, "already up to date") || strings.Contains(output, "既に最新") {
+		t.Errorf("stdout = %q; matcher-only change must NOT report 'already up to date'", output)
+	}
+	if !strings.Contains(output, "Refreshed") && !strings.Contains(output, "更新") {
+		t.Errorf("stdout = %q; matcher-only change must surface a Refreshed summary", output)
+	}
+}
+
 // TestHooksInstall_UpgradePreservesUserAddedHooks asserts that user
 // hooks in the target file are left alone while only Traceary-managed
 // entries are refreshed.

--- a/presentation/cli/hooks_upgrade_test.go
+++ b/presentation/cli/hooks_upgrade_test.go
@@ -160,6 +160,60 @@ func TestHooksInstall_UpgradeRejectsForceCombination(t *testing.T) {
 	}
 }
 
+// TestHooksInstall_UpgradeSkipsWhenClaudePluginActive asserts that
+// `--upgrade` on the Claude client short-circuits when the Traceary
+// Claude Code plugin is enabled, and that the skip notice does NOT
+// suggest `--force` as the remediation (that flag would overwrite user
+// hooks, which is the opposite of what --upgrade wants).
+func TestHooksInstall_UpgradeSkipsWhenClaudePluginActive(t *testing.T) {
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+	// Write a plugin-active settings.json in the fake home directory.
+	if err := os.MkdirAll(filepath.Join(homeDir, ".claude"), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, ".claude", "settings.json"), []byte(`{
+  "enabledPlugins": {
+    "traceary@traceary-plugins": true
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "claude",
+		"--project-dir", projectDir,
+		"--traceary-bin", "traceary",
+		"--upgrade",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+		t.Fatalf("settings.json should not be written under --upgrade when plugin is active; stat err = %v", err)
+	}
+
+	output := stdout.String()
+	// The upgrade-specific skip notice must name the plugin and NOT
+	// point users at --force (which would clobber user hooks).
+	if !strings.Contains(output, "traceary@traceary-plugins") {
+		t.Errorf("stdout = %q; want upgrade-skip notice naming the plugin", output)
+	}
+	if strings.Contains(output, "--force") {
+		t.Errorf("stdout = %q; --upgrade skip notice must NOT suggest --force (would clobber user hooks)", output)
+	}
+}
+
 // TestHooksInstall_UpgradePreservesUserAddedHooks asserts that user
 // hooks in the target file are left alone while only Traceary-managed
 // entries are refreshed.

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -94,6 +94,7 @@ type hooksInstallCommandInput struct {
 	outputPath  string
 	global      bool
 	force       bool
+	upgrade     bool
 	matcher     string
 }
 


### PR DESCRIPTION
## Summary
- Adds `traceary hooks install --upgrade`: merge-only migration that preserves user-added hooks, refreshes only Traceary-managed entries, and reports per-event diff (added / refreshed / unchanged).
- New `application.HooksOrchestrator.UpgradeWithMatcher(...) (path, HookUpgradeDiff, err)` method; implementation sits on top of the existing merge pipeline so `hooks install` (plain / `--force`) keeps prior behavior.
- Idempotent: re-running `--upgrade` on an up-to-date file reports \"already up to date\" and leaves the bytes unchanged. `--upgrade` and `--force` are now mutually exclusive.

## Motivation
v0.8.0 dogfooding (#637) found that `traceary doctor` reports stale clients (e.g. Codex missing `UserPromptSubmit`) but the only fix today is either: plain install (merges silently with no summary) or `--force` (clobbers user-added hooks). `--upgrade` gives operators an explicit non-destructive migration path with a summary they can audit.

## Test plan
- [x] `go test ./...` — merge-diff, orchestrator-upgrade (add / idempotent / preserve user hooks), CLI (add / idempotent / `--upgrade+--force` rejection / preserve user hooks).
- [x] `go tool golangci-lint run ./...` — 0 issues.
- [x] Local dogfood: run `--upgrade` on a hand-edited codex hooks.json missing `UserPromptSubmit`; confirm the missing event is added, user hook is preserved, and re-running is a no-op.

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)