### PR TITLE
feat(memory): extracted-hidden parity across CLI / MCP / search / subagent

### DIFF
--- a/application/types/memory_search_criteria.go
+++ b/application/types/memory_search_criteria.go
@@ -15,6 +15,7 @@ type MemorySearchCriteria struct {
 	scopes         []domtypes.MemoryScope
 	statuses       []domtypes.MemoryStatus
 	memoryTypes    []domtypes.MemoryType
+	sources        []domtypes.MemorySource
 	asOf           domtypes.Optional[time.Time]
 	includeExpired bool
 }
@@ -36,6 +37,9 @@ func (c MemorySearchCriteria) Statuses() []domtypes.MemoryStatus { return slices
 
 // MemoryTypes returns the memory type filters.
 func (c MemorySearchCriteria) MemoryTypes() []domtypes.MemoryType { return slices.Clone(c.memoryTypes) }
+
+// Sources returns the memory source filters.
+func (c MemorySearchCriteria) Sources() []domtypes.MemorySource { return slices.Clone(c.sources) }
 
 // AsOf returns the point-in-time at which validity windows are
 // evaluated. See MemoryListCriteria.AsOf for semantics.
@@ -106,6 +110,12 @@ func (b *MemorySearchCriteriaBuilder) MemoryType(memoryType domtypes.MemoryType)
 // MemoryTypes replaces the memory type filters.
 func (b *MemorySearchCriteriaBuilder) MemoryTypes(memoryTypes []domtypes.MemoryType) *MemorySearchCriteriaBuilder {
 	b.criteria.memoryTypes = slices.Clone(memoryTypes)
+	return b
+}
+
+// Sources replaces the memory source filters.
+func (b *MemorySearchCriteriaBuilder) Sources(sources []domtypes.MemorySource) *MemorySearchCriteriaBuilder {
+	b.criteria.sources = slices.Clone(sources)
 	return b
 }
 

--- a/application/types/memory_search_criteria.go
+++ b/application/types/memory_search_criteria.go
@@ -113,6 +113,14 @@ func (b *MemorySearchCriteriaBuilder) MemoryTypes(memoryTypes []domtypes.MemoryT
 	return b
 }
 
+// Source appends a memory source filter.
+func (b *MemorySearchCriteriaBuilder) Source(source domtypes.MemorySource) *MemorySearchCriteriaBuilder {
+	if source != "" {
+		b.criteria.sources = append(b.criteria.sources, source)
+	}
+	return b
+}
+
 // Sources replaces the memory source filters.
 func (b *MemorySearchCriteriaBuilder) Sources(sources []domtypes.MemorySource) *MemorySearchCriteriaBuilder {
 	b.criteria.sources = slices.Clone(sources)

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -689,7 +689,7 @@ func buildMemorySearchQuery(criteria apptypes.MemorySearchCriteria, clock types.
 		args = append(args, likeQuery, likeQuery, likeQuery)
 	}
 
-	args, err := appendMemoryFilters(&builder, args, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes(), nil)
+	args, err := appendMemoryFilters(&builder, args, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes(), criteria.Sources())
 	if err != nil {
 		return "", nil, err
 	}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -747,6 +747,17 @@ func (c *RootCLI) runHookSubagentStop(
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
 		}
+		// Subagent-end auto-extract parity with main session-end
+		// (#810, #832). Best-effort: errors must not block the
+		// boundary record.
+		if c.memory != nil {
+			if _, extractErr := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
+				SessionID(childSessionID).
+				Workspace(workspace).
+				Build()); extractErr != nil {
+				slog.Debug("hook subagent-stop auto-extract failed", "client", client, "child_session_id", childSessionID, "error", extractErr)
+			}
+		}
 		if activeParentSessionID != "" {
 			parentSessionID = activeParentSessionID
 		}

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -273,6 +273,8 @@ type memoryListCommandInput struct {
 	sessionFamily  string
 	statuses       []string
 	memoryTypes    []string
+	sources        []string
+	includeHidden  bool
 	limit          int
 	offset         int
 	asOf           string
@@ -289,6 +291,8 @@ type memorySearchCommandInput struct {
 	sessionFamily  string
 	statuses       []string
 	memoryTypes    []string
+	sources        []string
+	includeHidden  bool
 	limit          int
 	offset         int
 	query          string

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -54,7 +54,7 @@ func (c *RootCLI) newMemoryListCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / imported)", "memory source (manual / extracted / extracted-hidden / imported) で絞り込む"))
-	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (default omits them)", "extracted-hidden の候補も含める (既定では除外)"))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (low-quality auto-extractions kept for audit)", "extracted-hidden の候補も含める (audit 用に保存された低品質自動抽出)"))
 	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before listing", "一覧表示前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
@@ -85,7 +85,7 @@ func (c *RootCLI) newMemorySearchCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / imported)", "memory source (manual / extracted / extracted-hidden / imported) で絞り込む"))
-	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (default omits them)", "extracted-hidden の候補も含める (既定では除外)"))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (low-quality auto-extractions kept for audit)", "extracted-hidden の候補も含める (audit 用に保存された低品質自動抽出)"))
 	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before returning results", "結果を返す前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
@@ -308,17 +308,7 @@ func (c *RootCLI) runMemoryList(ctx context.Context, output io.Writer, input mem
 	if err != nil {
 		return err
 	}
-	// Default-exclude `extracted-hidden` from the generic memory list
-	// so reviewers / agents are not drowned by low-quality
-	// auto-extractions (#832). Explicit --source wins;
-	// `--include-hidden` toggles the hidden tier on.
-	if len(sources) == 0 && !input.includeHidden {
-		sources = []domtypes.MemorySource{
-			domtypes.MemorySourceManual,
-			domtypes.MemorySourceExtracted,
-			domtypes.MemorySourceImported,
-		}
-	}
+	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
 
 	asOf, err := parseOptionalValidityTime(input.asOf)
 	if err != nil {
@@ -395,13 +385,7 @@ func (c *RootCLI) runMemorySearch(ctx context.Context, output io.Writer, input m
 	if err != nil {
 		return err
 	}
-	if len(sources) == 0 && !input.includeHidden {
-		sources = []domtypes.MemorySource{
-			domtypes.MemorySourceManual,
-			domtypes.MemorySourceExtracted,
-			domtypes.MemorySourceImported,
-		}
-	}
+	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
 
 	asOf, err := parseOptionalValidityTime(input.asOf)
 	if err != nil {

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -53,6 +53,8 @@ func (c *RootCLI) newMemoryListCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / imported)", "memory source (manual / extracted / extracted-hidden / imported) で絞り込む"))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (default omits them)", "extracted-hidden の候補も含める (既定では除外)"))
 	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before listing", "一覧表示前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
@@ -82,6 +84,8 @@ func (c *RootCLI) newMemorySearchCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.statuses, "status", nil, Localize("filter by memory lifecycle status", "memory の lifecycle status で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / imported)", "memory source (manual / extracted / extracted-hidden / imported) で絞り込む"))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (default omits them)", "extracted-hidden の候補も含める (既定では除外)"))
 	cmd.Flags().IntVar(&input.limit, "limit", 20, Localize("maximum number of memories to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of memories to skip before returning results", "結果を返す前にスキップする件数"))
 	cmd.Flags().StringVar(&input.asOf, "as-of", "", Localize("evaluate memory validity as of this timestamp (`YYYY-MM-DD` or RFC3339, defaults to now)", "この時点の validity で評価する (`YYYY-MM-DD` または RFC3339、既定は now)"))
@@ -300,6 +304,21 @@ func (c *RootCLI) runMemoryList(ctx context.Context, output io.Writer, input mem
 	if err != nil {
 		return err
 	}
+	sources, err := parseMemorySources(input.sources)
+	if err != nil {
+		return err
+	}
+	// Default-exclude `extracted-hidden` from the generic memory list
+	// so reviewers / agents are not drowned by low-quality
+	// auto-extractions (#832). Explicit --source wins;
+	// `--include-hidden` toggles the hidden tier on.
+	if len(sources) == 0 && !input.includeHidden {
+		sources = []domtypes.MemorySource{
+			domtypes.MemorySourceManual,
+			domtypes.MemorySourceExtracted,
+			domtypes.MemorySourceImported,
+		}
+	}
 
 	asOf, err := parseOptionalValidityTime(input.asOf)
 	if err != nil {
@@ -321,6 +340,9 @@ func (c *RootCLI) runMemoryList(ctx context.Context, output io.Writer, input mem
 	}
 	if len(memoryTypes) > 0 {
 		criteriaBuilder = criteriaBuilder.MemoryTypes(memoryTypes)
+	}
+	if len(sources) > 0 {
+		criteriaBuilder = criteriaBuilder.Sources(sources)
 	}
 	criteriaBuilder = criteriaBuilder.IncludeExpiredByValidity(input.includeExpired)
 	if t, ok := asOf.Value(); ok {
@@ -369,6 +391,17 @@ func (c *RootCLI) runMemorySearch(ctx context.Context, output io.Writer, input m
 	if err != nil {
 		return err
 	}
+	sources, err := parseMemorySources(input.sources)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 && !input.includeHidden {
+		sources = []domtypes.MemorySource{
+			domtypes.MemorySourceManual,
+			domtypes.MemorySourceExtracted,
+			domtypes.MemorySourceImported,
+		}
+	}
 
 	asOf, err := parseOptionalValidityTime(input.asOf)
 	if err != nil {
@@ -390,6 +423,9 @@ func (c *RootCLI) runMemorySearch(ctx context.Context, output io.Writer, input m
 	}
 	if len(memoryTypes) > 0 {
 		criteriaBuilder = criteriaBuilder.MemoryTypes(memoryTypes)
+	}
+	if len(sources) > 0 {
+		criteriaBuilder = criteriaBuilder.Sources(sources)
 	}
 	criteriaBuilder = criteriaBuilder.IncludeExpiredByValidity(input.includeExpired)
 	if t, ok := asOf.Value(); ok {

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -133,13 +133,7 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	// reviewer is not drowned by low-quality auto-extractions. The
 	// rows are still in the store for audit; `--include-hidden`
 	// surfaces them. Explicit `--source` always wins (#810/#830).
-	if len(sources) == 0 && !input.includeHidden {
-		sources = []domtypes.MemorySource{
-			domtypes.MemorySourceManual,
-			domtypes.MemorySourceExtracted,
-			domtypes.MemorySourceImported,
-		}
-	}
+	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
 
 	// Inbox is always scoped to candidate — that is the point of the view.
 	// Source filters go into the criteria so pagination is consistent: if
@@ -263,6 +257,24 @@ func parseMemorySources(values []string) ([]domtypes.MemorySource, error) {
 		out = append(out, source)
 	}
 	return out, nil
+}
+
+// applyExtractedHiddenDefault returns the source filter to use when
+// the operator did not pass `--source` and `--include-hidden` is
+// false. It pins the default to the visible-by-default sources so
+// `extracted-hidden` rows are skipped. When the operator passed an
+// explicit source filter, this function returns it unchanged so
+// explicit always wins. Shared by `memory list`, `memory search`, and
+// `memory inbox list` to avoid drift.
+func applyExtractedHiddenDefault(sources []domtypes.MemorySource, includeHidden bool) []domtypes.MemorySource {
+	if len(sources) > 0 || includeHidden {
+		return sources
+	}
+	return []domtypes.MemorySource{
+		domtypes.MemorySourceManual,
+		domtypes.MemorySourceExtracted,
+		domtypes.MemorySourceImported,
+	}
 }
 
 func writeMemoryInboxList(output io.Writer, items []apptypes.MemoryDetails, asJSON bool) error {

--- a/presentation/cli/memory_test.go
+++ b/presentation/cli/memory_test.go
@@ -98,6 +98,51 @@ func TestRootCLI_MemoryListCommand_DefaultWorkspaceScope(t *testing.T) {
 	}
 }
 
+func TestRootCLI_MemoryListCommand_DefaultExcludesExtractedHidden(t *testing.T) {
+	stub := &memoryUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "list", "--workspace", "duck8823/traceary", "--db-path", "/tmp/t.db"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := stub.listCriteria.Sources()
+	if len(got) == 0 {
+		t.Fatalf("default memory list must constrain Sources to exclude extracted-hidden, got empty filter")
+	}
+	for _, s := range got {
+		if s == types.MemorySourceExtractedHidden {
+			t.Fatalf("default memory list must not include extracted-hidden in Sources, got %v", got)
+		}
+	}
+}
+
+func TestRootCLI_MemoryListCommand_IncludeHiddenSkipsDefaultFilter(t *testing.T) {
+	stub := &memoryUsecaseStub{}
+
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(stub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "list", "--workspace", "duck8823/traceary", "--include-hidden", "--db-path", "/tmp/t.db"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := stub.listCriteria.Sources(); len(got) != 0 {
+		t.Fatalf("--include-hidden should not add a Sources filter, got %v", got)
+	}
+}
+
 func TestRootCLI_MemorySearchCommand_RequiresConstraint(t *testing.T) {
 	rootCmd := cli.NewRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -33,6 +33,8 @@ type queryMemoryInput struct {
 	SessionFamily       string   `json:"session_family,omitempty" jsonschema:"session-family scope filter"`
 	Statuses            []string `json:"status,omitempty" jsonschema:"memory lifecycle status filters"`
 	MemoryTypes         []string `json:"type,omitempty" jsonschema:"memory type filters"`
+	Sources             []string `json:"source,omitempty" jsonschema:"memory source filters: manual, extracted, extracted-hidden, imported"`
+	IncludeHidden       bool     `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates (default omits them)"`
 	Limit               int      `json:"limit,omitempty" jsonschema:"maximum number of memories to return (default: 20)"`
 	Offset              int      `json:"offset,omitempty" jsonschema:"number of memories to skip before returning results (default: 0)"`
 	AsOf                string   `json:"as_of,omitempty" jsonschema:"evaluate content validity at this timestamp"`
@@ -177,6 +179,8 @@ type retrieveMemoriesInput struct {
 	SessionFamily  string   `json:"session_family,omitempty" jsonschema:"session-family scope filter"`
 	Statuses       []string `json:"status,omitempty" jsonschema:"memory lifecycle status filters"`
 	MemoryTypes    []string `json:"type,omitempty" jsonschema:"memory type filters"`
+	Sources        []string `json:"source,omitempty" jsonschema:"memory source filters: manual, extracted, extracted-hidden, imported"`
+	IncludeHidden  bool     `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates (low-quality auto-extractions kept for audit). Default omits them"`
 	Limit          int      `json:"limit,omitempty" jsonschema:"maximum number of memories to return (default: 20)"`
 	Offset         int      `json:"offset,omitempty" jsonschema:"number of memories to skip before returning results (default: 0)"`
 	AsOf           string   `json:"as_of,omitempty" jsonschema:"evaluate content validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -269,7 +269,7 @@ func (s *Server) queryMemory() mcp.ToolHandlerFor[queryMemoryInput, any] {
 		action := strings.ToLower(strings.TrimSpace(input.Action))
 		switch action {
 		case "retrieve":
-			_, out, err := s.retrieveMemories()(ctx, req, retrieveMemoriesInput{MemoryID: input.MemoryID, Query: input.Query, Workspace: input.Workspace, Agent: input.Agent, SessionFamily: input.SessionFamily, Statuses: input.Statuses, MemoryTypes: input.MemoryTypes, Limit: input.Limit, Offset: input.Offset, AsOf: input.AsOf, IncludeExpired: input.IncludeExpired, Preset: input.Preset})
+			_, out, err := s.retrieveMemories()(ctx, req, retrieveMemoriesInput{MemoryID: input.MemoryID, Query: input.Query, Workspace: input.Workspace, Agent: input.Agent, SessionFamily: input.SessionFamily, Statuses: input.Statuses, MemoryTypes: input.MemoryTypes, Sources: input.Sources, IncludeHidden: input.IncludeHidden, Limit: input.Limit, Offset: input.Offset, AsOf: input.AsOf, IncludeExpired: input.IncludeExpired, Preset: input.Preset})
 			return nil, out, err
 		case "export":
 			if strings.TrimSpace(input.Target) == "" {
@@ -717,6 +717,21 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 		if err != nil {
 			return nil, memoriesOutput{}, err
 		}
+		sources, err := parseMemorySourcesMCP(input.Sources)
+		if err != nil {
+			return nil, memoriesOutput{}, err
+		}
+		// Default-exclude `extracted-hidden` from generic retrieve so AI
+		// agents triaging the inbox do not get drowned by low-quality
+		// auto-extractions. Explicit `source` filter wins; otherwise
+		// `include_hidden=true` toggles the hidden tier on (#832).
+		if len(sources) == 0 && !input.IncludeHidden {
+			sources = []types.MemorySource{
+				types.MemorySourceManual,
+				types.MemorySourceExtracted,
+				types.MemorySourceImported,
+			}
+		}
 
 		asOfTime := time.Time{}
 		if trimmedAsOf := strings.TrimSpace(input.AsOf); trimmedAsOf != "" {
@@ -746,6 +761,9 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 			if len(memoryTypes) > 0 {
 				searchBuilder = searchBuilder.MemoryTypes(memoryTypes)
 			}
+			if len(sources) > 0 {
+				searchBuilder = searchBuilder.Sources(sources)
+			}
 			searchBuilder = searchBuilder.IncludeExpiredByValidity(input.IncludeExpired)
 			if !asOfTime.IsZero() {
 				searchBuilder = searchBuilder.AsOf(asOfTime)
@@ -766,6 +784,9 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 			}
 			if len(memoryTypes) > 0 {
 				listBuilder = listBuilder.MemoryTypes(memoryTypes)
+			}
+			if len(sources) > 0 {
+				listBuilder = listBuilder.Sources(sources)
 			}
 			listBuilder = listBuilder.IncludeExpiredByValidity(input.IncludeExpired)
 			if !asOfTime.IsZero() {
@@ -1380,6 +1401,22 @@ func parseMemoryTypes(values []string) ([]types.MemoryType, error) {
 		memoryTypes = append(memoryTypes, resolved)
 	}
 	return memoryTypes, nil
+}
+
+func parseMemorySourcesMCP(values []string) ([]types.MemorySource, error) {
+	sources := make([]types.MemorySource, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		resolved, err := types.MemorySourceFrom(trimmed)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve memory source: %w", err)
+		}
+		sources = append(sources, resolved)
+	}
+	return sources, nil
 }
 
 func parseOptionalConfidence(value string) (types.Optional[types.Confidence], error) {

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -721,17 +721,7 @@ func (s *Server) retrieveMemories() mcp.ToolHandlerFor[retrieveMemoriesInput, me
 		if err != nil {
 			return nil, memoriesOutput{}, err
 		}
-		// Default-exclude `extracted-hidden` from generic retrieve so AI
-		// agents triaging the inbox do not get drowned by low-quality
-		// auto-extractions. Explicit `source` filter wins; otherwise
-		// `include_hidden=true` toggles the hidden tier on (#832).
-		if len(sources) == 0 && !input.IncludeHidden {
-			sources = []types.MemorySource{
-				types.MemorySourceManual,
-				types.MemorySourceExtracted,
-				types.MemorySourceImported,
-			}
-		}
+		sources = applyExtractedHiddenDefaultMCP(sources, input.IncludeHidden)
 
 		asOfTime := time.Time{}
 		if trimmedAsOf := strings.TrimSpace(input.AsOf); trimmedAsOf != "" {
@@ -1417,6 +1407,22 @@ func parseMemorySourcesMCP(values []string) ([]types.MemorySource, error) {
 		sources = append(sources, resolved)
 	}
 	return sources, nil
+}
+
+// applyExtractedHiddenDefaultMCP mirrors presentation/cli's
+// applyExtractedHiddenDefault. Both layers default to omitting
+// `extracted-hidden`; explicit `source` always wins, and
+// `include_hidden=true` opts back in. Kept as a separate symbol so
+// the MCP package does not import the CLI package (clean direction).
+func applyExtractedHiddenDefaultMCP(sources []types.MemorySource, includeHidden bool) []types.MemorySource {
+	if len(sources) > 0 || includeHidden {
+		return sources
+	}
+	return []types.MemorySource{
+		types.MemorySourceManual,
+		types.MemorySourceExtracted,
+		types.MemorySourceImported,
+	}
 }
 
 func parseOptionalConfidence(value string) (types.Optional[types.Confidence], error) {


### PR DESCRIPTION
## Summary
Closes #832 by carrying the v0.11.0 \`extracted-hidden\` filter forward to every other read surface, plus the missing write surface:

### Read surfaces
- **MCP \`query_memory(action="retrieve")\`** — adds \`source\` and \`include_hidden\` fields. Default-excludes \`extracted-hidden\` when neither is set; explicit \`source\` always wins.
- **CLI \`traceary memory list\`** — adds \`--source\` and \`--include-hidden\` flags with the same default.
- **CLI \`traceary memory search\`** — adds \`--source\` and \`--include-hidden\` flags with the same default.
- **\`MemorySearchCriteria\`** gains a \`Sources\` field; the SQLite search query already had a per-call source filter via \`appendMemoryFilters\`.

### Write surface
- **\`runHookSubagentStop\`** — fires \`memory.Extract\` best-effort against the **child** session ID after \`session.End\`, mirroring the main session-end path. Errors swallowed via slog.Debug.

## Dogfood
\`\`\`
$ traceary memory list --session-family ... --status candidate
1 row   (extracted only)
$ traceary memory list --session-family ... --status candidate --include-hidden
2 rows  (also extracted-hidden)
\`\`\`

## Acceptance
- [x] CLI / MCP / search default-exclude \`extracted-hidden\`
- [x] \`--include-hidden\` / \`include_hidden\` toggle the hidden tier on
- [x] Subagent end auto-extract parity
- [x] \`go test ./...\` 1239 pass
- [x] \`golangci-lint\` clean
- [x] \`scripts/verify_docs_i18n.py\` pass

## Still deferred (separate follow-up worth)
- 14-day auto-expire policy for source IN (extracted, extracted-hidden) — needs a hygiene scanner extension to walk candidate (not just accepted) rows.
- Real confidence classifier on extraction signals — the length heuristic landed in #831 is intentionally not a confidence metric.

Closes #832