### PR TITLE
fix(mcp): omit body_blocks on search and get_context

### DIFF
--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -56,7 +56,7 @@ type eventOutput struct {
 	SessionID  string                    `json:"session_id" jsonschema:"session identifier"`
 	Workspace  string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
 	Body       string                    `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form"`
-	BodyBlocks []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; absent for legacy plain-text bodies and non-envelope JSON bodies"`
+	BodyBlocks []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; populated for list_events only — search and get_context omit it so thinking-block text does not leak through those surfaces; also absent for legacy plain-text bodies, non-envelope JSON bodies, and empty envelopes"`
 	SourceHook string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
 	CreatedAt  string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -485,7 +485,11 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 			return nil, eventsOutput{}, xerrors.Errorf("failed to search events: %w", err)
 		}
 
-		return nil, eventsOutput{Events: convertEvents(events)}, nil
+		// Search intentionally omits body_blocks so thinking content is
+		// not re-exposed through this surface — #682 strips thinking
+		// from the LIKE match, but the envelope is still attached to
+		// the returned event and body_blocks would bypass the gate.
+		return nil, eventsOutput{Events: convertEventsWithoutBlocks(events)}, nil
 	}
 }
 
@@ -500,7 +504,10 @@ func (s *Server) getContext() mcp.ToolHandlerFor[getContextInput, eventsOutput] 
 			return nil, eventsOutput{}, xerrors.Errorf("failed to get context: %w", err)
 		}
 
-		return nil, eventsOutput{Events: convertEvents(events)}, nil
+		// get_context also omits body_blocks for the same reason as
+		// search: the canonical envelope would re-expose thinking
+		// block text that other surfaces already strip.
+		return nil, eventsOutput{Events: convertEventsWithoutBlocks(events)}, nil
 	}
 }
 
@@ -1472,10 +1479,34 @@ func parseFlexibleTimeOptional(value string) (types.Optional[time.Time], error) 
 	return types.Some(parsed), nil
 }
 
+// convertEvents serializes events for MCP list_events. It includes
+// body_blocks (the canonical envelope form, thinking blocks and all)
+// because list_events is the primary surface where programmatic
+// consumers round-trip transcript structure.
+//
+// search / get_context deliberately use convertEventsWithoutBlocks so
+// their responses do not re-expose thinking-block text through the
+// MCP layer — #682 filters thinking out of the LIKE match, but the
+// full envelope is still attached to the returned event, and dumping
+// it via body_blocks would undo that protection on those surfaces.
 func convertEvents(events []*model.Event) []eventOutput {
+	return convertEventsInternal(events, true)
+}
+
+// convertEventsWithoutBlocks serializes events for MCP search /
+// get_context without the body_blocks field so thinking content
+// cannot leak through those surfaces.
+func convertEventsWithoutBlocks(events []*model.Event) []eventOutput {
+	return convertEventsInternal(events, false)
+}
+
+func convertEventsInternal(events []*model.Event, includeBlocks bool) []eventOutput {
 	outputs := make([]eventOutput, 0, len(events))
 	for _, event := range events {
-		blocks, _ := apptypes.DecodeCanonicalEnvelope(event.Body())
+		var blocks []apptypes.EventBodyBlock
+		if includeBlocks {
+			blocks, _ = apptypes.DecodeCanonicalEnvelope(event.Body())
+		}
 		outputs = append(outputs, eventOutput{
 			EventID:    event.EventID().String(),
 			Kind:       event.Kind().String(),


### PR DESCRIPTION
## Summary
Release-blocker fix from v0.8.2 quality phase.

Codex architect MUST: #684 added \`body_blocks\` to the shared \`eventOutput\` struct. \`search\` and \`get_context\` handlers also serialize \`eventOutput\`, so they started re-exposing thinking block text even though #682 filters it out of the SQL LIKE match. The full envelope stays attached to the returned event and \`body_blocks\` bypasses the plain-text gate.

Narrow the contract:
- \`list_events\` keeps populating \`body_blocks\` (primary surface for block-aware consumers).
- \`search\` and \`get_context\` go through a new \`convertEventsWithoutBlocks\` helper that omits \`body_blocks\` from the output.
- jsonschema description updated so consumers can rely on the scope.

## Test plan
- [x] \`go test ./...\` — 1034 passed
- [x] \`golangci-lint run\` — 0 issues
- [x] MCP stdio dogfood: list_events returns body_blocks; search / get_context omit it

🤖 Generated with [Claude Code](https://claude.com/claude-code)