### PR TITLE
feat(domain+sqlite): extend SessionSummary with latest event kind/message

### DIFF
--- a/application/types/session_summary.go
+++ b/application/types/session_summary.go
@@ -9,22 +9,35 @@ import (
 
 // SessionSummary holds aggregated information about a single session.
 type SessionSummary struct {
-	sessionID       domtypes.SessionID
-	workspace       domtypes.Workspace
-	client          domtypes.Client
-	startedAt       time.Time
-	endedAt         domtypes.Optional[time.Time]
-	status          string
-	totalEvents     int
-	commandCount    int
-	agents          []string
-	label           string
-	summary         string
-	parentSessionID domtypes.SessionID
-	spawnEventID    domtypes.EventID
-	subagentKind    string
-	spawnOrder      domtypes.Optional[int]
-	latestEventAt   time.Time
+	sessionID          domtypes.SessionID
+	workspace          domtypes.Workspace
+	client             domtypes.Client
+	startedAt          time.Time
+	endedAt            domtypes.Optional[time.Time]
+	status             string
+	totalEvents        int
+	commandCount       int
+	agents             []string
+	label              string
+	summary            string
+	parentSessionID    domtypes.SessionID
+	spawnEventID       domtypes.EventID
+	subagentKind       string
+	spawnOrder         domtypes.Optional[int]
+	latestEventAt      time.Time
+	latestEventKind    domtypes.EventKind
+	latestEventMessage string
+}
+
+// SessionSummaryLatestEvent carries latest-event metadata for SessionSummaryOf.
+type SessionSummaryLatestEvent struct {
+	Kind    domtypes.EventKind
+	Message string
+}
+
+// SessionSummaryLatestEventOf creates latest-event metadata for SessionSummaryOf.
+func SessionSummaryLatestEventOf(kind domtypes.EventKind, message string) SessionSummaryLatestEvent {
+	return SessionSummaryLatestEvent{Kind: kind, Message: message}
 }
 
 // SessionSummaryOf creates a SessionSummary.
@@ -43,11 +56,13 @@ func SessionSummaryOf(
 	spawnMetadata ...any,
 ) SessionSummary {
 	var (
-		spawnEventID  domtypes.EventID
-		subagentKind  string
-		spawnOrder    domtypes.Optional[int]
-		latestEventAt = startedAt
-		client        domtypes.Client
+		spawnEventID       domtypes.EventID
+		subagentKind       string
+		spawnOrder         domtypes.Optional[int]
+		latestEventAt      = startedAt
+		latestEventKind    domtypes.EventKind
+		latestEventMessage string
+		client             domtypes.Client
 	)
 	for _, metadata := range spawnMetadata {
 		switch value := metadata.(type) {
@@ -61,25 +76,30 @@ func SessionSummaryOf(
 			spawnOrder = value
 		case time.Time:
 			latestEventAt = value
+		case SessionSummaryLatestEvent:
+			latestEventKind = value.Kind
+			latestEventMessage = value.Message
 		}
 	}
 	return SessionSummary{
-		sessionID:       sessionID,
-		workspace:       workspace,
-		client:          client,
-		startedAt:       startedAt,
-		endedAt:         endedAt,
-		status:          status,
-		totalEvents:     totalEvents,
-		commandCount:    commandCount,
-		agents:          slices.Clone(agents),
-		label:           label,
-		summary:         summary,
-		parentSessionID: parentSessionID,
-		spawnEventID:    spawnEventID,
-		subagentKind:    subagentKind,
-		spawnOrder:      spawnOrder,
-		latestEventAt:   latestEventAt,
+		sessionID:          sessionID,
+		workspace:          workspace,
+		client:             client,
+		startedAt:          startedAt,
+		endedAt:            endedAt,
+		status:             status,
+		totalEvents:        totalEvents,
+		commandCount:       commandCount,
+		agents:             slices.Clone(agents),
+		label:              label,
+		summary:            summary,
+		parentSessionID:    parentSessionID,
+		spawnEventID:       spawnEventID,
+		subagentKind:       subagentKind,
+		spawnOrder:         spawnOrder,
+		latestEventAt:      latestEventAt,
+		latestEventKind:    latestEventKind,
+		latestEventMessage: latestEventMessage,
 	}
 }
 
@@ -130,3 +150,9 @@ func (s SessionSummary) SpawnOrder() domtypes.Optional[int] { return s.spawnOrde
 
 // LatestEventAt returns the latest recorded event timestamp in the session.
 func (s SessionSummary) LatestEventAt() time.Time { return s.latestEventAt }
+
+// LatestEventKind returns the kind of the latest recorded event in the session.
+func (s SessionSummary) LatestEventKind() domtypes.EventKind { return s.latestEventKind }
+
+// LatestEventMessage returns the plain-text message of the latest recorded event in the session.
+func (s SessionSummary) LatestEventMessage() string { return s.latestEventMessage }

--- a/application/types/session_summary_test.go
+++ b/application/types/session_summary_test.go
@@ -32,6 +32,8 @@ func TestSessionSummaryOf_Getters(t *testing.T) {
 		domtypes.EventID("spawn-event"),
 		"task",
 		domtypes.Some(4),
+		startedAt.Add(30*time.Minute),
+		apptypes.SessionSummaryLatestEventOf(domtypes.EventKindTranscript, "assistant reply"),
 	)
 
 	if diff := cmp.Diff(domtypes.SessionID("session-1"), summary.SessionID()); diff != "" {
@@ -81,6 +83,15 @@ func TestSessionSummaryOf_Getters(t *testing.T) {
 		t.Fatalf("SpawnOrder() should be present")
 	} else if diff := cmp.Diff(4, spawnOrder); diff != "" {
 		t.Errorf("SpawnOrder() mismatch (-want +got):\n%s", diff)
+	}
+	if !summary.LatestEventAt().Equal(startedAt.Add(30 * time.Minute)) {
+		t.Errorf("LatestEventAt() = %v, want %v", summary.LatestEventAt(), startedAt.Add(30*time.Minute))
+	}
+	if diff := cmp.Diff(domtypes.EventKindTranscript, summary.LatestEventKind()); diff != "" {
+		t.Errorf("LatestEventKind() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff("assistant reply", summary.LatestEventMessage()); diff != "" {
+		t.Errorf("LatestEventMessage() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -36,6 +36,7 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 主な index:
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
+- `idx_events_session_created_at_id_desc` on `(session_id, created_at DESC, id DESC)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
 - `idx_events_workspace_created_at` on `(workspace, created_at)`
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -36,6 +36,7 @@ Key columns:
 Important indexes:
 
 - `idx_events_session_created_at` on `(session_id, created_at)`
+- `idx_events_session_created_at_id_desc` on `(session_id, created_at DESC, id DESC)`
 - `idx_events_created_at` on `(created_at DESC, id DESC)`
 - `idx_events_workspace_created_at` on `(workspace, created_at)`
 

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
@@ -91,6 +92,21 @@ ALTER TABLE sessions ADD COLUMN spawn_order INTEGER;
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
     ON sessions(parent_session_id, spawn_order);`),
 		},
+		"000016_add_events_session_created_at_id_desc.sql": {
+			Data: []byte(`CREATE INDEX IF NOT EXISTS idx_events_session_created_at_id_desc
+ON events(session_id, created_at DESC, id DESC);`),
+		},
+	}
+}
+
+func saveListTestEvent(ctx context.Context, t *testing.T, ds *infra.EventDatasource, id string, kind types.EventKind, sessionID string, body string, createdAt time.Time) {
+	t.Helper()
+	eid, _ := types.EventIDFrom(id)
+	agent, _ := types.AgentFrom("codex")
+	sid, _ := types.SessionIDFrom(sessionID)
+	event := model.EventOf(eid, kind, types.Client("hook"), agent, sid, types.Workspace("duck8823/traceary"), body, createdAt)
+	if err := ds.Save(ctx, event); err != nil {
+		t.Fatalf("Save(%s) error = %v", id, err)
 	}
 }
 
@@ -644,4 +660,156 @@ func TestDatasource_LineageOf(t *testing.T) {
 	if !ok || spawnOrder != 1 {
 		t.Fatalf("child-1 spawn_order = (%d, %v), want (1, true)", spawnOrder, ok)
 	}
+}
+
+func TestDatasource_ListSummariesLatestEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses event id as tie breaker for equal timestamps", func(t *testing.T) {
+		t.Parallel()
+		fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+		ctx := context.Background()
+		if err := fixture.storeManager.Initialize(ctx); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+		started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		saveTestSession(ctx, t, fixture.sessionDS, "tie", started, types.None[time.Time](), "codex", "duck8823/traceary")
+		saveListTestEvent(ctx, t, fixture.eventDS, "event-a", types.EventKindNote, "tie", "older id", started.Add(time.Minute))
+		saveListTestEvent(ctx, t, fixture.eventDS, "event-z", types.EventKindReviewed, "tie", "newer id", started.Add(time.Minute))
+
+		summaries, err := fixture.sessionDS.ListSummaries(ctx, 10, 0, types.SessionID("tie"), types.Workspace(""), types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+		if err != nil {
+			t.Fatalf("ListSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if diff := cmp.Diff(types.EventKindReviewed, summaries[0].LatestEventKind()); diff != "" {
+			t.Fatalf("LatestEventKind() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("newer id", summaries[0].LatestEventMessage()); diff != "" {
+			t.Fatalf("LatestEventMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("empty when session has no events", func(t *testing.T) {
+		t.Parallel()
+		fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+		ctx := context.Background()
+		if err := fixture.storeManager.Initialize(ctx); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+		started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		saveTestSession(ctx, t, fixture.sessionDS, "empty", started, types.None[time.Time](), "codex", "duck8823/traceary")
+
+		summaries, err := fixture.sessionDS.ListSummaries(ctx, 10, 0, types.SessionID("empty"), types.Workspace(""), types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+		if err != nil {
+			t.Fatalf("ListSummaries() error = %v", err)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("got %d summaries, want 1", len(summaries))
+		}
+		if diff := cmp.Diff(types.EventKind(""), summaries[0].LatestEventKind()); diff != "" {
+			t.Fatalf("LatestEventKind() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("", summaries[0].LatestEventMessage()); diff != "" {
+			t.Fatalf("LatestEventMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("thinking-only transcript has empty plain message", func(t *testing.T) {
+		t.Parallel()
+		fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+		ctx := context.Background()
+		if err := fixture.storeManager.Initialize(ctx); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+		started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		saveTestSession(ctx, t, fixture.sessionDS, "thinking", started, types.None[time.Time](), "codex", "duck8823/traceary")
+		saveListTestEvent(ctx, t, fixture.eventDS, "thinking-event", types.EventKindTranscript, "thinking", `{"blocks":[{"type":"thinking","text":"hidden reasoning"}]}`, started.Add(time.Minute))
+
+		summaries, err := fixture.sessionDS.ListSummaries(ctx, 10, 0, types.SessionID("thinking"), types.Workspace(""), types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+		if err != nil {
+			t.Fatalf("ListSummaries() error = %v", err)
+		}
+		if diff := cmp.Diff(types.EventKindTranscript, summaries[0].LatestEventKind()); diff != "" {
+			t.Fatalf("LatestEventKind() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("", summaries[0].LatestEventMessage()); diff != "" {
+			t.Fatalf("LatestEventMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("session ended can be latest", func(t *testing.T) {
+		t.Parallel()
+		fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+		ctx := context.Background()
+		if err := fixture.storeManager.Initialize(ctx); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+		started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+		ended := started.Add(2 * time.Minute)
+		saveTestSession(ctx, t, fixture.sessionDS, "ended", started, types.Some(ended), "codex", "duck8823/traceary")
+		saveListTestEvent(ctx, t, fixture.eventDS, "ended-start", types.EventKindSessionStarted, "ended", "start", started)
+		saveListTestEvent(ctx, t, fixture.eventDS, "ended-end", types.EventKindSessionEnded, "ended", "session ended body", ended)
+
+		summaries, err := fixture.sessionDS.ListSummaries(ctx, 10, 0, types.SessionID("ended"), types.Workspace(""), types.Client(""), types.Agent(""), "", false, types.None[time.Time](), types.None[time.Time]())
+		if err != nil {
+			t.Fatalf("ListSummaries() error = %v", err)
+		}
+		if diff := cmp.Diff(types.EventKindSessionEnded, summaries[0].LatestEventKind()); diff != "" {
+			t.Fatalf("LatestEventKind() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff("session ended body", summaries[0].LatestEventMessage()); diff != "" {
+			t.Fatalf("LatestEventMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestDatasource_LineageAndTreeLatestEventsArePerSession(t *testing.T) {
+	t.Parallel()
+
+	fixture := newListSessionsFixture(t, filepath.Join(t.TempDir(), "traceary.db"), listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := fixture.storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	saveTestSession(ctx, t, fixture.sessionDS, "latest-root", started, types.None[time.Time](), "codex", "duck8823/traceary")
+	saveTestSessionWithParent(ctx, t, fixture.sessionDS, "latest-child", "latest-root", started.Add(time.Minute), 1)
+	saveListTestEvent(ctx, t, fixture.eventDS, "latest-root-1", types.EventKindNote, "latest-root", "root old", started)
+	saveListTestEvent(ctx, t, fixture.eventDS, "latest-root-2", types.EventKindPrompt, "latest-root", "root latest", started.Add(3*time.Minute))
+	saveListTestEvent(ctx, t, fixture.eventDS, "latest-child-1", types.EventKindNote, "latest-child", "child old", started.Add(time.Minute))
+	saveListTestEvent(ctx, t, fixture.eventDS, "latest-child-2", types.EventKindReviewed, "latest-child", "child latest", started.Add(2*time.Minute))
+
+	lineage, err := fixture.sessionDS.LineageOf(ctx, types.SessionID("latest-child"))
+	if err != nil {
+		t.Fatalf("LineageOf() error = %v", err)
+	}
+	assertSummaryLatest(t, lineage, "latest-root", types.EventKindPrompt, "root latest")
+	assertSummaryLatest(t, lineage, "latest-child", types.EventKindReviewed, "child latest")
+
+	tree, err := fixture.sessionDS.ListTreeSummaries(ctx, 10, types.Workspace("duck8823/traceary"), types.SessionID("latest-root"))
+	if err != nil {
+		t.Fatalf("ListTreeSummaries() error = %v", err)
+	}
+	assertSummaryLatest(t, tree, "latest-root", types.EventKindPrompt, "root latest")
+	assertSummaryLatest(t, tree, "latest-child", types.EventKindReviewed, "child latest")
+}
+
+func assertSummaryLatest(t *testing.T, summaries []apptypes.SessionSummary, sessionID string, wantKind types.EventKind, wantMessage string) {
+	t.Helper()
+	for _, summary := range summaries {
+		if summary.SessionID().String() != sessionID {
+			continue
+		}
+		if diff := cmp.Diff(wantKind, summary.LatestEventKind()); diff != "" {
+			t.Fatalf("%s LatestEventKind() mismatch (-want +got):\n%s", sessionID, diff)
+		}
+		if diff := cmp.Diff(wantMessage, summary.LatestEventMessage()); diff != "" {
+			t.Fatalf("%s LatestEventMessage() mismatch (-want +got):\n%s", sessionID, diff)
+		}
+		return
+	}
+	t.Fatalf("session %s not found in summaries", sessionID)
 }

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -574,21 +574,23 @@ func scanSessionSummary(row interface {
 	Scan(dest ...any) error
 }) (apptypes.SessionSummary, error) {
 	var (
-		sessionID        string
-		repo             string
-		client           string
-		startedAtStr     string
-		endedAtStr       sql.NullString
-		totalEvents      int
-		commandCount     int
-		latestEventAtStr string
-		agentsStr        sql.NullString
-		label            string
-		summary          string
-		parentSessionID  string
-		spawnEventID     string
-		subagentKind     string
-		spawnOrder       sql.NullInt64
+		sessionID          string
+		repo               string
+		client             string
+		startedAtStr       string
+		endedAtStr         sql.NullString
+		totalEvents        int
+		commandCount       int
+		latestEventAtStr   string
+		agentsStr          sql.NullString
+		label              string
+		summary            string
+		parentSessionID    string
+		spawnEventID       string
+		subagentKind       string
+		spawnOrder         sql.NullInt64
+		latestEventKindStr string
+		latestEventRawBody string
 	)
 
 	if err := row.Scan(
@@ -607,6 +609,8 @@ func scanSessionSummary(row interface {
 		&spawnEventID,
 		&subagentKind,
 		&spawnOrder,
+		&latestEventKindStr,
+		&latestEventRawBody,
 	); err != nil {
 		return apptypes.SessionSummary{}, xerrors.Errorf("failed to scan session summary: %w", err)
 	}
@@ -656,6 +660,7 @@ func scanSessionSummary(row interface {
 		subagentKind,
 		optionalIntFromNullInt64(spawnOrder),
 		latestEventAt,
+		apptypes.SessionSummaryLatestEventOf(types.EventKind(latestEventKindStr), apptypes.ExtractPlainBody(latestEventRawBody)),
 	), nil
 }
 

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -14,6 +14,33 @@ WITH RECURSIVE
   selected_ids(session_id) AS (
     SELECT session_id
     FROM descendants
+  ),
+  event_agg AS (
+    SELECT
+      e.session_id,
+      COUNT(*) AS total_events,
+      SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+      GROUP_CONCAT(DISTINCT e.agent) AS agents,
+      MAX(e.created_at) AS latest_event_at
+    FROM events e
+    JOIN selected_ids ON selected_ids.session_id = e.session_id
+    GROUP BY e.session_id
+  ),
+  latest_events AS (
+    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    FROM (
+      SELECT
+        e.session_id,
+        e.kind,
+        e.body,
+        ROW_NUMBER() OVER (
+          PARTITION BY e.session_id
+          ORDER BY e.created_at DESC, e.id DESC
+        ) AS rn
+      FROM events e
+      JOIN selected_ids ON selected_ids.session_id = e.session_id
+    )
+    WHERE rn = 1
   )
 SELECT
   s.session_id,
@@ -30,19 +57,13 @@ SELECT
   COALESCE(s.parent_session_id, '') AS parent_session_id,
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
-  s.spawn_order
+  s.spawn_order,
+  COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
+  COALESCE(latest.latest_event_body, '') AS latest_event_body
 FROM sessions s
 JOIN selected_ids ON selected_ids.session_id = s.session_id
-LEFT JOIN (
-  SELECT
-    e.session_id,
-    COUNT(*) AS total_events,
-    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-    GROUP_CONCAT(DISTINCT e.agent) AS agents,
-    MAX(e.created_at) AS latest_event_at
-  FROM events e
-  GROUP BY e.session_id
-) agg ON agg.session_id = s.session_id
+LEFT JOIN event_agg agg ON agg.session_id = s.session_id
+LEFT JOIN latest_events latest ON latest.session_id = s.session_id
 ORDER BY
   s.parent_session_id NULLS FIRST,
   s.spawn_order NULLS FIRST,

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -10,6 +10,8 @@ WITH
       AND (? = 0 OR s.ended_at IS NULL)
       AND (? = '' OR s.started_at >= ?)
       AND (? = '' OR s.started_at < ?)
+    ORDER BY s.started_at DESC
+    LIMIT ? OFFSET ?
   ),
   event_agg AS (
     SELECT
@@ -60,4 +62,3 @@ FROM filtered_sessions s
 LEFT JOIN event_agg agg ON agg.session_id = s.session_id
 LEFT JOIN latest_events latest ON latest.session_id = s.session_id
 ORDER BY s.started_at DESC
-LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -1,3 +1,43 @@
+WITH
+  filtered_sessions AS (
+    SELECT *
+    FROM sessions s
+    WHERE (? = '' OR s.session_id = ?)
+      AND (? = '' OR s.workspace = ?)
+      AND (? = '' OR s.client = ?)
+      AND (? = '' OR s.agent = ? OR s.subagent_kind = ? OR EXISTS (SELECT 1 FROM events agent_events WHERE agent_events.session_id = s.session_id AND agent_events.agent = ?))
+      AND (? = '' OR s.label = ?)
+      AND (? = 0 OR s.ended_at IS NULL)
+      AND (? = '' OR s.started_at >= ?)
+      AND (? = '' OR s.started_at < ?)
+  ),
+  event_agg AS (
+    SELECT
+      e.session_id,
+      COUNT(*) AS total_events,
+      SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+      GROUP_CONCAT(DISTINCT e.agent) AS agents,
+      MAX(e.created_at) AS latest_event_at
+    FROM events e
+    JOIN filtered_sessions fs ON fs.session_id = e.session_id
+    GROUP BY e.session_id
+  ),
+  latest_events AS (
+    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    FROM (
+      SELECT
+        e.session_id,
+        e.kind,
+        e.body,
+        ROW_NUMBER() OVER (
+          PARTITION BY e.session_id
+          ORDER BY e.created_at DESC, e.id DESC
+        ) AS rn
+      FROM events e
+      JOIN filtered_sessions fs ON fs.session_id = e.session_id
+    )
+    WHERE rn = 1
+  )
 SELECT
   s.session_id,
   s.workspace,
@@ -13,25 +53,11 @@ SELECT
   COALESCE(s.parent_session_id, '') AS parent_session_id,
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
-  s.spawn_order
-FROM sessions s
-LEFT JOIN (
-  SELECT
-    e.session_id,
-    COUNT(*) AS total_events,
-    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-    GROUP_CONCAT(DISTINCT e.agent) AS agents,
-    MAX(e.created_at) AS latest_event_at
-  FROM events e
-  GROUP BY e.session_id
-) agg ON agg.session_id = s.session_id
-WHERE (? = '' OR s.session_id = ?)
-  AND (? = '' OR s.workspace = ?)
-  AND (? = '' OR s.client = ?)
-  AND (? = '' OR s.agent = ? OR s.subagent_kind = ? OR EXISTS (SELECT 1 FROM events agent_events WHERE agent_events.session_id = s.session_id AND agent_events.agent = ?))
-  AND (? = '' OR s.label = ?)
-  AND (? = 0 OR s.ended_at IS NULL)
-  AND (? = '' OR s.started_at >= ?)
-  AND (? = '' OR s.started_at < ?)
+  s.spawn_order,
+  COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
+  COALESCE(latest.latest_event_body, '') AS latest_event_body
+FROM filtered_sessions s
+LEFT JOIN event_agg agg ON agg.session_id = s.session_id
+LEFT JOIN latest_events latest ON latest.session_id = s.session_id
 ORDER BY s.started_at DESC
 LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -25,6 +25,33 @@ WITH RECURSIVE
     JOIN lineage ON child.parent_session_id = lineage.session_id
     WHERE lineage.depth < 100
       AND instr(lineage.path, ',' || child.session_id || ',') = 0
+  ),
+  event_agg AS (
+    SELECT
+      e.session_id,
+      COUNT(*) AS total_events,
+      SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
+      GROUP_CONCAT(DISTINCT e.agent) AS agents,
+      MAX(e.created_at) AS latest_event_at
+    FROM events e
+    JOIN lineage ON lineage.session_id = e.session_id
+    GROUP BY e.session_id
+  ),
+  latest_events AS (
+    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    FROM (
+      SELECT
+        e.session_id,
+        e.kind,
+        e.body,
+        ROW_NUMBER() OVER (
+          PARTITION BY e.session_id
+          ORDER BY e.created_at DESC, e.id DESC
+        ) AS rn
+      FROM events e
+      JOIN lineage ON lineage.session_id = e.session_id
+    )
+    WHERE rn = 1
   )
 SELECT
   s.session_id,
@@ -41,19 +68,13 @@ SELECT
   COALESCE(s.parent_session_id, '') AS parent_session_id,
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
-  s.spawn_order
+  s.spawn_order,
+  COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
+  COALESCE(latest.latest_event_body, '') AS latest_event_body
 FROM sessions s
 JOIN lineage ON lineage.session_id = s.session_id
-LEFT JOIN (
-  SELECT
-    e.session_id,
-    COUNT(*) AS total_events,
-    SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-    GROUP_CONCAT(DISTINCT e.agent) AS agents,
-    MAX(e.created_at) AS latest_event_at
-  FROM events e
-  GROUP BY e.session_id
-) agg ON agg.session_id = s.session_id
+LEFT JOIN event_agg agg ON agg.session_id = s.session_id
+LEFT JOIN latest_events latest ON latest.session_id = s.session_id
 ORDER BY
   s.parent_session_id NULLS FIRST,
   s.spawn_order NULLS FIRST,

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -357,6 +357,62 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("session_status lineage tree and handoff do not expose latest event fields", func(t *testing.T) {
+		startResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "manage_session",
+			Arguments: map[string]any{
+				"action":     "start",
+				"session_id": "leak-guard-root",
+				"agent":      "codex",
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(manage_session start leak guard root) error = %v", err)
+		}
+		if startResult.IsError {
+			t.Fatalf("CallTool(manage_session start leak guard root) returned tool error")
+		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "record_event",
+			Arguments: map[string]any{
+				"type":       "log",
+				"message":    "latest event should remain internal",
+				"kind":       "note",
+				"agent":      "codex",
+				"session_id": "leak-guard-root",
+				"workspace":  "github.com/duck8823/traceary",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(record_event leak guard) error = %v", err)
+		}
+
+		for _, action := range []string{"lineage", "tree", "handoff"} {
+			t.Run(action, func(t *testing.T) {
+				result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+					Name: "session_status",
+					Arguments: map[string]any{
+						"action":     action,
+						"session_id": "leak-guard-root",
+					},
+				})
+				if err != nil {
+					t.Fatalf("CallTool(session_status %s) error = %v", action, err)
+				}
+				if result.IsError {
+					t.Fatalf("CallTool(session_status %s) returned tool error", action)
+				}
+
+				if action == "tree" {
+					assertNoLatestEventFieldLeak(t, decodeJSONArrayPayload(t, result))
+					return
+				}
+				assertNoLatestEventFieldLeak(t, decodeJSONPayload(t, result))
+			})
+		}
+	})
+
 	t.Run("session_status tree handles stored cyclic parent links", func(t *testing.T) {
 		startSession := func(sessionID, parentSessionID string) {
 			t.Helper()
@@ -1060,6 +1116,20 @@ func TestServer_BuildAndTools(t *testing.T) {
 			t.Fatalf("CallTool(add_log) IsError = false, want true")
 		}
 	})
+}
+
+func assertNoLatestEventFieldLeak(t *testing.T, payload any) {
+	t.Helper()
+	marshaled, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal(payload) error = %v", err)
+	}
+	body := string(marshaled)
+	for _, forbidden := range []string{"latest_event_kind", "latest_event_message", "latestEventKind", "latestEventMessage"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("payload contains forbidden latest event field %q: %s", forbidden, body)
+		}
+	}
 }
 
 func extractJSONStringValue(t *testing.T, result *mcp.CallToolResult, key string) string {

--- a/schema/sqlite/migrations/000016_add_events_session_created_at_id_desc.sql
+++ b/schema/sqlite/migrations/000016_add_events_session_created_at_id_desc.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_events_session_created_at_id_desc
+ON events(session_id, created_at DESC, id DESC);


### PR DESCRIPTION
Closes #793

## Summary

Add latest event kind/message to `SessionSummary` so subsequent v0.10.3 sub-issues (#794 text/TUI, #795 top JSON) can render workspace + last activity in a single query without N+1.

## Changes

- New SQLite index `(session_id, created_at DESC, id DESC)` for deterministic latest-event lookup
- `SessionSummary` gains `LatestEventKind` / `LatestEventMessage` (via dedicated `SessionSummaryLatestEvent` metadata to avoid colliding with the existing string subagent_kind metadata)
- `list_sessions.sql`, `list_session_tree.sql`, `session_lineage.sql` extended with a `latest_events` window-function CTE — all three SQLs updated together so `top`'s `expandTopSessionLineages` does not lose latest in the parent/child rows
- `scanSessionSummary` runs the new body through `application/types.ExtractPlainBody` so transcript thinking blocks never reach `LatestEventMessage`
- Infrastructure tests cover tie-breaker (id DESC), zero-event session, thinking-only transcript, `session_ended` as latest, lineage/tree parent vs. child latest
- MCP `session_status` JSON is asserted **not** to expose the new fields (lineage / tree / handoff). Exposure is deferred to #795 (top-only)
- `docs/storage/README{,.ja}.md` index list updated

## Out of scope

- text/TUI rendering (#794)
- top JSON contract split + latest_event field exposure (#795)

## Test plan

- [x] `go test ./...` — 1225 pass
- [x] `go tool golangci-lint run --timeout=5m` — 0 issues
- [x] `git diff -- presentation/cli/testdata` — no diff
- [ ] CI green
- [ ] Multi-AI review

🤖 Generated with [Claude Code](https://claude.com/claude-code)