### PR TITLE
feat: score memory extraction signals

### DIFF
--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -138,15 +138,13 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 			continue
 		}
 
-		// Quality filter (#810 follow-up #830): low-quality candidates
-		// are still persisted for audit, but tagged with the
-		// extracted-hidden source so the default inbox view skips
-		// them. `memory inbox --include-hidden` surfaces them when
-		// reviewers want to triage borderline cases. Artifact memory
-		// types are exempted because their facts are file paths /
-		// URLs / commands that can be short yet valid.
+		// Signal-quality classifier (#835): low-score candidates are
+		// still persisted for audit, but tagged with the extracted-hidden
+		// source so the default inbox view skips them. `memory inbox
+		// --include-hidden` surfaces them when reviewers want to triage
+		// borderline cases.
 		source := domtypes.MemorySourceExtracted
-		if spec.memoryType != domtypes.MemoryTypeArtifact && !passesExtractionQualityFilter(spec.fact) {
+		if spec.signalScore < extractionVisibleScoreThreshold {
 			source = domtypes.MemorySourceExtractedHidden
 		}
 
@@ -172,30 +170,80 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 	return results, nil
 }
 
-// extractionQualityMinRunesLatin is the soft minimum length, in runes,
-// a Latin-script candidate fact must reach to land at the visible
-// `extracted` source. Shorter facts are persisted under
-// `extracted-hidden` for audit; they stay reachable through
-// `memory inbox --include-hidden`. The threshold is intentionally a
-// length heuristic rather than a confidence classifier — extraction
-// signals do not yet carry confidence (#830).
+// extractionQualityMinRunesLatin contributes to the signal-quality score for
+// Latin-script candidates. Length alone no longer decides visibility (#835);
+// it is just one weak signal combined with labels, evidence, and artifacts.
 const extractionQualityMinRunesLatin = 20
 
-// extractionQualityMinRunesCJK is the lower threshold applied when the
-// fact contains CJK ideographs / kana / hangul. CJK text is much
-// information-denser per rune than Latin text — a 10-rune sentence in
-// Japanese is comparable to a 20-rune Latin sentence — so a single
-// global threshold over-rejects CJK candidates.
+// extractionQualityMinRunesCJK is the lower length score threshold applied
+// when the fact contains CJK ideographs / kana / hangul. CJK text is much
+// information-denser per rune than Latin text.
 const extractionQualityMinRunesCJK = 10
 
-func passesExtractionQualityFilter(fact string) bool {
-	trimmed := strings.TrimSpace(fact)
+const extractionVisibleScoreThreshold = 4
+
+func memoryExtractionSignalScore(spec memoryCandidateSpec) int {
+	if spec.memoryType == domtypes.MemoryTypeArtifact {
+		return extractionVisibleScoreThreshold
+	}
+
+	score := 0
+	if spec.structured {
+		score += 3
+	}
+	if len(spec.evidenceRefs) > 0 {
+		score++
+	}
+	if len(spec.artifactRefs) > 0 {
+		score++
+	}
+
+	trimmed := strings.TrimSpace(spec.fact)
 	runes := []rune(trimmed)
 	threshold := extractionQualityMinRunesLatin
 	if containsCJK(runes) {
 		threshold = extractionQualityMinRunesCJK
 	}
-	return len(runes) >= threshold
+	if len(runes) >= threshold {
+		score++
+	}
+	if len(runes) >= threshold*2 {
+		score++
+	}
+	if hasDurableSignalMarker(trimmed) {
+		score += 2
+	}
+
+	return score
+}
+
+func hasDurableSignalMarker(value string) bool {
+	lower := strings.ToLower(value)
+	return containsAny(lower,
+		"decision:",
+		"constraint:",
+		"lesson:",
+		"artifact:",
+		"preference:",
+		"decided ",
+		"agreed ",
+		"must ",
+		"must not",
+		"never ",
+		"always ",
+		"next time",
+		"remember to",
+		"決定",
+		"判断",
+		"制約",
+		"教訓",
+		"学び",
+		"必須",
+		"必要",
+		"次回",
+		"再起動",
+		"確認済み",
+	)
 }
 
 // containsCJK reports whether the rune slice carries at least one
@@ -374,6 +422,8 @@ type memoryCandidateSpec struct {
 	fact         string
 	evidenceRefs []domtypes.EvidenceRef
 	artifactRefs []domtypes.ArtifactRef
+	structured   bool
+	signalScore  int
 }
 
 func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []domtypes.EvidenceRef) ([]memoryCandidateSpec, error) {
@@ -426,12 +476,15 @@ func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef
 	if err != nil {
 		return memoryCandidateSpec{}, false, err
 	}
-	return memoryCandidateSpec{
+	spec := memoryCandidateSpec{
 		memoryType:   memoryType,
 		fact:         fact,
 		evidenceRefs: slices.Clone(evidenceRefs),
 		artifactRefs: artifactRefs,
-	}, true, nil
+		structured:   true,
+	}
+	spec.signalScore = memoryExtractionSignalScore(spec)
+	return spec, true, nil
 }
 
 func heuristicCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
@@ -449,12 +502,14 @@ func heuristicCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef)
 	if err != nil {
 		return memoryCandidateSpec{}, false, err
 	}
-	return memoryCandidateSpec{
+	spec := memoryCandidateSpec{
 		memoryType:   memoryType,
 		fact:         fact,
 		evidenceRefs: slices.Clone(evidenceRefs),
 		artifactRefs: artifactRefs,
-	}, true, nil
+	}
+	spec.signalScore = memoryExtractionSignalScore(spec)
+	return spec, true, nil
 }
 
 func candidateSegments(text string) []string {

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -127,17 +127,29 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 		return nil, err
 	}
 
-	results := make([]apptypes.MemoryDetails, 0, min(criteria.CandidateLimit(), len(specs)))
-	seenKeys := make(map[string]struct{}, len(specs))
+	bestSpecs := make(map[string]memoryCandidateSpec, len(specs))
+	orderedKeys := make([]string, 0, len(specs))
 	for _, spec := range specs {
 		key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
-		if _, exists := seenKeys[key]; exists {
-			continue
-		}
 		if _, exists := existingKeys[key]; exists {
 			continue
 		}
+		current, exists := bestSpecs[key]
+		if exists && current.signalScore >= spec.signalScore {
+			continue
+		}
+		if !exists {
+			orderedKeys = append(orderedKeys, key)
+		}
+		bestSpecs[key] = spec
+	}
 
+	results := make([]apptypes.MemoryDetails, 0, min(criteria.CandidateLimit(), len(bestSpecs)))
+	for _, key := range orderedKeys {
+		spec, ok := bestSpecs[key]
+		if !ok {
+			continue
+		}
 		// Signal-quality classifier (#835): low-score candidates are
 		// still persisted for audit, but tagged with the extracted-hidden
 		// source so the default inbox view skips them. `memory inbox
@@ -161,7 +173,6 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 			return nil, xerrors.Errorf("failed to propose extracted memory candidate: %w", err)
 		}
 		results = append(results, details)
-		seenKeys[key] = struct{}{}
 		if len(results) >= criteria.CandidateLimit() {
 			break
 		}

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -424,6 +424,65 @@ func TestMemoryUsecase_Extract_ScoresWeakSignalsAsHidden(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Extract_DeduplicatesByBestSignalScore(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-best-score"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		2,
+		0,
+		[]string{"claude"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	weakPrompt := mustExtractionEvent(t, "event-weak-duplicate", domtypes.EventKindPrompt, "must fix")
+	structuredPrompt := mustExtractionEvent(t, "event-structured-duplicate", domtypes.EventKindPrompt, "Constraint: must fix")
+
+	details := mustMemoryDetailsFromSummary(t, "memory-best-score-1", domtypes.MemoryTypeConstraint, "must fix")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details},
+	}
+
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: {weakPrompt, structuredPrompt},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-best-score")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(2).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(Extract()) = %d, want 1 deduped candidate", len(got))
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.fact != "must fix" {
+		t.Fatalf("fact = %q, want deduped structured fact", call.fact)
+	}
+	if call.source != domtypes.MemorySourceExtracted {
+		t.Fatalf("source = %q, want high-score extracted source", call.source)
+	}
+}
+
 func TestMemoryUsecase_Extract_DeduplicatesExistingAndGracefullyHandlesMissingPrompts(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -368,6 +368,62 @@ func TestMemoryUsecase_Extract_ClaudeJapaneseSummarySignals(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Extract_ScoresWeakSignalsAsHidden(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-score"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		2,
+		0,
+		[]string{"claude"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	weakPrompt := mustExtractionEvent(t, "event-weak", domtypes.EventKindPrompt, "must fix")
+	structuredPrompt := mustExtractionEvent(t, "event-structured", domtypes.EventKindPrompt, "Decision: Ship")
+
+	details1 := mustMemoryDetailsFromSummary(t, "memory-score-1", domtypes.MemoryTypeConstraint, "must fix")
+	details2 := mustMemoryDetailsFromSummary(t, "memory-score-2", domtypes.MemoryTypeDecision, "Ship")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{
+		proposeResult: []apptypes.MemoryDetails{details1, details2},
+	}
+
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: {weakPrompt, structuredPrompt},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(
+		context.Background(),
+		apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(domtypes.SessionID("session-score")).
+			Workspace(domtypes.Workspace("github.com/duck8823/traceary")).
+			EventLimit(2).
+			CandidateLimit(10).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 2 {
+		t.Fatalf("proposeCalls = %d, want 2", len(memoryUsecase.proposeCalls))
+	}
+	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceExtractedHidden {
+		t.Fatalf("weak source = %q, want extracted-hidden", got)
+	}
+	if got := memoryUsecase.proposeCalls[1].source; got != domtypes.MemorySourceExtracted {
+		t.Fatalf("structured source = %q, want extracted", got)
+	}
+}
+
 func TestMemoryUsecase_Extract_DeduplicatesExistingAndGracefullyHandlesMissingPrompts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Closes #835.

The extraction visibility gate used a raw Latin/CJK length threshold. That made source selection (`extracted` vs `extracted-hidden`) too dependent on text length and ignored stronger signals such as explicit labels, evidence, artifact refs, and durable decision/constraint/lesson markers.

## Changes

- Add a small signal score to each extracted memory candidate.
- Score combines:
  - structured label extraction
  - evidence refs
  - artifact refs
  - durable English/Japanese markers
  - Latin/CJK length as a weak signal
- Replace the length-only `passesExtractionQualityFilter` gate with a score threshold.
- Preserve review-only behavior: low-score candidates still persist as `source=extracted-hidden`.
- Add regression coverage for weak heuristic vs structured-label candidates.

## Verification

```sh
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go test ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go build ./...
GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go tool golangci-lint run
```

Results:

- `go test ./...`: 1266 passed in 19 packages
- `go build ./...`: success
- `golangci-lint run`: no issues found (`rtk` returned code 7 despite reporting no issues)
