### PR TITLE
feat(memory/supersede): propagate valid_from and valid_to to replacement

### DIFF
--- a/application/usecase/memory_extraction_usecase_impl_test.go
+++ b/application/usecase/memory_extraction_usecase_impl_test.go
@@ -62,7 +62,7 @@ func (s *memoryExtractionMemoryUsecaseStub) Reject(context.Context, domtypes.Mem
 	return apptypes.MemoryDetails{}, nil
 }
 
-func (s *memoryExtractionMemoryUsecaseStub) Supersede(context.Context, domtypes.MemoryID, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef) (apptypes.MemoryDetails, error) {
+func (s *memoryExtractionMemoryUsecaseStub) Supersede(context.Context, domtypes.MemoryID, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef, domtypes.Optional[time.Time], domtypes.Optional[time.Time]) (apptypes.MemoryDetails, error) {
 	return apptypes.MemoryDetails{}, nil
 }
 

--- a/application/usecase/memory_hygiene_usecase_impl.go
+++ b/application/usecase/memory_hygiene_usecase_impl.go
@@ -542,6 +542,9 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 		if err != nil {
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to show memory: %w", err)
 		}
+		// Redaction hit replaces the fact content but keeps the
+		// existing memory's temporal window — the operator-set
+		// validity is independent of the content sanitization.
 		superseded, err := u.memory.Supersede(
 			ctx,
 			memoryID,
@@ -552,6 +555,8 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 			details.Summary().Source(),
 			details.EvidenceRefs(),
 			details.ArtifactRefs(),
+			domtypes.Some(details.Summary().ValidFrom()),
+			details.Summary().ValidTo(),
 		)
 		if err != nil {
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to supersede memory: %w", err)
@@ -579,6 +584,12 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 		if strings.TrimSpace(replacementFact) == "" {
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("%s missing replacement fact", suggestion.Kind)
 		}
+		// Inherit the existing memory's validity window so the
+		// replacement keeps operator-set temporal boundaries.
+		// validity_overlap_supersede fires *because* the pair has
+		// overlapping windows — dropping the window at apply time
+		// would silently erase the temporal evidence that justified
+		// the suggestion in the first place (#665).
 		superseded, err := u.memory.Supersede(
 			ctx,
 			memoryID,
@@ -589,6 +600,8 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 			details.Summary().Source(),
 			details.EvidenceRefs(),
 			details.ArtifactRefs(),
+			domtypes.Some(details.Summary().ValidFrom()),
+			details.Summary().ValidTo(),
 		)
 		if err != nil {
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to supersede memory: %w", err)

--- a/application/usecase/memory_import_usecase_impl_test.go
+++ b/application/usecase/memory_import_usecase_impl_test.go
@@ -74,7 +74,7 @@ func (s *stubImportMemoryUsecase) Reject(context.Context, domtypes.MemoryID) (ap
 	return apptypes.MemoryDetails{}, nil
 }
 
-func (s *stubImportMemoryUsecase) Supersede(context.Context, domtypes.MemoryID, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef) (apptypes.MemoryDetails, error) {
+func (s *stubImportMemoryUsecase) Supersede(context.Context, domtypes.MemoryID, domtypes.MemoryType, domtypes.MemoryScope, string, domtypes.Optional[domtypes.Confidence], domtypes.MemorySource, []domtypes.EvidenceRef, []domtypes.ArtifactRef, domtypes.Optional[time.Time], domtypes.Optional[time.Time]) (apptypes.MemoryDetails, error) {
 	return apptypes.MemoryDetails{}, nil
 }
 

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -40,6 +40,14 @@ type MemoryUsecase interface {
 	Reject(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error)
 
 	// Supersede replaces an accepted memory with a new accepted memory.
+	// validFrom / validTo control the replacement's temporal validity
+	// window. Both default to the legacy behaviour (validFrom=now,
+	// validTo=open-ended) when None, which keeps manual supersede
+	// compatible with pre-v0.8.1 callers. Callers that need to carry
+	// a bounded window over to the replacement (e.g. the hygiene
+	// `validity_overlap_supersede` apply) must pass the explicit
+	// window through — without this, applying the suggestion would
+	// discard the very window that caused the pair to be flagged.
 	Supersede(
 		ctx context.Context,
 		memoryID domtypes.MemoryID,
@@ -50,6 +58,8 @@ type MemoryUsecase interface {
 		source domtypes.MemorySource,
 		evidenceRefs []domtypes.EvidenceRef,
 		artifactRefs []domtypes.ArtifactRef,
+		validFrom domtypes.Optional[time.Time],
+		validTo domtypes.Optional[time.Time],
 	) (apptypes.MemoryDetails, error)
 
 	// Expire expires an active memory at the given time. Empty expiry means now.

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -258,6 +258,25 @@ func (u *memoryUsecase) Supersede(
 		return apptypes.MemoryDetails{}, err
 	}
 
+	// Reject reversed validity windows up front, matching SetValidity
+	// (valid_to must not be earlier than valid_from). Without this a
+	// supersede caller coming in via CLI --from/--to or MCP
+	// supersede_memory valid_from/valid_to could persist a replacement
+	// whose window is inverted, which would then break hygiene and
+	// runtime retrieval that assume monotonic window bounds. When
+	// validFrom is None the replacement will be created with
+	// validFrom=now (per NewAcceptedMemoryWithValidity), so fall back
+	// to the wall clock for the comparison.
+	if to, ok := validTo.Value(); ok {
+		effectiveFrom := time.Now()
+		if from, hasFrom := validFrom.Value(); hasFrom {
+			effectiveFrom = from
+		}
+		if to.Before(effectiveFrom) {
+			return apptypes.MemoryDetails{}, xerrors.Errorf("valid_to must not be earlier than valid_from")
+		}
+	}
+
 	newMemoryID, err := newMemoryID()
 	if err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to generate replacement memory ID: %w", err)

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -222,6 +222,8 @@ func (u *memoryUsecase) Supersede(
 	source domtypes.MemorySource,
 	evidenceRefs []domtypes.EvidenceRef,
 	artifactRefs []domtypes.ArtifactRef,
+	validFrom domtypes.Optional[time.Time],
+	validTo domtypes.Optional[time.Time],
 ) (apptypes.MemoryDetails, error) {
 	if u.memoryRepo == nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
@@ -260,7 +262,7 @@ func (u *memoryUsecase) Supersede(
 	if err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to generate replacement memory ID: %w", err)
 	}
-	memory, err := model.NewAcceptedMemory(
+	memory, err := model.NewAcceptedMemoryWithValidity(
 		newMemoryID,
 		resolvedType,
 		resolvedScope,
@@ -270,6 +272,8 @@ func (u *memoryUsecase) Supersede(
 		evidenceRefs,
 		artifactRefs,
 		domtypes.Some(existing.MemoryID()),
+		validFrom,
+		validTo,
 	)
 	if err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build replacement memory: %w", err)

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -264,6 +264,8 @@ func TestMemoryUsecase_Supersede(t *testing.T) {
 		domtypes.MemorySource(""),
 		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindPR, "#467")},
 		nil,
+		domtypes.None[time.Time](),
+		domtypes.None[time.Time](),
 	)
 	if err != nil {
 		t.Fatalf("Supersede() error = %v", err)
@@ -279,6 +281,64 @@ func TestMemoryUsecase_Supersede(t *testing.T) {
 	}
 	if diff := cmp.Diff(domtypes.MemoryStatusAccepted, details.Summary().Status()); diff != "" {
 		t.Fatalf("replacement status mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestMemoryUsecase_SupersedeCarriesValidityWindow regression guard
+// for #665: passing an explicit validFrom / validTo through Supersede
+// must reach the replacement memory instead of being silently reset
+// to "validFrom=now, validTo=nil". This is the path `memory hygiene
+// apply` for validity_overlap_supersede relies on to preserve the
+// temporal evidence that triggered the suggestion.
+func TestMemoryUsecase_SupersedeCarriesValidityWindow(t *testing.T) {
+	t.Parallel()
+
+	originalID := mustMemoryID(t, "memory-original-validity")
+	original, err := model.NewAcceptedMemory(
+		originalID,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"old fact with validity",
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#665")},
+		nil,
+		domtypes.None[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{originalID.String(): original}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	validFrom := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	validTo := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	details, err := sut.Supersede(
+		context.Background(),
+		originalID,
+		domtypes.MemoryType(""),
+		nil,
+		"new fact inheriting validity",
+		domtypes.None[domtypes.Confidence](),
+		domtypes.MemorySource(""),
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindPR, "#669")},
+		nil,
+		domtypes.Some(validFrom),
+		domtypes.Some(validTo),
+	)
+	if err != nil {
+		t.Fatalf("Supersede() error = %v", err)
+	}
+	if got, want := details.Summary().ValidFrom(), validFrom; !got.Equal(want) {
+		t.Errorf("replacement validFrom = %v, want %v", got, want)
+	}
+	gotValidTo, ok := details.Summary().ValidTo().Value()
+	if !ok {
+		t.Fatalf("replacement validTo is None, want Some(%v)", validTo)
+	}
+	if !gotValidTo.Equal(validTo) {
+		t.Errorf("replacement validTo = %v, want %v", gotValidTo, validTo)
 	}
 }
 

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -342,6 +342,61 @@ func TestMemoryUsecase_SupersedeCarriesValidityWindow(t *testing.T) {
 	}
 }
 
+// TestMemoryUsecase_SupersedeRejectsReversedValidity regression guard
+// for the Codex verifier finding on #665: when both validFrom and
+// validTo are provided, the resulting replacement must not have a
+// reversed window (validTo < validFrom). Without this check a
+// `traceary memory supersede --from FUTURE --to PAST` invocation
+// would persist a broken row, which would then silently break
+// hygiene and runtime retrieval that assume monotonic window bounds.
+func TestMemoryUsecase_SupersedeRejectsReversedValidity(t *testing.T) {
+	t.Parallel()
+
+	originalID := mustMemoryID(t, "memory-supersede-reversed")
+	original, err := model.NewAcceptedMemory(
+		originalID,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("github.com/duck8823/traceary")),
+		"will be superseded",
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindIssue, "#665")},
+		nil,
+		domtypes.None[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewAcceptedMemory() error = %v", err)
+	}
+
+	repo := &memoryRepositoryStub{byID: map[string]*model.Memory{originalID.String(): original}}
+	sut := usecase.NewMemoryUsecase(repo, nil, nil)
+
+	future := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	past := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	_, err = sut.Supersede(
+		context.Background(),
+		originalID,
+		domtypes.MemoryType(""),
+		nil,
+		"replacement with reversed validity",
+		domtypes.None[domtypes.Confidence](),
+		domtypes.MemorySource(""),
+		[]domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindPR, "#676")},
+		nil,
+		domtypes.Some(future),
+		domtypes.Some(past),
+	)
+	if err == nil {
+		t.Fatalf("Supersede() with validFrom > validTo accepted; want error matching SetValidity policy")
+	}
+	if !strings.Contains(err.Error(), "valid_to must not be earlier than valid_from") {
+		t.Fatalf("Supersede() error = %q, want mention of the valid_to ordering rule", err)
+	}
+	if len(repo.supersessionCalls) != 0 {
+		t.Errorf("repo.SaveSupersession called %d times on reversed-window error; want 0", len(repo.supersessionCalls))
+	}
+}
+
 func TestMemoryUsecase_Expire(t *testing.T) {
 	t.Parallel()
 

--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -50,7 +50,8 @@ func NewMemoryCandidate(
 	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusCandidate, types.ConfidenceLow, source, evidenceRefs, artifactRefs, supersedes, types.None[time.Time]())
 }
 
-// NewAcceptedMemory creates an accepted memory.
+// NewAcceptedMemory creates an accepted memory with the default
+// validity window (validFrom=now, validTo=open-ended).
 func NewAcceptedMemory(
 	memoryID types.MemoryID,
 	memoryType types.MemoryType,
@@ -62,7 +63,38 @@ func NewAcceptedMemory(
 	artifactRefs []types.ArtifactRef,
 	supersedes types.Optional[types.MemoryID],
 ) (*Memory, error) {
-	return newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusAccepted, confidence, source, evidenceRefs, artifactRefs, supersedes, types.None[time.Time]())
+	return NewAcceptedMemoryWithValidity(memoryID, memoryType, scope, fact, confidence, source, evidenceRefs, artifactRefs, supersedes, types.None[time.Time](), types.None[time.Time]())
+}
+
+// NewAcceptedMemoryWithValidity creates an accepted memory with an
+// explicit temporal validity window. When validFrom is None the
+// memory starts valid from the current wall clock. validTo is
+// optional regardless: None means open-ended validity. Use this
+// variant when superseding a time-bounded memory so the replacement
+// inherits the intended window instead of silently resetting to
+// "valid from now".
+func NewAcceptedMemoryWithValidity(
+	memoryID types.MemoryID,
+	memoryType types.MemoryType,
+	scope types.MemoryScope,
+	fact string,
+	confidence types.Confidence,
+	source types.MemorySource,
+	evidenceRefs []types.EvidenceRef,
+	artifactRefs []types.ArtifactRef,
+	supersedes types.Optional[types.MemoryID],
+	validFrom types.Optional[time.Time],
+	validTo types.Optional[time.Time],
+) (*Memory, error) {
+	memory, err := newMemory(memoryID, memoryType, scope, fact, types.MemoryStatusAccepted, confidence, source, evidenceRefs, artifactRefs, supersedes, types.None[time.Time]())
+	if err != nil {
+		return nil, err
+	}
+	if explicit, ok := validFrom.Value(); ok {
+		memory.validFrom = explicit
+	}
+	memory.validTo = validTo
+	return memory, nil
 }
 
 func newMemory(

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -345,6 +345,8 @@ type memorySupersedeCommandInput struct {
 	source        string
 	evidenceRefs  []string
 	artifactRefs  []string
+	validFrom     string
+	validTo       string
 	idOnly        bool
 	asJSON        bool
 }

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -194,6 +194,8 @@ func (c *RootCLI) newMemorySupersedeCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.source, "source", "", Localize("memory source (defaults to manual)", "memory source (既定値は manual)"))
 	cmd.Flags().StringArrayVar(&input.evidenceRefs, "evidence", nil, Localize("evidence ref as kind:value (repeatable)", "kind:value 形式の evidence ref (複数指定可)"))
 	cmd.Flags().StringArrayVar(&input.artifactRefs, "artifact", nil, Localize("artifact ref as kind:value (repeatable)", "kind:value 形式の artifact ref (複数指定可)"))
+	cmd.Flags().StringVar(&input.validFrom, "from", "", Localize("replacement validFrom (YYYY-MM-DD or RFC3339). Defaults to now when omitted.", "置換後の validFrom (YYYY-MM-DD または RFC3339)。省略時は現在時刻。"))
+	cmd.Flags().StringVar(&input.validTo, "to", "", Localize("replacement validTo (YYYY-MM-DD or RFC3339). Defaults to open-ended when omitted.", "置換後の validTo (YYYY-MM-DD または RFC3339)。省略時は open-ended。"))
 	cmd.Flags().BoolVar(&input.idOnly, "id-only", false, Localize("print only the resulting memory ID", "結果の memory ID だけを出力する"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
@@ -533,7 +535,15 @@ func (c *RootCLI) runMemorySupersede(ctx context.Context, output io.Writer, inpu
 	if err != nil {
 		return err
 	}
-	details, err := c.memory.Supersede(ctx, memoryID, memoryType, scope, input.fact, confidence, source, evidenceRefs, artifactRefs)
+	validFrom, err := parseOptionalValidityTime(input.validFrom)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --from", "--from の解釈に失敗しました"), err)
+	}
+	validTo, err := parseOptionalValidityTime(input.validTo)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to parse --to", "--to の解釈に失敗しました"), err)
+	}
+	details, err := c.memory.Supersede(ctx, memoryID, memoryType, scope, input.fact, confidence, source, evidenceRefs, artifactRefs, validFrom, validTo)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to supersede durable memory", "durable memory の置換に失敗しました"), err)
 	}

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -325,7 +325,7 @@ func (s *memoryUsecaseStub) Reject(_ context.Context, _ types.MemoryID) (apptype
 	return s.rejectDetails, s.rejectErr
 }
 
-func (s *memoryUsecaseStub) Supersede(_ context.Context, _ types.MemoryID, _ types.MemoryType, _ types.MemoryScope, _ string, _ types.Optional[types.Confidence], _ types.MemorySource, _ []types.EvidenceRef, _ []types.ArtifactRef) (apptypes.MemoryDetails, error) {
+func (s *memoryUsecaseStub) Supersede(_ context.Context, _ types.MemoryID, _ types.MemoryType, _ types.MemoryScope, _ string, _ types.Optional[types.Confidence], _ types.MemorySource, _ []types.EvidenceRef, _ []types.ArtifactRef, _ types.Optional[time.Time], _ types.Optional[time.Time]) (apptypes.MemoryDetails, error) {
 	return s.supersedeDetails, s.supersedeErr
 }
 

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -165,6 +165,8 @@ type supersedeMemoryInput struct {
 	Source        string           `json:"source,omitempty" jsonschema:"replacement memory source (default: manual)"`
 	EvidenceRefs  []memoryRefInput `json:"evidence_refs,omitempty" jsonschema:"replacement evidence refs"`
 	ArtifactRefs  []memoryRefInput `json:"artifact_refs,omitempty" jsonschema:"replacement artifact refs"`
+	ValidFrom     string           `json:"valid_from,omitempty" jsonschema:"replacement validFrom (YYYY-MM-DD or RFC3339); defaults to now when omitted"`
+	ValidTo       string           `json:"valid_to,omitempty" jsonschema:"replacement validTo (YYYY-MM-DD or RFC3339); defaults to open-ended when omitted"`
 }
 
 // expireMemoryInput is the MCP input for the expire_memory tool.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -949,7 +949,23 @@ func (s *Server) supersedeMemory() mcp.ToolHandlerFor[supersedeMemoryInput, memo
 		if err != nil {
 			return nil, memoryOutput{}, err
 		}
-		details, err := s.memory.Supersede(ctx, memoryID, memoryType, scope, input.Fact, confidence, source, evidenceRefs, artifactRefs)
+		validFromOptional := types.None[time.Time]()
+		if strings.TrimSpace(input.ValidFrom) != "" {
+			validFrom, err := parseFlexibleTime(input.ValidFrom, false)
+			if err != nil {
+				return nil, memoryOutput{}, xerrors.Errorf("failed to parse valid_from: %w", err)
+			}
+			validFromOptional = types.Some(validFrom)
+		}
+		validToOptional := types.None[time.Time]()
+		if strings.TrimSpace(input.ValidTo) != "" {
+			validTo, err := parseFlexibleTime(input.ValidTo, false)
+			if err != nil {
+				return nil, memoryOutput{}, xerrors.Errorf("failed to parse valid_to: %w", err)
+			}
+			validToOptional = types.Some(validTo)
+		}
+		details, err := s.memory.Supersede(ctx, memoryID, memoryType, scope, input.Fact, confidence, source, evidenceRefs, artifactRefs, validFromOptional, validToOptional)
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to supersede memory: %w", err)
 		}


### PR DESCRIPTION
Closes #665.

## Summary

\`MemoryUsecase.Supersede\` previously called \`model.NewAcceptedMemory\`, which defaults the replacement to \`validFrom=time.Now(), validTo=nil\`. That silently dropped whatever window the caller intended to carry forward — especially painful for \`memory hygiene apply\` on \`validity_overlap_supersede\` suggestions: the detector fires because the pair has overlapping validity windows, and the apply was then deleting that window.

## Changes

- **Domain** (\`domain/model/memory.go\`): new constructor \`NewAcceptedMemoryWithValidity\` that carries an optional \`validFrom\` / \`validTo\` through. \`NewAcceptedMemory\` still works for callers that don't need a window.
- **Usecase interface + impl** (\`memory_usecase.go\` / \`memory_usecase_impl.go\`): \`Supersede\` gains \`validFrom, validTo types.Optional[time.Time]\`. None preserves pre-v0.8.1 default behaviour.
- **Hygiene apply** (\`memory_hygiene_usecase_impl.go\`): redaction_hit, supersede_candidate, and validity_overlap_supersede transitions all pass the existing memory's own window through to Supersede, preserving operator-set temporal boundaries.
- **CLI**: \`traceary memory supersede --from YYYY-MM-DD --to YYYY-MM-DD\` (reuses the validity-time parser shared with \`set-validity\`).
- **MCP**: \`supersede_memory\` accepts \`valid_from\` / \`valid_to\` strings.

## Regression tests

- \`TestMemoryUsecase_SupersedeCarriesValidityWindow\` — explicit validFrom + validTo round-trip through Supersede and appear on the resulting replacement.
- Existing \`TestMemoryUsecase_Supersede\` continues to verify pre-v0.8.1 default (None passes through).
- Existing \`TestMemoryHygieneScan_ValidityOverlapEmitsSupersede\` unchanged — scan side not affected.

## Test plan

- [x] \`go test ./...\` — all pass
- [x] \`go tool golangci-lint run\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)