### PR TITLE
docs(hooks): add host-coverage.md (en+ja)

### DIFF
--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -25,6 +25,8 @@
 
 ### Traceary 未配線のホスト hook
 
+上のライフサイクルマトリクスに既出の hook はここでは省略している（例: Gemini `BeforeAgent` は #806 で prompt 配線予定としてマトリクス側に記載、`PreCompress` は #807）。
+
 | Host | Hook | 状態 | 備考 |
 |---|---|---|---|
 | Claude Code | `SubagentStart` (`PreToolUse matcher=Task\|Agent`) | ● 配線済（subagent 補足、lifecycle event ではない） | `note` body marker として記録 |

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -1,0 +1,51 @@
+# ホスト hook 対応マトリクス
+
+[English](./host-coverage.md)
+
+このページでは各ホスト AI agent について、Traceary の [ライフサイクルイベント](./lifecycle-events.ja.md) が実際の hook に紐づいているか、ホストが公開しているが Traceary 側で未配線か、そもそもホストが公開していないかを記録する。
+
+凡例:
+
+- `●` 配線済（Traceary パッケージ統合に含まれる）
+- `○` ホスト側に hook はあるが Traceary 未配線
+- `✕` ホスト自体が公開していない
+
+**最終確認日: 2026-04-26.** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
+
+## ライフサイクルイベント → ホスト hook マトリクス
+
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | 確認方法 |
+|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ○ `BeforeAgent` (#806 で配線予定) | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ✕ Codex 0.125 に compact hook なし (upstream openai/codex#16098) | ○ `PreCompress` あり、Gemini 0.36.x に post-compress 相当の hook なし (#807 で marker 配線予定) | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ● `Stop` (best effort — Codex に `SessionEnd` は無い) | ● `SessionEnd` | `traceary list events --kind session_ended --limit 5` |
+
+### Traceary 未配線のホスト hook
+
+| Host | Hook | 状態 | 備考 |
+|---|---|---|---|
+| Claude Code | `SubagentStart` (`PreToolUse matcher=Task\|Agent`) | ● 配線済（subagent 補足、lifecycle event ではない） | `note` body marker として記録 |
+| Claude Code | `SubagentStop` | ● 配線済（subagent 補足） | 同上 |
+| Claude Code | `Notification`, `PreToolUse` (他 matcher), `StopFailure` | ○ 利用可 | 現行パッケージでは未配線 |
+| Codex CLI | `PreToolUse`, `PermissionRequest`, `Notification` | ○ 利用可 | 未配線 |
+| Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ 利用可 | 未配線 |
+
+## ホスト別参照
+
+- Claude Code: https://code.claude.com/docs/en/hooks · パッケージ config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
+- Codex CLI: upstream binary `codex-cli 0.125` — hook surface はローカルインストールのバイナリ文字列 (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionDenied`, `UserPromptSubmit`, `Elicitation`) から推定。compact hook tracking: openai/codex#16098. パッケージ config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
+- Gemini CLI: ローカルインストール同梱の hooks reference (`/opt/homebrew/Cellar/gemini-cli/0.36.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`). パッケージ config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+
+## 更新方法
+
+このマトリクスは手書きのスナップショット。更新手順:
+
+1. 確認したい host CLI をバンプ／再インストール。
+2. ホスト側 hook reference と上の表を diff。
+3. `●` セルごとに「確認方法」コマンドを実行し、`~/.config/traceary/traceary.db` に新しい行があることを確認。
+4. ページ冒頭の **最終確認日** を更新。
+
+`/schedule` 経由の日次 drift check は #814 で配線する。

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -25,6 +25,8 @@ Legend:
 
 ### Other host hooks Traceary does not wire today
 
+This list excludes hooks that already appear in the lifecycle matrix above (e.g. Gemini `BeforeAgent` is tracked there as a planned prompt source for #806; `PreCompress` for #807).
+
 | Host | Hook | Status | Note |
 |---|---|---|---|
 | Claude Code | `SubagentStart` (`PreToolUse matcher=Task\|Agent`) | ● wired (subagent capture, not a lifecycle event) | recorded as `note` body marker, not in the six lifecycle kinds |

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -1,0 +1,51 @@
+# Host Hook Coverage
+
+[日本語](./host-coverage.ja.md)
+
+This page tracks, per host AI agent, which Traceary [lifecycle events](./lifecycle-events.md) are wired to a real hook today, which hooks the host exposes but Traceary does not yet wire, and which are not supported by the host at all.
+
+Legend:
+
+- `●` wired in the packaged Traceary integration today
+- `○` available in the host but not wired by Traceary yet
+- `✕` not exposed by this host
+
+**Last verified: 2026-04-26.** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
+
+## Lifecycle event → host hook matrix
+
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Verification |
+|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ○ `BeforeAgent` (planned in #806) | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ✕ no compact hook in Codex 0.125 (upstream openai/codex#16098) | ○ `PreCompress` exists; no post-compress hook in Gemini 0.36.x (planned wiring in #807 — `PreCompress` marker only) | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ● `Stop` (best effort — Codex has no dedicated `SessionEnd`) | ● `SessionEnd` | `traceary list events --kind session_ended --limit 5` |
+
+### Other host hooks Traceary does not wire today
+
+| Host | Hook | Status | Note |
+|---|---|---|---|
+| Claude Code | `SubagentStart` (`PreToolUse matcher=Task\|Agent`) | ● wired (subagent capture, not a lifecycle event) | recorded as `note` body marker, not in the six lifecycle kinds |
+| Claude Code | `SubagentStop` | ● wired (subagent capture) | same |
+| Claude Code | `Notification`, `PreToolUse` (other matchers), `StopFailure` | ○ available | not in current packaged hooks |
+| Codex CLI | `PreToolUse`, `PermissionRequest`, `Notification` | ○ available | not wired |
+| Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ available | not wired |
+
+## Per-host references
+
+- Claude Code: https://code.claude.com/docs/en/hooks · packaged config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
+- Codex CLI: upstream binary `codex-cli 0.125` — hook surface inferred from local install strings (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionDenied`, `UserPromptSubmit`, `Elicitation`). Compact hook tracking: openai/codex#16098. Packaged config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
+- Gemini CLI: hooks reference shipped with the local install at `/opt/homebrew/Cellar/gemini-cli/0.36.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`. Packaged config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+
+## Maintenance
+
+This matrix is a manually curated snapshot. To refresh:
+
+1. Bump or re-install the host CLI you want to re-check.
+2. Diff the host's hook reference against the table above.
+3. For each `●` cell, run the verification command and confirm a recent row exists in `~/.config/traceary/traceary.db`.
+4. Update the **Last verified** date at the top of this page.
+
+A daily drift check is wired through `/schedule` (see #814).

--- a/docs/hooks/lifecycle-events.ja.md
+++ b/docs/hooks/lifecycle-events.ja.md
@@ -31,7 +31,7 @@
 ### `prompt`
 
 - ユーザの指示を redact 後そのまま記録。`traceary timeline` / `traceary search` / L2 `get_context` の本体に出る。
-- 現状 Claude Code と Codex CLI のみ発行。Gemini CLI は prompt 相当の hook を公開していない（[host-coverage.ja.md](./host-coverage.ja.md) 参照）。
+- 現状 Claude Code と Codex CLI のみ発行。Gemini CLI には `BeforeAgent` があるが Traceary 側で prompt として配線していない（[host-coverage.ja.md](./host-coverage.ja.md) と #806 参照）。
 - Body marker なし（生テキスト）。アシスタント側は `transcript` と区別する。
 
 ### `command_executed`
@@ -53,7 +53,7 @@
 ### `compact_summary`
 
 - ホスト側で context window が圧縮されたときに発行。
-- 現状 Claude Code のみ（`PostCompact`）。Codex 0.125 と Gemini には post-compact 相当の hook が無い（Gemini は `PreCompress` を持つが、生成された summary を渡す post 側 event は無い — v0.11.0 で追跡）。
+- 現状 Claude Code のみ（`PostCompact`）。Codex 0.125 に compact hook なし（upstream `openai/codex#16098`）。Gemini は `PreCompress` を持つが post-compress 側 event は無い — Traceary では #807 で `PreCompress` の marker 配線を予定。
 - L2 で、`SessionStart` matcher `compact` 経由のセッション再開時に `sessions.summary` の seed として使う。
 
 ### `session_ended`

--- a/docs/hooks/lifecycle-events.ja.md
+++ b/docs/hooks/lifecycle-events.ja.md
@@ -31,7 +31,7 @@
 ### `prompt`
 
 - ユーザの指示を redact 後そのまま記録。`traceary timeline` / `traceary search` / L2 `get_context` の本体に出る。
-- 現状 Claude Code と Codex CLI のみ発行。Gemini CLI は prompt 相当の hook を公開していない。
+- 現状 Claude Code と Codex CLI のみ発行。Gemini CLI は prompt 相当の hook を公開していない（[host-coverage.ja.md](./host-coverage.ja.md) 参照）。
 - Body marker なし（生テキスト）。アシスタント側は `transcript` と区別する。
 
 ### `command_executed`
@@ -59,11 +59,12 @@
 ### `session_ended`
 
 - `sessions` 行の終了境界として記録される。
-- Claude / Gemini は専用の `SessionEnd` を持つ。Codex は `SessionEnd` を公開していないため `Stop` で代用。
+- Claude / Gemini は専用の `SessionEnd` を持つ。Codex は `SessionEnd` を公開していないため `Stop` で代用（[host-coverage.ja.md](./host-coverage.ja.md) 参照）。
 - best-effort: ホストが hook を発火させずに終了するケース（kill -9、シェルクラッシュ）もあり、dangling session は L2 reconciliation で吸収する。
 
 ## 関連ドキュメント
 
 - [Event Lifecycle](../lifecycle.ja.md) — クライアント別 hook → event mapping。
 - [Hook Contract](./contract.ja.md) — capability tier (Tier 1 / 2 / 3)。
+- [ホスト hook 対応マトリクス](./host-coverage.ja.md) — host ごとの wired / available / unsupported。
 - [Memory layers](../memory/README.ja.md) — これらのイベントが L1 / L2 / L3 に流れる構造。

--- a/docs/hooks/lifecycle-events.md
+++ b/docs/hooks/lifecycle-events.md
@@ -31,7 +31,7 @@ All event bodies pass through built-in secret redaction plus operator-configured
 ### `prompt`
 
 - Captures the user's instruction text verbatim (after redaction). Visible in `traceary timeline`, `traceary search`, and the L2 `get_context` body.
-- Today only Claude Code and Codex CLI emit this. Gemini CLI does not expose a prompt-level hook.
+- Today only Claude Code and Codex CLI emit this. Gemini CLI does not expose a prompt-level hook (see [host-coverage.md](./host-coverage.md)).
 - Body marker: none (raw text). Distinct from `transcript`, which is the assistant side.
 
 ### `command_executed`
@@ -59,11 +59,12 @@ All event bodies pass through built-in secret redaction plus operator-configured
 ### `session_ended`
 
 - Marks the close boundary of a session row.
-- Claude / Gemini use a dedicated `SessionEnd` hook. Codex piggybacks on `Stop` because its CLI exposes no `SessionEnd`.
+- Claude / Gemini use a dedicated `SessionEnd` hook. Codex piggybacks on `Stop` because its CLI exposes no `SessionEnd` (see [host-coverage.md](./host-coverage.md)).
 - Best-effort: hosts may exit without firing the hook (kill -9, crashed shell). L2 reconciliation tolerates dangling sessions.
 
 ## Where to go next
 
 - [Event Lifecycle](../lifecycle.md) — hook → event mapping per client.
 - [Hook Contract](./contract.md) — capability tiers (Tier 1 / 2 / 3).
+- [Host hook coverage matrix](./host-coverage.md) — wired vs available vs unsupported per host.
 - [Memory layers](../memory/README.md) — how these events feed L1 / L2 / L3.

--- a/docs/hooks/lifecycle-events.md
+++ b/docs/hooks/lifecycle-events.md
@@ -31,7 +31,7 @@ All event bodies pass through built-in secret redaction plus operator-configured
 ### `prompt`
 
 - Captures the user's instruction text verbatim (after redaction). Visible in `traceary timeline`, `traceary search`, and the L2 `get_context` body.
-- Today only Claude Code and Codex CLI emit this. Gemini CLI does not expose a prompt-level hook (see [host-coverage.md](./host-coverage.md)).
+- Today only Claude Code and Codex CLI emit this. Gemini CLI exposes `BeforeAgent` but Traceary does not wire it as a prompt source yet — see [host-coverage.md](./host-coverage.md) and #806.
 - Body marker: none (raw text). Distinct from `transcript`, which is the assistant side.
 
 ### `command_executed`
@@ -53,7 +53,7 @@ All event bodies pass through built-in secret redaction plus operator-configured
 ### `compact_summary`
 
 - Emitted when the host compresses its in-memory context window.
-- Today only Claude Code emits this (`PostCompact`). Codex 0.125 and Gemini have no compact hook (Gemini exposes `PreCompress` but not a post-compress event with the resulting summary — tracked in v0.11.0).
+- Today only Claude Code emits this (`PostCompact`). Codex 0.125 has no compact hook (upstream `openai/codex#16098`). Gemini exposes `PreCompress` but not a post-compress event with the resulting summary — Traceary plans a `PreCompress` marker in #807.
 - Used by L2 to seed a `sessions.summary` value when a session is later resumed via `SessionStart` matcher `compact`.
 
 ### `session_ended`


### PR DESCRIPTION
## Summary
- Document, per host (Claude Code, Codex CLI 0.125, Gemini CLI 0.36), which Traceary lifecycle events are wired, which host hooks are available but unwired, and which are unsupported.
- Each row carries a verification command (`traceary list events --kind <kind>`) and the page tracks a `Last verified` date.
- Re-add forward references from `lifecycle-events.{md,ja.md}` (these were temporarily removed in #817 to avoid broken links between Wave 0 PRs).

## Acceptance
- [x] `python3 scripts/verify_docs_i18n.py` pass
- [x] 「最終確認日」フィールドあり (`/schedule` で更新するため)

Closes #805
Parent #803