### PR TITLE
feat(memory-hygiene): detect validity_overlap_supersede pairs

### DIFF
--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -33,6 +33,16 @@ const (
 	// the CLI apply path supersedes the older memory with the newer
 	// memory's content so the store converges on a single entry.
 	MemoryHygieneSuggestionSupersedeCandidate MemoryHygieneSuggestionKind = "supersede_candidate"
+	// MemoryHygieneSuggestionValidityOverlapSupersede flags two accepted
+	// memories that share (scope, type) and have overlapping temporal
+	// validity windows (valid_from/valid_to) while carrying facts that
+	// differ above the similarity threshold. The older memory is
+	// superseded by the newer one on apply, and the apply path keeps
+	// scope / type / refs so the retrieval surface stays consistent.
+	// Unlike SupersedeCandidate this detector is gated by window
+	// overlap: memories with disjoint validity windows are treated as
+	// separate historical facts.
+	MemoryHygieneSuggestionValidityOverlapSupersede MemoryHygieneSuggestionKind = "validity_overlap_supersede"
 )
 
 // MemoryHygieneScanCriteria carries the inputs the hygiene scanner
@@ -74,11 +84,12 @@ type MemoryHygieneSuggestion struct {
 // category was populated; the counts mirror what the CLI renders as a
 // human-readable summary.
 type MemoryHygieneScanResult struct {
-	Suggestions             []MemoryHygieneSuggestion
-	RedactionHitCount       int
-	ExpiryCandidateCount    int
-	DuplicateCount          int
-	SupersedeCandidateCount int
+	Suggestions                   []MemoryHygieneSuggestion
+	RedactionHitCount             int
+	ExpiryCandidateCount          int
+	DuplicateCount                int
+	SupersedeCandidateCount       int
+	ValidityOverlapSupersedeCount int
 }
 
 // MemoryHygieneApplyCriteria carries the inputs to the apply path. Ids

--- a/application/usecase/memory_hygiene_usecase_impl.go
+++ b/application/usecase/memory_hygiene_usecase_impl.go
@@ -169,14 +169,14 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	if similarityThreshold <= 0 {
 		similarityThreshold = defaultSupersedeSimilarityThreshold
 	}
-	// Validity-overlap supersede runs first because it is the more
-	// specific detector: (scope, type) match plus overlapping temporal
-	// validity windows is strictly stronger evidence than the
-	// supersede_candidate scope + similarity check alone. We then
-	// suppress supersede_candidate for pairs already captured by the
-	// validity-overlap detector so the reviewer sees each pair exactly
-	// once, under the most specific kind.
-	validityOverlapSuggestions := detectValidityOverlapSupersede(summaries, similarityThreshold)
+	// Validity-annotated classifier runs first because it produces the
+	// more specific signal: (scope, type) match plus explicit temporal
+	// evidence splits pairs cleanly into "same policy, overlapping"
+	// (emit validity_overlap_supersede) and "separate historical
+	// facts, disjoint" (silent). Both outcomes are then excluded from
+	// the generic supersede_candidate pass so the reviewer never sees
+	// a temporally-bounded pair reported under the weaker kind.
+	validityOverlapSuggestions, temporalDisjointPairs := classifyValidityAnnotatedPairs(summaries, similarityThreshold)
 	validityPairs := make(map[string]struct{}, len(validityOverlapSuggestions))
 	for _, suggestion := range validityOverlapSuggestions {
 		validityPairs[pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())] = struct{}{}
@@ -185,7 +185,11 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	supersedeSuggestions := detectSupersedeCandidates(summaries, duplicateIndex, similarityThreshold)
 	filteredSupersede := make([]apptypes.MemoryHygieneSuggestion, 0, len(supersedeSuggestions))
 	for _, suggestion := range supersedeSuggestions {
-		if _, captured := validityPairs[pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())]; captured {
+		key := pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())
+		if _, captured := validityPairs[key]; captured {
+			continue
+		}
+		if _, disjoint := temporalDisjointPairs[key]; disjoint {
 			continue
 		}
 		filteredSupersede = append(filteredSupersede, suggestion)
@@ -279,22 +283,30 @@ func detectSupersedeCandidates(summaries []apptypes.MemorySummary, duplicateBuck
 	return suggestions
 }
 
-// detectValidityOverlapSupersede groups accepted memories by
-// (scope, type), checks pairwise temporal validity-window overlap, and
-// emits a validity_overlap_supersede suggestion for every overlapping
-// pair whose facts differ above the similarity threshold. The newer
-// memory is the replacement; the older one gets superseded on apply.
+// classifyValidityAnnotatedPairs groups accepted memories by
+// (scope, type), inspects each pair whose similarity meets the
+// threshold and where at least one side carries an explicit valid_to,
+// and returns:
 //
-// The caller is responsible for suppressing the overlapping
-// supersede_candidate suggestions so each pair surfaces under exactly
-// one kind (the more specific one).
-func detectValidityOverlapSupersede(
+//   - validity_overlap_supersede suggestions for pairs whose windows
+//     overlap under half-open semantics (aligned with runtime validity
+//     evaluation), and
+//   - a set of pair keys whose windows are disjoint under the same
+//     semantics. The caller excludes those pairs from the generic
+//     supersede_candidate pass: they are separate historical facts
+//     the operator intentionally time-bounded, not merge candidates.
+//
+// Pairs where neither side carries an explicit valid_to fall through
+// (not reported in either output) so the caller's supersede_candidate
+// pipeline still handles them.
+func classifyValidityAnnotatedPairs(
 	summaries []apptypes.MemorySummary,
 	threshold float64,
-) []apptypes.MemoryHygieneSuggestion {
+) ([]apptypes.MemoryHygieneSuggestion, map[string]struct{}) {
 	if threshold <= 0 || threshold > 1 {
-		return nil
+		return nil, nil
 	}
+	disjointPairs := map[string]struct{}{}
 
 	type scopeTypeKey struct {
 		ScopeKind  domtypes.MemoryScopeKind
@@ -328,7 +340,12 @@ func detectValidityOverlapSupersede(
 				if group[i].Fact() == group[j].Fact() {
 					continue
 				}
-				if !validityWindowsOverlap(group[i], group[j]) {
+				_, aHasTo := group[i].ValidTo().Value()
+				_, bHasTo := group[j].ValidTo().Value()
+				// Pairs without any explicit upper bound are handled
+				// by the generic supersede_candidate pipeline — the
+				// operator has not expressed temporal intent yet.
+				if !aHasTo && !bHasTo {
 					continue
 				}
 				sim := jaccardSimilarity(wordSets[i], wordSets[j])
@@ -342,6 +359,13 @@ func detectValidityOverlapSupersede(
 					if older.MemoryID().String() > newer.MemoryID().String() {
 						older, newer = newer, older
 					}
+				}
+				if !validityWindowsOverlap(group[i], group[j]) {
+					// Temporally-bounded but disjoint — historical
+					// fact, exclude from supersede_candidate so the
+					// generic pass cannot report it either.
+					disjointPairs[pairKey(older.MemoryID().String(), newer.MemoryID().String())] = struct{}{}
+					continue
 				}
 				suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
 					MemoryID:            older.MemoryID(),
@@ -357,37 +381,30 @@ func detectValidityOverlapSupersede(
 			}
 		}
 	}
-	return suggestions
+	return suggestions, disjointPairs
 }
 
-// validityWindowsOverlap reports whether the closed/half-open temporal
-// validity windows of two memories intersect *and* at least one side
-// has an explicit valid_to bound. Requiring an explicit upper bound
-// keeps the detector focused on memories that a caller has
-// intentionally annotated with temporal intent: two memories with the
-// default open-ended window on both sides are already handled by the
-// generic supersede_candidate detector, so we do not double-report
-// them here.
+// validityWindowsOverlap reports whether the half-open temporal
+// validity windows [validFrom, validTo) of two memories intersect.
+// valid_to is treated as exclusive to stay consistent with the
+// runtime retrieval semantics (infrastructure/sqlite/memory_datasource
+// evaluates valid_from <= as_of AND valid_to > as_of), so two
+// adjacent windows — [t1, t2) and [t2, t3) — are reported as
+// disjoint rather than overlapping.
 func validityWindowsOverlap(a, b apptypes.MemorySummary) bool {
 	aFrom := a.ValidFrom()
 	bFrom := b.ValidFrom()
 	aTo, aHasTo := a.ValidTo().Value()
 	bTo, bHasTo := b.ValidTo().Value()
 
-	// No temporal boundary on either side → not a validity-overlap
-	// case. Fall through to supersede_candidate via the caller's
-	// dedup logic.
-	if !aHasTo && !bHasTo {
+	// Half-open overlap: [aFrom, aTo) ∩ [bFrom, bTo) is non-empty iff
+	//   aFrom < bTo  &&  bFrom < aTo
+	// An open upper bound collapses the strict less-than check to
+	// "always true" on that side.
+	if aHasTo && !bFrom.Before(aTo) {
 		return false
 	}
-
-	// Canonical overlap test for [aFrom, aTo] and [bFrom, bTo]:
-	//   aFrom <= bTo && bFrom <= aTo
-	// Open upper bounds collapse to "always true" for that side.
-	if aHasTo && bFrom.After(aTo) {
-		return false
-	}
-	if bHasTo && aFrom.After(bTo) {
+	if bHasTo && !aFrom.Before(bTo) {
 		return false
 	}
 	return true

--- a/application/usecase/memory_hygiene_usecase_impl.go
+++ b/application/usecase/memory_hygiene_usecase_impl.go
@@ -169,9 +169,32 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	if similarityThreshold <= 0 {
 		similarityThreshold = defaultSupersedeSimilarityThreshold
 	}
+	// Validity-overlap supersede runs first because it is the more
+	// specific detector: (scope, type) match plus overlapping temporal
+	// validity windows is strictly stronger evidence than the
+	// supersede_candidate scope + similarity check alone. We then
+	// suppress supersede_candidate for pairs already captured by the
+	// validity-overlap detector so the reviewer sees each pair exactly
+	// once, under the most specific kind.
+	validityOverlapSuggestions := detectValidityOverlapSupersede(summaries, similarityThreshold)
+	validityPairs := make(map[string]struct{}, len(validityOverlapSuggestions))
+	for _, suggestion := range validityOverlapSuggestions {
+		validityPairs[pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())] = struct{}{}
+	}
+
 	supersedeSuggestions := detectSupersedeCandidates(summaries, duplicateIndex, similarityThreshold)
-	result.Suggestions = append(result.Suggestions, supersedeSuggestions...)
-	result.SupersedeCandidateCount = len(supersedeSuggestions)
+	filteredSupersede := make([]apptypes.MemoryHygieneSuggestion, 0, len(supersedeSuggestions))
+	for _, suggestion := range supersedeSuggestions {
+		if _, captured := validityPairs[pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())]; captured {
+			continue
+		}
+		filteredSupersede = append(filteredSupersede, suggestion)
+	}
+	result.Suggestions = append(result.Suggestions, filteredSupersede...)
+	result.SupersedeCandidateCount = len(filteredSupersede)
+
+	result.Suggestions = append(result.Suggestions, validityOverlapSuggestions...)
+	result.ValidityOverlapSupersedeCount = len(validityOverlapSuggestions)
 
 	return result, nil
 }
@@ -254,6 +277,120 @@ func detectSupersedeCandidates(summaries []apptypes.MemorySummary, duplicateBuck
 		}
 	}
 	return suggestions
+}
+
+// detectValidityOverlapSupersede groups accepted memories by
+// (scope, type), checks pairwise temporal validity-window overlap, and
+// emits a validity_overlap_supersede suggestion for every overlapping
+// pair whose facts differ above the similarity threshold. The newer
+// memory is the replacement; the older one gets superseded on apply.
+//
+// The caller is responsible for suppressing the overlapping
+// supersede_candidate suggestions so each pair surfaces under exactly
+// one kind (the more specific one).
+func detectValidityOverlapSupersede(
+	summaries []apptypes.MemorySummary,
+	threshold float64,
+) []apptypes.MemoryHygieneSuggestion {
+	if threshold <= 0 || threshold > 1 {
+		return nil
+	}
+
+	type scopeTypeKey struct {
+		ScopeKind  domtypes.MemoryScopeKind
+		ScopeKey   string
+		MemoryType domtypes.MemoryType
+	}
+	groups := make(map[scopeTypeKey][]apptypes.MemorySummary, len(summaries))
+	for _, summary := range summaries {
+		if summary.Scope() == nil {
+			continue
+		}
+		key := scopeTypeKey{
+			ScopeKind:  summary.Scope().Kind(),
+			ScopeKey:   summary.Scope().Key(),
+			MemoryType: summary.MemoryType(),
+		}
+		groups[key] = append(groups[key], summary)
+	}
+
+	var suggestions []apptypes.MemoryHygieneSuggestion
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		wordSets := make([]map[string]struct{}, len(group))
+		for i, summary := range group {
+			wordSets[i] = toWordSet(summary.Fact())
+		}
+		for i := 0; i < len(group); i++ {
+			for j := i + 1; j < len(group); j++ {
+				if group[i].Fact() == group[j].Fact() {
+					continue
+				}
+				if !validityWindowsOverlap(group[i], group[j]) {
+					continue
+				}
+				sim := jaccardSimilarity(wordSets[i], wordSets[j])
+				if sim < threshold {
+					continue
+				}
+				older, newer := group[i], group[j]
+				if older.UpdatedAt().After(newer.UpdatedAt()) {
+					older, newer = newer, older
+				} else if older.UpdatedAt().Equal(newer.UpdatedAt()) {
+					if older.MemoryID().String() > newer.MemoryID().String() {
+						older, newer = newer, older
+					}
+				}
+				suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
+					MemoryID:            older.MemoryID(),
+					Kind:                apptypes.MemoryHygieneSuggestionValidityOverlapSupersede,
+					Reason:              fmt.Sprintf("validity window overlaps %s at similarity %.2f", newer.MemoryID().String(), sim),
+					Fact:                older.Fact(),
+					ReplacementMemoryID: newer.MemoryID(),
+					ReplacementFact:     newer.Fact(),
+					Similarity:          sim,
+					Scope:               older.Scope(),
+					UpdatedAt:           older.UpdatedAt(),
+				})
+			}
+		}
+	}
+	return suggestions
+}
+
+// validityWindowsOverlap reports whether the closed/half-open temporal
+// validity windows of two memories intersect *and* at least one side
+// has an explicit valid_to bound. Requiring an explicit upper bound
+// keeps the detector focused on memories that a caller has
+// intentionally annotated with temporal intent: two memories with the
+// default open-ended window on both sides are already handled by the
+// generic supersede_candidate detector, so we do not double-report
+// them here.
+func validityWindowsOverlap(a, b apptypes.MemorySummary) bool {
+	aFrom := a.ValidFrom()
+	bFrom := b.ValidFrom()
+	aTo, aHasTo := a.ValidTo().Value()
+	bTo, bHasTo := b.ValidTo().Value()
+
+	// No temporal boundary on either side → not a validity-overlap
+	// case. Fall through to supersede_candidate via the caller's
+	// dedup logic.
+	if !aHasTo && !bHasTo {
+		return false
+	}
+
+	// Canonical overlap test for [aFrom, aTo] and [bFrom, bTo]:
+	//   aFrom <= bTo && bFrom <= aTo
+	// Open upper bounds collapse to "always true" for that side.
+	if aHasTo && bFrom.After(aTo) {
+		return false
+	}
+	if bHasTo && aFrom.After(bTo) {
+		return false
+	}
+	return true
 }
 
 // pairKey returns a stable key for an unordered pair of memory ids so
@@ -415,14 +552,15 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to reject memory: %w", err)
 		}
 		return apptypes.MemoryHygieneApplied{MemoryID: memoryID.String(), Kind: suggestion.Kind, Transition: "reject", Details: rejected}, nil
-	case apptypes.MemoryHygieneSuggestionSupersedeCandidate:
+	case apptypes.MemoryHygieneSuggestionSupersedeCandidate,
+		apptypes.MemoryHygieneSuggestionValidityOverlapSupersede:
 		details, err := u.memory.Show(ctx, memoryID)
 		if err != nil {
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to show memory: %w", err)
 		}
 		replacementFact := suggestion.ReplacementFact
 		if strings.TrimSpace(replacementFact) == "" {
-			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("supersede candidate missing replacement fact")
+			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("%s missing replacement fact", suggestion.Kind)
 		}
 		superseded, err := u.memory.Supersede(
 			ctx,

--- a/application/usecase/memory_hygiene_usecase_impl_test.go
+++ b/application/usecase/memory_hygiene_usecase_impl_test.go
@@ -129,6 +129,207 @@ func TestMemoryHygieneScan_SimilarFactsEmitSupersedeCandidate(t *testing.T) {
 	}
 }
 
+// validitySummary is a helper for the validity_overlap_supersede tests
+// that sets an explicit valid_from / valid_to window on the memory
+// alongside updated_at, so the detector sees a realistic temporal
+// footprint.
+func validitySummary(
+	t *testing.T,
+	id string,
+	scope domtypes.MemoryScope,
+	memoryType domtypes.MemoryType,
+	fact string,
+	updatedAt time.Time,
+	validFrom time.Time,
+	validTo domtypes.Optional[time.Time],
+) apptypes.MemorySummary {
+	t.Helper()
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		memoryType,
+		scope,
+		fact,
+		domtypes.MemoryStatusAccepted,
+		domtypes.ConfidenceMedium,
+		domtypes.MemorySourceManual,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		validFrom,
+		validTo,
+		updatedAt,
+		updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	return summary
+}
+
+func TestMemoryHygieneScan_ValidityOverlapEmitsSupersede(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// Overlap case: both memories in same (scope, type), windows overlap,
+	// facts differ and word Jaccard is high.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-older", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon",
+				t1, t1, domtypes.Some(t3)),
+			validitySummary(t, "mem-newer", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon at 15:00",
+				t2, t2, domtypes.None[time.Time]()),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t3})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount == 0 {
+		t.Fatalf("expected at least one validity_overlap_supersede, suggestions=%+v", result.Suggestions)
+	}
+	var overlap *apptypes.MemoryHygieneSuggestion
+	for i, suggestion := range result.Suggestions {
+		if suggestion.Kind == apptypes.MemoryHygieneSuggestionValidityOverlapSupersede {
+			overlap = &result.Suggestions[i]
+			break
+		}
+	}
+	if overlap == nil {
+		t.Fatalf("no validity_overlap_supersede entry in suggestions=%+v", result.Suggestions)
+	}
+	if overlap.MemoryID.String() != "mem-older" {
+		t.Fatalf("older memory should be the supersede target, got %s", overlap.MemoryID)
+	}
+	if overlap.ReplacementMemoryID.String() != "mem-newer" {
+		t.Fatalf("newer memory should be the replacement, got %s", overlap.ReplacementMemoryID)
+	}
+}
+
+func TestMemoryHygieneScan_DisjointValidityWindowsAreNotSuperseded(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t4 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// Disjoint windows: [t1, t2] then [t3, t4] — first memory retired
+	// before the second took effect. The detector must treat them as
+	// separate historical facts, not supersede candidates.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-q1", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon",
+				t1, t1, domtypes.Some(t2)),
+			validitySummary(t, "mem-q2", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon at 15:00",
+				t3, t3, domtypes.Some(t4)),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t4})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount != 0 {
+		t.Fatalf("disjoint validity windows must not trigger validity_overlap_supersede, got count=%d", result.ValidityOverlapSupersedeCount)
+	}
+}
+
+func TestMemoryHygieneScan_ValidityOverlapDifferentTypesDoNotPair(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// Same scope, overlapping windows, similar facts, but different
+	// types — the pair must not be reported because type divergence
+	// means they are conceptually different knowledge objects.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-preference", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon",
+				t1, t1, domtypes.None[time.Time]()),
+			validitySummary(t, "mem-lesson", scope, domtypes.MemoryTypeLesson,
+				"deploy to staging every afternoon at 15:00",
+				t2, t2, domtypes.None[time.Time]()),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t2.Add(24 * time.Hour)})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount != 0 {
+		t.Fatalf("different memory types must not pair, got count=%d", result.ValidityOverlapSupersedeCount)
+	}
+}
+
+func TestMemoryHygieneScan_ValidityOverlapOverridesSupersedeCandidate(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// Pair qualifies for both detectors (same scope + similar facts for
+	// SupersedeCandidate, same type + overlapping windows for
+	// ValidityOverlap — the older memory has an explicit valid_to so
+	// the validity detector triggers). The more specific detector
+	// wins: the pair is reported only under validity_overlap_supersede
+	// so the reviewer does not see it twice.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-older", scope, domtypes.MemoryTypePreference,
+				"prefer bulleted commit messages",
+				t1, t1, domtypes.Some(t3)),
+			validitySummary(t, "mem-newer", scope, domtypes.MemoryTypePreference,
+				"prefer bulleted commit messages style",
+				t2, t2, domtypes.None[time.Time]()),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t2.Add(24 * time.Hour)})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.SupersedeCandidateCount != 0 {
+		t.Fatalf("SupersedeCandidateCount = %d, want 0 (validity_overlap should absorb the pair)", result.SupersedeCandidateCount)
+	}
+	if result.ValidityOverlapSupersedeCount != 1 {
+		t.Fatalf("ValidityOverlapSupersedeCount = %d, want 1", result.ValidityOverlapSupersedeCount)
+	}
+}
+
 func TestMemoryHygieneScan_EmptyStoreReturnsEmptyResult(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_hygiene_usecase_impl_test.go
+++ b/application/usecase/memory_hygiene_usecase_impl_test.go
@@ -253,6 +253,47 @@ func TestMemoryHygieneScan_DisjointValidityWindowsAreNotSuperseded(t *testing.T)
 	}
 }
 
+func TestMemoryHygieneScan_BothOpenEndedWindowsAreNotValidityOverlap(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	// Same scope, same type, similar facts, but BOTH memories have
+	// open-ended validity windows (valid_to=None). The validity-overlap
+	// detector must fall through — supersede_candidate handles this
+	// without temporal evidence — even though scopeTypeKey would
+	// otherwise group them. Regression guard for validityWindowsOverlap
+	// returning true when neither side has an explicit upper bound.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-a", scope, domtypes.MemoryTypePreference,
+				"prefer bulleted commit messages",
+				t1, t1, domtypes.None[time.Time]()),
+			validitySummary(t, "mem-b", scope, domtypes.MemoryTypePreference,
+				"prefer bulleted commit messages style",
+				t2, t2, domtypes.None[time.Time]()),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t2.Add(24 * time.Hour)})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount != 0 {
+		t.Fatalf("both open-ended validity windows must not trigger validity_overlap_supersede, got count=%d", result.ValidityOverlapSupersedeCount)
+	}
+	if result.SupersedeCandidateCount != 1 {
+		t.Fatalf("generic supersede_candidate should still catch the pair, got count=%d", result.SupersedeCandidateCount)
+	}
+}
+
 func TestMemoryHygieneScan_ValidityOverlapDifferentTypesDoNotPair(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_hygiene_usecase_impl_test.go
+++ b/application/usecase/memory_hygiene_usecase_impl_test.go
@@ -251,6 +251,89 @@ func TestMemoryHygieneScan_DisjointValidityWindowsAreNotSuperseded(t *testing.T)
 	if result.ValidityOverlapSupersedeCount != 0 {
 		t.Fatalf("disjoint validity windows must not trigger validity_overlap_supersede, got count=%d", result.ValidityOverlapSupersedeCount)
 	}
+	if result.SupersedeCandidateCount != 0 {
+		t.Fatalf("temporally-bounded disjoint pairs must not fall through to supersede_candidate, got count=%d", result.SupersedeCandidateCount)
+	}
+}
+
+func TestMemoryHygieneScan_TouchingValidityWindowsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// Adjacent windows [t1, t2) and [t2, t3) must be treated as
+	// disjoint under half-open semantics — runtime validity evaluates
+	// valid_to as exclusive, so the two memories are never
+	// simultaneously valid.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-first", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon",
+				t1, t1, domtypes.Some(t2)),
+			validitySummary(t, "mem-second", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon at 15:00",
+				t2, t2, domtypes.Some(t3)),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t3})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount != 0 {
+		t.Fatalf("touching [t1,t2) / [t2,t3) windows must not overlap under half-open semantics, got count=%d", result.ValidityOverlapSupersedeCount)
+	}
+	if result.SupersedeCandidateCount != 0 {
+		t.Fatalf("touching windows are separate historical facts and must not become supersede_candidate either, got count=%d", result.SupersedeCandidateCount)
+	}
+}
+
+func TestMemoryHygieneScan_OneOpenOneExplicitOverlapEmitsValidity(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceOf: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// One side carries an explicit valid_to that sits after the other
+	// side's valid_from, so the windows overlap under half-open
+	// semantics. Only one bound needs to be explicit for the detector
+	// to activate.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			validitySummary(t, "mem-explicit", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon",
+				t1, t1, domtypes.Some(t3)),
+			validitySummary(t, "mem-open", scope, domtypes.MemoryTypePreference,
+				"deploy to staging every afternoon at 15:00",
+				t2, t2, domtypes.None[time.Time]()),
+		},
+	}
+	sut := usecase.NewMemoryHygieneUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: t3.Add(24 * time.Hour)})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ValidityOverlapSupersedeCount != 1 {
+		t.Fatalf("one explicit + one open overlap must emit validity_overlap_supersede, got count=%d", result.ValidityOverlapSupersedeCount)
+	}
+	if result.SupersedeCandidateCount != 0 {
+		t.Fatalf("pair captured by validity_overlap should not also appear as supersede_candidate, got count=%d", result.SupersedeCandidateCount)
+	}
 }
 
 func TestMemoryHygieneScan_BothOpenEndedWindowsAreNotValidityOverlap(t *testing.T) {

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -108,7 +108,7 @@ accepted memory layer を定期的に手入れしたいときに使います。
 - `traceary memory hygiene apply --ids id1,id2,...`
 - MCP `scan_memory_hygiene`
 
-scan は accepted memory に対して 3 種類の条件をチェックします: 現在の redaction ルールで mask されるべき内容 (`redaction_hit`)、`--expiry-days` 以上更新が無い stale row (`expiry_candidate`)、同一 scope + 同一 fact の衝突 (`duplicate`)。apply は `--ids` に渡した memory について該当 suggestion の lifecycle transition を commit します (`redaction_hit` は sanitized fact に supersede、`expiry_candidate` は expire、`duplicate` は reject)。MCP 側の `scan_memory_hygiene` は read-only で、agent からも同じ hygiene 候補を確認できます。
+scan は accepted memory に対して 5 種類の条件をチェックします: 現在の redaction ルールで mask されるべき内容 (`redaction_hit`)、`--expiry-days` 以上更新が無い stale row (`expiry_candidate`)、同一 scope + 同一 fact の衝突 (`duplicate`)、scope を共有し単語 Jaccard 類似度が閾値を超える書き換えペア (`supersede_candidate`)、`(scope, type)` を共有し明示的な temporal validity window が重なるペア (`validity_overlap_supersede`)。validity_overlap_supersede はより具体的なシグナルで、両方の検出に該当するペアは重複表示せず `validity_overlap_supersede` 側だけ報告します。apply は `--ids` に渡した memory について該当 suggestion の lifecycle transition を commit します (`redaction_hit` は sanitized fact に supersede、`expiry_candidate` は expire、`duplicate` は reject、`supersede_candidate` / `validity_overlap_supersede` は新しい memory の fact で supersede)。MCP 側の `scan_memory_hygiene` は read-only で、agent からも同じ hygiene 候補を確認できます。
 
 ### ブリッジ / 書き出し経路
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -111,14 +111,22 @@ Use this periodically to keep the accepted layer tidy:
 - `traceary memory hygiene apply --ids id1,id2,...`
 - MCP `scan_memory_hygiene`
 
-Scan flags three conditions on `accepted` memories: content the current
+Scan flags five conditions on `accepted` memories: content the current
 redaction rules would mask (`redaction_hit`), stale rows that have not
-been updated in longer than `--expiry-days` (`expiry_candidate`), and
-scope + fact collisions (`duplicate`). Apply commits the lifecycle
-transition implied by each suggestion for the listed memory ids —
-`redaction_hit` becomes a supersede with the sanitized fact,
-`expiry_candidate` becomes an expire, `duplicate` becomes a reject.
-MCP exposes the scanner (read-only) via `scan_memory_hygiene` so agents
+been updated in longer than `--expiry-days` (`expiry_candidate`),
+scope + fact collisions (`duplicate`), scope-sharing pairs whose facts
+are similar enough to be rephrasings of the same idea
+(`supersede_candidate`), and `(scope, type)`-sharing pairs whose
+explicit temporal validity windows overlap (`validity_overlap_supersede`).
+The validity-overlap detector is the more specific signal: a pair that
+qualifies for both is reported only under `validity_overlap_supersede`
+to keep the reviewer's list free of duplicates. Apply commits the
+lifecycle transition implied by each suggestion for the listed memory
+ids — `redaction_hit` becomes a supersede with the sanitized fact,
+`expiry_candidate` becomes an expire, `duplicate` becomes a reject,
+and both `supersede_candidate` and `validity_overlap_supersede` become
+a supersede using the newer memory's fact as the replacement. MCP
+exposes the scanner (read-only) via `scan_memory_hygiene` so agents
 can surface hygiene suggestions alongside the inbox review workflow.
 
 ### Bridge / export path

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -198,17 +198,19 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygieneScanResult, asJSON bool) error {
 	if asJSON {
 		payload := struct {
-			RedactionHitCount       int                        `json:"redaction_hit_count"`
-			ExpiryCandidateCount    int                        `json:"expiry_candidate_count"`
-			DuplicateCount          int                        `json:"duplicate_count"`
-			SupersedeCandidateCount int                        `json:"supersede_candidate_count"`
-			Suggestions             []memoryHygieneOutputEntry `json:"suggestions"`
+			RedactionHitCount             int                        `json:"redaction_hit_count"`
+			ExpiryCandidateCount          int                        `json:"expiry_candidate_count"`
+			DuplicateCount                int                        `json:"duplicate_count"`
+			SupersedeCandidateCount       int                        `json:"supersede_candidate_count"`
+			ValidityOverlapSupersedeCount int                        `json:"validity_overlap_supersede_count"`
+			Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
 		}{
-			RedactionHitCount:       result.RedactionHitCount,
-			ExpiryCandidateCount:    result.ExpiryCandidateCount,
-			DuplicateCount:          result.DuplicateCount,
-			SupersedeCandidateCount: result.SupersedeCandidateCount,
-			Suggestions:             make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
+			RedactionHitCount:             result.RedactionHitCount,
+			ExpiryCandidateCount:          result.ExpiryCandidateCount,
+			DuplicateCount:                result.DuplicateCount,
+			SupersedeCandidateCount:       result.SupersedeCandidateCount,
+			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
+			Suggestions:                   make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
 			payload.Suggestions = append(payload.Suggestions, newMemoryHygieneOutputEntry(suggestion))
@@ -222,9 +224,9 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		return nil
 	}
 	if _, err := fmt.Fprintf(output, Localize(
-		"redaction_hits=%d expiry_candidates=%d duplicates=%d supersede_candidates=%d\n",
-		"redaction ヒット=%d expiry 候補=%d 重複=%d supersede 候補=%d\n",
-	), result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.SupersedeCandidateCount); err != nil {
+		"redaction_hits=%d expiry_candidates=%d duplicates=%d supersede_candidates=%d validity_overlap_supersedes=%d\n",
+		"redaction ヒット=%d expiry 候補=%d 重複=%d supersede 候補=%d validity 重複 supersede=%d\n",
+	), result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.SupersedeCandidateCount, result.ValidityOverlapSupersedeCount); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene summary", "hygiene サマリの出力に失敗しました"), err)
 	}
 	for _, suggestion := range result.Suggestions {

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -174,26 +174,27 @@ type importMemoryInstructionsOutput struct {
 }
 
 // memoryHygieneOutput mirrors the CLI `memory hygiene scan` shape so
-// agent hosts receive the same four-suggestion view an operator sees
+// agent hosts receive the same five-suggestion view an operator sees
 // on stdout.
 type memoryHygieneOutput struct {
-	RedactionHitCount       int                             `json:"redaction_hit_count" jsonschema:"number of accepted memories flagged by the current redaction rules"`
-	ExpiryCandidateCount    int                             `json:"expiry_candidate_count" jsonschema:"number of accepted memories older than the staleness threshold"`
-	DuplicateCount          int                             `json:"duplicate_count" jsonschema:"number of accepted memories that share scope + fact with another row"`
-	SupersedeCandidateCount int                             `json:"supersede_candidate_count" jsonschema:"number of accepted memories paired by word-Jaccard similarity"`
-	Suggestions             []memoryHygieneSuggestionOutput `json:"suggestions" jsonschema:"per-memory hygiene suggestions"`
+	RedactionHitCount             int                             `json:"redaction_hit_count" jsonschema:"number of accepted memories flagged by the current redaction rules"`
+	ExpiryCandidateCount          int                             `json:"expiry_candidate_count" jsonschema:"number of accepted memories older than the staleness threshold"`
+	DuplicateCount                int                             `json:"duplicate_count" jsonschema:"number of accepted memories that share scope + fact with another row"`
+	SupersedeCandidateCount       int                             `json:"supersede_candidate_count" jsonschema:"number of accepted memories paired by word-Jaccard similarity"`
+	ValidityOverlapSupersedeCount int                             `json:"validity_overlap_supersede_count" jsonschema:"number of accepted memories paired by (scope, type) with overlapping validity windows"`
+	Suggestions                   []memoryHygieneSuggestionOutput `json:"suggestions" jsonschema:"per-memory hygiene suggestions"`
 }
 
 type memoryHygieneSuggestionOutput struct {
 	MemoryID            string  `json:"memory_id" jsonschema:"memory identifier"`
-	Kind                string  `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate)"`
+	Kind                string  `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate / validity_overlap_supersede)"`
 	Reason              string  `json:"reason" jsonschema:"human-readable reason the scanner flagged this memory"`
 	Fact                string  `json:"fact" jsonschema:"stored fact at scan time"`
 	SanitizedFact       string  `json:"sanitized_fact,omitempty" jsonschema:"masked fact the apply path would write via supersede"`
 	DuplicateMemoryID   string  `json:"duplicate_memory_id,omitempty" jsonschema:"paired duplicate when kind=duplicate"`
 	ReplacementMemoryID string  `json:"replacement_memory_id,omitempty" jsonschema:"newer memory whose fact is suggested as the supersede replacement"`
 	ReplacementFact     string  `json:"replacement_fact,omitempty" jsonschema:"fact the apply path would write via supersede"`
-	Similarity          float64 `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate only)"`
+	Similarity          float64 `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate / validity_overlap_supersede only)"`
 	ScopeKind           string  `json:"scope_kind,omitempty" jsonschema:"scope kind"`
 	ScopeValue          string  `json:"scope_value,omitempty" jsonschema:"scope value"`
 	UpdatedAt           string  `json:"updated_at" jsonschema:"last update timestamp (RFC3339)"`

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -798,11 +798,12 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			return nil, memoryHygieneOutput{}, xerrors.Errorf("failed to scan memory hygiene: %w", err)
 		}
 		out := memoryHygieneOutput{
-			RedactionHitCount:       result.RedactionHitCount,
-			ExpiryCandidateCount:    result.ExpiryCandidateCount,
-			DuplicateCount:          result.DuplicateCount,
-			SupersedeCandidateCount: result.SupersedeCandidateCount,
-			Suggestions:             make([]memoryHygieneSuggestionOutput, 0, len(result.Suggestions)),
+			RedactionHitCount:             result.RedactionHitCount,
+			ExpiryCandidateCount:          result.ExpiryCandidateCount,
+			DuplicateCount:                result.DuplicateCount,
+			SupersedeCandidateCount:       result.SupersedeCandidateCount,
+			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
+			Suggestions:                   make([]memoryHygieneSuggestionOutput, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
 			entry := memoryHygieneSuggestionOutput{


### PR DESCRIPTION
## Summary
- Extend `memory hygiene scan` with a new suggestion kind `validity_overlap_supersede` that flags accepted memory pairs sharing `(scope, type)` whose explicit temporal validity windows overlap and whose facts diverge above the similarity threshold.
- Newer memory supersedes older via the existing `MemoryUsecase.Supersede` path (scope / type / refs preserved). Runs ahead of `supersede_candidate` and suppresses duplicate reporting for pairs that qualify for both.
- Default open-ended windows (valid_to nil on both sides) fall through to `supersede_candidate` as before — the detector requires at least one explicit `valid_to` so it only triggers on intentionally annotated pairs.

## Motivation
v0.8-3 (#565) wired temporal validity (`valid_from` / `valid_to`) into the retrieval surface. The follow-up is to let the hygiene scan use that axis as evidence: two memories marked with overlapping windows for the same `(scope, type)` are almost always rephrasings of the same policy, and the scanner can short-circuit review with a specific suggestion.

## Test plan
- [x] `go test ./...` — new detector unit tests (overlap emits / disjoint does not / different types do not pair / overlap overrides supersede_candidate) + existing hygiene tests stay green.
- [x] `go tool golangci-lint run ./...` — 0 issues.

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)