### PR TITLE
feat(mcp): add session_status(action='tree') for tree retrieval (#721)

### DIFF
--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -14,13 +14,15 @@ Traceary v0.10.0 が公開する MCP tool はちょうど 8 個です:
 | `manage_memory` | `propose`, `remember`, `accept`, `reject`, `expire`, `supersede`, `set_validity`, `import_instructions` | write; destructive subset: `reject`, `expire` |
 | `query_memory` | `retrieve`, `export`, `pack`, `scan_hygiene` | read |
 | `manage_session` | `start`, `end` | write |
-| `session_status` | `active`, `latest`, `handoff` | read |
+| `session_status` | `active`, `latest`, `handoff`, `tree` | read |
 | `record_event` | `type="log"` or `type="audit"` | write |
 | `list_events` | 変更なしの event listing | read |
 | `search` | 変更なしの event search | read |
 | `get_context` | 変更なしの recent-context read | read |
 
 `manage_memory.ids` は accept/reject flow 向けに単一 string と string array の両方を受け付けます。`record_event` は `type="log"` と `type="audit"` のどちらでも同じ shape を返します。
+
+`session_status(action="tree", session_id="...", depth=N)` は `session_id` を root とする session subtree を `traceary session tree --json` と同じ node array shape で返します。`depth` は任意で、`0` は root のみを返します。
 
 ## v0.10.0 移行表 (24 → 8 tools)
 
@@ -45,6 +47,7 @@ Traceary v0.10.0 が公開する MCP tool はちょうど 8 個です:
 | `active_session` | `session_status(action="active", ...)` |
 | `latest_session` | `session_status(action="latest", ...)` |
 | `session_handoff` | `session_status(action="handoff", ...)` |
+| `session tree --json --root <session-id>` | `session_status(action="tree", session_id="<session-id>", ...)` |
 | `add_log` | `record_event(type="log", ...)` |
 | `add_audit` | `record_event(type="audit", ...)` |
 | `list_events` | `list_events(...)` |

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -14,13 +14,15 @@ Traceary v0.10.0 exposes exactly 8 MCP tools:
 | `manage_memory` | `propose`, `remember`, `accept`, `reject`, `expire`, `supersede`, `set_validity`, `import_instructions` | write; destructive subset: `reject`, `expire` |
 | `query_memory` | `retrieve`, `export`, `pack`, `scan_hygiene` | read |
 | `manage_session` | `start`, `end` | write |
-| `session_status` | `active`, `latest`, `handoff` | read |
+| `session_status` | `active`, `latest`, `handoff`, `tree` | read |
 | `record_event` | `type="log"` or `type="audit"` | write |
 | `list_events` | unchanged event listing | read |
 | `search` | unchanged event search | read |
 | `get_context` | unchanged recent-context read | read |
 
 `manage_memory.ids` accepts either a single string or an array of strings for accept/reject flows. `record_event` returns one uniform shape for both `type="log"` and `type="audit"`.
+
+`session_status(action="tree", session_id="...", depth=N)` returns the JSON session subtree rooted at `session_id` using the same node array shape as `traceary session tree --json`; `depth` is optional and `0` returns only the root.
 
 ## v0.10.0 migration map (24 → 8 tools)
 
@@ -45,6 +47,7 @@ Traceary v0.10.0 exposes exactly 8 MCP tools:
 | `active_session` | `session_status(action="active", ...)` |
 | `latest_session` | `session_status(action="latest", ...)` |
 | `session_handoff` | `session_status(action="handoff", ...)` |
+| `session tree --json --root <session-id>` | `session_status(action="tree", session_id="<session-id>", ...)` |
 | `add_log` | `record_event(type="log", ...)` |
 | `add_audit` | `record_event(type="audit", ...)` |
 | `list_events` | `list_events(...)` |

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -47,7 +47,7 @@ type queryMemoryInput struct {
 
 // sessionActionInput is shared by manage_session and session_status.
 type sessionActionInput struct {
-	Action              string `json:"action" jsonschema:"required,action enum: start, end, active, latest, handoff, lineage"`
+	Action              string `json:"action" jsonschema:"required,action enum: start, end, active, latest, handoff, lineage, tree"`
 	Client              string `json:"client,omitempty" jsonschema:"recording channel or filter"`
 	Agent               string `json:"agent,omitempty" jsonschema:"actor name or filter"`
 	SessionID           string `json:"session_id,omitempty" jsonschema:"session identifier"`
@@ -60,6 +60,7 @@ type sessionActionInput struct {
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories"`
 	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp"`
+	Depth               *int   `json:"depth,omitempty" jsonschema:"maximum descendant depth for action=tree (0 returns only the root)"`
 }
 
 // recordEventInput is the MCP input for the record_event tool.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -116,7 +116,7 @@ func (s *Server) Build(ctx context.Context) (*mcp.Server, error) {
 	}, s.manageSession())
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "session_status",
-		Description: "Dispatch session status reads by action: active, latest, handoff, or lineage.",
+		Description: "Dispatch session status reads by action: active, latest, handoff, lineage, or tree.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, s.sessionStatus())
 	mcp.AddTool(server, &mcp.Tool{
@@ -319,8 +319,11 @@ func (s *Server) sessionStatus() mcp.ToolHandlerFor[sessionActionInput, any] {
 		case "lineage":
 			out, err := s.sessionLineage(ctx, input.SessionID)
 			return nil, out, err
+		case "tree":
+			out, err := s.sessionTree(ctx, input.SessionID, input.Depth)
+			return nil, out, err
 		default:
-			return nil, nil, xerrors.Errorf("session_status action must be one of active, latest, handoff, lineage")
+			return nil, nil, xerrors.Errorf("session_status action must be one of active, latest, handoff, lineage, tree")
 		}
 	}
 }
@@ -335,6 +338,21 @@ func (s *Server) sessionLineage(ctx context.Context, sessionID string) (sessionL
 		return sessionLineageOutput{}, xerrors.Errorf("failed to get session lineage: %w", err)
 	}
 	return newSessionLineageOutput(summaries), nil
+}
+
+func (s *Server) sessionTree(ctx context.Context, sessionID string, depth *int) ([]sessionLineageNodeOutput, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return nil, xerrors.Errorf("session_status action tree requires session_id")
+	}
+	if depth != nil && *depth < 0 {
+		return nil, xerrors.Errorf("session_status action tree requires depth to be greater than or equal to 0")
+	}
+	summaries, err := s.session.Lineage(ctx, types.SessionID(trimmedSessionID))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get session tree: %w", err)
+	}
+	return newSessionTreeOutput(summaries, trimmedSessionID, depth), nil
 }
 
 func (s *Server) recordEvent() mcp.ToolHandlerFor[recordEventInput, recordEventOutput] {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -2,6 +2,7 @@ package mcpserver_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -20,7 +21,7 @@ import (
 func TestServer_BuildAndTools(t *testing.T) {
 	t.Parallel()
 
-	server := newTestServer(t)
+	server, dbPath := newTestServerWithDBPath(t)
 	ctx := context.Background()
 	mcpServer, err := server.Build(ctx)
 	if err != nil {
@@ -353,6 +354,81 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 		if !missingIDResult.IsError {
 			t.Fatalf("CallTool(session_status tree missing id) IsError = false, want true")
+		}
+	})
+
+	t.Run("session_status tree handles stored cyclic parent links", func(t *testing.T) {
+		startSession := func(sessionID, parentSessionID string) {
+			t.Helper()
+			args := map[string]any{
+				"action":     "start",
+				"session_id": sessionID,
+				"agent":      "codex",
+				"workspace":  "github.com/duck8823/traceary",
+			}
+			if parentSessionID != "" {
+				args["parent_session_id"] = parentSessionID
+			}
+			result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "manage_session",
+				Arguments: args,
+			})
+			if err != nil {
+				t.Fatalf("CallTool(manage_session start %s) error = %v", sessionID, err)
+			}
+			if result.IsError {
+				t.Fatalf("CallTool(manage_session start %s) returned tool error", sessionID)
+			}
+		}
+
+		startSession("cycle-a", "")
+		startSession("cycle-b", "cycle-a")
+		updateSessionParentForMCPTest(ctx, t, dbPath, "cycle-a", "cycle-b")
+
+		treeResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action":     "tree",
+				"session_id": "cycle-a",
+				"depth":      500,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_status tree cycle) error = %v", err)
+		}
+		if treeResult.IsError {
+			t.Fatalf("CallTool(session_status tree cycle) returned tool error")
+		}
+
+		roots := decodeJSONArrayPayload(t, treeResult)
+		if len(roots) != 1 {
+			t.Fatalf("cycle tree roots len = %d, want 1", len(roots))
+		}
+		root := roots[0].(map[string]any)
+		if diff := cmp.Diff("cycle-a", root["session_id"]); diff != "" {
+			t.Fatalf("cycle root session_id mismatch (-want +got):\n%s", diff)
+		}
+		children := root["children"].([]any)
+		if len(children) != 1 {
+			t.Fatalf("cycle root children len = %d, want 1", len(children))
+		}
+		child := children[0].(map[string]any)
+		if diff := cmp.Diff("cycle-b", child["session_id"]); diff != "" {
+			t.Fatalf("cycle child session_id mismatch (-want +got):\n%s", diff)
+		}
+		grandchildren := child["children"].([]any)
+		if len(grandchildren) != 1 {
+			t.Fatalf("cycle child children len = %d, want 1", len(grandchildren))
+		}
+		cycleNode := grandchildren[0].(map[string]any)
+		if diff := cmp.Diff("cycle-a", cycleNode["session_id"]); diff != "" {
+			t.Fatalf("cycle marker session_id mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("cycle-detected", cycleNode["status"]); diff != "" {
+			t.Fatalf("cycle marker status mismatch (-want +got):\n%s", diff)
+		}
+		if descendants := cycleNode["children"].([]any); len(descendants) != 0 {
+			t.Fatalf("cycle marker children len = %d, want 0", len(descendants))
 		}
 	})
 
@@ -1056,6 +1132,24 @@ func decodeJSONArrayPayload(t *testing.T, result *mcp.CallToolResult) []any {
 
 func newTestServer(t *testing.T) *mcpserver.Server {
 	t.Helper()
+	server, _ := newTestServerWithDBPath(t)
+	return server
+}
+
+func updateSessionParentForMCPTest(ctx context.Context, t *testing.T, dbPath string, sessionID string, parentID string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, "UPDATE sessions SET parent_session_id = ? WHERE session_id = ?", parentID, sessionID); err != nil {
+		t.Fatalf("UPDATE sessions parent_session_id error = %v", err)
+	}
+}
+
+func newTestServerWithDBPath(t *testing.T) (*mcpserver.Server, string) {
+	t.Helper()
 
 	migrations := fstest.MapFS{
 		"000001_init.sql": {
@@ -1192,5 +1286,5 @@ CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
-	return server
+	return server, dbPath
 }

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -227,6 +227,135 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("session_status tree returns subtree rooted at session_id", func(t *testing.T) {
+		startSession := func(sessionID, parentSessionID, agent string) {
+			t.Helper()
+			args := map[string]any{
+				"action":     "start",
+				"session_id": sessionID,
+				"agent":      agent,
+				"workspace":  "github.com/duck8823/traceary",
+			}
+			if parentSessionID != "" {
+				args["parent_session_id"] = parentSessionID
+			}
+			result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+				Name:      "manage_session",
+				Arguments: args,
+			})
+			if err != nil {
+				t.Fatalf("CallTool(manage_session start %s) error = %v", sessionID, err)
+			}
+			if result.IsError {
+				t.Fatalf("CallTool(manage_session start %s) returned tool error", sessionID)
+			}
+		}
+
+		startSession("tree-root", "", "codex")
+		startSession("tree-child-a", "tree-root", "codex/explorer")
+		startSession("tree-child-b", "tree-root", "codex/worker")
+		startSession("tree-grandchild", "tree-child-a", "codex/reviewer")
+
+		treeResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action":     "tree",
+				"session_id": "tree-root",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_status tree) error = %v", err)
+		}
+		if treeResult.IsError {
+			t.Fatalf("CallTool(session_status tree) returned tool error")
+		}
+
+		roots := decodeJSONArrayPayload(t, treeResult)
+		if len(roots) != 1 {
+			t.Fatalf("tree roots len = %d, want 1", len(roots))
+		}
+		root, ok := roots[0].(map[string]any)
+		if !ok {
+			t.Fatalf("root type = %T, want map[string]any", roots[0])
+		}
+		if diff := cmp.Diff("tree-root", root["session_id"]); diff != "" {
+			t.Fatalf("root session_id mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(float64(0), root["depth"]); diff != "" {
+			t.Fatalf("root depth mismatch (-want +got):\n%s", diff)
+		}
+
+		children, ok := root["children"].([]any)
+		if !ok || len(children) != 2 {
+			t.Fatalf("root children = %T len=%d, want 2", root["children"], len(children))
+		}
+		childrenByID := map[string]map[string]any{}
+		for _, childValue := range children {
+			child, ok := childValue.(map[string]any)
+			if !ok {
+				t.Fatalf("child type = %T, want map[string]any", childValue)
+			}
+			childrenByID[child["session_id"].(string)] = child
+			if diff := cmp.Diff("tree-root", child["parent_session_id"]); diff != "" {
+				t.Fatalf("child parent_session_id mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(float64(1), child["depth"]); diff != "" {
+				t.Fatalf("child depth mismatch (-want +got):\n%s", diff)
+			}
+		}
+		childA := childrenByID["tree-child-a"]
+		if childA == nil {
+			t.Fatalf("tree-child-a missing from children: %#v", childrenByID)
+		}
+		grandchildren, ok := childA["children"].([]any)
+		if !ok || len(grandchildren) != 1 {
+			t.Fatalf("tree-child-a children = %T len=%d, want 1", childA["children"], len(grandchildren))
+		}
+		grandchild := grandchildren[0].(map[string]any)
+		if diff := cmp.Diff("tree-grandchild", grandchild["session_id"]); diff != "" {
+			t.Fatalf("grandchild session_id mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(float64(2), grandchild["depth"]); diff != "" {
+			t.Fatalf("grandchild depth mismatch (-want +got):\n%s", diff)
+		}
+
+		depthResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action":     "tree",
+				"session_id": "tree-root",
+				"depth":      1,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_status tree depth) error = %v", err)
+		}
+		if depthResult.IsError {
+			t.Fatalf("CallTool(session_status tree depth) returned tool error")
+		}
+		depthRoots := decodeJSONArrayPayload(t, depthResult)
+		depthRoot := depthRoots[0].(map[string]any)
+		for _, childValue := range depthRoot["children"].([]any) {
+			child := childValue.(map[string]any)
+			if grandchildren := child["children"].([]any); len(grandchildren) != 0 {
+				t.Fatalf("depth-limited child %s has %d grandchildren, want 0", child["session_id"], len(grandchildren))
+			}
+		}
+
+		missingIDResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action": "tree",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_status tree missing id) protocol error = %v", err)
+		}
+		if !missingIDResult.IsError {
+			t.Fatalf("CallTool(session_status tree missing id) IsError = false, want true")
+		}
+	})
+
 	t.Run("memory tools manage lifecycle and retrieval", func(t *testing.T) {
 		proposeResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "manage_memory",
@@ -900,6 +1029,25 @@ func decodeJSONPayload(t *testing.T, result *mcp.CallToolResult) map[string]any 
 	}
 
 	payload := map[string]any{}
+	if err := json.Unmarshal([]byte(textContent.Text), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	return payload
+}
+
+func decodeJSONArrayPayload(t *testing.T, result *mcp.CallToolResult) []any {
+	t.Helper()
+
+	if len(result.Content) == 0 {
+		t.Fatalf("tool result content is empty")
+	}
+
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type: %T", result.Content[0])
+	}
+
+	payload := []any{}
 	if err := json.Unmarshal([]byte(textContent.Text), &payload); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}

--- a/presentation/mcpserver/session_lineage.go
+++ b/presentation/mcpserver/session_lineage.go
@@ -14,6 +14,24 @@ type sessionLineageNode struct {
 }
 
 func newSessionLineageOutput(summaries []apptypes.SessionSummary) sessionLineageOutput {
+	_, roots := buildSessionLineageNodes(summaries)
+	output := sessionLineageOutput{Roots: make([]sessionLineageNodeOutput, 0, len(roots))}
+	for _, root := range roots {
+		output.Roots = append(output.Roots, sessionLineageNodeToOutput(root, 0))
+	}
+	return output
+}
+
+func newSessionTreeOutput(summaries []apptypes.SessionSummary, rootSessionID string, depthLimit *int) []sessionLineageNodeOutput {
+	nodeMap, _ := buildSessionLineageNodes(summaries)
+	root, ok := nodeMap[rootSessionID]
+	if !ok {
+		return []sessionLineageNodeOutput{}
+	}
+	return []sessionLineageNodeOutput{sessionLineageNodeToOutputWithDepthLimit(root, 0, depthLimit)}
+}
+
+func buildSessionLineageNodes(summaries []apptypes.SessionSummary) (map[string]*sessionLineageNode, []*sessionLineageNode) {
 	nodeMap := make(map[string]*sessionLineageNode, len(summaries))
 	roots := make([]*sessionLineageNode, 0)
 	for _, summary := range summaries {
@@ -30,12 +48,7 @@ func newSessionLineageOutput(summaries []apptypes.SessionSummary) sessionLineage
 		roots = append(roots, node)
 	}
 	sortSessionLineageNodes(roots)
-
-	output := sessionLineageOutput{Roots: make([]sessionLineageNodeOutput, 0, len(roots))}
-	for _, root := range roots {
-		output.Roots = append(output.Roots, sessionLineageNodeToOutput(root, 0))
-	}
-	return output
+	return nodeMap, roots
 }
 
 func sortSessionLineageNodes(nodes []*sessionLineageNode) {
@@ -63,6 +76,10 @@ func sessionLineageNodeLess(left, right *sessionLineageNode) bool {
 }
 
 func sessionLineageNodeToOutput(node *sessionLineageNode, depth int) sessionLineageNodeOutput {
+	return sessionLineageNodeToOutputWithDepthLimit(node, depth, nil)
+}
+
+func sessionLineageNodeToOutputWithDepthLimit(node *sessionLineageNode, depth int, depthLimit *int) sessionLineageNodeOutput {
 	summary := node.summary
 	output := sessionLineageNodeOutput{
 		SessionID:       summary.SessionID().String(),
@@ -90,8 +107,10 @@ func sessionLineageNodeToOutput(node *sessionLineageNode, depth int) sessionLine
 		durationSec := endedAt.Sub(summary.StartedAt()).Seconds()
 		output.DurationSec = &durationSec
 	}
-	for _, child := range node.children {
-		output.Children = append(output.Children, sessionLineageNodeToOutput(child, depth+1))
+	if depthLimit == nil || depth < *depthLimit {
+		for _, child := range node.children {
+			output.Children = append(output.Children, sessionLineageNodeToOutputWithDepthLimit(child, depth+1, depthLimit))
+		}
 	}
 	return output
 }

--- a/presentation/mcpserver/session_lineage.go
+++ b/presentation/mcpserver/session_lineage.go
@@ -8,6 +8,8 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
+const maxSessionTreeDepth = 100
+
 type sessionLineageNode struct {
 	summary  apptypes.SessionSummary
 	children []*sessionLineageNode
@@ -28,7 +30,7 @@ func newSessionTreeOutput(summaries []apptypes.SessionSummary, rootSessionID str
 	if !ok {
 		return []sessionLineageNodeOutput{}
 	}
-	return []sessionLineageNodeOutput{sessionLineageNodeToOutputWithDepthLimit(root, 0, depthLimit)}
+	return []sessionLineageNodeOutput{sessionLineageNodeToOutputWithDepthLimit(root, 0, effectiveSessionTreeDepthLimit(depthLimit), map[string]bool{})}
 }
 
 func buildSessionLineageNodes(summaries []apptypes.SessionSummary) (map[string]*sessionLineageNode, []*sessionLineageNode) {
@@ -52,11 +54,21 @@ func buildSessionLineageNodes(summaries []apptypes.SessionSummary) (map[string]*
 }
 
 func sortSessionLineageNodes(nodes []*sessionLineageNode) {
+	sortSessionLineageNodesWithVisited(nodes, map[string]bool{})
+}
+
+func sortSessionLineageNodesWithVisited(nodes []*sessionLineageNode, visited map[string]bool) {
 	sort.SliceStable(nodes, func(i, j int) bool {
 		return sessionLineageNodeLess(nodes[i], nodes[j])
 	})
 	for _, node := range nodes {
-		sortSessionLineageNodes(node.children)
+		sessionID := node.summary.SessionID().String()
+		if visited[sessionID] {
+			continue
+		}
+		visited[sessionID] = true
+		sortSessionLineageNodesWithVisited(node.children, visited)
+		delete(visited, sessionID)
 	}
 }
 
@@ -76,13 +88,22 @@ func sessionLineageNodeLess(left, right *sessionLineageNode) bool {
 }
 
 func sessionLineageNodeToOutput(node *sessionLineageNode, depth int) sessionLineageNodeOutput {
-	return sessionLineageNodeToOutputWithDepthLimit(node, depth, nil)
+	return sessionLineageNodeToOutputWithDepthLimit(node, depth, maxSessionTreeDepth, map[string]bool{})
 }
 
-func sessionLineageNodeToOutputWithDepthLimit(node *sessionLineageNode, depth int, depthLimit *int) sessionLineageNodeOutput {
+func effectiveSessionTreeDepthLimit(depthLimit *int) int {
+	if depthLimit == nil || *depthLimit > maxSessionTreeDepth {
+		return maxSessionTreeDepth
+	}
+	return *depthLimit
+}
+
+func sessionLineageNodeToOutputWithDepthLimit(node *sessionLineageNode, depth int, depthLimit int, visited map[string]bool) sessionLineageNodeOutput {
 	summary := node.summary
+	sessionID := summary.SessionID().String()
+	cycleDetected := visited[sessionID]
 	output := sessionLineageNodeOutput{
-		SessionID:       summary.SessionID().String(),
+		SessionID:       sessionID,
 		ParentSessionID: summary.ParentSessionID().String(),
 		SpawnEventID:    summary.SpawnEventID().String(),
 		SubagentKind:    summary.SubagentKind(),
@@ -107,10 +128,16 @@ func sessionLineageNodeToOutputWithDepthLimit(node *sessionLineageNode, depth in
 		durationSec := endedAt.Sub(summary.StartedAt()).Seconds()
 		output.DurationSec = &durationSec
 	}
-	if depthLimit == nil || depth < *depthLimit {
+	if cycleDetected {
+		output.Status = "cycle-detected"
+		return output
+	}
+	if depth < depthLimit {
+		visited[sessionID] = true
 		for _, child := range node.children {
-			output.Children = append(output.Children, sessionLineageNodeToOutputWithDepthLimit(child, depth+1, depthLimit))
+			output.Children = append(output.Children, sessionLineageNodeToOutputWithDepthLimit(child, depth+1, depthLimit, visited))
 		}
+		delete(visited, sessionID)
 	}
 	return output
 }

--- a/presentation/mcpserver/tool_metadata_test.go
+++ b/presentation/mcpserver/tool_metadata_test.go
@@ -54,7 +54,7 @@ func TestServer_ToolMetadata(t *testing.T) {
 		{name: "manage_memory", want: toolMetadataExpectation{description: "Dispatch durable memory writes by action; reject and expire are destructive actions.", destructiveTrue: true}},
 		{name: "query_memory", want: toolMetadataExpectation{description: "Dispatch durable memory reads by action: retrieve, export, pack, or scan_hygiene.", readOnly: true}},
 		{name: "manage_session", want: toolMetadataExpectation{description: "Dispatch session lifecycle writes by action: start or end. action=end is destructive (closes the session).", destructiveTrue: true}},
-		{name: "session_status", want: toolMetadataExpectation{description: "Dispatch session status reads by action: active, latest, handoff, or lineage.", readOnly: true}},
+		{name: "session_status", want: toolMetadataExpectation{description: "Dispatch session status reads by action: active, latest, handoff, lineage, or tree.", readOnly: true}},
 		{name: "record_event", want: toolMetadataExpectation{description: "Record a log or command audit event by type, returning one uniform event shape.", destructiveFalse: true}},
 		{name: "list_events", want: toolMetadataExpectation{description: "List recent events, logs, audits, prompts, transcripts, and summaries.", readOnly: true}},
 		{name: "search", want: toolMetadataExpectation{description: "Search events, logs, audits, prompts, transcripts, and summaries by text, time, or workspace.", readOnly: true}},


### PR DESCRIPTION
Extends the consolidated 8-tool namespace from #708 with a new `tree` action on `session_status` rather than adding a 9th tool.

- `session_status(action="tree", session_id, depth?)` returns the session tree
- Output mirrors the CLI session tree --json shape from #720
- Per-action validation: `tree` requires `session_id`
- docs/mcp/README.{md,ja.md} updated

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>