### PR TITLE
fix: classify durable memory extraction intent

### DIFF
--- a/application/types/memory_extraction_diagnostics.go
+++ b/application/types/memory_extraction_diagnostics.go
@@ -1,0 +1,28 @@
+package types
+
+import domtypes "github.com/duck8823/traceary/domain/types"
+
+// MemoryExtractionDebugReport explains how durable-memory extraction evaluated
+// each inspected signal segment. It is intentionally read-only: callers use it
+// for dogfooding and false-negative analysis without creating candidates.
+type MemoryExtractionDebugReport struct {
+	SessionID domtypes.SessionID
+	Workspace domtypes.Workspace
+	Segments  []MemoryExtractionSegmentDecision
+}
+
+// MemoryExtractionSegmentDecision captures the classifier features and final
+// extraction decision for one normalized signal segment.
+type MemoryExtractionSegmentDecision struct {
+	Text         string
+	Client       domtypes.Client
+	EventKind    domtypes.EventKind
+	SourceHook   string
+	MemoryType   domtypes.MemoryType
+	Features     []string
+	Score        int
+	Decision     string
+	Reason       string
+	EvidenceRefs []domtypes.EvidenceRef
+	ArtifactRefs []domtypes.ArtifactRef
+}

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -20,7 +20,7 @@ import (
 var (
 	explicitMemoryLabelPattern         = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
 	explicitJapaneseMemoryLabelPattern = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(好み|設定|要望|決定|判断|制約|教訓|学び|成果物|資料|修正|フィードバック)\s*[:：\-ー]\s*(.+)$`)
-	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory|remember(?:\s+this)?|keep\s+this\s+in\s+memory)\s*[:\-]\s*(.+)$`)
+	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory\s+note|remember(?:\s+this)?|keep\s+this\s+in\s+memory)\s*[:\-]\s*(.+)$`)
 	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて|覚えておく|記憶|メモリ|メモリー)\s*[:：\-ー]\s*(.+)$`)
 	urlRefPattern                      = regexp.MustCompile(`https?://[^\s)]+`)
 	issueRefPattern                    = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
@@ -222,6 +222,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	}
 
 	report := apptypes.MemoryExtractionDebugReport{SessionID: session.SessionID(), Workspace: session.Workspace()}
+	seenRunKeys := make(map[string]struct{})
 	for _, signal := range signals {
 		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
 		if err != nil {
@@ -253,12 +254,17 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			if _, exists := existingKeys[key]; exists {
 				decision.Decision = "skipped"
 				decision.Reason = "duplicate"
+			} else if _, exists := seenRunKeys[key]; exists {
+				decision.Decision = "skipped"
+				decision.Reason = "duplicate_in_run"
 			} else if spec.signalScore < extractionVisibleScoreThreshold {
 				decision.Decision = "hidden"
 				decision.Reason = "below_visible_threshold"
+				seenRunKeys[key] = struct{}{}
 			} else {
 				decision.Decision = "proposed"
 				decision.Reason = "visible_candidate"
+				seenRunKeys[key] = struct{}{}
 			}
 			report.Segments = append(report.Segments, decision)
 		}

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -21,7 +21,7 @@ var (
 	explicitMemoryLabelPattern         = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
 	explicitJapaneseMemoryLabelPattern = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(好み|設定|要望|決定|判断|制約|教訓|学び|成果物|資料|修正|フィードバック)\s*[:：\-ー]\s*(.+)$`)
 	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory\s+note|remember(?:\s+this)?|keep\s+this\s+in\s+memory)\s*[:\-]\s*(.+)$`)
-	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて|覚えておく|記憶|メモリ|メモリー)\s*[:：\-ー]\s*(.+)$`)
+	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて|覚えておく|記憶)\s*[:：\-ー]\s*(.+)$`)
 	urlRefPattern                      = regexp.MustCompile(`https?://[^\s)]+`)
 	issueRefPattern                    = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
 	prRefPattern                       = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
@@ -221,8 +221,15 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 		return apptypes.MemoryExtractionDebugReport{}, err
 	}
 
+	type candidateDecision struct {
+		segmentIndex int
+		key          string
+		score        int
+	}
+
 	report := apptypes.MemoryExtractionDebugReport{SessionID: session.SessionID(), Workspace: session.Workspace()}
-	seenRunKeys := make(map[string]struct{})
+	candidates := make([]candidateDecision, 0)
+	bestCandidateByKey := make(map[string]int)
 	for _, signal := range signals {
 		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
 		if err != nil {
@@ -250,24 +257,37 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			decision.Features = spec.intent.featureNames()
 			decision.Score = spec.signalScore
 			decision.ArtifactRefs = slices.Clone(spec.artifactRefs)
-			key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
-			if _, exists := existingKeys[key]; exists {
-				decision.Decision = "skipped"
-				decision.Reason = "duplicate"
-			} else if _, exists := seenRunKeys[key]; exists {
-				decision.Decision = "skipped"
-				decision.Reason = "duplicate_in_run"
-			} else if spec.signalScore < extractionVisibleScoreThreshold {
-				decision.Decision = "hidden"
-				decision.Reason = "below_visible_threshold"
-				seenRunKeys[key] = struct{}{}
-			} else {
-				decision.Decision = "proposed"
-				decision.Reason = "visible_candidate"
-				seenRunKeys[key] = struct{}{}
-			}
+			segmentIndex := len(report.Segments)
 			report.Segments = append(report.Segments, decision)
+			key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
+			candidateIndex := len(candidates)
+			candidates = append(candidates, candidateDecision{segmentIndex: segmentIndex, key: key, score: spec.signalScore})
+			bestIndex, exists := bestCandidateByKey[key]
+			if !exists || candidates[bestIndex].score < spec.signalScore {
+				bestCandidateByKey[key] = candidateIndex
+			}
 		}
+	}
+
+	for index, candidate := range candidates {
+		decision := &report.Segments[candidate.segmentIndex]
+		if _, exists := existingKeys[candidate.key]; exists {
+			decision.Decision = "skipped"
+			decision.Reason = "duplicate"
+			continue
+		}
+		if bestCandidateByKey[candidate.key] != index {
+			decision.Decision = "skipped"
+			decision.Reason = "duplicate_in_run"
+			continue
+		}
+		if candidate.score < extractionVisibleScoreThreshold {
+			decision.Decision = "hidden"
+			decision.Reason = "below_visible_threshold"
+			continue
+		}
+		decision.Decision = "proposed"
+		decision.Reason = "visible_candidate"
 	}
 	return report, nil
 }

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -20,6 +20,8 @@ import (
 var (
 	explicitMemoryLabelPattern         = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
 	explicitJapaneseMemoryLabelPattern = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(好み|設定|要望|決定|判断|制約|教訓|学び|成果物|資料|修正|フィードバック)\s*[:：\-ー]\s*(.+)$`)
+	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory|remember(?:\s+this)?|keep\s+this\s+in\s+memory)\s*[:\-]\s*(.+)$`)
+	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて|覚えておく|記憶|メモリ|メモリー)\s*[:：\-ー]\s*(.+)$`)
 	urlRefPattern                      = regexp.MustCompile(`https?://[^\s)]+`)
 	issueRefPattern                    = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
 	prRefPattern                       = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
@@ -181,6 +183,89 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 	return results, nil
 }
 
+func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) (apptypes.MemoryExtractionDebugReport, error) {
+	if u.sessionQuery == nil {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("session query service is not configured")
+	}
+	if u.eventQuery == nil {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("event query service is not configured")
+	}
+	if u.memory == nil {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("memory usecase is not configured")
+	}
+	if criteria.SessionID().String() == "" {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("session ID must not be empty")
+	}
+	if criteria.EventLimit() < 0 {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("event limit must be greater than or equal to 0")
+	}
+
+	session, ok, err := u.findTargetSession(ctx, criteria)
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, err
+	}
+	if !ok {
+		return apptypes.MemoryExtractionDebugReport{}, nil
+	}
+	scope := extractedMemoryScope(session)
+	extraRedactors, err := redaction.CompileExtraPatterns(u.extraRedactPatterns)
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("failed to compile extraction redaction patterns: %w", err)
+	}
+	existingKeys, err := u.loadExistingCandidateKeys(ctx, scope, extraRedactors)
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, err
+	}
+	signals, err := u.collectExtractionSignals(ctx, session, criteria.EventLimit())
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, err
+	}
+
+	report := apptypes.MemoryExtractionDebugReport{SessionID: session.SessionID(), Workspace: session.Workspace()}
+	for _, signal := range signals {
+		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
+		if err != nil {
+			return apptypes.MemoryExtractionDebugReport{}, err
+		}
+		for _, segment := range candidateSegments(signal.text) {
+			decision := apptypes.MemoryExtractionSegmentDecision{
+				Text:         segment,
+				Client:       signal.client,
+				EventKind:    signal.kind,
+				SourceHook:   signal.sourceHook,
+				EvidenceRefs: slices.Clone(evidenceRefs),
+			}
+			spec, ok, err := extractBestMemoryCandidateFromSegment(signal, segment, evidenceRefs)
+			if err != nil {
+				return apptypes.MemoryExtractionDebugReport{}, err
+			}
+			if !ok {
+				decision.Decision = "ignored"
+				decision.Reason = "no_memory_intent"
+				report.Segments = append(report.Segments, decision)
+				continue
+			}
+			decision.MemoryType = spec.memoryType
+			decision.Features = spec.intent.featureNames()
+			decision.Score = spec.signalScore
+			decision.ArtifactRefs = slices.Clone(spec.artifactRefs)
+			key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
+			if _, exists := existingKeys[key]; exists {
+				decision.Decision = "skipped"
+				decision.Reason = "duplicate"
+			} else if spec.signalScore < extractionVisibleScoreThreshold {
+				decision.Decision = "hidden"
+				decision.Reason = "below_visible_threshold"
+			} else {
+				decision.Decision = "proposed"
+				decision.Reason = "visible_candidate"
+			}
+			report.Segments = append(report.Segments, decision)
+		}
+	}
+	return report, nil
+}
+
 // extractionQualityMinRunesLatin contributes to the signal-quality score for
 // Latin-script candidates. Length alone no longer decides visibility (#835);
 // it is just one weak signal combined with labels, evidence, and artifacts.
@@ -199,6 +284,23 @@ func memoryExtractionSignalScore(spec memoryCandidateSpec) int {
 	}
 
 	score := 0
+	trimmed := strings.TrimSpace(spec.fact)
+	runes := []rune(trimmed)
+	threshold := extractionQualityMinRunesLatin
+	if containsCJK(runes) {
+		threshold = extractionQualityMinRunesCJK
+	}
+	hasSufficientLength := len(runes) >= threshold
+
+	if spec.intent.explicitRemember {
+		score += 5
+	}
+	if spec.intent.futureApplicability {
+		score += 2
+	}
+	if (spec.intent.userPreference || spec.intent.userCorrection || spec.intent.operationalConstraint || spec.intent.recurringWorkflow) && (spec.intent.explicitRemember || hasSufficientLength) {
+		score += 2
+	}
 	if spec.structured {
 		score += 3
 	}
@@ -209,13 +311,7 @@ func memoryExtractionSignalScore(spec memoryCandidateSpec) int {
 		score++
 	}
 
-	trimmed := strings.TrimSpace(spec.fact)
-	runes := []rune(trimmed)
-	threshold := extractionQualityMinRunesLatin
-	if containsCJK(runes) {
-		threshold = extractionQualityMinRunesCJK
-	}
-	if len(runes) >= threshold {
+	if hasSufficientLength {
 		score++
 	}
 	if len(runes) >= threshold*2 {
@@ -226,6 +322,70 @@ func memoryExtractionSignalScore(spec memoryCandidateSpec) int {
 	}
 
 	return score
+}
+
+type memoryIntentFeatures struct {
+	explicitRemember      bool
+	futureApplicability   bool
+	userPreference        bool
+	userCorrection        bool
+	operationalConstraint bool
+	recurringWorkflow     bool
+}
+
+func classifyMemoryIntent(value string) memoryIntentFeatures {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	features := memoryIntentFeatures{}
+	if explicitRememberLabelPattern.MatchString(value) || explicitJapaneseRememberPattern.MatchString(value) || containsAny(lower,
+		"remember this",
+		"remember to",
+		"keep this in memory",
+		"durable memory",
+		"覚えておいて",
+		"覚えておく",
+		"記憶して",
+	) {
+		features.explicitRemember = true
+	}
+	if containsAny(lower, "next time", "from now on", "going forward", "future", "今後", "以後", "次回", "次から", "これから") {
+		features.futureApplicability = true
+	}
+	if containsAny(lower, "prefer ", "preference", "please ", "respond in", "use english", "use japanese", "好み", "設定", "要望", "してほしい") {
+		features.userPreference = true
+	}
+	if containsAny(lower, "correction", "instead of", "rather than", "not ", "違う", "ではなく", "修正", "訂正") {
+		features.userCorrection = true
+	}
+	if containsAny(lower, "must ", "must not", "never ", "always ", "required", "forbidden", "only ", "cannot ", "can't ", "必須", "必要", "禁止", "不可", "常に", "必ず") {
+		features.operationalConstraint = true
+	}
+	if containsAny(lower, "review", "merge", "release", "issue", "pr ", "pull request", "poll", "polling", "dogfood", "workflow", "レビュー", "マージ", "リリース", "ポーリング", "起票") {
+		features.recurringWorkflow = true
+	}
+	return features
+}
+
+func (f memoryIntentFeatures) featureNames() []string {
+	names := make([]string, 0, 6)
+	if f.explicitRemember {
+		names = append(names, "explicit_remember")
+	}
+	if f.futureApplicability {
+		names = append(names, "future_applicability")
+	}
+	if f.userPreference {
+		names = append(names, "user_preference")
+	}
+	if f.userCorrection {
+		names = append(names, "user_correction")
+	}
+	if f.operationalConstraint {
+		names = append(names, "operational_constraint")
+	}
+	if f.recurringWorkflow {
+		names = append(names, "recurring_workflow")
+	}
+	return names
 }
 
 func hasDurableSignalMarker(value string) bool {
@@ -244,6 +404,9 @@ func hasDurableSignalMarker(value string) bool {
 		"always ",
 		"next time",
 		"remember to",
+		"remember this",
+		"durable memory",
+		"keep this in memory",
 		"決定",
 		"判断",
 		"制約",
@@ -254,6 +417,11 @@ func hasDurableSignalMarker(value string) bool {
 		"次回",
 		"再起動",
 		"確認済み",
+		"覚えておいて",
+		"覚えておく",
+		"記憶",
+		"今後",
+		"以後",
 	)
 }
 
@@ -352,15 +520,41 @@ type extractionSignal struct {
 	event           *model.Event
 	heuristics      bool
 	allowStructured bool
+	client          domtypes.Client
+	kind            domtypes.EventKind
+	sourceHook      string
 }
 
 func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]memoryCandidateSpec, error) {
-	signals := make([]extractionSignal, 0, 1+4*max(eventLimit, 1))
+	signals, err := u.collectExtractionSignals(ctx, session, eventLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	specs := make([]memoryCandidateSpec, 0, len(signals))
+	for _, signal := range signals {
+		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
+		if err != nil {
+			return nil, err
+		}
+		signalSpecs, err := extractMemoryCandidatesFromSignal(signal, evidenceRefs)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, signalSpecs...)
+	}
+
+	return specs, nil
+}
+
+func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]extractionSignal, error) {
+	signals := make([]extractionSignal, 0, 1+5*max(eventLimit, 1))
 	if summary := strings.TrimSpace(session.Summary()); summary != "" {
 		signals = append(signals, extractionSignal{
 			text:            summary,
 			heuristics:      true,
 			allowStructured: true,
+			kind:            domtypes.EventKind("session_summary"),
 		})
 	}
 
@@ -391,6 +585,9 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 				event:           event,
 				heuristics:      heuristics,
 				allowStructured: allowStructured,
+				client:          event.Client(),
+				kind:            event.Kind(),
+				sourceHook:      event.SourceHook(),
 			})
 		}
 		return nil
@@ -412,20 +609,7 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 		return nil, err
 	}
 
-	specs := make([]memoryCandidateSpec, 0, len(signals))
-	for _, signal := range signals {
-		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
-		if err != nil {
-			return nil, err
-		}
-		signalSpecs, err := extractMemoryCandidatesFromSignal(signal, evidenceRefs)
-		if err != nil {
-			return nil, err
-		}
-		specs = append(specs, signalSpecs...)
-	}
-
-	return specs, nil
+	return signals, nil
 }
 
 type memoryCandidateSpec struct {
@@ -434,6 +618,7 @@ type memoryCandidateSpec struct {
 	evidenceRefs []domtypes.EvidenceRef
 	artifactRefs []domtypes.ArtifactRef
 	structured   bool
+	intent       memoryIntentFeatures
 	signalScore  int
 }
 
@@ -441,61 +626,111 @@ func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []d
 	segments := candidateSegments(signal.text)
 	specs := make([]memoryCandidateSpec, 0, len(segments))
 	for _, segment := range segments {
-		if signal.allowStructured {
-			spec, ok, err := structuredCandidateSpec(segment, evidenceRefs)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				specs = append(specs, spec)
-				continue
-			}
+		spec, ok, err := extractBestMemoryCandidateFromSegment(signal, segment, evidenceRefs)
+		if err != nil {
+			return nil, err
 		}
-
-		if signal.heuristics {
-			spec, ok, err := heuristicCandidateSpec(segment, evidenceRefs)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				specs = append(specs, spec)
-			}
+		if ok {
+			specs = append(specs, spec)
 		}
 	}
 	return specs, nil
 }
 
-func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
-	matches := explicitMemoryLabelPattern.FindStringSubmatch(segment)
-	if len(matches) != 3 {
-		matches = explicitJapaneseMemoryLabelPattern.FindStringSubmatch(segment)
-		if len(matches) != 3 {
-			return memoryCandidateSpec{}, false, nil
+func extractBestMemoryCandidateFromSegment(signal extractionSignal, segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
+	if signal.allowStructured {
+		spec, ok, err := structuredCandidateSpec(segment, evidenceRefs)
+		if err != nil {
+			return memoryCandidateSpec{}, false, err
+		}
+		if ok {
+			return spec, true, nil
 		}
 	}
 
-	memoryType, err := memoryTypeFromLabel(matches[1])
-	if err != nil {
-		return memoryCandidateSpec{}, false, err
+	if signal.heuristics {
+		spec, ok, err := heuristicCandidateSpec(segment, evidenceRefs)
+		if err != nil {
+			return memoryCandidateSpec{}, false, err
+		}
+		if ok {
+			return spec, true, nil
+		}
 	}
-	fact := normalizeCandidateFact(matches[2])
+	return memoryCandidateSpec{}, false, nil
+}
+
+func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
+	matches := explicitMemoryLabelPattern.FindStringSubmatch(segment)
+	if len(matches) == 3 {
+		memoryType, err := memoryTypeFromLabel(matches[1])
+		if err != nil {
+			return memoryCandidateSpec{}, false, err
+		}
+		return buildMemoryCandidateSpec(memoryType, normalizeCandidateFact(matches[2]), evidenceRefs, true)
+	}
+	matches = explicitJapaneseMemoryLabelPattern.FindStringSubmatch(segment)
+	if len(matches) == 3 {
+		memoryType, err := memoryTypeFromLabel(matches[1])
+		if err != nil {
+			return memoryCandidateSpec{}, false, err
+		}
+		return buildMemoryCandidateSpec(memoryType, normalizeCandidateFact(matches[2]), evidenceRefs, true)
+	}
+
+	fact, ok := stripExplicitRememberLabel(segment)
+	if !ok {
+		return memoryCandidateSpec{}, false, nil
+	}
+	spec, ok, err := buildMemoryCandidateSpec(inferMemoryTypeForExplicitIntent(fact), fact, evidenceRefs, true)
+	if !ok || err != nil {
+		return spec, ok, err
+	}
+	spec.intent.explicitRemember = true
+	spec.signalScore = memoryExtractionSignalScore(spec)
+	return spec, true, nil
+}
+
+func buildMemoryCandidateSpec(memoryType domtypes.MemoryType, fact string, evidenceRefs []domtypes.EvidenceRef, structured bool) (memoryCandidateSpec, bool, error) {
+	fact = normalizeCandidateFact(fact)
 	if fact == "" {
 		return memoryCandidateSpec{}, false, nil
 	}
-
 	artifactRefs, err := inferArtifactRefs(fact)
 	if err != nil {
 		return memoryCandidateSpec{}, false, err
 	}
+	intent := classifyMemoryIntent(fact)
 	spec := memoryCandidateSpec{
 		memoryType:   memoryType,
 		fact:         fact,
 		evidenceRefs: slices.Clone(evidenceRefs),
 		artifactRefs: artifactRefs,
-		structured:   true,
+		structured:   structured,
+		intent:       intent,
 	}
 	spec.signalScore = memoryExtractionSignalScore(spec)
 	return spec, true, nil
+}
+
+func stripExplicitRememberLabel(segment string) (string, bool) {
+	if matches := explicitRememberLabelPattern.FindStringSubmatch(segment); len(matches) == 2 {
+		return normalizeCandidateFact(matches[1]), true
+	}
+	if matches := explicitJapaneseRememberPattern.FindStringSubmatch(segment); len(matches) == 2 {
+		return normalizeCandidateFact(matches[1]), true
+	}
+	return "", false
+}
+
+func inferMemoryTypeForExplicitIntent(fact string) domtypes.MemoryType {
+	if memoryType, ok := inferMemoryTypeFromText(fact); ok {
+		return memoryType
+	}
+	if refs, err := inferArtifactRefs(fact); err == nil && len(refs) > 0 {
+		return domtypes.MemoryTypeArtifact
+	}
+	return domtypes.MemoryTypeLesson
 }
 
 func heuristicCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
@@ -504,21 +739,21 @@ func heuristicCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef)
 		return memoryCandidateSpec{}, false, nil
 	}
 
+	intent := classifyMemoryIntent(fact)
 	memoryType, ok := inferMemoryTypeFromText(fact)
+	if !ok && intent.explicitRemember {
+		memoryType = inferMemoryTypeForExplicitIntent(fact)
+		ok = true
+	}
 	if !ok {
 		return memoryCandidateSpec{}, false, nil
 	}
 
-	artifactRefs, err := inferArtifactRefs(fact)
-	if err != nil {
-		return memoryCandidateSpec{}, false, err
+	spec, ok, err := buildMemoryCandidateSpec(memoryType, fact, evidenceRefs, false)
+	if !ok || err != nil {
+		return spec, ok, err
 	}
-	spec := memoryCandidateSpec{
-		memoryType:   memoryType,
-		fact:         fact,
-		evidenceRefs: slices.Clone(evidenceRefs),
-		artifactRefs: artifactRefs,
-	}
+	spec.intent = intent
 	spec.signalScore = memoryExtractionSignalScore(spec)
 	return spec, true, nil
 }
@@ -641,6 +876,9 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"learned ",
 		"next time",
 		"remember to",
+		"remember this",
+		"durable memory",
+		"keep this in memory",
 		"mistake",
 		"教訓",
 		"学び",
@@ -649,6 +887,11 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"restart",
 		"解消",
 		"確認済み",
+		"覚えておいて",
+		"覚えておく",
+		"記憶",
+		"今後",
+		"以後",
 		"誤り",
 	):
 		return domtypes.MemoryTypeLesson, true

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -199,6 +199,9 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	if criteria.EventLimit() < 0 {
 		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("event limit must be greater than or equal to 0")
 	}
+	if criteria.CandidateLimit() <= 0 {
+		return apptypes.MemoryExtractionDebugReport{}, xerrors.Errorf("candidate limit must be greater than or equal to 1")
+	}
 
 	session, ok, err := u.findTargetSession(ctx, criteria)
 	if err != nil {
@@ -269,6 +272,7 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 		}
 	}
 
+	emittedCandidates := 0
 	for index, candidate := range candidates {
 		decision := &report.Segments[candidate.segmentIndex]
 		if _, exists := existingKeys[candidate.key]; exists {
@@ -281,6 +285,12 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			decision.Reason = "duplicate_in_run"
 			continue
 		}
+		if emittedCandidates >= criteria.CandidateLimit() {
+			decision.Decision = "skipped"
+			decision.Reason = "candidate_limit"
+			continue
+		}
+		emittedCandidates++
 		if candidate.score < extractionVisibleScoreThreshold {
 			decision.Decision = "hidden"
 			decision.Reason = "below_visible_threshold"

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -233,6 +233,8 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	report := apptypes.MemoryExtractionDebugReport{SessionID: session.SessionID(), Workspace: session.Workspace()}
 	candidates := make([]candidateDecision, 0)
 	bestCandidateByKey := make(map[string]int)
+	seenKeys := make(map[string]struct{})
+	orderedKeys := make([]string, 0)
 	for _, signal := range signals {
 		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
 		if err != nil {
@@ -263,6 +265,10 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			segmentIndex := len(report.Segments)
 			report.Segments = append(report.Segments, decision)
 			key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
+			if _, exists := seenKeys[key]; !exists {
+				seenKeys[key] = struct{}{}
+				orderedKeys = append(orderedKeys, key)
+			}
 			candidateIndex := len(candidates)
 			candidates = append(candidates, candidateDecision{segmentIndex: segmentIndex, key: key, score: spec.signalScore})
 			bestIndex, exists := bestCandidateByKey[key]
@@ -272,7 +278,24 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 		}
 	}
 
+	selectedKeys := make(map[string]struct{})
+	limitSkippedKeys := make(map[string]struct{})
 	emittedCandidates := 0
+	for _, key := range orderedKeys {
+		if _, exists := existingKeys[key]; exists {
+			continue
+		}
+		if _, exists := bestCandidateByKey[key]; !exists {
+			continue
+		}
+		if emittedCandidates >= criteria.CandidateLimit() {
+			limitSkippedKeys[key] = struct{}{}
+			continue
+		}
+		selectedKeys[key] = struct{}{}
+		emittedCandidates++
+	}
+
 	for index, candidate := range candidates {
 		decision := &report.Segments[candidate.segmentIndex]
 		if _, exists := existingKeys[candidate.key]; exists {
@@ -285,12 +308,16 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 			decision.Reason = "duplicate_in_run"
 			continue
 		}
-		if emittedCandidates >= criteria.CandidateLimit() {
+		if _, exists := limitSkippedKeys[candidate.key]; exists {
 			decision.Decision = "skipped"
 			decision.Reason = "candidate_limit"
 			continue
 		}
-		emittedCandidates++
+		if _, exists := selectedKeys[candidate.key]; !exists {
+			decision.Decision = "skipped"
+			decision.Reason = "candidate_limit"
+			continue
+		}
 		if candidate.score < extractionVisibleScoreThreshold {
 			decision.Decision = "hidden"
 			decision.Reason = "below_visible_threshold"

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -97,6 +97,9 @@ type MemoryUsecase interface {
 	// Extract proposes candidate memories from existing session/history signals.
 	Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error)
 
+	// ExplainExtraction returns segment-level extraction diagnostics without proposing candidates.
+	ExplainExtraction(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) (apptypes.MemoryExtractionDebugReport, error)
+
 	// ImportCodex proposes candidate memories from host-native Codex memory sources.
 	ImportCodex(ctx context.Context, criteria apptypes.CodexImportCriteria) (apptypes.MemoryImportResult, error)
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1056,3 +1056,35 @@ func TestMemoryUsecase_ExplainExtraction_RespectsCandidateLimit(t *testing.T) {
 		t.Fatalf("second decision = %s/%s, want skipped/candidate_limit", report.Segments[1].Decision, report.Segments[1].Reason)
 	}
 }
+
+func TestMemoryUsecase_ExplainExtraction_AppliesCandidateLimitInExtractionKeyOrder(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-limit-key-order"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-debug-limit-key-order", domtypes.EventKindPrompt, strings.Join([]string{
+		"must fix",
+		"Remember: Check release workflow before announcing completion.",
+		"Constraint: must fix",
+	}, "\n"))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-limit-key-order")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(1).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if len(report.Segments) != 3 {
+		t.Fatalf("segments = %d, want 3", len(report.Segments))
+	}
+	if report.Segments[0].Decision != "skipped" || report.Segments[0].Reason != "duplicate_in_run" {
+		t.Fatalf("first decision = %s/%s, want skipped/duplicate_in_run", report.Segments[0].Decision, report.Segments[0].Reason)
+	}
+	if report.Segments[1].Decision != "skipped" || report.Segments[1].Reason != "candidate_limit" {
+		t.Fatalf("second decision = %s/%s, want skipped/candidate_limit", report.Segments[1].Decision, report.Segments[1].Reason)
+	}
+	if report.Segments[2].Decision != "proposed" {
+		t.Fatalf("third decision = %s, want proposed", report.Segments[2].Decision)
+	}
+}

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -853,4 +854,111 @@ func mustMemoryDetailsFromSummary(t *testing.T, memoryID string, memoryType domt
 		t.Fatalf("MemorySummaryOf() error = %v", err)
 	}
 	return apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{mustEvidenceRef(t, domtypes.EvidenceRefKindSession, "session-1")}, nil)
+}
+
+func TestMemoryUsecase_Extract_ExplicitDurableMemoryIntentFromCompactSummary(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(
+		domtypes.SessionID("session-durable-intent"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		time.Now().Add(-time.Hour),
+		domtypes.None[time.Time](),
+		"ended",
+		3,
+		0,
+		[]string{"codex"},
+		"",
+		"",
+		domtypes.SessionID(""),
+	)
+	compactEvent := mustExtractionEvent(t,
+		"event-durable-intent",
+		domtypes.EventKindCompactSummary,
+		"Durable Memory: When dogfooding v0.11.1, verify command audit show/context include INPUT and OUTPUT fields before closing the validation session. Evidence: dogfood session session-1.",
+	)
+	details := mustMemoryDetailsFromSummary(t, "memory-durable-intent", domtypes.MemoryTypeLesson, "When dogfooding v0.11.1, verify command audit show/context include INPUT and OUTPUT fields before closing the validation session. Evidence: dogfood session session-1.")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindCompactSummary: {compactEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-durable-intent")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(Extract()) = %d, want 1", len(got))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.memoryType != domtypes.MemoryTypeLesson {
+		t.Fatalf("memoryType = %q, want lesson fallback", call.memoryType)
+	}
+	if call.source != domtypes.MemorySourceExtracted {
+		t.Fatalf("source = %q, want visible extracted", call.source)
+	}
+	if strings.HasPrefix(call.fact, "Durable Memory:") {
+		t.Fatalf("fact kept explicit label: %q", call.fact)
+	}
+}
+
+func TestMemoryUsecase_Extract_JapaneseExplicitMemoryIntent(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-ja-intent"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 2, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-ja-intent", domtypes.EventKindPrompt, "覚えておいて: Codex review は数分かかることがあるので、PR review/check 状態をポーリングして待つ。")
+	details := mustMemoryDetailsFromSummary(t, "memory-ja-intent", domtypes.MemoryTypeLesson, "Codex review は数分かかることがあるので、PR review/check 状態をポーリングして待つ。")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-ja-intent")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
+	}
+	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceExtracted {
+		t.Fatalf("source = %q, want extracted", got)
+	}
+}
+
+func TestMemoryUsecase_ExplainExtraction_ReportsIgnoredAndProposedSegments(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 2, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-debug", domtypes.EventKindPrompt, strings.Join([]string{
+		"I ran the command and checked the output.",
+		"Remember: Poll Codex review status before assuming it timed out.",
+	}, "\n"))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if len(report.Segments) != 2 {
+		t.Fatalf("segments = %d, want 2", len(report.Segments))
+	}
+	if report.Segments[0].Decision != "ignored" || report.Segments[0].Reason != "no_memory_intent" {
+		t.Fatalf("first segment decision = %s/%s, want ignored/no_memory_intent", report.Segments[0].Decision, report.Segments[0].Reason)
+	}
+	second := report.Segments[1]
+	if second.Decision != "proposed" {
+		t.Fatalf("second decision = %s, want proposed", second.Decision)
+	}
+	if second.MemoryType != domtypes.MemoryTypeLesson {
+		t.Fatalf("second memory type = %q, want lesson", second.MemoryType)
+	}
+	if !slices.Contains(second.Features, "explicit_remember") {
+		t.Fatalf("features = %v, want explicit_remember", second.Features)
+	}
+	if second.Score < 4 {
+		t.Fatalf("score = %d, want visible threshold", second.Score)
+	}
 }

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1028,3 +1028,31 @@ func TestMemoryUsecase_Extract_DoesNotTreatJapaneseMemoryMetricAsDurableIntent(t
 		t.Fatalf("Japanese memory metric produced candidates: got=%d proposeCalls=%d", len(got), len(memoryUsecase.proposeCalls))
 	}
 }
+
+func TestMemoryUsecase_ExplainExtraction_RespectsCandidateLimit(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-limit"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-debug-limit", domtypes.EventKindPrompt, strings.Join([]string{
+		"Remember: Poll Codex review status before assuming it timed out.",
+		"Remember: Check release workflow before announcing completion.",
+	}, "\n"))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-limit")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(1).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if len(report.Segments) != 2 {
+		t.Fatalf("segments = %d, want 2", len(report.Segments))
+	}
+	if report.Segments[0].Decision != "proposed" {
+		t.Fatalf("first decision = %s, want proposed", report.Segments[0].Decision)
+	}
+	if report.Segments[1].Decision != "skipped" || report.Segments[1].Reason != "candidate_limit" {
+		t.Fatalf("second decision = %s/%s, want skipped/candidate_limit", report.Segments[1].Decision, report.Segments[1].Reason)
+	}
+}

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -962,3 +962,50 @@ func TestMemoryUsecase_ExplainExtraction_ReportsIgnoredAndProposedSegments(t *te
 		t.Fatalf("score = %d, want visible threshold", second.Score)
 	}
 }
+
+func TestMemoryUsecase_Extract_DoesNotTreatMetricMemoryLabelAsDurableIntent(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-memory-metric"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-memory-metric", domtypes.EventKindPrompt, "Memory: 2 GB")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-memory-metric")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 || len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("metric memory line produced candidates: got=%d proposeCalls=%d", len(got), len(memoryUsecase.proposeCalls))
+	}
+}
+
+func TestMemoryUsecase_ExplainExtraction_MarksDuplicateInRun(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-duplicates"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-debug-duplicates", domtypes.EventKindPrompt, strings.Join([]string{
+		"Remember: Poll Codex review status before assuming it timed out.",
+		"Remember: Poll Codex review status before assuming it timed out.",
+	}, "\n"))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-duplicates")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if len(report.Segments) != 2 {
+		t.Fatalf("segments = %d, want 2", len(report.Segments))
+	}
+	if report.Segments[0].Decision != "proposed" {
+		t.Fatalf("first decision = %s, want proposed", report.Segments[0].Decision)
+	}
+	if report.Segments[1].Decision != "skipped" || report.Segments[1].Reason != "duplicate_in_run" {
+		t.Fatalf("second decision = %s/%s, want skipped/duplicate_in_run", report.Segments[1].Decision, report.Segments[1].Reason)
+	}
+}

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -987,8 +987,8 @@ func TestMemoryUsecase_ExplainExtraction_MarksDuplicateInRun(t *testing.T) {
 
 	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-duplicates"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
 	promptEvent := mustExtractionEvent(t, "event-debug-duplicates", domtypes.EventKindPrompt, strings.Join([]string{
-		"Remember: Poll Codex review status before assuming it timed out.",
-		"Remember: Poll Codex review status before assuming it timed out.",
+		"must fix",
+		"Constraint: must fix",
 	}, "\n"))
 	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
 	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
@@ -1002,10 +1002,29 @@ func TestMemoryUsecase_ExplainExtraction_MarksDuplicateInRun(t *testing.T) {
 	if len(report.Segments) != 2 {
 		t.Fatalf("segments = %d, want 2", len(report.Segments))
 	}
-	if report.Segments[0].Decision != "proposed" {
-		t.Fatalf("first decision = %s, want proposed", report.Segments[0].Decision)
+	if report.Segments[0].Decision != "skipped" || report.Segments[0].Reason != "duplicate_in_run" {
+		t.Fatalf("first decision = %s/%s, want skipped/duplicate_in_run", report.Segments[0].Decision, report.Segments[0].Reason)
 	}
-	if report.Segments[1].Decision != "skipped" || report.Segments[1].Reason != "duplicate_in_run" {
-		t.Fatalf("second decision = %s/%s, want skipped/duplicate_in_run", report.Segments[1].Decision, report.Segments[1].Reason)
+	if report.Segments[1].Decision != "proposed" {
+		t.Fatalf("second decision = %s, want proposed", report.Segments[1].Decision)
+	}
+}
+
+func TestMemoryUsecase_Extract_DoesNotTreatJapaneseMemoryMetricAsDurableIntent(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-ja-memory-metric"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"codex"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-ja-memory-metric", domtypes.EventKindPrompt, "メモリ: 2 GB")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-ja-memory-metric")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 || len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("Japanese memory metric produced candidates: got=%d proposeCalls=%d", len(got), len(memoryUsecase.proposeCalls))
 	}
 }

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -473,12 +473,20 @@ func (u *memoryUsecase) Show(ctx context.Context, memoryID domtypes.MemoryID) (a
 }
 
 func (u *memoryUsecase) Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
-	return (&memoryExtractionUsecase{
+	return u.newMemoryExtractionUsecase().Extract(ctx, criteria)
+}
+
+func (u *memoryUsecase) ExplainExtraction(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) (apptypes.MemoryExtractionDebugReport, error) {
+	return u.newMemoryExtractionUsecase().Explain(ctx, criteria)
+}
+
+func (u *memoryUsecase) newMemoryExtractionUsecase() *memoryExtractionUsecase {
+	return &memoryExtractionUsecase{
 		sessionQuery:        u.sessionQuery,
 		eventQuery:          u.eventQuery,
 		memory:              u,
 		extraRedactPatterns: u.extraRedactPatterns,
-	}).Extract(ctx, criteria)
+	}
 }
 
 func (u *memoryUsecase) ImportCodex(ctx context.Context, criteria apptypes.CodexImportCriteria) (apptypes.MemoryImportResult, error) {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -369,6 +369,7 @@ type memoryExtractCommandInput struct {
 	workspace      string
 	eventLimit     int
 	candidateLimit int
+	debugSignals   bool
 	asJSON         bool
 }
 

--- a/presentation/cli/memory_extract.go
+++ b/presentation/cli/memory_extract.go
@@ -31,6 +31,7 @@ func (c *RootCLI) newMemoryExtractCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace used to resolve the target session", "対象 session 解決に使う workspace"))
 	cmd.Flags().IntVar(&input.eventLimit, "event-limit", 5, Localize("maximum number of recent events to inspect per signal kind", "signal kind ごとに調べる recent event 数"))
 	cmd.Flags().IntVar(&input.candidateLimit, "candidate-limit", 10, Localize("maximum number of candidates to create", "作成する candidate 数の上限"))
+	cmd.Flags().BoolVar(&input.debugSignals, "debug-signals", false, Localize("explain segment-level extraction decisions without creating candidates", "candidate を作成せず segment 単位の抽出判断を説明する"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -61,14 +62,26 @@ func (c *RootCLI) runMemoryExtract(ctx context.Context, output io.Writer, input 
 		return xerrors.Errorf(Localize("failed to resolve a target session for memory extraction", "memory extraction 対象の session を解決できませんでした"))
 	}
 
+	criteria := apptypes.NewMemoryExtractionCriteriaBuilder().
+		SessionID(types.SessionID(resolvedSessionID)).
+		Workspace(types.Workspace(resolvedLookupWorkspace)).
+		EventLimit(input.eventLimit).
+		CandidateLimit(input.candidateLimit).
+		Build()
+	if input.debugSignals {
+		report, err := c.memory.ExplainExtraction(ctx, criteria)
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to explain durable-memory extraction", "durable memory extraction の説明に失敗しました"), err)
+		}
+		if err := writeMemoryExtractionDebugReport(output, report, input.asJSON); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print extraction debug report", "抽出 debug report の出力に失敗しました"), err)
+		}
+		return nil
+	}
+
 	details, err := c.memory.Extract(
 		ctx,
-		apptypes.NewMemoryExtractionCriteriaBuilder().
-			SessionID(types.SessionID(resolvedSessionID)).
-			Workspace(types.Workspace(resolvedLookupWorkspace)).
-			EventLimit(input.eventLimit).
-			CandidateLimit(input.candidateLimit).
-			Build(),
+		criteria,
 	)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to extract durable-memory candidates", "durable memory candidate の抽出に失敗しました"), err)

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -247,4 +248,79 @@ func formatOptionalTime(value domtypes.Optional[time.Time]) string {
 	}
 
 	return "-"
+}
+
+type memoryExtractionDebugOutput struct {
+	SessionID string                               `json:"session_id"`
+	Workspace string                               `json:"workspace"`
+	Segments  []memoryExtractionSegmentDebugOutput `json:"segments"`
+}
+
+type memoryExtractionSegmentDebugOutput struct {
+	Text         string            `json:"text"`
+	Client       string            `json:"client,omitempty"`
+	EventKind    string            `json:"event_kind,omitempty"`
+	SourceHook   string            `json:"source_hook,omitempty"`
+	MemoryType   string            `json:"memory_type,omitempty"`
+	Features     []string          `json:"features,omitempty"`
+	Score        int               `json:"score"`
+	Decision     string            `json:"decision"`
+	Reason       string            `json:"reason"`
+	EvidenceRefs []memoryRefOutput `json:"evidence_refs,omitempty"`
+	ArtifactRefs []memoryRefOutput `json:"artifact_refs,omitempty"`
+}
+
+type memoryRefOutput struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+func writeMemoryExtractionDebugReport(output io.Writer, report apptypes.MemoryExtractionDebugReport, asJSON bool) error {
+	serialized := newMemoryExtractionDebugOutput(report)
+	if asJSON {
+		return writeJSON(output, serialized)
+	}
+	if _, err := fmt.Fprintf(output, "SESSION_ID\t%s\nWORKSPACE\t%s\n", serialized.SessionID, serialized.Workspace); err != nil {
+		return xerrors.Errorf("failed to print extraction debug header: %w", err)
+	}
+	if len(serialized.Segments) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No extraction signals were inspected.", "検査された extraction signal はありません。")); err != nil {
+			return xerrors.Errorf("failed to print empty extraction debug message: %w", err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintln(output, "DECISION\tREASON\tSCORE\tTYPE\tFEATURES\tTEXT"); err != nil {
+		return xerrors.Errorf("failed to print extraction debug table header: %w", err)
+	}
+	for _, segment := range serialized.Segments {
+		if _, err := fmt.Fprintf(output, "%s\t%s\t%d\t%s\t%s\t%s\n", segment.Decision, segment.Reason, segment.Score, segment.MemoryType, strings.Join(segment.Features, ","), truncateMessage(segment.Text)); err != nil {
+			return xerrors.Errorf("failed to print extraction debug row: %w", err)
+		}
+	}
+	return nil
+}
+
+func newMemoryExtractionDebugOutput(report apptypes.MemoryExtractionDebugReport) memoryExtractionDebugOutput {
+	segments := make([]memoryExtractionSegmentDebugOutput, 0, len(report.Segments))
+	for _, segment := range report.Segments {
+		out := memoryExtractionSegmentDebugOutput{
+			Text:       segment.Text,
+			Client:     segment.Client.String(),
+			EventKind:  segment.EventKind.String(),
+			SourceHook: segment.SourceHook,
+			MemoryType: segment.MemoryType.String(),
+			Features:   append([]string(nil), segment.Features...),
+			Score:      segment.Score,
+			Decision:   segment.Decision,
+			Reason:     segment.Reason,
+		}
+		for _, ref := range segment.EvidenceRefs {
+			out.EvidenceRefs = append(out.EvidenceRefs, memoryRefOutput{Kind: ref.Kind().String(), Value: ref.Value()})
+		}
+		for _, ref := range segment.ArtifactRefs {
+			out.ArtifactRefs = append(out.ArtifactRefs, memoryRefOutput{Kind: ref.Kind().String(), Value: ref.Value()})
+		}
+		segments = append(segments, out)
+	}
+	return memoryExtractionDebugOutput{SessionID: report.SessionID.String(), Workspace: report.Workspace.String(), Segments: segments}
 }

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -97,27 +97,27 @@ func (s *eventUsecaseStub) Timeline(_ context.Context, criteria apptypes.Timelin
 
 // sessionUsecaseStub implements usecase.SessionUsecase for testing.
 type sessionUsecaseStub struct {
-	startEvent     *model.Event
-	startErr       error
-	endEvent       *model.Event
-	endErr         error
-	labelErr       error
-	listResult     []apptypes.SessionSummary
-	listErr        error
-	listCriteria   apptypes.SessionListCriteria
-	treeResult     []apptypes.SessionSummary
-	treeErr        error
-	lineageResult  []apptypes.SessionSummary
-	lineageErr     error
-	activeEvent    *model.Event
-	activeErr      error
-	activeCriteria apptypes.SessionLookupCriteria
-	latestEvent    *model.Event
-	latestErr      error
-	latestCriteria apptypes.SessionLookupCriteria
-	handoff        types.Optional[apptypes.HandoffSummary]
-	handoffErr     error
-	setSummaryErr  error
+	startEvent      *model.Event
+	startErr        error
+	endEvent        *model.Event
+	endErr          error
+	labelErr        error
+	listResult      []apptypes.SessionSummary
+	listErr         error
+	listCriteria    apptypes.SessionListCriteria
+	treeResult      []apptypes.SessionSummary
+	treeErr         error
+	lineageResult   []apptypes.SessionSummary
+	lineageErr      error
+	activeEvent     *model.Event
+	activeErr       error
+	activeCriteria  apptypes.SessionLookupCriteria
+	latestEvent     *model.Event
+	latestErr       error
+	latestCriteria  apptypes.SessionLookupCriteria
+	handoff         types.Optional[apptypes.HandoffSummary]
+	handoffErr      error
+	setSummaryErr   error
 	setSummaryCalls map[types.SessionID]string
 
 	startCall struct {
@@ -455,6 +455,10 @@ func (s *memoryUsecaseStub) Show(_ context.Context, memoryID types.MemoryID) (ap
 func (s *memoryUsecaseStub) Extract(_ context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
 	s.extractCriteria = criteria
 	return s.extractDetails, s.extractErr
+}
+
+func (s *memoryUsecaseStub) ExplainExtraction(context.Context, apptypes.MemoryExtractionCriteria) (apptypes.MemoryExtractionDebugReport, error) {
+	return apptypes.MemoryExtractionDebugReport{}, nil
 }
 
 func (s *memoryUsecaseStub) ImportCodex(_ context.Context, criteria apptypes.CodexImportCriteria) (apptypes.MemoryImportResult, error) {


### PR DESCRIPTION
## Motivation

Closes #851.

Dogfooding v0.11.1 showed that `Durable Memory:` in compact-summary events was ignored because extraction relied on a narrow label vocabulary and opaque heuristics.

## Changes

- Add deterministic memory-intent features for explicit remember/future/preference/correction/constraint/workflow signals.
- Treat explicit memory intent as a visible candidate with fallback type inference instead of dropping ambiguous segments.
- Add `traceary memory extract --debug-signals` for segment-level extraction diagnostics without creating candidates.
- Preserve future calibration metadata in diagnostics (`client`, `event_kind`, `source_hook`).
- Add regression coverage for English/Japanese explicit intent and ignored operational chatter.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp go build ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache go tool golangci-lint run`
- Dogfood with temp DB:
  - `Durable Memory: ...` compact-summary produced a visible `lesson` candidate.
  - `memory extract --debug-signals --json` reported `explicit_remember`, score, decision, and duplicate reason after extraction.

## Gemini scout

Skipped in this environment because sending private PR diff to the external Gemini CLI was not approved by sandbox policy.
