### PR TITLE
feat(memory-tool): add native memory file backend (#741)

### DIFF
--- a/application/usecase/memory_tool_usecase.go
+++ b/application/usecase/memory_tool_usecase.go
@@ -1,0 +1,358 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const maxMemoryToolLines = 999999
+
+// MemoryToolUsecase implements Anthropic's native memory-tool commands.
+type MemoryToolUsecase interface {
+	View(ctx context.Context, path string, viewRange []int) (string, error)
+	Create(ctx context.Context, path string, fileText string) (string, error)
+	StrReplace(ctx context.Context, path string, oldStr string, newStr string) (string, error)
+	Insert(ctx context.Context, path string, insertLine int, insertText string) (string, error)
+	Delete(ctx context.Context, path string) (string, error)
+	Rename(ctx context.Context, oldPath string, newPath string) (string, error)
+}
+
+type memoryToolUsecase struct {
+	repository model.MemoryToolFileRepository
+	clock      types.Clock
+}
+
+// NewMemoryToolUsecase creates a usecase for Anthropic memory-tool commands.
+func NewMemoryToolUsecase(repository model.MemoryToolFileRepository, clock types.Clock) MemoryToolUsecase {
+	if clock == nil {
+		clock = types.SystemClock{}
+	}
+	return &memoryToolUsecase{repository: repository, clock: clock}
+}
+
+// View shows directory contents or file contents with optional line ranges.
+func (u *memoryToolUsecase) View(ctx context.Context, rawPath string, viewRange []int) (string, error) {
+	path, err := types.NewMemoryToolPath(rawPath)
+	if err != nil {
+		return "", xerrors.Errorf("invalid memory tool path: %w", err)
+	}
+	file, err := u.repository.FindByPath(ctx, path)
+	if err != nil {
+		return "", xerrors.Errorf("failed to find memory tool file: %w", err)
+	}
+	if found, ok := file.Value(); ok {
+		return renderMemoryToolFile(path, string(found.Content()), viewRange)
+	}
+	files, err := u.repository.List(ctx)
+	if err != nil {
+		return "", xerrors.Errorf("failed to list memory tool files: %w", err)
+	}
+	if path.IsRoot() || hasDescendant(files, path) {
+		return renderMemoryToolDirectory(path, files), nil
+	}
+	return fmt.Sprintf("The path %s does not exist. Please provide a valid path.", path.String()), nil
+}
+
+// Create creates a new memory-tool file.
+func (u *memoryToolUsecase) Create(ctx context.Context, rawPath string, fileText string) (string, error) {
+	path, err := types.NewMemoryToolPath(rawPath)
+	if err != nil {
+		return "", xerrors.Errorf("invalid memory tool path: %w", err)
+	}
+	if path.IsRoot() {
+		return fmt.Sprintf("Error: File %s already exists", path.String()), nil
+	}
+	if exists, err := u.pathExists(ctx, path); err != nil {
+		return "", err
+	} else if exists {
+		return fmt.Sprintf("Error: File %s already exists", path.String()), nil
+	}
+	file := model.NewMemoryToolFile(path, []byte(fileText), u.clock.Now())
+	if err := u.repository.Save(ctx, file); err != nil {
+		return "", xerrors.Errorf("failed to save memory tool file: %w", err)
+	}
+	return fmt.Sprintf("File created successfully at: %s", path.String()), nil
+}
+
+// StrReplace replaces a unique verbatim string in a memory-tool file.
+func (u *memoryToolUsecase) StrReplace(ctx context.Context, rawPath string, oldStr string, newStr string) (string, error) {
+	path, file, ok, err := u.findFile(ctx, rawPath)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return fmt.Sprintf("Error: The path %s does not exist. Please provide a valid path.", path.String()), nil
+	}
+
+	content := string(file.Content())
+	count := strings.Count(content, oldStr)
+	switch count {
+	case 0:
+		return fmt.Sprintf("No replacement was performed, old_str `%s` did not appear verbatim in %s.", oldStr, path.String()), nil
+	case 1:
+	default:
+		return fmt.Sprintf("No replacement was performed. Multiple occurrences of old_str `%s` in lines: %s. Please ensure it is unique", oldStr, occurrenceLines(content, oldStr)), nil
+	}
+
+	updatedContent := strings.Replace(content, oldStr, newStr, 1)
+	if err := u.repository.Save(ctx, file.WithContent([]byte(updatedContent), u.clock.Now())); err != nil {
+		return "", xerrors.Errorf("failed to save replaced memory tool file: %w", err)
+	}
+	rendered, err := renderMemoryToolFile(path, updatedContent, nil)
+	if err != nil {
+		return "", err
+	}
+	return "The memory file has been edited.\n" + rendered, nil
+}
+
+// Insert inserts text at a bounded line number.
+func (u *memoryToolUsecase) Insert(ctx context.Context, rawPath string, insertLine int, insertText string) (string, error) {
+	path, file, ok, err := u.findFile(ctx, rawPath)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return fmt.Sprintf("Error: The path %s does not exist", path.String()), nil
+	}
+	content := string(file.Content())
+	lines, trailingNewline := splitMemoryToolLines(content)
+	if insertLine < 0 || insertLine > len(lines) {
+		return fmt.Sprintf("Error: Invalid `insert_line` parameter: %d. It should be within the range of lines of the file: [0, %d]", insertLine, len(lines)), nil
+	}
+	insertLines, insertTrailingNewline := splitMemoryToolLines(insertText)
+	updatedLines := make([]string, 0, len(lines)+len(insertLines))
+	updatedLines = append(updatedLines, lines[:insertLine]...)
+	updatedLines = append(updatedLines, insertLines...)
+	updatedLines = append(updatedLines, lines[insertLine:]...)
+	updatedContent := joinMemoryToolLines(updatedLines, trailingNewline || insertTrailingNewline)
+	if err := u.repository.Save(ctx, file.WithContent([]byte(updatedContent), u.clock.Now())); err != nil {
+		return "", xerrors.Errorf("failed to save inserted memory tool file: %w", err)
+	}
+	return fmt.Sprintf("The file %s has been edited.", path.String()), nil
+}
+
+// Delete deletes a file or directory recursively.
+func (u *memoryToolUsecase) Delete(ctx context.Context, rawPath string) (string, error) {
+	path, err := types.NewMemoryToolPath(rawPath)
+	if err != nil {
+		return "", xerrors.Errorf("invalid memory tool path: %w", err)
+	}
+	deleted, err := u.repository.DeletePathPrefix(ctx, path)
+	if err != nil {
+		return "", xerrors.Errorf("failed to delete memory tool path: %w", err)
+	}
+	if deleted == 0 {
+		return fmt.Sprintf("Error: The path %s does not exist", path.String()), nil
+	}
+	return fmt.Sprintf("Successfully deleted %s", path.String()), nil
+}
+
+// Rename renames or moves a file or directory.
+func (u *memoryToolUsecase) Rename(ctx context.Context, rawOldPath string, rawNewPath string) (string, error) {
+	oldPath, err := types.NewMemoryToolPath(rawOldPath)
+	if err != nil {
+		return "", xerrors.Errorf("invalid source memory tool path: %w", err)
+	}
+	newPath, err := types.NewMemoryToolPath(rawNewPath)
+	if err != nil {
+		return "", xerrors.Errorf("invalid destination memory tool path: %w", err)
+	}
+	if exists, err := u.pathExists(ctx, oldPath); err != nil {
+		return "", err
+	} else if !exists {
+		return fmt.Sprintf("Error: The path %s does not exist", oldPath.String()), nil
+	}
+	if exists, err := u.pathExists(ctx, newPath); err != nil {
+		return "", err
+	} else if exists {
+		return fmt.Sprintf("Error: The destination %s already exists", newPath.String()), nil
+	}
+	if _, err := u.repository.RenamePathPrefix(ctx, oldPath, newPath, u.clock.Now()); err != nil {
+		return "", xerrors.Errorf("failed to rename memory tool path: %w", err)
+	}
+	return fmt.Sprintf("Successfully renamed %s to %s", oldPath.String(), newPath.String()), nil
+}
+
+func (u *memoryToolUsecase) findFile(ctx context.Context, rawPath string) (types.MemoryToolPath, *model.MemoryToolFile, bool, error) {
+	path, err := types.NewMemoryToolPath(rawPath)
+	if err != nil {
+		return "", nil, false, xerrors.Errorf("invalid memory tool path: %w", err)
+	}
+	file, err := u.repository.FindByPath(ctx, path)
+	if err != nil {
+		return "", nil, false, xerrors.Errorf("failed to find memory tool file: %w", err)
+	}
+	if found, ok := file.Value(); ok {
+		return path, found, true, nil
+	}
+	return path, nil, false, nil
+}
+
+func (u *memoryToolUsecase) pathExists(ctx context.Context, path types.MemoryToolPath) (bool, error) {
+	file, err := u.repository.FindByPath(ctx, path)
+	if err != nil {
+		return false, xerrors.Errorf("failed to find memory tool file: %w", err)
+	}
+	if _, ok := file.Value(); ok {
+		return true, nil
+	}
+	files, err := u.repository.List(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("failed to list memory tool files: %w", err)
+	}
+	return path.IsRoot() || hasDescendant(files, path), nil
+}
+
+func hasDescendant(files []*model.MemoryToolFile, path types.MemoryToolPath) bool {
+	for _, file := range files {
+		if file.Path().IsDescendantOf(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func renderMemoryToolFile(path types.MemoryToolPath, content string, viewRange []int) (string, error) {
+	lines, _ := splitMemoryToolLines(content)
+	if len(lines) > maxMemoryToolLines {
+		return fmt.Sprintf("File %s exceeds maximum line limit of 999,999 lines.", path.String()), nil
+	}
+	start, end, err := normalizeViewRange(viewRange, len(lines))
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "Here's the content of %s with line numbers:", path.String())
+	for index := start; index < end; index++ {
+		fmt.Fprintf(&builder, "\n%6d\t%s", index+1, lines[index])
+	}
+	return builder.String(), nil
+}
+
+func normalizeViewRange(viewRange []int, lineCount int) (int, int, error) {
+	if len(viewRange) == 0 {
+		return 0, lineCount, nil
+	}
+	if len(viewRange) != 2 {
+		return 0, 0, xerrors.Errorf("view_range must contain exactly two integers")
+	}
+	start := viewRange[0]
+	end := viewRange[1]
+	if start < 1 {
+		return 0, 0, xerrors.Errorf("view_range start must be >= 1")
+	}
+	if end == -1 || end > lineCount {
+		end = lineCount
+	}
+	if end < start-1 {
+		return 0, 0, xerrors.Errorf("view_range end must be >= start")
+	}
+	return start - 1, end, nil
+}
+
+func renderMemoryToolDirectory(path types.MemoryToolPath, files []*model.MemoryToolFile) string {
+	entries := directoryEntries(path, files)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "Here're the files and directories up to 2 levels deep in %s, excluding hidden items and node_modules:", path.String())
+	for _, entry := range entries {
+		fmt.Fprintf(&builder, "\n%5s\t%s", humanMemoryToolSize(entry.size), entry.path)
+	}
+	return builder.String()
+}
+
+type memoryToolDirectoryEntry struct {
+	path string
+	size int64
+}
+
+func directoryEntries(root types.MemoryToolPath, files []*model.MemoryToolFile) []memoryToolDirectoryEntry {
+	sizes := map[string]int64{root.String(): 0}
+	rootDepth := memoryToolDepth(root.String())
+	for _, file := range files {
+		filePath := file.Path().String()
+		if !isVisibleDescendantOrSelf(root.String(), filePath) {
+			continue
+		}
+		segments := strings.Split(strings.Trim(filePath, "/"), "/")
+		for depth := rootDepth + 1; depth <= len(segments) && depth <= rootDepth+2; depth++ {
+			entryPath := "/" + strings.Join(segments[:depth], "/")
+			sizes[entryPath] += file.SizeBytes()
+		}
+		sizes[root.String()] += file.SizeBytes()
+	}
+	entries := make([]memoryToolDirectoryEntry, 0, len(sizes))
+	for path, size := range sizes {
+		entries = append(entries, memoryToolDirectoryEntry{path: path, size: size})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	return entries
+}
+
+func isVisibleDescendantOrSelf(root string, path string) bool {
+	if path != root && !strings.HasPrefix(path, root+"/") {
+		return false
+	}
+	for _, segment := range strings.Split(strings.TrimPrefix(strings.Trim(path, "/"), "memories/"), "/") {
+		if segment == "" {
+			continue
+		}
+		if strings.HasPrefix(segment, ".") || segment == "node_modules" {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryToolDepth(path string) int {
+	return len(strings.Split(strings.Trim(path, "/"), "/"))
+}
+
+func humanMemoryToolSize(size int64) string {
+	const unit = 1024
+	if size < unit {
+		return fmt.Sprintf("%dB", size)
+	}
+	value := float64(size) / unit
+	for _, suffix := range []string{"K", "M", "G", "T"} {
+		if value < unit {
+			return fmt.Sprintf("%.1f%s", value, suffix)
+		}
+		value /= unit
+	}
+	return fmt.Sprintf("%.1fP", value)
+}
+
+func occurrenceLines(content string, needle string) string {
+	lines, _ := splitMemoryToolLines(content)
+	found := make([]string, 0)
+	for index, line := range lines {
+		if strings.Contains(line, needle) {
+			found = append(found, fmt.Sprintf("%d", index+1))
+		}
+	}
+	return strings.Join(found, ", ")
+}
+
+func splitMemoryToolLines(content string) ([]string, bool) {
+	if content == "" {
+		return []string{}, false
+	}
+	trailingNewline := strings.HasSuffix(content, "\n")
+	trimmed := strings.TrimSuffix(content, "\n")
+	return strings.Split(trimmed, "\n"), trailingNewline
+}
+
+func joinMemoryToolLines(lines []string, trailingNewline bool) string {
+	content := strings.Join(lines, "\n")
+	if trailingNewline {
+		content += "\n"
+	}
+	return content
+}

--- a/application/usecase/memory_tool_usecase.go
+++ b/application/usecase/memory_tool_usecase.go
@@ -131,7 +131,7 @@ func (u *memoryToolUsecase) Insert(ctx context.Context, rawPath string, insertLi
 	updatedLines = append(updatedLines, lines[:insertLine]...)
 	updatedLines = append(updatedLines, insertLines...)
 	updatedLines = append(updatedLines, lines[insertLine:]...)
-	updatedContent := joinMemoryToolLines(updatedLines, trailingNewline || insertTrailingNewline)
+	updatedContent := joinMemoryToolLines(updatedLines, trailingNewline || (insertLine == len(lines) && insertTrailingNewline))
 	if err := u.repository.Save(ctx, file.WithContent([]byte(updatedContent), u.clock.Now())); err != nil {
 		return "", xerrors.Errorf("failed to save inserted memory tool file: %w", err)
 	}

--- a/application/usecase/memory_tool_usecase_test.go
+++ b/application/usecase/memory_tool_usecase_test.go
@@ -1,0 +1,286 @@
+package usecase_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryToolUsecase_viewFileLineNumbersByteMatch(t *testing.T) {
+	t.Parallel()
+
+	repo := newMemoryToolRepositoryStub(t, map[string]string{
+		"/memories/notes.txt": strings.Join([]string{
+			"Hello World",
+			"This is line two",
+			"Line three",
+			"Line four",
+			"Line five",
+			"Line six",
+			"Line seven",
+			"Line eight",
+			"Line nine",
+			"Line ten",
+			"Line eleven",
+			"Line twelve",
+			"Line thirteen",
+			"Line fourteen",
+			"Line fifteen",
+			"Line sixteen",
+			"Line seventeen",
+			"Line eighteen",
+			"Line nineteen",
+			"Line twenty",
+			"Line twenty-one",
+			"Line twenty-two",
+			"Line twenty-three",
+			"Line twenty-four",
+			"Line twenty-five",
+			"Line twenty-six",
+			"Line twenty-seven",
+			"Line twenty-eight",
+			"Line twenty-nine",
+			"Line thirty",
+			"Line thirty-one",
+			"Line thirty-two",
+			"Line thirty-three",
+			"Line thirty-four",
+			"Line thirty-five",
+			"Line thirty-six",
+			"Line thirty-seven",
+			"Line thirty-eight",
+			"Line thirty-nine",
+			"Line forty",
+			"Line forty-one",
+			"Line forty-two",
+			"Line forty-three",
+			"Line forty-four",
+			"Line forty-five",
+			"Line forty-six",
+			"Line forty-seven",
+			"Line forty-eight",
+			"Line forty-nine",
+			"Line fifty",
+			"Line fifty-one",
+			"Line fifty-two",
+			"Line fifty-three",
+			"Line fifty-four",
+			"Line fifty-five",
+			"Line fifty-six",
+			"Line fifty-seven",
+			"Line fifty-eight",
+			"Line fifty-nine",
+			"Line sixty",
+			"Line sixty-one",
+			"Line sixty-two",
+			"Line sixty-three",
+			"Line sixty-four",
+			"Line sixty-five",
+			"Line sixty-six",
+			"Line sixty-seven",
+			"Line sixty-eight",
+			"Line sixty-nine",
+			"Line seventy",
+			"Line seventy-one",
+			"Line seventy-two",
+			"Line seventy-three",
+			"Line seventy-four",
+			"Line seventy-five",
+			"Line seventy-six",
+			"Line seventy-seven",
+			"Line seventy-eight",
+			"Line seventy-nine",
+			"Line eighty",
+			"Line eighty-one",
+			"Line eighty-two",
+			"Line eighty-three",
+			"Line eighty-four",
+			"Line eighty-five",
+			"Line eighty-six",
+			"Line eighty-seven",
+			"Line eighty-eight",
+			"Line eighty-nine",
+			"Line ninety",
+			"Line ninety-one",
+			"Line ninety-two",
+			"Line ninety-three",
+			"Line ninety-four",
+			"Line ninety-five",
+			"Line ninety-six",
+			"Line ninety-seven",
+			"Line ninety-eight",
+			"Line ninety-nine",
+			"Line one hundred",
+		}, "\n"),
+	})
+	sut := usecase.NewMemoryToolUsecase(repo, fixedClock{})
+
+	got, err := sut.View(context.Background(), "/memories/notes.txt", []int{1, 100})
+	if err != nil {
+		t.Fatalf("View() error = %v", err)
+	}
+
+	want := "Here's the content of /memories/notes.txt with line numbers:\n" +
+		"     1\tHello World\n" +
+		"     2\tThis is line two\n" +
+		"     3\tLine three\n" +
+		"     4\tLine four\n" +
+		"     5\tLine five\n" +
+		"     6\tLine six\n" +
+		"     7\tLine seven\n" +
+		"     8\tLine eight\n" +
+		"     9\tLine nine\n" +
+		"    10\tLine ten\n" +
+		strings.Join(makeExpectedNumberedLines(11, 99), "\n") + "\n" +
+		"   100\tLine one hundred"
+	if got != want {
+		t.Fatalf("View() output byte mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestMemoryToolUsecase_allCommandsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	repo := newMemoryToolRepositoryStub(t, nil)
+	sut := usecase.NewMemoryToolUsecase(repo, fixedClock{})
+	ctx := context.Background()
+
+	result, err := sut.Create(ctx, "/memories/notes.txt", "alpha\nbeta\n")
+	assertResult(t, result, err)
+	result, err = sut.Insert(ctx, "/memories/notes.txt", 1, "inserted\n")
+	assertResult(t, result, err)
+	result, err = sut.StrReplace(ctx, "/memories/notes.txt", "beta", "gamma")
+	assertResult(t, result, err)
+	got, err := sut.View(ctx, "/memories/notes.txt", nil)
+	if err != nil {
+		t.Fatalf("View() error = %v", err)
+	}
+	if !strings.Contains(got, "     2\tinserted") || !strings.Contains(got, "     3\tgamma") {
+		t.Fatalf("View() after edits = %q", got)
+	}
+	result, err = sut.Rename(ctx, "/memories/notes.txt", "/memories/archive/notes.txt")
+	assertResult(t, result, err)
+	result, err = sut.Delete(ctx, "/memories/archive")
+	assertResult(t, result, err)
+	got, err = sut.View(ctx, "/memories/archive/notes.txt", nil)
+	if err != nil {
+		t.Fatalf("View() deleted file error = %v", err)
+	}
+	if got != "The path /memories/archive/notes.txt does not exist. Please provide a valid path." {
+		t.Fatalf("deleted View() = %q", got)
+	}
+}
+
+func assertResult(t *testing.T, _ string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("command error = %v", err)
+	}
+}
+
+func makeExpectedNumberedLines(start int, end int) []string {
+	labels := map[int]string{
+		11: "eleven", 12: "twelve", 13: "thirteen", 14: "fourteen", 15: "fifteen",
+		16: "sixteen", 17: "seventeen", 18: "eighteen", 19: "nineteen", 20: "twenty",
+		21: "twenty-one", 22: "twenty-two", 23: "twenty-three", 24: "twenty-four", 25: "twenty-five",
+		26: "twenty-six", 27: "twenty-seven", 28: "twenty-eight", 29: "twenty-nine", 30: "thirty",
+		31: "thirty-one", 32: "thirty-two", 33: "thirty-three", 34: "thirty-four", 35: "thirty-five",
+		36: "thirty-six", 37: "thirty-seven", 38: "thirty-eight", 39: "thirty-nine", 40: "forty",
+		41: "forty-one", 42: "forty-two", 43: "forty-three", 44: "forty-four", 45: "forty-five",
+		46: "forty-six", 47: "forty-seven", 48: "forty-eight", 49: "forty-nine", 50: "fifty",
+		51: "fifty-one", 52: "fifty-two", 53: "fifty-three", 54: "fifty-four", 55: "fifty-five",
+		56: "fifty-six", 57: "fifty-seven", 58: "fifty-eight", 59: "fifty-nine", 60: "sixty",
+		61: "sixty-one", 62: "sixty-two", 63: "sixty-three", 64: "sixty-four", 65: "sixty-five",
+		66: "sixty-six", 67: "sixty-seven", 68: "sixty-eight", 69: "sixty-nine", 70: "seventy",
+		71: "seventy-one", 72: "seventy-two", 73: "seventy-three", 74: "seventy-four", 75: "seventy-five",
+		76: "seventy-six", 77: "seventy-seven", 78: "seventy-eight", 79: "seventy-nine", 80: "eighty",
+		81: "eighty-one", 82: "eighty-two", 83: "eighty-three", 84: "eighty-four", 85: "eighty-five",
+		86: "eighty-six", 87: "eighty-seven", 88: "eighty-eight", 89: "eighty-nine", 90: "ninety",
+		91: "ninety-one", 92: "ninety-two", 93: "ninety-three", 94: "ninety-four", 95: "ninety-five",
+		96: "ninety-six", 97: "ninety-seven", 98: "ninety-eight", 99: "ninety-nine",
+	}
+	lines := make([]string, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		lines = append(lines, fmt.Sprintf("%6d\tLine %s", i, labels[i]))
+	}
+	return lines
+}
+
+type fixedClock struct{}
+
+func (fixedClock) Now() time.Time {
+	return time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+}
+
+type memoryToolRepositoryStub struct {
+	files map[string]*model.MemoryToolFile
+}
+
+func newMemoryToolRepositoryStub(t *testing.T, files map[string]string) *memoryToolRepositoryStub {
+	t.Helper()
+	repo := &memoryToolRepositoryStub{files: map[string]*model.MemoryToolFile{}}
+	for pathString, content := range files {
+		path, err := types.NewMemoryToolPath(pathString)
+		if err != nil {
+			t.Fatalf("NewMemoryToolPath(%q) error = %v", pathString, err)
+		}
+		repo.files[path.String()] = model.NewMemoryToolFile(path, []byte(content), fixedClock{}.Now())
+	}
+	return repo
+}
+
+func (r *memoryToolRepositoryStub) Save(_ context.Context, file *model.MemoryToolFile) error {
+	r.files[file.Path().String()] = file
+	return nil
+}
+
+func (r *memoryToolRepositoryStub) FindByPath(_ context.Context, path types.MemoryToolPath) (types.Optional[*model.MemoryToolFile], error) {
+	if file, ok := r.files[path.String()]; ok {
+		return types.Some(file), nil
+	}
+	return types.None[*model.MemoryToolFile](), nil
+}
+
+func (r *memoryToolRepositoryStub) List(_ context.Context) ([]*model.MemoryToolFile, error) {
+	files := make([]*model.MemoryToolFile, 0, len(r.files))
+	for _, file := range r.files {
+		files = append(files, file)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path().String() < files[j].Path().String() })
+	return files, nil
+}
+
+func (r *memoryToolRepositoryStub) DeletePathPrefix(_ context.Context, path types.MemoryToolPath) (int64, error) {
+	var deleted int64
+	for filePath := range r.files {
+		if filePath == path.String() || strings.HasPrefix(filePath, path.String()+"/") {
+			delete(r.files, filePath)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (r *memoryToolRepositoryStub) RenamePathPrefix(_ context.Context, oldPath types.MemoryToolPath, newPath types.MemoryToolPath, updatedAt time.Time) (int64, error) {
+	moved := map[string]*model.MemoryToolFile{}
+	var count int64
+	for filePath, file := range r.files {
+		if filePath == oldPath.String() || strings.HasPrefix(filePath, oldPath.String()+"/") {
+			delete(r.files, filePath)
+			newFilePath, _ := types.NewMemoryToolPath(newPath.String() + strings.TrimPrefix(filePath, oldPath.String()))
+			moved[newFilePath.String()] = file.WithPath(newFilePath, updatedAt)
+			count++
+		}
+	}
+	for path, file := range moved {
+		r.files[path] = file
+	}
+	return count, nil
+}

--- a/application/usecase/memory_tool_usecase_test.go
+++ b/application/usecase/memory_tool_usecase_test.go
@@ -178,6 +178,48 @@ func TestMemoryToolUsecase_allCommandsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMemoryToolUsecase_insertInMiddlePreservesOriginalEOFState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "original without EOF newline stays without EOF newline",
+			content: "alpha\ngamma",
+			want:    "alpha\nbeta\ngamma",
+		},
+		{
+			name:    "original with EOF newline stays with EOF newline",
+			content: "alpha\ngamma\n",
+			want:    "alpha\nbeta\ngamma\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := newMemoryToolRepositoryStub(t, map[string]string{
+				"/memories/notes.txt": tt.content,
+			})
+			sut := usecase.NewMemoryToolUsecase(repo, fixedClock{})
+
+			if _, err := sut.Insert(context.Background(), "/memories/notes.txt", 1, "beta\n"); err != nil {
+				t.Fatalf("Insert() error = %v", err)
+			}
+
+			got := string(repo.files["/memories/notes.txt"].Content())
+			if got != tt.want {
+				t.Fatalf("saved content = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func assertResult(t *testing.T, _ string, err error) {
 	t.Helper()
 	if err != nil {

--- a/domain/model/memory_tool_file_repository.go
+++ b/domain/model/memory_tool_file_repository.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryToolFileRepository persists Anthropic memory-tool files.
+type MemoryToolFileRepository interface {
+	Save(ctx context.Context, file *MemoryToolFile) error
+	FindByPath(ctx context.Context, path types.MemoryToolPath) (types.Optional[*MemoryToolFile], error)
+	List(ctx context.Context) ([]*MemoryToolFile, error)
+	DeletePathPrefix(ctx context.Context, path types.MemoryToolPath) (int64, error)
+	RenamePathPrefix(ctx context.Context, oldPath types.MemoryToolPath, newPath types.MemoryToolPath, updatedAt time.Time) (int64, error)
+}

--- a/domain/model/memorytoolfile.go
+++ b/domain/model/memorytoolfile.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryToolFile is a filesystem-shaped file used by Anthropic's native
+// memory tool. It is intentionally separate from Traceary's durable Memory
+// aggregate.
+type MemoryToolFile struct {
+	path      types.MemoryToolPath
+	content   []byte
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+// NewMemoryToolFile constructs a new memory-tool file.
+func NewMemoryToolFile(path types.MemoryToolPath, content []byte, now time.Time) *MemoryToolFile {
+	return &MemoryToolFile{
+		path:      path,
+		content:   append([]byte(nil), content...),
+		createdAt: now,
+		updatedAt: now,
+	}
+}
+
+// MemoryToolFileOf restores a memory-tool file from persisted values.
+func MemoryToolFileOf(path types.MemoryToolPath, content []byte, createdAt time.Time, updatedAt time.Time) *MemoryToolFile {
+	return &MemoryToolFile{
+		path:      path,
+		content:   append([]byte(nil), content...),
+		createdAt: createdAt,
+		updatedAt: updatedAt,
+	}
+}
+
+// WithContent returns a copy with updated content and timestamp.
+func (f *MemoryToolFile) WithContent(content []byte, updatedAt time.Time) *MemoryToolFile {
+	return &MemoryToolFile{
+		path:      f.path,
+		content:   append([]byte(nil), content...),
+		createdAt: f.createdAt,
+		updatedAt: updatedAt,
+	}
+}
+
+// WithPath returns a copy with a new path and updated timestamp.
+func (f *MemoryToolFile) WithPath(path types.MemoryToolPath, updatedAt time.Time) *MemoryToolFile {
+	return &MemoryToolFile{
+		path:      path,
+		content:   append([]byte(nil), f.content...),
+		createdAt: f.createdAt,
+		updatedAt: updatedAt,
+	}
+}
+
+// Path returns the canonical memory-tool file path.
+func (f *MemoryToolFile) Path() types.MemoryToolPath { return f.path }
+
+// Content returns a defensive copy of the file content.
+func (f *MemoryToolFile) Content() []byte { return append([]byte(nil), f.content...) }
+
+// SizeBytes returns the content size in bytes.
+func (f *MemoryToolFile) SizeBytes() int64 { return int64(len(f.content)) }
+
+// CreatedAt returns when the file was created.
+func (f *MemoryToolFile) CreatedAt() time.Time { return f.createdAt }
+
+// UpdatedAt returns when the file was last updated.
+func (f *MemoryToolFile) UpdatedAt() time.Time { return f.updatedAt }

--- a/domain/types/memorytoolpath.go
+++ b/domain/types/memorytoolpath.go
@@ -1,0 +1,94 @@
+package types
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+const memoryToolRootPath = "/memories"
+
+// MemoryToolPath is a canonical, traversal-safe path inside the Anthropic
+// memory tool root.
+type MemoryToolPath string
+
+// NewMemoryToolPath validates and canonicalizes a memory tool path.
+func NewMemoryToolPath(raw string) (MemoryToolPath, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", xerrors.Errorf("memory tool path must not be empty")
+	}
+	if hasEncodedTraversal(trimmed) {
+		return "", xerrors.Errorf("memory tool path must not contain encoded traversal: %s", raw)
+	}
+	if hasTraversal(trimmed) {
+		return "", xerrors.Errorf("memory tool path must not contain traversal: %s", raw)
+	}
+	if !strings.HasPrefix(trimmed, memoryToolRootPath) {
+		return "", xerrors.Errorf("memory tool path must start with /memories: %s", raw)
+	}
+
+	normalized := strings.ReplaceAll(trimmed, "\\", "/")
+	cleaned := filepath.ToSlash(filepath.Clean(normalized))
+	if !isMemoryToolPathWithinRoot(cleaned) {
+		return "", xerrors.Errorf("memory tool path escapes /memories: %s", raw)
+	}
+	if hasHiddenEmptyOrParentSegment(cleaned) {
+		return "", xerrors.Errorf("memory tool path contains an invalid segment: %s", raw)
+	}
+
+	return MemoryToolPath(cleaned), nil
+}
+
+// String returns the canonical path string.
+func (p MemoryToolPath) String() string { return string(p) }
+
+// IsRoot reports whether the path is exactly /memories.
+func (p MemoryToolPath) IsRoot() bool { return p.String() == memoryToolRootPath }
+
+// IsDescendantOf reports whether p is below the supplied directory path.
+func (p MemoryToolPath) IsDescendantOf(parent MemoryToolPath) bool {
+	parentString := parent.String()
+	return p.String() != parentString && strings.HasPrefix(p.String(), parentString+"/")
+}
+
+func isMemoryToolPathWithinRoot(path string) bool {
+	return path == memoryToolRootPath || strings.HasPrefix(path, memoryToolRootPath+"/")
+}
+
+func hasTraversal(path string) bool {
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	return normalized == ".." ||
+		strings.HasPrefix(normalized, "../") ||
+		strings.Contains(normalized, "/../") ||
+		strings.HasSuffix(normalized, "/..")
+}
+
+func hasEncodedTraversal(path string) bool {
+	decoded := path
+	for range 3 {
+		next, err := url.PathUnescape(decoded)
+		if err != nil {
+			return true
+		}
+		if next == decoded {
+			break
+		}
+		decoded = next
+	}
+	return decoded != path && hasTraversal(strings.ToLower(decoded))
+}
+
+func hasHiddenEmptyOrParentSegment(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" {
+			continue
+		}
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/domain/types/memorytoolpath_test.go
+++ b/domain/types/memorytoolpath_test.go
@@ -1,0 +1,49 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestNewMemoryToolPath_rejectsMaliciousTraversalInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"../memories/file.txt",
+		"/tmp/memories/file.txt",
+		"/memories/../secrets.txt",
+		"/memories/..\\secrets.txt",
+		"/memories/a/../../secrets.txt",
+		"/memories/%2e%2e%2fsecrets.txt",
+		"/memories/%2E%2E%2Fsecrets.txt",
+		"/memories/%2e%2e%5csecrets.txt",
+		"/memories/%252e%252e%252fsecrets.txt",
+		"/memories2/secrets.txt",
+		"/memories/%2e%2e",
+		"/memories/%2E%2e/%2e%2E/secrets.txt",
+	}
+
+	for _, input := range tests {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			if got, err := types.NewMemoryToolPath(input); err == nil {
+				t.Fatalf("NewMemoryToolPath(%q) = %q, want error", input, got.String())
+			}
+		})
+	}
+}
+
+func TestNewMemoryToolPath_canonicalizesSafeInputs(t *testing.T) {
+	t.Parallel()
+
+	got, err := types.NewMemoryToolPath("/memories/project/./notes.txt")
+	if err != nil {
+		t.Fatalf("NewMemoryToolPath() error = %v", err)
+	}
+	if got.String() != "/memories/project/notes.txt" {
+		t.Fatalf("path = %q, want /memories/project/notes.txt", got.String())
+	}
+}

--- a/infrastructure/sqlite/memory_tool_file_datasource.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource.go
@@ -1,0 +1,227 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryToolFileDatasource is the SQLite-backed implementation of the
+// Anthropic memory-tool file repository.
+type MemoryToolFileDatasource struct {
+	db *Database
+}
+
+var _ model.MemoryToolFileRepository = (*MemoryToolFileDatasource)(nil)
+
+// NewMemoryToolFileDatasource creates a new MemoryToolFileDatasource.
+func NewMemoryToolFileDatasource(db *Database) *MemoryToolFileDatasource {
+	return &MemoryToolFileDatasource{db: db}
+}
+
+// Save inserts or updates a memory-tool file.
+func (d *MemoryToolFileDatasource) Save(ctx context.Context, file *model.MemoryToolFile) error {
+	if file == nil {
+		return xerrors.Errorf("memory tool file must not be nil")
+	}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to open DB for memory tool file save: %w", err)
+	}
+	defer closeSQLDB(db)
+
+	const query = `
+INSERT INTO memory_tool_files(path, content, created_at, updated_at, size_bytes)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(path) DO UPDATE SET
+    content = excluded.content,
+    updated_at = excluded.updated_at,
+    size_bytes = excluded.size_bytes;`
+	if _, err := db.ExecContext(
+		ctx,
+		query,
+		file.Path().String(),
+		file.Content(),
+		formatTimestamp(file.CreatedAt()),
+		formatTimestamp(file.UpdatedAt()),
+		file.SizeBytes(),
+	); err != nil {
+		return xerrors.Errorf("failed to save memory tool file: %w", err)
+	}
+	return nil
+}
+
+// FindByPath returns a memory-tool file by exact path.
+func (d *MemoryToolFileDatasource) FindByPath(ctx context.Context, path types.MemoryToolPath) (types.Optional[*model.MemoryToolFile], error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return types.None[*model.MemoryToolFile](), xerrors.Errorf("failed to open DB for memory tool file lookup: %w", err)
+	}
+	defer closeSQLDB(db)
+
+	const query = `
+SELECT path, content, created_at, updated_at
+FROM memory_tool_files
+WHERE path = ?;`
+	file, err := scanMemoryToolFile(db.QueryRowContext(ctx, query, path.String()))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return types.None[*model.MemoryToolFile](), nil
+		}
+		return types.None[*model.MemoryToolFile](), xerrors.Errorf("failed to scan memory tool file: %w", err)
+	}
+	return types.Some(file), nil
+}
+
+// List returns all memory-tool files ordered by path.
+func (d *MemoryToolFileDatasource) List(ctx context.Context) ([]*model.MemoryToolFile, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for memory tool file listing: %w", err)
+	}
+	defer closeSQLDB(db)
+
+	const query = `
+SELECT path, content, created_at, updated_at
+FROM memory_tool_files
+ORDER BY path ASC;`
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memory tool files: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	files := make([]*model.MemoryToolFile, 0)
+	for rows.Next() {
+		file, err := scanMemoryToolFile(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan memory tool file: %w", err)
+		}
+		files = append(files, file)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory tool files: %w", err)
+	}
+	return files, nil
+}
+
+// DeletePathPrefix deletes an exact file or all files below a directory path.
+func (d *MemoryToolFileDatasource) DeletePathPrefix(ctx context.Context, path types.MemoryToolPath) (int64, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to open DB for memory tool file delete: %w", err)
+	}
+	defer closeSQLDB(db)
+
+	result, err := db.ExecContext(ctx, `DELETE FROM memory_tool_files WHERE path = ? OR path LIKE ?;`, path.String(), path.String()+"/%")
+	if err != nil {
+		return 0, xerrors.Errorf("failed to delete memory tool files: %w", err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return 0, xerrors.Errorf("failed to read deleted memory tool file count: %w", err)
+	}
+	return count, nil
+}
+
+// RenamePathPrefix renames an exact file or all files below a directory path.
+func (d *MemoryToolFileDatasource) RenamePathPrefix(
+	ctx context.Context,
+	oldPath types.MemoryToolPath,
+	newPath types.MemoryToolPath,
+	updatedAt time.Time,
+) (int64, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to open DB for memory tool file rename: %w", err)
+	}
+	defer closeSQLDB(db)
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to begin memory tool file rename transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	rows, err := tx.QueryContext(ctx, `SELECT path FROM memory_tool_files WHERE path = ? OR path LIKE ? ORDER BY path ASC;`, oldPath.String(), oldPath.String()+"/%")
+	if err != nil {
+		return 0, xerrors.Errorf("failed to query renamed memory tool files: %w", err)
+	}
+	oldPaths := make([]string, 0)
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			_ = rows.Close()
+			return 0, xerrors.Errorf("failed to scan renamed memory tool file path: %w", err)
+		}
+		oldPaths = append(oldPaths, path)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, xerrors.Errorf("failed to close renamed memory tool file rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, xerrors.Errorf("failed to iterate renamed memory tool file paths: %w", err)
+	}
+
+	for _, oldFilePath := range oldPaths {
+		newFilePath := newPath.String() + strings.TrimPrefix(oldFilePath, oldPath.String())
+		if _, err := tx.ExecContext(ctx, `UPDATE memory_tool_files SET path = ?, updated_at = ? WHERE path = ?;`, newFilePath, formatTimestamp(updatedAt), oldFilePath); err != nil {
+			return 0, xerrors.Errorf("failed to rename memory tool file: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, xerrors.Errorf("failed to commit memory tool file rename: %w", err)
+	}
+	return int64(len(oldPaths)), nil
+}
+
+type memoryToolFileScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanMemoryToolFile(scanner memoryToolFileScanner) (*model.MemoryToolFile, error) {
+	var (
+		pathString      string
+		content         []byte
+		createdAtString string
+		updatedAtString string
+	)
+	if err := scanner.Scan(&pathString, &content, &createdAtString, &updatedAtString); err != nil {
+		return nil, xerrors.Errorf("failed to scan memory tool file row: %w", err)
+	}
+	path, err := types.NewMemoryToolPath(pathString)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore memory tool path: %w", err)
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, createdAtString)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse memory tool file created_at: %w", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, updatedAtString)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse memory tool file updated_at: %w", err)
+	}
+	return model.MemoryToolFileOf(path, content, createdAt, updatedAt), nil
+}
+
+func closeSQLDB(db *sql.DB) {
+	if err := db.Close(); err != nil {
+		slog.Debug("failed to close resource", "error", err)
+	}
+}

--- a/infrastructure/sqlite/memory_tool_file_datasource.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource.go
@@ -125,15 +125,29 @@ func (d *MemoryToolFileDatasource) DeletePathPrefix(ctx context.Context, path ty
 	}
 	defer closeSQLDB(db)
 
-	result, err := db.ExecContext(ctx, `DELETE FROM memory_tool_files WHERE path = ? OR path LIKE ?;`, path.String(), path.String()+"/%")
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, xerrors.Errorf("failed to delete memory tool files: %w", err)
+		return 0, xerrors.Errorf("failed to begin memory tool file delete transaction: %w", err)
 	}
-	count, err := result.RowsAffected()
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	paths, err := queryMemoryToolPathPrefix(ctx, tx, path)
 	if err != nil {
-		return 0, xerrors.Errorf("failed to read deleted memory tool file count: %w", err)
+		return 0, xerrors.Errorf("failed to query deleted memory tool file paths: %w", err)
 	}
-	return count, nil
+	for _, filePath := range paths {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM memory_tool_files WHERE path = ?;`, filePath.String()); err != nil {
+			return 0, xerrors.Errorf("failed to delete memory tool file: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, xerrors.Errorf("failed to commit memory tool file delete: %w", err)
+	}
+	return int64(len(paths)), nil
 }
 
 // RenamePathPrefix renames an exact file or all files below a directory path.
@@ -159,29 +173,14 @@ func (d *MemoryToolFileDatasource) RenamePathPrefix(
 		}
 	}()
 
-	rows, err := tx.QueryContext(ctx, `SELECT path FROM memory_tool_files WHERE path = ? OR path LIKE ? ORDER BY path ASC;`, oldPath.String(), oldPath.String()+"/%")
+	oldPaths, err := queryMemoryToolPathPrefix(ctx, tx, oldPath)
 	if err != nil {
-		return 0, xerrors.Errorf("failed to query renamed memory tool files: %w", err)
-	}
-	oldPaths := make([]string, 0)
-	for rows.Next() {
-		var path string
-		if err := rows.Scan(&path); err != nil {
-			_ = rows.Close()
-			return 0, xerrors.Errorf("failed to scan renamed memory tool file path: %w", err)
-		}
-		oldPaths = append(oldPaths, path)
-	}
-	if err := rows.Close(); err != nil {
-		return 0, xerrors.Errorf("failed to close renamed memory tool file rows: %w", err)
-	}
-	if err := rows.Err(); err != nil {
-		return 0, xerrors.Errorf("failed to iterate renamed memory tool file paths: %w", err)
+		return 0, xerrors.Errorf("failed to query renamed memory tool file paths: %w", err)
 	}
 
 	for _, oldFilePath := range oldPaths {
-		newFilePath := newPath.String() + strings.TrimPrefix(oldFilePath, oldPath.String())
-		if _, err := tx.ExecContext(ctx, `UPDATE memory_tool_files SET path = ?, updated_at = ? WHERE path = ?;`, newFilePath, formatTimestamp(updatedAt), oldFilePath); err != nil {
+		newFilePath := newPath.String() + strings.TrimPrefix(oldFilePath.String(), oldPath.String())
+		if _, err := tx.ExecContext(ctx, `UPDATE memory_tool_files SET path = ?, updated_at = ? WHERE path = ?;`, newFilePath, formatTimestamp(updatedAt), oldFilePath.String()); err != nil {
 			return 0, xerrors.Errorf("failed to rename memory tool file: %w", err)
 		}
 	}
@@ -189,6 +188,37 @@ func (d *MemoryToolFileDatasource) RenamePathPrefix(
 		return 0, xerrors.Errorf("failed to commit memory tool file rename: %w", err)
 	}
 	return int64(len(oldPaths)), nil
+}
+
+func queryMemoryToolPathPrefix(ctx context.Context, tx *sql.Tx, path types.MemoryToolPath) ([]types.MemoryToolPath, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT path FROM memory_tool_files ORDER BY path ASC;`)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query memory tool file paths: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	paths := make([]types.MemoryToolPath, 0)
+	for rows.Next() {
+		var rawPath string
+		if err := rows.Scan(&rawPath); err != nil {
+			return nil, xerrors.Errorf("failed to scan memory tool file path: %w", err)
+		}
+		filePath, err := types.NewMemoryToolPath(rawPath)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore memory tool path: %w", err)
+		}
+		if filePath == path || filePath.IsDescendantOf(path) {
+			paths = append(paths, filePath)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate memory tool file paths: %w", err)
+	}
+	return paths, nil
 }
 
 type memoryToolFileScanner interface {

--- a/infrastructure/sqlite/memory_tool_file_datasource_test.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource_test.go
@@ -55,6 +55,65 @@ func TestMemoryToolFileDatasource_roundTripThroughRepository(t *testing.T) {
 	}
 }
 
+func TestMemoryToolFileDatasource_deletePathPrefixUsesExactCaseSensitiveDescendantSemantics(t *testing.T) {
+	t.Parallel()
+
+	sut := newTestMemoryToolFileDatasource(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	for _, rawPath := range []string{
+		"/memories/a_1/file.txt",
+		"/memories/ab1/file.txt",
+		"/memories/A_1/file.txt",
+	} {
+		path := mustMemoryToolPath(t, rawPath)
+		if err := sut.Save(ctx, model.NewMemoryToolFile(path, []byte(rawPath), now)); err != nil {
+			t.Fatalf("Save(%q) error = %v", rawPath, err)
+		}
+	}
+
+	deleted, err := sut.DeletePathPrefix(ctx, mustMemoryToolPath(t, "/memories/a_1"))
+	if err != nil {
+		t.Fatalf("DeletePathPrefix() error = %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("DeletePathPrefix() deleted = %d, want 1", deleted)
+	}
+	assertMemoryToolPathMissing(t, sut, "/memories/a_1/file.txt")
+	assertMemoryToolPathExists(t, sut, "/memories/ab1/file.txt")
+	assertMemoryToolPathExists(t, sut, "/memories/A_1/file.txt")
+}
+
+func TestMemoryToolFileDatasource_renamePathPrefixUsesExactCaseSensitiveDescendantSemantics(t *testing.T) {
+	t.Parallel()
+
+	sut := newTestMemoryToolFileDatasource(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	for _, rawPath := range []string{
+		"/memories/a_1/file.txt",
+		"/memories/ab1/file.txt",
+		"/memories/A_1/file.txt",
+	} {
+		path := mustMemoryToolPath(t, rawPath)
+		if err := sut.Save(ctx, model.NewMemoryToolFile(path, []byte(rawPath), now)); err != nil {
+			t.Fatalf("Save(%q) error = %v", rawPath, err)
+		}
+	}
+
+	renamed, err := sut.RenamePathPrefix(ctx, mustMemoryToolPath(t, "/memories/a_1"), mustMemoryToolPath(t, "/memories/renamed"), now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("RenamePathPrefix() error = %v", err)
+	}
+	if renamed != 1 {
+		t.Fatalf("RenamePathPrefix() renamed = %d, want 1", renamed)
+	}
+	assertMemoryToolPathMissing(t, sut, "/memories/a_1/file.txt")
+	assertMemoryToolPathExists(t, sut, "/memories/renamed/file.txt")
+	assertMemoryToolPathExists(t, sut, "/memories/ab1/file.txt")
+	assertMemoryToolPathExists(t, sut, "/memories/A_1/file.txt")
+}
+
 func mustMemoryToolPath(t *testing.T, raw string) types.MemoryToolPath {
 	t.Helper()
 	path, err := types.NewMemoryToolPath(raw)
@@ -62,4 +121,37 @@ func mustMemoryToolPath(t *testing.T, raw string) types.MemoryToolPath {
 		t.Fatalf("NewMemoryToolPath(%q) error = %v", raw, err)
 	}
 	return path
+}
+
+func newTestMemoryToolFileDatasource(t *testing.T) *sqlite.MemoryToolFileDatasource {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return sqlite.NewMemoryToolFileDatasource(db)
+}
+
+func assertMemoryToolPathExists(t *testing.T, sut *sqlite.MemoryToolFileDatasource, rawPath string) {
+	t.Helper()
+	got, err := sut.FindByPath(context.Background(), mustMemoryToolPath(t, rawPath))
+	if err != nil {
+		t.Fatalf("FindByPath(%q) error = %v", rawPath, err)
+	}
+	if _, ok := got.Value(); !ok {
+		t.Fatalf("FindByPath(%q) returned none", rawPath)
+	}
+}
+
+func assertMemoryToolPathMissing(t *testing.T, sut *sqlite.MemoryToolFileDatasource, rawPath string) {
+	t.Helper()
+	got, err := sut.FindByPath(context.Background(), mustMemoryToolPath(t, rawPath))
+	if err != nil {
+		t.Fatalf("FindByPath(%q) error = %v", rawPath, err)
+	}
+	if file, ok := got.Value(); ok {
+		t.Fatalf("FindByPath(%q) returned %q", rawPath, file.Path().String())
+	}
 }

--- a/infrastructure/sqlite/memory_tool_file_datasource_test.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource_test.go
@@ -1,0 +1,65 @@
+package sqlite_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestMemoryToolFileDatasource_roundTripThroughRepository(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	sut := sqlite.NewMemoryToolFileDatasource(db)
+	path := mustMemoryToolPath(t, "/memories/project/notes.txt")
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	file := model.NewMemoryToolFile(path, []byte("alpha\nbeta\n"), now)
+
+	if err := sut.Save(context.Background(), file); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	restored, err := sut.FindByPath(context.Background(), path)
+	if err != nil {
+		t.Fatalf("FindByPath() error = %v", err)
+	}
+	got, ok := restored.Value()
+	if !ok {
+		t.Fatalf("FindByPath() returned none")
+	}
+	if got.Path().String() != path.String() || string(got.Content()) != "alpha\nbeta\n" || got.SizeBytes() != int64(len("alpha\nbeta\n")) {
+		t.Fatalf("restored file = path:%q content:%q size:%d", got.Path().String(), string(got.Content()), got.SizeBytes())
+	}
+
+	newPath := mustMemoryToolPath(t, "/memories/archive/notes.txt")
+	if renamed, err := sut.RenamePathPrefix(context.Background(), path, newPath, now.Add(time.Hour)); err != nil {
+		t.Fatalf("RenamePathPrefix() error = %v", err)
+	} else if renamed != 1 {
+		t.Fatalf("RenamePathPrefix() renamed = %d, want 1", renamed)
+	}
+	if deleted, err := sut.DeletePathPrefix(context.Background(), mustMemoryToolPath(t, "/memories/archive")); err != nil {
+		t.Fatalf("DeletePathPrefix() error = %v", err)
+	} else if deleted != 1 {
+		t.Fatalf("DeletePathPrefix() deleted = %d, want 1", deleted)
+	}
+}
+
+func mustMemoryToolPath(t *testing.T, raw string) types.MemoryToolPath {
+	t.Helper()
+	path, err := types.NewMemoryToolPath(raw)
+	if err != nil {
+		t.Fatalf("NewMemoryToolPath(%q) error = %v", raw, err)
+	}
+	return path
+}

--- a/schema/sqlite/migrations/000015_create_memory_tool_files.sql
+++ b/schema/sqlite/migrations/000015_create_memory_tool_files.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS memory_tool_files (
+    path TEXT PRIMARY KEY CHECK (path LIKE '/memories/%'),
+    content BLOB NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    size_bytes INTEGER NOT NULL CHECK (size_bytes >= 0)
+);
+


### PR DESCRIPTION
## Summary

Wave 6 step 1: SQLite-backed implementation of Anthropic's native memory tool (umbrella #699 — experimental in v0.10).

- Migration `schema/sqlite/migrations/000015_create_memory_tool_files.sql`: filesystem-shaped table (`path` PRIMARY KEY under `/memories/`, `content` BLOB, timestamps, cached `size_bytes`)
- Value object `domain/types/memorytoolpath.go`: construction-time validation
  - Must start with `/memories`
  - Rejects `../`, `..\`, URL-encoded traversal (`%2e%2e%2f` etc., case-insensitive)
  - `filepath.Clean` canonicalization + re-verify prefix
- Domain model `domain/model/memorytoolfile.go`
- Repository (domain interface) + SQLite impl `infrastructure/sqlite/memory_tool_file_datasource.go`
- Application usecase implements the 6 Anthropic memory-tool commands (`view` / `create` / `str_replace` / `insert` / `delete` / `rename`) with byte-exact return-string formatting per Anthropic docs (line-number padding 6 chars right-aligned, etc.)
- Existing `memories` aggregate untouched (separate table per locked decision in #699)

## Out of scope

MCP/SDK wiring lives in #742.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (1101 pass)
- [x] 10+ malicious path traversal inputs all rejected
- [x] Line-numbered output byte-matches spec
- [x] Round-trip through repository
- [x] `go tool golangci-lint run` (0 issues)

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>