### PR TITLE
feat(handoff): include candidate memories with status marker

### DIFF
--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -188,7 +188,15 @@ func (b *contextPackBuilder) loadMemories(
 		// the same pack shape as before.
 		builder = preset.ApplyToMemoryListCriteriaBuilder(builder)
 	} else {
-		builder = builder.Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted})
+		// Default handoff / get_context surface returns both accepted and
+		// candidate memories so the next session sees pending review
+		// items with a status marker rather than only the curated set.
+		// Callers that want strict accepted-only behavior should pass an
+		// explicit preset (resume / review / incident).
+		builder = builder.Statuses([]domtypes.MemoryStatus{
+			domtypes.MemoryStatusAccepted,
+			domtypes.MemoryStatusCandidate,
+		})
 	}
 	if asOfValue, ok := asOf.Value(); ok {
 		builder = builder.AsOf(asOfValue)

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -168,6 +168,14 @@ func buildCompactSummaryText(result types.Optional[apptypes.ContextPack]) (strin
 			if index > 0 {
 				sb.WriteString(" | ")
 			}
+			// Mark non-accepted entries so the resuming agent does not
+			// treat candidate facts as curated (parity with handoff
+			// text format — see #812).
+			if memory.Status() != types.MemoryStatusAccepted {
+				sb.WriteString("[")
+				sb.WriteString(memory.Status().String())
+				sb.WriteString("] ")
+			}
 			sb.WriteString(truncateCompactSummarySegment(memory.Fact(), 60))
 		}
 		sb.WriteString("\n")

--- a/presentation/cli/handoff.go
+++ b/presentation/cli/handoff.go
@@ -240,9 +240,18 @@ func writeHandoffText(output io.Writer, result types.Optional[apptypes.ContextPa
 		return xerrors.Errorf("failed to print memories heading: %w", err)
 	}
 	for _, memory := range pack.Memories() {
+		// Tag candidate (and any non-accepted) entries with a leading
+		// status marker so the reader can tell pending review items
+		// apart from curated ones. Accepted entries keep their
+		// established two-bracket layout.
+		statusPrefix := ""
+		if memory.Status() != types.MemoryStatusAccepted {
+			statusPrefix = fmt.Sprintf("[%s]", memory.Status())
+		}
 		if _, err := fmt.Fprintf(
 			output,
-			"- [%s][%s:%s] %s\n",
+			"- %s[%s][%s:%s] %s\n",
+			statusPrefix,
 			memory.MemoryType(),
 			memory.Scope().Kind(),
 			memory.Scope().Key(),

--- a/presentation/cli/handoff_test.go
+++ b/presentation/cli/handoff_test.go
@@ -82,6 +82,80 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("candidate memories surface with status marker", func(t *testing.T) {
+		t.Parallel()
+
+		acceptedSummary, err := apptypes.MemorySummaryOf(
+			types.MemoryID("memory-accepted"),
+			types.MemoryTypeDecision,
+			types.WorkspaceScopeOf(types.Workspace("duck8823/traceary")),
+			"Keep accepted entries unchanged",
+			types.MemoryStatusAccepted,
+			types.ConfidenceVerified,
+			types.MemorySourceManual,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			time.Now(),
+			types.None[time.Time](),
+			time.Now(),
+			time.Now(),
+		)
+		if err != nil {
+			t.Fatalf("MemorySummaryOf(accepted) error = %v", err)
+		}
+		candidateSummary, err := apptypes.MemorySummaryOf(
+			types.MemoryID("memory-candidate"),
+			types.MemoryTypeLesson,
+			types.WorkspaceScopeOf(types.Workspace("duck8823/traceary")),
+			"Pending review item from extraction",
+			types.MemoryStatusCandidate,
+			types.ConfidenceLow,
+			types.MemorySourceExtracted,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			time.Now(),
+			types.None[time.Time](),
+			time.Now(),
+			time.Now(),
+		)
+		if err != nil {
+			t.Fatalf("MemorySummaryOf(candidate) error = %v", err)
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithContext(&contextUsecaseStub{
+				handoff: types.Some(apptypes.ContextPackOf(
+					types.SessionID("session-marker"),
+					types.Workspace("duck8823/traceary"),
+					"",
+					"active",
+					0,
+					0,
+					nil,
+					apptypes.WorkingStateOf("", ""),
+					nil,
+					[]apptypes.MemorySummary{acceptedSummary, candidateSummary},
+				)),
+			}),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "handoff", "--db-path", filepath.Join(t.TempDir(), "traceary.db")})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		out := stdout.String()
+		if !strings.Contains(out, "[candidate][lesson]") {
+			t.Fatalf("candidate memory should render with [candidate] status prefix:\n%s", out)
+		}
+		if strings.Contains(out, "[accepted][decision]") {
+			t.Fatalf("accepted memory must not get a status prefix (existing layout); output:\n%s", out)
+		}
+	})
+
 	t.Run("session handoff subcommand reuses the same structured output", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- Default \`session handoff\` / MCP \`get_context\` / \`session_status(action="handoff")\` surfaces now return both \`accepted\` and \`candidate\` memories so the next session sees pending review items rather than only curated facts.
- Candidate (and any non-accepted) entries get a leading status prefix in the text output:
  \`\`\`
  - [candidate][lesson][workspace:foo/bar] pending fact
  - [decision][workspace:foo/bar] curated decision  ← unchanged
  \`\`\`
- Callers that want strict accepted-only behavior pass an explicit preset (\`resume\` / \`review\` / \`incident\`); the preset branch is untouched.
- MCP \`memorySummaryOutput.status\` was already serialized, so JSON consumers already see the field; no contract additions required for the JSON case.

## UX rationale
Per project memory: SessionStart push of pending items is intentionally avoided to prevent task-start interruption. Handoff is the right place to surface candidates — the operator is already in a "what was happening" frame of mind.

## Acceptance
- [x] Candidate memory rendered with \`[candidate]\` prefix in handoff text
- [x] Accepted memory keeps existing two-bracket layout
- [x] JSON contract: status field already serialized
- [x] \`go test ./...\` 1233 pass
- [x] \`golangci-lint\` clean

Closes #812
Parent #803