### PR TITLE
feat(skills): add traceary-memory-review and deprecate traceary-memory-capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,4 +95,9 @@ go tool golangci-lint run
 
 ### Durable memory capture (agent guidance)
 
-When working on this repository with a Claude Code agent, proactively call the `manage_memory(action="propose")` MCP tool when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. The candidate lands in Traceary's review inbox — it does not auto-accept. See the packaged `traceary-memory-capture` skill for trigger phrases, the five memory types, and the required input shape (exactly one of `workspace` / `agent` / `session_family`).
+Memory capture in v0.11.0+ is split into two narrow skills plus hook-driven auto-extraction:
+
+- `traceary-memory-review` — list and curate inbox candidates, write a short session recap. Trigger phrases are review-intent only ("Traceary inbox", "review memory candidates", "session recap").
+- `traceary-memory-remember` — write durable memory **only** when the user explicitly asks ("remember that", "覚えておいて"). Lands in `status=candidate` for review, never auto-accepted.
+
+Hook-driven auto-extraction (planned in v0.11.0 #810 / #811) populates the inbox so the LLM does not have to. The deprecated `traceary-memory-capture` skill is retained as a stub through v0.11 and removed in v0.12.

--- a/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-capture/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: traceary-memory-capture
-description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's manage_memory(action="propose") MCP tool so the candidate lands in the review inbox; manage_memory(action="accept") only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
-version: 1.0.0
+description: DEPRECATED — split into traceary-memory-review (inbox / session summary) and traceary-memory-remember (explicit write). Will be removed in v0.12. Empirically this skill never fired — over 30 days / 16,026 hook events the durable-phrase trigger produced 0 propose calls, so the work moved to hook-driven L2/L3 capture plus the two new skills above. This entry stays only so existing references resolve.
+version: 1.1.0
+---
+
+# Traceary memory capture (deprecated)
+
+This skill no longer fires by intent. Two replacements:
+
+- **`traceary-memory-review`** — list pending inbox candidates, accept / reject, write a session summary. Triggered by review-intent phrases ("Traceary inbox", "review memory candidates", "session recap").
+- **`traceary-memory-remember`** — write durable memory **only** when the user explicitly asks ("remember that", "覚えておいて"). Lands in `status=candidate` for review.
+
+The previous content of this skill is preserved below for reference only. New work should use the two skills above; this file will be removed in v0.12.
+
 ---
 
 # Traceary memory capture

--- a/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 
 # Traceary memory review
 
-Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to recap the current session. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
 
 ## Workflow
 
@@ -20,24 +20,17 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    })
    ```
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
-3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
    - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
-   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
-5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
-   ```
-   manage_session({
-     "action": "set_summary",
-     "session_id": "<current session id>",
-     "summary": "<your short recap>"
-   })
-   ```
+   - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Guardrails
 
-- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never accepts memory before the operator has seen the list.
 - **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
-- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: traceary-memory-review
+description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
+version: 1.0.0
+---
+
+# Traceary memory review
+
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+
+## Workflow
+
+1. **List candidates**. Call `query_memory` with `action="retrieve"` and `status=["candidate"]`. Default scope is the current workspace; broaden to agent / session_family only if the user says so.
+   ```
+   query_memory({
+     "action": "retrieve",
+     "status": ["candidate"],
+     "workspace": "<current workspace>",
+     "limit": 20
+   })
+   ```
+2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+4. **Apply decisions** via `manage_memory`:
+   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
+5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
+   ```
+   manage_session({
+     "action": "set_summary",
+     "session_id": "<current session id>",
+     "summary": "<your short recap>"
+   })
+   ```
+
+## Guardrails
+
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
+- **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
+- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/gemini-extension/GEMINI.md
+++ b/integrations/gemini-extension/GEMINI.md
@@ -10,4 +10,9 @@ Prefer the packaged MCP tools when the user asks about prior sessions, command a
 
 Use `/traceary-doctor` when the user needs setup or troubleshooting guidance.
 
-When the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session, proactively call `manage_memory(action="propose")` so the candidate lands in Traceary's review inbox. See the `traceary-memory-capture` skill for trigger phrases and guardrails (always propose, never auto-accept).
+Memory capture is split into two narrow skills:
+
+- `traceary-memory-review` — list / accept / reject the inbox; triggered by review-intent phrases ("Traceary inbox", "review memory candidates", "session recap").
+- `traceary-memory-remember` — write durable memory only when the user explicitly asks ("remember that", "覚えておいて"). Lands as `status=candidate` for review.
+
+The previous `traceary-memory-capture` skill is deprecated in v0.11.0 (will be removed in v0.12).

--- a/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-capture/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: traceary-memory-capture
-description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's manage_memory(action="propose") MCP tool so the candidate lands in the review inbox; manage_memory(action="accept") only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
-version: 1.0.0
+description: DEPRECATED — split into traceary-memory-review (inbox / session summary) and traceary-memory-remember (explicit write). Will be removed in v0.12. Empirically this skill never fired — over 30 days / 16,026 hook events the durable-phrase trigger produced 0 propose calls, so the work moved to hook-driven L2/L3 capture plus the two new skills above. This entry stays only so existing references resolve.
+version: 1.1.0
+---
+
+# Traceary memory capture (deprecated)
+
+This skill no longer fires by intent. Two replacements:
+
+- **`traceary-memory-review`** — list pending inbox candidates, accept / reject, write a session summary. Triggered by review-intent phrases ("Traceary inbox", "review memory candidates", "session recap").
+- **`traceary-memory-remember`** — write durable memory **only** when the user explicitly asks ("remember that", "覚えておいて"). Lands in `status=candidate` for review.
+
+The previous content of this skill is preserved below for reference only. New work should use the two skills above; this file will be removed in v0.12.
+
 ---
 
 # Traceary memory capture

--- a/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 
 # Traceary memory review
 
-Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to recap the current session. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
 
 ## Workflow
 
@@ -20,24 +20,17 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    })
    ```
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
-3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
    - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
-   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
-5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
-   ```
-   manage_session({
-     "action": "set_summary",
-     "session_id": "<current session id>",
-     "summary": "<your short recap>"
-   })
-   ```
+   - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Guardrails
 
-- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never accepts memory before the operator has seen the list.
 - **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
-- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: traceary-memory-review
+description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
+version: 1.0.0
+---
+
+# Traceary memory review
+
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+
+## Workflow
+
+1. **List candidates**. Call `query_memory` with `action="retrieve"` and `status=["candidate"]`. Default scope is the current workspace; broaden to agent / session_family only if the user says so.
+   ```
+   query_memory({
+     "action": "retrieve",
+     "status": ["candidate"],
+     "workspace": "<current workspace>",
+     "limit": 20
+   })
+   ```
+2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+4. **Apply decisions** via `manage_memory`:
+   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
+5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
+   ```
+   manage_session({
+     "action": "set_summary",
+     "session_id": "<current session id>",
+     "summary": "<your short recap>"
+   })
+   ```
+
+## Guardrails
+
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
+- **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
+- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/plugins/traceary/skills/traceary-memory-capture/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-capture/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: traceary-memory-capture
-description: Use when the conversation surfaces a durable decision, constraint, lesson, preference, or project artifact that should outlive the current session. Call Traceary's manage_memory(action="propose") MCP tool so the candidate lands in the review inbox; manage_memory(action="accept") only after the user confirms. Trigger on phrases like "let's always", "never X", "the rule is", "from now on", "remember that", "the decision is", "the constraint is", or when the user explicitly states a preference.
-version: 1.0.0
+description: DEPRECATED — split into traceary-memory-review (inbox / session summary) and traceary-memory-remember (explicit write). Will be removed in v0.12. Empirically this skill never fired — over 30 days / 16,026 hook events the durable-phrase trigger produced 0 propose calls, so the work moved to hook-driven L2/L3 capture plus the two new skills above. This entry stays only so existing references resolve.
+version: 1.1.0
+---
+
+# Traceary memory capture (deprecated)
+
+This skill no longer fires by intent. Two replacements:
+
+- **`traceary-memory-review`** — list pending inbox candidates, accept / reject, write a session summary. Triggered by review-intent phrases ("Traceary inbox", "review memory candidates", "session recap").
+- **`traceary-memory-remember`** — write durable memory **only** when the user explicitly asks ("remember that", "覚えておいて"). Lands in `status=candidate` for review.
+
+The previous content of this skill is preserved below for reference only. New work should use the two skills above; this file will be removed in v0.12.
+
 ---
 
 # Traceary memory capture

--- a/plugins/traceary/skills/traceary-memory-review/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-review/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 
 # Traceary memory review
 
-Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to recap the current session. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
 
 ## Workflow
 
@@ -20,24 +20,17 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    })
    ```
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
-3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
    - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
-   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
-5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
-   ```
-   manage_session({
-     "action": "set_summary",
-     "session_id": "<current session id>",
-     "summary": "<your short recap>"
-   })
-   ```
+   - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Guardrails
 
-- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never accepts memory before the operator has seen the list.
 - **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
-- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/plugins/traceary/skills/traceary-memory-review/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-review/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: traceary-memory-review
+description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
+version: 1.0.0
+---
+
+# Traceary memory review
+
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to capture a session summary for handoff. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+
+## Workflow
+
+1. **List candidates**. Call `query_memory` with `action="retrieve"` and `status=["candidate"]`. Default scope is the current workspace; broaden to agent / session_family only if the user says so.
+   ```
+   query_memory({
+     "action": "retrieve",
+     "status": ["candidate"],
+     "workspace": "<current workspace>",
+     "limit": 20
+   })
+   ```
+2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, edit, or ask to re-scope a candidate. Do not assume silence implies accept.
+4. **Apply decisions** via `manage_memory`:
+   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Edit: ask the operator to confirm the new fact text first, then `manage_memory({"action": "edit", "memory_id": "<id>", "fact": "<new fact>"})`.
+5. **(Optional) capture a session summary** when the operator asks for "session recap" / "summarize for next time". Compose a 3–5 sentence summary using only events visible from MCP `get_context` / `query_memory(pack)` and write it back via:
+   ```
+   manage_session({
+     "action": "set_summary",
+     "session_id": "<current session id>",
+     "summary": "<your short recap>"
+   })
+   ```
+
+## Guardrails
+
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never proposes / accepts memory before the operator has seen the list.
+- **No silent batch accept.** Always confirm per-id decisions with the operator. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint.
+- **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
+- **Stay scoped.** Default to the current workspace and the current session for summary writes. Wider scopes need an explicit operator instruction.
+- **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -141,7 +141,8 @@ def check_claude() -> None:
     require((ROOT / 'integrations' / 'claude-plugin' / 'scripts' / 'traceary-compact.sh').exists(), 'missing Claude compact hook script')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-help' / 'SKILL.md').exists(), 'missing Claude traceary-help skill')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Claude traceary-session-history skill')
-    require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Claude traceary-memory-capture skill')
+    require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Claude traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
+    require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Claude traceary-memory-review skill')
 
 
 def check_codex() -> None:
@@ -172,7 +173,8 @@ def check_codex() -> None:
     require((ROOT / 'plugins' / 'traceary' / 'commands' / 'help.md').exists(), 'missing Codex help command')
     require((ROOT / 'plugins' / 'traceary' / 'commands' / 'doctor.md').exists(), 'missing Codex doctor command')
     require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Codex traceary-session-history skill')
-    require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Codex traceary-memory-capture skill')
+    require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Codex traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
+    require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Codex traceary-memory-review skill')
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_root = Path(temp_dir)
@@ -352,7 +354,8 @@ def check_gemini() -> None:
     require((ROOT / 'integrations' / 'gemini-extension' / 'commands' / 'traceary-help.toml').exists(), 'missing Gemini help command')
     require((ROOT / 'integrations' / 'gemini-extension' / 'commands' / 'traceary-doctor.toml').exists(), 'missing Gemini doctor command')
     require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Gemini traceary-session-history skill')
-    require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-capture skill')
+    require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
+    require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-review skill')
     require((ROOT / 'integrations' / 'gemini-extension' / 'GEMINI.md').exists(), 'missing Gemini context file')
 
 


### PR DESCRIPTION
## Summary
- Add new \`traceary-memory-review\` skill (claude-plugin / gemini-extension / plugins/traceary). Triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap", JA equivalents). Workflow: list candidates → present → per-id accept/reject → optional \`manage_session(set_summary)\`.
- Mark old \`traceary-memory-capture\` skill DEPRECATED. The skill description was rewritten to point operators at \`traceary-memory-review\` and \`traceary-memory-remember\`. Body retained for reference; full removal scheduled for v0.12.
- Update \`scripts/verify_integrations.py\` to require the new skill across all three integrations.

## Background
Empirical DB query showed the original \`traceary-memory-capture\` skill never fired (0 propose calls in 30 days / 16,026 hook events). v0.11.0 splits review (this PR) and explicit write (#809) into two skills with much narrower trigger phrases. v0.11.0 also moves auto-capture to hook-driven L2/L3 (#810, #811) so the LLM is no longer the gatekeeper.

## Acceptance
- [x] Skill files in all three integration packages
- [x] verify_integrations.py enforces presence
- [x] MCP \`query_memory(action="retrieve", status=["candidate"])\` confirmed working live (empty inbox, expected)

Closes #808
Parent #803