### PR TITLE
v0.12.0-12: document host memory activation strategy

### DIFF
--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -11,6 +11,16 @@ Claude 向け package は `integrations/claude-plugin/` にあり、repository r
 - `Bash` / `mcp__.*` / 組み込み tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`) 向けの `PostToolUse` / `PostToolUseFailure` audit hook
 - slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
+## Memory activation strategy
+
+Claude integration の v0.12 は、Traceary の accepted memory store を MCP tools と instruction-file export 経由で使います。review 済み memory を Claude project instructions に見せるには、Traceary 管理ブロックとして export します。
+
+```sh
+traceary memory export --target claude --out CLAUDE.md
+```
+
+これは Codex host-native activation とは別の経路です。`traceary memory activate --target claude` は v0.12 では**未実装**で、Claude plugin は Claude-native memory file を書きません。Anthropic SDK loop を自前で持つ場合は experimental な [Anthropic native memory tool](./anthropic-memory-tool.ja.md) backend も使えますが、その store は curated な `memories` aggregate とは分離しています。将来の安全な Claude-native activation path は follow-up #883 で扱います。
+
 ## Install
 
 1. 先に Traceary CLI を入れます。

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -11,6 +11,24 @@ The Claude package lives under `integrations/claude-plugin/` and is published th
 - `PostToolUse` / `PostToolUseFailure` audit hooks for `Bash`, `mcp__.*`, and the built-in tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)
 - slash-style skills: `/traceary-help` plus the contextual `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember` skills. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて") and writes durable memory directly. The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
+## Memory activation strategy
+
+Claude integration in v0.12 uses Traceary's accepted memory store through MCP
+tools and instruction-file export. To make reviewed memories visible in Claude
+project instructions, export them into a Traceary-managed block:
+
+```sh
+traceary memory export --target claude --out CLAUDE.md
+```
+
+This is different from Codex host-native activation. `traceary memory activate
+--target claude` is **not implemented** in v0.12, and the Claude plugin does not
+write Claude-native memory files. If you own a direct Anthropic SDK loop, the
+experimental native memory-tool backend remains available via
+[`anthropic-memory-tool`](./anthropic-memory-tool.md), but that store is
+separate from the curated `memories` aggregate. Follow-up #883 tracks a future
+safe Claude-native activation path.
+
 ## Install
 
 1. Install the Traceary CLI first.

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -44,6 +44,19 @@ traceary doctor --client codex --json
 - slash command: `/traceary:help`, `/traceary:doctor`
 - 文脈に効く skill: `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember`。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
+## Memory activation strategy
+
+Codex は v0.12 で full Traceary host-native activation を持つ最初のホストです。accepted memory は引き続き Traceary の SQLite store を source of truth とし、activation command は Codex memory target（既定は `~/.codex/memories/traceary.md`）へ Traceary 管理ブロックだけを書きます。
+
+```sh
+traceary memory activate --target codex --dry-run --diff
+traceary memory activate --target codex --status
+traceary memory activate --target codex --apply
+traceary doctor --client codex --json
+```
+
+apply path は必要に応じて target directory/file を作成し、管理ブロック外の user-authored content を保持します。accepted memory set が変わっていなければ冪等に no-op となり、新しい marker version の管理ブロックは上書きしません。
+
 ## 更新
 
 リポジトリを更新して、次回 Codex が `/plugins` をリフレッシュした時に新しいバージョンを取り込みます。

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -44,6 +44,24 @@ traceary doctor --client codex --json
 - slash commands: `/traceary:help` and `/traceary:doctor`
 - contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて"). The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
+## Memory activation strategy
+
+Codex is the first host with full Traceary host-native activation in v0.12.
+Accepted memories remain in Traceary's SQLite store as the source of truth, and
+the activation command writes only a Traceary-managed block into the Codex memory
+target (`~/.codex/memories/traceary.md` by default):
+
+```sh
+traceary memory activate --target codex --dry-run --diff
+traceary memory activate --target codex --status
+traceary memory activate --target codex --apply
+traceary doctor --client codex --json
+```
+
+The apply path creates the target directory/file when needed, preserves
+user-authored content outside the managed block, is idempotent when the accepted
+memory set has not changed, and refuses newer managed-block marker versions.
+
 ## Update
 
 Refresh the repository and let Codex pick up the new plugin version on the next `/plugins` refresh:

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -13,6 +13,16 @@ Gemini 向け package は `integrations/gemini-extension/` にあります。Gem
 - slash command の `/traceary-help` と `/traceary-doctor`
 - 文脈で効く `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。旧 `traceary-memory-capture` は deprecated stub として残存（v0.12 で削除予定）。
 
+## Memory activation strategy
+
+Gemini integration の v0.12 は、Traceary の accepted memory store を MCP tools と instruction-file export 経由で使います。review 済み memory を Gemini instructions に見せるには、Traceary 管理ブロックとして export します。
+
+```sh
+traceary memory export --target gemini --out GEMINI.md
+```
+
+これは Codex host-native activation とは意図的に分けています。`traceary memory activate --target gemini` は v0.12 では**未実装**で、extension は Gemini-native memory file を書きません。host-native surface と preview / feature-flag 挙動が十分安定してから扱うため、将来の安全な Gemini-native activation path は follow-up #884 で追跡します。
+
 ## Install
 
 1. 先に Traceary CLI を入れます。

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -13,6 +13,22 @@ The Gemini package lives under `integrations/gemini-extension/`. Gemini CLI expe
 - slash commands: `/traceary-help` and `/traceary-doctor`
 - contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて"). The legacy `traceary-memory-capture` skill is retained as a deprecated stub (will be removed in v0.12).
 
+## Memory activation strategy
+
+Gemini integration in v0.12 uses Traceary's accepted memory store through MCP
+tools and instruction-file export. To make reviewed memories visible in Gemini
+instructions, export them into a Traceary-managed block:
+
+```sh
+traceary memory export --target gemini --out GEMINI.md
+```
+
+This is intentionally separate from Codex host-native activation. `traceary
+memory activate --target gemini` is **not implemented** in v0.12, and the
+extension does not write Gemini-native memory files. Follow-up #884 tracks a
+future safe Gemini-native activation path once the host-native surface and
+preview/feature-flag behavior are stable enough to target.
+
 ## Install
 
 1. Install the Traceary CLI first.

--- a/docs/memory/README.ja.md
+++ b/docs/memory/README.ja.md
@@ -178,6 +178,24 @@ Codex の既定 target は Traceary 管理ファイル (`~/.codex/memories/trace
 apply mode は必要に応じて target directory/file を作成し、Traceary 管理ブロックだけを置換し、その外側の user-authored content は保持します。出力には activated memory count を含み、新しい marker version の管理ブロックは古い binary で上書きしません。
 status mode は read-only で `missing` / `stale` / `in_sync` / `invalid` を表示し、Codex file の作成・更新が必要な場合は正確な dry-run/apply command を出力します。`traceary doctor --client codex` でも同じ activation status を確認できます。
 
+### ホスト別 activation strategy
+
+Traceary では 3 つの層を分けます。
+
+1. **Accepted memory store** — local SQLite の `memories` aggregate。review 済み durable fact の source of truth です。
+2. **Instruction-file export** — `traceary memory export --target <claude|codex|gemini>` が書く決定論的な markdown block。project/user instruction file を読むホスト向けの portable path です。
+3. **Host-native activation** — accepted store をホスト固有の native memory system から見えるようにする file/write path。Traceary 管理ブロック外の user-authored content は保持します。
+
+v0.12 で full host-native activation を実装しているのは **Codex** のみです。
+
+- `traceary memory activate --target codex --dry-run`
+- `traceary memory activate --target codex --status`
+- `traceary memory activate --target codex --apply`
+
+**Claude** の v0.12 推奨 workflow は、Traceary MCP tools と instruction-file export (`traceary memory export --target claude --out CLAUDE.md`) です。Anthropic SDK loop を自前で持つ場合だけ experimental な Anthropic native memory-tool backend も選べます。`memory activate --target claude` は v0.12 では未実装で、将来の safe write path は follow-up #883 で扱います。
+
+**Gemini** の v0.12 推奨 workflow は、Traceary MCP/extension と instruction-file export (`traceary memory export --target gemini --out GEMINI.md`) です。Gemini host-native activation write は意図的に defer しており、follow-up #884 で扱います。
+
 import は Codex の Markdown memory（既定値は `~/.codex/memories/*.md`）を読みます。legacy `MEMORY.md` は `## User preferences` / `## Reusable knowledge` / `## Failures and how to do differently` の allow-list を維持し、それ以外の Markdown shard は任意の見出し配下の bullet/list item を `source=imported` + `status=candidate` として記録します。evidence / artifact ref には元ファイルと行範囲を付与し、sanitizer は全ての imported fact に適用されます。auto-accept はされず、再実行時の dedupe は rejected / superseded / expired を含む全状態を見るので、一度 operator が reject した memory が別 run で resurrect することはありません。
 
 ### 参照する経路

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -224,6 +224,36 @@ it reports `missing`, `stale`, `in_sync`, or `invalid` and emits exact
 dry-run/apply commands when the Codex file needs to be created or refreshed.
 `traceary doctor --client codex` includes the same activation status.
 
+### Activation strategy by host
+
+Traceary uses three distinct layers:
+
+1. **Accepted memory store** — the local SQLite `memories` aggregate. This is
+   the source of truth for reviewed durable facts.
+2. **Instruction-file export** — deterministic markdown blocks written by
+   `traceary memory export --target <claude|codex|gemini>`. Export is the
+   portable path for hosts that consume project/user instruction files.
+3. **Host-native activation** — a host-specific file/write path that makes the
+   accepted store visible to that host's native memory system while preserving
+   user-authored content outside Traceary-managed blocks.
+
+v0.12 implements full host-native activation for **Codex** only:
+
+- `traceary memory activate --target codex --dry-run`
+- `traceary memory activate --target codex --status`
+- `traceary memory activate --target codex --apply`
+
+For **Claude**, the recommended v0.12 workflow remains Traceary MCP tools plus
+instruction-file export (`traceary memory export --target claude --out
+CLAUDE.md`) or the experimental Anthropic native memory-tool backend when you
+own the Anthropic SDK loop directly. `memory activate --target claude` is not
+implemented in v0.12; follow-up #883 tracks a future safe write path.
+
+For **Gemini**, the recommended v0.12 workflow is Traceary MCP/extension usage
+plus instruction-file export (`traceary memory export --target gemini --out
+GEMINI.md`). Gemini host-native activation writes are intentionally deferred;
+follow-up #884 tracks that work.
+
 Import reads local Codex Markdown memories (`~/.codex/memories/*.md` by
 default). Legacy `MEMORY.md` keeps the handbook allow-list
 (`## User preferences`, `## Reusable knowledge`, and `## Failures and how to


### PR DESCRIPTION
## Motivation

Closes #868.

This PR documents how the v0.12 activation model applies across Claude, Codex, and Gemini without implying that the Codex-only native write path exists for every host.

Stacked on #882 / #867 because the docs describe the completed dry-run/status/apply/status contract.

## Changes

- Document the three memory layers:
  - Traceary accepted memory store
  - instruction-file export
  - host-native activation
- Clarify that v0.12 implements full host-native activation only for Codex.
- Document Codex `memory activate --dry-run`, `--status`, `--apply`, and `doctor --client codex` behavior.
- Document Claude's recommended v0.12 path: MCP tools + `memory export --target claude --out CLAUDE.md`; native activation writes are deferred.
- Document Gemini's recommended v0.12 path: MCP/extension + `memory export --target gemini --out GEMINI.md`; native activation writes are deferred.
- Add explicit follow-up references for deferred host-native writes: #883 (Claude) and #884 (Gemini).
- Keep English/Japanese docs paired.

## Validation

- `rtk python3 scripts/verify_docs_i18n.py` — passed
- `GOCACHE=/tmp/traceary-gocache GOTMPDIR=/tmp rtk python3 scripts/verify_integrations.py` — passed
- `rtk python3 scripts/verify_landing.py` — passed

## Notes

Gemini review is attempted when available; the current local Gemini CLI requires OAuth browser auth and cannot complete in this sandboxed run (`listen EPERM: operation not permitted 0.0.0.0`).
