### PR TITLE
feat(memory): add low-quality candidate hygiene

### DIFF
--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -43,6 +43,15 @@ const (
 	// overlap: memories with disjoint validity windows are treated as
 	// separate historical facts.
 	MemoryHygieneSuggestionValidityOverlapSupersede MemoryHygieneSuggestionKind = "validity_overlap_supersede"
+	// MemoryHygieneSuggestionLowQualityCandidate flags a status=candidate
+	// memory whose fact text matches the deterministic low-quality
+	// classifier (#857). The apply path rejects the candidate so the
+	// inbox view stays focused on durable signals; accepted memories are
+	// never touched. The suggestion only fires for status=candidate, and
+	// extracted-hidden rows are inspected only when the caller opts in
+	// via MemoryHygieneScanCriteria.IncludeHiddenCandidates so the
+	// default scan stays predictable.
+	MemoryHygieneSuggestionLowQualityCandidate MemoryHygieneSuggestionKind = "low_quality_candidate"
 )
 
 // MemoryHygieneScanCriteria carries the inputs the hygiene scanner
@@ -50,11 +59,17 @@ const (
 // threshold controls the expiry suggestion window and falls back to a
 // usecase default when zero. SimilarityThreshold tunes the
 // supersede_candidate detector — 0 uses the usecase default (0.6).
+//
+// IncludeHiddenCandidates expands the candidate-noise pass to include
+// extracted-hidden rows (low-quality auto-extractions kept for audit).
+// Without it the scan only inspects visible candidates so the default
+// view matches what the operator sees in the inbox.
 type MemoryHygieneScanCriteria struct {
-	Scopes              []domtypes.MemoryScope
-	StalenessThreshold  time.Duration
-	SimilarityThreshold float64
-	Now                 time.Time
+	Scopes                  []domtypes.MemoryScope
+	StalenessThreshold      time.Duration
+	SimilarityThreshold     float64
+	Now                     time.Time
+	IncludeHiddenCandidates bool
 }
 
 // MemoryHygieneSuggestion is the serializable view of a single scan hit.
@@ -65,6 +80,13 @@ type MemoryHygieneScanCriteria struct {
 // hits so the apply path knows which memory becomes the replacement.
 // Similarity is the computed word-Jaccard score (0.0-1.0) — zero on
 // everything except supersede_candidate.
+//
+// Status / Source are populated for low_quality_candidate suggestions so
+// the reviewer can confirm the row is still a candidate (and which
+// extraction source produced it) before approving the apply path.
+// QualityReasons enumerates the deterministic noise markers that
+// classified the candidate as low-quality — the same vocabulary the
+// extractor diagnostics expose (#857).
 type MemoryHygieneSuggestion struct {
 	MemoryID            domtypes.MemoryID
 	Kind                MemoryHygieneSuggestionKind
@@ -77,6 +99,9 @@ type MemoryHygieneSuggestion struct {
 	Similarity          float64
 	Scope               domtypes.MemoryScope
 	UpdatedAt           time.Time
+	Status              domtypes.MemoryStatus
+	Source              domtypes.MemorySource
+	QualityReasons      []string
 }
 
 // MemoryHygieneScanResult summarises a single scan run. Suggestions keeps
@@ -90,15 +115,22 @@ type MemoryHygieneScanResult struct {
 	DuplicateCount                int
 	SupersedeCandidateCount       int
 	ValidityOverlapSupersedeCount int
+	LowQualityCandidateCount      int
 }
 
 // MemoryHygieneApplyCriteria carries the inputs to the apply path. Ids
 // reference memories the caller already saw in a Scan result; the
 // usecase re-runs the scan to make sure the transition still applies.
+//
+// IncludeHiddenCandidates mirrors the scan flag so an apply targeting a
+// previously-hidden candidate id still finds the suggestion when the
+// re-scan runs. Without it, the re-scan would miss the row and the
+// apply would fail with "no current hygiene suggestion".
 type MemoryHygieneApplyCriteria struct {
-	MemoryIDs          []string
-	StalenessThreshold time.Duration
-	Now                time.Time
+	MemoryIDs               []string
+	StalenessThreshold      time.Duration
+	Now                     time.Time
+	IncludeHiddenCandidates bool
 }
 
 // MemoryHygieneApplyResult mirrors the inbox batch output shape so both

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -42,6 +42,11 @@ const hygieneScanPageSize = 2000
 // memory that trips any of the three hygiene rules. The function is
 // deliberately simple: each rule is independent so an operator can
 // triage the suggestions without the scanner second-guessing them.
+//
+// Candidate hygiene runs as a separate pass on status=candidate rows so
+// the deterministic low-quality classifier (#857) can flag noisy
+// auto-extractions. The candidate pass never inspects accepted memories,
+// so the apply path that consumes its suggestions cannot mutate them.
 func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
 	if u.memoryQuery == nil {
 		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory query service is not configured")
@@ -186,7 +191,61 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	result.Suggestions = append(result.Suggestions, validityOverlapSuggestions...)
 	result.ValidityOverlapSupersedeCount = len(validityOverlapSuggestions)
 
+	candidateSuggestions, err := u.scanLowQualityCandidates(ctx, criteria)
+	if err != nil {
+		return apptypes.MemoryHygieneScanResult{}, err
+	}
+	result.Suggestions = append(result.Suggestions, candidateSuggestions...)
+	result.LowQualityCandidateCount = len(candidateSuggestions)
+
 	return result, nil
+}
+
+// scanLowQualityCandidates walks every status=candidate memory in scope
+// and emits a low_quality_candidate suggestion for each row whose fact
+// matches the deterministic extraction-noise classifier (#857). The
+// default pass restricts the source to MemorySourceExtracted because
+// extracted-hidden rows are already suppressed from the inbox; callers
+// who explicitly opt into IncludeHiddenCandidates also see those rows
+// so they can clean up backlog from before the extractor learned to
+// hide them.
+//
+// The candidate pass is a separate read so the existing redaction /
+// expiry / duplicate / supersede passes keep operating on accepted
+// memories only — there is no path through this scan that mutates an
+// accepted row, satisfying the issue's guarantee that the candidate
+// cleanup path cannot touch accepted memories.
+func (u *memoryHygieneUsecase) scanLowQualityCandidates(
+	ctx context.Context,
+	criteria apptypes.MemoryHygieneScanCriteria,
+) ([]apptypes.MemoryHygieneSuggestion, error) {
+	sources := []domtypes.MemorySource{domtypes.MemorySourceExtracted}
+	if criteria.IncludeHiddenCandidates {
+		sources = append(sources, domtypes.MemorySourceExtractedHidden)
+	}
+	candidates, err := u.loadCandidateSummaries(ctx, criteria.Scopes, sources)
+	if err != nil {
+		return nil, err
+	}
+	suggestions := make([]apptypes.MemoryHygieneSuggestion, 0, len(candidates))
+	for _, candidate := range candidates {
+		reasons := classifyExtractionNoise(candidate.Fact())
+		if len(reasons) == 0 {
+			continue
+		}
+		suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
+			MemoryID:       candidate.MemoryID(),
+			Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+			Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
+			Fact:           candidate.Fact(),
+			Scope:          candidate.Scope(),
+			UpdatedAt:      candidate.UpdatedAt(),
+			Status:         candidate.Status(),
+			Source:         candidate.Source(),
+			QualityReasons: reasons,
+		})
+	}
+	return suggestions, nil
 }
 
 // detectSupersedeCandidates groups accepted memories by scope, computes
@@ -467,8 +526,9 @@ func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.Memo
 		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory usecase is not configured")
 	}
 	scanResult, err := u.Scan(ctx, apptypes.MemoryHygieneScanCriteria{
-		StalenessThreshold: criteria.StalenessThreshold,
-		Now:                criteria.Now,
+		StalenessThreshold:      criteria.StalenessThreshold,
+		Now:                     criteria.Now,
+		IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
 	})
 	if err != nil {
 		return apptypes.MemoryHygieneApplyResult{}, err
@@ -560,6 +620,19 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to reject memory: %w", err)
 		}
 		return apptypes.MemoryHygieneApplied{MemoryID: memoryID.String(), Kind: suggestion.Kind, Transition: "reject", Details: rejected}, nil
+	case apptypes.MemoryHygieneSuggestionLowQualityCandidate:
+		// Low-quality candidates are rejected outright. The scan only
+		// flags status=candidate rows so this branch can never receive
+		// an accepted memory id, satisfying the issue's guarantee that
+		// the candidate cleanup path leaves accepted memories alone.
+		// Reject() in turn refuses to operate on accepted memories, so
+		// any race that flipped the row to accepted between scan and
+		// apply surfaces as an error in the per-id failure list.
+		rejected, err := u.memory.Reject(ctx, memoryID)
+		if err != nil {
+			return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("failed to reject low-quality candidate: %w", err)
+		}
+		return apptypes.MemoryHygieneApplied{MemoryID: memoryID.String(), Kind: suggestion.Kind, Transition: "reject", Details: rejected}, nil
 	case apptypes.MemoryHygieneSuggestionSupersedeCandidate,
 		apptypes.MemoryHygieneSuggestionValidityOverlapSupersede:
 		details, err := u.memory.Show(ctx, memoryID)
@@ -603,18 +676,44 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 // worth of memories is still scanned in full. The scan stops when the
 // datasource returns fewer rows than the requested page size.
 func (u *memoryHygieneUsecase) loadAcceptedSummaries(ctx context.Context, scopes []domtypes.MemoryScope) ([]apptypes.MemorySummary, error) {
+	return u.loadSummariesPage(ctx, scopes, []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}, nil, "accepted")
+}
+
+// loadCandidateSummaries walks every candidate memory in scope and
+// (optional) sources in hygieneScanPageSize-sized pages. Sources is
+// applied as an inclusive filter — passing only MemorySourceExtracted
+// excludes manually-proposed candidates from the noise pass so a
+// reviewer's deliberate proposal is never tagged as low-quality.
+func (u *memoryHygieneUsecase) loadCandidateSummaries(
+	ctx context.Context,
+	scopes []domtypes.MemoryScope,
+	sources []domtypes.MemorySource,
+) ([]apptypes.MemorySummary, error) {
+	return u.loadSummariesPage(ctx, scopes, []domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, sources, "candidate")
+}
+
+func (u *memoryHygieneUsecase) loadSummariesPage(
+	ctx context.Context,
+	scopes []domtypes.MemoryScope,
+	statuses []domtypes.MemoryStatus,
+	sources []domtypes.MemorySource,
+	label string,
+) ([]apptypes.MemorySummary, error) {
 	var all []apptypes.MemorySummary
 	offset := 0
 	for {
 		builder := apptypes.NewMemoryListCriteriaBuilder(hygieneScanPageSize).
 			Offset(offset).
-			Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted})
+			Statuses(statuses)
 		if len(scopes) > 0 {
 			builder = builder.Scopes(scopes)
 		}
+		if len(sources) > 0 {
+			builder = builder.Sources(sources)
+		}
 		page, err := u.memoryQuery.List(ctx, builder.Build())
 		if err != nil {
-			return nil, xerrors.Errorf("failed to list accepted memories: %w", err)
+			return nil, xerrors.Errorf("failed to list %s memories: %w", label, err)
 		}
 		if len(page) == 0 {
 			break

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -7,6 +7,7 @@ import (
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
@@ -467,7 +468,373 @@ func TestMemoryHygieneScan_EmptyStoreReturnsEmptyResult(t *testing.T) {
 	if len(result.Suggestions) != 0 {
 		t.Fatalf("expected empty suggestions, got %d", len(result.Suggestions))
 	}
-	if result.RedactionHitCount+result.ExpiryCandidateCount+result.DuplicateCount != 0 {
-		t.Fatalf("expected zero counts across all suggestion kinds, got r=%d e=%d d=%d", result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount)
+	if result.RedactionHitCount+result.ExpiryCandidateCount+result.DuplicateCount+result.LowQualityCandidateCount != 0 {
+		t.Fatalf("expected zero counts across all suggestion kinds, got r=%d e=%d d=%d l=%d", result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.LowQualityCandidateCount)
+	}
+}
+
+// candidateSummary builds a status=candidate MemorySummary with the
+// supplied source so the candidate hygiene tests can flip between
+// extracted (visible by default) and extracted-hidden (only inspected
+// when the caller opts in).
+func candidateSummary(t *testing.T, id string, scope domtypes.MemoryScope, fact string, source domtypes.MemorySource, updatedAt time.Time) apptypes.MemorySummary {
+	t.Helper()
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypePreference,
+		scope,
+		fact,
+		domtypes.MemoryStatusCandidate,
+		domtypes.ConfidenceMedium,
+		source,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		updatedAt,
+		domtypes.None[time.Time](),
+		updatedAt,
+		updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	return summary
+}
+
+func TestMemoryHygieneScan_LowQualityCandidatesSurfaceWithReasons(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// Each candidate represents one of the noisy patterns the issue
+	// calls out: diff fragment, standalone command, and review-only
+	// conclusion. The classifier already covers more reasons but the
+	// regression bar is "at least diff fragments, standalone commands,
+	// and review-conclusion noise" per #864.
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-diff", scope, "+def _required_env(name):", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-cmd", scope, "git pull --ff-only origin main", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-review", scope, "MUST findings: none", domtypes.MemorySourceExtracted, now),
+			// High-signal candidate must remain untouched even though
+			// it is also status=candidate.
+			candidateSummary(t, "mem-keep", scope, "Always run go test before merging", domtypes.MemorySourceExtracted, now),
+			// Hidden source must NOT be inspected unless the caller
+			// opts in (see TestMemoryHygieneScan_HiddenCandidatesRequireOptIn).
+			candidateSummary(t, "mem-hidden", scope, "+old_helper()", domtypes.MemorySourceExtractedHidden, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: now})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.LowQualityCandidateCount != 3 {
+		t.Fatalf("LowQualityCandidateCount = %d, want 3 (diff/cmd/review)", result.LowQualityCandidateCount)
+	}
+	flagged := map[string]apptypes.MemoryHygieneSuggestion{}
+	for _, suggestion := range result.Suggestions {
+		if suggestion.Kind == apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+			flagged[suggestion.MemoryID.String()] = suggestion
+		}
+	}
+	for _, want := range []string{"mem-diff", "mem-cmd", "mem-review"} {
+		suggestion, ok := flagged[want]
+		if !ok {
+			t.Fatalf("expected %s to be flagged as low_quality_candidate, got %v", want, flagged)
+		}
+		if suggestion.Status != domtypes.MemoryStatusCandidate {
+			t.Fatalf("%s: status = %q, want candidate", want, suggestion.Status)
+		}
+		if suggestion.Source != domtypes.MemorySourceExtracted {
+			t.Fatalf("%s: source = %q, want extracted", want, suggestion.Source)
+		}
+		if len(suggestion.QualityReasons) == 0 {
+			t.Fatalf("%s: QualityReasons must not be empty", want)
+		}
+		if suggestion.Reason == "" {
+			t.Fatalf("%s: Reason must not be empty", want)
+		}
+	}
+	if _, leaked := flagged["mem-keep"]; leaked {
+		t.Fatalf("durable preference must not be flagged as low-quality")
+	}
+	if _, leaked := flagged["mem-hidden"]; leaked {
+		t.Fatalf("extracted-hidden candidate must require --include-hidden to surface, got %+v", flagged["mem-hidden"])
+	}
+
+	expectedReasons := map[string]string{
+		"mem-diff":   "diff_fragment",
+		"mem-cmd":    "standalone_command",
+		"mem-review": "review_conclusion",
+	}
+	for id, marker := range expectedReasons {
+		suggestion := flagged[id]
+		matched := false
+		for _, reason := range suggestion.QualityReasons {
+			if reason == marker {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("%s: expected QualityReasons to include %q, got %v", id, marker, suggestion.QualityReasons)
+		}
+	}
+}
+
+func TestMemoryHygieneScan_HiddenCandidatesRequireOptIn(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-hidden", scope, "+old_helper()", domtypes.MemorySourceExtractedHidden, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now:                     now,
+		IncludeHiddenCandidates: true,
+	})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.LowQualityCandidateCount != 1 {
+		t.Fatalf("LowQualityCandidateCount = %d, want 1 once hidden candidates are inspected", result.LowQualityCandidateCount)
+	}
+	var flagged *apptypes.MemoryHygieneSuggestion
+	for i := range result.Suggestions {
+		if result.Suggestions[i].Kind == apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+			flagged = &result.Suggestions[i]
+			break
+		}
+	}
+	if flagged == nil {
+		t.Fatalf("expected the hidden candidate to be flagged with IncludeHiddenCandidates=true")
+	}
+	if flagged.MemoryID.String() != "mem-hidden" {
+		t.Fatalf("MemoryID = %q, want mem-hidden", flagged.MemoryID)
+	}
+	if flagged.Source != domtypes.MemorySourceExtractedHidden {
+		t.Fatalf("Source = %q, want extracted-hidden", flagged.Source)
+	}
+}
+
+// candidateApplyMemoryRepository is a minimal model.MemoryRepository
+// stub for the candidate apply tests. It serves the candidate memory
+// ids the test seeds, records the ids that flowed through Save() so we
+// can assert the lifecycle transition the apply path drove, and refuses
+// to surface accepted ids — so any test that would otherwise mutate an
+// accepted memory through the candidate path fails fast.
+type candidateApplyMemoryRepository struct {
+	candidates map[string]*model.Memory
+	saved      []*model.Memory
+	saveErr    error
+	findErr    error
+}
+
+func newCandidateApplyMemoryRepository(t *testing.T, scope domtypes.MemoryScope, candidates map[string]string) *candidateApplyMemoryRepository {
+	t.Helper()
+	repo := &candidateApplyMemoryRepository{candidates: make(map[string]*model.Memory, len(candidates))}
+	for id, fact := range candidates {
+		evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L1")
+		if err != nil {
+			t.Fatalf("EvidenceRefFrom: %v", err)
+		}
+		memory, err := model.NewMemoryCandidate(
+			domtypes.MemoryID(id),
+			domtypes.MemoryTypePreference,
+			scope,
+			fact,
+			domtypes.MemorySourceExtracted,
+			[]domtypes.EvidenceRef{evidence},
+			nil,
+			domtypes.None[domtypes.MemoryID](),
+		)
+		if err != nil {
+			t.Fatalf("NewMemoryCandidate: %v", err)
+		}
+		repo.candidates[id] = memory
+	}
+	return repo
+}
+
+func (r *candidateApplyMemoryRepository) Save(_ context.Context, memory *model.Memory) error {
+	if r.saveErr != nil {
+		return r.saveErr
+	}
+	r.saved = append(r.saved, memory)
+	return nil
+}
+
+func (r *candidateApplyMemoryRepository) SaveSupersession(context.Context, *model.Memory, *model.Memory) error {
+	return nil
+}
+
+func (r *candidateApplyMemoryRepository) FindByID(_ context.Context, memoryID domtypes.MemoryID) (domtypes.Optional[*model.Memory], error) {
+	if r.findErr != nil {
+		return domtypes.None[*model.Memory](), r.findErr
+	}
+	if memory, ok := r.candidates[memoryID.String()]; ok {
+		return domtypes.Some(memory), nil
+	}
+	return domtypes.None[*model.Memory](), nil
+}
+
+func (r *candidateApplyMemoryRepository) rejectedIDs() []string {
+	ids := make([]string, 0, len(r.saved))
+	for _, memory := range r.saved {
+		if memory.Status() == domtypes.MemoryStatusRejected {
+			ids = append(ids, memory.MemoryID().String())
+		}
+	}
+	return ids
+}
+
+func TestMemoryHygieneApply_RejectsLowQualityCandidate(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	noisyCandidate := candidateSummary(t, "mem-noise", scope, "+def _required_env(name):", domtypes.MemorySourceExtracted, now)
+	durableAccepted := acceptedSummaryAt(t, "mem-keep", scope, "Always run go test before merging", now)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{noisyCandidate, durableAccepted},
+	}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{
+		"mem-noise": "+def _required_env(name):",
+	})
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	result, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"mem-noise"},
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Failures) != 0 {
+		t.Fatalf("Apply failures = %+v, want none", result.Failures)
+	}
+	if len(result.Applied) != 1 {
+		t.Fatalf("Applied entries = %d, want 1", len(result.Applied))
+	}
+	if result.Applied[0].Transition != "reject" {
+		t.Fatalf("Transition = %q, want reject", result.Applied[0].Transition)
+	}
+	if result.Applied[0].Kind != apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+		t.Fatalf("Kind = %q, want low_quality_candidate", result.Applied[0].Kind)
+	}
+	rejected := repo.rejectedIDs()
+	if len(rejected) != 1 || rejected[0] != "mem-noise" {
+		t.Fatalf("rejected ids = %v, want [mem-noise]", rejected)
+	}
+}
+
+func TestMemoryHygieneApply_AcceptedMemoriesUntouchedByCandidatePath(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// An accepted memory whose fact happens to look like noise must not
+	// trip the candidate cleanup path. The candidate scan filters by
+	// status=candidate, so even when an operator passes the accepted
+	// id to apply the re-scan does not produce a suggestion for it.
+	noisyAccepted := acceptedSummaryAt(t, "mem-accepted-noise", scope, "+def _required_env(name):", now)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{noisyAccepted},
+	}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{})
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	result, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"mem-accepted-noise"},
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Applied) != 0 {
+		t.Fatalf("Applied = %+v, want none (accepted row must not be touched by candidate cleanup)", result.Applied)
+	}
+	if len(result.Failures) != 1 {
+		t.Fatalf("Failures = %+v, want one (id without a current suggestion)", result.Failures)
+	}
+	if rejected := repo.rejectedIDs(); len(rejected) != 0 {
+		t.Fatalf("rejected ids = %v, want none — accepted memories must never go through the candidate apply path", rejected)
+	}
+}
+
+func TestMemoryHygieneApply_HiddenCandidateRequiresOptIn(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	hiddenNoisy := candidateSummary(t, "mem-hidden", scope, "+def helper():", domtypes.MemorySourceExtractedHidden, now)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{hiddenNoisy},
+	}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{
+		"mem-hidden": "+def helper():",
+	})
+	// Override the seeded source so the repo serves a hidden candidate
+	// the apply path should reject only when IncludeHiddenCandidates is
+	// set. NewMemoryCandidate hard-codes MemorySourceExtracted so we
+	// rebuild the candidate using the hidden source explicitly.
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L1")
+	if err != nil {
+		t.Fatalf("EvidenceRefFrom: %v", err)
+	}
+	hiddenMemory, err := model.NewMemoryCandidate(
+		domtypes.MemoryID("mem-hidden"),
+		domtypes.MemoryTypePreference,
+		scope,
+		"+def helper():",
+		domtypes.MemorySourceExtractedHidden,
+		[]domtypes.EvidenceRef{evidence},
+		nil,
+		domtypes.None[domtypes.MemoryID](),
+	)
+	if err != nil {
+		t.Fatalf("NewMemoryCandidate hidden: %v", err)
+	}
+	repo.candidates["mem-hidden"] = hiddenMemory
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	withoutOptIn, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"mem-hidden"},
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(withoutOptIn.Applied) != 0 {
+		t.Fatalf("Applied without IncludeHiddenCandidates = %+v, want none", withoutOptIn.Applied)
+	}
+	if len(withoutOptIn.Failures) != 1 {
+		t.Fatalf("Failures without IncludeHiddenCandidates = %+v, want one", withoutOptIn.Failures)
+	}
+
+	withOptIn, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs:               []string{"mem-hidden"},
+		Now:                     now,
+		IncludeHiddenCandidates: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply with IncludeHiddenCandidates: %v", err)
+	}
+	if len(withOptIn.Applied) != 1 {
+		t.Fatalf("Applied with IncludeHiddenCandidates = %+v, want one", withOptIn.Applied)
+	}
+	if withOptIn.Applied[0].Transition != "reject" {
+		t.Fatalf("Transition = %q, want reject", withOptIn.Applied[0].Transition)
 	}
 }

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -30,7 +30,40 @@ type stubMemoryQueryService struct {
 
 func (s *stubMemoryQueryService) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.calls = append(s.calls, criteria)
-	return s.summaries, nil
+	statuses := criteria.Statuses()
+	sources := criteria.Sources()
+	if len(statuses) == 0 && len(sources) == 0 {
+		return s.summaries, nil
+	}
+	filtered := make([]apptypes.MemorySummary, 0, len(s.summaries))
+	for _, summary := range s.summaries {
+		if len(statuses) > 0 && !statusContains(statuses, summary.Status()) {
+			continue
+		}
+		if len(sources) > 0 && !sourceContains(sources, summary.Source()) {
+			continue
+		}
+		filtered = append(filtered, summary)
+	}
+	return filtered, nil
+}
+
+func statusContains(statuses []domtypes.MemoryStatus, target domtypes.MemoryStatus) bool {
+	for _, status := range statuses {
+		if status == target {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceContains(sources []domtypes.MemorySource, target domtypes.MemorySource) bool {
+	for _, source := range sources {
+		if source == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *stubMemoryQueryService) Search(_ context.Context, _ apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -440,22 +440,29 @@ type memoryImportInstructionsCommandInput struct {
 }
 
 // memoryHygieneScanCommandInput is the resolved input to the
-// `traceary memory hygiene scan` command.
+// `traceary memory hygiene scan` command. includeHidden expands the
+// candidate-noise pass (#864) to inspect extracted-hidden rows so an
+// operator can clean up the backlog of low-quality candidates from
+// before the extractor learned to hide them.
 type memoryHygieneScanCommandInput struct {
-	dbPath     string
-	workspace  string
-	expiryDays int
-	similarity float64
-	asJSON     bool
+	dbPath        string
+	workspace     string
+	expiryDays    int
+	similarity    float64
+	includeHidden bool
+	asJSON        bool
 }
 
 // memoryHygieneApplyCommandInput is the resolved input to
 // `traceary memory hygiene apply`. Ids reference memories seen in a
 // prior scan; the usecase re-scans internally to confirm the transition
-// is still appropriate before mutating state.
+// is still appropriate before mutating state. includeHidden mirrors the
+// scan flag so an apply targeting a previously-hidden low-quality
+// candidate still finds the suggestion on re-scan.
 type memoryHygieneApplyCommandInput struct {
-	dbPath     string
-	ids        []string
-	expiryDays int
-	asJSON     bool
+	dbPath        string
+	ids           []string
+	expiryDays    int
+	includeHidden bool
+	asJSON        bool
 }

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -45,6 +45,10 @@ func (c *RootCLI) newMemoryHygieneApplyCommand() *cobra.Command {
 		"number of days without update before a memory is considered an expiry candidate",
 		"expiry 候補として検出するまでの未更新日数",
 	))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize(
+		"include extracted-hidden low-quality candidates when re-scanning before apply",
+		"apply 前の再スキャンで extracted-hidden の低品質 candidate も対象に含める",
+	))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -67,8 +71,9 @@ func (c *RootCLI) runMemoryHygieneApply(ctx context.Context, output io.Writer, i
 		return err
 	}
 	result, err := c.memory.Apply(ctx, apptypes.MemoryHygieneApplyCriteria{
-		MemoryIDs:          ids,
-		StalenessThreshold: time.Duration(input.expiryDays) * 24 * time.Hour,
+		MemoryIDs:               ids,
+		StalenessThreshold:      time.Duration(input.expiryDays) * 24 * time.Hour,
+		IncludeHiddenCandidates: input.includeHidden,
 	})
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to apply hygiene suggestions", "hygiene 候補の適用に失敗しました"), err)
@@ -124,7 +129,7 @@ func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
 	input := memoryHygieneScanCommandInput{expiryDays: defaultHygieneExpiryDays}
 	cmd := &cobra.Command{
 		Use:   "scan",
-		Short: Localize("Scan accepted memories for redaction / expiry / duplicate / supersede / validity-overlap suggestions", "accepted memory に対して redaction / expiry / duplicate / supersede / validity-overlap の hygiene 候補を検出する"),
+		Short: Localize("Scan accepted memories for redaction / expiry / duplicate / supersede / validity-overlap and candidate memories for low-quality noise", "accepted memory に対して redaction / expiry / duplicate / supersede / validity-overlap、candidate memory に対して低品質ノイズの hygiene 候補を検出する"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runMemoryHygieneScan(cmd.Context(), cmd.OutOrStdout(), input)
@@ -142,6 +147,10 @@ func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
 	cmd.Flags().Float64Var(&input.similarity, "similarity", 0, Localize(
 		"word-Jaccard threshold for supersede_candidate detection (0.0-1.0; 0 uses the default 0.6)",
 		"supersede_candidate 検出の word-Jaccard 閾値 (0.0-1.0、0 は既定値 0.6)",
+	))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize(
+		"inspect extracted-hidden candidates as well (default scans visible candidates only)",
+		"extracted-hidden の candidate も検査対象に含める (既定では visible candidate のみ)",
 	))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
@@ -166,8 +175,9 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 		return err
 	}
 	criteria := apptypes.MemoryHygieneScanCriteria{
-		StalenessThreshold:  time.Duration(input.expiryDays) * 24 * time.Hour,
-		SimilarityThreshold: input.similarity,
+		StalenessThreshold:      time.Duration(input.expiryDays) * 24 * time.Hour,
+		SimilarityThreshold:     input.similarity,
+		IncludeHiddenCandidates: input.includeHidden,
 	}
 	if scope != nil {
 		criteria.Scopes = []domtypes.MemoryScope{scope}
@@ -188,6 +198,7 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 			DuplicateCount:                result.DuplicateCount,
 			SupersedeCandidateCount:       result.SupersedeCandidateCount,
 			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
+			LowQualityCandidateCount:      result.LowQualityCandidateCount,
 			Suggestions:                   make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
@@ -202,9 +213,9 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		return nil
 	}
 	if _, err := fmt.Fprintf(output, Localize(
-		"redaction_hits=%d expiry_candidates=%d duplicates=%d supersede_candidates=%d validity_overlap_supersedes=%d\n",
-		"redaction ヒット=%d expiry 候補=%d 重複=%d supersede 候補=%d validity 重複 supersede=%d\n",
-	), result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.SupersedeCandidateCount, result.ValidityOverlapSupersedeCount); err != nil {
+		"redaction_hits=%d expiry_candidates=%d duplicates=%d supersede_candidates=%d validity_overlap_supersedes=%d low_quality_candidates=%d\n",
+		"redaction ヒット=%d expiry 候補=%d 重複=%d supersede 候補=%d validity 重複 supersede=%d 低品質 candidate=%d\n",
+	), result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.SupersedeCandidateCount, result.ValidityOverlapSupersedeCount, result.LowQualityCandidateCount); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene summary", "hygiene サマリの出力に失敗しました"), err)
 	}
 	for _, suggestion := range result.Suggestions {
@@ -217,6 +228,12 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		}
 		if suggestion.SanitizedFact != "" {
 			extra += fmt.Sprintf(" sanitized=%q", truncateMessage(suggestion.SanitizedFact))
+		}
+		if suggestion.Status != "" {
+			extra += fmt.Sprintf(" status=%s", suggestion.Status)
+		}
+		if suggestion.Source != "" {
+			extra += fmt.Sprintf(" source=%s", suggestion.Source)
 		}
 		if _, err := fmt.Fprintf(output, "%s\t%s\t%s\t%s%s\t%s\n",
 			suggestion.MemoryID.String(),
@@ -233,18 +250,21 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 }
 
 type memoryHygieneOutputEntry struct {
-	MemoryID            string  `json:"memory_id"`
-	Kind                string  `json:"kind"`
-	Reason              string  `json:"reason"`
-	Fact                string  `json:"fact"`
-	SanitizedFact       string  `json:"sanitized_fact,omitempty"`
-	DuplicateMemoryID   string  `json:"duplicate_memory_id,omitempty"`
-	ReplacementMemoryID string  `json:"replacement_memory_id,omitempty"`
-	ReplacementFact     string  `json:"replacement_fact,omitempty"`
-	Similarity          float64 `json:"similarity,omitempty"`
-	ScopeKind           string  `json:"scope_kind,omitempty"`
-	ScopeValue          string  `json:"scope_value,omitempty"`
-	UpdatedAt           string  `json:"updated_at"`
+	MemoryID            string   `json:"memory_id"`
+	Kind                string   `json:"kind"`
+	Reason              string   `json:"reason"`
+	Fact                string   `json:"fact"`
+	SanitizedFact       string   `json:"sanitized_fact,omitempty"`
+	DuplicateMemoryID   string   `json:"duplicate_memory_id,omitempty"`
+	ReplacementMemoryID string   `json:"replacement_memory_id,omitempty"`
+	ReplacementFact     string   `json:"replacement_fact,omitempty"`
+	Similarity          float64  `json:"similarity,omitempty"`
+	ScopeKind           string   `json:"scope_kind,omitempty"`
+	ScopeValue          string   `json:"scope_value,omitempty"`
+	UpdatedAt           string   `json:"updated_at"`
+	Status              string   `json:"status,omitempty"`
+	Source              string   `json:"source,omitempty"`
+	QualityReasons      []string `json:"quality_reasons,omitempty"`
 }
 
 func newMemoryHygieneOutputEntry(suggestion apptypes.MemoryHygieneSuggestion) memoryHygieneOutputEntry {
@@ -267,6 +287,15 @@ func newMemoryHygieneOutputEntry(suggestion apptypes.MemoryHygieneSuggestion) me
 	if suggestion.Scope != nil {
 		entry.ScopeKind = suggestion.Scope.Kind().String()
 		entry.ScopeValue = suggestion.Scope.Key()
+	}
+	if suggestion.Status != "" {
+		entry.Status = suggestion.Status.String()
+	}
+	if suggestion.Source != "" {
+		entry.Source = suggestion.Source.String()
+	}
+	if len(suggestion.QualityReasons) > 0 {
+		entry.QualityReasons = append(entry.QualityReasons, suggestion.QualityReasons...)
 	}
 	return entry
 }

--- a/presentation/cli/memory_hygiene_test.go
+++ b/presentation/cli/memory_hygiene_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON pins the
+// low_quality_candidate JSON shape so consumers can rely on the new
+// fields (#864). The fixture mirrors the wire output an MCP host would
+// see, and the assertions check both the count and the per-suggestion
+// fields.
+func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	updatedAt := time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+
+	suggestion := apptypes.MemoryHygieneSuggestion{
+		MemoryID:       domtypes.MemoryID("mem-noise"),
+		Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+		Reason:         "low-quality extraction: diff_fragment",
+		Fact:           "+def _required_env(name):",
+		Scope:          scope,
+		UpdatedAt:      updatedAt,
+		Status:         domtypes.MemoryStatusCandidate,
+		Source:         domtypes.MemorySourceExtracted,
+		QualityReasons: []string{"diff_fragment"},
+	}
+	result := apptypes.MemoryHygieneScanResult{
+		Suggestions:              []apptypes.MemoryHygieneSuggestion{suggestion},
+		LowQualityCandidateCount: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := writeMemoryHygieneScanResult(&buf, result, true); err != nil {
+		t.Fatalf("writeMemoryHygieneScanResult: %v", err)
+	}
+
+	var payload struct {
+		LowQualityCandidateCount int `json:"low_quality_candidate_count"`
+		Suggestions              []struct {
+			MemoryID       string   `json:"memory_id"`
+			Kind           string   `json:"kind"`
+			Reason         string   `json:"reason"`
+			Fact           string   `json:"fact"`
+			Status         string   `json:"status"`
+			Source         string   `json:"source"`
+			QualityReasons []string `json:"quality_reasons"`
+		} `json:"suggestions"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v\noutput=%s", err, buf.String())
+	}
+	if payload.LowQualityCandidateCount != 1 {
+		t.Fatalf("low_quality_candidate_count = %d, want 1", payload.LowQualityCandidateCount)
+	}
+	if len(payload.Suggestions) != 1 {
+		t.Fatalf("suggestions = %d, want 1", len(payload.Suggestions))
+	}
+	got := payload.Suggestions[0]
+	if got.Kind != "low_quality_candidate" {
+		t.Fatalf("kind = %q, want low_quality_candidate", got.Kind)
+	}
+	if got.Status != "candidate" {
+		t.Fatalf("status = %q, want candidate", got.Status)
+	}
+	if got.Source != "extracted" {
+		t.Fatalf("source = %q, want extracted", got.Source)
+	}
+	if len(got.QualityReasons) != 1 || got.QualityReasons[0] != "diff_fragment" {
+		t.Fatalf("quality_reasons = %v, want [diff_fragment]", got.QualityReasons)
+	}
+	if got.Reason == "" {
+		t.Fatalf("reason must not be empty")
+	}
+	if got.Fact != "+def _required_env(name):" {
+		t.Fatalf("fact = %q, want diff fragment", got.Fact)
+	}
+}
+
+func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+
+	suggestion := apptypes.MemoryHygieneSuggestion{
+		MemoryID:       domtypes.MemoryID("mem-noise"),
+		Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+		Reason:         "low-quality extraction: standalone_command",
+		Fact:           "git pull --ff-only origin main",
+		Scope:          scope,
+		UpdatedAt:      time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC),
+		Status:         domtypes.MemoryStatusCandidate,
+		Source:         domtypes.MemorySourceExtracted,
+		QualityReasons: []string{"standalone_command"},
+	}
+	result := apptypes.MemoryHygieneScanResult{
+		Suggestions:              []apptypes.MemoryHygieneSuggestion{suggestion},
+		LowQualityCandidateCount: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := writeMemoryHygieneScanResult(&buf, result, false); err != nil {
+		t.Fatalf("writeMemoryHygieneScanResult: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"low_quality_candidate",
+		"mem-noise",
+		"status=candidate",
+		"source=extracted",
+		"git pull --ff-only origin main",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q\noutput=%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "低品質") && !strings.Contains(out, "low_quality_candidates=1") {
+		t.Fatalf("summary line missing low-quality counter: %s", out)
+	}
+}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -189,12 +189,17 @@ type memoryHygieneApplyFailureOutput struct {
 }
 
 // memoryHygieneScanOutput is the JSON shape of a memory hygiene scan result.
+// low_quality_candidate_count keeps the number of candidate-side
+// suggestions discoverable without walking Suggestions on the consumer
+// side, mirroring the other counters. The field is documented in the
+// hygiene scan tests so MCP/JSON consumers can rely on the new shape.
 type memoryHygieneScanOutput struct {
 	RedactionHitCount             int                        `json:"redaction_hit_count"`
 	ExpiryCandidateCount          int                        `json:"expiry_candidate_count"`
 	DuplicateCount                int                        `json:"duplicate_count"`
 	SupersedeCandidateCount       int                        `json:"supersede_candidate_count"`
 	ValidityOverlapSupersedeCount int                        `json:"validity_overlap_supersede_count"`
+	LowQualityCandidateCount      int                        `json:"low_quality_candidate_count"`
 	Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
 }
 

--- a/presentation/cli/testdata/memory/hygiene-scan.golden.json
+++ b/presentation/cli/testdata/memory/hygiene-scan.golden.json
@@ -4,6 +4,7 @@
   "duplicate_count": 0,
   "supersede_candidate_count": 1,
   "validity_overlap_supersede_count": 0,
+  "low_quality_candidate_count": 0,
   "suggestions": [
     {
       "memory_id": "memory-golden-accepted",

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -283,11 +283,13 @@ type rejectMemoriesBatchInput struct {
 
 // scanMemoryHygieneInput is the MCP input for the scan_memory_hygiene
 // tool. The tool is read-only; agents use it to inspect redaction /
-// expiry / duplicate suggestions before deciding whether to drive
-// supersede / expire / reject via the single-memory tools.
+// expiry / duplicate / supersede / low-quality candidate suggestions
+// before deciding whether to drive supersede / expire / reject via the
+// single-memory tools or the candidate apply path.
 type scanMemoryHygieneInput struct {
-	Workspace  string `json:"workspace,omitempty" jsonschema:"workspace scope to scan (omitted scans every scope)"`
-	ExpiryDays int    `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
+	Workspace     string `json:"workspace,omitempty" jsonschema:"workspace scope to scan (omitted scans every scope)"`
+	ExpiryDays    int    `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
+	IncludeHidden bool   `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates in the low-quality candidate pass (default omits them)"`
 }
 
 // exportMemoriesInput is the MCP input for the export_memories tool that

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -41,18 +41,18 @@ type eventsOutput struct {
 
 // eventOutput is an individual event in an eventsOutput list.
 type eventOutput struct {
-	EventID        string                    `json:"event_id" jsonschema:"event ID"`
-	Kind           string                    `json:"kind" jsonschema:"event kind"`
-	Client         string                    `json:"client" jsonschema:"recording channel"`
-	Agent          string                    `json:"agent" jsonschema:"actor"`
-	SessionID      string                    `json:"session_id" jsonschema:"session identifier"`
-	Workspace      string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body           string                    `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form. May be truncated to body_limit characters; check body_truncated and body_length"`
-	BodyBlocks     []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; populated for list_events only — search and get_context omit it so thinking-block text does not leak through those surfaces; also absent for legacy plain-text bodies, non-envelope JSON bodies, empty envelopes, and rows whose body is truncated"`
-	BodyTruncated  bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to retrieve the full content"`
-	BodyLength     int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
-	SourceHook     string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
-	CreatedAt      string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID       string                    `json:"event_id" jsonschema:"event ID"`
+	Kind          string                    `json:"kind" jsonschema:"event kind"`
+	Client        string                    `json:"client" jsonschema:"recording channel"`
+	Agent         string                    `json:"agent" jsonschema:"actor"`
+	SessionID     string                    `json:"session_id" jsonschema:"session identifier"`
+	Workspace     string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body          string                    `json:"body" jsonschema:"event body as a plain-text projection; for transcript JSON envelopes this joins the text blocks and excludes thinking blocks — use body_blocks for the canonical structured form. May be truncated to body_limit characters; check body_truncated and body_length"`
+	BodyBlocks    []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; populated for list_events only — search and get_context omit it so thinking-block text does not leak through those surfaces; also absent for legacy plain-text bodies, non-envelope JSON bodies, empty envelopes, and rows whose body is truncated"`
+	BodyTruncated bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to retrieve the full content"`
+	BodyLength    int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
+	SourceHook    string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt     string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.
@@ -201,28 +201,33 @@ type importMemoryInstructionsOutput struct {
 }
 
 // memoryHygieneOutput mirrors the CLI `memory hygiene scan` shape so
-// agent hosts receive the same five-suggestion view an operator sees
-// on stdout.
+// agent hosts receive the same six-suggestion view an operator sees on
+// stdout. low_quality_candidate_count is the v0.12 candidate-noise
+// counter (#864) and is documented in tests as part of the JSON shape.
 type memoryHygieneOutput struct {
 	RedactionHitCount             int                             `json:"redaction_hit_count" jsonschema:"number of accepted memories flagged by the current redaction rules"`
 	ExpiryCandidateCount          int                             `json:"expiry_candidate_count" jsonschema:"number of accepted memories older than the staleness threshold"`
 	DuplicateCount                int                             `json:"duplicate_count" jsonschema:"number of accepted memories that share scope + fact with another row"`
 	SupersedeCandidateCount       int                             `json:"supersede_candidate_count" jsonschema:"number of accepted memories paired by word-Jaccard similarity"`
 	ValidityOverlapSupersedeCount int                             `json:"validity_overlap_supersede_count" jsonschema:"number of accepted memories paired by (scope, type) with overlapping validity windows"`
+	LowQualityCandidateCount      int                             `json:"low_quality_candidate_count" jsonschema:"number of candidate memories flagged by the deterministic low-quality classifier"`
 	Suggestions                   []memoryHygieneSuggestionOutput `json:"suggestions" jsonschema:"per-memory hygiene suggestions"`
 }
 
 type memoryHygieneSuggestionOutput struct {
-	MemoryID            string  `json:"memory_id" jsonschema:"memory identifier"`
-	Kind                string  `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate / validity_overlap_supersede)"`
-	Reason              string  `json:"reason" jsonschema:"human-readable reason the scanner flagged this memory"`
-	Fact                string  `json:"fact" jsonschema:"stored fact at scan time"`
-	SanitizedFact       string  `json:"sanitized_fact,omitempty" jsonschema:"masked fact the apply path would write via supersede"`
-	DuplicateMemoryID   string  `json:"duplicate_memory_id,omitempty" jsonschema:"paired duplicate when kind=duplicate"`
-	ReplacementMemoryID string  `json:"replacement_memory_id,omitempty" jsonschema:"newer memory whose fact is suggested as the supersede replacement"`
-	ReplacementFact     string  `json:"replacement_fact,omitempty" jsonschema:"fact the apply path would write via supersede"`
-	Similarity          float64 `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate / validity_overlap_supersede only)"`
-	ScopeKind           string  `json:"scope_kind,omitempty" jsonschema:"scope kind"`
-	ScopeValue          string  `json:"scope_value,omitempty" jsonschema:"scope value"`
-	UpdatedAt           string  `json:"updated_at" jsonschema:"last update timestamp (RFC3339)"`
+	MemoryID            string   `json:"memory_id" jsonschema:"memory identifier"`
+	Kind                string   `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate / validity_overlap_supersede / low_quality_candidate)"`
+	Reason              string   `json:"reason" jsonschema:"human-readable reason the scanner flagged this memory"`
+	Fact                string   `json:"fact" jsonschema:"stored fact at scan time"`
+	SanitizedFact       string   `json:"sanitized_fact,omitempty" jsonschema:"masked fact the apply path would write via supersede"`
+	DuplicateMemoryID   string   `json:"duplicate_memory_id,omitempty" jsonschema:"paired duplicate when kind=duplicate"`
+	ReplacementMemoryID string   `json:"replacement_memory_id,omitempty" jsonschema:"newer memory whose fact is suggested as the supersede replacement"`
+	ReplacementFact     string   `json:"replacement_fact,omitempty" jsonschema:"fact the apply path would write via supersede"`
+	Similarity          float64  `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate / validity_overlap_supersede only)"`
+	ScopeKind           string   `json:"scope_kind,omitempty" jsonschema:"scope kind"`
+	ScopeValue          string   `json:"scope_value,omitempty" jsonschema:"scope value"`
+	UpdatedAt           string   `json:"updated_at" jsonschema:"last update timestamp (RFC3339)"`
+	Status              string   `json:"status,omitempty" jsonschema:"memory lifecycle status (only populated for candidate-side suggestions)"`
+	Source              string   `json:"source,omitempty" jsonschema:"memory source (only populated for candidate-side suggestions)"`
+	QualityReasons      []string `json:"quality_reasons,omitempty" jsonschema:"deterministic noise markers from the extraction-quality classifier (low_quality_candidate only)"`
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -281,7 +281,7 @@ func (s *Server) queryMemory() mcp.ToolHandlerFor[queryMemoryInput, any] {
 			_, out, err := s.memoryPack()(ctx, req, memoryPackInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, AsOf: input.AsOf})
 			return nil, out, err
 		case "scan_hygiene":
-			_, out, err := s.scanMemoryHygiene()(ctx, req, scanMemoryHygieneInput{Workspace: input.Workspace, ExpiryDays: input.ExpiryDays})
+			_, out, err := s.scanMemoryHygiene()(ctx, req, scanMemoryHygieneInput{Workspace: input.Workspace, ExpiryDays: input.ExpiryDays, IncludeHidden: input.IncludeHidden})
 			return nil, out, err
 		default:
 			return nil, nil, xerrors.Errorf("query_memory action must be one of retrieve, export, pack, scan_hygiene")
@@ -932,7 +932,7 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 		if s.memory == nil {
 			return nil, memoryHygieneOutput{}, xerrors.Errorf("memory usecase is not configured")
 		}
-		criteria := apptypes.MemoryHygieneScanCriteria{}
+		criteria := apptypes.MemoryHygieneScanCriteria{IncludeHiddenCandidates: input.IncludeHidden}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
 			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
@@ -953,6 +953,7 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			DuplicateCount:                result.DuplicateCount,
 			SupersedeCandidateCount:       result.SupersedeCandidateCount,
 			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
+			LowQualityCandidateCount:      result.LowQualityCandidateCount,
 			Suggestions:                   make([]memoryHygieneSuggestionOutput, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
@@ -975,6 +976,15 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			if suggestion.Scope != nil {
 				entry.ScopeKind = suggestion.Scope.Kind().String()
 				entry.ScopeValue = suggestion.Scope.Key()
+			}
+			if suggestion.Status != "" {
+				entry.Status = suggestion.Status.String()
+			}
+			if suggestion.Source != "" {
+				entry.Source = suggestion.Source.String()
+			}
+			if len(suggestion.QualityReasons) > 0 {
+				entry.QualityReasons = append(entry.QualityReasons, suggestion.QualityReasons...)
 			}
 			out.Suggestions = append(out.Suggestions, entry)
 		}


### PR DESCRIPTION
## Motivation

Closes #864.

This is a stacked PR on top of #870 / #857 because the low-quality candidate hygiene pass reuses the deterministic classifier introduced there. It should be retargeted to `main` after #870 merges.

Dogfooding showed that existing noisy extracted candidates need a review/apply cleanup path, not just future extraction-time hiding.

## Changes

- Add `low_quality_candidate` hygiene suggestions for `status=candidate` extracted memories whose facts match the #857 low-quality classifier.
- Keep default scans focused on visible `source=extracted` candidates; `--include-hidden` / `include_hidden` opts into `extracted-hidden` backlog cleanup.
- Add apply support that rejects selected low-quality candidates while leaving accepted memories untouched.
- Expose candidate `status`, `source`, and `quality_reasons` in CLI and MCP hygiene scan output.
- Add CLI text/JSON tests and usecase regression coverage for diff fragments, standalone commands, review conclusions, hidden opt-in, and accepted-memory safety.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...` — 1370 passed in 19 packages
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...` — success
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache rtk go tool golangci-lint run` — no issues found (`rtk` returned code 7 despite the underlying lint output reporting no issues)

## Gemini scout

`Gemini scout: ✅ no blockers`

## Notes

- This PR intentionally does not change extraction scoring; #857 owns extraction-time classification.
- No MCP apply path was added. MCP agents can inspect `query_memory(action="scan_hygiene")` and reject selected candidates through existing memory lifecycle writes.