### PR TITLE
feat(bundle): export/import sessions + command_audits (#738)

### DIFF
--- a/application/usecase/bundle_usecase.go
+++ b/application/usecase/bundle_usecase.go
@@ -267,6 +267,7 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 	if err != nil {
 		return xerrors.Errorf("failed to list sessions for bundle: %w", err)
 	}
+	sessions = filterSessionsForBundleExport(sessions, events, opts)
 	commandAudits, err := u.repository.ListBundleCommandAudits(ctx)
 	if err != nil {
 		return xerrors.Errorf("failed to list command audits for bundle: %w", err)
@@ -1151,6 +1152,48 @@ func encodeCommandAuditsNDJSON(audits []*model.CommandAudit) (*bytes.Buffer, err
 		}
 	}
 	return buf, nil
+}
+
+func filterSessionsForBundleExport(sessions []*model.Session, events []*model.Event, opts BundleExportOptions) []*model.Session {
+	referencedSessionIDs := make(map[string]struct{}, len(events))
+	for _, event := range events {
+		referencedSessionIDs[event.SessionID().String()] = struct{}{}
+	}
+
+	filtered := make([]*model.Session, 0, len(sessions))
+	includedSessionIDs := make(map[string]struct{}, len(sessions))
+	for _, session := range sessions {
+		if sessionMatchesBundleExportFilters(session, opts) {
+			filtered = append(filtered, session)
+			includedSessionIDs[session.SessionID().String()] = struct{}{}
+		}
+	}
+
+	for _, session := range sessions {
+		sessionID := session.SessionID().String()
+		if _, referenced := referencedSessionIDs[sessionID]; !referenced {
+			continue
+		}
+		if _, alreadyIncluded := includedSessionIDs[sessionID]; alreadyIncluded {
+			continue
+		}
+		filtered = append(filtered, session)
+		includedSessionIDs[sessionID] = struct{}{}
+	}
+	return filtered
+}
+
+func sessionMatchesBundleExportFilters(session *model.Session, opts BundleExportOptions) bool {
+	if opts.Workspace.String() != "" && session.Workspace() != opts.Workspace {
+		return false
+	}
+	if !opts.Since.IsZero() && session.StartedAt().Before(opts.Since) {
+		return false
+	}
+	if !opts.Until.IsZero() && !session.StartedAt().Before(opts.Until) {
+		return false
+	}
+	return true
 }
 
 func filterCommandAuditsForEvents(audits []*model.CommandAudit, events []*model.Event) []*model.CommandAudit {

--- a/application/usecase/bundle_usecase.go
+++ b/application/usecase/bundle_usecase.go
@@ -131,8 +131,12 @@ type BundleImportResult struct {
 	// EventsImported / EventsSkipped count events that were newly
 	// written vs dropped because of a pre-existing (event_id)
 	// collision.
-	EventsImported int
-	EventsSkipped  int
+	EventsImported        int
+	EventsSkipped         int
+	SessionsImported      int
+	SessionsSkipped       int
+	CommandAuditsImported int
+	CommandAuditsSkipped  int
 	// MemoriesImported / MemoriesSkipped count durable memories that were newly
 	// written vs dropped because of a pre-existing memory id collision.
 	MemoriesImported int
@@ -198,6 +202,8 @@ var (
 type BundleEventRepository interface {
 	// SchemaVersion is the current schema_migrations max version.
 	SchemaVersion(ctx context.Context) (int, error)
+	ListBundleSessions(ctx context.Context) ([]*model.Session, error)
+	ListBundleCommandAudits(ctx context.Context) ([]*model.CommandAudit, error)
 	// ListBundleMemories returns all durable memories and their refs for bundle export.
 	ListBundleMemories(ctx context.Context) ([]apptypes.MemoryDetails, error)
 	// BeginBundleImport starts the single transaction used by all table
@@ -208,7 +214,9 @@ type BundleEventRepository interface {
 // BundleImportTransaction is the write-side transaction shared by all
 // bundle table importers.
 type BundleImportTransaction interface {
+	ImportSession(ctx context.Context, session *model.Session, policy BundleConflictPolicy, missingParent BundleMissingParentPolicy) (bool, error)
 	ImportEvent(ctx context.Context, event *model.Event, policy BundleConflictPolicy) (bool, error)
+	ImportCommandAudit(ctx context.Context, audit *model.CommandAudit, policy BundleConflictPolicy) (bool, error)
 	ImportMemory(ctx context.Context, memory *model.Memory, policy BundleConflictPolicy) (bool, error)
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
@@ -255,19 +263,38 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 		return xerrors.Errorf("failed to list events for bundle: %w", err)
 	}
 
+	sessions, err := u.repository.ListBundleSessions(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to list sessions for bundle: %w", err)
+	}
+	commandAudits, err := u.repository.ListBundleCommandAudits(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to list command audits for bundle: %w", err)
+	}
+	commandAudits = filterCommandAuditsForEvents(commandAudits, events)
 	memories, err := u.repository.ListBundleMemories(ctx)
 	if err != nil {
 		return xerrors.Errorf("failed to list memories for bundle: %w", err)
 	}
 
 	registry := u.bundleTableRegistry()
+	sessionsImporter := registry["sessions"]
+	sessionsBuf, err := sessionsImporter.Export(ctx, bundleExportInputRows{Sessions: sessions})
+	if err != nil {
+		return xerrors.Errorf("failed to encode sessions: %w", err)
+	}
 	eventsImporter := registry["events"]
-	eventsBuf, err := eventsImporter.Export(ctx, events, nil)
+	eventsBuf, err := eventsImporter.Export(ctx, bundleExportInputRows{Events: events})
 	if err != nil {
 		return xerrors.Errorf("failed to encode events: %w", err)
 	}
+	commandAuditsImporter := registry["command_audits"]
+	commandAuditsBuf, err := commandAuditsImporter.Export(ctx, bundleExportInputRows{CommandAudits: commandAudits})
+	if err != nil {
+		return xerrors.Errorf("failed to encode command audits: %w", err)
+	}
 	memoriesImporter := registry["memories"]
-	memoriesBuf, err := memoriesImporter.Export(ctx, nil, memories)
+	memoriesBuf, err := memoriesImporter.Export(ctx, bundleExportInputRows{Memories: memories})
 	if err != nil {
 		return xerrors.Errorf("failed to encode memories: %w", err)
 	}
@@ -288,11 +315,23 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 			Workspace: opts.Workspace.String(),
 		},
 		Tables: map[string]bundleTableEntry{
+			"sessions": {
+				TableName: "sessions",
+				File:      sessionsImporter.FileName(),
+				RowCount:  len(sessions),
+				Checksum:  hashSHA256(sessionsBuf.Bytes()),
+			},
 			"events": {
 				TableName: "events",
 				File:      eventsImporter.FileName(),
 				RowCount:  len(events),
 				Checksum:  hashSHA256(eventsBuf.Bytes()),
+			},
+			"command_audits": {
+				TableName: "command_audits",
+				File:      commandAuditsImporter.FileName(),
+				RowCount:  len(commandAudits),
+				Checksum:  hashSHA256(commandAuditsBuf.Bytes()),
 			},
 			"memories": {
 				TableName: "memories",
@@ -308,9 +347,11 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 	}
 
 	plaintext, err := encodeTarGz(map[string][]byte{
-		"manifest.json":   manifestBytes,
-		"events.ndjson":   eventsBuf.Bytes(),
-		"memories.ndjson": memoriesBuf.Bytes(),
+		"manifest.json":         manifestBytes,
+		"sessions.ndjson":       sessionsBuf.Bytes(),
+		"events.ndjson":         eventsBuf.Bytes(),
+		"command_audits.ndjson": commandAuditsBuf.Bytes(),
+		"memories.ndjson":       memoriesBuf.Bytes(),
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to build tar.gz: %w", err)
@@ -336,7 +377,8 @@ func (u *bundleUsecase) Import(ctx context.Context, opts BundleImportOptions) (B
 	if err != nil {
 		return BundleImportResult{}, err
 	}
-	if _, err := opts.MissingParent.normalized(); err != nil {
+	missingParent, err := opts.MissingParent.normalized()
+	if err != nil {
 		return BundleImportResult{}, err
 	}
 	encrypted, err := os.ReadFile(opts.InPath)
@@ -412,14 +454,20 @@ func (u *bundleUsecase) Import(ctx context.Context, opts BundleImportOptions) (B
 				entry.TableName, entry.RowCount, len(rows),
 			)
 		}
-		imported, skipped, err := importer.Apply(ctx, tx, rows, onConflict)
+		imported, skipped, err := importer.Apply(ctx, tx, rows, bundleImportPolicy{OnConflict: onConflict, MissingParent: missingParent})
 		if err != nil {
 			return result, xerrors.Errorf("failed to import %s: %w", entry.TableName, err)
 		}
 		switch entry.TableName {
+		case "sessions":
+			result.SessionsImported += imported
+			result.SessionsSkipped += skipped
 		case "events":
 			result.EventsImported += imported
 			result.EventsSkipped += skipped
+		case "command_audits":
+			result.CommandAuditsImported += imported
+			result.CommandAuditsSkipped += skipped
 		case "memories":
 			result.MemoriesImported += imported
 			result.MemoriesSkipped += skipped
@@ -436,21 +484,94 @@ func (u *bundleUsecase) Import(ctx context.Context, opts BundleImportOptions) (B
 
 type bundleRow any
 
+type bundleExportInputRows struct {
+	Sessions      []*model.Session
+	Events        []*model.Event
+	CommandAudits []*model.CommandAudit
+	Memories      []apptypes.MemoryDetails
+}
+
+type bundleImportPolicy struct {
+	OnConflict    BundleConflictPolicy
+	MissingParent BundleMissingParentPolicy
+}
+
 type bundleTableImporter interface {
 	Name() string
 	FileName() string
-	Export(context.Context, []*model.Event, []apptypes.MemoryDetails) (*bytes.Buffer, error)
+	Export(context.Context, bundleExportInputRows) (*bytes.Buffer, error)
 	Decode(io.Reader) ([]bundleRow, error)
-	Apply(context.Context, BundleImportTransaction, []bundleRow, BundleConflictPolicy) (imported int, skipped int, err error)
+	Apply(context.Context, BundleImportTransaction, []bundleRow, bundleImportPolicy) (imported int, skipped int, err error)
 }
 
 func (u *bundleUsecase) bundleTableRegistry() map[string]bundleTableImporter {
+	sessions := bundleSessionsTable{}
 	events := bundleEventsTable{}
+	commandAudits := bundleCommandAuditsTable{}
 	memories := bundleMemoriesTable{}
 	return map[string]bundleTableImporter{
-		events.Name():   events,
-		memories.Name(): memories,
+		sessions.Name():      sessions,
+		events.Name():        events,
+		commandAudits.Name(): commandAudits,
+		memories.Name():      memories,
 	}
+}
+
+func bundleTableImportOrder() []string {
+	return []string{"sessions", "events", "command_audits", "memories"}
+}
+
+type bundleSessionsTable struct{}
+
+func (bundleSessionsTable) Name() string { return "sessions" }
+
+func (bundleSessionsTable) FileName() string { return "sessions.ndjson" }
+
+func (bundleSessionsTable) Export(_ context.Context, input bundleExportInputRows) (*bytes.Buffer, error) {
+	return encodeSessionsNDJSON(input.Sessions)
+}
+
+func (bundleSessionsTable) Decode(r io.Reader) ([]bundleRow, error) {
+	decoder := json.NewDecoder(r)
+	rows := []bundleRow{}
+	for decoder.More() {
+		var row bundleSessionRow
+		if err := decoder.Decode(&row); err != nil {
+			return nil, xerrors.Errorf("session row: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (bundleSessionsTable) Apply(
+	ctx context.Context,
+	tx BundleImportTransaction,
+	rows []bundleRow,
+	policy bundleImportPolicy,
+) (int, int, error) {
+	sortedRows, err := sortBundleSessionRows(rows)
+	if err != nil {
+		return 0, 0, err
+	}
+	imported := 0
+	skipped := 0
+	for _, row := range sortedRows {
+		session, err := row.toSession()
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("restore session: %w", err)
+		}
+		didImport, err := tx.ImportSession(ctx, session, policy.OnConflict, policy.MissingParent)
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("session %s: %w", session.SessionID(), err)
+		}
+		if didImport {
+			imported++
+		} else {
+			skipped++
+		}
+	}
+	return imported, skipped, nil
 }
 
 type bundleEventsTable struct{}
@@ -459,8 +580,8 @@ func (bundleEventsTable) Name() string { return "events" }
 
 func (bundleEventsTable) FileName() string { return "events.ndjson" }
 
-func (bundleEventsTable) Export(_ context.Context, events []*model.Event, _ []apptypes.MemoryDetails) (*bytes.Buffer, error) {
-	return encodeEventsNDJSON(events)
+func (bundleEventsTable) Export(_ context.Context, input bundleExportInputRows) (*bytes.Buffer, error) {
+	return encodeEventsNDJSON(input.Events)
 }
 
 func (bundleEventsTable) Decode(r io.Reader) ([]bundleRow, error) {
@@ -480,7 +601,7 @@ func (bundleEventsTable) Apply(
 	ctx context.Context,
 	tx BundleImportTransaction,
 	rows []bundleRow,
-	policy BundleConflictPolicy,
+	policy bundleImportPolicy,
 ) (int, int, error) {
 	imported := 0
 	skipped := 0
@@ -493,9 +614,62 @@ func (bundleEventsTable) Apply(
 		if err != nil {
 			return imported, skipped, xerrors.Errorf("restore event: %w", err)
 		}
-		didImport, err := tx.ImportEvent(ctx, event, policy)
+		didImport, err := tx.ImportEvent(ctx, event, policy.OnConflict)
 		if err != nil {
 			return imported, skipped, xerrors.Errorf("event %s: %w", event.EventID(), err)
+		}
+		if didImport {
+			imported++
+		} else {
+			skipped++
+		}
+	}
+	return imported, skipped, nil
+}
+
+type bundleCommandAuditsTable struct{}
+
+func (bundleCommandAuditsTable) Name() string { return "command_audits" }
+
+func (bundleCommandAuditsTable) FileName() string { return "command_audits.ndjson" }
+
+func (bundleCommandAuditsTable) Export(_ context.Context, input bundleExportInputRows) (*bytes.Buffer, error) {
+	return encodeCommandAuditsNDJSON(input.CommandAudits)
+}
+
+func (bundleCommandAuditsTable) Decode(r io.Reader) ([]bundleRow, error) {
+	decoder := json.NewDecoder(r)
+	rows := []bundleRow{}
+	for decoder.More() {
+		var row bundleCommandAuditRow
+		if err := decoder.Decode(&row); err != nil {
+			return nil, xerrors.Errorf("command audit row: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (bundleCommandAuditsTable) Apply(
+	ctx context.Context,
+	tx BundleImportTransaction,
+	rows []bundleRow,
+	policy bundleImportPolicy,
+) (int, int, error) {
+	imported := 0
+	skipped := 0
+	for _, generic := range rows {
+		row, ok := generic.(bundleCommandAuditRow)
+		if !ok {
+			return imported, skipped, xerrors.Errorf("unexpected command_audits row type %T", generic)
+		}
+		audit, err := row.toCommandAudit()
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("restore command audit: %w", err)
+		}
+		didImport, err := tx.ImportCommandAudit(ctx, audit, policy.OnConflict)
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("command audit %s: %w", audit.EventID(), err)
 		}
 		if didImport {
 			imported++
@@ -512,8 +686,8 @@ func (bundleMemoriesTable) Name() string { return "memories" }
 
 func (bundleMemoriesTable) FileName() string { return "memories.ndjson" }
 
-func (bundleMemoriesTable) Export(_ context.Context, _ []*model.Event, memories []apptypes.MemoryDetails) (*bytes.Buffer, error) {
-	return encodeMemoriesNDJSON(memories)
+func (bundleMemoriesTable) Export(_ context.Context, input bundleExportInputRows) (*bytes.Buffer, error) {
+	return encodeMemoriesNDJSON(input.Memories)
 }
 
 func (bundleMemoriesTable) Decode(r io.Reader) ([]bundleRow, error) {
@@ -533,7 +707,7 @@ func (bundleMemoriesTable) Apply(
 	ctx context.Context,
 	tx BundleImportTransaction,
 	rows []bundleRow,
-	policy BundleConflictPolicy,
+	policy bundleImportPolicy,
 ) (int, int, error) {
 	sortedRows, err := topologicallySortBundleMemoryRows(rows)
 	if err != nil {
@@ -546,7 +720,7 @@ func (bundleMemoriesTable) Apply(
 		if err != nil {
 			return imported, skipped, xerrors.Errorf("restore memory: %w", err)
 		}
-		didImport, err := tx.ImportMemory(ctx, memory, policy)
+		didImport, err := tx.ImportMemory(ctx, memory, policy.OnConflict)
 		if err != nil {
 			return imported, skipped, xerrors.Errorf("memory %s: %w", memory.MemoryID(), err)
 		}
@@ -594,13 +768,17 @@ func manifestTableEntries(
 		if len(manifest.Tables) == 0 {
 			return nil, xerrors.Errorf("bundle manifest has no table entries")
 		}
-		names := make([]string, 0, len(manifest.Tables))
 		for name := range manifest.Tables {
-			names = append(names, name)
+			if _, ok := registry[name]; !ok {
+				return nil, xerrors.Errorf("bundle table %s is not supported by this build", name)
+			}
 		}
-		sort.Strings(names)
+		names := bundleTableImportOrder()
 		entries := make([]bundleTableEntry, 0, len(names))
 		for _, name := range names {
+			if _, present := manifest.Tables[name]; !present {
+				continue
+			}
 			entry := manifest.Tables[name]
 			if entry.TableName == "" {
 				entry.TableName = name
@@ -664,6 +842,31 @@ type bundleEventRow struct {
 	Body       string `json:"body"`
 	SourceHook string `json:"source_hook,omitempty"`
 	CreatedAt  string `json:"created_at"`
+}
+
+type bundleSessionRow struct {
+	SessionID       string `json:"session_id"`
+	StartedAt       string `json:"started_at"`
+	EndedAt         string `json:"ended_at,omitempty"`
+	Client          string `json:"client"`
+	Agent           string `json:"agent"`
+	Workspace       string `json:"workspace"`
+	Label           string `json:"label,omitempty"`
+	Summary         string `json:"summary,omitempty"`
+	ParentSessionID string `json:"parent_session_id,omitempty"`
+	SpawnEventID    string `json:"spawn_event_id,omitempty"`
+	SubagentKind    string `json:"subagent_kind,omitempty"`
+	SpawnOrder      *int   `json:"spawn_order,omitempty"`
+}
+
+type bundleCommandAuditRow struct {
+	EventID         string `json:"event_id"`
+	Command         string `json:"command"`
+	Input           string `json:"input"`
+	Output          string `json:"output"`
+	InputTruncated  bool   `json:"input_truncated"`
+	OutputTruncated bool   `json:"output_truncated"`
+	ExitCode        *int   `json:"exit_code,omitempty"`
 }
 
 type bundleRefRow struct {
@@ -769,6 +972,63 @@ func (r bundleMemoryRow) toMemory() (*model.Memory, error) {
 	return model.MemoryOf(memoryID, memoryType, scope, r.Fact, status, confidence, source, evidenceRefs, artifactRefs, supersedes, expiresAt, validFrom, validTo, createdAt, updatedAt), nil
 }
 
+func (r bundleSessionRow) toSession() (*model.Session, error) {
+	sessionID, err := types.SessionIDFrom(r.SessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("session_id: %w", err)
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, r.StartedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("started_at: %w", err)
+	}
+	endedAt, err := parseOptionalBundleTime(r.EndedAt, "ended_at")
+	if err != nil {
+		return nil, err
+	}
+	agent, err := types.AgentFrom(r.Agent)
+	if err != nil {
+		return nil, xerrors.Errorf("agent: %w", err)
+	}
+	spawnOrder := types.None[int]()
+	if r.SpawnOrder != nil {
+		spawnOrder = types.Some(*r.SpawnOrder)
+	}
+	return model.SessionOf(
+		sessionID,
+		startedAt,
+		endedAt,
+		types.Client(r.Client),
+		agent,
+		types.Workspace(r.Workspace),
+		r.Label,
+		r.Summary,
+		types.SessionID(r.ParentSessionID),
+		types.EventID(r.SpawnEventID),
+		r.SubagentKind,
+		spawnOrder,
+	), nil
+}
+
+func (r bundleCommandAuditRow) toCommandAudit() (*model.CommandAudit, error) {
+	eventID, err := types.EventIDFrom(r.EventID)
+	if err != nil {
+		return nil, xerrors.Errorf("event_id: %w", err)
+	}
+	exitCode := types.None[int]()
+	if r.ExitCode != nil {
+		exitCode = types.Some(*r.ExitCode)
+	}
+	return model.CommandAuditOf(
+		eventID,
+		r.Command,
+		r.Input,
+		r.Output,
+		r.InputTruncated,
+		r.OutputTruncated,
+		exitCode,
+	), nil
+}
+
 func (r bundleEventRow) toEvent() (*model.Event, error) {
 	eventID, err := types.EventIDFrom(r.EventID)
 	if err != nil {
@@ -798,6 +1058,47 @@ func (r bundleEventRow) toEvent() (*model.Event, error) {
 	), nil
 }
 
+func encodeSessionsNDJSON(sessions []*model.Session) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	sorted := append([]*model.Session(nil), sessions...)
+	sort.Slice(sorted, func(i, j int) bool {
+		leftParent := sorted[i].ParentSessionID().String()
+		rightParent := sorted[j].ParentSessionID().String()
+		if (leftParent == "") != (rightParent == "") {
+			return leftParent == ""
+		}
+		if leftParent != rightParent {
+			return leftParent < rightParent
+		}
+		return sorted[i].SessionID().String() < sorted[j].SessionID().String()
+	})
+	enc := json.NewEncoder(buf)
+	for _, session := range sorted {
+		row := bundleSessionRow{
+			SessionID:       session.SessionID().String(),
+			StartedAt:       session.StartedAt().UTC().Format(time.RFC3339Nano),
+			Client:          session.Client().String(),
+			Agent:           session.Agent().String(),
+			Workspace:       session.Workspace().String(),
+			Label:           session.Label(),
+			Summary:         session.Summary(),
+			ParentSessionID: session.ParentSessionID().String(),
+			SpawnEventID:    session.SpawnEventID().String(),
+			SubagentKind:    session.SubagentKind(),
+		}
+		if endedAt, ok := session.EndedAt().Value(); ok {
+			row.EndedAt = endedAt.UTC().Format(time.RFC3339Nano)
+		}
+		if spawnOrder, ok := session.SpawnOrder().Value(); ok {
+			row.SpawnOrder = &spawnOrder
+		}
+		if err := enc.Encode(row); err != nil {
+			return nil, xerrors.Errorf("encode session: %w", err)
+		}
+	}
+	return buf, nil
+}
+
 func encodeEventsNDJSON(events []*model.Event) (*bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
 	// Sort to make output reproducible for a given filter set.
@@ -824,6 +1125,46 @@ func encodeEventsNDJSON(events []*model.Event) (*bytes.Buffer, error) {
 		}
 	}
 	return buf, nil
+}
+
+func encodeCommandAuditsNDJSON(audits []*model.CommandAudit) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	sorted := append([]*model.CommandAudit(nil), audits...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].EventID().String() < sorted[j].EventID().String()
+	})
+	enc := json.NewEncoder(buf)
+	for _, audit := range sorted {
+		row := bundleCommandAuditRow{
+			EventID:         audit.EventID().String(),
+			Command:         audit.Command(),
+			Input:           audit.Input(),
+			Output:          audit.Output(),
+			InputTruncated:  audit.InputTruncated(),
+			OutputTruncated: audit.OutputTruncated(),
+		}
+		if exitCode, ok := audit.ExitCode().Value(); ok {
+			row.ExitCode = &exitCode
+		}
+		if err := enc.Encode(row); err != nil {
+			return nil, xerrors.Errorf("encode command audit: %w", err)
+		}
+	}
+	return buf, nil
+}
+
+func filterCommandAuditsForEvents(audits []*model.CommandAudit, events []*model.Event) []*model.CommandAudit {
+	eventIDs := make(map[string]struct{}, len(events))
+	for _, event := range events {
+		eventIDs[event.EventID().String()] = struct{}{}
+	}
+	filtered := make([]*model.CommandAudit, 0, len(audits))
+	for _, audit := range audits {
+		if _, ok := eventIDs[audit.EventID().String()]; ok {
+			filtered = append(filtered, audit)
+		}
+	}
+	return filtered
 }
 
 func encodeMemoriesNDJSON(memories []apptypes.MemoryDetails) (*bytes.Buffer, error) {
@@ -885,6 +1226,29 @@ func topologicallySortBundleMemoryRows(rows []bundleRow) ([]bundleMemoryRow, err
 		sorted = append(sorted, memories[idx])
 	}
 	return sorted, nil
+}
+
+func sortBundleSessionRows(rows []bundleRow) ([]bundleSessionRow, error) {
+	sessions := make([]bundleSessionRow, 0, len(rows))
+	for _, generic := range rows {
+		row, ok := generic.(bundleSessionRow)
+		if !ok {
+			return nil, xerrors.Errorf("unexpected sessions row type %T", generic)
+		}
+		sessions = append(sessions, row)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		leftParent := sessions[i].ParentSessionID
+		rightParent := sessions[j].ParentSessionID
+		if (leftParent == "") != (rightParent == "") {
+			return leftParent == ""
+		}
+		if leftParent != rightParent {
+			return leftParent < rightParent
+		}
+		return sessions[i].SessionID < sessions[j].SessionID
+	})
+	return sessions, nil
 }
 
 func topologicallySortMemoryDetails(memories []apptypes.MemoryDetails) []apptypes.MemoryDetails {

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -54,6 +54,10 @@ func (f fakeEventQuery) ListTimelineBlocks(context.Context, types.Workspace, tim
 type fakeBundleRepo struct {
 	schema                    int
 	events                    map[string]bool
+	sessions                  map[string]*model.Session
+	commandAudits             map[string]*model.CommandAudit
+	exportSessions            []*model.Session
+	exportCommandAudits       []*model.CommandAudit
 	memories                  map[string]*model.Memory
 	exportMemories            []apptypes.MemoryDetails
 	enforceMemorySupersedesFK bool
@@ -61,6 +65,12 @@ type fakeBundleRepo struct {
 }
 
 func (r *fakeBundleRepo) SchemaVersion(context.Context) (int, error) { return r.schema, nil }
+func (r *fakeBundleRepo) ListBundleSessions(context.Context) ([]*model.Session, error) {
+	return r.exportSessions, nil
+}
+func (r *fakeBundleRepo) ListBundleCommandAudits(context.Context) ([]*model.CommandAudit, error) {
+	return r.exportCommandAudits, nil
+}
 func (r *fakeBundleRepo) ListBundleMemories(context.Context) ([]apptypes.MemoryDetails, error) {
 	return r.exportMemories, nil
 }
@@ -69,6 +79,41 @@ func (r *fakeBundleRepo) BeginBundleImport(context.Context) (usecase.BundleImpor
 }
 
 type fakeBundleTx struct{ repo *fakeBundleRepo }
+
+func (tx *fakeBundleTx) ImportSession(_ context.Context, session *model.Session, policy usecase.BundleConflictPolicy, missingParent usecase.BundleMissingParentPolicy) (bool, error) {
+	r := tx.repo
+	if r.forceErr != nil {
+		return false, r.forceErr
+	}
+	if r.sessions == nil {
+		r.sessions = map[string]*model.Session{}
+	}
+	if parent := session.ParentSessionID().String(); parent != "" {
+		if _, ok := r.sessions[parent]; !ok {
+			switch missingParent {
+			case usecase.BundleMissingParentSkip:
+				return false, nil
+			case usecase.BundleMissingParentBackfill:
+				r.sessions[parent] = model.SessionOf(session.ParentSessionID(), session.StartedAt(), types.None[time.Time](), session.Client(), session.Agent(), session.Workspace(), "traceary:bundle-backfilled-parent", "", "")
+			default:
+				return false, xerrors.Errorf("parent session not found: %s", parent)
+			}
+		}
+	}
+	id := session.SessionID().String()
+	if _, ok := r.sessions[id]; ok {
+		if policy == usecase.BundleConflictError {
+			return false, xerrors.Errorf("session conflict")
+		}
+		if policy == usecase.BundleConflictReplace {
+			r.sessions[id] = session
+			return true, nil
+		}
+		return false, nil
+	}
+	r.sessions[id] = session
+	return true, nil
+}
 
 func (tx *fakeBundleTx) ImportEvent(_ context.Context, event *model.Event, policy usecase.BundleConflictPolicy) (bool, error) {
 	r := tx.repo
@@ -89,6 +134,32 @@ func (tx *fakeBundleTx) ImportEvent(_ context.Context, event *model.Event, polic
 		return false, nil
 	}
 	r.events[id] = true
+	return true, nil
+}
+
+func (tx *fakeBundleTx) ImportCommandAudit(_ context.Context, audit *model.CommandAudit, policy usecase.BundleConflictPolicy) (bool, error) {
+	r := tx.repo
+	if r.forceErr != nil {
+		return false, r.forceErr
+	}
+	if r.commandAudits == nil {
+		r.commandAudits = map[string]*model.CommandAudit{}
+	}
+	id := audit.EventID().String()
+	if _, ok := r.events[id]; !ok {
+		return false, xerrors.Errorf("foreign key constraint failed: event_id %s is missing", id)
+	}
+	if _, ok := r.commandAudits[id]; ok {
+		if policy == usecase.BundleConflictError {
+			return false, xerrors.Errorf("command audit conflict")
+		}
+		if policy == usecase.BundleConflictReplace {
+			r.commandAudits[id] = audit
+			return true, nil
+		}
+		return false, nil
+	}
+	r.commandAudits[id] = audit
 	return true, nil
 }
 func (tx *fakeBundleTx) ImportMemory(_ context.Context, memory *model.Memory, policy usecase.BundleConflictPolicy) (bool, error) {
@@ -142,6 +213,43 @@ func mustEvent(t *testing.T, id string, ts time.Time) *model.Event {
 		sessionID, types.Workspace("ws"),
 		"body-"+id, ts,
 	)
+}
+
+func mustSession(t *testing.T, id, parent string, ts time.Time) *model.Session {
+	t.Helper()
+	sessionID, err := types.SessionIDFrom(id)
+	if err != nil {
+		t.Fatalf("SessionIDFrom: %v", err)
+	}
+	agent, err := types.AgentFrom("test")
+	if err != nil {
+		t.Fatalf("AgentFrom: %v", err)
+	}
+	return model.SessionOf(
+		sessionID,
+		ts,
+		types.None[time.Time](),
+		types.Client("cli"),
+		agent,
+		types.Workspace("ws"),
+		"label-"+id,
+		"summary-"+id,
+		types.SessionID(parent),
+	)
+}
+
+func mustCommandAudit(t *testing.T, eventID string) *model.CommandAudit {
+	t.Helper()
+	id, err := types.EventIDFrom(eventID)
+	if err != nil {
+		t.Fatalf("EventIDFrom: %v", err)
+	}
+	audit, err := model.NewCommandAudit(id, "go test ./...", "stdin", "stdout", false, false)
+	if err != nil {
+		t.Fatalf("NewCommandAudit: %v", err)
+	}
+	audit.SetExitCode(types.Some(0))
+	return audit
 }
 
 func mustMemoryDetails(t *testing.T, id string, status types.MemoryStatus, ts time.Time) apptypes.MemoryDetails {
@@ -248,6 +356,105 @@ func TestBundleUsecase_RoundTrip(t *testing.T) {
 	}
 	if result2.EventsImported != 0 || result2.EventsSkipped != 2 {
 		t.Fatalf("Re-Import result = %+v, want 0 imported / 2 skipped", result2)
+	}
+}
+
+func TestBundleUsecase_RoundTripSessionsAndCommandAudits(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	parent := mustSession(t, "session-parent", "", ts)
+	child := mustSession(t, "session-child", "session-parent", ts.Add(time.Minute))
+	events := []*model.Event{mustEvent(t, "e-1", ts)}
+	exportRepo := &fakeBundleRepo{
+		schema:              13,
+		exportSessions:      []*model.Session{child, parent},
+		exportCommandAudits: []*model.CommandAudit{mustCommandAudit(t, "e-1")},
+	}
+	exportUC := usecase.NewBundleUsecase(fakeEventQuery{events: events}, exportRepo, func() time.Time { return ts })
+	out := filepath.Join(t.TempDir(), "bundle.tbun")
+	if err := exportUC.Export(context.Background(), usecase.BundleExportOptions{
+		OutPath:    out,
+		Passphrase: []byte("pass1"),
+	}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	files := openTestBundle(t, out, []byte("pass1"))
+	if _, ok := files["sessions.ndjson"]; !ok {
+		t.Fatalf("bundle missing sessions.ndjson")
+	}
+	if _, ok := files["command_audits.ndjson"]; !ok {
+		t.Fatalf("bundle missing command_audits.ndjson")
+	}
+
+	importRepo := &fakeBundleRepo{schema: 13}
+	importUC := usecase.NewBundleUsecase(fakeEventQuery{}, importRepo, nil)
+	result, err := importUC.Import(context.Background(), usecase.BundleImportOptions{
+		InPath:     out,
+		Passphrase: []byte("pass1"),
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.SessionsImported != 2 || result.CommandAuditsImported != 1 {
+		t.Fatalf("Import result = %+v, want sessions=2 audits=1", result)
+	}
+	gotChild := importRepo.sessions["session-child"]
+	if gotChild == nil {
+		t.Fatalf("child session not imported")
+	}
+	if got := gotChild.ParentSessionID().String(); got != "session-parent" {
+		t.Fatalf("child parent_session_id = %q, want session-parent", got)
+	}
+	if importRepo.commandAudits["e-1"] == nil {
+		t.Fatalf("command audit not imported")
+	}
+}
+
+func TestBundleUsecase_MissingSessionParentRejectsOrBackfills(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	child := mustSession(t, "session-child", "session-parent", ts)
+	exportRepo := &fakeBundleRepo{schema: 13, exportSessions: []*model.Session{child}}
+	exportUC := usecase.NewBundleUsecase(fakeEventQuery{}, exportRepo, func() time.Time { return ts })
+	out := filepath.Join(t.TempDir(), "bundle.tbun")
+	if err := exportUC.Export(context.Background(), usecase.BundleExportOptions{
+		OutPath:    out,
+		Passphrase: []byte("pass1"),
+	}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	rejectRepo := &fakeBundleRepo{schema: 13}
+	rejectUC := usecase.NewBundleUsecase(fakeEventQuery{}, rejectRepo, nil)
+	_, err := rejectUC.Import(context.Background(), usecase.BundleImportOptions{
+		InPath:     out,
+		Passphrase: []byte("pass1"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "parent session not found") {
+		t.Fatalf("Import reject error = %v, want parent session not found", err)
+	}
+
+	backfillRepo := &fakeBundleRepo{schema: 13}
+	backfillUC := usecase.NewBundleUsecase(fakeEventQuery{}, backfillRepo, nil)
+	result, err := backfillUC.Import(context.Background(), usecase.BundleImportOptions{
+		InPath:        out,
+		Passphrase:    []byte("pass1"),
+		MissingParent: usecase.BundleMissingParentBackfill,
+	})
+	if err != nil {
+		t.Fatalf("Import backfill: %v", err)
+	}
+	if result.SessionsImported != 1 {
+		t.Fatalf("Import result = %+v, want 1 child session imported", result)
+	}
+	stub := backfillRepo.sessions["session-parent"]
+	if stub == nil {
+		t.Fatalf("backfilled parent not found")
+	}
+	if got := stub.Label(); got != "traceary:bundle-backfilled-parent" {
+		t.Fatalf("backfilled label = %q, want marker label", got)
 	}
 }
 

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -196,6 +196,11 @@ func (tx *fakeBundleTx) Rollback(context.Context) error { return nil }
 
 func mustEvent(t *testing.T, id string, ts time.Time) *model.Event {
 	t.Helper()
+	return mustEventInSessionWorkspace(t, id, ts, "session-x", types.Workspace("ws"))
+}
+
+func mustEventInSessionWorkspace(t *testing.T, id string, ts time.Time, session string, workspace types.Workspace) *model.Event {
+	t.Helper()
 	eventID, err := types.EventIDFrom(id)
 	if err != nil {
 		t.Fatalf("EventIDFrom: %v", err)
@@ -204,18 +209,23 @@ func mustEvent(t *testing.T, id string, ts time.Time) *model.Event {
 	if err != nil {
 		t.Fatalf("AgentFrom: %v", err)
 	}
-	sessionID, err := types.SessionIDFrom("session-x")
+	sessionID, err := types.SessionIDFrom(session)
 	if err != nil {
 		t.Fatalf("SessionIDFrom: %v", err)
 	}
 	return model.EventOf(
 		eventID, types.EventKindNote, types.Client("cli"), agent,
-		sessionID, types.Workspace("ws"),
+		sessionID, workspace,
 		"body-"+id, ts,
 	)
 }
 
 func mustSession(t *testing.T, id, parent string, ts time.Time) *model.Session {
+	t.Helper()
+	return mustSessionInWorkspace(t, id, parent, ts, types.Workspace("ws"))
+}
+
+func mustSessionInWorkspace(t *testing.T, id, parent string, ts time.Time, workspace types.Workspace) *model.Session {
 	t.Helper()
 	sessionID, err := types.SessionIDFrom(id)
 	if err != nil {
@@ -231,7 +241,7 @@ func mustSession(t *testing.T, id, parent string, ts time.Time) *model.Session {
 		types.None[time.Time](),
 		types.Client("cli"),
 		agent,
-		types.Workspace("ws"),
+		workspace,
 		"label-"+id,
 		"summary-"+id,
 		types.SessionID(parent),
@@ -408,6 +418,52 @@ func TestBundleUsecase_RoundTripSessionsAndCommandAudits(t *testing.T) {
 	}
 	if importRepo.commandAudits["e-1"] == nil {
 		t.Fatalf("command audit not imported")
+	}
+}
+
+func TestBundleUsecase_ExportFiltersSessionsAndKeepsEventReferencedSessions(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	fooWorkspace := types.Workspace("foo")
+	barWorkspace := types.Workspace("bar")
+	fooSession := mustSessionInWorkspace(t, "session-foo", "", ts, fooWorkspace)
+	fooUnreferencedSession := mustSessionInWorkspace(t, "session-foo-unreferenced", "", ts.Add(time.Minute), fooWorkspace)
+	barReferencedSession := mustSessionInWorkspace(t, "session-bar-referenced", "", ts.Add(2*time.Minute), barWorkspace)
+	barUnrelatedSession := mustSessionInWorkspace(t, "session-bar-unrelated", "", ts.Add(3*time.Minute), barWorkspace)
+	oldFooSession := mustSessionInWorkspace(t, "session-foo-old", "", ts.Add(-2*time.Hour), fooWorkspace)
+
+	events := []*model.Event{
+		mustEventInSessionWorkspace(t, "e-foo", ts.Add(10*time.Minute), "session-foo", fooWorkspace),
+		mustEventInSessionWorkspace(t, "e-bar-reference", ts.Add(11*time.Minute), "session-bar-referenced", fooWorkspace),
+	}
+	exportRepo := &fakeBundleRepo{
+		schema: 13,
+		exportSessions: []*model.Session{
+			fooSession,
+			fooUnreferencedSession,
+			barReferencedSession,
+			barUnrelatedSession,
+			oldFooSession,
+		},
+	}
+	exportUC := usecase.NewBundleUsecase(fakeEventQuery{events: events}, exportRepo, func() time.Time { return ts })
+	out := filepath.Join(t.TempDir(), "bundle.tbun")
+	if err := exportUC.Export(context.Background(), usecase.BundleExportOptions{
+		OutPath:    out,
+		Passphrase: []byte("pass1"),
+		Workspace:  fooWorkspace,
+		Since:      ts.Add(-time.Hour),
+		Until:      ts.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	files := openTestBundle(t, out, []byte("pass1"))
+	got := decodeBundleSessionIDs(t, files["sessions.ndjson"])
+	want := []string{"session-bar-referenced", "session-foo", "session-foo-unreferenced"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("exported session IDs = %v, want %v", got, want)
 	}
 }
 
@@ -1032,6 +1088,25 @@ func openTestBundle(t *testing.T, path string, passphrase []byte) map[string][]b
 		files[hdr.Name] = content
 	}
 	return files
+}
+
+func decodeBundleSessionIDs(t *testing.T, data []byte) []string {
+	t.Helper()
+	ids := []string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var row struct {
+			SessionID string `json:"session_id"`
+		}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("unmarshal session row: %v", err)
+		}
+		ids = append(ids, row.SessionID)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func hashForTest(data []byte) string {

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -24,7 +25,10 @@ import (
 const (
 	sqliteCodePrimaryKeyConflict = 1555
 	sqliteCodeUniqueConflict     = 2067
+	sqliteCodeForeignKeyConflict = 787
 )
+
+const bundleBackfilledParentSessionLabel = "traceary:bundle-backfilled-parent"
 
 // BundleDatasource implements usecase.BundleEventRepository with the
 // SQLite-backed Traceary store. Kept as a thin adapter on top of
@@ -60,6 +64,84 @@ func (d *BundleDatasource) SchemaVersion(ctx context.Context) (int, error) {
 		return 0, xerrors.Errorf("failed to read schema_migrations: %w", err)
 	}
 	return version, nil
+}
+
+// ListBundleSessions returns every session in parents-first order for bundle export.
+func (d *BundleDatasource) ListBundleSessions(ctx context.Context) ([]*model.Session, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for bundle session export: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	rows, err := db.QueryContext(ctx, `
+SELECT session_id, started_at, ended_at, client, agent, workspace, label, summary,
+       COALESCE(parent_session_id, ''), COALESCE(spawn_event_id, ''), subagent_kind, spawn_order
+FROM sessions
+ORDER BY
+  CASE WHEN parent_session_id IS NULL THEN 0 ELSE 1 END,
+  parent_session_id,
+  session_id`)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query sessions for bundle export: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	out := []*model.Session{}
+	for rows.Next() {
+		session, err := scanBundleSession(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan bundle session row: %w", err)
+		}
+		out = append(out, session)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate bundle session rows: %w", err)
+	}
+	return out, nil
+}
+
+// ListBundleCommandAudits returns every command audit in deterministic order for bundle export.
+func (d *BundleDatasource) ListBundleCommandAudits(ctx context.Context) ([]*model.CommandAudit, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for bundle command audit export: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	rows, err := db.QueryContext(ctx, `
+SELECT event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code
+FROM command_audits
+ORDER BY event_id`)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query command audits for bundle export: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	out := []*model.CommandAudit{}
+	for rows.Next() {
+		audit, err := scanBundleCommandAudit(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan bundle command audit row: %w", err)
+		}
+		out = append(out, audit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate bundle command audit rows: %w", err)
+	}
+	return out, nil
 }
 
 // ListBundleMemories returns every durable memory with refs for bundle export.
@@ -131,6 +213,56 @@ type bundleImportTx struct {
 	tx *sql.Tx
 }
 
+// ImportSession inserts or replaces the session according to policy. Missing
+// parent sessions are handled by the caller-selected bundle parent policy.
+func (t *bundleImportTx) ImportSession(
+	ctx context.Context,
+	session *model.Session,
+	policy usecase.BundleConflictPolicy,
+	missingParent usecase.BundleMissingParentPolicy,
+) (bool, error) {
+	if session == nil {
+		return false, xerrors.Errorf("session must not be nil")
+	}
+	if session.ParentSessionID().String() != "" {
+		if session.ParentSessionID() == session.SessionID() {
+			return false, xerrors.Errorf("session cannot be its own parent")
+		}
+		parentExists, err := t.sessionExists(ctx, session.ParentSessionID())
+		if err != nil {
+			return false, err
+		}
+		if !parentExists {
+			switch missingParent {
+			case usecase.BundleMissingParentSkip:
+				return false, nil
+			case usecase.BundleMissingParentBackfill:
+				if err := t.backfillParentSession(ctx, session); err != nil {
+					return false, err
+				}
+			default:
+				return false, xerrors.Errorf("parent session not found: %s", session.ParentSessionID())
+			}
+		}
+	}
+	exists, err := t.sessionExists(ctx, session.SessionID())
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		switch policy {
+		case usecase.BundleConflictSkip:
+			return false, nil
+		case usecase.BundleConflictError:
+			return false, xerrors.Errorf("session conflict")
+		}
+	}
+	if err := t.upsertSession(ctx, session); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // ImportEvent inserts or replaces the event according to policy. For
 // skip, a unique-constraint violation on the event id returns
 // (false, nil) so re-importing the same bundle remains idempotent and
@@ -176,6 +308,64 @@ ON CONFLICT(id) DO UPDATE SET
 	return false, xerrors.Errorf("failed to import event %s: %w", event.EventID(), err)
 }
 
+// ImportCommandAudit inserts or replaces the command audit according to policy.
+// A missing event row is intentionally surfaced as an FK error so audits cannot
+// land before or without their referenced event.
+func (t *bundleImportTx) ImportCommandAudit(ctx context.Context, audit *model.CommandAudit, policy usecase.BundleConflictPolicy) (bool, error) {
+	if audit == nil {
+		return false, xerrors.Errorf("command audit must not be nil")
+	}
+	exists, err := t.commandAuditExists(ctx, audit.EventID())
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		switch policy {
+		case usecase.BundleConflictSkip:
+			return false, nil
+		case usecase.BundleConflictError:
+			return false, xerrors.Errorf("command audit conflict")
+		}
+	}
+	query := insertCommandAuditQuery
+	if policy == usecase.BundleConflictReplace {
+		query = `INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(event_id) DO UPDATE SET
+  command_text = excluded.command_text,
+  input_text = excluded.input_text,
+  output_text = excluded.output_text,
+  input_truncated = excluded.input_truncated,
+  output_truncated = excluded.output_truncated,
+  exit_code = excluded.exit_code`
+	}
+	var exitCodeSQL *int
+	if exitCode, ok := audit.ExitCode().Value(); ok {
+		exitCodeSQL = &exitCode
+	}
+	_, err = t.tx.ExecContext(
+		ctx,
+		query,
+		audit.EventID().String(),
+		audit.Command(),
+		audit.Input(),
+		audit.Output(),
+		audit.InputTruncated(),
+		audit.OutputTruncated(),
+		exitCodeSQL,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if policy == usecase.BundleConflictSkip && isSQLiteUniqueOrPKConflict(err) {
+		return false, nil
+	}
+	if isSQLiteForeignKeyConflict(err) {
+		return false, xerrors.Errorf("event not found for command audit %s: %w", audit.EventID(), err)
+	}
+	return false, xerrors.Errorf("failed to import command audit %s: %w", audit.EventID(), err)
+}
+
 // ImportMemory inserts or replaces a durable memory according to policy.
 func (t *bundleImportTx) ImportMemory(ctx context.Context, memory *model.Memory, policy usecase.BundleConflictPolicy) (bool, error) {
 	if memory == nil {
@@ -209,6 +399,104 @@ func (t *bundleImportTx) memoryExists(ctx context.Context, memoryID types.Memory
 		return false, nil
 	}
 	return false, xerrors.Errorf("failed to check memory conflict %s: %w", memoryID, err)
+}
+
+func (t *bundleImportTx) sessionExists(ctx context.Context, sessionID types.SessionID) (bool, error) {
+	var value int
+	err := t.tx.QueryRowContext(ctx, `SELECT 1 FROM sessions WHERE session_id = ?`, sessionID.String()).Scan(&value)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, xerrors.Errorf("failed to check session conflict %s: %w", sessionID, err)
+}
+
+func (t *bundleImportTx) commandAuditExists(ctx context.Context, eventID types.EventID) (bool, error) {
+	var value int
+	err := t.tx.QueryRowContext(ctx, `SELECT 1 FROM command_audits WHERE event_id = ?`, eventID.String()).Scan(&value)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, xerrors.Errorf("failed to check command audit conflict %s: %w", eventID, err)
+}
+
+func (t *bundleImportTx) backfillParentSession(ctx context.Context, child *model.Session) error {
+	parent := model.SessionOf(
+		child.ParentSessionID(),
+		child.StartedAt(),
+		types.None[time.Time](),
+		child.Client(),
+		child.Agent(),
+		child.Workspace(),
+		bundleBackfilledParentSessionLabel,
+		"Backfilled by Traceary bundle import because the child session referenced a missing parent.",
+		"",
+	)
+	return t.upsertSession(ctx, parent)
+}
+
+func (t *bundleImportTx) upsertSession(ctx context.Context, session *model.Session) error {
+	var parentSessionID *string
+	if session.ParentSessionID().String() != "" {
+		v := session.ParentSessionID().String()
+		parentSessionID = &v
+	}
+	var spawnEventID *string
+	if session.SpawnEventID().String() != "" {
+		v := session.SpawnEventID().String()
+		spawnEventID = &v
+	}
+	var endedAt *string
+	if value, ok := session.EndedAt().Value(); ok {
+		v := formatTimestamp(value)
+		endedAt = &v
+	}
+	var spawnOrder *int
+	if value, ok := session.SpawnOrder().Value(); ok {
+		spawnOrder = &value
+	}
+	_, err := t.tx.ExecContext(ctx, `
+INSERT INTO sessions (
+  session_id, started_at, ended_at, client, agent, workspace, label, summary,
+  parent_session_id, spawn_event_id, subagent_kind, spawn_order
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_id) DO UPDATE SET
+  started_at = excluded.started_at,
+  ended_at = excluded.ended_at,
+  client = excluded.client,
+  agent = excluded.agent,
+  workspace = excluded.workspace,
+  label = excluded.label,
+  summary = excluded.summary,
+  parent_session_id = excluded.parent_session_id,
+  spawn_event_id = excluded.spawn_event_id,
+  subagent_kind = excluded.subagent_kind,
+  spawn_order = excluded.spawn_order`,
+		session.SessionID().String(),
+		formatTimestamp(session.StartedAt()),
+		endedAt,
+		session.Client().String(),
+		session.Agent().String(),
+		session.Workspace().String(),
+		session.Label(),
+		session.Summary(),
+		parentSessionID,
+		spawnEventID,
+		session.SubagentKind(),
+		spawnOrder,
+	)
+	if err != nil {
+		if isSQLiteForeignKeyConflict(err) && session.ParentSessionID().String() != "" {
+			return xerrors.Errorf("parent session not found: %s", session.ParentSessionID())
+		}
+		return xerrors.Errorf("failed to import session %s: %w", session.SessionID(), err)
+	}
+	return nil
 }
 
 func (t *bundleImportTx) Commit(context.Context) error {
@@ -251,6 +539,116 @@ func isSQLiteUniqueOrPKConflict(err error) bool {
 	}
 	code := sqliteErr.Code()
 	return code == sqliteCodePrimaryKeyConflict || code == sqliteCodeUniqueConflict
+}
+
+func isSQLiteForeignKeyConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr *sqlitelib.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	return sqliteErr.Code() == sqliteCodeForeignKeyConflict
+}
+
+func scanBundleSession(row interface {
+	Scan(dest ...any) error
+}) (*model.Session, error) {
+	var (
+		sessionID       string
+		startedAtValue  string
+		endedAtValue    sql.NullString
+		clientValue     string
+		agentValue      string
+		workspaceValue  string
+		labelValue      string
+		summaryValue    string
+		parentSessionID string
+		spawnEventID    string
+		subagentKind    string
+		spawnOrder      sql.NullInt64
+	)
+	if err := row.Scan(
+		&sessionID,
+		&startedAtValue,
+		&endedAtValue,
+		&clientValue,
+		&agentValue,
+		&workspaceValue,
+		&labelValue,
+		&summaryValue,
+		&parentSessionID,
+		&spawnEventID,
+		&subagentKind,
+		&spawnOrder,
+	); err != nil {
+		return nil, xerrors.Errorf("scan session: %w", err)
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, startedAtValue)
+	if err != nil {
+		return nil, xerrors.Errorf("started_at: %w", err)
+	}
+	endedAt := types.None[time.Time]()
+	if endedAtValue.Valid {
+		value, err := time.Parse(time.RFC3339Nano, endedAtValue.String)
+		if err != nil {
+			return nil, xerrors.Errorf("ended_at: %w", err)
+		}
+		endedAt = types.Some(value)
+	}
+	agent, err := types.AgentFrom(agentValue)
+	if err != nil {
+		return nil, xerrors.Errorf("agent: %w", err)
+	}
+	return model.SessionOf(
+		types.SessionID(sessionID),
+		startedAt,
+		endedAt,
+		types.Client(clientValue),
+		agent,
+		types.Workspace(workspaceValue),
+		labelValue,
+		summaryValue,
+		types.SessionID(parentSessionID),
+		types.EventID(spawnEventID),
+		subagentKind,
+		optionalIntFromNullInt64(spawnOrder),
+	), nil
+}
+
+func scanBundleCommandAudit(row interface {
+	Scan(dest ...any) error
+}) (*model.CommandAudit, error) {
+	var (
+		eventID         string
+		commandText     string
+		inputText       string
+		outputText      string
+		inputTruncated  bool
+		outputTruncated bool
+		exitCode        sql.NullInt64
+	)
+	if err := row.Scan(
+		&eventID,
+		&commandText,
+		&inputText,
+		&outputText,
+		&inputTruncated,
+		&outputTruncated,
+		&exitCode,
+	); err != nil {
+		return nil, xerrors.Errorf("scan command audit: %w", err)
+	}
+	return model.CommandAuditOf(
+		types.EventID(eventID),
+		commandText,
+		inputText,
+		outputText,
+		inputTruncated,
+		outputTruncated,
+		optionalIntFromNullInt64(exitCode),
+	), nil
 }
 
 // ensure sql import stays referenced; datasource uses it indirectly

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -1,0 +1,115 @@
+package sqlite_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestBundleDatasource_CommandAuditBeforeEventFailsFK(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	eventStore := sqlite.NewEventDatasource(db)
+	sut := sqlite.NewBundleDatasource(db, eventStore)
+	tx, err := sut.BeginBundleImport(context.Background())
+	if err != nil {
+		t.Fatalf("BeginBundleImport() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	eventID, err := types.EventIDFrom("event-1")
+	if err != nil {
+		t.Fatalf("EventIDFrom() error = %v", err)
+	}
+	audit, err := model.NewCommandAudit(eventID, "go test ./...", "", "", false, false)
+	if err != nil {
+		t.Fatalf("NewCommandAudit() error = %v", err)
+	}
+
+	_, err = tx.ImportCommandAudit(context.Background(), audit, usecase.BundleConflictSkip)
+	if err == nil {
+		t.Fatalf("ImportCommandAudit() succeeded before event import, want FK error")
+	}
+	if !strings.Contains(err.Error(), "event not found") && !strings.Contains(err.Error(), "FOREIGN KEY") {
+		t.Fatalf("ImportCommandAudit() error = %v, want FK/event-not-found error", err)
+	}
+}
+
+func TestBundleDatasource_ImportSessionBackfillsMissingParent(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	eventStore := sqlite.NewEventDatasource(db)
+	sut := sqlite.NewBundleDatasource(db, eventStore)
+	tx, err := sut.BeginBundleImport(context.Background())
+	if err != nil {
+		t.Fatalf("BeginBundleImport() error = %v", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(context.Background())
+		}
+	}()
+
+	agent, err := types.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	child := model.SessionOf(
+		types.SessionID("child-session"),
+		time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC),
+		types.None[time.Time](),
+		types.Client("cli"),
+		agent,
+		types.Workspace("ws"),
+		"child",
+		"",
+		types.SessionID("missing-parent"),
+	)
+	imported, err := tx.ImportSession(context.Background(), child, usecase.BundleConflictSkip, usecase.BundleMissingParentBackfill)
+	if err != nil {
+		t.Fatalf("ImportSession() error = %v", err)
+	}
+	if !imported {
+		t.Fatalf("ImportSession() imported = false, want true")
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	committed = true
+
+	sessionStore := sqlite.NewSessionDatasource(db)
+	stub, err := sessionStore.FindByID(context.Background(), types.SessionID("missing-parent"))
+	if err != nil {
+		t.Fatalf("FindByID(parent) error = %v", err)
+	}
+	parent, ok := stub.Value()
+	if !ok {
+		t.Fatalf("backfilled parent not found")
+	}
+	if got := parent.Label(); got != "traceary:bundle-backfilled-parent" {
+		t.Fatalf("parent label = %q, want marker", got)
+	}
+}

--- a/presentation/cli/bundle.go
+++ b/presentation/cli/bundle.go
@@ -187,11 +187,15 @@ func (c *RootCLI) runBundleImport(ctx context.Context, output io.Writer, input b
 		enc := json.NewEncoder(output)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(bundleImportOutput{
-			EventsImported:      result.EventsImported,
-			EventsSkipped:       result.EventsSkipped,
-			MemoriesImported:    result.MemoriesImported,
-			MemoriesSkipped:     result.MemoriesSkipped,
-			BundleSchemaVersion: result.BundleSchemaVersion,
+			SessionsImported:      result.SessionsImported,
+			SessionsSkipped:       result.SessionsSkipped,
+			EventsImported:        result.EventsImported,
+			EventsSkipped:         result.EventsSkipped,
+			CommandAuditsImported: result.CommandAuditsImported,
+			CommandAuditsSkipped:  result.CommandAuditsSkipped,
+			MemoriesImported:      result.MemoriesImported,
+			MemoriesSkipped:       result.MemoriesSkipped,
+			BundleSchemaVersion:   result.BundleSchemaVersion,
 		}); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print bundle import result", "bundle import 結果の出力に失敗しました"), err)
 		}
@@ -199,9 +203,13 @@ func (c *RootCLI) runBundleImport(ctx context.Context, output io.Writer, input b
 	}
 	if _, err := fmt.Fprintf(
 		output,
-		"%s: events_imported=%d, events_skipped=%d, memories_imported=%d, memories_skipped=%d, schema=%d\n",
+		"%s: sessions_imported=%d, sessions_skipped=%d, events_imported=%d, events_skipped=%d, command_audits_imported=%d, command_audits_skipped=%d, memories_imported=%d, memories_skipped=%d, schema=%d\n",
 		Localize("Imported bundle", "bundle を取り込みました"),
-		result.EventsImported, result.EventsSkipped, result.MemoriesImported, result.MemoriesSkipped, result.BundleSchemaVersion,
+		result.SessionsImported, result.SessionsSkipped,
+		result.EventsImported, result.EventsSkipped,
+		result.CommandAuditsImported, result.CommandAuditsSkipped,
+		result.MemoriesImported, result.MemoriesSkipped,
+		result.BundleSchemaVersion,
 	); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print bundle import result", "bundle import 結果の出力に失敗しました"), err)
 	}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -128,11 +128,15 @@ type timelineBlockOutput struct {
 
 // bundleImportOutput is the JSON shape of a bundle import result.
 type bundleImportOutput struct {
-	EventsImported      int `json:"events_imported"`
-	EventsSkipped       int `json:"events_skipped"`
-	MemoriesImported    int `json:"memories_imported"`
-	MemoriesSkipped     int `json:"memories_skipped"`
-	BundleSchemaVersion int `json:"bundle_schema_version"`
+	SessionsImported      int `json:"sessions_imported"`
+	SessionsSkipped       int `json:"sessions_skipped"`
+	EventsImported        int `json:"events_imported"`
+	EventsSkipped         int `json:"events_skipped"`
+	CommandAuditsImported int `json:"command_audits_imported"`
+	CommandAuditsSkipped  int `json:"command_audits_skipped"`
+	MemoriesImported      int `json:"memories_imported"`
+	MemoriesSkipped       int `json:"memories_skipped"`
+	BundleSchemaVersion   int `json:"bundle_schema_version"`
 }
 
 // memoryHygieneApplyOutput is the JSON shape of a memory hygiene apply result.

--- a/presentation/cli/testdata/bundle/import.golden.json
+++ b/presentation/cli/testdata/bundle/import.golden.json
@@ -1,6 +1,10 @@
 {
+  "sessions_imported": 0,
+  "sessions_skipped": 0,
   "events_imported": 3,
   "events_skipped": 1,
+  "command_audits_imported": 0,
+  "command_audits_skipped": 0,
   "memories_imported": 0,
   "memories_skipped": 0,
   "bundle_schema_version": 12


### PR DESCRIPTION
Builds on #737 (manifest v2) and #719 (auto parent inference).

- Export: sessions.ndjson (parents-first ordering) and command_audits.ndjson
- Import: BundleSessionRepository / BundleCommandAuditRepository with imported-bool contract
- Order in tx: sessions → events → command_audits
- `--missing-parent={reject,skip,backfill}`, default reject; backfill writes stub session with marker label
- command_audits referencing missing event_id (both bundle + DB) → reject
- Tests: round-trip parent/child, missing-parent matrix, FK reverse-order verification

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>