### PR TITLE
feat(skills): add traceary-memory-remember (explicit-write only)

### DIFF
--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -9,7 +9,7 @@ Claude 向け package は `integrations/claude-plugin/` にあり、repository r
 - `traceary mcp-server` を使う `traceary` MCP server
 - `SessionStart` / `SessionEnd` hook
 - `Bash` / `mcp__.*` / 組み込み tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`) 向けの `PostToolUse` / `PostToolUseFailure` audit hook
-- slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-capture` skill（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `manage_memory(action="propose")` を能動的に呼ぶよう誘導します）
+- slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
 ## Install
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -9,7 +9,7 @@ The Claude package lives under `integrations/claude-plugin/` and is published th
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart` / `SessionEnd` hooks
 - `PostToolUse` / `PostToolUseFailure` audit hooks for `Bash`, `mcp__.*`, and the built-in tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)
-- slash-style skills: `/traceary-help` plus the contextual `traceary-session-history` and `traceary-memory-capture` skills (the latter prompts the agent to proactively call `manage_memory(action="propose")` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
+- slash-style skills: `/traceary-help` plus the contextual `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember` skills. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて") and writes durable memory directly. The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
 ## Install
 

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -42,7 +42,7 @@ traceary doctor --client codex --json
 - `traceary mcp-server` を呼ぶ `traceary` MCP server
 - `SessionStart`, `UserPromptSubmit`, `Stop`（session 終了 + transcript）, `PostToolUse` hook（`plugins/traceary/hooks.json` で宣言、manifest から参照）
 - slash command: `/traceary:help`, `/traceary:doctor`
-- 文脈に効く skill: `traceary-session-history` / `traceary-memory-capture`（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `manage_memory(action="propose")` を能動的に呼ぶよう誘導します）
+- 文脈に効く skill: `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember`。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
 ## 更新
 

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -42,7 +42,7 @@ traceary doctor --client codex --json
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart`, `UserPromptSubmit`, `Stop` (session end + transcript), and `PostToolUse` hooks (declared in `plugins/traceary/hooks.json` and referenced from the plugin manifest)
 - slash commands: `/traceary:help` and `/traceary:doctor`
-- contextual skills: `traceary-session-history` and `traceary-memory-capture` (the latter prompts the agent to proactively call `manage_memory(action="propose")` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
+- contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて"). The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
 ## Update
 

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -11,7 +11,7 @@ Gemini 向け package は `integrations/gemini-extension/` にあります。Gem
 - `AfterAgent` transcript hook（agent の応答を `transcript` event として記録）
 - `run_shell_command` 向け `AfterTool` audit hook
 - slash command の `/traceary-help` と `/traceary-doctor`
-- 文脈で効く `traceary-session-history` / `traceary-memory-capture` skill（後者は decision / constraint / lesson / preference / artifact を発見したときにエージェントが `manage_memory(action="propose")` を能動的に呼ぶよう誘導します）
+- 文脈で効く `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
 ## Install
 

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -11,7 +11,7 @@ The Gemini package lives under `integrations/gemini-extension/`. Gemini CLI expe
 - `AfterAgent` transcript hook — records the agent response as a `transcript` event
 - `AfterTool` shell-audit hook for `run_shell_command`
 - slash commands: `/traceary-help` and `/traceary-doctor`
-- contextual skills: `traceary-session-history` and `traceary-memory-capture` (the latter prompts the agent to proactively call `manage_memory(action="propose")` when the conversation surfaces a durable decision / constraint / lesson / preference / artifact)
+- contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて"). The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
 ## Install
 

--- a/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
@@ -16,7 +16,10 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    - `session_family` — applies to a session family (rare; use only when the operator says so).
 2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
 3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
-4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+4. **Call `manage_memory`**:
+   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
+   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+
    ```
    manage_memory({
      "action": "remember",
@@ -26,12 +29,12 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: traceary-memory-remember
+description: Use ONLY when the user explicitly asks to remember a specific durable fact, decision, constraint, or preference. Trigger phrases — "覚えておいて", "remember that", "for the record", "save this as", "記憶しておいて", "メモして". Do NOT use for generic notes, status updates, or session summaries. The candidate lands in the review inbox; never auto-accepted.
+version: 1.0.0
+---
+
+# Traceary memory remember
+
+Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
+
+## Workflow
+
+1. **Confirm scope**. Pick exactly one of:
+   - `workspace` — applies to the current repo / workspace identifier (default for repo-scoped facts).
+   - `agent` — applies to a specific agent identity across workspaces.
+   - `session_family` — applies to a session family (rare; use only when the operator says so).
+2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
+3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
+4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+   ```
+   manage_memory({
+     "action": "remember",
+     "type": "constraint",
+     "workspace": "<current workspace>",
+     "fact": "<short, durable statement>",
+     "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+   })
+   ```
+5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+
+## Guardrails
+
+- **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
+- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
+- **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
+- **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
@@ -22,8 +22,8 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
 3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
-   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
-   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
 5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 

--- a/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
@@ -16,7 +16,10 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    - `session_family` — applies to a session family (rare; use only when the operator says so).
 2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
 3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
-4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+4. **Call `manage_memory`**:
+   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
+   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+
    ```
    manage_memory({
      "action": "remember",
@@ -26,12 +29,12 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: traceary-memory-remember
+description: Use ONLY when the user explicitly asks to remember a specific durable fact, decision, constraint, or preference. Trigger phrases — "覚えておいて", "remember that", "for the record", "save this as", "記憶しておいて", "メモして". Do NOT use for generic notes, status updates, or session summaries. The candidate lands in the review inbox; never auto-accepted.
+version: 1.0.0
+---
+
+# Traceary memory remember
+
+Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
+
+## Workflow
+
+1. **Confirm scope**. Pick exactly one of:
+   - `workspace` — applies to the current repo / workspace identifier (default for repo-scoped facts).
+   - `agent` — applies to a specific agent identity across workspaces.
+   - `session_family` — applies to a session family (rare; use only when the operator says so).
+2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
+3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
+4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+   ```
+   manage_memory({
+     "action": "remember",
+     "type": "constraint",
+     "workspace": "<current workspace>",
+     "fact": "<short, durable statement>",
+     "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+   })
+   ```
+5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+
+## Guardrails
+
+- **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
+- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
+- **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
+- **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
@@ -22,8 +22,8 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
 3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
-   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
-   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
 5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 

--- a/plugins/traceary/skills/traceary-memory-remember/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-remember/SKILL.md
@@ -16,7 +16,10 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    - `session_family` — applies to a session family (rare; use only when the operator says so).
 2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
 3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
-4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+4. **Call `manage_memory`**:
+   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
+   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+
    ```
    manage_memory({
      "action": "remember",
@@ -26,12 +29,12 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/plugins/traceary/skills/traceary-memory-remember/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-remember/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: traceary-memory-remember
+description: Use ONLY when the user explicitly asks to remember a specific durable fact, decision, constraint, or preference. Trigger phrases — "覚えておいて", "remember that", "for the record", "save this as", "記憶しておいて", "メモして". Do NOT use for generic notes, status updates, or session summaries. The candidate lands in the review inbox; never auto-accepted.
+version: 1.0.0
+---
+
+# Traceary memory remember
+
+Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
+
+## Workflow
+
+1. **Confirm scope**. Pick exactly one of:
+   - `workspace` — applies to the current repo / workspace identifier (default for repo-scoped facts).
+   - `agent` — applies to a specific agent identity across workspaces.
+   - `session_family` — applies to a session family (rare; use only when the operator says so).
+2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
+3. **Build evidence_refs**. Each ref has `kind` (one of `event`, `session`, `url`, `file`, `issue`) and `value`. At minimum include the current `session` id; add `event` ids, `file` paths, `issue` numbers, or `url`s when they support the fact.
+4. **Call `manage_memory`** with `action="remember"`. The candidate lands at `status=candidate`; it is **not** auto-accepted.
+   ```
+   manage_memory({
+     "action": "remember",
+     "type": "constraint",
+     "workspace": "<current workspace>",
+     "fact": "<short, durable statement>",
+     "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+   })
+   ```
+5. **Inform the operator** that the fact landed in the review inbox and can be promoted with `traceary-memory-review` (accept) or rolled back with `manage_memory(action="reject")`.
+
+## Guardrails
+
+- **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
+- **Never accept on the user's behalf.** Always leave the new memory at `status=candidate`. Acceptance happens in `traceary-memory-review`.
+- **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
+- **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
+- **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/plugins/traceary/skills/traceary-memory-review/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-review/SKILL.md
@@ -22,8 +22,8 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
 2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
 3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
 4. **Apply decisions** via `manage_memory`:
-   - Accept: `manage_memory({"action": "accept", "memory_ids": ["<id>", ...]})`
-   - Reject: `manage_memory({"action": "reject", "memory_ids": ["<id>", ...]})`
+   - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
 5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 

--- a/scripts/verify_integrations.py
+++ b/scripts/verify_integrations.py
@@ -143,6 +143,7 @@ def check_claude() -> None:
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Claude traceary-session-history skill')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Claude traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
     require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Claude traceary-memory-review skill')
+    require((ROOT / 'integrations' / 'claude-plugin' / 'skills' / 'traceary-memory-remember' / 'SKILL.md').exists(), 'missing Claude traceary-memory-remember skill')
 
 
 def check_codex() -> None:
@@ -175,6 +176,7 @@ def check_codex() -> None:
     require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Codex traceary-session-history skill')
     require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Codex traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
     require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Codex traceary-memory-review skill')
+    require((ROOT / 'plugins' / 'traceary' / 'skills' / 'traceary-memory-remember' / 'SKILL.md').exists(), 'missing Codex traceary-memory-remember skill')
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_root = Path(temp_dir)
@@ -356,6 +358,7 @@ def check_gemini() -> None:
     require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-session-history' / 'SKILL.md').exists(), 'missing Gemini traceary-session-history skill')
     require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-capture' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-capture skill (kept until v0.12 as deprecated stub)')
     require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-review' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-review skill')
+    require((ROOT / 'integrations' / 'gemini-extension' / 'skills' / 'traceary-memory-remember' / 'SKILL.md').exists(), 'missing Gemini traceary-memory-remember skill')
     require((ROOT / 'integrations' / 'gemini-extension' / 'GEMINI.md').exists(), 'missing Gemini context file')
 
 


### PR DESCRIPTION
## Summary
- Add new \`traceary-memory-remember\` skill in claude-plugin / gemini-extension / plugins/traceary.
- Trigger is **explicit-write only**: "remember that", "覚えておいて", "save this as", JA equivalents. Generic notes / status updates / session summaries do NOT trigger this skill — those go to \`traceary-memory-review\`.
- Workflow: scope (exactly one of workspace / agent / session_family) → memory type → evidence_refs → \`manage_memory(action="remember")\` → leave at \`status=candidate\` for review.
- \`scripts/verify_integrations.py\` updated to require the new skill in all three integrations.

## Acceptance
- [x] Skill files present in all three integration packages
- [x] verify_integrations.py enforces presence
- [x] MCP \`manage_memory(action="remember")\` is the live, tested path (verified previously in v0.10.x dogfooding)

Closes #809
Parent #803