### PR TITLE
fix: extract memories from Claude compact summaries

### DIFF
--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -18,12 +18,13 @@ import (
 )
 
 var (
-	explicitMemoryLabelPattern = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
-	urlRefPattern              = regexp.MustCompile(`https?://[^\s)]+`)
-	issueRefPattern            = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
-	prRefPattern               = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
-	bareFileRefPattern         = regexp.MustCompile(`(?i)\b[A-Za-z0-9_.-]+\.(?:[A-Za-z0-9_-]+\.)*(?:go|md|json|sh|sql|yaml|yml|toml|ts|tsx|js|jsx|py|rb|ini|cfg|conf|proto|tpl)\b`)
-	pathLikeRefPattern         = regexp.MustCompile(`(?:\./|\.\./|/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_-]+)*`)
+	explicitMemoryLabelPattern         = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
+	explicitJapaneseMemoryLabelPattern = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(好み|設定|要望|決定|判断|制約|教訓|学び|成果物|資料|修正|フィードバック)\s*[:：\-ー]\s*(.+)$`)
+	urlRefPattern                      = regexp.MustCompile(`https?://[^\s)]+`)
+	issueRefPattern                    = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
+	prRefPattern                       = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
+	bareFileRefPattern                 = regexp.MustCompile(`(?i)\b[A-Za-z0-9_.-]+\.(?:[A-Za-z0-9_-]+\.)*(?:go|md|json|sh|sql|yaml|yml|toml|ts|tsx|js|jsx|py|rb|ini|cfg|conf|proto|tpl)\b`)
+	pathLikeRefPattern                 = regexp.MustCompile(`(?:\./|\.\./|/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_-]+)*`)
 )
 
 var extensionlessArtifactRootSegments = map[string]struct{}{
@@ -348,7 +349,7 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 	if err := appendKindSignals(domtypes.EventKindNote, true, true); err != nil {
 		return nil, err
 	}
-	if err := appendKindSignals(domtypes.EventKindCompactSummary, false, true); err != nil {
+	if err := appendKindSignals(domtypes.EventKindCompactSummary, true, true); err != nil {
 		return nil, err
 	}
 
@@ -406,7 +407,10 @@ func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []d
 func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
 	matches := explicitMemoryLabelPattern.FindStringSubmatch(segment)
 	if len(matches) != 3 {
-		return memoryCandidateSpec{}, false, nil
+		matches = explicitJapaneseMemoryLabelPattern.FindStringSubmatch(segment)
+		if len(matches) != 3 {
+			return memoryCandidateSpec{}, false, nil
+		}
 	}
 
 	memoryType, err := memoryTypeFromLabel(matches[1])
@@ -485,13 +489,23 @@ func memoryTypeFromLabel(label string) (domtypes.MemoryType, error) {
 	switch strings.ToLower(strings.TrimSpace(label)) {
 	case "preference", "feedback", "correction":
 		return domtypes.MemoryTypePreference, nil
+	case "好み", "設定", "要望", "修正", "フィードバック":
+		return domtypes.MemoryTypePreference, nil
 	case "decision":
+		return domtypes.MemoryTypeDecision, nil
+	case "決定", "判断":
 		return domtypes.MemoryTypeDecision, nil
 	case "constraint":
 		return domtypes.MemoryTypeConstraint, nil
+	case "制約":
+		return domtypes.MemoryTypeConstraint, nil
 	case "lesson":
 		return domtypes.MemoryTypeLesson, nil
+	case "教訓", "学び":
+		return domtypes.MemoryTypeLesson, nil
 	case "artifact":
+		return domtypes.MemoryTypeArtifact, nil
+	case "成果物", "資料":
 		return domtypes.MemoryTypeArtifact, nil
 	default:
 		return domtypes.MemoryType(""), xerrors.Errorf("unsupported memory label: %s", label)
@@ -515,8 +529,30 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"use japanese",
 		"correction:",
 		"feedback:",
+		"してください",
+		"してほしい",
+		"常に",
+		"必ず",
 	):
 		return domtypes.MemoryTypePreference, true
+	case containsAny(lower,
+		"decision:",
+		"decided ",
+		"we chose",
+		"chosen ",
+		"agreed ",
+		"not tech-debt",
+		"not technical debt",
+		"not be treated as tech-debt",
+		"決定",
+		"判断",
+		"採用",
+		"ではない",
+		"扱わない",
+		"扱う",
+		"済み",
+	):
+		return domtypes.MemoryTypeDecision, true
 	case containsAny(lower,
 		"must ",
 		"must not",
@@ -526,22 +562,28 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"only ",
 		"forbidden",
 		"out of scope",
+		"必須",
+		"必要",
+		"不可",
+		"できない",
+		"してはいけない",
+		"禁止",
 	):
 		return domtypes.MemoryTypeConstraint, true
-	case containsAny(lower,
-		"decision:",
-		"decided ",
-		"we chose",
-		"chosen ",
-		"agreed ",
-	):
-		return domtypes.MemoryTypeDecision, true
 	case containsAny(lower,
 		"lesson:",
 		"learned ",
 		"next time",
 		"remember to",
 		"mistake",
+		"教訓",
+		"学び",
+		"次回",
+		"再起動",
+		"restart",
+		"解消",
+		"確認済み",
+		"誤り",
 	):
 		return domtypes.MemoryTypeLesson, true
 	default:

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -287,6 +288,83 @@ func TestMemoryUsecase_Extract_IncludesTranscriptEvents(t *testing.T) {
 	}
 	if memoryUsecase.proposeCalls[0].memoryType != domtypes.MemoryTypeDecision {
 		t.Errorf("memoryType = %v, want Decision", memoryUsecase.proposeCalls[0].memoryType)
+	}
+}
+
+func TestMemoryUsecase_Extract_ClaudeJapaneseSummarySignals(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-claude-ja"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		3,
+		0,
+		[]string{"claude"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	compactEvent := mustExtractionEvent(t,
+		"event-claude-summary",
+		domtypes.EventKindCompactSummary,
+		strings.Join([]string{
+			"<summary>",
+			"835 は tech-debt ではない。設計/API 判断が必要な新規タスクとして扱う。",
+			"次回 Claude Code restart で stale MCP server cache は解消する。",
+			"v0.11.0 release PR #840 と Homebrew PR #841 は merge 済み。",
+			"</summary>",
+		}, "\n"),
+	)
+
+	details1 := mustMemoryDetailsFromSummary(t, "memory-claude-ja-1", domtypes.MemoryTypeDecision, "835 は tech-debt ではない。設計/API 判断が必要な新規タスクとして扱う。")
+	details2 := mustMemoryDetailsFromSummary(t, "memory-claude-ja-2", domtypes.MemoryTypeLesson, "次回 Claude Code restart で stale MCP server cache は解消する。")
+	details3 := mustMemoryDetailsFromSummary(t, "memory-claude-ja-3", domtypes.MemoryTypeDecision, "v0.11.0 release PR #840 と Homebrew PR #841 は merge 済み。")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details1, details2, details3},
+	}
+
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindCompactSummary: {compactEvent},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-claude-ja")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(1).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(Extract()) = %d, want 3", len(got))
+	}
+
+	gotTypes := make([]domtypes.MemoryType, 0, len(memoryUsecase.proposeCalls))
+	gotFacts := make([]string, 0, len(memoryUsecase.proposeCalls))
+	for _, call := range memoryUsecase.proposeCalls {
+		gotTypes = append(gotTypes, call.memoryType)
+		gotFacts = append(gotFacts, call.fact)
+	}
+	if diff := cmp.Diff([]domtypes.MemoryType{domtypes.MemoryTypeDecision, domtypes.MemoryTypeLesson, domtypes.MemoryTypeDecision}, gotTypes); diff != "" {
+		t.Fatalf("memory types mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{
+		"835 は tech-debt ではない。設計/API 判断が必要な新規タスクとして扱う。",
+		"次回 Claude Code restart で stale MCP server cache は解消する。",
+		"v0.11.0 release PR #840 と Homebrew PR #841 は merge 済み。",
+	}, gotFacts); diff != "" {
+		t.Fatalf("facts mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Closes #844.

Claude Code already records memory-relevant `prompt`, `transcript`, and `compact_summary` events, but extraction only applied free-form heuristics to prompts/transcripts/notes/reviewed events. Compact summaries were effectively limited to explicit `Decision:` / `Lesson:`-style labels, so Claude-style Japanese summaries produced no candidates.

## Changes

- Run heuristic candidate extraction for compact-summary events as well as structured label extraction.
- Add Japanese explicit memory labels such as `決定`, `判断`, `制約`, `教訓`, `学び`, `成果物`.
- Add Japanese/Claude-summary durable markers for decision, constraint, preference, and lesson inference.
- Add a regression test using Claude-style Japanese compact summary lines matching the reported issue.

## Verification

```sh
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go test ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go build ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go tool golangci-lint run
```

Results:

- `go test ./...`: 1265 passed in 19 packages
- `go build ./...`: success
- `golangci-lint run`: no issues found (`rtk` returned code 7 despite reporting no issues)
