### PR TITLE
v0.13.0-2: generalize host activation target resolution and safe writers

### DIFF
--- a/application/usecase/activation_file_writer.go
+++ b/application/usecase/activation_file_writer.go
@@ -1,0 +1,138 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+)
+
+// activationFileWriter abstracts the filesystem operations the
+// memory-activation usecase needs to safely inspect, read, and write
+// a single managed file. Implementations must enforce the v0.12 Codex
+// activation safety contract independently for every file they touch:
+// reject symlinks and directories, preserve existing permissions,
+// create parent directories with restrictive permissions, write
+// through a temp file in the same directory, sync, and rename
+// atomically. The interface is intentionally narrow so the same
+// contract can be reused for the v0.13 host-context stub file and the
+// external memory file in later issues.
+type activationFileWriter interface {
+	// Inspect lstats the path and returns its FileInfo. The boolean is
+	// true when the path exists. An error is returned for unsafe
+	// targets (symlinks, directories) or when stat itself fails.
+	// Status callers use Inspect to surface "invalid" before reading
+	// or writing.
+	Inspect(path string) (info os.FileInfo, exists bool, err error)
+	// ReadIfExists returns the existing content. exists=false when the
+	// file does not exist. Other errors (including symlink rejection)
+	// are returned as-is.
+	ReadIfExists(path string) (content string, exists bool, err error)
+	// WriteAtomic writes the content via a temp file in the same
+	// directory, then renames atomically. Existing file permissions
+	// are preserved; new files are created with 0o600. Parent
+	// directories are created with 0o700 when missing. Symlink and
+	// directory targets are rejected with the same error wording the
+	// v0.12 Codex activation reported.
+	WriteAtomic(path string, content string) error
+}
+
+// osActivationFileWriter is the default activationFileWriter backed by
+// the local filesystem via the `os` package. It is the only writer the
+// activation usecase wires up in v0.13.0-2; downstream issues can swap
+// in a stricter writer (for example one that uses the fd-pinned safe
+// FS helpers in `infrastructure/filesystem`) without touching
+// memoryActivationUsecase.
+type osActivationFileWriter struct{}
+
+// Inspect reports the file state. Symlinks and directories are
+// rejected so callers cannot accidentally rewrite arbitrary files
+// reached through a managed path.
+func (osActivationFileWriter) Inspect(path string) (os.FileInfo, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, xerrors.Errorf("failed to stat activation target %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, true, xerrors.Errorf("activation target symlinks are not supported: %s", path)
+	}
+	if info.IsDir() {
+		return nil, true, xerrors.Errorf("activation target is a directory: %s", path)
+	}
+	return info, true, nil
+}
+
+// ReadIfExists reads the file content, returning exists=false when the
+// file does not exist. It first runs Inspect so read-only plan/status
+// paths follow the same symlink and directory refusal contract as
+// WriteAtomic.
+func (w osActivationFileWriter) ReadIfExists(path string) (string, bool, error) {
+	if _, exists, err := w.Inspect(path); err != nil || !exists {
+		return "", exists, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, xerrors.Errorf("failed to read activation target %s: %w", path, err)
+	}
+	return string(data), true, nil
+}
+
+// WriteAtomic creates the parent directory with 0o700 if missing,
+// writes content to a temp file in the same directory, syncs, and
+// renames atomically. Existing files keep their permissions; brand-new
+// files are created with 0o600. Symlink and directory targets are
+// rejected before any write occurs so a malicious symlink target
+// cannot be replaced with attacker-controlled content.
+func (w osActivationFileWriter) WriteAtomic(path string, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return xerrors.Errorf("failed to create activation target directory %s: %w", dir, err)
+	}
+	perm := os.FileMode(0o600)
+	info, exists, err := w.Inspect(path)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if mode := info.Mode().Perm(); mode != 0 {
+			perm = mode
+		}
+	}
+	tmp, err := os.CreateTemp(dir, ".traceary-"+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return xerrors.Errorf("failed to create temporary activation target in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to chmod temporary activation target %s: %w", tmpPath, err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to write temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to sync temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return xerrors.Errorf("failed to close temporary activation target %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return xerrors.Errorf("failed to replace activation target %s: %w", path, err)
+	}
+	cleanup = false
+	return nil
+}

--- a/application/usecase/activation_file_writer_internal_test.go
+++ b/application/usecase/activation_file_writer_internal_test.go
@@ -35,3 +35,56 @@ func TestOSActivationFileWriter_ReadIfExistsRejectsDirectory(t *testing.T) {
 		t.Fatalf("ReadIfExists error = %v, want directory rejection", err)
 	}
 }
+
+func TestOSActivationFileWriter_WriteAtomicCreatesNewFileWithRestrictedPermissions(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "nested", "traceary.md")
+	if err := (osActivationFileWriter{}).WriteAtomic(target, "managed\n"); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "managed\n" {
+		t.Fatalf("content = %q, want managed block", data)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 0600", got)
+	}
+}
+
+func TestOSActivationFileWriter_WriteAtomicPreservesExistingPermissions(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "traceary.md")
+	if err := os.WriteFile(target, []byte("old\n"), 0o640); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(target, 0o640); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	if err := (osActivationFileWriter{}).WriteAtomic(target, "new\n"); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "new\n" {
+		t.Fatalf("content = %q, want replacement", data)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("mode = %o, want preserved 0640", got)
+	}
+}

--- a/application/usecase/activation_file_writer_internal_test.go
+++ b/application/usecase/activation_file_writer_internal_test.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOSActivationFileWriter_ReadIfExistsRejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "traceary.md")
+	if err := os.WriteFile(target, []byte("secret target\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	_, _, err := osActivationFileWriter{}.ReadIfExists(link)
+	if err == nil || !strings.Contains(err.Error(), "symlinks are not supported") {
+		t.Fatalf("ReadIfExists error = %v, want symlink rejection", err)
+	}
+}
+
+func TestOSActivationFileWriter_ReadIfExistsRejectsDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, _, err := osActivationFileWriter{}.ReadIfExists(dir)
+	if err == nil || !strings.Contains(err.Error(), "activation target is a directory") {
+		t.Fatalf("ReadIfExists error = %v, want directory rejection", err)
+	}
+}

--- a/application/usecase/activation_target.go
+++ b/application/usecase/activation_target.go
@@ -1,0 +1,80 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// codexActivationFileName is the canonical filename Traceary writes when
+// it activates accepted memories into Codex's native memory directory.
+// The default activation root is `~/.codex/memories`, so the resulting
+// path is `~/.codex/memories/traceary.md`.
+const codexActivationFileName = "traceary.md"
+
+// activationTarget resolves the host file Traceary will manage for one
+// activation criteria. v0.13.0-2 only ships the Codex single-file
+// resolver. The descriptor is host-agnostic so v0.13.0-3+ can plug in
+// two-file Claude / Gemini resolvers (host-context import stub +
+// external memory file) without rewriting memoryActivationUsecase.
+type activationTarget interface {
+	// Target returns the host this descriptor activates.
+	Target() apptypes.MemoryBridgeTarget
+	// ResolvePath returns the absolute path of the file that will be
+	// inspected, read, or written by the activation usecase.
+	ResolvePath(criteria apptypes.MemoryActivationCriteria) (string, error)
+}
+
+type codexActivationTarget struct{}
+
+// Target returns MemoryBridgeTargetCodex.
+func (codexActivationTarget) Target() apptypes.MemoryBridgeTarget {
+	return apptypes.MemoryBridgeTargetCodex
+}
+
+// ResolvePath returns the absolute file path Codex activation manages.
+// `criteria.Path` (when non-empty) wins over both `criteria.Root` and the
+// default; `criteria.Root` overrides the default; otherwise the path is
+// `<HOME>/.codex/memories/traceary.md`.
+func (codexActivationTarget) ResolvePath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve activation path: %w", err)
+		}
+		return abs, nil
+	}
+	root := strings.TrimSpace(criteria.Root)
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve user home directory: %w", err)
+		}
+		root = filepath.Join(home, ".codex", "memories")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", xerrors.Errorf("failed to resolve codex memory root: %w", err)
+	}
+	return filepath.Join(absRoot, codexActivationFileName), nil
+}
+
+// resolveActivationTarget dispatches a MemoryBridgeTarget to its
+// host-specific descriptor. Targets that are reserved by the contract
+// but not yet wired through the activation usecase return a
+// "not supported yet" error so the CLI surface stays in lockstep with
+// the implementation work tracked in the v0.13.0 milestone.
+func resolveActivationTarget(target apptypes.MemoryBridgeTarget) (activationTarget, error) {
+	if _, ok := apptypes.MemoryBridgeTargetOf(target.String()); !ok {
+		return nil, xerrors.Errorf("unsupported memory activation target: %s", target)
+	}
+	switch target {
+	case apptypes.MemoryBridgeTargetCodex:
+		return codexActivationTarget{}, nil
+	}
+	return nil, xerrors.Errorf("memory activation target %s is not supported yet", target)
+}

--- a/application/usecase/activation_target_internal_test.go
+++ b/application/usecase/activation_target_internal_test.go
@@ -1,0 +1,97 @@
+package usecase
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestResolveActivationTarget_ReturnsCodexDescriptor(t *testing.T) {
+	t.Parallel()
+
+	target, err := resolveActivationTarget(apptypes.MemoryBridgeTargetCodex)
+	if err != nil {
+		t.Fatalf("resolveActivationTarget(codex) error = %v", err)
+	}
+	if got := target.Target(); got != apptypes.MemoryBridgeTargetCodex {
+		t.Fatalf("Target() = %q, want codex", got)
+	}
+}
+
+func TestResolveActivationTarget_RejectsUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveActivationTarget(apptypes.MemoryBridgeTarget("unknown"))
+	if err == nil || !strings.Contains(err.Error(), "unsupported memory activation target") {
+		t.Fatalf("resolveActivationTarget(unknown) err = %v, want unsupported-target rejection", err)
+	}
+}
+
+func TestResolveActivationTarget_RejectsClaudeAndGeminiUntilLaterIssues(t *testing.T) {
+	t.Parallel()
+
+	cases := []apptypes.MemoryBridgeTarget{
+		apptypes.MemoryBridgeTargetClaude,
+		apptypes.MemoryBridgeTargetGemini,
+	}
+	for _, target := range cases {
+		t.Run(string(target), func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveActivationTarget(target)
+			if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+				t.Fatalf("resolveActivationTarget(%q) err = %v, want not-supported-yet rejection", target, err)
+			}
+		})
+	}
+}
+
+func TestCodexActivationTarget_PathOverrideWinsOverRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "custom.md")
+	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Path:   custom,
+		Root:   filepath.Join(dir, "ignored"),
+	})
+	if err != nil {
+		t.Fatalf("ResolvePath error = %v", err)
+	}
+	if got != custom {
+		t.Fatalf("ResolvePath = %q, want %q (Path must override Root)", got, custom)
+	}
+}
+
+func TestCodexActivationTarget_RootOverrideAppendsTracearyMd(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+		Root:   dir,
+	})
+	if err != nil {
+		t.Fatalf("ResolvePath error = %v", err)
+	}
+	want := filepath.Join(dir, codexActivationFileName)
+	if got != want {
+		t.Fatalf("ResolvePath = %q, want %q", got, want)
+	}
+}
+
+func TestCodexActivationTarget_DefaultPathStillUsesCodexHomeAndFilename(t *testing.T) {
+	t.Parallel()
+
+	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetCodex,
+	})
+	if err != nil {
+		t.Fatalf("ResolvePath error = %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join(".codex", "memories", codexActivationFileName)) {
+		t.Fatalf("default ResolvePath = %q, want suffix .codex/memories/%s (default Codex layout must not change)", got, codexActivationFileName)
+	}
+}

--- a/application/usecase/managed_block.go
+++ b/application/usecase/managed_block.go
@@ -1,0 +1,174 @@
+package usecase
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// managedBlockMarkers describes the marker contract Traceary uses to find,
+// parse, and replace a managed region inside a host file. Different host
+// activation files use different marker prefixes (the v0.13 host-context
+// import stub and the external memory file each get their own markers),
+// so the parser is parameterized rather than hard-coded to one prefix.
+type managedBlockMarkers struct {
+	// Begin is the canonical begin line for the current marker version.
+	Begin string
+	// End is the canonical end line. Marker end lines do not carry a
+	// version suffix in the v0.12 contract.
+	End string
+	// BeginPattern matches every supported begin marker version.
+	BeginPattern *regexp.Regexp
+	// CurrentVersion is the highest version Traceary will overwrite. A
+	// region whose begin marker version exceeds this is rejected.
+	CurrentVersion int
+}
+
+// memoryBridgeBlockMarkers is the marker contract for the Traceary-managed
+// memory block (`<!-- traceary-memories:* -->`). v0.12 ships this single
+// contract for Codex; v0.13 reuses the same contract for Claude/Gemini
+// external memory files. The activation usecase is the only caller in
+// v0.13.0-2; #891 introduces the stub-marker contract for the host
+// context import line.
+var memoryBridgeBlockMarkers = managedBlockMarkers{
+	Begin:          MemoryBridgeMarkerBegin,
+	End:            MemoryBridgeMarkerEnd,
+	BeginPattern:   memoryBridgeBeginPattern,
+	CurrentVersion: MemoryBridgeCurrentVersion,
+}
+
+// managedBlockRegion is the byte range a managed region occupies inside
+// the host file. The semi-open interval [start, end) covers the begin
+// marker line through and including the end marker line (and its
+// trailing newline if any), so callers can substitute the entire region
+// without manual offset arithmetic.
+type managedBlockRegion struct {
+	start int
+	end   int
+}
+
+// findRegion scans content for a Traceary managed region. The boolean is
+// false when no begin marker is present. An error is returned for
+// malformed or unsupported regions: orphan begin markers, duplicate begin
+// or end markers, and begin markers whose version exceeds CurrentVersion.
+func (m managedBlockMarkers) findRegion(content string) (managedBlockRegion, bool, error) {
+	offset := 0
+	beginStart := -1
+	endOffset := -1
+	for _, line := range splitContentLines(content) {
+		trimmed := strings.TrimSpace(line.text)
+		if version, ok := matchManagedBeginLine(m.BeginPattern, trimmed); ok {
+			if version > m.CurrentVersion {
+				return managedBlockRegion{}, false, xerrors.Errorf("refusing to overwrite newer Traceary managed block version v%d (current v%d)", version, m.CurrentVersion)
+			}
+			if beginStart >= 0 {
+				return managedBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory blocks found")
+			}
+			beginStart = offset
+		}
+		if trimmed == m.End {
+			if beginStart < 0 {
+				offset += len(line.raw)
+				continue
+			}
+			if endOffset >= 0 {
+				return managedBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory end markers found")
+			}
+			endOffset = offset + len(line.raw)
+		}
+		offset += len(line.raw)
+	}
+	if beginStart < 0 {
+		return managedBlockRegion{}, false, nil
+	}
+	if endOffset < 0 {
+		return managedBlockRegion{}, false, xerrors.Errorf("Traceary managed memory begin marker found without end marker")
+	}
+	return managedBlockRegion{start: beginStart, end: endOffset}, true, nil
+}
+
+// replaceOrAppend computes the merged content and observable apply
+// action for a host file managed by these markers. exists indicates
+// whether the original file is present; when false the managed block
+// becomes the entire content. When the region is found, the existing
+// region is replaced; otherwise the block is appended at end-of-file
+// using the v0.12 spacing rule (preserve user content, leave one blank
+// line before the managed region).
+func (m managedBlockMarkers) replaceOrAppend(existing string, exists bool, managedBlock string) (string, apptypes.MemoryActivationApplyAction, error) {
+	if !exists {
+		return managedBlock, apptypes.MemoryActivationApplyCreated, nil
+	}
+	region, found, err := m.findRegion(existing)
+	if err != nil {
+		return "", "", err
+	}
+	if found {
+		merged := existing[:region.start] + managedBlock + existing[region.end:]
+		if merged == existing {
+			return existing, apptypes.MemoryActivationApplyNoop, nil
+		}
+		return merged, apptypes.MemoryActivationApplyUpdated, nil
+	}
+	merged := appendManagedBlockWithSpacing(existing, managedBlock)
+	if merged == existing {
+		return existing, apptypes.MemoryActivationApplyNoop, nil
+	}
+	return merged, apptypes.MemoryActivationApplyUpdated, nil
+}
+
+func matchManagedBeginLine(pattern *regexp.Regexp, line string) (int, bool) {
+	match := pattern.FindStringSubmatch(line)
+	if match == nil {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+// appendManagedBlockWithSpacing appends a managed block to existing
+// content using the activation-contract spacing rule: leave exactly one
+// blank line before the managed region so the user's content and the
+// managed region remain visibly separate after a `cat` of the file.
+func appendManagedBlockWithSpacing(existing, managedBlock string) string {
+	if existing == "" {
+		return managedBlock
+	}
+	if !strings.HasSuffix(existing, "\n") {
+		return existing + "\n\n" + managedBlock
+	}
+	if !strings.HasSuffix(existing, "\n\n") {
+		return existing + "\n" + managedBlock
+	}
+	return existing + managedBlock
+}
+
+type contentLine struct {
+	raw  string
+	text string
+}
+
+func splitContentLines(content string) []contentLine {
+	if content == "" {
+		return nil
+	}
+	lines := make([]contentLine, 0, strings.Count(content, "\n")+1)
+	for len(content) > 0 {
+		next := strings.IndexByte(content, '\n')
+		if next < 0 {
+			lines = append(lines, contentLine{raw: content, text: strings.TrimSuffix(content, "\r")})
+			break
+		}
+		raw := content[:next+1]
+		text := strings.TrimSuffix(strings.TrimSuffix(raw, "\n"), "\r")
+		lines = append(lines, contentLine{raw: raw, text: text})
+		content = content[next+1:]
+	}
+	return lines
+}

--- a/application/usecase/managed_block_internal_test.go
+++ b/application/usecase/managed_block_internal_test.go
@@ -1,0 +1,228 @@
+package usecase
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// fakeMarkers exercises managedBlockMarkers with a marker prefix that is
+// not the v0.12 Codex `traceary-memories` marker. The host-context import
+// stub planned for v0.13.0-3 reuses the same parser with different
+// markers, so this confirms the primitive is host-agnostic and not
+// accidentally coupled to memoryBridgeBlockMarkers.
+var fakeMarkers = managedBlockMarkers{
+	Begin:          "<!-- fake:begin:v1 -->",
+	End:            "<!-- fake:end -->",
+	BeginPattern:   regexp.MustCompile(`^<!-- fake:begin:v(\d+) -->$`),
+	CurrentVersion: 1,
+}
+
+func TestManagedBlockMarkers_FindRegion_ReturnsRegionWithCustomMarkers(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		"prelude",
+		fakeMarkers.Begin,
+		"managed body",
+		fakeMarkers.End,
+		"trailer",
+		"",
+	}, "\n")
+	region, found, err := fakeMarkers.findRegion(content)
+	if err != nil {
+		t.Fatalf("findRegion error = %v", err)
+	}
+	if !found {
+		t.Fatalf("findRegion found = false, want true")
+	}
+	if got := content[region.start:region.end]; got != fakeMarkers.Begin+"\nmanaged body\n"+fakeMarkers.End+"\n" {
+		t.Fatalf("region content mismatch: %q", got)
+	}
+}
+
+func TestManagedBlockMarkers_FindRegion_RejectsDuplicateBegin(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		fakeMarkers.Begin,
+		"first",
+		fakeMarkers.End,
+		"",
+		fakeMarkers.Begin,
+		"second",
+		fakeMarkers.End,
+		"",
+	}, "\n")
+	_, _, err := fakeMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "multiple Traceary managed memory blocks") {
+		t.Fatalf("findRegion error = %v, want duplicate-begin rejection", err)
+	}
+}
+
+func TestManagedBlockMarkers_FindRegion_RejectsNewerVersion(t *testing.T) {
+	t.Parallel()
+
+	content := "<!-- fake:begin:v9 -->\nfuture\n" + fakeMarkers.End + "\n"
+	_, _, err := fakeMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite newer Traceary managed block version v9") {
+		t.Fatalf("findRegion error = %v, want newer-version rejection", err)
+	}
+}
+
+func TestManagedBlockMarkers_FindRegion_RejectsOrphanBegin(t *testing.T) {
+	t.Parallel()
+
+	content := fakeMarkers.Begin + "\nbody without end\n"
+	_, _, err := fakeMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "without end marker") {
+		t.Fatalf("findRegion error = %v, want orphan-begin rejection", err)
+	}
+}
+
+func TestManagedBlockMarkers_FindRegion_IgnoresOrphanEnd(t *testing.T) {
+	t.Parallel()
+
+	content := "user prose mentioning " + fakeMarkers.End + " literally\n"
+	_, found, err := fakeMarkers.findRegion(content)
+	if err != nil {
+		t.Fatalf("findRegion error = %v", err)
+	}
+	if found {
+		t.Fatalf("findRegion found = true, want false (orphan end is treated as user content)")
+	}
+}
+
+func TestManagedBlockMarkers_FindRegion_RejectsDuplicateEnd(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Join([]string{
+		fakeMarkers.Begin,
+		"body",
+		fakeMarkers.End,
+		fakeMarkers.End,
+		"",
+	}, "\n")
+	_, _, err := fakeMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "multiple Traceary managed memory end markers") {
+		t.Fatalf("findRegion error = %v, want duplicate-end rejection", err)
+	}
+}
+
+func TestManagedBlockMarkers_ReplaceOrAppend_CreatesWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	managed := fakeMarkers.Begin + "\nfresh\n" + fakeMarkers.End + "\n"
+	got, action, err := fakeMarkers.replaceOrAppend("", false, managed)
+	if err != nil {
+		t.Fatalf("replaceOrAppend error = %v", err)
+	}
+	if action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("action = %q, want created", action)
+	}
+	if got != managed {
+		t.Fatalf("content = %q, want %q", got, managed)
+	}
+}
+
+func TestManagedBlockMarkers_ReplaceOrAppend_ReplacesExistingRegion(t *testing.T) {
+	t.Parallel()
+
+	existing := "preface\n\n" + fakeMarkers.Begin + "\nstale\n" + fakeMarkers.End + "\n\nepilogue\n"
+	managed := fakeMarkers.Begin + "\nrefreshed\n" + fakeMarkers.End + "\n"
+	got, action, err := fakeMarkers.replaceOrAppend(existing, true, managed)
+	if err != nil {
+		t.Fatalf("replaceOrAppend error = %v", err)
+	}
+	if action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("action = %q, want updated", action)
+	}
+	if !strings.Contains(got, "preface\n") || !strings.Contains(got, "epilogue\n") {
+		t.Fatalf("user-authored content lost: %q", got)
+	}
+	if strings.Contains(got, "stale") {
+		t.Fatalf("stale managed body retained: %q", got)
+	}
+	if !strings.Contains(got, "refreshed") {
+		t.Fatalf("fresh managed body missing: %q", got)
+	}
+}
+
+func TestManagedBlockMarkers_ReplaceOrAppend_NoopWhenIdentical(t *testing.T) {
+	t.Parallel()
+
+	managed := fakeMarkers.Begin + "\nstable\n" + fakeMarkers.End + "\n"
+	existing := "user notes\n\n" + managed
+	got, action, err := fakeMarkers.replaceOrAppend(existing, true, managed)
+	if err != nil {
+		t.Fatalf("replaceOrAppend error = %v", err)
+	}
+	if action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("action = %q, want noop", action)
+	}
+	if got != existing {
+		t.Fatalf("content changed for identical block: %q", got)
+	}
+}
+
+func TestManagedBlockMarkers_ReplaceOrAppend_AppendsWithSpacing(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		existing string
+		want     string
+	}{
+		{
+			name:     "no trailing newline",
+			existing: "intro line",
+			want:     "intro line\n\nBLOCK",
+		},
+		{
+			name:     "single trailing newline",
+			existing: "intro line\n",
+			want:     "intro line\n\nBLOCK",
+		},
+		{
+			name:     "blank line already present",
+			existing: "intro line\n\n",
+			want:     "intro line\n\nBLOCK",
+		},
+		{
+			name:     "empty",
+			existing: "",
+			want:     "BLOCK",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := appendManagedBlockWithSpacing(tc.existing, "BLOCK")
+			if got != tc.want {
+				t.Fatalf("appendManagedBlockWithSpacing(%q, BLOCK) = %q, want %q", tc.existing, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMemoryBridgeBlockMarkers_FindsCanonicalCodexRegion(t *testing.T) {
+	t.Parallel()
+
+	content := "preface\n\n" + MemoryBridgeMarkerBegin + "\nbody\n" + MemoryBridgeMarkerEnd + "\n"
+	region, found, err := memoryBridgeBlockMarkers.findRegion(content)
+	if err != nil {
+		t.Fatalf("findRegion error = %v", err)
+	}
+	if !found {
+		t.Fatalf("found = false, want canonical Codex marker recognized")
+	}
+	got := content[region.start:region.end]
+	want := MemoryBridgeMarkerBegin + "\nbody\n" + MemoryBridgeMarkerEnd + "\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("canonical region mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -3,8 +3,6 @@ package usecase
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -13,10 +11,20 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
-const codexActivationFileName = "traceary.md"
-
 type memoryActivationUsecase struct {
 	memoryQuery queryservice.MemoryQueryService
+	// fileWriter is the safe-write adapter for the activation target
+	// file. The zero value uses osActivationFileWriter so callers that
+	// build the usecase inline (memoryUsecase delegations and tests)
+	// keep the v0.12 filesystem semantics without explicit wiring.
+	fileWriter activationFileWriter
+}
+
+func (u *memoryActivationUsecase) writer() activationFileWriter {
+	if u.fileWriter == nil {
+		return osActivationFileWriter{}
+	}
+	return u.fileWriter
 }
 
 func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
@@ -30,11 +38,12 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 		return apptypes.MemoryActivationPlan{}, err
 	}
 
-	existing, exists, err := readExistingActivationTarget(targetPath)
+	writer := u.writer()
+	existing, exists, err := writer.ReadIfExists(targetPath)
 	if err != nil {
-		return apptypes.MemoryActivationPlan{}, err
+		return apptypes.MemoryActivationPlan{}, xerrors.Errorf("failed to load activation target for plan: %w", err)
 	}
-	planned, _, err := mergeActivationTarget(existing, exists, exportResult.Markdown)
+	planned, _, err := memoryBridgeBlockMarkers.replaceOrAppend(existing, exists, exportResult.Markdown)
 	if err != nil {
 		return apptypes.MemoryActivationPlan{}, err
 	}
@@ -65,17 +74,18 @@ func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.M
 		return apptypes.MemoryActivationApplyResult{}, err
 	}
 
-	existing, exists, err := readExistingActivationTarget(targetPath)
+	writer := u.writer()
+	existing, exists, err := writer.ReadIfExists(targetPath)
 	if err != nil {
-		return apptypes.MemoryActivationApplyResult{}, err
+		return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("failed to load activation target before apply: %w", err)
 	}
-	planned, action, err := mergeActivationTarget(existing, exists, exportResult.Markdown)
+	planned, action, err := memoryBridgeBlockMarkers.replaceOrAppend(existing, exists, exportResult.Markdown)
 	if err != nil {
 		return apptypes.MemoryActivationApplyResult{}, err
 	}
 	if action != apptypes.MemoryActivationApplyNoop {
-		if err := writeActivationTargetAtomic(targetPath, planned); err != nil {
-			return apptypes.MemoryActivationApplyResult{}, err
+		if err := writer.WriteAtomic(targetPath, planned); err != nil {
+			return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("failed to apply activation target: %w", err)
 		}
 	}
 
@@ -106,13 +116,14 @@ func (u *memoryActivationUsecase) Status(ctx context.Context, criteria apptypes.
 		ActivatedCount: exportResult.ExportedCount,
 	}
 
-	if _, _, err := inspectActivationTargetForWrite(targetPath); err != nil {
+	writer := u.writer()
+	if _, _, err := writer.Inspect(targetPath); err != nil {
 		result.State = apptypes.MemoryActivationStatusInvalid
 		result.Message = err.Error()
 		return result, nil
 	}
 
-	existing, exists, err := readExistingActivationTarget(targetPath)
+	existing, exists, err := writer.ReadIfExists(targetPath)
 	if err != nil {
 		result.State = apptypes.MemoryActivationStatusInvalid
 		result.Message = err.Error()
@@ -124,7 +135,7 @@ func (u *memoryActivationUsecase) Status(ctx context.Context, criteria apptypes.
 		result.Message = "activation target file is missing"
 		return result, nil
 	}
-	region, found, err := findMemoryBridgeBlockRegion(existing)
+	region, found, err := memoryBridgeBlockMarkers.findRegion(existing)
 	if err != nil {
 		result.State = apptypes.MemoryActivationStatusInvalid
 		result.Message = err.Error()
@@ -153,213 +164,19 @@ func (u *memoryActivationUsecase) renderActivationBlock(ctx context.Context, cri
 	})
 }
 
+// resolveMemoryActivationTargetPath dispatches the criteria to the
+// host-specific descriptor and returns the absolute file path the
+// activation usecase will manage.
 func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
-	if _, ok := apptypes.MemoryBridgeTargetOf(criteria.Target.String()); !ok {
-		return "", xerrors.Errorf("unsupported memory activation target: %s", criteria.Target)
-	}
-	if criteria.Target != apptypes.MemoryBridgeTargetCodex {
-		return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
-	}
-	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
-		abs, err := filepath.Abs(trimmed)
-		if err != nil {
-			return "", xerrors.Errorf("failed to resolve activation path: %w", err)
-		}
-		return abs, nil
-	}
-	switch criteria.Target {
-	case apptypes.MemoryBridgeTargetCodex:
-		root := strings.TrimSpace(criteria.Root)
-		if root == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", xerrors.Errorf("failed to resolve user home directory: %w", err)
-			}
-			root = filepath.Join(home, ".codex", "memories")
-		}
-		absRoot, err := filepath.Abs(root)
-		if err != nil {
-			return "", xerrors.Errorf("failed to resolve codex memory root: %w", err)
-		}
-		return filepath.Join(absRoot, codexActivationFileName), nil
-	}
-	return "", xerrors.Errorf("memory activation target %s is not supported yet", criteria.Target)
-}
-
-func readExistingActivationTarget(path string) (string, bool, error) {
-	data, err := os.ReadFile(path)
+	target, err := resolveActivationTarget(criteria.Target)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", false, nil
-		}
-		return "", false, xerrors.Errorf("failed to read activation target %s: %w", path, err)
+		return "", err
 	}
-	return string(data), true, nil
-}
-
-func mergeActivationTarget(existing string, exists bool, managedBlock string) (string, apptypes.MemoryActivationApplyAction, error) {
-	if !exists {
-		return managedBlock, apptypes.MemoryActivationApplyCreated, nil
-	}
-	region, found, err := findMemoryBridgeBlockRegion(existing)
+	path, err := target.ResolvePath(criteria)
 	if err != nil {
-		return "", "", err
+		return "", xerrors.Errorf("failed to resolve %s activation target path: %w", criteria.Target, err)
 	}
-	if found {
-		merged := existing[:region.start] + managedBlock + existing[region.end:]
-		if merged == existing {
-			return existing, apptypes.MemoryActivationApplyNoop, nil
-		}
-		return merged, apptypes.MemoryActivationApplyUpdated, nil
-	}
-	merged := appendManagedBlock(existing, managedBlock)
-	if merged == existing {
-		return existing, apptypes.MemoryActivationApplyNoop, nil
-	}
-	return merged, apptypes.MemoryActivationApplyUpdated, nil
-}
-
-type memoryBridgeBlockRegion struct {
-	start int
-	end   int
-}
-
-func findMemoryBridgeBlockRegion(content string) (memoryBridgeBlockRegion, bool, error) {
-	offset := 0
-	beginStart := -1
-	endOffset := -1
-	for _, line := range splitContentLines(content) {
-		trimmed := strings.TrimSpace(line.text)
-		if version, ok := MatchMemoryBridgeBeginLine(trimmed); ok {
-			if version > MemoryBridgeCurrentVersion {
-				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("refusing to overwrite newer Traceary managed block version v%d (current v%d)", version, MemoryBridgeCurrentVersion)
-			}
-			if beginStart >= 0 {
-				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory blocks found")
-			}
-			beginStart = offset
-		}
-		if trimmed == MemoryBridgeMarkerEnd {
-			if beginStart < 0 {
-				offset += len(line.raw)
-				continue
-			}
-			if endOffset >= 0 {
-				return memoryBridgeBlockRegion{}, false, xerrors.Errorf("multiple Traceary managed memory end markers found")
-			}
-			endOffset = offset + len(line.raw)
-		}
-		offset += len(line.raw)
-	}
-	if beginStart < 0 {
-		return memoryBridgeBlockRegion{}, false, nil
-	}
-	if endOffset < 0 {
-		return memoryBridgeBlockRegion{}, false, xerrors.Errorf("Traceary managed memory begin marker found without end marker")
-	}
-	return memoryBridgeBlockRegion{start: beginStart, end: endOffset}, true, nil
-}
-
-type contentLine struct {
-	raw  string
-	text string
-}
-
-func splitContentLines(content string) []contentLine {
-	if content == "" {
-		return nil
-	}
-	lines := make([]contentLine, 0, strings.Count(content, "\n")+1)
-	for len(content) > 0 {
-		next := strings.IndexByte(content, '\n')
-		if next < 0 {
-			lines = append(lines, contentLine{raw: content, text: strings.TrimSuffix(content, "\r")})
-			break
-		}
-		raw := content[:next+1]
-		text := strings.TrimSuffix(strings.TrimSuffix(raw, "\n"), "\r")
-		lines = append(lines, contentLine{raw: raw, text: text})
-		content = content[next+1:]
-	}
-	return lines
-}
-
-func appendManagedBlock(existing string, managedBlock string) string {
-	if existing == "" {
-		return managedBlock
-	}
-	if !strings.HasSuffix(existing, "\n") {
-		return existing + "\n\n" + managedBlock
-	}
-	if !strings.HasSuffix(existing, "\n\n") {
-		return existing + "\n" + managedBlock
-	}
-	return existing + managedBlock
-}
-
-func writeActivationTargetAtomic(path string, content string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return xerrors.Errorf("failed to create activation target directory %s: %w", dir, err)
-	}
-	perm := os.FileMode(0o600)
-	info, statExists, err := inspectActivationTargetForWrite(path)
-	if err != nil {
-		return err
-	}
-	if statExists {
-		if mode := info.Mode().Perm(); mode != 0 {
-			perm = mode
-		}
-	}
-	tmp, err := os.CreateTemp(dir, ".traceary-"+filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return xerrors.Errorf("failed to create temporary activation target in %s: %w", dir, err)
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		return xerrors.Errorf("failed to chmod temporary activation target %s: %w", tmpPath, err)
-	}
-	if _, err := tmp.WriteString(content); err != nil {
-		_ = tmp.Close()
-		return xerrors.Errorf("failed to write temporary activation target %s: %w", tmpPath, err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return xerrors.Errorf("failed to sync temporary activation target %s: %w", tmpPath, err)
-	}
-	if err := tmp.Close(); err != nil {
-		return xerrors.Errorf("failed to close temporary activation target %s: %w", tmpPath, err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return xerrors.Errorf("failed to replace activation target %s: %w", path, err)
-	}
-	cleanup = false
-	return nil
-}
-
-func inspectActivationTargetForWrite(path string) (os.FileInfo, bool, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, false, nil
-		}
-		return nil, false, xerrors.Errorf("failed to stat activation target %s: %w", path, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, true, xerrors.Errorf("activation target symlinks are not supported: %s", path)
-	}
-	if info.IsDir() {
-		return nil, true, xerrors.Errorf("activation target is a directory: %s", path)
-	}
-	return info, true, nil
+	return path, nil
 }
 
 func renderActivationDiff(path string, existing string, planned string) string {


### PR DESCRIPTION
## Motivation

v0.13.0 needs Claude/Gemini activation to reuse the v0.12 Codex safety model instead of duplicating marker parsing, target resolution, and filesystem write logic. This PR prepares those shared primitives while keeping the existing Codex activation surface unchanged.

## Changes

- Extracts marker parsing / managed-region replacement into parameterized `managedBlockMarkers` primitives.
- Extracts activation target resolution into host descriptors, with only Codex wired for now.
- Extracts safe inspect/read/write behavior into a narrow activation file writer.
- Keeps Claude/Gemini activation unsupported until their later sub-issues.
- Adds regression tests for marker host-agnosticism, Codex target resolution, safe read rejection for symlink/directory targets, and direct writer permission/replacement behavior.

## Review notes

- Implementation was performed by Claude Code Opus 4.7 Max per orchestration plan.
- Codex review pass added explicit `ReadIfExists` symlink/directory refusal so read-only plan/status paths share the same unsafe-target policy as writes.
- Gemini scout: ✅ no blockers; NIT for direct `WriteAtomic` tests was addressed.
- No CLI flags, JSON output shapes, doctor output, or Codex default path are intentionally changed.

## Verification

- `rtk go test ./application/usecase -run 'TestOSActivationFileWriter|TestMemoryUsecase_ActivatePlan|TestMemoryUsecase_Activate|TestMemoryUsecase_ActivationStatus'` — passed (`17 passed` before the additional direct writer tests)
- `rtk go test ./application/usecase -run 'TestOSActivationFileWriter'` — passed (`4 passed`)
- `rtk go test ./...` — passed (`1534 passed in 19 packages`)
- `rtk go build ./...` — passed
- `go tool golangci-lint run` — passed (`0 issues.`)
- `rtk git diff --check` — passed

Closes #890