### PR TITLE
v0.12.0-9: define host-native memory activation dry-run plan

### DIFF
--- a/application/types/memory_activation.go
+++ b/application/types/memory_activation.go
@@ -1,0 +1,26 @@
+package types
+
+import domtypes "github.com/duck8823/traceary/domain/types"
+
+// MemoryActivationCriteria describes a dry-run host activation plan. The
+// planner resolves a target file and renders the content, but it never writes
+// to disk; later write-side usecases consume the same target contract.
+type MemoryActivationCriteria struct {
+	Target        MemoryBridgeTarget
+	Root          string
+	Path          string
+	Scopes        []domtypes.MemoryScope
+	IncludeGlobal bool
+	Diff          bool
+}
+
+// MemoryActivationPlan is the resolved dry-run output for a host-native
+// activation. Markdown is the content that would be written to TargetPath.
+type MemoryActivationPlan struct {
+	Target     MemoryBridgeTarget
+	TargetPath string
+	Scopes     []domtypes.MemoryScope
+	Markdown   string
+	Existing   bool
+	Diff       string
+}

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -57,6 +57,9 @@ func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteri
 	if _, ok := apptypes.MemoryBridgeTargetOf(criteria.Target.String()); !ok {
 		return "", xerrors.Errorf("unsupported memory activation target: %s", criteria.Target)
 	}
+	if criteria.Target != apptypes.MemoryBridgeTargetCodex {
+		return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
+	}
 	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
 		abs, err := filepath.Abs(trimmed)
 		if err != nil {
@@ -79,9 +82,8 @@ func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteri
 			return "", xerrors.Errorf("failed to resolve codex memory root: %w", err)
 		}
 		return filepath.Join(absRoot, codexActivationFileName), nil
-	default:
-		return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
 	}
+	return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
 }
 
 func readExistingActivationTarget(path string) (string, bool, error) {

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -1,0 +1,117 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const codexActivationFileName = "traceary.md"
+
+type memoryActivationUsecase struct {
+	memoryQuery queryservice.MemoryQueryService
+}
+
+func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
+	targetPath, err := resolveMemoryActivationTargetPath(criteria)
+	if err != nil {
+		return apptypes.MemoryActivationPlan{}, err
+	}
+
+	exportResult, err := (&memoryExportUsecase{memoryQuery: u.memoryQuery}).Export(ctx, apptypes.MemoryExportCriteria{
+		Target:        criteria.Target,
+		Scopes:        criteria.Scopes,
+		IncludeGlobal: criteria.IncludeGlobal,
+	})
+	if err != nil {
+		return apptypes.MemoryActivationPlan{}, err
+	}
+
+	existing, exists, err := readExistingActivationTarget(targetPath)
+	if err != nil {
+		return apptypes.MemoryActivationPlan{}, err
+	}
+	diff := ""
+	if criteria.Diff && exists && existing != exportResult.Markdown {
+		diff = renderActivationDiff(targetPath, existing, exportResult.Markdown)
+	}
+
+	return apptypes.MemoryActivationPlan{
+		Target:     criteria.Target,
+		TargetPath: targetPath,
+		Scopes:     exportResult.Scopes,
+		Markdown:   exportResult.Markdown,
+		Existing:   exists,
+		Diff:       diff,
+	}, nil
+}
+
+func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+	if _, ok := apptypes.MemoryBridgeTargetOf(criteria.Target.String()); !ok {
+		return "", xerrors.Errorf("unsupported memory activation target: %s", criteria.Target)
+	}
+	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve activation path: %w", err)
+		}
+		return abs, nil
+	}
+	switch criteria.Target {
+	case apptypes.MemoryBridgeTargetCodex:
+		root := strings.TrimSpace(criteria.Root)
+		if root == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", xerrors.Errorf("failed to resolve user home directory: %w", err)
+			}
+			root = filepath.Join(home, ".codex", "memories")
+		}
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve codex memory root: %w", err)
+		}
+		return filepath.Join(absRoot, codexActivationFileName), nil
+	default:
+		return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
+	}
+}
+
+func readExistingActivationTarget(path string) (string, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, xerrors.Errorf("failed to read activation target %s: %w", path, err)
+	}
+	return string(data), true, nil
+}
+
+func renderActivationDiff(path string, existing string, planned string) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "--- %s\n", path)
+	fmt.Fprintf(&builder, "+++ %s (planned)\n", path)
+	for _, line := range splitDiffLines(existing) {
+		fmt.Fprintf(&builder, "-%s\n", line)
+	}
+	for _, line := range splitDiffLines(planned) {
+		fmt.Fprintf(&builder, "+%s\n", line)
+	}
+	return builder.String()
+}
+
+func splitDiffLines(value string) []string {
+	trimmed := strings.TrimSuffix(value, "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -1,0 +1,99 @@
+package usecase_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryUsecase_ActivatePlan_DefaultCodexTargetIsDryRunOnly(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	workspaceScope := domtypes.WorkspaceScopeOf(workspace)
+	globalScope := domtypes.GlobalScopeOf()
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-global", domtypes.MemoryTypeConstraint, globalScope, "always request Codex review"),
+			mustAcceptedSummary(t, "m-workspace", domtypes.MemoryTypePreference, workspaceScope, "prefer concise PRs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target:        apptypes.MemoryBridgeTargetCodex,
+		Root:          root,
+		Scopes:        []domtypes.MemoryScope{workspaceScope},
+		IncludeGlobal: true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if want := filepath.Join(root, "traceary.md"); plan.TargetPath != want {
+		t.Fatalf("TargetPath = %q, want %q", plan.TargetPath, want)
+	}
+	if _, err := os.Stat(plan.TargetPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run plan must not create the target file, stat err = %v", err)
+	}
+	assertMemoryScopes(t, query.calls[0].Scopes(), []domtypes.MemoryScope{workspaceScope, globalScope})
+	if !strings.Contains(plan.Markdown, usecase.MemoryBridgeMarkerBegin) || !strings.Contains(plan.Markdown, "## Global memories") {
+		t.Fatalf("planned markdown missing managed markers/global section: %q", plan.Markdown)
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_PathOverrideAndExistingDiff(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "custom.md")
+	if err := os.WriteFile(targetPath, []byte("old content\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	scope := domtypes.WorkspaceScopeOf(workspace)
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m1", domtypes.MemoryTypePreference, scope, "prefer concise PRs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+		Diff:   true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if !plan.Existing {
+		t.Fatalf("Existing = false, want true")
+	}
+	if plan.TargetPath != targetPath {
+		t.Fatalf("TargetPath = %q, want path override %q", plan.TargetPath, targetPath)
+	}
+	if !strings.Contains(plan.Diff, "--- "+targetPath) || !strings.Contains(plan.Diff, "-old content") || !strings.Contains(plan.Diff, "+<!-- traceary-memories:begin:v1 -->") {
+		t.Fatalf("unexpected diff: %q", plan.Diff)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "old content\n" {
+		t.Fatalf("dry-run diff must not mutate existing file, got %q", string(data))
+	}
+}

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -97,3 +97,16 @@ func TestMemoryUsecase_ActivatePlan_PathOverrideAndExistingDiff(t *testing.T) {
 		t.Fatalf("dry-run diff must not mutate existing file, got %q", string(data))
 	}
 }
+
+func TestMemoryUsecase_ActivatePlan_RejectsUnsupportedTargetWithPathOverride(t *testing.T) {
+	t.Parallel()
+
+	sut := usecase.NewMemoryUsecase(nil, &stubExportMemoryQuery{}, nil)
+	_, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Path:   filepath.Join(t.TempDir(), "CLAUDE.md"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("ActivatePlan error = %v, want unsupported target", err)
+	}
+}

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -122,6 +122,9 @@ type MemoryUsecase interface {
 
 	// Export serializes accepted durable memories into host instruction markdown.
 	Export(ctx context.Context, criteria apptypes.MemoryExportCriteria) (apptypes.MemoryExportResult, error)
+
+	// ActivatePlan resolves a host-native activation target and renders the dry-run content.
+	ActivatePlan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error)
 }
 
 type memoryProposer interface {

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -636,6 +636,10 @@ func (u *memoryUsecase) Export(ctx context.Context, criteria apptypes.MemoryExpo
 	return (&memoryExportUsecase{memoryQuery: u.memoryQuery}).Export(ctx, criteria)
 }
 
+func (u *memoryUsecase) ActivatePlan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
+	return (&memoryActivationUsecase{memoryQuery: u.memoryQuery}).Plan(ctx, criteria)
+}
+
 func (u *memoryUsecase) findMemoryByID(ctx context.Context, memoryID domtypes.MemoryID) (*model.Memory, error) {
 	resolvedMemoryID, err := domtypes.MemoryIDFrom(memoryID.String())
 	if err != nil {

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -350,6 +350,20 @@ accepted な durable memory をホスト別 instruction file (CLAUDE.md / AGENTS
 - `--out` — 書き出し先パス。`-` (または未指定) で stdout へ
 - `--json` — 書き出しサマリを JSON で出力
 
+### `traceary memory activate`
+
+host-native activation をファイル書き込みなしで計画します。v0.12.0 では dry-run 専用で、`memory activate --target codex --dry-run` は Traceary 管理の Codex target (`~/.codex/memories/traceary.md`、または `--root <dir>/traceary.md` / `--path <file>` で上書き) を解決し、書き込まれる予定の content を表示します。計画される content は `memory export` と同じ workspace + global scope ルールを使います。`--diff` を指定すると既存 target file との差分を表示します。
+
+主な flag:
+
+- `--target` — 現時点では `codex`
+- `--dry-run` — このリリースでは必須。ファイルは作成・更新しません
+- `--root` — Codex memory root の上書き
+- `--path` — target file の明示上書き
+- `--workspace` / `--include-global` / `--no-global` — activation scope control
+- `--diff` — target file が存在する場合に diff を含める
+- `--json` — activation plan を JSON で出力
+
 ### `traceary memory import instructions`
 
 ホスト別 instruction file (CLAUDE.md / AGENTS.md / GEMINI.md) を読み、Traceary が書いた管理ブロック外の bullet を `candidate` として取り込みます。管理ブロック内はすでに store に存在するため意図的に skip します。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -350,6 +350,20 @@ Useful flags:
 - `--out` — output path; pass `-` (or omit) to write to stdout
 - `--json` — print a summary of the export result in addition to writing the file
 
+### `traceary memory activate`
+
+Plan host-native activation without writing files. For v0.12.0 the command is dry-run only; `memory activate --target codex --dry-run` resolves the Traceary-managed Codex target (`~/.codex/memories/traceary.md`, or `--root <dir>/traceary.md` / `--path <file>` when overridden) and prints the content that would be written. The planned content uses the same workspace + global export semantics as `memory export`. Pass `--diff` to compare the planned content with an existing target file.
+
+Useful flags:
+
+- `--target` — currently `codex`
+- `--dry-run` — required in this release; never writes or creates files
+- `--root` — Codex memory root override
+- `--path` — explicit target file override
+- `--workspace` / `--include-global` / `--no-global` — activation scope controls
+- `--diff` — include a diff when the target file exists
+- `--json` — print the activation plan as JSON
+
 ### `traceary memory import instructions`
 
 Read a host instruction file (CLAUDE.md / AGENTS.md / GEMINI.md) and create `candidate` durable memories for every bullet outside the Traceary-managed block. Bullets inside the managed block are already represented in the store via export, so they are intentionally skipped.

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -168,6 +168,12 @@ export 出力は常に `<!-- traceary-memories:begin:v1 -->` / `<!-- traceary-me
 
 workspace export は user-level の運用ルール (PR title や review policy など) も host file に載るよう、既定で `global` memory を含めます。Markdown は `Global memories` / `Workspace memories` など scope ごとに見出しを分けます。従来の workspace-only filter を維持したい場合は `--no-global` (MCP では `include_global=false`) を使い、既定挙動を明示したい場合は `--include-global` を指定します。
 
+host-native file を変更する前段として activation planning を dry-run で使えます。
+
+- `traceary memory activate --target codex --dry-run`
+
+Codex の既定 target は Traceary 管理ファイル (`~/.codex/memories/traceary.md`) で、user-authored な memory shard を上書きしません。`--root` / `--path` で明示上書きでき、`--diff` で既存 target file との差分を表示できます。
+
 import は Codex の Markdown memory（既定値は `~/.codex/memories/*.md`）を読みます。legacy `MEMORY.md` は `## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` の allow-list を維持し、それ以外の Markdown shard は任意の見出し配下の bullet/list item を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
 
 ### 参照する経路

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -205,6 +205,16 @@ scope groups under distinct headings. Use `--no-global` (or
 `include_global=false` over MCP) to preserve the old workspace-only
 filter; use `--include-global` to make the default explicit.
 
+Activation planning is available as a dry-run layer before any host-native
+file is mutated:
+
+- `traceary memory activate --target codex --dry-run`
+
+The Codex default target is Traceary-managed
+(`~/.codex/memories/traceary.md`) so user-authored memory shards are not
+overwritten. `--root` and `--path` provide explicit overrides, and `--diff`
+prints a planned diff against an existing target file.
+
 Import reads local Codex Markdown memories (`~/.codex/memories/*.md` by
 default). Legacy `MEMORY.md` keeps the handbook allow-list
 (`## User preferences`, `## Reusable knowledge`, and `## Failures and how to

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -445,6 +445,22 @@ type memoryExportCommandInput struct {
 	asJSON        bool
 }
 
+// memoryActivateCommandInput is the resolved input to `traceary memory
+// activate`. v0.12's first activation surface is dry-run only; the
+// write-side path is introduced by the follow-up issue.
+type memoryActivateCommandInput struct {
+	dbPath        string
+	target        string
+	root          string
+	path          string
+	workspace     string
+	includeGlobal bool
+	noGlobal      bool
+	dryRun        bool
+	diff          bool
+	asJSON        bool
+}
+
 // memoryImportInstructionsCommandInput is the resolved input to
 // `traceary memory import instructions`. Path / Source are independent
 // of the Codex-memory import subcommand so operators can mix both in the

--- a/presentation/cli/memory.go
+++ b/presentation/cli/memory.go
@@ -28,6 +28,7 @@ func (c *RootCLI) newMemoryCommand() *cobra.Command {
 	memoryCmd.AddCommand(c.newMemoryImportCommand())
 	memoryCmd.AddCommand(c.newMemoryInboxCommand())
 	memoryCmd.AddCommand(c.newMemoryExportCommand())
+	memoryCmd.AddCommand(c.newMemoryActivateCommand())
 	memoryCmd.AddCommand(c.newMemoryHygieneCommand())
 	memoryCmd.AddCommand(c.newMemoryAcceptCommand())
 	memoryCmd.AddCommand(c.newMemoryRejectCommand())

--- a/presentation/cli/memory_activate.go
+++ b/presentation/cli/memory_activate.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func (c *RootCLI) newMemoryActivateCommand() *cobra.Command {
+	input := memoryActivateCommandInput{includeGlobal: true}
+	cmd := &cobra.Command{
+		Use:   "activate",
+		Short: Localize("Plan host-native durable-memory activation", "host-native durable-memory activation を計画する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryActivate(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.target, "target", "", Localize("activation target host (codex)", "activation 対象ホスト (codex)"))
+	cmd.Flags().StringVar(&input.root, "root", "", Localize("host memory root override (Codex default: ~/.codex/memories)", "host memory root の上書き (Codex 既定: ~/.codex/memories)"))
+	cmd.Flags().StringVar(&input.path, "path", "", Localize("explicit activation target file path override", "activation 対象ファイルパスを明示的に上書き"))
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace scope to activate (defaults to env/detected workspace)", "activation 対象の workspace scope (未指定時は env/検出 workspace)"))
+	cmd.Flags().BoolVar(&input.includeGlobal, "include-global", true, Localize("include global memories alongside a workspace activation (default true)", "workspace activation に global memory も含める (default true)"))
+	cmd.Flags().BoolVar(&input.noGlobal, "no-global", false, Localize("activate only the explicit workspace scope; do not include global memories", "明示した workspace scope のみを activation し、global memory は含めない"))
+	cmd.Flags().BoolVar(&input.dryRun, "dry-run", false, Localize("print the activation plan without writing files", "ファイルを書き込まず activation plan を表示する"))
+	cmd.Flags().BoolVar(&input.diff, "diff", false, Localize("include a diff against the existing target file when present", "既存の対象ファイルがある場合に diff を含める"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	_ = cmd.MarkFlagRequired("target")
+	return cmd
+}
+
+func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input memoryActivateCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory activation ユースケースが設定されていません"))
+	}
+	if !input.dryRun {
+		return xerrors.Errorf(Localize("memory activate currently supports --dry-run only", "memory activate は現在 --dry-run のみ対応しています"))
+	}
+	target, ok := apptypes.MemoryBridgeTargetOf(strings.ToLower(strings.TrimSpace(input.target)))
+	if !ok || target != apptypes.MemoryBridgeTargetCodex {
+		return xerrors.Errorf(Localize("--target must be codex", "--target は codex を指定してください"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	scope, err := resolveExportScope(ctx, input.workspace)
+	if err != nil {
+		return err
+	}
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: target,
+		Root:   input.root,
+		Path:   input.path,
+		Diff:   input.diff,
+	}
+	if scope != nil {
+		criteria.Scopes = []domtypes.MemoryScope{scope}
+		criteria.IncludeGlobal = input.includeGlobal && !input.noGlobal
+	}
+	plan, err := c.memory.ActivatePlan(ctx, criteria)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to plan memory activation", "memory activation plan の作成に失敗しました"), err)
+	}
+	return writeMemoryActivationPlan(output, plan, input.asJSON)
+}
+
+func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationPlan, asJSON bool) error {
+	if asJSON {
+		payload := memoryActivationPlanOutput{
+			Target:     plan.Target.String(),
+			TargetPath: plan.TargetPath,
+			Existing:   plan.Existing,
+			Markdown:   plan.Markdown,
+			Diff:       plan.Diff,
+		}
+		encoder := json.NewEncoder(output)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to encode memory activation plan", "memory activation plan の JSON 出力に失敗しました"), err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(output, "target: %s\nexisting: %t\n\n", plan.TargetPath, plan.Existing); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation plan", "memory activation plan の出力に失敗しました"), err)
+	}
+	body := plan.Markdown
+	if plan.Diff != "" {
+		body = plan.Diff
+	}
+	if _, err := fmt.Fprint(output, body); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation content", "memory activation content の出力に失敗しました"), err)
+	}
+	return nil
+}

--- a/presentation/cli/memory_activate_test.go
+++ b/presentation/cli/memory_activate_test.go
@@ -1,0 +1,89 @@
+package cli_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_MemoryActivateDryRunPrintsPlan(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "traceary.md")
+	memoryStub := &memoryUsecaseStub{
+		activationPlan: apptypes.MemoryActivationPlan{
+			Target:     apptypes.MemoryBridgeTargetCodex,
+			TargetPath: targetPath,
+			Markdown:   "<!-- traceary-memories:begin:v1 -->\nplanned\n<!-- traceary-memories:end -->\n",
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "codex",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "target: "+targetPath) || !strings.Contains(stdout.String(), "planned") {
+		t.Fatalf("stdout = %q; want target path and planned content", stdout.String())
+	}
+	assertMemoryActivateCall(t, memoryStub, true)
+}
+
+func TestRootCLI_MemoryActivateRejectsNonDryRun(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "activate", "--target", "codex"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error without --dry-run")
+	}
+	if len(memoryStub.activationPlanCalls) != 0 {
+		t.Fatalf("ActivatePlan should not be called without --dry-run")
+	}
+}
+
+func assertMemoryActivateCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGlobal bool) {
+	t.Helper()
+	if len(stub.activationPlanCalls) != 1 {
+		t.Fatalf("activation plan calls = %d, want 1", len(stub.activationPlanCalls))
+	}
+	call := stub.activationPlanCalls[0]
+	if call.Target != apptypes.MemoryBridgeTargetCodex {
+		t.Fatalf("Target = %q, want codex", call.Target)
+	}
+	if call.IncludeGlobal != wantIncludeGlobal {
+		t.Fatalf("IncludeGlobal = %v, want %v", call.IncludeGlobal, wantIncludeGlobal)
+	}
+	if len(call.Scopes) != 1 {
+		t.Fatalf("Scopes len = %d, want 1", len(call.Scopes))
+	}
+	if call.Scopes[0].Kind() != types.MemoryScopeKindWorkspace || call.Scopes[0].Key() != "github.com/duck8823/traceary" {
+		t.Fatalf("Scopes[0] = %s:%s, want workspace:github.com/duck8823/traceary", call.Scopes[0].Kind(), call.Scopes[0].Key())
+	}
+}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -231,6 +231,15 @@ type memoryExportOutput struct {
 	ExportedCount int    `json:"exported_count"`
 }
 
+// memoryActivationPlanOutput is the JSON shape of a dry-run activation plan.
+type memoryActivationPlanOutput struct {
+	Target     string `json:"target"`
+	TargetPath string `json:"target_path"`
+	Existing   bool   `json:"existing"`
+	Markdown   string `json:"markdown"`
+	Diff       string `json:"diff,omitempty"`
+}
+
 func formatJSONTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -362,6 +362,8 @@ type memoryUsecaseStub struct {
 	applyErr           error
 	exportResult       apptypes.MemoryExportResult
 	exportErr          error
+	activationPlan     apptypes.MemoryActivationPlan
+	activationPlanErr  error
 
 	rememberCall struct {
 		memoryType   types.MemoryType
@@ -394,6 +396,7 @@ type memoryUsecaseStub struct {
 	importCalls          []apptypes.CodexImportCriteria
 	bridgeImportCalls    []apptypes.MemoryBridgeImportCriteria
 	exportCalls          []apptypes.MemoryExportCriteria
+	activationPlanCalls  []apptypes.MemoryActivationCriteria
 }
 
 func (s *memoryUsecaseStub) Remember(_ context.Context, memoryType types.MemoryType, scope types.MemoryScope, fact string, confidence types.Optional[types.Confidence], source types.MemorySource, evidenceRefs []types.EvidenceRef, artifactRefs []types.ArtifactRef) (apptypes.MemoryDetails, error) {
@@ -490,6 +493,11 @@ func (s *memoryUsecaseStub) Apply(_ context.Context, _ apptypes.MemoryHygieneApp
 func (s *memoryUsecaseStub) Export(_ context.Context, criteria apptypes.MemoryExportCriteria) (apptypes.MemoryExportResult, error) {
 	s.exportCalls = append(s.exportCalls, criteria)
 	return s.exportResult, s.exportErr
+}
+
+func (s *memoryUsecaseStub) ActivatePlan(_ context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
+	s.activationPlanCalls = append(s.activationPlanCalls, criteria)
+	return s.activationPlan, s.activationPlanErr
 }
 
 // storeManagementUsecaseStub implements usecase.StoreManagementUsecase for testing.


### PR DESCRIPTION
## Motivation

Before Traceary writes host-native memory files, operators need a safe planning layer that resolves the target, renders the managed content, and optionally compares it with an existing file. This avoids overwriting user-authored Codex memory shards and gives #861 a concrete write contract to build on.

## Changes

- Add memory activation criteria/result types and a dry-run planning usecase.
- Resolve the Codex default activation target to the Traceary-managed `traceary.md` file under the Codex memory root.
- Support `--root` and `--path` overrides.
- Render activation content through the existing export path, preserving workspace + global scope semantics from #860.
- Add `traceary memory activate --target codex --dry-run` with text/JSON output and optional `--diff`.
- Keep activation dry-run only; no files are created or mutated.
- Document activation planning and add usecase/CLI tests for path resolution, overrides, missing/existing targets, diff output, markers, and scope behavior.

## Review notes

- Gemini scout remains unavailable in this sandboxed run: local Gemini CLI opens browser authentication and does not complete headless review.
- Requesting PR review via `@codex review` after ready.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./application/usecase ./presentation/cli -run 'TestMemoryUsecase_ActivatePlan|TestRootCLI_MemoryActivate|TestRootCLI_MemoryFamily_JSON_Goldens'`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...`
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go tool golangci-lint run` (No issues found; rtk exits 7)

Closes #866
