### PR TITLE
feat(doctor): warn when multiple plugin cache versions coexist

### DIFF
--- a/infrastructure/filesystem/claude_plugin_detector.go
+++ b/infrastructure/filesystem/claude_plugin_detector.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -92,6 +93,14 @@ type ClaudePluginCacheStatus struct {
 	// CachedVersion is the highest version found under CachePath. Empty
 	// when no versioned directory exists (plugin never cached yet).
 	CachedVersion string
+	// CachedVersions lists every non-orphaned versioned cache directory
+	// found under CachePath, sorted from highest to lowest by semver.
+	// Diagnostics use the full list to detect the session-snapshot
+	// ambiguity reported in #670: when more than one version coexists,
+	// a long-lived Claude Code session may still be running hooks
+	// registered against an older subdir even though CachedVersion
+	// (the highest) matches the marketplace.
+	CachedVersions []string
 	// MarketplaceVersion is the plugin.json "version" Claude Code sees
 	// via `~/.claude/plugins/marketplaces/<marketplace>/...`. Empty when
 	// the marketplace clone is missing.
@@ -99,6 +108,16 @@ type ClaudePluginCacheStatus struct {
 	// MarketplacePath is the plugin.json path that was read (empty if
 	// the read failed).
 	MarketplacePath string
+}
+
+// HasMultipleCachedVersions reports whether the plugin's cache directory
+// holds more than one non-orphaned version subdirectory. When true, a
+// resumed Claude Code session could have snapshotted its hook registry
+// against any of them — not necessarily the highest — so the operator
+// should be told to restart without `--continue` to guarantee the
+// newest hooks are live.
+func (s ClaudePluginCacheStatus) HasMultipleCachedVersions() bool {
+	return len(s.CachedVersions) > 1
 }
 
 // Stale reports whether the cached plugin is at an older semver than
@@ -147,10 +166,19 @@ func DetectClaudePluginCacheStatus(home, pluginKey string) ClaudePluginCacheStat
 			if _, err := os.Stat(filepath.Join(status.CachePath, name, ".orphaned_at")); err == nil {
 				continue
 			}
+			status.CachedVersions = append(status.CachedVersions, name)
 			if status.CachedVersion == "" || semver.Compare("v"+name, "v"+status.CachedVersion) > 0 {
 				status.CachedVersion = name
 			}
 		}
+		// Sort CachedVersions descending so diagnostics can print
+		// "cached N, N-1, ..." without additional sorting. semver
+		// comparator ordering; fall back to string order when one
+		// side isn't parseable (defensive — directory names are
+		// expected to be plain semver).
+		sort.SliceStable(status.CachedVersions, func(i, j int) bool {
+			return semver.Compare("v"+status.CachedVersions[i], "v"+status.CachedVersions[j]) > 0
+		})
 	}
 
 	if content, err := os.ReadFile(status.MarketplacePath); err == nil {

--- a/infrastructure/filesystem/claude_plugin_detector_test.go
+++ b/infrastructure/filesystem/claude_plugin_detector_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestDetectClaudeTracearyPluginIn_NoSettingsFile(t *testing.T) {
@@ -195,6 +197,34 @@ func TestDetectClaudePluginCacheStatus_PicksHighestCachedVersion(t *testing.T) {
 	}
 	if !got.Stale() {
 		t.Errorf("Stale() = false, want true (0.7.0 < 0.7.2)")
+	}
+	wantVersions := []string{"0.7.0", "0.6.1", "0.5.1"}
+	if diff := cmp.Diff(wantVersions, got.CachedVersions); diff != "" {
+		t.Errorf("CachedVersions mismatch (-want +got):\n%s", diff)
+	}
+	if !got.HasMultipleCachedVersions() {
+		t.Errorf("HasMultipleCachedVersions() = false, want true (3 versions coexisting)")
+	}
+}
+
+// TestDetectClaudePluginCacheStatus_SingleCachedVersionIsNotMultiple
+// regression test for #670: a single cached version must NOT trigger
+// the multi-version warning path. Without this guard the doctor would
+// warn every operator even on a clean install.
+func TestDetectClaudePluginCacheStatus_SingleCachedVersionIsNotMultiple(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.8.0")
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.8.0")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if got.HasMultipleCachedVersions() {
+		t.Errorf("HasMultipleCachedVersions() = true, want false for single cached version")
+	}
+	if diff := cmp.Diff([]string{"0.8.0"}, got.CachedVersions); diff != "" {
+		t.Errorf("CachedVersions mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/infrastructure/filesystem/claude_plugin_detector_test.go
+++ b/infrastructure/filesystem/claude_plugin_detector_test.go
@@ -207,6 +207,31 @@ func TestDetectClaudePluginCacheStatus_PicksHighestCachedVersion(t *testing.T) {
 	}
 }
 
+// TestDetectClaudePluginCacheStatus_StaleAndMultipleCoexist asserts
+// that when the cache is BOTH stale AND carries multiple version
+// subdirs, the detector reports both conditions true. The doctor
+// layer relies on this so it can compose a single WARN that carries
+// both remedies (#670 follow-up). Before the combined-message fix,
+// the doctor returned on Stale() and silently dropped the
+// fresh-session restart guidance.
+func TestDetectClaudePluginCacheStatus_StaleAndMultipleCoexist(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.6.0")
+	writePluginCache(t, home, "traceary-plugins", "traceary", "0.7.0")
+	writePluginMarketplaceManifest(t, home, "traceary-plugins", "0.8.0")
+
+	got := DetectClaudePluginCacheStatus(home, "traceary@traceary-plugins")
+
+	if !got.Stale() {
+		t.Errorf("Stale() = false, want true (0.7.0 < 0.8.0)")
+	}
+	if !got.HasMultipleCachedVersions() {
+		t.Errorf("HasMultipleCachedVersions() = false, want true (0.6.0 + 0.7.0 coexist)")
+	}
+}
+
 // TestDetectClaudePluginCacheStatus_SingleCachedVersionIsNotMultiple
 // regression test for #670: a single cached version must NOT trigger
 // the multi-version warning path. Without this guard the doctor would

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -212,6 +212,23 @@ func inspectClaudePluginCacheStatus() *doctorCheck {
 			),
 		}
 	}
+	// Even when the highest cached version matches the marketplace,
+	// multiple version subdirs coexisting means a resumed Claude Code
+	// session might still run the older snapshot (#670). Doctor cannot
+	// inspect the live session's hook registry, but it can point the
+	// operator at the restart + old-cache-cleanup remedy.
+	if status.HasMultipleCachedVersions() {
+		others := strings.Join(status.CachedVersions[1:], ", ")
+		return &doctorCheck{
+			Name:   "claude-plugin-cache",
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"claude plugin cache %s has multiple cached versions (current %s, older also present: %s). A resumed Claude Code session (via `--continue` / cmux) can still be running the older snapshot. Fully restart Claude Code (no resume) so the new hooks fire; optionally remove `%s/<old>` to remove the ambiguity",
+				"claude plugin cache %s に複数のバージョンが残っています (current %s、古いもの: %s)。`--continue` で resume されたセッションでは古いスナップショットの hook が動き続ける可能性があります。完全に再起動 (resume しない) すれば新しい hook が有効になります。古い subdir (`%s/<old>`) を削除すれば恒久的に解消します",
+				status.CachePath, status.CachedVersion, others, status.CachePath,
+			),
+		}
+	}
 	return &doctorCheck{
 		Name:   "claude-plugin-cache",
 		Status: doctorStatusPass,

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -201,32 +201,41 @@ func inspectClaudePluginCacheStatus() *doctorCheck {
 	if status.CachedVersion == "" || status.MarketplaceVersion == "" {
 		return nil
 	}
+	// Evaluate the two WARN conditions together so a single cache
+	// that is BOTH stale AND has multiple cached versions gets one
+	// unified message — otherwise the stale branch would return
+	// first and the #670 fresh-session remedy would be silently
+	// dropped.
+	staleSegment, multiSegment := "", ""
 	if status.Stale() {
-		return &doctorCheck{
-			Name:   "claude-plugin-cache",
-			Status: doctorStatusWarn,
-			Message: localizef(
-				"claude plugin cache %s is older than the marketplace manifest (cached %s, marketplace %s at %s). `brew upgrade traceary` does not refresh the plugin cache; run `claude plugins update %s` to activate the newer hooks",
-				"claude plugin cache %s は marketplace manifest より古いバージョンです (cached %s, marketplace %s at %s)。`brew upgrade traceary` では plugin cache は更新されません。新しい hook を有効にするには `claude plugins update %s` を実行してください",
-				status.CachePath, status.CachedVersion, status.MarketplaceVersion, status.MarketplacePath, detection.PluginKey,
-			),
-		}
+		staleSegment = localizef(
+			"claude plugin cache %s is older than the marketplace manifest (cached %s, marketplace %s at %s). `brew upgrade traceary` does not refresh the plugin cache; run `claude plugins update %s` to activate the newer hooks",
+			"claude plugin cache %s は marketplace manifest より古いバージョンです (cached %s, marketplace %s at %s)。`brew upgrade traceary` では plugin cache は更新されません。新しい hook を有効にするには `claude plugins update %s` を実行してください",
+			status.CachePath, status.CachedVersion, status.MarketplaceVersion, status.MarketplacePath, detection.PluginKey,
+		)
 	}
-	// Even when the highest cached version matches the marketplace,
-	// multiple version subdirs coexisting means a resumed Claude Code
-	// session might still run the older snapshot (#670). Doctor cannot
-	// inspect the live session's hook registry, but it can point the
-	// operator at the restart + old-cache-cleanup remedy.
 	if status.HasMultipleCachedVersions() {
 		others := strings.Join(status.CachedVersions[1:], ", ")
+		multiSegment = localizef(
+			"claude plugin cache %s has multiple cached versions (current %s, older also present: %s). A resumed Claude Code session (via `--continue` / cmux) can still be running the older snapshot. Fully restart Claude Code (no resume) so the new hooks fire; optionally remove `%s/<old>` to remove the ambiguity",
+			"claude plugin cache %s に複数のバージョンが残っています (current %s、古いもの: %s)。`--continue` で resume されたセッションでは古いスナップショットの hook が動き続ける可能性があります。完全に再起動 (resume しない) すれば新しい hook が有効になります。古い subdir (`%s/<old>`) を削除すれば恒久的に解消します",
+			status.CachePath, status.CachedVersion, others, status.CachePath,
+		)
+	}
+	if staleSegment != "" || multiSegment != "" {
+		var message string
+		switch {
+		case staleSegment != "" && multiSegment != "":
+			message = staleSegment + " " + multiSegment
+		case staleSegment != "":
+			message = staleSegment
+		default:
+			message = multiSegment
+		}
 		return &doctorCheck{
-			Name:   "claude-plugin-cache",
-			Status: doctorStatusWarn,
-			Message: localizef(
-				"claude plugin cache %s has multiple cached versions (current %s, older also present: %s). A resumed Claude Code session (via `--continue` / cmux) can still be running the older snapshot. Fully restart Claude Code (no resume) so the new hooks fire; optionally remove `%s/<old>` to remove the ambiguity",
-				"claude plugin cache %s に複数のバージョンが残っています (current %s、古いもの: %s)。`--continue` で resume されたセッションでは古いスナップショットの hook が動き続ける可能性があります。完全に再起動 (resume しない) すれば新しい hook が有効になります。古い subdir (`%s/<old>`) を削除すれば恒久的に解消します",
-				status.CachePath, status.CachedVersion, others, status.CachePath,
-			),
+			Name:    "claude-plugin-cache",
+			Status:  doctorStatusWarn,
+			Message: message,
 		}
 	}
 	return &doctorCheck{


### PR DESCRIPTION
Closes #670.

## Summary

v0.8 dogfooding surfaced a silent failure mode: after \`git pull\` on the marketplace clone, \`~/.claude/plugins/cache/traceary-plugins/traceary/\` held both \`0.6.0\` and \`0.8.0\`. The running Claude Code session had snapshotted its hook registry against \`0.6.0\` at startup (resume scenario), so \`Stop\` → transcript, \`SubagentStop\`, \`PreCompact\`, and the expanded \`PostToolUse\` matcher never fired — even though \`traceary doctor\` reported \`claude-plugin-cache PASS (cached 0.8.0, marketplace 0.8.0)\` because the check only looked at the highest cached version.

## Fix

Surface the multi-version ambiguity as a doctor WARN:

- \`ClaudePluginCacheStatus.CachedVersions\` now lists every non-orphaned subdir, sorted highest-to-lowest.
- \`HasMultipleCachedVersions()\` returns true when more than one coexists.
- Doctor \`claude-plugin-cache\` check WARNs in that case with the older versions listed and two remedies:
  1. Fully restart Claude Code (no \`--continue\`) so the new hooks fire.
  2. Optionally remove older \`<cache>/<old>\` subdirs to eliminate the ambiguity permanently.

## Why a warning, not a fix

Doctor cannot inspect the live Claude Code session's hook registry (Claude Code doesn't expose that). The best traceary can do is tell the operator what might have happened and how to resolve it. Automatic cleanup of old cache dirs is deliberately NOT in this PR — Claude Code may still be using them in another running session, and racing its plugin manager is risky.

## Test plan

- [x] \`go test ./...\` — all pass
- [x] \`go tool golangci-lint run\` — clean
- [x] New \`TestDetectClaudePluginCacheStatus_SingleCachedVersionIsNotMultiple\` — single-version cache must NOT trigger the warning (regression guard)
- [x] Existing \`TestDetectClaudePluginCacheStatus_PicksHighestCachedVersion\` extended with \`CachedVersions\` + \`HasMultipleCachedVersions\` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)