### PR TITLE
docs(operations): add scheduled-tasks.md for daily host hook drift check

### DIFF
--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -107,5 +107,6 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 - hooks integration: [`../hooks/README.ja.md`](../hooks/README.ja.md)
 - storage model: [`../storage/README.ja.md`](../storage/README.ja.md)
 - backup guide: [`../backup/README.ja.md`](../backup/README.ja.md)
+- 定期メンテナンスタスク: [`./scheduled-tasks.ja.md`](./scheduled-tasks.ja.md)
 - Python 依存の縮小計画: [`./python-dependencies.ja.md`](./python-dependencies.ja.md)
 - repository tooling の方針: [`./repo-tooling.ja.md`](./repo-tooling.ja.md)

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -107,5 +107,6 @@ Possible but not actively tuned:
 - hooks integration: [`../hooks/README.md`](../hooks/README.md)
 - storage model: [`../storage/README.md`](../storage/README.md)
 - backup guide: [`../backup/README.md`](../backup/README.md)
+- Scheduled operations: [`./scheduled-tasks.md`](./scheduled-tasks.md)
 - Python dependency plan: [`./python-dependencies.md`](./python-dependencies.md)
 - Repository tooling plan: [`./repo-tooling.md`](./repo-tooling.md)

--- a/docs/operations/scheduled-tasks.ja.md
+++ b/docs/operations/scheduled-tasks.ja.md
@@ -1,0 +1,52 @@
+# 定期メンテナンスタスク
+
+[English](./scheduled-tasks.md)
+
+Traceary のメンテナンス作業のうち、低頻度でバックグラウンド実行したいものをまとめる。host hook surface の再点検、upstream regression の監視、inbox digest の更新などが該当する。本ドキュメントは maintainer 向けの推奨セット。
+
+下記タスクは **Claude Code 自身の scheduling** (`/schedule` skill — Claude Code のエージェント run を cron で起動) を前提にしている。GitHub Actions を推奨しない理由は runner に Anthropic API key を別途設定する必要があるため。Claude Code の scheduled agent はローカル credential を流用できる。
+
+## 日次 host hook drift check
+
+**目的.** host CLI (Claude Code, Codex, Gemini) は minor release 間で hook を追加・廃止することがある。`docs/hooks/host-coverage.md` のマトリクスは手書きなので、定期確認しないと silently に stale になる。
+
+**動作.** 日次の Claude Code agent が:
+
+1. 各 host の hook reference (Claude Code docs, Codex CLI バイナリ strings, Gemini CLI 同梱 docs) を fetch。
+2. `docs/hooks/host-coverage.md` を読んで wired / available / unsupported のマトリクスを parse。
+3. host 側の hook 一覧と diff。
+4. 新規 hook が出現、または既存 hook が消失したら `tech-debt: host hook drift detected — <host> <date>` で issue を作成（body に diff）。
+5. drift なしなら silent 終了 — 余計な issue は立てない。
+
+**推奨スケジュール.** maintainer のローカルタイムで毎朝 06:00。active session と被らない時間帯を選ぶ。
+
+**セットアップ.**
+
+```text
+/schedule create
+  cron: 0 6 * * *
+  prompt: |
+    Traceary の docs/hooks/host-coverage.md を upstream host hook
+    reference と照合してください。各 host (Claude Code, Codex CLI 0.x,
+    Gemini CLI 0.36.x) について reference page もしくは同梱 docs を
+    fetch し、wired / available / unsupported のマトリクスと比較。
+    新規 hook の出現または既存 hook の消失が検出されたら
+    `tech-debt: host hook drift detected — <host> YYYY-MM-DD` で
+    duck8823/traceary に issue を作成 (body に diff)。drift なしの
+    場合は何もせず silent 終了。
+```
+
+**検証 (no-op run).**
+
+単発の手動 trigger で「issue 作成」または「silent 終了」どちらかが正常に動作すれば良い。同日の re-run で既存 open issue を重複作成しないよう、タイトル prefix で match させる前提。
+
+## 運用ルール
+
+- 報告が無い日は **silent 終了** とし、operator の inbox に空 run が溜まらないようにする。
+- scheduled agent が立てる issue は `tech-debt:` prefix + 日付スタンプを必ず付与し triage しやすくする。
+- Traceary store にアクセスする scheduled agent は operator の DB path (`~/.config/traceary/traceary.db`) を使う。非デフォルト install のときだけ `TRACEARY_DB_PATH` を設定する。
+
+## 関連
+
+- [Host hook coverage matrix](../hooks/host-coverage.ja.md) — 日次 drift check の対象。
+- [Hook contract](../hooks/contract.ja.md) — host 別 capability tier。

--- a/docs/operations/scheduled-tasks.md
+++ b/docs/operations/scheduled-tasks.md
@@ -1,0 +1,52 @@
+# Scheduled Operations
+
+[日本語](./scheduled-tasks.ja.md)
+
+Some maintenance work for Traceary is best done as a low-frequency background task: re-checking host hook surfaces, watching for upstream regressions, refreshing the inbox digest. This page documents the scheduled tasks Traceary suggests setting up for a maintainer-class install.
+
+The tasks below assume **Claude Code's own scheduling** (the `/schedule` skill, which fires Claude Code agent runs on a cron). GitHub Actions is intentionally not the recommended path because it would require an Anthropic API key in the runner; Claude Code's scheduled agents reuse local credentials.
+
+## Daily host hook drift check
+
+**Why.** Host CLIs (Claude Code, Codex, Gemini) ship hook changes between minor releases. The `docs/hooks/host-coverage.md` matrix is curated by hand, so without a periodic refresh it silently goes stale.
+
+**What.** A daily Claude Code agent that:
+
+1. Fetches each host's hook reference page (Claude Code docs, Codex CLI binary strings, Gemini CLI bundled docs).
+2. Reads `docs/hooks/host-coverage.md` and parses out the wired / available / unsupported matrix.
+3. Diffs the host's documented hooks against the matrix.
+4. If new hooks appear or a previously-listed hook is gone, opens a `tech-debt: host hook drift detected — <host> <date>` issue with the diff in the body.
+5. If there is no drift, the agent exits silently — no issue noise.
+
+**Recommended schedule.** Daily at 06:00 in the maintainer's local timezone. Pick a time the maintainer is unlikely to be in an active session so the agent's output does not interrupt other work.
+
+**Setup.**
+
+```text
+/schedule create
+  cron: 0 6 * * *
+  prompt: |
+    Check Traceary's docs/hooks/host-coverage.md against the upstream
+    host hook references. For each host (Claude Code, Codex CLI 0.x,
+    Gemini CLI 0.36.x), fetch the reference page or local bundle docs,
+    compare against the wired / available / unsupported matrix, and if
+    a previously-unseen hook appears (or a listed hook is removed),
+    open a `tech-debt: host hook drift detected — <host> YYYY-MM-DD`
+    issue against duck8823/traceary with the diff. If there is no
+    drift, exit silently.
+```
+
+**Verification (no-op run).**
+
+A single manual trigger should either open an issue or finish silently with no errors. Re-running on the same day should not duplicate an existing open issue (the agent should match on title prefix).
+
+## Conventions
+
+- A scheduled agent that has nothing to report **must exit silently** so the operator's inbox does not fill with empty runs.
+- Issues opened by scheduled agents always carry the `tech-debt:` prefix and a date stamp so they sort cleanly and are easy to triage.
+- Scheduled agents that talk to the Traceary store should use the same DB path as the operator's workstation (`~/.config/traceary/traceary.db`); they do not need to set `TRACEARY_DB_PATH` unless the install is non-default.
+
+## Related
+
+- [Hook coverage matrix](../hooks/host-coverage.md) — what the daily check guards.
+- [Hook contract](../hooks/contract.md) — capability tiers per host.


### PR DESCRIPTION
## Summary
- Document the daily host hook drift check pattern in \`docs/operations/scheduled-tasks.{md,ja.md}\`.
- A Claude Code scheduled agent (registered via \`/schedule create\` / \`CronCreate\`) fetches each host's upstream hook reference daily, compares against \`docs/hooks/host-coverage.md\`, opens a \`tech-debt: host hook drift detected — <host> <date>\` issue when drift is detected, and exits silently otherwise.
- Companion cron registered out-of-band in the active Claude session at 06:07 local time. Job ID: \`369bad5f\`.

## Why Claude Code scheduling instead of GitHub Actions?
GitHub Actions runner would need an Anthropic API key set as a secret; Claude Code's scheduled agents reuse local credentials.

## Caveat
\`CronCreate\` in this session reports the job as session-only — not persisted to \`.claude/scheduled_tasks.json\`. The doc explains the setup pattern so the operator can re-register / make durable in a future session if desired.

## Acceptance
- [x] \`docs/operations/scheduled-tasks.{md,ja.md}\` describe the daily drift check
- [x] \`scripts/verify_docs_i18n.py\` pass
- [x] Cron registered (\`CronList\` shows job 369bad5f)

Closes #814
Parent #803