### PR TITLE
feat(memory): promote remember-intent candidates

### DIFF
--- a/application/types/memory_list_criteria.go
+++ b/application/types/memory_list_criteria.go
@@ -21,14 +21,15 @@ func DefaultActiveMemoryStatuses() []domtypes.MemoryStatus {
 // MemoryListCriteria holds filter parameters for memory listing.
 // Zero-value fields are ignored unless documented otherwise.
 type MemoryListCriteria struct {
-	limit           int
-	offset          int
-	scopes          []domtypes.MemoryScope
-	statuses        []domtypes.MemoryStatus
-	memoryTypes     []domtypes.MemoryType
-	sources         []domtypes.MemorySource
-	asOf            domtypes.Optional[time.Time]
-	includeExpired  bool
+	limit                  int
+	offset                 int
+	scopes                 []domtypes.MemoryScope
+	statuses               []domtypes.MemoryStatus
+	memoryTypes            []domtypes.MemoryType
+	sources                []domtypes.MemorySource
+	asOf                   domtypes.Optional[time.Time]
+	includeExpired         bool
+	rememberIntentPriority bool
 }
 
 // Limit returns the maximum number of results.
@@ -60,6 +61,12 @@ func (c MemoryListCriteria) AsOf() domtypes.Optional[time.Time] { return c.asOf 
 // the past as well. Defaults to false so the common case
 // ("give me memories that are still valid right now") is the default.
 func (c MemoryListCriteria) IncludeExpiredByValidity() bool { return c.includeExpired }
+
+// RememberIntentPriority reports whether remember-intent rows should be
+// returned ahead of other rows in the result set. The flag is honoured at the
+// query layer so pagination (--limit/--offset) is consistent with the
+// displayed order. Used by the inbox view; default is false.
+func (c MemoryListCriteria) RememberIntentPriority() bool { return c.rememberIntentPriority }
 
 // MemoryListCriteriaBuilder builds a MemoryListCriteria value.
 type MemoryListCriteriaBuilder struct {
@@ -146,6 +153,15 @@ func (b *MemoryListCriteriaBuilder) AsOf(asOf time.Time) *MemoryListCriteriaBuil
 // the past are included in results. Default is false.
 func (b *MemoryListCriteriaBuilder) IncludeExpiredByValidity(include bool) *MemoryListCriteriaBuilder {
 	b.criteria.includeExpired = include
+	return b
+}
+
+// RememberIntentPriority toggles whether remember-intent rows should be
+// returned ahead of other rows in the result set. The flag is honoured at the
+// query layer so pagination is consistent with the displayed order. Default
+// is false.
+func (b *MemoryListCriteriaBuilder) RememberIntentPriority(priority bool) *MemoryListCriteriaBuilder {
+	b.criteria.rememberIntentPriority = priority
 	return b
 }
 

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -699,7 +699,11 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 		return nil, err
 	}
 
-	rememberSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), signals)
+	rememberContextSignals, err := u.collectRememberIntentContextSignals(ctx, session, eventLimit)
+	if err != nil {
+		return nil, err
+	}
+	rememberSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), rememberContextSignals)
 	if err != nil {
 		return nil, err
 	}
@@ -900,6 +904,43 @@ func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, 
 		return nil, err
 	}
 
+	return signals, nil
+}
+
+func (u *memoryExtractionUsecase) collectRememberIntentContextSignals(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]extractionSignal, error) {
+	if eventLimit == 0 {
+		return nil, nil
+	}
+	events, err := u.eventQuery.ListRecent(
+		ctx,
+		eventLimit,
+		0,
+		domtypes.EventKind(""),
+		domtypes.Client(""),
+		domtypes.Agent(""),
+		session.SessionID(),
+		domtypes.Workspace(""),
+		false,
+		time.Time{},
+		time.Time{},
+		"",
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list recent events for remember-intent context: %w", err)
+	}
+	signals := make([]extractionSignal, 0, len(events))
+	for _, event := range events {
+		if event.Kind() != domtypes.EventKindPrompt && event.Kind() != domtypes.EventKindTranscript {
+			continue
+		}
+		signals = append(signals, extractionSignal{
+			text:       apptypes.ExtractPlainBody(event.Body()),
+			event:      event,
+			client:     event.Client(),
+			kind:       event.Kind(),
+			sourceHook: event.SourceHook(),
+		})
+	}
 	return signals, nil
 }
 
@@ -1246,7 +1287,7 @@ func cleanRememberIntentFactRemainder(value string) string {
 	// text follows the trigger. Drop them here as a second line of defense
 	// behind the imperative gate.
 	switch strings.ToLower(trimmed) {
-	case "", "please", "pls", "this", "that", "it", "ね", "ください", "お願いします",
+	case "", "please", "pls", "do", "kindly", "this", "that", "it", "ね", "ください", "お願いします",
 		"don't", "dont", "don´t", "do not", "donot",
 		"never", "no", "not",
 		"won't", "wont", "can't", "cant", "couldn't", "couldnt",

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -269,7 +269,11 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	bestCandidateByKey := make(map[string]int)
 	seenKeys := make(map[string]struct{})
 	orderedKeys := make([]string, 0)
-	rememberContextSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), signals)
+	rememberContextSignals, err := u.collectRememberIntentContextSignals(ctx, session, criteria.EventLimit())
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, err
+	}
+	rememberContextSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), rememberContextSignals)
 	if err != nil {
 		return apptypes.MemoryExtractionDebugReport{}, err
 	}

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -268,6 +268,41 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 	bestCandidateByKey := make(map[string]int)
 	seenKeys := make(map[string]struct{})
 	orderedKeys := make([]string, 0)
+	rememberContextSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), signals)
+	if err != nil {
+		return apptypes.MemoryExtractionDebugReport{}, err
+	}
+	for _, spec := range rememberContextSpecs {
+		decision := apptypes.MemoryExtractionSegmentDecision{
+			Text:              spec.fact,
+			EventKind:         domtypes.EventKindPrompt,
+			MemoryType:        spec.memoryType,
+			Features:          spec.intent.featureNames(),
+			Score:             spec.signalScore,
+			EvidenceRefs:      slices.Clone(spec.evidenceRefs),
+			ArtifactRefs:      slices.Clone(spec.artifactRefs),
+			LowQualityReasons: slices.Clone(spec.lowQualityReasons),
+		}
+		segmentIndex := len(report.Segments)
+		report.Segments = append(report.Segments, decision)
+		key := memoryCandidateKey(scope, spec.memoryType, sanitizeCandidateFact(spec.fact, extraRedactors))
+		if _, exists := seenKeys[key]; !exists {
+			seenKeys[key] = struct{}{}
+			orderedKeys = append(orderedKeys, key)
+		}
+		candidateIndex := len(candidates)
+		candidates = append(candidates, candidateDecision{
+			segmentIndex:      segmentIndex,
+			key:               key,
+			score:             spec.signalScore,
+			explicitRemember:  spec.intent.explicitRemember,
+			lowQualityReasons: slices.Clone(spec.lowQualityReasons),
+		})
+		bestIndex, exists := bestCandidateByKey[key]
+		if !exists || candidates[bestIndex].score < spec.signalScore {
+			bestCandidateByKey[key] = candidateIndex
+		}
+	}
 	for _, signal := range signals {
 		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
 		if err != nil {
@@ -280,6 +315,12 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 				EventKind:    signal.kind,
 				SourceHook:   signal.sourceHook,
 				EvidenceRefs: slices.Clone(evidenceRefs),
+			}
+			if isShortRememberIntentSegment(segment) {
+				decision.Decision = "ignored"
+				decision.Reason = "remember_intent_context_only"
+				report.Segments = append(report.Segments, decision)
+				continue
 			}
 			spec, ok, err := extractBestMemoryCandidateFromSegment(signal, segment, evidenceRefs)
 			if err != nil {
@@ -982,9 +1023,8 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 	if normalized == "" {
 		return "", false
 	}
-	lower := strings.ToLower(normalized)
 	for _, trigger := range rememberIntentEnglishTriggers {
-		index := strings.Index(lower, trigger)
+		index := indexFoldASCII(normalized, trigger)
 		if index < 0 {
 			continue
 		}
@@ -1006,6 +1046,21 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 		return "", false
 	}
 	return "", false
+}
+
+func indexFoldASCII(value string, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	for index := range value {
+		if index+len(needle) > len(value) {
+			continue
+		}
+		if strings.EqualFold(value[index:index+len(needle)], needle) {
+			return index
+		}
+	}
+	return -1
 }
 
 func rememberIntentFactAroundTrigger(value string, index int, triggerLength int) string {

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -33,6 +33,7 @@ var (
 
 var (
 	rememberIntentEnglishTriggers = []string{
+		"keep this in memory",
 		"keep this in mind",
 		"remember this",
 		"remember that",

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -1126,10 +1126,6 @@ func isImperativeEnglishRememberContext(value string, index int) bool {
 	return false
 }
 
-func indexFoldASCII(value string, needle string) int {
-	return indexFoldASCIIFrom(value, needle, 0)
-}
-
 func indexFoldASCIIFrom(value string, needle string, start int) int {
 	if needle == "" {
 		return start

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -916,35 +916,35 @@ func (u *memoryExtractionUsecase) collectRememberIntentContextSignals(ctx contex
 	if eventLimit == 0 {
 		return nil, nil
 	}
-	events, err := u.eventQuery.ListRecent(
-		ctx,
-		eventLimit,
-		0,
-		domtypes.EventKind(""),
-		domtypes.Client(""),
-		domtypes.Agent(""),
-		session.SessionID(),
-		domtypes.Workspace(""),
-		false,
-		time.Time{},
-		time.Time{},
-		"",
-	)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to list recent events for remember-intent context: %w", err)
-	}
-	signals := make([]extractionSignal, 0, len(events))
-	for _, event := range events {
-		if event.Kind() != domtypes.EventKindPrompt && event.Kind() != domtypes.EventKindTranscript {
-			continue
+	kinds := []domtypes.EventKind{domtypes.EventKindPrompt, domtypes.EventKindTranscript}
+	signals := make([]extractionSignal, 0, len(kinds)*eventLimit)
+	for _, kind := range kinds {
+		events, err := u.eventQuery.ListRecent(
+			ctx,
+			eventLimit,
+			0,
+			kind,
+			domtypes.Client(""),
+			domtypes.Agent(""),
+			session.SessionID(),
+			domtypes.Workspace(""),
+			false,
+			time.Time{},
+			time.Time{},
+			"",
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to list %s events for remember-intent context: %w", kind, err)
 		}
-		signals = append(signals, extractionSignal{
-			text:       apptypes.ExtractPlainBody(event.Body()),
-			event:      event,
-			client:     event.Client(),
-			kind:       event.Kind(),
-			sourceHook: event.SourceHook(),
-		})
+		for _, event := range events {
+			signals = append(signals, extractionSignal{
+				text:       apptypes.ExtractPlainBody(event.Body()),
+				event:      event,
+				client:     event.Client(),
+				kind:       event.Kind(),
+				sourceHook: event.SourceHook(),
+			})
+		}
 	}
 	return signals, nil
 }

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,13 +21,30 @@ import (
 var (
 	explicitMemoryLabelPattern         = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:(?:user\s+)?(preference|decision|constraint|lesson|artifact|feedback|correction))s?\s*[:\-]\s*(.+)$`)
 	explicitJapaneseMemoryLabelPattern = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(好み|設定|要望|決定|判断|制約|教訓|学び|成果物|資料|修正|フィードバック)\s*[:：\-ー]\s*(.+)$`)
-	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory\s+note|remember(?:\s+this)?|keep\s+this\s+in\s+memory)\s*[:\-]\s*(.+)$`)
-	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて|覚えておく|記憶)\s*[:：\-ー]\s*(.+)$`)
+	explicitRememberLabelPattern       = regexp.MustCompile(`(?i)^(?:[-*]\s+|\d+\.\s+)?(?:durable\s+memory|memory\s+note|remember(?:\s+(?:this|that))?|keep\s+this\s+in\s+(?:memory|mind))\s*[:\-]\s*(.+)$`)
+	explicitJapaneseRememberPattern    = regexp.MustCompile(`^(?:[-*]\s+|\d+\.\s+)?(?:覚えておいて(?:ください)?|おぼえておいて(?:ください)?|覚えておく|覚えてください|記憶しておいて(?:ください)?|記憶して(?:ください)?|記憶)\s*[:：\-ー]\s*(.+)$`)
 	urlRefPattern                      = regexp.MustCompile(`https?://[^\s)]+`)
 	issueRefPattern                    = regexp.MustCompile(`(?i)\bissues?\s*#(\d+)\b`)
 	prRefPattern                       = regexp.MustCompile(`(?i)\b(?:pr|pull request)\s*#(\d+)\b`)
 	bareFileRefPattern                 = regexp.MustCompile(`(?i)\b[A-Za-z0-9_.-]+\.(?:[A-Za-z0-9_-]+\.)*(?:go|md|json|sh|sql|yaml|yml|toml|ts|tsx|js|jsx|py|rb|ini|cfg|conf|proto|tpl)\b`)
 	pathLikeRefPattern                 = regexp.MustCompile(`(?:\./|\.\./|/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9_-]+)*`)
+)
+
+var (
+	rememberIntentEnglishTriggers = []string{
+		"keep this in mind",
+		"remember this",
+		"remember that",
+	}
+	rememberIntentJapaneseTriggers = []string{
+		"記憶しておいてください",
+		"おぼえておいてください",
+		"覚えておいてください",
+		"記憶しておいて",
+		"おぼえておいて",
+		"覚えてください",
+		"覚えておいて",
+	}
 )
 
 var extensionlessArtifactRootSegments = map[string]struct{}{
@@ -164,12 +182,15 @@ func (u *memoryExtractionUsecase) Extract(ctx context.Context, criteria apptypes
 		// declarations, PR/Round chatter) are also routed to
 		// extracted-hidden. The explicit-remember intent is exempt so
 		// user-driven `remember this:` prompts always remain visible.
-		source := domtypes.MemorySourceExtracted
-		if spec.signalScore < extractionVisibleScoreThreshold {
-			source = domtypes.MemorySourceExtractedHidden
-		}
-		if len(spec.lowQualityReasons) > 0 && !spec.intent.explicitRemember {
-			source = domtypes.MemorySourceExtractedHidden
+		source := spec.source
+		if source == "" {
+			source = domtypes.MemorySourceExtracted
+			if spec.signalScore < extractionVisibleScoreThreshold {
+				source = domtypes.MemorySourceExtractedHidden
+			}
+			if len(spec.lowQualityReasons) > 0 && !spec.intent.explicitRemember {
+				source = domtypes.MemorySourceExtractedHidden
+			}
 		}
 
 		details, err := u.memory.Propose(
@@ -425,11 +446,16 @@ func classifyMemoryIntent(value string) memoryIntentFeatures {
 	features := memoryIntentFeatures{}
 	if explicitRememberLabelPattern.MatchString(value) || explicitJapaneseRememberPattern.MatchString(value) || containsAny(lower,
 		"remember this",
+		"remember that",
 		"remember to",
 		"keep this in memory",
+		"keep this in mind",
 		"durable memory",
 		"覚えておいて",
+		"おぼえておいて",
+		"覚えてください",
 		"覚えておく",
+		"記憶しておいて",
 		"記憶して",
 	) {
 		features.explicitRemember = true
@@ -492,8 +518,10 @@ func hasDurableSignalMarker(value string) bool {
 		"next time",
 		"remember to",
 		"remember this",
+		"remember that",
 		"durable memory",
 		"keep this in memory",
+		"keep this in mind",
 		"決定",
 		"判断",
 		"制約",
@@ -507,7 +535,10 @@ func hasDurableSignalMarker(value string) bool {
 		"再起動",
 		"確認済み",
 		"覚えておいて",
+		"おぼえておいて",
+		"覚えてください",
 		"覚えておく",
+		"記憶しておいて",
 		"記憶",
 		"今後",
 		"以後",
@@ -629,7 +660,11 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 		return nil, err
 	}
 
-	specs := make([]memoryCandidateSpec, 0, len(signals))
+	rememberSpecs, err := collectRememberIntentContextSpecs(session.SessionID(), signals)
+	if err != nil {
+		return nil, err
+	}
+	genericSpecs := make([]memoryCandidateSpec, 0, len(signals))
 	for _, signal := range signals {
 		evidenceRefs, err := buildSignalEvidenceRefs(session.SessionID(), signal.event)
 		if err != nil {
@@ -639,10 +674,105 @@ func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, ses
 		if err != nil {
 			return nil, err
 		}
-		specs = append(specs, signalSpecs...)
+		for _, spec := range signalSpecs {
+			if spec.source == domtypes.MemorySourceRememberIntent {
+				rememberSpecs = append(rememberSpecs, spec)
+				continue
+			}
+			genericSpecs = append(genericSpecs, spec)
+		}
 	}
 
+	specs := make([]memoryCandidateSpec, 0, len(rememberSpecs)+len(genericSpecs))
+	specs = append(specs, rememberSpecs...)
+	specs = append(specs, genericSpecs...)
 	return specs, nil
+}
+
+func collectRememberIntentContextSpecs(sessionID domtypes.SessionID, signals []extractionSignal) ([]memoryCandidateSpec, error) {
+	timeline := make([]extractionSignal, 0, len(signals))
+	for _, signal := range signals {
+		if signal.event == nil {
+			continue
+		}
+		if signal.kind != domtypes.EventKindPrompt && signal.kind != domtypes.EventKindTranscript {
+			continue
+		}
+		timeline = append(timeline, signal)
+	}
+	sort.SliceStable(timeline, func(i, j int) bool {
+		left := timeline[i].event.CreatedAt()
+		right := timeline[j].event.CreatedAt()
+		if left.Equal(right) {
+			return timeline[i].event.EventID().String() < timeline[j].event.EventID().String()
+		}
+		return left.Before(right)
+	})
+
+	specs := make([]memoryCandidateSpec, 0)
+	for index, signal := range timeline {
+		if signal.kind != domtypes.EventKindPrompt || !isShortRememberIntentSegment(signal.text) {
+			continue
+		}
+		contextSignal, ok := previousRememberIntentContext(timeline[:index])
+		if !ok {
+			continue
+		}
+		fact := rememberIntentContextFact(contextSignal.text)
+		if fact == "" {
+			continue
+		}
+		rememberEvidenceRefs, err := buildSignalEvidenceRefs(sessionID, signal.event)
+		if err != nil {
+			return nil, err
+		}
+		contextEvidenceRefs, err := buildSignalEvidenceRefs(sessionID, contextSignal.event)
+		if err != nil {
+			return nil, err
+		}
+		evidenceRefs := mergeEvidenceRefs(rememberEvidenceRefs, contextEvidenceRefs)
+		spec, ok, err := buildMemoryCandidateSpec(inferMemoryTypeForExplicitIntent(fact), fact, evidenceRefs, false)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		spec.intent.explicitRemember = true
+		spec.source = domtypes.MemorySourceRememberIntent
+		spec.signalScore = memoryExtractionSignalScore(spec)
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func previousRememberIntentContext(signals []extractionSignal) (extractionSignal, bool) {
+	for index := len(signals) - 1; index >= 0; index-- {
+		signal := signals[index]
+		if signal.kind != domtypes.EventKindPrompt && signal.kind != domtypes.EventKindTranscript {
+			continue
+		}
+		if rememberIntentContextFact(signal.text) == "" {
+			continue
+		}
+		return signal, true
+	}
+	return extractionSignal{}, false
+}
+
+func rememberIntentContextFact(text string) string {
+	segments := candidateSegments(text)
+	for index := len(segments) - 1; index >= 0; index-- {
+		segment := segments[index]
+		if isShortRememberIntentSegment(segment) {
+			continue
+		}
+		if fact, ok := rememberIntentFactFromSegment(segment); ok {
+			return boundRememberIntentContext(fact)
+		}
+		return boundRememberIntentContext(segment)
+	}
+	return ""
 }
 
 func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]extractionSignal, error) {
@@ -713,6 +843,7 @@ func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, 
 type memoryCandidateSpec struct {
 	memoryType        domtypes.MemoryType
 	fact              string
+	source            domtypes.MemorySource
 	evidenceRefs      []domtypes.EvidenceRef
 	artifactRefs      []domtypes.ArtifactRef
 	structured        bool
@@ -725,15 +856,28 @@ func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []d
 	segments := candidateSegments(signal.text)
 	specs := make([]memoryCandidateSpec, 0, len(segments))
 	for _, segment := range segments {
+		if isShortRememberIntentSegment(segment) {
+			continue
+		}
 		spec, ok, err := extractBestMemoryCandidateFromSegment(signal, segment, evidenceRefs)
 		if err != nil {
 			return nil, err
 		}
 		if ok {
+			if shouldUseRememberIntentSource(signal, spec) {
+				spec.source = domtypes.MemorySourceRememberIntent
+			}
 			specs = append(specs, spec)
 		}
 	}
 	return specs, nil
+}
+
+func shouldUseRememberIntentSource(signal extractionSignal, spec memoryCandidateSpec) bool {
+	if !spec.intent.explicitRemember {
+		return false
+	}
+	return signal.kind == domtypes.EventKindPrompt || signal.kind == domtypes.EventKindTranscript
 }
 
 func extractBestMemoryCandidateFromSegment(signal extractionSignal, segment string, evidenceRefs []domtypes.EvidenceRef) (memoryCandidateSpec, bool, error) {
@@ -777,7 +921,7 @@ func structuredCandidateSpec(segment string, evidenceRefs []domtypes.EvidenceRef
 		return buildMemoryCandidateSpec(memoryType, normalizeCandidateFact(matches[2]), evidenceRefs, true)
 	}
 
-	fact, ok := stripExplicitRememberLabel(segment)
+	fact, ok := rememberIntentFactFromSegment(segment)
 	if !ok {
 		return memoryCandidateSpec{}, false, nil
 	}
@@ -821,6 +965,112 @@ func stripExplicitRememberLabel(segment string) (string, bool) {
 		return normalizeCandidateFact(matches[1]), true
 	}
 	return "", false
+}
+
+func rememberIntentFactFromSegment(segment string) (string, bool) {
+	if fact, ok := stripExplicitRememberLabel(segment); ok {
+		return fact, true
+	}
+	if fact, ok := extractInlineRememberIntentFact(segment); ok {
+		return fact, true
+	}
+	return "", false
+}
+
+func extractInlineRememberIntentFact(segment string) (string, bool) {
+	normalized := normalizeCandidateFact(segment)
+	if normalized == "" {
+		return "", false
+	}
+	lower := strings.ToLower(normalized)
+	for _, trigger := range rememberIntentEnglishTriggers {
+		index := strings.Index(lower, trigger)
+		if index < 0 {
+			continue
+		}
+		fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
+		if fact != "" {
+			return fact, true
+		}
+		return "", false
+	}
+	for _, trigger := range rememberIntentJapaneseTriggers {
+		index := strings.Index(normalized, trigger)
+		if index < 0 {
+			continue
+		}
+		fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
+		if fact != "" {
+			return fact, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func rememberIntentFactAroundTrigger(value string, index int, triggerLength int) string {
+	before := cleanRememberIntentFactRemainder(value[:index])
+	after := cleanRememberIntentFactRemainder(value[index+triggerLength:])
+	if after != "" {
+		return after
+	}
+	return before
+}
+
+func cleanRememberIntentFactRemainder(value string) string {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.Trim(trimmed, " \t\r\n:：-ー,，.。!！?？;；「」『』()[]{}")
+	lower := strings.ToLower(trimmed)
+	for _, prefix := range []string{"please ", "pls ", "that "} {
+		if strings.HasPrefix(lower, prefix) {
+			trimmed = strings.TrimSpace(trimmed[len(prefix):])
+			lower = strings.ToLower(trimmed)
+		}
+	}
+	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "を"))
+	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "は"))
+	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "ね"))
+	switch strings.ToLower(trimmed) {
+	case "", "please", "pls", "this", "that", "it", "ね", "ください", "お願いします":
+		return ""
+	}
+	return normalizeCandidateFact(trimmed)
+}
+
+func isShortRememberIntentSegment(segment string) bool {
+	normalized := normalizeCandidateFact(segment)
+	if normalized == "" {
+		return false
+	}
+	if fact, ok := rememberIntentFactFromSegment(normalized); ok && fact != "" {
+		return false
+	}
+	lower := strings.ToLower(normalized)
+	for _, trigger := range rememberIntentEnglishTriggers {
+		if strings.Contains(lower, trigger) {
+			return true
+		}
+	}
+	for _, trigger := range rememberIntentJapaneseTriggers {
+		if strings.Contains(normalized, trigger) {
+			return true
+		}
+	}
+	return false
+}
+
+const rememberIntentContextMaxRunes = 500
+
+func boundRememberIntentContext(value string) string {
+	normalized := normalizeCandidateFact(value)
+	if normalized == "" {
+		return ""
+	}
+	runes := []rune(normalized)
+	if len(runes) <= rememberIntentContextMaxRunes {
+		return normalized
+	}
+	return string(runes[:rememberIntentContextMaxRunes])
 }
 
 func inferMemoryTypeForExplicitIntent(fact string) domtypes.MemoryType {
@@ -977,8 +1227,10 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"next time",
 		"remember to",
 		"remember this",
+		"remember that",
 		"durable memory",
 		"keep this in memory",
+		"keep this in mind",
 		"mistake",
 		"教訓",
 		"学び",
@@ -988,7 +1240,10 @@ func inferMemoryTypeFromText(text string) (domtypes.MemoryType, bool) {
 		"解消",
 		"確認済み",
 		"覚えておいて",
+		"おぼえておいて",
+		"覚えてください",
 		"覚えておく",
+		"記憶しておいて",
 		"記憶",
 		"今後",
 		"以後",
@@ -1029,6 +1284,22 @@ func buildSignalEvidenceRefs(sessionID domtypes.SessionID, event *model.Event) (
 		evidenceRefs = append(evidenceRefs, ref)
 	}
 	return evidenceRefs, nil
+}
+
+func mergeEvidenceRefs(groups ...[]domtypes.EvidenceRef) []domtypes.EvidenceRef {
+	refs := make([]domtypes.EvidenceRef, 0)
+	seen := make(map[string]struct{})
+	for _, group := range groups {
+		for _, ref := range group {
+			key := ref.Kind().String() + ":" + ref.Value()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }
 
 func inferArtifactRefs(text string) ([]domtypes.ArtifactRef, error) {

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -1049,24 +1049,28 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 		return "", false
 	}
 	for _, trigger := range rememberIntentEnglishTriggers {
-		index := indexFoldASCII(normalized, trigger)
-		if index < 0 {
-			continue
+		searchStart := 0
+		for searchStart < len(normalized) {
+			index := indexFoldASCIIFrom(normalized, trigger, searchStart)
+			if index < 0 {
+				break
+			}
+			// Only treat the inline trigger as explicit remember-intent when
+			// it is used imperatively (start of a clause, after a sentence
+			// boundary, or after a polite softener). This rejects declarative
+			// phrasing like "I remember that we already fixed this" and
+			// trigger-only negations like "Don't remember this." without
+			// discarding later imperative instructions in the same segment.
+			if !isImperativeEnglishRememberContext(normalized, index) {
+				searchStart = index + len(trigger)
+				continue
+			}
+			fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
+			if fact != "" {
+				return fact, true
+			}
+			searchStart = index + len(trigger)
 		}
-		// Only treat the inline trigger as explicit remember-intent when it
-		// is used imperatively (start of a clause, after a sentence boundary,
-		// or after a polite softener). This rejects declarative phrasing like
-		// "I remember that we already fixed this" and trigger-only negations
-		// like "Don't remember this." which would otherwise produce
-		// remember-intent candidates from non-intent prose.
-		if !isImperativeEnglishRememberContext(normalized, index) {
-			return "", false
-		}
-		fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
-		if fact != "" {
-			return fact, true
-		}
-		return "", false
 	}
 	for _, trigger := range rememberIntentJapaneseTriggers {
 		index := strings.Index(normalized, trigger)
@@ -1123,10 +1127,21 @@ func isImperativeEnglishRememberContext(value string, index int) bool {
 }
 
 func indexFoldASCII(value string, needle string) int {
+	return indexFoldASCIIFrom(value, needle, 0)
+}
+
+func indexFoldASCIIFrom(value string, needle string, start int) int {
 	if needle == "" {
-		return 0
+		return start
 	}
-	for index := range value {
+	if start < 0 {
+		start = 0
+	}
+	if start > len(value) {
+		return -1
+	}
+	for offset := range value[start:] {
+		index := start + offset
 		if index+len(needle) > len(value) {
 			continue
 		}

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -1073,15 +1073,28 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 		}
 	}
 	for _, trigger := range rememberIntentJapaneseTriggers {
-		index := strings.Index(normalized, trigger)
-		if index < 0 {
-			continue
+		searchStart := 0
+		for searchStart < len(normalized) {
+			relativeIndex := strings.Index(normalized[searchStart:], trigger)
+			if relativeIndex < 0 {
+				break
+			}
+			index := searchStart + relativeIndex
+			// Japanese remember phrases can also appear in non-imperative
+			// thanks/declarative clauses ("覚えておいてくれてありがとう").
+			// Require either a clause boundary, whitespace before the fact,
+			// a polite short prompt, or a trigger at the end of a clause before
+			// promoting the surrounding text as explicit remember intent.
+			if !isImperativeJapaneseRememberContext(normalized, index, len(trigger)) {
+				searchStart = index + len(trigger)
+				continue
+			}
+			fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
+			if fact != "" {
+				return fact, true
+			}
+			searchStart = index + len(trigger)
 		}
-		fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
-		if fact != "" {
-			return fact, true
-		}
-		return "", false
 	}
 	return "", false
 }
@@ -1124,6 +1137,67 @@ func isImperativeEnglishRememberContext(value string, index int) bool {
 		return true
 	}
 	return false
+}
+
+const japaneseRememberFactDelimiters = ":：-ー,，.。!！?？;；「」『』()[]{}"
+
+var japaneseRememberNonImperativeContinuations = []string{
+	"くれて",
+	"くれた",
+	"くれる",
+	"くださり",
+	"くださって",
+	"もらって",
+	"もらえる",
+	"いただいて",
+	"いただき",
+	"ありがとう",
+	"ありがとうございます",
+}
+
+func isImperativeJapaneseRememberContext(value string, index int, triggerLength int) bool {
+	suffix := value[index+triggerLength:]
+	if suffix == "" || strings.TrimSpace(suffix) == "" {
+		return true
+	}
+	if startsWithASCIIWhitespace(suffix) {
+		return true
+	}
+	first, _ := utf8.DecodeRuneInString(suffix)
+	if strings.ContainsRune(japaneseRememberFactDelimiters, first) {
+		return true
+	}
+	for _, continuation := range japaneseRememberNonImperativeContinuations {
+		if strings.HasPrefix(suffix, continuation) {
+			return false
+		}
+	}
+	for _, particle := range []string{"ね", "よ"} {
+		if strings.HasPrefix(suffix, particle) {
+			remainder := strings.TrimPrefix(suffix, particle)
+			if remainder == "" || strings.TrimSpace(remainder) == "" {
+				return true
+			}
+			if startsWithASCIIWhitespace(remainder) {
+				return true
+			}
+			next, _ := utf8.DecodeRuneInString(remainder)
+			return strings.ContainsRune(japaneseRememberFactDelimiters, next)
+		}
+	}
+	return false
+}
+
+func startsWithASCIIWhitespace(value string) bool {
+	if value == "" {
+		return false
+	}
+	switch value[0] {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
 }
 
 func indexFoldASCIIFrom(value string, needle string, start int) int {

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -811,7 +811,17 @@ func rememberIntentContextFact(text string) string {
 		if fact, ok := rememberIntentFactFromSegment(segment); ok {
 			return boundRememberIntentContext(fact)
 		}
-		return boundRememberIntentContext(segment)
+		fact := normalizeCandidateFact(segment)
+		if fact == "" {
+			continue
+		}
+		if _, ok := inferMemoryTypeFromText(fact); !ok {
+			continue
+		}
+		if len(classifyExtractionNoise(fact)) > 0 {
+			continue
+		}
+		return boundRememberIntentContext(fact)
 	}
 	return ""
 }

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -486,19 +486,9 @@ type memoryIntentFeatures struct {
 func classifyMemoryIntent(value string) memoryIntentFeatures {
 	lower := strings.ToLower(strings.TrimSpace(value))
 	features := memoryIntentFeatures{}
-	if explicitRememberLabelPattern.MatchString(value) || explicitJapaneseRememberPattern.MatchString(value) || containsAny(lower,
-		"remember this",
-		"remember that",
+	if hasExplicitRememberIntentMarker(value) || containsAny(lower,
 		"remember to",
-		"keep this in memory",
-		"keep this in mind",
 		"durable memory",
-		"覚えておいて",
-		"おぼえておいて",
-		"覚えてください",
-		"覚えておく",
-		"記憶しておいて",
-		"記憶して",
 	) {
 		features.explicitRemember = true
 	}
@@ -545,6 +535,9 @@ func (f memoryIntentFeatures) featureNames() []string {
 
 func hasDurableSignalMarker(value string) bool {
 	lower := strings.ToLower(value)
+	if hasExplicitRememberIntentMarker(value) {
+		return true
+	}
 	return containsAny(lower,
 		"decision:",
 		"constraint:",
@@ -559,11 +552,7 @@ func hasDurableSignalMarker(value string) bool {
 		"always ",
 		"next time",
 		"remember to",
-		"remember this",
-		"remember that",
 		"durable memory",
-		"keep this in memory",
-		"keep this in mind",
 		"決定",
 		"判断",
 		"制約",
@@ -576,12 +565,6 @@ func hasDurableSignalMarker(value string) bool {
 		"次回",
 		"再起動",
 		"確認済み",
-		"覚えておいて",
-		"おぼえておいて",
-		"覚えてください",
-		"覚えておく",
-		"記憶しておいて",
-		"記憶",
 		"今後",
 		"以後",
 		// Japanese preference / request markers — durable signals equivalent
@@ -594,6 +577,20 @@ func hasDurableSignalMarker(value string) bool {
 		"要望",
 		"希望",
 	)
+}
+
+func hasExplicitRememberIntentMarker(value string) bool {
+	normalized := normalizeCandidateFact(value)
+	if normalized == "" {
+		return false
+	}
+	if explicitRememberLabelPattern.MatchString(normalized) || explicitJapaneseRememberPattern.MatchString(normalized) {
+		return true
+	}
+	if fact, ok := extractInlineRememberIntentFact(normalized); ok && fact != "" {
+		return true
+	}
+	return isShortEnglishRememberIntentSegment(normalized) || isShortJapaneseRememberIntentSegment(normalized)
 }
 
 // containsCJK reports whether the rune slice carries at least one
@@ -1267,18 +1264,48 @@ func isShortRememberIntentSegment(segment string) bool {
 	if fact, ok := rememberIntentFactFromSegment(normalized); ok && fact != "" {
 		return false
 	}
-	lower := strings.ToLower(normalized)
+	return isShortEnglishRememberIntentSegment(normalized) || isShortJapaneseRememberIntentSegment(normalized)
+}
+
+func isShortEnglishRememberIntentSegment(normalized string) bool {
 	for _, trigger := range rememberIntentEnglishTriggers {
-		if strings.Contains(lower, trigger) {
-			return true
-		}
-	}
-	for _, trigger := range rememberIntentJapaneseTriggers {
-		if strings.Contains(normalized, trigger) {
-			return true
+		searchStart := 0
+		for searchStart < len(normalized) {
+			index := indexFoldASCIIFrom(normalized, trigger, searchStart)
+			if index < 0 {
+				break
+			}
+			if isImperativeEnglishRememberContext(normalized, index) && rememberIntentTriggerHasNoFact(normalized, index, len(trigger)) {
+				return true
+			}
+			searchStart = index + len(trigger)
 		}
 	}
 	return false
+}
+
+func isShortJapaneseRememberIntentSegment(normalized string) bool {
+	for _, trigger := range rememberIntentJapaneseTriggers {
+		searchStart := 0
+		for searchStart < len(normalized) {
+			relativeIndex := strings.Index(normalized[searchStart:], trigger)
+			if relativeIndex < 0 {
+				break
+			}
+			index := searchStart + relativeIndex
+			if isImperativeJapaneseRememberContext(normalized, index, len(trigger)) && rememberIntentTriggerHasNoFact(normalized, index, len(trigger)) {
+				return true
+			}
+			searchStart = index + len(trigger)
+		}
+	}
+	return false
+}
+
+func rememberIntentTriggerHasNoFact(value string, index int, triggerLength int) bool {
+	before := cleanRememberIntentFactRemainder(value[:index])
+	after := cleanRememberIntentFactRemainder(value[index+triggerLength:])
+	return before == "" && after == ""
 }
 
 const rememberIntentContextMaxRunes = 500

--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/xerrors"
 
@@ -784,19 +785,33 @@ func collectRememberIntentContextSpecs(sessionID domtypes.SessionID, signals []e
 		spec.signalScore = memoryExtractionSignalScore(spec)
 		specs = append(specs, spec)
 	}
+	// Reverse so the newest remember-intent prompt comes first. Extract
+	// applies CandidateLimit by first-seen key, so without this older context
+	// would consume the budget before more recent facts.
+	slices.Reverse(specs)
 	return specs, nil
 }
 
+// rememberIntentContextLookback bounds how far back a short remember-only
+// prompt scans for adjacent factual context. Anything further away than the
+// last few prompt/transcript turns is treated as unrelated stale chatter and
+// will not be used as evidence for the candidate.
+const rememberIntentContextLookback = 3
+
 func previousRememberIntentContext(signals []extractionSignal) (extractionSignal, bool) {
+	examined := 0
 	for index := len(signals) - 1; index >= 0; index-- {
 		signal := signals[index]
 		if signal.kind != domtypes.EventKindPrompt && signal.kind != domtypes.EventKindTranscript {
 			continue
 		}
-		if rememberIntentContextFact(signal.text) == "" {
-			continue
+		examined++
+		if rememberIntentContextFact(signal.text) != "" {
+			return signal, true
 		}
-		return signal, true
+		if examined >= rememberIntentContextLookback {
+			return extractionSignal{}, false
+		}
 	}
 	return extractionSignal{}, false
 }
@@ -1038,6 +1053,15 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 		if index < 0 {
 			continue
 		}
+		// Only treat the inline trigger as explicit remember-intent when it
+		// is used imperatively (start of a clause, after a sentence boundary,
+		// or after a polite softener). This rejects declarative phrasing like
+		// "I remember that we already fixed this" and trigger-only negations
+		// like "Don't remember this." which would otherwise produce
+		// remember-intent candidates from non-intent prose.
+		if !isImperativeEnglishRememberContext(normalized, index) {
+			return "", false
+		}
 		fact := rememberIntentFactAroundTrigger(normalized, index, len(trigger))
 		if fact != "" {
 			return fact, true
@@ -1056,6 +1080,46 @@ func extractInlineRememberIntentFact(segment string) (string, bool) {
 		return "", false
 	}
 	return "", false
+}
+
+// imperativeRememberContextEndings list characters that mark a clause boundary
+// before an English remember-intent trigger. When the immediately-preceding
+// non-whitespace character belongs to this set, the trigger introduces a new
+// imperative clause ("..., remember this." / "Stop. Remember this.").
+const imperativeRememberContextEndings = ".!?;:,、。"
+
+// imperativeRememberSoftenerTokens list polite request markers that may
+// directly precede an imperative trigger ("please remember this:", "kindly
+// remember that", "do remember"). They are the only non-boundary tokens that
+// count as imperative context.
+var imperativeRememberSoftenerTokens = map[string]struct{}{
+	"please": {},
+	"pls":    {},
+	"kindly": {},
+	"do":     {},
+}
+
+func isImperativeEnglishRememberContext(value string, index int) bool {
+	before := strings.TrimRight(value[:index], " \t\r\n")
+	if before == "" {
+		return true
+	}
+	last, _ := utf8.DecodeLastRuneInString(before)
+	if strings.ContainsRune(imperativeRememberContextEndings, last) {
+		return true
+	}
+	lastSpace := strings.LastIndexAny(before, " \t")
+	var lastToken string
+	if lastSpace < 0 {
+		lastToken = strings.ToLower(before)
+	} else {
+		lastToken = strings.ToLower(before[lastSpace+1:])
+	}
+	lastToken = strings.Trim(lastToken, "`'\"()[]{}.,:;!?")
+	if _, ok := imperativeRememberSoftenerTokens[lastToken]; ok {
+		return true
+	}
+	return false
 }
 
 func indexFoldASCII(value string, needle string) int {
@@ -1095,8 +1159,16 @@ func cleanRememberIntentFactRemainder(value string) string {
 	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "を"))
 	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "は"))
 	trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "ね"))
+	// Negation-only remainders ("Don't remember this." → "Don't") would
+	// otherwise be promoted to a remember-intent candidate when no factual
+	// text follows the trigger. Drop them here as a second line of defense
+	// behind the imperative gate.
 	switch strings.ToLower(trimmed) {
-	case "", "please", "pls", "this", "that", "it", "ね", "ください", "お願いします":
+	case "", "please", "pls", "this", "that", "it", "ね", "ください", "お願いします",
+		"don't", "dont", "don´t", "do not", "donot",
+		"never", "no", "not",
+		"won't", "wont", "can't", "cant", "couldn't", "couldnt",
+		"shouldn't", "shouldnt", "wouldn't", "wouldnt":
 		return ""
 	}
 	return normalizeCandidateFact(trimmed)

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1331,6 +1331,51 @@ func TestMemoryUsecase_Extract_TriggerOnlyNegationsRejected(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Extract_SoftenerOnlyRememberTriggersAreContextOnly(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "english do softener",
+			body: "do remember this",
+		},
+		{
+			name: "english kindly softener",
+			body: "kindly remember this",
+		},
+		{
+			name: "english please softener",
+			body: "please remember this",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := apptypes.SessionSummaryOf(domtypes.SessionID("session-softener-remember"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+			promptEvent := mustExtractionEvent(t, "event-softener-remember", domtypes.EventKindPrompt, tc.body)
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+			sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+			eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+			sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+			_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-softener-remember")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			for _, call := range memoryUsecase.proposeCalls {
+				if call.source == domtypes.MemorySourceRememberIntent {
+					t.Fatalf("softener-only prompt %q must not produce remember-intent candidate (got fact %q)", tc.body, call.fact)
+				}
+			}
+		})
+	}
+}
+
 // TestMemoryUsecase_Extract_ShortRememberIntentDoesNotBindStaleContext pins
 // the bounded lookback so a short remember-only prompt does not pull a
 // factual context from many turns earlier when intervening turns are
@@ -1365,6 +1410,41 @@ func TestMemoryUsecase_Extract_ShortRememberIntentDoesNotBindStaleContext(t *tes
 	for _, call := range memoryUsecase.proposeCalls {
 		if call.source == domtypes.MemorySourceRememberIntent {
 			t.Fatalf("stale factual context far behind a short remember prompt must not be linked: got fact %q", call.fact)
+		}
+	}
+}
+
+func TestMemoryUsecase_Extract_ShortRememberIntentUsesUnifiedChronology(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 3, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	olderTranscript := mustExtractionEventAt(t, "event-old-transcript-context", domtypes.EventKindTranscript, "Always run go test before merging.", now)
+	rememberEvent := mustExtractionEventAt(t, "event-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(2*time.Second))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKind(""):           {rememberEvent},
+			domtypes.EventKindPrompt:         {rememberEvent},
+			domtypes.EventKindTranscript:     {olderTranscript},
+			domtypes.EventKindReviewed:       {},
+			domtypes.EventKindNote:           {},
+			domtypes.EventKindCompactSummary: {},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] == 0 {
+		t.Fatalf("ListRecent was not called for the unified event chronology")
+	}
+	for _, call := range memoryUsecase.proposeCalls {
+		if call.source == domtypes.MemorySourceRememberIntent {
+			t.Fatalf("short remember prompt must not bind stale per-kind transcript context: got fact %q", call.fact)
 		}
 	}
 }

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1198,6 +1198,32 @@ func TestMemoryUsecase_Extract_JapaneseDeclarativeRememberPhrasesAreNotRememberI
 	}
 }
 
+func TestMemoryUsecase_Extract_DeclarativeRememberStillUsesHeuristics(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-decl-remember-heuristic"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-decl-remember-heuristic", domtypes.EventKindPrompt, "I remember that we should always run go test before merging.")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-decl-remember-heuristic")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 heuristic candidate", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.source == domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want heuristic extraction rather than remember-intent", call.source)
+	}
+	if call.fact != "I remember that we should always run go test before merging." {
+		t.Fatalf("fact = %q, want original heuristic fact", call.fact)
+	}
+}
+
 func TestMemoryUsecase_Extract_InlineRememberContinuesAfterDeclarativeMatch(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -832,6 +832,21 @@ func mustExtractionEvent(t *testing.T, eventID string, kind domtypes.EventKind, 
 	return event
 }
 
+func mustExtractionEventAt(t *testing.T, eventID string, kind domtypes.EventKind, body string, createdAt time.Time) *model.Event {
+	t.Helper()
+
+	return model.EventOf(
+		domtypes.EventID(eventID),
+		kind,
+		domtypes.Client("cli"),
+		domtypes.Agent("claude"),
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		body,
+		createdAt,
+	)
+}
+
 func mustMemoryDetailsFromSummary(t *testing.T, memoryID string, memoryType domtypes.MemoryType, fact string) apptypes.MemoryDetails {
 	t.Helper()
 
@@ -920,8 +935,112 @@ func TestMemoryUsecase_Extract_JapaneseExplicitMemoryIntent(t *testing.T) {
 	if len(memoryUsecase.proposeCalls) != 1 {
 		t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
 	}
-	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceExtracted {
-		t.Fatalf("source = %q, want extracted", got)
+	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want remember-intent", got)
+	}
+}
+
+func TestMemoryUsecase_Extract_RememberIntentInlineFactsUseRememberSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		body     string
+		wantFact string
+	}{
+		{
+			name:     "english trigger before fact without colon",
+			body:     "remember this Codex review can take a few minutes before comments appear.",
+			wantFact: "Codex review can take a few minutes before comments appear",
+		},
+		{
+			name:     "english trigger after fact",
+			body:     "Codex review can take a few minutes before comments appear, remember this.",
+			wantFact: "Codex review can take a few minutes before comments appear",
+		},
+		{
+			name:     "japanese trigger before fact",
+			body:     "覚えておいて: Codex review は数分かかることがある。",
+			wantFact: "Codex review は数分かかることがある。",
+		},
+		{
+			name:     "japanese trigger after fact",
+			body:     "Codex review は数分かかることがあるので覚えておいて",
+			wantFact: "Codex review は数分かかることがあるので",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-inline"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+			promptEvent := mustExtractionEvent(t, "event-remember-inline", domtypes.EventKindPrompt, tc.body)
+			details := mustMemoryDetailsFromSummary(t, "memory-remember-inline", domtypes.MemoryTypeLesson, tc.wantFact)
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+			sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+			eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+			sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+			_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-inline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			if len(memoryUsecase.proposeCalls) != 1 {
+				t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
+			}
+			call := memoryUsecase.proposeCalls[0]
+			if call.fact != tc.wantFact {
+				t.Fatalf("fact = %q, want %q", call.fact, tc.wantFact)
+			}
+			if call.source != domtypes.MemorySourceRememberIntent {
+				t.Fatalf("source = %q, want remember-intent", call.source)
+			}
+		})
+	}
+}
+
+func TestMemoryUsecase_Extract_ShortRememberIntentUsesAdjacentContextEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-context"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 2, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	contextEvent := mustExtractionEventAt(t, "event-context", domtypes.EventKindPrompt, "Please answer in Japanese for this repository.", now)
+	rememberEvent := mustExtractionEventAt(t, "event-remember-short", domtypes.EventKindPrompt, "覚えておいてね", now.Add(time.Second))
+	details := mustMemoryDetailsFromSummary(t, "memory-remember-context", domtypes.MemoryTypePreference, "Please answer in Japanese for this repository.")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: {rememberEvent, contextEvent},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-context")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(2).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 adjacent-context candidate", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.fact != "Please answer in Japanese for this repository." {
+		t.Fatalf("fact = %q, want adjacent context fact", call.fact)
+	}
+	if call.source != domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want remember-intent", call.source)
+	}
+	gotEvidence := make(map[string]bool)
+	for _, ref := range call.evidenceRefs {
+		if ref.Kind() == domtypes.EvidenceRefKindEvent {
+			gotEvidence[ref.Value()] = true
+		}
+	}
+	for _, eventID := range []string{"event-remember-short", "event-context"} {
+		if !gotEvidence[eventID] {
+			t.Fatalf("evidence refs = %v, want event %s", call.evidenceRefs, eventID)
+		}
 	}
 }
 
@@ -1236,8 +1355,8 @@ func TestMemoryUsecase_Extract_KeepsExplicitRememberVisibleEvenWhenNoisy(t *test
 	if len(memoryUsecase.proposeCalls) != 1 {
 		t.Fatalf("proposeCalls = %d, want 1 visible candidate", len(memoryUsecase.proposeCalls))
 	}
-	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceExtracted {
-		t.Fatalf("source = %q, want extracted (explicit remember overrides noise)", got)
+	if got := memoryUsecase.proposeCalls[0].source; got != domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want remember-intent (explicit remember overrides noise)", got)
 	}
 }
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1153,6 +1153,33 @@ func TestMemoryUsecase_Extract_DeclarativeRememberPhrasesAreNotRememberIntent(t 
 	}
 }
 
+func TestMemoryUsecase_Extract_InlineRememberContinuesAfterDeclarativeMatch(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-decl-then-imperative"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-decl-then-imperative", domtypes.EventKindPrompt, "I remember that this was flaky, remember this: run tests first")
+	details := mustMemoryDetailsFromSummary(t, "memory-decl-then-imperative", domtypes.MemoryTypeLesson, "run tests first")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-decl-then-imperative")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 imperative remember candidate", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.source != domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want remember-intent", call.source)
+	}
+	if call.fact != "run tests first" {
+		t.Fatalf("fact = %q, want later imperative fact", call.fact)
+	}
+}
+
 // TestMemoryUsecase_Extract_TriggerOnlyNegationsRejected ensures that prompts
 // like "Don't remember this." or "do not remember this" never produce durable
 // memory candidates. The inline trigger parser used to treat the leading text

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -954,8 +954,13 @@ func TestMemoryUsecase_Extract_RememberIntentInlineFactsUseRememberSource(t *tes
 			wantFact: "Codex review can take a few minutes before comments appear",
 		},
 		{
+			// Verifies the inline trigger scan stays byte-safe when the
+			// preceding text contains a Unicode character whose lowercase
+			// form expands ("İ" → "i̇"). The imperative gate still requires
+			// a sentence boundary before the trigger, so the regression is
+			// kept inside an imperative context.
 			name:     "english trigger after unicode case-folding expansion",
-			body:     "İ remember this use Japanese responses",
+			body:     "İ. Remember this use Japanese responses",
 			wantFact: "use Japanese responses",
 		},
 		{
@@ -1095,6 +1100,184 @@ func TestMemoryUsecase_Extract_ShortRememberIntentSkipsNonFactualAdjacentAck(t *
 	}
 }
 
+// TestMemoryUsecase_Extract_DeclarativeRememberPhrasesAreNotRememberIntent
+// pins the imperative gate so declarative prose like "I remember that we
+// already fixed this" is no longer promoted as a remember-intent candidate by
+// the inline trigger parser. Each case must end with no Propose call.
+func TestMemoryUsecase_Extract_DeclarativeRememberPhrasesAreNotRememberIntent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "first-person declarative remember that",
+			body: "I remember that we already fixed this",
+		},
+		{
+			name: "first-person past tense remember this",
+			body: "I remember this from the migration last quarter",
+		},
+		{
+			name: "third-person declarative remember",
+			body: "she remember that the build was broken",
+		},
+		{
+			name: "subordinate clause remember that",
+			body: "the docs say I remember that we always run tests",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := apptypes.SessionSummaryOf(domtypes.SessionID("session-decl-remember"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+			promptEvent := mustExtractionEvent(t, "event-decl-remember", domtypes.EventKindPrompt, tc.body)
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+			sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+			eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+			sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+			_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-decl-remember")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			for _, call := range memoryUsecase.proposeCalls {
+				if call.source == domtypes.MemorySourceRememberIntent {
+					t.Fatalf("declarative phrasing %q must not produce remember-intent candidate (got fact %q)", tc.body, call.fact)
+				}
+			}
+		})
+	}
+}
+
+// TestMemoryUsecase_Extract_TriggerOnlyNegationsRejected ensures that prompts
+// like "Don't remember this." or "do not remember this" never produce durable
+// memory candidates. The inline trigger parser used to treat the leading text
+// as the fact when no factual continuation followed the trigger.
+func TestMemoryUsecase_Extract_TriggerOnlyNegationsRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "english don't trigger negation",
+			body: "Don't remember this.",
+		},
+		{
+			name: "english do not trigger negation",
+			body: "do not remember this",
+		},
+		{
+			name: "english never remember trigger",
+			body: "never remember this",
+		},
+		{
+			name: "english trailing don't keep this in mind",
+			body: "Don't keep this in mind.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := apptypes.SessionSummaryOf(domtypes.SessionID("session-neg-remember"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+			promptEvent := mustExtractionEvent(t, "event-neg-remember", domtypes.EventKindPrompt, tc.body)
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+			sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+			eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+			sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+			_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-neg-remember")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			for _, call := range memoryUsecase.proposeCalls {
+				if call.source == domtypes.MemorySourceRememberIntent {
+					t.Fatalf("negation prompt %q must not produce remember-intent candidate (got fact %q)", tc.body, call.fact)
+				}
+			}
+		})
+	}
+}
+
+// TestMemoryUsecase_Extract_ShortRememberIntentDoesNotBindStaleContext pins
+// the bounded lookback so a short remember-only prompt does not pull a
+// factual context from many turns earlier when intervening turns are
+// non-factual chatter. The earliest context event must NOT be promoted.
+func TestMemoryUsecase_Extract_ShortRememberIntentDoesNotBindStaleContext(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-stale"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 6, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	staleFactualEvent := mustExtractionEventAt(t, "event-stale-context", domtypes.EventKindPrompt, "Always run go test before merging.", now)
+	noisePrompts := []*model.Event{
+		mustExtractionEventAt(t, "event-noise-prompt-1", domtypes.EventKindPrompt, "Hmm.", now.Add(time.Second)),
+		mustExtractionEventAt(t, "event-noise-prompt-2", domtypes.EventKindPrompt, "Got it.", now.Add(2*time.Second)),
+		mustExtractionEventAt(t, "event-noise-prompt-3", domtypes.EventKindPrompt, "Right.", now.Add(3*time.Second)),
+	}
+	rememberEvent := mustExtractionEventAt(t, "event-remember-far", domtypes.EventKindPrompt, "覚えておいてね", now.Add(4*time.Second))
+	allPrompts := append([]*model.Event{rememberEvent}, noisePrompts...)
+	allPrompts = append(allPrompts, staleFactualEvent)
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: allPrompts,
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-stale")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(10).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	for _, call := range memoryUsecase.proposeCalls {
+		if call.source == domtypes.MemorySourceRememberIntent {
+			t.Fatalf("stale factual context far behind a short remember prompt must not be linked: got fact %q", call.fact)
+		}
+	}
+}
+
+// TestMemoryUsecase_Extract_RememberIntentContextSpecsPreserveRecency pins
+// that when multiple short remember-only prompts appear, the most recent
+// one's context candidate is preferred when CandidateLimit caps the result.
+func TestMemoryUsecase_Extract_RememberIntentContextSpecsPreserveRecency(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-recency"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 4, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	olderContext := mustExtractionEventAt(t, "event-older-context", domtypes.EventKindPrompt, "Always run go test before merging.", now)
+	olderRemember := mustExtractionEventAt(t, "event-older-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(time.Second))
+	newerContext := mustExtractionEventAt(t, "event-newer-context", domtypes.EventKindPrompt, "Prefer Japanese answers in this repository.", now.Add(2*time.Second))
+	newerRemember := mustExtractionEventAt(t, "event-newer-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(3*time.Second))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: {newerRemember, newerContext, olderRemember, olderContext},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-recency")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(10).CandidateLimit(1).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 (CandidateLimit=1)", len(memoryUsecase.proposeCalls))
+	}
+	got := memoryUsecase.proposeCalls[0]
+	if got.fact != "Prefer Japanese answers in this repository." {
+		t.Fatalf("fact = %q, want newer context fact (recency preserved)", got.fact)
+	}
+}
+
 func TestMemoryUsecase_ExplainExtraction_ReportsShortRememberIntentContextCandidate(t *testing.T) {
 	t.Parallel()
 
@@ -1148,6 +1331,32 @@ func TestMemoryUsecase_ExplainExtraction_ReportsShortRememberIntentContextCandid
 	for _, eventID := range []string{"event-debug-remember-short", "event-debug-context"} {
 		if !gotEvidence[eventID] {
 			t.Fatalf("proposed evidence refs = %v, want event %s", proposed.EvidenceRefs, eventID)
+		}
+	}
+}
+
+// TestMemoryUsecase_ExplainExtraction_DeclarativeRememberPhrasingNotPromoted
+// pins that the debug report agrees with Extract on the imperative gate so an
+// operator diagnosing why a candidate was created sees the same decision.
+// Declarative "I remember that ..." prose must NOT appear as a proposed
+// remember-intent candidate in the debug report.
+func TestMemoryUsecase_ExplainExtraction_DeclarativeRememberPhrasingNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-decl-remember"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-debug-decl-remember", domtypes.EventKindPrompt, "I remember that we already fixed this")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-decl-remember")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	for _, segment := range report.Segments {
+		if segment.Decision == "proposed" && slices.Contains(segment.Features, "explicit_remember") {
+			t.Fatalf("declarative remember phrasing surfaced as proposed remember-intent: %+v", segment)
 		}
 	}
 }

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1423,15 +1423,19 @@ func TestMemoryUsecase_Extract_ShortRememberIntentUsesUnifiedChronology(t *testi
 	t.Parallel()
 
 	now := time.Now()
-	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 3, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 5, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
 	olderTranscript := mustExtractionEventAt(t, "event-old-transcript-context", domtypes.EventKindTranscript, "Always run go test before merging.", now)
-	rememberEvent := mustExtractionEventAt(t, "event-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(2*time.Second))
+	noisePrompts := []*model.Event{
+		mustExtractionEventAt(t, "event-unified-noise-prompt-1", domtypes.EventKindPrompt, "Hmm.", now.Add(time.Second)),
+		mustExtractionEventAt(t, "event-unified-noise-prompt-2", domtypes.EventKindPrompt, "Got it.", now.Add(2*time.Second)),
+		mustExtractionEventAt(t, "event-unified-noise-prompt-3", domtypes.EventKindPrompt, "Right.", now.Add(3*time.Second)),
+	}
+	rememberEvent := mustExtractionEventAt(t, "event-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(4*time.Second))
 	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
 	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
 	eventQuery := &eventQueryServiceStub{
 		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
-			domtypes.EventKind(""):           {rememberEvent},
-			domtypes.EventKindPrompt:         {rememberEvent},
+			domtypes.EventKindPrompt:         append([]*model.Event{rememberEvent}, noisePrompts...),
 			domtypes.EventKindTranscript:     {olderTranscript},
 			domtypes.EventKindReviewed:       {},
 			domtypes.EventKindNote:           {},
@@ -1440,18 +1444,69 @@ func TestMemoryUsecase_Extract_ShortRememberIntentUsesUnifiedChronology(t *testi
 	}
 	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
 
-	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(4).CandidateLimit(10).Build())
 	if err != nil {
 		t.Fatalf("Extract() error = %v", err)
 	}
-	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] == 0 {
-		t.Fatalf("ListRecent was not called for the unified event chronology")
+	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] != 0 {
+		t.Fatalf("ListRecent used an unfiltered remember chronology; want prompt/transcript kind queries")
+	}
+	for _, kind := range []domtypes.EventKind{domtypes.EventKindPrompt, domtypes.EventKindTranscript} {
+		if eventQuery.listRecentCallsByKind[kind] == 0 {
+			t.Fatalf("ListRecent was not called for %s remember chronology", kind)
+		}
+		if got := eventQuery.listRecentLimitByKind[kind]; got != 4 {
+			t.Fatalf("ListRecent limit for %s = %d, want 4", kind, got)
+		}
 	}
 	for _, call := range memoryUsecase.proposeCalls {
 		if call.source == domtypes.MemorySourceRememberIntent {
 			t.Fatalf("short remember prompt must not bind stale per-kind transcript context: got fact %q", call.fact)
 		}
 	}
+}
+
+func TestMemoryUsecase_Extract_ShortRememberIntentIgnoresNonPromptGlobalNoise(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-global-noise"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 4, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	contextEvent := mustExtractionEventAt(t, "event-remember-context", domtypes.EventKindPrompt, "Always run go test before merging.", now)
+	reviewNoise := mustExtractionEventAt(t, "event-remember-review-noise", domtypes.EventKindReviewed, "Reviewed the diff.", now.Add(time.Second))
+	noteNoise := mustExtractionEventAt(t, "event-remember-note-noise", domtypes.EventKindNote, "Working note.", now.Add(2*time.Second))
+	rememberEvent := mustExtractionEventAt(t, "event-remember-short-noise", domtypes.EventKindPrompt, "keep this in memory", now.Add(3*time.Second))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKind(""):           {noteNoise, reviewNoise},
+			domtypes.EventKindPrompt:         {rememberEvent, contextEvent},
+			domtypes.EventKindTranscript:     {},
+			domtypes.EventKindReviewed:       {reviewNoise},
+			domtypes.EventKindNote:           {noteNoise},
+			domtypes.EventKindCompactSummary: {},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-global-noise")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(2).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] != 0 {
+		t.Fatalf("ListRecent used an unfiltered remember chronology that can be exhausted by non-prompt noise")
+	}
+	for _, kind := range []domtypes.EventKind{domtypes.EventKindPrompt, domtypes.EventKindTranscript} {
+		if got := eventQuery.listRecentLimitByKind[kind]; got != 2 {
+			t.Fatalf("ListRecent limit for %s = %d, want 2", kind, got)
+		}
+	}
+	for _, call := range memoryUsecase.proposeCalls {
+		if call.source == domtypes.MemorySourceRememberIntent && call.fact == "Always run go test before merging." {
+			return
+		}
+	}
+	t.Fatalf("proposeCalls = %+v, want remember-intent candidate from adjacent prompt context", memoryUsecase.proposeCalls)
 }
 
 // TestMemoryUsecase_Extract_RememberIntentContextSpecsPreserveRecency pins
@@ -1549,15 +1604,19 @@ func TestMemoryUsecase_ExplainExtraction_UsesUnifiedRememberIntentChronology(t *
 	t.Parallel()
 
 	now := time.Now()
-	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 3, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 5, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
 	olderTranscript := mustExtractionEventAt(t, "event-debug-old-transcript-context", domtypes.EventKindTranscript, "Always run go test before merging.", now)
-	rememberEvent := mustExtractionEventAt(t, "event-debug-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(2*time.Second))
+	noisePrompts := []*model.Event{
+		mustExtractionEventAt(t, "event-debug-unified-noise-prompt-1", domtypes.EventKindPrompt, "Hmm.", now.Add(time.Second)),
+		mustExtractionEventAt(t, "event-debug-unified-noise-prompt-2", domtypes.EventKindPrompt, "Got it.", now.Add(2*time.Second)),
+		mustExtractionEventAt(t, "event-debug-unified-noise-prompt-3", domtypes.EventKindPrompt, "Right.", now.Add(3*time.Second)),
+	}
+	rememberEvent := mustExtractionEventAt(t, "event-debug-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(4*time.Second))
 	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
 	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
 	eventQuery := &eventQueryServiceStub{
 		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
-			domtypes.EventKind(""):           {rememberEvent},
-			domtypes.EventKindPrompt:         {rememberEvent},
+			domtypes.EventKindPrompt:         append([]*model.Event{rememberEvent}, noisePrompts...),
 			domtypes.EventKindTranscript:     {olderTranscript},
 			domtypes.EventKindReviewed:       {},
 			domtypes.EventKindNote:           {},
@@ -1566,12 +1625,20 @@ func TestMemoryUsecase_ExplainExtraction_UsesUnifiedRememberIntentChronology(t *
 	}
 	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
 
-	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(4).CandidateLimit(10).Build())
 	if err != nil {
 		t.Fatalf("ExplainExtraction() error = %v", err)
 	}
-	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] == 0 {
-		t.Fatalf("ListRecent was not called for the unified event chronology")
+	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] != 0 {
+		t.Fatalf("ListRecent used an unfiltered remember chronology; want prompt/transcript kind queries")
+	}
+	for _, kind := range []domtypes.EventKind{domtypes.EventKindPrompt, domtypes.EventKindTranscript} {
+		if eventQuery.listRecentCallsByKind[kind] == 0 {
+			t.Fatalf("ListRecent was not called for %s remember chronology", kind)
+		}
+		if got := eventQuery.listRecentLimitByKind[kind]; got != 4 {
+			t.Fatalf("ListRecent limit for %s = %d, want 4", kind, got)
+		}
 	}
 	for _, segment := range report.Segments {
 		if segment.Decision == "proposed" && slices.Contains(segment.Features, "explicit_remember") {

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1540,6 +1540,41 @@ func TestMemoryUsecase_ExplainExtraction_ReportsShortRememberIntentContextCandid
 	}
 }
 
+func TestMemoryUsecase_ExplainExtraction_UsesUnifiedRememberIntentChronology(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-remember-unified-timeline"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 3, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	olderTranscript := mustExtractionEventAt(t, "event-debug-old-transcript-context", domtypes.EventKindTranscript, "Always run go test before merging.", now)
+	rememberEvent := mustExtractionEventAt(t, "event-debug-latest-remember", domtypes.EventKindPrompt, "覚えておいてね", now.Add(2*time.Second))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKind(""):           {rememberEvent},
+			domtypes.EventKindPrompt:         {rememberEvent},
+			domtypes.EventKindTranscript:     {olderTranscript},
+			domtypes.EventKindReviewed:       {},
+			domtypes.EventKindNote:           {},
+			domtypes.EventKindCompactSummary: {},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-remember-unified-timeline")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if eventQuery.listRecentCallsByKind[domtypes.EventKind("")] == 0 {
+		t.Fatalf("ListRecent was not called for the unified event chronology")
+	}
+	for _, segment := range report.Segments {
+		if segment.Decision == "proposed" && slices.Contains(segment.Features, "explicit_remember") {
+			t.Fatalf("debug report must not bind stale per-kind transcript context as remember-intent: %+v", segment)
+		}
+	}
+}
+
 // TestMemoryUsecase_ExplainExtraction_DeclarativeRememberPhrasingNotPromoted
 // pins that the debug report agrees with Extract on the imperative gate so an
 // operator diagnosing why a candidate was created sees the same decision.

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1049,6 +1049,52 @@ func TestMemoryUsecase_Extract_ShortRememberIntentUsesAdjacentContextEvidence(t 
 	}
 }
 
+func TestMemoryUsecase_Extract_ShortRememberIntentSkipsNonFactualAdjacentAck(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-remember-skip-ack"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 3, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	contextEvent := mustExtractionEventAt(t, "event-factual-context", domtypes.EventKindPrompt, "Always run go test before merging.", now)
+	ackEvent := mustExtractionEventAt(t, "event-ack-context", domtypes.EventKindTranscript, "Sure, got it.", now.Add(time.Second))
+	rememberEvent := mustExtractionEventAt(t, "event-remember-after-ack", domtypes.EventKindPrompt, "覚えておいてね", now.Add(2*time.Second))
+	details := mustMemoryDetailsFromSummary(t, "memory-remember-skip-ack", domtypes.MemoryTypePreference, "Always run go test before merging.")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt:     {rememberEvent, contextEvent},
+			domtypes.EventKindTranscript: {ackEvent},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-remember-skip-ack")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(3).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 adjacent factual context candidate", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.fact != "Always run go test before merging." {
+		t.Fatalf("fact = %q, want factual context rather than acknowledgement", call.fact)
+	}
+	gotEvidence := make(map[string]bool)
+	for _, ref := range call.evidenceRefs {
+		if ref.Kind() == domtypes.EvidenceRefKindEvent {
+			gotEvidence[ref.Value()] = true
+		}
+	}
+	if gotEvidence["event-ack-context"] {
+		t.Fatalf("evidence refs = %v, should not include non-factual acknowledgement", call.evidenceRefs)
+	}
+	for _, eventID := range []string{"event-remember-after-ack", "event-factual-context"} {
+		if !gotEvidence[eventID] {
+			t.Fatalf("evidence refs = %v, want event %s", call.evidenceRefs, eventID)
+		}
+	}
+}
+
 func TestMemoryUsecase_ExplainExtraction_ReportsShortRememberIntentContextCandidate(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -954,6 +954,11 @@ func TestMemoryUsecase_Extract_RememberIntentInlineFactsUseRememberSource(t *tes
 			wantFact: "Codex review can take a few minutes before comments appear",
 		},
 		{
+			name:     "english keep this in memory trigger before fact",
+			body:     "keep this in memory we always run go test before merge",
+			wantFact: "we always run go test before merge",
+		},
+		{
 			// Verifies the inline trigger scan stays byte-safe when the
 			// preceding text contains a Unicode character whose lowercase
 			// form expands ("İ" → "i̇"). The imperative gate still requires

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1153,6 +1153,51 @@ func TestMemoryUsecase_Extract_DeclarativeRememberPhrasesAreNotRememberIntent(t 
 	}
 }
 
+func TestMemoryUsecase_Extract_JapaneseDeclarativeRememberPhrasesAreNotRememberIntent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "thanks for remembering",
+			body: "覚えておいてくれてありがとう",
+		},
+		{
+			name: "polite continuation without fact",
+			body: "覚えておいてくれると助かります",
+		},
+		{
+			name: "thanks for remembering politely",
+			body: "覚えておいてくださってありがとうございます",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := apptypes.SessionSummaryOf(domtypes.SessionID("session-ja-decl-remember"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+			promptEvent := mustExtractionEvent(t, "event-ja-decl-remember", domtypes.EventKindPrompt, tc.body)
+			memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+			sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+			eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+			sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+			_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-ja-decl-remember")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+			for _, call := range memoryUsecase.proposeCalls {
+				if call.source == domtypes.MemorySourceRememberIntent {
+					t.Fatalf("Japanese declarative phrasing %q must not produce remember-intent candidate (got fact %q)", tc.body, call.fact)
+				}
+			}
+		})
+	}
+}
+
 func TestMemoryUsecase_Extract_InlineRememberContinuesAfterDeclarativeMatch(t *testing.T) {
 	t.Parallel()
 
@@ -1177,6 +1222,33 @@ func TestMemoryUsecase_Extract_InlineRememberContinuesAfterDeclarativeMatch(t *t
 	}
 	if call.fact != "run tests first" {
 		t.Fatalf("fact = %q, want later imperative fact", call.fact)
+	}
+}
+
+func TestMemoryUsecase_Extract_JapaneseInlineRememberContinuesAfterDeclarativeMatch(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-ja-decl-then-imperative"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	promptEvent := mustExtractionEvent(t, "event-ja-decl-then-imperative", domtypes.EventKindPrompt, "覚えておいてくれてありがとう。覚えておいて: go test before merge")
+	details := mustMemoryDetailsFromSummary(t, "memory-ja-decl-then-imperative", domtypes.MemoryTypeLesson, "go test before merge")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindPrompt: {promptEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-ja-decl-then-imperative")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1 imperative remember candidate", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.source != domtypes.MemorySourceRememberIntent {
+		t.Fatalf("source = %q, want remember-intent", call.source)
+	}
+	if call.fact != "go test before merge" {
+		t.Fatalf("fact = %q, want later Japanese imperative fact", call.fact)
 	}
 }
 

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -954,6 +954,11 @@ func TestMemoryUsecase_Extract_RememberIntentInlineFactsUseRememberSource(t *tes
 			wantFact: "Codex review can take a few minutes before comments appear",
 		},
 		{
+			name:     "english trigger after unicode case-folding expansion",
+			body:     "İ remember this use Japanese responses",
+			wantFact: "use Japanese responses",
+		},
+		{
 			name:     "english trigger after fact",
 			body:     "Codex review can take a few minutes before comments appear, remember this.",
 			wantFact: "Codex review can take a few minutes before comments appear",
@@ -1040,6 +1045,63 @@ func TestMemoryUsecase_Extract_ShortRememberIntentUsesAdjacentContextEvidence(t 
 	for _, eventID := range []string{"event-remember-short", "event-context"} {
 		if !gotEvidence[eventID] {
 			t.Fatalf("evidence refs = %v, want event %s", call.evidenceRefs, eventID)
+		}
+	}
+}
+
+func TestMemoryUsecase_ExplainExtraction_ReportsShortRememberIntentContextCandidate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-remember-context"), domtypes.Workspace("github.com/duck8823/traceary"), now.Add(-time.Hour), domtypes.None[time.Time](), "ended", 2, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	contextEvent := mustExtractionEventAt(t, "event-debug-context", domtypes.EventKindPrompt, "Please answer in Japanese for this repository.", now)
+	rememberEvent := mustExtractionEventAt(t, "event-debug-remember-short", domtypes.EventKindPrompt, "覚えておいてね", now.Add(time.Second))
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{
+		listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+			domtypes.EventKindPrompt: {rememberEvent, contextEvent},
+		},
+	}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-remember-context")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(2).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+
+	var proposed *apptypes.MemoryExtractionSegmentDecision
+	foundContextOnlyPrompt := false
+	for index := range report.Segments {
+		segment := &report.Segments[index]
+		if segment.Decision == "ignored" && segment.Reason == "remember_intent_context_only" && segment.Text == "覚えておいてね" {
+			foundContextOnlyPrompt = true
+		}
+		if segment.Decision == "proposed" && segment.Text == "Please answer in Japanese for this repository." {
+			proposed = segment
+		}
+	}
+	if !foundContextOnlyPrompt {
+		t.Fatalf("segments = %+v, want short remember prompt marked remember_intent_context_only", report.Segments)
+	}
+	if proposed == nil {
+		t.Fatalf("segments = %+v, want proposed adjacent-context candidate", report.Segments)
+	}
+	if proposed.MemoryType != domtypes.MemoryTypePreference {
+		t.Fatalf("proposed memory type = %q, want preference", proposed.MemoryType)
+	}
+	if !slices.Contains(proposed.Features, "explicit_remember") {
+		t.Fatalf("proposed features = %v, want explicit_remember", proposed.Features)
+	}
+	gotEvidence := make(map[string]bool)
+	for _, ref := range proposed.EvidenceRefs {
+		if ref.Kind() == domtypes.EvidenceRefKindEvent {
+			gotEvidence[ref.Value()] = true
+		}
+	}
+	for _, eventID := range []string{"event-debug-remember-short", "event-debug-context"} {
+		if !gotEvidence[eventID] {
+			t.Fatalf("proposed evidence refs = %v, want event %s", proposed.EvidenceRefs, eventID)
 		}
 	}
 }

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -171,6 +171,13 @@ func (s *eventQueryServiceStub) ListRecent(
 	if result, ok := s.listRecentResultByKind[kind]; ok {
 		return result, nil
 	}
+	if kind == "" && s.listRecentResult == nil && len(s.listRecentResultByKind) > 0 {
+		merged := make([]*model.Event, 0)
+		for _, result := range s.listRecentResultByKind {
+			merged = append(merged, result...)
+		}
+		return merged, nil
+	}
 	return s.listRecentResult, nil
 }
 

--- a/domain/types/memory_source.go
+++ b/domain/types/memory_source.go
@@ -21,6 +21,13 @@ const (
 	// default inbox view so reviewers do not get drowned by low-quality
 	// candidates.
 	MemorySourceExtractedHidden MemorySource = "extracted-hidden"
+	// MemorySourceRememberIntent indicates a candidate produced from an
+	// explicit user remember-intent prompt (e.g. "remember this:", "覚えて
+	// おいて") or from the immediately adjacent context of a short
+	// remember-intent confirmation. The candidate stays reviewable
+	// (status=candidate) and is prioritized above generic extracted
+	// candidates in the default inbox view.
+	MemorySourceRememberIntent MemorySource = "remember-intent"
 	// MemorySourceImported indicates a memory imported from another source.
 	MemorySourceImported MemorySource = "imported"
 )
@@ -29,6 +36,7 @@ var knownMemorySources = []MemorySource{
 	MemorySourceManual,
 	MemorySourceExtracted,
 	MemorySourceExtractedHidden,
+	MemorySourceRememberIntent,
 	MemorySourceImported,
 }
 

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -657,7 +657,16 @@ func buildMemoryListQuery(criteria apptypes.MemoryListCriteria, clock types.Cloc
 		return "", nil, err
 	}
 	args = appendMemoryValidityWindowFilter(&builder, args, criteria.AsOf(), criteria.IncludeExpiredByValidity(), clock)
-	builder.WriteString(" ORDER BY m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
+	builder.WriteString(" ORDER BY ")
+	if criteria.RememberIntentPriority() {
+		// Pin remember-intent rows to the top of the result set BEFORE
+		// LIMIT/OFFSET applies so pagination is consistent with the
+		// displayed priority. Used by `memory inbox list` (#856).
+		builder.WriteString("CASE WHEN m.source = '")
+		builder.WriteString(types.MemorySourceRememberIntent.String())
+		builder.WriteString("' THEN 0 ELSE 1 END, ")
+	}
+	builder.WriteString("m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
 	args = append(args, criteria.Limit(), criteria.Offset())
 	return builder.String(), args, nil
 }

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -555,6 +555,49 @@ func TestMemoryDatasource_List(t *testing.T) {
 	})
 }
 
+func TestMemoryDatasource_List_RememberIntentPriorityAppliesBeforePagination(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	// Three candidates whose updated_at puts the remember-intent row in the
+	// middle of the timeline. Without query-level priority, a LIMIT 1 page
+	// would surface the most recent extracted candidate and leave the
+	// remember-intent row hidden until later pages.
+	scope := mustWorkspaceScope(t, "github.com/duck8823/traceary")
+	fixtureMemories := []*model.Memory{
+		memoryOf(t, "mem-extracted-newest", types.MemoryTypeLesson, scope, "newest extracted", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC)),
+		memoryOf(t, "mem-remember-intent-mid", types.MemoryTypePreference, scope, "remember-intent middle", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceRememberIntent, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC)),
+		memoryOf(t, "mem-extracted-oldest", types.MemoryTypeLesson, scope, "oldest extracted", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)),
+	}
+	for _, memory := range fixtureMemories {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+
+	criteria := apptypes.NewMemoryListCriteriaBuilder(1).
+		Statuses([]types.MemoryStatus{types.MemoryStatusCandidate}).
+		RememberIntentPriority(true).
+		Build()
+	summaries, err := sut.List(ctx, criteria)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got := len(summaries); got != 1 {
+		t.Fatalf("len(List()) = %d, want 1 (LIMIT 1)", got)
+	}
+	if diff := cmp.Diff("mem-remember-intent-mid", summaries[0].MemoryID().String()); diff != "" {
+		t.Fatalf("first page must surface remember-intent row before extracted rows; mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestMemoryDatasource_Search(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -142,12 +141,19 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	// 21st imported candidate matches, the datasource returns the match
 	// instead of handing back an empty page because the first 20 rows
 	// were some other source.
+	//
+	// RememberIntentPriority is enforced at the query layer so remember-intent
+	// rows surface ahead of other candidates BEFORE limit/offset applies — a
+	// post-fetch in-memory sort would only re-order the current page and
+	// could let a remember-intent row that lives just past the page boundary
+	// stay hidden until later pages (#856).
 	criteria := apptypes.NewMemoryListCriteriaBuilder(input.limit).
 		Offset(input.offset).
 		Scopes(scopes).
 		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
 		MemoryTypes(memoryTypes).
 		Sources(sources).
+		RememberIntentPriority(true).
 		Build()
 	summaries, err := c.memory.List(ctx, criteria)
 	if err != nil {
@@ -162,30 +168,7 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		}
 		items = append(items, details)
 	}
-	prioritizeRememberIntentInboxItems(items)
 	return writeMemoryInboxList(output, items, input.asJSON)
-}
-
-func prioritizeRememberIntentInboxItems(items []apptypes.MemoryDetails) {
-	slices.SortStableFunc(items, func(left, right apptypes.MemoryDetails) int {
-		leftPriority := memoryInboxSourcePriority(left.Summary().Source())
-		rightPriority := memoryInboxSourcePriority(right.Summary().Source())
-		switch {
-		case leftPriority < rightPriority:
-			return -1
-		case leftPriority > rightPriority:
-			return 1
-		default:
-			return 0
-		}
-	})
-}
-
-func memoryInboxSourcePriority(source domtypes.MemorySource) int {
-	if source == domtypes.MemorySourceRememberIntent {
-		return 0
-	}
-	return 1
 }
 
 func (c *RootCLI) runMemoryInboxBatch(ctx context.Context, output io.Writer, input memoryInboxBatchCommandInput, action memoryInboxAction) error {

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,7 +46,7 @@ func (c *RootCLI) newMemoryInboxListCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("filter by agent scope", "agent scope で絞り込む"))
 	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
-	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / imported)", "memory source (manual / extracted / extracted-hidden / imported) で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / remember-intent / imported)", "memory source (manual / extracted / extracted-hidden / remember-intent / imported) で絞り込む"))
 	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (low-quality auto-extractions kept for audit)", "extracted-hidden の候補も含める (audit 用に保存された低品質自動抽出)"))
 	cmd.Flags().IntVar(&input.limit, "limit", defaultMemoryInboxLimit, Localize("maximum number of candidates to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of candidates to skip before listing", "一覧表示前にスキップする件数"))
@@ -161,7 +162,30 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		}
 		items = append(items, details)
 	}
+	prioritizeRememberIntentInboxItems(items)
 	return writeMemoryInboxList(output, items, input.asJSON)
+}
+
+func prioritizeRememberIntentInboxItems(items []apptypes.MemoryDetails) {
+	slices.SortStableFunc(items, func(left, right apptypes.MemoryDetails) int {
+		leftPriority := memoryInboxSourcePriority(left.Summary().Source())
+		rightPriority := memoryInboxSourcePriority(right.Summary().Source())
+		switch {
+		case leftPriority < rightPriority:
+			return -1
+		case leftPriority > rightPriority:
+			return 1
+		default:
+			return 0
+		}
+	})
+}
+
+func memoryInboxSourcePriority(source domtypes.MemorySource) int {
+	if source == domtypes.MemorySourceRememberIntent {
+		return 0
+	}
+	return 1
 }
 
 func (c *RootCLI) runMemoryInboxBatch(ctx context.Context, output io.Writer, input memoryInboxBatchCommandInput, action memoryInboxAction) error {
@@ -273,6 +297,7 @@ func applyExtractedHiddenDefault(sources []domtypes.MemorySource, includeHidden 
 	return []domtypes.MemorySource{
 		domtypes.MemorySourceManual,
 		domtypes.MemorySourceExtracted,
+		domtypes.MemorySourceRememberIntent,
 		domtypes.MemorySourceImported,
 	}
 }

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -163,6 +163,32 @@ func TestMemoryInboxList_IncludeHiddenSkipsDefaultFilter(t *testing.T) {
 	}
 }
 
+// TestMemoryInboxList_RememberIntentPriorityFlagSetOnCriteria pins that the
+// inbox view enables the remember-intent priority flag at the query layer
+// so pagination is consistent with the displayed priority order. A
+// post-fetch in-memory sort would only re-order the current page and could
+// hide remember-intent rows past page boundaries.
+func TestMemoryInboxList_RememberIntentPriorityFlagSetOnCriteria(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db", "--limit", "5", "--offset", "10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !memoryStub.listCriteria.RememberIntentPriority() {
+		t.Fatalf("inbox list must enable RememberIntentPriority on the criteria so ordering is applied before LIMIT/OFFSET")
+	}
+}
+
 func TestMemoryInboxAccept_BatchIDs(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1447,6 +1447,7 @@ func applyExtractedHiddenDefaultMCP(sources []types.MemorySource, includeHidden 
 	return []types.MemorySource{
 		types.MemorySourceManual,
 		types.MemorySourceExtracted,
+		types.MemorySourceRememberIntent,
 		types.MemorySourceImported,
 	}
 }


### PR DESCRIPTION
## Motivation

Closes #856.

This PR promotes explicit user remember-intent prompts into reviewable durable-memory candidates. It covers both prompts that include the fact directly and short follow-up prompts that need the immediately adjacent prompt/transcript context.

Stacked on #870 / #857 because it depends on the extraction-noise classifier behavior. Retarget to `main` after #870 merges.

## Changes

- Add `source=remember-intent` for prompt/transcript-derived explicit remember-intent candidates.
- Extract facts from inline English/Japanese remember triggers without requiring a colon.
- Use bounded adjacent prompt/transcript context for short remember-only prompts such as `覚えておいてね`.
- Attach evidence refs for both the remember-intent event and the context event when adjacent context is used.
- Keep remember-intent candidates reviewable as `candidate` via `Propose`; no auto-accept behavior.
- Include remember-intent candidates in default inbox source filters and prioritize them in `memory inbox list` output.
- Add Japanese/English trigger and adjacent-context evidence tests.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp go test ./...` — passed (1394 tests / 19 packages)
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp go build ./...` — passed
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp GOLANGCI_LINT_CACHE=/tmp/traceary-golangci-cache go tool golangci-lint run` — no issues found (local `rtk` wrapper exits 7, consistent with prior runs)

## Notes

Gemini review is attempted when available; the current local Gemini CLI requires OAuth browser auth and cannot complete in this sandboxed run.
