### PR TITLE
fix: consolidate Log redaction into EventUsecase (mirror AuditRedaction)

### DIFF
--- a/application/types/log_redaction.go
+++ b/application/types/log_redaction.go
@@ -1,0 +1,41 @@
+package types
+
+import "slices"
+
+// LogRedaction holds redaction settings for event logging via
+// EventUsecase.Log. It mirrors AuditRedaction for the Audit path so
+// every log-ingest surface (CLI `traceary log`, transcript hook, MCP
+// add_log) carries the same policy shape and the usecase
+// implementation can apply redaction once on behalf of all callers.
+//
+// The zero value is intentionally a pass-through: no extra patterns,
+// matching today's behaviour for non-transcript kinds.
+type LogRedaction struct {
+	extraRedactPatterns []string
+}
+
+// ExtraRedactPatterns returns additional redaction regex patterns.
+func (r LogRedaction) ExtraRedactPatterns() []string {
+	return slices.Clone(r.extraRedactPatterns)
+}
+
+// LogRedactionBuilder builds a LogRedaction value.
+type LogRedactionBuilder struct {
+	redaction LogRedaction
+}
+
+// NewLogRedactionBuilder starts building an empty LogRedaction.
+func NewLogRedactionBuilder() *LogRedactionBuilder {
+	return &LogRedactionBuilder{}
+}
+
+// ExtraRedactPatterns sets additional redaction regex patterns.
+func (b *LogRedactionBuilder) ExtraRedactPatterns(patterns []string) *LogRedactionBuilder {
+	b.redaction.extraRedactPatterns = slices.Clone(patterns)
+	return b
+}
+
+// Build finalizes and returns the LogRedaction.
+func (b *LogRedactionBuilder) Build() LogRedaction {
+	return b.redaction
+}

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -11,7 +11,12 @@ import (
 // EventUsecase consolidates event recording and query operations.
 type EventUsecase interface {
 	// Log records a log event. Zero-value kind defaults to note.
-	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error)
+	// logCfg carries redaction settings; its zero value is a
+	// pass-through for non-transcript kinds. For EventKindTranscript
+	// the implementation applies built-in redactors + the caller's
+	// extra patterns before persisting so no log-ingest surface has
+	// to re-implement that policy in the presentation layer.
+	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error)
 
 	// Audit records a command execution audit event.
 	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -34,7 +34,7 @@ func NewEventUsecase(
 	}
 }
 
-func (u *eventUsecase) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
+func (u *eventUsecase) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
 	if u.eventRepo == nil {
 		return nil, xerrors.Errorf("event repository is not configured")
 	}
@@ -52,6 +52,21 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 			return nil, xerrors.Errorf("failed to resolve event kind: %w", err)
 		}
 		resolvedKind = resolved
+	}
+
+	// Transcript events routinely re-state secrets the agent saw
+	// earlier in the turn (API keys read from .env, Bearer tokens
+	// echoed from header dumps, private keys pasted into chat). Apply
+	// the shared redaction policy once inside the usecase so every
+	// log-ingest surface (CLI log, transcript hook, MCP add_log)
+	// gets the same coverage without re-implementing the 5-line
+	// CompileExtraPatterns+Apply block in the presentation layer.
+	if resolvedKind == types.EventKindTranscript {
+		extraRedactors, err := redaction.CompileExtraPatterns(logCfg.ExtraRedactPatterns())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to compile extra redaction patterns for transcript: %w", err)
+		}
+		message, _ = redaction.Apply(message, extraRedactors)
 	}
 
 	eventID, err := newEventID()

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -2,10 +2,12 @@ package usecase_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
@@ -42,6 +44,7 @@ func TestEventUsecase_Log(t *testing.T) {
 			types.Agent("codex"),
 			types.SessionID("session-1"),
 			types.Workspace("duck8823/traceary"),
+			apptypes.LogRedaction{},
 		)
 		if err != nil {
 			t.Fatalf("Log() error = %v", err)
@@ -88,6 +91,7 @@ func TestEventUsecase_Log(t *testing.T) {
 			types.Agent("claude"),
 			types.SessionID("session-1"),
 			types.Workspace("duck8823/traceary"),
+			apptypes.LogRedaction{},
 		)
 		if err != nil {
 			t.Fatalf("Log() error = %v", err)
@@ -110,6 +114,7 @@ func TestEventUsecase_Log(t *testing.T) {
 			types.Agent("manual"),
 			types.SessionID("session-1"),
 			types.Workspace(""),
+			apptypes.LogRedaction{},
 		)
 		if err != nil {
 			t.Fatalf("Log() error = %v", err)
@@ -132,9 +137,72 @@ func TestEventUsecase_Log(t *testing.T) {
 			types.Agent("manual"),
 			types.SessionID("session-1"),
 			types.Workspace(""),
+			apptypes.LogRedaction{},
 		)
 		if err == nil {
 			t.Fatalf("Log() error = nil, want error for invalid kind")
+		}
+	})
+
+	t.Run("transcript kind applies builtin + extra redactors inside the usecase", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewEventUsecase(stub, nil)
+
+		cfg := apptypes.NewLogRedactionBuilder().
+			ExtraRedactPatterns([]string{`my_custom_secret=\S+`}).
+			Build()
+		got, err := sut.Log(context.Background(),
+			"Authorization: Bearer abc.DEF-123 and my_custom_secret=s3cr3tValue42 follows",
+			types.EventKindTranscript,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("session-1"),
+			types.Workspace("duck8823/traceary"),
+			cfg,
+		)
+		if err != nil {
+			t.Fatalf("Log() error = %v", err)
+		}
+		body := got.Body()
+		if strings.Contains(body, "s3cr3tValue42") {
+			t.Errorf("transcript body leaked operator extra pattern: %q", body)
+		}
+		if strings.Contains(body, "abc.DEF-123") {
+			t.Errorf("transcript body leaked Bearer token (builtin redactor regression): %q", body)
+		}
+		if !strings.Contains(body, "[REDACTED]") {
+			t.Errorf("transcript body missing [REDACTED] placeholder: %q", body)
+		}
+	})
+
+	t.Run("non-transcript kind passes body through untouched even with patterns", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &eventRepositoryStub{}
+		sut := usecase.NewEventUsecase(stub, nil)
+
+		cfg := apptypes.NewLogRedactionBuilder().
+			ExtraRedactPatterns([]string{`my_custom_secret=\S+`}).
+			Build()
+		// Prompt and compact_summary bodies intentionally keep operator
+		// intent verbatim; the kind-aware gate inside EventUsecase.Log
+		// must not apply redaction to those kinds.
+		got, err := sut.Log(context.Background(),
+			"my_custom_secret=keepme",
+			types.EventKindPrompt,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("session-1"),
+			types.Workspace("duck8823/traceary"),
+			cfg,
+		)
+		if err != nil {
+			t.Fatalf("Log() error = %v", err)
+		}
+		if diff := cmp.Diff("my_custom_secret=keepme", got.Body()); diff != "" {
+			t.Fatalf("Body() mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -151,6 +219,7 @@ func TestEventUsecase_Log(t *testing.T) {
 			types.Agent(""),
 			types.SessionID("session-1"),
 			types.Workspace(""),
+			apptypes.LogRedaction{},
 		)
 		if err == nil {
 			t.Fatalf("Log() error = nil, want error")

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/redaction"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -426,7 +425,7 @@ func (c *RootCLI) runHookCompact(
 			body = "compact triggered"
 			kind = types.EventKind("")
 		}
-		_, err = c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace)
+		_, err = c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 		if err != nil {
 			return xerrors.Errorf("failed to record compact hook event: %w", err)
 		}
@@ -459,7 +458,7 @@ func (c *RootCLI) runHookCompact(
 		if preContext != "" {
 			body = types.EventBodyMarkerCompactPreSnapshot + " " + preContext
 		}
-		_, err = c.event.Log(ctx, body, types.EventKindCompactSummary, types.Client("hook"), agent, sessionID, workspace)
+		_, err = c.event.Log(ctx, body, types.EventKindCompactSummary, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 		if err != nil {
 			return xerrors.Errorf("failed to record pre-compact hook event: %w", err)
 		}
@@ -524,7 +523,7 @@ func (c *RootCLI) runHookSubagentStop(
 	if subagentType != "" {
 		body = types.EventBodyMarkerSubagentStop + " " + subagentType
 	}
-	_, err = c.event.Log(ctx, body, types.EventKindSessionEnded, types.Client("hook"), agent, sessionID, workspace)
+	_, err = c.event.Log(ctx, body, types.EventKindSessionEnded, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 	if err != nil {
 		return xerrors.Errorf("failed to record subagent-stop event: %w", err)
 	}
@@ -576,7 +575,7 @@ func (c *RootCLI) runHookPrompt(
 	if err := c.storeManagement.Initialize(ctx); err != nil {
 		return xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	_, err = c.event.Log(ctx, promptText, types.EventKindPrompt, types.Client("hook"), agent, sessionID, workspace)
+	_, err = c.event.Log(ctx, promptText, types.EventKindPrompt, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 
 	if err != nil {
 		return xerrors.Errorf("failed to record hook prompt: %w", err)
@@ -634,19 +633,16 @@ func (c *RootCLI) runHookTranscript(
 	if !ok || strings.TrimSpace(transcriptText) == "" {
 		return nil
 	}
-	// Transcript text routinely carries things the assistant re-stated
-	// from files or shell output — API keys from .env files, Bearer
-	// tokens from header dumps, private keys pasted into chat. Apply
-	// the built-in audit redactors plus any operator-configured
-	// extra_redact_patterns before persisting so `traceary tail` cannot
-	// leak them back later. Extra patterns that fail to compile should
-	// not silently bypass redaction: bail out instead, matching the
-	// audit path's policy (event_usecase_impl.go Audit).
-	extraRedactors, err := redaction.CompileExtraPatterns(c.extraRedactPatterns)
-	if err != nil {
-		return xerrors.Errorf("failed to compile extra redaction patterns for transcript: %w", err)
-	}
-	transcriptText, _ = redaction.Apply(transcriptText, extraRedactors)
+	// Transcript bodies can echo secrets the assistant saw earlier in
+	// the turn (API keys from .env, Bearer tokens from header dumps,
+	// private keys pasted into chat). Hand the operator-configured
+	// extra_redact_patterns to EventUsecase.Log; the usecase applies
+	// the shared built-in redactors + the extras once on behalf of
+	// every log-ingest surface so this hook, the CLI log command,
+	// and MCP add_log all converge on the same policy.
+	logCfg := apptypes.NewLogRedactionBuilder().
+		ExtraRedactPatterns(c.extraRedactPatterns).
+		Build()
 
 	sessionID, err := resolveHookSessionID(payload, client)
 	if err != nil {
@@ -671,7 +667,7 @@ func (c *RootCLI) runHookTranscript(
 	if err := c.storeManagement.Initialize(ctx); err != nil {
 		return xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	if _, err := c.event.Log(ctx, transcriptText, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace); err != nil {
+	if _, err := c.event.Log(ctx, transcriptText, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg); err != nil {
 		return xerrors.Errorf("failed to record hook transcript: %w", err)
 	}
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
@@ -670,12 +672,14 @@ func TestRootCLI_HookTranscriptCommand_RecordsLastAssistantMessage(t *testing.T)
 	}
 }
 
-// TestRootCLI_HookTranscriptCommand_AppliesExtraRedactPatterns asserts
-// that operator-configured extra_redact_patterns also run against the
-// transcript body, matching the audit path's policy. Before #626 the
-// transcript hook used ApplyBuiltin only and silently leaked any
-// org-specific secret shape that the audit path successfully masked.
-func TestRootCLI_HookTranscriptCommand_AppliesExtraRedactPatterns(t *testing.T) {
+// TestRootCLI_HookTranscriptCommand_PassesExtraRedactPatternsThroughLogCfg
+// asserts that operator-configured extra_redact_patterns are handed to
+// EventUsecase.Log via LogRedaction (the usecase performs the actual
+// redaction; CLI / hooks only select the policy). Before #626 the
+// transcript hook did the redaction in the presentation layer itself;
+// #666 consolidated it inside EventUsecase.Log so this test now only
+// verifies the config hand-off.
+func TestRootCLI_HookTranscriptCommand_PassesExtraRedactPatternsThroughLogCfg(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-transcript-extra")
 
 	homeDir := t.TempDir()
@@ -730,11 +734,13 @@ func TestRootCLI_HookTranscriptCommand_AppliesExtraRedactPatterns(t *testing.T) 
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	if strings.Contains(eventStub.logCall.message, "s3cr3tValue42") {
-		t.Errorf("transcript log message leaked secret via extra pattern: %q", eventStub.logCall.message)
+	got := eventStub.logCall.logCfg.ExtraRedactPatterns()
+	want := []string{`my_custom_secret=\S+`}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("logCfg.ExtraRedactPatterns() mismatch (-want +got):\n%s", diff)
 	}
-	if !strings.Contains(eventStub.logCall.message, "[REDACTED]") {
-		t.Errorf("transcript log message missing [REDACTED] placeholder: %q", eventStub.logCall.message)
+	if got, want := eventStub.logCall.kind, types.EventKindTranscript; got != want {
+		t.Errorf("log kind = %q, want %q", got, want)
 	}
 }
 
@@ -903,14 +909,12 @@ func TestRootCLI_HookTranscriptCommand_Codex(t *testing.T) {
 	if !strings.HasPrefix(eventStub.logCall.message, "Codex reply body.") {
 		t.Errorf("transcript log message prefix = %q, want it to start with \"Codex reply body.\"", eventStub.logCall.message)
 	}
-	if strings.Contains(eventStub.logCall.message, "s3cr3tValue42") {
-		t.Errorf("transcript log message leaked secret via extra pattern: %q", eventStub.logCall.message)
-	}
-	if strings.Contains(eventStub.logCall.message, "abc.DEF-123") {
-		t.Errorf("transcript log message leaked Bearer token (builtin redactor regression): %q", eventStub.logCall.message)
-	}
-	if !strings.Contains(eventStub.logCall.message, "[REDACTED]") {
-		t.Errorf("transcript log message missing [REDACTED] placeholder: %q", eventStub.logCall.message)
+	// Redaction now runs inside EventUsecase.Log (#666). The CLI
+	// layer's job is to hand the operator-configured extra patterns
+	// over via LogRedaction; the actual redaction behaviour is
+	// covered by application/usecase/record_log_test.go.
+	if diff := cmp.Diff([]string{`my_custom_secret=\S+`}, eventStub.logCall.logCfg.ExtraRedactPatterns()); diff != "" {
+		t.Errorf("logCfg.ExtraRedactPatterns() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1016,14 +1020,11 @@ func TestRootCLI_HookTranscriptCommand_Gemini(t *testing.T) {
 	if !strings.HasPrefix(eventStub.logCall.message, "Gemini summary.") {
 		t.Errorf("transcript log message prefix = %q, want it to start with \"Gemini summary.\"", eventStub.logCall.message)
 	}
-	if strings.Contains(eventStub.logCall.message, "s3cr3tValue42") {
-		t.Errorf("transcript log message leaked secret via extra pattern: %q", eventStub.logCall.message)
-	}
-	if strings.Contains(eventStub.logCall.message, "abc.DEF-123") {
-		t.Errorf("transcript log message leaked Bearer token (builtin redactor regression): %q", eventStub.logCall.message)
-	}
-	if !strings.Contains(eventStub.logCall.message, "[REDACTED]") {
-		t.Errorf("transcript log message missing [REDACTED] placeholder: %q", eventStub.logCall.message)
+	// Same split as the Codex test: CLI hands LogRedaction over,
+	// EventUsecase.Log does the actual redaction (covered in
+	// application/usecase/record_log_test.go).
+	if diff := cmp.Diff([]string{`my_custom_secret=\S+`}, eventStub.logCall.logCfg.ExtraRedactPatterns()); diff != "" {
+		t.Errorf("logCfg.ExtraRedactPatterns() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/redaction"
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -112,19 +112,14 @@ func (c *RootCLI) runLog(ctx context.Context, output io.Writer, input logCommand
 	workspace := types.Workspace(resolvedRepo)
 	kind := types.EventKind(strings.TrimSpace(input.kind))
 	message := input.message
-	// Match the Stop-hook transcript capture policy (#626) and the MCP
-	// add_log path (#648): when the caller records a transcript event
-	// through the CLI, run the same redactor chain before persistence.
-	// Prompt / compact_summary bodies are left verbatim on purpose —
-	// operator intent is documented in docs/environment/README.md.
-	if kind == types.EventKindTranscript {
-		extraRedactors, compileErr := redaction.CompileExtraPatterns(c.extraRedactPatterns)
-		if compileErr != nil {
-			return xerrors.Errorf("%s: %w", Localize("failed to compile extra redaction patterns for transcript", "transcript 用の extra redaction pattern の compile に失敗しました"), compileErr)
-		}
-		message, _ = redaction.Apply(message, extraRedactors)
-	}
-	event, err := c.event.Log(ctx, message, kind, client, agent, sessionID, workspace)
+	// EventUsecase.Log applies the redaction policy itself when the
+	// kind is transcript (mirrors AuditRedaction for the Audit path),
+	// so callers only hand over the config. Non-transcript kinds
+	// pass through the zero-value LogRedaction unchanged.
+	logCfg := apptypes.NewLogRedactionBuilder().
+		ExtraRedactPatterns(c.extraRedactPatterns).
+		Build()
+	event, err := c.event.Log(ctx, message, kind, client, agent, sessionID, workspace, logCfg)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to record log", "ログ記録に失敗しました"), err)
 	}

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -23,7 +23,7 @@ type tailEventUsecaseStub struct {
 	onListWindow        func(callIndex int, criteria apptypes.EventListCriteria)
 }
 
-func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace) (*model.Event, error) {
+func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, types.Client, types.Agent, types.SessionID, types.Workspace, apptypes.LogRedaction) (*model.Event, error) {
 	return nil, nil
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -34,6 +34,7 @@ type eventUsecaseStub struct {
 		agent     types.Agent
 		sessionID types.SessionID
 		workspace types.Workspace
+		logCfg    apptypes.LogRedaction
 	}
 	auditCall struct {
 		command   string
@@ -48,13 +49,14 @@ type eventUsecaseStub struct {
 	}
 }
 
-func (s *eventUsecaseStub) Log(_ context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace) (*model.Event, error) {
+func (s *eventUsecaseStub) Log(_ context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
 	s.logCall.message = message
 	s.logCall.kind = kind
 	s.logCall.client = client
 	s.logCall.agent = agent
 	s.logCall.sessionID = sessionID
 	s.logCall.workspace = workspace
+	s.logCall.logCfg = logCfg
 	return s.logEvent, s.logErr
 }
 func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/xerrors"
 
-	"github.com/duck8823/traceary/application/redaction"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
@@ -246,20 +245,13 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input addLogInput) (*mcp.CallToolResult, addLogOutput, error) {
 		kind := types.EventKind(strings.TrimSpace(input.Kind))
 		message := input.Message
-		// v0.8 dogfooding finding (#648): `kind=transcript` bodies
-		// come from the same sensitive surface as the Stop-hook
-		// transcript capture path, so apply the built-in + operator-
-		// supplied extra redactors before persistence. Prompt and
-		// compact_summary remain uncut by design because those kinds
-		// intentionally preserve operator intent (documented in
-		// docs/environment/README.md).
-		if kind == types.EventKindTranscript {
-			extraRedactors, err := redaction.CompileExtraPatterns(s.extraRedactPatterns)
-			if err != nil {
-				return nil, addLogOutput{}, xerrors.Errorf("failed to compile extra redaction patterns for transcript: %w", err)
-			}
-			message, _ = redaction.Apply(message, extraRedactors)
-		}
+		// EventUsecase.Log applies the redaction policy itself when
+		// kind == transcript (see #648, consolidated in #666). We
+		// only hand over the config here so MCP, CLI log, and the
+		// transcript hook share a single implementation path.
+		logCfg := apptypes.NewLogRedactionBuilder().
+			ExtraRedactPatterns(s.extraRedactPatterns).
+			Build()
 
 		event, err := s.event.Log(ctx,
 			message,
@@ -268,6 +260,7 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 			types.Agent(resolveValue(input.Agent, defaultAgentValue)),
 			types.SessionID(resolveValue(input.SessionID, defaultSessionValue)),
 			types.Workspace(strings.TrimSpace(input.Workspace)),
+			logCfg,
 		)
 		if err != nil {
 			return nil, addLogOutput{}, xerrors.Errorf("failed to record log: %w", err)


### PR DESCRIPTION
## Summary

Closes #666.

`EventUsecase.Log` now accepts `apptypes.LogRedaction` (mirroring `AuditRedaction` for the Audit path) and performs the built-in + operator-configured redactor chain inside the usecase when `kind == EventKindTranscript`. Three presentation-layer callers (CLI `traceary log`, transcript hook, MCP `add_log`) dropped the duplicated 5-line `CompileExtraPatterns + Apply` block and now only hand the config over.

## Why

Per quality-phase Claude-architect finding: every new log-ingest surface had to remember the redaction block or silently leak secrets. Moving the policy into the usecase keeps a single implementation and matches the shape already used by Audit.

## What changes

- `application/types/log_redaction.go` — new value object + Builder (shape matches `AuditRedaction`). Zero value = pass-through.
- `application/usecase/event_usecase.go` / `event_usecase_impl.go` — `Log` signature extended with `LogRedaction`; redaction applied inside on `transcript` kind.
- `presentation/cli/log.go` / `hook_runtime.go` / `presentation/mcpserver/server.go` — drop the inline `CompileExtraPatterns + Apply` and hand `LogRedaction` to `Log` instead.
- `presentation/cli/usecase_stubs_test.go` / `tail_test.go` — stubs updated, `logCall.logCfg` captured for assertion.
- `application/usecase/record_log_test.go` — two new cases: transcript kind applies built-in + extra, non-transcript kinds (`prompt`) pass through verbatim.
- `presentation/cli/hook_runtime_test.go` — Claude/Codex/Gemini transcript tests now verify the config hand-off (the usecase test covers the redaction behaviour end-to-end).

## Test plan

- [x] `go test ./...` — all pass
- [x] `go tool golangci-lint run` — clean
- [x] New usecase unit tests cover `transcript` (redact) and `prompt` (pass-through) branches

Part of v0.8 dogfooding: this PR was implemented by Claude Code running against the v0.8-live plugin + v0.8 dev binary as a live exercise of the new hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)