### PR TITLE
fix(doctor): soft-pass plugin version checks for dev builds (#777)

### DIFF
--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -18,7 +18,10 @@ type doctorPluginInstall struct {
 	UpdateHint       string
 }
 
-var doctorVersionPrefixPattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+){0,2}(?:[-+][0-9A-Za-z.-]+)?`)
+var (
+	doctorVersionPrefixPattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+){0,2}(?:[-+][0-9A-Za-z.-]+)?`)
+	doctorPseudoVersionPattern = regexp.MustCompile(`-0\.\d{14}-[a-f0-9]{12,}$`)
+)
 
 func (c *RootCLI) inspectPluginVersionChecks(currentVersion string) []doctorCheck {
 	checks := []doctorCheck{}
@@ -77,6 +80,18 @@ func inspectPluginVersion(install doctorPluginInstall, currentVersion string) do
 	if current == "" || current == "dev" {
 		return doctorCheck{Name: name, Status: doctorStatusSkip, Message: localizef("running traceary version is %q; skipped plugin version comparison for %s", "実行中 traceary version は %q のため %s plugin version 比較を skip しました", currentVersion, install.Client)}
 	}
+	if isDevBuild(currentVersion) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"%s plugin version comparison soft-passed because traceary is running a dev build: %s (%s)",
+				"traceary が dev build として実行中のため %s plugin version 比較を soft-pass しました: %s (%s)",
+				install.Client, currentVersion, install.ManifestPath,
+			),
+			Hint: "running a dev build (rebuild + reinstall plugin to verify version alignment)",
+		}
+	}
 	installedVersion := ""
 	if install.InstalledVersion != "" {
 		installedVersion = strings.TrimSpace(install.InstalledVersion)
@@ -112,4 +127,16 @@ func normalizeDoctorVersion(version string) string {
 		return version[:index]
 	}
 	return version
+}
+
+func isDevBuild(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return false
+	}
+	lower := strings.ToLower(version)
+	if strings.Contains(lower, "devel") || strings.Contains(lower, "dirty") {
+		return true
+	}
+	return doctorPseudoVersionPattern.MatchString(normalizeDoctorVersion(version))
 }

--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -77,20 +77,8 @@ func detectManifestInstalls(pattern, client, hint string) []doctorPluginInstall 
 func inspectPluginVersion(install doctorPluginInstall, currentVersion string) doctorCheck {
 	name := install.Client + "-plugin-version"
 	current := normalizeDoctorVersion(currentVersion)
-	if current == "" || current == "dev" {
+	if current == "" {
 		return doctorCheck{Name: name, Status: doctorStatusSkip, Message: localizef("running traceary version is %q; skipped plugin version comparison for %s", "実行中 traceary version は %q のため %s plugin version 比較を skip しました", currentVersion, install.Client)}
-	}
-	if isDevBuild(currentVersion) {
-		return doctorCheck{
-			Name:   name,
-			Status: doctorStatusPass,
-			Message: localizef(
-				"%s plugin version comparison soft-passed because traceary is running a dev build: %s (%s)",
-				"traceary が dev build として実行中のため %s plugin version 比較を soft-pass しました: %s (%s)",
-				install.Client, currentVersion, install.ManifestPath,
-			),
-			Hint: "running a dev build (rebuild + reinstall plugin to verify version alignment)",
-		}
 	}
 	installedVersion := ""
 	if install.InstalledVersion != "" {
@@ -108,6 +96,18 @@ func inspectPluginVersion(install doctorPluginInstall, currentVersion string) do
 	installed := normalizeDoctorVersion(installedVersion)
 	if installed == "" {
 		return doctorCheck{Name: name, Status: doctorStatusWarn, Message: localizef("%s plugin manifest has no version: %s", "%s plugin manifest に version がありません: %s", install.Client, install.ManifestPath), Hint: "reinstall plugin to align", FixCommand: install.UpdateHint}
+	}
+	if isDevBuild(currentVersion) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"%s plugin version comparison soft-passed because traceary is running a dev build: %s (plugin %s at %s)",
+				"traceary が dev build として実行中のため %s plugin version 比較を soft-pass しました: %s (plugin %s at %s)",
+				install.Client, currentVersion, installedVersion, install.ManifestPath,
+			),
+			Hint: "running a dev build (rebuild + reinstall plugin to verify version alignment)",
+		}
 	}
 	if installed != current {
 		return doctorCheck{Name: name, Status: doctorStatusWarn, Message: localizef("%s plugin version %s does not match running traceary version %s (%s)", "%s plugin version %s は実行中 traceary version %s と一致しません (%s)", install.Client, installedVersion, currentVersion, install.ManifestPath), Hint: "reinstall plugin to align", FixCommand: install.UpdateHint}
@@ -135,7 +135,7 @@ func isDevBuild(version string) bool {
 		return false
 	}
 	lower := strings.ToLower(version)
-	if strings.Contains(lower, "devel") || strings.Contains(lower, "dirty") {
+	if lower == "dev" || strings.Contains(lower, "devel") || strings.Contains(lower, "dirty") {
 		return true
 	}
 	return doctorPseudoVersionPattern.MatchString(normalizeDoctorVersion(version))

--- a/presentation/cli/doctor_plugin_version_test.go
+++ b/presentation/cli/doctor_plugin_version_test.go
@@ -87,6 +87,68 @@ func TestInspectPluginVersionSoftPassesDevBuilds(t *testing.T) {
 	}
 }
 
+func TestInspectPluginVersionDevBuildValidatesManifestBeforeSoftPass(t *testing.T) {
+	tests := map[string]struct {
+		manifestContent string
+		manifestPath    func(t *testing.T) string
+		wantStatus      string
+		wantMessagePart string
+		wantHint        string
+	}{
+		"valid mismatched plugin version soft-passes comparison": {
+			manifestContent: `{"name":"traceary","version":"0.9.0"}`,
+			wantStatus:      doctorStatusPass,
+			wantMessagePart: "soft-passed",
+			wantHint:        "running a dev build (rebuild + reinstall plugin to verify version alignment)",
+		},
+		"unreadable manifest fails before soft-pass": {
+			manifestPath: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantStatus:      doctorStatusFail,
+			wantMessagePart: "failed to read codex plugin manifest version",
+		},
+		"parse error fails before soft-pass": {
+			manifestContent: `{`,
+			wantStatus:      doctorStatusFail,
+			wantMessagePart: "failed to read codex plugin manifest version",
+		},
+		"missing version warns before soft-pass": {
+			manifestContent: `{"name":"traceary"}`,
+			wantStatus:      doctorStatusWarn,
+			wantMessagePart: "has no version",
+			wantHint:        "reinstall plugin to align",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			manifest := ""
+			if tt.manifestPath != nil {
+				manifest = tt.manifestPath(t)
+			} else {
+				manifest = filepath.Join(t.TempDir(), "plugin.json")
+				if err := os.WriteFile(manifest, []byte(tt.manifestContent), 0o644); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+			install := doctorPluginInstall{Client: "codex", ManifestPath: manifest, UpdateHint: "reinstall plugin to align"}
+
+			got := inspectPluginVersion(install, "dev")
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q; msg=%q", got.Status, tt.wantStatus, got.Message)
+			}
+			if !strings.Contains(got.Message, tt.wantMessagePart) {
+				t.Fatalf("message = %q, want to contain %q", got.Message, tt.wantMessagePart)
+			}
+			if got.Hint != tt.wantHint {
+				t.Fatalf("hint = %q, want %q", got.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
 func TestInspectPluginVersionReleaseTaggedBuildMatch(t *testing.T) {
 	manifest := filepath.Join(t.TempDir(), "plugin.json")
 	if err := os.WriteFile(manifest, []byte(`{"name":"traceary","version":"0.10.0"}`), 0o644); err != nil {

--- a/presentation/cli/doctor_plugin_version_test.go
+++ b/presentation/cli/doctor_plugin_version_test.go
@@ -58,6 +58,51 @@ func TestInspectPluginVersionNormalizesBuildMetadata(t *testing.T) {
 	}
 }
 
+func TestInspectPluginVersionSoftPassesDevBuilds(t *testing.T) {
+	tests := map[string]string{
+		"pseudo version": "0.9.1-0.20260425142357-7c744ac214bf",
+		"devel marker":   "devel (local build)",
+		"dirty marker":   "0.10.0 (commit=abc, dirty)",
+	}
+
+	for name, runningVersion := range tests {
+		t.Run(name, func(t *testing.T) {
+			manifest := filepath.Join(t.TempDir(), "plugin.json")
+			if err := os.WriteFile(manifest, []byte(`{"name":"traceary","version":"0.9.0"}`), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			install := doctorPluginInstall{Client: "codex", ManifestPath: manifest, UpdateHint: "reinstall plugin to align"}
+
+			got := inspectPluginVersion(install, runningVersion)
+			if got.Status != doctorStatusPass {
+				t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+			}
+			if got.Hint != "running a dev build (rebuild + reinstall plugin to verify version alignment)" {
+				t.Fatalf("hint = %q, want dev build hint", got.Hint)
+			}
+			if got.FixCommand != "" {
+				t.Fatalf("FixCommand = %q, want empty", got.FixCommand)
+			}
+		})
+	}
+}
+
+func TestInspectPluginVersionReleaseTaggedBuildMatch(t *testing.T) {
+	manifest := filepath.Join(t.TempDir(), "plugin.json")
+	if err := os.WriteFile(manifest, []byte(`{"name":"traceary","version":"0.10.0"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	install := doctorPluginInstall{Client: "gemini", ManifestPath: manifest, UpdateHint: "gemini extensions update traceary"}
+
+	got := inspectPluginVersion(install, "0.10.0")
+	if got.Status != doctorStatusPass {
+		t.Fatalf("status = %q, want pass; msg=%q", got.Status, got.Message)
+	}
+	if got.Hint != "" || got.FixCommand != "" {
+		t.Fatalf("hint/fix should be empty for matching release: %+v", got)
+	}
+}
+
 func TestNormalizeDoctorVersion(t *testing.T) {
 	tests := map[string]string{
 		"0.9.0 (commit=abc, date=2026, go=1.24)": "0.9.0",


### PR DESCRIPTION
Quality-phase follow-up.

Plugin-version checks now detect dev builds (Go pseudo-version suffix `-0.YYYYMMDDHHMMSS-<hash>` or `devel`/`dirty` markers) and return PASS-with-note instead of WARN, eliminating spurious exit-code-2 from `go build && doctor` on the maintainer workstation.

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>