### PR TITLE
feat(session): add lineage query support and spawn_order ordering (#725)

### DIFF
--- a/application/queryservice/session_query.go
+++ b/application/queryservice/session_query.go
@@ -16,4 +16,6 @@ type SessionQueryService interface {
 	FindLatest(ctx context.Context, client types.Client, agent types.Agent, workspace types.Workspace, activeOnly bool) (types.Optional[*model.Event], error)
 	// ListSummaries returns session summaries matching the criteria.
 	ListSummaries(ctx context.Context, limit, offset int, sessionID types.SessionID, workspace types.Workspace, client types.Client, agent types.Agent, label string, from, to types.Optional[time.Time]) ([]apptypes.SessionSummary, error)
+	// LineageOf returns the full session tree rooted at the topmost ancestor of sessionID.
+	LineageOf(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error)
 }

--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -49,6 +49,30 @@ func TestSessionUsecase_Start(t *testing.T) {
 	})
 }
 
+func TestSessionUsecase_StartRejectsSelfParent(t *testing.T) {
+	t.Parallel()
+
+	sessionStub := &sessionRepositoryStub{}
+	sut := usecase.NewSessionUsecase(nil, sessionStub, nil, nil)
+
+	_, err := sut.Start(context.Background(),
+		types.Client("cli"),
+		types.Agent("codex"),
+		types.SessionID("self-parent"),
+		types.Workspace("duck8823/traceary"),
+		types.SessionID(" self-parent "),
+	)
+	if err == nil {
+		t.Fatalf("Start() error = nil, want self-parent rejection")
+	}
+	if !errors.Is(err, model.ErrInvalidSessionState) {
+		t.Fatalf("Start() error = %v, want ErrInvalidSessionState", err)
+	}
+	if sessionStub.saveBoundaryCalled {
+		t.Fatalf("SessionRepository.SaveBoundary() should not be called when session parent points to itself")
+	}
+}
+
 func TestSessionUsecase_StartChild(t *testing.T) {
 	t.Parallel()
 
@@ -108,6 +132,29 @@ func TestSessionUsecase_StartChild(t *testing.T) {
 		t.Fatalf("SpawnOrder() should be present")
 	} else if diff := cmp.Diff(2, got); diff != "" {
 		t.Fatalf("SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSessionUsecase_StartChildRejectsSelfParent(t *testing.T) {
+	t.Parallel()
+
+	sut := usecase.NewSessionUsecase(nil, &sessionRepositoryStub{}, nil, nil)
+
+	_, err := sut.StartChild(
+		context.Background(),
+		types.SessionID("same-session"),
+		types.SessionID("same-session"),
+		types.Agent("claude/code-reviewer"),
+		types.Workspace("github.com/duck8823/traceary"),
+		types.EventID("toolu_1"),
+		"task",
+		mustTime(t),
+	)
+	if err == nil {
+		t.Fatalf("StartChild() error = nil, want self-parent rejection")
+	}
+	if !errors.Is(err, model.ErrInvalidSessionState) {
+		t.Fatalf("StartChild() error = %v, want ErrInvalidSessionState", err)
 	}
 }
 

--- a/application/usecase/replay_usecase_impl_test.go
+++ b/application/usecase/replay_usecase_impl_test.go
@@ -22,6 +22,9 @@ func (s *stubReplaySessionQuery) FindLatest(context.Context, domtypes.Client, do
 func (s *stubReplaySessionQuery) ListSummaries(context.Context, int, int, domtypes.SessionID, domtypes.Workspace, domtypes.Client, domtypes.Agent, string, domtypes.Optional[time.Time], domtypes.Optional[time.Time]) ([]apptypes.SessionSummary, error) {
 	return s.sessions, nil
 }
+func (s *stubReplaySessionQuery) LineageOf(context.Context, domtypes.SessionID) ([]apptypes.SessionSummary, error) {
+	return nil, nil
+}
 
 type stubReplayEventQuery struct {
 	eventsBySession map[domtypes.SessionID][]*model.Event

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -33,6 +33,9 @@ type SessionUsecase interface {
 	// Zero-value workspace returns sessions across all workspaces.
 	Tree(ctx context.Context, workspace types.Workspace, limit int) ([]apptypes.SessionSummary, error)
 
+	// Lineage returns the full hierarchy rooted at the topmost ancestor of sessionID.
+	Lineage(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error)
+
 	// Active returns the session_started event for the active session matching the criteria.
 	// Returns an empty Optional when no active session exists.
 	Active(ctx context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error)

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -237,6 +237,23 @@ func (u *sessionUsecase) Tree(ctx context.Context, workspace types.Workspace, li
 	return summaries, nil
 }
 
+func (u *sessionUsecase) Lineage(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID.String())
+	if trimmedSessionID == "" {
+		return nil, xerrors.Errorf("session ID must not be empty")
+	}
+	resolvedSessionID, err := types.SessionIDFrom(trimmedSessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to resolve session ID: %w", err)
+	}
+
+	summaries, err := u.sessionQuery.LineageOf(ctx, resolvedSessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get session lineage: %w", err)
+	}
+	return summaries, nil
+}
+
 func (u *sessionUsecase) Active(ctx context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
 	result, err := u.sessionQuery.FindLatest(ctx, criteria.Client(), criteria.Agent(), criteria.Workspace(), true)
 	if err != nil {

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -47,6 +47,13 @@ func (u *sessionUsecase) Start(ctx context.Context, client types.Client, agent t
 	if _, err := types.AgentFrom(agent.String()); err != nil {
 		return nil, xerrors.Errorf("failed to start session: %w", err)
 	}
+	resolvedParentSessionID, err := resolveOptionalParentSessionID(parentSessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to start session: %w", err)
+	}
+	if resolvedParentSessionID != "" && resolvedParentSessionID == resolvedSessionID {
+		return nil, xerrors.Errorf("cannot start session %s with itself as parent: %w", resolvedSessionID, model.ErrInvalidSessionState)
+	}
 
 	// When the caller provided an explicit session ID, the session must not
 	// already exist; otherwise the start would silently no-op the session row
@@ -66,7 +73,7 @@ func (u *sessionUsecase) Start(ctx context.Context, client types.Client, agent t
 		return nil, xerrors.Errorf("failed to start session: %w", err)
 	}
 
-	session := buildSessionFromBoundary(event, parentSessionID)
+	session := buildSessionFromBoundary(event, resolvedParentSessionID)
 	if err := u.sessionRepo.SaveBoundary(ctx, session, event); err != nil {
 		return nil, xerrors.Errorf("failed to save session start: %w", err)
 	}
@@ -95,6 +102,9 @@ func (u *sessionUsecase) StartChild(
 	resolvedChildID, err := types.SessionIDFrom(childID.String())
 	if err != nil {
 		return nil, xerrors.Errorf("failed to start child session: %w", err)
+	}
+	if parentID == resolvedChildID {
+		return nil, xerrors.Errorf("cannot start child session %s with itself as parent: %w", resolvedChildID, model.ErrInvalidSessionState)
 	}
 	resolvedAgent, err := types.AgentFrom(agent.String())
 	if err != nil {
@@ -311,6 +321,18 @@ func (u *sessionUsecase) resolveSessionStartID(sessionID types.SessionID) (types
 		return types.SessionID(""), false, xerrors.Errorf("failed to convert session ID: %w", err)
 	}
 	return resolved, false, nil
+}
+
+func resolveOptionalParentSessionID(parentSessionID types.SessionID) (types.SessionID, error) {
+	trimmedValue := strings.TrimSpace(parentSessionID.String())
+	if trimmedValue == "" {
+		return types.SessionID(""), nil
+	}
+	resolved, err := types.SessionIDFrom(trimmedValue)
+	if err != nil {
+		return types.SessionID(""), xerrors.Errorf("failed to convert parent session ID: %w", err)
+	}
+	return resolved, nil
 }
 
 // buildBoundaryEvent constructs the session start/end event.

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -35,6 +35,11 @@ type sessionQueryServiceStub struct {
 	listLabel           string
 	listFrom            types.Optional[time.Time]
 	listTo              types.Optional[time.Time]
+
+	lineageResult    []apptypes.SessionSummary
+	lineageErr       error
+	lineageCalls     int
+	lineageSessionID types.SessionID
 }
 
 func (s *sessionQueryServiceStub) FindLatest(
@@ -79,6 +84,15 @@ func (s *sessionQueryServiceStub) ListSummaries(
 		return nil, s.listSummariesErr
 	}
 	return s.listSummariesResult, nil
+}
+
+func (s *sessionQueryServiceStub) LineageOf(_ context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error) {
+	s.lineageCalls++
+	s.lineageSessionID = sessionID
+	if s.lineageErr != nil {
+		return nil, s.lineageErr
+	}
+	return s.lineageResult, nil
 }
 
 type eventQueryServiceStub struct {
@@ -800,6 +814,44 @@ func TestSessionUsecase_Handoff(t *testing.T) {
 		_, err := sut.Handoff(context.Background(), types.SessionID("session-1"), types.Workspace(""), 5)
 		if err == nil {
 			t.Fatalf("Handoff() error = nil, want error")
+		}
+	})
+}
+
+func TestSessionUsecase_Lineage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delegates to query service", func(t *testing.T) {
+		t.Parallel()
+
+		want := []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(types.SessionID("root"), types.Workspace("ws"), mustTime(t), types.None[time.Time](), "active", 1, 0, nil, "", "", types.SessionID("")),
+		}
+		queryStub := &sessionQueryServiceStub{lineageResult: want}
+		sut := usecase.NewSessionUsecase(nil, nil, queryStub, &eventQueryServiceStub{})
+
+		got, err := sut.Lineage(context.Background(), types.SessionID(" child "))
+		if err != nil {
+			t.Fatalf("Lineage() error = %v", err)
+		}
+		if len(got) != 1 || got[0].SessionID() != want[0].SessionID() {
+			t.Fatalf("Lineage() = %+v, want root summary", got)
+		}
+		if queryStub.lineageCalls != 1 || queryStub.lineageSessionID != types.SessionID("child") {
+			t.Fatalf("LineageOf call = (%d, %q), want (1, child)", queryStub.lineageCalls, queryStub.lineageSessionID)
+		}
+	})
+
+	t.Run("rejects empty session id", func(t *testing.T) {
+		t.Parallel()
+
+		queryStub := &sessionQueryServiceStub{}
+		sut := usecase.NewSessionUsecase(nil, nil, queryStub, &eventQueryServiceStub{})
+		if _, err := sut.Lineage(context.Background(), types.SessionID(" ")); err == nil {
+			t.Fatalf("Lineage() error = nil, want error")
+		}
+		if queryStub.lineageCalls != 0 {
+			t.Fatalf("LineageOf calls = %d, want 0", queryStub.lineageCalls)
 		}
 	})
 }

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -498,7 +498,7 @@ session の一覧サマリーを表示します。
 
 ### `traceary session tree`
 
-読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: Claude Code の subagent なら `claude/Explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。JSON 出力では各ノードに `parent_session_id` / `depth` / 数値の `duration_sec` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
+読み込んだ session の parent → child → grandchild 階層を描画します。各行は session id / status / 最も具体的な subagent role (例: Claude Code の subagent なら `claude/Explore`) / workspace / duration / `N cmds/M events` breakdown を表示します。同じ親を持つ child は `spawn_order` 昇順で並び、`spawn_order` を持たない top-level session は `started_at` 順で並びます。JSON 出力では各ノードに `parent_session_id` / `spawn_event_id` / `subagent_kind` / `spawn_order` / `depth` / 数値の `duration_sec` / `subagent_type` を追加し、外部ツールが lineage を扱えるようにしています。
 
 主な flag:
 
@@ -506,6 +506,14 @@ session の一覧サマリーを表示します。
 - `--limit`
 - `--root <session-id>` — 指定 session を root とするサブツリーのみ表示
 - `--ongoing-only` — active session を含む lineage だけを残す
+- `--json`
+
+### `traceary session lineage <session-id>`
+
+指定 session を含む lineage 全体を表示します。Traceary は `<session-id>` から最上位の ancestor まで上にたどり、その root と全 descendant を `session tree` と同じ text / JSON node 形式で返します。
+
+主な flag:
+
 - `--json`
 
 ### `traceary session label <label-text>`

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -498,7 +498,7 @@ Useful flags:
 
 ### `traceary session tree`
 
-Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude/Explore` for Claude Code subagents), workspace, duration, and an `N cmds/M events` breakdown. The JSON surface adds `parent_session_id`, `depth`, numeric `duration_sec`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
+Render the parent → child → grandchild lineage for every loaded session. Each row shows the session id, status, most specific subagent role (for example `claude/Explore` for Claude Code subagents), workspace, duration, and an `N cmds/M events` breakdown. Children of the same parent are ordered by `spawn_order` ascending; top-level sessions with no `spawn_order` are ordered by `started_at`. The JSON surface adds `parent_session_id`, `spawn_event_id`, `subagent_kind`, `spawn_order`, `depth`, numeric `duration_sec`, and `subagent_type` to every node so external tooling can reason about lineage without replaying the text format.
 
 Useful flags:
 
@@ -506,6 +506,14 @@ Useful flags:
 - `--limit`
 - `--root <session-id>` — focus on the subtree rooted at the given session
 - `--ongoing-only` — keep only lineages that still contain an active session
+- `--json`
+
+### `traceary session lineage <session-id>`
+
+Render the full lineage that contains a session: Traceary walks up from `<session-id>` to the topmost ancestor, then returns that root and all descendants using the same text and JSON node shape as `session tree`.
+
+Useful flags:
+
 - `--json`
 
 ### `traceary session label <label-text>`

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -2,9 +2,11 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -381,6 +383,93 @@ func TestDatasource_ListSummaries(t *testing.T) {
 		}
 	})
 
+}
+
+func TestDatasource_LineageOfCycleDetection(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "self-cycle", started, types.None[time.Time](), "claude", "duck8823/traceary")
+	updateTestSessionParent(ctx, t, dbPath, "self-cycle", "self-cycle")
+	saveTestSession(ctx, t, fixture.sessionDS, "cycle-a", started, types.None[time.Time](), "claude", "duck8823/traceary")
+	saveTestSessionWithParent(ctx, t, fixture.sessionDS, "cycle-b", "cycle-a", started.Add(time.Minute), 1)
+	updateTestSessionParent(ctx, t, dbPath, "cycle-a", "cycle-b")
+
+	lineageCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	selfGot, err := fixture.sessionDS.LineageOf(lineageCtx, types.SessionID("self-cycle"))
+	if err != nil {
+		t.Fatalf("LineageOf() self-cycle error = %v", err)
+	}
+	if len(selfGot) != 1 || selfGot[0].SessionID() != types.SessionID("self-cycle") {
+		t.Fatalf("LineageOf() self-cycle = %+v, want self-cycle once", selfGot)
+	}
+
+	got, err := fixture.sessionDS.LineageOf(lineageCtx, types.SessionID("cycle-a"))
+	if err != nil {
+		t.Fatalf("LineageOf() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	sort.Strings(gotIDs)
+	wantIDs := []string{"cycle-a", "cycle-b"}
+	if diff := cmp.Diff(wantIDs, gotIDs); diff != "" {
+		t.Fatalf("LineageOf() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDatasource_RejectsSelfParentSession(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	agent, _ := types.AgentFrom("codex")
+	sid, _ := types.SessionIDFrom("self-parent")
+	session := model.SessionOf(
+		sid,
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		types.None[time.Time](),
+		types.Client("cli"),
+		agent,
+		types.Workspace("duck8823/traceary"),
+		"",
+		"",
+		sid,
+	)
+
+	err := fixture.sessionDS.SaveSessionBoundaryForTest(ctx, session)
+	if err == nil {
+		t.Fatalf("SaveSessionBoundaryForTest() error = nil, want self-parent rejection")
+	}
+	if !strings.Contains(err.Error(), "itself as parent") {
+		t.Fatalf("SaveSessionBoundaryForTest() error = %v, want self-parent rejection", err)
+	}
+}
+
+func updateTestSessionParent(ctx context.Context, t *testing.T, dbPath string, sessionID string, parentID string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, "UPDATE sessions SET parent_session_id = ? WHERE session_id = ?", parentID, sessionID); err != nil {
+		t.Fatalf("UPDATE sessions parent_session_id error = %v", err)
+	}
 }
 
 func TestDatasource_LineageOf(t *testing.T) {

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -3,6 +3,8 @@ package sqlite_test
 import (
 	"context"
 	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -94,6 +96,31 @@ func saveTestSession(ctx context.Context, t *testing.T, ds *infra.SessionDatasou
 	ag, _ := types.AgentFrom(agent)
 	sid, _ := types.SessionIDFrom(sessionID)
 	session := model.SessionOf(sid, startedAt, endedAt, types.Client("hook"), ag, types.Workspace(workspace), "", "", types.SessionID(""))
+	if err := ds.SaveSessionBoundaryForTest(ctx, session); err != nil {
+		t.Fatalf("SaveSessionBoundaryForTest() error = %v", err)
+	}
+}
+
+func saveTestSessionWithParent(ctx context.Context, t *testing.T, ds *infra.SessionDatasource, sessionID string, parentID string, startedAt time.Time, order int) {
+	t.Helper()
+	agent, _ := types.AgentFrom("codex")
+	sid, _ := types.SessionIDFrom(sessionID)
+	parentSID, _ := types.SessionIDFrom(parentID)
+	spawnEventID, _ := types.EventIDFrom("spawn-" + sessionID)
+	session := model.SessionOf(
+		sid,
+		startedAt,
+		types.None[time.Time](),
+		types.Client("hook"),
+		agent,
+		types.Workspace("duck8823/traceary"),
+		"",
+		"",
+		parentSID,
+		spawnEventID,
+		"task",
+		types.Some(order),
+	)
 	if err := ds.SaveSessionBoundaryForTest(ctx, session); err != nil {
 		t.Fatalf("SaveSessionBoundaryForTest() error = %v", err)
 	}
@@ -354,4 +381,48 @@ func TestDatasource_ListSummaries(t *testing.T) {
 		}
 	})
 
+}
+
+func TestDatasource_LineageOf(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "root", started, types.None[time.Time](), "claude", "duck8823/traceary")
+	saveTestSessionWithParent(ctx, t, fixture.sessionDS, "child-2", "root", started, 2)
+	saveTestSessionWithParent(ctx, t, fixture.sessionDS, "child-1", "root", started, 1)
+	saveTestSessionWithParent(ctx, t, fixture.sessionDS, "grandchild", "child-1", started.Add(time.Minute), 1)
+	saveTestSession(ctx, t, fixture.sessionDS, "unrelated", started, types.None[time.Time](), "claude", "duck8823/traceary")
+
+	got, err := fixture.sessionDS.LineageOf(ctx, types.SessionID("child-1"))
+	if err != nil {
+		t.Fatalf("LineageOf() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	wantIDs := []string{"root", "child-1", "child-2", "grandchild"}
+	gotIDSet := append([]string(nil), gotIDs...)
+	sort.Strings(gotIDSet)
+	wantIDSet := append([]string(nil), wantIDs...)
+	sort.Strings(wantIDSet)
+	if diff := cmp.Diff(wantIDSet, gotIDSet); diff != "" {
+		t.Fatalf("LineageOf() IDs mismatch (-want +got):\n%s", diff)
+	}
+	childOneIndex := slices.Index(gotIDs, "child-1")
+	childTwoIndex := slices.Index(gotIDs, "child-2")
+	if childOneIndex < 0 || childTwoIndex < 0 || childOneIndex > childTwoIndex {
+		t.Fatalf("siblings were not ordered by spawn_order: %v", gotIDs)
+	}
+	spawnOrder, ok := got[childOneIndex].SpawnOrder().Value()
+	if !ok || spawnOrder != 1 {
+		t.Fatalf("child-1 spawn_order = (%d, %v), want (1, true)", spawnOrder, ok)
+	}
 }

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -147,6 +147,10 @@ type sqlExecer interface {
 // existing row (false), so the caller can decide whether the pre-existing
 // state is acceptable.
 func insertSessionRowIfMissing(ctx context.Context, exec sqlExecer, session *model.Session) (bool, error) {
+	if session.ParentSessionID().String() != "" && session.ParentSessionID() == session.SessionID() {
+		return false, xerrors.Errorf("cannot save session %s with itself as parent: %w", session.SessionID(), model.ErrInvalidSessionState)
+	}
+
 	var parentSessionID *string
 	if session.ParentSessionID().String() != "" {
 		v := session.ParentSessionID().String()

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -35,6 +35,9 @@ var findLatestSessionQuery string
 //go:embed sql/list_sessions.sql
 var listSessionsQuery string
 
+//go:embed sql/session_lineage.sql
+var sessionLineageQuery string
+
 // SessionDatasource is the SQLite-backed implementation of the session
 // repository and session query service.
 type SessionDatasource struct {
@@ -460,6 +463,44 @@ func (d *SessionDatasource) ListSummaries(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("failed to iterate session summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+// LineageOf returns the full session family rooted at the topmost ancestor of
+// sessionID. An unknown session ID returns an empty slice.
+func (d *SessionDatasource) LineageOf(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for session lineage: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	rows, err := db.QueryContext(ctx, sessionLineageQuery, sessionID.String())
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query session lineage: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]apptypes.SessionSummary, 0)
+	for rows.Next() {
+		summary, err := scanSessionSummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan session lineage row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate session lineage rows: %w", err)
 	}
 
 	return summaries, nil

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -1,0 +1,53 @@
+WITH RECURSIVE
+  ancestors(session_id, parent_session_id, depth) AS (
+    SELECT session_id, parent_session_id, 0
+    FROM sessions
+    WHERE session_id = ?
+    UNION ALL
+    SELECT parent.session_id, parent.parent_session_id, ancestors.depth + 1
+    FROM sessions parent
+    JOIN ancestors ON ancestors.parent_session_id = parent.session_id
+  ),
+  lineage_root(session_id) AS (
+    SELECT session_id
+    FROM ancestors
+    ORDER BY depth DESC
+    LIMIT 1
+  ),
+  lineage(session_id) AS (
+    SELECT session_id
+    FROM lineage_root
+    UNION ALL
+    SELECT child.session_id
+    FROM sessions child
+    JOIN lineage ON child.parent_session_id = lineage.session_id
+  )
+SELECT
+  s.session_id,
+  s.workspace,
+  s.started_at,
+  s.ended_at,
+  COALESCE(agg.total_events, 0) AS total_events,
+  COALESCE(agg.command_count, 0) AS command_count,
+  COALESCE(agg.agents, '') AS agents,
+  s.label,
+  s.summary,
+  COALESCE(s.parent_session_id, '') AS parent_session_id,
+  COALESCE(s.spawn_event_id, '') AS spawn_event_id,
+  s.subagent_kind,
+  s.spawn_order
+FROM sessions s
+JOIN lineage ON lineage.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    e.session_id,
+    COUNT(*) AS total_events,
+    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+    GROUP_CONCAT(DISTINCT e.agent) AS agents
+  FROM events e
+  GROUP BY e.session_id
+) agg ON agg.session_id = s.session_id
+ORDER BY
+  s.parent_session_id NULLS FIRST,
+  s.spawn_order NULLS FIRST,
+  s.started_at ASC

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -1,12 +1,14 @@
 WITH RECURSIVE
-  ancestors(session_id, parent_session_id, depth) AS (
-    SELECT session_id, parent_session_id, 0
+  ancestors(session_id, parent_session_id, depth, path) AS (
+    SELECT session_id, parent_session_id, 0, ',' || session_id || ','
     FROM sessions
     WHERE session_id = ?
     UNION ALL
-    SELECT parent.session_id, parent.parent_session_id, ancestors.depth + 1
+    SELECT parent.session_id, parent.parent_session_id, ancestors.depth + 1, ancestors.path || parent.session_id || ','
     FROM sessions parent
     JOIN ancestors ON ancestors.parent_session_id = parent.session_id
+    WHERE ancestors.depth < 100
+      AND instr(ancestors.path, ',' || parent.session_id || ',') = 0
   ),
   lineage_root(session_id) AS (
     SELECT session_id
@@ -14,13 +16,15 @@ WITH RECURSIVE
     ORDER BY depth DESC
     LIMIT 1
   ),
-  lineage(session_id) AS (
-    SELECT session_id
+  lineage(session_id, depth, path) AS (
+    SELECT session_id, 0, ',' || session_id || ','
     FROM lineage_root
     UNION ALL
-    SELECT child.session_id
+    SELECT child.session_id, lineage.depth + 1, lineage.path || child.session_id || ','
     FROM sessions child
     JOIN lineage ON child.parent_session_id = lineage.session_id
+    WHERE lineage.depth < 100
+      AND instr(lineage.path, ',' || child.session_id || ',') = 0
   )
 SELECT
   s.session_id,

--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -30,6 +30,7 @@ func (c *RootCLI) newSessionCommand() *cobra.Command {
 	sessionCmd.AddCommand(c.newSessionLabelCommand())
 	sessionCmd.AddCommand(c.newSessionHandoffCommand())
 	sessionCmd.AddCommand(c.newSessionTreeCommand())
+	sessionCmd.AddCommand(c.newSessionLineageCommand())
 	sessionCmd.AddCommand(c.newSessionGCCommand())
 
 	return sessionCmd

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,10 +43,7 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 
 			resolvedRepo := resolveWorkspaceValue(ctx, repo)
 
-			criteria := apptypes.NewSessionListCriteriaBuilder(limit).
-				Workspace(types.Workspace(resolvedRepo)).
-				Build()
-			summaries, err := c.session.List(ctx, criteria)
+			summaries, err := c.session.Tree(ctx, types.Workspace(resolvedRepo), limit)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
 			}
@@ -70,6 +68,44 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 		"keep only lineages that contain at least one active session",
 		"active session を少なくとも1つ含む lineage だけに絞る",
 	))
+
+	return cmd
+}
+
+func (c *RootCLI) newSessionLineageCommand() *cobra.Command {
+	var (
+		dbPath string
+		asJSON bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "lineage <session-id>",
+		Short: Localize("Display the full lineage containing a session", "指定セッションを含む lineage 全体を表示する"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			output := cmd.OutOrStdout()
+
+			resolvedDBPath, err := resolveDBPath(dbPath)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
+			}
+			c.applyDatabasePath(resolvedDBPath)
+			if err := c.storeManagement.Initialize(ctx); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+			}
+
+			summaries, err := c.session.Lineage(ctx, types.SessionID(strings.TrimSpace(args[0])))
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to get session lineage", "セッション lineage の取得に失敗しました"), err)
+			}
+
+			return writeSessionTreeFiltered(output, summaries, sessionTreeFilter{asJSON: asJSON})
+		},
+	}
+
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 
 	return cmd
 }
@@ -109,6 +145,7 @@ func writeSessionTreeFiltered(output io.Writer, summaries []apptypes.SessionSumm
 		}
 		roots = append(roots, node)
 	}
+	sortSessionNodes(roots)
 
 	if filter.root != "" {
 		if rootNode, ok := nodeMap[filter.root]; ok {
@@ -138,6 +175,30 @@ func writeSessionTreeFiltered(output io.Writer, summaries []apptypes.SessionSumm
 	}
 
 	return nil
+}
+
+func sortSessionNodes(nodes []*sessionNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return sessionNodeLess(nodes[i], nodes[j])
+	})
+	for _, node := range nodes {
+		sortSessionNodes(node.children)
+	}
+}
+
+func sessionNodeLess(left, right *sessionNode) bool {
+	leftOrder, leftHasOrder := left.summary.SpawnOrder().Value()
+	rightOrder, rightHasOrder := right.summary.SpawnOrder().Value()
+	if leftHasOrder && rightHasOrder && leftOrder != rightOrder {
+		return leftOrder < rightOrder
+	}
+	if leftHasOrder != rightHasOrder {
+		return leftHasOrder
+	}
+	if !left.summary.StartedAt().Equal(right.summary.StartedAt()) {
+		return left.summary.StartedAt().Before(right.summary.StartedAt())
+	}
+	return false
 }
 
 // keepOngoingLineages prunes every subtree whose sessions are all ended so

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -322,6 +322,71 @@ func TestRootCLI_SessionTreeCommand_RootFilter(t *testing.T) {
 	}
 }
 
+func TestRootCLI_SessionTreeCommand_OrdersSiblingsBySpawnOrder(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	listStub := &sessionUsecaseStub{
+		listResult: []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(types.SessionID("root"), types.Workspace("ws"), started, types.None[time.Time](), "active", 1, 0, []string{"claude"}, "", "", types.SessionID("")),
+			apptypes.SessionSummaryOf(types.SessionID("child-2"), types.Workspace("ws"), started, types.None[time.Time](), "active", 1, 0, []string{"codex"}, "", "", types.SessionID("root"), types.EventID("spawn-2"), "task", types.Some(2)),
+			apptypes.SessionSummaryOf(types.SessionID("child-1"), types.Workspace("ws"), started, types.None[time.Time](), "active", 1, 0, []string{"codex"}, "", "", types.SessionID("root"), types.EventID("spawn-1"), "task", types.Some(1)),
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(listStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "tree", "--db-path", "/tmp/test-traceary.db", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var trees []struct {
+		Children []struct {
+			SessionID string `json:"session_id"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &trees); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(trees) != 1 || len(trees[0].Children) != 2 {
+		t.Fatalf("unexpected tree shape: %+v", trees)
+	}
+	if trees[0].Children[0].SessionID != "child-1" || trees[0].Children[1].SessionID != "child-2" {
+		t.Fatalf("children were not ordered by spawn_order: %+v", trees[0].Children)
+	}
+}
+
+func TestRootCLI_SessionLineageCommand_JSON(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	lineageStub := &sessionUsecaseStub{
+		lineageResult: []apptypes.SessionSummary{
+			apptypes.SessionSummaryOf(types.SessionID("root"), types.Workspace("ws"), started, types.None[time.Time](), "active", 1, 0, []string{"claude"}, "", "", types.SessionID("")),
+			apptypes.SessionSummaryOf(types.SessionID("child"), types.Workspace("ws"), started.Add(time.Minute), types.None[time.Time](), "active", 1, 0, []string{"codex"}, "", "", types.SessionID("root"), types.EventID("spawn"), "task", types.Some(1)),
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(lineageStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "lineage", "child", "--db-path", "/tmp/test-traceary.db", "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"session_id": "root"`) || !strings.Contains(stdout.String(), `"session_id": "child"`) {
+		t.Fatalf("lineage JSON should include root and child, got: %s", stdout.String())
+	}
+}
+
 func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -104,6 +104,8 @@ type sessionUsecaseStub struct {
 	listErr        error
 	treeResult     []apptypes.SessionSummary
 	treeErr        error
+	lineageResult  []apptypes.SessionSummary
+	lineageErr     error
 	activeEvent    *model.Event
 	activeErr      error
 	activeCriteria apptypes.SessionLookupCriteria
@@ -189,7 +191,13 @@ func (s *sessionUsecaseStub) List(_ context.Context, _ apptypes.SessionListCrite
 	return s.listResult, s.listErr
 }
 func (s *sessionUsecaseStub) Tree(_ context.Context, _ types.Workspace, _ int) ([]apptypes.SessionSummary, error) {
+	if s.treeResult == nil && s.treeErr == nil {
+		return s.listResult, s.listErr
+	}
 	return s.treeResult, s.treeErr
+}
+func (s *sessionUsecaseStub) Lineage(_ context.Context, _ types.SessionID) ([]apptypes.SessionSummary, error) {
+	return s.lineageResult, s.lineageErr
 }
 func (s *sessionUsecaseStub) Active(_ context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error) {
 	s.activeCriteria = criteria

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -47,7 +47,7 @@ type queryMemoryInput struct {
 
 // sessionActionInput is shared by manage_session and session_status.
 type sessionActionInput struct {
-	Action              string `json:"action" jsonschema:"required,action enum"`
+	Action              string `json:"action" jsonschema:"required,action enum: start, end, active, latest, handoff, lineage"`
 	Client              string `json:"client,omitempty" jsonschema:"recording channel or filter"`
 	Agent               string `json:"agent,omitempty" jsonschema:"actor name or filter"`
 	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier"`

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -68,6 +68,32 @@ type sessionHandoffOutput struct {
 	Memories       []memorySummaryOutput `json:"memories,omitempty"`
 }
 
+// sessionLineageOutput is the MCP output for session_status action=lineage.
+type sessionLineageOutput struct {
+	Roots []sessionLineageNodeOutput `json:"roots" jsonschema:"top-level root nodes in the lineage tree"`
+}
+
+type sessionLineageNodeOutput struct {
+	SessionID       string                     `json:"session_id" jsonschema:"session identifier"`
+	ParentSessionID string                     `json:"parent_session_id,omitempty" jsonschema:"parent session identifier"`
+	SpawnEventID    string                     `json:"spawn_event_id,omitempty" jsonschema:"event that spawned this child session"`
+	SubagentKind    string                     `json:"subagent_kind,omitempty" jsonschema:"subagent spawn kind"`
+	SpawnOrder      *int                       `json:"spawn_order,omitempty" jsonschema:"sibling spawn order"`
+	Depth           int                        `json:"depth" jsonschema:"depth from the lineage root"`
+	Workspace       string                     `json:"workspace,omitempty" jsonschema:"workspace identifier"`
+	Label           string                     `json:"label,omitempty" jsonschema:"user-assigned session label"`
+	Summary         string                     `json:"summary,omitempty" jsonschema:"session summary"`
+	StartedAt       string                     `json:"started_at" jsonschema:"start timestamp"`
+	EndedAt         *string                    `json:"ended_at,omitempty" jsonschema:"end timestamp"`
+	Status          string                     `json:"status" jsonschema:"session status"`
+	DurationSec     *float64                   `json:"duration_sec,omitempty" jsonschema:"duration in seconds"`
+	TotalEvents     int                        `json:"total_events" jsonschema:"total event count"`
+	CommandCount    int                        `json:"command_count" jsonschema:"command event count"`
+	Agents          []string                   `json:"agents" jsonschema:"agents seen in this session"`
+	SubagentType    string                     `json:"subagent_type,omitempty" jsonschema:"most specific subagent role"`
+	Children        []sessionLineageNodeOutput `json:"children" jsonschema:"child sessions ordered by spawn_order"`
+}
+
 // memoryPackOutput is the MCP output for the memory_pack tool.
 type memoryPackOutput = sessionHandoffOutput
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -116,7 +116,7 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 	}, s.manageSession())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "session_status",
-		Description: "Dispatch session status reads by action: active, latest, or handoff.",
+		Description: "Dispatch session status reads by action: active, latest, handoff, or lineage.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.sessionStatus())
 	mcp.AddTool(server, &mcp.Tool{
@@ -316,10 +316,25 @@ func (s *Server) sessionStatus() mcp.ToolHandlerFor[sessionActionInput, any] {
 		case "handoff":
 			_, out, err := s.sessionHandoff()(ctx, req, sessionHandoffInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, AsOf: input.AsOf})
 			return nil, out, err
+		case "lineage":
+			out, err := s.sessionLineage(ctx, input.SessionID)
+			return nil, out, err
 		default:
-			return nil, nil, xerrors.Errorf("session_status action must be one of active, latest, handoff")
+			return nil, nil, xerrors.Errorf("session_status action must be one of active, latest, handoff, lineage")
 		}
 	}
+}
+
+func (s *Server) sessionLineage(ctx context.Context, sessionID string) (sessionLineageOutput, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return sessionLineageOutput{}, xerrors.Errorf("session_status action lineage requires session_id")
+	}
+	summaries, err := s.session.Lineage(ctx, types.SessionID(trimmedSessionID))
+	if err != nil {
+		return sessionLineageOutput{}, xerrors.Errorf("failed to get session lineage: %w", err)
+	}
+	return newSessionLineageOutput(summaries), nil
 }
 
 func (s *Server) recordEvent() mcp.ToolHandlerFor[recordEventInput, recordEventOutput] {

--- a/presentation/mcpserver/session_lineage.go
+++ b/presentation/mcpserver/session_lineage.go
@@ -1,0 +1,109 @@
+package mcpserver
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+type sessionLineageNode struct {
+	summary  apptypes.SessionSummary
+	children []*sessionLineageNode
+}
+
+func newSessionLineageOutput(summaries []apptypes.SessionSummary) sessionLineageOutput {
+	nodeMap := make(map[string]*sessionLineageNode, len(summaries))
+	roots := make([]*sessionLineageNode, 0)
+	for _, summary := range summaries {
+		nodeMap[summary.SessionID().String()] = &sessionLineageNode{summary: summary}
+	}
+	for _, summary := range summaries {
+		node := nodeMap[summary.SessionID().String()]
+		if parentID := summary.ParentSessionID().String(); parentID != "" {
+			if parent, ok := nodeMap[parentID]; ok {
+				parent.children = append(parent.children, node)
+				continue
+			}
+		}
+		roots = append(roots, node)
+	}
+	sortSessionLineageNodes(roots)
+
+	output := sessionLineageOutput{Roots: make([]sessionLineageNodeOutput, 0, len(roots))}
+	for _, root := range roots {
+		output.Roots = append(output.Roots, sessionLineageNodeToOutput(root, 0))
+	}
+	return output
+}
+
+func sortSessionLineageNodes(nodes []*sessionLineageNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return sessionLineageNodeLess(nodes[i], nodes[j])
+	})
+	for _, node := range nodes {
+		sortSessionLineageNodes(node.children)
+	}
+}
+
+func sessionLineageNodeLess(left, right *sessionLineageNode) bool {
+	leftOrder, leftHasOrder := left.summary.SpawnOrder().Value()
+	rightOrder, rightHasOrder := right.summary.SpawnOrder().Value()
+	if leftHasOrder && rightHasOrder && leftOrder != rightOrder {
+		return leftOrder < rightOrder
+	}
+	if leftHasOrder != rightHasOrder {
+		return leftHasOrder
+	}
+	if !left.summary.StartedAt().Equal(right.summary.StartedAt()) {
+		return left.summary.StartedAt().Before(right.summary.StartedAt())
+	}
+	return false
+}
+
+func sessionLineageNodeToOutput(node *sessionLineageNode, depth int) sessionLineageNodeOutput {
+	summary := node.summary
+	output := sessionLineageNodeOutput{
+		SessionID:       summary.SessionID().String(),
+		ParentSessionID: summary.ParentSessionID().String(),
+		SpawnEventID:    summary.SpawnEventID().String(),
+		SubagentKind:    summary.SubagentKind(),
+		Depth:           depth,
+		Workspace:       summary.Workspace().String(),
+		Label:           summary.Label(),
+		Summary:         summary.Summary(),
+		StartedAt:       summary.StartedAt().UTC().Format(time.RFC3339Nano),
+		Status:          summary.Status(),
+		TotalEvents:     summary.TotalEvents(),
+		CommandCount:    summary.CommandCount(),
+		Agents:          summary.Agents(),
+		SubagentType:    sessionLineageSubagentType(summary.Agents()),
+		Children:        make([]sessionLineageNodeOutput, 0, len(node.children)),
+	}
+	if spawnOrder, ok := summary.SpawnOrder().Value(); ok {
+		output.SpawnOrder = &spawnOrder
+	}
+	if endedAt, ok := summary.EndedAt().Value(); ok {
+		endedAtString := endedAt.UTC().Format(time.RFC3339Nano)
+		output.EndedAt = &endedAtString
+		durationSec := endedAt.Sub(summary.StartedAt()).Seconds()
+		output.DurationSec = &durationSec
+	}
+	for _, child := range node.children {
+		output.Children = append(output.Children, sessionLineageNodeToOutput(child, depth+1))
+	}
+	return output
+}
+
+func sessionLineageSubagentType(agents []string) string {
+	if len(agents) == 0 {
+		return ""
+	}
+	for _, agent := range agents {
+		if strings.Contains(agent, "/") {
+			return agent
+		}
+	}
+	return agents[0]
+}

--- a/presentation/mcpserver/tool_metadata_test.go
+++ b/presentation/mcpserver/tool_metadata_test.go
@@ -54,7 +54,7 @@ func TestServer_ToolMetadata(t *testing.T) {
 		{name: "manage_memory", want: toolMetadataExpectation{description: "Dispatch durable memory writes by action; reject and expire are destructive actions.", destructiveTrue: true}},
 		{name: "query_memory", want: toolMetadataExpectation{description: "Dispatch durable memory reads by action: retrieve, export, pack, or scan_hygiene.", readOnly: true}},
 		{name: "manage_session", want: toolMetadataExpectation{description: "Dispatch session lifecycle writes by action: start or end. action=end is destructive (closes the session).", destructiveTrue: true}},
-		{name: "session_status", want: toolMetadataExpectation{description: "Dispatch session status reads by action: active, latest, or handoff.", readOnly: true}},
+		{name: "session_status", want: toolMetadataExpectation{description: "Dispatch session status reads by action: active, latest, handoff, or lineage.", readOnly: true}},
 		{name: "record_event", want: toolMetadataExpectation{description: "Record a log or command audit event by type, returning one uniform event shape.", destructiveFalse: true}},
 		{name: "list_events", want: toolMetadataExpectation{description: "List recent events, logs, audits, prompts, transcripts, and summaries.", readOnly: true}},
 		{name: "search", want: toolMetadataExpectation{description: "Search events, logs, audits, prompts, transcripts, and summaries by text, time, or workspace.", readOnly: true}},


### PR DESCRIPTION
Wave 4 step 4: lineage query support across query service / CLI / MCP. Builds on #722-#724.

- New query service method walks from any session id to root + descendants (full tree)
- spawn_order ASC ordering for siblings; NULL spawn_order (top-level) sorted by started_at
- session tree honors spawn_order ordering

`go test ./...` 1146 pass / lint 0 issues.

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>