### PR TITLE
feat(hooks): sync Claude PreCompact summary into sessions.summary

### DIFF
--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -382,6 +382,8 @@ type sessionRepositoryStub struct {
 	saveBoundaryErr    error
 	nextChildOrder     int
 	nextChildOrderErr  error
+	updateSummaryErr   error
+	updatedSummaries   map[types.SessionID]string
 }
 
 func (s *sessionRepositoryStub) FindByID(
@@ -421,6 +423,17 @@ func (s *sessionRepositoryStub) NextChildSpawnOrder(_ context.Context, _ types.S
 		return 1, nil
 	}
 	return s.nextChildOrder, nil
+}
+
+func (s *sessionRepositoryStub) UpdateSummaryIfEmpty(_ context.Context, sessionID types.SessionID, summary string) (bool, error) {
+	if s.updateSummaryErr != nil {
+		return false, s.updateSummaryErr
+	}
+	if s.updatedSummaries == nil {
+		s.updatedSummaries = make(map[types.SessionID]string)
+	}
+	s.updatedSummaries[sessionID] = summary
+	return true, nil
 }
 
 func mustTime(t *testing.T) time.Time {

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -45,6 +45,11 @@ type SessionUsecase interface {
 	// Returns an empty Optional when no matching session exists.
 	Latest(ctx context.Context, criteria apptypes.SessionLookupCriteria) (types.Optional[*model.Event], error)
 
+	// SetSummaryIfEmpty stores summary into sessions.summary when the existing
+	// value is NULL or empty. Manually authored summaries are preserved.
+	// Returns true when a row was actually updated.
+	SetSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error)
+
 	// Handoff returns the legacy session handoff summary shape used by older CLI
 	// and MCP callers.
 	//

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -220,6 +220,25 @@ func (u *sessionUsecase) Label(ctx context.Context, sessionID types.SessionID, l
 	return nil
 }
 
+func (u *sessionUsecase) SetSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID.String())
+	if trimmedSessionID == "" {
+		return false, xerrors.Errorf("session ID must not be empty")
+	}
+	if strings.TrimSpace(summary) == "" {
+		return false, nil
+	}
+	resolvedSessionID, err := types.SessionIDFrom(trimmedSessionID)
+	if err != nil {
+		return false, xerrors.Errorf("failed to resolve session ID: %w", err)
+	}
+	updated, err := u.sessionRepo.UpdateSummaryIfEmpty(ctx, resolvedSessionID, summary)
+	if err != nil {
+		return false, xerrors.Errorf("failed to update session summary: %w", err)
+	}
+	return updated, nil
+}
+
 func (u *sessionUsecase) List(ctx context.Context, criteria apptypes.SessionListCriteria) ([]apptypes.SessionSummary, error) {
 	if criteria.Limit() <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")

--- a/domain/model/session_repository.go
+++ b/domain/model/session_repository.go
@@ -20,4 +20,8 @@ type SessionRepository interface {
 	// NextChildSpawnOrder returns the next sibling order for a child session
 	// under the given parent.
 	NextChildSpawnOrder(ctx context.Context, parentSessionID types.SessionID) (int, error)
+	// UpdateSummaryIfEmpty writes summary into sessions.summary when the
+	// existing value is NULL or empty, leaving manually authored summaries
+	// untouched. Returns true when a row was updated.
+	UpdateSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error)
 }

--- a/infrastructure/sqlite/save_boundary_test.go
+++ b/infrastructure/sqlite/save_boundary_test.go
@@ -235,6 +235,76 @@ func TestSessionDatasource_SaveBoundary_End(t *testing.T) {
 	}
 }
 
+// TestSessionDatasource_SaveBoundary_EndPreservesPreviouslySyncedSummary
+// asserts that an empty summary at SessionEnd does not clobber a summary
+// previously written by UpdateSummaryIfEmpty (e.g. PreCompact sync — see #811).
+func TestSessionDatasource_SaveBoundary_EndPreservesPreviouslySyncedSummary(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := infra.NewDatabase(dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := infra.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	sessionDS := infra.NewSessionDatasource(db)
+
+	sessionID, _ := types.SessionIDFrom("session-precompact-sync")
+	agent, _ := types.AgentFrom("claude")
+	startedAt := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+
+	startSession := model.NewSession(sessionID, startedAt, types.Client("cli"), agent, types.Workspace("workspace"))
+	startEventID, _ := types.EventIDFrom("event-start-sync")
+	startEvent := model.EventOf(
+		startEventID, types.EventKindSessionStarted,
+		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
+		"session started", startedAt,
+	)
+	if err := sessionDS.SaveBoundary(ctx, startSession, startEvent); err != nil {
+		t.Fatalf("SaveBoundary(start) error = %v", err)
+	}
+
+	preCompactSummary := "Discussed compact behavior, agreed on PreCompact body sync."
+	updated, err := sessionDS.UpdateSummaryIfEmpty(ctx, sessionID, preCompactSummary)
+	if err != nil {
+		t.Fatalf("UpdateSummaryIfEmpty() error = %v", err)
+	}
+	if !updated {
+		t.Fatalf("UpdateSummaryIfEmpty() should report an update on an empty summary")
+	}
+
+	// Now end the session with an empty summary (the path runHookSession
+	// uses on SessionEnd hook).
+	endedAt := startedAt.Add(time.Hour)
+	storedOpt, err := sessionDS.FindByID(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	storedSession, _ := storedOpt.Value()
+	if err := storedSession.End(endedAt, ""); err != nil {
+		t.Fatalf("End() error = %v", err)
+	}
+
+	endEventID, _ := types.EventIDFrom("event-end-sync")
+	endEvent := model.EventOf(
+		endEventID, types.EventKindSessionEnded,
+		types.Client("cli"), agent, sessionID, types.Workspace("workspace"),
+		"session ended", endedAt,
+	)
+	if err := sessionDS.SaveBoundary(ctx, storedSession, endEvent); err != nil {
+		t.Fatalf("SaveBoundary(end) error = %v", err)
+	}
+
+	resultOpt, err := sessionDS.FindByID(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("FindByID(after end) error = %v", err)
+	}
+	result, _ := resultOpt.Value()
+	if diff := cmp.Diff(preCompactSummary, result.Summary()); diff != "" {
+		t.Errorf("Summary should be preserved when SessionEnd carries empty summary (-want +got):\n%s", diff)
+	}
+}
+
 // TestSessionDatasource_Save_LabelDoesNotTouchEndedAt asserts that persisting
 // a label change leaves the ended_at column untouched. Without this guarantee,
 // a session label operation that interleaves with a session end would clobber

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -238,11 +238,16 @@ func saveSessionBoundary(ctx context.Context, exec sqlExecer, session *model.Ses
 	}
 
 	endedAt, _ := session.EndedAt().Value()
+	summary := session.Summary()
+	// summary is bound twice: once for the empty-check, once for the
+	// SET branch. Empty new summaries leave any previously-synced
+	// summary (e.g. from PreCompact) untouched. See #811.
 	result, err := exec.ExecContext(
 		ctx,
 		updateSessionEndQuery,
 		formatTimestamp(endedAt),
-		session.Summary(),
+		summary,
+		summary,
 		session.SessionID().String(),
 	)
 	if err != nil {

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -26,6 +26,9 @@ var updateSessionLabelQuery string
 //go:embed sql/update_session_end.sql
 var updateSessionEndQuery string
 
+//go:embed sql/update_session_summary_if_empty.sql
+var updateSessionSummaryIfEmptyQuery string
+
 //go:embed sql/select_session_by_id.sql
 var selectSessionByIDQuery string
 
@@ -365,6 +368,38 @@ func (d *SessionDatasource) NextChildSpawnOrder(ctx context.Context, parentSessi
 		return 0, xerrors.Errorf("failed to query child spawn order: %w", err)
 	}
 	return order, nil
+}
+
+// UpdateSummaryIfEmpty writes summary into sessions.summary when the row's
+// existing value is NULL or empty. Manually authored summaries are left
+// alone. Returns true when a row was actually updated.
+func (d *SessionDatasource) UpdateSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error) {
+	if strings.TrimSpace(sessionID.String()) == "" {
+		return false, xerrors.Errorf("session ID must not be empty")
+	}
+	if strings.TrimSpace(summary) == "" {
+		return false, nil
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("failed to open DB for session summary update: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	res, err := db.ExecContext(ctx, updateSessionSummaryIfEmptyQuery, summary, sessionID.String())
+	if err != nil {
+		return false, xerrors.Errorf("failed to update session summary: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, xerrors.Errorf("failed to read rows affected: %w", err)
+	}
+	return rows > 0, nil
 }
 
 // FindLatest returns the session_started event for the latest matching

--- a/infrastructure/sqlite/sql/update_session_end.sql
+++ b/infrastructure/sqlite/sql/update_session_end.sql
@@ -1,1 +1,5 @@
-UPDATE sessions SET ended_at = ?, summary = ? WHERE session_id = ? AND ended_at IS NULL
+UPDATE sessions
+SET ended_at = ?,
+    summary = CASE WHEN ? = '' THEN summary ELSE ? END
+WHERE session_id = ?
+  AND ended_at IS NULL

--- a/infrastructure/sqlite/sql/update_session_summary_if_empty.sql
+++ b/infrastructure/sqlite/sql/update_session_summary_if_empty.sql
@@ -1,0 +1,1 @@
+UPDATE sessions SET summary = ? WHERE session_id = ? AND (summary IS NULL OR summary = '')

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -556,6 +556,18 @@ func (c *RootCLI) runHookCompact(
 		if err != nil {
 			return xerrors.Errorf("failed to record pre-compact hook event: %w", err)
 		}
+		// Sync the digest into sessions.summary so timeline / handoff
+		// surfaces have a useful header without waiting for SessionEnd.
+		// Only Claude carries a real digest — Gemini's PreCompress body
+		// is just the trigger value, not a summary.
+		if client == "claude" && c.session != nil {
+			rawDigest := hookPayloadString(payload, "pre_compact_context", "")
+			if strings.TrimSpace(rawDigest) != "" {
+				if _, err := c.session.SetSummaryIfEmpty(ctx, sessionID, rawDigest); err != nil {
+					return xerrors.Errorf("failed to sync pre-compact summary into session: %w", err)
+				}
+			}
+		}
 		return nil
 	case "session-start-compact":
 		if output == nil {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -611,6 +611,113 @@ func TestRootCLI_HookCompactCommand_RecordsPreCompactSnapshot(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HookCompactCommand_PreCompactSyncsSessionSummaryWhenEmpty(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("sync-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-pre-compact-sync"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("sync-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"",
+			time.Now(),
+		),
+	}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"pre_compact_context":"Discussed compact behavior, agreed on PreCompact body sync."}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "pre-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(pre-compact) error = %v", err)
+	}
+	if got := eventStub.logCall.message; got == "" {
+		t.Fatalf("pre-compact log body must not be empty when pre_compact_context is provided")
+	}
+	got, ok := sessionStub.setSummaryCalls[types.SessionID("sync-session")]
+	if !ok {
+		t.Fatalf("SetSummaryIfEmpty was not called for the active session")
+	}
+	if want := "Discussed compact behavior, agreed on PreCompact body sync."; got != want {
+		t.Fatalf("SetSummaryIfEmpty body = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_PreCompactSkipsSessionSummarySyncForEmptyBody(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("trigger-only"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-trigger-only"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("trigger-only"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"",
+			time.Now(),
+		),
+	}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"trigger":"size-threshold"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "pre-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(pre-compact) error = %v", err)
+	}
+	if _, ok := sessionStub.setSummaryCalls[types.SessionID("trigger-only")]; ok {
+		t.Fatalf("SetSummaryIfEmpty must not be called when pre_compact_context is empty (trigger-only payload)")
+	}
+}
+
 func TestRootCLI_HookSubagentStopCommand_RecordsSessionEnded(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -117,6 +117,8 @@ type sessionUsecaseStub struct {
 	latestCriteria apptypes.SessionLookupCriteria
 	handoff        types.Optional[apptypes.HandoffSummary]
 	handoffErr     error
+	setSummaryErr  error
+	setSummaryCalls map[types.SessionID]string
 
 	startCall struct {
 		client          types.Client
@@ -228,6 +230,17 @@ func (s *sessionUsecaseStub) Latest(_ context.Context, criteria apptypes.Session
 }
 func (s *sessionUsecaseStub) Handoff(_ context.Context, _ types.SessionID, _ types.Workspace, _ int) (types.Optional[apptypes.HandoffSummary], error) {
 	return s.handoff, s.handoffErr
+}
+
+func (s *sessionUsecaseStub) SetSummaryIfEmpty(_ context.Context, sessionID types.SessionID, summary string) (bool, error) {
+	if s.setSummaryErr != nil {
+		return false, s.setSummaryErr
+	}
+	if s.setSummaryCalls == nil {
+		s.setSummaryCalls = make(map[types.SessionID]string)
+	}
+	s.setSummaryCalls[sessionID] = summary
+	return true, nil
 }
 
 type contextUsecaseStub struct {


### PR DESCRIPTION
## Summary
- Wire Claude \`PreCompact\` digest body (\`pre_compact_context\` field) into \`sessions.summary\` so timeline / handoff / replay surfaces have a useful header without waiting for SessionEnd.
- Only writes when the existing \`sessions.summary\` is NULL or empty — manually-authored summaries are preserved.
- Skips for Codex (no compact hook) and Gemini (\`PreCompress\` only carries \`trigger\`, not a digest).

## Implementation
- \`domain/model/session_repository.go\`: new \`UpdateSummaryIfEmpty\` interface method.
- \`infrastructure/sqlite/sql/update_session_summary_if_empty.sql\`: \`UPDATE sessions SET summary = ? WHERE session_id = ? AND (summary IS NULL OR summary = '')\`.
- \`application/usecase/session_usecase\`: \`SetSummaryIfEmpty\` pass-through.
- \`presentation/cli/hook_runtime.go\`: in \`runHookCompact\` pre-compact path, after \`event.Log\`, call \`session.SetSummaryIfEmpty\` when client=claude and \`pre_compact_context\` is non-empty.

## Dogfood
\`\`\`
$ TRACEARY_HOOK_STATE_KEY=dogfood-811 traceary hook session claude start
session-c1b5c1b7fcd6030f6f49e53a4729d0f1
$ echo '{"pre_compact_context":"v0.11 #811 dogfood: PreCompact summary sync."}' \\
    | TRACEARY_HOOK_STATE_KEY=dogfood-811 traceary hook compact claude pre-compact
$ sqlite3 ~/.config/traceary/traceary.db "SELECT s.session_id, substr(s.summary,1,60), substr(e.body,1,60) FROM sessions s LEFT JOIN events e ON e.session_id = s.session_id AND e.kind='compact_summary' ..."
session-...|v0.11 #811 dogfood: PreCompact summary sync.|v0.11 #811 dogfood: PreCompact summary sync.
\`\`\`

## Acceptance
- [x] sessions.summary AND compact_summary event both updated
- [x] Manually-authored summaries preserved (only-if-empty WHERE)
- [x] Trigger-only payloads (Gemini-style) do not sync
- [x] Codex / Gemini paths unaffected
- [x] \`go test ./...\` 1229 pass
- [x] \`golangci-lint\` clean

Closes #811
Parent #803