### PR TITLE
feat(events): expose source_hook on read side + retire body-prefix markers

### DIFF
--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -12,7 +12,7 @@ import (
 // EventQueryService provides read-side operations for events.
 type EventQueryService interface {
 	// ListRecent returns events in descending time order.
-	ListRecent(ctx context.Context, limit, offset int, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, failuresOnly bool, from, to time.Time) ([]*model.Event, error)
+	ListRecent(ctx context.Context, limit, offset int, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, failuresOnly bool, from, to time.Time, sourceHook string) ([]*model.Event, error)
 	// ListWindow returns every event matching the criteria whose created_at
 	// falls in [From, To) under a single read snapshot so concurrent writers
 	// cannot cause the scan to drop events. Callers supply the batch size via

--- a/application/types/event_list_criteria.go
+++ b/application/types/event_list_criteria.go
@@ -26,6 +26,7 @@ type EventListCriteria struct {
 	failuresOnly bool
 	from         time.Time
 	to           time.Time
+	sourceHook   string
 }
 
 // Limit returns the maximum number of results to return.
@@ -57,6 +58,12 @@ func (c EventListCriteria) From() time.Time { return c.from }
 
 // To returns the upper bound of the time range (exclusive).
 func (c EventListCriteria) To() time.Time { return c.to }
+
+// SourceHook returns the source-hook filter (empty string means no filter).
+// Callers match events that were stamped with this hook identifier by the
+// hook runtime (e.g. "stop", "subagent_stop", "pre_compact"). Matching
+// includes a legacy body-prefix fallback while pre-#672 rows still exist.
+func (c EventListCriteria) SourceHook() string { return c.sourceHook }
 
 // EventListCriteriaBuilder builds an EventListCriteria value.
 type EventListCriteriaBuilder struct {
@@ -120,6 +127,12 @@ func (b *EventListCriteriaBuilder) From(from time.Time) *EventListCriteriaBuilde
 // To sets the upper bound of the time range (exclusive).
 func (b *EventListCriteriaBuilder) To(to time.Time) *EventListCriteriaBuilder {
 	b.criteria.to = to
+	return b
+}
+
+// SourceHook sets the source-hook filter; empty string clears the filter.
+func (b *EventListCriteriaBuilder) SourceHook(sourceHook string) *EventListCriteriaBuilder {
+	b.criteria.sourceHook = sourceHook
 	return b
 }
 

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -111,6 +111,7 @@ func (b *contextPackBuilder) loadRecentCommands(ctx context.Context, session app
 		false,
 		time.Time{},
 		time.Time{},
+		"",
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list recent command events for context pack: %w", err)
@@ -141,13 +142,19 @@ func (b *contextPackBuilder) loadCompactSummary(ctx context.Context, session app
 		false,
 		time.Time{},
 		time.Time{},
+		"",
 	)
 	if err != nil {
 		return "", xerrors.Errorf("failed to list compact summary events for context pack: %w", err)
 	}
 	for _, event := range events {
 		body := event.Body()
-		if strings.HasPrefix(strings.TrimSpace(body), domtypes.EventBodyMarkerCompactPreSnapshot) {
+		// Skip PreCompact snapshots: new rows carry source_hook =
+		// "pre_compact"; legacy (pre-#672) rows still carry the
+		// "[phase:pre-compact]" body prefix and must keep working
+		// through the migration window.
+		if event.SourceHook() == "pre_compact" ||
+			strings.HasPrefix(strings.TrimSpace(body), domtypes.EventBodyMarkerCompactPreSnapshot) {
 			continue
 		}
 		return extractCompactSummarySignal(body), nil

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -213,7 +213,7 @@ func (u *eventUsecase) List(ctx context.Context, criteria apptypes.EventListCrit
 		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
 	}
 
-	events, err := u.eventQuery.ListRecent(ctx, criteria.Limit(), criteria.Offset(), criteria.Kind(), criteria.Client(), criteria.Agent(), criteria.SessionID(), criteria.Workspace(), criteria.FailuresOnly(), criteria.From(), criteria.To())
+	events, err := u.eventQuery.ListRecent(ctx, criteria.Limit(), criteria.Offset(), criteria.Kind(), criteria.Client(), criteria.Agent(), criteria.SessionID(), criteria.Workspace(), criteria.FailuresOnly(), criteria.From(), criteria.To(), criteria.SourceHook())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list events: %w", err)
 	}

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -272,6 +272,7 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 			false,
 			time.Time{},
 			time.Time{},
+			"",
 		)
 		if err != nil {
 			return xerrors.Errorf("failed to list %s events for extraction: %w", kind, err)

--- a/application/usecase/replay_usecase_impl.go
+++ b/application/usecase/replay_usecase_impl.go
@@ -108,6 +108,7 @@ func (u *replayUsecase) Bundle(ctx context.Context, criteria apptypes.ReplayCrit
 			false,
 			time.Time{},
 			time.Time{},
+			"",
 		)
 		if err != nil {
 			return apptypes.ReplayBundle{}, xerrors.Errorf("failed to list events for session %s: %w", session.SessionID().String(), err)
@@ -212,6 +213,7 @@ func (u *replayUsecase) loadFailureHotspots(ctx context.Context, criteria apptyp
 		true,
 		from,
 		now,
+		"",
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list failure events for replay hotspot: %w", err)

--- a/application/usecase/replay_usecase_impl_test.go
+++ b/application/usecase/replay_usecase_impl_test.go
@@ -29,7 +29,7 @@ type stubReplayEventQuery struct {
 	timelineBlocks  []apptypes.TimelineBlock
 }
 
-func (s *stubReplayEventQuery) ListRecent(_ context.Context, _, _ int, _ domtypes.EventKind, _ domtypes.Client, _ domtypes.Agent, sessionID domtypes.SessionID, _ domtypes.Workspace, failuresOnly bool, _, _ time.Time) ([]*model.Event, error) {
+func (s *stubReplayEventQuery) ListRecent(_ context.Context, _, _ int, _ domtypes.EventKind, _ domtypes.Client, _ domtypes.Agent, sessionID domtypes.SessionID, _ domtypes.Workspace, failuresOnly bool, _, _ time.Time, _ string) ([]*model.Event, error) {
 	if failuresOnly {
 		return s.failureEvents, nil
 	}

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -104,6 +104,7 @@ func (s *eventQueryServiceStub) ListRecent(
 	workspace types.Workspace,
 	_ bool,
 	_, _ time.Time,
+	_ string,
 ) ([]*model.Event, error) {
 	s.listRecentCalls++
 	s.listRecentLimit = limit

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -173,6 +173,7 @@ func (d *EventDatasource) ListRecent(
 	kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace,
 	failuresOnly bool,
 	from, to time.Time,
+	sourceHook string,
 ) ([]*model.Event, error) {
 	if limit <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
@@ -211,6 +212,7 @@ func (d *EventDatasource) ListRecent(
 		boolToInt(failuresOnly),
 		fromValue, fromValue,
 		toValue, toValue,
+		sourceHook, sourceHook, sourceHook, sourceHook,
 		limit,
 		offset,
 	)
@@ -294,6 +296,7 @@ func (d *EventDatasource) ListWindow(
 	sessionID := criteria.SessionID()
 	workspace := criteria.Workspace()
 	failuresFlag := boolToInt(criteria.FailuresOnly())
+	sourceHook := criteria.SourceHook()
 
 	events := make([]*model.Event, 0, batch)
 	offset := 0
@@ -309,6 +312,7 @@ func (d *EventDatasource) ListWindow(
 			failuresFlag,
 			fromValue, fromValue,
 			toValue, toValue,
+			sourceHook, sourceHook, sourceHook, sourceHook,
 			batch,
 			offset,
 		)
@@ -718,14 +722,15 @@ func scanEvent(rowScanner interface {
 	Scan(dest ...any) error
 }) (*model.Event, error) {
 	var (
-		eventIDValue   string
-		eventKindValue string
-		clientValue    string
-		agentValue     string
-		sessionIDValue string
-		repoValue      string
-		bodyValue      string
-		createdAtValue string
+		eventIDValue    string
+		eventKindValue  string
+		clientValue     string
+		agentValue      string
+		sessionIDValue  string
+		repoValue       string
+		bodyValue       string
+		sourceHookValue sql.NullString
+		createdAtValue  string
 	)
 
 	if err := rowScanner.Scan(
@@ -736,6 +741,7 @@ func scanEvent(rowScanner interface {
 		&sessionIDValue,
 		&repoValue,
 		&bodyValue,
+		&sourceHookValue,
 		&createdAtValue,
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event row: %w", err)
@@ -749,6 +755,7 @@ func scanEvent(rowScanner interface {
 		sessionIDValue,
 		repoValue,
 		bodyValue,
+		sourceHookValue.String,
 		createdAtValue,
 	)
 }
@@ -767,14 +774,15 @@ func scanEventWithAudit(
 	exitCodeValue *sql.NullInt64,
 ) (*model.Event, error) {
 	var (
-		eventIDValue   string
-		eventKindValue string
-		clientValue    string
-		agentValue     string
-		sessionIDValue string
-		repoValue      string
-		bodyValue      string
-		createdAtValue string
+		eventIDValue    string
+		eventKindValue  string
+		clientValue     string
+		agentValue      string
+		sessionIDValue  string
+		repoValue       string
+		bodyValue       string
+		sourceHookValue sql.NullString
+		createdAtValue  string
 	)
 
 	if err := rowScanner.Scan(
@@ -785,6 +793,7 @@ func scanEventWithAudit(
 		&sessionIDValue,
 		&repoValue,
 		&bodyValue,
+		&sourceHookValue,
 		&createdAtValue,
 		commandTextValue,
 		inputTextValue,
@@ -804,6 +813,7 @@ func scanEventWithAudit(
 		sessionIDValue,
 		repoValue,
 		bodyValue,
+		sourceHookValue.String,
 		createdAtValue,
 	)
 }
@@ -816,6 +826,7 @@ func restoreEvent(
 	sessionIDValue string,
 	repoValue string,
 	bodyValue string,
+	sourceHookValue string,
 	createdAtValue string,
 ) (*model.Event, error) {
 	eventID, err := types.EventIDOf(eventIDValue)
@@ -839,7 +850,7 @@ func restoreEvent(
 		return nil, xerrors.Errorf("failed to restore created_at: %w", err)
 	}
 
-	return model.EventOf(
+	return model.EventOfWithSourceHook(
 		eventID,
 		eventKind,
 		types.Client(clientValue),
@@ -848,6 +859,7 @@ func restoreEvent(
 		types.Workspace(repoValue),
 		bodyValue,
 		createdAt,
+		sourceHookValue,
 	), nil
 }
 

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -88,7 +88,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("Save(newer) error = %v", err)
 	}
 
-	got, err := sut.ListRecent(context.Background(), 10, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{})
+	got, err := sut.ListRecent(context.Background(), 10, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}
@@ -170,7 +170,7 @@ CREATE TABLE command_audits (
 		t.Fatalf("Save() error = %v", err)
 	}
 
-	got, err := sut.ListRecent(context.Background(), 1, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{})
+	got, err := sut.ListRecent(context.Background(), 1, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}
@@ -242,7 +242,7 @@ CREATE TABLE command_audits (
 		}
 	}
 
-	got, err := sut.ListRecent(context.Background(), 1, 1, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{})
+	got, err := sut.ListRecent(context.Background(), 1, 1, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}
@@ -315,7 +315,7 @@ CREATE TABLE command_audits (
 		}
 	}
 
-	got, err := sut.ListRecent(context.Background(), 10, 0, types.EventKindNote, types.Client("cli"), types.Agent("codex"), types.SessionID("session-1"), types.Workspace("duck8823/traceary"), false, time.Time{}, time.Time{})
+	got, err := sut.ListRecent(context.Background(), 10, 0, types.EventKindNote, types.Client("cli"), types.Agent("codex"), types.SessionID("session-1"), types.Workspace("duck8823/traceary"), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}

--- a/infrastructure/sqlite/save_boundary_test.go
+++ b/infrastructure/sqlite/save_boundary_test.go
@@ -57,7 +57,7 @@ func TestSessionDatasource_SaveBoundary_Start(t *testing.T) {
 	}
 
 	// Event row was inserted
-	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionStarted, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{})
+	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionStarted, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}
@@ -359,7 +359,7 @@ func TestSessionDatasource_SaveBoundary_DuplicateEndRejected(t *testing.T) {
 
 	// The duplicate session_ended event must also have been rolled back —
 	// only the first end event should be persisted.
-	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionEnded, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{})
+	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionEnded, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}
@@ -422,7 +422,7 @@ func TestSessionDatasource_SaveBoundary_DuplicateStartRejected(t *testing.T) {
 
 	// Only the first session_started event must remain; the second must
 	// have been rolled back together with the duplicate row attempt.
-	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionStarted, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{})
+	events, err := eventDS.ListRecent(ctx, 10, 0, types.EventKindSessionStarted, types.Client(""), types.Agent(""), sessionID, types.Workspace(""), false, time.Time{}, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListRecent() error = %v", err)
 	}

--- a/infrastructure/sqlite/sql/find_latest_session.sql
+++ b/infrastructure/sqlite/sql/find_latest_session.sql
@@ -6,6 +6,7 @@ WITH candidate_sessions AS (
             started.session_id,
             started.workspace,
             started.body,
+            started.source_hook,
             started.created_at,
             (
               SELECT boundary.created_at
@@ -70,6 +71,7 @@ SELECT id,
        session_id,
        workspace,
        body,
+       source_hook,
        created_at
   FROM candidate_sessions
  ORDER BY CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END DESC,

--- a/infrastructure/sqlite/sql/get_context_events.sql
+++ b/infrastructure/sqlite/sql/get_context_events.sql
@@ -1,4 +1,4 @@
-SELECT id, kind, client, agent, session_id, workspace, body, created_at
+SELECT id, kind, client, agent, session_id, workspace, body, source_hook, created_at
   FROM events
  WHERE (? = '' OR workspace = ?)
    AND (? = '' OR session_id = ?)

--- a/infrastructure/sqlite/sql/get_event_details.sql
+++ b/infrastructure/sqlite/sql/get_event_details.sql
@@ -1,4 +1,4 @@
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.created_at,
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at,
        ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code
   FROM events AS e
   LEFT JOIN command_audits AS ca

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -1,4 +1,4 @@
-SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.created_at
+SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits a ON a.event_id = e.id
  WHERE (? = '' OR

--- a/infrastructure/sqlite/sql/select_recent_events.sql
+++ b/infrastructure/sqlite/sql/select_recent_events.sql
@@ -1,4 +1,4 @@
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.created_at
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE (? = '' OR e.kind = ?)
@@ -9,5 +9,17 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.cre
    AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
    AND (? = '' OR e.created_at >= ?)
    AND (? = '' OR e.created_at < ?)
+   AND (
+         ? = ''
+      OR e.source_hook = ?
+      OR (
+           ? = 'subagent_stop' AND e.kind = 'session_ended'
+               AND e.body LIKE '[phase:subagent]%'
+         )
+      OR (
+           ? = 'pre_compact' AND e.kind = 'compact_summary'
+               AND e.body LIKE '[phase:pre-compact]%'
+         )
+       )
  ORDER BY e.created_at DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/presentation/cli/context_command.go
+++ b/presentation/cli/context_command.go
@@ -165,11 +165,16 @@ func writeContextText(output io.Writer, sessionID string, repo string, events []
 	}
 
 	for _, event := range events {
+		hookSuffix := ""
+		if hook := event.SourceHook(); hook != "" {
+			hookSuffix = " (hook=" + hook + ")"
+		}
 		if _, err := fmt.Fprintf(
 			output,
-			"- %s [%s] %s %s/%s %s\n",
+			"- %s [%s]%s %s %s/%s %s\n",
 			event.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
 			event.Kind(),
+			hookSuffix,
 			event.EventID(),
 			formatOptionalColumn(event.Client().String()),
 			event.Agent(),

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -41,14 +41,15 @@ func writeEventJSON(output io.Writer, e *model.Event) error {
 
 func newEventOutput(e *model.Event) event {
 	return event{
-		EventID:   e.EventID().String(),
-		Kind:      e.Kind().String(),
-		Client:    e.Client().String(),
-		Agent:     e.Agent().String(),
-		SessionID: e.SessionID().String(),
-		Workspace: e.Workspace().String(),
-		Message:   apptypes.ExtractPlainBody(e.Body()),
-		CreatedAt: e.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
+		EventID:    e.EventID().String(),
+		Kind:       e.Kind().String(),
+		Client:     e.Client().String(),
+		Agent:      e.Agent().String(),
+		SessionID:  e.SessionID().String(),
+		Workspace:  e.Workspace().String(),
+		Message:    apptypes.ExtractPlainBody(e.Body()),
+		SourceHook: e.SourceHook(),
+		CreatedAt:  e.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
 	}
 }
 

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -65,7 +65,7 @@ func formatTextTimestamp(ts time.Time, opts eventTextFormatOptions, layout strin
 }
 
 func formatEventWideHeader() string {
-	return "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE"
+	return "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE"
 }
 
 func formatEventWideRow(event *model.Event, opts eventTextFormatOptions) string {
@@ -76,6 +76,7 @@ func formatEventWideRow(event *model.Event, opts eventTextFormatOptions) string 
 		string(event.Agent()),
 		event.SessionID().String(),
 		formatOptionalColumn(event.Workspace().String()),
+		formatOptionalColumn(event.SourceHook()),
 		truncateMessage(apptypes.ExtractPlainBody(event.Body())),
 	}, "\t")
 }
@@ -167,6 +168,8 @@ func renderCompactToken(event *model.Event, id readFieldID, opts eventTextFormat
 		return "exit=" + formatOptionalExitCode(extras.exitCode)
 	case readFieldEventID:
 		return "id=" + event.EventID().String()
+	case readFieldSourceHook:
+		return "hook=" + formatOptionalColumn(event.SourceHook())
 	}
 	return ""
 }

--- a/presentation/cli/event_text_formatter_test.go
+++ b/presentation/cli/event_text_formatter_test.go
@@ -154,7 +154,7 @@ func TestFormatEventWideRow_UTCMatchesLegacyFormat(t *testing.T) {
 	)
 
 	got := formatEventWideRow(event, eventTextFormatOptions{wide: true, utc: true})
-	want := "2026-04-15T09:30:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tpayload"
+	want := "2026-04-15T09:30:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tpayload"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("wide row mismatch (-want +got):\n%s", diff)
 	}
@@ -326,8 +326,8 @@ func TestWriteEvents_WideUTCMatchesLegacyTable(t *testing.T) {
 	if err := writeEvents(&buf, []*model.Event{event}, eventTextFormatOptions{wide: true, utc: true}, nil); err != nil {
 		t.Fatalf("writeEvents() error = %v", err)
 	}
-	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
-		"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\thello\n"
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE\n" +
+		"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\thello\n"
 	if diff := cmp.Diff(want, buf.String()); diff != "" {
 		t.Fatalf("writeEvents() wide+utc mismatch (-want +got):\n%s", diff)
 	}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -490,11 +490,11 @@ func (c *RootCLI) runHookCompact(
 		if preContext == "" {
 			preContext = hookPayloadString(payload, "trigger", "")
 		}
-		body := types.EventBodyMarkerCompactPreSnapshot
-		if preContext != "" {
-			body = types.EventBodyMarkerCompactPreSnapshot + " " + preContext
-		}
-		_, err = c.event.Log(ctx, body, types.EventKindCompactSummary, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
+		// source_hook = "pre_compact" (stamped via ctx) now discriminates
+		// the snapshot from post-compact digests. We intentionally drop
+		// the legacy `[phase:pre-compact]` body prefix: readers fall back
+		// to the marker only for pre-#672 rows that lack source_hook.
+		_, err = c.event.Log(ctx, preContext, types.EventKindCompactSummary, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 		if err != nil {
 			return xerrors.Errorf("failed to record pre-compact hook event: %w", err)
 		}
@@ -555,16 +555,12 @@ func (c *RootCLI) runHookSubagentStop(
 		return err
 	}
 	// Claude Code's SubagentStop hook fires whenever a Task-tool subagent
-	// completes. The payload typically carries `subagent_type` or
-	// `subagent_id`; we persist an explicit session_ended event marked
-	// with a `[phase:subagent]` prefix so subagent lifecycle is
-	// recoverable without relying on agent_type inference on PostToolUse.
+	// completes. source_hook = "subagent_stop" (stamped via ctx) now
+	// discriminates the subagent boundary from main-session session_ended
+	// events; the legacy `[phase:subagent]` body prefix is retired on
+	// write but readers still match it for pre-#672 rows.
 	subagentType := hookPayloadString(payload, "subagent_type", "")
-	body := types.EventBodyMarkerSubagentStop
-	if subagentType != "" {
-		body = types.EventBodyMarkerSubagentStop + " " + subagentType
-	}
-	_, err = c.event.Log(ctx, body, types.EventKindSessionEnded, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
+	_, err = c.event.Log(ctx, subagentType, types.EventKindSessionEnded, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 	if err != nil {
 		return xerrors.Errorf("failed to record subagent-stop event: %w", err)
 	}

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -457,11 +457,11 @@ func TestRootCLI_HookCompactCommand_RecordsPreCompactSnapshot(t *testing.T) {
 	if got, want := eventStub.logCall.kind, types.EventKindCompactSummary; got != want {
 		t.Fatalf("pre-compact log kind = %q, want %q", got, want)
 	}
-	if !strings.HasPrefix(eventStub.logCall.message, types.EventBodyMarkerCompactPreSnapshot) {
-		t.Fatalf("pre-compact log message = %q, want prefix %q", eventStub.logCall.message, types.EventBodyMarkerCompactPreSnapshot)
+	if got, want := eventStub.logCall.message, "size-threshold"; got != want {
+		t.Fatalf("pre-compact log message = %q, want %q (phase marker is retired; source_hook discriminates)", got, want)
 	}
-	if !strings.Contains(eventStub.logCall.message, "size-threshold") {
-		t.Fatalf("pre-compact log message = %q, want trigger context appended", eventStub.logCall.message)
+	if got, want := eventStub.logCall.sourceHook, "pre_compact"; got != want {
+		t.Fatalf("pre-compact log source_hook = %q, want %q", got, want)
 	}
 }
 
@@ -511,11 +511,11 @@ func TestRootCLI_HookSubagentStopCommand_RecordsSessionEnded(t *testing.T) {
 	if got, want := eventStub.logCall.kind, types.EventKindSessionEnded; got != want {
 		t.Fatalf("subagent-stop log kind = %q, want %q", got, want)
 	}
-	if !strings.HasPrefix(eventStub.logCall.message, types.EventBodyMarkerSubagentStop) {
-		t.Fatalf("subagent-stop log message = %q, want prefix %q", eventStub.logCall.message, types.EventBodyMarkerSubagentStop)
+	if got, want := eventStub.logCall.message, "code-reviewer"; got != want {
+		t.Fatalf("subagent-stop log message = %q, want %q (phase marker is retired; source_hook discriminates)", got, want)
 	}
-	if !strings.Contains(eventStub.logCall.message, "code-reviewer") {
-		t.Fatalf("subagent-stop log message = %q, want subagent_type appended", eventStub.logCall.message)
+	if got, want := eventStub.logCall.sourceHook, "subagent_stop"; got != want {
+		t.Fatalf("subagent-stop log source_hook = %q, want %q", got, want)
 	}
 }
 

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -120,6 +120,7 @@ type listCommandInput struct {
 	to           string
 	until        string
 	failuresOnly bool
+	sourceHook   string
 	asJSON       bool
 	wide         bool
 	utc          bool
@@ -134,6 +135,7 @@ type listCommandInput struct {
 	sessionIDSet    bool
 	repoSet         bool
 	failuresOnlySet bool
+	sourceHookSet   bool
 	color           string
 	colorSet        bool
 }

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -27,6 +27,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 		to           string
 		until        string
 		failuresOnly bool
+		sourceHook   string
 		asJSON       bool
 		wide         bool
 		utc          bool
@@ -54,6 +55,8 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 				to:              to,
 				until:           until,
 				failuresOnly:    failuresOnly,
+				sourceHook:      sourceHook,
+				sourceHookSet:   cmd.Flags().Changed("source-hook"),
 				asJSON:          asJSON,
 				wide:            wide,
 				utc:             utc,
@@ -85,6 +88,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&to, "to", "", Localize("end date (`YYYY-MM-DD` or RFC3339)", "終了日 (`YYYY-MM-DD` または RFC3339)"))
 	listCmd.Flags().StringVar(&until, "until", "", Localize("end date (`YYYY-MM-DD` or RFC3339) (alias for `--to`)", "終了日 (`YYYY-MM-DD` または RFC3339) (`--to` の別名)"))
 	listCmd.Flags().BoolVar(&failuresOnly, "failures", false, Localize("show only failed commands", "失敗したコマンドのみ表示"))
+	listCmd.Flags().StringVar(&sourceHook, "source-hook", "", Localize("filter by hook identifier that produced the event (e.g. stop, subagent_stop, pre_compact, post_compact, session_start, session_end, user_prompt_submit, post_tool_use, after_agent, after_tool)", "イベントを生成した hook 識別子で絞り込む (例: stop, subagent_stop, pre_compact, post_compact, session_start, session_end, user_prompt_submit, post_tool_use, after_agent, after_tool)"))
 	listCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	listCmd.Flags().BoolVar(&wide, "wide", false, Localize("use the legacy tab-separated seven-column format", "従来のタブ区切り 7 カラム形式で出力する"))
 	listCmd.Flags().BoolVar(&utc, "utc", false, Localize("print text timestamps in UTC instead of local time", "テキスト出力のタイムスタンプを現地時刻ではなく UTC で出力する"))
@@ -161,6 +165,7 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		SessionID(types.SessionID(strings.TrimSpace(input.sessionID))).
 		Workspace(types.Workspace(resolveWorkspaceValue(ctx, input.repo))).
 		FailuresOnly(input.failuresOnly).
+		SourceHook(strings.TrimSpace(input.sourceHook)).
 		From(fromTime).
 		To(toTime).
 		Build()

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -69,8 +69,8 @@ func TestRootCLI_ListCommand(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
-		want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
-			"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\thello\n"
+		want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE\n" +
+			"2026-04-07T12:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\thello\n"
 		if stdout.String() != want {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -2,14 +2,15 @@ package cli
 
 // event is the JSON shape of an event in CLI output.
 type event struct {
-	EventID   string `json:"event_id"`
-	Kind      string `json:"kind"`
-	Client    string `json:"client"`
-	Agent     string `json:"agent"`
-	SessionID string `json:"session_id"`
-	Workspace string `json:"workspace"`
-	Message   string `json:"message"`
-	CreatedAt string `json:"created_at"`
+	EventID    string `json:"event_id"`
+	Kind       string `json:"kind"`
+	Client     string `json:"client"`
+	Agent      string `json:"agent"`
+	SessionID  string `json:"session_id"`
+	Workspace  string `json:"workspace"`
+	Message    string `json:"message"`
+	SourceHook string `json:"source_hook,omitempty"`
+	CreatedAt  string `json:"created_at"`
 }
 
 // commandAudit is the JSON shape of a command audit in CLI output.

--- a/presentation/cli/read_fields.go
+++ b/presentation/cli/read_fields.go
@@ -24,6 +24,7 @@ const (
 	readFieldMessage   readFieldID = "message"
 	readFieldExitCode  readFieldID = "exit_code"
 	readFieldEventID   readFieldID = "id"
+	readFieldSourceHook readFieldID = "source_hook"
 )
 
 // supportedReadFields is the canonical list of field IDs accepted by the
@@ -39,6 +40,7 @@ var supportedReadFields = []readFieldID{
 	readFieldMessage,
 	readFieldExitCode,
 	readFieldEventID,
+	readFieldSourceHook,
 }
 
 // defaultReadFields is the built-in default column order. Starting in

--- a/presentation/cli/replay.go
+++ b/presentation/cli/replay.go
@@ -180,12 +180,13 @@ type replaySession struct {
 }
 
 type replayEvent struct {
-	EventID   string
-	Kind      string
-	CreatedAt time.Time
-	Client    string
-	Agent     string
-	Body      string
+	EventID    string
+	Kind       string
+	CreatedAt  time.Time
+	Client     string
+	Agent      string
+	Body       string
+	SourceHook string
 }
 
 type replayMemory struct {
@@ -217,12 +218,13 @@ func replayDataFromBundle(bundle apptypes.ReplayBundle, dbPathFlag string) repla
 		converted := make([]replayEvent, 0, len(events))
 		for _, event := range events {
 			converted = append(converted, replayEvent{
-				EventID:   event.EventID().String(),
-				Kind:      event.Kind().String(),
-				CreatedAt: event.CreatedAt().UTC(),
-				Client:    event.Client().String(),
-				Agent:     event.Agent().String(),
-				Body:      apptypes.ExtractPlainBody(event.Body()),
+				EventID:    event.EventID().String(),
+				Kind:       event.Kind().String(),
+				CreatedAt:  event.CreatedAt().UTC(),
+				Client:     event.Client().String(),
+				Agent:      event.Agent().String(),
+				Body:       apptypes.ExtractPlainBody(event.Body()),
+				SourceHook: event.SourceHook(),
 			})
 		}
 		data.Sessions = append(data.Sessions, replaySession{

--- a/presentation/cli/replay_template.html
+++ b/presentation/cli/replay_template.html
@@ -41,6 +41,7 @@
   ul.events li { padding: 6px 0; border-bottom: 1px dashed var(--border); display: grid; grid-template-columns: 180px 150px 200px 1fr; gap: 12px; }
   ul.events li .t { color: var(--muted); font-family: ui-monospace,'SF Mono',Menlo,monospace; font-size: 12px; }
   ul.events li .k { font-family: ui-monospace,'SF Mono',Menlo,monospace; font-size: 12px; }
+  ul.events li .k .hook { color: var(--muted); font-size: 11px; }
   ul.events li .agent { color: var(--muted); font-family: ui-monospace,'SF Mono',Menlo,monospace; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   ul.events li .k.prompt { color: var(--prompt); }
   ul.events li .k.transcript { color: var(--transcript); }
@@ -96,7 +97,7 @@
           {{range .Events}}
             <li>
               <span class="t">{{fmtInstant .CreatedAt}}</span>
-              <span class="k {{.Kind}}">{{.Kind}}</span>
+              <span class="k {{.Kind}}">{{.Kind}}{{if .SourceHook}} <span class="hook" title="producing hook">{{.SourceHook}}</span>{{end}}</span>
               <span class="agent" title="{{.Agent}} · {{.Client}}">{{.Agent}}{{if .Client}} / {{.Client}}{{end}}</span>
               <span class="body">{{short .Body 480}}</span>
             </li>

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -65,13 +65,14 @@ func writeEventDetails(output io.Writer, eventDetails apptypes.EventDetails) err
 	event := eventDetails.Event()
 	if _, err := fmt.Fprintf(
 		output,
-		"EVENT_ID: %s\nKIND: %s\nCLIENT: %s\nAGENT: %s\nSESSION_ID: %s\nWORKSPACE: %s\nCREATED_AT: %s\nMESSAGE: %s\n",
+		"EVENT_ID: %s\nKIND: %s\nCLIENT: %s\nAGENT: %s\nSESSION_ID: %s\nWORKSPACE: %s\nSOURCE_HOOK: %s\nCREATED_AT: %s\nMESSAGE: %s\n",
 		event.EventID(),
 		event.Kind(),
 		formatOptionalColumn(event.Client().String()),
 		event.Agent(),
 		event.SessionID(),
 		formatOptionalColumn(event.Workspace().String()),
+		formatOptionalColumn(event.SourceHook()),
 		event.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
 		apptypes.ExtractPlainBody(event.Body()),
 	); err != nil {

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -76,6 +76,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 			"AGENT: codex\n" +
 			"SESSION_ID: session-1\n" +
 			"WORKSPACE: duck8823/traceary\n" +
+			"SOURCE_HOOK: -\n" +
 			"CREATED_AT: 2026-04-08T12:00:00Z\n" +
 			"MESSAGE: go test ./...\n" +
 			"\n" +

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -167,10 +167,10 @@ func TestRunTail_PrintsInitialEventsAndFollowsNewEvents(t *testing.T) {
 		t.Fatalf("runTail() error = %v", err)
 	}
 
-	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
-		"2026-04-13T18:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tolder\n" +
-		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tnewer\n" +
-		"2026-04-13T18:10:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tlatest\n"
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE\n" +
+		"2026-04-13T18:00:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tolder\n" +
+		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tnewer\n" +
+		"2026-04-13T18:10:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tlatest\n"
 	if stdout.String() != want {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 	}
@@ -226,8 +226,8 @@ func TestRunTail_ZeroLimitStartsFromNow(t *testing.T) {
 		t.Fatalf("runTail() error = %v", err)
 	}
 
-	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
-		"2026-04-13T19:45:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tnew\n"
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE\n" +
+		"2026-04-13T19:45:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tnew\n"
 	if stdout.String() != want {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 	}
@@ -345,8 +345,8 @@ func TestRunTail_DoesNotReEmitBoundaryEventWhenFromEqualsInitialTimestamp(t *tes
 		t.Fatalf("runTail() error = %v", err)
 	}
 
-	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tMESSAGE\n" +
-		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\tboundary\n"
+	want := "CREATED_AT\tKIND\tCLIENT\tAGENT\tSESSION_ID\tWORKSPACE\tSOURCE_HOOK\tMESSAGE\n" +
+		"2026-04-13T18:05:00Z\tnote\tcli\tcodex\tsession-1\tduck8823/traceary\t-\tboundary\n"
 	if stdout.String() != want {
 		t.Fatalf("stdout = %q, want %q (event must appear exactly once despite From()==cursor.timestamp)", stdout.String(), want)
 	}

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -28,13 +28,14 @@ type eventUsecaseStub struct {
 	timelineErr    error
 
 	logCall struct {
-		message   string
-		kind      types.EventKind
-		client    types.Client
-		agent     types.Agent
-		sessionID types.SessionID
-		workspace types.Workspace
-		logCfg    apptypes.LogRedaction
+		message    string
+		kind       types.EventKind
+		client     types.Client
+		agent      types.Agent
+		sessionID  types.SessionID
+		workspace  types.Workspace
+		logCfg     apptypes.LogRedaction
+		sourceHook string
 	}
 	auditCall struct {
 		command   string
@@ -49,7 +50,7 @@ type eventUsecaseStub struct {
 	}
 }
 
-func (s *eventUsecaseStub) Log(_ context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
+func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
 	s.logCall.message = message
 	s.logCall.kind = kind
 	s.logCall.client = client
@@ -57,6 +58,7 @@ func (s *eventUsecaseStub) Log(_ context.Context, message string, kind types.Eve
 	s.logCall.sessionID = sessionID
 	s.logCall.workspace = workspace
 	s.logCall.logCfg = logCfg
+	s.logCall.sourceHook = apptypes.SourceHookFromContext(ctx)
 	return s.logEvent, s.logErr
 }
 func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -55,8 +55,9 @@ type listEventsInput struct {
 	Agent     string `json:"agent,omitempty" jsonschema:"filter by agent"`
 	SessionID string `json:"session_id,omitempty" jsonschema:"filter by session ID"`
 	Workspace string `json:"workspace,omitempty" jsonschema:"filter by work context"`
-	From      string `json:"from,omitempty" jsonschema:"start time (YYYY-MM-DD or RFC3339)"`
-	To        string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
+	From       string `json:"from,omitempty" jsonschema:"start time (YYYY-MM-DD or RFC3339)"`
+	To         string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
+	SourceHook string `json:"source_hook,omitempty" jsonschema:"filter by hook identifier that produced the event (stop, subagent_stop, pre_compact, post_compact, session_start, session_end, user_prompt_submit, post_tool_use, after_agent, after_tool)"`
 }
 
 // searchInput is the MCP input for the search tool.

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -15,13 +15,14 @@ type addLogOutput struct {
 
 // sessionEventOutput is the MCP output for session tools (start/end/active/latest).
 type sessionEventOutput struct {
-	EventID   string `json:"event_id" jsonschema:"saved or referenced event ID"`
-	Kind      string `json:"kind" jsonschema:"event kind"`
-	Client    string `json:"client" jsonschema:"recording channel"`
-	Agent     string `json:"agent" jsonschema:"actor"`
-	SessionID string `json:"session_id" jsonschema:"session identifier"`
-	Workspace string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	CreatedAt string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID    string `json:"event_id" jsonschema:"saved or referenced event ID"`
+	Kind       string `json:"kind" jsonschema:"event kind"`
+	Client     string `json:"client" jsonschema:"recording channel"`
+	Agent      string `json:"agent" jsonschema:"actor"`
+	SessionID  string `json:"session_id" jsonschema:"session identifier"`
+	Workspace  string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	SourceHook string `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt  string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // addAuditOutput is the MCP output for the add_audit tool.

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -2,14 +2,15 @@ package mcpserver
 
 // addLogOutput is the MCP output for the add_log tool.
 type addLogOutput struct {
-	EventID   string `json:"event_id" jsonschema:"saved event ID"`
-	Kind      string `json:"kind" jsonschema:"event kind"`
-	Client    string `json:"client" jsonschema:"recording channel"`
-	Agent     string `json:"agent" jsonschema:"actor"`
-	SessionID string `json:"session_id" jsonschema:"session identifier"`
-	Workspace string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body      string `json:"body" jsonschema:"event body"`
-	CreatedAt string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID    string `json:"event_id" jsonschema:"saved event ID"`
+	Kind       string `json:"kind" jsonschema:"event kind"`
+	Client     string `json:"client" jsonschema:"recording channel"`
+	Agent      string `json:"agent" jsonschema:"actor"`
+	SessionID  string `json:"session_id" jsonschema:"session identifier"`
+	Workspace  string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body       string `json:"body" jsonschema:"event body"`
+	SourceHook string `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt  string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionEventOutput is the MCP output for session tools (start/end/active/latest).
@@ -44,14 +45,15 @@ type eventsOutput struct {
 
 // eventOutput is an individual event in an eventsOutput list.
 type eventOutput struct {
-	EventID   string `json:"event_id" jsonschema:"event ID"`
-	Kind      string `json:"kind" jsonschema:"event kind"`
-	Client    string `json:"client" jsonschema:"recording channel"`
-	Agent     string `json:"agent" jsonschema:"actor"`
-	SessionID string `json:"session_id" jsonschema:"session identifier"`
-	Workspace string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body      string `json:"body" jsonschema:"event body"`
-	CreatedAt string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID    string `json:"event_id" jsonschema:"event ID"`
+	Kind       string `json:"kind" jsonschema:"event kind"`
+	Client     string `json:"client" jsonschema:"recording channel"`
+	Agent      string `json:"agent" jsonschema:"actor"`
+	SessionID  string `json:"session_id" jsonschema:"session identifier"`
+	Workspace  string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body       string `json:"body" jsonschema:"event body"`
+	SourceHook string `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt  string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -267,14 +267,15 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 		}
 
 		return nil, addLogOutput{
-			EventID:   event.EventID().String(),
-			Kind:      event.Kind().String(),
-			Client:    event.Client().String(),
-			Agent:     event.Agent().String(),
-			SessionID: event.SessionID().String(),
-			Workspace: event.Workspace().String(),
-			Body:      apptypes.ExtractPlainBody(event.Body()),
-			CreatedAt: event.CreatedAt().UTC().Format(time.RFC3339Nano),
+			EventID:    event.EventID().String(),
+			Kind:       event.Kind().String(),
+			Client:     event.Client().String(),
+			Agent:      event.Agent().String(),
+			SessionID:  event.SessionID().String(),
+			Workspace:  event.Workspace().String(),
+			Body:       apptypes.ExtractPlainBody(event.Body()),
+			SourceHook: event.SourceHook(),
+			CreatedAt:  event.CreatedAt().UTC().Format(time.RFC3339Nano),
 		}, nil
 	}
 }
@@ -414,6 +415,7 @@ func (s *Server) listEvents() mcp.ToolHandlerFor[listEventsInput, eventsOutput] 
 			Agent(types.Agent(strings.TrimSpace(input.Agent))).
 			SessionID(types.SessionID(strings.TrimSpace(input.SessionID))).
 			Workspace(types.Workspace(strings.TrimSpace(input.Workspace))).
+			SourceHook(strings.TrimSpace(input.SourceHook)).
 			From(from).
 			To(to).
 			Build()
@@ -1471,14 +1473,15 @@ func convertEvents(events []*model.Event) []eventOutput {
 	outputs := make([]eventOutput, 0, len(events))
 	for _, event := range events {
 		outputs = append(outputs, eventOutput{
-			EventID:   event.EventID().String(),
-			Kind:      event.Kind().String(),
-			Client:    event.Client().String(),
+			EventID:    event.EventID().String(),
+			Kind:       event.Kind().String(),
+			Client:     event.Client().String(),
 			Agent:     event.Agent().String(),
-			SessionID: event.SessionID().String(),
-			Workspace: event.Workspace().String(),
-			Body:      apptypes.ExtractPlainBody(event.Body()),
-			CreatedAt: event.CreatedAt().UTC().Format(time.RFC3339Nano),
+			SessionID:  event.SessionID().String(),
+			Workspace:  event.Workspace().String(),
+			Body:       apptypes.ExtractPlainBody(event.Body()),
+			SourceHook: event.SourceHook(),
+			CreatedAt:  event.CreatedAt().UTC().Format(time.RFC3339Nano),
 		})
 	}
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -430,13 +430,14 @@ func (s *Server) listEvents() mcp.ToolHandlerFor[listEventsInput, eventsOutput] 
 
 func newSessionEventOutput(event *model.Event) sessionEventOutput {
 	return sessionEventOutput{
-		EventID:   event.EventID().String(),
-		Kind:      event.Kind().String(),
-		Client:    event.Client().String(),
-		Agent:     event.Agent().String(),
-		SessionID: event.SessionID().String(),
-		Workspace: event.Workspace().String(),
-		CreatedAt: event.CreatedAt().UTC().Format(time.RFC3339Nano),
+		EventID:    event.EventID().String(),
+		Kind:       event.Kind().String(),
+		Client:     event.Client().String(),
+		Agent:      event.Agent().String(),
+		SessionID:  event.SessionID().String(),
+		Workspace:  event.Workspace().String(),
+		SourceHook: event.SourceHook(),
+		CreatedAt:  event.CreatedAt().UTC().Format(time.RFC3339Nano),
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #679.

- Plumbs `events.source_hook` through all read-side SQL + scan/restore pipelines so the column actually surfaces in CLI JSON, \`traceary show\`, MCP list_events / add_log, and replay HTML.
- Adds \`traceary list --source-hook <name>\` and MCP list_events \`source_hook\` param. Filter matches \`e.source_hook = ?\` plus legacy body-prefix fallback for pre-#672 rows (\`[phase:subagent]\` for subagent_stop, \`[phase:pre-compact]\` for pre_compact).
- Retires write-side body-prefix markers: hook_runtime persists \`compact_summary\` with just the trigger context and \`session_ended\` (SubagentStop) with just the subagent_type; source_hook (stamped via ctx) discriminates. context_pack_builder now prefers source_hook over the body prefix and keeps the prefix check only for legacy rows.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` — 1019 passed / 16 packages
- [x] \`go tool golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)