### PR TITLE
fix(hooks): preserve parent agent during lazy subagent synthesis (#775)

### DIFF
--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -683,6 +683,7 @@ func (c *RootCLI) runHookSubagentStop(
 	activeToolUseID := ""
 	activeParentSessionID := types.SessionID("")
 	childWasActive := false
+	lazySynthesizedChild := false
 	if toolUseID != "" {
 		active, findErr := findHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
 		if findErr != nil {
@@ -711,15 +712,11 @@ func (c *RootCLI) runHookSubagentStop(
 	}
 	if childSessionID != "" {
 		if !childWasActive {
-			childAgent := agent
-			if subagentType := hookPayloadString(payload, "subagent_type", ""); subagentType != "" {
-				if resolvedAgent, resolveErr := types.AgentFrom(strings.TrimSpace(client) + "/" + subagentType); resolveErr == nil {
-					childAgent = resolvedAgent
-				}
-			}
+			childAgent := resolveHookSubagentAgentOrDefault(client, payload, agent)
 			if _, startErr := c.session.StartChild(ctx, parentSessionID, childSessionID, childAgent, workspace, types.EventID(toolUseID), "task", time.Now()); startErr != nil {
 				return xerrors.Errorf("failed to synthesize missing subagent start: %w", startErr)
 			}
+			lazySynthesizedChild = true
 		}
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
@@ -736,6 +733,9 @@ func (c *RootCLI) runHookSubagentStop(
 	// discriminates the subagent boundary from main-session session_ended
 	// events; the legacy `[phase:subagent]` body prefix is retired on
 	// write but readers still match it for pre-#672 rows.
+	if lazySynthesizedChild {
+		return nil
+	}
 	subagentType := hookPayloadString(payload, "subagent_type", "")
 	_, err = c.event.Log(ctx, subagentType, types.EventKindSessionEnded, types.Client("hook"), agent, parentSessionID, workspace, apptypes.LogRedaction{})
 	if err != nil {
@@ -1111,6 +1111,21 @@ func resolveHookAgent(client string, payload []byte) (types.Agent, error) {
 	}
 
 	return agent, nil
+}
+
+func resolveHookSubagentAgentOrDefault(client string, payload []byte, defaultAgent types.Agent) types.Agent {
+	subagentType := hookPayloadString(payload, "subagent_type", "")
+	if subagentType == "" {
+		subagentType = hookPayloadString(payload, "tool_input.subagent_type", "")
+	}
+	if strings.TrimSpace(subagentType) == "" {
+		return defaultAgent
+	}
+	agent, err := types.AgentFrom(strings.TrimSpace(client) + "/" + strings.TrimSpace(subagentType))
+	if err != nil {
+		return defaultAgent
+	}
+	return agent
 }
 
 func (c *RootCLI) inferHookParentSessionID(ctx context.Context, payload []byte, client string, agent types.Agent, workspace types.Workspace) (types.SessionID, error) {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -1266,6 +1266,111 @@ func TestRootCLI_HookSubagentStopCommand_LazilySynthesizesMissingStart(t *testin
 	}
 }
 
+func TestRootCLI_HookSubagentStopCommand_LazySynthesisKeepsParentAgent(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "lazy-plan-key")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-lazy-plan-key"), []byte("parent-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-lazy-plan-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	t.Setenv("TRACEARY_DB_PATH", dbPath)
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	sessionDS := sqliteinfra.NewSessionDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	sessionUC := usecase.NewSessionUsecase(eventDS, sessionDS, sessionDS, eventDS)
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	ctx := context.Background()
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if _, err := sessionUC.Start(ctx, types.Client("hook"), types.Agent("claude"), types.SessionID("parent-session"), types.Workspace("github.com/duck8823/traceary"), ""); err != nil {
+		t.Fatalf("Start(parent) error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithSession(sessionUC),
+		cli.WithEvent(eventUC),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"parent-session","tool_use_id":"toolu_plan","agent_type":"Plan","subagent_type":"Plan"}`))
+	rootCmd.SetArgs([]string{"hook", "subagent-stop", "claude"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(subagent-stop) error = %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var parentAgent string
+	if err := sqlDB.QueryRow(`SELECT agent FROM sessions WHERE session_id = ?`, "parent-session").Scan(&parentAgent); err != nil {
+		t.Fatalf("query parent agent error = %v", err)
+	}
+	if parentAgent != "claude" {
+		t.Fatalf("parent session agent = %q, want claude", parentAgent)
+	}
+	var childParent, childAgent, childKind string
+	if err := sqlDB.QueryRow(`SELECT COALESCE(parent_session_id, ''), agent, subagent_kind FROM sessions WHERE session_id = ?`, "parent-session:sub:toolu_plan").Scan(&childParent, &childAgent, &childKind); err != nil {
+		t.Fatalf("query child session error = %v", err)
+	}
+	if childParent != "parent-session" || childAgent != "claude/Plan" || childKind != "task" {
+		t.Fatalf("child metadata = parent:%q agent:%q kind:%q, want parent-session claude/Plan task", childParent, childAgent, childKind)
+	}
+	var parentPlanEvents int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM events WHERE session_id = ? AND agent = ?`, "parent-session", "claude/Plan").Scan(&parentPlanEvents); err != nil {
+		t.Fatalf("query parent Plan event count error = %v", err)
+	}
+	if parentPlanEvents != 0 {
+		t.Fatalf("parent claude/Plan events = %d, want 0", parentPlanEvents)
+	}
+
+	stdout := &bytes.Buffer{}
+	topCmd := newTestRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithSession(sessionUC),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	topCmd.SetOut(stdout)
+	topCmd.SetErr(&bytes.Buffer{})
+	topCmd.SetArgs([]string{"top", "--snapshot", "--json", "--db-path", dbPath})
+	if err := topCmd.Execute(); err != nil {
+		t.Fatalf("Execute(top --snapshot --json) error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, `"agents": [
+      "claude"
+    ]`) {
+		t.Fatalf("top JSON parent agents should stay claude only, got: %s", output)
+	}
+	if !strings.Contains(output, `"session_id": "parent-session:sub:toolu_plan"`) {
+		t.Fatalf("top JSON should include synthesized Plan child, got: %s", output)
+	}
+	if !strings.Contains(output, `"subagent_kind": "task"`) {
+		t.Fatalf("top JSON should include child subagent_kind=task, got: %s", output)
+	}
+	if !strings.Contains(output, `"subagent_type": "claude/Plan"`) {
+		t.Fatalf("top JSON should include child subagent_type=claude/Plan, got: %s", output)
+	}
+}
+
 func TestRootCLI_HookSubagentStopCommand_NoOpWhenSessionIDMissing(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-missing")
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -1360,14 +1360,8 @@ func TestRootCLI_HookSubagentStopCommand_LazySynthesisKeepsParentAgent(t *testin
     ]`) {
 		t.Fatalf("top JSON parent agents should stay claude only, got: %s", output)
 	}
-	if !strings.Contains(output, `"session_id": "parent-session:sub:toolu_plan"`) {
-		t.Fatalf("top JSON should include synthesized Plan child, got: %s", output)
-	}
-	if !strings.Contains(output, `"subagent_kind": "task"`) {
-		t.Fatalf("top JSON should include child subagent_kind=task, got: %s", output)
-	}
-	if !strings.Contains(output, `"subagent_type": "claude/Plan"`) {
-		t.Fatalf("top JSON should include child subagent_type=claude/Plan, got: %s", output)
+	if strings.Contains(output, `"session_id": "parent-session:sub:toolu_plan"`) {
+		t.Fatalf("top JSON should prune ended synthesized Plan child, got: %s", output)
 	}
 }
 

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -216,6 +216,9 @@ func keepOngoingLineages(roots []*sessionNode) []*sessionNode {
 }
 
 func pruneEndedLineages(node *sessionNode) bool {
+	if isSessionActive(node.summary) {
+		return true
+	}
 	keptChildren := node.children[:0]
 	for _, child := range node.children {
 		if pruneEndedLineages(child) {
@@ -223,9 +226,6 @@ func pruneEndedLineages(node *sessionNode) bool {
 		}
 	}
 	node.children = keptChildren
-	if isSessionActive(node.summary) {
-		return true
-	}
 	return len(node.children) > 0
 }
 

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -216,9 +216,6 @@ func keepOngoingLineages(roots []*sessionNode) []*sessionNode {
 }
 
 func pruneEndedLineages(node *sessionNode) bool {
-	if isSessionActive(node.summary) {
-		return true
-	}
 	keptChildren := node.children[:0]
 	for _, child := range node.children {
 		if pruneEndedLineages(child) {
@@ -226,7 +223,7 @@ func pruneEndedLineages(node *sessionNode) bool {
 		}
 	}
 	node.children = keptChildren
-	return len(node.children) > 0
+	return isSessionActive(node.summary) || len(node.children) > 0
 }
 
 // isSessionActive treats only sessions with status=active as live. A

--- a/presentation/cli/session_tree_test.go
+++ b/presentation/cli/session_tree_test.go
@@ -401,6 +401,12 @@ func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
 				"active", 1, 0, []string{"claude"}, "", "", types.SessionID(""),
 			),
 			apptypes.SessionSummaryOf(
+				types.SessionID("ended-child-under-live-root"),
+				types.Workspace("ws"),
+				started, types.Some(ended),
+				"ended", 1, 0, []string{"codex"}, "", "", types.SessionID("live-root"),
+			),
+			apptypes.SessionSummaryOf(
 				types.SessionID("dead-root"),
 				types.Workspace("ws"),
 				started, types.Some(ended),
@@ -437,6 +443,9 @@ func TestRootCLI_SessionTreeCommand_OngoingOnly(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "live-root") {
 		t.Fatalf("--ongoing-only should keep live-root, got %q", out)
+	}
+	if strings.Contains(out, "ended-child-under-live-root") {
+		t.Fatalf("--ongoing-only should prune ended descendants under active parents, got %q", out)
 	}
 	if strings.Contains(out, "dead-root") || strings.Contains(out, "dead-child") {
 		t.Fatalf("--ongoing-only should prune dead lineage, got %q", out)


### PR DESCRIPTION
Quality-phase follow-up.

Lazy-synthesis path (SubagentStop without prior PreToolUse:Task) silently relabeled the parent session's agent (e.g. `claude` → `claude/Plan`). Parent metadata is now preserved; a child session row is synthesized instead, keyed by tool_use_id (or stable id from event_id when missing).

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>