### PR TITLE
fix(search): skip thinking-block text in transcript JSON envelopes

### DIFF
--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -211,6 +211,58 @@ func TestDatasource_Search_SkipsThinkingOnlyMatches(t *testing.T) {
 	}
 }
 
+func TestDatasource_Search_PreservesNonCanonicalBlocksBody(t *testing.T) {
+	t.Parallel()
+
+	// Non-canonical envelope: has a "blocks" key but elements do not
+	// match the {type:string, text:string} shape. ExtractPlainBody
+	// returns the raw body for these, so search must keep the raw body
+	// searchable too — otherwise the search surface and the display
+	// surface disagree.
+	migrations := searchEventsMigrations()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	ws := "github.com/duck8823/traceary"
+	cases := []struct {
+		name string
+		id   string
+		body string
+	}{
+		{"element missing type/text", "event-foreign-shape", `{"blocks":[{"foo":"non-canonical-needle"}]}`},
+		{"text field is non-string", "event-nonstring-text", `{"blocks":[{"type":"text","text":42}]}`},
+		{"type field is non-string", "event-nonstring-type", `{"blocks":[{"type":42,"text":"non-canonical-needle"}]}`},
+		{"blocks:null falls through", "event-blocks-null", `{"blocks":null,"note":"non-canonical-needle"}`},
+	}
+	for i, c := range cases {
+		fixture := newSearchEventFixture(
+			t,
+			c.id,
+			types.EventKindNote,
+			ws,
+			c.body,
+			time.Date(2026, 4, 15, 12, i, 0, 0, time.UTC),
+		)
+		if err := sut.Save(context.Background(), fixture); err != nil {
+			t.Fatalf("Save(%s) error = %v", c.name, err)
+		}
+	}
+
+	filtered, err := sut.Search(context.Background(), "non-canonical-needle", types.Workspace(ws), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	// All 3 bodies that contain the needle literal in their raw JSON
+	// must match (the nonstring-text case does not contain the string
+	// "non-canonical-needle", so we expect 3 hits, not 4).
+	if len(filtered) != 3 {
+		t.Fatalf("len(filtered) = %d, want 3 (non-canonical envelopes must remain raw-searchable)", len(filtered))
+	}
+}
+
 func TestDatasource_Search_PreservesNonEnvelopeJSONBody(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -147,6 +147,137 @@ CREATE TABLE command_audits (
 			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
 		}
 	})
+
+	t.Run("matches literal backslashes in search queries", func(t *testing.T) {
+		t.Parallel()
+
+		filtered, err := sut.Search(context.Background(), `C:\traceary\logs`, types.Workspace("github.com/duck8823/traceary"), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Time{}, time.Time{}, 10, 0, false)
+		if err != nil {
+			t.Fatalf("Search() error = %v", err)
+		}
+		if len(filtered) != 1 {
+			t.Fatalf("len(filtered) = %d, want 1", len(filtered))
+		}
+		if diff := cmp.Diff("event-path", filtered[0].EventID().String()); diff != "" {
+			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestDatasource_Search_SkipsThinkingOnlyMatches(t *testing.T) {
+	t.Parallel()
+
+	migrations := searchEventsMigrations()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	ws := "github.com/duck8823/traceary"
+	thinkingOnly := newSearchEventFixture(
+		t,
+		"event-thinking-only",
+		types.EventKindTranscript,
+		ws,
+		`{"blocks":[{"type":"thinking","text":"secret-needle reasoning"}]}`,
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), thinkingOnly); err != nil {
+		t.Fatalf("Save(thinkingOnly) error = %v", err)
+	}
+
+	mixed := newSearchEventFixture(
+		t,
+		"event-mixed",
+		types.EventKindTranscript,
+		ws,
+		`{"blocks":[{"type":"thinking","text":"ignore me"},{"type":"text","text":"secret-needle visible"}]}`,
+		time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), mixed); err != nil {
+		t.Fatalf("Save(mixed) error = %v", err)
+	}
+
+	filtered, err := sut.Search(context.Background(), "secret-needle", types.Workspace(ws), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("len(filtered) = %d, want 1 (mixed-block row only; thinking-only row must be filtered out)", len(filtered))
+	}
+	if diff := cmp.Diff("event-mixed", filtered[0].EventID().String()); diff != "" {
+		t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDatasource_Search_PreservesNonEnvelopeJSONBody(t *testing.T) {
+	t.Parallel()
+
+	migrations := searchEventsMigrations()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	ws := "github.com/duck8823/traceary"
+	nonEnvelope := newSearchEventFixture(
+		t,
+		"event-non-envelope",
+		types.EventKindNote,
+		ws,
+		`{"foo":"unique-json-marker"}`,
+		time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), nonEnvelope); err != nil {
+		t.Fatalf("Save(nonEnvelope) error = %v", err)
+	}
+
+	filtered, err := sut.Search(context.Background(), "unique-json-marker", types.Workspace(ws), types.SessionID(""), types.Client(""), types.Agent(""), types.EventKind(""), time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("len(filtered) = %d, want 1", len(filtered))
+	}
+	if diff := cmp.Diff("event-non-envelope", filtered[0].EventID().String()); diff != "" {
+		t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func searchEventsMigrations() fstest.MapFS {
+	return fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    source_hook TEXT
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER
+);`),
+		},
+	}
 }
 
 func newSearchEventFixture(

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -1,8 +1,23 @@
+-- Transcript / prompt bodies from v0.8.1+ are JSON envelopes that
+-- separate thinking blocks from user-visible text blocks (see #662).
+-- Matching raw body would let a "needle" inside a thinking block
+-- surface as a search hit that then renders empty via ExtractPlainBody
+-- (confusing UX and effectively leaking internal reasoning into the
+-- search surface). Strip thinking before matching: when body parses as
+-- a canonical envelope, match only the joined text-block content;
+-- otherwise keep the raw body (legacy plain text, non-envelope JSON).
 SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits a ON a.event_id = e.id
  WHERE (? = '' OR
-        e.body LIKE ? ESCAPE '\' OR
+        (CASE WHEN json_valid(e.body) AND json_type(e.body, '$.blocks') = 'array'
+              THEN COALESCE(
+                     (SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
+                        FROM json_each(json_extract(e.body, '$.blocks'))
+                       WHERE json_extract(value, '$.type') = 'text'),
+                     '')
+              ELSE e.body
+         END) LIKE ? ESCAPE '\' OR
         COALESCE(a.command_text, '') LIKE ? ESCAPE '\' OR
         COALESCE(a.input_text, '') LIKE ? ESCAPE '\' OR
         COALESCE(a.output_text, '') LIKE ? ESCAPE '\')

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -10,7 +10,14 @@ SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.bo
   FROM events e
   LEFT JOIN command_audits a ON a.event_id = e.id
  WHERE (? = '' OR
-        (CASE WHEN json_valid(e.body) AND json_type(e.body, '$.blocks') = 'array'
+        (CASE WHEN json_valid(e.body)
+                   AND json_type(e.body, '$.blocks') = 'array'
+                   AND NOT EXISTS (
+                     SELECT 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
+                   )
               THEN COALESCE(
                      (SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
                         FROM json_each(json_extract(e.body, '$.blocks'))


### PR DESCRIPTION
## Summary
Closes #682.

Since #662/#680, transcript bodies are stored as \`{"blocks":[{"type":"thinking","text":"..."},{"type":"text","text":"..."}]}\` JSON envelopes. The search SQL still ran \`e.body LIKE ?\` against the raw stored body, so a query that only matched text inside a \`thinking\` block returned the row — but CLI/MCP rendered it via \`ExtractPlainBody\` with thinking stripped, so the user saw a "match" they could not locate in the displayed body.

Fix: in \`search_events.sql\`, match against a CASE expression that extracts only text-block content when the body is a canonical envelope. Legacy plain-text rows and non-envelope JSON bodies keep matching verbatim.

## Test plan
- [x] \`go test ./...\` — 1022 passed / 16 packages (2 new test cases: thinking-only filtered, non-envelope JSON preserved)
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)