### PR TITLE
feat(events): add source_hook column and stamp per-hook provenance (write side)

### DIFF
--- a/application/types/source_hook.go
+++ b/application/types/source_hook.go
@@ -1,0 +1,38 @@
+package types
+
+import "context"
+
+// sourceHookContextKey is the unexported key used to thread the
+// host-side hook name ("stop", "session_start", "after_agent", ...)
+// through the usecase layer so event writers can stamp it on the
+// resulting event row without every method signature growing a
+// new parameter. Only hook-driven code paths set this; CLI and MCP
+// writes leave it unset, which persists as NULL source_hook.
+type sourceHookContextKey struct{}
+
+// WithSourceHook returns a derived context that carries the supplied
+// hook-event identifier. Use this in hook runtime functions
+// immediately before calling into an EventUsecase / SessionUsecase
+// so the event written by the usecase picks up the tag.
+//
+// name should be one of the stable identifiers documented on the
+// events.source_hook migration (e.g. "stop", "session_start",
+// "subagent_stop", "pre_compact", "after_agent"). Empty names are
+// discarded — passing "" is equivalent to not calling WithSourceHook
+// at all and keeps the column NULL.
+func WithSourceHook(ctx context.Context, name string) context.Context {
+	if name == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sourceHookContextKey{}, name)
+}
+
+// SourceHookFromContext extracts the hook-event identifier previously
+// stored by WithSourceHook. Returns "" when none is present — the
+// caller persists "" as NULL in the database so legacy / non-hook
+// writes are distinguishable from hook-driven writes that simply
+// forgot to tag.
+func SourceHookFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(sourceHookContextKey{}).(string)
+	return v
+}

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -86,6 +86,7 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 	if err != nil {
 		return nil, xerrors.Errorf("failed to build log event: %w", err)
 	}
+	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 	if err := u.eventRepo.Save(ctx, event); err != nil {
 		return nil, xerrors.Errorf("failed to save log event: %w", err)
 	}
@@ -160,6 +161,7 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to build audit event: %w", err)
 	}
+	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 
 	if err := u.eventRepo.SaveWithAudit(ctx, event, commandAudit); err != nil {
 		return nil, nil, xerrors.Errorf("failed to save audit event: %w", err)

--- a/application/usecase/record_log_test.go
+++ b/application/usecase/record_log_test.go
@@ -229,3 +229,62 @@ func TestEventUsecase_Log(t *testing.T) {
 		}
 	})
 }
+
+// TestEventUsecase_Log_StampsSourceHookFromContext regression guard
+// for #672: when the caller threads WithSourceHook through ctx, the
+// persisted Event carries the tag so downstream queries can tell a
+// Claude `Stop` apart from a Gemini `AfterAgent` (both produce
+// transcript kind) without parsing the body string.
+func TestEventUsecase_Log_StampsSourceHookFromContext(t *testing.T) {
+	t.Parallel()
+
+	stub := &eventRepositoryStub{}
+	sut := usecase.NewEventUsecase(stub, nil)
+
+	ctx := apptypes.WithSourceHook(context.Background(), "stop")
+	got, err := sut.Log(ctx,
+		"transcript body",
+		types.EventKindTranscript,
+		types.Client("hook"),
+		types.Agent("claude"),
+		types.SessionID("session-1"),
+		types.Workspace("github.com/example/repo"),
+		apptypes.LogRedaction{},
+	)
+	if err != nil {
+		t.Fatalf("Log() error = %v", err)
+	}
+	if got.SourceHook() != "stop" {
+		t.Errorf("returned event SourceHook() = %q, want %q", got.SourceHook(), "stop")
+	}
+	if stub.savedEvent.SourceHook() != "stop" {
+		t.Errorf("saved event SourceHook() = %q, want %q", stub.savedEvent.SourceHook(), "stop")
+	}
+}
+
+// TestEventUsecase_Log_LeavesSourceHookEmptyWithoutContext asserts
+// that non-hook writers (CLI `traceary log`, MCP `add_log`) leave
+// source_hook empty — the DB column stays NULL and queries can
+// cleanly filter hook-driven vs user-driven writes.
+func TestEventUsecase_Log_LeavesSourceHookEmptyWithoutContext(t *testing.T) {
+	t.Parallel()
+
+	stub := &eventRepositoryStub{}
+	sut := usecase.NewEventUsecase(stub, nil)
+
+	got, err := sut.Log(context.Background(),
+		"manual note",
+		types.EventKindNote,
+		types.Client("cli"),
+		types.Agent("manual"),
+		types.SessionID("session-1"),
+		types.Workspace("github.com/example/repo"),
+		apptypes.LogRedaction{},
+	)
+	if err != nil {
+		t.Fatalf("Log() error = %v", err)
+	}
+	if got.SourceHook() != "" {
+		t.Errorf("SourceHook() = %q, want empty for non-hook ctx", got.SourceHook())
+	}
+}

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -61,7 +61,7 @@ func (u *sessionUsecase) Start(ctx context.Context, client types.Client, agent t
 		}
 	}
 
-	event, err := u.buildBoundaryEvent(types.EventKindSessionStarted, client, agent, resolvedSessionID, workspace)
+	event, err := u.buildBoundaryEvent(ctx, types.EventKindSessionStarted, client, agent, resolvedSessionID, workspace)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to start session: %w", err)
 	}
@@ -98,7 +98,7 @@ func (u *sessionUsecase) End(ctx context.Context, client types.Client, agent typ
 		return nil, xerrors.Errorf("failed to end session: %w", err)
 	}
 
-	event, err := u.buildBoundaryEvent(types.EventKindSessionEnded, resolvedClient, resolvedAgent, resolvedSessionID, resolvedWorkspace)
+	event, err := u.buildBoundaryEvent(ctx, types.EventKindSessionEnded, resolvedClient, resolvedAgent, resolvedSessionID, resolvedWorkspace)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to end session: %w", err)
 	}
@@ -230,6 +230,7 @@ func (u *sessionUsecase) resolveSessionStartID(sessionID types.SessionID) (types
 
 // buildBoundaryEvent constructs the session start/end event.
 func (u *sessionUsecase) buildBoundaryEvent(
+	ctx context.Context,
 	kind types.EventKind,
 	client types.Client,
 	agent types.Agent,
@@ -244,6 +245,7 @@ func (u *sessionUsecase) buildBoundaryEvent(
 	if err != nil {
 		return nil, xerrors.Errorf("failed to build session boundary event: %w", err)
 	}
+	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 	return event, nil
 }
 

--- a/domain/model/event.go
+++ b/domain/model/event.go
@@ -13,14 +13,15 @@ var nowFunc = time.Now
 
 // Event is the smallest recorded unit in Traceary history.
 type Event struct {
-	eventID   types.EventID
-	kind      types.EventKind
-	client    types.Client
-	agent     types.Agent
-	sessionID types.SessionID
-	workspace types.Workspace
-	body      string
-	createdAt time.Time
+	eventID    types.EventID
+	kind       types.EventKind
+	client     types.Client
+	agent      types.Agent
+	sessionID  types.SessionID
+	workspace  types.Workspace
+	body       string
+	createdAt  time.Time
+	sourceHook string
 }
 
 // NewEvent creates a new Event.
@@ -71,6 +72,45 @@ func EventOf(
 		createdAt: createdAt,
 	}
 }
+
+// EventOfWithSourceHook restores an Event including the source_hook
+// column (added in migration 000011). Legacy rows from before that
+// migration keep "" here — readers that don't care about provenance
+// can keep using EventOf.
+func EventOfWithSourceHook(
+	eventID types.EventID,
+	kind types.EventKind,
+	client types.Client,
+	agent types.Agent,
+	sessionID types.SessionID,
+	workspace types.Workspace,
+	body string,
+	createdAt time.Time,
+	sourceHook string,
+) *Event {
+	event := EventOf(eventID, kind, client, agent, sessionID, workspace, body, createdAt)
+	event.sourceHook = sourceHook
+	return event
+}
+
+// SetSourceHook stamps the host-side hook-event identifier that
+// produced the event (for example "stop", "subagent_stop",
+// "pre_compact", "after_agent"). Empty values are ignored so a
+// caller that doesn't know / doesn't care leaves the tag unchanged.
+// Called by the hook runtime layer immediately before Save.
+func (e *Event) SetSourceHook(name string) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return
+	}
+	e.sourceHook = trimmed
+}
+
+// SourceHook returns the host-side hook-event identifier set by
+// SetSourceHook. Empty when the event was not produced by a hook
+// (for example a `traceary log` write) or pre-dates the
+// source_hook column migration.
+func (e *Event) SourceHook() string { return e.sourceHook }
 
 // EventID returns the event ID.
 func (e *Event) EventID() types.EventID { return e.eventID }

--- a/infrastructure/sqlite/backup_store_test.go
+++ b/infrastructure/sqlite/backup_store_test.go
@@ -232,7 +232,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -27,7 +27,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -157,6 +157,19 @@ func formatTimestamp(timestamp time.Time) string {
 	return timestamp.UTC().Format(time.RFC3339Nano)
 }
 
+// nullableString converts a Go string to a value suitable for SQLite
+// TEXT columns that distinguish "" from NULL. Empty strings become
+// NULL; non-empty strings are bound as-is. Used for columns like
+// events.source_hook where empty and NULL mean "no tag" and we want
+// the persisted representation to be a single NULL rather than a
+// mix of empty strings and NULLs.
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
 // formatMemoryValidityTimestamp renders a time.Time as a fixed-width
 // RFC3339 string with nine fractional-second digits, e.g.
 // "2026-04-10T00:00:00.123000000Z". Unlike RFC3339Nano (which trims

--- a/infrastructure/sqlite/datasource_test.go
+++ b/infrastructure/sqlite/datasource_test.go
@@ -23,7 +23,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 	}

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -84,6 +84,7 @@ func (d *EventDatasource) Save(ctx context.Context, event *model.Event) error {
 		event.Workspace().String(),
 		event.Body(),
 		formatTimestamp(event.CreatedAt()),
+		nullableString(event.SourceHook()),
 	); err != nil {
 		return xerrors.Errorf("failed to insert event: %w", err)
 	}
@@ -135,6 +136,7 @@ func (d *EventDatasource) SaveWithAudit(
 		event.Workspace().String(),
 		event.Body(),
 		formatTimestamp(event.CreatedAt()),
+		nullableString(event.SourceHook()),
 	); err != nil {
 		return xerrors.Errorf("failed to insert event: %w", err)
 	}

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -28,7 +28,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -119,7 +120,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 	}
@@ -192,7 +194,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -263,7 +266,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -405,7 +409,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -510,7 +515,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -558,7 +564,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -629,7 +636,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -25,7 +25,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -251,7 +252,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {
@@ -333,7 +335,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -80,7 +80,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/get_context_events_test.go
+++ b/infrastructure/sqlite/get_context_events_test.go
@@ -24,7 +24,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/get_event_details_test.go
+++ b/infrastructure/sqlite/get_event_details_test.go
@@ -24,7 +24,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -37,7 +37,8 @@ func listSessionsTestMigrations() fstest.MapFS {
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -25,7 +25,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -114,6 +114,7 @@ func (d *SessionDatasource) SaveBoundary(ctx context.Context, session *model.Ses
 		event.Workspace().String(),
 		event.Body(),
 		formatTimestamp(event.CreatedAt()),
+		nullableString(event.SourceHook()),
 	); err != nil {
 		return xerrors.Errorf("failed to insert boundary event: %w", err)
 	}

--- a/infrastructure/sqlite/sql/insert_event.sql
+++ b/infrastructure/sqlite/sql/insert_event.sql
@@ -1,2 +1,2 @@
-INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -26,7 +26,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -179,6 +179,20 @@ func (c *RootCLI) runHookSession(
 		return xerrors.Errorf("unsupported hook session action: %s", action)
 	}
 
+	// Tag downstream events with which host hook fired so
+	// retrospective queries can tell a Claude SessionEnd apart from
+	// a Codex Stop even though both produce a session_ended row
+	// (#672). start / end map to session_start / session_end; stop
+	// is Codex's session-end-equivalent.
+	switch action {
+	case "start":
+		ctx = apptypes.WithSourceHook(ctx, "session_start")
+	case "end":
+		ctx = apptypes.WithSourceHook(ctx, "session_end")
+	case "stop":
+		ctx = apptypes.WithSourceHook(ctx, "stop")
+	}
+
 	payload, err := readHookPayload(input)
 	if err != nil {
 		return err
@@ -296,6 +310,17 @@ func (c *RootCLI) runHookAudit(
 	if c.event == nil {
 		return xerrors.Errorf("record command audit usecase is not configured")
 	}
+	// Tag for #672: per-client audit is PostToolUse on Claude/Codex
+	// and AfterTool on Gemini. The hook runtime does not yet know
+	// whether Claude Code dispatched this via PostToolUse or the
+	// PostToolUseFailure variant — both go through the same handler,
+	// so we stamp the coarser "post_tool_use" for now; the exit-code
+	// distinction remains recoverable via the command_audits table.
+	if client == "gemini" {
+		ctx = apptypes.WithSourceHook(ctx, "after_tool")
+	} else {
+		ctx = apptypes.WithSourceHook(ctx, "post_tool_use")
+	}
 
 	payload, err := readHookPayload(input)
 	if err != nil {
@@ -385,6 +410,17 @@ func (c *RootCLI) runHookCompact(
 ) error {
 	if c.storeManagement == nil {
 		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	// Tag for #672: PreCompact and PostCompact both produce the
+	// compact_summary kind, so source_hook carries the phase
+	// without relying on body-prefix marker parsing. The
+	// session-start-compact branch writes no event so tagging
+	// there is a no-op.
+	switch action {
+	case "pre-compact":
+		ctx = apptypes.WithSourceHook(ctx, "pre_compact")
+	case "post-compact":
+		ctx = apptypes.WithSourceHook(ctx, "post_compact")
 	}
 
 	payload, err := readHookPayload(input)
@@ -486,6 +522,11 @@ func (c *RootCLI) runHookSubagentStop(
 	if c.event == nil {
 		return xerrors.Errorf("event usecase is not configured")
 	}
+	// Tag for #672: SubagentStop produces a session_ended event
+	// (distinguished today only via the `[phase:subagent]` body
+	// prefix). source_hook lets downstream queries filter without
+	// parsing the body string.
+	ctx = apptypes.WithSourceHook(ctx, "subagent_stop")
 	payload, err := readHookPayload(input)
 	if err != nil {
 		return err
@@ -543,6 +584,7 @@ func (c *RootCLI) runHookPrompt(
 	if c.event == nil {
 		return xerrors.Errorf("record log usecase is not configured")
 	}
+	ctx = apptypes.WithSourceHook(ctx, "user_prompt_submit")
 
 	payload, err := readHookPayload(input)
 	if err != nil {
@@ -615,6 +657,14 @@ func (c *RootCLI) runHookTranscript(
 	}
 	if c.event == nil {
 		return xerrors.Errorf("record log usecase is not configured")
+	}
+	// Tag for #672: transcript comes from Claude / Codex Stop or
+	// Gemini AfterAgent. Downstream readers can distinguish via
+	// source_hook without parsing the client's hook envelope.
+	if client == "gemini" {
+		ctx = apptypes.WithSourceHook(ctx, "after_agent")
+	} else {
+		ctx = apptypes.WithSourceHook(ctx, "stop")
 	}
 
 	payload, err := readHookPayload(input)

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -877,7 +877,8 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    source_hook TEXT
 );`),
 		},
 		"000002_add_event_metadata.sql": {

--- a/schema/sqlite/migrations/000011_add_events_source_hook.sql
+++ b/schema/sqlite/migrations/000011_add_events_source_hook.sql
@@ -1,0 +1,40 @@
+-- Add source_hook column so an event can record the exact host-side
+-- hook event that produced it. Legacy rows stay NULL; readers treat
+-- NULL as "unknown source" and keep working as before. See #672.
+--
+-- Host → source_hook vocabulary (stable identifiers so downstream
+-- tools can filter without depending on client-specific capitalization):
+--   claude:
+--     session_start     — SessionStart
+--     session_end       — SessionEnd
+--     stop              — Stop  (also emits transcript + session_ended
+--                        for Codex; source_hook disambiguates)
+--     subagent_stop     — SubagentStop
+--     pre_compact       — PreCompact
+--     post_compact      — PostCompact
+--     user_prompt_submit— UserPromptSubmit
+--     post_tool_use     — PostToolUse
+--     post_tool_use_failure — PostToolUseFailure
+--   codex:
+--     session_start     — SessionStart
+--     stop              — Stop (fires transcript + session end pair)
+--     user_prompt_submit— UserPromptSubmit
+--     post_tool_use     — PostToolUse
+--   gemini:
+--     session_start     — SessionStart
+--     session_end       — SessionEnd
+--     after_agent       — AfterAgent (transcript)
+--     after_tool        — AfterTool  (audit)
+--
+-- Empty / NULL source_hook remains valid for non-hook writes
+-- (`traceary log`, MCP add_log, etc.).
+ALTER TABLE events ADD COLUMN source_hook TEXT;
+
+-- Readers can filter by source_hook cheaply; without an index large
+-- histories would require a table scan just to answer
+-- "all SubagentStop events in this workspace". Partial (WHERE
+-- source_hook IS NOT NULL) keeps the index from indexing every legacy
+-- NULL row.
+CREATE INDEX idx_events_source_hook
+    ON events(source_hook)
+    WHERE source_hook IS NOT NULL;


### PR DESCRIPTION
Closes #672 (write side — see \"Scope split\" below).

## Summary

Adds a new \`events.source_hook TEXT\` column (migration 000011) plus the plumbing to tag every hook-driven write with which host-side hook fired. Event kinds that collapse multiple hooks into one row (session_ended covers Claude SessionEnd / Codex Stop / Claude SubagentStop; compact_summary covers Pre/Post Compact; transcript covers Claude Stop / Codex Stop / Gemini AfterAgent) are now retrospectively distinguishable without parsing the body-prefix markers.

## Design choices

- **Context-value threading.** A new \`application/types.WithSourceHook(ctx, name)\` / \`SourceHookFromContext(ctx)\` pair lets hook runtime handlers stamp a tag without every usecase interface gaining a new parameter. Non-hook writes (CLI \`log\`, MCP \`add_log\`) pass ctx through unchanged → empty source_hook → NULL column.
- **Stable vocabulary.** Identifiers are snake_case host-neutral strings (\`stop\`, \`session_start\`, \`subagent_stop\`, \`pre_compact\`, \`after_agent\`, etc.) documented on the migration file.
- **NULL is a first-class \"no tag\" value.** Pre-v0.8.1 rows stay NULL; a partial index (\`WHERE source_hook IS NOT NULL\`) keeps the index cheap.
- **Hooks that produce no event** (e.g. Claude compact \`session-start-compact\` which only emits stdout) simply skip the WithSourceHook wrapping — zero cost.

## Scope split (read side deferred)

This PR covers the **write side** end-to-end:

- Schema migration 000011
- \`domain/model.Event.SetSourceHook\` / \`SourceHook\`
- SQLite INSERT binding + \`nullableString\` helper for empty→NULL
- Context helpers in \`application/types\`
- Usecase-level stamping (Log, Audit, Session Start / End)
- Hook runtime handlers wrap ctx per fire

Read-side surface (\`traceary list --source-hook stop\` filter, JSON field exposure, \`--phase:subagent\` body-prefix retirement) is kept for a follow-up PR so this one stays reviewable and so the read-side design can be informed by real usage once v0.8 → v0.8.1 users start tagging events.

## Test plan

- [x] \`go test ./...\` — all pass
- [x] \`go tool golangci-lint run\` — clean
- [x] New \`TestEventUsecase_Log_StampsSourceHookFromContext\` / \`TestEventUsecase_Log_LeavesSourceHookEmptyWithoutContext\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)