### PR TITLE
fix(session): include requested tree root outside limit (#774)

### DIFF
--- a/application/queryservice/session_query.go
+++ b/application/queryservice/session_query.go
@@ -16,6 +16,9 @@ type SessionQueryService interface {
 	FindLatest(ctx context.Context, client types.Client, agent types.Agent, workspace types.Workspace, activeOnly bool) (types.Optional[*model.Event], error)
 	// ListSummaries returns session summaries matching the criteria.
 	ListSummaries(ctx context.Context, limit, offset int, sessionID types.SessionID, workspace types.Workspace, client types.Client, agent types.Agent, label string, activeOnly bool, from, to types.Optional[time.Time]) ([]apptypes.SessionSummary, error)
+	// ListTreeSummaries returns sessions for the tree view. When rootSessionID is set,
+	// the root session is always included in addition to the limited recent candidates.
+	ListTreeSummaries(ctx context.Context, limit int, workspace types.Workspace, rootSessionID types.SessionID) ([]apptypes.SessionSummary, error)
 	// LineageOf returns the full session tree rooted at the topmost ancestor of sessionID.
 	LineageOf(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error)
 }

--- a/application/queryservice/session_query.go
+++ b/application/queryservice/session_query.go
@@ -17,7 +17,7 @@ type SessionQueryService interface {
 	// ListSummaries returns session summaries matching the criteria.
 	ListSummaries(ctx context.Context, limit, offset int, sessionID types.SessionID, workspace types.Workspace, client types.Client, agent types.Agent, label string, activeOnly bool, from, to types.Optional[time.Time]) ([]apptypes.SessionSummary, error)
 	// ListTreeSummaries returns sessions for the tree view. When rootSessionID is set,
-	// the root session is always included in addition to the limited recent candidates.
+	// the root session and its descendants are returned without applying the recent-session limit.
 	ListTreeSummaries(ctx context.Context, limit int, workspace types.Workspace, rootSessionID types.SessionID) ([]apptypes.SessionSummary, error)
 	// LineageOf returns the full session tree rooted at the topmost ancestor of sessionID.
 	LineageOf(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error)

--- a/application/usecase/replay_usecase_impl_test.go
+++ b/application/usecase/replay_usecase_impl_test.go
@@ -22,6 +22,9 @@ func (s *stubReplaySessionQuery) FindLatest(context.Context, domtypes.Client, do
 func (s *stubReplaySessionQuery) ListSummaries(context.Context, int, int, domtypes.SessionID, domtypes.Workspace, domtypes.Client, domtypes.Agent, string, bool, domtypes.Optional[time.Time], domtypes.Optional[time.Time]) ([]apptypes.SessionSummary, error) {
 	return s.sessions, nil
 }
+func (s *stubReplaySessionQuery) ListTreeSummaries(context.Context, int, domtypes.Workspace, domtypes.SessionID) ([]apptypes.SessionSummary, error) {
+	return s.sessions, nil
+}
 func (s *stubReplaySessionQuery) LineageOf(context.Context, domtypes.SessionID) ([]apptypes.SessionSummary, error) {
 	return nil, nil
 }

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -30,8 +30,9 @@ type SessionUsecase interface {
 	List(ctx context.Context, criteria apptypes.SessionListCriteria) ([]apptypes.SessionSummary, error)
 
 	// Tree returns session summaries as a hierarchy for the given workspace.
-	// Zero-value workspace returns sessions across all workspaces.
-	Tree(ctx context.Context, workspace types.Workspace, limit int) ([]apptypes.SessionSummary, error)
+	// Zero-value workspace returns sessions across all workspaces. When rootSessionID
+	// is set, the requested root is included regardless of the limit window.
+	Tree(ctx context.Context, workspace types.Workspace, rootSessionID types.SessionID, limit int) ([]apptypes.SessionSummary, error)
 
 	// Lineage returns the full hierarchy rooted at the topmost ancestor of sessionID.
 	Lineage(ctx context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error)

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -235,12 +235,20 @@ func (u *sessionUsecase) List(ctx context.Context, criteria apptypes.SessionList
 	return summaries, nil
 }
 
-func (u *sessionUsecase) Tree(ctx context.Context, workspace types.Workspace, limit int) ([]apptypes.SessionSummary, error) {
+func (u *sessionUsecase) Tree(ctx context.Context, workspace types.Workspace, rootSessionID types.SessionID, limit int) ([]apptypes.SessionSummary, error) {
 	if limit <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
 	}
+	trimmedRootID := strings.TrimSpace(rootSessionID.String())
+	if trimmedRootID != "" {
+		resolvedRootID, err := types.SessionIDFrom(trimmedRootID)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve root session ID: %w", err)
+		}
+		rootSessionID = resolvedRootID
+	}
 
-	summaries, err := u.sessionQuery.ListSummaries(ctx, limit, 0, types.SessionID(""), workspace, types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+	summaries, err := u.sessionQuery.ListTreeSummaries(ctx, limit, workspace, rootSessionID)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to list sessions for tree: %w", err)
 	}

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -89,6 +89,29 @@ func (s *sessionQueryServiceStub) ListSummaries(
 	return s.listSummariesResult, nil
 }
 
+func (s *sessionQueryServiceStub) ListTreeSummaries(
+	_ context.Context,
+	limit int,
+	workspace types.Workspace,
+	rootSessionID types.SessionID,
+) ([]apptypes.SessionSummary, error) {
+	s.listSummariesCalls++
+	s.listLimit = limit
+	s.listOffset = 0
+	s.listSessionID = rootSessionID
+	s.listWorkspace = workspace
+	s.listClient = types.Client("")
+	s.listAgent = types.Agent("")
+	s.listLabel = ""
+	s.listActiveOnly = false
+	s.listFrom = types.None[time.Time]()
+	s.listTo = types.None[time.Time]()
+	if s.listSummariesErr != nil {
+		return nil, s.listSummariesErr
+	}
+	return s.listSummariesResult, nil
+}
+
 func (s *sessionQueryServiceStub) LineageOf(_ context.Context, sessionID types.SessionID) ([]apptypes.SessionSummary, error) {
 	s.lineageCalls++
 	s.lineageSessionID = sessionID
@@ -576,7 +599,7 @@ func TestSessionUsecase_Tree(t *testing.T) {
 		queryStub := &sessionQueryServiceStub{}
 		sut := usecase.NewSessionUsecase(nil, nil, queryStub, nil)
 
-		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), 0)
+		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), types.SessionID(""), 0)
 		if err == nil {
 			t.Fatalf("Tree() error = nil, want error")
 		}
@@ -591,7 +614,7 @@ func TestSessionUsecase_Tree(t *testing.T) {
 		queryStub := &sessionQueryServiceStub{}
 		sut := usecase.NewSessionUsecase(nil, nil, queryStub, nil)
 
-		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), -1)
+		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), types.SessionID(""), -1)
 		if err == nil {
 			t.Fatalf("Tree() error = nil, want error")
 		}
@@ -618,7 +641,7 @@ func TestSessionUsecase_Tree(t *testing.T) {
 		queryStub := &sessionQueryServiceStub{listSummariesResult: want}
 		sut := usecase.NewSessionUsecase(nil, nil, queryStub, nil)
 
-		got, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), 50)
+		got, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), types.SessionID(""), 50)
 		if err != nil {
 			t.Fatalf("Tree() error = %v", err)
 		}
@@ -648,7 +671,7 @@ func TestSessionUsecase_Tree(t *testing.T) {
 		queryStub := &sessionQueryServiceStub{listSummariesErr: errors.New("query failed")}
 		sut := usecase.NewSessionUsecase(nil, nil, queryStub, nil)
 
-		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), 10)
+		_, err := sut.Tree(context.Background(), types.Workspace("duck8823/traceary"), types.SessionID(""), 10)
 		if err == nil {
 			t.Fatalf("Tree() error = nil, want error")
 		}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -106,6 +106,11 @@ func saveTestSession(ctx context.Context, t *testing.T, ds *infra.SessionDatasou
 
 func saveTestSessionWithParent(ctx context.Context, t *testing.T, ds *infra.SessionDatasource, sessionID string, parentID string, startedAt time.Time, order int) {
 	t.Helper()
+	saveTestSessionWithParentInWorkspace(ctx, t, ds, sessionID, parentID, startedAt, order, "duck8823/traceary")
+}
+
+func saveTestSessionWithParentInWorkspace(ctx context.Context, t *testing.T, ds *infra.SessionDatasource, sessionID string, parentID string, startedAt time.Time, order int, workspace string) {
+	t.Helper()
 	agent, _ := types.AgentFrom("codex")
 	sid, _ := types.SessionIDFrom(sessionID)
 	parentSID, _ := types.SessionIDFrom(parentID)
@@ -116,7 +121,7 @@ func saveTestSessionWithParent(ctx context.Context, t *testing.T, ds *infra.Sess
 		types.None[time.Time](),
 		types.Client("hook"),
 		agent,
-		types.Workspace("duck8823/traceary"),
+		types.Workspace(workspace),
 		"",
 		"",
 		parentSID,
@@ -433,6 +438,62 @@ type fakeClock struct {
 }
 
 func (c fakeClock) Now() time.Time { return c.now }
+
+func TestDatasource_ListTreeSummariesWithRootAppliesWorkspaceToDescendants(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "parent", started, types.None[time.Time](), "codex", "workspace-a")
+	saveTestSessionWithParentInWorkspace(ctx, t, fixture.sessionDS, "child-in-a", "parent", started.Add(time.Minute), 1, "workspace-a")
+	saveTestSessionWithParentInWorkspace(ctx, t, fixture.sessionDS, "child-in-b", "parent", started.Add(2*time.Minute), 2, "workspace-b")
+
+	got, err := fixture.sessionDS.ListTreeSummaries(ctx, 50, types.Workspace("workspace-a"), types.SessionID("parent"))
+	if err != nil {
+		t.Fatalf("ListTreeSummaries() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	if diff := cmp.Diff([]string{"parent", "child-in-a"}, gotIDs); diff != "" {
+		t.Fatalf("ListTreeSummaries() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDatasource_ListTreeSummariesIncludesRequestedRootOutsideWorkspace(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "parent", started, types.None[time.Time](), "codex", "workspace-b")
+	saveTestSessionWithParentInWorkspace(ctx, t, fixture.sessionDS, "child-in-a", "parent", started.Add(time.Minute), 1, "workspace-a")
+	saveTestSessionWithParentInWorkspace(ctx, t, fixture.sessionDS, "child-in-b", "parent", started.Add(2*time.Minute), 2, "workspace-b")
+
+	got, err := fixture.sessionDS.ListTreeSummaries(ctx, 50, types.Workspace("workspace-a"), types.SessionID("parent"))
+	if err != nil {
+		t.Fatalf("ListTreeSummaries() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	if diff := cmp.Diff([]string{"parent", "child-in-a"}, gotIDs); diff != "" {
+		t.Fatalf("ListTreeSummaries() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
 
 func TestDatasource_ListTreeSummariesIncludesRequestedRootOutsideLimit(t *testing.T) {
 	t.Parallel()

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -524,6 +524,39 @@ func TestDatasource_ListTreeSummariesIncludesRequestedRootOutsideLimit(t *testin
 	}
 }
 
+func TestDatasource_ListTreeSummariesWithRootIncludesDescendantsOutsideRecentLimit(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "parent", started, types.None[time.Time](), "claude", "duck8823/traceary")
+	for i := 0; i < 5; i++ {
+		saveTestSessionWithParent(ctx, t, fixture.sessionDS, fmt.Sprintf("child-%02d", i+1), "parent", started.Add(time.Duration(i+1)*time.Minute), i+1)
+	}
+	for i := 0; i < 100; i++ {
+		saveTestSession(ctx, t, fixture.sessionDS, fmt.Sprintf("newer-unrelated-%03d", i), started.Add(time.Duration(i+1)*time.Hour), types.None[time.Time](), "codex", "duck8823/traceary")
+	}
+
+	got, err := fixture.sessionDS.ListTreeSummaries(ctx, 3, types.Workspace("duck8823/traceary"), types.SessionID("parent"))
+	if err != nil {
+		t.Fatalf("ListTreeSummaries() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	wantIDs := []string{"parent", "child-01", "child-02", "child-03", "child-04", "child-05"}
+	if diff := cmp.Diff(wantIDs, gotIDs); diff != "" {
+		t.Fatalf("ListTreeSummaries() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestDatasource_RejectsSelfParentSession(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -424,6 +425,41 @@ func TestDatasource_LineageOfCycleDetection(t *testing.T) {
 	wantIDs := []string{"cycle-a", "cycle-b"}
 	if diff := cmp.Diff(wantIDs, gotIDs); diff != "" {
 		t.Fatalf("LineageOf() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c fakeClock) Now() time.Time { return c.now }
+
+func TestDatasource_ListTreeSummariesIncludesRequestedRootOutsideLimit(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	fixture := newListSessionsFixture(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "old-root", started, types.None[time.Time](), "claude", "duck8823/traceary")
+	for i := 0; i < 60; i++ {
+		saveTestSession(ctx, t, fixture.sessionDS, fmt.Sprintf("newer-unrelated-%02d", i), started.Add(time.Duration(i+1)*time.Minute), types.None[time.Time](), "codex", "duck8823/traceary")
+	}
+
+	got, err := fixture.sessionDS.ListTreeSummaries(ctx, 50, types.Workspace("duck8823/traceary"), types.SessionID("old-root"))
+	if err != nil {
+		t.Fatalf("ListTreeSummaries() error = %v", err)
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, summary := range got {
+		gotIDs = append(gotIDs, summary.SessionID().String())
+	}
+	if diff := cmp.Diff([]string{"old-root"}, gotIDs); diff != "" {
+		t.Fatalf("ListTreeSummaries() IDs mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -16,12 +16,6 @@ import (
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
-type fakeClock struct {
-	now time.Time
-}
-
-func (c fakeClock) Now() time.Time { return c.now }
-
 func newMemoryDatasource(
 	t *testing.T,
 	dbPath string,

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -35,6 +35,9 @@ var findLatestSessionQuery string
 //go:embed sql/list_sessions.sql
 var listSessionsQuery string
 
+//go:embed sql/list_session_tree.sql
+var listSessionTreeQuery string
+
 //go:embed sql/session_lineage.sql
 var sessionLineageQuery string
 
@@ -468,6 +471,63 @@ func (d *SessionDatasource) ListSummaries(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("failed to iterate session summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+// ListTreeSummaries returns sessions for the tree view. Without a root filter it
+// preserves the regular recent-session listing behavior. With a root filter it
+// selects the recent limited candidates that are descendants of the requested
+// root and unions the root row itself so --root never disappears solely because
+// it is older than the limit window.
+func (d *SessionDatasource) ListTreeSummaries(
+	ctx context.Context,
+	limit int,
+	workspace types.Workspace,
+	rootSessionID types.SessionID,
+) ([]apptypes.SessionSummary, error) {
+	if strings.TrimSpace(rootSessionID.String()) == "" {
+		return d.ListSummaries(ctx, limit, 0, types.SessionID(""), workspace, types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for session tree: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	rows, err := db.QueryContext(
+		ctx,
+		listSessionTreeQuery,
+		rootSessionID.String(),
+		workspace.String(), workspace.String(),
+		limit,
+		rootSessionID.String(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query session tree summaries: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	summaries := make([]apptypes.SessionSummary, 0)
+	for rows.Next() {
+		summary, err := scanSessionSummary(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan session tree summary row: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate session tree summary rows: %w", err)
 	}
 
 	return summaries, nil

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -479,8 +479,9 @@ func (d *SessionDatasource) ListSummaries(
 // ListTreeSummaries returns sessions for the tree view. Without a root filter it
 // preserves the regular recent-session listing behavior. With a root filter it
 // selects the recent limited candidates that are descendants of the requested
-// root and unions the root row itself so --root never disappears solely because
-// it is older than the limit window.
+// root and match the workspace filter when provided. It unions the root row
+// itself so --root never disappears solely because it is older than the limit
+// window or outside the requested workspace.
 func (d *SessionDatasource) ListTreeSummaries(
 	ctx context.Context,
 	limit int,
@@ -505,6 +506,7 @@ func (d *SessionDatasource) ListTreeSummaries(
 		ctx,
 		listSessionTreeQuery,
 		rootSessionID.String(),
+		workspace.String(), workspace.String(),
 		workspace.String(), workspace.String(),
 		limit,
 		rootSessionID.String(),

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -478,10 +478,10 @@ func (d *SessionDatasource) ListSummaries(
 
 // ListTreeSummaries returns sessions for the tree view. Without a root filter it
 // preserves the regular recent-session listing behavior. With a root filter it
-// selects the recent limited candidates that are descendants of the requested
-// root and match the workspace filter when provided. It unions the root row
-// itself so --root never disappears solely because it is older than the limit
-// window or outside the requested workspace.
+// returns the requested root and its full descendant subtree. The workspace
+// filter applies to descendants when provided, while the requested root is kept
+// even if it is outside that workspace. The recent-session limit is intentionally
+// not applied to descendants of an explicit root.
 func (d *SessionDatasource) ListTreeSummaries(
 	ctx context.Context,
 	limit int,
@@ -507,9 +507,6 @@ func (d *SessionDatasource) ListTreeSummaries(
 		listSessionTreeQuery,
 		rootSessionID.String(),
 		workspace.String(), workspace.String(),
-		workspace.String(), workspace.String(),
-		limit,
-		rootSessionID.String(),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query session tree summaries: %w", err)

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -1,0 +1,60 @@
+WITH RECURSIVE
+  descendants(session_id, depth, path) AS (
+    SELECT session_id, 0, ',' || session_id || ','
+    FROM sessions
+    WHERE session_id = ?
+    UNION ALL
+    SELECT child.session_id, descendants.depth + 1, descendants.path || child.session_id || ','
+    FROM sessions child
+    JOIN descendants ON child.parent_session_id = descendants.session_id
+    WHERE descendants.depth < 100
+      AND instr(descendants.path, ',' || child.session_id || ',') = 0
+  ),
+  candidate_ids(session_id) AS (
+    SELECT s.session_id
+    FROM sessions s
+    WHERE (? = '' OR s.workspace = ?)
+    ORDER BY s.started_at DESC
+    LIMIT ?
+  ),
+  selected_ids(session_id) AS (
+    SELECT descendants.session_id
+    FROM descendants
+    JOIN candidate_ids ON candidate_ids.session_id = descendants.session_id
+    UNION
+    SELECT session_id
+    FROM descendants
+    WHERE session_id = ?
+  )
+SELECT
+  s.session_id,
+  s.workspace,
+  s.client,
+  s.started_at,
+  s.ended_at,
+  COALESCE(agg.total_events, 0) AS total_events,
+  COALESCE(agg.command_count, 0) AS command_count,
+  COALESCE(agg.latest_event_at, s.started_at) AS latest_event_at,
+  COALESCE(agg.agents, '') AS agents,
+  s.label,
+  s.summary,
+  COALESCE(s.parent_session_id, '') AS parent_session_id,
+  COALESCE(s.spawn_event_id, '') AS spawn_event_id,
+  s.subagent_kind,
+  s.spawn_order
+FROM sessions s
+JOIN selected_ids ON selected_ids.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    e.session_id,
+    COUNT(*) AS total_events,
+    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+    GROUP_CONCAT(DISTINCT e.agent) AS agents,
+    MAX(e.created_at) AS latest_event_at
+  FROM events e
+  GROUP BY e.session_id
+) agg ON agg.session_id = s.session_id
+ORDER BY
+  s.parent_session_id NULLS FIRST,
+  s.spawn_order NULLS FIRST,
+  s.started_at ASC

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -11,21 +11,9 @@ WITH RECURSIVE
       AND instr(descendants.path, ',' || child.session_id || ',') = 0
       AND (? = '' OR child.workspace = ?)
   ),
-  candidate_ids(session_id) AS (
-    SELECT s.session_id
-    FROM sessions s
-    WHERE (? = '' OR s.workspace = ?)
-    ORDER BY s.started_at DESC
-    LIMIT ?
-  ),
   selected_ids(session_id) AS (
-    SELECT descendants.session_id
-    FROM descendants
-    JOIN candidate_ids ON candidate_ids.session_id = descendants.session_id
-    UNION
     SELECT session_id
     FROM descendants
-    WHERE session_id = ?
   )
 SELECT
   s.session_id,

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -9,6 +9,7 @@ WITH RECURSIVE
     JOIN descendants ON child.parent_session_id = descendants.session_id
     WHERE descendants.depth < 100
       AND instr(descendants.path, ',' || child.session_id || ',') = 0
+      AND (? = '' OR child.workspace = ?)
   ),
   candidate_ids(session_id) AS (
     SELECT s.session_id

--- a/presentation/cli/session_tree.go
+++ b/presentation/cli/session_tree.go
@@ -43,7 +43,7 @@ func (c *RootCLI) newSessionTreeCommand() *cobra.Command {
 
 			resolvedRepo := resolveWorkspaceValue(ctx, repo)
 
-			summaries, err := c.session.Tree(ctx, types.Workspace(resolvedRepo), limit)
+			summaries, err := c.session.Tree(ctx, types.Workspace(resolvedRepo), types.SessionID(strings.TrimSpace(rootID)), limit)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
 			}
@@ -178,11 +178,21 @@ func writeSessionTreeFiltered(output io.Writer, summaries []apptypes.SessionSumm
 }
 
 func sortSessionNodes(nodes []*sessionNode) {
+	sortSessionNodesWithVisited(nodes, map[string]bool{})
+}
+
+func sortSessionNodesWithVisited(nodes []*sessionNode, visited map[string]bool) {
 	sort.SliceStable(nodes, func(i, j int) bool {
 		return sessionNodeLess(nodes[i], nodes[j])
 	})
 	for _, node := range nodes {
-		sortSessionNodes(node.children)
+		sessionID := node.summary.SessionID().String()
+		if visited[sessionID] {
+			continue
+		}
+		visited[sessionID] = true
+		sortSessionNodesWithVisited(node.children, visited)
+		delete(visited, sessionID)
 	}
 }
 
@@ -252,6 +262,10 @@ func writeSessionTreeEmpty(output io.Writer, asJSON bool) error {
 }
 
 func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
+	return sessionNodeToOutputWithVisited(node, depth, map[string]bool{})
+}
+
+func sessionNodeToOutputWithVisited(node *sessionNode, depth int, visited map[string]bool) *sessionTreeNode {
 	s := node.summary
 	jn := &sessionTreeNode{
 		SessionID:       string(s.SessionID()),
@@ -280,9 +294,15 @@ func sessionNodeToOutput(node *sessionNode, depth int) *sessionTreeNode {
 		secs := dur.Seconds()
 		jn.DurationSec = &secs
 	}
-	for _, child := range node.children {
-		jn.Children = append(jn.Children, sessionNodeToOutput(child, depth+1))
+	if visited[s.SessionID().String()] {
+		jn.Status = "cycle-detected"
+		return jn
 	}
+	visited[s.SessionID().String()] = true
+	for _, child := range node.children {
+		jn.Children = append(jn.Children, sessionNodeToOutputWithVisited(child, depth+1, visited))
+	}
+	delete(visited, s.SessionID().String())
 	return jn
 }
 
@@ -319,6 +339,10 @@ func writeSessionTreeJSON(output io.Writer, roots []*sessionNode) error {
 }
 
 func printNode(output io.Writer, node *sessionNode, prefix string, isLast bool) error {
+	return printNodeWithVisited(output, node, prefix, isLast, map[string]bool{})
+}
+
+func printNodeWithVisited(output io.Writer, node *sessionNode, prefix string, isLast bool, visited map[string]bool) error {
 	s := node.summary
 
 	connector := "\u251c\u2500\u2500 "
@@ -345,10 +369,16 @@ func printNode(output io.Writer, node *sessionNode, prefix string, isLast bool) 
 		subagentFragment = " " + subagent
 	}
 
+	status := s.Status()
+	cycleDetected := visited[s.SessionID().String()]
+	if cycleDetected {
+		status = "cycle-detected"
+	}
+
 	line := fmt.Sprintf("%s%s%s [%s]%s %s (%s, %d cmds/%d events)%s\n",
 		prefix, connector,
 		s.SessionID(),
-		s.Status(),
+		status,
 		subagentFragment,
 		formatOptionalColumn(s.Workspace().String()),
 		duration,
@@ -370,11 +400,16 @@ func printNode(output io.Writer, node *sessionNode, prefix string, isLast bool) 
 		}
 	}
 
+	if cycleDetected {
+		return nil
+	}
+	visited[s.SessionID().String()] = true
 	for i, child := range node.children {
-		if err := printNode(output, child, childPrefix, i == len(node.children)-1); err != nil {
+		if err := printNodeWithVisited(output, child, childPrefix, i == len(node.children)-1, visited); err != nil {
 			return err
 		}
 	}
+	delete(visited, s.SessionID().String())
 
 	return nil
 }

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -192,7 +192,7 @@ func (s *sessionUsecaseStub) List(_ context.Context, criteria apptypes.SessionLi
 	s.listCriteria = criteria
 	return s.listResult, s.listErr
 }
-func (s *sessionUsecaseStub) Tree(_ context.Context, _ types.Workspace, _ int) ([]apptypes.SessionSummary, error) {
+func (s *sessionUsecaseStub) Tree(_ context.Context, _ types.Workspace, _ types.SessionID, _ int) ([]apptypes.SessionSummary, error) {
 	if s.treeResult == nil && s.treeErr == nil {
 		return s.listResult, s.listErr
 	}


### PR DESCRIPTION
Quality-phase follow-up.

`session tree --root <id>` now always fetches the requested root regardless of `--limit`. The cycle guard from #764 is preserved. Regression test exercises a root older than the default limit window.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>