### PR TITLE
v0.13.0-3: add managed import-stub activation planning primitives

### DIFF
--- a/application/usecase/import_stub_activation.go
+++ b/application/usecase/import_stub_activation.go
@@ -154,17 +154,23 @@ func (p *importStubActivationPlanner) Apply(plan importStubActivationPlan) (impo
 		return importStubActivationApplyResult{}, xerrors.Errorf("refusing to apply invalid host context stub %s: %s", plan.HostContext.Path, plan.HostContext.Message)
 	}
 	writer := p.writer()
-	result := importStubActivationApplyResult(plan)
+	result := importStubActivationApplyResult{
+		Target:         plan.Target,
+		Scopes:         slices.Clone(plan.Scopes),
+		ActivatedCount: plan.ActivatedCount,
+	}
 	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyNoop {
 		if err := writer.WriteAtomic(plan.ExternalMemory.Path, plan.ExternalMemory.Markdown); err != nil {
 			return result, xerrors.Errorf("failed to apply external memory file %s: %w", plan.ExternalMemory.Path, err)
 		}
 	}
+	result.ExternalMemory = plan.ExternalMemory
 	if plan.HostContext.Action != apptypes.MemoryActivationApplyNoop {
 		if err := writer.WriteAtomic(plan.HostContext.Path, plan.HostContext.Markdown); err != nil {
 			return result, xerrors.Errorf("failed to apply host context stub %s: %w", plan.HostContext.Path, err)
 		}
 	}
+	result.HostContext = plan.HostContext
 	return result, nil
 }
 

--- a/application/usecase/import_stub_activation.go
+++ b/application/usecase/import_stub_activation.go
@@ -1,0 +1,224 @@
+package usecase
+
+import (
+	"slices"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// importStubActivationCriteria carries the inputs the two-file planner
+// needs to compute a managed import-stub activation plan. The two paths
+// are typically anchored to the same activation root, but the planner
+// itself does not enforce a layout — the host-specific resolver in
+// #892/#894 picks where each file lives.
+type importStubActivationCriteria struct {
+	// Target identifies the host (claude/gemini). It is reserved for
+	// stub warning text and downstream telemetry; the planner does not
+	// branch on it.
+	Target apptypes.MemoryBridgeTarget
+	// HostContextPath is the absolute path to the host context file
+	// (CLAUDE.md / GEMINI.md). The planner inspects, reads, and writes
+	// only this file's managed stub region.
+	HostContextPath string
+	// ExternalMemoryPath is the absolute path to the Traceary-managed
+	// external memory file (e.g. .traceary/memories/<host>.md).
+	ExternalMemoryPath string
+	// ImportPath is the literal value rendered after the `@` inside the
+	// stub. Callers choose relative-vs-absolute encoding before passing
+	// it in.
+	ImportPath string
+	// ExternalMarkdown is the rendered managed memory block that will
+	// occupy the external file's managed region. The planner does not
+	// re-render the export; the caller (memoryActivationUsecase) is
+	// responsible for invoking memory_export.
+	ExternalMarkdown string
+	// Scopes / ActivatedCount are pass-through bookkeeping so the
+	// planner output stays self-describing for callers that build the
+	// final user-facing report.
+	Scopes         []domtypes.MemoryScope
+	ActivatedCount int
+	// Diff requests per-component diff rendering. When true, the
+	// planner populates activationComponentPlan.Diff for components
+	// whose existing content differs from the planned content.
+	Diff bool
+}
+
+// activationComponentPlan is the per-file plan inside a two-file
+// activation pair. Each file carries its own status and action so
+// callers can report the host context stub and the external memory file
+// independently. Markdown is the planned full file content, ready for
+// activationFileWriter.WriteAtomic.
+type activationComponentPlan struct {
+	Path     string
+	Existing bool
+	Markdown string
+	Action   apptypes.MemoryActivationApplyAction
+	Status   apptypes.MemoryActivationStatusState
+	Diff     string
+	Message  string
+}
+
+// importStubActivationPlan is the two-file activation plan emitted by
+// importStubActivationPlanner.Plan. v0.13.0-3 keeps the type internal to
+// the usecase package; #892/#894 wire it through resolveActivationTarget
+// when adding --target claude / gemini.
+//
+// Callers rendering both diffs to operators should use orderedDiffs() to
+// preserve the canonical apply order documented in the v0.13 ADR.
+type importStubActivationPlan struct {
+	Target         apptypes.MemoryBridgeTarget
+	HostContext    activationComponentPlan
+	ExternalMemory activationComponentPlan
+	Scopes         []domtypes.MemoryScope
+	ActivatedCount int
+}
+
+// orderedDiffs returns the per-component diffs in the canonical apply
+// order: external memory file first, host context stub second. This
+// mirrors the ADR's apply ordering so dry-run output and the eventual
+// apply behave the same way.
+func (p importStubActivationPlan) orderedDiffs() []string {
+	out := make([]string, 0, 2)
+	if p.ExternalMemory.Diff != "" {
+		out = append(out, p.ExternalMemory.Diff)
+	}
+	if p.HostContext.Diff != "" {
+		out = append(out, p.HostContext.Diff)
+	}
+	return out
+}
+
+// importStubActivationApplyResult mirrors importStubActivationPlan and
+// carries the post-write per-component state. Each component still
+// carries its observable Action so callers can produce a precise audit
+// log even when one file was a noop.
+type importStubActivationApplyResult struct {
+	Target         apptypes.MemoryBridgeTarget
+	HostContext    activationComponentPlan
+	ExternalMemory activationComponentPlan
+	Scopes         []domtypes.MemoryScope
+	ActivatedCount int
+}
+
+// importStubActivationPlanner computes and applies two-file activation
+// plans (host context stub + external memory file). It reuses the v0.12
+// managed-block parser and activation file writer so symlink / directory
+// / newer-version refusals stay consistent with single-file Codex
+// activation.
+type importStubActivationPlanner struct {
+	// fileWriter is the safe-write adapter used for both files. The
+	// zero value falls back to osActivationFileWriter so tests and the
+	// future memoryActivationUsecase wiring keep the v0.12 filesystem
+	// semantics without explicit configuration.
+	fileWriter activationFileWriter
+}
+
+func (p *importStubActivationPlanner) writer() activationFileWriter {
+	if p.fileWriter == nil {
+		return osActivationFileWriter{}
+	}
+	return p.fileWriter
+}
+
+// Plan computes a read-only two-file activation plan. It does not
+// mutate disk. Per-component Status absorbs marker / writer errors so
+// callers see both component states even when only one file is unsafe.
+func (p *importStubActivationPlanner) Plan(criteria importStubActivationCriteria) importStubActivationPlan {
+	stub := renderImportStubBlock(criteria.Target, criteria.ImportPath)
+	host := p.planComponent(criteria.HostContextPath, importStubBlockMarkers, stub, criteria.Diff)
+	external := p.planComponent(criteria.ExternalMemoryPath, memoryBridgeBlockMarkers, criteria.ExternalMarkdown, criteria.Diff)
+	return importStubActivationPlan{
+		Target:         criteria.Target,
+		HostContext:    host,
+		ExternalMemory: external,
+		Scopes:         slices.Clone(criteria.Scopes),
+		ActivatedCount: criteria.ActivatedCount,
+	}
+}
+
+// Apply writes the external memory file first and the host context stub
+// second, matching the v0.13 ADR's apply ordering. Apply refuses to
+// write when either component is Invalid; otherwise it skips writes for
+// components whose Action is Noop. When the external write succeeds and
+// the host write fails, the caller must rerun the plan; partial writes
+// converge under the v0.12 managed-block contract because each managed
+// region is written idempotently.
+func (p *importStubActivationPlanner) Apply(plan importStubActivationPlan) (importStubActivationApplyResult, error) {
+	if plan.ExternalMemory.Status == apptypes.MemoryActivationStatusInvalid {
+		return importStubActivationApplyResult{}, xerrors.Errorf("refusing to apply invalid external memory file %s: %s", plan.ExternalMemory.Path, plan.ExternalMemory.Message)
+	}
+	if plan.HostContext.Status == apptypes.MemoryActivationStatusInvalid {
+		return importStubActivationApplyResult{}, xerrors.Errorf("refusing to apply invalid host context stub %s: %s", plan.HostContext.Path, plan.HostContext.Message)
+	}
+	writer := p.writer()
+	result := importStubActivationApplyResult(plan)
+	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyNoop {
+		if err := writer.WriteAtomic(plan.ExternalMemory.Path, plan.ExternalMemory.Markdown); err != nil {
+			return result, xerrors.Errorf("failed to apply external memory file %s: %w", plan.ExternalMemory.Path, err)
+		}
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyNoop {
+		if err := writer.WriteAtomic(plan.HostContext.Path, plan.HostContext.Markdown); err != nil {
+			return result, xerrors.Errorf("failed to apply host context stub %s: %w", plan.HostContext.Path, err)
+		}
+	}
+	return result, nil
+}
+
+// planComponent computes the planned content / action / status for one
+// file in a two-file activation pair. Errors from inspect / read /
+// region parsing land in Status=invalid and Message so callers can
+// surface them per-file without the whole plan failing.
+func (p *importStubActivationPlanner) planComponent(path string, markers managedBlockMarkers, managedBlock string, withDiff bool) activationComponentPlan {
+	plan := activationComponentPlan{Path: path}
+	writer := p.writer()
+	if _, _, err := writer.Inspect(path); err != nil {
+		plan.Status = apptypes.MemoryActivationStatusInvalid
+		plan.Message = err.Error()
+		return plan
+	}
+	existing, exists, err := writer.ReadIfExists(path)
+	if err != nil {
+		plan.Status = apptypes.MemoryActivationStatusInvalid
+		plan.Message = err.Error()
+		return plan
+	}
+	plan.Existing = exists
+	planned, action, mergeErr := markers.replaceOrAppend(existing, exists, managedBlock)
+	if mergeErr != nil {
+		plan.Status = apptypes.MemoryActivationStatusInvalid
+		plan.Message = mergeErr.Error()
+		return plan
+	}
+	plan.Markdown = planned
+	plan.Action = action
+	plan.Status = computeComponentStatus(existing, exists, managedBlock, markers)
+	if withDiff && exists && existing != planned {
+		plan.Diff = renderActivationDiff(path, existing, planned)
+	}
+	return plan
+}
+
+// computeComponentStatus turns the existing-file vs planned-block
+// comparison into the four status values used by --status. It mirrors
+// memoryActivationUsecase.Status for a single file so v0.13.0-3 ships
+// identical wording for orphaned / unterminated regions.
+func computeComponentStatus(existing string, exists bool, managedBlock string, markers managedBlockMarkers) apptypes.MemoryActivationStatusState {
+	if !exists {
+		return apptypes.MemoryActivationStatusMissing
+	}
+	region, found, err := markers.findRegion(existing)
+	if err != nil {
+		return apptypes.MemoryActivationStatusInvalid
+	}
+	if !found {
+		return apptypes.MemoryActivationStatusMissing
+	}
+	if existing[region.start:region.end] == managedBlock {
+		return apptypes.MemoryActivationStatusInSync
+	}
+	return apptypes.MemoryActivationStatusStale
+}

--- a/application/usecase/import_stub_activation_internal_test.go
+++ b/application/usecase/import_stub_activation_internal_test.go
@@ -560,7 +560,7 @@ func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnExternalWri
 
 	planner := newPlannerWithWriter(writer)
 	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
-	_, err := planner.Apply(plan)
+	result, err := planner.Apply(plan)
 	if err == nil {
 		t.Fatalf("Apply err = nil, want permission failure on external write")
 	}
@@ -573,6 +573,12 @@ func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnExternalWri
 	if writer.writes[0].path != "/repo/.traceary/memories/claude.md" {
 		t.Fatalf("attempted write path = %q, want external", writer.writes[0].path)
 	}
+	if result.ExternalMemory.Action != "" {
+		t.Fatalf("result.ExternalMemory.Action = %q, want empty because the external write failed", result.ExternalMemory.Action)
+	}
+	if result.HostContext.Action != "" {
+		t.Fatalf("result.HostContext.Action = %q, want empty because host write was never attempted", result.HostContext.Action)
+	}
 }
 
 func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnHostWriteAfterExternalSucceeds(t *testing.T) {
@@ -583,7 +589,7 @@ func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnHostWriteAf
 
 	planner := newPlannerWithWriter(writer)
 	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
-	_, err := planner.Apply(plan)
+	result, err := planner.Apply(plan)
 	if err == nil {
 		t.Fatalf("Apply err = nil, want permission failure on host write")
 	}
@@ -600,5 +606,11 @@ func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnHostWriteAf
 	}
 	if _, present := writer.files["/repo/CLAUDE.md"]; present {
 		t.Fatalf("host context file must not be persisted on permission failure")
+	}
+	if result.ExternalMemory.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("result.ExternalMemory.Action = %q, want created because external write succeeded", result.ExternalMemory.Action)
+	}
+	if result.HostContext.Action != "" {
+		t.Fatalf("result.HostContext.Action = %q, want empty because host write failed", result.HostContext.Action)
 	}
 }

--- a/application/usecase/import_stub_activation_internal_test.go
+++ b/application/usecase/import_stub_activation_internal_test.go
@@ -1,0 +1,604 @@
+package usecase
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// fakeActivationFileWriter is a controllable activationFileWriter used
+// by the planner tests so they can simulate inspect / read / write
+// failures without leaning on platform-specific filesystem behavior.
+type fakeActivationFileWriter struct {
+	files      map[string]string
+	inspectErr map[string]error
+	readErr    map[string]error
+	writeErr   map[string]error
+	writes     []fakeActivationWrite
+}
+
+type fakeActivationWrite struct {
+	path    string
+	content string
+}
+
+func newFakeActivationFileWriter() *fakeActivationFileWriter {
+	return &fakeActivationFileWriter{
+		files:      map[string]string{},
+		inspectErr: map[string]error{},
+		readErr:    map[string]error{},
+		writeErr:   map[string]error{},
+	}
+}
+
+func (f *fakeActivationFileWriter) Inspect(path string) (os.FileInfo, bool, error) {
+	if err := f.inspectErr[path]; err != nil {
+		return nil, false, err
+	}
+	if _, ok := f.files[path]; ok {
+		return nil, true, nil
+	}
+	return nil, false, nil
+}
+
+func (f *fakeActivationFileWriter) ReadIfExists(path string) (string, bool, error) {
+	if err := f.readErr[path]; err != nil {
+		return "", false, err
+	}
+	if v, ok := f.files[path]; ok {
+		return v, true, nil
+	}
+	return "", false, nil
+}
+
+func (f *fakeActivationFileWriter) WriteAtomic(path string, content string) error {
+	f.writes = append(f.writes, fakeActivationWrite{path: path, content: content})
+	if err := f.writeErr[path]; err != nil {
+		return err
+	}
+	f.files[path] = content
+	return nil
+}
+
+func mustExternalMemoryBlock() string {
+	return MemoryBridgeMarkerBegin + "\n" + memoryBridgeWarning + "\n\n# Traceary-managed claude memories\n\n_No accepted durable memories matched the export scope._\n\n" + MemoryBridgeMarkerEnd + "\n"
+}
+
+func newPlannerWithWriter(writer activationFileWriter) *importStubActivationPlanner {
+	return &importStubActivationPlanner{fileWriter: writer}
+}
+
+func planClaudeFixture(criteria importStubActivationCriteria) importStubActivationCriteria {
+	if criteria.Target == "" {
+		criteria.Target = apptypes.MemoryBridgeTargetClaude
+	}
+	if criteria.HostContextPath == "" {
+		criteria.HostContextPath = "/repo/CLAUDE.md"
+	}
+	if criteria.ExternalMemoryPath == "" {
+		criteria.ExternalMemoryPath = "/repo/.traceary/memories/claude.md"
+	}
+	if criteria.ImportPath == "" {
+		criteria.ImportPath = "./.traceary/memories/claude.md"
+	}
+	if criteria.ExternalMarkdown == "" {
+		criteria.ExternalMarkdown = mustExternalMemoryBlock()
+	}
+	return criteria
+}
+
+func TestImportStubActivationPlanner_PlanCreatesBothFilesWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.Status = %q, want missing", plan.HostContext.Status)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("ExternalMemory.Status = %q, want missing", plan.ExternalMemory.Status)
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("HostContext.Action = %q, want created", plan.HostContext.Action)
+	}
+	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("ExternalMemory.Action = %q, want created", plan.ExternalMemory.Action)
+	}
+	if plan.HostContext.Existing || plan.ExternalMemory.Existing {
+		t.Fatalf("Existing = host=%v external=%v, want both false", plan.HostContext.Existing, plan.ExternalMemory.Existing)
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "@./.traceary/memories/claude.md") {
+		t.Fatalf("planned host stub missing import line: %q", plan.HostContext.Markdown)
+	}
+	if !strings.Contains(plan.ExternalMemory.Markdown, MemoryBridgeMarkerBegin) {
+		t.Fatalf("planned external memory missing managed block: %q", plan.ExternalMemory.Markdown)
+	}
+	if len(writer.writes) != 0 {
+		t.Fatalf("Plan must not write any files, got %d writes", len(writer.writes))
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsBothInSyncWhenAlreadyApplied(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	external := mustExternalMemoryBlock()
+	writer.files["/repo/CLAUDE.md"] = "# user notes\n\n" + stub
+	writer.files["/repo/.traceary/memories/claude.md"] = external
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+	}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("HostContext.Status = %q, want in_sync", plan.HostContext.Status)
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("HostContext.Action = %q, want noop", plan.HostContext.Action)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.Status = %q, want in_sync", plan.ExternalMemory.Status)
+	}
+	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("ExternalMemory.Action = %q, want noop", plan.ExternalMemory.Action)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsStaleStubAndInSyncExternal(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	external := mustExternalMemoryBlock()
+	writer.files["/repo/CLAUDE.md"] = "# user notes\n\n<!-- traceary-memory-import:begin:v1 -->\n<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target claude --dry-run --diff` before applying updates. -->\n@./old-path/claude.md\n<!-- traceary-memory-import:end -->\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = external
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+	}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("HostContext.Status = %q, want stale", plan.HostContext.Status)
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("HostContext.Action = %q, want updated", plan.HostContext.Action)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.Status = %q, want in_sync", plan.ExternalMemory.Status)
+	}
+	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("ExternalMemory.Action = %q, want noop", plan.ExternalMemory.Action)
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "# user notes") {
+		t.Fatalf("planned host markdown lost user content: %q", plan.HostContext.Markdown)
+	}
+	if strings.Contains(plan.HostContext.Markdown, "./old-path/claude.md") {
+		t.Fatalf("planned host markdown retained stale import path: %q", plan.HostContext.Markdown)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInSyncStubAndStaleExternal(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	staleExternal := MemoryBridgeMarkerBegin + "\nstale managed body\n" + MemoryBridgeMarkerEnd + "\n"
+	writer.files["/repo/CLAUDE.md"] = "# user notes\n\n" + stub
+	writer.files["/repo/.traceary/memories/claude.md"] = "preface\n\n" + staleExternal + "\nepilogue\n"
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("HostContext.Status = %q, want in_sync", plan.HostContext.Status)
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("HostContext.Action = %q, want noop", plan.HostContext.Action)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("ExternalMemory.Status = %q, want stale", plan.ExternalMemory.Status)
+	}
+	if plan.ExternalMemory.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("ExternalMemory.Action = %q, want updated", plan.ExternalMemory.Action)
+	}
+	for _, want := range []string{"preface", "epilogue"} {
+		if !strings.Contains(plan.ExternalMemory.Markdown, want) {
+			t.Fatalf("planned external markdown lost %q: %q", want, plan.ExternalMemory.Markdown)
+		}
+	}
+	if strings.Contains(plan.ExternalMemory.Markdown, "stale managed body") {
+		t.Fatalf("planned external markdown retained stale body: %q", plan.ExternalMemory.Markdown)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsHostMissingWhenContextLacksStub(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	external := mustExternalMemoryBlock()
+	writer.files["/repo/CLAUDE.md"] = "# user notes\n\n- a hand-written instruction\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = external
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+	}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.Status = %q, want missing (file exists, stub absent)", plan.HostContext.Status)
+	}
+	if plan.HostContext.Action != apptypes.MemoryActivationApplyUpdated {
+		t.Fatalf("HostContext.Action = %q, want updated (append stub)", plan.HostContext.Action)
+	}
+	if !plan.HostContext.Existing {
+		t.Fatalf("HostContext.Existing = false, want true (file is on disk)")
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "# user notes\n\n- a hand-written instruction\n\n<!-- traceary-memory-import:begin:v1 -->") {
+		t.Fatalf("planned host markdown did not append stub after preserving user content: %q", plan.HostContext.Markdown)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInvalidWhenStubBeginIsOrphan(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	writer.files["/repo/CLAUDE.md"] = "<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/claude.md\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = mustExternalMemoryBlock()
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.Status = %q, want invalid", plan.HostContext.Status)
+	}
+	if !strings.Contains(plan.HostContext.Message, "without end marker") {
+		t.Fatalf("HostContext.Message = %q, want orphan-begin reason", plan.HostContext.Message)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.Status = %q, want unaffected in_sync", plan.ExternalMemory.Status)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInvalidWhenExternalHasDuplicateBegin(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	writer.files["/repo/CLAUDE.md"] = stub
+	external := MemoryBridgeMarkerBegin + "\nbody1\n" + MemoryBridgeMarkerEnd + "\n" + MemoryBridgeMarkerBegin + "\nbody2\n" + MemoryBridgeMarkerEnd + "\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = external
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("ExternalMemory.Status = %q, want invalid", plan.ExternalMemory.Status)
+	}
+	if !strings.Contains(plan.ExternalMemory.Message, "multiple Traceary managed memory blocks") {
+		t.Fatalf("ExternalMemory.Message = %q, want duplicate-begin reason", plan.ExternalMemory.Message)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInvalidWhenStubMarkerVersionIsNewer(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	writer.files["/repo/CLAUDE.md"] = "<!-- traceary-memory-import:begin:v9 -->\n@./.traceary/memories/claude.md\n<!-- traceary-memory-import:end -->\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = mustExternalMemoryBlock()
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.Status = %q, want invalid", plan.HostContext.Status)
+	}
+	if !strings.Contains(plan.HostContext.Message, "refusing to overwrite newer Traceary managed block version v9") {
+		t.Fatalf("HostContext.Message = %q, want newer-version refusal", plan.HostContext.Message)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInvalidWhenExternalMarkerVersionIsNewer(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	writer.files["/repo/CLAUDE.md"] = stub
+	writer.files["/repo/.traceary/memories/claude.md"] = "<!-- traceary-memories:begin:v99 -->\nfuture\n" + MemoryBridgeMarkerEnd + "\n"
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("ExternalMemory.Status = %q, want invalid", plan.ExternalMemory.Status)
+	}
+	if !strings.Contains(plan.ExternalMemory.Message, "refusing to overwrite newer Traceary managed block version v99") {
+		t.Fatalf("ExternalMemory.Message = %q, want newer-version refusal", plan.ExternalMemory.Message)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanReportsInvalidWhenInspectFailsOnHost(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	writer.inspectErr["/repo/CLAUDE.md"] = errors.New("activation target symlinks are not supported: /repo/CLAUDE.md")
+	writer.files["/repo/.traceary/memories/claude.md"] = mustExternalMemoryBlock()
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.Status = %q, want invalid", plan.HostContext.Status)
+	}
+	if !strings.Contains(plan.HostContext.Message, "symlinks are not supported") {
+		t.Fatalf("HostContext.Message = %q, want symlink reason", plan.HostContext.Message)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.Status = %q, want unaffected in_sync", plan.ExternalMemory.Status)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanRejectsHostSymlinkOnRealFilesystem(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	hostPath := filepath.Join(dir, "CLAUDE.md")
+	missingTarget := filepath.Join(dir, "missing.md")
+	if err := os.Symlink(missingTarget, hostPath); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	externalPath := filepath.Join(dir, "external.md")
+	if err := os.WriteFile(externalPath, []byte(mustExternalMemoryBlock()), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	plan := (&importStubActivationPlanner{}).Plan(importStubActivationCriteria{
+		Target:             apptypes.MemoryBridgeTargetClaude,
+		HostContextPath:    hostPath,
+		ExternalMemoryPath: externalPath,
+		ImportPath:         "./external.md",
+		ExternalMarkdown:   mustExternalMemoryBlock(),
+	})
+
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.Status = %q, want invalid", plan.HostContext.Status)
+	}
+	if !strings.Contains(plan.HostContext.Message, "symlinks are not supported") {
+		t.Fatalf("HostContext.Message = %q, want symlink rejection", plan.HostContext.Message)
+	}
+	info, statErr := os.Lstat(hostPath)
+	if statErr != nil {
+		t.Fatalf("Lstat: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("plan must not replace dangling symlink, got mode %s", info.Mode())
+	}
+}
+
+func TestImportStubActivationPlanner_PlanRendersDiffsForChangedComponentsOnly(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	external := mustExternalMemoryBlock()
+	// host context is in_sync; only external is stale, so only the
+	// external diff should be populated.
+	writer.files["/repo/CLAUDE.md"] = stub
+	writer.files["/repo/.traceary/memories/claude.md"] = MemoryBridgeMarkerBegin + "\nold body\n" + MemoryBridgeMarkerEnd + "\n"
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+		Diff:             true,
+	}))
+
+	if plan.HostContext.Diff != "" {
+		t.Fatalf("HostContext.Diff = %q, want empty for in_sync component", plan.HostContext.Diff)
+	}
+	if plan.ExternalMemory.Diff == "" {
+		t.Fatalf("ExternalMemory.Diff is empty, want diff for stale component")
+	}
+	if !strings.Contains(plan.ExternalMemory.Diff, "--- /repo/.traceary/memories/claude.md") {
+		t.Fatalf("ExternalMemory.Diff missing path header: %q", plan.ExternalMemory.Diff)
+	}
+	got := plan.orderedDiffs()
+	if len(got) != 1 || got[0] != plan.ExternalMemory.Diff {
+		t.Fatalf("orderedDiffs = %v, want only external diff", got)
+	}
+}
+
+func TestImportStubActivationPlanner_PlanOrderedDiffsPutsExternalFirst(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	external := mustExternalMemoryBlock()
+	writer.files["/repo/CLAUDE.md"] = "<!-- traceary-memory-import:begin:v1 -->\n<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target claude --dry-run --diff` before applying updates. -->\n@./old.md\n<!-- traceary-memory-import:end -->\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = MemoryBridgeMarkerBegin + "\nold body\n" + MemoryBridgeMarkerEnd + "\n"
+
+	plan := newPlannerWithWriter(writer).Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+		Diff:             true,
+	}))
+
+	got := plan.orderedDiffs()
+	if len(got) != 2 {
+		t.Fatalf("orderedDiffs len = %d, want 2", len(got))
+	}
+	if got[0] != plan.ExternalMemory.Diff {
+		t.Fatalf("orderedDiffs[0] != ExternalMemory.Diff (apply order requires external first)")
+	}
+	if got[1] != plan.HostContext.Diff {
+		t.Fatalf("orderedDiffs[1] != HostContext.Diff (apply order requires host second)")
+	}
+}
+
+func TestImportStubActivationPlanner_ApplyWritesBothFilesInExternalThenHostOrder(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
+
+	result, err := planner.Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.HostContext.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("result HostContext.Action = %q, want created", result.HostContext.Action)
+	}
+	if result.ExternalMemory.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("result ExternalMemory.Action = %q, want created", result.ExternalMemory.Action)
+	}
+	if len(writer.writes) != 2 {
+		t.Fatalf("writes = %d, want 2", len(writer.writes))
+	}
+	if writer.writes[0].path != "/repo/.traceary/memories/claude.md" {
+		t.Fatalf("first write = %q, want external memory file (apply order: external first)", writer.writes[0].path)
+	}
+	if writer.writes[1].path != "/repo/CLAUDE.md" {
+		t.Fatalf("second write = %q, want host context file (apply order: host second)", writer.writes[1].path)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplyOnlyWritesNonNoopComponents(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	external := mustExternalMemoryBlock()
+	// Stub is already in sync; only the external file is stale.
+	writer.files["/repo/CLAUDE.md"] = stub
+	writer.files["/repo/.traceary/memories/claude.md"] = MemoryBridgeMarkerBegin + "\nold body\n" + MemoryBridgeMarkerEnd + "\n"
+
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+	}))
+	if _, err := planner.Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(writer.writes) != 1 || writer.writes[0].path != "/repo/.traceary/memories/claude.md" {
+		t.Fatalf("writes = %+v, want exactly the external memory write", writer.writes)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplyIsIdempotentAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	planner := newPlannerWithWriter(writer)
+
+	first, err := planner.Apply(planner.Plan(planClaudeFixture(importStubActivationCriteria{})))
+	if err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if first.HostContext.Action != apptypes.MemoryActivationApplyCreated || first.ExternalMemory.Action != apptypes.MemoryActivationApplyCreated {
+		t.Fatalf("first apply actions = host=%q external=%q, want both created", first.HostContext.Action, first.ExternalMemory.Action)
+	}
+
+	secondPlan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
+	if secondPlan.HostContext.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("second plan HostContext.Status = %q, want in_sync after apply", secondPlan.HostContext.Status)
+	}
+	if secondPlan.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("second plan ExternalMemory.Status = %q, want in_sync after apply", secondPlan.ExternalMemory.Status)
+	}
+
+	writesBefore := len(writer.writes)
+	second, err := planner.Apply(secondPlan)
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if second.HostContext.Action != apptypes.MemoryActivationApplyNoop || second.ExternalMemory.Action != apptypes.MemoryActivationApplyNoop {
+		t.Fatalf("second apply actions = host=%q external=%q, want both noop", second.HostContext.Action, second.ExternalMemory.Action)
+	}
+	if len(writer.writes) != writesBefore {
+		t.Fatalf("second apply emitted %d additional writes, want zero (noop)", len(writer.writes)-writesBefore)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplyRefusesWhenExternalIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	writer.files["/repo/CLAUDE.md"] = stub
+	writer.files["/repo/.traceary/memories/claude.md"] = MemoryBridgeMarkerBegin + "\nbody1\n" + MemoryBridgeMarkerEnd + "\n" + MemoryBridgeMarkerBegin + "\nbody2\n" + MemoryBridgeMarkerEnd + "\n"
+
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
+	if _, err := planner.Apply(plan); err == nil || !strings.Contains(err.Error(), "refusing to apply invalid external memory file") {
+		t.Fatalf("Apply err = %v, want invalid-external refusal", err)
+	}
+	if len(writer.writes) != 0 {
+		t.Fatalf("Apply must not write when external is invalid, got writes = %+v", writer.writes)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplyRefusesWhenHostIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	external := mustExternalMemoryBlock()
+	writer.files["/repo/CLAUDE.md"] = "<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/claude.md\n"
+	writer.files["/repo/.traceary/memories/claude.md"] = external
+
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{
+		ExternalMarkdown: external,
+	}))
+	if _, err := planner.Apply(plan); err == nil || !strings.Contains(err.Error(), "refusing to apply invalid host context stub") {
+		t.Fatalf("Apply err = %v, want invalid-host refusal", err)
+	}
+	if len(writer.writes) != 0 {
+		t.Fatalf("Apply must not write when host is invalid, got writes = %+v", writer.writes)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnExternalWrite(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	writer.writeErr["/repo/.traceary/memories/claude.md"] = errors.New("simulated EACCES on external memory file")
+
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
+	_, err := planner.Apply(plan)
+	if err == nil {
+		t.Fatalf("Apply err = nil, want permission failure on external write")
+	}
+	if !strings.Contains(err.Error(), "simulated EACCES on external memory file") {
+		t.Fatalf("Apply err = %v, want wrapped permission failure", err)
+	}
+	if len(writer.writes) != 1 {
+		t.Fatalf("writes = %d, want 1 (only external attempted before host)", len(writer.writes))
+	}
+	if writer.writes[0].path != "/repo/.traceary/memories/claude.md" {
+		t.Fatalf("attempted write path = %q, want external", writer.writes[0].path)
+	}
+}
+
+func TestImportStubActivationPlanner_ApplySurfacesPermissionFailureOnHostWriteAfterExternalSucceeds(t *testing.T) {
+	t.Parallel()
+
+	writer := newFakeActivationFileWriter()
+	writer.writeErr["/repo/CLAUDE.md"] = errors.New("simulated EACCES on host context file")
+
+	planner := newPlannerWithWriter(writer)
+	plan := planner.Plan(planClaudeFixture(importStubActivationCriteria{}))
+	_, err := planner.Apply(plan)
+	if err == nil {
+		t.Fatalf("Apply err = nil, want permission failure on host write")
+	}
+	if !strings.Contains(err.Error(), "simulated EACCES on host context file") {
+		t.Fatalf("Apply err = %v, want wrapped host permission failure", err)
+	}
+	if len(writer.writes) != 2 {
+		t.Fatalf("writes = %d, want 2 (external succeeded, host attempted)", len(writer.writes))
+	}
+	if got, ok := writer.files["/repo/.traceary/memories/claude.md"]; !ok {
+		t.Fatalf("external memory file should have been written before host failure, got files=%v", writer.files)
+	} else if got == "" {
+		t.Fatalf("external memory file content empty after partial apply")
+	}
+	if _, present := writer.files["/repo/CLAUDE.md"]; present {
+		t.Fatalf("host context file must not be persisted on permission failure")
+	}
+}

--- a/application/usecase/import_stub_block.go
+++ b/application/usecase/import_stub_block.go
@@ -1,0 +1,65 @@
+package usecase
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// importStubMarker* describe the v0.13 host-context stub markers used by
+// the Claude/Gemini activation strategy. The stub uses a different marker
+// family from the v0.12 traceary-memories block so a CLAUDE.md /
+// GEMINI.md that imports the external memory file is never confused with
+// a file that *is* an external memory file.
+const (
+	importStubMarkerBegin    = "<!-- traceary-memory-import:begin:v1 -->"
+	importStubMarkerEnd      = "<!-- traceary-memory-import:end -->"
+	importStubCurrentVersion = 1
+)
+
+// importStubWarningTemplate is the canonical DO NOT EDIT comment Traceary
+// renders inside the host-context import stub. The %s is the host name
+// (claude/gemini) so the operator's remediation command points at the
+// right activation target.
+const importStubWarningTemplate = "<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target %s --dry-run --diff` before applying updates. -->"
+
+// importStubBeginPattern matches every begin marker version so the
+// parser recognises (and refuses to overwrite) a future v2 stub.
+var importStubBeginPattern = regexp.MustCompile(`^<!-- traceary-memory-import:begin:v(\d+) -->$`)
+
+// importStubBlockMarkers reuses the v0.12 managed-block parser with the
+// stub-specific marker contract. Orphan-begin, duplicate-begin/end, and
+// newer-version rejections are inherited from managedBlockMarkers, so
+// the stub region behaves identically to the existing memory bridge
+// block under the same edge cases.
+var importStubBlockMarkers = managedBlockMarkers{
+	Begin:          importStubMarkerBegin,
+	End:            importStubMarkerEnd,
+	BeginPattern:   importStubBeginPattern,
+	CurrentVersion: importStubCurrentVersion,
+}
+
+// renderImportStubBlock produces the canonical four-line markdown stub
+// Traceary writes into the host context file (CLAUDE.md / GEMINI.md).
+// The trailing newline lets appendManagedBlockWithSpacing keep one blank
+// line between the stub and any user-authored content that follows it.
+//
+// importPath is rendered verbatim under `@`, so the host-specific
+// activation target resolver in #892/#894 controls the relative-vs-
+// absolute decision. The default Claude/Gemini layout passes
+// `./.traceary/memories/<host>.md`.
+func renderImportStubBlock(target apptypes.MemoryBridgeTarget, importPath string) string {
+	var body strings.Builder
+	body.WriteString(importStubMarkerBegin)
+	body.WriteString("\n")
+	fmt.Fprintf(&body, importStubWarningTemplate, target.String())
+	body.WriteString("\n")
+	body.WriteString("@")
+	body.WriteString(importPath)
+	body.WriteString("\n")
+	body.WriteString(importStubMarkerEnd)
+	body.WriteString("\n")
+	return body.String()
+}

--- a/application/usecase/import_stub_block_internal_test.go
+++ b/application/usecase/import_stub_block_internal_test.go
@@ -1,0 +1,103 @@
+package usecase
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestRenderImportStubBlock_RendersCanonicalLinesForClaude(t *testing.T) {
+	t.Parallel()
+
+	got := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	want := strings.Join([]string{
+		"<!-- traceary-memory-import:begin:v1 -->",
+		"<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target claude --dry-run --diff` before applying updates. -->",
+		"@./.traceary/memories/claude.md",
+		"<!-- traceary-memory-import:end -->",
+		"",
+	}, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("renderImportStubBlock mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderImportStubBlock_TargetNameAppearsInWarningForGemini(t *testing.T) {
+	t.Parallel()
+
+	got := renderImportStubBlock(apptypes.MemoryBridgeTargetGemini, "/abs/path/external.md")
+	if !strings.Contains(got, "--target gemini") {
+		t.Fatalf("warning missing target name: %q", got)
+	}
+	if !strings.Contains(got, "@/abs/path/external.md") {
+		t.Fatalf("absolute import path missing from stub: %q", got)
+	}
+}
+
+func TestImportStubBlockMarkers_FindsCanonicalStubRegion(t *testing.T) {
+	t.Parallel()
+
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./.traceary/memories/claude.md")
+	content := "# CLAUDE.md\n\n" + stub + "\n## user section\n"
+	region, found, err := importStubBlockMarkers.findRegion(content)
+	if err != nil {
+		t.Fatalf("findRegion error = %v", err)
+	}
+	if !found {
+		t.Fatalf("findRegion found = false, want true")
+	}
+	if got := content[region.start:region.end]; got != stub {
+		t.Fatalf("region content mismatch: got %q want %q", got, stub)
+	}
+}
+
+func TestImportStubBlockMarkers_RejectsNewerStubVersion(t *testing.T) {
+	t.Parallel()
+
+	content := "<!-- traceary-memory-import:begin:v9 -->\n@./.traceary/memories/claude.md\n<!-- traceary-memory-import:end -->\n"
+	_, _, err := importStubBlockMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite newer Traceary managed block version v9") {
+		t.Fatalf("findRegion err = %v, want newer-version rejection", err)
+	}
+}
+
+func TestImportStubBlockMarkers_RejectsDuplicateStubBegin(t *testing.T) {
+	t.Parallel()
+
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetGemini, "./external.md")
+	content := stub + "\n" + stub
+	_, _, err := importStubBlockMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "multiple Traceary managed memory blocks") {
+		t.Fatalf("findRegion err = %v, want duplicate-begin rejection", err)
+	}
+}
+
+func TestImportStubBlockMarkers_RejectsOrphanStubBegin(t *testing.T) {
+	t.Parallel()
+
+	content := "<!-- traceary-memory-import:begin:v1 -->\n@./external.md\n"
+	_, _, err := importStubBlockMarkers.findRegion(content)
+	if err == nil || !strings.Contains(err.Error(), "without end marker") {
+		t.Fatalf("findRegion err = %v, want orphan-begin rejection", err)
+	}
+}
+
+func TestImportStubBlockMarkers_DistinctFromMemoryBridgeBlockMarkers(t *testing.T) {
+	t.Parallel()
+
+	// A canonical traceary-memories block must NOT be recognized as a
+	// stub region (and vice versa) so the host context file and the
+	// external memory file never get mistaken for one another by the
+	// parser.
+	memoryBlock := MemoryBridgeMarkerBegin + "\nbody\n" + MemoryBridgeMarkerEnd + "\n"
+	if _, found, err := importStubBlockMarkers.findRegion(memoryBlock); err != nil || found {
+		t.Fatalf("importStubBlockMarkers.findRegion(memoryBlock) = found=%v err=%v, want found=false err=nil", found, err)
+	}
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, "./external.md")
+	if _, found, err := memoryBridgeBlockMarkers.findRegion(stub); err != nil || found {
+		t.Fatalf("memoryBridgeBlockMarkers.findRegion(stub) = found=%v err=%v, want found=false err=nil", found, err)
+	}
+}


### PR DESCRIPTION
## Motivation

Claude/Gemini activation needs a reusable two-file planner before host-specific CLI wiring is added. The planner must reason about the host context import stub and the external Traceary-managed memory file independently while preserving the v0.12 managed-block safety model.

## Changes

- Adds the Traceary-managed import-stub marker contract and renderer.
- Adds an internal two-file import-stub activation planner.
- Tracks per-component status/action/diff for the host context stub and external memory file.
- Applies in ADR order: external memory file first, host context stub second.
- Keeps all new surfaces internal; no Claude/Gemini user-visible commands are added.
- Adds unit coverage for create/update/noop, stale/missing/invalid states, newer/duplicate/orphan markers, symlink and injected permission failures, deterministic diff ordering, partial write failure, and idempotent apply.

## Review notes

- Implementation was performed by Claude Code Opus 4.7 Max per orchestration plan.
- Codex review pass verified the new planner remains internal and Codex single-file activation tests continue to pass.

## Verification

- `rtk go test ./application/usecase -run 'TestImportStub'` — passed (`25 passed`)
- `rtk go test ./...` — passed (`1561 passed in 19 packages`)
- `rtk go build ./...` — passed
- `go tool golangci-lint run` — passed (`0 issues.`)
- `rtk git diff --check` — passed

Closes #891
