### PR TITLE
v0.12.0-7: include global memories in host exports

### DIFF
--- a/application/types/memory_bridge.go
+++ b/application/types/memory_bridge.go
@@ -26,11 +26,14 @@ const (
 func (t MemoryBridgeTarget) String() string { return string(t) }
 
 // MemoryExportCriteria is the input to the export usecase. An empty scope
-// means the caller accepted the default (workspace scope resolved from
-// the environment) and the usecase will apply the active-workspace rule.
+// exports every accepted memory. Callers that pass explicit workspace
+// scopes can set IncludeGlobal to add the global memory scope beside the
+// workspace filter.
 type MemoryExportCriteria struct {
 	Target MemoryBridgeTarget
 	Scopes []domtypes.MemoryScope
+	// IncludeGlobal adds the global scope when Scopes is non-empty.
+	IncludeGlobal bool
 }
 
 // MemoryExportResult carries the serialized markdown emitted by an export

--- a/application/usecase/memory_export.go
+++ b/application/usecase/memory_export.go
@@ -67,8 +67,9 @@ func (u *memoryExportUsecase) Export(ctx context.Context, criteria apptypes.Memo
 
 	builder := apptypes.NewMemoryListCriteriaBuilder(maxMemoryBridgeRows).
 		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted})
-	if len(criteria.Scopes) > 0 {
-		builder = builder.Scopes(criteria.Scopes)
+	exportScopes := memoryExportScopes(criteria.Scopes, criteria.IncludeGlobal)
+	if len(exportScopes) > 0 {
+		builder = builder.Scopes(exportScopes)
 	}
 	list := builder.Build()
 
@@ -80,10 +81,39 @@ func (u *memoryExportUsecase) Export(ctx context.Context, criteria apptypes.Memo
 	markdown := renderMemoryBridgeBlock(criteria.Target, summaries)
 	return apptypes.MemoryExportResult{
 		Target:        criteria.Target,
-		Scopes:        criteria.Scopes,
+		Scopes:        exportScopes,
 		Markdown:      markdown,
 		ExportedCount: len(summaries),
 	}, nil
+}
+
+func memoryExportScopes(scopes []domtypes.MemoryScope, includeGlobal bool) []domtypes.MemoryScope {
+	if len(scopes) == 0 {
+		return nil
+	}
+	result := append([]domtypes.MemoryScope(nil), scopes...)
+	if includeGlobal {
+		result = append(result, domtypes.GlobalScopeOf())
+	}
+	return dedupeMemoryScopes(result)
+}
+
+func dedupeMemoryScopes(scopes []domtypes.MemoryScope) []domtypes.MemoryScope {
+	seen := make(map[string]struct{}, len(scopes))
+	result := make([]domtypes.MemoryScope, 0, len(scopes))
+	for _, scope := range scopes {
+		if scope == nil {
+			result = append(result, scope)
+			continue
+		}
+		key := scope.Kind().String() + "\x00" + scope.Key()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, scope)
+	}
+	return result
 }
 
 // maxMemoryBridgeRows caps the single-shot export. Real operators run
@@ -96,17 +126,23 @@ const maxMemoryBridgeRows = 2000
 // inside the host instruction file. Sorting keeps the output
 // idempotent — summaries come back in updated_at order from the store,
 // which is not stable if two memories share the same timestamp, so the
-// function re-sorts by memory type + fact.
+// function re-sorts by scope + memory type + fact.
 func renderMemoryBridgeBlock(target apptypes.MemoryBridgeTarget, summaries []apptypes.MemorySummary) string {
 	sorted := append([]apptypes.MemorySummary(nil), summaries...)
 	sort.SliceStable(sorted, func(i, j int) bool {
+		leftScopeRank, rightScopeRank := memoryScopeRenderRank(sorted[i].Scope()), memoryScopeRenderRank(sorted[j].Scope())
+		if leftScopeRank != rightScopeRank {
+			return leftScopeRank < rightScopeRank
+		}
+		if memoryScopeLabel(sorted[i].Scope()) != memoryScopeLabel(sorted[j].Scope()) {
+			return memoryScopeLabel(sorted[i].Scope()) < memoryScopeLabel(sorted[j].Scope())
+		}
 		if sorted[i].MemoryType() != sorted[j].MemoryType() {
 			return sorted[i].MemoryType() < sorted[j].MemoryType()
 		}
 		return sorted[i].Fact() < sorted[j].Fact()
 	})
 
-	grouped := groupMemoriesByType(sorted)
 	typeOrder := []domtypes.MemoryType{
 		domtypes.MemoryTypePreference,
 		domtypes.MemoryTypeDecision,
@@ -124,22 +160,49 @@ func renderMemoryBridgeBlock(target apptypes.MemoryBridgeTarget, summaries []app
 	if len(sorted) == 0 {
 		body.WriteString("_No accepted durable memories matched the export scope._\n\n")
 	}
-	for _, memoryType := range typeOrder {
-		entries, ok := grouped[memoryType]
-		if !ok {
-			continue
+	for _, scopeGroup := range groupMemoriesByScope(sorted) {
+		fmt.Fprintf(&body, "## %s\n\n", titleForMemoryScope(scopeGroup.scope))
+		grouped := groupMemoriesByType(scopeGroup.summaries)
+		for _, memoryType := range typeOrder {
+			entries, ok := grouped[memoryType]
+			if !ok {
+				continue
+			}
+			fmt.Fprintf(&body, "### %s\n\n", titleForMemoryType(memoryType))
+			for _, summary := range entries {
+				body.WriteString("- ")
+				body.WriteString(escapeMarkdownBullet(summary.Fact()))
+				fmt.Fprintf(&body, " (memory_id: %s, scope: %s)\n", summary.MemoryID().String(), memoryScopeLabel(summary.Scope()))
+			}
+			body.WriteString("\n")
 		}
-		fmt.Fprintf(&body, "## %s\n\n", titleForMemoryType(memoryType))
-		for _, summary := range entries {
-			body.WriteString("- ")
-			body.WriteString(escapeMarkdownBullet(summary.Fact()))
-			fmt.Fprintf(&body, " (memory_id: %s, scope: %s)\n", summary.MemoryID().String(), memoryScopeLabel(summary.Scope()))
-		}
-		body.WriteString("\n")
 	}
 	body.WriteString(MemoryBridgeMarkerEnd)
 	body.WriteString("\n")
 	return body.String()
+}
+
+type memoryScopeGroup struct {
+	scope     domtypes.MemoryScope
+	summaries []apptypes.MemorySummary
+}
+
+func groupMemoriesByScope(summaries []apptypes.MemorySummary) []memoryScopeGroup {
+	groups := make([]memoryScopeGroup, 0)
+	for _, summary := range summaries {
+		if len(groups) == 0 || !sameMemoryScope(groups[len(groups)-1].scope, summary.Scope()) {
+			groups = append(groups, memoryScopeGroup{scope: summary.Scope()})
+		}
+		groups[len(groups)-1].summaries = append(groups[len(groups)-1].summaries, summary)
+	}
+	return groups
+}
+
+func sameMemoryScope(left, right domtypes.MemoryScope) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Kind() == right.Kind() && left.Key() == right.Key()
 }
 
 func groupMemoriesByType(summaries []apptypes.MemorySummary) map[domtypes.MemoryType][]apptypes.MemorySummary {
@@ -167,11 +230,50 @@ func titleForMemoryType(memoryType domtypes.MemoryType) string {
 	}
 }
 
+func titleForMemoryScope(scope domtypes.MemoryScope) string {
+	if scope == nil {
+		return "Unknown-scope memories"
+	}
+	switch scope.Kind() {
+	case domtypes.MemoryScopeKindGlobal:
+		return "Global memories"
+	case domtypes.MemoryScopeKindWorkspace:
+		return fmt.Sprintf("Workspace memories: %s", scope.Key())
+	case domtypes.MemoryScopeKindSessionFamily:
+		return fmt.Sprintf("Session-family memories: %s", scope.Key())
+	case domtypes.MemoryScopeKindAgent:
+		return fmt.Sprintf("Agent memories: %s", scope.Key())
+	default:
+		return fmt.Sprintf("%s memories: %s", scope.Kind().String(), scope.Key())
+	}
+}
+
 func memoryScopeLabel(scope domtypes.MemoryScope) string {
 	if scope == nil {
 		return "?"
 	}
+	if scope.Kind() == domtypes.MemoryScopeKindGlobal {
+		return "global"
+	}
 	return fmt.Sprintf("%s=%s", scope.Kind().String(), scope.Key())
+}
+
+func memoryScopeRenderRank(scope domtypes.MemoryScope) int {
+	if scope == nil {
+		return 99
+	}
+	switch scope.Kind() {
+	case domtypes.MemoryScopeKindGlobal:
+		return 0
+	case domtypes.MemoryScopeKindWorkspace:
+		return 1
+	case domtypes.MemoryScopeKindSessionFamily:
+		return 2
+	case domtypes.MemoryScopeKindAgent:
+		return 3
+	default:
+		return 98
+	}
 }
 
 // escapeMarkdownBullet keeps multi-line facts readable inside a bullet by

--- a/application/usecase/memory_usecase_export_test.go
+++ b/application/usecase/memory_usecase_export_test.go
@@ -60,22 +60,36 @@ func TestMemoryUsecase_Export_RendersStableMarkdown(t *testing.T) {
 		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	scope := domtypes.WorkspaceScopeOf(workspace)
+	globalScope := domtypes.GlobalScopeOf()
 	query := &stubExportMemoryQuery{
 		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m0", domtypes.MemoryTypeConstraint, globalScope, "always request Codex review"),
 			mustAcceptedSummary(t, "m1", domtypes.MemoryTypeDecision, scope, "use SQLite for storage"),
 			mustAcceptedSummary(t, "m2", domtypes.MemoryTypePreference, scope, "prefer bulleted commits"),
 		},
 	}
 	sut := usecase.NewMemoryUsecase(nil, query, nil)
 	result, err := sut.Export(context.Background(), apptypes.MemoryExportCriteria{
-		Target: apptypes.MemoryBridgeTargetClaude,
-		Scopes: []domtypes.MemoryScope{scope},
+		Target:        apptypes.MemoryBridgeTargetClaude,
+		Scopes:        []domtypes.MemoryScope{scope},
+		IncludeGlobal: true,
 	})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
-	if result.ExportedCount != 2 {
-		t.Fatalf("expected 2 exported memories, got %d", result.ExportedCount)
+	if result.ExportedCount != 3 {
+		t.Fatalf("expected 3 exported memories, got %d", result.ExportedCount)
+	}
+	if len(query.calls) != 1 {
+		t.Fatalf("expected one query call, got %d", len(query.calls))
+	}
+	assertMemoryScopes(t, query.calls[0].Scopes(), []domtypes.MemoryScope{scope, globalScope})
+	assertMemoryScopes(t, result.Scopes, []domtypes.MemoryScope{scope, globalScope})
+	if !strings.Contains(result.Markdown, "## Global memories") {
+		t.Fatalf("expected Global memories section, got %q", result.Markdown)
+	}
+	if !strings.Contains(result.Markdown, "## Workspace memories: github.com/example/repo") {
+		t.Fatalf("expected Workspace memories section, got %q", result.Markdown)
 	}
 	if !strings.Contains(result.Markdown, usecase.MemoryBridgeMarkerBegin) {
 		t.Fatalf("output missing begin marker: %q", result.Markdown)
@@ -92,14 +106,78 @@ func TestMemoryUsecase_Export_RendersStableMarkdown(t *testing.T) {
 
 	// Export must be idempotent — same summaries produce the same markdown.
 	result2, err := sut.Export(context.Background(), apptypes.MemoryExportCriteria{
-		Target: apptypes.MemoryBridgeTargetClaude,
-		Scopes: []domtypes.MemoryScope{scope},
+		Target:        apptypes.MemoryBridgeTargetClaude,
+		Scopes:        []domtypes.MemoryScope{scope},
+		IncludeGlobal: true,
 	})
 	if err != nil {
 		t.Fatalf("Export (second run): %v", err)
 	}
 	if result.Markdown != result2.Markdown {
 		t.Fatalf("export is not idempotent")
+	}
+}
+
+func TestMemoryUsecase_Export_NoGlobalOptOutKeepsExplicitScopeOnly(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m1", domtypes.MemoryTypePreference, scope, "prefer bulleted commits"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Export(context.Background(), apptypes.MemoryExportCriteria{
+		Target:        apptypes.MemoryBridgeTargetCodex,
+		Scopes:        []domtypes.MemoryScope{scope},
+		IncludeGlobal: false,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if len(query.calls) != 1 {
+		t.Fatalf("expected one query call, got %d", len(query.calls))
+	}
+	assertMemoryScopes(t, query.calls[0].Scopes(), []domtypes.MemoryScope{scope})
+	assertMemoryScopes(t, result.Scopes, []domtypes.MemoryScope{scope})
+}
+
+func TestMemoryUsecase_Export_RootWorkspaceCanRenderGlobalMemories(t *testing.T) {
+	t.Parallel()
+
+	rootWorkspace, err := domtypes.WorkspaceFrom("/")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	rootScope := domtypes.WorkspaceScopeOf(rootWorkspace)
+	globalScope := domtypes.GlobalScopeOf()
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-global", domtypes.MemoryTypeConstraint, globalScope, "always request Codex review"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Export(context.Background(), apptypes.MemoryExportCriteria{
+		Target:        apptypes.MemoryBridgeTargetCodex,
+		Scopes:        []domtypes.MemoryScope{rootScope},
+		IncludeGlobal: true,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	assertMemoryScopes(t, query.calls[0].Scopes(), []domtypes.MemoryScope{rootScope, globalScope})
+	if result.ExportedCount != 1 {
+		t.Fatalf("ExportedCount = %d, want 1", result.ExportedCount)
+	}
+	if !strings.Contains(result.Markdown, "## Global memories") || !strings.Contains(result.Markdown, "always request Codex review") {
+		t.Fatalf("global memory missing from root workspace export: %q", result.Markdown)
 	}
 }
 
@@ -131,5 +209,17 @@ func TestMemoryUsecase_Export_RejectsUnknownTarget(t *testing.T) {
 	_, err := sut.Export(context.Background(), apptypes.MemoryExportCriteria{Target: apptypes.MemoryBridgeTarget("unknown")})
 	if err == nil {
 		t.Fatalf("expected error for unknown target")
+	}
+}
+
+func assertMemoryScopes(t *testing.T, got []domtypes.MemoryScope, want []domtypes.MemoryScope) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("scope length = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Kind() != want[i].Kind() || got[i].Key() != want[i].Key() {
+			t.Fatalf("scope[%d] = %s:%s, want %s:%s", i, got[i].Kind(), got[i].Key(), want[i].Kind(), want[i].Key())
+		}
 	}
 }

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -344,7 +344,9 @@ accepted な durable memory をホスト別 instruction file (CLAUDE.md / AGENTS
 主な flag:
 
 - `--target` — `claude` / `codex` / `gemini` のいずれか
-- `--workspace` — 書き出し対象の workspace scope (未指定時は env/検出 workspace)
+- `--workspace` — 書き出し対象の workspace scope (未指定時は env/検出 workspace)。workspace export は host-level ルールも反映されるよう、既定で `global` memory も含めます。
+- `--include-global` — workspace scope と一緒に `global` memory を含める (default `true`)
+- `--no-global` — opt out して明示した workspace scope のみを書き出す
 - `--out` — 書き出し先パス。`-` (または未指定) で stdout へ
 - `--json` — 書き出しサマリを JSON で出力
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -344,7 +344,9 @@ Write the accepted durable memories for the current scope into a host-native ins
 Useful flags:
 
 - `--target` — one of `claude`, `codex`, `gemini`
-- `--workspace` — scope filter (defaults to env/detected workspace)
+- `--workspace` — workspace scope filter (defaults to env/detected workspace). Workspace exports include `global` memories by default so host-level rules follow the repository export.
+- `--include-global` — include `global` memories alongside the workspace scope (default `true`)
+- `--no-global` — opt out and export only the explicit workspace scope
 - `--out` — output path; pass `-` (or omit) to write to stdout
 - `--json` — print a summary of the export result in addition to writing the file
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -166,6 +166,8 @@ Traceary をローカルの source of truth として保ちつつ、accepted な
 
 export 出力は常に `<!-- traceary-memories:begin:v1 -->` / `<!-- traceary-memories:end -->` マーカーで囲まれており、続けて `memory import instructions` を走らせても重複 candidate は作られません。operator やホストの auto-memory 機能が管理ブロック外に書き足した bullet は inbox に candidate として入り、レビュー対象になります。
 
+workspace export は user-level の運用ルール (PR title や review policy など) も host file に載るよう、既定で `global` memory を含めます。Markdown は `Global memories` / `Workspace memories` など scope ごとに見出しを分けます。従来の workspace-only filter を維持したい場合は `--no-global` (MCP では `include_global=false`) を使い、既定挙動を明示したい場合は `--include-global` を指定します。
+
 import は Codex の handbook（既定値は `~/.codex/memories/MEMORY.md`）を読み、`## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` 配下の各 bullet を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
 
 ### 参照する経路

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -197,6 +197,14 @@ instructions` run round-trips cleanly. Bullets added outside the managed
 block by the operator (or the host's own auto-memory feature) land in the
 inbox as candidates for review.
 
+Workspace exports include `global` memories by default so user-level
+operating rules (for example PR title or review policy) are available
+next to repository-specific memories in the generated host file. The
+markdown separates `Global memories`, `Workspace memories`, and other
+scope groups under distinct headings. Use `--no-global` (or
+`include_global=false` over MCP) to preserve the old workspace-only
+filter; use `--include-global` to make the default explicit.
+
 Import reads the local Codex handbook (`~/.codex/memories/MEMORY.md` by
 default) and records each bullet under `## User preferences`, `## Reusable
 knowledge`, and `## Failures and how to do differently` as a `candidate`

--- a/domain/types/memory_scope.go
+++ b/domain/types/memory_scope.go
@@ -11,6 +11,8 @@ import (
 type MemoryScopeKind string
 
 const (
+	// MemoryScopeKindGlobal scopes memory to every workspace / host export.
+	MemoryScopeKindGlobal MemoryScopeKind = "global"
 	// MemoryScopeKindWorkspace scopes memory to a workspace.
 	MemoryScopeKindWorkspace MemoryScopeKind = "workspace"
 	// MemoryScopeKindAgent scopes memory to an agent.
@@ -20,6 +22,7 @@ const (
 )
 
 var knownMemoryScopeKinds = []MemoryScopeKind{
+	MemoryScopeKindGlobal,
 	MemoryScopeKindWorkspace,
 	MemoryScopeKindAgent,
 	MemoryScopeKindSessionFamily,
@@ -31,6 +34,24 @@ type MemoryScope interface {
 	Kind() MemoryScopeKind
 	Key() string
 }
+
+const globalMemoryScopeKey = "global"
+
+// GlobalScope constrains memory to every workspace / host export.
+type GlobalScope struct{}
+
+// GlobalScopeOf creates a GlobalScope.
+func GlobalScopeOf() GlobalScope {
+	return GlobalScope{}
+}
+
+func (GlobalScope) mustEmbedMemoryScope() {}
+
+// Kind returns the scope kind.
+func (GlobalScope) Kind() MemoryScopeKind { return MemoryScopeKindGlobal }
+
+// Key returns the flattened key representation.
+func (GlobalScope) Key() string { return globalMemoryScopeKey }
 
 // MemoryScopeKindFrom creates a MemoryScopeKind from a string.
 func MemoryScopeKindFrom(value string) (MemoryScopeKind, error) {
@@ -118,6 +139,11 @@ func MemoryScopeFrom(kind string, value string) (MemoryScope, error) {
 	}
 
 	switch resolvedKind {
+	case MemoryScopeKindGlobal:
+		if strings.TrimSpace(value) != globalMemoryScopeKey {
+			return nil, xerrors.Errorf("invalid global scope value: %s", value)
+		}
+		return GlobalScopeOf(), nil
 	case MemoryScopeKindWorkspace:
 		workspace, err := WorkspaceFrom(value)
 		if err != nil {

--- a/domain/types/memory_scope_test.go
+++ b/domain/types/memory_scope_test.go
@@ -17,8 +17,10 @@ func TestMemoryScopeKindFrom(t *testing.T) {
 		want    types.MemoryScopeKind
 		wantErr bool
 	}{
+		{name: "global", input: "global", want: types.MemoryScopeKindGlobal},
 		{name: "workspace", input: "workspace", want: types.MemoryScopeKindWorkspace},
 		{name: "agent", input: "agent", want: types.MemoryScopeKindAgent},
+		{name: "session family", input: "session_family", want: types.MemoryScopeKindSessionFamily},
 		{name: "rejects empty", input: "", wantErr: true},
 		{name: "rejects unknown", input: "user", wantErr: true},
 	}
@@ -49,11 +51,13 @@ func TestMemoryScopeFrom(t *testing.T) {
 		wantKey  string
 		wantErr  bool
 	}{
+		{name: "global scope", kind: "global", value: "global", wantKind: types.MemoryScopeKindGlobal, wantKey: "global"},
 		{name: "workspace scope", kind: "workspace", value: "github.com/duck8823/traceary", wantKind: types.MemoryScopeKindWorkspace, wantKey: "github.com/duck8823/traceary"},
 		{name: "agent scope", kind: "agent", value: "codex", wantKind: types.MemoryScopeKindAgent, wantKey: "codex"},
 		{name: "session family scope", kind: "session_family", value: "session-123", wantKind: types.MemoryScopeKindSessionFamily, wantKey: "session-123"},
 		{name: "rejects unknown kind", kind: "user", value: "abc", wantErr: true},
 		{name: "rejects invalid value", kind: "workspace", value: " ", wantErr: true},
+		{name: "rejects invalid global value", kind: "global", value: "workspace", wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -436,11 +436,13 @@ type memoryInboxBatchCommandInput struct {
 // usecase itself stays filesystem-free so tests can exercise the
 // rendering without touching the disk.
 type memoryExportCommandInput struct {
-	dbPath    string
-	target    string
-	workspace string
-	outPath   string
-	asJSON    bool
+	dbPath        string
+	target        string
+	workspace     string
+	outPath       string
+	includeGlobal bool
+	noGlobal      bool
+	asJSON        bool
 }
 
 // memoryImportInstructionsCommandInput is the resolved input to

--- a/presentation/cli/memory_bridge.go
+++ b/presentation/cli/memory_bridge.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (c *RootCLI) newMemoryExportCommand() *cobra.Command {
-	input := memoryExportCommandInput{}
+	input := memoryExportCommandInput{includeGlobal: true}
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: Localize("Export accepted durable memories into a host instruction file", "accepted durable memory をホスト別 instruction file に書き出す"),
@@ -39,6 +39,14 @@ func (c *RootCLI) newMemoryExportCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.outPath, "out", "", Localize(
 		"output path for the generated instruction file (use - to write to stdout)",
 		"書き出し先ファイル (- を指定すると stdout へ出力)",
+	))
+	cmd.Flags().BoolVar(&input.includeGlobal, "include-global", true, Localize(
+		"include global memories alongside an explicit workspace export (default true)",
+		"明示した workspace export に global memory も含める (default true)",
+	))
+	cmd.Flags().BoolVar(&input.noGlobal, "no-global", false, Localize(
+		"export only the explicit workspace scope; do not include global memories",
+		"明示した workspace scope のみを書き出し、global memory は含めない",
 	))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON summary", "JSON 形式で結果サマリを出力する"))
 	_ = cmd.MarkFlagRequired("target")
@@ -92,6 +100,7 @@ func (c *RootCLI) runMemoryExport(ctx context.Context, output io.Writer, warnWri
 	criteria := apptypes.MemoryExportCriteria{Target: target}
 	if scope != nil {
 		criteria.Scopes = []domtypes.MemoryScope{scope}
+		criteria.IncludeGlobal = input.includeGlobal && !input.noGlobal
 	}
 	result, err := c.memory.Export(ctx, criteria)
 	if err != nil {

--- a/presentation/cli/memory_bridge_command_test.go
+++ b/presentation/cli/memory_bridge_command_test.go
@@ -1,0 +1,93 @@
+package cli_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_MemoryExport_DefaultIncludesGlobalAndReportsJSONCount(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{
+		exportResult: apptypes.MemoryExportResult{
+			Target:        apptypes.MemoryBridgeTargetCodex,
+			Markdown:      "<!-- traceary-memories:begin:v1 -->\nmanaged\n<!-- traceary-memories:end -->\n",
+			ExportedCount: 2,
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "export",
+		"--target", "codex",
+		"--workspace", "github.com/duck8823/traceary",
+		"--out", filepath.Join(t.TempDir(), "AGENTS.md"),
+		"--json",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertMemoryExportCall(t, memoryStub, true)
+	if !strings.Contains(stdout.String(), `"exported_count": 2`) {
+		t.Fatalf("stdout = %q; want exported_count 2", stdout.String())
+	}
+}
+
+func TestRootCLI_MemoryExport_NoGlobalOptOut(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{
+		exportResult: apptypes.MemoryExportResult{
+			Target:        apptypes.MemoryBridgeTargetCodex,
+			Markdown:      "<!-- traceary-memories:begin:v1 -->\nmanaged\n<!-- traceary-memories:end -->\n",
+			ExportedCount: 1,
+		},
+	}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "export",
+		"--target", "codex",
+		"--workspace", "github.com/duck8823/traceary",
+		"--out", filepath.Join(t.TempDir(), "AGENTS.md"),
+		"--no-global",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertMemoryExportCall(t, memoryStub, false)
+}
+
+func assertMemoryExportCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGlobal bool) {
+	t.Helper()
+	if len(stub.exportCalls) != 1 {
+		t.Fatalf("export calls = %d, want 1", len(stub.exportCalls))
+	}
+	call := stub.exportCalls[0]
+	if call.IncludeGlobal != wantIncludeGlobal {
+		t.Fatalf("IncludeGlobal = %v, want %v", call.IncludeGlobal, wantIncludeGlobal)
+	}
+	if len(call.Scopes) != 1 {
+		t.Fatalf("Scopes len = %d, want 1", len(call.Scopes))
+	}
+	if call.Scopes[0].Kind() != types.MemoryScopeKindWorkspace || call.Scopes[0].Key() != "github.com/duck8823/traceary" {
+		t.Fatalf("Scopes[0] = %s:%s, want workspace:github.com/duck8823/traceary", call.Scopes[0].Kind(), call.Scopes[0].Key())
+	}
+}

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -45,6 +45,8 @@ type queryMemoryInput struct {
 	MemoryLimit         *int     `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
 	ExpiryDays          int      `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
 	Target              string   `json:"target,omitempty" jsonschema:"export target host (claude / codex / gemini)"`
+	IncludeGlobal       *bool    `json:"include_global,omitempty" jsonschema:"include global memories alongside a workspace export (default true)"`
+	NoGlobal            bool     `json:"no_global,omitempty" jsonschema:"export only the explicit workspace scope; do not include global memories"`
 }
 
 // sessionActionInput is shared by manage_session and session_status.
@@ -298,8 +300,10 @@ type scanMemoryHygieneInput struct {
 // filesystem-free — the generated markdown comes back in the response so
 // the caller decides what to do with it.
 type exportMemoriesInput struct {
-	Target    string `json:"target" jsonschema:"export target host (claude / codex / gemini)"`
-	Workspace string `json:"workspace,omitempty" jsonschema:"workspace scope to export (omitted exports every accepted memory)"`
+	Target        string `json:"target" jsonschema:"export target host (claude / codex / gemini)"`
+	Workspace     string `json:"workspace,omitempty" jsonschema:"workspace scope to export (omitted exports every accepted memory)"`
+	IncludeGlobal *bool  `json:"include_global,omitempty" jsonschema:"include global memories alongside a workspace export (default true)"`
+	NoGlobal      bool   `json:"no_global,omitempty" jsonschema:"export only the explicit workspace scope; do not include global memories"`
 }
 
 // importMemoryInstructionsInput is the MCP input for the

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -275,7 +275,7 @@ func (s *Server) queryMemory() mcp.ToolHandlerFor[queryMemoryInput, any] {
 			if strings.TrimSpace(input.Target) == "" {
 				return nil, nil, xerrors.Errorf("query_memory action export requires target")
 			}
-			_, out, err := s.exportMemories()(ctx, req, exportMemoriesInput{Target: input.Target, Workspace: input.Workspace})
+			_, out, err := s.exportMemories()(ctx, req, exportMemoriesInput{Target: input.Target, Workspace: input.Workspace, IncludeGlobal: input.IncludeGlobal, NoGlobal: input.NoGlobal})
 			return nil, out, err
 		case "pack":
 			_, out, err := s.memoryPack()(ctx, req, memoryPackInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, AsOf: input.AsOf})
@@ -1012,6 +1012,7 @@ func (s *Server) exportMemories() mcp.ToolHandlerFor[exportMemoriesInput, export
 				return nil, exportMemoriesOutput{}, xerrors.Errorf("failed to resolve workspace: %w", err)
 			}
 			criteria.Scopes = []types.MemoryScope{types.WorkspaceScopeOf(resolvedWorkspace)}
+			criteria.IncludeGlobal = resolveMCPExportIncludeGlobal(input.IncludeGlobal, input.NoGlobal)
 		}
 		result, err := s.memory.Export(ctx, criteria)
 		if err != nil {
@@ -1023,6 +1024,16 @@ func (s *Server) exportMemories() mcp.ToolHandlerFor[exportMemoriesInput, export
 			Markdown:      result.Markdown,
 		}, nil
 	}
+}
+
+func resolveMCPExportIncludeGlobal(includeGlobal *bool, noGlobal bool) bool {
+	if noGlobal {
+		return false
+	}
+	if includeGlobal != nil {
+		return *includeGlobal
+	}
+	return true
 }
 
 // importMemoryInstructions mirrors the CLI `memory import instructions`


### PR DESCRIPTION
## Motivation

Dogfooding showed that workspace-scoped host exports omitted accepted user-level operating rules. As a result, exporting `AGENTS.md` / `CLAUDE.md` for a repo could drop globally applicable instructions such as review policy or PR-title conventions unless operators copied them manually.

## Changes

- Add a first-class `global` durable-memory scope.
- Make workspace exports include `global` memories by default, with `--no-global` / `include_global=false` opt-out controls.
- Render exported markdown under scope-specific headings (`Global memories`, `Workspace memories`, etc.) before type-specific sections.
- Extend MCP export inputs with `include_global` / `no_global`.
- Update CLI / memory docs and tests for default include, opt-out, root workspace + global-only output, and JSON summary counts.

## Review notes

- Gemini scout was attempted from the local CLI, but it stopped on browser authentication and could not produce a review in this sandboxed run.
- Requesting PR review via `@codex review` after the draft is ready.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./domain/types ./application/usecase ./presentation/cli ./presentation/mcpserver -run 'TestMemoryScope|TestMemoryUsecase_Export|TestRootCLI_MemoryExport|TestWriteMemoryExportJSONSummary|TestRootCLI_MemoryFamily_JSON_Goldens|TestServer|TestToolMetadata'`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go tool golangci-lint run` (No issues found; rtk exits 7)

Closes #860
