### PR TITLE
v0.12.0-10: activate accepted memories into Codex files

### DIFF
--- a/application/types/memory_activation.go
+++ b/application/types/memory_activation.go
@@ -31,9 +31,12 @@ type MemoryActivationPlan struct {
 type MemoryActivationApplyAction string
 
 const (
+	// MemoryActivationApplyCreated means the activation target file was created.
 	MemoryActivationApplyCreated MemoryActivationApplyAction = "created"
+	// MemoryActivationApplyUpdated means an existing activation target changed.
 	MemoryActivationApplyUpdated MemoryActivationApplyAction = "updated"
-	MemoryActivationApplyNoop    MemoryActivationApplyAction = "noop"
+	// MemoryActivationApplyNoop means the activation target was already current.
+	MemoryActivationApplyNoop MemoryActivationApplyAction = "noop"
 )
 
 // String returns the canonical string form.

--- a/application/types/memory_activation.go
+++ b/application/types/memory_activation.go
@@ -17,10 +17,35 @@ type MemoryActivationCriteria struct {
 // MemoryActivationPlan is the resolved dry-run output for a host-native
 // activation. Markdown is the content that would be written to TargetPath.
 type MemoryActivationPlan struct {
-	Target     MemoryBridgeTarget
-	TargetPath string
-	Scopes     []domtypes.MemoryScope
-	Markdown   string
-	Existing   bool
-	Diff       string
+	Target         MemoryBridgeTarget
+	TargetPath     string
+	Scopes         []domtypes.MemoryScope
+	Markdown       string
+	Existing       bool
+	Diff           string
+	ActivatedCount int
+}
+
+// MemoryActivationApplyAction summarizes the observable filesystem outcome of
+// a non-dry-run activation.
+type MemoryActivationApplyAction string
+
+const (
+	MemoryActivationApplyCreated MemoryActivationApplyAction = "created"
+	MemoryActivationApplyUpdated MemoryActivationApplyAction = "updated"
+	MemoryActivationApplyNoop    MemoryActivationApplyAction = "noop"
+)
+
+// String returns the canonical string form.
+func (a MemoryActivationApplyAction) String() string { return string(a) }
+
+// MemoryActivationApplyResult reports the effect of writing accepted memories
+// into a host-native activation target.
+type MemoryActivationApplyResult struct {
+	Target         MemoryBridgeTarget
+	TargetPath     string
+	Scopes         []domtypes.MemoryScope
+	Action         MemoryActivationApplyAction
+	Existing       bool
+	ActivatedCount int
 }

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -247,11 +247,7 @@ func writeActivationTargetAtomic(path string, content string, existed bool) erro
 		return xerrors.Errorf("failed to create activation target directory %s: %w", dir, err)
 	}
 	perm := os.FileMode(0o600)
-	if existed {
-		info, err := os.Lstat(path)
-		if err != nil {
-			return xerrors.Errorf("failed to stat activation target %s: %w", path, err)
-		}
+	if info, err := os.Lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return xerrors.Errorf("activation target symlinks are not supported: %s", path)
 		}
@@ -261,6 +257,8 @@ func writeActivationTargetAtomic(path string, content string, existed bool) erro
 		if mode := info.Mode().Perm(); mode != 0 {
 			perm = mode
 		}
+	} else if existed || !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to stat activation target %s: %w", path, err)
 	}
 	tmp, err := os.CreateTemp(dir, ".traceary-"+filepath.Base(path)+".*.tmp")
 	if err != nil {

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -25,11 +25,7 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 		return apptypes.MemoryActivationPlan{}, err
 	}
 
-	exportResult, err := (&memoryExportUsecase{memoryQuery: u.memoryQuery}).Export(ctx, apptypes.MemoryExportCriteria{
-		Target:        criteria.Target,
-		Scopes:        criteria.Scopes,
-		IncludeGlobal: criteria.IncludeGlobal,
-	})
+	exportResult, err := u.renderActivationBlock(ctx, criteria)
 	if err != nil {
 		return apptypes.MemoryActivationPlan{}, err
 	}
@@ -38,19 +34,67 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 	if err != nil {
 		return apptypes.MemoryActivationPlan{}, err
 	}
+	planned, _, err := mergeActivationTarget(existing, exists, exportResult.Markdown)
+	if err != nil {
+		return apptypes.MemoryActivationPlan{}, err
+	}
 	diff := ""
-	if criteria.Diff && exists && existing != exportResult.Markdown {
-		diff = renderActivationDiff(targetPath, existing, exportResult.Markdown)
+	if criteria.Diff && exists && existing != planned {
+		diff = renderActivationDiff(targetPath, existing, planned)
 	}
 
 	return apptypes.MemoryActivationPlan{
-		Target:     criteria.Target,
-		TargetPath: targetPath,
-		Scopes:     exportResult.Scopes,
-		Markdown:   exportResult.Markdown,
-		Existing:   exists,
-		Diff:       diff,
+		Target:         criteria.Target,
+		TargetPath:     targetPath,
+		Scopes:         exportResult.Scopes,
+		Markdown:       planned,
+		Existing:       exists,
+		Diff:           diff,
+		ActivatedCount: exportResult.ExportedCount,
 	}, nil
+}
+
+func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationApplyResult, error) {
+	targetPath, err := resolveMemoryActivationTargetPath(criteria)
+	if err != nil {
+		return apptypes.MemoryActivationApplyResult{}, err
+	}
+
+	exportResult, err := u.renderActivationBlock(ctx, criteria)
+	if err != nil {
+		return apptypes.MemoryActivationApplyResult{}, err
+	}
+
+	existing, exists, err := readExistingActivationTarget(targetPath)
+	if err != nil {
+		return apptypes.MemoryActivationApplyResult{}, err
+	}
+	planned, action, err := mergeActivationTarget(existing, exists, exportResult.Markdown)
+	if err != nil {
+		return apptypes.MemoryActivationApplyResult{}, err
+	}
+	if action != apptypes.MemoryActivationApplyNoop {
+		if err := writeActivationTargetAtomic(targetPath, planned, exists); err != nil {
+			return apptypes.MemoryActivationApplyResult{}, err
+		}
+	}
+
+	return apptypes.MemoryActivationApplyResult{
+		Target:         criteria.Target,
+		TargetPath:     targetPath,
+		Scopes:         exportResult.Scopes,
+		Action:         action,
+		Existing:       exists,
+		ActivatedCount: exportResult.ExportedCount,
+	}, nil
+}
+
+func (u *memoryActivationUsecase) renderActivationBlock(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryExportResult, error) {
+	return (&memoryExportUsecase{memoryQuery: u.memoryQuery}).Export(ctx, apptypes.MemoryExportCriteria{
+		Target:        criteria.Target,
+		Scopes:        criteria.Scopes,
+		IncludeGlobal: criteria.IncludeGlobal,
+	})
 }
 
 func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
@@ -95,6 +139,160 @@ func readExistingActivationTarget(path string) (string, bool, error) {
 		return "", false, xerrors.Errorf("failed to read activation target %s: %w", path, err)
 	}
 	return string(data), true, nil
+}
+
+func mergeActivationTarget(existing string, exists bool, managedBlock string) (string, apptypes.MemoryActivationApplyAction, error) {
+	if !exists {
+		return managedBlock, apptypes.MemoryActivationApplyCreated, nil
+	}
+	region, found, err := findMemoryBridgeBlockRegion(existing)
+	if err != nil {
+		return "", "", err
+	}
+	if found {
+		merged := existing[:region.start] + managedBlock + existing[region.end:]
+		if merged == existing {
+			return existing, apptypes.MemoryActivationApplyNoop, nil
+		}
+		return merged, apptypes.MemoryActivationApplyUpdated, nil
+	}
+	merged := appendManagedBlock(existing, managedBlock)
+	if merged == existing {
+		return existing, apptypes.MemoryActivationApplyNoop, nil
+	}
+	return merged, apptypes.MemoryActivationApplyUpdated, nil
+}
+
+type memoryBridgeBlockRegion struct {
+	start int
+	end   int
+}
+
+func findMemoryBridgeBlockRegion(content string) (memoryBridgeBlockRegion, bool, error) {
+	offset := 0
+	beginStart := -1
+	endOffset := -1
+	for _, line := range splitContentLines(content) {
+		trimmed := strings.TrimSpace(line.text)
+		if version, ok := MatchMemoryBridgeBeginLine(trimmed); ok {
+			if version > MemoryBridgeCurrentVersion {
+				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("refusing to overwrite newer Traceary managed block version v%d (current v%d)", version, MemoryBridgeCurrentVersion)
+			}
+			if beginStart >= 0 {
+				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory blocks found")
+			}
+			beginStart = offset
+		}
+		if trimmed == MemoryBridgeMarkerEnd {
+			if beginStart < 0 {
+				offset += len(line.raw)
+				continue
+			}
+			if endOffset >= 0 {
+				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory end markers found")
+			}
+			endOffset = offset + len(line.raw)
+		}
+		offset += len(line.raw)
+	}
+	if beginStart < 0 {
+		return memoryBridgeBlockRegion{}, false, nil
+	}
+	if endOffset < 0 {
+		return memoryBridgeBlockRegion{}, false, xerrors.Errorf("Traceary managed memory begin marker found without end marker")
+	}
+	return memoryBridgeBlockRegion{start: beginStart, end: endOffset}, true, nil
+}
+
+type contentLine struct {
+	raw  string
+	text string
+}
+
+func splitContentLines(content string) []contentLine {
+	if content == "" {
+		return nil
+	}
+	lines := make([]contentLine, 0, strings.Count(content, "\n")+1)
+	for len(content) > 0 {
+		next := strings.IndexByte(content, '\n')
+		if next < 0 {
+			lines = append(lines, contentLine{raw: content, text: strings.TrimSuffix(content, "\r")})
+			break
+		}
+		raw := content[:next+1]
+		text := strings.TrimSuffix(strings.TrimSuffix(raw, "\n"), "\r")
+		lines = append(lines, contentLine{raw: raw, text: text})
+		content = content[next+1:]
+	}
+	return lines
+}
+
+func appendManagedBlock(existing string, managedBlock string) string {
+	if existing == "" {
+		return managedBlock
+	}
+	if !strings.HasSuffix(existing, "\n") {
+		return existing + "\n\n" + managedBlock
+	}
+	if !strings.HasSuffix(existing, "\n\n") {
+		return existing + "\n" + managedBlock
+	}
+	return existing + managedBlock
+}
+
+func writeActivationTargetAtomic(path string, content string, existed bool) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return xerrors.Errorf("failed to create activation target directory %s: %w", dir, err)
+	}
+	perm := os.FileMode(0o600)
+	if existed {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return xerrors.Errorf("failed to stat activation target %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return xerrors.Errorf("activation target symlinks are not supported: %s", path)
+		}
+		if info.IsDir() {
+			return xerrors.Errorf("activation target is a directory: %s", path)
+		}
+		if mode := info.Mode().Perm(); mode != 0 {
+			perm = mode
+		}
+	}
+	tmp, err := os.CreateTemp(dir, ".traceary-"+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return xerrors.Errorf("failed to create temporary activation target in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to chmod temporary activation target %s: %w", tmpPath, err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to write temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to sync temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return xerrors.Errorf("failed to close temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return xerrors.Errorf("failed to replace activation target %s: %w", path, err)
+	}
+	cleanup = false
+	return nil
 }
 
 func renderActivationDiff(path string, existing string, planned string) string {

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -342,6 +342,40 @@ func TestMemoryUsecase_Activate_RefusesNewerManagedBlockVersion(t *testing.T) {
 	}
 }
 
+func TestMemoryUsecase_Activate_RejectsDanglingSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "traceary.md")
+	missingTarget := filepath.Join(dir, "missing.md")
+	if err := os.Symlink(missingTarget, targetPath); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-dangling-symlink", domtypes.MemoryTypePreference, scope, "reject dangling symlink activation targets"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	_, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err == nil || !strings.Contains(err.Error(), "symlinks are not supported") {
+		t.Fatalf("Activate error = %v, want symlink rejection", err)
+	}
+	info, statErr := os.Lstat(targetPath)
+	if statErr != nil {
+		t.Fatalf("Lstat: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("activation replaced dangling symlink with mode %s", info.Mode())
+	}
+}
+
 func mustWorkspaceScope(t *testing.T, value string) domtypes.MemoryScope {
 	t.Helper()
 	workspace, err := domtypes.WorkspaceFrom(value)

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -49,6 +49,9 @@ func TestMemoryUsecase_ActivatePlan_DefaultCodexTargetIsDryRunOnly(t *testing.T)
 	if !strings.Contains(plan.Markdown, usecase.MemoryBridgeMarkerBegin) || !strings.Contains(plan.Markdown, "## Global memories") {
 		t.Fatalf("planned markdown missing managed markers/global section: %q", plan.Markdown)
 	}
+	if plan.ActivatedCount != 2 {
+		t.Fatalf("ActivatedCount = %d, want 2", plan.ActivatedCount)
+	}
 }
 
 func TestMemoryUsecase_ActivatePlan_PathOverrideAndExistingDiff(t *testing.T) {
@@ -109,4 +112,241 @@ func TestMemoryUsecase_ActivatePlan_RejectsUnsupportedTargetWithPathOverride(t *
 	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
 		t.Fatalf("ActivatePlan error = %v, want unsupported target", err)
 	}
+}
+func TestMemoryUsecase_Activate_CreatesCodexTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m1", domtypes.MemoryTypePreference, scope, "prefer concise PRs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Root:   filepath.Join(root, "nested"),
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if result.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("Action = %q, want created", result.Action)
+	}
+	if result.ActivatedCount != 1 {
+		t.Fatalf("ActivatedCount = %d, want 1", result.ActivatedCount)
+	}
+	data, err := os.ReadFile(result.TargetPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, usecase.MemoryBridgeMarkerBegin) || !strings.Contains(got, "prefer concise PRs") {
+		t.Fatalf("target file missing managed memory: %q", got)
+	}
+}
+
+func TestMemoryUsecase_Activate_ReplacesManagedBlockAndPreservesUserContent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "traceary.md")
+	existing := strings.Join([]string{
+		"# User-authored memory",
+		"",
+		"- keep this note",
+		usecase.MemoryBridgeMarkerBegin,
+		"old managed content",
+		usecase.MemoryBridgeMarkerEnd,
+		"",
+		"afterword",
+		"",
+	}, "\n")
+	if err := os.WriteFile(targetPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m2", domtypes.MemoryTypeDecision, scope, "use Traceary as source of truth"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if result.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("Action = %q, want updated", result.Action)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"# User-authored memory", "- keep this note", "afterword", "use Traceary as source of truth"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("target file missing %q: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "old managed content") {
+		t.Fatalf("old managed block was not replaced: %q", got)
+	}
+}
+
+func TestMemoryUsecase_Activate_AppendsManagedBlockWhenNoExistingBlock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "traceary.md")
+	if err := os.WriteFile(targetPath, []byte("# User content\n\n- manual Codex note\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m3", domtypes.MemoryTypeConstraint, scope, "always preserve user-authored shards"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if result.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("Action = %q, want updated", result.Action)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "# User content\n\n- manual Codex note\n\n"+usecase.MemoryBridgeMarkerBegin) {
+		t.Fatalf("managed block was not appended after preserving user content: %q", got)
+	}
+}
+
+func TestMemoryUsecase_Activate_AppendsManagedBlockWhenOnlyEndMarkerExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "traceary.md")
+	existing := "# User content\n\n- docs mention " + usecase.MemoryBridgeMarkerEnd + " literally\n"
+	if err := os.WriteFile(targetPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-end-marker", domtypes.MemoryTypeConstraint, scope, "orphan end markers should stay user content"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	result, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if result.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("Action = %q, want updated", result.Action)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, existing) || !strings.Contains(got, "orphan end markers should stay user content") {
+		t.Fatalf("activation should preserve orphan end marker content and append managed block, got %q", got)
+	}
+}
+
+func TestMemoryUsecase_Activate_IsIdempotentWhenContentUnchanged(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m4", domtypes.MemoryTypeLesson, scope, "rerunning activation should be a no-op"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	}
+	first, err := sut.Activate(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("Activate first: %v", err)
+	}
+	second, err := sut.Activate(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("Activate second: %v", err)
+	}
+	if first.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("first Action = %q, want created", first.Action)
+	}
+	if second.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("second Action = %q, want noop", second.Action)
+	}
+}
+
+func TestMemoryUsecase_Activate_RefusesNewerManagedBlockVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "traceary.md")
+	existing := "<!-- traceary-memories:begin:v99 -->\nfuture content\n" + usecase.MemoryBridgeMarkerEnd + "\n"
+	if err := os.WriteFile(targetPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m5", domtypes.MemoryTypePreference, scope, "prefer safe activation"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	_, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   targetPath,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err == nil {
+		t.Fatalf("expected newer managed block refusal")
+	}
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if string(data) != existing {
+		t.Fatalf("newer managed block file mutated: %q", string(data))
+	}
+}
+
+func mustWorkspaceScope(t *testing.T, value string) domtypes.MemoryScope {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom(value)
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	return domtypes.WorkspaceScopeOf(workspace)
 }

--- a/application/usecase/memory_export.go
+++ b/application/usecase/memory_export.go
@@ -29,7 +29,7 @@ const (
 	MemoryBridgeMarkerBegin    = "<!-- traceary-memories:begin:v1 -->"
 	MemoryBridgeMarkerEnd      = "<!-- traceary-memories:end -->"
 	MemoryBridgeCurrentVersion = 1
-	memoryBridgeWarning        = "<!-- DO NOT EDIT: this block is managed by `traceary memory export`. Hand edits will be overwritten on the next export. -->"
+	memoryBridgeWarning        = "<!-- DO NOT EDIT: this block is managed by Traceary. Hand edits will be overwritten by `traceary memory export` or `traceary memory activate`. -->"
 )
 
 // memoryBridgeBeginPattern matches every begin marker Traceary has ever

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -125,6 +125,9 @@ type MemoryUsecase interface {
 
 	// ActivatePlan resolves a host-native activation target and renders the dry-run content.
 	ActivatePlan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error)
+
+	// Activate writes accepted durable memories into a host-native activation target.
+	Activate(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationApplyResult, error)
 }
 
 type memoryProposer interface {

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -640,6 +640,10 @@ func (u *memoryUsecase) ActivatePlan(ctx context.Context, criteria apptypes.Memo
 	return (&memoryActivationUsecase{memoryQuery: u.memoryQuery}).Plan(ctx, criteria)
 }
 
+func (u *memoryUsecase) Activate(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationApplyResult, error) {
+	return (&memoryActivationUsecase{memoryQuery: u.memoryQuery}).Apply(ctx, criteria)
+}
+
 func (u *memoryUsecase) findMemoryByID(ctx context.Context, memoryID domtypes.MemoryID) (*model.Memory, error) {
 	resolvedMemoryID, err := domtypes.MemoryIDFrom(memoryID.String())
 	if err != nil {

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -352,17 +352,18 @@ accepted な durable memory をホスト別 instruction file (CLAUDE.md / AGENTS
 
 ### `traceary memory activate`
 
-host-native activation をファイル書き込みなしで計画します。v0.12.0 では dry-run 専用で、`memory activate --target codex --dry-run` は Traceary 管理の Codex target (`~/.codex/memories/traceary.md`、または `--root <dir>/traceary.md` / `--path <file>` で上書き) を解決し、書き込まれる予定の content を表示します。計画される content は `memory export` と同じ workspace + global scope ルールを使います。`--diff` を指定すると既存 target file との差分を表示します。
+accepted な memory を Traceary 管理の Codex native memory file に activation します。`memory activate --target codex --dry-run` は target (`~/.codex/memories/traceary.md`、または `--root <dir>/traceary.md` / `--path <file>` で上書き) を解決し、filesystem を変更せずに書き込まれる予定の content を表示します。`memory activate --target codex --apply` は directory/file を必要に応じて作成し、Traceary 管理ブロックだけを置換して、その外側の user-authored content は保持します。memory が変わらない再実行は no-op になり、新しい marker version の管理ブロックは古い binary で上書きしません。
 
 主な flag:
 
 - `--target` — 現時点では `codex`
-- `--dry-run` — このリリースでは必須。ファイルは作成・更新しません
+- `--dry-run` — ファイルを作成・更新せず activation plan を表示
+- `--apply` — activation target file に書き込む
 - `--root` — Codex memory root の上書き
 - `--path` — target file の明示上書き
 - `--workspace` / `--include-global` / `--no-global` — activation scope control
-- `--diff` — target file が存在する場合に diff を含める
-- `--json` — activation plan を JSON で出力
+- `--diff` — target file が存在する場合に diff を含める (dry-run のみ)
+- `--json` — activation plan / apply result を JSON で出力
 
 ### `traceary memory import instructions`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -352,17 +352,18 @@ Useful flags:
 
 ### `traceary memory activate`
 
-Plan host-native activation without writing files. For v0.12.0 the command is dry-run only; `memory activate --target codex --dry-run` resolves the Traceary-managed Codex target (`~/.codex/memories/traceary.md`, or `--root <dir>/traceary.md` / `--path <file>` when overridden) and prints the content that would be written. The planned content uses the same workspace + global export semantics as `memory export`. Pass `--diff` to compare the planned content with an existing target file.
+Activate accepted memories into a Traceary-managed Codex native memory file. `memory activate --target codex --dry-run` resolves the target (`~/.codex/memories/traceary.md`, or `--root <dir>/traceary.md` / `--path <file>` when overridden) and prints the content that would be written without mutating the filesystem. `memory activate --target codex --apply` writes the file, creating the directory/file when needed, replacing only the Traceary-managed block, and preserving user-authored content outside that block. Re-running with unchanged memories is a no-op, and Traceary refuses to overwrite a managed block from a newer marker version.
 
 Useful flags:
 
 - `--target` — currently `codex`
-- `--dry-run` — required in this release; never writes or creates files
+- `--dry-run` — print the activation plan without writing or creating files
+- `--apply` — write the activation target file
 - `--root` — Codex memory root override
 - `--path` — explicit target file override
 - `--workspace` / `--include-global` / `--no-global` — activation scope controls
-- `--diff` — include a diff when the target file exists
-- `--json` — print the activation plan as JSON
+- `--diff` — include a diff when the target file exists (dry-run only)
+- `--json` — print the activation plan or apply result as JSON
 
 ### `traceary memory import instructions`
 

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -168,11 +168,13 @@ export 出力は常に `<!-- traceary-memories:begin:v1 -->` / `<!-- traceary-me
 
 workspace export は user-level の運用ルール (PR title や review policy など) も host file に載るよう、既定で `global` memory を含めます。Markdown は `Global memories` / `Workspace memories` など scope ごとに見出しを分けます。従来の workspace-only filter を維持したい場合は `--no-global` (MCP では `include_global=false`) を使い、既定挙動を明示したい場合は `--include-global` を指定します。
 
-host-native file を変更する前段として activation planning を dry-run で使えます。
+host-native file を変更する前段として activation planning を dry-run で使い、その後明示的に apply できます。
 
 - `traceary memory activate --target codex --dry-run`
+- `traceary memory activate --target codex --apply`
 
 Codex の既定 target は Traceary 管理ファイル (`~/.codex/memories/traceary.md`) で、user-authored な memory shard を上書きしません。`--root` / `--path` で明示上書きでき、`--diff` で既存 target file との差分を表示できます。
+apply mode は必要に応じて target directory/file を作成し、Traceary 管理ブロックだけを置換し、その外側の user-authored content は保持します。出力には activated memory count を含み、新しい marker version の管理ブロックは古い binary で上書きしません。
 
 import は Codex の Markdown memory（既定値は `~/.codex/memories/*.md`）を読みます。legacy `MEMORY.md` は `## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` の allow-list を維持し、それ以外の Markdown shard は任意の見出し配下の bullet/list item を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
 

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -205,15 +205,20 @@ scope groups under distinct headings. Use `--no-global` (or
 `include_global=false` over MCP) to preserve the old workspace-only
 filter; use `--include-global` to make the default explicit.
 
-Activation planning is available as a dry-run layer before any host-native
-file is mutated:
+Activation can be planned before any host-native file is mutated, then
+applied explicitly:
 
 - `traceary memory activate --target codex --dry-run`
+- `traceary memory activate --target codex --apply`
 
 The Codex default target is Traceary-managed
 (`~/.codex/memories/traceary.md`) so user-authored memory shards are not
-overwritten. `--root` and `--path` provide explicit overrides, and `--diff`
-prints a planned diff against an existing target file.
+overwritten. `--root` and `--path` provide explicit overrides, and
+`--diff` prints a planned diff against an existing target file in dry-run
+mode. Apply mode creates the target directory/file when needed, replaces
+only the Traceary-managed block, preserves user-authored content outside
+that block, reports the activated memory count, and refuses to overwrite a
+managed block stamped with a newer marker version.
 
 Import reads local Codex Markdown memories (`~/.codex/memories/*.md` by
 default). Legacy `MEMORY.md` keeps the handbook allow-list

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -446,8 +446,8 @@ type memoryExportCommandInput struct {
 }
 
 // memoryActivateCommandInput is the resolved input to `traceary memory
-// activate`. v0.12's first activation surface is dry-run only; the
-// write-side path is introduced by the follow-up issue.
+// activate`. Callers must explicitly choose dry-run planning or apply mode
+// so host-native memory files are never mutated by accident.
 type memoryActivateCommandInput struct {
 	dbPath        string
 	target        string
@@ -457,6 +457,7 @@ type memoryActivateCommandInput struct {
 	includeGlobal bool
 	noGlobal      bool
 	dryRun        bool
+	apply         bool
 	diff          bool
 	asJSON        bool
 }

--- a/presentation/cli/memory_activate.go
+++ b/presentation/cli/memory_activate.go
@@ -32,6 +32,7 @@ func (c *RootCLI) newMemoryActivateCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&input.includeGlobal, "include-global", true, Localize("include global memories alongside a workspace activation (default true)", "workspace activation に global memory も含める (default true)"))
 	cmd.Flags().BoolVar(&input.noGlobal, "no-global", false, Localize("activate only the explicit workspace scope; do not include global memories", "明示した workspace scope のみを activation し、global memory は含めない"))
 	cmd.Flags().BoolVar(&input.dryRun, "dry-run", false, Localize("print the activation plan without writing files", "ファイルを書き込まず activation plan を表示する"))
+	cmd.Flags().BoolVar(&input.apply, "apply", false, Localize("write the activation target file", "activation target file に書き込む"))
 	cmd.Flags().BoolVar(&input.diff, "diff", false, Localize("include a diff against the existing target file when present", "既存の対象ファイルがある場合に diff を含める"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	_ = cmd.MarkFlagRequired("target")
@@ -45,8 +46,11 @@ func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input
 	if c.memory == nil {
 		return xerrors.Errorf(Localize("memory usecase is not configured", "memory activation ユースケースが設定されていません"))
 	}
-	if !input.dryRun {
-		return xerrors.Errorf(Localize("memory activate currently supports --dry-run only", "memory activate は現在 --dry-run のみ対応しています"))
+	if input.dryRun == input.apply {
+		return xerrors.Errorf(Localize("pass exactly one of --dry-run or --apply", "--dry-run または --apply のどちらか一方を指定してください"))
+	}
+	if input.diff && input.apply {
+		return xerrors.Errorf(Localize("--diff can only be used with --dry-run", "--diff は --dry-run と一緒にのみ使用できます"))
 	}
 	target, ok := apptypes.MemoryBridgeTargetOf(strings.ToLower(strings.TrimSpace(input.target)))
 	if !ok || target != apptypes.MemoryBridgeTargetCodex {
@@ -69,6 +73,13 @@ func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input
 		criteria.Scopes = []domtypes.MemoryScope{scope}
 		criteria.IncludeGlobal = input.includeGlobal && !input.noGlobal
 	}
+	if input.apply {
+		result, err := c.memory.Activate(ctx, criteria)
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to activate memories", "memory activation に失敗しました"), err)
+		}
+		return writeMemoryActivationApplyResult(output, result, input.asJSON)
+	}
 	plan, err := c.memory.ActivatePlan(ctx, criteria)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to plan memory activation", "memory activation plan の作成に失敗しました"), err)
@@ -79,11 +90,12 @@ func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input
 func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationPlan, asJSON bool) error {
 	if asJSON {
 		payload := memoryActivationPlanOutput{
-			Target:     plan.Target.String(),
-			TargetPath: plan.TargetPath,
-			Existing:   plan.Existing,
-			Markdown:   plan.Markdown,
-			Diff:       plan.Diff,
+			Target:         plan.Target.String(),
+			TargetPath:     plan.TargetPath,
+			Existing:       plan.Existing,
+			ActivatedCount: plan.ActivatedCount,
+			Markdown:       plan.Markdown,
+			Diff:           plan.Diff,
 		}
 		encoder := json.NewEncoder(output)
 		encoder.SetEscapeHTML(false)
@@ -102,6 +114,35 @@ func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationP
 	}
 	if _, err := fmt.Fprint(output, body); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation content", "memory activation content の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func writeMemoryActivationApplyResult(output io.Writer, result apptypes.MemoryActivationApplyResult, asJSON bool) error {
+	if asJSON {
+		payload := memoryActivationApplyOutput{
+			Target:         result.Target.String(),
+			TargetPath:     result.TargetPath,
+			Action:         result.Action.String(),
+			Existing:       result.Existing,
+			ActivatedCount: result.ActivatedCount,
+		}
+		encoder := json.NewEncoder(output)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to encode memory activation result", "memory activation result の JSON 出力に失敗しました"), err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		"target: %s\nactivated_count: %d\naction: %s\n",
+		result.TargetPath,
+		result.ActivatedCount,
+		result.Action.String(),
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation result", "memory activation result の出力に失敗しました"), err)
 	}
 	return nil
 }

--- a/presentation/cli/memory_activate_test.go
+++ b/presentation/cli/memory_activate_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -61,10 +62,123 @@ func TestRootCLI_MemoryActivateRejectsNonDryRun(t *testing.T) {
 
 	err := rootCmd.Execute()
 	if err == nil {
-		t.Fatalf("expected error without --dry-run")
+		t.Fatalf("expected error without --dry-run or --apply")
 	}
 	if len(memoryStub.activationPlanCalls) != 0 {
 		t.Fatalf("ActivatePlan should not be called without --dry-run")
+	}
+	if len(memoryStub.activationCalls) != 0 {
+		t.Fatalf("Activate should not be called without --apply")
+	}
+}
+
+func TestRootCLI_MemoryActivateApplyPrintsSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "traceary.md")
+	memoryStub := &memoryUsecaseStub{
+		activationResult: apptypes.MemoryActivationApplyResult{
+			Target:         apptypes.MemoryBridgeTargetCodex,
+			TargetPath:     targetPath,
+			Action:         apptypes.MemoryActivationApplyCreated,
+			ActivatedCount: 2,
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "codex",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--apply",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "target: "+targetPath) || !strings.Contains(out, "activated_count: 2") || !strings.Contains(out, "action: created") {
+		t.Fatalf("stdout = %q; want activation summary", out)
+	}
+	assertMemoryApplyCall(t, memoryStub, true)
+	if len(memoryStub.activationPlanCalls) != 0 {
+		t.Fatalf("ActivatePlan should not be called in apply mode")
+	}
+}
+
+func TestRootCLI_MemoryActivateApplyJSON(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "traceary.md")
+	memoryStub := &memoryUsecaseStub{
+		activationResult: apptypes.MemoryActivationApplyResult{
+			Target:         apptypes.MemoryBridgeTargetCodex,
+			TargetPath:     targetPath,
+			Action:         apptypes.MemoryActivationApplyNoop,
+			Existing:       true,
+			ActivatedCount: 3,
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "codex",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--apply",
+		"--json",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var payload struct {
+		Target         string `json:"target"`
+		TargetPath     string `json:"target_path"`
+		Action         string `json:"action"`
+		Existing       bool   `json:"existing"`
+		ActivatedCount int    `json:"activated_count"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout=%s", err, stdout.String())
+	}
+	if payload.Target != "codex" || payload.TargetPath != targetPath || payload.Action != "noop" || !payload.Existing || payload.ActivatedCount != 3 {
+		t.Fatalf("payload = %+v, want codex/noop existing count", payload)
+	}
+}
+
+func TestRootCLI_MemoryActivateRejectsDiffWithApply(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"memory", "activate", "--target", "codex", "--apply", "--diff"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for --diff with --apply")
+	}
+	if len(memoryStub.activationCalls) != 0 || len(memoryStub.activationPlanCalls) != 0 {
+		t.Fatalf("memory usecase should not be called for invalid mode")
 	}
 }
 
@@ -74,6 +188,26 @@ func assertMemoryActivateCall(t *testing.T, stub *memoryUsecaseStub, wantInclude
 		t.Fatalf("activation plan calls = %d, want 1", len(stub.activationPlanCalls))
 	}
 	call := stub.activationPlanCalls[0]
+	if call.Target != apptypes.MemoryBridgeTargetCodex {
+		t.Fatalf("Target = %q, want codex", call.Target)
+	}
+	if call.IncludeGlobal != wantIncludeGlobal {
+		t.Fatalf("IncludeGlobal = %v, want %v", call.IncludeGlobal, wantIncludeGlobal)
+	}
+	if len(call.Scopes) != 1 {
+		t.Fatalf("Scopes len = %d, want 1", len(call.Scopes))
+	}
+	if call.Scopes[0].Kind() != types.MemoryScopeKindWorkspace || call.Scopes[0].Key() != "github.com/duck8823/traceary" {
+		t.Fatalf("Scopes[0] = %s:%s, want workspace:github.com/duck8823/traceary", call.Scopes[0].Kind(), call.Scopes[0].Key())
+	}
+}
+
+func assertMemoryApplyCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGlobal bool) {
+	t.Helper()
+	if len(stub.activationCalls) != 1 {
+		t.Fatalf("activation calls = %d, want 1", len(stub.activationCalls))
+	}
+	call := stub.activationCalls[0]
 	if call.Target != apptypes.MemoryBridgeTargetCodex {
 		t.Fatalf("Target = %q, want codex", call.Target)
 	}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -233,11 +233,21 @@ type memoryExportOutput struct {
 
 // memoryActivationPlanOutput is the JSON shape of a dry-run activation plan.
 type memoryActivationPlanOutput struct {
-	Target     string `json:"target"`
-	TargetPath string `json:"target_path"`
-	Existing   bool   `json:"existing"`
-	Markdown   string `json:"markdown"`
-	Diff       string `json:"diff,omitempty"`
+	Target         string `json:"target"`
+	TargetPath     string `json:"target_path"`
+	Existing       bool   `json:"existing"`
+	ActivatedCount int    `json:"activated_count"`
+	Markdown       string `json:"markdown"`
+	Diff           string `json:"diff,omitempty"`
+}
+
+// memoryActivationApplyOutput is the JSON shape of a write activation result.
+type memoryActivationApplyOutput struct {
+	Target         string `json:"target"`
+	TargetPath     string `json:"target_path"`
+	Action         string `json:"action"`
+	Existing       bool   `json:"existing"`
+	ActivatedCount int    `json:"activated_count"`
 }
 
 func formatJSONTime(t time.Time) string {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -364,6 +364,8 @@ type memoryUsecaseStub struct {
 	exportErr          error
 	activationPlan     apptypes.MemoryActivationPlan
 	activationPlanErr  error
+	activationResult   apptypes.MemoryActivationApplyResult
+	activationErr      error
 
 	rememberCall struct {
 		memoryType   types.MemoryType
@@ -397,6 +399,7 @@ type memoryUsecaseStub struct {
 	bridgeImportCalls    []apptypes.MemoryBridgeImportCriteria
 	exportCalls          []apptypes.MemoryExportCriteria
 	activationPlanCalls  []apptypes.MemoryActivationCriteria
+	activationCalls      []apptypes.MemoryActivationCriteria
 }
 
 func (s *memoryUsecaseStub) Remember(_ context.Context, memoryType types.MemoryType, scope types.MemoryScope, fact string, confidence types.Optional[types.Confidence], source types.MemorySource, evidenceRefs []types.EvidenceRef, artifactRefs []types.ArtifactRef) (apptypes.MemoryDetails, error) {
@@ -498,6 +501,11 @@ func (s *memoryUsecaseStub) Export(_ context.Context, criteria apptypes.MemoryEx
 func (s *memoryUsecaseStub) ActivatePlan(_ context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
 	s.activationPlanCalls = append(s.activationPlanCalls, criteria)
 	return s.activationPlan, s.activationPlanErr
+}
+
+func (s *memoryUsecaseStub) Activate(_ context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationApplyResult, error) {
+	s.activationCalls = append(s.activationCalls, criteria)
+	return s.activationResult, s.activationErr
 }
 
 // storeManagementUsecaseStub implements usecase.StoreManagementUsecase for testing.


### PR DESCRIPTION
## Motivation

Closes #861.

This PR implements the write/apply half of Codex native memory activation. It builds on #880's dry-run activation plan and safely writes accepted Traceary durable memories into the Traceary-managed Codex target file.

Stacked on #880 / #866 and #876 / #860 because activation writes reuse the dry-run target contract and workspace + global export semantics.

## Changes

- Add `MemoryUsecase.Activate` and an apply result model for host-native activation writes.
- Add `traceary memory activate --target codex --apply` as the explicit write mode; `--dry-run` remains the non-mutating plan mode.
- Write to the resolved Codex target (`~/.codex/memories/traceary.md`, `--root`, or `--path`) with atomic replacement.
- Create target directories/files when applying.
- Replace only the Traceary-managed block and preserve user-authored content outside the block.
- Append a managed block when an existing target has no Traceary block.
- Make re-runs idempotent (`action: noop`) when content is unchanged.
- Refuse to overwrite managed blocks stamped with a newer marker version.
- Add text and JSON apply summaries with target path, action, and activated memory count.
- Document `--apply`, dry-run diff behavior, preservation guarantees, and newer-version refusal.

## Validation

- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./application/usecase ./presentation/cli -run 'TestMemoryUsecase_Activate|TestRootCLI_MemoryActivate'` — passed (12 tests / 2 packages)
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./application/usecase ./presentation/cli -run 'TestMemoryUsecase_Export|TestMemoryUsecase_Activate|TestRootCLI_MemoryActivate'` — passed (17 tests / 2 packages)
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go test ./...` — passed (1459 tests / 19 packages)
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go build ./...` — passed
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk go tool golangci-lint run` — no issues

## Dogfooding

- `traceary memory activate --target codex --dry-run --json` against a temp DB/root produced the planned Codex file without writing.
- `traceary memory activate --target codex --apply --json` against a temp DB/root created the target file.
- Re-running the same apply command returned `action: noop`.
- Recorded one accepted temp memory via `traceary memory remember` and verified activation wrote it with `activated_count: 1` and a Codex markdown bullet.

## Notes

Gemini review is attempted when available; the current local Gemini CLI requires OAuth browser auth and cannot complete in this sandboxed run.
