### PR TITLE
feat(memory): route clear/reset summaries into extraction

### DIFF
--- a/application/usecase/memory_extraction.go
+++ b/application/usecase/memory_extraction.go
@@ -325,6 +325,12 @@ func (u *memoryExtractionUsecase) Explain(ctx context.Context, criteria apptypes
 				SourceHook:   signal.sourceHook,
 				EvidenceRefs: slices.Clone(evidenceRefs),
 			}
+			if signal.skipReason != "" {
+				decision.Decision = "ignored"
+				decision.Reason = signal.skipReason
+				report.Segments = append(report.Segments, decision)
+				continue
+			}
 			if isShortRememberIntentSegment(segment) {
 				decision.Decision = "ignored"
 				decision.Reason = "remember_intent_context_only"
@@ -699,6 +705,7 @@ type extractionSignal struct {
 	client          domtypes.Client
 	kind            domtypes.EventKind
 	sourceHook      string
+	skipReason      string
 }
 
 func (u *memoryExtractionUsecase) collectCandidateSpecs(ctx context.Context, session apptypes.SessionSummary, eventLimit int) ([]memoryCandidateSpec, error) {
@@ -884,8 +891,9 @@ func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, 
 		}
 		for _, event := range events {
 			body := apptypes.ExtractPlainBody(event.Body())
-			if kind == domtypes.EventKindCompactSummary && !shouldUseCompactSummaryExtractionSignal(event, body) {
-				continue
+			skipReason := ""
+			if kind == domtypes.EventKindCompactSummary {
+				skipReason = compactSummaryExtractionSkipReason(event, body)
 			}
 			signals = append(signals, extractionSignal{
 				text:            body,
@@ -895,6 +903,7 @@ func (u *memoryExtractionUsecase) collectExtractionSignals(ctx context.Context, 
 				client:          event.Client(),
 				kind:            event.Kind(),
 				sourceHook:      event.SourceHook(),
+				skipReason:      skipReason,
 			})
 		}
 		return nil
@@ -956,25 +965,24 @@ func (u *memoryExtractionUsecase) collectRememberIntentContextSignals(ctx contex
 	return signals, nil
 }
 
-func shouldUseCompactSummaryExtractionSignal(event *model.Event, body string) bool {
+func compactSummaryExtractionSkipReason(event *model.Event, body string) string {
 	if event == nil {
-		return false
+		return "missing_event"
 	}
 	trimmed := strings.TrimSpace(body)
 	if trimmed == "" {
-		return false
+		return "empty_summary"
 	}
 	if event.SourceHook() == "pre_compact" || strings.HasPrefix(trimmed, domtypes.EventBodyMarkerCompactPreSnapshot) {
-		return false
+		return "pre_compact_snapshot"
 	}
 	lower := strings.ToLower(trimmed)
 	switch lower {
-	case "manual", "auto", "automatic", "compact triggered", "triggered", "clear", "reset":
-		return false
+	case "manual", "auto", "automatic", "compact triggered", "triggered", "clear", "cleared", "context cleared", "reset", "reset context", "context reset":
+		return "marker_only_context_boundary"
 	default:
-		return true
+		return ""
 	}
-
 }
 
 type memoryCandidateSpec struct {
@@ -990,6 +998,9 @@ type memoryCandidateSpec struct {
 }
 
 func extractMemoryCandidatesFromSignal(signal extractionSignal, evidenceRefs []domtypes.EvidenceRef) ([]memoryCandidateSpec, error) {
+	if signal.skipReason != "" {
+		return nil, nil
+	}
 	segments := candidateSegments(signal.text)
 	specs := make([]memoryCandidateSpec, 0, len(segments))
 	for _, segment := range segments {

--- a/application/usecase/memory_usecase_extraction_test.go
+++ b/application/usecase/memory_usecase_extraction_test.go
@@ -1015,6 +1015,87 @@ func TestMemoryUsecase_Extract_SkipsPreCompactMarkerOnlySummary(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Extract_ClearResetSummaryBodyProducesCandidate(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-clear-summary"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	clearEvent := mustExtractionEvent(t, "event-clear-summary", domtypes.EventKindCompactSummary, "Decision: After /clear, use traceary session handoff --compact-only before resuming implementation.")
+	clearEvent.SetSourceHook("clear")
+	details := mustMemoryDetailsFromSummary(t, "memory-clear-summary", domtypes.MemoryTypeDecision, "After /clear, use traceary session handoff --compact-only before resuming implementation.")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{proposeResult: []apptypes.MemoryDetails{details}}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindCompactSummary: {clearEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	_, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-clear-summary")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(memoryUsecase.proposeCalls) != 1 {
+		t.Fatalf("proposeCalls = %d, want 1", len(memoryUsecase.proposeCalls))
+	}
+	call := memoryUsecase.proposeCalls[0]
+	if call.source != domtypes.MemorySourceCompactSummary {
+		t.Fatalf("source = %q, want compact-summary", call.source)
+	}
+	gotEvidence := make(map[string]bool)
+	for _, ref := range call.evidenceRefs {
+		if ref.Kind() == domtypes.EvidenceRefKindEvent {
+			gotEvidence[ref.Value()] = true
+		}
+	}
+	if !gotEvidence["event-clear-summary"] {
+		t.Fatalf("evidenceRefs = %v, want clear/reset summary event id", call.evidenceRefs)
+	}
+}
+
+func TestMemoryUsecase_Extract_SkipsClearResetMarkerOnlySummary(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-clear-marker"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	clearEvent := mustExtractionEvent(t, "event-clear-marker", domtypes.EventKindCompactSummary, "clear")
+	clearEvent.SetSourceHook("clear")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindCompactSummary: {clearEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	got, err := sut.Extract(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-clear-marker")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	if len(got) != 0 || len(memoryUsecase.proposeCalls) != 0 {
+		t.Fatalf("clear marker produced candidates: got=%d calls=%d", len(got), len(memoryUsecase.proposeCalls))
+	}
+}
+
+func TestMemoryUsecase_ExplainExtraction_ReportsClearResetMarkerSkipReason(t *testing.T) {
+	t.Parallel()
+
+	session := apptypes.SessionSummaryOf(domtypes.SessionID("session-debug-clear-marker"), domtypes.Workspace("github.com/duck8823/traceary"), time.Now().Add(-time.Hour), domtypes.None[time.Time](), "ended", 1, 0, []string{"claude"}, "", "", domtypes.SessionID(""))
+	clearEvent := mustExtractionEvent(t, "event-debug-clear-marker", domtypes.EventKindCompactSummary, "reset")
+	clearEvent.SetSourceHook("reset")
+	memoryUsecase := &memoryExtractionMemoryUsecaseStub{}
+	sessionQuery := &sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}}
+	eventQuery := &eventQueryServiceStub{listRecentResultByKind: map[domtypes.EventKind][]*model.Event{domtypes.EventKindCompactSummary: {clearEvent}}}
+	sut := usecase.NewMemoryUsecase(memoryUsecase, memoryUsecase, nil, usecase.MemoryUsecaseDependencies{SessionQuery: sessionQuery, EventQuery: eventQuery})
+
+	report, err := sut.ExplainExtraction(context.Background(), apptypes.NewMemoryExtractionCriteriaBuilder().SessionID(domtypes.SessionID("session-debug-clear-marker")).Workspace(domtypes.Workspace("github.com/duck8823/traceary")).EventLimit(1).CandidateLimit(10).Build())
+	if err != nil {
+		t.Fatalf("ExplainExtraction() error = %v", err)
+	}
+	if len(report.Segments) != 1 {
+		t.Fatalf("segments = %d, want 1", len(report.Segments))
+	}
+	segment := report.Segments[0]
+	if segment.Decision != "ignored" || segment.Reason != "marker_only_context_boundary" {
+		t.Fatalf("segment decision/reason = %s/%s, want ignored/marker_only_context_boundary", segment.Decision, segment.Reason)
+	}
+	if segment.EventKind != domtypes.EventKindCompactSummary || segment.SourceHook != "reset" {
+		t.Fatalf("segment provenance = %s/%s, want compact_summary/reset", segment.EventKind, segment.SourceHook)
+	}
+}
+
 func TestMemoryUsecase_ExplainExtraction_ShowsPostCompactSummaryDecision(t *testing.T) {
 	t.Parallel()
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -108,6 +108,12 @@ v0.11.0 以降、hook 経由の session 終了 (`traceary hook session <client> 
 
 長さベースの quality filter により、短い候補 (20 rune 未満。artifact ref は除外) は `source=extracted` ではなく `source=extracted-hidden` で保存されます。hidden 行は audit 用に store に残りますが、`traceary memory inbox list` の既定 view には出ません。`--include-hidden` で surface できます。
 
+#### context boundary からの抽出
+
+`traceary memory extract` は、意味のある post-compact summary と clear/reset 相当の summary event を抽出入力として扱います。compact-summary 系 event からできた candidate は `source=compact-summary` になり、元 event を evidence として保持するため、accept 前に reviewer が実際の host signal を確認できます。
+
+`manual`、`clear`、`reset` のような marker-only lifecycle signal や、context が clear された事実だけを Traceary に通知する host からは candidate を作りません。`memory extract --debug-signals --json` では、これらは `ignored` かつ `reason=marker_only_context_boundary` として表示されます（pre-compact snapshot の場合は `pre_compact_snapshot`）。現時点では Claude の post-compact は summary text を渡せますが、clear/reset の support は host が summary body を提供できるかに依存します。host が marker だけを emit する場合、Traceary は boundary を記録・debug 表示しますが、durable memory を捏造しません。
+
 ### レビューする経路
 
 candidate が溜まってきて、accepted に昇格させる前に inbox を walk したいときは次を使います。

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -108,6 +108,12 @@ Since v0.11.0, the hook-driven session-end path (`traceary hook session <client>
 
 A length-based quality filter routes short candidates (under 20 runes; artifact refs are exempt) to `source=extracted-hidden` instead of `source=extracted`. The hidden rows stay in the store for audit but are skipped by the default `traceary memory inbox list` view; `--include-hidden` surfaces them.
 
+#### Context-boundary extraction
+
+`traceary memory extract` treats meaningful post-compact summaries and clear/reset-equivalent summary events as extraction inputs. Candidates from compact-summary style events use `source=compact-summary` and keep the originating event as evidence, so reviewers can inspect the exact host signal before accepting.
+
+Marker-only lifecycle signals such as `manual`, `clear`, `reset`, or hosts that only notify Traceary that context was cleared do not create candidates. In `memory extract --debug-signals --json`, those rows appear as `ignored` with `reason=marker_only_context_boundary` (or `pre_compact_snapshot` for pre-compact snapshots). Today Claude post-compact can provide summary text; clear/reset support depends on whether the host supplies a summary body. When a host only emits a marker, Traceary records/debugs the boundary but does not fabricate durable memory.
+
 ### Review path
 
 Use these once candidates have accumulated in the store and you need to


### PR DESCRIPTION
## Motivation

Clear/reset-equivalent host boundaries can carry useful summary text, but marker-only lifecycle events must not fabricate durable memory. v0.12.0 needs this distinction so reviewers can trust `source=compact-summary` candidates and debug skipped host signals.

## Changes

- Route meaningful clear/reset compact-summary event bodies into memory extraction as `source=compact-summary`.
- Keep marker-only clear/reset/pre-compact signals out of candidate generation while surfacing explicit debug skip reasons.
- Add regression tests for clear/reset summary extraction, marker-only skips, and debug provenance.
- Document context-boundary extraction behavior and host limitations in the durable memory guide.

## Validation

- `go test ./application/usecase -run 'TestMemoryUsecase_(Extract_ClearResetSummaryBodyProducesCandidate|Extract_SkipsClearResetMarkerOnlySummary|ExplainExtraction_ReportsClearResetMarkerSkipReason|Extract_SkipsPreCompactMarkerOnlySummary|ExplainExtraction_ShowsPostCompactSummaryDecision)'` — passed
- `go test ./...` — passed
- `go build ./...` — passed
- `go tool golangci-lint run` — no issues found (local rtk wrapper exits 7 as before)

Closes #865
