### PR TITLE
refactor(doctor): remove infrastructure/filesystem import

### DIFF
--- a/application/claude_plugin_detector.go
+++ b/application/claude_plugin_detector.go
@@ -1,0 +1,22 @@
+package application
+
+// ClaudePluginDetector resolves whether the Traceary Claude Code plugin
+// is enabled for the given host home directory. Presentation callers
+// depend on this interface so the presentation layer stays free of
+// direct infrastructure imports.
+type ClaudePluginDetector interface {
+	DetectClaudeTracearyPluginIn(home string) ClaudePluginDetection
+}
+
+// ClaudePluginDetection reports whether the Traceary Claude Code
+// plugin is enabled in the user's global Claude settings.
+type ClaudePluginDetection struct {
+	// Active is true when the user's ~/.claude/settings.json lists a
+	// Traceary plugin under enabledPlugins with value true.
+	Active bool
+	// SettingsPath is the absolute path that was consulted.
+	SettingsPath string
+	// PluginKey is the enabledPlugins key that matched, e.g.
+	// "traceary@traceary-plugins". Empty when Active is false.
+	PluginKey string
+}

--- a/application/hooks_inspector.go
+++ b/application/hooks_inspector.go
@@ -14,4 +14,10 @@ type HooksInspector interface {
 	// ErrHookConfigInvalidHooksField when the "hooks" field has the wrong
 	// shape.
 	Inspect(content []byte) (hasHooksField bool, hasTracearyManagedHook bool, err error)
+	// ExtractManagedKeyFromEntry returns the canonical Traceary-managed
+	// key extracted from a hook entry's name / command pair, or an
+	// empty string if the entry is not Traceary-managed. Presentation
+	// code uses this to recognise installed hook entries without
+	// re-implementing the command parsing.
+	ExtractManagedKeyFromEntry(name, command string) string
 }

--- a/application/plugin_cache_inspector.go
+++ b/application/plugin_cache_inspector.go
@@ -1,0 +1,63 @@
+package application
+
+import "golang.org/x/mod/semver"
+
+// PluginCacheInspector reports the state of the host's Traceary plugin
+// cache (currently only Claude Code has this concept). Implementations
+// live in the infrastructure layer so presentation code depends only
+// on this interface.
+type PluginCacheInspector interface {
+	// DetectClaudePluginCacheStatus resolves the cached plugin version
+	// and the marketplace plugin.json version for the given pluginKey
+	// (of the form "<plugin>@<marketplace>"). Missing caches and
+	// missing marketplace clones are reported via empty fields rather
+	// than as errors; only structural IO errors surface through the
+	// returned struct.
+	DetectClaudePluginCacheStatus(home, pluginKey string) PluginCacheStatus
+}
+
+// PluginCacheStatus describes the cached Traceary plugin version
+// alongside the version the marketplace currently advertises. When
+// the two drift (e.g. operator ran `brew upgrade traceary` without
+// `claude plugins update`), the host continues to run an older hook
+// set than the CLI supports.
+type PluginCacheStatus struct {
+	// CachePath is the directory scanned for cached plugin versions.
+	// Empty when detection could not resolve it.
+	CachePath string
+	// CachedVersion is the highest version found under CachePath.
+	// Empty when no versioned directory exists (plugin never cached).
+	CachedVersion string
+	// CachedVersions lists every non-orphaned versioned cache
+	// directory found under CachePath, sorted from highest to lowest
+	// by semver. Diagnostics use the full list to detect the
+	// session-snapshot ambiguity reported in #670.
+	CachedVersions []string
+	// MarketplaceVersion is the plugin.json "version" Claude Code
+	// sees via `~/.claude/plugins/marketplaces/<marketplace>/...`.
+	// Empty when the marketplace clone is missing.
+	MarketplaceVersion string
+	// MarketplacePath is the plugin.json path that was read (empty if
+	// the read failed).
+	MarketplacePath string
+}
+
+// HasMultipleCachedVersions reports whether the plugin's cache
+// directory holds more than one non-orphaned version subdirectory.
+// When true, a resumed Claude Code session could have snapshotted its
+// hook registry against any of them, so operators should restart
+// without `--continue` to guarantee the newest hooks are live.
+func (s PluginCacheStatus) HasMultipleCachedVersions() bool {
+	return len(s.CachedVersions) > 1
+}
+
+// Stale reports whether the cached plugin is at an older semver than
+// the marketplace currently offers. Returns false when either version
+// is unresolved — a missing cache or missing marketplace is surfaced
+// to the caller through the struct fields rather than as "stale".
+func (s PluginCacheStatus) Stale() bool {
+	if s.CachedVersion == "" || s.MarketplaceVersion == "" {
+		return false
+	}
+	return semver.Compare("v"+s.CachedVersion, "v"+s.MarketplaceVersion) < 0
+}

--- a/infrastructure/filesystem/claude_plugin_detector_adapter.go
+++ b/infrastructure/filesystem/claude_plugin_detector_adapter.go
@@ -1,0 +1,23 @@
+package filesystem
+
+import "github.com/duck8823/traceary/application"
+
+// ClaudePluginDetectorAdapter implements application.ClaudePluginDetector
+// by delegating to the existing DetectClaudeTracearyPluginIn function.
+type ClaudePluginDetectorAdapter struct{}
+
+// NewClaudePluginDetectorAdapter constructs a detector adapter.
+func NewClaudePluginDetectorAdapter() *ClaudePluginDetectorAdapter {
+	return &ClaudePluginDetectorAdapter{}
+}
+
+// DetectClaudeTracearyPluginIn adapts the infrastructure value object
+// to the application-level ClaudePluginDetection shape.
+func (a *ClaudePluginDetectorAdapter) DetectClaudeTracearyPluginIn(home string) application.ClaudePluginDetection {
+	detection := DetectClaudeTracearyPluginIn(home)
+	return application.ClaudePluginDetection{
+		Active:       detection.Active,
+		SettingsPath: detection.SettingsPath,
+		PluginKey:    detection.PluginKey,
+	}
+}

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -51,3 +51,11 @@ func (i *HooksInspector) Inspect(content []byte) (bool, bool, error) {
 
 	return true, false, nil
 }
+
+// ExtractManagedKeyFromEntry delegates to the free ExtractTracearyManagedKeyFromEntry
+// function so presentation code can consume the canonical-key extraction
+// through the application.HooksInspector interface without importing the
+// infrastructure package directly.
+func (i *HooksInspector) ExtractManagedKeyFromEntry(name, command string) string {
+	return ExtractTracearyManagedKeyFromEntry(name, command)
+}

--- a/infrastructure/filesystem/plugin_cache_inspector.go
+++ b/infrastructure/filesystem/plugin_cache_inspector.go
@@ -1,0 +1,28 @@
+package filesystem
+
+import "github.com/duck8823/traceary/application"
+
+// PluginCacheInspector implements application.PluginCacheInspector by
+// delegating to the existing filesystem-level detector. It adapts the
+// infrastructure value-object to the application type so presentation
+// code depends only on the application package.
+type PluginCacheInspector struct{}
+
+// NewPluginCacheInspector constructs a PluginCacheInspector.
+func NewPluginCacheInspector() *PluginCacheInspector {
+	return &PluginCacheInspector{}
+}
+
+// DetectClaudePluginCacheStatus resolves the cached plugin version
+// and the marketplace plugin.json version for the given pluginKey
+// (of the form "<plugin>@<marketplace>").
+func (i *PluginCacheInspector) DetectClaudePluginCacheStatus(home, pluginKey string) application.PluginCacheStatus {
+	status := DetectClaudePluginCacheStatus(home, pluginKey)
+	return application.PluginCacheStatus{
+		CachePath:          status.CachePath,
+		CachedVersion:      status.CachedVersion,
+		CachedVersions:     status.CachedVersions,
+		MarketplaceVersion: status.MarketplaceVersion,
+		MarketplacePath:    status.MarketplacePath,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -186,6 +186,8 @@ func run() error {
 	})
 	codexIntegrationUsecase := usecase.NewCodexIntegrationUsecase(filesystem.NewCodexIntegrationManager(hooksOrchestrator))
 	hooksInspector := filesystem.NewHooksInspector()
+	pluginCacheInspector := filesystem.NewPluginCacheInspector()
+	pluginDetector := filesystem.NewClaudePluginDetectorAdapter()
 
 	rootCmd := cli.NewRootCLI(
 		cli.WithEvent(eventUsecase),
@@ -203,6 +205,8 @@ func run() error {
 		cli.WithMCPServerRunner(mcpServer),
 		cli.WithHooksOrchestrator(hooksOrchestrator),
 		cli.WithHooksInspector(hooksInspector),
+		cli.WithPluginCacheInspector(pluginCacheInspector),
+		cli.WithClaudePluginDetector(pluginDetector),
 		cli.WithExtraRedactPatterns(extraRedactPatterns),
 		cli.WithDefaultReadFields(defaultReadFields),
 		cli.WithReadPresets(readPresets),

--- a/presentation/cli/claude_plugin_detection.go
+++ b/presentation/cli/claude_plugin_detection.go
@@ -1,18 +1,21 @@
 package cli
 
 import (
-	"github.com/duck8823/traceary/infrastructure/filesystem"
+	"github.com/duck8823/traceary/application"
 )
 
 // detectClaudeTracearyPluginForCLI resolves the user's home directory
-// through userHomeDirFunc (which tests can override) and returns whether
-// the Claude Code plugin for Traceary is enabled. If the home lookup
-// fails we fall back to Active=false so callers treat the environment
-// as "no plugin" and fall through to the default settings.json flow.
-func detectClaudeTracearyPluginForCLI() filesystem.ClaudePluginDetection {
+// through userHomeDirFunc (which tests can override) and returns
+// whether the Claude Code plugin for Traceary is enabled. A nil
+// detector (e.g. unit tests that did not inject one) falls back to
+// Active=false so callers treat the environment as "no plugin".
+func (c *RootCLI) detectClaudeTracearyPluginForCLI() application.ClaudePluginDetection {
+	if c == nil || c.pluginDetector == nil {
+		return application.ClaudePluginDetection{}
+	}
 	home, err := userHomeDirFunc()
 	if err != nil {
-		return filesystem.ClaudePluginDetection{}
+		return application.ClaudePluginDetection{}
 	}
-	return filesystem.DetectClaudeTracearyPluginIn(home)
+	return c.pluginDetector.DetectClaudeTracearyPluginIn(home)
 }

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain/types"
-	"github.com/duck8823/traceary/infrastructure/filesystem"
 )
 
 const (
@@ -165,7 +164,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		}
 
 		if targetClient == "claude" {
-			if cacheCheck := inspectClaudePluginCacheStatus(); cacheCheck != nil {
+			if cacheCheck := c.inspectClaudePluginCacheStatus(); cacheCheck != nil {
 				report.Checks = append(report.Checks, *cacheCheck)
 			}
 		}
@@ -188,16 +187,19 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 // stay dark until the operator runs `claude plugins update`. The check
 // returns nil when the plugin is not active or when either side cannot
 // be resolved (reported indirectly by the existing claude-config check).
-func inspectClaudePluginCacheStatus() *doctorCheck {
-	detection := detectClaudeTracearyPluginForCLI()
+func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
+	detection := c.detectClaudeTracearyPluginForCLI()
 	if !detection.Active {
+		return nil
+	}
+	if c.pluginCacheInspector == nil {
 		return nil
 	}
 	home, err := userHomeDirFunc()
 	if err != nil {
 		return nil
 	}
-	status := filesystem.DetectClaudePluginCacheStatus(home, detection.PluginKey)
+	status := c.pluginCacheInspector.DetectClaudePluginCacheStatus(home, detection.PluginKey)
 	if status.CachedVersion == "" || status.MarketplaceVersion == "" {
 		return nil
 	}
@@ -380,7 +382,7 @@ func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir strin
 		return c.inspectDoctorConfigFile(client, outputPath)
 	}
 
-	detection := detectClaudeTracearyPluginForCLI()
+	detection := c.detectClaudeTracearyPluginForCLI()
 	configCheck := c.inspectDoctorConfigFile(client, outputPath)
 
 	if detection.Active {
@@ -583,7 +585,7 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 
 	if hasTracearyManagedHook {
 		if client == "codex" {
-			if missing := missingTracearyManagedCodexEvents(content); len(missing) > 0 {
+			if missing := c.missingTracearyManagedCodexEvents(content); len(missing) > 0 {
 				return doctorCheck{
 					Name:   client + "-config",
 					Status: doctorStatusWarn,
@@ -639,7 +641,7 @@ var codexManagedEventKeys = map[string]string{
 // hooks.json content. Unknown / non-object JSON shapes are reported as an
 // empty slice so the outer inspector branch (which already checked hook
 // shape) remains authoritative.
-func missingTracearyManagedCodexEvents(content []byte) []string {
+func (c *RootCLI) missingTracearyManagedCodexEvents(content []byte) []string {
 	var root struct {
 		Hooks map[string]json.RawMessage `json:"hooks"`
 	}
@@ -657,7 +659,7 @@ func missingTracearyManagedCodexEvents(content []byte) []string {
 			missing = append(missing, event)
 			continue
 		}
-		if !hasEntryWithManagedKey(raw, expectedKey) {
+		if !c.hasEntryWithManagedKey(raw, expectedKey) {
 			missing = append(missing, event)
 		}
 	}
@@ -668,8 +670,11 @@ func missingTracearyManagedCodexEvents(content []byte) []string {
 // contain at least one command whose parsed Traceary managed key equals
 // expectedKey. Empty expectedKey always returns false so the caller cannot
 // accidentally match user-managed commands.
-func hasEntryWithManagedKey(raw json.RawMessage, expectedKey string) bool {
+func (c *RootCLI) hasEntryWithManagedKey(raw json.RawMessage, expectedKey string) bool {
 	if expectedKey == "" {
+		return false
+	}
+	if c.hooksInspector == nil {
 		return false
 	}
 	var entries []struct {
@@ -690,7 +695,7 @@ func hasEntryWithManagedKey(raw json.RawMessage, expectedKey string) bool {
 			// Use the Name-aware extractor so entries installed via
 			// `--traceary-bin <non-traceary-basename>` (dev builds)
 			// are still recognized through the `traceary-*` Name.
-			if filesystem.ExtractTracearyManagedKeyFromEntry(h.Name, h.Command) == expectedKey {
+			if c.hooksInspector.ExtractManagedKeyFromEntry(h.Name, h.Command) == expectedKey {
 				return true
 			}
 		}

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -196,7 +196,7 @@ func (c *RootCLI) runHooksInstall(
 	// to override; require --force for an intentional duplicate.
 	canonicalClient := normalizeHooksClientForDisplay(c, input.client)
 	if canonicalClient == "claude" {
-		detection := detectClaudeTracearyPluginForCLI()
+		detection := c.detectClaudeTracearyPluginForCLI()
 		if detection.Active && input.upgrade {
 			// --upgrade is the non-destructive path, so pointing users
 			// at --force here would be actively wrong: --force clobbers

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -23,8 +23,10 @@ type RootCLI struct {
 	codexIntegration    usecase.CodexIntegrationUsecase
 	storeManagement     usecase.StoreManagementUsecase
 	mcpServerRunner     MCPServerRunner
-	hooksOrchestrator   application.HooksOrchestrator
-	hooksInspector      application.HooksInspector
+	hooksOrchestrator    application.HooksOrchestrator
+	hooksInspector       application.HooksInspector
+	pluginCacheInspector application.PluginCacheInspector
+	pluginDetector       application.ClaudePluginDetector
 	extraRedactPatterns []string
 	defaultReadFields   []string
 	readPresets         map[string]presentation.ReadPreset
@@ -129,6 +131,20 @@ func WithHooksOrchestrator(orchestrator application.HooksOrchestrator) RootCLIOp
 // to inspect client hook configurations.
 func WithHooksInspector(inspector application.HooksInspector) RootCLIOption {
 	return func(c *RootCLI) { c.hooksInspector = inspector }
+}
+
+// WithPluginCacheInspector injects the PluginCacheInspector used by the
+// doctor command to detect cached-vs-marketplace drift on hosts that
+// have a per-plugin version cache (Claude Code).
+func WithPluginCacheInspector(inspector application.PluginCacheInspector) RootCLIOption {
+	return func(c *RootCLI) { c.pluginCacheInspector = inspector }
+}
+
+// WithClaudePluginDetector injects the ClaudePluginDetector used by
+// doctor / hooks install to detect whether the Traceary Claude Code
+// plugin is active in the user's global settings.
+func WithClaudePluginDetector(detector application.ClaudePluginDetector) RootCLIOption {
+	return func(c *RootCLI) { c.pluginDetector = detector }
 }
 
 // WithExtraRedactPatterns injects additional redaction regex patterns used

--- a/presentation/cli/testhelpers_test.go
+++ b/presentation/cli/testhelpers_test.go
@@ -26,6 +26,8 @@ func newTestHooksOptions() []cli.RootCLIOption {
 			"gemini": filesystem.NewGeminiHooksHandler(),
 		})),
 		cli.WithHooksInspector(filesystem.NewHooksInspector()),
+		cli.WithPluginCacheInspector(filesystem.NewPluginCacheInspector()),
+		cli.WithClaudePluginDetector(filesystem.NewClaudePluginDetectorAdapter()),
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #685.

\`presentation/cli\` was reaching into \`infrastructure/filesystem\` directly for three symbols (\`DetectClaudePluginCacheStatus\`, \`DetectClaudeTracearyPluginIn\`, \`ExtractTracearyManagedKeyFromEntry\`) — a hexagonal-architecture violation flagged by Claude architect during the v0.8.1 quality phase.

Introduce application-layer contracts and infrastructure adapters:
- \`application.PluginCacheInspector\` + \`PluginCacheStatus\` (with \`Stale\` / \`HasMultipleCachedVersions\`)
- \`application.ClaudePluginDetector\` + \`ClaudePluginDetection\`
- \`application.HooksInspector.ExtractManagedKeyFromEntry\`

presentation/cli:
- \`WithPluginCacheInspector\` / \`WithClaudePluginDetector\` options on \`RootCLI\`.
- Former free functions become \`RootCLI\` methods that consume the injected dependencies.

## Acceptance
- [x] \`grep -r "infrastructure/" presentation/cli/ --include="*.go"\` returns no non-test hits.
- [x] \`go test ./...\` pass (1034/1034).
- [x] \`golangci-lint run\` clean.
- [x] Behaviour unchanged (existing doctor / hooks-install tests still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)