### PR TITLE
refactor(types): rename validating constructors to From

### DIFF
--- a/application/types/memory_details_test.go
+++ b/application/types/memory_details_test.go
@@ -14,10 +14,10 @@ import (
 func TestMemoryDetailsFrom(t *testing.T) {
 	t.Parallel()
 
-	memoryID, _ := domtypes.MemoryIDOf("mem-details")
-	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
-	evidenceRef, _ := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindIssue, "454")
-	artifactRef, _ := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindPR, "466")
+	memoryID, _ := domtypes.MemoryIDFrom("mem-details")
+	workspace, _ := domtypes.WorkspaceFrom("github.com/duck8823/traceary")
+	evidenceRef, _ := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindIssue, "454")
+	artifactRef, _ := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindPR, "466")
 	memory := model.MemoryOf(
 		memoryID,
 		domtypes.MemoryTypeArtifact,

--- a/application/types/memory_list_criteria_test.go
+++ b/application/types/memory_list_criteria_test.go
@@ -22,7 +22,7 @@ func TestDefaultActiveMemoryStatuses(t *testing.T) {
 func TestMemoryListCriteriaBuilder(t *testing.T) {
 	t.Parallel()
 
-	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
+	workspace, _ := domtypes.WorkspaceFrom("github.com/duck8823/traceary")
 	criteria := apptypes.NewMemoryListCriteriaBuilder(20).
 		Offset(5).
 		Scope(domtypes.WorkspaceScopeOf(workspace)).

--- a/application/types/memory_search_criteria_test.go
+++ b/application/types/memory_search_criteria_test.go
@@ -12,7 +12,7 @@ import (
 func TestMemorySearchCriteriaBuilder(t *testing.T) {
 	t.Parallel()
 
-	agent, _ := domtypes.AgentOf("codex")
+	agent, _ := domtypes.AgentFrom("codex")
 	criteria := apptypes.NewMemorySearchCriteriaBuilder(10).
 		Query("release").
 		Offset(2).

--- a/application/types/memory_summary_test.go
+++ b/application/types/memory_summary_test.go
@@ -14,9 +14,9 @@ import (
 func TestMemorySummaryOf(t *testing.T) {
 	t.Parallel()
 
-	memoryID, _ := domtypes.MemoryIDOf("mem-1")
-	workspace, _ := domtypes.WorkspaceOf("github.com/duck8823/traceary")
-	supersedes, _ := domtypes.MemoryIDOf("mem-0")
+	memoryID, _ := domtypes.MemoryIDFrom("mem-1")
+	workspace, _ := domtypes.WorkspaceFrom("github.com/duck8823/traceary")
+	supersedes, _ := domtypes.MemoryIDFrom("mem-0")
 	expiresAt := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
 	createdAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 	updatedAt := time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC)
@@ -54,8 +54,8 @@ func TestMemorySummaryOf(t *testing.T) {
 func TestMemorySummaryFrom(t *testing.T) {
 	t.Parallel()
 
-	memoryID, _ := domtypes.MemoryIDOf("mem-2")
-	agent, _ := domtypes.AgentOf("codex")
+	memoryID, _ := domtypes.MemoryIDFrom("mem-2")
+	agent, _ := domtypes.AgentFrom("codex")
 	memory := model.MemoryOf(
 		memoryID,
 		domtypes.MemoryTypeLesson,

--- a/application/usecase/bundle_usecase.go
+++ b/application/usecase/bundle_usecase.go
@@ -326,19 +326,19 @@ type bundleEventRow struct {
 }
 
 func (r bundleEventRow) toEvent() (*model.Event, error) {
-	eventID, err := types.EventIDOf(r.EventID)
+	eventID, err := types.EventIDFrom(r.EventID)
 	if err != nil {
 		return nil, xerrors.Errorf("event_id: %w", err)
 	}
-	kind, err := types.EventKindOf(r.Kind)
+	kind, err := types.EventKindFrom(r.Kind)
 	if err != nil {
 		return nil, xerrors.Errorf("kind: %w", err)
 	}
-	agent, err := types.AgentOf(r.Agent)
+	agent, err := types.AgentFrom(r.Agent)
 	if err != nil {
 		return nil, xerrors.Errorf("agent: %w", err)
 	}
-	sessionID, err := types.SessionIDOf(r.SessionID)
+	sessionID, err := types.SessionIDFrom(r.SessionID)
 	if err != nil {
 		return nil, xerrors.Errorf("session_id: %w", err)
 	}

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -71,17 +71,17 @@ func (r *fakeBundleRepo) ImportEvent(_ context.Context, event *model.Event) (boo
 
 func mustEvent(t *testing.T, id string, ts time.Time) *model.Event {
 	t.Helper()
-	eventID, err := types.EventIDOf(id)
+	eventID, err := types.EventIDFrom(id)
 	if err != nil {
-		t.Fatalf("EventIDOf: %v", err)
+		t.Fatalf("EventIDFrom: %v", err)
 	}
-	agent, err := types.AgentOf("test")
+	agent, err := types.AgentFrom("test")
 	if err != nil {
-		t.Fatalf("AgentOf: %v", err)
+		t.Fatalf("AgentFrom: %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-x")
+	sessionID, err := types.SessionIDFrom("session-x")
 	if err != nil {
-		t.Fatalf("SessionIDOf: %v", err)
+		t.Fatalf("SessionIDFrom: %v", err)
 	}
 	return model.EventOf(
 		eventID, types.EventKindNote, types.Client("cli"), agent,

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -226,7 +226,7 @@ func relevantMemoryScopes(session apptypes.SessionSummary) []domtypes.MemoryScop
 		appendScope(domtypes.SessionFamilyScopeOf(session.SessionID()))
 	}
 	for _, agentValue := range session.Agents() {
-		agent, err := domtypes.AgentOf(agentValue)
+		agent, err := domtypes.AgentFrom(agentValue)
 		if err != nil {
 			continue
 		}

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -39,15 +39,15 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 		return nil, xerrors.Errorf("event repository is not configured")
 	}
 
-	if _, err := types.AgentOf(agent.String()); err != nil {
+	if _, err := types.AgentFrom(agent.String()); err != nil {
 		return nil, xerrors.Errorf("failed to resolve agent: %w", err)
 	}
-	if _, err := types.SessionIDOf(sessionID.String()); err != nil {
+	if _, err := types.SessionIDFrom(sessionID.String()); err != nil {
 		return nil, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
 	resolvedKind := types.EventKindNote
 	if strings.TrimSpace(kind.String()) != "" {
-		resolved, err := types.EventKindOf(kind.String())
+		resolved, err := types.EventKindFrom(kind.String())
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve event kind: %w", err)
 		}
@@ -109,10 +109,10 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 		return nil, nil, xerrors.Errorf("event repository is not configured")
 	}
 
-	if _, err := types.AgentOf(agent.String()); err != nil {
+	if _, err := types.AgentFrom(agent.String()); err != nil {
 		return nil, nil, xerrors.Errorf("failed to resolve agent: %w", err)
 	}
-	if _, err := types.SessionIDOf(sessionID.String()); err != nil {
+	if _, err := types.SessionIDFrom(sessionID.String()); err != nil {
 		return nil, nil, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
 	eventID, err := newEventID()
@@ -294,7 +294,7 @@ func resolveOptionalSearchKind(value string) (types.EventKind, error) {
 		return types.EventKindCommandExecuted, nil
 	}
 
-	kind, err := types.EventKindOf(trimmedValue)
+	kind, err := types.EventKindFrom(trimmedValue)
 	if err != nil {
 		return types.EventKind(""), xerrors.Errorf("failed to resolve kind: %w", err)
 	}

--- a/application/usecase/id_generator.go
+++ b/application/usecase/id_generator.go
@@ -15,7 +15,7 @@ func newEventID() (types.EventID, error) {
 		return types.EventID(""), xerrors.Errorf("failed to generate event ID: %w", err)
 	}
 
-	eventID, err := types.EventIDOf(value)
+	eventID, err := types.EventIDFrom(value)
 	if err != nil {
 		return types.EventID(""), xerrors.Errorf("failed to convert event ID: %w", err)
 	}
@@ -29,7 +29,7 @@ func newMemoryID() (types.MemoryID, error) {
 		return types.MemoryID(""), xerrors.Errorf("failed to generate memory ID: %w", err)
 	}
 
-	memoryID, err := types.MemoryIDOf("memory-" + value)
+	memoryID, err := types.MemoryIDFrom("memory-" + value)
 	if err != nil {
 		return types.MemoryID(""), xerrors.Errorf("failed to convert memory ID: %w", err)
 	}
@@ -42,7 +42,7 @@ func newSessionID() (types.SessionID, error) {
 		return types.SessionID(""), xerrors.Errorf("failed to generate session ID: %w", err)
 	}
 
-	sessionID, err := types.SessionIDOf("session-" + value)
+	sessionID, err := types.SessionIDFrom("session-" + value)
 	if err != nil {
 		return types.SessionID(""), xerrors.Errorf("failed to convert session ID: %w", err)
 	}
@@ -56,7 +56,7 @@ func newMemoryEdgeID() (types.MemoryEdgeID, error) {
 		return types.MemoryEdgeID(""), xerrors.Errorf("failed to generate memory edge ID: %w", err)
 	}
 
-	edgeID, err := types.MemoryEdgeIDOf("edge-" + value)
+	edgeID, err := types.MemoryEdgeIDFrom("edge-" + value)
 	if err != nil {
 		return types.MemoryEdgeID(""), xerrors.Errorf("failed to convert memory edge ID: %w", err)
 	}

--- a/application/usecase/memory_bridge_import_usecase_impl.go
+++ b/application/usecase/memory_bridge_import_usecase_impl.go
@@ -78,12 +78,12 @@ func (u *memoryBridgeImportUsecase) ImportInstructions(ctx context.Context, crit
 	}
 
 	for _, bullet := range bullets {
-		evidence, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindFile, fmt.Sprintf("%s#L%d", bullet.SourcePath, bullet.Line))
+		evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, fmt.Sprintf("%s#L%d", bullet.SourcePath, bullet.Line))
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("skipped bullet at %s:%d (evidence ref rejected: %v)", bullet.SourcePath, bullet.Line, err))
 			continue
 		}
-		artifact, err := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindFile, bullet.SourcePath)
+		artifact, err := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindFile, bullet.SourcePath)
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("skipped bullet at %s:%d (artifact ref rejected: %v)", bullet.SourcePath, bullet.Line, err))
 			continue

--- a/application/usecase/memory_bridge_import_usecase_impl_test.go
+++ b/application/usecase/memory_bridge_import_usecase_impl_test.go
@@ -13,9 +13,9 @@ import (
 func TestMemoryBridgeImport_ProposesBulletsOutsideMarkers(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 
 	content := strings.Join([]string{
@@ -65,9 +65,9 @@ func TestMemoryBridgeImport_ProposesBulletsOutsideMarkers(t *testing.T) {
 func TestMemoryBridgeImport_FutureMarkerVersionStillSkipsManagedBlock(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 
 	// A future Traceary build wrote the block as :v42; the current build

--- a/application/usecase/memory_export_usecase_impl_test.go
+++ b/application/usecase/memory_export_usecase_impl_test.go
@@ -55,9 +55,9 @@ func mustAcceptedSummary(t *testing.T, id string, memoryType domtypes.MemoryType
 func TestMemoryExportUsecase_RendersStableMarkdown(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	query := &stubExportMemoryQuery{

--- a/application/usecase/memory_extraction_usecase_impl.go
+++ b/application/usecase/memory_extraction_usecase_impl.go
@@ -516,14 +516,14 @@ func containsAny(value string, needles ...string) bool {
 func buildSignalEvidenceRefs(sessionID domtypes.SessionID, event *model.Event) ([]domtypes.EvidenceRef, error) {
 	evidenceRefs := make([]domtypes.EvidenceRef, 0, 2)
 	if sessionID.String() != "" {
-		ref, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindSession, sessionID.String())
+		ref, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindSession, sessionID.String())
 		if err != nil {
 			return nil, xerrors.Errorf("failed to build session evidence ref: %w", err)
 		}
 		evidenceRefs = append(evidenceRefs, ref)
 	}
 	if event != nil {
-		ref, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindEvent, event.EventID().String())
+		ref, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindEvent, event.EventID().String())
 		if err != nil {
 			return nil, xerrors.Errorf("failed to build event evidence ref: %w", err)
 		}
@@ -540,7 +540,7 @@ func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {
 		if _, exists := seen[key]; exists {
 			return nil
 		}
-		ref, err := domtypes.ArtifactRefOf(kind, value)
+		ref, err := domtypes.ArtifactRefFrom(kind, value)
 		if err != nil {
 			return xerrors.Errorf("invalid artifact ref %s:%s: %w", kind, value, err)
 		}

--- a/application/usecase/memory_extraction_usecase_internal_test.go
+++ b/application/usecase/memory_extraction_usecase_internal_test.go
@@ -98,8 +98,8 @@ func TestInferArtifactRefs_ProducesValidArtifactRefs(t *testing.T) {
 	}
 
 	for _, ref := range refs {
-		if _, err := domtypes.ArtifactRefOf(ref.Kind(), ref.Value()); err != nil {
-			t.Fatalf("ArtifactRefOf(%s, %q) error = %v", ref.Kind(), ref.Value(), err)
+		if _, err := domtypes.ArtifactRefFrom(ref.Kind(), ref.Value()); err != nil {
+			t.Fatalf("ArtifactRefFrom(%s, %q) error = %v", ref.Kind(), ref.Value(), err)
 		}
 	}
 }

--- a/application/usecase/memory_hygiene_usecase_impl.go
+++ b/application/usecase/memory_hygiene_usecase_impl.go
@@ -514,7 +514,7 @@ func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.Memo
 			})
 			continue
 		}
-		memoryID, err := domtypes.MemoryIDOf(trimmed)
+		memoryID, err := domtypes.MemoryIDFrom(trimmed)
 		if err != nil {
 			result.Failures = append(result.Failures, apptypes.MemoryHygieneApplyFailure{
 				MemoryID: trimmed,

--- a/application/usecase/memory_hygiene_usecase_impl_test.go
+++ b/application/usecase/memory_hygiene_usecase_impl_test.go
@@ -36,9 +36,9 @@ func acceptedSummaryAt(t *testing.T, id string, scope domtypes.MemoryScope, fact
 func TestMemoryHygieneScan_DetectsRedactionExpiryAndDuplicates(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	now := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
@@ -80,9 +80,9 @@ func TestMemoryHygieneScan_DetectsRedactionExpiryAndDuplicates(t *testing.T) {
 func TestMemoryHygieneScan_SimilarFactsEmitSupersedeCandidate(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	older := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -168,9 +168,9 @@ func validitySummary(
 func TestMemoryHygieneScan_ValidityOverlapEmitsSupersede(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -219,9 +219,9 @@ func TestMemoryHygieneScan_ValidityOverlapEmitsSupersede(t *testing.T) {
 func TestMemoryHygieneScan_DisjointValidityWindowsAreNotSuperseded(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -259,9 +259,9 @@ func TestMemoryHygieneScan_DisjointValidityWindowsAreNotSuperseded(t *testing.T)
 func TestMemoryHygieneScan_TouchingValidityWindowsAreDisjoint(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -299,9 +299,9 @@ func TestMemoryHygieneScan_TouchingValidityWindowsAreDisjoint(t *testing.T) {
 func TestMemoryHygieneScan_OneOpenOneExplicitOverlapEmitsValidity(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -339,9 +339,9 @@ func TestMemoryHygieneScan_OneOpenOneExplicitOverlapEmitsValidity(t *testing.T) 
 func TestMemoryHygieneScan_BothOpenEndedWindowsAreNotValidityOverlap(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -380,9 +380,9 @@ func TestMemoryHygieneScan_BothOpenEndedWindowsAreNotValidityOverlap(t *testing.
 func TestMemoryHygieneScan_ValidityOverlapDifferentTypesDoNotPair(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -415,9 +415,9 @@ func TestMemoryHygieneScan_ValidityOverlapDifferentTypesDoNotPair(t *testing.T) 
 func TestMemoryHygieneScan_ValidityOverlapOverridesSupersedeCandidate(t *testing.T) {
 	t.Parallel()
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
 	t1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)

--- a/application/usecase/memory_import_usecase_impl_test.go
+++ b/application/usecase/memory_import_usecase_impl_test.go
@@ -123,7 +123,7 @@ func buildImportDetails(scope domtypes.MemoryScope, fact string, status domtypes
 	}
 	var artifacts []domtypes.ArtifactRef
 	if sourcePath != "" {
-		artifact, err := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindFile, sourcePath)
+		artifact, err := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindFile, sourcePath)
 		if err != nil {
 			panic(err)
 		}
@@ -134,22 +134,22 @@ func buildImportDetails(scope domtypes.MemoryScope, fact string, status domtypes
 
 func workspaceScope(t *testing.T, value string) domtypes.MemoryScope {
 	t.Helper()
-	workspace, err := domtypes.WorkspaceOf(value)
+	workspace, err := domtypes.WorkspaceFrom(value)
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	return domtypes.WorkspaceScopeOf(workspace)
 }
 
 func importCandidate(t *testing.T, fact string, scope domtypes.MemoryScope) apptypes.ImportedMemoryCandidate {
 	t.Helper()
-	evidence, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L1")
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L1")
 	if err != nil {
-		t.Fatalf("EvidenceRefOf: %v", err)
+		t.Fatalf("EvidenceRefFrom: %v", err)
 	}
-	artifact, err := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindFile, "/tmp/MEMORY.md")
+	artifact, err := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindFile, "/tmp/MEMORY.md")
 	if err != nil {
-		t.Fatalf("ArtifactRefOf: %v", err)
+		t.Fatalf("ArtifactRefFrom: %v", err)
 	}
 	return apptypes.ImportedMemoryCandidate{
 		MemoryType:   domtypes.MemoryTypePreference,

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -437,7 +437,7 @@ func (u *memoryUsecase) Show(ctx context.Context, memoryID domtypes.MemoryID) (a
 	if u.memoryQuery == nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("memory query service is not configured")
 	}
-	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID.String())
+	resolvedMemoryID, err := domtypes.MemoryIDFrom(memoryID.String())
 	if err != nil {
 		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to resolve memory ID: %w", err)
 	}
@@ -450,7 +450,7 @@ func (u *memoryUsecase) Show(ctx context.Context, memoryID domtypes.MemoryID) (a
 }
 
 func (u *memoryUsecase) findMemoryByID(ctx context.Context, memoryID domtypes.MemoryID) (*model.Memory, error) {
-	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID.String())
+	resolvedMemoryID, err := domtypes.MemoryIDFrom(memoryID.String())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to resolve memory ID: %w", err)
 	}
@@ -478,7 +478,7 @@ func sanitizeEvidenceRefs(refs []domtypes.EvidenceRef, extraRedactors []redactio
 	sanitized := make([]domtypes.EvidenceRef, 0, len(refs))
 	for _, ref := range refs {
 		value, _ := redaction.Apply(ref.Value(), extraRedactors)
-		resolvedRef, err := domtypes.EvidenceRefOf(ref.Kind(), value)
+		resolvedRef, err := domtypes.EvidenceRefFrom(ref.Kind(), value)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to sanitize evidence ref: %w", err)
 		}
@@ -491,7 +491,7 @@ func sanitizeArtifactRefs(refs []domtypes.ArtifactRef, extraRedactors []redactio
 	sanitized := make([]domtypes.ArtifactRef, 0, len(refs))
 	for _, ref := range refs {
 		value, _ := redaction.Apply(ref.Value(), extraRedactors)
-		resolvedRef, err := domtypes.ArtifactRefOf(ref.Kind(), value)
+		resolvedRef, err := domtypes.ArtifactRefFrom(ref.Kind(), value)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to sanitize artifact ref: %w", err)
 		}
@@ -501,7 +501,7 @@ func sanitizeArtifactRefs(refs []domtypes.ArtifactRef, extraRedactors []redactio
 }
 
 func resolveRequiredMemoryType(memoryType domtypes.MemoryType) (domtypes.MemoryType, error) {
-	resolved, err := domtypes.MemoryTypeOf(memoryType.String())
+	resolved, err := domtypes.MemoryTypeFrom(memoryType.String())
 	if err != nil {
 		return domtypes.MemoryType(""), xerrors.Errorf("failed to resolve memory type: %w", err)
 	}
@@ -536,7 +536,7 @@ func resolveMemorySource(source domtypes.MemorySource) (domtypes.MemorySource, e
 	if strings.TrimSpace(source.String()) == "" {
 		return domtypes.MemorySourceManual, nil
 	}
-	resolved, err := domtypes.MemorySourceOf(source.String())
+	resolved, err := domtypes.MemorySourceFrom(source.String())
 	if err != nil {
 		return domtypes.MemorySource(""), xerrors.Errorf("failed to resolve memory source: %w", err)
 	}
@@ -545,7 +545,7 @@ func resolveMemorySource(source domtypes.MemorySource) (domtypes.MemorySource, e
 
 func resolveAcceptedConfidence(confidence domtypes.Optional[domtypes.Confidence]) (domtypes.Confidence, error) {
 	if value, ok := confidence.Value(); ok {
-		resolved, err := domtypes.ConfidenceOf(value.String())
+		resolved, err := domtypes.ConfidenceFrom(value.String())
 		if err != nil {
 			return domtypes.Confidence(""), xerrors.Errorf("failed to resolve confidence: %w", err)
 		}

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -581,9 +581,9 @@ func TestMemoryUsecase_Show(t *testing.T) {
 func mustMemoryID(t *testing.T, value string) domtypes.MemoryID {
 	t.Helper()
 
-	memoryID, err := domtypes.MemoryIDOf(value)
+	memoryID, err := domtypes.MemoryIDFrom(value)
 	if err != nil {
-		t.Fatalf("MemoryIDOf() error = %v", err)
+		t.Fatalf("MemoryIDFrom() error = %v", err)
 	}
 	return memoryID
 }
@@ -591,9 +591,9 @@ func mustMemoryID(t *testing.T, value string) domtypes.MemoryID {
 func mustEvidenceRef(t *testing.T, kind domtypes.EvidenceRefKind, value string) domtypes.EvidenceRef {
 	t.Helper()
 
-	ref, err := domtypes.EvidenceRefOf(kind, value)
+	ref, err := domtypes.EvidenceRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("EvidenceRefOf() error = %v", err)
+		t.Fatalf("EvidenceRefFrom() error = %v", err)
 	}
 	return ref
 }
@@ -601,9 +601,9 @@ func mustEvidenceRef(t *testing.T, kind domtypes.EvidenceRefKind, value string) 
 func mustArtifactRef(t *testing.T, kind domtypes.ArtifactRefKind, value string) domtypes.ArtifactRef {
 	t.Helper()
 
-	ref, err := domtypes.ArtifactRefOf(kind, value)
+	ref, err := domtypes.ArtifactRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("ArtifactRefOf() error = %v", err)
+		t.Fatalf("ArtifactRefFrom() error = %v", err)
 	}
 	return ref
 }

--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -74,8 +74,8 @@ func TestSessionUsecase_End(t *testing.T) {
 	t.Run("saves session end event", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, _ := types.SessionIDOf("session-1")
-		agent, _ := types.AgentOf("codex")
+		sessionID, _ := types.SessionIDFrom("session-1")
+		agent, _ := types.AgentFrom("codex")
 		existing := model.SessionOf(
 			sessionID, mustTime(t), types.None[time.Time](),
 			types.Client("cli"), agent, types.Workspace("duck8823/traceary"),
@@ -109,13 +109,13 @@ func TestSessionUsecase_End(t *testing.T) {
 	t.Run("session end inherits client/agent/repo from start", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, err := types.SessionIDOf("session-1")
+		sessionID, err := types.SessionIDFrom("session-1")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
-		startAgent, err := types.AgentOf("claude")
+		startAgent, err := types.AgentFrom("claude")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
 
 		stub := &eventRepositoryStub{}
@@ -156,13 +156,13 @@ func TestSessionUsecase_End(t *testing.T) {
 	t.Run("session end prefers explicit client/agent over inherited", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, err := types.SessionIDOf("session-1")
+		sessionID, err := types.SessionIDFrom("session-1")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
-		startAgent, err := types.AgentOf("claude")
+		startAgent, err := types.AgentFrom("claude")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
 
 		stub := &eventRepositoryStub{}
@@ -222,13 +222,13 @@ func TestSessionUsecase_End(t *testing.T) {
 	t.Run("returns ErrInvalidSessionState when session is already ended", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, err := types.SessionIDOf("session-already-ended")
+		sessionID, err := types.SessionIDFrom("session-already-ended")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
-		agent, err := types.AgentOf("claude")
+		agent, err := types.AgentFrom("claude")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
 		endedAt := mustTime(t).Add(time.Hour)
 		alreadyEnded := model.SessionOf(
@@ -339,13 +339,13 @@ func TestSessionUsecase_SessionSaver(t *testing.T) {
 	t.Run("calls SaveBoundary on session end with existing session", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, err := types.SessionIDOf("test-session")
+		sessionID, err := types.SessionIDFrom("test-session")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
-		agent, err := types.AgentOf("claude")
+		agent, err := types.AgentFrom("claude")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
 
 		eventStub := &eventRepositoryStub{}
@@ -413,8 +413,8 @@ func TestSessionUsecase_SessionSaver(t *testing.T) {
 	t.Run("session start returns ErrInvalidSessionState when explicit session ID already exists", func(t *testing.T) {
 		t.Parallel()
 
-		existingID, _ := types.SessionIDOf("existing-session")
-		agent, _ := types.AgentOf("claude")
+		existingID, _ := types.SessionIDFrom("existing-session")
+		agent, _ := types.AgentFrom("claude")
 		existingSession := model.SessionOf(
 			existingID, mustTime(t), types.None[time.Time](),
 			types.Client("cli"), agent, types.Workspace("duck8823/traceary"),

--- a/application/usecase/replay_usecase_impl_test.go
+++ b/application/usecase/replay_usecase_impl_test.go
@@ -71,9 +71,9 @@ func (s *stubReplayMemoryQuery) GetDetails(context.Context, domtypes.MemoryID) (
 
 func sessionSummary(t *testing.T, id string, workspace string) apptypes.SessionSummary {
 	t.Helper()
-	ws, err := domtypes.WorkspaceOf(workspace)
+	ws, err := domtypes.WorkspaceFrom(workspace)
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	return apptypes.SessionSummaryOf(
 		domtypes.SessionID(id),
@@ -87,9 +87,9 @@ func sessionSummary(t *testing.T, id string, workspace string) apptypes.SessionS
 
 func memorySummary(t *testing.T, id string, workspace string, fact string) apptypes.MemorySummary {
 	t.Helper()
-	ws, err := domtypes.WorkspaceOf(workspace)
+	ws, err := domtypes.WorkspaceFrom(workspace)
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(ws)
 	now := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -44,7 +44,7 @@ func (u *sessionUsecase) Start(ctx context.Context, client types.Client, agent t
 	if err != nil {
 		return nil, xerrors.Errorf("failed to start session: %w", err)
 	}
-	if _, err := types.AgentOf(agent.String()); err != nil {
+	if _, err := types.AgentFrom(agent.String()); err != nil {
 		return nil, xerrors.Errorf("failed to start session: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func (u *sessionUsecase) End(ctx context.Context, client types.Client, agent typ
 		return nil, xerrors.Errorf("session repository is not configured")
 	}
 
-	resolvedSessionID, err := types.SessionIDOf(sessionID.String())
+	resolvedSessionID, err := types.SessionIDFrom(sessionID.String())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to end session: %w", err)
 	}
@@ -94,7 +94,7 @@ func (u *sessionUsecase) End(ctx context.Context, client types.Client, agent typ
 	}
 
 	resolvedClient, resolvedAgent, resolvedWorkspace := inheritAttribution(client, agent, workspace, existingSession)
-	if _, err := types.AgentOf(resolvedAgent.String()); err != nil {
+	if _, err := types.AgentFrom(resolvedAgent.String()); err != nil {
 		return nil, xerrors.Errorf("failed to end session: %w", err)
 	}
 
@@ -119,7 +119,7 @@ func (u *sessionUsecase) Label(ctx context.Context, sessionID types.SessionID, l
 		return xerrors.Errorf("session ID must not be empty")
 	}
 
-	resolvedSessionID, err := types.SessionIDOf(trimmedSessionID)
+	resolvedSessionID, err := types.SessionIDFrom(trimmedSessionID)
 	if err != nil {
 		return xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
@@ -221,7 +221,7 @@ func (u *sessionUsecase) resolveSessionStartID(sessionID types.SessionID) (types
 		return generated, true, nil
 	}
 
-	resolved, err := types.SessionIDOf(trimmedValue)
+	resolved, err := types.SessionIDFrom(trimmedValue)
 	if err != nil {
 		return types.SessionID(""), false, xerrors.Errorf("failed to convert session ID: %w", err)
 	}

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -184,13 +184,13 @@ func (s *eventQueryServiceStub) ListTimelineBlocks(
 func TestSessionUsecase_Label(t *testing.T) {
 	t.Parallel()
 
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("claude")
+	agent, err := types.AgentFrom("claude")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
 
 	t.Run("sets label on existing session", func(t *testing.T) {

--- a/domain/model/command_audit_test.go
+++ b/domain/model/command_audit_test.go
@@ -12,9 +12,9 @@ import (
 func TestNewCommandAudit(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
 
 	t.Run("creates command audit successfully", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestNewCommandAudit(t *testing.T) {
 func TestCommandAuditOf(t *testing.T) {
 	t.Parallel()
 
-	eventID, _ := types.EventIDOf("event-2")
+	eventID, _ := types.EventIDFrom("event-2")
 
 	audit := model.CommandAuditOf(eventID, "go build", "input-data", "output-data", false, true, types.None[int]())
 

--- a/domain/model/event_test.go
+++ b/domain/model/event_test.go
@@ -13,17 +13,17 @@ func TestNewEvent(t *testing.T) {
 	model.SetNowFunc(func() time.Time { return fixedTime })
 	defer model.ResetNowFunc()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	tests := []struct {
@@ -83,9 +83,9 @@ func TestNewEvent(t *testing.T) {
 func TestEventOf(t *testing.T) {
 	t.Parallel()
 
-	eventID, _ := types.EventIDOf("event-1")
-	agent, _ := types.AgentOf("claude")
-	sessionID, _ := types.SessionIDOf("session-1")
+	eventID, _ := types.EventIDFrom("event-1")
+	agent, _ := types.AgentFrom("claude")
+	sessionID, _ := types.SessionIDFrom("session-1")
 	ts := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 
 	event := model.EventOf(eventID, types.EventKindNote, types.Client("cli"), agent, sessionID, types.Workspace("duck8823/traceary"), "hello", ts)

--- a/domain/model/memory_test.go
+++ b/domain/model/memory_test.go
@@ -16,9 +16,9 @@ func TestNewMemoryCandidate(t *testing.T) {
 	model.SetNowFunc(func() time.Time { return now })
 	defer model.ResetNowFunc()
 
-	memoryID, _ := types.MemoryIDOf("mem-1")
-	evidence, _ := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-1")
-	artifact, _ := types.ArtifactRefOf(types.ArtifactRefKindURL, "https://example.com/docs")
+	memoryID, _ := types.MemoryIDFrom("mem-1")
+	evidence, _ := types.EvidenceRefFrom(types.EvidenceRefKindEvent, "event-1")
+	artifact, _ := types.ArtifactRefFrom(types.ArtifactRefKindURL, "https://example.com/docs")
 	memory, err := model.NewMemoryCandidate(
 		memoryID,
 		types.MemoryTypeDecision,
@@ -76,8 +76,8 @@ func TestNewMemoryCandidate(t *testing.T) {
 func TestNewAcceptedMemory(t *testing.T) {
 	t.Parallel()
 
-	memoryID, _ := types.MemoryIDOf("mem-2")
-	previousID, _ := types.MemoryIDOf("mem-1")
+	memoryID, _ := types.MemoryIDFrom("mem-2")
+	previousID, _ := types.MemoryIDFrom("mem-1")
 	memory, err := model.NewAcceptedMemory(
 		memoryID,
 		types.MemoryTypePreference,
@@ -111,7 +111,7 @@ func TestMemory_StateTransitions(t *testing.T) {
 
 	newCandidate := func(t *testing.T) *model.Memory {
 		t.Helper()
-		memoryID, _ := types.MemoryIDOf("mem-transition")
+		memoryID, _ := types.MemoryIDFrom("mem-transition")
 		memory, err := model.NewMemoryCandidate(
 			memoryID,
 			types.MemoryTypeLesson,
@@ -236,9 +236,9 @@ func TestMemory_StateTransitions(t *testing.T) {
 func TestNewMemoryCandidate_ClonesSlices(t *testing.T) {
 	t.Parallel()
 
-	memoryID, _ := types.MemoryIDOf("mem-clone")
-	evidence, _ := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-9")
-	artifact, _ := types.ArtifactRefOf(types.ArtifactRefKindFile, "docs/spec.md")
+	memoryID, _ := types.MemoryIDFrom("mem-clone")
+	evidence, _ := types.EvidenceRefFrom(types.EvidenceRefKindEvent, "event-9")
+	artifact, _ := types.ArtifactRefFrom(types.ArtifactRefKindFile, "docs/spec.md")
 	evidenceRefs := []types.EvidenceRef{evidence}
 	artifactRefs := []types.ArtifactRef{artifact}
 	memory, err := model.NewMemoryCandidate(

--- a/domain/model/session_test.go
+++ b/domain/model/session_test.go
@@ -14,13 +14,13 @@ import (
 func TestNewSession(t *testing.T) {
 	t.Parallel()
 
-	agent, err := types.AgentOf("claude")
+	agent, err := types.AgentFrom("claude")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sid, err := types.SessionIDOf("session-1")
+	sid, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 
@@ -58,8 +58,8 @@ func TestNewSession(t *testing.T) {
 func TestSessionOf(t *testing.T) {
 	t.Parallel()
 
-	agent, _ := types.AgentOf("codex")
-	sid, _ := types.SessionIDOf("session-2")
+	agent, _ := types.AgentFrom("codex")
+	sid, _ := types.SessionIDFrom("session-2")
 	start := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 10, 13, 0, 0, 0, time.UTC)
 
@@ -87,8 +87,8 @@ func TestSessionOf(t *testing.T) {
 func TestSession_End(t *testing.T) {
 	t.Parallel()
 
-	agent, _ := types.AgentOf("claude")
-	sid, _ := types.SessionIDOf("session-end")
+	agent, _ := types.AgentFrom("claude")
+	sid, _ := types.SessionIDFrom("session-end")
 	start := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 11, 13, 30, 0, 0, time.UTC)
 
@@ -152,8 +152,8 @@ func TestSession_End(t *testing.T) {
 func TestSession_SetLabel(t *testing.T) {
 	t.Parallel()
 
-	agent, _ := types.AgentOf("claude")
-	sid, _ := types.SessionIDOf("session-3")
+	agent, _ := types.AgentFrom("claude")
+	sid, _ := types.SessionIDFrom("session-3")
 	now := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
 
 	session := model.NewSession(sid, now, types.Client("cli"), agent, types.Workspace("duck8823/traceary"))

--- a/domain/types/agent.go
+++ b/domain/types/agent.go
@@ -9,8 +9,8 @@ import (
 // Agent is a value object representing the actor that produced an event.
 type Agent string
 
-// AgentOf creates an Agent from a string.
-func AgentOf(value string) (Agent, error) {
+// AgentFrom creates an Agent from a string.
+func AgentFrom(value string) (Agent, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return Agent(""), xerrors.Errorf("agent must not be empty")

--- a/domain/types/agent_test.go
+++ b/domain/types/agent_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestAgentOf(t *testing.T) {
+func TestAgentFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -25,12 +25,12 @@ func TestAgentOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.AgentOf(tt.input)
+			got, err := types.AgentFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("AgentOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("AgentFrom(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Errorf("AgentOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+				t.Errorf("AgentFrom(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
 	}

--- a/domain/types/artifact_ref.go
+++ b/domain/types/artifact_ref.go
@@ -34,8 +34,8 @@ type ArtifactRef struct {
 	value string
 }
 
-// ArtifactRefKindOf creates an ArtifactRefKind from a string.
-func ArtifactRefKindOf(value string) (ArtifactRefKind, error) {
+// ArtifactRefKindFrom creates an ArtifactRefKind from a string.
+func ArtifactRefKindFrom(value string) (ArtifactRefKind, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return ArtifactRefKind(""), xerrors.Errorf("artifact ref kind must not be empty")
@@ -46,13 +46,13 @@ func ArtifactRefKindOf(value string) (ArtifactRefKind, error) {
 	return ArtifactRefKind(""), xerrors.Errorf("unknown artifact ref kind: %s", trimmedValue)
 }
 
-// ArtifactRefOf creates an ArtifactRef.
-func ArtifactRefOf(kind ArtifactRefKind, value string) (ArtifactRef, error) {
+// ArtifactRefFrom creates an ArtifactRef.
+func ArtifactRefFrom(kind ArtifactRefKind, value string) (ArtifactRef, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return ArtifactRef{}, xerrors.Errorf("artifact ref value must not be empty")
 	}
-	if _, err := ArtifactRefKindOf(kind.String()); err != nil {
+	if _, err := ArtifactRefKindFrom(kind.String()); err != nil {
 		return ArtifactRef{}, err
 	}
 	return ArtifactRef{kind: kind, value: trimmedValue}, nil

--- a/domain/types/artifact_ref_test.go
+++ b/domain/types/artifact_ref_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestArtifactRefOf(t *testing.T) {
+func TestArtifactRefFrom(t *testing.T) {
 	t.Parallel()
 
-	ref, err := types.ArtifactRefOf(types.ArtifactRefKindFile, "docs/spec.md")
+	ref, err := types.ArtifactRefFrom(types.ArtifactRefKindFile, "docs/spec.md")
 	if err != nil {
-		t.Fatalf("ArtifactRefOf() error = %v", err)
+		t.Fatalf("ArtifactRefFrom() error = %v", err)
 	}
 	if ref.Kind() != types.ArtifactRefKindFile {
 		t.Fatalf("Kind() = %v, want %v", ref.Kind(), types.ArtifactRefKindFile)
@@ -21,13 +21,13 @@ func TestArtifactRefOf(t *testing.T) {
 	}
 }
 
-func TestArtifactRefOf_RejectsInvalidInput(t *testing.T) {
+func TestArtifactRefFrom_RejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
-	if _, err := types.ArtifactRefOf(types.ArtifactRefKind(""), "value"); err == nil {
-		t.Fatalf("ArtifactRefOf() error = nil, want error for empty kind")
+	if _, err := types.ArtifactRefFrom(types.ArtifactRefKind(""), "value"); err == nil {
+		t.Fatalf("ArtifactRefFrom() error = nil, want error for empty kind")
 	}
-	if _, err := types.ArtifactRefOf(types.ArtifactRefKindFile, " "); err == nil {
-		t.Fatalf("ArtifactRefOf() error = nil, want error for empty value")
+	if _, err := types.ArtifactRefFrom(types.ArtifactRefKindFile, " "); err == nil {
+		t.Fatalf("ArtifactRefFrom() error = nil, want error for empty value")
 	}
 }

--- a/domain/types/client.go
+++ b/domain/types/client.go
@@ -11,8 +11,8 @@ import (
 // by additional integrations (e.g. cli, hook, mcp).
 type Client string
 
-// ClientOf creates a Client from a string.
-func ClientOf(value string) (Client, error) {
+// ClientFrom creates a Client from a string.
+func ClientFrom(value string) (Client, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return Client(""), xerrors.Errorf("client must not be empty")

--- a/domain/types/client_test.go
+++ b/domain/types/client_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestClientOf(t *testing.T) {
+func TestClientFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -27,12 +27,12 @@ func TestClientOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.ClientOf(tt.input)
+			got, err := types.ClientFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("ClientOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("ClientFrom(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Errorf("ClientOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+				t.Errorf("ClientFrom(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
 	}

--- a/domain/types/confidence.go
+++ b/domain/types/confidence.go
@@ -28,8 +28,8 @@ var knownConfidenceLevels = []Confidence{
 	ConfidenceVerified,
 }
 
-// ConfidenceOf creates a Confidence from a string.
-func ConfidenceOf(value string) (Confidence, error) {
+// ConfidenceFrom creates a Confidence from a string.
+func ConfidenceFrom(value string) (Confidence, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return Confidence(""), xerrors.Errorf("confidence must not be empty")

--- a/domain/types/confidence_test.go
+++ b/domain/types/confidence_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestConfidenceOf(t *testing.T) {
+func TestConfidenceFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -25,12 +25,12 @@ func TestConfidenceOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.ConfidenceOf(tt.input)
+			got, err := types.ConfidenceFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("ConfidenceOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("ConfidenceFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Fatalf("ConfidenceOf() = %v, want %v", got, tt.want)
+				t.Fatalf("ConfidenceFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/event_id.go
+++ b/domain/types/event_id.go
@@ -9,8 +9,8 @@ import (
 // EventID is a value object representing an event identifier.
 type EventID string
 
-// EventIDOf creates an EventID from a string.
-func EventIDOf(value string) (EventID, error) {
+// EventIDFrom creates an EventID from a string.
+func EventIDFrom(value string) (EventID, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return EventID(""), xerrors.Errorf("event ID must not be empty")

--- a/domain/types/event_id_test.go
+++ b/domain/types/event_id_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestEventIDOf(t *testing.T) {
+func TestEventIDFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -24,12 +24,12 @@ func TestEventIDOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.EventIDOf(tt.input)
+			got, err := types.EventIDFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("EventIDOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("EventIDFrom(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Errorf("EventIDOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+				t.Errorf("EventIDFrom(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
 	}

--- a/domain/types/event_kind.go
+++ b/domain/types/event_kind.go
@@ -42,8 +42,8 @@ var knownEventKinds = []EventKind{
 	EventKindTranscript,
 }
 
-// EventKindOf builds EventKind from a string value.
-func EventKindOf(value string) (EventKind, error) {
+// EventKindFrom builds EventKind from a string value.
+func EventKindFrom(value string) (EventKind, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return EventKind(""), xerrors.Errorf("event kind must not be empty")

--- a/domain/types/event_kind_test.go
+++ b/domain/types/event_kind_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestEventKindOf(t *testing.T) {
+func TestEventKindFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -51,9 +51,9 @@ func TestEventKindOf(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := types.EventKindOf(tt.value)
+			got, err := types.EventKindFrom(tt.value)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("EventKindOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("EventKindFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
 				if tt.name == "returns error for unknown event kind" &&
@@ -63,7 +63,7 @@ func TestEventKindOf(t *testing.T) {
 				return
 			}
 			if got != tt.want {
-				t.Fatalf("EventKindOf() = %v, want %v", got, tt.want)
+				t.Fatalf("EventKindFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/evidence_ref.go
+++ b/domain/types/evidence_ref.go
@@ -40,8 +40,8 @@ type EvidenceRef struct {
 	value string
 }
 
-// EvidenceRefKindOf creates an EvidenceRefKind from a string.
-func EvidenceRefKindOf(value string) (EvidenceRefKind, error) {
+// EvidenceRefKindFrom creates an EvidenceRefKind from a string.
+func EvidenceRefKindFrom(value string) (EvidenceRefKind, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return EvidenceRefKind(""), xerrors.Errorf("evidence ref kind must not be empty")
@@ -52,13 +52,13 @@ func EvidenceRefKindOf(value string) (EvidenceRefKind, error) {
 	return EvidenceRefKind(""), xerrors.Errorf("unknown evidence ref kind: %s", trimmedValue)
 }
 
-// EvidenceRefOf creates an EvidenceRef.
-func EvidenceRefOf(kind EvidenceRefKind, value string) (EvidenceRef, error) {
+// EvidenceRefFrom creates an EvidenceRef.
+func EvidenceRefFrom(kind EvidenceRefKind, value string) (EvidenceRef, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return EvidenceRef{}, xerrors.Errorf("evidence ref value must not be empty")
 	}
-	if _, err := EvidenceRefKindOf(kind.String()); err != nil {
+	if _, err := EvidenceRefKindFrom(kind.String()); err != nil {
 		return EvidenceRef{}, err
 	}
 	return EvidenceRef{kind: kind, value: trimmedValue}, nil

--- a/domain/types/evidence_ref_test.go
+++ b/domain/types/evidence_ref_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestEvidenceRefOf(t *testing.T) {
+func TestEvidenceRefFrom(t *testing.T) {
 	t.Parallel()
 
-	ref, err := types.EvidenceRefOf(types.EvidenceRefKindEvent, "event-123")
+	ref, err := types.EvidenceRefFrom(types.EvidenceRefKindEvent, "event-123")
 	if err != nil {
-		t.Fatalf("EvidenceRefOf() error = %v", err)
+		t.Fatalf("EvidenceRefFrom() error = %v", err)
 	}
 	if ref.Kind() != types.EvidenceRefKindEvent {
 		t.Fatalf("Kind() = %v, want %v", ref.Kind(), types.EvidenceRefKindEvent)
@@ -21,13 +21,13 @@ func TestEvidenceRefOf(t *testing.T) {
 	}
 }
 
-func TestEvidenceRefOf_RejectsInvalidInput(t *testing.T) {
+func TestEvidenceRefFrom_RejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
-	if _, err := types.EvidenceRefOf(types.EvidenceRefKind(""), "value"); err == nil {
-		t.Fatalf("EvidenceRefOf() error = nil, want error for empty kind")
+	if _, err := types.EvidenceRefFrom(types.EvidenceRefKind(""), "value"); err == nil {
+		t.Fatalf("EvidenceRefFrom() error = nil, want error for empty kind")
 	}
-	if _, err := types.EvidenceRefOf(types.EvidenceRefKindEvent, " "); err == nil {
-		t.Fatalf("EvidenceRefOf() error = nil, want error for empty value")
+	if _, err := types.EvidenceRefFrom(types.EvidenceRefKindEvent, " "); err == nil {
+		t.Fatalf("EvidenceRefFrom() error = nil, want error for empty value")
 	}
 }

--- a/domain/types/memory_edge_id.go
+++ b/domain/types/memory_edge_id.go
@@ -11,10 +11,10 @@ import (
 // within a single SQLite store and has no cross-store meaning.
 type MemoryEdgeID string
 
-// MemoryEdgeIDOf creates a MemoryEdgeID from a string. Empty /
+// MemoryEdgeIDFrom creates a MemoryEdgeID from a string. Empty /
 // whitespace-only values are rejected — callers should pass a fresh
 // UUID-like token the edge repository can write.
-func MemoryEdgeIDOf(value string) (MemoryEdgeID, error) {
+func MemoryEdgeIDFrom(value string) (MemoryEdgeID, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
 		return MemoryEdgeID(""), xerrors.Errorf("memory edge ID must not be empty")

--- a/domain/types/memory_id.go
+++ b/domain/types/memory_id.go
@@ -9,8 +9,8 @@ import (
 // MemoryID identifies a durable memory.
 type MemoryID string
 
-// MemoryIDOf creates a MemoryID from a string.
-func MemoryIDOf(value string) (MemoryID, error) {
+// MemoryIDFrom creates a MemoryID from a string.
+func MemoryIDFrom(value string) (MemoryID, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return MemoryID(""), xerrors.Errorf("memory ID must not be empty")

--- a/domain/types/memory_id_test.go
+++ b/domain/types/memory_id_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestMemoryIDOf(t *testing.T) {
+func TestMemoryIDFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -24,12 +24,12 @@ func TestMemoryIDOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.MemoryIDOf(tt.input)
+			got, err := types.MemoryIDFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("MemoryIDOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("MemoryIDFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Fatalf("MemoryIDOf().String() = %q, want %q", got.String(), tt.want)
+				t.Fatalf("MemoryIDFrom().String() = %q, want %q", got.String(), tt.want)
 			}
 		})
 	}

--- a/domain/types/memory_scope.go
+++ b/domain/types/memory_scope.go
@@ -32,8 +32,8 @@ type MemoryScope interface {
 	Key() string
 }
 
-// MemoryScopeKindOf creates a MemoryScopeKind from a string.
-func MemoryScopeKindOf(value string) (MemoryScopeKind, error) {
+// MemoryScopeKindFrom creates a MemoryScopeKind from a string.
+func MemoryScopeKindFrom(value string) (MemoryScopeKind, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return MemoryScopeKind(""), xerrors.Errorf("memory scope kind must not be empty")
@@ -112,26 +112,26 @@ func (s SessionFamilyScope) SessionID() SessionID { return s.sessionID }
 
 // MemoryScopeFrom restores a typed MemoryScope from persisted values.
 func MemoryScopeFrom(kind string, value string) (MemoryScope, error) {
-	resolvedKind, err := MemoryScopeKindOf(kind)
+	resolvedKind, err := MemoryScopeKindFrom(kind)
 	if err != nil {
 		return nil, err
 	}
 
 	switch resolvedKind {
 	case MemoryScopeKindWorkspace:
-		workspace, err := WorkspaceOf(value)
+		workspace, err := WorkspaceFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("invalid workspace scope: %w", err)
 		}
 		return WorkspaceScopeOf(workspace), nil
 	case MemoryScopeKindAgent:
-		agent, err := AgentOf(value)
+		agent, err := AgentFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("invalid agent scope: %w", err)
 		}
 		return AgentScopeOf(agent), nil
 	case MemoryScopeKindSessionFamily:
-		sessionID, err := SessionIDOf(value)
+		sessionID, err := SessionIDFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("invalid session family scope: %w", err)
 		}

--- a/domain/types/memory_scope_test.go
+++ b/domain/types/memory_scope_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestMemoryScopeKindOf(t *testing.T) {
+func TestMemoryScopeKindFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -27,12 +27,12 @@ func TestMemoryScopeKindOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.MemoryScopeKindOf(tt.input)
+			got, err := types.MemoryScopeKindFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("MemoryScopeKindOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("MemoryScopeKindFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Fatalf("MemoryScopeKindOf() = %v, want %v", got, tt.want)
+				t.Fatalf("MemoryScopeKindFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/memory_source.go
+++ b/domain/types/memory_source.go
@@ -25,8 +25,8 @@ var knownMemorySources = []MemorySource{
 	MemorySourceImported,
 }
 
-// MemorySourceOf creates a MemorySource from a string.
-func MemorySourceOf(value string) (MemorySource, error) {
+// MemorySourceFrom creates a MemorySource from a string.
+func MemorySourceFrom(value string) (MemorySource, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return MemorySource(""), xerrors.Errorf("memory source must not be empty")

--- a/domain/types/memory_source_test.go
+++ b/domain/types/memory_source_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestMemorySourceOf(t *testing.T) {
+func TestMemorySourceFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -25,12 +25,12 @@ func TestMemorySourceOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.MemorySourceOf(tt.input)
+			got, err := types.MemorySourceFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("MemorySourceOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("MemorySourceFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Fatalf("MemorySourceOf() = %v, want %v", got, tt.want)
+				t.Fatalf("MemorySourceFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/memory_status.go
+++ b/domain/types/memory_status.go
@@ -31,8 +31,8 @@ var knownMemoryStatuses = []MemoryStatus{
 	MemoryStatusExpired,
 }
 
-// MemoryStatusOf creates a MemoryStatus from a string.
-func MemoryStatusOf(value string) (MemoryStatus, error) {
+// MemoryStatusFrom creates a MemoryStatus from a string.
+func MemoryStatusFrom(value string) (MemoryStatus, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return MemoryStatus(""), xerrors.Errorf("memory status must not be empty")

--- a/domain/types/memory_status_test.go
+++ b/domain/types/memory_status_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestMemoryStatusOf(t *testing.T) {
+func TestMemoryStatusFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -25,12 +25,12 @@ func TestMemoryStatusOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.MemoryStatusOf(tt.input)
+			got, err := types.MemoryStatusFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("MemoryStatusOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("MemoryStatusFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Fatalf("MemoryStatusOf() = %v, want %v", got, tt.want)
+				t.Fatalf("MemoryStatusFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/memory_type.go
+++ b/domain/types/memory_type.go
@@ -31,8 +31,8 @@ var knownMemoryTypes = []MemoryType{
 	MemoryTypeArtifact,
 }
 
-// MemoryTypeOf creates a MemoryType from a string.
-func MemoryTypeOf(value string) (MemoryType, error) {
+// MemoryTypeFrom creates a MemoryType from a string.
+func MemoryTypeFrom(value string) (MemoryType, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return MemoryType(""), xerrors.Errorf("memory type must not be empty")

--- a/domain/types/memory_type_test.go
+++ b/domain/types/memory_type_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestMemoryTypeOf(t *testing.T) {
+func TestMemoryTypeFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -25,12 +25,12 @@ func TestMemoryTypeOf(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.MemoryTypeOf(tt.input)
+			got, err := types.MemoryTypeFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("MemoryTypeOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("MemoryTypeFrom() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Fatalf("MemoryTypeOf() = %v, want %v", got, tt.want)
+				t.Fatalf("MemoryTypeFrom() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/types/session_id.go
+++ b/domain/types/session_id.go
@@ -9,8 +9,8 @@ import (
 // SessionID is a value object representing a work session identifier.
 type SessionID string
 
-// SessionIDOf creates a SessionID from a string.
-func SessionIDOf(value string) (SessionID, error) {
+// SessionIDFrom creates a SessionID from a string.
+func SessionIDFrom(value string) (SessionID, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return SessionID(""), xerrors.Errorf("session ID must not be empty")

--- a/domain/types/session_id_test.go
+++ b/domain/types/session_id_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestSessionIDOf(t *testing.T) {
+func TestSessionIDFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -24,12 +24,12 @@ func TestSessionIDOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.SessionIDOf(tt.input)
+			got, err := types.SessionIDFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("SessionIDOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("SessionIDFrom(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Errorf("SessionIDOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+				t.Errorf("SessionIDFrom(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
 	}

--- a/domain/types/workspace.go
+++ b/domain/types/workspace.go
@@ -11,8 +11,8 @@ import (
 // paths (github.com/org/repo) and absolute filesystem paths.
 type Workspace string
 
-// WorkspaceOf creates a Workspace from a string.
-func WorkspaceOf(value string) (Workspace, error) {
+// WorkspaceFrom creates a Workspace from a string.
+func WorkspaceFrom(value string) (Workspace, error) {
 	trimmedValue := strings.TrimSpace(value)
 	if trimmedValue == "" {
 		return Workspace(""), xerrors.Errorf("workspace must not be empty")

--- a/domain/types/workspace_test.go
+++ b/domain/types/workspace_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestWorkspaceOf(t *testing.T) {
+func TestWorkspaceFrom(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -26,12 +26,12 @@ func TestWorkspaceOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := types.WorkspaceOf(tt.input)
+			got, err := types.WorkspaceFrom(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("WorkspaceOf(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Fatalf("WorkspaceFrom(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
 			if !tt.wantErr && got.String() != tt.want {
-				t.Errorf("WorkspaceOf(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
+				t.Errorf("WorkspaceFrom(%q).String() = %q, want %q", tt.input, got.String(), tt.want)
 			}
 		})
 	}

--- a/infrastructure/filesystem/codex_memory_source.go
+++ b/infrastructure/filesystem/codex_memory_source.go
@@ -147,7 +147,7 @@ func (s *codexMemorySource) Load(
 			continue
 		}
 
-		evidence, err := domtypes.EvidenceRefOf(
+		evidence, err := domtypes.EvidenceRefFrom(
 			domtypes.EvidenceRefKindFile,
 			fmt.Sprintf("%s#L%d-L%d", containedPath, bullet.startLine, bullet.endLine),
 		)
@@ -155,7 +155,7 @@ func (s *codexMemorySource) Load(
 			warnings = append(warnings, fmt.Sprintf("skipped bullet at %s:%d (evidence ref rejected: %v)", containedPath, bullet.startLine, err))
 			continue
 		}
-		artifact, err := domtypes.ArtifactRefOf(domtypes.ArtifactRefKindFile, containedPath)
+		artifact, err := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindFile, containedPath)
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("skipped bullet at %s:%d (artifact ref rejected: %v)", containedPath, bullet.startLine, err))
 			continue
@@ -435,7 +435,7 @@ func resolveCandidateScope(
 }
 
 func newWorkspaceScope(value string) (domtypes.MemoryScope, error) {
-	workspace, err := domtypes.WorkspaceOf(value)
+	workspace, err := domtypes.WorkspaceFrom(value)
 	if err != nil {
 		return nil, xerrors.Errorf("invalid workspace scope value: %w", err)
 	}

--- a/infrastructure/filesystem/codex_memory_source_test.go
+++ b/infrastructure/filesystem/codex_memory_source_test.go
@@ -165,9 +165,9 @@ func TestCodexMemorySource_LoadUsesWorkspaceFallbackWhenCWDMissing(t *testing.T)
 		t.Fatalf("write MEMORY.md: %v", err)
 	}
 
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	source := NewCodexMemorySource()
 	candidates, _, err := source.Load(context.Background(), apptypes.CodexImportCriteria{
@@ -227,9 +227,9 @@ func TestCodexMemorySource_LoadEmitsWarningForOversizedLine(t *testing.T) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("mkdir memories: %v", err)
 	}
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	giant := strings.Repeat("a", 64*1024)
 	content := "# Task Group: x\n\n## User preferences\n- short bullet before giant.\n- " + giant + "\n- short bullet after giant.\n"

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -55,17 +55,17 @@ CREATE TABLE command_audits (
 		t.Fatalf("Initialize() error = %v", err)
 	}
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	event := model.EventOf(
 		eventID,

--- a/infrastructure/sqlite/database_concurrency_test.go
+++ b/infrastructure/sqlite/database_concurrency_test.go
@@ -82,17 +82,17 @@ func TestDatabase_ConcurrentWritersAndReaders_NoSQLITE_BUSY(t *testing.T) {
 func newConcurrencyTestEvent(t *testing.T, eventIDValue, sessionIDValue string, createdAt time.Time) *model.Event {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf(sessionIDValue)
+	sessionID, err := types.SessionIDFrom(sessionIDValue)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -819,19 +819,19 @@ func restoreEvent(
 	sourceHookValue string,
 	createdAtValue string,
 ) (*model.Event, error) {
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore event ID: %w", err)
 	}
-	eventKind, err := types.EventKindOf(eventKindValue)
+	eventKind, err := types.EventKindFrom(eventKindValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore event kind: %w", err)
 	}
-	agent, err := types.AgentOf(agentValue)
+	agent, err := types.AgentFrom(agentValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore agent: %w", err)
 	}
-	sessionID, err := types.SessionIDOf(sessionIDValue)
+	sessionID, err := types.SessionIDFrom(sessionIDValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore session ID: %w", err)
 	}

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -436,9 +436,9 @@ CREATE TABLE command_audits (
 func mustEventIDForSQLite(t *testing.T, value string) types.EventID {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(value)
+	eventID, err := types.EventIDFrom(value)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
 
 	return eventID
@@ -447,9 +447,9 @@ func mustEventIDForSQLite(t *testing.T, value string) types.EventID {
 func mustAgentForSQLite(t *testing.T, value string) types.Agent {
 	t.Helper()
 
-	agent, err := types.AgentOf(value)
+	agent, err := types.AgentFrom(value)
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
 
 	return agent
@@ -458,9 +458,9 @@ func mustAgentForSQLite(t *testing.T, value string) types.Agent {
 func mustSessionIDForSQLite(t *testing.T, value string) types.SessionID {
 	t.Helper()
 
-	sessionID, err := types.SessionIDOf(value)
+	sessionID, err := types.SessionIDFrom(value)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return sessionID
@@ -478,17 +478,17 @@ func newEventForSQLiteTest(
 ) *model.Event {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf(agentValue)
+	agent, err := types.AgentFrom(agentValue)
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf(sessionIDValue)
+	sessionID, err := types.SessionIDFrom(sessionIDValue)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -404,17 +404,17 @@ func newFindLatestSessionEventFixture(
 ) *model.Event {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf(sessionIDValue)
+	sessionID, err := types.SessionIDFrom(sessionIDValue)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -160,17 +160,17 @@ func newGCEventFixture(
 ) *model.Event {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -84,8 +84,8 @@ GROUP BY e.session_id;`),
 
 func saveTestSession(ctx context.Context, t *testing.T, ds *infra.SessionDatasource, sessionID string, startedAt time.Time, endedAt types.Optional[time.Time], agent string, workspace string) {
 	t.Helper()
-	ag, _ := types.AgentOf(agent)
-	sid, _ := types.SessionIDOf(sessionID)
+	ag, _ := types.AgentFrom(agent)
+	sid, _ := types.SessionIDFrom(sessionID)
 	session := model.SessionOf(sid, startedAt, endedAt, types.Client("hook"), ag, types.Workspace(workspace), "", "", types.SessionID(""))
 	if err := ds.SaveSessionBoundaryForTest(ctx, session); err != nil {
 		t.Fatalf("SaveSessionBoundaryForTest() error = %v", err)
@@ -122,9 +122,9 @@ func TestDatasource_ListSummaries(t *testing.T) {
 		}
 
 		for _, e := range events {
-			eid, _ := types.EventIDOf(e.id)
-			agent, _ := types.AgentOf(e.agent)
-			sid, _ := types.SessionIDOf(e.sessionID)
+			eid, _ := types.EventIDFrom(e.id)
+			agent, _ := types.AgentFrom(e.agent)
+			sid, _ := types.SessionIDFrom(e.sessionID)
 			event, _ := model.NewEvent(eid, e.kind, "hook", agent, sid, "duck8823/traceary", e.body)
 			if err := fixture.eventDS.Save(ctx, event); err != nil {
 				t.Fatalf("Save() error = %v", err)
@@ -196,9 +196,9 @@ func TestDatasource_ListSummaries(t *testing.T) {
 			{"e1", "claude", "s1"},
 			{"e2", "codex", "s2"},
 		} {
-			eid, _ := types.EventIDOf(e.id)
-			agent, _ := types.AgentOf(e.agent)
-			sid, _ := types.SessionIDOf(e.sid)
+			eid, _ := types.EventIDFrom(e.id)
+			agent, _ := types.AgentFrom(e.agent)
+			sid, _ := types.SessionIDFrom(e.sid)
 			event, _ := model.NewEvent(eid, types.EventKindSessionStarted, "hook", agent, sid, "workspace", "start")
 			if err := fixture.eventDS.Save(ctx, event); err != nil {
 				t.Fatalf("Save() error = %v", err)
@@ -239,9 +239,9 @@ func TestDatasource_ListSummaries(t *testing.T) {
 			{"e1", "s-old", 1},
 			{"e2", "s-new", 10},
 		} {
-			eid, _ := types.EventIDOf(e.id)
-			agent, _ := types.AgentOf("claude")
-			sid, _ := types.SessionIDOf(e.sid)
+			eid, _ := types.EventIDFrom(e.id)
+			agent, _ := types.AgentFrom("claude")
+			sid, _ := types.SessionIDFrom(e.sid)
 			ts := time.Date(2026, 4, e.dayOfMon, 12, 0, 0, 0, time.UTC)
 			event := model.EventOf(eid, types.EventKindSessionStarted, "hook", agent, sid, "workspace", "start", ts)
 			if err := fixture.eventDS.Save(ctx, event); err != nil {
@@ -280,9 +280,9 @@ func TestDatasource_ListSummaries(t *testing.T) {
 			{"e1", "claude", "s1"},
 			{"e2", "claude", "s2"},
 		} {
-			eid, _ := types.EventIDOf(e.id)
-			agent, _ := types.AgentOf(e.agent)
-			sid, _ := types.SessionIDOf(e.sid)
+			eid, _ := types.EventIDFrom(e.id)
+			agent, _ := types.AgentFrom(e.agent)
+			sid, _ := types.SessionIDFrom(e.sid)
 			event, _ := model.NewEvent(eid, types.EventKindSessionStarted, "hook", agent, sid, "workspace", "start")
 			if err := fixture.eventDS.Save(ctx, event); err != nil {
 				t.Fatalf("Save() error = %v", err)
@@ -323,9 +323,9 @@ func TestDatasource_ListSummaries(t *testing.T) {
 			{"e1", "s-old", 1},
 			{"e2", "s-new", 10},
 		} {
-			eid, _ := types.EventIDOf(e.id)
-			agent, _ := types.AgentOf("claude")
-			sid, _ := types.SessionIDOf(e.sid)
+			eid, _ := types.EventIDFrom(e.id)
+			agent, _ := types.AgentFrom("claude")
+			sid, _ := types.SessionIDFrom(e.sid)
 			ts := time.Date(2026, 4, e.dayOfMon, 12, 0, 0, 0, time.UTC)
 			event := model.EventOf(eid, types.EventKindSessionStarted, "hook", agent, sid, "workspace", "start", ts)
 			if err := fixture.eventDS.Save(ctx, event); err != nil {

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -420,11 +420,11 @@ func scanMemorySummary(rowScanner interface {
 }
 
 func restoreMemorySummary(row memoryRow) (apptypes.MemorySummary, error) {
-	memoryID, err := types.MemoryIDOf(row.memoryID)
+	memoryID, err := types.MemoryIDFrom(row.memoryID)
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory ID: %w", err)
 	}
-	memoryType, err := types.MemoryTypeOf(row.memoryType)
+	memoryType, err := types.MemoryTypeFrom(row.memoryType)
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory type: %w", err)
 	}
@@ -432,21 +432,21 @@ func restoreMemorySummary(row memoryRow) (apptypes.MemorySummary, error) {
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory scope: %w", err)
 	}
-	status, err := types.MemoryStatusOf(row.status)
+	status, err := types.MemoryStatusFrom(row.status)
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory status: %w", err)
 	}
-	confidence, err := types.ConfidenceOf(row.confidence)
+	confidence, err := types.ConfidenceFrom(row.confidence)
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory confidence: %w", err)
 	}
-	source, err := types.MemorySourceOf(row.source)
+	source, err := types.MemorySourceFrom(row.source)
 	if err != nil {
 		return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore memory source: %w", err)
 	}
 	supersedes := types.None[types.MemoryID]()
 	if row.supersedes.Valid {
-		memoryIDValue, err := types.MemoryIDOf(row.supersedes.String)
+		memoryIDValue, err := types.MemoryIDFrom(row.supersedes.String)
 		if err != nil {
 			return apptypes.MemorySummary{}, xerrors.Errorf("failed to restore superseded memory ID: %w", err)
 		}
@@ -589,11 +589,11 @@ func loadMemoryEvidenceRefs(ctx context.Context, db *sql.DB, memoryID types.Memo
 		if err := rows.Scan(&kindValue, &refValue); err != nil {
 			return nil, xerrors.Errorf("failed to scan memory evidence ref row: %w", err)
 		}
-		kind, err := types.EvidenceRefKindOf(kindValue)
+		kind, err := types.EvidenceRefKindFrom(kindValue)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore evidence ref kind: %w", err)
 		}
-		evidenceRef, err := types.EvidenceRefOf(kind, refValue)
+		evidenceRef, err := types.EvidenceRefFrom(kind, refValue)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore evidence ref: %w", err)
 		}
@@ -623,11 +623,11 @@ func loadMemoryArtifactRefs(ctx context.Context, db *sql.DB, memoryID types.Memo
 		if err := rows.Scan(&kindValue, &refValue); err != nil {
 			return nil, xerrors.Errorf("failed to scan memory artifact ref row: %w", err)
 		}
-		kind, err := types.ArtifactRefKindOf(kindValue)
+		kind, err := types.ArtifactRefKindFrom(kindValue)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore artifact ref kind: %w", err)
 		}
-		artifactRef, err := types.ArtifactRefOf(kind, refValue)
+		artifactRef, err := types.ArtifactRefFrom(kind, refValue)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore artifact ref: %w", err)
 		}

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -103,54 +103,54 @@ WHERE valid_to IS NOT NULL;`),
 
 func mustMemoryID(t *testing.T, value string) types.MemoryID {
 	t.Helper()
-	memoryID, err := types.MemoryIDOf(value)
+	memoryID, err := types.MemoryIDFrom(value)
 	if err != nil {
-		t.Fatalf("MemoryIDOf() error = %v", err)
+		t.Fatalf("MemoryIDFrom() error = %v", err)
 	}
 	return memoryID
 }
 
 func mustWorkspaceScope(t *testing.T, value string) types.MemoryScope {
 	t.Helper()
-	workspace, err := types.WorkspaceOf(value)
+	workspace, err := types.WorkspaceFrom(value)
 	if err != nil {
-		t.Fatalf("WorkspaceOf() error = %v", err)
+		t.Fatalf("WorkspaceFrom() error = %v", err)
 	}
 	return types.WorkspaceScopeOf(workspace)
 }
 
 func mustAgentScope(t *testing.T, value string) types.MemoryScope {
 	t.Helper()
-	agent, err := types.AgentOf(value)
+	agent, err := types.AgentFrom(value)
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
 	return types.AgentScopeOf(agent)
 }
 
 func mustSessionFamilyScope(t *testing.T, value string) types.MemoryScope {
 	t.Helper()
-	sessionID, err := types.SessionIDOf(value)
+	sessionID, err := types.SessionIDFrom(value)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	return types.SessionFamilyScopeOf(sessionID)
 }
 
 func mustEvidenceRef(t *testing.T, kind types.EvidenceRefKind, value string) types.EvidenceRef {
 	t.Helper()
-	ref, err := types.EvidenceRefOf(kind, value)
+	ref, err := types.EvidenceRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("EvidenceRefOf() error = %v", err)
+		t.Fatalf("EvidenceRefFrom() error = %v", err)
 	}
 	return ref
 }
 
 func mustArtifactRef(t *testing.T, kind types.ArtifactRefKind, value string) types.ArtifactRef {
 	t.Helper()
-	ref, err := types.ArtifactRefOf(kind, value)
+	ref, err := types.ArtifactRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("ArtifactRefOf() error = %v", err)
+		t.Fatalf("ArtifactRefFrom() error = %v", err)
 	}
 	return ref
 }

--- a/infrastructure/sqlite/memory_edge_datasource.go
+++ b/infrastructure/sqlite/memory_edge_datasource.go
@@ -147,15 +147,15 @@ func scanMemoryEdge(scanner interface {
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan edge: %w", err)
 	}
-	edgeID, err := types.MemoryEdgeIDOf(idValue)
+	edgeID, err := types.MemoryEdgeIDFrom(idValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore edge ID: %w", err)
 	}
-	fromID, err := types.MemoryIDOf(fromIDValue)
+	fromID, err := types.MemoryIDFrom(fromIDValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore from memory ID: %w", err)
 	}
-	toID, err := types.MemoryIDOf(toIDValue)
+	toID, err := types.MemoryIDFrom(toIDValue)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore to memory ID: %w", err)
 	}

--- a/infrastructure/sqlite/save_boundary_test.go
+++ b/infrastructure/sqlite/save_boundary_test.go
@@ -26,12 +26,12 @@ func TestSessionDatasource_SaveBoundary_Start(t *testing.T) {
 	sessionDS := infra.NewSessionDatasource(db)
 	eventDS := infra.NewEventDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-start")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-start")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 	session := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
 
-	eventID, _ := types.EventIDOf("event-start")
+	eventID, _ := types.EventIDFrom("event-start")
 	event := model.EventOf(
 		eventID,
 		types.EventKindSessionStarted,
@@ -80,13 +80,13 @@ func TestSessionDatasource_SaveBoundary_End(t *testing.T) {
 	}
 	sessionDS := infra.NewSessionDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-end")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-end")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	// First, start the session.
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -107,7 +107,7 @@ func TestSessionDatasource_SaveBoundary_End(t *testing.T) {
 		t.Fatalf("End() error = %v", err)
 	}
 
-	endEventID, _ := types.EventIDOf("event-end")
+	endEventID, _ := types.EventIDFrom("event-end")
 	endEvent := model.EventOf(
 		endEventID, types.EventKindSessionEnded,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -150,12 +150,12 @@ func TestSessionDatasource_Save_LabelDoesNotTouchEndedAt(t *testing.T) {
 	}
 	sessionDS := infra.NewSessionDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-label-only")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-label-only")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -202,12 +202,12 @@ func TestSessionDatasource_SaveBoundary_EndPreservesLabel(t *testing.T) {
 	}
 	sessionDS := infra.NewSessionDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-label-vs-end")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-label-vs-end")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -241,7 +241,7 @@ func TestSessionDatasource_SaveBoundary_EndPreservesLabel(t *testing.T) {
 	if err := endingSession.End(endedAt, "wrapped up"); err != nil {
 		t.Fatalf("End() error = %v", err)
 	}
-	endEventID, _ := types.EventIDOf("event-end")
+	endEventID, _ := types.EventIDFrom("event-end")
 	endEvent := model.EventOf(
 		endEventID, types.EventKindSessionEnded,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -282,12 +282,12 @@ func TestSessionDatasource_SaveBoundary_DuplicateEndRejected(t *testing.T) {
 	sessionDS := infra.NewSessionDatasource(db)
 	eventDS := infra.NewEventDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-double-end")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-double-end")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -307,7 +307,7 @@ func TestSessionDatasource_SaveBoundary_DuplicateEndRejected(t *testing.T) {
 	if err := firstEnding.End(firstEndedAt, "first"); err != nil {
 		t.Fatalf("End(first) error = %v", err)
 	}
-	firstEventID, _ := types.EventIDOf("event-end-1")
+	firstEventID, _ := types.EventIDFrom("event-end-1")
 	firstEndEvent := model.EventOf(
 		firstEventID, types.EventKindSessionEnded,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -329,7 +329,7 @@ func TestSessionDatasource_SaveBoundary_DuplicateEndRejected(t *testing.T) {
 	if err := secondEnding.End(secondEndedAt, "second"); err != nil {
 		t.Fatalf("End(second) error = %v", err)
 	}
-	secondEventID, _ := types.EventIDOf("event-end-2")
+	secondEventID, _ := types.EventIDFrom("event-end-2")
 	secondEndEvent := model.EventOf(
 		secondEventID, types.EventKindSessionEnded,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -390,12 +390,12 @@ func TestSessionDatasource_SaveBoundary_DuplicateStartRejected(t *testing.T) {
 	sessionDS := infra.NewSessionDatasource(db)
 	eventDS := infra.NewEventDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-double-start")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-double-start")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	firstSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	firstEventID, _ := types.EventIDOf("event-start-1")
+	firstEventID, _ := types.EventIDFrom("event-start-1")
 	firstEvent := model.EventOf(
 		firstEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -406,7 +406,7 @@ func TestSessionDatasource_SaveBoundary_DuplicateStartRejected(t *testing.T) {
 	}
 
 	secondSession := model.NewSession(sessionID, startedAt.Add(time.Minute), types.Client("cli"), agent, types.Workspace("workspace"))
-	secondEventID, _ := types.EventIDOf("event-start-2")
+	secondEventID, _ := types.EventIDFrom("event-start-2")
 	secondEvent := model.EventOf(
 		secondEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -449,12 +449,12 @@ func TestSessionDatasource_Save_LabelOnEndedSession(t *testing.T) {
 	}
 	sessionDS := infra.NewSessionDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-label-after-end")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-label-after-end")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -474,7 +474,7 @@ func TestSessionDatasource_Save_LabelOnEndedSession(t *testing.T) {
 	if err := endingSession.End(endedAt, "done"); err != nil {
 		t.Fatalf("End() error = %v", err)
 	}
-	endEventID, _ := types.EventIDOf("event-end")
+	endEventID, _ := types.EventIDFrom("event-end")
 	endEvent := model.EventOf(
 		endEventID, types.EventKindSessionEnded,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
@@ -530,12 +530,12 @@ func TestSessionDatasource_Save_ClearLabel(t *testing.T) {
 	}
 	sessionDS := infra.NewSessionDatasource(db)
 
-	sessionID, _ := types.SessionIDOf("session-clear-label")
-	agent, _ := types.AgentOf("claude")
+	sessionID, _ := types.SessionIDFrom("session-clear-label")
+	agent, _ := types.AgentFrom("claude")
 	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 
 	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
-	startEventID, _ := types.EventIDOf("event-start")
+	startEventID, _ := types.EventIDFrom("event-start")
 	startEvent := model.EventOf(
 		startEventID, types.EventKindSessionStarted,
 		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -75,9 +75,9 @@ CREATE TABLE command_audits (
 		t.Fatalf("SaveWithAudit() error = %v", err)
 	}
 
-	pathEventID, _ := types.EventIDOf("event-path")
-	pathAgent, _ := types.AgentOf("codex")
-	pathSessionID, _ := types.SessionIDOf("session-path")
+	pathEventID, _ := types.EventIDFrom("event-path")
+	pathAgent, _ := types.AgentFrom("codex")
+	pathSessionID, _ := types.SessionIDFrom("session-path")
 	pathEvent := model.EventOf(
 		pathEventID,
 		types.EventKindNote,
@@ -342,17 +342,17 @@ func newSearchEventFixture(
 ) *model.Event {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(eventIDValue)
+	eventID, err := types.EventIDFrom(eventIDValue)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -277,7 +277,7 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		return types.None[*model.Session](), xerrors.Errorf("failed to scan session row: %w", err)
 	}
 
-	sid, err := types.SessionIDOf(sessionIDValue)
+	sid, err := types.SessionIDFrom(sessionIDValue)
 	if err != nil {
 		return types.None[*model.Session](), xerrors.Errorf("failed to restore session ID: %w", err)
 	}
@@ -285,7 +285,7 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 	if err != nil {
 		return types.None[*model.Session](), xerrors.Errorf("failed to parse started_at: %w", err)
 	}
-	agent, err := types.AgentOf(agentValue)
+	agent, err := types.AgentFrom(agentValue)
 	if err != nil {
 		return types.None[*model.Session](), xerrors.Errorf("failed to restore agent: %w", err)
 	}

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -49,9 +49,9 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 
 	saveEvent := func(t *testing.T, ds *sqlite.EventDatasource, id string, workspace string, createdAt time.Time) {
 		t.Helper()
-		eventID, _ := types.EventIDOf(id)
-		agent, _ := types.AgentOf("claude")
-		sessionID, _ := types.SessionIDOf("session-1")
+		eventID, _ := types.EventIDFrom(id)
+		agent, _ := types.AgentFrom("claude")
+		sessionID, _ := types.SessionIDFrom("session-1")
 		event := model.EventOf(eventID, types.EventKindCommandExecuted, types.Client("hook"), agent, sessionID, types.Workspace(workspace), "cmd", createdAt)
 		if err := ds.Save(context.Background(), event); err != nil {
 			t.Fatalf("Save() error = %v", err)
@@ -122,9 +122,9 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 
 	saveEventKind := func(t *testing.T, ds *sqlite.EventDatasource, id string, workspace string, kind types.EventKind, body string, createdAt time.Time) {
 		t.Helper()
-		eventID, _ := types.EventIDOf(id)
-		agent, _ := types.AgentOf("claude")
-		sessionID, _ := types.SessionIDOf("session-1")
+		eventID, _ := types.EventIDFrom(id)
+		agent, _ := types.AgentFrom("claude")
+		sessionID, _ := types.SessionIDFrom("session-1")
 		event := model.EventOf(eventID, kind, types.Client("hook"), agent, sessionID, types.Workspace(workspace), body, createdAt)
 		if err := ds.Save(context.Background(), event); err != nil {
 			t.Fatalf("Save() error = %v", err)

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -175,9 +175,9 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve secret handling policy", "secret 取り扱いポリシーの解決に失敗しました"), err)
 	}
 
-	client, _ := types.ClientOf(resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue))
-	agent, _ := types.AgentOf(resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue))
-	sid, _ := types.SessionIDOf(sessionResolution.sessionID)
+	client, _ := types.ClientFrom(resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue))
+	agent, _ := types.AgentFrom(resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue))
+	sid, _ := types.SessionIDFrom(sessionResolution.sessionID)
 	auditCfg := apptypes.NewAuditRedactionBuilder().
 		AllowSecrets(allowSecrets).
 		MaxInputBytes(maxInputBytes).

--- a/presentation/cli/audit_test.go
+++ b/presentation/cli/audit_test.go
@@ -16,17 +16,17 @@ import (
 func TestRootCLI_AuditCommand(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -85,13 +85,13 @@ func TestRootCLI_AuditCommand_FallsBackFromStaleActiveSession(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-stale-audit")
+	eventID, err := types.EventIDFrom("event-stale-audit")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -161,9 +161,9 @@ func TestRootCLI_AuditCommand_FallsBackFromStaleActiveSession(t *testing.T) {
 func mustEventID(t *testing.T, value string) types.EventID {
 	t.Helper()
 
-	eventID, err := types.EventIDOf(value)
+	eventID, err := types.EventIDFrom(value)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
 
 	return eventID
@@ -172,17 +172,17 @@ func mustEventID(t *testing.T, value string) types.EventID {
 func TestRootCLI_AuditCommand_IdOnly(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 
-	eventID, err := types.EventIDOf("event-id-only")
+	eventID, err := types.EventIDFrom("event-id-only")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -236,17 +236,17 @@ func TestRootCLI_AuditCommand_IdOnly(t *testing.T) {
 func TestRootCLI_AuditCommand_NamedFlags(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 
-	eventID, err := types.EventIDOf("event-5")
+	eventID, err := types.EventIDFrom("event-5")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -387,17 +387,17 @@ func TestRootCLI_AuditCommand_TruncationNotice(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 	t.Setenv("TRACEARY_MAX_AUDIT_OUTPUT_BYTES", "128")
 
-	eventID, err := types.EventIDOf("event-2")
+	eventID, err := types.EventIDFrom("event-2")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -455,17 +455,17 @@ func TestRootCLI_AuditCommand_TruncationNotice(t *testing.T) {
 func TestRootCLI_AuditCommand_RedactionNotice(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 
-	eventID, err := types.EventIDOf("event-3")
+	eventID, err := types.EventIDFrom("event-3")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
@@ -525,17 +525,17 @@ func TestRootCLI_AuditCommand_AllowSecretsEnv(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 	t.Setenv("TRACEARY_ALLOW_SECRETS", "true")
 
-	eventID, err := types.EventIDOf("event-4")
+	eventID, err := types.EventIDFrom("event-4")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 	commandAudit, err := model.NewCommandAudit(
 		eventID,

--- a/presentation/cli/compact_summary_test.go
+++ b/presentation/cli/compact_summary_test.go
@@ -18,7 +18,7 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 	t.Run("prints summary with active session and recent commands", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, _ := types.SessionIDOf("session-abc")
+		sessionID, _ := types.SessionIDFrom("session-abc")
 
 		dbPath := filepath.Join(t.TempDir(), "traceary.db")
 		contextStub := &contextUsecaseStub{
@@ -135,7 +135,7 @@ func TestRootCLI_CompactSummaryCommand(t *testing.T) {
 	t.Run("includes memories when available", func(t *testing.T) {
 		t.Parallel()
 
-		sessionID, _ := types.SessionIDOf("session-abc")
+		sessionID, _ := types.SessionIDFrom("session-abc")
 		scope := types.WorkspaceScopeOf(types.Workspace("duck8823/traceary"))
 		memorySummary, err := apptypes.MemorySummaryOf(
 			types.MemoryID("memory-1"),

--- a/presentation/cli/context_command_test.go
+++ b/presentation/cli/context_command_test.go
@@ -21,17 +21,17 @@ func TestRootCLI_ContextCommand(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	t.Run("resolves latest session and displays context", func(t *testing.T) {

--- a/presentation/cli/db_path_flag_test.go
+++ b/presentation/cli/db_path_flag_test.go
@@ -23,8 +23,8 @@ import (
 func TestRootCLI_DBPathFlagPropagates(t *testing.T) {
 	// Not t.Parallel(): each sub-test manipulates process-wide environ.
 
-	sessionID, _ := types.SessionIDOf("flag-propagates")
-	agent, _ := types.AgentOf("smoke")
+	sessionID, _ := types.SessionIDFrom("flag-propagates")
+	agent, _ := types.AgentFrom("smoke")
 	startEvent := model.EventOf(
 		types.EventID("evt-start"),
 		types.EventKindSessionStarted,

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -928,7 +928,7 @@ func resolveHookAgent(client string, payload []byte) (types.Agent, error) {
 		agentValue += "/" + agentType
 	}
 
-	agent, err := types.AgentOf(agentValue)
+	agent, err := types.AgentFrom(agentValue)
 	if err != nil {
 		return "", xerrors.Errorf("failed to resolve hook agent: %w", err)
 	}

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -17,17 +17,17 @@ func TestRootCLI_ListCommand(t *testing.T) {
 	t.Run("displays event list", func(t *testing.T) {
 		t.Parallel()
 
-		eventID, err := types.EventIDOf("event-1")
+		eventID, err := types.EventIDFrom("event-1")
 		if err != nil {
-			t.Fatalf("EventIDOf() error = %v", err)
+			t.Fatalf("EventIDFrom() error = %v", err)
 		}
-		agent, err := types.AgentOf("codex")
+		agent, err := types.AgentFrom("codex")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
-		sessionID, err := types.SessionIDOf("session-1")
+		sessionID, err := types.SessionIDFrom("session-1")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
 
 		listStub := &eventUsecaseStub{
@@ -79,17 +79,17 @@ func TestRootCLI_ListCommand(t *testing.T) {
 	t.Run("displays event list in JSON format", func(t *testing.T) {
 		t.Parallel()
 
-		eventID, err := types.EventIDOf("event-2")
+		eventID, err := types.EventIDFrom("event-2")
 		if err != nil {
-			t.Fatalf("EventIDOf() error = %v", err)
+			t.Fatalf("EventIDFrom() error = %v", err)
 		}
-		agent, err := types.AgentOf("codex")
+		agent, err := types.AgentFrom("codex")
 		if err != nil {
-			t.Fatalf("AgentOf() error = %v", err)
+			t.Fatalf("AgentFrom() error = %v", err)
 		}
-		sessionID, err := types.SessionIDOf("session-2")
+		sessionID, err := types.SessionIDFrom("session-2")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
 
 		listStub := &eventUsecaseStub{

--- a/presentation/cli/log.go
+++ b/presentation/cli/log.go
@@ -106,9 +106,9 @@ func (c *RootCLI) runLog(ctx context.Context, output io.Writer, input logCommand
 		return err
 	}
 
-	client, _ := types.ClientOf(resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue))
-	agent, _ := types.AgentOf(resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue))
-	sessionID, _ := types.SessionIDOf(sessionResolution.sessionID)
+	client, _ := types.ClientFrom(resolveOptionalValue(input.client, "TRACEARY_CLIENT", defaultClientValue))
+	agent, _ := types.AgentFrom(resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue))
+	sessionID, _ := types.SessionIDFrom(sessionResolution.sessionID)
 	workspace := types.Workspace(resolvedRepo)
 	kind := types.EventKind(strings.TrimSpace(input.kind))
 	message := input.message

--- a/presentation/cli/log_test.go
+++ b/presentation/cli/log_test.go
@@ -15,17 +15,17 @@ import (
 )
 
 func TestRootCLI_LogCommand(t *testing.T) {
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	t.Run("records log with flag values", func(t *testing.T) {
@@ -212,13 +212,13 @@ func TestRootCLI_LogCommand(t *testing.T) {
 		})
 		defer cli.ResetDetectRepoContextFunc()
 
-		activeEventID, err := types.EventIDOf("event-session-start")
+		activeEventID, err := types.EventIDFrom("event-session-start")
 		if err != nil {
-			t.Fatalf("EventIDOf() error = %v", err)
+			t.Fatalf("EventIDFrom() error = %v", err)
 		}
-		activeSessionID, err := types.SessionIDOf("session-active")
+		activeSessionID, err := types.SessionIDFrom("session-active")
 		if err != nil {
-			t.Fatalf("SessionIDOf() error = %v", err)
+			t.Fatalf("SessionIDFrom() error = %v", err)
 		}
 
 		stdout := &bytes.Buffer{}
@@ -311,9 +311,9 @@ func fixedLogTime() time.Time {
 func mustSessionID(t *testing.T, value string) types.SessionID {
 	t.Helper()
 
-	sessionID, err := types.SessionIDOf(value)
+	sessionID, err := types.SessionIDFrom(value)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return sessionID

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -416,7 +416,7 @@ func (c *RootCLI) runMemoryShow(ctx context.Context, output io.Writer, dbPath st
 	if err := c.initializeStore(ctx, dbPath); err != nil {
 		return err
 	}
-	resolvedMemoryID, err := domtypes.MemoryIDOf(memoryID)
+	resolvedMemoryID, err := domtypes.MemoryIDFrom(memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -471,7 +471,7 @@ func (c *RootCLI) runMemoryAccept(ctx context.Context, output io.Writer, input m
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
-	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	memoryID, err := domtypes.MemoryIDFrom(input.memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -490,7 +490,7 @@ func (c *RootCLI) runMemoryReject(ctx context.Context, output io.Writer, input m
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
-	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	memoryID, err := domtypes.MemoryIDFrom(input.memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -508,7 +508,7 @@ func (c *RootCLI) runMemorySupersede(ctx context.Context, output io.Writer, inpu
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
-	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	memoryID, err := domtypes.MemoryIDFrom(input.memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -555,7 +555,7 @@ func (c *RootCLI) runMemoryExpire(ctx context.Context, output io.Writer, input m
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
-	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	memoryID, err := domtypes.MemoryIDFrom(input.memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -574,7 +574,7 @@ func (c *RootCLI) runMemorySetValidity(ctx context.Context, output io.Writer, in
 	if err := c.initializeMemoryStore(ctx, input.dbPath); err != nil {
 		return err
 	}
-	memoryID, err := domtypes.MemoryIDOf(input.memoryID)
+	memoryID, err := domtypes.MemoryIDFrom(input.memoryID)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve memory ID", "memory ID の解決に失敗しました"), err)
 	}
@@ -678,7 +678,7 @@ func validateMemoryWriteInput(input memoryWriteCommandInput) error {
 }
 
 func parseRequiredMemoryType(value string) (domtypes.MemoryType, error) {
-	resolved, err := domtypes.MemoryTypeOf(value)
+	resolved, err := domtypes.MemoryTypeFrom(value)
 	if err != nil {
 		return domtypes.MemoryType(""), xerrors.Errorf("%s: %w", Localize("failed to resolve memory type", "memory type の解決に失敗しました"), err)
 	}
@@ -696,7 +696,7 @@ func parseOptionalConfidence(value string) (domtypes.Optional[domtypes.Confidenc
 	if strings.TrimSpace(value) == "" {
 		return domtypes.None[domtypes.Confidence](), nil
 	}
-	confidence, err := domtypes.ConfidenceOf(value)
+	confidence, err := domtypes.ConfidenceFrom(value)
 	if err != nil {
 		return domtypes.None[domtypes.Confidence](), xerrors.Errorf("%s: %w", Localize("failed to resolve confidence", "confidence の解決に失敗しました"), err)
 	}
@@ -707,7 +707,7 @@ func parseMemorySource(value string) (domtypes.MemorySource, error) {
 	if strings.TrimSpace(value) == "" {
 		return domtypes.MemorySource(""), nil
 	}
-	source, err := domtypes.MemorySourceOf(value)
+	source, err := domtypes.MemorySourceFrom(value)
 	if err != nil {
 		return domtypes.MemorySource(""), xerrors.Errorf("%s: %w", Localize("failed to resolve memory source", "memory source の解決に失敗しました"), err)
 	}
@@ -720,7 +720,7 @@ func parseMemoryStatuses(values []string) ([]domtypes.MemoryStatus, error) {
 		if strings.TrimSpace(value) == "" {
 			continue
 		}
-		status, err := domtypes.MemoryStatusOf(value)
+		status, err := domtypes.MemoryStatusFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve memory status", "memory status の解決に失敗しました"), err)
 		}
@@ -735,7 +735,7 @@ func parseMemoryTypes(values []string) ([]domtypes.MemoryType, error) {
 		if strings.TrimSpace(value) == "" {
 			continue
 		}
-		memoryType, err := domtypes.MemoryTypeOf(value)
+		memoryType, err := domtypes.MemoryTypeFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve memory type", "memory type の解決に失敗しました"), err)
 		}
@@ -751,11 +751,11 @@ func parseEvidenceRefs(values []string) ([]domtypes.EvidenceRef, error) {
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to parse evidence ref", "evidence ref の解析に失敗しました"), err)
 		}
-		resolvedKind, err := domtypes.EvidenceRefKindOf(kind)
+		resolvedKind, err := domtypes.EvidenceRefKindFrom(kind)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve evidence ref kind", "evidence ref kind の解決に失敗しました"), err)
 		}
-		ref, err := domtypes.EvidenceRefOf(resolvedKind, rawValue)
+		ref, err := domtypes.EvidenceRefFrom(resolvedKind, rawValue)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve evidence ref", "evidence ref の解決に失敗しました"), err)
 		}
@@ -771,11 +771,11 @@ func parseArtifactRefs(values []string) ([]domtypes.ArtifactRef, error) {
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to parse artifact ref", "artifact ref の解析に失敗しました"), err)
 		}
-		resolvedKind, err := domtypes.ArtifactRefKindOf(kind)
+		resolvedKind, err := domtypes.ArtifactRefKindFrom(kind)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve artifact ref kind", "artifact ref kind の解決に失敗しました"), err)
 		}
-		ref, err := domtypes.ArtifactRefOf(resolvedKind, rawValue)
+		ref, err := domtypes.ArtifactRefFrom(resolvedKind, rawValue)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve artifact ref", "artifact ref の解決に失敗しました"), err)
 		}
@@ -795,14 +795,14 @@ func parseKindValueToken(value string) (string, string, error) {
 
 func resolveMemoryWriteScope(ctx context.Context, workspace string, agent string, sessionFamily string) (domtypes.MemoryScope, error) {
 	if strings.TrimSpace(agent) != "" {
-		resolvedAgent, err := domtypes.AgentOf(agent)
+		resolvedAgent, err := domtypes.AgentFrom(agent)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
 		}
 		return domtypes.AgentScopeOf(resolvedAgent), nil
 	}
 	if strings.TrimSpace(sessionFamily) != "" {
-		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		resolvedSessionID, err := domtypes.SessionIDFrom(sessionFamily)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
 		}
@@ -812,7 +812,7 @@ func resolveMemoryWriteScope(ctx context.Context, workspace string, agent string
 	if strings.TrimSpace(resolvedWorkspace) == "" {
 		return nil, xerrors.Errorf(Localize("workspace scope could not be resolved", "workspace scope を解決できませんでした"))
 	}
-	workspaceValue, err := domtypes.WorkspaceOf(resolvedWorkspace)
+	workspaceValue, err := domtypes.WorkspaceFrom(resolvedWorkspace)
 	if err != nil {
 		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
 	}
@@ -821,14 +821,14 @@ func resolveMemoryWriteScope(ctx context.Context, workspace string, agent string
 
 func resolveOptionalMemoryScope(workspace string, agent string, sessionFamily string) (domtypes.MemoryScope, error) {
 	if strings.TrimSpace(agent) != "" {
-		resolvedAgent, err := domtypes.AgentOf(agent)
+		resolvedAgent, err := domtypes.AgentFrom(agent)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
 		}
 		return domtypes.AgentScopeOf(resolvedAgent), nil
 	}
 	if strings.TrimSpace(sessionFamily) != "" {
-		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		resolvedSessionID, err := domtypes.SessionIDFrom(sessionFamily)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
 		}
@@ -837,7 +837,7 @@ func resolveOptionalMemoryScope(workspace string, agent string, sessionFamily st
 	if strings.TrimSpace(workspace) == "" {
 		return nil, nil
 	}
-	workspaceValue, err := domtypes.WorkspaceOf(workspace)
+	workspaceValue, err := domtypes.WorkspaceFrom(workspace)
 	if err != nil {
 		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
 	}
@@ -847,21 +847,21 @@ func resolveOptionalMemoryScope(workspace string, agent string, sessionFamily st
 func resolveMemoryFilterScopes(ctx context.Context, workspace string, agent string, sessionFamily string, defaultWorkspace bool) ([]domtypes.MemoryScope, error) {
 	scopes := make([]domtypes.MemoryScope, 0, 3)
 	if strings.TrimSpace(workspace) != "" {
-		workspaceValue, err := domtypes.WorkspaceOf(workspace)
+		workspaceValue, err := domtypes.WorkspaceFrom(workspace)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
 		}
 		scopes = append(scopes, domtypes.WorkspaceScopeOf(workspaceValue))
 	}
 	if strings.TrimSpace(agent) != "" {
-		resolvedAgent, err := domtypes.AgentOf(agent)
+		resolvedAgent, err := domtypes.AgentFrom(agent)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve agent scope", "agent scope の解決に失敗しました"), err)
 		}
 		scopes = append(scopes, domtypes.AgentScopeOf(resolvedAgent))
 	}
 	if strings.TrimSpace(sessionFamily) != "" {
-		resolvedSessionID, err := domtypes.SessionIDOf(sessionFamily)
+		resolvedSessionID, err := domtypes.SessionIDFrom(sessionFamily)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve session-family scope", "session-family scope の解決に失敗しました"), err)
 		}
@@ -874,7 +874,7 @@ func resolveMemoryFilterScopes(ctx context.Context, workspace string, agent stri
 	if strings.TrimSpace(resolvedWorkspace) == "" {
 		return nil, nil
 	}
-	workspaceValue, err := domtypes.WorkspaceOf(resolvedWorkspace)
+	workspaceValue, err := domtypes.WorkspaceFrom(resolvedWorkspace)
 	if err != nil {
 		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace scope", "workspace scope の解決に失敗しました"), err)
 	}

--- a/presentation/cli/memory_bridge.go
+++ b/presentation/cli/memory_bridge.go
@@ -148,7 +148,7 @@ func resolveExportScope(ctx context.Context, raw string) (domtypes.MemoryScope, 
 	if strings.TrimSpace(resolved) == "" {
 		return nil, nil
 	}
-	workspace, err := domtypes.WorkspaceOf(resolved)
+	workspace, err := domtypes.WorkspaceFrom(resolved)
 	if err != nil {
 		return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve workspace", "workspace の解決に失敗しました"), err)
 	}

--- a/presentation/cli/memory_graph.go
+++ b/presentation/cli/memory_graph.go
@@ -131,11 +131,11 @@ func (c *RootCLI) runMemoryGraphAdd(ctx context.Context, output io.Writer, input
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 
-	fromID, err := domtypes.MemoryIDOf(strings.TrimSpace(input.fromID))
+	fromID, err := domtypes.MemoryIDFrom(strings.TrimSpace(input.fromID))
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to parse from memory ID", "from memory ID の解析に失敗しました"), err)
 	}
-	toID, err := domtypes.MemoryIDOf(strings.TrimSpace(input.toID))
+	toID, err := domtypes.MemoryIDFrom(strings.TrimSpace(input.toID))
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to parse to memory ID", "to memory ID の解析に失敗しました"), err)
 	}

--- a/presentation/cli/memory_import.go
+++ b/presentation/cli/memory_import.go
@@ -161,7 +161,7 @@ func resolveImportFallbackWorkspace(ctx context.Context, raw string) (domtypes.W
 	if strings.TrimSpace(resolved) == "" {
 		return domtypes.Workspace(""), nil
 	}
-	workspace, err := domtypes.WorkspaceOf(resolved)
+	workspace, err := domtypes.WorkspaceFrom(resolved)
 	if err != nil {
 		return domtypes.Workspace(""), xerrors.Errorf("%s: %w", Localize("failed to resolve workspace", "workspace の解決に失敗しました"), err)
 	}

--- a/presentation/cli/memory_import_test.go
+++ b/presentation/cli/memory_import_test.go
@@ -14,9 +14,9 @@ import (
 
 func buildMemoryImportStubDetails(t *testing.T, fact string) apptypes.MemoryDetails {
 	t.Helper()
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	summary, err := apptypes.MemorySummaryOf(
 		domtypes.MemoryID("memory-import-cli"),

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -179,7 +179,7 @@ func (c *RootCLI) runMemoryInboxBatch(ctx context.Context, output io.Writer, inp
 
 	result := memoryInboxBatchResult{Action: string(action)}
 	for _, rawID := range ids {
-		memoryID, err := domtypes.MemoryIDOf(rawID)
+		memoryID, err := domtypes.MemoryIDFrom(rawID)
 		if err != nil {
 			result.Failures = append(result.Failures, memoryInboxFailure{ID: rawID, Error: err.Error()})
 			continue
@@ -243,7 +243,7 @@ func parseMemorySources(values []string) ([]domtypes.MemorySource, error) {
 		if strings.TrimSpace(value) == "" {
 			continue
 		}
-		source, err := domtypes.MemorySourceOf(value)
+		source, err := domtypes.MemorySourceFrom(value)
 		if err != nil {
 			return nil, xerrors.Errorf("%s: %w", Localize("failed to resolve memory source", "memory source の解決に失敗しました"), err)
 		}

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -14,9 +14,9 @@ import (
 
 func buildInboxCandidateDetails(t *testing.T, id string, fact string, source domtypes.MemorySource) apptypes.MemoryDetails {
 	t.Helper()
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	summary, err := apptypes.MemorySummaryOf(
 		domtypes.MemoryID(id),
@@ -36,9 +36,9 @@ func buildInboxCandidateDetails(t *testing.T, id string, fact string, source dom
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)
 	}
-	evidence, err := domtypes.EvidenceRefOf(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L2")
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L2")
 	if err != nil {
-		t.Fatalf("EvidenceRefOf: %v", err)
+		t.Fatalf("EvidenceRefFrom: %v", err)
 	}
 	return apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{evidence}, nil)
 }
@@ -168,9 +168,9 @@ func TestMemoryInboxAccept_EmptyIDsErrors(t *testing.T) {
 
 func mustSummaryWithStatus(t *testing.T, id string, status domtypes.MemoryStatus) apptypes.MemorySummary {
 	t.Helper()
-	workspace, err := domtypes.WorkspaceOf("github.com/example/repo")
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
-		t.Fatalf("WorkspaceOf: %v", err)
+		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	summary, err := apptypes.MemorySummaryOf(
 		domtypes.MemoryID(id),

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -554,27 +554,27 @@ func mustMemoryDetails(t *testing.T, memoryIDValue string, fact string, status t
 
 func mustMemoryIDForCLI(t *testing.T, value string) types.MemoryID {
 	t.Helper()
-	memoryID, err := types.MemoryIDOf(value)
+	memoryID, err := types.MemoryIDFrom(value)
 	if err != nil {
-		t.Fatalf("MemoryIDOf() error = %v", err)
+		t.Fatalf("MemoryIDFrom() error = %v", err)
 	}
 	return memoryID
 }
 
 func mustEvidenceRefForCLI(t *testing.T, kind types.EvidenceRefKind, value string) types.EvidenceRef {
 	t.Helper()
-	ref, err := types.EvidenceRefOf(kind, value)
+	ref, err := types.EvidenceRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("EvidenceRefOf() error = %v", err)
+		t.Fatalf("EvidenceRefFrom() error = %v", err)
 	}
 	return ref
 }
 
 func mustArtifactRefForCLI(t *testing.T, kind types.ArtifactRefKind, value string) types.ArtifactRef {
 	t.Helper()
-	ref, err := types.ArtifactRefOf(kind, value)
+	ref, err := types.ArtifactRefFrom(kind, value)
 	if err != nil {
-		t.Fatalf("ArtifactRefOf() error = %v", err)
+		t.Fatalf("ArtifactRefFrom() error = %v", err)
 	}
 	return ref
 }

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -18,17 +18,17 @@ func TestRootCLI_SearchCommand(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -82,17 +82,17 @@ func TestRootCLI_SearchCommand_JSON(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-2")
+	eventID, err := types.EventIDFrom("event-2")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-2")
+	sessionID, err := types.SessionIDFrom("session-2")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -242,7 +242,7 @@ func (c *RootCLI) runSessionBoundary(
 	if agentStr == "" {
 		agentStr = defaultAgentValue
 	}
-	agent, _ := types.AgentOf(agentStr)
+	agent, _ := types.AgentFrom(agentStr)
 	sid := types.SessionID(input.sessionID)
 	ws := types.Workspace(resolveSessionBoundaryRepo(input))
 	if ws == "" {

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -19,17 +19,17 @@ import (
 func TestRootCLI_SessionStartCommand(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -71,17 +71,17 @@ func TestRootCLI_SessionStartCommand(t *testing.T) {
 func TestRootCLI_SessionStartCommand_IdOnly(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-start-id-only")
+	eventID, err := types.EventIDFrom("event-start-id-only")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-start-id-only")
+	sessionID, err := types.SessionIDFrom("session-start-id-only")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -159,17 +159,17 @@ func TestRootCLI_SessionStartCommand_UsesDetectedRepoByDefault(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-1b")
+	eventID, err := types.EventIDFrom("event-1b")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-auto-repo")
+	sessionID, err := types.SessionIDFrom("session-auto-repo")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -205,17 +205,17 @@ func TestRootCLI_SessionEndCommand(t *testing.T) {
 	})
 	defer cli.ResetDetectRepoContextFunc()
 
-	eventID, err := types.EventIDOf("event-2")
+	eventID, err := types.EventIDFrom("event-2")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -250,17 +250,17 @@ func TestRootCLI_SessionEndCommand(t *testing.T) {
 func TestRootCLI_SessionEndCommand_IdOnly(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 
-	eventID, err := types.EventIDOf("event-end-id-only")
+	eventID, err := types.EventIDFrom("event-end-id-only")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-env")
+	sessionID, err := types.SessionIDFrom("session-env")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -334,17 +334,17 @@ func TestRootCLI_SessionEndCommand_JSON(t *testing.T) {
 func TestRootCLI_SessionLatestCommand(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-3")
+	eventID, err := types.EventIDFrom("event-3")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-latest")
+	sessionID, err := types.SessionIDFrom("session-latest")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -422,17 +422,17 @@ func TestRootCLI_SessionLatestCommand_JSON(t *testing.T) {
 func TestRootCLI_SessionActiveCommand(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-4")
+	eventID, err := types.EventIDFrom("event-4")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-active")
+	sessionID, err := types.SessionIDFrom("session-active")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -472,17 +472,17 @@ func TestRootCLI_SessionActiveCommand(t *testing.T) {
 func TestRootCLI_SessionActiveCommand_StaleError(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-5")
+	eventID, err := types.EventIDFrom("event-5")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-stale")
+	sessionID, err := types.SessionIDFrom("session-stale")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	rootCmd := cli.NewRootCLI(
@@ -521,17 +521,17 @@ func TestRootCLI_SessionActiveCommand_StaleError(t *testing.T) {
 func TestRootCLI_SessionActiveCommand_AllowStale(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-6")
+	eventID, err := types.EventIDFrom("event-6")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-stale")
+	sessionID, err := types.SessionIDFrom("session-stale")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	stdout := &bytes.Buffer{}
@@ -603,9 +603,9 @@ func decodeJSONMap(t *testing.T, value string) map[string]any {
 func mustAgent(t *testing.T, value string) types.Agent {
 	t.Helper()
 
-	agent, err := types.AgentOf(value)
+	agent, err := types.AgentFrom(value)
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
 
 	return agent

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -16,17 +16,17 @@ import (
 func TestRootCLI_ShowCommand(t *testing.T) {
 	t.Parallel()
 
-	eventID, err := types.EventIDOf("event-1")
+	eventID, err := types.EventIDFrom("event-1")
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	agent, err := types.AgentOf("codex")
+	agent, err := types.AgentFrom("codex")
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	sessionID, err := types.SessionIDOf("session-1")
+	sessionID, err := types.SessionIDFrom("session-1")
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	t.Run("displays event details", func(t *testing.T) {

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -451,17 +451,17 @@ func TestPollTailEvents_DelegatesPagingToWindowQuery(t *testing.T) {
 func mustTailEvent(t *testing.T, eventID string, client string, agent string, sessionID string, workspace string, body string, createdAt time.Time) *model.Event {
 	t.Helper()
 
-	resolvedEventID, err := types.EventIDOf(eventID)
+	resolvedEventID, err := types.EventIDFrom(eventID)
 	if err != nil {
-		t.Fatalf("EventIDOf() error = %v", err)
+		t.Fatalf("EventIDFrom() error = %v", err)
 	}
-	resolvedAgent, err := types.AgentOf(agent)
+	resolvedAgent, err := types.AgentFrom(agent)
 	if err != nil {
-		t.Fatalf("AgentOf() error = %v", err)
+		t.Fatalf("AgentFrom() error = %v", err)
 	}
-	resolvedSessionID, err := types.SessionIDOf(sessionID)
+	resolvedSessionID, err := types.SessionIDFrom(sessionID)
 	if err != nil {
-		t.Fatalf("SessionIDOf() error = %v", err)
+		t.Fatalf("SessionIDFrom() error = %v", err)
 	}
 
 	return model.EventOf(

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -576,7 +576,7 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input retrieveMemoriesInput) (*mcp.CallToolResult, memoriesOutput, error) {
 		memoryIDValue := strings.TrimSpace(input.MemoryID)
 		if memoryIDValue != "" {
-			memoryID, err := types.MemoryIDOf(memoryIDValue)
+			memoryID, err := types.MemoryIDFrom(memoryIDValue)
 			if err != nil {
 				return nil, memoriesOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 			}
@@ -714,7 +714,7 @@ func (s *Server) proposeMemory() mcp.ToolHandlerFor[proposeMemoryInput, memoryOu
 
 func (s *Server) acceptMemory() mcp.ToolHandlerFor[acceptMemoryInput, memoryOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input acceptMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
-		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		memoryID, err := types.MemoryIDFrom(strings.TrimSpace(input.MemoryID))
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 		}
@@ -732,7 +732,7 @@ func (s *Server) acceptMemory() mcp.ToolHandlerFor[acceptMemoryInput, memoryOutp
 
 func (s *Server) rejectMemory() mcp.ToolHandlerFor[rejectMemoryInput, memoryOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input rejectMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
-		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		memoryID, err := types.MemoryIDFrom(strings.TrimSpace(input.MemoryID))
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 		}
@@ -763,7 +763,7 @@ func (s *Server) acceptMemoriesBatch() mcp.ToolHandlerFor[acceptMemoriesBatchInp
 			if trimmed == "" {
 				continue
 			}
-			memoryID, err := types.MemoryIDOf(trimmed)
+			memoryID, err := types.MemoryIDFrom(trimmed)
 			if err != nil {
 				out.Failures = append(out.Failures, inboxBatchMemoryFailureOutput{MemoryID: trimmed, Error: err.Error()})
 				continue
@@ -789,7 +789,7 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 		}
 		criteria := apptypes.MemoryHygieneScanCriteria{}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
-			resolvedWorkspace, err := types.WorkspaceOf(workspace)
+			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
 				return nil, memoryHygieneOutput{}, xerrors.Errorf("failed to resolve workspace: %w", err)
 			}
@@ -852,7 +852,7 @@ func (s *Server) exportMemories() mcp.ToolHandlerFor[exportMemoriesInput, export
 		}
 		criteria := apptypes.MemoryExportCriteria{Target: target}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
-			resolvedWorkspace, err := types.WorkspaceOf(workspace)
+			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
 				return nil, exportMemoriesOutput{}, xerrors.Errorf("failed to resolve workspace: %w", err)
 			}
@@ -888,7 +888,7 @@ func (s *Server) importMemoryInstructions() mcp.ToolHandlerFor[importMemoryInstr
 			Markdown: input.Markdown,
 		}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
-			resolvedWorkspace, err := types.WorkspaceOf(workspace)
+			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
 				return nil, importMemoryInstructionsOutput{}, xerrors.Errorf("failed to resolve workspace: %w", err)
 			}
@@ -926,7 +926,7 @@ func (s *Server) rejectMemoriesBatch() mcp.ToolHandlerFor[rejectMemoriesBatchInp
 			if trimmed == "" {
 				continue
 			}
-			memoryID, err := types.MemoryIDOf(trimmed)
+			memoryID, err := types.MemoryIDFrom(trimmed)
 			if err != nil {
 				out.Failures = append(out.Failures, inboxBatchMemoryFailureOutput{MemoryID: trimmed, Error: err.Error()})
 				continue
@@ -944,7 +944,7 @@ func (s *Server) rejectMemoriesBatch() mcp.ToolHandlerFor[rejectMemoriesBatchInp
 
 func (s *Server) supersedeMemory() mcp.ToolHandlerFor[supersedeMemoryInput, memoryOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input supersedeMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
-		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		memoryID, err := types.MemoryIDFrom(strings.TrimSpace(input.MemoryID))
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 		}
@@ -987,7 +987,7 @@ func (s *Server) supersedeMemory() mcp.ToolHandlerFor[supersedeMemoryInput, memo
 
 func (s *Server) expireMemory() mcp.ToolHandlerFor[expireMemoryInput, memoryOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input expireMemoryInput) (*mcp.CallToolResult, memoryOutput, error) {
-		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		memoryID, err := types.MemoryIDFrom(strings.TrimSpace(input.MemoryID))
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 		}
@@ -1009,7 +1009,7 @@ func (s *Server) expireMemory() mcp.ToolHandlerFor[expireMemoryInput, memoryOutp
 
 func (s *Server) setMemoryValidity() mcp.ToolHandlerFor[setMemoryValidityInput, memoryOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, input setMemoryValidityInput) (*mcp.CallToolResult, memoryOutput, error) {
-		memoryID, err := types.MemoryIDOf(strings.TrimSpace(input.MemoryID))
+		memoryID, err := types.MemoryIDFrom(strings.TrimSpace(input.MemoryID))
 		if err != nil {
 			return nil, memoryOutput{}, xerrors.Errorf("failed to resolve memory_id: %w", err)
 		}
@@ -1189,21 +1189,21 @@ func formatOptionalMemoryIDPtr(value types.Optional[types.MemoryID]) *string {
 func parseMemoryScopes(workspace string, agent string, sessionFamily string) ([]types.MemoryScope, error) {
 	scopes := make([]types.MemoryScope, 0, 3)
 	if trimmedWorkspace := strings.TrimSpace(workspace); trimmedWorkspace != "" {
-		resolvedWorkspace, err := types.WorkspaceOf(trimmedWorkspace)
+		resolvedWorkspace, err := types.WorkspaceFrom(trimmedWorkspace)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve workspace scope: %w", err)
 		}
 		scopes = append(scopes, types.WorkspaceScopeOf(resolvedWorkspace))
 	}
 	if trimmedAgent := strings.TrimSpace(agent); trimmedAgent != "" {
-		resolvedAgent, err := types.AgentOf(trimmedAgent)
+		resolvedAgent, err := types.AgentFrom(trimmedAgent)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve agent scope: %w", err)
 		}
 		scopes = append(scopes, types.AgentScopeOf(resolvedAgent))
 	}
 	if trimmedSessionFamily := strings.TrimSpace(sessionFamily); trimmedSessionFamily != "" {
-		resolvedSessionID, err := types.SessionIDOf(trimmedSessionFamily)
+		resolvedSessionID, err := types.SessionIDFrom(trimmedSessionFamily)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve session_family scope: %w", err)
 		}
@@ -1243,7 +1243,7 @@ func parseOptionalMemoryScope(workspace string, agent string, sessionFamily stri
 func parseMemoryStatuses(values []string) ([]types.MemoryStatus, error) {
 	statuses := make([]types.MemoryStatus, 0, len(values))
 	for _, value := range values {
-		resolved, err := types.MemoryStatusOf(strings.TrimSpace(value))
+		resolved, err := types.MemoryStatusFrom(strings.TrimSpace(value))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve memory status: %w", err)
 		}
@@ -1255,7 +1255,7 @@ func parseMemoryStatuses(values []string) ([]types.MemoryStatus, error) {
 func parseMemoryTypes(values []string) ([]types.MemoryType, error) {
 	memoryTypes := make([]types.MemoryType, 0, len(values))
 	for _, value := range values {
-		resolved, err := types.MemoryTypeOf(strings.TrimSpace(value))
+		resolved, err := types.MemoryTypeFrom(strings.TrimSpace(value))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve memory type: %w", err)
 		}
@@ -1268,7 +1268,7 @@ func parseOptionalConfidence(value string) (types.Optional[types.Confidence], er
 	if strings.TrimSpace(value) == "" {
 		return types.None[types.Confidence](), nil
 	}
-	resolved, err := types.ConfidenceOf(strings.TrimSpace(value))
+	resolved, err := types.ConfidenceFrom(strings.TrimSpace(value))
 	if err != nil {
 		return types.None[types.Confidence](), xerrors.Errorf("failed to resolve confidence: %w", err)
 	}
@@ -1279,7 +1279,7 @@ func parseMemorySource(value string) (types.MemorySource, error) {
 	if strings.TrimSpace(value) == "" {
 		return types.MemorySource(""), nil
 	}
-	resolved, err := types.MemorySourceOf(strings.TrimSpace(value))
+	resolved, err := types.MemorySourceFrom(strings.TrimSpace(value))
 	if err != nil {
 		return types.MemorySource(""), xerrors.Errorf("failed to resolve memory source: %w", err)
 	}
@@ -1289,11 +1289,11 @@ func parseMemorySource(value string) (types.MemorySource, error) {
 func parseEvidenceRefs(refs []memoryRefInput) ([]types.EvidenceRef, error) {
 	outputs := make([]types.EvidenceRef, 0, len(refs))
 	for _, ref := range refs {
-		kind, err := types.EvidenceRefKindOf(strings.TrimSpace(ref.Kind))
+		kind, err := types.EvidenceRefKindFrom(strings.TrimSpace(ref.Kind))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve evidence ref kind: %w", err)
 		}
-		resolved, err := types.EvidenceRefOf(kind, strings.TrimSpace(ref.Value))
+		resolved, err := types.EvidenceRefFrom(kind, strings.TrimSpace(ref.Value))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve evidence ref: %w", err)
 		}
@@ -1305,11 +1305,11 @@ func parseEvidenceRefs(refs []memoryRefInput) ([]types.EvidenceRef, error) {
 func parseArtifactRefs(refs []memoryRefInput) ([]types.ArtifactRef, error) {
 	outputs := make([]types.ArtifactRef, 0, len(refs))
 	for _, ref := range refs {
-		kind, err := types.ArtifactRefKindOf(strings.TrimSpace(ref.Kind))
+		kind, err := types.ArtifactRefKindFrom(strings.TrimSpace(ref.Kind))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve artifact ref kind: %w", err)
 		}
-		resolved, err := types.ArtifactRefOf(kind, strings.TrimSpace(ref.Value))
+		resolved, err := types.ArtifactRefFrom(kind, strings.TrimSpace(ref.Value))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to resolve artifact ref: %w", err)
 		}
@@ -1328,7 +1328,7 @@ func parseMemoryWriteInput(
 	evidenceRefs []memoryRefInput,
 	artifactRefs []memoryRefInput,
 ) (types.MemoryType, types.MemoryScope, types.Optional[types.Confidence], types.MemorySource, []types.EvidenceRef, []types.ArtifactRef, error) {
-	resolvedType, err := types.MemoryTypeOf(strings.TrimSpace(memoryType))
+	resolvedType, err := types.MemoryTypeFrom(strings.TrimSpace(memoryType))
 	if err != nil {
 		return types.MemoryType(""), nil, types.None[types.Confidence](), types.MemorySource(""), nil, nil, xerrors.Errorf("failed to resolve memory type: %w", err)
 	}
@@ -1389,7 +1389,7 @@ func parseOptionalMemoryWriteInput(
 ) (types.MemoryType, types.MemoryScope, types.Optional[types.Confidence], types.MemorySource, []types.EvidenceRef, []types.ArtifactRef, error) {
 	var resolvedType types.MemoryType
 	if strings.TrimSpace(memoryType) != "" {
-		value, err := types.MemoryTypeOf(strings.TrimSpace(memoryType))
+		value, err := types.MemoryTypeFrom(strings.TrimSpace(memoryType))
 		if err != nil {
 			return types.MemoryType(""), nil, types.None[types.Confidence](), types.MemorySource(""), nil, nil, xerrors.Errorf("failed to resolve memory type: %w", err)
 		}


### PR DESCRIPTION
## Motivation

Issue #710 standardizes domain value-object constructor names so validating/converting factories use `From` while non-validating wrappers continue to use `Of`.

## Changes

- Renamed validating `domain/types` constructors from `*Of` to `*From`.
- Updated all Go call sites and tests for the breaking pre-1.0 API rename.
- Kept non-validating wrappers as `*Of`:
  - `MemoryEdgeRelationOf`
  - `WorkspaceScopeOf`
  - `AgentScopeOf`
  - `SessionFamilyScopeOf`

## Validation

- `go build ./...`
- `go test ./...`
- `go tool golangci-lint run`

Closes #710
