### PR TITLE
fix(sqlite/memory): normalise validity timestamps to fixed-width nano

### DIFF
--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -157,6 +157,26 @@ func formatTimestamp(timestamp time.Time) string {
 	return timestamp.UTC().Format(time.RFC3339Nano)
 }
 
+// formatMemoryValidityTimestamp renders a time.Time as a fixed-width
+// RFC3339 string with nine fractional-second digits, e.g.
+// "2026-04-10T00:00:00.123000000Z". Unlike RFC3339Nano (which trims
+// trailing zeros and therefore emits variable-width output), this
+// representation is lexicographically ordered in the same direction
+// as real time, so SQLite can compare memories.valid_from /
+// memories.valid_to with a plain `<` / `>` against a bind parameter
+// without wrapping the column in datetime() — which would both drop
+// sub-second precision AND make the idx_memories_valid_window index
+// unusable (see #664).
+//
+// The format is only used for the memory validity columns so other
+// timestamps (created_at, updated_at, expires_at, event timestamps)
+// keep the existing RFC3339Nano shape; migration 000010 backfills
+// pre-v0.8.1 rows so the validity columns are consistent across
+// historical and new data.
+func formatMemoryValidityTimestamp(timestamp time.Time) string {
+	return timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z07:00")
+}
+
 func boolToInt(b bool) int {
 	if b {
 		return 1

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -154,10 +154,10 @@ func persistMemoryTx(ctx context.Context, tx *sql.Tx, memory *model.Memory) erro
 		formatted := formatTimestamp(expiresAt)
 		expiresAtValue = &formatted
 	}
-	validFromValue := formatTimestamp(memory.ValidFrom())
+	validFromValue := formatMemoryValidityTimestamp(memory.ValidFrom())
 	var validToValue *string
 	if validTo, ok := memory.ValidTo().Value(); ok {
-		formatted := formatTimestamp(validTo)
+		formatted := formatMemoryValidityTimestamp(validTo)
 		validToValue = &formatted
 	}
 
@@ -696,15 +696,15 @@ func buildMemorySearchQuery(criteria apptypes.MemorySearchCriteria) (string, []a
 // current wall clock so callers that do not care about time travel
 // still get "still-valid-right-now" semantics by default.
 //
-// Timestamps are stored via formatTimestamp, which uses
-// time.RFC3339Nano. That format emits variable-width fractional seconds
-// (`2026-04-10T00:00:00Z` vs `2026-04-10T00:00:00.1Z`), so a plain
-// lexicographic TEXT comparison reorders same-second values
-// incorrectly (because `.` < `Z`). Wrap every comparand in
-// `datetime(...)` so SQLite compares the values as real timestamps
-// instead. For legacy rows where valid_from is NULL the scan side
-// already falls back to created_at; mirror that here with COALESCE so
-// filter and restore stay consistent.
+// Timestamps are persisted via formatMemoryValidityTimestamp, which
+// always emits 9-digit fractional seconds so plain lex TEXT compare
+// matches real temporal order. Migration 000010 backfilled pre-v0.8.1
+// rows to the same shape, so the filter does not need to wrap
+// columns in SQLite's datetime() (which would both truncate sub-
+// second precision and force a SCAN instead of using
+// idx_memories_valid_window). Backfill of NULL valid_from from
+// created_at is handled by migration 000009, so COALESCE is no
+// longer required and dropping it keeps the predicate sargable.
 func appendMemoryValidityWindowFilter(
 	builder *strings.Builder,
 	args []any,
@@ -718,9 +718,9 @@ func appendMemoryValidityWindowFilter(
 	if explicit, ok := asOf.Value(); ok {
 		evaluationTime = explicit
 	}
-	formatted := formatTimestamp(evaluationTime)
-	builder.WriteString(" AND datetime(COALESCE(m.valid_from, m.created_at)) <= datetime(?)")
-	builder.WriteString(" AND (m.valid_to IS NULL OR datetime(m.valid_to) > datetime(?))")
+	formatted := formatMemoryValidityTimestamp(evaluationTime)
+	builder.WriteString(" AND m.valid_from <= ?")
+	builder.WriteString(" AND (m.valid_to IS NULL OR m.valid_to > ?)")
 	return append(args, formatted, formatted)
 }
 

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -74,6 +74,30 @@ ALTER TABLE memories ADD COLUMN valid_to TEXT;
 UPDATE memories SET valid_from = created_at WHERE valid_from IS NULL;
 CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
 		},
+		"000010_normalize_memory_validity_precision.sql": {
+			Data: []byte(`UPDATE memories
+SET valid_from =
+  CASE
+    WHEN instr(valid_from, '.') = 0
+      THEN substr(valid_from, 1, length(valid_from) - 1) || '.000000000Z'
+    ELSE
+      substr(valid_from, 1, instr(valid_from, '.')) ||
+      substr(substr(valid_from, instr(valid_from, '.') + 1, length(valid_from) - instr(valid_from, '.') - 1) || '000000000', 1, 9) ||
+      'Z'
+  END
+WHERE valid_from IS NOT NULL;
+UPDATE memories
+SET valid_to =
+  CASE
+    WHEN instr(valid_to, '.') = 0
+      THEN substr(valid_to, 1, length(valid_to) - 1) || '.000000000Z'
+    ELSE
+      substr(valid_to, 1, instr(valid_to, '.')) ||
+      substr(substr(valid_to, instr(valid_to, '.') + 1, length(valid_to) - instr(valid_to, '.') - 1) || '000000000', 1, 9) ||
+      'Z'
+  END
+WHERE valid_to IS NOT NULL;`),
+		},
 	}
 }
 
@@ -622,5 +646,88 @@ func TestMemoryDatasource_Search(t *testing.T) {
 	}
 	if diff := cmp.Diff("mem-path", pathResults[0].MemoryID().String()); diff != "" {
 		t.Fatalf("path result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestMemoryDatasource_ValiditySubSecondBoundaryRespectsPrecision
+// regression test for #664: the validity filter must honour
+// sub-second resolution rather than truncating to whole seconds via
+// SQLite's datetime(). Two memories with valid_to at
+// 00:00:00.100Z and 00:00:00.900Z are distinguishable when `as_of`
+// falls at 00:00:00.500Z — before the fix, `datetime()` collapsed
+// everything inside the same wall second to a single value so both
+// rows either returned or didn't depending on the wall-clock
+// truncation target.
+func TestMemoryDatasource_ValiditySubSecondBoundaryRespectsPrecision(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "validity.db")
+	sut, store := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	sameSecond := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	memoryEarlyExpiry := model.MemoryOf(
+		mustMemoryID(t, "mem-validity-early"),
+		types.MemoryTypeDecision,
+		mustWorkspaceScope(t, "github.com/example/validity"),
+		"expires at .100 of the second",
+		types.MemoryStatusAccepted,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindURL, "https://example/early")},
+		nil,
+		types.None[types.MemoryID](),
+		types.None[time.Time](),
+		sameSecond,
+		types.Some(sameSecond.Add(100*time.Millisecond)),
+		sameSecond,
+		sameSecond,
+	)
+	memoryLateExpiry := model.MemoryOf(
+		mustMemoryID(t, "mem-validity-late"),
+		types.MemoryTypeDecision,
+		mustWorkspaceScope(t, "github.com/example/validity"),
+		"expires at .900 of the second",
+		types.MemoryStatusAccepted,
+		types.ConfidenceVerified,
+		types.MemorySourceManual,
+		[]types.EvidenceRef{mustEvidenceRef(t, types.EvidenceRefKindURL, "https://example/late")},
+		nil,
+		types.None[types.MemoryID](),
+		types.None[time.Time](),
+		sameSecond,
+		types.Some(sameSecond.Add(900*time.Millisecond)),
+		sameSecond,
+		sameSecond,
+	)
+	for _, memory := range []*model.Memory{memoryEarlyExpiry, memoryLateExpiry} {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+
+	// as_of at .500 should include only the late-expiry memory
+	// (its window still covers that instant) and exclude the
+	// early one whose window already closed at .100.
+	asOfMidSecond := sameSecond.Add(500 * time.Millisecond)
+	criteria := apptypes.NewMemoryListCriteriaBuilder(10).
+		AsOf(asOfMidSecond).
+		Build()
+	summaries, err := sut.List(ctx, criteria)
+	if err != nil {
+		t.Fatalf("List(as_of=%s) error = %v", asOfMidSecond, err)
+	}
+	if got := len(summaries); got != 1 {
+		var ids []string
+		for _, s := range summaries {
+			ids = append(ids, s.MemoryID().String())
+		}
+		t.Fatalf("List(as_of=.500) returned %d memories (%v), want 1 (mem-validity-late only)", got, ids)
+	}
+	if got, want := summaries[0].MemoryID().String(), "mem-validity-late"; got != want {
+		t.Fatalf("List(as_of=.500)[0] = %q, want %q", got, want)
 	}
 }

--- a/schema/sqlite/migrations/000010_normalize_memory_validity_precision.sql
+++ b/schema/sqlite/migrations/000010_normalize_memory_validity_precision.sql
@@ -1,0 +1,40 @@
+-- Normalize memories.valid_from / valid_to to a fixed-width RFC3339Nano
+-- representation so lex comparison (and the idx_memories_valid_window
+-- index created in 000009) can be used without wrapping the column in
+-- SQLite's datetime(), which truncates to second precision.
+--
+-- Before: variable-width fractional seconds ("...00Z", "...00.1Z",
+-- "...00.123456789Z"). Lex compare fails because `.` (0x2E) sorts
+-- before `Z` (0x5A), so "...00Z" > "...00.100Z".
+-- After:  always nine fractional digits followed by Z
+-- ("...00.000000000Z"). Lex compare matches real temporal order and
+-- the filter can drop the datetime() wrap, finally using the index.
+--
+-- The normalization preserves full precision: values that were
+-- already written with fewer than 9 fractional digits are padded
+-- with trailing zeros (semantically identical); values without a
+-- fractional component gain .000000000.
+
+UPDATE memories
+SET valid_from =
+  CASE
+    WHEN instr(valid_from, '.') = 0
+      THEN substr(valid_from, 1, length(valid_from) - 1) || '.000000000Z'
+    ELSE
+      substr(valid_from, 1, instr(valid_from, '.')) ||
+      substr(substr(valid_from, instr(valid_from, '.') + 1, length(valid_from) - instr(valid_from, '.') - 1) || '000000000', 1, 9) ||
+      'Z'
+  END
+WHERE valid_from IS NOT NULL;
+
+UPDATE memories
+SET valid_to =
+  CASE
+    WHEN instr(valid_to, '.') = 0
+      THEN substr(valid_to, 1, length(valid_to) - 1) || '.000000000Z'
+    ELSE
+      substr(valid_to, 1, instr(valid_to, '.')) ||
+      substr(substr(valid_to, instr(valid_to, '.') + 1, length(valid_to) - instr(valid_to, '.') - 1) || '000000000', 1, 9) ||
+      'Z'
+  END
+WHERE valid_to IS NOT NULL;


### PR DESCRIPTION
Closes #664.

## Summary

The validity filter (\`valid_from\` / \`valid_to\`) in \`memory_datasource.go\` wrapped both columns in SQLite's \`datetime(...)\` because \`formatTimestamp\` (RFC3339Nano) emits variable-width fractional seconds, which would otherwise reorder same-second values lexicographically (\`.\` < \`Z\`). That wrap fixed ordering but introduced two regressions:

1. **Sub-second precision loss** — \`datetime()\` truncates to whole seconds, so memories with \`valid_to=...00.100Z\` and \`valid_to=...00.900Z\` became indistinguishable against any same-second \`as_of\`.
2. **Index unusable** — wrapping the column forces a table SCAN; \`idx_memories_valid_window\` (created in 000009) was present but never picked up.

## Fix

- Added \`formatMemoryValidityTimestamp\` that always emits nine fractional digits (\`2026-04-10T00:00:00.123000000Z\`). Output is lex-orderable without any function wrap.
- Filter rewritten to \`valid_from <= ? AND (valid_to IS NULL OR valid_to > ?)\` — sargable against the index.
- Migration 000010 backfills pre-v0.8.1 rows so historical \`valid_from\`/\`valid_to\` values match the new shape (SQL-level \`substr\` / \`instr\` logic, no Go migration needed).
- Dropped \`COALESCE(valid_from, created_at)\` fallback: 000009 already backfilled NULL valid_from from created_at, so the column is guaranteed non-NULL for every historical row.

## Test plan

- [x] \`go test ./...\` — all pass
- [x] \`go tool golangci-lint run\` — clean
- [x] New \`TestMemoryDatasource_ValiditySubSecondBoundaryRespectsPrecision\` — two memories with \`valid_to=.100Z\` and \`.900Z\` against \`as_of=.500Z\` now return only the late-expiry memory (before fix: both or neither depending on second-truncation direction)

## Not release-blocking for v0.8.0

Typical operator usage is day- or second-precision, so the truncation bug didn't surface in v0.8.0 dogfooding. Still worth fixing for v0.8.1 + enables the index at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)