### PR TITLE
fix(smoke): write correct projects.json shape for Gemini CLI

### DIFF
--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -32,7 +32,13 @@ run_gemini() {
   local tmp_home
   tmp_home="$(mktemp -d)"
   mkdir -p "${tmp_home}/.gemini"
-  printf '{}\n' > "${tmp_home}/.gemini/projects.json"
+  # Gemini CLI 0.38 expects projects.json to carry a top-level "projects"
+  # map. Plain `{}` makes ProjectRegistry.getShortId read
+  # `undefined[<path>]` during cleanupCheckpoints, which prints "Early
+  # cleanup failed" / "Tool output cleanup failed" warnings per
+  # invocation (#536). Writing the correct empty-but-keyed shape keeps
+  # cleanup silent without weakening smoke coverage.
+  printf '{"projects":{}}\n' > "${tmp_home}/.gemini/projects.json"
   HOME="${tmp_home}" gemini extensions validate "${ROOT_DIR}/integrations/gemini-extension"
   printf 'y\n' | HOME="${tmp_home}" gemini extensions link "${ROOT_DIR}/integrations/gemini-extension"
   local list_output


### PR DESCRIPTION
## Summary
Closes #536.

\`./scripts/smoke_test_integrations.sh gemini\` emitted noisy \`Early cleanup failed\` / \`Tool output cleanup failed\` warnings per invocation. Root cause: Gemini CLI 0.38 expects \`~/.gemini/projects.json\` to be \`{"projects":{}}\` — the smoke script wrote plain \`{}\` so \`ProjectRegistry.getShortId\` during cleanup threw when it tried to read \`undefined[<path>]\`.

Fix: write the correct empty-but-keyed shape.

## Test plan
- [x] \`scripts/smoke_test_integrations.sh gemini\` — no cleanup warnings
- [x] \`scripts/verify_docs_i18n.py\` pass
- [x] \`scripts/verify_integrations.py\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)