### PR TITLE
v0.12.0-8: import Codex memories from multi-file layouts

### DIFF
--- a/application/codex_memory_source.go
+++ b/application/codex_memory_source.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CodexMemorySource reads raw candidate rows out of a Codex memory layout
-// (for example ~/.codex/memories/MEMORY.md). It is declared in the
+// (for example ~/.codex/memories/*.md). It is declared in the
 // application package so the usecase can depend on the interface and the
 // filesystem adapter can supply the concrete reader without dragging in
 // parser-specific types.

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -378,7 +378,7 @@ durable memory inbox をレビューします。`list` は candidate memory を 
 
 ### `traceary memory import codex`
 
-ローカルの Codex memory layout（既定値は `~/.codex/memories/MEMORY.md`）から durable memory の candidate を取り込みます。今リリースでは handbook 相当の `MEMORY.md` のみを読み、`raw_memories.md` や `rollout_summaries/*` は対象外です。`## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` 配下の各 bullet が `source=imported` + `status=candidate` で記録され、evidence/artifact ref として元ファイル・行範囲が付与されます。scope は Codex の `applies_to: cwd=...` から解決し、ヒントが無い場合は `--workspace` flag の値を fallback に使います。取り込み時は既存の redaction rule を必ず通し、auto-accept は行いません。再実行は冪等で、同じ scope/fact の memory が既に存在する場合（rejected/superseded/expired を含むすべての状態）は duplicate として skip するため、一度 reject した memory が自動的に resurrect することはありません。
+ローカルの Codex memory layout（既定値は `~/.codex/memories` 配下の `*.md`）から durable memory の candidate を取り込みます。legacy `MEMORY.md` は handbook allow-list (`## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently`) を維持し、それ以外の Markdown shard は任意の見出し配下の bullet/list item を取り込みます。各 bullet が `source=imported` + `status=candidate` で記録され、evidence/artifact ref として元ファイル・行範囲が付与されます。scope は Codex の `applies_to: cwd=...` から解決し、ヒントが無い場合は `--workspace` flag の値を fallback に使います。取り込み時は既存の redaction rule を必ず通し、auto-accept は行いません。再実行は冪等で、同じ scope/fact の memory が既に存在する場合（rejected/superseded/expired を含むすべての状態）は duplicate として skip するため、一度 reject した memory が自動的に resurrect することはありません。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -378,7 +378,7 @@ The `--source` filter pairs naturally with the extraction and import paths:
 
 ### `traceary memory import codex`
 
-Import durable-memory candidates from a local Codex memory layout — by default `~/.codex/memories/MEMORY.md`. Only the handbook file is read; raw memories and rollout summaries are intentionally skipped in this release. Each bullet under `## User preferences`, `## Reusable knowledge`, or `## Failures and how to do differently` becomes a `candidate` with `source=imported`, file evidence/artifact refs, and a scope resolved from the Codex `applies_to: cwd=...` hint (falling back to `--workspace` when the source file does not declare one). Sanitization runs on every imported fact, and nothing is auto-accepted. Re-running the command is idempotent: existing candidates (at any lifecycle status, including rejected) suppress a duplicate import so previously reviewed memories are never resurrected.
+Import durable-memory candidates from a local Codex memory layout — by default every `*.md` file under `~/.codex/memories`. Legacy `MEMORY.md` keeps the handbook allow-list (`## User preferences`, `## Reusable knowledge`, `## Failures and how to do differently`), while additional Markdown shards import bullet/list items under any heading. Each candidate gets `source=imported`, file evidence/artifact refs with line ranges, and a scope resolved from the Codex `applies_to: cwd=...` hint (falling back to `--workspace` when the source file does not declare one). Sanitization runs on every imported fact, and nothing is auto-accepted. Re-running the command is idempotent: existing candidates (at any lifecycle status, including rejected) suppress a duplicate import so previously reviewed memories are never resurrected.
 
 Useful flags:
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -168,7 +168,7 @@ export 出力は常に `<!-- traceary-memories:begin:v1 -->` / `<!-- traceary-me
 
 workspace export は user-level の運用ルール (PR title や review policy など) も host file に載るよう、既定で `global` memory を含めます。Markdown は `Global memories` / `Workspace memories` など scope ごとに見出しを分けます。従来の workspace-only filter を維持したい場合は `--no-global` (MCP では `include_global=false`) を使い、既定挙動を明示したい場合は `--include-global` を指定します。
 
-import は Codex の handbook（既定値は `~/.codex/memories/MEMORY.md`）を読み、`## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` 配下の各 bullet を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
+import は Codex の Markdown memory（既定値は `~/.codex/memories/*.md`）を読みます。legacy `MEMORY.md` は `## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` の allow-list を維持し、それ以外の Markdown shard は任意の見出し配下の bullet/list item を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
 
 ### 参照する経路
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -205,13 +205,15 @@ scope groups under distinct headings. Use `--no-global` (or
 `include_global=false` over MCP) to preserve the old workspace-only
 filter; use `--include-global` to make the default explicit.
 
-Import reads the local Codex handbook (`~/.codex/memories/MEMORY.md` by
-default) and records each bullet under `## User preferences`, `## Reusable
-knowledge`, and `## Failures and how to do differently` as a `candidate`
-with `source=imported` plus file-level evidence/artifact refs. The sanitizer
-runs on every imported fact, nothing is auto-accepted, and dedupe walks
-every lifecycle status (including rejected) so memories the operator has
-already declined are never resurrected by a later import run.
+Import reads local Codex Markdown memories (`~/.codex/memories/*.md` by
+default). Legacy `MEMORY.md` keeps the handbook allow-list
+(`## User preferences`, `## Reusable knowledge`, and `## Failures and how to
+do differently`); additional Markdown shards import bullet/list items under
+any heading. Each row lands as a `candidate` with `source=imported` plus
+file-level evidence/artifact refs. The sanitizer runs on every imported fact,
+nothing is auto-accepted, and dedupe walks every lifecycle status (including
+rejected) so memories the operator has already declined are never resurrected
+by a later import run.
 
 ### Query path
 

--- a/infrastructure/filesystem/codex_memory_source.go
+++ b/infrastructure/filesystem/codex_memory_source.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -17,17 +19,16 @@ import (
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
-// codexMemorySource parses ~/.codex/memories/MEMORY.md into durable-memory
-// candidates. v0.7-3 deliberately limits the reader to the handbook-style
-// MEMORY.md file — raw memories and rollout summaries are intentionally
-// excluded to keep the candidate surface reviewable.
+// codexMemorySource parses ~/.codex/memories/*.md files into durable-memory
+// candidates. Legacy MEMORY.md keeps its handbook section allow-list, while
+// additional Markdown files are treated as user-authored memory shards.
 type codexMemorySource struct {
 	maxBulletBytes int64
 	maxFileBytes   int64
 }
 
-// NewCodexMemorySource returns the default Codex MEMORY.md reader. The
-// configured limits are generous enough for real handbook files but still
+// NewCodexMemorySource returns the default Codex memory reader. The
+// configured limits are generous enough for real Markdown memory files but still
 // clamp pathological inputs so a runaway file never blocks the import.
 func NewCodexMemorySource() application.CodexMemorySource {
 	return &codexMemorySource{
@@ -42,10 +43,10 @@ const (
 	codexMemoryFileName              = "MEMORY.md"
 )
 
-// Load reads MEMORY.md from criteria.Root and extracts every bullet under
-// the supported sections. It returns candidates plus non-fatal warnings for
-// the CLI to surface; parser failures that make the run unsafe (bad root,
-// path escape, unreadable file) still come back as errors.
+// Load reads Markdown files from criteria.Root and extracts memory bullets.
+// It returns candidates plus non-fatal warnings for the CLI to surface;
+// parser failures that make the run unsafe (bad root, path escape,
+// unreadable file) still come back as errors.
 func (s *codexMemorySource) Load(
 	ctx context.Context,
 	criteria apptypes.CodexImportCriteria,
@@ -78,22 +79,71 @@ func (s *codexMemorySource) Load(
 		return nil, nil, xerrors.Errorf("codex memory root is not a directory: %s", root)
 	}
 
-	memoryPath := filepath.Join(root, codexMemoryFileName)
-	// Lstat the raw path first so a symlinked MEMORY.md cannot redirect the
-	// reader at another file inside the root (for example raw_memories.md).
-	// This preserves the "handbook only" scope guarantee even when the
-	// caller deliberately points MEMORY.md at another path.
-	entryInfo, err := os.Lstat(memoryPath)
+	walkRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil, nil
-		}
-		return nil, nil, xerrors.Errorf("failed to stat %s: %w", memoryPath, err)
+		return nil, nil, xerrors.Errorf("failed to resolve codex memory root %q: %w", root, err)
 	}
-	if entryInfo.Mode()&os.ModeSymlink != 0 {
-		return nil, nil, xerrors.Errorf("codex MEMORY.md must not be a symlink: %s", memoryPath)
+	memoryPaths, err := discoverCodexMemoryMarkdownFiles(walkRoot)
+	if err != nil {
+		return nil, nil, err
 	}
 
+	candidates := make([]apptypes.ImportedMemoryCandidate, 0)
+	var warnings []string
+	for _, memoryPath := range memoryPaths {
+		select {
+		case <-ctx.Done():
+			return nil, warnings, ctx.Err()
+		default:
+		}
+
+		fileCandidates, fileWarnings, err := s.loadCodexMemoryMarkdownFile(ctx, root, memoryPath, criteria)
+		if err != nil {
+			return nil, warnings, err
+		}
+		warnings = append(warnings, fileWarnings...)
+		candidates = append(candidates, fileCandidates...)
+	}
+
+	return candidates, warnings, nil
+}
+
+func discoverCodexMemoryMarkdownFiles(root string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return xerrors.Errorf("failed to inspect codex memory path %s: %w", path, walkErr)
+		}
+		if path == root {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+				return xerrors.Errorf("codex memory file must not be a symlink: %s", path)
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
+func (s *codexMemorySource) loadCodexMemoryMarkdownFile(
+	_ context.Context,
+	root string,
+	memoryPath string,
+	criteria apptypes.CodexImportCriteria,
+) ([]apptypes.ImportedMemoryCandidate, []string, error) {
 	containedPath, err := resolveCodexMemoryFile(root, memoryPath)
 	if err != nil {
 		return nil, nil, err
@@ -110,10 +160,10 @@ func (s *codexMemorySource) Load(
 		return nil, nil, xerrors.Errorf("failed to stat %s: %w", containedPath, err)
 	}
 	if !fileInfo.Mode().IsRegular() {
-		return nil, nil, xerrors.Errorf("codex MEMORY.md is not a regular file: %s", containedPath)
+		return nil, nil, xerrors.Errorf("codex memory file is not a regular file: %s", containedPath)
 	}
 	if fileInfo.Size() > s.maxFileBytes {
-		return nil, []string{fmt.Sprintf("codex MEMORY.md exceeds size guard (%d bytes); skipping", fileInfo.Size())}, nil
+		return nil, []string{fmt.Sprintf("codex memory file %s exceeds size guard (%d bytes); skipping", containedPath, fileInfo.Size())}, nil
 	}
 
 	file, err := os.Open(containedPath)
@@ -122,14 +172,19 @@ func (s *codexMemorySource) Load(
 	}
 	defer func() { _ = file.Close() }()
 
-	parsed, warnings, err := parseCodexMemoryFile(file, s.maxBulletBytes)
+	parseMode := codexParseModeGeneric
+	if isLegacyCodexMemoryFile(containedPath) {
+		parseMode = codexParseModeLegacyHandbook
+	}
+	parsed, parseWarnings, err := parseCodexMemoryFile(file, s.maxBulletBytes, parseMode)
+	warnings := prefixCodexMemoryWarnings(containedPath, parseWarnings)
 	if err != nil {
 		return nil, warnings, xerrors.Errorf("failed to parse %s: %w", containedPath, err)
 	}
 
 	candidates := make([]apptypes.ImportedMemoryCandidate, 0, len(parsed.bullets))
 	for _, bullet := range parsed.bullets {
-		memoryType, ok := sectionMemoryType(bullet.section)
+		memoryType, ok := codexMemoryTypeForBullet(bullet, containedPath)
 		if !ok {
 			continue
 		}
@@ -170,8 +225,22 @@ func (s *codexMemorySource) Load(
 			SourcePath:   containedPath,
 		})
 	}
-
 	return candidates, warnings, nil
+}
+
+func prefixCodexMemoryWarnings(path string, warnings []string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	prefixed := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		prefixed = append(prefixed, fmt.Sprintf("%s: %s", path, warning))
+	}
+	return prefixed
+}
+
+func isLegacyCodexMemoryFile(path string) bool {
+	return strings.EqualFold(filepath.Base(path), codexMemoryFileName)
 }
 
 // resolveCodexMemoryFile ensures the candidate file stays inside root after
@@ -190,8 +259,8 @@ func resolveCodexMemoryFile(root, memoryPath string) (string, error) {
 		return "", xerrors.Errorf("failed to resolve root %s: %w", root, err)
 	}
 	rel, err := filepath.Rel(resolvedRoot, resolved)
-	if err != nil || strings.HasPrefix(rel, "..") || rel == ".." {
-		return "", xerrors.Errorf("codex MEMORY.md escapes the configured root: %s", resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", xerrors.Errorf("codex memory file escapes the configured root: %s", resolved)
 	}
 	return resolved, nil
 }
@@ -212,6 +281,7 @@ const (
 	codexSectionUserPreferences = "User preferences"
 	codexSectionReusable        = "Reusable knowledge"
 	codexSectionFailures        = "Failures and how to do differently"
+	codexSectionGeneric         = "Generic memory"
 )
 
 var knownCodexSections = map[string]struct{}{
@@ -220,28 +290,56 @@ var knownCodexSections = map[string]struct{}{
 	codexSectionFailures:        {},
 }
 
-func sectionMemoryType(section string) (domtypes.MemoryType, bool) {
+func codexMemoryTypeForBullet(bullet codexMemoryBullet, sourcePath string) (domtypes.MemoryType, bool) {
+	return sectionMemoryType(bullet.section, sourcePath)
+}
+
+func sectionMemoryType(section string, sourcePath string) (domtypes.MemoryType, bool) {
 	switch section {
 	case codexSectionUserPreferences:
 		return domtypes.MemoryTypePreference, true
 	case codexSectionReusable, codexSectionFailures:
 		return domtypes.MemoryTypeLesson, true
+	}
+
+	lower := strings.ToLower(section + " " + strings.TrimSuffix(filepath.Base(sourcePath), filepath.Ext(sourcePath)))
+	switch {
+	case strings.Contains(lower, "preference"):
+		return domtypes.MemoryTypePreference, true
+	case strings.Contains(lower, "decision"):
+		return domtypes.MemoryTypeDecision, true
+	case strings.Contains(lower, "constraint") ||
+		strings.Contains(lower, "rule") ||
+		strings.Contains(lower, "policy") ||
+		strings.Contains(lower, "format"):
+		return domtypes.MemoryTypeConstraint, true
+	case strings.Contains(lower, "failure") ||
+		strings.Contains(lower, "lesson") ||
+		strings.Contains(lower, "how to do differently"):
+		return domtypes.MemoryTypeLesson, true
 	default:
-		return domtypes.MemoryType(""), false
+		return domtypes.MemoryTypeLesson, true
 	}
 }
 
-// parseCodexMemoryFile scans the Codex handbook top-down. State is carried
-// through three pointers: the current Task Group's `applies_to: cwd=...`
-// hint, the current known section heading, and the bullet currently being
-// collected. Bullets close when we encounter another bullet, a new heading,
-// or end-of-file.
+type codexParseMode int
+
+const (
+	codexParseModeLegacyHandbook codexParseMode = iota
+	codexParseModeGeneric
+)
+
+// parseCodexMemoryFile scans one Codex Markdown memory file top-down. State
+// is carried through three pointers: the current Task Group's
+// `applies_to: cwd=...` hint, the current section heading, and the bullet
+// currently being collected. Bullets close when we encounter another bullet,
+// a new heading, or end-of-file.
 //
 // The reader uses bufio.Reader.ReadString rather than bufio.Scanner so a
 // single pathological line (for example a malformed handbook with a
 // multi-megabyte one-line bullet) degrades to a size-guard warning instead
 // of bubbling up as a fatal scanner error that aborts the whole import.
-func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64) (codexMemoryParseResult, []string, error) {
+func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64, mode codexParseMode) (codexMemoryParseResult, []string, error) {
 	var result codexMemoryParseResult
 	var warnings []string
 
@@ -265,7 +363,10 @@ func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64) (codexMemoryPa
 			bulletBuilder.Reset()
 			return
 		}
-		if _, ok := knownCodexSections[currentBullet.section]; ok {
+		if mode == codexParseModeGeneric {
+			currentBullet.fact = fact
+			result.bullets = append(result.bullets, *currentBullet)
+		} else if _, ok := knownCodexSections[currentBullet.section]; ok {
 			currentBullet.fact = fact
 			result.bullets = append(result.bullets, *currentBullet)
 		}
@@ -301,7 +402,9 @@ func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64) (codexMemoryPa
 				currentCWD = ""
 				currentSection = ""
 			}
-			if heading.level == 2 {
+			if mode == codexParseModeGeneric {
+				currentSection = heading.title
+			} else if heading.level == 2 {
 				if _, known := knownCodexSections[heading.title]; known {
 					currentSection = heading.title
 				} else {
@@ -321,19 +424,23 @@ func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64) (codexMemoryPa
 			}
 			continue
 		}
-		if strings.HasPrefix(line, "- ") {
+		if text, ok := parseMarkdownListItem(line); ok {
 			flushBullet()
-			if currentSection == "" {
+			if currentSection == "" && mode == codexParseModeLegacyHandbook {
 				continue
 			}
+			section := currentSection
+			if section == "" {
+				section = codexSectionGeneric
+			}
 			currentBullet = &codexMemoryBullet{
-				section:   currentSection,
+				section:   section,
 				cwd:       currentCWD,
 				startLine: lineNo,
 				endLine:   lineNo,
 			}
 			bulletBuilder.Reset()
-			bulletBuilder.WriteString(strings.TrimPrefix(line, "- "))
+			bulletBuilder.WriteString(text)
 			if int64(bulletBuilder.Len()) > maxBulletBytes {
 				warnings = append(warnings, fmt.Sprintf("bullet at line %d exceeds size guard; skipping", lineNo))
 				currentBullet = nil
@@ -363,6 +470,25 @@ func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64) (codexMemoryPa
 	flushBullet()
 
 	return result, warnings, nil
+}
+
+var orderedMarkdownListItemPattern = regexp.MustCompile(`^\d+[\.)]\s+(.+)$`)
+
+func parseMarkdownListItem(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " ")
+	if len(line)-len(trimmed) > 3 {
+		return "", false
+	}
+	for _, marker := range []string{"- ", "* ", "+ "} {
+		if strings.HasPrefix(trimmed, marker) {
+			return strings.TrimPrefix(trimmed, marker), true
+		}
+	}
+	match := orderedMarkdownListItemPattern.FindStringSubmatch(trimmed)
+	if match == nil {
+		return "", false
+	}
+	return match[1], true
 }
 
 type codexHeading struct {

--- a/infrastructure/filesystem/codex_memory_source.go
+++ b/infrastructure/filesystem/codex_memory_source.go
@@ -93,7 +93,7 @@ func (s *codexMemorySource) Load(
 	for _, memoryPath := range memoryPaths {
 		select {
 		case <-ctx.Done():
-			return nil, warnings, ctx.Err()
+			return nil, warnings, xerrors.Errorf("codex memory import cancelled: %w", ctx.Err())
 		default:
 		}
 
@@ -133,7 +133,7 @@ func discoverCodexMemoryMarkdownFiles(root string) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to discover codex memory markdown files under %s: %w", root, err)
 	}
 	return paths, nil
 }

--- a/infrastructure/filesystem/codex_memory_source.go
+++ b/infrastructure/filesystem/codex_memory_source.go
@@ -83,7 +83,7 @@ func (s *codexMemorySource) Load(
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to resolve codex memory root %q: %w", root, err)
 	}
-	memoryPaths, err := discoverCodexMemoryMarkdownFiles(walkRoot)
+	memoryPaths, err := discoverCodexMemoryMarkdownFiles(ctx, walkRoot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,7 +97,7 @@ func (s *codexMemorySource) Load(
 		default:
 		}
 
-		fileCandidates, fileWarnings, err := s.loadCodexMemoryMarkdownFile(ctx, root, memoryPath, criteria)
+		fileCandidates, fileWarnings, err := s.loadCodexMemoryMarkdownFile(ctx, walkRoot, memoryPath, criteria)
 		if err != nil {
 			return nil, warnings, err
 		}
@@ -108,9 +108,14 @@ func (s *codexMemorySource) Load(
 	return candidates, warnings, nil
 }
 
-func discoverCodexMemoryMarkdownFiles(root string) ([]string, error) {
+func discoverCodexMemoryMarkdownFiles(ctx context.Context, root string) ([]string, error) {
 	var paths []string
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		if walkErr != nil {
 			return xerrors.Errorf("failed to inspect codex memory path %s: %w", path, walkErr)
 		}
@@ -133,6 +138,9 @@ func discoverCodexMemoryMarkdownFiles(root string) ([]string, error) {
 		return nil
 	})
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, xerrors.Errorf("codex memory import cancelled: %w", ctxErr)
+		}
 		return nil, xerrors.Errorf("failed to discover codex memory markdown files under %s: %w", root, err)
 	}
 	return paths, nil
@@ -173,7 +181,7 @@ func (s *codexMemorySource) loadCodexMemoryMarkdownFile(
 	defer func() { _ = file.Close() }()
 
 	parseMode := codexParseModeGeneric
-	if isLegacyCodexMemoryFile(containedPath) {
+	if isLegacyCodexMemoryFile(root, containedPath) {
 		parseMode = codexParseModeLegacyHandbook
 	}
 	parsed, parseWarnings, err := parseCodexMemoryFile(file, s.maxBulletBytes, parseMode)
@@ -239,8 +247,8 @@ func prefixCodexMemoryWarnings(path string, warnings []string) []string {
 	return prefixed
 }
 
-func isLegacyCodexMemoryFile(path string) bool {
-	return strings.EqualFold(filepath.Base(path), codexMemoryFileName)
+func isLegacyCodexMemoryFile(root, path string) bool {
+	return filepath.Clean(path) == filepath.Join(filepath.Clean(root), codexMemoryFileName)
 }
 
 // resolveCodexMemoryFile ensures the candidate file stays inside root after

--- a/infrastructure/filesystem/codex_memory_source.go
+++ b/infrastructure/filesystem/codex_memory_source.go
@@ -406,7 +406,7 @@ func parseCodexMemoryFile(reader io.Reader, maxBulletBytes int64, mode codexPars
 
 		if heading, ok := parseCodexHeading(line); ok {
 			flushBullet()
-			if heading.level == 1 {
+			if mode == codexParseModeLegacyHandbook && heading.level == 1 {
 				currentCWD = ""
 				currentSection = ""
 			}

--- a/infrastructure/filesystem/codex_memory_source_test.go
+++ b/infrastructure/filesystem/codex_memory_source_test.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,6 +187,78 @@ func TestCodexMemorySource_LoadParsesMultiFileLayout(t *testing.T) {
 	}
 	if candidates[2].MemoryType != domtypes.MemoryTypeConstraint {
 		t.Fatalf("pr-title-format.md should infer constraint memories, got %s", candidates[2].MemoryType)
+	}
+}
+
+func TestCodexMemorySource_LoadTreatsOnlyRootMemoryMDAsLegacy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "memories")
+	nested := filepath.Join(root, "teams")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "memory.md"), []byte(`# Lowercase shard
+## Team-specific rules
+- Lowercase root shard should use generic parsing.
+`), 0o600); err != nil {
+		t.Fatalf("write lowercase shard: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "MEMORY.md"), []byte(`# Nested shard
+## Team-specific rules
+- Nested MEMORY.md should use generic parsing.
+`), 0o600); err != nil {
+		t.Fatalf("write nested MEMORY.md: %v", err)
+	}
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	source := NewCodexMemorySource()
+	candidates, warnings, err := source.Load(context.Background(), apptypes.CodexImportCriteria{
+		Root:              root,
+		WorkspaceFallback: workspace,
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	facts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		facts = append(facts, candidate.Fact)
+	}
+	for _, want := range []string{
+		"Lowercase root shard should use generic parsing.",
+		"Nested MEMORY.md should use generic parsing.",
+	} {
+		if !containsAny(facts, want) {
+			t.Fatalf("missing fact %q in %v", want, facts)
+		}
+	}
+}
+
+func TestCodexMemorySource_LoadHonorsCancelledContextDuringDiscovery(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "memories")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir memories: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "notes.md"), []byte("- ignored after cancellation\n"), 0o600); err != nil {
+		t.Fatalf("write notes: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	source := NewCodexMemorySource()
+	_, _, err := source.Load(ctx, apptypes.CodexImportCriteria{Root: root})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load error = %v, want context.Canceled", err)
 	}
 }
 

--- a/infrastructure/filesystem/codex_memory_source_test.go
+++ b/infrastructure/filesystem/codex_memory_source_test.go
@@ -241,6 +241,41 @@ func TestCodexMemorySource_LoadTreatsOnlyRootMemoryMDAsLegacy(t *testing.T) {
 	}
 }
 
+func TestCodexMemorySource_LoadGenericShardPreservesCWDAcrossH1(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	root := filepath.Join(dir, "memories")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir memories: %v", err)
+	}
+	content := "# First section\napplies_to: cwd=" + projectDir + "\n\n- First bullet keeps declared cwd.\n\n# Second section\n- Second bullet keeps the same cwd.\n"
+	if err := os.WriteFile(filepath.Join(root, "team-shard.md"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write shard: %v", err)
+	}
+
+	source := NewCodexMemorySource()
+	candidates, warnings, err := source.Load(context.Background(), apptypes.CodexImportCriteria{Root: root})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(candidates))
+	}
+	for _, candidate := range candidates {
+		if candidate.Scope.Key() != projectDir {
+			t.Fatalf("candidate %q scope = %q, want cwd %q", candidate.Fact, candidate.Scope.Key(), projectDir)
+		}
+	}
+}
+
 func TestCodexMemorySource_LoadHonorsCancelledContextDuringDiscovery(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesystem/codex_memory_source_test.go
+++ b/infrastructure/filesystem/codex_memory_source_test.go
@@ -102,6 +102,93 @@ func TestCodexMemorySource_LoadParsesSupportedSections(t *testing.T) {
 	}
 }
 
+func TestCodexMemorySource_LoadParsesMultiFileLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "memories")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir memories: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "confluence-writing.md"), []byte(`# Confluence writing
+- Prefer short sections with explicit owners.
+* Link related Jira tickets from the summary.
+`), 0o600); err != nil {
+		t.Fatalf("write confluence: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pr-title-format.md"), []byte(`# PR title format
+1. Prefix release issues with the version.
+2. Keep the title imperative.
+`), 0o600); err != nil {
+		t.Fatalf("write pr-title: %v", err)
+	}
+	nested := filepath.Join(root, "teams")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "jira-ticket-creation-rules.md"), []byte(`## Ticket rules
+- Include acceptance criteria.
+`), 0o600); err != nil {
+		t.Fatalf("write nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "raw_memories.txt"), []byte("- ignored\n"), 0o600); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	source := NewCodexMemorySource()
+	candidates, warnings, err := source.Load(context.Background(), apptypes.CodexImportCriteria{
+		Root:              root,
+		WorkspaceFallback: workspace,
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(candidates) != 5 {
+		t.Fatalf("expected 5 candidates from markdown shards, got %d", len(candidates))
+	}
+
+	gotFacts := make([]string, 0, len(candidates))
+	gotPaths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		gotFacts = append(gotFacts, candidate.Fact)
+		gotPaths = append(gotPaths, filepath.Base(candidate.SourcePath))
+		if len(candidate.EvidenceRefs) != 1 || !strings.Contains(candidate.EvidenceRefs[0].Value(), "#L") {
+			t.Fatalf("candidate %q missing line-range evidence: %+v", candidate.Fact, candidate.EvidenceRefs)
+		}
+		if len(candidate.ArtifactRefs) != 1 || candidate.ArtifactRefs[0].Value() != candidate.SourcePath {
+			t.Fatalf("candidate %q missing source artifact: %+v", candidate.Fact, candidate.ArtifactRefs)
+		}
+		if candidate.Scope.Key() != "github.com/example/repo" {
+			t.Fatalf("candidate %q scope = %q, want workspace fallback", candidate.Fact, candidate.Scope.Key())
+		}
+	}
+	wantFacts := []string{
+		"Prefer short sections with explicit owners.",
+		"Link related Jira tickets from the summary.",
+		"Prefix release issues with the version.",
+		"Keep the title imperative.",
+		"Include acceptance criteria.",
+	}
+	for _, want := range wantFacts {
+		if !containsAny(gotFacts, want) {
+			t.Fatalf("missing fact %q in %v", want, gotFacts)
+		}
+	}
+	if gotPaths[0] != "confluence-writing.md" || gotPaths[2] != "pr-title-format.md" || gotPaths[4] != "jira-ticket-creation-rules.md" {
+		t.Fatalf("import order should be deterministic by path, got paths %v", gotPaths)
+	}
+	if candidates[2].MemoryType != domtypes.MemoryTypeConstraint {
+		t.Fatalf("pr-title-format.md should infer constraint memories, got %s", candidates[2].MemoryType)
+	}
+}
+
 func TestCodexMemorySource_LoadMissingRootReturnsNil(t *testing.T) {
 	t.Parallel()
 
@@ -250,6 +337,41 @@ func TestCodexMemorySource_LoadEmitsWarningForOversizedLine(t *testing.T) {
 	}
 	if len(warnings) == 0 {
 		t.Fatalf("expected a size-guard warning, got none")
+	}
+}
+
+func TestCodexMemorySource_LoadSkipsOversizedMarkdownFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "memories")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir memories: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "large.md"), []byte(strings.Repeat("x", 128)), 0o600); err != nil {
+		t.Fatalf("write large: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "small.md"), []byte("- usable bullet\n"), 0o600); err != nil {
+		t.Fatalf("write small: %v", err)
+	}
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+
+	source := &codexMemorySource{maxBulletBytes: defaultCodexMaxBulletBytes, maxFileBytes: 32}
+	candidates, warnings, err := source.Load(context.Background(), apptypes.CodexImportCriteria{
+		Root:              root,
+		WorkspaceFallback: workspace,
+	})
+	if err != nil {
+		t.Fatalf("Load should not fail on oversized file, got %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Fact != "usable bullet" {
+		t.Fatalf("expected only small.md candidate, got %+v", candidates)
+	}
+	if len(warnings) == 0 || !strings.Contains(strings.Join(warnings, "\n"), "exceeds size guard") {
+		t.Fatalf("expected oversized-file warning, got %v", warnings)
 	}
 }
 

--- a/presentation/cli/memory_import.go
+++ b/presentation/cli/memory_import.go
@@ -38,7 +38,7 @@ func (c *RootCLI) newMemoryImportCodexCommand() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "codex",
-		Short: Localize("Import ~/.codex/memories/MEMORY.md as durable-memory candidates", "~/.codex/memories/MEMORY.md を durable memory の candidate として取り込む"),
+		Short: Localize("Import ~/.codex/memories/*.md as durable-memory candidates", "~/.codex/memories/*.md を durable memory の candidate として取り込む"),
 		Args:  noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runMemoryImportCodex(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), input)


### PR DESCRIPTION
## Motivation

Dogfooding found Codex memory layouts with multiple Markdown shards such as `confluence-writing.md`, `jira-ticket-creation-rules.md`, `user_preferences.md`, and `pr-title-format.md`. The importer only read `MEMORY.md`, so valid host-native memories were silently omitted.

## Changes

- Walk `*.md` files under the Codex memory root in deterministic order.
- Preserve legacy `MEMORY.md` handbook allow-list behavior.
- Import bullet/list items from additional Markdown shards under any heading.
- Keep symlink/path-containment checks and per-file/per-line/per-bullet size guards.
- Attach source file evidence refs with line ranges and file artifact refs for every imported candidate.
- Update CLI/docs to describe multi-file imports.
- Add source tests for multi-file layout, deterministic traversal, legacy behavior, symlink protection, oversized line, and oversized file handling.

## Review notes

- Gemini scout remains unavailable in this sandboxed run: local Gemini CLI opens browser authentication and does not complete headless review.
- Requesting PR review via `@codex review` after ready.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./infrastructure/filesystem -run 'TestCodexMemorySource'`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./application/usecase ./presentation/cli -run 'TestMemoryUsecase_ImportCodex|TestMemoryImportCodex'`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./infrastructure/filesystem ./application/usecase ./presentation/cli -run 'TestCodexMemorySource|TestMemoryUsecase_ImportCodex|TestMemoryImportCodex|TestRootCLI_MemoryFamily_JSON_Goldens'`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go tool golangci-lint run` (No issues found; rtk exits 7)

Closes #859
