### PR TITLE
feat(mcp): expose body_blocks for canonical transcript envelopes

### DIFF
--- a/application/types/event_body_blocks.go
+++ b/application/types/event_body_blocks.go
@@ -38,6 +38,20 @@ type EventBodyBlocks struct {
 	Blocks []EventBodyBlock `json:"blocks"`
 }
 
+// DecodeCanonicalEnvelope is the exported form of
+// decodeCanonicalEnvelope. Callers that need to render block-structured
+// output (for example MCP tools that want to expose thinking vs text
+// separately) can use it to decide whether a body is a canonical
+// envelope worth serialising as blocks — returning ok=false means
+// "fall back to the raw body / plain-text projection".
+func DecodeCanonicalEnvelope(body string) ([]EventBodyBlock, bool) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || trimmed[0] != '{' {
+		return nil, false
+	}
+	return decodeCanonicalEnvelope(trimmed)
+}
+
 // decodeCanonicalEnvelope returns the block slice encoded in body if
 // and only if body is a canonical transcript envelope:
 //

--- a/application/types/event_body_blocks_test.go
+++ b/application/types/event_body_blocks_test.go
@@ -77,6 +77,40 @@ func TestExtractPlainBody(t *testing.T) {
 	}
 }
 
+func TestDecodeCanonicalEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		body      string
+		wantOK    bool
+		wantCount int
+	}{
+		{"empty body not envelope", "", false, 0},
+		{"legacy plain text not envelope", "hello", false, 0},
+		{"non-envelope JSON not envelope", `{"foo":"bar"}`, false, 0},
+		{"capital-B Blocks is not envelope", `{"Blocks":[{"type":"text","text":"hi"}]}`, false, 0},
+		{"blocks:null not envelope", `{"blocks":null}`, false, 0},
+		{"element missing type/text not envelope", `{"blocks":[{"foo":"bar"}]}`, false, 0},
+		{"non-string type not envelope", `{"blocks":[{"type":42,"text":"x"}]}`, false, 0},
+		{"empty blocks array is envelope", `{"blocks":[]}`, true, 0},
+		{"canonical envelope returns blocks", `{"blocks":[{"type":"thinking","text":"a"},{"type":"text","text":"b"}]}`, true, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := DecodeCanonicalEnvelope(tc.body)
+			if ok != tc.wantOK {
+				t.Errorf("DecodeCanonicalEnvelope(%q) ok = %v, want %v", tc.body, ok, tc.wantOK)
+			}
+			if len(got) != tc.wantCount {
+				t.Errorf("DecodeCanonicalEnvelope(%q) len = %d, want %d", tc.body, len(got), tc.wantCount)
+			}
+		})
+	}
+}
+
 func TestParseEventBodyBlocks(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -11,7 +11,7 @@ type addLogOutput struct {
 	SessionID  string                     `json:"session_id" jsonschema:"session identifier"`
 	Workspace  string                     `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
 	Body       string                     `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form"`
-	BodyBlocks []apptypes.EventBodyBlock  `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; absent for legacy plain-text bodies and non-envelope JSON bodies"`
+	BodyBlocks []apptypes.EventBodyBlock  `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope with at least one block; absent for legacy plain-text bodies, non-envelope JSON bodies, and empty envelopes"`
 	SourceHook string                     `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
 	CreatedAt  string                     `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -1,16 +1,19 @@
 package mcpserver
 
+import apptypes "github.com/duck8823/traceary/application/types"
+
 // addLogOutput is the MCP output for the add_log tool.
 type addLogOutput struct {
-	EventID    string `json:"event_id" jsonschema:"saved event ID"`
-	Kind       string `json:"kind" jsonschema:"event kind"`
-	Client     string `json:"client" jsonschema:"recording channel"`
-	Agent      string `json:"agent" jsonschema:"actor"`
-	SessionID  string `json:"session_id" jsonschema:"session identifier"`
-	Workspace  string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body       string `json:"body" jsonschema:"event body"`
-	SourceHook string `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
-	CreatedAt  string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID    string                     `json:"event_id" jsonschema:"saved event ID"`
+	Kind       string                     `json:"kind" jsonschema:"event kind"`
+	Client     string                     `json:"client" jsonschema:"recording channel"`
+	Agent      string                     `json:"agent" jsonschema:"actor"`
+	SessionID  string                     `json:"session_id" jsonschema:"session identifier"`
+	Workspace  string                     `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body       string                     `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form"`
+	BodyBlocks []apptypes.EventBodyBlock  `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; absent for legacy plain-text bodies and non-envelope JSON bodies"`
+	SourceHook string                     `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt  string                     `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionEventOutput is the MCP output for session tools (start/end/active/latest).
@@ -46,15 +49,16 @@ type eventsOutput struct {
 
 // eventOutput is an individual event in an eventsOutput list.
 type eventOutput struct {
-	EventID    string `json:"event_id" jsonschema:"event ID"`
-	Kind       string `json:"kind" jsonschema:"event kind"`
-	Client     string `json:"client" jsonschema:"recording channel"`
-	Agent      string `json:"agent" jsonschema:"actor"`
-	SessionID  string `json:"session_id" jsonschema:"session identifier"`
-	Workspace  string `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body       string `json:"body" jsonschema:"event body"`
-	SourceHook string `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
-	CreatedAt  string `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID    string                    `json:"event_id" jsonschema:"event ID"`
+	Kind       string                    `json:"kind" jsonschema:"event kind"`
+	Client     string                    `json:"client" jsonschema:"recording channel"`
+	Agent      string                    `json:"agent" jsonschema:"actor"`
+	SessionID  string                    `json:"session_id" jsonschema:"session identifier"`
+	Workspace  string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body       string                    `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form"`
+	BodyBlocks []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; absent for legacy plain-text bodies and non-envelope JSON bodies"`
+	SourceHook string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt  string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -266,6 +266,7 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 			return nil, addLogOutput{}, xerrors.Errorf("failed to record log: %w", err)
 		}
 
+		blocks, _ := apptypes.DecodeCanonicalEnvelope(event.Body())
 		return nil, addLogOutput{
 			EventID:    event.EventID().String(),
 			Kind:       event.Kind().String(),
@@ -274,6 +275,7 @@ func (s *Server) addLog() mcp.ToolHandlerFor[addLogInput, addLogOutput] {
 			SessionID:  event.SessionID().String(),
 			Workspace:  event.Workspace().String(),
 			Body:       apptypes.ExtractPlainBody(event.Body()),
+			BodyBlocks: blocks,
 			SourceHook: event.SourceHook(),
 			CreatedAt:  event.CreatedAt().UTC().Format(time.RFC3339Nano),
 		}, nil
@@ -1473,14 +1475,16 @@ func parseFlexibleTimeOptional(value string) (types.Optional[time.Time], error) 
 func convertEvents(events []*model.Event) []eventOutput {
 	outputs := make([]eventOutput, 0, len(events))
 	for _, event := range events {
+		blocks, _ := apptypes.DecodeCanonicalEnvelope(event.Body())
 		outputs = append(outputs, eventOutput{
 			EventID:    event.EventID().String(),
 			Kind:       event.Kind().String(),
 			Client:     event.Client().String(),
-			Agent:     event.Agent().String(),
+			Agent:      event.Agent().String(),
 			SessionID:  event.SessionID().String(),
 			Workspace:  event.Workspace().String(),
 			Body:       apptypes.ExtractPlainBody(event.Body()),
+			BodyBlocks: blocks,
 			SourceHook: event.SourceHook(),
 			CreatedAt:  event.CreatedAt().UTC().Format(time.RFC3339Nano),
 		})


### PR DESCRIPTION
## Summary
Closes #684.

MCP \`list_events\` / \`add_log\` have been returning \`body\` as the plain-text projection since v0.8.1, which strips thinking blocks. Correct for human-facing display, wrong for programmatic consumers that need to round-trip a transcript or render blocks themselves.

Add \`body_blocks\` alongside \`body\`:
- \`body\` stays the plain-text projection → no breaking change.
- \`body_blocks\` is a typed array, present only when the body is a canonical envelope (same gate as \`ExtractPlainBody\` uses via \`DecodeCanonicalEnvelope\`).

## Test plan
- [x] \`go test ./...\` — 1033 passed / 16 packages
- [x] \`golangci-lint run\` — 0 issues
- [x] Dogfood: \`list_events\` with a transcript envelope returns both \`body\` (plain text) and \`body_blocks\` (thinking + text preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)