### PR TITLE
feat(session): add subagent spawn metadata schema (#722)

### DIFF
--- a/application/types/session_summary.go
+++ b/application/types/session_summary.go
@@ -20,6 +20,9 @@ type SessionSummary struct {
 	label           string
 	summary         string
 	parentSessionID domtypes.SessionID
+	spawnEventID    domtypes.EventID
+	subagentKind    string
+	spawnOrder      domtypes.Optional[int]
 }
 
 // SessionSummaryOf creates a SessionSummary.
@@ -35,7 +38,28 @@ func SessionSummaryOf(
 	label string,
 	summary string,
 	parentSessionID domtypes.SessionID,
+	spawnMetadata ...any,
 ) SessionSummary {
+	var (
+		spawnEventID domtypes.EventID
+		subagentKind string
+		spawnOrder   domtypes.Optional[int]
+	)
+	if len(spawnMetadata) >= 1 {
+		if value, ok := spawnMetadata[0].(domtypes.EventID); ok {
+			spawnEventID = value
+		}
+	}
+	if len(spawnMetadata) >= 2 {
+		if value, ok := spawnMetadata[1].(string); ok {
+			subagentKind = value
+		}
+	}
+	if len(spawnMetadata) >= 3 {
+		if value, ok := spawnMetadata[2].(domtypes.Optional[int]); ok {
+			spawnOrder = value
+		}
+	}
 	return SessionSummary{
 		sessionID:       sessionID,
 		workspace:       workspace,
@@ -48,6 +72,9 @@ func SessionSummaryOf(
 		label:           label,
 		summary:         summary,
 		parentSessionID: parentSessionID,
+		spawnEventID:    spawnEventID,
+		subagentKind:    subagentKind,
+		spawnOrder:      spawnOrder,
 	}
 }
 
@@ -83,3 +110,12 @@ func (s SessionSummary) Summary() string { return s.summary }
 
 // ParentSessionID returns the parent session ID.
 func (s SessionSummary) ParentSessionID() domtypes.SessionID { return s.parentSessionID }
+
+// SpawnEventID returns the event that spawned this session, or empty if unknown.
+func (s SessionSummary) SpawnEventID() domtypes.EventID { return s.spawnEventID }
+
+// SubagentKind returns the kind of subagent spawn, or empty for top-level sessions.
+func (s SessionSummary) SubagentKind() string { return s.subagentKind }
+
+// SpawnOrder returns this child session's sibling order when available.
+func (s SessionSummary) SpawnOrder() domtypes.Optional[int] { return s.spawnOrder }

--- a/application/types/session_summary_test.go
+++ b/application/types/session_summary_test.go
@@ -29,6 +29,9 @@ func TestSessionSummaryOf_Getters(t *testing.T) {
 		"daily-standup",
 		"body text",
 		domtypes.SessionID("parent-session"),
+		domtypes.EventID("spawn-event"),
+		"task",
+		domtypes.Some(4),
 	)
 
 	if diff := cmp.Diff(domtypes.SessionID("session-1"), summary.SessionID()); diff != "" {
@@ -67,6 +70,17 @@ func TestSessionSummaryOf_Getters(t *testing.T) {
 	}
 	if diff := cmp.Diff(domtypes.SessionID("parent-session"), summary.ParentSessionID()); diff != "" {
 		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(domtypes.EventID("spawn-event"), summary.SpawnEventID()); diff != "" {
+		t.Errorf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("task", summary.SubagentKind()); diff != "" {
+		t.Errorf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if spawnOrder, ok := summary.SpawnOrder().Value(); !ok {
+		t.Fatalf("SpawnOrder() should be present")
+	} else if diff := cmp.Diff(4, spawnOrder); diff != "" {
+		t.Errorf("SpawnOrder() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -17,6 +17,9 @@ type Session struct {
 	label           string
 	summary         string
 	parentSessionID types.SessionID
+	spawnEventID    types.EventID
+	subagentKind    string
+	spawnOrder      types.Optional[int]
 }
 
 // NewSession creates a new Session for session start.
@@ -36,6 +39,24 @@ func NewSession(
 	}
 }
 
+// NewChildSession creates a new child Session spawned from a parent session.
+func NewChildSession(
+	parent *Session,
+	sessionID types.SessionID,
+	agent types.Agent,
+	workspace types.Workspace,
+	spawnEventID types.EventID,
+	kind string,
+	order int,
+) *Session {
+	session := NewSession(sessionID, parent.StartedAt(), parent.Client(), agent, workspace)
+	session.parentSessionID = parent.SessionID()
+	session.spawnEventID = spawnEventID
+	session.subagentKind = kind
+	session.spawnOrder = types.Some(order)
+	return session
+}
+
 // SessionOf restores a Session from persisted data.
 func SessionOf(
 	sessionID types.SessionID,
@@ -47,7 +68,28 @@ func SessionOf(
 	label string,
 	summary string,
 	parentSessionID types.SessionID,
+	spawnMetadata ...any,
 ) *Session {
+	var (
+		spawnEventID types.EventID
+		subagentKind string
+		spawnOrder   types.Optional[int]
+	)
+	if len(spawnMetadata) >= 1 {
+		if value, ok := spawnMetadata[0].(types.EventID); ok {
+			spawnEventID = value
+		}
+	}
+	if len(spawnMetadata) >= 2 {
+		if value, ok := spawnMetadata[1].(string); ok {
+			subagentKind = value
+		}
+	}
+	if len(spawnMetadata) >= 3 {
+		if value, ok := spawnMetadata[2].(types.Optional[int]); ok {
+			spawnOrder = value
+		}
+	}
 	return &Session{
 		sessionID:       sessionID,
 		startedAt:       startedAt,
@@ -58,6 +100,9 @@ func SessionOf(
 		label:           label,
 		summary:         summary,
 		parentSessionID: parentSessionID,
+		spawnEventID:    spawnEventID,
+		subagentKind:    subagentKind,
+		spawnOrder:      spawnOrder,
 	}
 }
 
@@ -101,3 +146,12 @@ func (s *Session) Summary() string { return s.summary }
 
 // ParentSessionID returns the parent session ID, or empty if top-level.
 func (s *Session) ParentSessionID() types.SessionID { return s.parentSessionID }
+
+// SpawnEventID returns the event that spawned this session, or empty if unknown.
+func (s *Session) SpawnEventID() types.EventID { return s.spawnEventID }
+
+// SubagentKind returns the kind of subagent spawn, or empty for top-level sessions.
+func (s *Session) SubagentKind() string { return s.subagentKind }
+
+// SpawnOrder returns this child session's sibling order when available.
+func (s *Session) SpawnOrder() types.Optional[int] { return s.spawnOrder }

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -43,13 +43,14 @@ func NewSession(
 func NewChildSession(
 	parent *Session,
 	sessionID types.SessionID,
+	startedAt time.Time,
 	agent types.Agent,
 	workspace types.Workspace,
 	spawnEventID types.EventID,
 	kind string,
 	order int,
 ) *Session {
-	session := NewSession(sessionID, parent.StartedAt(), parent.Client(), agent, workspace)
+	session := NewSession(sessionID, startedAt, parent.Client(), agent, workspace)
 	session.parentSessionID = parent.SessionID()
 	session.spawnEventID = spawnEventID
 	session.subagentKind = kind

--- a/domain/model/session_test.go
+++ b/domain/model/session_test.go
@@ -118,9 +118,11 @@ func TestNewChildSession(t *testing.T) {
 	start := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	parent := model.NewSession(parentID, start, types.Client("hook"), parentAgent, types.Workspace("parent-workspace"))
 
+	childStart := start.Add(5 * time.Second)
 	child := model.NewChildSession(
 		parent,
 		childID,
+		childStart,
 		childAgent,
 		types.Workspace("child-workspace"),
 		types.EventID("spawn-event"),
@@ -130,6 +132,12 @@ func TestNewChildSession(t *testing.T) {
 
 	if diff := cmp.Diff(childID, child.SessionID()); diff != "" {
 		t.Errorf("SessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(childStart, child.StartedAt()); diff != "" {
+		t.Errorf("StartedAt() mismatch (-want +got):\n%s", diff)
+	}
+	if child.StartedAt().Equal(parent.StartedAt()) {
+		t.Errorf("StartedAt() should use the child start time, got parent start time %s", child.StartedAt())
 	}
 	if diff := cmp.Diff(parentID, child.ParentSessionID()); diff != "" {
 		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)

--- a/domain/model/session_test.go
+++ b/domain/model/session_test.go
@@ -53,6 +53,15 @@ func TestNewSession(t *testing.T) {
 	if diff := cmp.Diff(types.SessionID(""), session.ParentSessionID()); diff != "" {
 		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)
 	}
+	if diff := cmp.Diff(types.EventID(""), session.SpawnEventID()); diff != "" {
+		t.Errorf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("", session.SubagentKind()); diff != "" {
+		t.Errorf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if _, ok := session.SpawnOrder().Value(); ok {
+		t.Errorf("SpawnOrder() should be empty")
+	}
 }
 
 func TestSessionOf(t *testing.T) {
@@ -63,7 +72,11 @@ func TestSessionOf(t *testing.T) {
 	start := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 10, 13, 0, 0, 0, time.UTC)
 
-	session := model.SessionOf(sid, start, types.Some(end), types.Client("cli"), agent, types.Workspace("workspace"), "sprint-1", "did stuff", types.SessionID("parent-123"))
+	session := model.SessionOf(
+		sid, start, types.Some(end), types.Client("cli"), agent, types.Workspace("workspace"),
+		"sprint-1", "did stuff", types.SessionID("parent-123"),
+		types.EventID("spawn-event-1"), "task", types.Some(3),
+	)
 
 	if diff := cmp.Diff(sid, session.SessionID()); diff != "" {
 		t.Errorf("SessionID() mismatch (-want +got):\n%s", diff)
@@ -81,6 +94,56 @@ func TestSessionOf(t *testing.T) {
 	}
 	if diff := cmp.Diff(types.SessionID("parent-123"), session.ParentSessionID()); diff != "" {
 		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.EventID("spawn-event-1"), session.SpawnEventID()); diff != "" {
+		t.Errorf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("task", session.SubagentKind()); diff != "" {
+		t.Errorf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if spawnOrder, ok := session.SpawnOrder().Value(); !ok {
+		t.Errorf("SpawnOrder() should be present")
+	} else if diff := cmp.Diff(3, spawnOrder); diff != "" {
+		t.Errorf("SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNewChildSession(t *testing.T) {
+	t.Parallel()
+
+	parentAgent, _ := types.AgentFrom("codex")
+	childAgent, _ := types.AgentFrom("codex/reviewer")
+	parentID, _ := types.SessionIDFrom("parent-session")
+	childID, _ := types.SessionIDFrom("child-session")
+	start := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	parent := model.NewSession(parentID, start, types.Client("hook"), parentAgent, types.Workspace("parent-workspace"))
+
+	child := model.NewChildSession(
+		parent,
+		childID,
+		childAgent,
+		types.Workspace("child-workspace"),
+		types.EventID("spawn-event"),
+		"worker",
+		2,
+	)
+
+	if diff := cmp.Diff(childID, child.SessionID()); diff != "" {
+		t.Errorf("SessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(parentID, child.ParentSessionID()); diff != "" {
+		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.EventID("spawn-event"), child.SpawnEventID()); diff != "" {
+		t.Errorf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("worker", child.SubagentKind()); diff != "" {
+		t.Errorf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if spawnOrder, ok := child.SpawnOrder().Value(); !ok {
+		t.Errorf("SpawnOrder() should be present")
+	} else if diff := cmp.Diff(2, spawnOrder); diff != "" {
+		t.Errorf("SpawnOrder() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -79,6 +79,13 @@ SELECT
 FROM events e
 GROUP BY e.session_id;`),
 		},
+		"000014_add_session_spawn_metadata.sql": {
+			Data: []byte(`ALTER TABLE sessions ADD COLUMN spawn_event_id TEXT;
+ALTER TABLE sessions ADD COLUMN subagent_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE sessions ADD COLUMN spawn_order INTEGER;
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
+    ON sessions(parent_session_id, spawn_order);`),
+		},
 	}
 }
 

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -94,6 +95,32 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	if migrationCount != wantMigrations {
 		t.Errorf("schema_migrations count = %d, want %d", migrationCount, wantMigrations)
 	}
+
+	assertSessionSpawnMetadataSchema(t, db)
+}
+
+func TestMigration014_addsSessionSpawnMetadataToUpgradedDatabase(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	preV010 := migrationsWithout(t, "../../schema/sqlite/migrations", "000014_add_session_spawn_metadata.sql")
+	ds := newStoreManagementDatasource(t, dbPath, preV010)
+	if err := ds.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(pre-v0.10) error = %v", err)
+	}
+
+	ds = newStoreManagementDatasource(t, dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	if err := ds.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(upgrade) error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	assertSessionSpawnMetadataSchema(t, db)
 }
 
 func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
@@ -132,6 +159,101 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 	if count != wantMigrations {
 		t.Errorf("schema_migrations count = %d, want %d", count, wantMigrations)
+	}
+}
+
+func migrationsWithout(t *testing.T, dir string, excludedNames ...string) fstest.MapFS {
+	t.Helper()
+
+	excluded := make(map[string]struct{}, len(excludedNames))
+	for _, name := range excludedNames {
+		excluded[name] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	migrations := fstest.MapFS{}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		if _, ok := excluded[entry.Name()]; ok {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", entry.Name(), err)
+		}
+		migrations[entry.Name()] = &fstest.MapFile{Data: data}
+	}
+	return migrations
+}
+
+func assertSessionSpawnMetadataSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	rows, err := db.Query(`PRAGMA table_info(sessions)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(sessions) error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type column struct {
+		typ        string
+		notNull    bool
+		defaultVal string
+	}
+	columns := map[string]column{}
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			typ        string
+			notNull    int
+			defaultVal sql.NullString
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultVal, &pk); err != nil {
+			t.Fatalf("scan table_info row error = %v", err)
+		}
+		columns[name] = column{
+			typ:        strings.ToUpper(typ),
+			notNull:    notNull == 1,
+			defaultVal: defaultVal.String,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table_info rows error = %v", err)
+	}
+
+	assertColumn := func(name, typ string, notNull bool, defaultVal string) {
+		t.Helper()
+		got, ok := columns[name]
+		if !ok {
+			t.Fatalf("sessions.%s column not found", name)
+		}
+		if got.typ != typ {
+			t.Errorf("sessions.%s type = %q, want %q", name, got.typ, typ)
+		}
+		if got.notNull != notNull {
+			t.Errorf("sessions.%s notNull = %v, want %v", name, got.notNull, notNull)
+		}
+		if got.defaultVal != defaultVal {
+			t.Errorf("sessions.%s default = %q, want %q", name, got.defaultVal, defaultVal)
+		}
+	}
+	assertColumn("spawn_event_id", "TEXT", false, "")
+	assertColumn("subagent_kind", "TEXT", true, "''")
+	assertColumn("spawn_order", "INTEGER", false, "")
+
+	var indexCount int
+	if err := db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_sessions_parent_spawn_order'`).Scan(&indexCount); err != nil {
+		t.Fatalf("query index count error = %v", err)
+	}
+	if indexCount != 1 {
+		t.Fatalf("idx_sessions_parent_spawn_order index count = %d, want 1", indexCount)
 	}
 }
 

--- a/infrastructure/sqlite/save_boundary_test.go
+++ b/infrastructure/sqlite/save_boundary_test.go
@@ -69,6 +69,104 @@ func TestSessionDatasource_SaveBoundary_Start(t *testing.T) {
 	}
 }
 
+func TestSessionDatasource_SaveBoundary_RoundTripsSpawnMetadata(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := infra.NewDatabase(dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := infra.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	sessionDS := infra.NewSessionDatasource(db)
+
+	parentID, _ := types.SessionIDFrom("parent-session")
+	childID, _ := types.SessionIDFrom("child-session")
+	parentAgent, _ := types.AgentFrom("codex")
+	childAgent, _ := types.AgentFrom("codex/worker")
+	startedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+
+	parent := model.NewSession(parentID, startedAt, types.Client("cli"), parentAgent, types.Workspace("workspace"))
+	parentEvent := model.EventOf(
+		types.EventID("parent-start"),
+		types.EventKindSessionStarted,
+		types.Client("cli"),
+		parentAgent,
+		parentID,
+		types.Workspace("workspace"),
+		"parent session started",
+		startedAt,
+	)
+	if err := sessionDS.SaveBoundary(ctx, parent, parentEvent); err != nil {
+		t.Fatalf("SaveBoundary(parent) error = %v", err)
+	}
+
+	child := model.NewChildSession(
+		parent,
+		childID,
+		childAgent,
+		types.Workspace("workspace"),
+		types.EventID("spawn-event"),
+		"worker",
+		2,
+	)
+	childEvent := model.EventOf(
+		types.EventID("child-start"),
+		types.EventKindSessionStarted,
+		types.Client("cli"),
+		childAgent,
+		childID,
+		types.Workspace("workspace"),
+		"child session started",
+		startedAt.Add(time.Second),
+	)
+	if err := sessionDS.SaveBoundary(ctx, child, childEvent); err != nil {
+		t.Fatalf("SaveBoundary(child) error = %v", err)
+	}
+
+	storedOpt, err := sessionDS.FindByID(ctx, childID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	stored, ok := storedOpt.Value()
+	if !ok {
+		t.Fatalf("FindByID() should be present")
+	}
+	if diff := cmp.Diff(parentID, stored.ParentSessionID()); diff != "" {
+		t.Errorf("ParentSessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.EventID("spawn-event"), stored.SpawnEventID()); diff != "" {
+		t.Errorf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("worker", stored.SubagentKind()); diff != "" {
+		t.Errorf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if spawnOrder, ok := stored.SpawnOrder().Value(); !ok {
+		t.Fatalf("SpawnOrder() should be present")
+	} else if diff := cmp.Diff(2, spawnOrder); diff != "" {
+		t.Errorf("SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+
+	summaries, err := sessionDS.ListSummaries(ctx, 10, 0, childID, types.Workspace(""), types.Client(""), types.Agent(""), "", types.None[time.Time](), types.None[time.Time]())
+	if err != nil {
+		t.Fatalf("ListSummaries() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("ListSummaries() len = %d, want 1", len(summaries))
+	}
+	if diff := cmp.Diff(types.EventID("spawn-event"), summaries[0].SpawnEventID()); diff != "" {
+		t.Errorf("summary SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("worker", summaries[0].SubagentKind()); diff != "" {
+		t.Errorf("summary SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if spawnOrder, ok := summaries[0].SpawnOrder().Value(); !ok {
+		t.Fatalf("summary SpawnOrder() should be present")
+	} else if diff := cmp.Diff(2, spawnOrder); diff != "" {
+		t.Errorf("summary SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestSessionDatasource_SaveBoundary_End(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/save_boundary_test.go
+++ b/infrastructure/sqlite/save_boundary_test.go
@@ -101,9 +101,11 @@ func TestSessionDatasource_SaveBoundary_RoundTripsSpawnMetadata(t *testing.T) {
 		t.Fatalf("SaveBoundary(parent) error = %v", err)
 	}
 
+	childStartedAt := startedAt.Add(time.Second)
 	child := model.NewChildSession(
 		parent,
 		childID,
+		childStartedAt,
 		childAgent,
 		types.Workspace("workspace"),
 		types.EventID("spawn-event"),
@@ -118,7 +120,7 @@ func TestSessionDatasource_SaveBoundary_RoundTripsSpawnMetadata(t *testing.T) {
 		childID,
 		types.Workspace("workspace"),
 		"child session started",
-		startedAt.Add(time.Second),
+		childStartedAt,
 	)
 	if err := sessionDS.SaveBoundary(ctx, child, childEvent); err != nil {
 		t.Fatalf("SaveBoundary(child) error = %v", err)

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -149,6 +149,15 @@ func insertSessionRowIfMissing(ctx context.Context, exec sqlExecer, session *mod
 		v := session.ParentSessionID().String()
 		parentSessionID = &v
 	}
+	var spawnEventID *string
+	if session.SpawnEventID().String() != "" {
+		v := session.SpawnEventID().String()
+		spawnEventID = &v
+	}
+	var spawnOrder *int
+	if value, ok := session.SpawnOrder().Value(); ok {
+		spawnOrder = &value
+	}
 	result, err := exec.ExecContext(
 		ctx,
 		insertSessionQuery,
@@ -158,6 +167,9 @@ func insertSessionRowIfMissing(ctx context.Context, exec sqlExecer, session *mod
 		session.Agent().String(),
 		session.Workspace().String(),
 		parentSessionID,
+		spawnEventID,
+		session.SubagentKind(),
+		spawnOrder,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") && session.ParentSessionID().String() != "" {
@@ -258,6 +270,9 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		labelValue           string
 		summaryValue         string
 		parentSessionIDValue string
+		spawnEventIDValue    string
+		subagentKindValue    string
+		spawnOrderValue      sql.NullInt64
 	)
 
 	if err := row.Scan(
@@ -270,6 +285,9 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		&labelValue,
 		&summaryValue,
 		&parentSessionIDValue,
+		&spawnEventIDValue,
+		&subagentKindValue,
+		&spawnOrderValue,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.None[*model.Session](), nil
@@ -309,6 +327,9 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		labelValue,
 		summaryValue,
 		types.SessionID(parentSessionIDValue),
+		types.EventID(spawnEventIDValue),
+		subagentKindValue,
+		optionalIntFromNullInt64(spawnOrderValue),
 	)), nil
 }
 
@@ -434,6 +455,9 @@ func scanSessionSummary(row interface {
 		label           string
 		summary         string
 		parentSessionID string
+		spawnEventID    string
+		subagentKind    string
+		spawnOrder      sql.NullInt64
 	)
 
 	if err := row.Scan(
@@ -447,6 +471,9 @@ func scanSessionSummary(row interface {
 		&label,
 		&summary,
 		&parentSessionID,
+		&spawnEventID,
+		&subagentKind,
+		&spawnOrder,
 	); err != nil {
 		return apptypes.SessionSummary{}, xerrors.Errorf("failed to scan session summary: %w", err)
 	}
@@ -486,5 +513,15 @@ func scanSessionSummary(row interface {
 		label,
 		summary,
 		types.SessionID(parentSessionID),
+		types.EventID(spawnEventID),
+		subagentKind,
+		optionalIntFromNullInt64(spawnOrder),
 	), nil
+}
+
+func optionalIntFromNullInt64(value sql.NullInt64) types.Optional[int] {
+	if !value.Valid {
+		return types.None[int]()
+	}
+	return types.Some(int(value.Int64))
 }

--- a/infrastructure/sqlite/sql/insert_session.sql
+++ b/infrastructure/sqlite/sql/insert_session.sql
@@ -1,1 +1,1 @@
-INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, workspace, parent_session_id) VALUES (?, ?, ?, ?, ?, ?)
+INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, workspace, parent_session_id, spawn_event_id, subagent_kind, spawn_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -8,7 +8,10 @@ SELECT
   COALESCE(agg.agents, '') AS agents,
   s.label,
   s.summary,
-  COALESCE(s.parent_session_id, '') AS parent_session_id
+  COALESCE(s.parent_session_id, '') AS parent_session_id,
+  COALESCE(s.spawn_event_id, '') AS spawn_event_id,
+  s.subagent_kind,
+  s.spawn_order
 FROM sessions s
 LEFT JOIN (
   SELECT

--- a/infrastructure/sqlite/sql/select_session_by_id.sql
+++ b/infrastructure/sqlite/sql/select_session_by_id.sql
@@ -1,1 +1,1 @@
-SELECT session_id, started_at, ended_at, client, agent, workspace, label, summary, COALESCE(parent_session_id, '') FROM sessions WHERE session_id = ?
+SELECT session_id, started_at, ended_at, client, agent, workspace, label, summary, COALESCE(parent_session_id, ''), COALESCE(spawn_event_id, ''), subagent_kind, spawn_order FROM sessions WHERE session_id = ?

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -42,6 +42,9 @@ type contextOutput struct {
 type sessionTreeNode struct {
 	SessionID       string             `json:"session_id"`
 	ParentSessionID string             `json:"parent_session_id,omitempty"`
+	SpawnEventID    string             `json:"spawn_event_id,omitempty"`
+	SubagentKind    string             `json:"subagent_kind,omitempty"`
+	SpawnOrder      *int               `json:"spawn_order,omitempty"`
 	Depth           int                `json:"depth"`
 	Workspace       string             `json:"workspace,omitempty"`
 	Label           string             `json:"label,omitempty"`
@@ -89,6 +92,9 @@ type sessionSummaryOutput struct {
 	Label           string   `json:"label,omitempty"`
 	Summary         string   `json:"summary,omitempty"`
 	ParentSessionID string   `json:"parent_session_id,omitempty"`
+	SpawnEventID    string   `json:"spawn_event_id,omitempty"`
+	SubagentKind    string   `json:"subagent_kind,omitempty"`
+	SpawnOrder      *int     `json:"spawn_order,omitempty"`
 	StartedAt       string   `json:"started_at"`
 	EndedAt         *string  `json:"ended_at,omitempty"`
 	Status          string   `json:"status"`

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -167,11 +167,16 @@ func writeSessionSummariesJSON(output io.Writer, summaries []apptypes.SessionSum
 			Label:           s.Label(),
 			Summary:         s.Summary(),
 			ParentSessionID: string(s.ParentSessionID()),
+			SpawnEventID:    s.SpawnEventID().String(),
+			SubagentKind:    s.SubagentKind(),
 			StartedAt:       formatJSONTime(s.StartedAt()),
 			Status:          s.Status(),
 			TotalEvents:     s.TotalEvents(),
 			CommandCount:    s.CommandCount(),
 			Agents:          s.Agents(),
+		}
+		if spawnOrder, ok := s.SpawnOrder().Value(); ok {
+			item.SpawnOrder = &spawnOrder
 		}
 		if endedAt, ok := s.EndedAt().Value(); ok {
 			endStr := formatJSONTime(endedAt)

--- a/presentation/cli/session_list_test.go
+++ b/presentation/cli/session_list_test.go
@@ -117,6 +117,9 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 					"release",
 					"Prepare release notes",
 					types.SessionID("root-session"),
+					types.EventID("spawn-event"),
+					"worker",
+					types.Some(2),
 				),
 			},
 		}
@@ -147,6 +150,15 @@ func TestRootCLI_SessionListCommand(t *testing.T) {
 		}
 		if !strings.Contains(output, `"parent_session_id": "root-session"`) {
 			t.Fatalf("JSON output should contain parent_session_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"spawn_event_id": "spawn-event"`) {
+			t.Fatalf("JSON output should contain spawn_event_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"subagent_kind": "worker"`) {
+			t.Fatalf("JSON output should contain subagent_kind, got: %s", output)
+		}
+		if !strings.Contains(output, `"spawn_order": 2`) {
+			t.Fatalf("JSON output should contain spawn_order, got: %s", output)
 		}
 	})
 

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -195,6 +195,8 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 	jn := &sessionTreeNode{
 		SessionID:       string(s.SessionID()),
 		ParentSessionID: s.ParentSessionID().String(),
+		SpawnEventID:    s.SpawnEventID().String(),
+		SubagentKind:    s.SubagentKind(),
 		Depth:           depth,
 		Workspace:       string(s.Workspace()),
 		Label:           s.Label(),
@@ -206,6 +208,9 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 		Agents:          s.Agents(),
 		SubagentType:    extractSubagentType(s.Agents()),
 		Children:        make([]*sessionTreeNode, 0, len(node.children)),
+	}
+	if spawnOrder, ok := s.SpawnOrder().Value(); ok {
+		jn.SpawnOrder = &spawnOrder
 	}
 	if endedAt, ok := s.EndedAt().Value(); ok {
 		endStr := formatJSONTime(endedAt)

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -49,6 +49,9 @@ func TestRootCLI_SessionTreeCommand_JSON(t *testing.T) {
 					"",
 					"",
 					types.SessionID("root-session"),
+					types.EventID("spawn-event"),
+					"task",
+					types.Some(1),
 				),
 			},
 		}
@@ -97,6 +100,15 @@ func TestRootCLI_SessionTreeCommand_JSON(t *testing.T) {
 		// Verify nested children
 		if !strings.Contains(output, `"session_id": "child-session"`) {
 			t.Fatalf("JSON output should contain child session_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"spawn_event_id": "spawn-event"`) {
+			t.Fatalf("JSON output should contain child spawn_event_id, got: %s", output)
+		}
+		if !strings.Contains(output, `"subagent_kind": "task"`) {
+			t.Fatalf("JSON output should contain child subagent_kind, got: %s", output)
+		}
+		if !strings.Contains(output, `"spawn_order": 1`) {
+			t.Fatalf("JSON output should contain child spawn_order, got: %s", output)
 		}
 		// Child has no ended_at so no duration_sec -- just verify it's nested in children
 		if !strings.Contains(output, `"children"`) {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -953,6 +953,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     parent_session_id TEXT REFERENCES sessions(session_id)
 );`),
 		},
+		"000014_add_session_spawn_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE sessions ADD COLUMN spawn_event_id TEXT;
+ALTER TABLE sessions ADD COLUMN subagent_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE sessions ADD COLUMN spawn_order INTEGER;
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
+    ON sessions(parent_session_id, spawn_order);`),
+		},
 		"000008_create_memories.sql": {
 			Data: []byte(`
 CREATE TABLE memories (

--- a/schema/sqlite/migrations/000014_add_session_spawn_metadata.sql
+++ b/schema/sqlite/migrations/000014_add_session_spawn_metadata.sql
@@ -1,0 +1,6 @@
+ALTER TABLE sessions ADD COLUMN spawn_event_id TEXT;
+ALTER TABLE sessions ADD COLUMN subagent_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE sessions ADD COLUMN spawn_order INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
+    ON sessions(parent_session_id, spawn_order);


### PR DESCRIPTION
## Summary

Wave 4 step 1: schema + domain + repository support for subagent spawn metadata. Hook handlers UNCHANGED in this PR — that's #723 (PreToolUse:Task hook capture).

- Migration `schema/sqlite/migrations/000014_add_session_spawn_metadata.sql`: adds `spawn_event_id TEXT`, `subagent_kind TEXT NOT NULL DEFAULT ''`, `spawn_order INTEGER` + index `idx_sessions_parent_spawn_order`
- `domain/model/session.go`: threads 3 fields through `SessionOf`; new `NewChildSession(parent, id, agent, workspace, spawnEventID, kind, order)` constructor; `NewSession` (top-level) unchanged
- `model.SessionRepository.SaveBoundary` + SQLite impl: read/write new columns
- `application/queryservice` `SessionSummary`: surfaces `spawn_event_id` / `subagent_kind` / `spawn_order` (omitempty for `spawn_event_id` and `spawn_order`)

## Test plan

- [x] `go test ./...` (migration test asserts columns + index on fresh DB and upgraded pre-v0.10 DB)
- [x] Session round-trips 3 new fields through repository save/find
- [x] SessionSummary JSON includes new fields with omitempty as specified
- [x] `go tool golangci-lint run` (0 issues)

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>