### PR TITLE
fix: recognise non-canonical --traceary-bin basenames via Name prefix

### DIFF
--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -170,7 +170,13 @@ func tracearyManagedKeySet(matchers []hookMatcherDocument) map[string]struct{} {
 			matcherValue = *matcher.Matcher
 		}
 		for _, command := range matcher.Hooks {
-			if key := extractTracearyManagedKey(command.Command); key != "" {
+			// Use the Name-aware extractor so entries installed with a
+			// non-canonical `--traceary-bin` path (dev builds, custom
+			// wrappers where filepath.Base(bin) != "traceary") are still
+			// recognized through the `traceary-*` Name prefix. Without
+			// this, `--upgrade` would misreport added / refreshed events
+			// as `0 event(s) unchanged` even though the file changed.
+			if key := extractTracearyManagedKeyFromEntry(command.Name, command.Command); key != "" {
 				keys[matcherValue+"\x00"+key] = struct{}{}
 			}
 		}
@@ -242,6 +248,34 @@ var tracearyHookScriptPattern = regexp.MustCompile(`traceary-(session|audit|comp
 // user-managed ones without re-implementing the parser, and this wrapper
 // keeps that parser as the single source of truth.
 func ExtractTracearyManagedKey(commandValue string) string {
+	return extractTracearyManagedKey(commandValue)
+}
+
+// ExtractTracearyManagedKeyFromEntry is the exported counterpart of
+// extractTracearyManagedKeyFromEntry. See that function for the detection
+// policy; diagnostics that can inspect both the entry name and the command
+// (for example `traceary doctor`) should call this variant so a dev build
+// installed via `--traceary-bin /tmp/traceary-qa` is still recognized as
+// Traceary-managed through the `traceary-*` Name prefix.
+func ExtractTracearyManagedKeyFromEntry(name, commandValue string) string {
+	return extractTracearyManagedKeyFromEntry(name, commandValue)
+}
+
+// extractTracearyManagedKeyFromEntry returns the stable managed key derived
+// from the direct-command form when either (a) the entry name starts with
+// the `traceary-` prefix, or (b) the command's binary token basename is
+// `traceary`. The Name-prefix shortcut keeps non-canonical `--traceary-bin`
+// basenames (dev builds like `/tmp/traceary-qa`, custom wrappers) from
+// being misclassified as user commands just because the binary filename
+// differs from `traceary`. Falls back to extractTracearyManagedKey for
+// legacy script-form entries that do not carry a `traceary-*` Name.
+func extractTracearyManagedKeyFromEntry(name, commandValue string) string {
+	if strings.HasPrefix(strings.TrimSpace(name), "traceary-") {
+		directCommand, ok := parseTracearyDirectManagedCommand(strings.TrimSpace(commandValue))
+		if ok {
+			return directCommand.managedKey
+		}
+	}
 	return extractTracearyManagedKey(commandValue)
 }
 

--- a/infrastructure/filesystem/hooks_merge_test.go
+++ b/infrastructure/filesystem/hooks_merge_test.go
@@ -482,3 +482,67 @@ func TestExtractTracearyManagedKey(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractTracearyManagedKeyFromEntry covers the Name-aware variant
+// used by diff reporting (hooks install --upgrade) and by the doctor
+// codex-config check. The Name prefix `traceary-*` admits entries whose
+// command binary basename is not `traceary` (dev builds, custom
+// wrappers) so operators using `--traceary-bin /tmp/traceary-qa` do not
+// see a misleading `0 event(s) unchanged` upgrade summary or a
+// `codex-config is missing managed events` doctor warning.
+func TestExtractTracearyManagedKeyFromEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		hookNm  string
+		command string
+		want    string
+	}{
+		{
+			name:    "non-canonical binary recognized via traceary- name prefix",
+			hookNm:  "traceary-session-start",
+			command: "'/tmp/traceary-qa' 'hook' 'session' 'codex' 'start'",
+			want:    "traceary-session.sh:codex:start",
+		},
+		{
+			name:    "canonical binary still works without name hint",
+			hookNm:  "",
+			command: "'traceary' 'hook' 'session' 'codex' 'start'",
+			want:    "traceary-session.sh:codex:start",
+		},
+		{
+			name:    "canonical binary with traceary- name prefix (happy path, matches via name)",
+			hookNm:  "traceary-transcript",
+			command: "'traceary' 'hook' 'transcript' 'gemini'",
+			want:    "traceary-transcript.sh:gemini",
+		},
+		{
+			name:    "unrelated name + unrelated command stays empty",
+			hookNm:  "user-custom",
+			command: "echo hello",
+			want:    "",
+		},
+		{
+			name:    "user-named command pointing at non-traceary binary stays empty",
+			hookNm:  "",
+			command: "'/tmp/traceary-qa' 'hook' 'session' 'codex' 'start'",
+			want:    "",
+		},
+		{
+			name:    "name prefix without parseable direct command falls through to legacy extractor",
+			hookNm:  "traceary-session-start",
+			command: "bash '/scripts/traceary-session.sh' 'claude' 'start'",
+			want:    "traceary-session.sh:claude:start",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if diff := cmp.Diff(tt.want, extractTracearyManagedKeyFromEntry(tt.hookNm, tt.command)); diff != "" {
+				t.Fatalf("extractTracearyManagedKeyFromEntry() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -648,6 +648,7 @@ func hasEntryWithManagedKey(raw json.RawMessage, expectedKey string) bool {
 	}
 	var entries []struct {
 		Hooks []struct {
+			Name    string `json:"name"`
 			Type    string `json:"type"`
 			Command string `json:"command"`
 		} `json:"hooks"`
@@ -660,7 +661,10 @@ func hasEntryWithManagedKey(raw json.RawMessage, expectedKey string) bool {
 			if h.Type != "command" {
 				continue
 			}
-			if filesystem.ExtractTracearyManagedKey(h.Command) == expectedKey {
+			// Use the Name-aware extractor so entries installed via
+			// `--traceary-bin <non-traceary-basename>` (dev builds)
+			// are still recognized through the `traceary-*` Name.
+			if filesystem.ExtractTracearyManagedKeyFromEntry(h.Name, h.Command) == expectedKey {
 				return true
 			}
 		}

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -298,6 +298,51 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("codex config installed with non-canonical traceary-bin still passes", func(t *testing.T) {
+		// Regression guard for #667: an operator running a dev build
+		// via `--traceary-bin /tmp/traceary-qa` ends up with hook
+		// commands whose binary basename is not `traceary`. Before the
+		// fix, doctor's codex-config check rejected every such entry
+		// because it only parsed the binary token, producing a
+		// misleading "missing Traceary-managed events" warning. The
+		// Name-aware extractor added in #667 treats the `traceary-*`
+		// name prefix as a sufficient signal.
+		codexDir := filepath.Join(homeDir, ".codex")
+		if err := os.MkdirAll(codexDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		complete := `{
+			"hooks": {
+				"SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'session' 'codex' 'start'"}]}],
+				"UserPromptSubmit": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'prompt' 'codex'"}]}],
+				"Stop": [{"hooks": [{"name": "traceary-session-stop", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'session' 'codex' 'stop'"}]}],
+				"PostToolUse": [{"matcher": "", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'audit' 'codex'"}]}]
+			}
+		}`
+		if err := os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(complete), 0o644); err != nil {
+			t.Fatalf("WriteFile(non-canonical codex hooks) error = %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(codexDir) })
+
+		initStub := &storeManagementUsecaseStub{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(initStub)).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "codex", "--project-dir", projectDir, "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		for _, check := range report.Checks {
+			if check.Name == "codex-config" && check.Status != "pass" {
+				t.Fatalf("codex-config status = %q, want pass for non-canonical --traceary-bin install (message: %q)", check.Status, check.Message)
+			}
+		}
+	})
+
 	t.Run("invalid Traceary config fails doctor", func(t *testing.T) {
 		configDir := filepath.Join(homeDir, ".config", "traceary")
 		if err := os.MkdirAll(configDir, 0o755); err != nil {

--- a/presentation/cli/hooks_upgrade_test.go
+++ b/presentation/cli/hooks_upgrade_test.go
@@ -334,3 +334,73 @@ func TestHooksInstall_UpgradePreservesUserAddedHooks(t *testing.T) {
 		t.Errorf("merged settings lost user-added hook: %s", content)
 	}
 }
+
+// TestHooksInstall_UpgradeWithNonCanonicalTracearyBin asserts that
+// --upgrade correctly reports Added events when the Traceary binary is
+// installed under a non-canonical basename (e.g. a dev build at
+// /tmp/traceary-qa). Regression guard for #667: before the fix,
+// `tracearyManagedKeySet` rejected the existing entries because
+// `filepath.Base("/tmp/traceary-qa") != "traceary"`, which made the
+// upgrade silently modify the file while reporting "0 event(s)
+// unchanged" to stdout.
+func TestHooksInstall_UpgradeWithNonCanonicalTracearyBin(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// Seed a Gemini settings.json with pre-v0.8 Traceary-managed
+	// entries but no AfterAgent, all referencing a non-canonical
+	// binary basename. The entry names still carry the canonical
+	// `traceary-*` prefix, which is the signal `--upgrade` uses to
+	// recognize them as managed.
+	geminiPath := filepath.Join(homeDir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(geminiPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := []byte(`{
+  "hooks": {
+    "SessionStart": [{"matcher":"*","hooks":[{"name":"traceary-session-start","type":"command","command":"'/tmp/traceary-qa' 'hook' 'session' 'gemini' 'start'","timeout":5000,"description":"Start a Traceary session"}]}],
+    "SessionEnd":   [{"matcher":"*","hooks":[{"name":"traceary-session-end","type":"command","command":"'/tmp/traceary-qa' 'hook' 'session' 'gemini' 'end'","timeout":5000,"description":"Finish a Traceary session"}]}],
+    "AfterTool":    [{"matcher":"run_shell_command","hooks":[{"name":"traceary-audit","type":"command","command":"'/tmp/traceary-qa' 'hook' 'audit' 'gemini'","timeout":5000,"description":"Record shell command audits in Traceary"}]}]
+  }
+}
+`)
+	if err := os.WriteFile(geminiPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"hooks", "install",
+		"--client", "gemini",
+		"--project-dir", projectDir,
+		"--global",
+		"--traceary-bin", "/tmp/traceary-qa",
+		"--upgrade",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	// Summary must acknowledge AfterAgent was added, not misreport 0 events.
+	if !strings.Contains(output, "AfterAgent") {
+		t.Errorf("stdout = %q; want AfterAgent to appear in the summary", output)
+	}
+	if strings.Contains(output, "0 event(s) unchanged") || strings.Contains(output, "already up to date") {
+		t.Errorf("stdout = %q; must not misreport no-op when AfterAgent was actually added", output)
+	}
+
+	// File must have AfterAgent wired.
+	content, err := os.ReadFile(geminiPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "AfterAgent") {
+		t.Errorf("gemini settings.json = %q; want AfterAgent added after --upgrade", content)
+	}
+}


### PR DESCRIPTION
Closes #667.

## Summary

`tracearyManagedKeySet` (used by \`hooks install --upgrade\` diff reporting) and \`traceary doctor --client codex\` previously rejected hook entries whose command binary basename is not literally \`traceary\`. Dev-build installs via \`--traceary-bin /tmp/traceary-qa\` produced commands like \`'/tmp/traceary-qa' 'hook' 'session' 'codex' 'start'\` — valid Traceary-managed entries (the entry Name is still \`traceary-session-start\`) that these two code paths treated as user-managed.

Observable consequences before the fix:

1. \`hooks install --upgrade\` silently migrated the file but printed \`0 event(s) unchanged\`, losing the Added summary.
2. \`doctor --client codex\` warned \"codex config is missing Traceary-managed events (SessionStart, UserPromptSubmit, Stop, PostToolUse)\" for a clean install.

## Fix

New helper \`extractTracearyManagedKeyFromEntry(name, command)\` treats the \`traceary-*\` Name prefix as a first-class signal (same policy \`isTracearyManagedHookCommandDocument\` already uses for the merge side) and falls back to the original binary-token check. Two surfaces adopt it:

- \`tracearyManagedKeySet\` — diff reporting on \`--upgrade\`.
- \`hasEntryWithManagedKey\` (doctor codex-config) — reads the Name field out of the hook JSON and delegates.

Non-canonical installs now report the real diff and pass the doctor check.

## Why it's not a v0.8.0 blocker

Typical installs (brew, \`go install\`, plugin-delivered) all have basename \`traceary\` and were unaffected. Only dev / custom-wrapper setups trip the bug, so this lands cleanly in v0.8.1.

## Test plan

- [x] \`go test ./...\` — all pass
- [x] \`go tool golangci-lint run\` — clean
- [x] Unit: \`TestExtractTracearyManagedKeyFromEntry\` (6 cases covering name-prefix, canonical binary, falling through, legacy script form)
- [x] Symptom 1 regression: \`TestHooksInstall_UpgradeWithNonCanonicalTracearyBin\` — seeds Gemini settings.json missing AfterAgent with \`/tmp/traceary-qa\` entries; asserts the summary reports AfterAgent Added (not \"0 unchanged\")
- [x] Symptom 2 regression: \`TestRootCLI_DoctorCommand/codex_config_installed_with_non-canonical_traceary-bin_still_passes\`

Dogfooded live: this PR was implemented and reviewed inside a fresh Claude Code session running the v0.8 plugin + dev binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)