### PR TITLE
refactor: freeze CLI JSON output shapes (#729)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,11 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [v0.10.0] - Unreleased
+
+### Breaking changes
+- **CLI JSON timestamp と duration の freeze (#729)** — golden fixture を記録する前段として、CLI `--json` のすべての timestamp フィールド (`created_at` / `started_at` / `ended_at` / `valid_from` / `valid_to` 等) を UTC RFC3339Nano (`YYYY-MM-DDTHH:MM:SS[.nnnnnnnnn]Z`) に統一。`traceary session tree --json` は `duration_ms` を削除し `duration_sec` のみを保持。`traceary timeline --json` は string `duration` を numeric `duration_sec` に置き換え。
+
 ## [v0.9.0] - 2026-04-25
 
 マイナーリリース: **multi-host local memory substrate completion (v1.0 前の安定化)**。v0.9 では v1.0 スコーピング前の portability + 構造ギャップを埋めます。CLI のトップレベル整理、durable memory への additive な temporal graph overlay、暗号化済みクロスマシン event バンドル、agent SDK 統合 docs の整備が中心です。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+
+## [v0.10.0] - Unreleased
+
+### Breaking changes
+- **CLI JSON timestamp and duration freeze (#729)** — all CLI `--json` timestamp fields (`created_at`, `started_at`, `ended_at`, `valid_from`, `valid_to`, etc.) now serialize as UTC RFC3339Nano (`YYYY-MM-DDTHH:MM:SS[.nnnnnnnnn]Z`) before golden fixtures are recorded. `traceary session tree --json` drops `duration_ms` and keeps `duration_sec`; `traceary timeline --json` replaces the string `duration` field with numeric `duration_sec`.
+
 ## [v0.9.0] - 2026-04-25
 
 Minor release: **multi-host local memory substrate completion (pre-v1.0 stabilization)**. v0.9 closes the remaining portability + structural gaps before a v1.0 scoping discussion. New top-level CLI grouping, an additive temporal graph overlay on durable memory, encrypted cross-machine event bundles, and consolidated agent-SDK integration docs.

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -100,7 +100,7 @@ session 解決ルールは `traceary log` と同じです。
 
 `tail` はイベントの流れをその場で追いかけるためのコマンドです。最初に最近の backlog を表示し、その後はローカルストアに追加される一致 event を継続して追跡します。hook が正しく動いているか、想定した session / workspace に書き込まれているか、失敗がリアルタイムで見えているかを確認したいときに向いています。`list` のように 1 回で終わらず、`search` のようなキーワード検索も行いません。`handoff` と違って working memory は組み立てず、生の event stream をそのまま表示します。
 
-デフォルトのテキスト出力は `HH:MM:SS  kind  agent=<agent>  sess=<先頭8文字>  ws=<basename>  message` というコンパクトな 1 行形式で、約 100 カラムに収まり、タイムスタンプは現地時刻 (local time) を使用します。`--wide` で従来の 7 カラム tab 区切り形式、`--utc` でテキスト出力のタイムスタンプを UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前と完全に同一のバイト列を再現するので、既存スクリプトとの互換を保てます。`--json` を付けると改行区切り JSON（1 行 1 event）を出力し、パイプラインから逐次処理できます（JSON の時刻は RFC3339 のままで `--utc` の影響を受けません）。
+デフォルトのテキスト出力は `HH:MM:SS  kind  agent=<agent>  sess=<先頭8文字>  ws=<basename>  message` というコンパクトな 1 行形式で、約 100 カラムに収まり、タイムスタンプは現地時刻 (local time) を使用します。`--wide` で従来の 7 カラム tab 区切り形式、`--utc` でテキスト出力のタイムスタンプを UTC に切り替えられます。`--wide --utc` を組み合わせると v0.6.1 以前と完全に同一のバイト列を再現するので、既存スクリプトとの互換を保てます。`--json` を付けると改行区切り JSON（1 行 1 event）を出力し、パイプラインから逐次処理できます（JSON の時刻は UTC RFC3339Nano で `--utc` の影響を受けません）。
 
 > コンパクト表示の session ID (`sess=<先頭8文字>`) は人間が目視する前提の短縮形です。機械処理には `--wide --utc` または `--json` を利用してください。
 
@@ -151,7 +151,7 @@ session 解決ルールは `traceary log` と同じです。
 
 ギャップ検出による作業タイムラインを、ワークスペース単位のアクティビティ要約付きで表示します。
 
-`timeline` は直近のイベントをアイドルギャップ（デフォルト 15 分）で区切って連続する作業ブロックに分け、各ブロック内で workspace ごとに整列された 1 行を表示します。ワークスペース単位のアクティビティ要約は **`compact_summary` → 最初の `prompt` → kind counts** のフォールバック順で選ばれ、そのブロック内でそのワークスペースに存在するシグナルが 1 行に展開されます。デフォルトのテキスト出力は現地時刻 (local time) で、`--utc` で UTC に切り替えられます。`--json` はブロックスキーマに `workspace_breakdown` 配列 (`{workspace, event_count, kind_counts, agents, summary, summary_source}`) を追加します（既存フィールドは維持され後方互換）。
+`timeline` は直近のイベントをアイドルギャップ（デフォルト 15 分）で区切って連続する作業ブロックに分け、各ブロック内で workspace ごとに整列された 1 行を表示します。ワークスペース単位のアクティビティ要約は **`compact_summary` → 最初の `prompt` → kind counts** のフォールバック順で選ばれ、そのブロック内でそのワークスペースに存在するシグナルが 1 行に展開されます。デフォルトのテキスト出力は現地時刻 (local time) で、`--utc` で UTC に切り替えられます。`--json` は UTC RFC3339Nano の `start` / `end`、数値の `duration_sec`、および `workspace_breakdown` 配列 (`{workspace, event_count, kind_counts, agents, summary, summary_source}`) を出力します。
 
 主な flag:
 
@@ -497,7 +497,7 @@ session の一覧サマリーを表示します。
 
 ### `traceary session tree`
 
-読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: Claude Code の subagent なら `claude/Explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / `duration_ms` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
+読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: Claude Code の subagent なら `claude/Explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / 数値の `duration_sec` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -100,7 +100,7 @@ Follow new events as they arrive.
 
 `tail` is the live observation view. It prints a recent backlog first and then keeps following new matching events from the local store. Use it when you want to confirm that hooks are firing, that the expected session/workspace is receiving writes, or that failures are surfacing in real time. Unlike `list`, it does not exit after one snapshot. Unlike `search`, it does not perform keyword matching. Unlike `handoff`, it stays at the raw event-stream layer rather than assembling working memory.
 
-Default text output is a compact single-line row (`HH:MM:SS  kind  agent=<agent>  sess=<first-8>  ws=<basename>  message`) that fits within ~100 columns and uses local time. Pass `--wide` for the legacy tab-separated seven-column shape, or `--utc` to force UTC timestamps in either text mode. `--wide --utc` reproduces the pre-v0.6.1 format byte-for-byte for scripts that parse it. `--json` emits newline-delimited JSON objects (one event per line) so pipelines can consume the stream incrementally; timestamps in JSON remain RFC3339 and are unaffected by `--utc`.
+Default text output is a compact single-line row (`HH:MM:SS  kind  agent=<agent>  sess=<first-8>  ws=<basename>  message`) that fits within ~100 columns and uses local time. Pass `--wide` for the legacy tab-separated seven-column shape, or `--utc` to force UTC timestamps in either text mode. `--wide --utc` reproduces the pre-v0.6.1 format byte-for-byte for scripts that parse it. `--json` emits newline-delimited JSON objects (one event per line) so pipelines can consume the stream incrementally; timestamps in JSON are UTC RFC3339Nano and are unaffected by `--utc`.
 
 > The compact session ID (`sess=<first-8>`) is intended for human scanning only. For machine processing, use `--wide --utc` or `--json`.
 
@@ -151,7 +151,7 @@ Useful flags:
 
 Show work timeline with gap-based block detection and per-workspace activity summaries.
 
-`timeline` groups recent events into contiguous work blocks separated by idle gaps (default: 15 minutes) and prints one aligned sub-row per workspace inside each block. The per-workspace activity summary is picked using the fallback chain **`compact_summary` → first `prompt` → kind counts**, so whichever signal exists for that workspace in the block lights up the line. Default text output uses local time; pass `--utc` for UTC. `--json` extends the block schema with a `workspace_breakdown` array (`{workspace, event_count, kind_counts, agents, summary, summary_source}`) — existing consumers keep working unchanged.
+`timeline` groups recent events into contiguous work blocks separated by idle gaps (default: 15 minutes) and prints one aligned sub-row per workspace inside each block. The per-workspace activity summary is picked using the fallback chain **`compact_summary` → first `prompt` → kind counts**, so whichever signal exists for that workspace in the block lights up the line. Default text output uses local time; pass `--utc` for UTC. `--json` emits UTC RFC3339Nano `start` / `end` timestamps, numeric `duration_sec`, and a `workspace_breakdown` array (`{workspace, event_count, kind_counts, agents, summary, summary_source}`).
 
 Useful flags:
 
@@ -497,7 +497,7 @@ Useful flags:
 
 ### `traceary session tree`
 
-Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude/Explore` for Claude Code subagents), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, `duration_ms`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
+Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude/Explore` for Claude Code subagents), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, numeric `duration_sec`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
 
 Useful flags:
 

--- a/presentation/cli/bundle.go
+++ b/presentation/cli/bundle.go
@@ -32,12 +32,12 @@ func (c *RootCLI) newBundleCommand() *cobra.Command {
 
 func (c *RootCLI) newBundleExportCommand() *cobra.Command {
 	var (
-		dbPath          string
-		outPath         string
-		sinceValue      string
-		untilValue      string
-		workspaceValue  string
-		passphraseEnv   string
+		dbPath         string
+		outPath        string
+		sinceValue     string
+		untilValue     string
+		workspaceValue string
+		passphraseEnv  string
 	)
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -176,10 +176,10 @@ func (c *RootCLI) runBundleImport(ctx context.Context, output io.Writer, input b
 	if input.asJSON {
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
-		if err := enc.Encode(map[string]any{
-			"events_imported":       result.EventsImported,
-			"events_skipped":        result.EventsSkipped,
-			"bundle_schema_version": result.BundleSchemaVersion,
+		if err := enc.Encode(bundleImportOutput{
+			EventsImported:      result.EventsImported,
+			EventsSkipped:       result.EventsSkipped,
+			BundleSchemaVersion: result.BundleSchemaVersion,
 		}); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print bundle import result", "bundle import 結果の出力に失敗しました"), err)
 		}

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -49,7 +49,7 @@ func newEventOutput(e *model.Event) event {
 		Workspace:  e.Workspace().String(),
 		Message:    apptypes.ExtractPlainBody(e.Body()),
 		SourceHook: e.SourceHook(),
-		CreatedAt:  e.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:  formatJSONTime(e.CreatedAt()),
 	}
 }
 

--- a/presentation/cli/memory_bridge.go
+++ b/presentation/cli/memory_bridge.go
@@ -256,10 +256,7 @@ const (
 )
 
 func writeMemoryExportJSONSummary(output io.Writer, result apptypes.MemoryExportResult) error {
-	payload := struct {
-		Target        string `json:"target"`
-		ExportedCount int    `json:"exported_count"`
-	}{
+	payload := memoryExportOutput{
 		Target:        result.Target.String(),
 		ExportedCount: result.ExportedCount,
 	}

--- a/presentation/cli/memory_graph.go
+++ b/presentation/cli/memory_graph.go
@@ -32,12 +32,12 @@ func (c *RootCLI) newMemoryGraphCommand() *cobra.Command {
 
 func (c *RootCLI) newMemoryGraphAddCommand() *cobra.Command {
 	var (
-		dbPath     string
-		toMemory   string
-		relation   string
-		validFrom  string
-		validTo    string
-		asJSON     bool
+		dbPath    string
+		toMemory  string
+		relation  string
+		validFrom string
+		validTo   string
+		asJSON    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "add <from-memory-id>",
@@ -196,13 +196,13 @@ func (c *RootCLI) runMemoryGraphList(ctx context.Context, output io.Writer, inpu
 }
 
 type memoryEdgeJSON struct {
-	ID           string `json:"id"`
-	From         string `json:"from_memory_id"`
-	To           string `json:"to_memory_id"`
-	Relation     string `json:"relation_type"`
-	ValidFrom    string `json:"valid_from"`
-	ValidTo      string `json:"valid_to,omitempty"`
-	CreatedAt    string `json:"created_at"`
+	ID        string `json:"id"`
+	From      string `json:"from_memory_id"`
+	To        string `json:"to_memory_id"`
+	Relation  string `json:"relation_type"`
+	ValidFrom string `json:"valid_from"`
+	ValidTo   string `json:"valid_to,omitempty"`
+	CreatedAt string `json:"created_at"`
 }
 
 func memoryEdgeToJSON(edge *model.MemoryEdge) memoryEdgeJSON {
@@ -211,11 +211,11 @@ func memoryEdgeToJSON(edge *model.MemoryEdge) memoryEdgeJSON {
 		From:      edge.FromMemoryID().String(),
 		To:        edge.ToMemoryID().String(),
 		Relation:  edge.RelationType().String(),
-		ValidFrom: edge.ValidFrom().UTC().Format(time.RFC3339Nano),
-		CreatedAt: edge.CreatedAt().UTC().Format(time.RFC3339Nano),
+		ValidFrom: formatJSONTime(edge.ValidFrom()),
+		CreatedAt: formatJSONTime(edge.CreatedAt()),
 	}
 	if to, ok := edge.ValidTo().Value(); ok {
-		out.ValidTo = to.UTC().Format(time.RFC3339Nano)
+		out.ValidTo = formatJSONTime(to)
 	}
 	return out
 }
@@ -236,7 +236,7 @@ func printMemoryEdge(output io.Writer, edge *model.MemoryEdge, asJSON bool) erro
 		edge.FromMemoryID(),
 		edge.RelationType(),
 		edge.ToMemoryID(),
-		edge.ValidFrom().UTC().Format(time.RFC3339Nano),
+		formatJSONTime(edge.ValidFrom()),
 		formatOptionalEdgeBound(edge.ValidTo()),
 	)
 	if err != nil {
@@ -274,7 +274,7 @@ func printMemoryEdges(output io.Writer, edges []*model.MemoryEdge, asJSON bool) 
 
 func formatOptionalEdgeBound(value domtypes.Optional[time.Time]) string {
 	if t, ok := value.Value(); ok {
-		return t.UTC().Format(time.RFC3339Nano)
+		return formatJSONTime(t)
 	}
 	return "-"
 }

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -81,15 +81,12 @@ func writeMemoryHygieneApplyResult(output io.Writer, result apptypes.MemoryHygie
 		encoder := json.NewEncoder(output)
 		encoder.SetEscapeHTML(false)
 		encoder.SetIndent("", "  ")
-		payload := struct {
-			Applied  []applyAppliedOutput `json:"applied"`
-			Failures []applyFailureOutput `json:"failures,omitempty"`
-		}{
-			Applied:  make([]applyAppliedOutput, 0, len(result.Applied)),
-			Failures: make([]applyFailureOutput, 0, len(result.Failures)),
+		payload := memoryHygieneApplyOutput{
+			Applied:  make([]memoryHygieneApplyAppliedOutput, 0, len(result.Applied)),
+			Failures: make([]memoryHygieneApplyFailureOutput, 0, len(result.Failures)),
 		}
 		for _, applied := range result.Applied {
-			payload.Applied = append(payload.Applied, applyAppliedOutput{
+			payload.Applied = append(payload.Applied, memoryHygieneApplyAppliedOutput{
 				MemoryID:   applied.MemoryID,
 				Kind:       string(applied.Kind),
 				Transition: applied.Transition,
@@ -97,7 +94,7 @@ func writeMemoryHygieneApplyResult(output io.Writer, result apptypes.MemoryHygie
 			})
 		}
 		for _, failure := range result.Failures {
-			payload.Failures = append(payload.Failures, applyFailureOutput{MemoryID: failure.MemoryID, Error: failure.Error})
+			payload.Failures = append(payload.Failures, memoryHygieneApplyFailureOutput{MemoryID: failure.MemoryID, Error: failure.Error})
 		}
 		if err := encoder.Encode(payload); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to encode hygiene apply result", "hygiene apply 結果の JSON 出力に失敗しました"), err)
@@ -121,18 +118,6 @@ func writeMemoryHygieneApplyResult(output io.Writer, result apptypes.MemoryHygie
 		}
 	}
 	return nil
-}
-
-type applyAppliedOutput struct {
-	MemoryID   string `json:"memory_id"`
-	Kind       string `json:"kind"`
-	Transition string `json:"transition"`
-	Status     string `json:"status"`
-}
-
-type applyFailureOutput struct {
-	MemoryID string `json:"memory_id"`
-	Error    string `json:"error"`
 }
 
 func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
@@ -197,14 +182,7 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 
 func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygieneScanResult, asJSON bool) error {
 	if asJSON {
-		payload := struct {
-			RedactionHitCount             int                        `json:"redaction_hit_count"`
-			ExpiryCandidateCount          int                        `json:"expiry_candidate_count"`
-			DuplicateCount                int                        `json:"duplicate_count"`
-			SupersedeCandidateCount       int                        `json:"supersede_candidate_count"`
-			ValidityOverlapSupersedeCount int                        `json:"validity_overlap_supersede_count"`
-			Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
-		}{
+		payload := memoryHygieneScanOutput{
 			RedactionHitCount:             result.RedactionHitCount,
 			ExpiryCandidateCount:          result.ExpiryCandidateCount,
 			DuplicateCount:                result.DuplicateCount,
@@ -277,7 +255,7 @@ func newMemoryHygieneOutputEntry(suggestion apptypes.MemoryHygieneSuggestion) me
 		Fact:          suggestion.Fact,
 		SanitizedFact: suggestion.SanitizedFact,
 		Similarity:    suggestion.Similarity,
-		UpdatedAt:     suggestion.UpdatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:     formatJSONTime(suggestion.UpdatedAt),
 	}
 	if suggestion.DuplicateMemoryID != "" {
 		entry.DuplicateMemoryID = suggestion.DuplicateMemoryID.String()

--- a/presentation/cli/memory_import.go
+++ b/presentation/cli/memory_import.go
@@ -183,12 +183,7 @@ func writeMemoryImportResult(output io.Writer, warnWriter io.Writer, result appt
 		for _, details := range result.Imported {
 			imported = append(imported, newMemoryDetailsOutput(details))
 		}
-		payload := struct {
-			Imported              []memoryDetailsOutput `json:"imported"`
-			SkippedDuplicateCount int                   `json:"skipped_duplicate_count"`
-			SkippedRejectedCount  int                   `json:"skipped_rejected_count"`
-			Warnings              []string              `json:"warnings,omitempty"`
-		}{
+		payload := memoryImportOutput{
 			Imported:              imported,
 			SkippedDuplicateCount: result.SkippedDuplicateCount,
 			SkippedRejectedCount:  result.SkippedRejectedCount,

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -290,11 +290,7 @@ func writeMemoryInboxList(output io.Writer, items []apptypes.MemoryDetails, asJS
 
 func writeMemoryInboxBatch(output io.Writer, result memoryInboxBatchResult, asJSON bool) error {
 	if asJSON {
-		payload := struct {
-			Action    string                `json:"action"`
-			Processed []memoryDetailsOutput `json:"processed"`
-			Failures  []memoryInboxFailure  `json:"failures,omitempty"`
-		}{
+		payload := memoryInboxBatchOutput{
 			Action:    result.Action,
 			Processed: make([]memoryDetailsOutput, 0, len(result.Processed)),
 			Failures:  result.Failures,

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -80,7 +80,7 @@ func writeMemorySummaries(output io.Writer, summaries []apptypes.MemorySummary) 
 		if _, err := fmt.Fprintf(
 			output,
 			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			summary.UpdatedAt().UTC().Format(time.RFC3339),
+			formatJSONTime(summary.UpdatedAt()),
 			summary.MemoryID(),
 			summary.MemoryType(),
 			formatMemoryScope(summary.Scope()),
@@ -109,10 +109,10 @@ func writeMemoryDetails(output io.Writer, details apptypes.MemoryDetails) error 
 		summary.Source(),
 		formatOptionalMemoryID(summary.Supersedes()),
 		formatOptionalTime(summary.ExpiresAt()),
-		summary.ValidFrom().UTC().Format(time.RFC3339),
+		formatJSONTime(summary.ValidFrom()),
 		formatOptionalTime(summary.ValidTo()),
-		summary.CreatedAt().UTC().Format(time.RFC3339),
-		summary.UpdatedAt().UTC().Format(time.RFC3339),
+		formatJSONTime(summary.CreatedAt()),
+		formatJSONTime(summary.UpdatedAt()),
 		summary.Fact(),
 	); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory fields", "durable memory 共通項目の出力に失敗しました"), err)
@@ -175,13 +175,13 @@ func newMemorySummaryOutput(summary apptypes.MemorySummary) memorySummaryOutput 
 
 	var expiresAt *string
 	if value, ok := summary.ExpiresAt().Value(); ok {
-		resolved := value.UTC().Format(time.RFC3339)
+		resolved := formatJSONTime(value)
 		expiresAt = &resolved
 	}
 
 	var validTo *string
 	if value, ok := summary.ValidTo().Value(); ok {
-		resolved := value.UTC().Format(time.RFC3339)
+		resolved := formatJSONTime(value)
 		validTo = &resolved
 	}
 
@@ -196,10 +196,10 @@ func newMemorySummaryOutput(summary apptypes.MemorySummary) memorySummaryOutput 
 		Source:     summary.Source().String(),
 		Supersedes: supersedes,
 		ExpiresAt:  expiresAt,
-		ValidFrom:  summary.ValidFrom().UTC().Format(time.RFC3339),
+		ValidFrom:  formatJSONTime(summary.ValidFrom()),
 		ValidTo:    validTo,
-		CreatedAt:  summary.CreatedAt().UTC().Format(time.RFC3339),
-		UpdatedAt:  summary.UpdatedAt().UTC().Format(time.RFC3339),
+		CreatedAt:  formatJSONTime(summary.CreatedAt()),
+		UpdatedAt:  formatJSONTime(summary.UpdatedAt()),
 	}
 }
 

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -80,7 +80,7 @@ func writeMemorySummaries(output io.Writer, summaries []apptypes.MemorySummary) 
 		if _, err := fmt.Fprintf(
 			output,
 			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			formatJSONTime(summary.UpdatedAt()),
+			formatTextTime(summary.UpdatedAt()),
 			summary.MemoryID(),
 			summary.MemoryType(),
 			formatMemoryScope(summary.Scope()),
@@ -109,10 +109,10 @@ func writeMemoryDetails(output io.Writer, details apptypes.MemoryDetails) error 
 		summary.Source(),
 		formatOptionalMemoryID(summary.Supersedes()),
 		formatOptionalTime(summary.ExpiresAt()),
-		formatJSONTime(summary.ValidFrom()),
+		formatTextTime(summary.ValidFrom()),
 		formatOptionalTime(summary.ValidTo()),
-		formatJSONTime(summary.CreatedAt()),
-		formatJSONTime(summary.UpdatedAt()),
+		formatTextTime(summary.CreatedAt()),
+		formatTextTime(summary.UpdatedAt()),
 		summary.Fact(),
 	); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory fields", "durable memory 共通項目の出力に失敗しました"), err)
@@ -235,6 +235,10 @@ func formatOptionalMemoryID(value domtypes.Optional[domtypes.MemoryID]) string {
 	}
 
 	return "-"
+}
+
+func formatTextTime(value time.Time) string {
+	return value.UTC().Format(time.RFC3339)
 }
 
 func formatOptionalTime(value domtypes.Optional[time.Time]) string {

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -1,5 +1,7 @@
 package cli
 
+import "time"
+
 // event is the JSON shape of an event in CLI output.
 type event struct {
 	EventID    string `json:"event_id"`
@@ -48,7 +50,6 @@ type sessionTreeNode struct {
 	EndedAt         *string            `json:"ended_at,omitempty"`
 	Status          string             `json:"status"`
 	DurationSec     *float64           `json:"duration_sec,omitempty"`
-	DurationMs      *int64             `json:"duration_ms,omitempty"`
 	TotalEvents     int                `json:"total_events"`
 	CommandCount    int                `json:"command_count"`
 	Agents          []string           `json:"agents"`
@@ -79,4 +80,102 @@ type memoryDetailsOutput struct {
 	Summary      memorySummaryOutput `json:"summary"`
 	EvidenceRefs []string            `json:"evidence_refs"`
 	ArtifactRefs []string            `json:"artifact_refs"`
+}
+
+// sessionSummaryOutput is the JSON shape of a session summary in list output.
+type sessionSummaryOutput struct {
+	SessionID       string   `json:"session_id"`
+	Workspace       string   `json:"workspace,omitempty"`
+	Label           string   `json:"label,omitempty"`
+	Summary         string   `json:"summary,omitempty"`
+	ParentSessionID string   `json:"parent_session_id,omitempty"`
+	StartedAt       string   `json:"started_at"`
+	EndedAt         *string  `json:"ended_at,omitempty"`
+	Status          string   `json:"status"`
+	DurationSec     *float64 `json:"duration_sec,omitempty"`
+	TotalEvents     int      `json:"total_events"`
+	CommandCount    int      `json:"command_count"`
+	Agents          []string `json:"agents"`
+}
+
+// timelineWorkspaceBreakdownOutput is the JSON shape of a workspace within a timeline block.
+type timelineWorkspaceBreakdownOutput struct {
+	Workspace     string         `json:"workspace"`
+	EventCount    int            `json:"event_count"`
+	KindCounts    map[string]int `json:"kind_counts"`
+	Agents        []string       `json:"agents"`
+	Summary       string         `json:"summary"`
+	SummarySource string         `json:"summary_source"`
+}
+
+// timelineBlockOutput is the JSON shape of a timeline block.
+type timelineBlockOutput struct {
+	Start              string                             `json:"start"`
+	End                string                             `json:"end"`
+	DurationSec        float64                            `json:"duration_sec"`
+	EventCount         int                                `json:"event_count"`
+	Workspaces         []string                           `json:"workspaces"`
+	Agents             []string                           `json:"agents"`
+	KindCounts         map[string]int                     `json:"kind_counts"`
+	WorkspaceBreakdown []timelineWorkspaceBreakdownOutput `json:"workspace_breakdown"`
+}
+
+// bundleImportOutput is the JSON shape of a bundle import result.
+type bundleImportOutput struct {
+	EventsImported      int `json:"events_imported"`
+	EventsSkipped       int `json:"events_skipped"`
+	BundleSchemaVersion int `json:"bundle_schema_version"`
+}
+
+// memoryHygieneApplyOutput is the JSON shape of a memory hygiene apply result.
+type memoryHygieneApplyOutput struct {
+	Applied  []memoryHygieneApplyAppliedOutput `json:"applied"`
+	Failures []memoryHygieneApplyFailureOutput `json:"failures,omitempty"`
+}
+
+type memoryHygieneApplyAppliedOutput struct {
+	MemoryID   string `json:"memory_id"`
+	Kind       string `json:"kind"`
+	Transition string `json:"transition"`
+	Status     string `json:"status"`
+}
+
+type memoryHygieneApplyFailureOutput struct {
+	MemoryID string `json:"memory_id"`
+	Error    string `json:"error"`
+}
+
+// memoryHygieneScanOutput is the JSON shape of a memory hygiene scan result.
+type memoryHygieneScanOutput struct {
+	RedactionHitCount             int                        `json:"redaction_hit_count"`
+	ExpiryCandidateCount          int                        `json:"expiry_candidate_count"`
+	DuplicateCount                int                        `json:"duplicate_count"`
+	SupersedeCandidateCount       int                        `json:"supersede_candidate_count"`
+	ValidityOverlapSupersedeCount int                        `json:"validity_overlap_supersede_count"`
+	Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
+}
+
+// memoryInboxBatchOutput is the JSON shape of a memory inbox batch result.
+type memoryInboxBatchOutput struct {
+	Action    string                `json:"action"`
+	Processed []memoryDetailsOutput `json:"processed"`
+	Failures  []memoryInboxFailure  `json:"failures,omitempty"`
+}
+
+// memoryImportOutput is the JSON shape of a memory import result.
+type memoryImportOutput struct {
+	Imported              []memoryDetailsOutput `json:"imported"`
+	SkippedDuplicateCount int                   `json:"skipped_duplicate_count"`
+	SkippedRejectedCount  int                   `json:"skipped_rejected_count"`
+	Warnings              []string              `json:"warnings,omitempty"`
+}
+
+// memoryExportOutput is the JSON shape of a memory export summary.
+type memoryExportOutput struct {
+	Target        string `json:"target"`
+	ExportedCount int    `json:"exported_count"`
+}
+
+func formatJSONTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/presentation/cli/output_types_test.go
+++ b/presentation/cli/output_types_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatJSONTime_UsesUTCAndRFC3339Nano(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("JST", 9*60*60)
+	got := formatJSONTime(time.Date(2026, 4, 25, 12, 34, 56, 123456789, loc))
+	want := "2026-04-25T03:34:56.123456789Z"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("formatJSONTime mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNamedJSONRootShapes(t *testing.T) {
+	t.Parallel()
+
+	endedAt := "2026-04-25T03:35:56.123456789Z"
+	duration := 60.5
+	payload := []sessionSummaryOutput{{
+		SessionID:       "session-1",
+		Workspace:       "workspace-1",
+		StartedAt:       "2026-04-25T03:34:55.623456789Z",
+		EndedAt:         &endedAt,
+		Status:          "ended",
+		DurationSec:     &duration,
+		TotalEvents:     2,
+		CommandCount:    1,
+		Agents:          []string{"codex"},
+		ParentSessionID: "parent-1",
+	}}
+
+	var out bytes.Buffer
+	if err := writeJSON(&out, payload); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	want := `[
+  {
+    "session_id": "session-1",
+    "workspace": "workspace-1",
+    "parent_session_id": "parent-1",
+    "started_at": "2026-04-25T03:34:55.623456789Z",
+    "ended_at": "2026-04-25T03:35:56.123456789Z",
+    "status": "ended",
+    "duration_sec": 60.5,
+    "total_events": 2,
+    "command_count": 1,
+    "agents": [
+      "codex"
+    ]
+  }
+]
+`
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("session summary JSON shape mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTimelineBlockOutputShape(t *testing.T) {
+	t.Parallel()
+
+	payload := []timelineBlockOutput{{
+		Start:       "2026-04-25T03:00:00.123456789Z",
+		End:         "2026-04-25T03:15:00.123456789Z",
+		DurationSec: 900,
+		EventCount:  3,
+		Workspaces:  []string{"ws"},
+		Agents:      []string{"codex"},
+		KindCounts:  map[string]int{"note": 3},
+		WorkspaceBreakdown: []timelineWorkspaceBreakdownOutput{{
+			Workspace:     "ws",
+			EventCount:    3,
+			KindCounts:    map[string]int{"note": 3},
+			Agents:        []string{"codex"},
+			Summary:       "note: 3",
+			SummarySource: "kind_counts",
+		}},
+	}}
+
+	var out bytes.Buffer
+	if err := writeJSON(&out, payload); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	want := `[
+  {
+    "start": "2026-04-25T03:00:00.123456789Z",
+    "end": "2026-04-25T03:15:00.123456789Z",
+    "duration_sec": 900,
+    "event_count": 3,
+    "workspaces": [
+      "ws"
+    ],
+    "agents": [
+      "codex"
+    ],
+    "kind_counts": {
+      "note": 3
+    },
+    "workspace_breakdown": [
+      {
+        "workspace": "ws",
+        "event_count": 3,
+        "kind_counts": {
+          "note": 3
+        },
+        "agents": [
+          "codex"
+        ],
+        "summary": "note: 3",
+        "summary_source": "kind_counts"
+      }
+    ]
+  }
+]
+`
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("timeline JSON shape mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -159,37 +159,22 @@ func writeSessionSummaries(output io.Writer, summaries []apptypes.SessionSummary
 }
 
 func writeSessionSummariesJSON(output io.Writer, summaries []apptypes.SessionSummary) error {
-	type jsonSummary struct {
-		SessionID       string   `json:"session_id"`
-		Workspace       string   `json:"workspace,omitempty"`
-		Label           string   `json:"label,omitempty"`
-		Summary         string   `json:"summary,omitempty"`
-		ParentSessionID string   `json:"parent_session_id,omitempty"`
-		StartedAt       string   `json:"started_at"`
-		EndedAt         *string  `json:"ended_at,omitempty"`
-		Status          string   `json:"status"`
-		DurationSec     *float64 `json:"duration_sec,omitempty"`
-		TotalEvents     int      `json:"total_events"`
-		CommandCount    int      `json:"command_count"`
-		Agents          []string `json:"agents"`
-	}
-
-	items := make([]jsonSummary, 0, len(summaries))
+	items := make([]sessionSummaryOutput, 0, len(summaries))
 	for _, s := range summaries {
-		item := jsonSummary{
+		item := sessionSummaryOutput{
 			SessionID:       string(s.SessionID()),
 			Workspace:       string(s.Workspace()),
 			Label:           s.Label(),
 			Summary:         s.Summary(),
 			ParentSessionID: string(s.ParentSessionID()),
-			StartedAt:       s.StartedAt().UTC().Format(time.RFC3339),
+			StartedAt:       formatJSONTime(s.StartedAt()),
 			Status:          s.Status(),
 			TotalEvents:     s.TotalEvents(),
 			CommandCount:    s.CommandCount(),
 			Agents:          s.Agents(),
 		}
 		if endedAt, ok := s.EndedAt().Value(); ok {
-			endStr := endedAt.UTC().Format(time.RFC3339)
+			endStr := formatJSONTime(endedAt)
 			item.EndedAt = &endStr
 			dur := endedAt.Sub(s.StartedAt()).Seconds()
 			item.DurationSec = &dur

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -16,12 +15,12 @@ import (
 
 func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 	var (
-		dbPath       string
-		repo         string
-		limit        int
-		asJSON       bool
-		rootID       string
-		ongoingOnly  bool
+		dbPath      string
+		repo        string
+		limit       int
+		asJSON      bool
+		rootID      string
+		ongoingOnly bool
 	)
 
 	cmd := &cobra.Command{
@@ -200,7 +199,7 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 		Workspace:       string(s.Workspace()),
 		Label:           s.Label(),
 		Summary:         s.Summary(),
-		StartedAt:       s.StartedAt().UTC().Format(time.RFC3339),
+		StartedAt:       formatJSONTime(s.StartedAt()),
 		Status:          s.Status(),
 		TotalEvents:     s.TotalEvents(),
 		CommandCount:    s.CommandCount(),
@@ -209,13 +208,11 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 		Children:        make([]*sessionTreeNode, 0, len(node.children)),
 	}
 	if endedAt, ok := s.EndedAt().Value(); ok {
-		endStr := endedAt.UTC().Format(time.RFC3339)
+		endStr := formatJSONTime(endedAt)
 		jn.EndedAt = &endStr
 		dur := endedAt.Sub(s.StartedAt())
 		secs := dur.Seconds()
-		ms := dur.Milliseconds()
 		jn.DurationSec = &secs
-		jn.DurationMs = &ms
 	}
 	for _, child := range node.children {
 		jn.Children = append(jn.Children, sessionNodeToOutput(child, depth+1))

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -217,12 +217,11 @@ func TestRootCLI_SessionTreeCommand_LineageFields(t *testing.T) {
 	}
 
 	var trees []struct {
-		SessionID       string  `json:"session_id"`
-		ParentSessionID string  `json:"parent_session_id"`
-		Depth           int     `json:"depth"`
-		DurationMs      *int64  `json:"duration_ms"`
+		SessionID       string   `json:"session_id"`
+		ParentSessionID string   `json:"parent_session_id"`
+		Depth           int      `json:"depth"`
 		DurationSec     *float64 `json:"duration_sec"`
-		SubagentType    string  `json:"subagent_type"`
+		SubagentType    string   `json:"subagent_type"`
 		Children        []struct {
 			SessionID       string `json:"session_id"`
 			ParentSessionID string `json:"parent_session_id"`
@@ -243,8 +242,11 @@ func TestRootCLI_SessionTreeCommand_LineageFields(t *testing.T) {
 	if root.ParentSessionID != "" {
 		t.Fatalf("root parent_session_id = %q, want empty", root.ParentSessionID)
 	}
-	if root.DurationMs == nil || *root.DurationMs != 90_000 {
-		t.Fatalf("root duration_ms = %v, want 90000", root.DurationMs)
+	if root.DurationSec == nil || *root.DurationSec != 90 {
+		t.Fatalf("root duration_sec = %v, want 90", root.DurationSec)
+	}
+	if strings.Contains(stdout.String(), `"duration_ms"`) {
+		t.Fatalf("JSON output should not contain duration_ms, got: %s", stdout.String())
 	}
 	if root.SubagentType != "claude" {
 		t.Fatalf("root subagent_type = %q, want claude", root.SubagentType)

--- a/presentation/cli/timeline.go
+++ b/presentation/cli/timeline.go
@@ -242,31 +242,12 @@ func formatKindCounts(counts map[string]int) string {
 }
 
 func writeTimelineJSON(output io.Writer, blocks []apptypes.TimelineBlock) error {
-	type jsonWorkspaceBreakdown struct {
-		Workspace     string         `json:"workspace"`
-		EventCount    int            `json:"event_count"`
-		KindCounts    map[string]int `json:"kind_counts"`
-		Agents        []string       `json:"agents"`
-		Summary       string         `json:"summary"`
-		SummarySource string         `json:"summary_source"`
-	}
-	type jsonBlock struct {
-		Start              string                   `json:"start"`
-		End                string                   `json:"end"`
-		Duration           string                   `json:"duration"`
-		EventCount         int                      `json:"event_count"`
-		Workspaces         []string                 `json:"workspaces"`
-		Agents             []string                 `json:"agents"`
-		KindCounts         map[string]int           `json:"kind_counts"`
-		WorkspaceBreakdown []jsonWorkspaceBreakdown `json:"workspace_breakdown"`
-	}
-
-	result := make([]jsonBlock, 0, len(blocks))
+	result := make([]timelineBlockOutput, 0, len(blocks))
 	for _, b := range blocks {
 		breakdown := b.WorkspaceBreakdown()
-		wsOut := make([]jsonWorkspaceBreakdown, 0, len(breakdown))
+		wsOut := make([]timelineWorkspaceBreakdownOutput, 0, len(breakdown))
 		for _, ws := range breakdown {
-			wsOut = append(wsOut, jsonWorkspaceBreakdown{
+			wsOut = append(wsOut, timelineWorkspaceBreakdownOutput{
 				Workspace:     ws.Workspace(),
 				EventCount:    ws.EventCount(),
 				KindCounts:    computeKindCounts(ws.Kinds()),
@@ -275,10 +256,10 @@ func writeTimelineJSON(output io.Writer, blocks []apptypes.TimelineBlock) error 
 				SummarySource: string(ws.SummarySource()),
 			})
 		}
-		result = append(result, jsonBlock{
-			Start:              b.BlockStart().Format(time.RFC3339),
-			End:                b.BlockEnd().Format(time.RFC3339),
-			Duration:           formatDuration(b.BlockEnd().Sub(b.BlockStart())),
+		result = append(result, timelineBlockOutput{
+			Start:              formatJSONTime(b.BlockStart()),
+			End:                formatJSONTime(b.BlockEnd()),
+			DurationSec:        b.BlockEnd().Sub(b.BlockStart()).Seconds(),
 			EventCount:         b.EventCount(),
 			Workspaces:         b.Workspaces(),
 			Agents:             b.Agents(),

--- a/presentation/cli/timeline_test.go
+++ b/presentation/cli/timeline_test.go
@@ -63,7 +63,7 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 
 		output := stdout.String()
 		if !strings.Contains(output, "3h30m") {
-			t.Errorf("output missing duration, got: %s", output)
+			t.Errorf("output missing duration_sec, got: %s", output)
 		}
 		if !strings.Contains(output, "github.com/duck8823/traceary") {
 			t.Errorf("output missing workspace, got: %s", output)
@@ -138,8 +138,8 @@ func TestRootCLI_TimelineCommand(t *testing.T) {
 		if !strings.Contains(output, `"event_count": 5`) {
 			t.Errorf("output missing event_count, got: %s", output)
 		}
-		if !strings.Contains(output, `"duration": "1h0m"`) {
-			t.Errorf("output missing duration, got: %s", output)
+		if !strings.Contains(output, `"duration_sec": 3600`) {
+			t.Errorf("output missing duration_sec, got: %s", output)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Freeze unstable CLI `--json` output shapes BEFORE goldens are recorded (Wave 2 gating issue for v0.10).

- Standardised all `--json` timestamps on `t.UTC().Format(time.RFC3339Nano)` (`created_at`, `started_at`, `ended_at`, `valid_from`, `valid_to`, `expires_at`, `updated_at`, etc.)
- Promoted anonymous JSON-root structs in `presentation/cli/` to named types (`sessionSummaryOutput`, `timelineBlockOutput`, `bundleImportOutput`, `memoryHygieneApplyOutput`, `memoryHygieneScanOutput`, `memoryInboxBatchOutput`, `memoryImportOutput`, `memoryExportOutput`, `timelineWorkspaceBreakdownOutput`)
- `session tree --json`: drop `duration_ms`, keep `duration_sec` only
- `timeline --json`: replace string `duration` with numeric `duration_sec`
- CHANGELOG + `docs/cli/README{,.ja}.md` updated for breaking change

## Test plan

- [x] `go test ./...` (1049 pass)
- [x] `go build ./...`
- [x] `go tool golangci-lint run` (0 issues)
- [x] new unit tests assert RFC3339Nano UTC + named-struct JSON shape

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>