### PR TITLE
feat(hooks): harden nested Task subagent capture (#724)

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -51,6 +51,12 @@
 - `tool_response.exitCode` から exit code を抽出（利用可能時）
 - MCP ツール名 fallback: `tool_input.command` → `tool_name`
 
+Claude Task subagent capture:
+- `PreToolUse:Task` は現在 active な直近の親セッション配下に child session を開始する。その child がさらに Task を開始した場合、grandchild は top-level session ではなく child にリンクする。
+- active Task state は parent session ごとに管理するため、sibling の `spawn_order` は各 `parent_session_id` 内で独立して採番される。
+- `tool_use_id` が欠落している場合は `event_id` から安定した Task key を合成する。後続の `PostToolUse` / `SubagentStop` が `tool_use_id` を渡さない場合は、親配下の most-recent active child にフォールバックする。
+- `SubagentStop` が到達しなかった orphan active Task entry は、hook state を次に読む時または新しい session start 時に 24 時間超で prune する。これにより host process の crash / kill 後に stale child state が後続 capture へ漏れることを防ぐ。
+
 ## 欠落機能のフォールバック
 
 | 欠落機能 | フォールバック |

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -51,6 +51,12 @@ All tiers:
 - Exit code extraction from `tool_response.exitCode` when available
 - MCP tool name fallback: `tool_input.command` → `tool_name`
 
+Claude Task subagent capture:
+- `PreToolUse:Task` opens a child session under the currently active immediate parent. If that child starts another Task, Traceary links the grandchild to the child rather than to the top-level session.
+- Active Task state is tracked per parent session, so sibling spawn order is allocated independently within each `parent_session_id`.
+- If `tool_use_id` is missing, Traceary synthesizes a stable Task key from `event_id`. If a later `PostToolUse` / `SubagentStop` omits `tool_use_id`, Traceary falls back to the most-recent active child under the parent.
+- Orphaned active Task entries whose `SubagentStop` never arrived are pruned after 24 hours when hook state is next read or a new session starts. This prevents a crashed or killed host process from leaking stale child state into later captures.
+
 ## Fallback for Missing Capabilities
 
 | Missing Capability | Fallback |

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -24,6 +24,8 @@ import (
 
 const hookStateDirEnvKey = "TRACEARY_HOOK_STATE_DIR"
 
+const hookActiveSubagentStateTTL = 24 * time.Hour
+
 type hookParentProcessInfo struct {
 	parentPID int
 	command   string
@@ -36,6 +38,12 @@ type hookActiveSubagentState struct {
 type hookActiveSubagentChild struct {
 	ChildSessionID types.SessionID `json:"child_session_id"`
 	StartedAt      time.Time       `json:"started_at"`
+}
+
+type hookResolvedActiveSubagent struct {
+	ParentSessionID types.SessionID
+	ToolUseID       string
+	ChildSessionID  types.SessionID
 }
 
 var hookParentProcessLookup = defaultHookParentProcessLookup
@@ -255,6 +263,12 @@ func (c *RootCLI) runHookSession(
 		if err := writeHookSessionState(client, event.SessionID()); err != nil {
 			return err
 		}
+		if err := clearHookActiveSubagentState(client, event.SessionID(), ""); err != nil {
+			return err
+		}
+		if err := cleanupHookActiveSubagentStates(client); err != nil {
+			return err
+		}
 		if err := clearHookSessionEndMarker(client, event.SessionID()); err != nil {
 			return err
 		}
@@ -320,6 +334,9 @@ func (c *RootCLI) runHookSession(
 			return err
 		}
 		if err := clearHookActiveSubagentState(client, sessionID, ""); err != nil {
+			return err
+		}
+		if err := cleanupHookActiveSubagentStates(client); err != nil {
 			return err
 		}
 		if err := markHookSessionEnded(client, sessionID); err != nil {
@@ -560,14 +577,14 @@ func (c *RootCLI) runHookSubagentStart(
 	if err != nil {
 		return err
 	}
-	parentSessionID, err := resolveHookParentSessionID(payload, client)
+	parentSessionID, err := resolveHookSubagentStartParentSessionID(payload, client)
 	if err != nil {
 		return err
 	}
 	if parentSessionID == "" {
 		return nil
 	}
-	toolUseID := hookPayloadString(payload, "tool_use_id", "")
+	toolUseID := resolveHookToolUseID(payload)
 	if toolUseID == "" {
 		return nil
 	}
@@ -653,24 +670,34 @@ func (c *RootCLI) runHookSubagentStop(
 	if err != nil {
 		return err
 	}
-	toolUseID := hookPayloadString(payload, "tool_use_id", "")
+	toolUseID := resolveHookToolUseID(payload)
 	childSessionID := types.SessionID("")
 	activeToolUseID := ""
+	activeParentSessionID := types.SessionID("")
 	childWasActive := false
 	if toolUseID != "" {
-		childSessionID, childWasActive, err = readHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
-		if err != nil {
-			return err
+		active, findErr := findHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
+		if findErr != nil {
+			return findErr
+		}
+		childSessionID = active.ChildSessionID
+		activeParentSessionID = active.ParentSessionID
+		childWasActive = childSessionID != ""
+		if activeParentSessionID == "" {
+			activeParentSessionID = parentSessionID
 		}
 		if childSessionID == "" {
 			childSessionID = synthesizeHookChildSessionID(parentSessionID, toolUseID)
 		}
 		activeToolUseID = toolUseID
 	} else {
-		activeToolUseID, childSessionID, err = readHookLatestActiveSubagentState(client, parentSessionID)
-		if err != nil {
-			return err
+		active, findErr := findHookDeepestLatestActiveSubagentState(client, parentSessionID)
+		if findErr != nil {
+			return findErr
 		}
+		activeToolUseID = active.ToolUseID
+		childSessionID = active.ChildSessionID
+		activeParentSessionID = active.ParentSessionID
 		childWasActive = childSessionID != ""
 	}
 	if childSessionID != "" {
@@ -687,6 +714,9 @@ func (c *RootCLI) runHookSubagentStop(
 		}
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
+		}
+		if activeParentSessionID != "" {
+			parentSessionID = activeParentSessionID
 		}
 		if err := clearHookActiveSubagentState(client, parentSessionID, activeToolUseID); err != nil {
 			return err
@@ -1081,15 +1111,22 @@ func resolveHookSessionID(payload []byte, client string) (types.SessionID, error
 	if parentSessionID == "" {
 		return "", nil
 	}
-	_, childSessionID, err := readHookLatestActiveSubagentState(client, parentSessionID)
+	active, err := findHookDeepestLatestActiveSubagentState(client, parentSessionID)
 	if err != nil {
 		return "", err
 	}
-	if childSessionID != "" {
-		return childSessionID, nil
+	if active.ChildSessionID != "" {
+		return active.ChildSessionID, nil
 	}
 
 	return parentSessionID, nil
+}
+
+func resolveHookSubagentStartParentSessionID(payload []byte, client string) (types.SessionID, error) {
+	if hookPayloadString(payload, "session_id", "") == "" {
+		return resolveHookParentSessionID(payload, client)
+	}
+	return resolveHookSessionID(payload, client)
 }
 
 func resolveHookParentSessionID(payload []byte, client string) (types.SessionID, error) {
@@ -1102,6 +1139,16 @@ func resolveHookParentSessionID(payload []byte, client string) (types.SessionID,
 
 func synthesizeHookChildSessionID(parentSessionID types.SessionID, toolUseID string) types.SessionID {
 	return types.SessionID(parentSessionID.String() + ":sub:" + strings.TrimSpace(toolUseID))
+}
+
+func resolveHookToolUseID(payload []byte) string {
+	if toolUseID := strings.TrimSpace(hookPayloadString(payload, "tool_use_id", "")); toolUseID != "" {
+		return toolUseID
+	}
+	if eventID := strings.TrimSpace(hookPayloadString(payload, "event_id", "")); eventID != "" {
+		return "event-" + eventID
+	}
+	return ""
 }
 
 func resolveHookWorkspace(ctx context.Context, payload []byte, client string, preferState bool) (types.Workspace, error) {
@@ -1408,7 +1455,8 @@ func withHookActiveSubagentStateLock(client string, parentSessionID types.Sessio
 }
 
 func writeHookActiveSubagentState(client string, parentSessionID types.SessionID, toolUseID string, childSessionID types.SessionID) error {
-	if strings.TrimSpace(toolUseID) == "" {
+	toolUseID = strings.TrimSpace(toolUseID)
+	if toolUseID == "" {
 		return nil
 	}
 	return withHookActiveSubagentStateLock(client, parentSessionID, func() error {
@@ -1466,7 +1514,40 @@ func readHookActiveSubagentStateFile(statePath string) (hookActiveSubagentState,
 	if state.Children == nil {
 		state.Children = map[string]hookActiveSubagentChild{}
 	}
+	if pruneHookActiveSubagentState(&state, time.Now().UTC()) {
+		if len(state.Children) == 0 {
+			if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+				return hookActiveSubagentState{}, xerrors.Errorf("failed to clear stale hook active-subagent state: %w", err)
+			}
+		} else {
+			data, err := json.Marshal(state)
+			if err != nil {
+				return hookActiveSubagentState{}, xerrors.Errorf("failed to encode hook active-subagent state: %w", err)
+			}
+			if err := os.WriteFile(statePath, data, 0o600); err != nil {
+				return hookActiveSubagentState{}, xerrors.Errorf("failed to write hook active-subagent state: %w", err)
+			}
+		}
+	}
 	return state, nil
+}
+
+func pruneHookActiveSubagentState(state *hookActiveSubagentState, now time.Time) bool {
+	if state == nil || hookActiveSubagentStateTTL <= 0 {
+		return false
+	}
+	changed := false
+	cutoff := now.Add(-hookActiveSubagentStateTTL)
+	for toolUseID, child := range state.Children {
+		if child.StartedAt.IsZero() {
+			continue
+		}
+		if child.StartedAt.Before(cutoff) {
+			delete(state.Children, toolUseID)
+			changed = true
+		}
+	}
+	return changed
 }
 
 func readHookActiveSubagentStateForTool(client string, parentSessionID types.SessionID, toolUseID string) (types.SessionID, bool, error) {
@@ -1483,6 +1564,44 @@ func readHookActiveSubagentStateForTool(client string, parentSessionID types.Ses
 		return "", false, nil
 	}
 	return child.ChildSessionID, true, nil
+}
+
+func findHookActiveSubagentStateForTool(client string, rootParentSessionID types.SessionID, toolUseID string) (hookResolvedActiveSubagent, error) {
+	if strings.TrimSpace(toolUseID) == "" {
+		return hookResolvedActiveSubagent{}, nil
+	}
+	return findHookActiveSubagentStateForToolDepth(client, rootParentSessionID, toolUseID, 0)
+}
+
+func findHookActiveSubagentStateForToolDepth(client string, parentSessionID types.SessionID, toolUseID string, depth int) (hookResolvedActiveSubagent, error) {
+	if depth >= 32 || parentSessionID == "" {
+		return hookResolvedActiveSubagent{}, nil
+	}
+	childSessionID, ok, err := readHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
+	if err != nil {
+		return hookResolvedActiveSubagent{}, err
+	}
+	if ok {
+		return hookResolvedActiveSubagent{
+			ParentSessionID: parentSessionID,
+			ToolUseID:       toolUseID,
+			ChildSessionID:  childSessionID,
+		}, nil
+	}
+	children, err := readHookActiveSubagentChildren(client, parentSessionID)
+	if err != nil {
+		return hookResolvedActiveSubagent{}, err
+	}
+	for _, childSessionID := range children {
+		found, err := findHookActiveSubagentStateForToolDepth(client, childSessionID, toolUseID, depth+1)
+		if err != nil {
+			return hookResolvedActiveSubagent{}, err
+		}
+		if found.ChildSessionID != "" {
+			return found, nil
+		}
+	}
+	return hookResolvedActiveSubagent{}, nil
 }
 
 func readHookLatestActiveSubagentState(client string, parentSessionID types.SessionID) (string, types.SessionID, error) {
@@ -1508,6 +1627,53 @@ func readHookLatestActiveSubagentState(client string, parentSessionID types.Sess
 		}
 	}
 	return latestToolUseID, latestChildID, nil
+}
+
+func readHookActiveSubagentChildren(client string, parentSessionID types.SessionID) ([]types.SessionID, error) {
+	statePath, err := hookActiveSubagentStatePath(client, parentSessionID)
+	if err != nil {
+		return nil, err
+	}
+	state, err := readHookActiveSubagentStateFile(statePath)
+	if err != nil {
+		return nil, err
+	}
+	children := make([]types.SessionID, 0, len(state.Children))
+	for _, child := range state.Children {
+		if child.ChildSessionID != "" {
+			children = append(children, child.ChildSessionID)
+		}
+	}
+	return children, nil
+}
+
+func findHookDeepestLatestActiveSubagentState(client string, rootParentSessionID types.SessionID) (hookResolvedActiveSubagent, error) {
+	return findHookDeepestLatestActiveSubagentStateDepth(client, rootParentSessionID, 0)
+}
+
+func findHookDeepestLatestActiveSubagentStateDepth(client string, parentSessionID types.SessionID, depth int) (hookResolvedActiveSubagent, error) {
+	if depth >= 32 || parentSessionID == "" {
+		return hookResolvedActiveSubagent{}, nil
+	}
+	toolUseID, childSessionID, err := readHookLatestActiveSubagentState(client, parentSessionID)
+	if err != nil {
+		return hookResolvedActiveSubagent{}, err
+	}
+	if childSessionID == "" {
+		return hookResolvedActiveSubagent{}, nil
+	}
+	deeper, err := findHookDeepestLatestActiveSubagentStateDepth(client, childSessionID, depth+1)
+	if err != nil {
+		return hookResolvedActiveSubagent{}, err
+	}
+	if deeper.ChildSessionID != "" {
+		return deeper, nil
+	}
+	return hookResolvedActiveSubagent{
+		ParentSessionID: parentSessionID,
+		ToolUseID:       toolUseID,
+		ChildSessionID:  childSessionID,
+	}, nil
 }
 
 func clearHookActiveSubagentState(client string, parentSessionID types.SessionID, toolUseID string) error {
@@ -1542,6 +1708,32 @@ func clearHookActiveSubagentState(client string, parentSessionID types.SessionID
 		}
 		return nil
 	})
+}
+
+func cleanupHookActiveSubagentStates(client string) error {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return err
+	}
+	activeDir := filepath.Join(stateDir, "active-subagents")
+	entries, err := os.ReadDir(activeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return xerrors.Errorf("failed to read hook active-subagent state directory: %w", err)
+	}
+	prefix := client + "-"
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".lock") || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		statePath := filepath.Join(activeDir, entry.Name())
+		if _, err := readHookActiveSubagentStateFile(statePath); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeHookWorkspaceState(client string, workspace types.Workspace) error {

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -691,13 +691,14 @@ func (c *RootCLI) runHookSubagentStop(
 		}
 		activeToolUseID = toolUseID
 	} else {
-		active, findErr := findHookDeepestLatestActiveSubagentState(client, parentSessionID)
+		var latestChildSessionID types.SessionID
+		var findErr error
+		activeToolUseID, latestChildSessionID, findErr = readHookLatestActiveSubagentState(client, parentSessionID)
 		if findErr != nil {
 			return findErr
 		}
-		activeToolUseID = active.ToolUseID
-		childSessionID = active.ChildSessionID
-		activeParentSessionID = active.ParentSessionID
+		childSessionID = latestChildSessionID
+		activeParentSessionID = parentSessionID
 		childWasActive = childSessionID != ""
 	}
 	if childSessionID != "" {
@@ -1123,10 +1124,7 @@ func resolveHookSessionID(payload []byte, client string) (types.SessionID, error
 }
 
 func resolveHookSubagentStartParentSessionID(payload []byte, client string) (types.SessionID, error) {
-	if hookPayloadString(payload, "session_id", "") == "" {
-		return resolveHookParentSessionID(payload, client)
-	}
-	return resolveHookSessionID(payload, client)
+	return resolveHookParentSessionID(payload, client)
 }
 
 func resolveHookParentSessionID(payload []byte, client string) (types.SessionID, error) {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -634,6 +634,8 @@ func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
 	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_1","tool_input":{"subagent_type":"worker"}}`, nil)
 	time.Sleep(time.Millisecond)
 	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_2","tool_input":{"subagent_type":"qa"}}`, nil)
+	time.Sleep(time.Millisecond)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_3","tool_input":{"subagent_type":"planner"}}`, nil)
 
 	sqlDB, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -664,8 +666,8 @@ func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("Rows error = %v", err)
 	}
-	if len(children) != 2 {
-		t.Fatalf("child rows len = %d, want 2: %#v", len(children), children)
+	if len(children) != 3 {
+		t.Fatalf("child rows len = %d, want 3: %#v", len(children), children)
 	}
 	if children[0].id != "parent-session:sub:toolu_1" || children[0].spawnOrder != 1 {
 		t.Fatalf("first child = %#v, want toolu_1 spawn_order 1", children[0])
@@ -673,43 +675,268 @@ func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
 	if children[1].id != "parent-session:sub:toolu_2" || children[1].spawnOrder != 2 {
 		t.Fatalf("second child = %#v, want toolu_2 spawn_order 2", children[1])
 	}
+	if children[2].id != "parent-session:sub:toolu_3" || children[2].spawnOrder != 3 {
+		t.Fatalf("third child = %#v, want toolu_3 spawn_order 3", children[2])
+	}
 
 	auditStub := &eventUsecaseStub{}
 	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
-	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_2"); got != want {
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_3"); got != want {
 		t.Fatalf("audit sessionID with overlapping children = %q, want %q", got, want)
 	}
 
 	runHook([]string{"hook", "subagent-stop", "claude"}, `{"tool_use_id":"toolu_1","subagent_type":"worker"}`, nil)
-	var child1Ended, child2Ended bool
+	var child1Ended, child2Ended, child3Ended bool
 	if err := sqlDB.QueryRow(`SELECT ended_at IS NOT NULL FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_1").Scan(&child1Ended); err != nil {
 		t.Fatalf("query child1 ended error = %v", err)
 	}
 	if err := sqlDB.QueryRow(`SELECT ended_at IS NOT NULL FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_2").Scan(&child2Ended); err != nil {
 		t.Fatalf("query child2 ended error = %v", err)
 	}
-	if !child1Ended || child2Ended {
-		t.Fatalf("after stopping toolu_1: child1 ended=%v child2 ended=%v, want true/false", child1Ended, child2Ended)
+	if err := sqlDB.QueryRow(`SELECT ended_at IS NOT NULL FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_3").Scan(&child3Ended); err != nil {
+		t.Fatalf("query child3 ended error = %v", err)
+	}
+	if !child1Ended || child2Ended || child3Ended {
+		t.Fatalf("after stopping toolu_1: child1 ended=%v child2 ended=%v child3 ended=%v, want true/false/false", child1Ended, child2Ended, child3Ended)
 	}
 	activeState, err := os.ReadFile(filepath.Join(stateDir, "active-subagents", "claude-parent-session"))
 	if err != nil {
 		t.Fatalf("ReadFile(active state after first stop) error = %v", err)
 	}
-	if strings.Contains(string(activeState), "toolu_1") || !strings.Contains(string(activeState), "toolu_2") {
-		t.Fatalf("active state after stopping toolu_1 = %s, want only toolu_2 active", string(activeState))
+	if strings.Contains(string(activeState), "toolu_1") || !strings.Contains(string(activeState), "toolu_2") || !strings.Contains(string(activeState), "toolu_3") {
+		t.Fatalf("active state after stopping toolu_1 = %s, want toolu_2 and toolu_3 active", string(activeState))
 	}
 
 	auditStub = &eventUsecaseStub{}
 	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
-	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_2"); got != want {
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_3"); got != want {
 		t.Fatalf("audit sessionID after stopping toolu_1 = %q, want %q", got, want)
 	}
 
 	runHook([]string{"hook", "subagent-stop", "claude"}, `{"tool_use_id":"toolu_2","subagent_type":"qa"}`, nil)
 	auditStub = &eventUsecaseStub{}
 	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_3"); got != want {
+		t.Fatalf("audit sessionID after stopping toolu_2 = %q, want %q", got, want)
+	}
+
+	runHook([]string{"hook", "subagent-stop", "claude"}, `{"tool_use_id":"toolu_3","subagent_type":"planner"}`, nil)
+	auditStub = &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
 	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session"); got != want {
 		t.Fatalf("audit sessionID after both children stop = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSubagentState_TracksNestedTaskChildren(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "nested-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-nested-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-nested-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	t.Setenv("TRACEARY_DB_PATH", dbPath)
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	sessionDS := sqliteinfra.NewSessionDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	sessionUC := usecase.NewSessionUsecase(eventDS, sessionDS, sessionDS, eventDS)
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	ctx := context.Background()
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if _, err := sessionUC.Start(ctx, types.Client("hook"), types.Agent("claude"), types.SessionID("parent-session"), types.Workspace("github.com/duck8823/traceary"), ""); err != nil {
+		t.Fatalf("Start(parent) error = %v", err)
+	}
+	runHook := func(args []string, payload string, eventOverride *eventUsecaseStub) {
+		t.Helper()
+		opts := []cli.RootCLIOption{
+			cli.WithStoreManagement(storeUC),
+			cli.WithSession(sessionUC),
+			cli.WithDatabasePathSetter(db.SetPath),
+		}
+		if eventOverride != nil {
+			opts = append(opts, cli.WithEvent(eventOverride))
+		} else {
+			opts = append(opts, cli.WithEvent(eventUC))
+		}
+		rootCmd := newTestRootCLI(opts...).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetIn(strings.NewReader(payload))
+		rootCmd.SetArgs(args)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute(%v) error = %v", args, err)
+		}
+	}
+
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"session_id":"parent-session","tool_use_id":"toolu_child","tool_input":{"subagent_type":"worker"}}`, nil)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"session_id":"parent-session:sub:toolu_child","tool_use_id":"toolu_grandchild","tool_input":{"subagent_type":"qa"}}`, nil)
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var childParent, grandchildParent string
+	var childOrder, grandchildOrder int
+	if err := sqlDB.QueryRow(`SELECT parent_session_id, spawn_order FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_child").Scan(&childParent, &childOrder); err != nil {
+		t.Fatalf("query child error = %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT parent_session_id, spawn_order FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_child:sub:toolu_grandchild").Scan(&grandchildParent, &grandchildOrder); err != nil {
+		t.Fatalf("query grandchild error = %v", err)
+	}
+	if childParent != "parent-session" || childOrder != 1 {
+		t.Fatalf("child parent/order = %q/%d, want parent-session/1", childParent, childOrder)
+	}
+	if grandchildParent != "parent-session:sub:toolu_child" || grandchildOrder != 1 {
+		t.Fatalf("grandchild parent/order = %q/%d, want child/1", grandchildParent, grandchildOrder)
+	}
+
+	auditStub := &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_child:sub:toolu_grandchild"); got != want {
+		t.Fatalf("nested audit sessionID = %q, want %q", got, want)
+	}
+
+	runHook([]string{"hook", "subagent-stop", "claude"}, `{"session_id":"parent-session","tool_use_id":"toolu_grandchild","subagent_type":"qa"}`, nil)
+	auditStub = &eventUsecaseStub{}
+	runHook([]string{"hook", "audit", "claude"}, `{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`, auditStub)
+	if got, want := auditStub.auditCall.sessionID, types.SessionID("parent-session:sub:toolu_child"); got != want {
+		t.Fatalf("nested audit after grandchild stop sessionID = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSubagentState_PrunesOrphanedActiveChild(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "orphan-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	activeDir := filepath.Join(stateDir, "active-subagents")
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-orphan-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	staleStartedAt := time.Now().Add(-25 * time.Hour).UTC().Format(time.RFC3339)
+	activeJSON := `{"children":{"toolu_stale":{"child_session_id":"parent-session:sub:toolu_stale","started_at":"` + staleStartedAt + `"}}}`
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(activeJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile(active state) error = %v", err)
+	}
+
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"parent-session","tool_name":"Read","tool_input":{"file_path":"README.md"},"tool_response":{"content":"ok"}}`))
+	rootCmd.SetArgs([]string{"hook", "audit", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(audit) error = %v", err)
+	}
+	if got, want := eventStub.auditCall.sessionID, types.SessionID("parent-session"); got != want {
+		t.Fatalf("audit sessionID after orphan pruning = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
+		t.Fatalf("stale active state should be removed; stat err=%v", err)
+	}
+}
+
+func TestRootCLI_HookSubagentStartCommand_SynthesizesToolUseIDFromEventID(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "missing-tool-use-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-missing-tool-use-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"event_id":"evt_123","tool_input":{"subagent_type":"worker"}}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-start", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-start) error = %v", err)
+	}
+	if got, want := sessionStub.startChildCall.childID, types.SessionID("parent-session:sub:event-evt_123"); got != want {
+		t.Fatalf("StartChild childID = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookSubagentStopCommand_UsesLatestActiveChildWhenToolUseIDMissing(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "stop-missing-tool-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	activeDir := filepath.Join(stateDir, "active-subagents")
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-missing-tool-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	activeJSON := `{"children":{"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"` +
+		time.Now().Add(-time.Second).UTC().Format(time.RFC3339) +
+		`"}}}`
+	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(activeJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile(active state) error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{}
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"subagent_type":"worker"}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-stop", "claude"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-stop) error = %v", err)
+	}
+	if got, want := sessionStub.endCall.sessionID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+		t.Fatalf("End child sessionID = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
+		t.Fatalf("active state should be cleared after missing-id stop; stat err=%v", err)
 	}
 }
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -576,6 +576,65 @@ func TestRootCLI_HookSubagentStartCommand_CreatesChildAndActiveState(t *testing.
 	}
 }
 
+func TestRootCLI_HookSubagentStartCommand_UsesExplicitSessionIDAsParentForOverlappingSiblings(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "explicit-sibling-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	sessionStub := &sessionUsecaseStub{}
+	runStart := func(payload string) {
+		t.Helper()
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithSession(sessionStub),
+		).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetIn(strings.NewReader(payload))
+		rootCmd.SetArgs([]string{"hook", "subagent-start", "claude"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute(subagent-start) error = %v", err)
+		}
+	}
+
+	runStart(`{"session_id":"parent-session","tool_use_id":"toolu_1","tool_input":{"subagent_type":"worker"}}`)
+	time.Sleep(time.Millisecond)
+	runStart(`{"session_id":"parent-session","tool_use_id":"toolu_2","tool_input":{"subagent_type":"qa"}}`)
+
+	if len(sessionStub.startChildCalls) != 2 {
+		t.Fatalf("StartChild calls len = %d, want 2", len(sessionStub.startChildCalls))
+	}
+	for i, call := range sessionStub.startChildCalls {
+		if got, want := call.parent, types.SessionID("parent-session"); got != want {
+			t.Fatalf("StartChild call %d parent = %q, want %q", i, got, want)
+		}
+	}
+	if got, want := sessionStub.startChildCalls[0].childID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+		t.Fatalf("first childID = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startChildCalls[1].childID, types.SessionID("parent-session:sub:toolu_2"); got != want {
+		t.Fatalf("second childID = %q, want %q", got, want)
+	}
+
+	activeState, err := os.ReadFile(filepath.Join(stateDir, "active-subagents", "claude-parent-session"))
+	if err != nil {
+		t.Fatalf("ReadFile(parent active state) error = %v", err)
+	}
+	if !strings.Contains(string(activeState), `"toolu_1"`) || !strings.Contains(string(activeState), `"toolu_2"`) {
+		t.Fatalf("parent active state = %s, want both siblings", string(activeState))
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "active-subagents", "claude-parent-session:sub:toolu_1")); !os.IsNotExist(err) {
+		t.Fatalf("nested active state should not exist; stat err=%v", err)
+	}
+}
+
 func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "overlap-key")
 
@@ -631,11 +690,11 @@ func TestRootCLI_HookSubagentState_TracksOverlappingTaskChildren(t *testing.T) {
 		}
 	}
 
-	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_1","tool_input":{"subagent_type":"worker"}}`, nil)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"session_id":"parent-session","tool_use_id":"toolu_1","tool_input":{"subagent_type":"worker"}}`, nil)
 	time.Sleep(time.Millisecond)
-	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_2","tool_input":{"subagent_type":"qa"}}`, nil)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"session_id":"parent-session","tool_use_id":"toolu_2","tool_input":{"subagent_type":"qa"}}`, nil)
 	time.Sleep(time.Millisecond)
-	runHook([]string{"hook", "subagent-start", "claude"}, `{"tool_use_id":"toolu_3","tool_input":{"subagent_type":"planner"}}`, nil)
+	runHook([]string{"hook", "subagent-start", "claude"}, `{"session_id":"parent-session","tool_use_id":"toolu_3","tool_input":{"subagent_type":"planner"}}`, nil)
 
 	sqlDB, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -910,9 +969,12 @@ func TestRootCLI_HookSubagentStopCommand_UsesLatestActiveChildWhenToolUseIDMissi
 	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-missing-tool-key"), []byte("parent-session"), 0o600); err != nil {
 		t.Fatalf("WriteFile(session state) error = %v", err)
 	}
-	activeJSON := `{"children":{"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"` +
-		time.Now().Add(-time.Second).UTC().Format(time.RFC3339) +
-		`"}}}`
+	olderStartedAt := time.Now().Add(-2 * time.Second).UTC().Format(time.RFC3339)
+	newerStartedAt := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	activeJSON := `{"children":{` +
+		`"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"` + olderStartedAt + `"},` +
+		`"toolu_2":{"child_session_id":"parent-session:sub:toolu_2","started_at":"` + newerStartedAt + `"}` +
+		`}}`
 	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(activeJSON), 0o600); err != nil {
 		t.Fatalf("WriteFile(active state) error = %v", err)
 	}
@@ -932,11 +994,15 @@ func TestRootCLI_HookSubagentStopCommand_UsesLatestActiveChildWhenToolUseIDMissi
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute(subagent-stop) error = %v", err)
 	}
-	if got, want := sessionStub.endCall.sessionID, types.SessionID("parent-session:sub:toolu_1"); got != want {
+	if got, want := sessionStub.endCall.sessionID, types.SessionID("parent-session:sub:toolu_2"); got != want {
 		t.Fatalf("End child sessionID = %q, want %q", got, want)
 	}
-	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
-		t.Fatalf("active state should be cleared after missing-id stop; stat err=%v", err)
+	activeState, err := os.ReadFile(filepath.Join(activeDir, "claude-parent-session"))
+	if err != nil {
+		t.Fatalf("ReadFile(active state after missing-id stop) error = %v", err)
+	}
+	if strings.Contains(string(activeState), "toolu_2") || !strings.Contains(string(activeState), "toolu_1") {
+		t.Fatalf("active state after missing-id stop = %s, want only older toolu_1 remaining", string(activeState))
 	}
 }
 


### PR DESCRIPTION
Wave 4 step 3: nested + parallel + crash-recovery hardening on top of #723 (PR #759).

- Nested capture (sub-subagent): `parent_session_id` is the inner subagent, not the top parent
- Per-immediate-parent `spawn_order` (unique within parent)
- Crash recovery: orphan active-state entries aged out / detected; next session start does not inherit stale state
- Edge: missing `tool_use_id` synthesized from event_id (stable); SubagentStop without tool_use_id falls back to most-recent active child
- Tests: 3-level nested, 3-way parallel siblings, orphan recovery, missing tool_use_id

`go test ./...` 1128 pass / lint 0 issues.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>