### PR TITLE
fix: expose audit input and output in event body

### DIFF
--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -246,6 +246,9 @@ func relevantMemoryScopes(session apptypes.SessionSummary) []domtypes.MemoryScop
 }
 
 func summarizeCommand(command string) string {
+	if beforeDetails, _, found := strings.Cut(strings.TrimSpace(command), "\n\n"); found {
+		command = beforeDetails
+	}
 	trimmed := strings.Join(strings.Fields(command), " ")
 	if trimmed == "" {
 		return "-"

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -166,7 +167,7 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 		agent,
 		sessionID,
 		workspace,
-		commandAudit.Command(),
+		commandAuditEventBody(commandAudit),
 	)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to build audit event: %w", err)
@@ -178,6 +179,45 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 	}
 
 	return event, commandAudit, nil
+}
+
+func commandAuditEventBody(commandAudit *model.CommandAudit) string {
+	if commandAudit == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString(commandAudit.Command())
+
+	exitCode, hasExitCode := commandAudit.ExitCode().Value()
+	if hasExitCode || commandAudit.Input() != "" || commandAudit.Output() != "" || commandAudit.InputTruncated() || commandAudit.OutputTruncated() {
+		builder.WriteString("\n")
+	}
+	if hasExitCode {
+		builder.WriteString("\nEXIT_CODE: ")
+		builder.WriteString(strconv.Itoa(exitCode))
+		builder.WriteString("\n")
+	}
+	if commandAudit.Input() != "" || commandAudit.InputTruncated() {
+		builder.WriteString("\nINPUT")
+		if commandAudit.InputTruncated() {
+			builder.WriteString(" (truncated)")
+		}
+		builder.WriteString(":\n")
+		builder.WriteString(commandAudit.Input())
+		builder.WriteString("\n")
+	}
+	if commandAudit.Output() != "" || commandAudit.OutputTruncated() {
+		builder.WriteString("\nOUTPUT")
+		if commandAudit.OutputTruncated() {
+			builder.WriteString(" (truncated)")
+		}
+		builder.WriteString(":\n")
+		builder.WriteString(commandAudit.Output())
+		builder.WriteString("\n")
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
 }
 
 func (u *eventUsecase) Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error) {

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -69,7 +69,8 @@ func TestEventUsecase_Audit(t *testing.T) {
 		if diff := cmp.Diff("command_executed", event.Kind().String()); diff != "" {
 			t.Fatalf("Kind() mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff("go test ./...", event.Body()); diff != "" {
+		wantBody := "go test ./...\n\nINPUT:\nstdin\n\nOUTPUT:\nstdout"
+		if diff := cmp.Diff(wantBody, event.Body()); diff != "" {
 			t.Fatalf("Body() mismatch (-want +got):\n%s", diff)
 		}
 	})


### PR DESCRIPTION
## Motivation

Closes #842.

`command_executed` events had a command audit row with input/output details, but the event body exposed through list/search-style surfaces only contained the command line. That made Bash evidence hard to retrieve from generic event listing and MCP `list_events` responses.

## Changes

- Persist command audit events with a readable body containing:
  - command line
  - exit code when available
  - captured input payload
  - captured output payload
  - truncation markers when applicable
- Keep context handoff recent-command summaries focused on the command line by trimming the detailed audit body after the first paragraph.
- Update the command-audit usecase regression test.

## Verification

```sh
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go tool golangci-lint run
```

Results:

- `go test ./...`: 1264 passed in 19 packages
- `go build ./...`: success
- `golangci-lint run`: no issues found (`rtk` returned code 7 despite the underlying output reporting no issues; rerun without `rtk` previously showed cache-write warnings only under sandboxed cache paths)
