### PR TITLE
v0.13.0-4: add Claude activation status and dry-run

### DIFF
--- a/application/types/memory_activation.go
+++ b/application/types/memory_activation.go
@@ -16,6 +16,12 @@ type MemoryActivationCriteria struct {
 
 // MemoryActivationPlan is the resolved dry-run output for a host-native
 // activation. Markdown is the content that would be written to TargetPath.
+//
+// For two-file targets (Claude / Gemini) the top-level fields describe the
+// host context file so codex JSON consumers continue to see the same shape;
+// component-level details for both files are exposed through HostContext and
+// ExternalMemory so callers that understand the pair contract can render
+// per-file diffs and apply paths.
 type MemoryActivationPlan struct {
 	Target         MemoryBridgeTarget
 	TargetPath     string
@@ -24,6 +30,23 @@ type MemoryActivationPlan struct {
 	Existing       bool
 	Diff           string
 	ActivatedCount int
+	HostContext    *MemoryActivationComponent
+	ExternalMemory *MemoryActivationComponent
+}
+
+// MemoryActivationComponent is the per-file plan inside a two-file
+// activation pair (host context stub + external memory file). Single-file
+// targets do not populate this type; two-file targets populate one
+// MemoryActivationComponent per file so callers see the planned content,
+// status, and diff for each file independently.
+type MemoryActivationComponent struct {
+	Path     string
+	Existing bool
+	Markdown string
+	Diff     string
+	Action   MemoryActivationApplyAction
+	State    MemoryActivationStatusState
+	Message  string
 }
 
 // MemoryActivationApplyAction summarizes the observable filesystem outcome of
@@ -73,6 +96,11 @@ func (s MemoryActivationStatusState) String() string { return string(s) }
 
 // MemoryActivationStatusResult is the read-only activation health view used by
 // `memory activate --status` and doctor.
+//
+// For two-file targets the top-level State is the aggregated pair state per
+// the v0.13 ADR (invalid > missing > stale > in_sync), and the per-file
+// HostContext / ExternalMemory components carry the underlying state and
+// path so doctor can give actionable remediation without reparsing files.
 type MemoryActivationStatusResult struct {
 	Target         MemoryBridgeTarget
 	TargetPath     string
@@ -81,4 +109,6 @@ type MemoryActivationStatusResult struct {
 	Existing       bool
 	ActivatedCount int
 	Message        string
+	HostContext    *MemoryActivationComponent
+	ExternalMemory *MemoryActivationComponent
 }

--- a/application/usecase/activation_target.go
+++ b/application/usecase/activation_target.go
@@ -16,17 +16,61 @@ import (
 // path is `~/.codex/memories/traceary.md`.
 const codexActivationFileName = "traceary.md"
 
+// claudeHostContextFileName is the canonical CLAUDE.md filename Claude
+// Code loads at session start. Traceary writes the import stub region
+// inside this file when --target claude is applied.
+const claudeHostContextFileName = "CLAUDE.md"
+
+// claudeExternalMemoryRelDir / claudeExternalMemoryFileName describe the
+// hidden directory layout Traceary owns under the activation root.
+// `<root>/.traceary/memories/claude.md` is the v0.13 default external
+// memory file, and the rendered import line is the relative form
+// `./.traceary/memories/claude.md` so Claude resolves it relative to
+// the host CLAUDE.md.
+const (
+	claudeExternalMemoryRelDir   = ".traceary/memories"
+	claudeExternalMemoryFileName = "claude.md"
+)
+
+// activationTargetResolution describes the file paths Traceary will
+// inspect, read, or write for one activation criteria. Single-file
+// targets (Codex) populate only HostContextPath. Two-file targets
+// (Claude/Gemini) populate ExternalMemoryPath and ImportPath as well so
+// the usecase can drive the v0.13 import-stub planner without branching
+// on the target name.
+type activationTargetResolution struct {
+	// HostContextPath is the absolute path to the file Traceary owns the
+	// managed region inside (single-file: the activation file itself;
+	// two-file: the host context file such as CLAUDE.md).
+	HostContextPath string
+	// ExternalMemoryPath is the absolute path to the external memory
+	// file that holds the rendered accepted memories. Empty for
+	// single-file targets.
+	ExternalMemoryPath string
+	// ImportPath is the literal value rendered after `@` inside the
+	// host context import stub. Empty for single-file targets.
+	ImportPath string
+}
+
+// IsTwoFile reports whether the resolution describes a host-context +
+// external-memory pair (Claude / Gemini) rather than a single Traceary
+// managed file (Codex).
+func (r activationTargetResolution) IsTwoFile() bool {
+	return strings.TrimSpace(r.ExternalMemoryPath) != ""
+}
+
 // activationTarget resolves the host file Traceary will manage for one
-// activation criteria. v0.13.0-2 only ships the Codex single-file
-// resolver. The descriptor is host-agnostic so v0.13.0-3+ can plug in
-// two-file Claude / Gemini resolvers (host-context import stub +
-// external memory file) without rewriting memoryActivationUsecase.
+// activation criteria. v0.13.0-2 shipped the Codex single-file resolver;
+// v0.13.0-4 adds the Claude two-file resolver for read-only
+// status/dry-run/diff. The descriptor is host-agnostic so future
+// targets (Gemini in #894) plug in without rewriting the usecase.
 type activationTarget interface {
 	// Target returns the host this descriptor activates.
 	Target() apptypes.MemoryBridgeTarget
-	// ResolvePath returns the absolute path of the file that will be
-	// inspected, read, or written by the activation usecase.
-	ResolvePath(criteria apptypes.MemoryActivationCriteria) (string, error)
+	// Resolve returns the file paths Traceary will manage for the
+	// criteria. Errors come from path resolution (e.g. inability to
+	// locate $HOME for the Codex default), never from disk inspection.
+	Resolve(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error)
 }
 
 type codexActivationTarget struct{}
@@ -36,38 +80,159 @@ func (codexActivationTarget) Target() apptypes.MemoryBridgeTarget {
 	return apptypes.MemoryBridgeTargetCodex
 }
 
-// ResolvePath returns the absolute file path Codex activation manages.
-// `criteria.Path` (when non-empty) wins over both `criteria.Root` and the
-// default; `criteria.Root` overrides the default; otherwise the path is
-// `<HOME>/.codex/memories/traceary.md`.
-func (codexActivationTarget) ResolvePath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+// Resolve returns the absolute file path Codex activation manages.
+// `criteria.Path` (when non-empty) wins over both `criteria.Root` and
+// the default; `criteria.Root` overrides the default; otherwise the
+// path is `<HOME>/.codex/memories/traceary.md`.
+func (codexActivationTarget) Resolve(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error) {
 	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
 		abs, err := filepath.Abs(trimmed)
 		if err != nil {
-			return "", xerrors.Errorf("failed to resolve activation path: %w", err)
+			return activationTargetResolution{}, xerrors.Errorf("failed to resolve activation path: %w", err)
 		}
-		return abs, nil
+		return activationTargetResolution{HostContextPath: abs}, nil
 	}
 	root := strings.TrimSpace(criteria.Root)
 	if root == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", xerrors.Errorf("failed to resolve user home directory: %w", err)
+			return activationTargetResolution{}, xerrors.Errorf("failed to resolve user home directory: %w", err)
 		}
 		root = filepath.Join(home, ".codex", "memories")
 	}
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		return "", xerrors.Errorf("failed to resolve codex memory root: %w", err)
+		return activationTargetResolution{}, xerrors.Errorf("failed to resolve codex memory root: %w", err)
 	}
-	return filepath.Join(absRoot, codexActivationFileName), nil
+	return activationTargetResolution{HostContextPath: filepath.Join(absRoot, codexActivationFileName)}, nil
+}
+
+type claudeActivationTarget struct{}
+
+// Target returns MemoryBridgeTargetClaude.
+func (claudeActivationTarget) Target() apptypes.MemoryBridgeTarget {
+	return apptypes.MemoryBridgeTargetClaude
+}
+
+// Resolve returns the host context (CLAUDE.md) and external memory
+// file Traceary will manage for Claude activation. Path / Root /
+// default-detection precedence follows the v0.13 ADR:
+//
+//   - --path picks the host context file; the external memory path is
+//     derived as `<dir of path>/.traceary/memories/claude.md`.
+//   - --root picks the activation root; the host context file is
+//     `<root>/CLAUDE.md` and the external file is
+//     `<root>/.traceary/memories/claude.md`.
+//   - Otherwise the activation root is the nearest ancestor of the
+//     command working directory that contains `.git`, falling back to
+//     the working directory when no `.git` is found.
+//
+// The import path is always rendered relative to the host context file
+// so the resulting `@./.traceary/memories/claude.md` expression matches
+// the documented Claude import format. When the host context file and
+// external memory file do not share a directory tree (a future custom
+// override), the import path falls back to the absolute external path.
+func (claudeActivationTarget) Resolve(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error) {
+	hostContextPath, err := claudeHostContextPath(criteria)
+	if err != nil {
+		return activationTargetResolution{}, err
+	}
+	externalMemoryPath := claudeExternalMemoryPath(hostContextPath)
+	importPath, err := claudeImportPath(hostContextPath, externalMemoryPath)
+	if err != nil {
+		return activationTargetResolution{}, err
+	}
+	return activationTargetResolution{
+		HostContextPath:    hostContextPath,
+		ExternalMemoryPath: externalMemoryPath,
+		ImportPath:         importPath,
+	}, nil
+}
+
+func claudeHostContextPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve claude host context path: %w", err)
+		}
+		return abs, nil
+	}
+	if trimmed := strings.TrimSpace(criteria.Root); trimmed != "" {
+		absRoot, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve claude activation root: %w", err)
+		}
+		return filepath.Join(absRoot, claudeHostContextFileName), nil
+	}
+	root, err := detectClaudeActivationRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, claudeHostContextFileName), nil
+}
+
+func claudeExternalMemoryPath(hostContextPath string) string {
+	hostDir := filepath.Dir(hostContextPath)
+	return filepath.Join(hostDir, filepath.FromSlash(claudeExternalMemoryRelDir), claudeExternalMemoryFileName)
+}
+
+// claudeImportPath renders the literal text Traceary writes after `@`
+// inside the host context import stub. Claude resolves relative imports
+// against the file containing the import, so the renderer always
+// prefers the relative form when the external file lives below the
+// host context directory. When a future override puts the external
+// file outside that subtree, the function returns the absolute path so
+// the generated stub still resolves cleanly.
+func claudeImportPath(hostContextPath, externalMemoryPath string) (string, error) {
+	hostDir := filepath.Dir(hostContextPath)
+	rel, err := filepath.Rel(hostDir, externalMemoryPath)
+	if err != nil {
+		return "", xerrors.Errorf("failed to compute relative claude import path: %w", err)
+	}
+	relSlash := filepath.ToSlash(rel)
+	if strings.HasPrefix(relSlash, "../") || relSlash == ".." {
+		return externalMemoryPath, nil
+	}
+	if strings.HasPrefix(relSlash, "./") || relSlash == "." {
+		return relSlash, nil
+	}
+	return "./" + relSlash, nil
+}
+
+// detectClaudeActivationRoot walks the command working directory
+// upwards searching for the nearest ancestor that contains a `.git`
+// entry. When no `.git` is found, the current working directory is
+// returned per the v0.13 ADR. Symlink and stat errors propagate so a
+// broken filesystem cannot silently move the activation root.
+func detectClaudeActivationRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", xerrors.Errorf("failed to resolve claude activation working directory: %w", err)
+	}
+	current, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", xerrors.Errorf("failed to resolve claude activation absolute working directory: %w", err)
+	}
+	for {
+		gitPath := filepath.Join(current, ".git")
+		if _, statErr := os.Lstat(gitPath); statErr == nil {
+			return current, nil
+		} else if !os.IsNotExist(statErr) {
+			return "", xerrors.Errorf("failed to inspect git root candidate %s: %w", gitPath, statErr)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return cwd, nil
+		}
+		current = parent
+	}
 }
 
 // resolveActivationTarget dispatches a MemoryBridgeTarget to its
-// host-specific descriptor. Targets that are reserved by the contract
-// but not yet wired through the activation usecase return a
-// "not supported yet" error so the CLI surface stays in lockstep with
-// the implementation work tracked in the v0.13.0 milestone.
+// host-specific descriptor. Targets reserved by the contract but not
+// yet wired through the activation usecase return a "not supported
+// yet" error so the CLI surface stays in lockstep with the
+// implementation work tracked in the v0.13.0 milestone.
 func resolveActivationTarget(target apptypes.MemoryBridgeTarget) (activationTarget, error) {
 	if _, ok := apptypes.MemoryBridgeTargetOf(target.String()); !ok {
 		return nil, xerrors.Errorf("unsupported memory activation target: %s", target)
@@ -75,6 +240,8 @@ func resolveActivationTarget(target apptypes.MemoryBridgeTarget) (activationTarg
 	switch target {
 	case apptypes.MemoryBridgeTargetCodex:
 		return codexActivationTarget{}, nil
+	case apptypes.MemoryBridgeTargetClaude:
+		return claudeActivationTarget{}, nil
 	}
 	return nil, xerrors.Errorf("memory activation target %s is not supported yet", target)
 }

--- a/application/usecase/activation_target_internal_test.go
+++ b/application/usecase/activation_target_internal_test.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,6 +21,18 @@ func TestResolveActivationTarget_ReturnsCodexDescriptor(t *testing.T) {
 	}
 }
 
+func TestResolveActivationTarget_ReturnsClaudeDescriptor(t *testing.T) {
+	t.Parallel()
+
+	target, err := resolveActivationTarget(apptypes.MemoryBridgeTargetClaude)
+	if err != nil {
+		t.Fatalf("resolveActivationTarget(claude) error = %v", err)
+	}
+	if got := target.Target(); got != apptypes.MemoryBridgeTargetClaude {
+		t.Fatalf("Target() = %q, want claude", got)
+	}
+}
+
 func TestResolveActivationTarget_RejectsUnknownTarget(t *testing.T) {
 	t.Parallel()
 
@@ -29,21 +42,12 @@ func TestResolveActivationTarget_RejectsUnknownTarget(t *testing.T) {
 	}
 }
 
-func TestResolveActivationTarget_RejectsClaudeAndGeminiUntilLaterIssues(t *testing.T) {
+func TestResolveActivationTarget_RejectsGeminiUntilLaterIssues(t *testing.T) {
 	t.Parallel()
 
-	cases := []apptypes.MemoryBridgeTarget{
-		apptypes.MemoryBridgeTargetClaude,
-		apptypes.MemoryBridgeTargetGemini,
-	}
-	for _, target := range cases {
-		t.Run(string(target), func(t *testing.T) {
-			t.Parallel()
-			_, err := resolveActivationTarget(target)
-			if err == nil || !strings.Contains(err.Error(), "not supported yet") {
-				t.Fatalf("resolveActivationTarget(%q) err = %v, want not-supported-yet rejection", target, err)
-			}
-		})
+	_, err := resolveActivationTarget(apptypes.MemoryBridgeTargetGemini)
+	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("resolveActivationTarget(gemini) err = %v, want not-supported-yet rejection", err)
 	}
 }
 
@@ -52,16 +56,19 @@ func TestCodexActivationTarget_PathOverrideWinsOverRoot(t *testing.T) {
 
 	dir := t.TempDir()
 	custom := filepath.Join(dir, "custom.md")
-	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+	got, err := codexActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
 		Target: apptypes.MemoryBridgeTargetCodex,
 		Path:   custom,
 		Root:   filepath.Join(dir, "ignored"),
 	})
 	if err != nil {
-		t.Fatalf("ResolvePath error = %v", err)
+		t.Fatalf("Resolve error = %v", err)
 	}
-	if got != custom {
-		t.Fatalf("ResolvePath = %q, want %q (Path must override Root)", got, custom)
+	if got.HostContextPath != custom {
+		t.Fatalf("HostContextPath = %q, want %q (Path must override Root)", got.HostContextPath, custom)
+	}
+	if got.IsTwoFile() {
+		t.Fatalf("codex resolution must not be two-file: %+v", got)
 	}
 }
 
@@ -69,29 +76,163 @@ func TestCodexActivationTarget_RootOverrideAppendsTracearyMd(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+	got, err := codexActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
 		Target: apptypes.MemoryBridgeTargetCodex,
 		Root:   dir,
 	})
 	if err != nil {
-		t.Fatalf("ResolvePath error = %v", err)
+		t.Fatalf("Resolve error = %v", err)
 	}
 	want := filepath.Join(dir, codexActivationFileName)
-	if got != want {
-		t.Fatalf("ResolvePath = %q, want %q", got, want)
+	if got.HostContextPath != want {
+		t.Fatalf("HostContextPath = %q, want %q", got.HostContextPath, want)
 	}
 }
 
 func TestCodexActivationTarget_DefaultPathStillUsesCodexHomeAndFilename(t *testing.T) {
 	t.Parallel()
 
-	got, err := codexActivationTarget{}.ResolvePath(apptypes.MemoryActivationCriteria{
+	got, err := codexActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
 		Target: apptypes.MemoryBridgeTargetCodex,
 	})
 	if err != nil {
-		t.Fatalf("ResolvePath error = %v", err)
+		t.Fatalf("Resolve error = %v", err)
 	}
-	if !strings.HasSuffix(got, filepath.Join(".codex", "memories", codexActivationFileName)) {
-		t.Fatalf("default ResolvePath = %q, want suffix .codex/memories/%s (default Codex layout must not change)", got, codexActivationFileName)
+	if !strings.HasSuffix(got.HostContextPath, filepath.Join(".codex", "memories", codexActivationFileName)) {
+		t.Fatalf("default HostContextPath = %q, want suffix .codex/memories/%s (default Codex layout must not change)", got.HostContextPath, codexActivationFileName)
 	}
+}
+
+func TestClaudeActivationTarget_PathOverrideWinsOverRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "nested", "OTHER.md")
+	if err := os.MkdirAll(filepath.Dir(custom), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	got, err := claudeActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Path:   custom,
+		Root:   filepath.Join(dir, "ignored"),
+	})
+	if err != nil {
+		t.Fatalf("Resolve error = %v", err)
+	}
+	if got.HostContextPath != custom {
+		t.Fatalf("HostContextPath = %q, want %q (Path must override Root)", got.HostContextPath, custom)
+	}
+	wantExternal := filepath.Join(filepath.Dir(custom), filepath.FromSlash(claudeExternalMemoryRelDir), claudeExternalMemoryFileName)
+	if got.ExternalMemoryPath != wantExternal {
+		t.Fatalf("ExternalMemoryPath = %q, want %q (must derive from Path's directory)", got.ExternalMemoryPath, wantExternal)
+	}
+	if got.ImportPath != "./.traceary/memories/claude.md" {
+		t.Fatalf("ImportPath = %q, want ./.traceary/memories/claude.md", got.ImportPath)
+	}
+}
+
+func TestClaudeActivationTarget_RootOverrideUsesCanonicalLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	got, err := claudeActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Resolve error = %v", err)
+	}
+	wantHost := filepath.Join(dir, claudeHostContextFileName)
+	if got.HostContextPath != wantHost {
+		t.Fatalf("HostContextPath = %q, want %q", got.HostContextPath, wantHost)
+	}
+	wantExternal := filepath.Join(dir, filepath.FromSlash(claudeExternalMemoryRelDir), claudeExternalMemoryFileName)
+	if got.ExternalMemoryPath != wantExternal {
+		t.Fatalf("ExternalMemoryPath = %q, want %q", got.ExternalMemoryPath, wantExternal)
+	}
+	if got.ImportPath != "./.traceary/memories/claude.md" {
+		t.Fatalf("ImportPath = %q, want ./.traceary/memories/claude.md", got.ImportPath)
+	}
+	if !got.IsTwoFile() {
+		t.Fatalf("claude resolution must be two-file: %+v", got)
+	}
+}
+
+func TestClaudeActivationTarget_DefaultRootDetectsGitAncestor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+	nested := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("MkdirAll(nested): %v", err)
+	}
+	// macOS exposes t.TempDir() as `/var/folders/...` while the
+	// resolved path is `/private/var/folders/...`. The detector calls
+	// os.Getwd from inside `nested`, which the kernel returns through
+	// the resolved (private) prefix, so the assertion must compare
+	// against the same prefix.
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	withWorkingDir(t, nested, func() {
+		got, err := claudeActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+			Target: apptypes.MemoryBridgeTargetClaude,
+		})
+		if err != nil {
+			t.Fatalf("Resolve error = %v", err)
+		}
+		wantHost := filepath.Join(resolvedRoot, claudeHostContextFileName)
+		if got.HostContextPath != wantHost {
+			t.Fatalf("HostContextPath = %q, want git ancestor %q", got.HostContextPath, wantHost)
+		}
+	})
+}
+
+func TestClaudeActivationTarget_DefaultRootFallsBackToCwdWhenNoGit(t *testing.T) {
+	// Not parallel-safe: withWorkingDir uses os.Chdir which mutates
+	// process-global state, so this test must serialise with the other
+	// chdir-based test (TestClaudeActivationTarget_DefaultRootDetectsGitAncestor).
+	root := t.TempDir()
+	withWorkingDir(t, root, func() {
+		got, err := claudeActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+			Target: apptypes.MemoryBridgeTargetClaude,
+		})
+		if err != nil {
+			t.Fatalf("Resolve error = %v", err)
+		}
+		// Use os.Getwd() to compare evaluated paths in case the
+		// platform resolves the temp dir through symlinks (macOS
+		// /var → /private/var).
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		wantHost := filepath.Join(cwd, claudeHostContextFileName)
+		if got.HostContextPath != wantHost {
+			t.Fatalf("HostContextPath = %q, want cwd fallback %q", got.HostContextPath, wantHost)
+		}
+	})
+}
+
+// withWorkingDir runs fn with the process working directory set to dir
+// and restores the previous working directory afterwards. The helper is
+// not parallel-safe; tests using it serialise their os.Chdir calls
+// because they share the global cwd.
+func withWorkingDir(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%q): %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("restore Chdir(%q): %v", previous, err)
+		}
+	})
+	fn()
 }

--- a/application/usecase/claude_import_readiness_internal_test.go
+++ b/application/usecase/claude_import_readiness_internal_test.go
@@ -1,0 +1,132 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// TestClaudeActivationTarget_ImportLineMatchesDocumentedClaudeFormat is
+// the readiness-gate evidence required by the v0.13 host-native memory
+// activation ADR for Claude. Live-launching Claude Code from CI is
+// non-deterministic (auth state, the documented first-time external
+// import approval dialog, model selection), so this test instead pins
+// the rendered import line to the exact markdown form Claude's official
+// memory documentation says it expands at session start:
+//
+//	@<relative-path-to-import>
+//
+// Source: <https://code.claude.com/docs/en/memory>. The accompanying
+// scripts/smoke_test_claude_activation.sh materialises the same plan
+// onto disk so an operator can run `claude` in a temp project and
+// confirm the live runtime resolution. The two together — this test
+// plus that script — form the documented readiness evidence the ADR
+// requires before a Claude --apply PR can graduate to ready.
+func TestClaudeActivationTarget_ImportLineMatchesDocumentedClaudeFormat(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	resolution, err := claudeActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetClaude, resolution.ImportPath)
+
+	// Marker contract: the begin marker carries a version, the end
+	// marker does not. The first non-marker line in the stub must be
+	// the warning, the second must be the import line.
+	lines := strings.Split(strings.TrimRight(stub, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("rendered stub must have exactly 4 lines (begin, warning, import, end), got %d: %q", len(lines), stub)
+	}
+	if lines[0] != "<!-- traceary-memory-import:begin:v1 -->" {
+		t.Fatalf("stub[0] = %q, want documented begin marker", lines[0])
+	}
+	if lines[3] != "<!-- traceary-memory-import:end -->" {
+		t.Fatalf("stub[3] = %q, want documented end marker", lines[3])
+	}
+
+	importLine := lines[2]
+	if !strings.HasPrefix(importLine, "@") {
+		t.Fatalf("import line must start with '@' per Claude memory docs, got %q", importLine)
+	}
+	importPath := strings.TrimPrefix(importLine, "@")
+
+	// Claude resolves relative imports against the directory containing
+	// the host context file. Render the relative path back to an
+	// absolute one and confirm it points at the planned external memory
+	// file the activation usecase will manage.
+	hostDir := filepath.Dir(resolution.HostContextPath)
+	resolvedAbs := filepath.Clean(filepath.Join(hostDir, filepath.FromSlash(importPath)))
+	if resolvedAbs != resolution.ExternalMemoryPath {
+		t.Fatalf("import line %q does not resolve to the planned external memory file: got %q, want %q", importLine, resolvedAbs, resolution.ExternalMemoryPath)
+	}
+
+	// The default v0.13 layout must use the documented hidden directory
+	// import (the official Claude memory docs include the
+	// `@~/.claude/...` example, so a hidden `.traceary/` import is in
+	// scope). Pin the canonical relative form so a future refactor
+	// cannot silently switch to an absolute or escaping path.
+	if importPath != "./.traceary/memories/claude.md" {
+		t.Fatalf("default import path = %q, want ./.traceary/memories/claude.md", importPath)
+	}
+
+	// External memory file must live below the host context directory
+	// so the relative import never escapes the activation root. A
+	// future absolute override is acceptable, but the default must
+	// stay confined.
+	rel, err := filepath.Rel(hostDir, resolution.ExternalMemoryPath)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	if strings.HasPrefix(filepath.ToSlash(rel), "../") {
+		t.Fatalf("external memory file %q escapes host context directory %q via %q", resolution.ExternalMemoryPath, hostDir, rel)
+	}
+
+	// Sanity-check that the planner can materialise the pair onto the
+	// real filesystem under the same temp root used by the smoke
+	// script. This protects the readiness gate from regressions in the
+	// safe writer (symlink refusal, atomic rename) without launching
+	// Claude.
+	planner := &importStubActivationPlanner{}
+	plan := planner.Plan(importStubActivationCriteria{
+		Target:             apptypes.MemoryBridgeTargetClaude,
+		HostContextPath:    resolution.HostContextPath,
+		ExternalMemoryPath: resolution.ExternalMemoryPath,
+		ImportPath:         resolution.ImportPath,
+		ExternalMarkdown:   "<!-- traceary-memories:begin:v1 -->\nplaceholder\n<!-- traceary-memories:end -->\n",
+	})
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.Status = %q, want missing on a fresh root", plan.HostContext.Status)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("ExternalMemory.Status = %q, want missing on a fresh root", plan.ExternalMemory.Status)
+	}
+
+	// The smoke script writes the planned content into the temp
+	// project. Reproduce that step here so a regression in
+	// renderImportStubBlock would also be caught when the script is
+	// executed manually for the live runtime probe.
+	if err := os.MkdirAll(filepath.Dir(resolution.ExternalMemoryPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(resolution.HostContextPath, []byte(plan.HostContext.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+	if err := os.WriteFile(resolution.ExternalMemoryPath, []byte(plan.ExternalMemory.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	roundtrip, err := os.ReadFile(resolution.HostContextPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(roundtrip), importLine) {
+		t.Fatalf("materialised CLAUDE.md missing import line %q, got %q", importLine, roundtrip)
+	}
+}

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -28,7 +28,7 @@ func (u *memoryActivationUsecase) writer() activationFileWriter {
 }
 
 func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationPlan, error) {
-	targetPath, err := resolveMemoryActivationTargetPath(criteria)
+	resolution, err := resolveMemoryActivationTargetResolution(criteria)
 	if err != nil {
 		return apptypes.MemoryActivationPlan{}, err
 	}
@@ -38,8 +38,12 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 		return apptypes.MemoryActivationPlan{}, err
 	}
 
+	if resolution.IsTwoFile() {
+		return u.planTwoFile(criteria, resolution, exportResult), nil
+	}
+
 	writer := u.writer()
-	existing, exists, err := writer.ReadIfExists(targetPath)
+	existing, exists, err := writer.ReadIfExists(resolution.HostContextPath)
 	if err != nil {
 		return apptypes.MemoryActivationPlan{}, xerrors.Errorf("failed to load activation target for plan: %w", err)
 	}
@@ -49,12 +53,12 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 	}
 	diff := ""
 	if criteria.Diff && exists && existing != planned {
-		diff = renderActivationDiff(targetPath, existing, planned)
+		diff = renderActivationDiff(resolution.HostContextPath, existing, planned)
 	}
 
 	return apptypes.MemoryActivationPlan{
 		Target:         criteria.Target,
-		TargetPath:     targetPath,
+		TargetPath:     resolution.HostContextPath,
 		Scopes:         exportResult.Scopes,
 		Markdown:       planned,
 		Existing:       exists,
@@ -64,9 +68,13 @@ func (u *memoryActivationUsecase) Plan(ctx context.Context, criteria apptypes.Me
 }
 
 func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationApplyResult, error) {
-	targetPath, err := resolveMemoryActivationTargetPath(criteria)
+	resolution, err := resolveMemoryActivationTargetResolution(criteria)
 	if err != nil {
 		return apptypes.MemoryActivationApplyResult{}, err
+	}
+
+	if resolution.IsTwoFile() {
+		return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("memory activation --apply is not supported yet for target %s", criteria.Target)
 	}
 
 	exportResult, err := u.renderActivationBlock(ctx, criteria)
@@ -75,7 +83,7 @@ func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.M
 	}
 
 	writer := u.writer()
-	existing, exists, err := writer.ReadIfExists(targetPath)
+	existing, exists, err := writer.ReadIfExists(resolution.HostContextPath)
 	if err != nil {
 		return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("failed to load activation target before apply: %w", err)
 	}
@@ -84,14 +92,14 @@ func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.M
 		return apptypes.MemoryActivationApplyResult{}, err
 	}
 	if action != apptypes.MemoryActivationApplyNoop {
-		if err := writer.WriteAtomic(targetPath, planned); err != nil {
+		if err := writer.WriteAtomic(resolution.HostContextPath, planned); err != nil {
 			return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("failed to apply activation target: %w", err)
 		}
 	}
 
 	return apptypes.MemoryActivationApplyResult{
 		Target:         criteria.Target,
-		TargetPath:     targetPath,
+		TargetPath:     resolution.HostContextPath,
 		Scopes:         exportResult.Scopes,
 		Action:         action,
 		Existing:       exists,
@@ -100,7 +108,7 @@ func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.M
 }
 
 func (u *memoryActivationUsecase) Status(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryActivationStatusResult, error) {
-	targetPath, err := resolveMemoryActivationTargetPath(criteria)
+	resolution, err := resolveMemoryActivationTargetResolution(criteria)
 	if err != nil {
 		return apptypes.MemoryActivationStatusResult{}, err
 	}
@@ -109,21 +117,26 @@ func (u *memoryActivationUsecase) Status(ctx context.Context, criteria apptypes.
 	if err != nil {
 		return apptypes.MemoryActivationStatusResult{}, err
 	}
+
+	if resolution.IsTwoFile() {
+		return u.statusTwoFile(criteria, resolution, exportResult), nil
+	}
+
 	result := apptypes.MemoryActivationStatusResult{
 		Target:         criteria.Target,
-		TargetPath:     targetPath,
+		TargetPath:     resolution.HostContextPath,
 		Scopes:         exportResult.Scopes,
 		ActivatedCount: exportResult.ExportedCount,
 	}
 
 	writer := u.writer()
-	if _, _, err := writer.Inspect(targetPath); err != nil {
+	if _, _, err := writer.Inspect(resolution.HostContextPath); err != nil {
 		result.State = apptypes.MemoryActivationStatusInvalid
 		result.Message = err.Error()
 		return result, nil
 	}
 
-	existing, exists, err := writer.ReadIfExists(targetPath)
+	existing, exists, err := writer.ReadIfExists(resolution.HostContextPath)
 	if err != nil {
 		result.State = apptypes.MemoryActivationStatusInvalid
 		result.Message = err.Error()
@@ -156,6 +169,132 @@ func (u *memoryActivationUsecase) Status(ctx context.Context, criteria apptypes.
 	return result, nil
 }
 
+func (u *memoryActivationUsecase) planTwoFile(criteria apptypes.MemoryActivationCriteria, resolution activationTargetResolution, exportResult apptypes.MemoryExportResult) apptypes.MemoryActivationPlan {
+	planner := &importStubActivationPlanner{fileWriter: u.fileWriter}
+	pair := planner.Plan(importStubActivationCriteria{
+		Target:             criteria.Target,
+		HostContextPath:    resolution.HostContextPath,
+		ExternalMemoryPath: resolution.ExternalMemoryPath,
+		ImportPath:         resolution.ImportPath,
+		ExternalMarkdown:   exportResult.Markdown,
+		Scopes:             exportResult.Scopes,
+		ActivatedCount:     exportResult.ExportedCount,
+		Diff:               criteria.Diff,
+	})
+	host := componentFromPlan(pair.HostContext)
+	external := componentFromPlan(pair.ExternalMemory)
+	plan := apptypes.MemoryActivationPlan{
+		Target:         criteria.Target,
+		TargetPath:     resolution.HostContextPath,
+		Scopes:         exportResult.Scopes,
+		Markdown:       pair.HostContext.Markdown,
+		Existing:       pair.HostContext.Existing,
+		Diff:           strings.Join(pair.orderedDiffs(), "\n"),
+		ActivatedCount: exportResult.ExportedCount,
+		HostContext:    &host,
+		ExternalMemory: &external,
+	}
+	return plan
+}
+
+func (u *memoryActivationUsecase) statusTwoFile(criteria apptypes.MemoryActivationCriteria, resolution activationTargetResolution, exportResult apptypes.MemoryExportResult) apptypes.MemoryActivationStatusResult {
+	planner := &importStubActivationPlanner{fileWriter: u.fileWriter}
+	pair := planner.Plan(importStubActivationCriteria{
+		Target:             criteria.Target,
+		HostContextPath:    resolution.HostContextPath,
+		ExternalMemoryPath: resolution.ExternalMemoryPath,
+		ImportPath:         resolution.ImportPath,
+		ExternalMarkdown:   exportResult.Markdown,
+		Scopes:             exportResult.Scopes,
+		ActivatedCount:     exportResult.ExportedCount,
+	})
+	host := componentFromPlan(pair.HostContext)
+	external := componentFromPlan(pair.ExternalMemory)
+	state := aggregateTwoFileStatus(host.State, external.State)
+	return apptypes.MemoryActivationStatusResult{
+		Target:         criteria.Target,
+		TargetPath:     resolution.HostContextPath,
+		Scopes:         exportResult.Scopes,
+		State:          state,
+		Existing:       pair.HostContext.Existing,
+		ActivatedCount: exportResult.ExportedCount,
+		Message:        statusMessageForPair(state, host, external),
+		HostContext:    &host,
+		ExternalMemory: &external,
+	}
+}
+
+// componentFromPlan maps the planner's per-file result onto the public
+// MemoryActivationComponent type so callers outside the usecase package
+// can consume the per-file diff and state without reaching into the
+// internal planner type.
+func componentFromPlan(plan activationComponentPlan) apptypes.MemoryActivationComponent {
+	return apptypes.MemoryActivationComponent{
+		Path:     plan.Path,
+		Existing: plan.Existing,
+		Markdown: plan.Markdown,
+		Diff:     plan.Diff,
+		Action:   plan.Action,
+		State:    plan.Status,
+		Message:  plan.Message,
+	}
+}
+
+// aggregateTwoFileStatus collapses the per-file states into the pair
+// state documented in the v0.13 ADR. The priority is invalid → missing
+// → stale → in_sync; any in-sync value short-circuits only when both
+// components are in sync.
+func aggregateTwoFileStatus(host apptypes.MemoryActivationStatusState, external apptypes.MemoryActivationStatusState) apptypes.MemoryActivationStatusState {
+	if host == apptypes.MemoryActivationStatusInvalid || external == apptypes.MemoryActivationStatusInvalid {
+		return apptypes.MemoryActivationStatusInvalid
+	}
+	if host == apptypes.MemoryActivationStatusMissing || external == apptypes.MemoryActivationStatusMissing {
+		return apptypes.MemoryActivationStatusMissing
+	}
+	if host == apptypes.MemoryActivationStatusStale || external == apptypes.MemoryActivationStatusStale {
+		return apptypes.MemoryActivationStatusStale
+	}
+	return apptypes.MemoryActivationStatusInSync
+}
+
+func statusMessageForPair(state apptypes.MemoryActivationStatusState, host, external apptypes.MemoryActivationComponent) string {
+	switch state {
+	case apptypes.MemoryActivationStatusInSync:
+		return "activation pair is in sync"
+	case apptypes.MemoryActivationStatusInvalid:
+		if external.Message != "" && external.State == apptypes.MemoryActivationStatusInvalid {
+			return fmt.Sprintf("external memory file invalid: %s", external.Message)
+		}
+		if host.Message != "" {
+			return fmt.Sprintf("host context file invalid: %s", host.Message)
+		}
+		return "activation pair is invalid"
+	case apptypes.MemoryActivationStatusMissing:
+		switch {
+		case host.State == apptypes.MemoryActivationStatusMissing && external.State == apptypes.MemoryActivationStatusMissing:
+			return "host context import stub and external memory file are missing"
+		case host.State == apptypes.MemoryActivationStatusMissing:
+			return "host context import stub is missing"
+		case external.State == apptypes.MemoryActivationStatusMissing:
+			return "external memory file is missing"
+		default:
+			return "activation pair is missing"
+		}
+	case apptypes.MemoryActivationStatusStale:
+		switch {
+		case host.State == apptypes.MemoryActivationStatusStale && external.State == apptypes.MemoryActivationStatusStale:
+			return "host context import stub and external memory file are stale"
+		case host.State == apptypes.MemoryActivationStatusStale:
+			return "host context import stub is stale"
+		case external.State == apptypes.MemoryActivationStatusStale:
+			return "external memory file is stale"
+		default:
+			return "activation pair is stale"
+		}
+	}
+	return ""
+}
+
 func (u *memoryActivationUsecase) renderActivationBlock(ctx context.Context, criteria apptypes.MemoryActivationCriteria) (apptypes.MemoryExportResult, error) {
 	return (&memoryExportUsecase{memoryQuery: u.memoryQuery}).Export(ctx, apptypes.MemoryExportCriteria{
 		Target:        criteria.Target,
@@ -164,19 +303,20 @@ func (u *memoryActivationUsecase) renderActivationBlock(ctx context.Context, cri
 	})
 }
 
-// resolveMemoryActivationTargetPath dispatches the criteria to the
-// host-specific descriptor and returns the absolute file path the
-// activation usecase will manage.
-func resolveMemoryActivationTargetPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+// resolveMemoryActivationTargetResolution dispatches the criteria to the
+// host-specific descriptor and returns the resolved file path(s). For
+// single-file targets only HostContextPath is populated; two-file
+// targets fill ExternalMemoryPath and ImportPath as well.
+func resolveMemoryActivationTargetResolution(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error) {
 	target, err := resolveActivationTarget(criteria.Target)
 	if err != nil {
-		return "", err
+		return activationTargetResolution{}, err
 	}
-	path, err := target.ResolvePath(criteria)
+	resolution, err := target.Resolve(criteria)
 	if err != nil {
-		return "", xerrors.Errorf("failed to resolve %s activation target path: %w", criteria.Target, err)
+		return activationTargetResolution{}, xerrors.Errorf("failed to resolve %s activation target: %w", criteria.Target, err)
 	}
-	return path, nil
+	return resolution, nil
 }
 
 func renderActivationDiff(path string, existing string, planned string) string {

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -101,13 +101,13 @@ func TestMemoryUsecase_ActivatePlan_PathOverrideAndExistingDiff(t *testing.T) {
 	}
 }
 
-func TestMemoryUsecase_ActivatePlan_RejectsUnsupportedTargetWithPathOverride(t *testing.T) {
+func TestMemoryUsecase_ActivatePlan_RejectsGeminiUntilLaterIssue(t *testing.T) {
 	t.Parallel()
 
 	sut := usecase.NewMemoryUsecase(nil, &stubExportMemoryQuery{}, nil)
 	_, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
-		Target: apptypes.MemoryBridgeTargetClaude,
-		Path:   filepath.Join(t.TempDir(), "CLAUDE.md"),
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Path:   filepath.Join(t.TempDir(), "GEMINI.md"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
 		t.Fatalf("ActivatePlan error = %v, want unsupported target", err)
@@ -533,4 +533,306 @@ func mustWorkspaceScope(t *testing.T, value string) domtypes.MemoryScope {
 		t.Fatalf("WorkspaceFrom: %v", err)
 	}
 	return domtypes.WorkspaceScopeOf(workspace)
+}
+
+func TestMemoryUsecase_ActivatePlan_ClaudeMissingPairExposesComponents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-plan", domtypes.MemoryTypePreference, scope, "prefer concise PRs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if plan.HostContext == nil || plan.ExternalMemory == nil {
+		t.Fatalf("two-file plan must expose components, got %+v", plan)
+	}
+	wantHost := filepath.Join(root, "CLAUDE.md")
+	wantExternal := filepath.Join(root, ".traceary", "memories", "claude.md")
+	if plan.HostContext.Path != wantHost {
+		t.Fatalf("HostContext.Path = %q, want %q", plan.HostContext.Path, wantHost)
+	}
+	if plan.ExternalMemory.Path != wantExternal {
+		t.Fatalf("ExternalMemory.Path = %q, want %q", plan.ExternalMemory.Path, wantExternal)
+	}
+	if plan.HostContext.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.State = %q, want missing", plan.HostContext.State)
+	}
+	if plan.ExternalMemory.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("ExternalMemory.State = %q, want missing", plan.ExternalMemory.State)
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "@./.traceary/memories/claude.md") {
+		t.Fatalf("HostContext.Markdown missing relative import line: %q", plan.HostContext.Markdown)
+	}
+	if !strings.Contains(plan.ExternalMemory.Markdown, "prefer concise PRs") {
+		t.Fatalf("ExternalMemory.Markdown missing accepted memory: %q", plan.ExternalMemory.Markdown)
+	}
+	if _, err := os.Stat(wantHost); !os.IsNotExist(err) {
+		t.Fatalf("dry-run plan must not create CLAUDE.md, stat err = %v", err)
+	}
+	if _, err := os.Stat(wantExternal); !os.IsNotExist(err) {
+		t.Fatalf("dry-run plan must not create external memory file, stat err = %v", err)
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_ClaudeDiffRendersDeterministically(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	if err := os.WriteFile(hostPath, []byte("# user notes\n\n<!-- traceary-memory-import:begin:v1 -->\n@./old.md\n<!-- traceary-memory-import:end -->\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(usecase.MemoryBridgeMarkerBegin+"\nold body\n"+usecase.MemoryBridgeMarkerEnd+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-diff", domtypes.MemoryTypePreference, scope, "prefer fresh activation"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+		Diff:   true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if plan.ExternalMemory.Diff == "" {
+		t.Fatalf("ExternalMemory.Diff is empty, want stale-content diff")
+	}
+	if plan.HostContext.Diff == "" {
+		t.Fatalf("HostContext.Diff is empty, want stub diff")
+	}
+	// The aggregate diff must order external before host so dry-run output
+	// matches the documented apply order.
+	externalIdx := strings.Index(plan.Diff, "--- "+externalPath)
+	hostIdx := strings.Index(plan.Diff, "--- "+hostPath)
+	if externalIdx < 0 || hostIdx < 0 || externalIdx >= hostIdx {
+		t.Fatalf("Plan.Diff must order external before host, externalIdx=%d hostIdx=%d diff=%q", externalIdx, hostIdx, plan.Diff)
+	}
+	// The aggregate diff must keep a readable boundary between the two
+	// per-component diffs. Each component diff ends in "\n", and joining
+	// with "\n" produces a blank line that separates the headers.
+	if !strings.Contains(plan.Diff, plan.ExternalMemory.Diff+"\n--- "+hostPath) {
+		t.Fatalf("Plan.Diff must separate external and host diffs with a blank line, got %q", plan.Diff)
+	}
+
+	plan2, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+		Diff:   true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan second: %v", err)
+	}
+	if plan.Diff != plan2.Diff {
+		t.Fatalf("diff is not deterministic across runs")
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_ClaudeRejectsApplyMode(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-apply", domtypes.MemoryTypePreference, scope, "prefer staged Claude apply"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	_, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("Activate err = %v, want claude apply refusal", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "CLAUDE.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("apply refusal must not create CLAUDE.md, stat err = %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".traceary", "memories", "claude.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("apply refusal must not create external memory file, stat err = %v", statErr)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_ClaudeMissingPair(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-missing", domtypes.MemoryTypePreference, scope, "prefer claude status"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	status, err := sut.ActivationStatus(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("State = %q, want missing", status.State)
+	}
+	if status.HostContext == nil || status.ExternalMemory == nil {
+		t.Fatalf("two-file status must expose components, got %+v", status)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusMissing || status.ExternalMemory.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("component states = host=%q external=%q, want both missing", status.HostContext.State, status.ExternalMemory.State)
+	}
+	if !strings.Contains(status.Message, "stub") {
+		t.Fatalf("Message = %q, want pair-aware message", status.Message)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_ClaudeStaleStubInSyncExternal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	if err := os.WriteFile(hostPath, []byte("<!-- traceary-memory-import:begin:v1 -->\n@./stale.md\n<!-- traceary-memory-import:end -->\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll external: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-stale", domtypes.MemoryTypePreference, scope, "prefer stable stubs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	}
+	plan, err := sut.ActivatePlan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(plan.ExternalMemory.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+
+	status, err := sut.ActivationStatus(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("State = %q, want stale (host stale, external in_sync)", status.State)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("HostContext.State = %q, want stale", status.HostContext.State)
+	}
+	if status.ExternalMemory.State != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.State = %q, want in_sync", status.ExternalMemory.State)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_ClaudeInvalidStubBeginsWithoutEnd(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	if err := os.WriteFile(hostPath, []byte("<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/claude.md\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-invalid", domtypes.MemoryTypePreference, scope, "prefer invalid pair detection"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	status, err := sut.ActivationStatus(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("State = %q, want invalid", status.State)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.State = %q, want invalid", status.HostContext.State)
+	}
+	if !strings.Contains(status.HostContext.Message, "without end marker") {
+		t.Fatalf("HostContext.Message = %q, want orphan-begin reason", status.HostContext.Message)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_ClaudeInSyncAfterPlanWriteback(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-claude-insync", domtypes.MemoryTypePreference, scope, "prefer in_sync claude pair"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	}
+	plan, err := sut.ActivatePlan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll external: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(plan.ExternalMemory.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	if err := os.WriteFile(hostPath, []byte(plan.HostContext.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+
+	status, err := sut.ActivationStatus(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("State = %q, want in_sync after writing planned content", status.State)
+	}
 }

--- a/docs/architecture/host-native-memory-activation.ja.md
+++ b/docs/architecture/host-native-memory-activation.ja.md
@@ -128,6 +128,13 @@ JSON output は host context file と external memory file の component-level d
 
 host import visibility は release dogfood だけではなく、implementation-readiness gate です。最初の Claude/Gemini read-only PR では、host が planned import path を解決することを smoke test または記録済み manual verification として残します。apply PR は、その証跡が出るまで draft / blocked のままにします。
 
+Claude については、v0.13.0-4 の read-only PR が以下 2 つの artefact を組み合わせて、ライブ launch のフレーキネスに依存しない readiness 証跡を残します。
+
+- `application/usecase/claude_import_readiness_internal_test.go` は、rendering 済み import line・marker layout・external file 解決を Claude 公式 memory documentation の `@<relative-path>` フォーマット（`CLAUDE.md` のあるディレクトリ基準）に固定します。CI 上で常時実行されるため、リファクタで import path を黙って動かせません。
+- `scripts/smoke_test_claude_activation.sh` は `traceary memory activate --target claude --dry-run --json` の生成 plan を使って一時プロジェクト (`.git`、`CLAUDE.md`、`.traceary/memories/claude.md`) を materialize します。既定では structural check 後に一時プロジェクトを削除します。manual runtime probe のために保持して、そのディレクトリで `claude` を起動する場合は `TRACEARY_KEEP_SMOKE_TEMP=1` を指定します。Claude Code の初回 external-import approval dialog と認証状態のため、無人ランタイム probe は非決定的です。ライブ launch は `TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` を指定したときだけ実行します。
+
+Claude `--apply` PR (#893) では、`TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` で記録した `smoke_test_claude_activation.sh` のログを PR に添付するか、別 gate を採用する場合はその根拠を ADR にも追記する必要があります。
+
 ## apply semantics
 
 `--status` と `--dry-run` は read-only です。変更するのは `--apply` だけです。

--- a/docs/architecture/host-native-memory-activation.md
+++ b/docs/architecture/host-native-memory-activation.md
@@ -128,6 +128,13 @@ JSON output should expose component-level details for the host context file and 
 
 Host import visibility is an implementation-readiness gate, not only a release dogfood task. The first Claude/Gemini read-only PRs must include a smoke test or recorded manual verification that the host resolves the planned import path; the apply PRs must stay draft/blocked until that evidence exists.
 
+For Claude, the v0.13.0-4 read-only PR records that evidence in two artefacts that together stand in for a flaky live launch:
+
+- `application/usecase/claude_import_readiness_internal_test.go` pins the rendered import line, marker layout, and external-file resolution to the exact form Claude's official memory documentation specifies (`@<relative-path>` resolved against the directory containing `CLAUDE.md`). It runs in CI, so a refactor cannot silently move the import path.
+- `scripts/smoke_test_claude_activation.sh` materialises a temp project (`.git`, `CLAUDE.md`, `.traceary/memories/claude.md`) using the live `traceary memory activate --target claude --dry-run --json` plan. By default it removes the temp project after the structural check; set `TRACEARY_KEEP_SMOKE_TEMP=1` to retain it and launch `claude` from that directory for a manual runtime probe. The live launch is gated behind `TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` because Claude Code's first-time external-import approval dialog and authentication state make an unattended runtime probe non-deterministic.
+
+The Claude `--apply` PR (#893) must keep the live runtime evidence in scope: either a maintainer-recorded `smoke_test_claude_activation.sh` run with `TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` attached to the PR, or an updated ADR explaining why an alternative gate is acceptable.
+
 ## Apply semantics
 
 `--status` and `--dry-run` are read-only. `--apply` is the only mutating mode.

--- a/presentation/cli/memory_activate.go
+++ b/presentation/cli/memory_activate.go
@@ -25,8 +25,8 @@ func (c *RootCLI) newMemoryActivateCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().StringVar(&input.target, "target", "", Localize("activation target host (codex)", "activation 対象ホスト (codex)"))
-	cmd.Flags().StringVar(&input.root, "root", "", Localize("host memory root override (Codex default: ~/.codex/memories)", "host memory root の上書き (Codex 既定: ~/.codex/memories)"))
+	cmd.Flags().StringVar(&input.target, "target", "", Localize("activation target host (codex, claude)", "activation 対象ホスト (codex, claude)"))
+	cmd.Flags().StringVar(&input.root, "root", "", Localize("host memory root override (Codex default: ~/.codex/memories; Claude default: nearest .git ancestor or cwd)", "host memory root の上書き (Codex 既定: ~/.codex/memories; Claude 既定: 直近の .git 祖先または cwd)"))
 	cmd.Flags().StringVar(&input.path, "path", "", Localize("explicit activation target file path override", "activation 対象ファイルパスを明示的に上書き"))
 	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace scope to activate (defaults to env/detected workspace)", "activation 対象の workspace scope (未指定時は env/検出 workspace)"))
 	cmd.Flags().BoolVar(&input.includeGlobal, "include-global", true, Localize("include global memories alongside a workspace activation (default true)", "workspace activation に global memory も含める (default true)"))
@@ -54,8 +54,18 @@ func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input
 		return xerrors.Errorf(Localize("--diff can only be used with --dry-run", "--diff は --dry-run と一緒にのみ使用できます"))
 	}
 	target, ok := apptypes.MemoryBridgeTargetOf(strings.ToLower(strings.TrimSpace(input.target)))
-	if !ok || target != apptypes.MemoryBridgeTargetCodex {
-		return xerrors.Errorf(Localize("--target must be codex", "--target は codex を指定してください"))
+	if !ok {
+		return xerrors.Errorf(Localize("--target must be codex or claude", "--target は codex または claude を指定してください"))
+	}
+	switch target {
+	case apptypes.MemoryBridgeTargetCodex:
+		// fully supported (status / dry-run / apply)
+	case apptypes.MemoryBridgeTargetClaude:
+		if input.apply {
+			return xerrors.Errorf(Localize("memory activate --target claude --apply is not supported yet (read-only status / dry-run only)", "memory activate --target claude --apply は未対応です (status / dry-run のみ可)"))
+		}
+	default:
+		return xerrors.Errorf(Localize("--target must be codex or claude", "--target は codex または claude を指定してください"))
 	}
 	if err := c.initializeStore(ctx, input.dbPath); err != nil {
 		return err
@@ -115,6 +125,8 @@ func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationP
 			ActivatedCount: plan.ActivatedCount,
 			Markdown:       plan.Markdown,
 			Diff:           plan.Diff,
+			HostContext:    componentOutput(plan.HostContext),
+			ExternalMemory: componentOutput(plan.ExternalMemory),
 		}
 		encoder := json.NewEncoder(output)
 		encoder.SetEscapeHTML(false)
@@ -123,6 +135,9 @@ func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationP
 			return xerrors.Errorf("%s: %w", Localize("failed to encode memory activation plan", "memory activation plan の JSON 出力に失敗しました"), err)
 		}
 		return nil
+	}
+	if plan.HostContext != nil && plan.ExternalMemory != nil {
+		return writeMemoryActivationPairPlanText(output, plan)
 	}
 	if _, err := fmt.Fprintf(output, "target: %s\nexisting: %t\n\n", plan.TargetPath, plan.Existing); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation plan", "memory activation plan の出力に失敗しました"), err)
@@ -135,6 +150,67 @@ func writeMemoryActivationPlan(output io.Writer, plan apptypes.MemoryActivationP
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation content", "memory activation content の出力に失敗しました"), err)
 	}
 	return nil
+}
+
+// writeMemoryActivationPairPlanText renders the dry-run / diff text for a
+// two-file activation pair (Claude / Gemini). External memory is rendered
+// first because it matches the documented apply ordering, and each
+// component is labelled so operators can tell which planned content
+// corresponds to which file.
+func writeMemoryActivationPairPlanText(output io.Writer, plan apptypes.MemoryActivationPlan) error {
+	host := plan.HostContext
+	external := plan.ExternalMemory
+	if _, err := fmt.Fprintf(output, "target: %s\n", plan.Target.String()); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation plan", "memory activation plan の出力に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		"external_memory: %s (existing: %t, action: %s)\nhost_context: %s (existing: %t, action: %s)\n\n",
+		external.Path, external.Existing, external.Action,
+		host.Path, host.Existing, host.Action,
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation plan", "memory activation plan の出力に失敗しました"), err)
+	}
+	if external.Diff != "" || host.Diff != "" {
+		if external.Diff != "" {
+			if _, err := fmt.Fprintf(output, "# external memory diff\n%s", external.Diff); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to print memory activation diff", "memory activation diff の出力に失敗しました"), err)
+			}
+		}
+		if host.Diff != "" {
+			if external.Diff != "" {
+				if _, err := fmt.Fprint(output, "\n"); err != nil {
+					return xerrors.Errorf("%s: %w", Localize("failed to print memory activation diff", "memory activation diff の出力に失敗しました"), err)
+				}
+			}
+			if _, err := fmt.Fprintf(output, "# host context diff\n%s", host.Diff); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to print memory activation diff", "memory activation diff の出力に失敗しました"), err)
+			}
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(output, "# external memory plan\n%s\n", external.Markdown); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation content", "memory activation content の出力に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintf(output, "# host context plan\n%s", host.Markdown); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation content", "memory activation content の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func componentOutput(component *apptypes.MemoryActivationComponent) *memoryActivationComponentOutput {
+	if component == nil {
+		return nil
+	}
+	return &memoryActivationComponentOutput{
+		Path:     component.Path,
+		Existing: component.Existing,
+		Markdown: component.Markdown,
+		Diff:     component.Diff,
+		Action:   component.Action.String(),
+		State:    component.State.String(),
+		Message:  component.Message,
+	}
 }
 
 type memoryActivationCommandSet struct {
@@ -161,10 +237,22 @@ func memoryActivationCommands(criteria apptypes.MemoryActivationCriteria) memory
 	if hasWorkspaceScope && !criteria.IncludeGlobal {
 		base = append(base, "--no-global")
 	}
-	return memoryActivationCommandSet{
+	set := memoryActivationCommandSet{
 		DryRun: renderShellCommand(append(append([]string(nil), base...), "--dry-run", "--diff")),
-		Apply:  renderShellCommand(append(append([]string(nil), base...), "--apply")),
 	}
+	if memoryActivationApplySupported(criteria.Target) {
+		set.Apply = renderShellCommand(append(append([]string(nil), base...), "--apply"))
+	}
+	return set
+}
+
+// memoryActivationApplySupported reports whether `memory activate
+// --apply` is available for the given target. Claude apply lands in
+// #893; until then --status must not surface a remediation command that
+// the CLI would refuse, so this helper gates both the JSON
+// `apply_command` field and the text `next_apply` line.
+func memoryActivationApplySupported(target apptypes.MemoryBridgeTarget) bool {
+	return target == apptypes.MemoryBridgeTargetCodex
 }
 
 func renderShellCommand(args []string) string {
@@ -206,10 +294,16 @@ func writeMemoryActivationStatus(output io.Writer, result apptypes.MemoryActivat
 			Existing:       result.Existing,
 			ActivatedCount: result.ActivatedCount,
 			Message:        result.Message,
+			HostContext:    componentOutput(result.HostContext),
+			ExternalMemory: componentOutput(result.ExternalMemory),
 		}
 		if memoryActivationStatusHasRemediation(result.State) {
 			payload.DryRunCommand = commands.DryRun
 			payload.ApplyCommand = commands.Apply
+			// commands.Apply is empty for targets where --apply is not
+			// supported yet (Claude until #893). The JSON field uses
+			// `omitempty` so the payload simply drops `apply_command`
+			// instead of advertising a command the CLI would refuse.
 		}
 		encoder := json.NewEncoder(output)
 		encoder.SetEscapeHTML(false)
@@ -230,11 +324,26 @@ func writeMemoryActivationStatus(output io.Writer, result apptypes.MemoryActivat
 	); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation status", "memory activation status の出力に失敗しました"), err)
 	}
+	if result.HostContext != nil && result.ExternalMemory != nil {
+		if _, err := fmt.Fprintf(
+			output,
+			"external_memory: %s (state: %s, existing: %t)\nhost_context: %s (state: %s, existing: %t)\n",
+			result.ExternalMemory.Path, result.ExternalMemory.State, result.ExternalMemory.Existing,
+			result.HostContext.Path, result.HostContext.State, result.HostContext.Existing,
+		); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory activation status", "memory activation status の出力に失敗しました"), err)
+		}
+	}
 	if !memoryActivationStatusHasRemediation(result.State) {
 		return nil
 	}
-	if _, err := fmt.Fprintf(output, "next_dry_run: %s\nnext_apply: %s\n", commands.DryRun, commands.Apply); err != nil {
+	if _, err := fmt.Fprintf(output, "next_dry_run: %s\n", commands.DryRun); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory activation remediation", "memory activation remediation の出力に失敗しました"), err)
+	}
+	if commands.Apply != "" {
+		if _, err := fmt.Fprintf(output, "next_apply: %s\n", commands.Apply); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory activation remediation", "memory activation remediation の出力に失敗しました"), err)
+		}
 	}
 	return nil
 }

--- a/presentation/cli/memory_activate_test.go
+++ b/presentation/cli/memory_activate_test.go
@@ -365,6 +365,291 @@ func assertMemoryStatusCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGl
 	}
 }
 
+func TestRootCLI_MemoryActivateClaudeDryRunRendersComponents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	memoryStub := &memoryUsecaseStub{
+		activationPlan: apptypes.MemoryActivationPlan{
+			Target:     apptypes.MemoryBridgeTargetClaude,
+			TargetPath: hostPath,
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:     hostPath,
+				Existing: false,
+				Markdown: "<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/claude.md\n<!-- traceary-memory-import:end -->\n",
+				Action:   apptypes.MemoryActivationApplyCreated,
+				State:    apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:     externalPath,
+				Existing: false,
+				Markdown: "<!-- traceary-memories:begin:v1 -->\nplanned\n<!-- traceary-memories:end -->\n",
+				Action:   apptypes.MemoryActivationApplyCreated,
+				State:    apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "claude",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"target: claude",
+		"external_memory: " + externalPath,
+		"host_context: " + hostPath,
+		"# external memory plan",
+		"# host context plan",
+		"@./.traceary/memories/claude.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q: %q", want, out)
+		}
+	}
+	if len(memoryStub.activationPlanCalls) != 1 {
+		t.Fatalf("activation plan calls = %d, want 1", len(memoryStub.activationPlanCalls))
+	}
+	if memoryStub.activationPlanCalls[0].Target != apptypes.MemoryBridgeTargetClaude {
+		t.Fatalf("Target = %q, want claude", memoryStub.activationPlanCalls[0].Target)
+	}
+}
+
+func TestRootCLI_MemoryActivateClaudeDryRunDiffOrdersExternalFirst(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	memoryStub := &memoryUsecaseStub{
+		activationPlan: apptypes.MemoryActivationPlan{
+			Target:     apptypes.MemoryBridgeTargetClaude,
+			TargetPath: hostPath,
+			Diff:       "--- " + externalPath + "\n+++ " + externalPath + " (planned)\n--- " + hostPath + "\n+++ " + hostPath + " (planned)\n",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:     hostPath,
+				Existing: true,
+				Diff:     "--- " + hostPath + "\n+++ " + hostPath + " (planned)\n",
+				State:    apptypes.MemoryActivationStatusStale,
+				Action:   apptypes.MemoryActivationApplyUpdated,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:     externalPath,
+				Existing: true,
+				Diff:     "--- " + externalPath + "\n+++ " + externalPath + " (planned)\n",
+				State:    apptypes.MemoryActivationStatusStale,
+				Action:   apptypes.MemoryActivationApplyUpdated,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "claude",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--dry-run",
+		"--diff",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	externalIdx := strings.Index(out, "# external memory diff")
+	hostIdx := strings.Index(out, "# host context diff")
+	if externalIdx < 0 || hostIdx < 0 || externalIdx >= hostIdx {
+		t.Fatalf("diff output must order external before host, externalIdx=%d hostIdx=%d out=%q", externalIdx, hostIdx, out)
+	}
+	if len(memoryStub.activationPlanCalls) != 1 {
+		t.Fatalf("activation plan calls = %d, want 1", len(memoryStub.activationPlanCalls))
+	}
+	if !memoryStub.activationPlanCalls[0].Diff {
+		t.Fatalf("plan call did not propagate Diff=true")
+	}
+}
+
+func TestRootCLI_MemoryActivateClaudeStatusJSONIncludesComponentsAndDryRunCommand(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	memoryStub := &memoryUsecaseStub{
+		activationStatus: apptypes.MemoryActivationStatusResult{
+			Target:         apptypes.MemoryBridgeTargetClaude,
+			TargetPath:     hostPath,
+			State:          apptypes.MemoryActivationStatusMissing,
+			Existing:       false,
+			ActivatedCount: 1,
+			Message:        "host context import stub and external memory file are missing",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:  hostPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:  externalPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "claude",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--status",
+		"--json",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var payload struct {
+		Target         string `json:"target"`
+		TargetPath     string `json:"target_path"`
+		State          string `json:"state"`
+		ActivatedCount int    `json:"activated_count"`
+		DryRunCommand  string `json:"dry_run_command"`
+		ApplyCommand   string `json:"apply_command"`
+		HostContext    *struct {
+			Path  string `json:"path"`
+			State string `json:"state"`
+		} `json:"host_context"`
+		ExternalMemory *struct {
+			Path  string `json:"path"`
+			State string `json:"state"`
+		} `json:"external_memory"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout=%s", err, stdout.String())
+	}
+	if payload.Target != "claude" || payload.TargetPath != hostPath || payload.State != "missing" {
+		t.Fatalf("payload = %+v, want claude/missing", payload)
+	}
+	if payload.HostContext == nil || payload.HostContext.Path != hostPath || payload.HostContext.State != "missing" {
+		t.Fatalf("host_context = %+v, want missing component", payload.HostContext)
+	}
+	if payload.ExternalMemory == nil || payload.ExternalMemory.Path != externalPath || payload.ExternalMemory.State != "missing" {
+		t.Fatalf("external_memory = %+v, want missing component", payload.ExternalMemory)
+	}
+	if !strings.Contains(payload.DryRunCommand, "--target claude") || !strings.Contains(payload.DryRunCommand, "--dry-run --diff") {
+		t.Fatalf("dry_run_command = %q, want claude dry-run command", payload.DryRunCommand)
+	}
+	if payload.ApplyCommand != "" {
+		t.Fatalf("apply_command = %q, want empty for claude (apply unsupported until #893)", payload.ApplyCommand)
+	}
+}
+
+func TestRootCLI_MemoryActivateClaudeStatusTextOmitsApplyRemediation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "CLAUDE.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "claude.md")
+	memoryStub := &memoryUsecaseStub{
+		activationStatus: apptypes.MemoryActivationStatusResult{
+			Target:         apptypes.MemoryBridgeTargetClaude,
+			TargetPath:     hostPath,
+			State:          apptypes.MemoryActivationStatusMissing,
+			Existing:       false,
+			ActivatedCount: 1,
+			Message:        "host context import stub and external memory file are missing",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:  hostPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:  externalPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "claude",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--status",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "next_dry_run:") {
+		t.Fatalf("stdout missing next_dry_run remediation: %q", out)
+	}
+	if strings.Contains(out, "next_apply:") {
+		t.Fatalf("stdout must omit next_apply for claude (apply unsupported until #893): %q", out)
+	}
+}
+
+func TestRootCLI_MemoryActivateClaudeApplyRefused(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	stderr := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(stderr)
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "claude",
+		"--apply",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected --target claude --apply to be refused")
+	}
+	if !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("err = %v, want claude apply refusal", err)
+	}
+	if len(memoryStub.activationCalls) != 0 || len(memoryStub.activationPlanCalls) != 0 || len(memoryStub.activationStatusCalls) != 0 {
+		t.Fatalf("memory usecase should not be invoked when apply is refused: plan=%d apply=%d status=%d",
+			len(memoryStub.activationPlanCalls), len(memoryStub.activationCalls), len(memoryStub.activationStatusCalls))
+	}
+}
+
 func assertMemoryApplyCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGlobal bool) {
 	t.Helper()
 	if len(stub.activationCalls) != 1 {

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -232,13 +232,31 @@ type memoryExportOutput struct {
 }
 
 // memoryActivationPlanOutput is the JSON shape of a dry-run activation plan.
+//
+// HostContext / ExternalMemory are populated only for two-file targets
+// (Claude / Gemini); single-file Codex output omits them so existing
+// JSON consumers see the same shape they did in v0.12.
 type memoryActivationPlanOutput struct {
-	Target         string `json:"target"`
-	TargetPath     string `json:"target_path"`
-	Existing       bool   `json:"existing"`
-	ActivatedCount int    `json:"activated_count"`
-	Markdown       string `json:"markdown"`
-	Diff           string `json:"diff,omitempty"`
+	Target         string                           `json:"target"`
+	TargetPath     string                           `json:"target_path"`
+	Existing       bool                             `json:"existing"`
+	ActivatedCount int                              `json:"activated_count"`
+	Markdown       string                           `json:"markdown"`
+	Diff           string                           `json:"diff,omitempty"`
+	HostContext    *memoryActivationComponentOutput `json:"host_context,omitempty"`
+	ExternalMemory *memoryActivationComponentOutput `json:"external_memory,omitempty"`
+}
+
+// memoryActivationComponentOutput is the JSON shape of one file inside a
+// two-file activation pair.
+type memoryActivationComponentOutput struct {
+	Path     string `json:"path"`
+	Existing bool   `json:"existing"`
+	Markdown string `json:"markdown,omitempty"`
+	Diff     string `json:"diff,omitempty"`
+	Action   string `json:"action,omitempty"`
+	State    string `json:"state,omitempty"`
+	Message  string `json:"message,omitempty"`
 }
 
 // memoryActivationApplyOutput is the JSON shape of a write activation result.
@@ -252,14 +270,16 @@ type memoryActivationApplyOutput struct {
 
 // memoryActivationStatusOutput is the JSON shape of a read-only activation status.
 type memoryActivationStatusOutput struct {
-	Target         string `json:"target"`
-	TargetPath     string `json:"target_path"`
-	State          string `json:"state"`
-	Existing       bool   `json:"existing"`
-	ActivatedCount int    `json:"activated_count"`
-	Message        string `json:"message"`
-	DryRunCommand  string `json:"dry_run_command,omitempty"`
-	ApplyCommand   string `json:"apply_command,omitempty"`
+	Target         string                           `json:"target"`
+	TargetPath     string                           `json:"target_path"`
+	State          string                           `json:"state"`
+	Existing       bool                             `json:"existing"`
+	ActivatedCount int                              `json:"activated_count"`
+	Message        string                           `json:"message"`
+	DryRunCommand  string                           `json:"dry_run_command,omitempty"`
+	ApplyCommand   string                           `json:"apply_command,omitempty"`
+	HostContext    *memoryActivationComponentOutput `json:"host_context,omitempty"`
+	ExternalMemory *memoryActivationComponentOutput `json:"external_memory,omitempty"`
 }
 
 func formatJSONTime(t time.Time) string {

--- a/scripts/smoke_test_claude_activation.sh
+++ b/scripts/smoke_test_claude_activation.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# smoke_test_claude_activation.sh materialises a temp project and runs
+# `traceary memory activate --target claude --dry-run` so an operator can
+# manually verify Claude Code loads the resulting `.traceary/` import
+# path. The script is best-effort: launching Claude Code from CI is
+# non-deterministic (auth, model availability, first-time approval
+# dialog), so the live runtime probe is gated behind
+# TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1 and falls through to a printed
+# manual verification when claude is not available. The structural
+# checks (file paths, marker layout, import-line format) always run
+# regardless of claude availability.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TMP_PROJECT="$(mktemp -d)"
+KEEP_TEMP="${TRACEARY_KEEP_SMOKE_TEMP:-0}"
+if [[ "${KEEP_TEMP}" != "1" ]]; then
+  trap 'rm -rf "${TMP_PROJECT}"' EXIT
+fi
+
+mkdir -p "${TMP_PROJECT}/.git"
+echo 'ref: refs/heads/main' > "${TMP_PROJECT}/.git/HEAD"
+
+(cd "${ROOT_DIR}" && go run . memory activate \
+  --target claude \
+  --db-path "${TMP_PROJECT}/traceary.db" \
+  --root "${TMP_PROJECT}" \
+  --workspace github.com/duck8823/traceary-claude-smoke \
+  --dry-run \
+  --json) > "${TMP_PROJECT}/plan.json"
+
+python3 - "${TMP_PROJECT}/plan.json" <<'PY'
+import json
+import os
+import sys
+
+plan_path = sys.argv[1]
+with open(plan_path, encoding="utf-8") as fp:
+    plan = json.load(fp)
+
+target = plan.get("target")
+assert target == "claude", f"unexpected target: {target}"
+
+host = plan.get("host_context")
+external = plan.get("external_memory")
+assert host is not None, "host_context component missing"
+assert external is not None, "external_memory component missing"
+
+assert host["path"].endswith(os.sep + "CLAUDE.md"), f"host path not CLAUDE.md: {host['path']}"
+assert external["path"].endswith(os.path.join(".traceary", "memories", "claude.md")), f"unexpected external path: {external['path']}"
+
+stub = host["markdown"]
+assert "<!-- traceary-memory-import:begin:v1 -->" in stub, "missing begin marker"
+assert "<!-- traceary-memory-import:end -->" in stub, "missing end marker"
+assert "@./.traceary/memories/claude.md" in stub, f"missing relative import line: {stub}"
+
+print("ok: traceary memory activate --target claude --dry-run produced the expected pair plan")
+PY
+
+# Materialise the planned files so the operator can launch Claude Code
+# in this directory and confirm the import resolves. Artefacts live
+# inside ${TMP_PROJECT}; by default the trap rm -rf cleans them up at
+# exit. Set TRACEARY_KEEP_SMOKE_TEMP=1 to retain ${TMP_PROJECT} for a
+# manual probe (no trap is installed in that mode).
+python3 - "${TMP_PROJECT}/plan.json" "${TMP_PROJECT}" <<'PY'
+import json
+import os
+import sys
+
+plan_path = sys.argv[1]
+project = sys.argv[2]
+with open(plan_path, encoding="utf-8") as fp:
+    plan = json.load(fp)
+
+host = plan["host_context"]
+external = plan["external_memory"]
+
+os.makedirs(os.path.dirname(external["path"]), exist_ok=True)
+with open(external["path"], "w", encoding="utf-8") as fp:
+    fp.write(external["markdown"])
+with open(host["path"], "w", encoding="utf-8") as fp:
+    fp.write(host["markdown"])
+
+print(f"materialised pair under {project}")
+print(f"  CLAUDE.md = {host['path']}")
+print(f"  external memory = {external['path']}")
+PY
+
+if [[ "${TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE:-0}" != "1" ]]; then
+  if [[ "${KEEP_TEMP}" == "1" ]]; then
+    echo "manual runtime probe: cd \"${TMP_PROJECT}\" and run \`claude\` to confirm the @./.traceary/memories/claude.md import loads."
+  else
+    echo 'set TRACEARY_KEEP_SMOKE_TEMP=1 to retain the temp project for a manual `claude` probe (default: temp project is removed at exit).'
+  fi
+  echo 'ok: structural smoke test passed (set TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1 for an authenticated live probe).'
+  exit 0
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo 'skip: claude binary not found; structural checks already passed.'
+  exit 0
+fi
+
+# Live probe: ask Claude Code to echo back the marker we placed in the
+# external memory file. Whether this works depends on the operator's
+# Claude auth state and on whether Claude Code has approved the
+# external import (the documented first-time approval dialog).
+claude --print --model sonnet --permission-mode plan \
+  --working-directory "${TMP_PROJECT}" \
+  'Quote one bullet from the Traceary-managed memories that you can see in CLAUDE.md, verbatim.'


### PR DESCRIPTION
## Motivation

Closes #892.

Add the read-only Claude activation surface for v0.13.0 so operators can inspect the planned `CLAUDE.md` import stub and `.traceary/memories/claude.md` external memory file before the mutating apply work in #893.

## Changes

- Resolve `--target claude` to the nearest `.git` root (or cwd), with `--root` / `--path` overrides.
- Add two-file Claude dry-run, diff, JSON, and status output using the import-stub planner from #891.
- Keep `--target claude --apply` refused in #892 and omit `apply_command` / `next_apply` from Claude status remediation until #893.
- Add readiness evidence for Claude import visibility:
  - CI test pinning the `@./.traceary/memories/claude.md` import line and resolution.
  - Structural smoke script for materialising a temp Claude project.
- Update the host-native activation ADR with the Claude readiness gate.

## Validation

- `go test ./application/usecase -run 'TestClaude|TestMemoryUsecase_ActivatePlan_Claude|TestMemoryUsecase_ActivationStatus_Claude'`
- `go test ./presentation/cli -run 'MemoryActivate.*Claude'`
- `go test ./...`
- `go build ./...`
- `go tool golangci-lint run`
- `python3 scripts/verify_docs_i18n.py`
- `bash scripts/smoke_test_claude_activation.sh`
- `git diff --check`

## Review notes

- Implemented by Claude Code Opus 4.7 Max; Codex reviewed and tightened the remediation/status behavior before commit.
- The live Claude runtime probe remains gated for #893 because first-time import approval and auth state are non-deterministic in CI.
