### PR TITLE
feat(hooks): capture Claude Task subagent starts via PreToolUse:Task (#723)

### DIFF
--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -49,6 +49,68 @@ func TestSessionUsecase_Start(t *testing.T) {
 	})
 }
 
+func TestSessionUsecase_StartChild(t *testing.T) {
+	t.Parallel()
+
+	parent := model.SessionOf(
+		types.SessionID("parent-session"),
+		mustTime(t),
+		types.None[time.Time](),
+		types.Client("hook"),
+		types.Agent("claude"),
+		types.Workspace("github.com/duck8823/traceary"),
+		"", "",
+		types.SessionID(""),
+	)
+	sessionStub := &sessionRepositoryStub{
+		session:        parent,
+		nextChildOrder: 2,
+	}
+	sut := usecase.NewSessionUsecase(nil, sessionStub, nil, nil)
+	startedAt := time.Date(2026, 4, 25, 10, 11, 12, 0, time.UTC)
+
+	event, err := sut.StartChild(
+		context.Background(),
+		types.SessionID("parent-session"),
+		types.SessionID("parent-session:sub:toolu_1"),
+		types.Agent("claude/code-reviewer"),
+		types.Workspace("github.com/duck8823/traceary"),
+		types.EventID("toolu_1"),
+		"task",
+		startedAt,
+	)
+	if err != nil {
+		t.Fatalf("StartChild() error = %v", err)
+	}
+	if event == nil {
+		t.Fatalf("StartChild() event is nil")
+	}
+	if diff := cmp.Diff(types.SessionID("parent-session:sub:toolu_1"), event.SessionID()); diff != "" {
+		t.Fatalf("event SessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(startedAt, event.CreatedAt()); diff != "" {
+		t.Fatalf("event CreatedAt() mismatch (-want +got):\n%s", diff)
+	}
+	child := sessionStub.savedBoundary
+	if child == nil {
+		t.Fatalf("saved child session is nil")
+	}
+	if diff := cmp.Diff(types.SessionID("parent-session"), child.ParentSessionID()); diff != "" {
+		t.Fatalf("ParentSessionID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(types.EventID("toolu_1"), child.SpawnEventID()); diff != "" {
+		t.Fatalf("SpawnEventID() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("task", child.SubagentKind()); diff != "" {
+		t.Fatalf("SubagentKind() mismatch (-want +got):\n%s", diff)
+	}
+	if got, ok := child.SpawnOrder().Value(); !ok {
+		t.Fatalf("SpawnOrder() should be present")
+	} else if diff := cmp.Diff(2, got); diff != "" {
+		t.Fatalf("SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestSessionUsecase_End(t *testing.T) {
 	t.Parallel()
 
@@ -271,16 +333,21 @@ type sessionRepositoryStub struct {
 	savedBoundary      *model.Session
 	savedEvent         *model.Event
 	saveBoundaryErr    error
+	nextChildOrder     int
+	nextChildOrderErr  error
 }
 
 func (s *sessionRepositoryStub) FindByID(
 	_ context.Context,
-	_ types.SessionID,
+	sessionID types.SessionID,
 ) (types.Optional[*model.Session], error) {
 	if s.findErr != nil {
 		return types.None[*model.Session](), s.findErr
 	}
 	if s.empty || s.session == nil {
+		return types.None[*model.Session](), nil
+	}
+	if s.session.SessionID() != sessionID {
 		return types.None[*model.Session](), nil
 	}
 	return types.Some(s.session), nil
@@ -297,6 +364,16 @@ func (s *sessionRepositoryStub) SaveBoundary(_ context.Context, session *model.S
 	s.savedBoundary = session
 	s.savedEvent = event
 	return s.saveBoundaryErr
+}
+
+func (s *sessionRepositoryStub) NextChildSpawnOrder(_ context.Context, _ types.SessionID) (int, error) {
+	if s.nextChildOrderErr != nil {
+		return 0, s.nextChildOrderErr
+	}
+	if s.nextChildOrder == 0 {
+		return 1, nil
+	}
+	return s.nextChildOrder, nil
 }
 
 func mustTime(t *testing.T) time.Time {

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"time"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
@@ -14,6 +15,9 @@ type SessionUsecase interface {
 	// Start begins a new session. If sessionID is zero, a new ID is generated.
 	// Zero-value parentSessionID means no parent (top-level session).
 	Start(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, parentSessionID types.SessionID) (*model.Event, error)
+
+	// StartChild begins a child session spawned from an existing parent.
+	StartChild(ctx context.Context, parent types.SessionID, childID types.SessionID, agent types.Agent, workspace types.Workspace, spawnEventID types.EventID, kind string, startedAt time.Time) (*model.Event, error)
 
 	// End closes an existing session. Zero-value client/agent/workspace
 	// falls back to values from the corresponding session_started event.

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -74,6 +74,74 @@ func (u *sessionUsecase) Start(ctx context.Context, client types.Client, agent t
 	return event, nil
 }
 
+func (u *sessionUsecase) StartChild(
+	ctx context.Context,
+	parent types.SessionID,
+	childID types.SessionID,
+	agent types.Agent,
+	workspace types.Workspace,
+	spawnEventID types.EventID,
+	kind string,
+	startedAt time.Time,
+) (*model.Event, error) {
+	if u.sessionRepo == nil {
+		return nil, xerrors.Errorf("session repository is not configured")
+	}
+
+	parentID, err := types.SessionIDFrom(parent.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start child session: %w", err)
+	}
+	resolvedChildID, err := types.SessionIDFrom(childID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start child session: %w", err)
+	}
+	resolvedAgent, err := types.AgentFrom(agent.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start child session: %w", err)
+	}
+	if strings.TrimSpace(kind) == "" {
+		return nil, xerrors.Errorf("failed to start child session: subagent kind must not be empty")
+	}
+	if spawnEventID.String() == "" {
+		return nil, xerrors.Errorf("failed to start child session: spawn event ID must not be empty")
+	}
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+
+	parentResult, err := u.sessionRepo.FindByID(ctx, parentID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to find parent session: %w", err)
+	}
+	parentSession, ok := parentResult.Value()
+	if !ok {
+		return nil, xerrors.Errorf("parent session not found: %s", parentID)
+	}
+	existingChild, err := u.sessionRepo.FindByID(ctx, resolvedChildID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to check existing child session: %w", err)
+	}
+	if _, ok := existingChild.Value(); ok {
+		return nil, xerrors.Errorf("cannot start child session %s: %w", resolvedChildID, model.ErrInvalidSessionState)
+	}
+
+	spawnOrder, err := u.sessionRepo.NextChildSpawnOrder(ctx, parentID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to allocate child spawn order: %w", err)
+	}
+	event, err := u.buildBoundaryEventAt(ctx, types.EventKindSessionStarted, parentSession.Client(), resolvedAgent, resolvedChildID, workspace, startedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start child session: %w", err)
+	}
+	session := model.NewChildSession(parentSession, resolvedChildID, startedAt, resolvedAgent, workspace, spawnEventID, strings.TrimSpace(kind), spawnOrder)
+	if err := u.sessionRepo.SaveBoundary(ctx, session, event); err != nil {
+		return nil, xerrors.Errorf("failed to save child session start: %w", err)
+	}
+
+	return event, nil
+}
+
 func (u *sessionUsecase) End(ctx context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error) {
 	if u.sessionRepo == nil {
 		return nil, xerrors.Errorf("session repository is not configured")
@@ -245,6 +313,24 @@ func (u *sessionUsecase) buildBoundaryEvent(
 	if err != nil {
 		return nil, xerrors.Errorf("failed to build session boundary event: %w", err)
 	}
+	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
+	return event, nil
+}
+
+func (u *sessionUsecase) buildBoundaryEventAt(
+	ctx context.Context,
+	kind types.EventKind,
+	client types.Client,
+	agent types.Agent,
+	sessionID types.SessionID,
+	workspace types.Workspace,
+	createdAt time.Time,
+) (*model.Event, error) {
+	eventID, err := newEventID()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to generate event ID: %w", err)
+	}
+	event := model.EventOf(eventID, kind, client, agent, sessionID, workspace, sessionBoundaryBody(kind), createdAt)
 	event.SetSourceHook(apptypes.SourceHookFromContext(ctx))
 	return event, nil
 }

--- a/domain/model/session_repository.go
+++ b/domain/model/session_repository.go
@@ -17,4 +17,7 @@ type SessionRepository interface {
 	// FindByID returns the session for the given ID.
 	// Returns an empty Optional when the session does not exist.
 	FindByID(ctx context.Context, sessionID types.SessionID) (types.Optional[*Session], error)
+	// NextChildSpawnOrder returns the next sibling order for a child session
+	// under the given parent.
+	NextChildSpawnOrder(ctx context.Context, parentSessionID types.SessionID) (int, error)
 }

--- a/infrastructure/filesystem/claude_hooks_handler.go
+++ b/infrastructure/filesystem/claude_hooks_handler.go
@@ -93,6 +93,7 @@ func (h *ClaudeHooksHandler) BuildWithMatcher(tracearyBin string, preset ClaudeM
 	compactResumeCommand := newHookRuntimeCommand(tracearyBin, "hook", "compact", "claude", "session-start-compact")
 	promptCommand := newHookRuntimeCommand(tracearyBin, "hook", "prompt", "claude")
 	transcriptCommand := newHookRuntimeCommand(tracearyBin, "hook", "transcript", "claude")
+	subagentStartCommand := newHookRuntimeCommand(tracearyBin, "hook", "subagent-start", "claude")
 	subagentStopCommand := newHookRuntimeCommand(tracearyBin, "hook", "subagent-stop", "claude")
 
 	// Build the PostToolUse / PostToolUseFailure entries according to
@@ -129,6 +130,7 @@ func (h *ClaudeHooksHandler) BuildWithMatcher(tracearyBin string, preset ClaudeM
 		"SessionEnd",
 		"Stop",
 		"SubagentStop",
+		"PreToolUse",
 		"PostToolUse",
 		"PostToolUseFailure",
 		"PreCompact",
@@ -157,6 +159,11 @@ func (h *ClaudeHooksHandler) BuildWithMatcher(tracearyBin string, preset ClaudeM
 		"SubagentStop": {
 			model.HookEntryOf(types.Some("*"), []model.HookCommand{
 				model.HookCommandOf("traceary-subagent-stop", "command", subagentStopCommand, types.None[int](), "", managedKeyOf("traceary-subagent-stop.sh", "claude")),
+			}),
+		},
+		"PreToolUse": {
+			model.HookEntryOf(types.Some("Task"), []model.HookCommand{
+				model.HookCommandOf("traceary-subagent-start", "command", subagentStartCommand, types.None[int](), "", managedKeyOf("traceary-subagent-start.sh", "claude")),
 			}),
 		},
 		"PostToolUse":        postToolUseEntries,

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -22,6 +22,7 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		"SessionEnd",
 		"Stop",
 		"SubagentStop",
+		"PreToolUse",
 		"PostToolUse",
 		"PostToolUseFailure",
 		"PreCompact",
@@ -115,6 +116,28 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		}
 		if diff := cmp.Diff("traceary-audit.sh:claude", entries[2].Commands()[0].ManagedKey()); diff != "" {
 			t.Fatalf("PostToolUse[2] managed key mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("PreToolUse captures Task subagent start", func(t *testing.T) {
+		t.Parallel()
+
+		entries := hooks.Entries("PreToolUse")
+		if diff := cmp.Diff(1, len(entries)); diff != "" {
+			t.Fatalf("len(PreToolUse entries) mismatch (-want +got):\n%s", diff)
+		}
+		matcher, _ := entries[0].Matcher().Value()
+		if diff := cmp.Diff("Task", matcher); diff != "" {
+			t.Fatalf("PreToolUse matcher mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("traceary-subagent-start.sh:claude", entries[0].Commands()[0].ManagedKey()); diff != "" {
+			t.Fatalf("PreToolUse managed key mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("traceary-subagent-start", entries[0].Commands()[0].Name()); diff != "" {
+			t.Fatalf("PreToolUse name mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(`'traceary' 'hook' 'subagent-start' 'claude'`, entries[0].Commands()[0].Command()); diff != "" {
+			t.Fatalf("PreToolUse command mismatch (-want +got):\n%s", diff)
 		}
 	})
 

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -17,19 +17,26 @@ import (
 // are disjoint and sorted alphabetically for stable output.
 //
 // AddedEvents     : the event had no Traceary-managed commands in the
-//                   existing config but the desired config includes at
-//                   least one Traceary command for it.
+//
+//	existing config but the desired config includes at
+//	least one Traceary command for it.
+//
 // RefreshedEvents : the event already had Traceary-managed commands in
-//                   the existing config, but the normalized command set
-//                   is different from the desired set (upgrade, demotion,
-//                   or binary-path rename).
+//
+//	the existing config, but the normalized command set
+//	is different from the desired set (upgrade, demotion,
+//	or binary-path rename).
+//
 // PreservedEvents : the normalized Traceary command set is identical, so
-//                   re-running would produce the same bytes.
+//
+//	re-running would produce the same bytes.
+//
 // RemovedEvents   : the event is only in the existing config (no longer
-//                   emitted by the current release) but held Traceary-
-//                   managed commands; the merge strips those so the
-//                   Traceary footprint on disk stays consistent with the
-//                   running binary.
+//
+//	emitted by the current release) but held Traceary-
+//	managed commands; the merge strips those so the
+//	Traceary footprint on disk stays consistent with the
+//	running binary.
 type hookMergeDiff struct {
 	AddedEvents     []string
 	RefreshedEvents []string
@@ -381,6 +388,12 @@ func parseTracearyDirectManagedCommand(commandValue string) (directManagedComman
 			return directManagedCommand{}, false
 		}
 		directCommand.managedKey = managedKeyOf("traceary-subagent-stop.sh", tokens[3])
+		return directCommand, true
+	case "subagent-start":
+		if len(tokens) != 4 {
+			return directManagedCommand{}, false
+		}
+		directCommand.managedKey = managedKeyOf("traceary-subagent-start.sh", tokens[3])
 		return directCommand, true
 	default:
 		return directManagedCommand{}, false

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -333,6 +333,30 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 	)), nil
 }
 
+// NextChildSpawnOrder returns one greater than the current maximum
+// spawn_order among the parent's children.
+func (d *SessionDatasource) NextChildSpawnOrder(ctx context.Context, parentSessionID types.SessionID) (int, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to open DB for child spawn order lookup: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	var order int
+	if err := db.QueryRowContext(
+		ctx,
+		`SELECT COALESCE(MAX(spawn_order), 0) + 1 FROM sessions WHERE parent_session_id = ?`,
+		parentSessionID.String(),
+	).Scan(&order); err != nil {
+		return 0, xerrors.Errorf("failed to query child spawn order: %w", err)
+	}
+	return order, nil
+}
+
 // FindLatest returns the session_started event for the latest matching
 // session. Returns an empty Optional when no matching session exists.
 func (d *SessionDatasource) FindLatest(

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -94,6 +94,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'subagent-start' 'claude'"
+          }
+        ]
+      }
+    ],
     "PostCompact": [
       {
         "matcher": "*",

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -29,6 +29,15 @@ type hookParentProcessInfo struct {
 	command   string
 }
 
+type hookActiveSubagentState struct {
+	Children map[string]hookActiveSubagentChild `json:"children"`
+}
+
+type hookActiveSubagentChild struct {
+	ChildSessionID types.SessionID `json:"child_session_id"`
+	StartedAt      time.Time       `json:"started_at"`
+}
+
 var hookParentProcessLookup = defaultHookParentProcessLookup
 
 func (c *RootCLI) newHookCommand() *cobra.Command {
@@ -310,7 +319,7 @@ func (c *RootCLI) runHookSession(
 		if err := clearHookWorkspaceState(client); err != nil {
 			return err
 		}
-		if err := clearHookActiveSubagentState(client, sessionID); err != nil {
+		if err := clearHookActiveSubagentState(client, sessionID, ""); err != nil {
 			return err
 		}
 		if err := markHookSessionEnded(client, sessionID); err != nil {
@@ -591,7 +600,7 @@ func (c *RootCLI) runHookSubagentStart(
 	if _, err := c.session.StartChild(ctx, parentSessionID, childSessionID, agent, workspace, types.EventID(toolUseID), "task", time.Now()); err != nil {
 		return xerrors.Errorf("failed to record subagent start: %w", err)
 	}
-	if err := writeHookActiveSubagentState(client, parentSessionID, childSessionID); err != nil {
+	if err := writeHookActiveSubagentState(client, parentSessionID, toolUseID, childSessionID); err != nil {
 		return err
 	}
 	return nil
@@ -646,18 +655,26 @@ func (c *RootCLI) runHookSubagentStop(
 	}
 	toolUseID := hookPayloadString(payload, "tool_use_id", "")
 	childSessionID := types.SessionID("")
+	activeToolUseID := ""
+	childWasActive := false
 	if toolUseID != "" {
-		childSessionID = synthesizeHookChildSessionID(parentSessionID, toolUseID)
-	} else {
-		childSessionID, err = readHookActiveSubagentState(client, parentSessionID)
+		childSessionID, childWasActive, err = readHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
 		if err != nil {
 			return err
 		}
+		if childSessionID == "" {
+			childSessionID = synthesizeHookChildSessionID(parentSessionID, toolUseID)
+		}
+		activeToolUseID = toolUseID
+	} else {
+		activeToolUseID, childSessionID, err = readHookLatestActiveSubagentState(client, parentSessionID)
+		if err != nil {
+			return err
+		}
+		childWasActive = childSessionID != ""
 	}
 	if childSessionID != "" {
-		if activeChildID, readErr := readHookActiveSubagentState(client, parentSessionID); readErr != nil {
-			return readErr
-		} else if activeChildID == "" {
+		if !childWasActive {
 			childAgent := agent
 			if subagentType := hookPayloadString(payload, "subagent_type", ""); subagentType != "" {
 				if resolvedAgent, resolveErr := types.AgentFrom(strings.TrimSpace(client) + "/" + subagentType); resolveErr == nil {
@@ -671,7 +688,7 @@ func (c *RootCLI) runHookSubagentStop(
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
 		}
-		if err := clearHookActiveSubagentState(client, parentSessionID); err != nil {
+		if err := clearHookActiveSubagentState(client, parentSessionID, activeToolUseID); err != nil {
 			return err
 		}
 	}
@@ -1064,7 +1081,7 @@ func resolveHookSessionID(payload []byte, client string) (types.SessionID, error
 	if parentSessionID == "" {
 		return "", nil
 	}
-	childSessionID, err := readHookActiveSubagentState(client, parentSessionID)
+	_, childSessionID, err := readHookLatestActiveSubagentState(client, parentSessionID)
 	if err != nil {
 		return "", err
 	}
@@ -1365,7 +1382,7 @@ func clearHookSessionState(client string) error {
 	return nil
 }
 
-func writeHookActiveSubagentState(client string, parentSessionID types.SessionID, childSessionID types.SessionID) error {
+func withHookActiveSubagentStateLock(client string, parentSessionID types.SessionID, fn func() error) error {
 	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
 	if err != nil {
 		return err
@@ -1373,36 +1390,158 @@ func writeHookActiveSubagentState(client string, parentSessionID types.SessionID
 	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
 		return xerrors.Errorf("failed to create hook active-subagent state directory: %w", err)
 	}
-	if err := os.WriteFile(statePath, []byte(childSessionID), 0o600); err != nil {
-		return xerrors.Errorf("failed to write hook active-subagent state: %w", err)
+	lockPath := statePath + ".lock"
+	for i := 0; ; i++ {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			defer func() { _ = os.Remove(lockPath) }()
+			return fn()
+		}
+		if !os.IsExist(err) {
+			return xerrors.Errorf("failed to lock hook active-subagent state: %w", err)
+		}
+		if i >= 100 {
+			return xerrors.Errorf("failed to lock hook active-subagent state: timed out")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	return nil
 }
 
-func readHookActiveSubagentState(client string, parentSessionID types.SessionID) (types.SessionID, error) {
-	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
-	if err != nil {
-		return "", err
+func writeHookActiveSubagentState(client string, parentSessionID types.SessionID, toolUseID string, childSessionID types.SessionID) error {
+	if strings.TrimSpace(toolUseID) == "" {
+		return nil
 	}
+	return withHookActiveSubagentStateLock(client, parentSessionID, func() error {
+		statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+		if err != nil {
+			return err
+		}
+		state, err := readHookActiveSubagentStateFile(statePath)
+		if err != nil {
+			return err
+		}
+		if state.Children == nil {
+			state.Children = map[string]hookActiveSubagentChild{}
+		}
+		state.Children[toolUseID] = hookActiveSubagentChild{
+			ChildSessionID: childSessionID,
+			StartedAt:      time.Now().UTC(),
+		}
+		data, err := json.Marshal(state)
+		if err != nil {
+			return xerrors.Errorf("failed to encode hook active-subagent state: %w", err)
+		}
+		if err := os.WriteFile(statePath, data, 0o600); err != nil {
+			return xerrors.Errorf("failed to write hook active-subagent state: %w", err)
+		}
+		return nil
+	})
+}
+
+func readHookActiveSubagentStateFile(statePath string) (hookActiveSubagentState, error) {
 	data, err := os.ReadFile(statePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return hookActiveSubagentState{Children: map[string]hookActiveSubagentChild{}}, nil
 		}
-		return "", xerrors.Errorf("failed to read hook active-subagent state: %w", err)
+		return hookActiveSubagentState{}, xerrors.Errorf("failed to read hook active-subagent state: %w", err)
 	}
-	return types.SessionID(strings.TrimSpace(string(data))), nil
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return hookActiveSubagentState{Children: map[string]hookActiveSubagentChild{}}, nil
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return hookActiveSubagentState{
+			Children: map[string]hookActiveSubagentChild{
+				"legacy": {
+					ChildSessionID: types.SessionID(trimmed),
+				},
+			},
+		}, nil
+	}
+	var state hookActiveSubagentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return hookActiveSubagentState{}, xerrors.Errorf("failed to decode hook active-subagent state: %w", err)
+	}
+	if state.Children == nil {
+		state.Children = map[string]hookActiveSubagentChild{}
+	}
+	return state, nil
 }
 
-func clearHookActiveSubagentState(client string, parentSessionID types.SessionID) error {
+func readHookActiveSubagentStateForTool(client string, parentSessionID types.SessionID, toolUseID string) (types.SessionID, bool, error) {
 	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
 	if err != nil {
-		return err
+		return "", false, err
 	}
-	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
-		return xerrors.Errorf("failed to clear hook active-subagent state: %w", err)
+	state, err := readHookActiveSubagentStateFile(statePath)
+	if err != nil {
+		return "", false, err
 	}
-	return nil
+	child, ok := state.Children[toolUseID]
+	if !ok || child.ChildSessionID == "" {
+		return "", false, nil
+	}
+	return child.ChildSessionID, true, nil
+}
+
+func readHookLatestActiveSubagentState(client string, parentSessionID types.SessionID) (string, types.SessionID, error) {
+	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+	if err != nil {
+		return "", "", err
+	}
+	state, err := readHookActiveSubagentStateFile(statePath)
+	if err != nil {
+		return "", "", err
+	}
+	var latestToolUseID string
+	var latestChildID types.SessionID
+	var latestStartedAt time.Time
+	for toolUseID, child := range state.Children {
+		if child.ChildSessionID == "" {
+			continue
+		}
+		if latestChildID == "" || child.StartedAt.After(latestStartedAt) {
+			latestToolUseID = toolUseID
+			latestChildID = child.ChildSessionID
+			latestStartedAt = child.StartedAt
+		}
+	}
+	return latestToolUseID, latestChildID, nil
+}
+
+func clearHookActiveSubagentState(client string, parentSessionID types.SessionID, toolUseID string) error {
+	return withHookActiveSubagentStateLock(client, parentSessionID, func() error {
+		statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(toolUseID) == "" || toolUseID == "legacy" {
+			if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+				return xerrors.Errorf("failed to clear hook active-subagent state: %w", err)
+			}
+			return nil
+		}
+		state, err := readHookActiveSubagentStateFile(statePath)
+		if err != nil {
+			return err
+		}
+		delete(state.Children, toolUseID)
+		if len(state.Children) == 0 {
+			if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+				return xerrors.Errorf("failed to clear hook active-subagent state: %w", err)
+			}
+			return nil
+		}
+		data, err := json.Marshal(state)
+		if err != nil {
+			return xerrors.Errorf("failed to encode hook active-subagent state: %w", err)
+		}
+		if err := os.WriteFile(statePath, data, 0o600); err != nil {
+			return xerrors.Errorf("failed to write hook active-subagent state: %w", err)
+		}
+		return nil
+	})
 }
 
 func writeHookWorkspaceState(client string, workspace types.Workspace) error {

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -39,6 +40,7 @@ func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd.AddCommand(c.newHookSessionCommand())
 	hookCmd.AddCommand(c.newHookAuditCommand())
 	hookCmd.AddCommand(c.newHookCompactCommand())
+	hookCmd.AddCommand(c.newHookSubagentStartCommand())
 	hookCmd.AddCommand(c.newHookSubagentStopCommand())
 	hookCmd.AddCommand(c.newHookPromptCommand())
 	hookCmd.AddCommand(c.newHookTranscriptCommand())
@@ -95,6 +97,25 @@ func (c *RootCLI) newHookCompactCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runHookBestEffort("compact", func() error {
 				return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+func (c *RootCLI) newHookSubagentStartCommand() *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    "subagent-start <client>",
+		Short:  "Record a subagent-start boundary event",
+		Hidden: true,
+		Args:   exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHookBestEffort("subagent-start", func() error {
+				return c.runHookSubagentStart(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
 			})
 		},
 	}
@@ -287,6 +308,9 @@ func (c *RootCLI) runHookSession(
 			return err
 		}
 		if err := clearHookWorkspaceState(client); err != nil {
+			return err
+		}
+		if err := clearHookActiveSubagentState(client, sessionID); err != nil {
 			return err
 		}
 		if err := markHookSessionEnded(client, sessionID); err != nil {
@@ -509,6 +533,69 @@ func (c *RootCLI) runHookCompact(
 	}
 }
 
+func (c *RootCLI) runHookSubagentStart(
+	ctx context.Context,
+	input io.Reader,
+	client string,
+	dbPath string,
+) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.session == nil {
+		return xerrors.Errorf("session usecase is not configured")
+	}
+	ctx = apptypes.WithSourceHook(ctx, "pre_tool_use")
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	parentSessionID, err := resolveHookParentSessionID(payload, client)
+	if err != nil {
+		return err
+	}
+	if parentSessionID == "" {
+		return nil
+	}
+	toolUseID := hookPayloadString(payload, "tool_use_id", "")
+	if toolUseID == "" {
+		return nil
+	}
+	subagentType := hookPayloadString(payload, "subagent_type", "")
+	if subagentType == "" {
+		subagentType = hookPayloadString(payload, "tool_input.subagent_type", "")
+	}
+	if subagentType == "" {
+		subagentType = "task"
+	}
+	agent, err := types.AgentFrom(strings.TrimSpace(client) + "/" + subagentType)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve subagent agent: %w", err)
+	}
+	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+	if err != nil {
+		return err
+	}
+
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve DB path: %w", err)
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+
+	childSessionID := synthesizeHookChildSessionID(parentSessionID, toolUseID)
+	if _, err := c.session.StartChild(ctx, parentSessionID, childSessionID, agent, workspace, types.EventID(toolUseID), "task", time.Now()); err != nil {
+		return xerrors.Errorf("failed to record subagent start: %w", err)
+	}
+	if err := writeHookActiveSubagentState(client, parentSessionID, childSessionID); err != nil {
+		return err
+	}
+	return nil
+}
 
 func (c *RootCLI) runHookSubagentStop(
 	ctx context.Context,
@@ -521,6 +608,9 @@ func (c *RootCLI) runHookSubagentStop(
 	}
 	if c.event == nil {
 		return xerrors.Errorf("event usecase is not configured")
+	}
+	if c.session == nil {
+		return xerrors.Errorf("session usecase is not configured")
 	}
 	// Tag for #672: SubagentStop produces a session_ended event
 	// (distinguished today only via the `[phase:subagent]` body
@@ -539,11 +629,11 @@ func (c *RootCLI) runHookSubagentStop(
 	if err := c.storeManagement.Initialize(ctx); err != nil {
 		return xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	sessionID, err := resolveHookSessionID(payload, client)
+	parentSessionID, err := resolveHookParentSessionID(payload, client)
 	if err != nil {
 		return err
 	}
-	if sessionID == "" {
+	if parentSessionID == "" {
 		return nil
 	}
 	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
@@ -554,19 +644,49 @@ func (c *RootCLI) runHookSubagentStop(
 	if err != nil {
 		return err
 	}
+	toolUseID := hookPayloadString(payload, "tool_use_id", "")
+	childSessionID := types.SessionID("")
+	if toolUseID != "" {
+		childSessionID = synthesizeHookChildSessionID(parentSessionID, toolUseID)
+	} else {
+		childSessionID, err = readHookActiveSubagentState(client, parentSessionID)
+		if err != nil {
+			return err
+		}
+	}
+	if childSessionID != "" {
+		if activeChildID, readErr := readHookActiveSubagentState(client, parentSessionID); readErr != nil {
+			return readErr
+		} else if activeChildID == "" {
+			childAgent := agent
+			if subagentType := hookPayloadString(payload, "subagent_type", ""); subagentType != "" {
+				if resolvedAgent, resolveErr := types.AgentFrom(strings.TrimSpace(client) + "/" + subagentType); resolveErr == nil {
+					childAgent = resolvedAgent
+				}
+			}
+			if _, startErr := c.session.StartChild(ctx, parentSessionID, childSessionID, childAgent, workspace, types.EventID(toolUseID), "task", time.Now()); startErr != nil {
+				return xerrors.Errorf("failed to synthesize missing subagent start: %w", startErr)
+			}
+		}
+		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
+			return xerrors.Errorf("failed to end subagent session: %w", err)
+		}
+		if err := clearHookActiveSubagentState(client, parentSessionID); err != nil {
+			return err
+		}
+	}
 	// Claude Code's SubagentStop hook fires whenever a Task-tool subagent
 	// completes. source_hook = "subagent_stop" (stamped via ctx) now
 	// discriminates the subagent boundary from main-session session_ended
 	// events; the legacy `[phase:subagent]` body prefix is retired on
 	// write but readers still match it for pre-#672 rows.
 	subagentType := hookPayloadString(payload, "subagent_type", "")
-	_, err = c.event.Log(ctx, subagentType, types.EventKindSessionEnded, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
+	_, err = c.event.Log(ctx, subagentType, types.EventKindSessionEnded, types.Client("hook"), agent, parentSessionID, workspace, apptypes.LogRedaction{})
 	if err != nil {
 		return xerrors.Errorf("failed to record subagent-stop event: %w", err)
 	}
 	return nil
 }
-
 
 func (c *RootCLI) runHookPrompt(
 	ctx context.Context,
@@ -937,12 +1057,34 @@ func resolveHookAgent(client string, payload []byte) (types.Agent, error) {
 }
 
 func resolveHookSessionID(payload []byte, client string) (types.SessionID, error) {
+	parentSessionID, err := resolveHookParentSessionID(payload, client)
+	if err != nil {
+		return "", err
+	}
+	if parentSessionID == "" {
+		return "", nil
+	}
+	childSessionID, err := readHookActiveSubagentState(client, parentSessionID)
+	if err != nil {
+		return "", err
+	}
+	if childSessionID != "" {
+		return childSessionID, nil
+	}
+
+	return parentSessionID, nil
+}
+
+func resolveHookParentSessionID(payload []byte, client string) (types.SessionID, error) {
 	sessionID := types.SessionID(hookPayloadString(payload, "session_id", ""))
 	if sessionID != "" {
 		return sessionID, nil
 	}
-
 	return readHookSessionState(client)
+}
+
+func synthesizeHookChildSessionID(parentSessionID types.SessionID, toolUseID string) types.SessionID {
+	return types.SessionID(parentSessionID.String() + ":sub:" + strings.TrimSpace(toolUseID))
 }
 
 func resolveHookWorkspace(ctx context.Context, payload []byte, client string, preferState bool) (types.Workspace, error) {
@@ -1170,6 +1312,15 @@ func hookSessionEndMarkerPath(client string, sessionID types.SessionID) (string,
 	return filepath.Join(stateDir, "ended", client+"-"+sanitizedSessionID), nil
 }
 
+func hookActiveSubagentStatePath(client string, parentSessionID types.SessionID) (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	sanitizedParentSessionID := sanitizeHookStateKey(parentSessionID.String())
+	return filepath.Join(stateDir, "active-subagents", client+"-"+sanitizedParentSessionID), nil
+}
+
 func writeHookSessionState(client string, sessionID types.SessionID) error {
 	statePath, err := hookSessionStatePath(client)
 	if err != nil {
@@ -1211,6 +1362,46 @@ func clearHookSessionState(client string) error {
 		return xerrors.Errorf("failed to clear hook session state: %w", err)
 	}
 
+	return nil
+}
+
+func writeHookActiveSubagentState(client string, parentSessionID types.SessionID, childSessionID types.SessionID) error {
+	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return xerrors.Errorf("failed to create hook active-subagent state directory: %w", err)
+	}
+	if err := os.WriteFile(statePath, []byte(childSessionID), 0o600); err != nil {
+		return xerrors.Errorf("failed to write hook active-subagent state: %w", err)
+	}
+	return nil
+}
+
+func readHookActiveSubagentState(client string, parentSessionID types.SessionID) (types.SessionID, error) {
+	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", xerrors.Errorf("failed to read hook active-subagent state: %w", err)
+	}
+	return types.SessionID(strings.TrimSpace(string(data))), nil
+}
+
+func clearHookActiveSubagentState(client string, parentSessionID types.SessionID) error {
+	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear hook active-subagent state: %w", err)
+	}
 	return nil
 }
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -12,8 +14,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -566,8 +570,146 @@ func TestRootCLI_HookSubagentStartCommand_CreatesChildAndActiveState(t *testing.
 	if err != nil {
 		t.Fatalf("ReadFile(active state) error = %v", err)
 	}
-	if got, want := strings.TrimSpace(string(data)), "parent-session:sub:toolu_1"; got != want {
-		t.Fatalf("active child state = %q, want %q", got, want)
+	stateJSON := string(data)
+	if !strings.Contains(stateJSON, `"toolu_1"`) || !strings.Contains(stateJSON, `"child_session_id":"parent-session:sub:toolu_1"`) {
+		t.Fatalf("active child state = %s, want JSON entry for toolu_1", stateJSON)
+	}
+}
+
+func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "overlap-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-overlap-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-overlap-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	t.Setenv("TRACEARY_DB_PATH", dbPath)
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	sessionDS := sqliteinfra.NewSessionDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	sessionUC := usecase.NewSessionUsecase(eventDS, sessionDS, sessionDS, eventDS)
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	ctx := context.Background()
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if _, err := sessionUC.Start(ctx, types.Client("hook"), types.Agent("claude"), types.SessionID("parent-session"), types.Workspace("github.com/duck8823/traceary"), ""); err != nil {
+		t.Fatalf("Start(parent) error = %v", err)
+	}
+	runHook := func(args []string, payload string, eventOverride *eventUsecaseStub) {
+		t.Helper()
+		opts := []cli.RootCLIOption{
+			cli.WithStoreManagement(storeUC),
+			cli.WithSession(sessionUC),
+			cli.WithDatabasePathSetter(db.SetPath),
+		}
+		if eventOverride != nil {
+			opts = append(opts, cli.WithEvent(eventOverride))
+		} else {
+			opts = append(opts, cli.WithEvent(eventUC))
+		}
+		rootCmd := newTestRootCLI(opts...).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetIn(strings.NewReader(payload))
+		rootCmd.SetArgs(args)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute(%v) error = %v", args, err)
+		}
+	}
+
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_1","tool_input":{"subagent_type":"worker"}}`, nil)
+	time.Sleep(time.Millisecond)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_2","tool_input":{"subagent_type":"qa"}}`, nil)
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	rows, err := sqlDB.Query(`SELECT session_id, spawn_order, ended_at IS NOT NULL FROM sessions WHERE parent_session_id = ? ORDER BY spawn_order`, "parent-session")
+	if err != nil {
+		t.Fatalf("query children error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var children []struct {
+		id         string
+		spawnOrder int
+		ended      bool
+	}
+	for rows.Next() {
+		var child struct {
+			id         string
+			spawnOrder int
+			ended      bool
+		}
+		if err := rows.Scan(&child.id, &child.spawnOrder, &child.ended); err != nil {
+			t.Fatalf("Scan(child) error = %v", err)
+		}
+		children = append(children, child)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("Rows error = %v", err)
+	}
+	if len(children) != 2 {
+		t.Fatalf("child rows len = %d, want 2: %#v", len(children), children)
+	}
+	if children[0].id != "parent-session:sub:toolu_1" || children[0].spawnOrder != 1 {
+		t.Fatalf("first child = %#v, want toolu_1 spawn_order 1", children[0])
+	}
+	if children[1].id != "parent-session:sub:toolu_2" || children[1].spawnOrder != 2 {
+		t.Fatalf("second child = %#v, want toolu_2 spawn_order 2", children[1])
+	}
+
+	auditStub := &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_2"); got != want {
+		t.Fatalf("audit sessionID with overlapping children = %q, want %q", got, want)
+	}
+
+	runHook([]string{"hook", "subagent-stop", "claude"}, `{"tool_use_id":"toolu_1","subagent_type":"worker"}`, nil)
+	var child1Ended, child2Ended bool
+	if err := sqlDB.QueryRow(`SELECT ended_at IS NOT NULL FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_1").Scan(&child1Ended); err != nil {
+		t.Fatalf("query child1 ended error = %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT ended_at IS NOT NULL FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_2").Scan(&child2Ended); err != nil {
+		t.Fatalf("query child2 ended error = %v", err)
+	}
+	if !child1Ended || child2Ended {
+		t.Fatalf("after stopping toolu_1: child1 ended=%v child2 ended=%v, want true/false", child1Ended, child2Ended)
+	}
+	activeState, err := os.ReadFile(filepath.Join(stateDir, "active-subagents", "claude-parent-session"))
+	if err != nil {
+		t.Fatalf("ReadFile(active state after first stop) error = %v", err)
+	}
+	if strings.Contains(string(activeState), "toolu_1") || !strings.Contains(string(activeState), "toolu_2") {
+		t.Fatalf("active state after stopping toolu_1 = %s, want only toolu_2 active", string(activeState))
+	}
+
+	auditStub = &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_2"); got != want {
+		t.Fatalf("audit sessionID after stopping toolu_1 = %q, want %q", got, want)
+	}
+
+	runHook([]string{"hook", "subagent-stop", "claude"}, `{"tool_use_id":"toolu_2","subagent_type":"qa"}`, nil)
+	auditStub = &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session"); got != want {
+		t.Fatalf("audit sessionID after both children stop = %q, want %q", got, want)
 	}
 }
 
@@ -586,7 +728,7 @@ func TestRootCLI_HookAuditCommand_UsesActiveSubagentSession(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(stateDir, "claude-audit-child-key"), []byte("parent-session"), 0o600); err != nil {
 		t.Fatalf("WriteFile(session state) error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte("parent-session:sub:toolu_1"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(`{"children":{"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"2026-04-25T00:00:00Z"}}}`), 0o600); err != nil {
 		t.Fatalf("WriteFile(active state) error = %v", err)
 	}
 
@@ -623,7 +765,7 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-child-key"), []byte("parent-session"), 0o600); err != nil {
 		t.Fatalf("WriteFile(session state) error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte("parent-session:sub:toolu_1"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(`{"children":{"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"2026-04-25T00:00:00Z"}}}`), 0o600); err != nil {
 		t.Fatalf("WriteFile(active state) error = %v", err)
 	}
 	sessionStub := &sessionUsecaseStub{}
@@ -648,7 +790,7 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 		t.Fatalf("back-compat log sessionID = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
-		t.Fatalf("active state should be cleared; stat err=%v", err)
+		t.Fatalf("active state should be cleared after final child stops; stat err=%v", err)
 	}
 }
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -445,6 +445,7 @@ func TestRootCLI_HookCompactCommand_RecordsPreCompactSnapshot(t *testing.T) {
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithEvent(eventStub),
+		cli.WithSession(&sessionUsecaseStub{}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -499,6 +500,7 @@ func TestRootCLI_HookSubagentStopCommand_RecordsSessionEnded(t *testing.T) {
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithEvent(eventStub),
+		cli.WithSession(&sessionUsecaseStub{}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -516,6 +518,175 @@ func TestRootCLI_HookSubagentStopCommand_RecordsSessionEnded(t *testing.T) {
 	}
 	if got, want := eventStub.logCall.sourceHook, "subagent_stop"; got != want {
 		t.Fatalf("subagent-stop log source_hook = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSubagentStartCommand_CreatesChildAndActiveState(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "start-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-start-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-start-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"tool_use_id":"toolu_1","tool_input":{"subagent_type":"code-reviewer"}}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-start", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-start) error = %v", err)
+	}
+	if got, want := sessionStub.startChildCall.parent, types.SessionID("parent-session"); got != want {
+		t.Fatalf("StartChild parent = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startChildCall.childID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+		t.Fatalf("StartChild childID = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startChildCall.agent, types.Agent("claude/code-reviewer"); got != want {
+		t.Fatalf("StartChild agent = %q, want %q", got, want)
+	}
+	activePath := filepath.Join(stateDir, "active-subagents", "claude-parent-session")
+	data, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("ReadFile(active state) error = %v", err)
+	}
+	if got, want := strings.TrimSpace(string(data)), "parent-session:sub:toolu_1"; got != want {
+		t.Fatalf("active child state = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookAuditCommand_UsesActiveSubagentSession(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "audit-child-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	activeDir := filepath.Join(stateDir, "active-subagents")
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-audit-child-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte("parent-session:sub:toolu_1"), 0o600); err != nil {
+		t.Fatalf("WriteFile(active state) error = %v", err)
+	}
+
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`))
+	rootCmd.SetArgs([]string{"hook", "audit", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(audit) error = %v", err)
+	}
+	if got, want := eventStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+		t.Fatalf("audit sessionID = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "stop-child-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	activeDir := filepath.Join(stateDir, "active-subagents")
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-child-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte("parent-session:sub:toolu_1"), 0o600); err != nil {
+		t.Fatalf("WriteFile(active state) error = %v", err)
+	}
+	sessionStub := &sessionUsecaseStub{}
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"tool_use_id":"toolu_1","subagent_type":"code-reviewer"}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-stop", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-stop) error = %v", err)
+	}
+	if got, want := sessionStub.endCall.sessionID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+		t.Fatalf("End child sessionID = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.sessionID, types.SessionID("parent-session"); got != want {
+		t.Fatalf("back-compat log sessionID = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
+		t.Fatalf("active state should be cleared; stat err=%v", err)
+	}
+}
+
+func TestRootCLI_HookSubagentStopCommand_LazilySynthesizesMissingStart(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "lazy-child-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-lazy-child-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{}
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"tool_use_id":"toolu_legacy","subagent_type":"reviewer"}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-stop", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-stop) error = %v", err)
+	}
+	if got, want := sessionStub.startChildCall.childID, types.SessionID("parent-session:sub:toolu_legacy"); got != want {
+		t.Fatalf("lazy StartChild childID = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.endCall.sessionID, types.SessionID("parent-session:sub:toolu_legacy"); got != want {
+		t.Fatalf("lazy End child sessionID = %q, want %q", got, want)
 	}
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -120,6 +120,15 @@ type sessionUsecaseStub struct {
 		workspace       types.Workspace
 		parentSessionID types.SessionID
 	}
+	startChildCall struct {
+		parent       types.SessionID
+		childID      types.SessionID
+		agent        types.Agent
+		workspace    types.Workspace
+		spawnEventID types.EventID
+		kind         string
+		startedAt    time.Time
+	}
 	endCall struct {
 		client    types.Client
 		agent     types.Agent
@@ -135,6 +144,16 @@ func (s *sessionUsecaseStub) Start(_ context.Context, client types.Client, agent
 	s.startCall.sessionID = sessionID
 	s.startCall.workspace = workspace
 	s.startCall.parentSessionID = parentSessionID
+	return s.startEvent, s.startErr
+}
+func (s *sessionUsecaseStub) StartChild(_ context.Context, parent types.SessionID, childID types.SessionID, agent types.Agent, workspace types.Workspace, spawnEventID types.EventID, kind string, startedAt time.Time) (*model.Event, error) {
+	s.startChildCall.parent = parent
+	s.startChildCall.childID = childID
+	s.startChildCall.agent = agent
+	s.startChildCall.workspace = workspace
+	s.startChildCall.spawnEventID = spawnEventID
+	s.startChildCall.kind = kind
+	s.startChildCall.startedAt = startedAt
 	return s.startEvent, s.startErr
 }
 func (s *sessionUsecaseStub) End(_ context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error) {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -129,7 +129,23 @@ type sessionUsecaseStub struct {
 		kind         string
 		startedAt    time.Time
 	}
+	startChildCalls []struct {
+		parent       types.SessionID
+		childID      types.SessionID
+		agent        types.Agent
+		workspace    types.Workspace
+		spawnEventID types.EventID
+		kind         string
+		startedAt    time.Time
+	}
 	endCall struct {
+		client    types.Client
+		agent     types.Agent
+		sessionID types.SessionID
+		workspace types.Workspace
+		summary   string
+	}
+	endCalls []struct {
 		client    types.Client
 		agent     types.Agent
 		sessionID types.SessionID
@@ -154,6 +170,7 @@ func (s *sessionUsecaseStub) StartChild(_ context.Context, parent types.SessionI
 	s.startChildCall.spawnEventID = spawnEventID
 	s.startChildCall.kind = kind
 	s.startChildCall.startedAt = startedAt
+	s.startChildCalls = append(s.startChildCalls, s.startChildCall)
 	return s.startEvent, s.startErr
 }
 func (s *sessionUsecaseStub) End(_ context.Context, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, summary string) (*model.Event, error) {
@@ -162,6 +179,7 @@ func (s *sessionUsecaseStub) End(_ context.Context, client types.Client, agent t
 	s.endCall.sessionID = sessionID
 	s.endCall.workspace = workspace
 	s.endCall.summary = summary
+	s.endCalls = append(s.endCalls, s.endCall)
 	return s.endEvent, s.endErr
 }
 func (s *sessionUsecaseStub) Label(_ context.Context, _ types.SessionID, _ string) error {


### PR DESCRIPTION
## Summary

Wave 4 step 2: capture Claude Code subagent (Task tool) spawn via a new PreToolUse:Task hook and persist a child session row using the schema landed in #722 (PR #755).

- New CLI: \`traceary hook subagent-start <client>\`
- New usecase: \`SessionUsecase.StartChild(ctx, parent, childID, agent, workspace, spawnEventID, kind, startedAt)\` — \`spawn_order = MAX(spawn_order)+1\` per parent
- Child id format: \`<parent>:sub:<tool_use_id>\`; agent: \`<client>/<subagent_type>\` (fallback: \`task\`)
- Per-parent active-subagent state file written next to the existing hook-state directory; \`resolveHookSessionID\` prefers the active child id over the parent id
- \`runHookSubagentStop\` reads \`tool_use_id\`, ends the child row, clears active-subagent state, and KEEPS emitting the parent-side \`session_ended\` event for back-compat
- Lazy-synthesis path: pre-v0.10 plugin installs (no PreToolUse:Task) still produce non-broken trees
- Wired \`PreToolUse\` matcher \`Task\` in \`integrations/claude-plugin/hooks/hooks.json\` calling \`traceary hook subagent-start claude\`

## Test plan

- [x] PreToolUse:Task creates child row with \`subagent_kind=task\` and increments \`spawn_order\` for siblings
- [x] audit hooks between Pre/Post target the child id
- [x] SubagentStop closes the child row
- [x] lazy-synthesis on missing PreToolUse still produces parent-linked child row
- [x] \`traceary session tree\` against captured fixture renders parent with Task child indented
- [x] \`go build ./...\` / \`go test ./...\` / \`go tool golangci-lint run\` all green

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>