### PR TITLE
feat(gc): auto-expire stale auto-extracted candidates after 14 days

### DIFF
--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -154,7 +154,7 @@ target ごとの policy:
 
 - `events`: `events.created_at < cutoff` の row を削除します。紐づく `command_audits` は foreign key により cascade されます。
 - `sessions`: `COALESCE(ended_at, started_at) < cutoff` かつ surviving event から参照されていない終了済み session を削除します。active session (`ended_at IS NULL`) は常に保護されます。
-- `memories`: `updated_at < cutoff` の `expired` / `superseded` memory だけを削除します。`accepted`、`candidate`、その他の status は status が変わらない限り無期限に保持します。evidence/artifact ref は cascade され、削除対象を指す `supersedes_memory_id` は FK 整合性維持のため事前に NULL へ更新されます。
+- `memories`: `updated_at < cutoff` の `expired` / `superseded` memory だけを削除します。`accepted`、手動追加された `candidate`、その他の status は status が変わらない限り無期限に保持します。**例外:** auto-extracted candidate (`source IN (extracted, extracted-hidden)`) は 14 日以上経過したものを同じ pass で削除します — これらは best-effort signal で curated fact ではないため、短い retention で inbox を整理します。evidence/artifact ref は cascade され、削除対象を指す `supersedes_memory_id` は FK 整合性維持のため事前に NULL へ更新されます。
 - `memory_edges`: `valid_to < cutoff` の終了済み edge を削除します。endpoint の memory が削除される場合も edge は自動 cascade されます。
 - `all`: events、sessions、memories、memory_edges の順に依存関係を保って適用します。
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -155,7 +155,7 @@ Target policies:
 
 - `events`: delete rows where `events.created_at < cutoff`; linked `command_audits` cascade via foreign keys.
 - `sessions`: delete ended sessions where `COALESCE(ended_at, started_at) < cutoff` and no surviving events reference the session. Active sessions (`ended_at IS NULL`) are always protected.
-- `memories`: delete only `expired` or `superseded` memories where `updated_at < cutoff`. `accepted`, `candidate`, and other statuses are kept indefinitely unless their status changes. Evidence/artifact refs cascade; `supersedes_memory_id` pointers to deleted rows are cleared first to preserve FK integrity.
+- `memories`: delete only `expired` or `superseded` memories where `updated_at < cutoff`. `accepted`, manually-added `candidate`, and other statuses are kept indefinitely unless their status changes. **Exception:** auto-extracted candidates (`source IN (extracted, extracted-hidden)`) older than 14 days are also deleted in this pass — these rows are best-effort signal, not curated facts, and short retention keeps the inbox honest. Evidence/artifact refs cascade; `supersedes_memory_id` pointers to deleted rows are cleared first to preserve FK integrity.
 - `memory_edges`: delete closed edges where `valid_to < cutoff`; edges also cascade automatically when either endpoint memory is deleted.
 - `all`: apply the policies in dependency order: events, sessions, memories, then memory_edges.
 

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -362,6 +362,45 @@ func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *te
 	assertNoForeignKeyViolations(t, db)
 }
 
+// TestDatasource_CollectGarbage_clearsSupersedesRefBeforeDeletingStaleExtractedCandidate
+// verifies that an unusual graph in which a manual memory supersedes
+// an auto-extracted candidate does not trip a foreign-key violation
+// when the candidate ages out under the 14-day rule.
+func TestDatasource_CollectGarbage_clearsSupersedesRefBeforeDeletingStaleExtractedCandidate(t *testing.T) {
+	t.Parallel()
+
+	dbPath, storeManager := prepareRetentionFixture(t)
+	db := openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	now := time.Now().UTC()
+	stale := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	insertRetentionMemoryWithSource(t, db, "stale-extracted", "candidate", "extracted", "", stale)
+	// Manual memory points at the stale extracted candidate via
+	// supersedes_memory_id. The clearing pass must NULL the link
+	// before the delete fires.
+	insertRetentionMemoryWithSource(t, db, "manual-pointer", "accepted", "manual", "stale-extracted", stale)
+
+	if _, err := storeManager.CollectGarbage(
+		context.Background(),
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		apptypes.GarbageCollectionTargetMemories,
+		false,
+	); err != nil {
+		t.Fatalf("CollectGarbage() error = %v", err)
+	}
+	assertRetentionIDs(t, db, "memories", "id", []string{"manual-pointer"})
+	assertNoForeignKeyViolations(t, db)
+	var supersedes sql.NullString
+	if err := db.QueryRow(`SELECT supersedes_memory_id FROM memories WHERE id = 'manual-pointer'`).Scan(&supersedes); err != nil {
+		t.Fatalf("query supersedes_memory_id: %v", err)
+	}
+	if supersedes.Valid {
+		t.Fatalf("supersedes_memory_id = %q, want NULL after deleting referenced extracted candidate", supersedes.String)
+	}
+}
+
 func TestDatasource_CollectGarbage_deletesOldClosedMemoryEdges(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -315,6 +315,53 @@ func TestDatasource_CollectGarbage_deletesOnlyExpiredAndSupersededMemoriesWithCa
 	assertNoForeignKeyViolations(t, db)
 }
 
+func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *testing.T) {
+	t.Parallel()
+
+	dbPath, storeManager := prepareRetentionFixture(t)
+	db := openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	now := time.Now().UTC()
+	stale := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
+	fresh := now.Add(-3 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	// Stale candidates from extraction: should be auto-deleted.
+	insertRetentionMemoryWithSource(t, db, "extracted-stale", "candidate", "extracted", "", stale)
+	insertRetentionMemoryWithSource(t, db, "hidden-stale", "candidate", "extracted-hidden", "", stale)
+	// Fresh extracted candidate: keep.
+	insertRetentionMemoryWithSource(t, db, "extracted-fresh", "candidate", "extracted", "", fresh)
+	// Manual / imported candidates do not auto-expire on this short window.
+	insertRetentionMemoryWithSource(t, db, "manual-old", "candidate", "manual", "", stale)
+	insertRetentionMemoryWithSource(t, db, "imported-old", "candidate", "imported", "", stale)
+	// Accepted extraction is curated and survives gc unless it is
+	// expired/superseded.
+	insertRetentionMemoryWithSource(t, db, "extracted-accepted", "accepted", "extracted", "", stale)
+
+	// Use a `before` cutoff far in the past so the operator-controlled
+	// retention does not delete anything; only the 14-day extracted
+	// auto-expire should fire.
+	deletedCount, err := storeManager.CollectGarbage(
+		context.Background(),
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		apptypes.GarbageCollectionTargetMemories,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("CollectGarbage() error = %v", err)
+	}
+	if diff := cmp.Diff(2, deletedCount); diff != "" {
+		t.Fatalf("deletedCount mismatch (-want +got):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "memories", "id", []string{
+		"extracted-accepted",
+		"extracted-fresh",
+		"imported-old",
+		"manual-old",
+	})
+	assertNoForeignKeyViolations(t, db)
+}
+
 func TestDatasource_CollectGarbage_deletesOldClosedMemoryEdges(t *testing.T) {
 	t.Parallel()
 
@@ -434,12 +481,17 @@ func execRetentionSQL(t *testing.T, db *sql.DB, query string, args ...any) {
 
 func insertRetentionMemory(t *testing.T, db *sql.DB, id, status, supersedesID, updatedAt string) {
 	t.Helper()
+	insertRetentionMemoryWithSource(t, db, id, status, "manual", supersedesID, updatedAt)
+}
+
+func insertRetentionMemoryWithSource(t *testing.T, db *sql.DB, id, status, source, supersedesID, updatedAt string) {
+	t.Helper()
 	var supersedes any
 	if supersedesID != "" {
 		supersedes = supersedesID
 	}
 	execRetentionSQL(t, db, `INSERT INTO memories (id, type, scope_kind, scope_value, fact, status, confidence, source, supersedes_memory_id, expires_at, valid_from, valid_to, created_at, updated_at)
-		VALUES (?, 'preference', 'workspace', 'repo', ?, ?, 'medium', 'manual', ?, NULL, '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z', ?)`, id, id, status, supersedes, updatedAt)
+		VALUES (?, 'preference', 'workspace', 'repo', ?, ?, 'medium', ?, ?, NULL, '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z', ?)`, id, id, status, source, supersedes, updatedAt)
 }
 
 func assertRetentionIDs(t *testing.T, db *sql.DB, table, column string, want []string) {

--- a/infrastructure/sqlite/sql/clear_stale_extracted_candidate_supersedes_refs.sql
+++ b/infrastructure/sqlite/sql/clear_stale_extracted_candidate_supersedes_refs.sql
@@ -1,0 +1,9 @@
+UPDATE memories
+   SET supersedes_memory_id = NULL
+ WHERE supersedes_memory_id IN (
+       SELECT id
+         FROM memories
+        WHERE status = 'candidate'
+          AND source IN ('extracted', 'extracted-hidden')
+          AND updated_at < ?
+ )

--- a/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
+++ b/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
@@ -1,0 +1,4 @@
+DELETE FROM memories
+WHERE status = 'candidate'
+  AND source IN ('extracted', 'extracted-hidden')
+  AND updated_at < ?

--- a/infrastructure/sqlite/store_management_datasource.go
+++ b/infrastructure/sqlite/store_management_datasource.go
@@ -34,6 +34,9 @@ var deleteOldMemoriesQuery string
 //go:embed sql/delete_stale_extracted_candidates.sql
 var deleteStaleExtractedCandidatesQuery string
 
+//go:embed sql/clear_stale_extracted_candidate_supersedes_refs.sql
+var clearStaleExtractedCandidateSupersedesRefsQuery string
+
 // staleExtractedCandidateRetention is the fixed retention window
 // applied to candidate memories with `source IN (extracted,
 // extracted-hidden)`. The default operator-controlled cutoff
@@ -290,6 +293,13 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 		// operator-controlled cutoff because these rows are best-effort
 		// signal, not curated facts. See #810/#832.
 		extractedCutoff := formatTimestamp(time.Now().Add(-staleExtractedCandidateRetention))
+		// Clear supersedes_memory_id references that point at stale
+		// extracted candidates first so the subsequent delete cannot
+		// trip a foreign-key constraint when an unusual operator
+		// graph references one of these candidates.
+		if _, err := tx.ExecContext(ctx, clearStaleExtractedCandidateSupersedesRefsQuery, extractedCutoff); err != nil {
+			return 0, xerrors.Errorf("failed to clear stale extracted candidate supersedes references: %w", err)
+		}
 		extractedCount, err := execRowsAffected(ctx, tx, deleteStaleExtractedCandidatesQuery, extractedCutoff)
 		if err != nil {
 			return 0, xerrors.Errorf("failed to delete stale extracted candidates: %w", err)

--- a/infrastructure/sqlite/store_management_datasource.go
+++ b/infrastructure/sqlite/store_management_datasource.go
@@ -31,6 +31,19 @@ var clearDeletedMemorySupersedesRefsQuery string
 //go:embed sql/delete_old_memories.sql
 var deleteOldMemoriesQuery string
 
+//go:embed sql/delete_stale_extracted_candidates.sql
+var deleteStaleExtractedCandidatesQuery string
+
+// staleExtractedCandidateRetention is the fixed retention window
+// applied to candidate memories with `source IN (extracted,
+// extracted-hidden)`. The default operator-controlled cutoff
+// (`--keep-days`) protects long-lived facts; this shorter window
+// applies only to auto-extracted candidates that were never reviewed.
+// Untouched extracted candidates older than this are deleted on the
+// next gc pass that targets `memories` or `all`. Tracked under
+// v0.11.0 sub-issue #832.
+const staleExtractedCandidateRetention = 14 * 24 * time.Hour
+
 //go:embed sql/delete_old_memory_edges.sql
 var deleteOldMemoryEdgesQuery string
 
@@ -272,6 +285,16 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 			return 0, xerrors.Errorf("failed to delete old memories: %w", err)
 		}
 		total += count
+		// Auto-expire stale auto-extracted candidates that the operator
+		// never reviewed. The retention window is shorter than the
+		// operator-controlled cutoff because these rows are best-effort
+		// signal, not curated facts. See #810/#832.
+		extractedCutoff := formatTimestamp(time.Now().Add(-staleExtractedCandidateRetention))
+		extractedCount, err := execRowsAffected(ctx, tx, deleteStaleExtractedCandidatesQuery, extractedCutoff)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to delete stale extracted candidates: %w", err)
+		}
+		total += extractedCount
 	}
 	if target == apptypes.GarbageCollectionTargetMemoryEdges || target == apptypes.GarbageCollectionTargetAll {
 		count, err := execRowsAffected(ctx, tx, deleteOldMemoryEdgesQuery, memoryEdgeBeforeValue)


### PR DESCRIPTION
## Summary
Adds a fixed 14-day retention window for candidate memories with \`source IN (extracted, extracted-hidden)\`. Untouched extracted candidates older than 14 days are deleted on the next gc pass that targets \`memories\` or \`all\`.

## Why a separate, shorter window?
Extracted rows are best-effort signal: hook auto-fire generates them at every session end, so without expiry the inbox grows unbounded with stale, never-reviewed candidates. 14 days is long enough for a weekly review pass; longer than that means the row was effectively ignored.

The operator's \`--keep-days\` cutoff still controls every other policy in the same pass — manual / imported candidates and accepted extractions follow that regular cutoff.

## Implementation
- New \`delete_stale_extracted_candidates.sql\` keyed on \`status='candidate' AND source IN ('extracted','extracted-hidden') AND updated_at < ?\`.
- \`store_management_datasource.go\` calls it inside the \`memories\` / \`all\` gc pass with a fixed \`now - 14d\` cutoff (constant \`staleExtractedCandidateRetention\`).
- \`docs/storage/README.{md,ja.md}\` document the exception inline next to the existing memories policy.

## Test cases
- Stale \`extracted\` and \`extracted-hidden\` candidates deleted (count=2).
- Fresh extracted candidate kept.
- Manual / imported candidates kept regardless of age.
- Accepted extracted memory kept (status guard).
- Operator cutoff far in the past does not interfere with the auto-expire.

## Acceptance
- [x] 14d retention applies only to candidate + extracted/extracted-hidden source
- [x] \`go test ./...\` 1240 pass
- [x] \`golangci-lint\` clean
- [x] \`scripts/verify_docs_i18n.py\` pass

Closes the remaining auto-expire item from #810 / #832 follow-up. The confidence-classifier item is the only thing left from #832 and is genuinely new design work; tracked separately.