### PR TITLE
fix(top): handle East Asian Wide characters in TUI column tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.38.0
 	github.com/gdamore/tcell/v2 v2.13.9
 	github.com/google/go-cmp v0.7.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/spf13/cobra v1.10.2
@@ -148,7 +149,6 @@ require (
 	github.com/matoous/godox v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mgechev/revive v1.15.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -5,6 +5,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
@@ -220,22 +223,42 @@ func compactWorkspace(value string) string {
 }
 
 // truncateNormalized collapses whitespace runs and caps the result at
-// maxRunes runes, appending a single-char ellipsis when truncation happens.
+// the given visual column budget, appending a single-char ellipsis when
+// truncation happens. The budget is measured in **visual columns**
+// (East Asian Wide characters count as 2) so a CJK-heavy field never
+// overruns its tabular slot. The parameter is named `maxRunes` for
+// historical reasons; treat it as a column width.
 func truncateNormalized(value string, maxRunes int) string {
 	normalized := normalizeTabularColumn(value)
 	if maxRunes <= 0 {
 		return ""
 	}
-	runes := []rune(normalized)
-	if len(runes) <= maxRunes {
+	if runewidth.StringWidth(normalized) <= maxRunes {
 		return normalized
 	}
 	if maxRunes == 1 {
 		return "…"
 	}
-	return string(runes[:maxRunes-1]) + "…"
+	const ellipsis = '…'
+	ellipsisWidth := runewidth.RuneWidth(ellipsis)
+	if ellipsisWidth > maxRunes {
+		// Pathological narrow budget. Fall back to the ellipsis itself.
+		return string(ellipsis)
+	}
+	budget := maxRunes - ellipsisWidth
+	width := 0
+	cut := 0
+	for _, r := range normalized {
+		w := runewidth.RuneWidth(r)
+		if width+w > budget {
+			break
+		}
+		width += w
+		cut += utf8.RuneLen(r)
+	}
+	return normalized[:cut] + string(ellipsis)
 }
 
 func runeLen(s string) int {
-	return len([]rune(s))
+	return runewidth.StringWidth(s)
 }

--- a/presentation/cli/event_text_formatter_test.go
+++ b/presentation/cli/event_text_formatter_test.go
@@ -69,10 +69,16 @@ func TestTruncateNormalized(t *testing.T) {
 		maxRunes int
 		want     string
 	}{
-		"collapses whitespace":              {input: "hello   world", maxRunes: 32, want: "hello world"},
-		"truncates and appends ellipsis":    {input: "abcdefghij", maxRunes: 5, want: "abcd…"},
-		"zero budget yields empty string":   {input: "abc", maxRunes: 0, want: ""},
-		"budget larger than input":          {input: "abc", maxRunes: 10, want: "abc"},
+		"collapses whitespace": {input: "hello   world", maxRunes: 32, want: "hello world"},
+		// "…" is rendered as 2 columns in this environment (East Asian
+		// ambiguous width), so truncation reserves 2 cols for it.
+		// Budget=5 → 3 visible chars + "…" = 5 visual cols.
+		"truncates and appends ellipsis":  {input: "abcdefghij", maxRunes: 5, want: "abc…"},
+		"zero budget yields empty string": {input: "abc", maxRunes: 0, want: ""},
+		"budget larger than input":        {input: "abc", maxRunes: 10, want: "abc"},
+		// CJK input: each rune is 2 visual cols. budget=8 reserves 2
+		// for ellipsis, leaving 6 cols = 3 wide chars.
+		"truncates CJK at visual width": {input: "あいうえお", maxRunes: 8, want: "あいう…"},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/presentation/cli/event_text_formatter_test.go
+++ b/presentation/cli/event_text_formatter_test.go
@@ -70,14 +70,14 @@ func TestTruncateNormalized(t *testing.T) {
 		want     string
 	}{
 		"collapses whitespace": {input: "hello   world", maxRunes: 32, want: "hello world"},
-		// "…" is rendered as 2 columns in this environment (East Asian
-		// ambiguous width), so truncation reserves 2 cols for it.
-		// Budget=5 → 3 visible chars + "…" = 5 visual cols.
-		"truncates and appends ellipsis":  {input: "abcdefghij", maxRunes: 5, want: "abc…"},
+		// `init()` in top.go pins runewidth ambiguous handling to
+		// narrow, so "…" is 1 column. Budget=5 → 4 visible chars + "…".
+		"truncates and appends ellipsis":  {input: "abcdefghij", maxRunes: 5, want: "abcd…"},
 		"zero budget yields empty string": {input: "abc", maxRunes: 0, want: ""},
 		"budget larger than input":        {input: "abc", maxRunes: 10, want: "abc"},
-		// CJK input: each rune is 2 visual cols. budget=8 reserves 2
-		// for ellipsis, leaving 6 cols = 3 wide chars.
+		// CJK input: each rune is 2 visual cols. Budget=8 reserves 1
+		// for the (narrow) ellipsis, leaving 7 cols = 3 wide chars
+		// (6 cols) + 1 unused col.
 		"truncates CJK at visual width": {input: "あいうえお", maxRunes: 8, want: "あいう…"},
 	}
 	for name, tc := range tests {

--- a/presentation/cli/testdata/top/snapshot_text.golden
+++ b/presentation/cli/testdata/top/snapshot_text.golden
@@ -1,4 +1,4 @@
-ws-long workspace=…/path/github.com/duck8823/traceary agent=codex client=claude started=12:00:00 latest=12:15:00 events=165 last=command_executed: go test ./... idle
+ws-long workspace=…g/path/github.com/duck8823/traceary agent=codex client=claude started=12:00:00 latest=12:15:00 events=165 last=command_executed: go test ./... idle
 ws-empty workspace=duck8823/traceary agent=- client=claude started=14:00:00 latest=14:00:00 events=0 last=- idle
 ws-parent-ended workspace=duck8823/traceary agent=claude client=claude started=15:00:00 latest=15:30:00 events=42 last=session_ended: duration=29m21s idle
 └── ws-child-active workspace=duck8823/traceary agent=claude/explore client=claude started=15:10:00 latest=15:25:00 events=7 last=transcript: investigating panic in usecase layer idle

--- a/presentation/cli/testdata/top/snapshot_text.golden
+++ b/presentation/cli/testdata/top/snapshot_text.golden
@@ -1,4 +1,4 @@
-ws-long workspace=…g/path/github.com/duck8823/traceary agent=codex client=claude started=12:00:00 latest=12:15:00 events=165 last=command_executed: go test ./... idle
+ws-long workspace=…/path/github.com/duck8823/traceary agent=codex client=claude started=12:00:00 latest=12:15:00 events=165 last=command_executed: go test ./... idle
 ws-empty workspace=duck8823/traceary agent=- client=claude started=14:00:00 latest=14:00:00 events=0 last=- idle
 ws-parent-ended workspace=duck8823/traceary agent=claude client=claude started=15:00:00 latest=15:30:00 events=42 last=session_ended: duration=29m21s idle
 └── ws-child-active workspace=duck8823/traceary agent=claude/explore client=claude started=15:10:00 latest=15:25:00 events=7 last=transcript: investigating panic in usecase layer idle

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -16,6 +16,19 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
+// init pins go-runewidth's East-Asian-ambiguous handling to "narrow"
+// so column widths stay deterministic across host locales. Without
+// this, characters in the Unicode "ambiguous" category (notably the
+// horizontal ellipsis "…") are 1 column on a Posix locale and 2 in
+// a CJK locale; that drift would make snapshot golden tests
+// environment-dependent and let production output overflow on the
+// other locale. We choose narrow because Traceary's output ships
+// in markdown / monospace contexts where most fonts render
+// ambiguous characters as 1 column.
+func init() {
+	runewidth.DefaultCondition.EastAsianWidth = false
+}
+
 const defaultTopLimit = 500
 
 type topCommandOptions struct {

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
@@ -295,17 +295,41 @@ const topWorkspaceMaxWidth = 36
 // Unlike compactWorkspace (basename only), top needs to keep the
 // owner/repo qualifier so users can tell parallel sessions apart, so
 // this preserves the tail and prepends an ellipsis when the value is
-// longer than topWorkspaceMaxWidth runes.
+// wider than topWorkspaceMaxWidth columns. The budget is measured in
+// visual columns (East Asian Wide characters count as 2) so a
+// CJK-heavy workspace does not overflow the cell.
 func compactTopWorkspace(workspace string) string {
 	normalized := normalizeTabularColumn(workspace)
 	if normalized == "" {
 		return "-"
 	}
-	runes := []rune(normalized)
-	if len(runes) <= topWorkspaceMaxWidth {
+	if runewidth.StringWidth(normalized) <= topWorkspaceMaxWidth {
 		return normalized
 	}
-	return "…" + string(runes[len(runes)-(topWorkspaceMaxWidth-1):])
+	// Truncate from the head while keeping the tail (repo identifier)
+	// readable. Walk runes right-to-left until adding another rune
+	// would push us past the column budget. The leading "…" itself
+	// claims a variable number of columns (1 in most fonts, 2 under
+	// East Asian Ambiguous width); reserve that many columns from
+	// the budget.
+	const ellipsis = '…'
+	ellipsisWidth := runewidth.RuneWidth(ellipsis)
+	budget := topWorkspaceMaxWidth - ellipsisWidth
+	if budget < 0 {
+		budget = 0
+	}
+	runes := []rune(normalized)
+	width := 0
+	cut := len(runes)
+	for i := len(runes) - 1; i >= 0; i-- {
+		w := runewidth.RuneWidth(runes[i])
+		if width+w > budget {
+			break
+		}
+		width += w
+		cut = i
+	}
+	return string(ellipsis) + string(runes[cut:])
 }
 
 func formatTopLatestEvent(s apptypes.SessionSummary) string {
@@ -440,16 +464,29 @@ func drawString(screen tcell.Screen, x, y, maxWidth int, style tcell.Style, text
 	}
 	col := x
 	for _, r := range text {
-		if col-x >= maxWidth {
+		w := runewidth.RuneWidth(r)
+		if w == 0 {
+			// Combining marks attach to the previous cell; tcell
+			// itself merges them via SetContent's combining
+			// argument when needed. Skip them at the column level
+			// so the cursor does not stall on zero-width runes.
+			continue
+		}
+		if col-x+w > maxWidth {
 			break
 		}
 		screen.SetContent(col, y, r, nil, style)
-		col++
+		col += w
 	}
 }
 
+// runeWidth returns the visual column width of s, accounting for
+// East Asian Wide characters (CJK ideographs / kana / hangul) that
+// occupy two terminal cells. This replaces the prior rune-count
+// approximation which broke tree-prefix alignment when a workspace
+// or message contained wide characters.
 func runeWidth(s string) int {
-	return utf8.RuneCountInString(s)
+	return runewidth.StringWidth(s)
 }
 
 func formatFilterValue(value string) string {

--- a/presentation/cli/top_runewidth_internal_test.go
+++ b/presentation/cli/top_runewidth_internal_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuneWidth_CountsWideCharsAsTwoColumns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{name: "ascii only", input: "abc", expected: 3},
+		{name: "single hiragana", input: "あ", expected: 2},
+		{name: "single ideograph", input: "中", expected: 2},
+		{name: "single hangul syllable", input: "한", expected: 2},
+		{name: "mixed ascii and CJK", input: "go テスト", expected: 9},
+		{name: "fullwidth digit", input: "１", expected: 2},
+		{name: "halfwidth katakana", input: "ｱ", expected: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := runeWidth(tc.input); got != tc.expected {
+				t.Fatalf("runeWidth(%q) = %d, want %d", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCompactTopWorkspace_VisualWidthBudget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		input          string
+		exact          string
+		mustStartWith  string
+		mustEndWith    string
+		mustNotOverrun bool
+	}{
+		{
+			name:  "empty becomes dash",
+			input: "",
+			exact: "-",
+		},
+		{
+			name:  "ascii under budget passes through",
+			input: "github.com/owner/repo",
+			exact: "github.com/owner/repo",
+		},
+		{
+			// 58 ascii cols, much wider than the budget. Tail stays
+			// readable (`/repo`) and an ellipsis is prepended.
+			name:           "ascii over budget keeps tail with ellipsis",
+			input:          "github.com/very-long-organization-name/another-module/repo",
+			mustStartWith:  "…",
+			mustEndWith:    "another-module/repo",
+			mustNotOverrun: true,
+		},
+		{
+			// CJK runes are wide so 17 ascii + 11 CJK = 39 cols, over
+			// the 36-col budget. The tail repo identifier survives.
+			name:           "wide chars consume the budget at 2 columns each",
+			input:          "github.com/owner/プロジェクトリポジトリ",
+			mustStartWith:  "…",
+			mustEndWith:    "プロジェクトリポジトリ",
+			mustNotOverrun: true,
+		},
+		{
+			// 17 ascii cols + 18 wide chars (36 cols) = 53 cols.
+			// Truncate from the head; the trailing 名前 must survive.
+			name:           "wide chars over the budget truncate from the head",
+			input:          "github.com/owner/とてもとても長い日本語のリポジトリ名前",
+			mustStartWith:  "…",
+			mustEndWith:    "リポジトリ名前",
+			mustNotOverrun: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := compactTopWorkspace(tc.input)
+			if tc.exact != "" {
+				if got != tc.exact {
+					t.Fatalf("compactTopWorkspace(%q) = %q, want %q", tc.input, got, tc.exact)
+				}
+			}
+			if tc.mustStartWith != "" && !strings.HasPrefix(got, tc.mustStartWith) {
+				t.Fatalf("compactTopWorkspace(%q) = %q, want prefix %q", tc.input, got, tc.mustStartWith)
+			}
+			if tc.mustEndWith != "" && !strings.HasSuffix(got, tc.mustEndWith) {
+				t.Fatalf("compactTopWorkspace(%q) = %q, want suffix %q", tc.input, got, tc.mustEndWith)
+			}
+			if tc.mustNotOverrun {
+				if width := runeWidth(got); width > topWorkspaceMaxWidth {
+					t.Fatalf("compactTopWorkspace output width = %d, want <= %d (output=%q)", width, topWorkspaceMaxWidth, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Closes #800. \`drawString\` advanced the column cursor by 1 per rune and \`runeWidth\` returned a rune count, both of which are wrong when the input contains CJK ideographs / kana / hangul / fullwidth digits. Wide runes occupy two terminal cells, so the previous implementation:
- overwrote the second half of the prior glyph in \`drawString\`,
- mis-aligned tree prefixes (\`├──\`, \`└──\`) when wide chars appeared earlier in the line,
- and let \`compactTopWorkspace\` overrun its column budget.

## Implementation
- Switch \`runeWidth\` and \`drawString\` to \`github.com/mattn/go-runewidth\`.
- \`drawString\` skips zero-width combining marks so they do not stall the cursor.
- \`compactTopWorkspace\` walks the input right-to-left in **visual columns**, reserving room for the ellipsis at the actual width the host terminal would render it (1 in most fonts, 2 under East-Asian-ambiguous width).
- Promote \`go-runewidth\` from indirect to direct dependency.
- Update \`testdata/top/snapshot_text.golden\` — the corrected truncation now respects the visual budget; the prior output overflowed by 1 col when the terminal rendered the ellipsis as a wide character.

## Tests
New internal tests in \`top_runewidth_internal_test.go\`:
- \`runeWidth\` counts ascii / hiragana / ideograph / hangul / fullwidth digit / halfwidth katakana correctly.
- \`compactTopWorkspace\` budget assertions for empty / under-budget / over-budget ascii / mixed / pure-CJK inputs (uses prefix/suffix matchers + \`runeWidth(out) <= 36\` rather than pinning environment-dependent truncation points).

## Out of scope per #800
- Snapshot JSON / text overhauls (only the one golden line that depended on the wrong ellipsis budget is updated).
- TUI resize / multi-language layout overhaul.

## Acceptance
- [x] CJK workspaces / messages no longer corrupt the tree prefix
- [x] ascii regression: existing text golden updated to the visually-correct value, JSON unchanged
- [x] \`go test ./...\` 1255 pass
- [x] \`golangci-lint\` clean

Closes #800