### PR TITLE
v0.13.0-6: add Gemini activation status and dry-run

### DIFF
--- a/application/usecase/activation_target.go
+++ b/application/usecase/activation_target.go
@@ -32,6 +32,24 @@ const (
 	claudeExternalMemoryFileName = "claude.md"
 )
 
+// geminiHostContextFileName is the canonical GEMINI.md filename Gemini
+// CLI loads as hierarchical context. Traceary writes the import stub
+// region inside this file when --target gemini is applied (planned for
+// v0.13.0-7 / #895). The v0.13.0-6 status/dry-run path renders the
+// stub without mutating disk.
+const geminiHostContextFileName = "GEMINI.md"
+
+// geminiExternalMemoryRelDir / geminiExternalMemoryFileName describe
+// the hidden directory layout Traceary owns under the activation root
+// for Gemini. `<root>/.traceary/memories/gemini.md` is the v0.13
+// default external memory file, and the rendered import line is the
+// relative form `./.traceary/memories/gemini.md` so Gemini resolves it
+// relative to the host GEMINI.md per its Memory Import Processor docs.
+const (
+	geminiExternalMemoryRelDir   = ".traceary/memories"
+	geminiExternalMemoryFileName = "gemini.md"
+)
+
 // activationTargetResolution describes the file paths Traceary will
 // inspect, read, or write for one activation criteria. Single-file
 // targets (Codex) populate only HostContextPath. Two-file targets
@@ -107,6 +125,52 @@ func (codexActivationTarget) Resolve(criteria apptypes.MemoryActivationCriteria)
 	return activationTargetResolution{HostContextPath: filepath.Join(absRoot, codexActivationFileName)}, nil
 }
 
+// hostContextActivationConfig describes the canonical layout for a
+// two-file host activation target (host context file + external memory
+// file). Claude (CLAUDE.md / .traceary/memories/claude.md) and Gemini
+// (GEMINI.md / .traceary/memories/gemini.md) share the same resolution
+// algorithm and only differ in these constants, so the resolver is
+// parameterised on this struct rather than duplicated per target.
+type hostContextActivationConfig struct {
+	// Target identifies the host activation target the config drives.
+	// It is used purely for error messages so failures are
+	// attributable to the right target.
+	Target apptypes.MemoryBridgeTarget
+	// HostFileName is the canonical instruction file the host loads at
+	// session start (e.g. CLAUDE.md, GEMINI.md). Traceary writes the
+	// import stub region inside this file.
+	HostFileName string
+	// ExternalMemoryRelDir is the directory under the activation root
+	// that Traceary owns for this host's external memory file. The
+	// path is rendered with forward slashes; the resolver converts it
+	// to platform separators before joining.
+	ExternalMemoryRelDir string
+	// ExternalMemoryFileName is the file Traceary writes inside
+	// ExternalMemoryRelDir to hold the rendered managed memory block.
+	ExternalMemoryFileName string
+}
+
+// claudeActivationConfig is the v0.13 default layout for Claude Code.
+var claudeActivationConfig = hostContextActivationConfig{
+	Target:                 apptypes.MemoryBridgeTargetClaude,
+	HostFileName:           claudeHostContextFileName,
+	ExternalMemoryRelDir:   claudeExternalMemoryRelDir,
+	ExternalMemoryFileName: claudeExternalMemoryFileName,
+}
+
+// geminiActivationConfig is the v0.13 default layout for Gemini CLI.
+// The hidden `.traceary/memories/gemini.md` external file mirrors the
+// Claude layout so Traceary's diff/status/apply story is identical for
+// both hosts. The host instruction file is GEMINI.md per the Gemini
+// CLI memory documentation; Traceary never modifies the
+// `## Gemini Added Memories` section produced by `save_memory`.
+var geminiActivationConfig = hostContextActivationConfig{
+	Target:                 apptypes.MemoryBridgeTargetGemini,
+	HostFileName:           geminiHostContextFileName,
+	ExternalMemoryRelDir:   geminiExternalMemoryRelDir,
+	ExternalMemoryFileName: geminiExternalMemoryFileName,
+}
+
 type claudeActivationTarget struct{}
 
 // Target returns MemoryBridgeTargetClaude.
@@ -133,61 +197,97 @@ func (claudeActivationTarget) Target() apptypes.MemoryBridgeTarget {
 // external memory file do not share a directory tree (a future custom
 // override), the import path falls back to the absolute external path.
 func (claudeActivationTarget) Resolve(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error) {
-	hostContextPath, err := claudeHostContextPath(criteria)
+	return resolveHostContextActivation(criteria, claudeActivationConfig)
+}
+
+type geminiActivationTarget struct{}
+
+// Target returns MemoryBridgeTargetGemini.
+func (geminiActivationTarget) Target() apptypes.MemoryBridgeTarget {
+	return apptypes.MemoryBridgeTargetGemini
+}
+
+// Resolve returns the host context (GEMINI.md) and external memory
+// file Traceary will manage for Gemini activation. The resolution
+// rules and import-path semantics are identical to Claude — Path beats
+// Root beats nearest-`.git` ancestor with cwd fallback — so Gemini
+// reuses the shared host-context resolver. The rendered import line is
+// `@./.traceary/memories/gemini.md`, matching the v0.13 ADR contract
+// and the Gemini CLI Memory Import Processor's documented relative
+// path resolution.
+//
+// v0.13.0-6 ships the read-only status/dry-run/diff surface; --apply
+// stays refused at the usecase boundary until #895 wires the apply
+// path. Traceary never writes into Gemini's
+// `## Gemini Added Memories` section regardless of mode — the import
+// stub lives outside that section because the planner's safe append
+// rule only attaches the managed region at end-of-file.
+func (geminiActivationTarget) Resolve(criteria apptypes.MemoryActivationCriteria) (activationTargetResolution, error) {
+	return resolveHostContextActivation(criteria, geminiActivationConfig)
+}
+
+// resolveHostContextActivation runs the shared two-file path
+// resolution algorithm for one host config. The function is the only
+// caller that knows the activation root precedence (Path > Root >
+// nearest-`.git` ancestor > cwd) so adding a third host (or
+// renaming a path) does not require touching the per-target Resolve
+// methods.
+func resolveHostContextActivation(criteria apptypes.MemoryActivationCriteria, config hostContextActivationConfig) (activationTargetResolution, error) {
+	hostPath, err := resolveHostContextPath(criteria, config)
 	if err != nil {
 		return activationTargetResolution{}, err
 	}
-	externalMemoryPath := claudeExternalMemoryPath(hostContextPath)
-	importPath, err := claudeImportPath(hostContextPath, externalMemoryPath)
+	externalMemoryPath := hostExternalMemoryPath(hostPath, config)
+	importPath, err := hostImportPath(hostPath, externalMemoryPath, config)
 	if err != nil {
 		return activationTargetResolution{}, err
 	}
 	return activationTargetResolution{
-		HostContextPath:    hostContextPath,
+		HostContextPath:    hostPath,
 		ExternalMemoryPath: externalMemoryPath,
 		ImportPath:         importPath,
 	}, nil
 }
 
-func claudeHostContextPath(criteria apptypes.MemoryActivationCriteria) (string, error) {
+func resolveHostContextPath(criteria apptypes.MemoryActivationCriteria, config hostContextActivationConfig) (string, error) {
 	if trimmed := strings.TrimSpace(criteria.Path); trimmed != "" {
 		abs, err := filepath.Abs(trimmed)
 		if err != nil {
-			return "", xerrors.Errorf("failed to resolve claude host context path: %w", err)
+			return "", xerrors.Errorf("failed to resolve %s host context path: %w", config.Target, err)
 		}
 		return abs, nil
 	}
 	if trimmed := strings.TrimSpace(criteria.Root); trimmed != "" {
 		absRoot, err := filepath.Abs(trimmed)
 		if err != nil {
-			return "", xerrors.Errorf("failed to resolve claude activation root: %w", err)
+			return "", xerrors.Errorf("failed to resolve %s activation root: %w", config.Target, err)
 		}
-		return filepath.Join(absRoot, claudeHostContextFileName), nil
+		return filepath.Join(absRoot, config.HostFileName), nil
 	}
-	root, err := detectClaudeActivationRoot()
+	root, err := detectHostActivationRoot(config.Target)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(root, claudeHostContextFileName), nil
+	return filepath.Join(root, config.HostFileName), nil
 }
 
-func claudeExternalMemoryPath(hostContextPath string) string {
+func hostExternalMemoryPath(hostContextPath string, config hostContextActivationConfig) string {
 	hostDir := filepath.Dir(hostContextPath)
-	return filepath.Join(hostDir, filepath.FromSlash(claudeExternalMemoryRelDir), claudeExternalMemoryFileName)
+	return filepath.Join(hostDir, filepath.FromSlash(config.ExternalMemoryRelDir), config.ExternalMemoryFileName)
 }
 
-// claudeImportPath renders the literal text Traceary writes after `@`
-// inside the host context import stub. Claude resolves relative imports
-// against the file containing the import, so the renderer always
-// prefers the relative form when the external file lives below the
-// host context directory. When a future override puts the external
-// file outside that subtree, the function returns the absolute path so
-// the generated stub still resolves cleanly.
-func claudeImportPath(hostContextPath, externalMemoryPath string) (string, error) {
+// hostImportPath renders the literal text Traceary writes after `@`
+// inside the host context import stub. Both Claude and Gemini resolve
+// relative imports against the file containing the import, so the
+// renderer always prefers the relative form when the external file
+// lives below the host context directory. When a future override puts
+// the external file outside that subtree, the function returns the
+// absolute path so the generated stub still resolves cleanly.
+func hostImportPath(hostContextPath, externalMemoryPath string, config hostContextActivationConfig) (string, error) {
 	hostDir := filepath.Dir(hostContextPath)
 	rel, err := filepath.Rel(hostDir, externalMemoryPath)
 	if err != nil {
-		return "", xerrors.Errorf("failed to compute relative claude import path: %w", err)
+		return "", xerrors.Errorf("failed to compute relative %s import path: %w", config.Target, err)
 	}
 	relSlash := filepath.ToSlash(rel)
 	if strings.HasPrefix(relSlash, "../") || relSlash == ".." {
@@ -199,19 +299,20 @@ func claudeImportPath(hostContextPath, externalMemoryPath string) (string, error
 	return "./" + relSlash, nil
 }
 
-// detectClaudeActivationRoot walks the command working directory
+// detectHostActivationRoot walks the command working directory
 // upwards searching for the nearest ancestor that contains a `.git`
 // entry. When no `.git` is found, the current working directory is
 // returned per the v0.13 ADR. Symlink and stat errors propagate so a
-// broken filesystem cannot silently move the activation root.
-func detectClaudeActivationRoot() (string, error) {
+// broken filesystem cannot silently move the activation root. The
+// target name is used purely so error messages name the right host.
+func detectHostActivationRoot(target apptypes.MemoryBridgeTarget) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", xerrors.Errorf("failed to resolve claude activation working directory: %w", err)
+		return "", xerrors.Errorf("failed to resolve %s activation working directory: %w", target, err)
 	}
 	current, err := filepath.Abs(cwd)
 	if err != nil {
-		return "", xerrors.Errorf("failed to resolve claude activation absolute working directory: %w", err)
+		return "", xerrors.Errorf("failed to resolve %s activation absolute working directory: %w", target, err)
 	}
 	for {
 		gitPath := filepath.Join(current, ".git")
@@ -242,6 +343,8 @@ func resolveActivationTarget(target apptypes.MemoryBridgeTarget) (activationTarg
 		return codexActivationTarget{}, nil
 	case apptypes.MemoryBridgeTargetClaude:
 		return claudeActivationTarget{}, nil
+	case apptypes.MemoryBridgeTargetGemini:
+		return geminiActivationTarget{}, nil
 	}
 	return nil, xerrors.Errorf("memory activation target %s is not supported yet", target)
 }

--- a/application/usecase/activation_target_internal_test.go
+++ b/application/usecase/activation_target_internal_test.go
@@ -42,12 +42,15 @@ func TestResolveActivationTarget_RejectsUnknownTarget(t *testing.T) {
 	}
 }
 
-func TestResolveActivationTarget_RejectsGeminiUntilLaterIssues(t *testing.T) {
+func TestResolveActivationTarget_ReturnsGeminiDescriptor(t *testing.T) {
 	t.Parallel()
 
-	_, err := resolveActivationTarget(apptypes.MemoryBridgeTargetGemini)
-	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
-		t.Fatalf("resolveActivationTarget(gemini) err = %v, want not-supported-yet rejection", err)
+	target, err := resolveActivationTarget(apptypes.MemoryBridgeTargetGemini)
+	if err != nil {
+		t.Fatalf("resolveActivationTarget(gemini) error = %v", err)
+	}
+	if got := target.Target(); got != apptypes.MemoryBridgeTargetGemini {
+		t.Fatalf("Target() = %q, want gemini", got)
 	}
 }
 
@@ -210,6 +213,108 @@ func TestClaudeActivationTarget_DefaultRootFallsBackToCwdWhenNoGit(t *testing.T)
 			t.Fatalf("Getwd: %v", err)
 		}
 		wantHost := filepath.Join(cwd, claudeHostContextFileName)
+		if got.HostContextPath != wantHost {
+			t.Fatalf("HostContextPath = %q, want cwd fallback %q", got.HostContextPath, wantHost)
+		}
+	})
+}
+
+func TestGeminiActivationTarget_PathOverrideWinsOverRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "nested", "OTHER.md")
+	if err := os.MkdirAll(filepath.Dir(custom), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	got, err := geminiActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Path:   custom,
+		Root:   filepath.Join(dir, "ignored"),
+	})
+	if err != nil {
+		t.Fatalf("Resolve error = %v", err)
+	}
+	if got.HostContextPath != custom {
+		t.Fatalf("HostContextPath = %q, want %q (Path must override Root)", got.HostContextPath, custom)
+	}
+	wantExternal := filepath.Join(filepath.Dir(custom), filepath.FromSlash(geminiExternalMemoryRelDir), geminiExternalMemoryFileName)
+	if got.ExternalMemoryPath != wantExternal {
+		t.Fatalf("ExternalMemoryPath = %q, want %q (must derive from Path's directory)", got.ExternalMemoryPath, wantExternal)
+	}
+	if got.ImportPath != "./.traceary/memories/gemini.md" {
+		t.Fatalf("ImportPath = %q, want ./.traceary/memories/gemini.md", got.ImportPath)
+	}
+}
+
+func TestGeminiActivationTarget_RootOverrideUsesCanonicalLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	got, err := geminiActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Resolve error = %v", err)
+	}
+	wantHost := filepath.Join(dir, geminiHostContextFileName)
+	if got.HostContextPath != wantHost {
+		t.Fatalf("HostContextPath = %q, want %q", got.HostContextPath, wantHost)
+	}
+	wantExternal := filepath.Join(dir, filepath.FromSlash(geminiExternalMemoryRelDir), geminiExternalMemoryFileName)
+	if got.ExternalMemoryPath != wantExternal {
+		t.Fatalf("ExternalMemoryPath = %q, want %q", got.ExternalMemoryPath, wantExternal)
+	}
+	if got.ImportPath != "./.traceary/memories/gemini.md" {
+		t.Fatalf("ImportPath = %q, want ./.traceary/memories/gemini.md", got.ImportPath)
+	}
+	if !got.IsTwoFile() {
+		t.Fatalf("gemini resolution must be two-file: %+v", got)
+	}
+}
+
+func TestGeminiActivationTarget_DefaultRootDetectsGitAncestor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+	nested := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("MkdirAll(nested): %v", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	withWorkingDir(t, nested, func() {
+		got, err := geminiActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+			Target: apptypes.MemoryBridgeTargetGemini,
+		})
+		if err != nil {
+			t.Fatalf("Resolve error = %v", err)
+		}
+		wantHost := filepath.Join(resolvedRoot, geminiHostContextFileName)
+		if got.HostContextPath != wantHost {
+			t.Fatalf("HostContextPath = %q, want git ancestor %q", got.HostContextPath, wantHost)
+		}
+	})
+}
+
+func TestGeminiActivationTarget_DefaultRootFallsBackToCwdWhenNoGit(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root, func() {
+		got, err := geminiActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+			Target: apptypes.MemoryBridgeTargetGemini,
+		})
+		if err != nil {
+			t.Fatalf("Resolve error = %v", err)
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		wantHost := filepath.Join(cwd, geminiHostContextFileName)
 		if got.HostContextPath != wantHost {
 			t.Fatalf("HostContextPath = %q, want cwd fallback %q", got.HostContextPath, wantHost)
 		}

--- a/application/usecase/gemini_import_readiness_internal_test.go
+++ b/application/usecase/gemini_import_readiness_internal_test.go
@@ -1,0 +1,137 @@
+package usecase
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// TestGeminiActivationTarget_ImportLineMatchesDocumentedGeminiFormat is
+// the readiness-gate evidence required by the v0.13 host-native memory
+// activation ADR for Gemini. Live-launching Gemini CLI from CI is
+// non-deterministic (auth state, model availability, hierarchical
+// memory file load order), so this test instead pins the rendered
+// import line to the exact markdown form Gemini's official Memory
+// Import Processor documentation says it expands at session start:
+//
+//	@<relative-path-to-import>
+//
+// Source: <https://google-gemini.github.io/gemini-cli/docs/core/memport.html>.
+// The accompanying scripts/smoke_test_gemini_activation.sh materialises
+// the same plan onto disk so an operator can run `gemini` in a temp
+// project and confirm the live runtime resolution. The two together —
+// this test plus that script — form the documented readiness evidence
+// the ADR requires before a Gemini --apply PR (#895) can graduate to
+// ready.
+func TestGeminiActivationTarget_ImportLineMatchesDocumentedGeminiFormat(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	resolution, err := geminiActivationTarget{}.Resolve(apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	stub := renderImportStubBlock(apptypes.MemoryBridgeTargetGemini, resolution.ImportPath)
+
+	lines := strings.Split(strings.TrimRight(stub, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("rendered stub must have exactly 4 lines (begin, warning, import, end), got %d: %q", len(lines), stub)
+	}
+	if lines[0] != "<!-- traceary-memory-import:begin:v1 -->" {
+		t.Fatalf("stub[0] = %q, want documented begin marker", lines[0])
+	}
+	if lines[3] != "<!-- traceary-memory-import:end -->" {
+		t.Fatalf("stub[3] = %q, want documented end marker", lines[3])
+	}
+
+	importLine := lines[2]
+	if !strings.HasPrefix(importLine, "@") {
+		t.Fatalf("import line must start with '@' per Gemini memory import docs, got %q", importLine)
+	}
+	importPath := strings.TrimPrefix(importLine, "@")
+
+	// Gemini's Memory Import Processor resolves relative imports
+	// against the directory containing the host context file. Render
+	// the relative path back to an absolute one and confirm it points
+	// at the planned external memory file the activation usecase will
+	// manage.
+	hostDir := filepath.Dir(resolution.HostContextPath)
+	resolvedAbs := filepath.Clean(filepath.Join(hostDir, filepath.FromSlash(importPath)))
+	if resolvedAbs != resolution.ExternalMemoryPath {
+		t.Fatalf("import line %q does not resolve to the planned external memory file: got %q, want %q", importLine, resolvedAbs, resolution.ExternalMemoryPath)
+	}
+
+	// The default v0.13 layout must use the documented hidden
+	// directory import. Pin the canonical relative form so a future
+	// refactor cannot silently switch to an absolute or escaping path.
+	if importPath != "./.traceary/memories/gemini.md" {
+		t.Fatalf("default import path = %q, want ./.traceary/memories/gemini.md", importPath)
+	}
+
+	// External memory file must live below the host context directory
+	// so the relative import never escapes the activation root. A
+	// future absolute override is acceptable, but the default must
+	// stay confined.
+	rel, err := filepath.Rel(hostDir, resolution.ExternalMemoryPath)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	if strings.HasPrefix(filepath.ToSlash(rel), "../") {
+		t.Fatalf("external memory file %q escapes host context directory %q via %q", resolution.ExternalMemoryPath, hostDir, rel)
+	}
+
+	// The DO NOT EDIT warning must reference the gemini target so the
+	// remediation command points users at the correct activate
+	// invocation. Renderers that branch on target wording would
+	// otherwise leave Gemini operators with a Claude-pointing message.
+	warning := lines[1]
+	if !strings.Contains(warning, "--target gemini") {
+		t.Fatalf("stub warning must mention --target gemini, got %q", warning)
+	}
+
+	// Sanity-check that the internal planner can materialise the pair
+	// onto the real filesystem under the same temp root used by the
+	// smoke script. The product-level `memory activate --target gemini
+	// --apply` command remains refused until #895; this internal
+	// writeback is readiness evidence that the shared safe writer can
+	// already handle the Gemini layout once the public apply gate is
+	// opened.
+	planner := &importStubActivationPlanner{}
+	plan := planner.Plan(importStubActivationCriteria{
+		Target:             apptypes.MemoryBridgeTargetGemini,
+		HostContextPath:    resolution.HostContextPath,
+		ExternalMemoryPath: resolution.ExternalMemoryPath,
+		ImportPath:         resolution.ImportPath,
+		ExternalMarkdown:   "<!-- traceary-memories:begin:v1 -->\nplaceholder\n<!-- traceary-memories:end -->\n",
+	})
+	if plan.HostContext.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.Status = %q, want missing on a fresh root", plan.HostContext.Status)
+	}
+	if plan.ExternalMemory.Status != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("ExternalMemory.Status = %q, want missing on a fresh root", plan.ExternalMemory.Status)
+	}
+
+	applyResult, err := planner.Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply internal planner: %v", err)
+	}
+	if applyResult.HostContext.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("applied HostContext.Status = %q, want in_sync", applyResult.HostContext.Status)
+	}
+	if applyResult.ExternalMemory.Status != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("applied ExternalMemory.Status = %q, want in_sync", applyResult.ExternalMemory.Status)
+	}
+	roundtrip, err := os.ReadFile(resolution.HostContextPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(roundtrip), importLine) {
+		t.Fatalf("materialised GEMINI.md missing import line %q, got %q", importLine, roundtrip)
+	}
+}

--- a/application/usecase/memory_activation.go
+++ b/application/usecase/memory_activation.go
@@ -73,6 +73,10 @@ func (u *memoryActivationUsecase) Apply(ctx context.Context, criteria apptypes.M
 		return apptypes.MemoryActivationApplyResult{}, err
 	}
 
+	if criteria.Target == apptypes.MemoryBridgeTargetGemini {
+		return apptypes.MemoryActivationApplyResult{}, xerrors.Errorf("memory activation --apply is not supported yet for target %s", criteria.Target)
+	}
+
 	exportResult, err := u.renderActivationBlock(ctx, criteria)
 	if err != nil {
 		return apptypes.MemoryActivationApplyResult{}, err

--- a/application/usecase/memory_activation_test.go
+++ b/application/usecase/memory_activation_test.go
@@ -101,16 +101,31 @@ func TestMemoryUsecase_ActivatePlan_PathOverrideAndExistingDiff(t *testing.T) {
 	}
 }
 
-func TestMemoryUsecase_ActivatePlan_RejectsGeminiUntilLaterIssue(t *testing.T) {
+func TestMemoryUsecase_Activate_RefusesGeminiApplyUntilLaterIssue(t *testing.T) {
 	t.Parallel()
 
-	sut := usecase.NewMemoryUsecase(nil, &stubExportMemoryQuery{}, nil)
-	_, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-apply-refused", domtypes.MemoryTypePreference, scope, "Gemini --apply lands in #895"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	_, err := sut.Activate(context.Background(), apptypes.MemoryActivationCriteria{
 		Target: apptypes.MemoryBridgeTargetGemini,
-		Path:   filepath.Join(t.TempDir(), "GEMINI.md"),
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
 	})
 	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
-		t.Fatalf("ActivatePlan error = %v, want unsupported target", err)
+		t.Fatalf("Activate err = %v, want gemini --apply rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "GEMINI.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("apply must not create GEMINI.md when refused, stat err = %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".traceary", "memories", "gemini.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("apply must not create external memory file when refused, stat err = %v", statErr)
 	}
 }
 func TestMemoryUsecase_Activate_CreatesCodexTarget(t *testing.T) {
@@ -1059,6 +1074,414 @@ func TestMemoryUsecase_ActivationStatus_ClaudeInSyncAfterPlanWriteback(t *testin
 	sut := usecase.NewMemoryUsecase(nil, query, nil)
 	criteria := apptypes.MemoryActivationCriteria{
 		Target: apptypes.MemoryBridgeTargetClaude,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	}
+	plan, err := sut.ActivatePlan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll external: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(plan.ExternalMemory.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	if err := os.WriteFile(hostPath, []byte(plan.HostContext.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+
+	status, err := sut.ActivationStatus(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("State = %q, want in_sync after writing planned content", status.State)
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_GeminiMissingPairExposesComponents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-plan", domtypes.MemoryTypePreference, scope, "prefer concise PRs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if plan.HostContext == nil || plan.ExternalMemory == nil {
+		t.Fatalf("two-file plan must expose components, got %+v", plan)
+	}
+	wantHost := filepath.Join(root, "GEMINI.md")
+	wantExternal := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	if plan.HostContext.Path != wantHost {
+		t.Fatalf("HostContext.Path = %q, want %q", plan.HostContext.Path, wantHost)
+	}
+	if plan.ExternalMemory.Path != wantExternal {
+		t.Fatalf("ExternalMemory.Path = %q, want %q", plan.ExternalMemory.Path, wantExternal)
+	}
+	if plan.HostContext.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("HostContext.State = %q, want missing", plan.HostContext.State)
+	}
+	if plan.ExternalMemory.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("ExternalMemory.State = %q, want missing", plan.ExternalMemory.State)
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "@./.traceary/memories/gemini.md") {
+		t.Fatalf("HostContext.Markdown missing relative import line: %q", plan.HostContext.Markdown)
+	}
+	if !strings.Contains(plan.HostContext.Markdown, "--target gemini") {
+		t.Fatalf("HostContext.Markdown remediation must point at --target gemini, got %q", plan.HostContext.Markdown)
+	}
+	if !strings.Contains(plan.ExternalMemory.Markdown, "prefer concise PRs") {
+		t.Fatalf("ExternalMemory.Markdown missing accepted memory: %q", plan.ExternalMemory.Markdown)
+	}
+	if _, err := os.Stat(wantHost); !os.IsNotExist(err) {
+		t.Fatalf("dry-run plan must not create GEMINI.md, stat err = %v", err)
+	}
+	if _, err := os.Stat(wantExternal); !os.IsNotExist(err) {
+		t.Fatalf("dry-run plan must not create external memory file, stat err = %v", err)
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_GeminiPreservesAddedMemoriesSection(t *testing.T) {
+	t.Parallel()
+
+	// Gemini's `save_memory` tool owns `## Gemini Added Memories` in
+	// the user's GEMINI.md. The v0.13 ADR forbids touching that section
+	// during activation. This test seeds a host context file that
+	// contains the section, runs --dry-run, and asserts that the
+	// rendered managed stub is appended without disturbing the
+	// existing user-authored section.
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	addedMemories := strings.Join([]string{
+		"# Project notes",
+		"",
+		"- prefer English commit messages",
+		"",
+		"## Gemini Added Memories",
+		"",
+		"- The user prefers concise replies.",
+		"- Always cite sources.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(hostPath, []byte(addedMemories), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-preserve", domtypes.MemoryTypeDecision, scope, "Traceary owns its managed import region only"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if plan.HostContext == nil {
+		t.Fatalf("ActivatePlan returned nil HostContext: %+v", plan)
+	}
+	planned := plan.HostContext.Markdown
+	if !strings.HasPrefix(planned, addedMemories) {
+		t.Fatalf("planned host context did not preserve the user-authored prefix verbatim: %q", planned)
+	}
+	if !strings.Contains(planned, "## Gemini Added Memories") {
+		t.Fatalf("planned host context dropped the Gemini Added Memories section: %q", planned)
+	}
+	if strings.Count(planned, "## Gemini Added Memories") != 1 {
+		t.Fatalf("planned host context duplicated the Gemini Added Memories section: %q", planned)
+	}
+	if !strings.Contains(planned, "<!-- traceary-memory-import:begin:v1 -->") {
+		t.Fatalf("planned host context missing managed import stub: %q", planned)
+	}
+	beginIdx := strings.Index(planned, "<!-- traceary-memory-import:begin:v1 -->")
+	addedIdx := strings.Index(planned, "## Gemini Added Memories")
+	if beginIdx < 0 || addedIdx < 0 || beginIdx < addedIdx {
+		t.Fatalf("managed import stub must be appended after the Gemini Added Memories section, got beginIdx=%d addedIdx=%d", beginIdx, addedIdx)
+	}
+
+	// Dry-run must not mutate disk; the on-disk content must match the
+	// original byte-for-byte.
+	disk, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(disk) != addedMemories {
+		t.Fatalf("dry-run mutated GEMINI.md: %q", disk)
+	}
+}
+
+func TestMemoryUsecase_ActivatePlan_GeminiDiffRendersDeterministically(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	if err := os.WriteFile(hostPath, []byte("# user notes\n\n<!-- traceary-memory-import:begin:v1 -->\n@./old.md\n<!-- traceary-memory-import:end -->\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(usecase.MemoryBridgeMarkerBegin+"\nold body\n"+usecase.MemoryBridgeMarkerEnd+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-diff", domtypes.MemoryTypePreference, scope, "prefer fresh activation"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	plan, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+		Diff:   true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if plan.ExternalMemory.Diff == "" {
+		t.Fatalf("ExternalMemory.Diff is empty, want stale-content diff")
+	}
+	if plan.HostContext.Diff == "" {
+		t.Fatalf("HostContext.Diff is empty, want stub diff")
+	}
+	externalIdx := strings.Index(plan.Diff, "--- "+externalPath)
+	hostIdx := strings.Index(plan.Diff, "--- "+hostPath)
+	if externalIdx < 0 || hostIdx < 0 || externalIdx >= hostIdx {
+		t.Fatalf("Plan.Diff must order external before host, externalIdx=%d hostIdx=%d diff=%q", externalIdx, hostIdx, plan.Diff)
+	}
+	if !strings.Contains(plan.Diff, plan.ExternalMemory.Diff+"\n--- "+hostPath) {
+		t.Fatalf("Plan.Diff must separate external and host diffs with a blank line, got %q", plan.Diff)
+	}
+
+	plan2, err := sut.ActivatePlan(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+		Diff:   true,
+	})
+	if err != nil {
+		t.Fatalf("ActivatePlan second: %v", err)
+	}
+	if plan.Diff != plan2.Diff {
+		t.Fatalf("diff is not deterministic across runs")
+	}
+
+	// Dry-run + diff must not mutate either file.
+	hostDisk, err := os.ReadFile(hostPath)
+	if err != nil {
+		t.Fatalf("ReadFile host: %v", err)
+	}
+	if !strings.Contains(string(hostDisk), "@./old.md") {
+		t.Fatalf("dry-run mutated GEMINI.md: %q", hostDisk)
+	}
+	externalDisk, err := os.ReadFile(externalPath)
+	if err != nil {
+		t.Fatalf("ReadFile external: %v", err)
+	}
+	if !strings.Contains(string(externalDisk), "old body") {
+		t.Fatalf("dry-run mutated external memory file: %q", externalDisk)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_GeminiMissingPair(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-missing", domtypes.MemoryTypePreference, scope, "prefer gemini status"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	status, err := sut.ActivationStatus(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("State = %q, want missing", status.State)
+	}
+	if status.HostContext == nil || status.ExternalMemory == nil {
+		t.Fatalf("two-file status must expose components, got %+v", status)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusMissing || status.ExternalMemory.State != apptypes.MemoryActivationStatusMissing {
+		t.Fatalf("component states = host=%q external=%q, want both missing", status.HostContext.State, status.ExternalMemory.State)
+	}
+	if !strings.Contains(status.Message, "stub") {
+		t.Fatalf("Message = %q, want pair-aware message", status.Message)
+	}
+	if status.HostContext.Path != filepath.Join(root, "GEMINI.md") {
+		t.Fatalf("HostContext.Path = %q, want GEMINI.md", status.HostContext.Path)
+	}
+	if status.ExternalMemory.Path != filepath.Join(root, ".traceary", "memories", "gemini.md") {
+		t.Fatalf("ExternalMemory.Path = %q, want gemini.md", status.ExternalMemory.Path)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_GeminiStaleStubInSyncExternal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	if err := os.WriteFile(hostPath, []byte("<!-- traceary-memory-import:begin:v1 -->\n@./stale.md\n<!-- traceary-memory-import:end -->\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile host: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(externalPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll external: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-stale", domtypes.MemoryTypePreference, scope, "prefer stable stubs"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	}
+	plan, err := sut.ActivatePlan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivatePlan: %v", err)
+	}
+	if err := os.WriteFile(externalPath, []byte(plan.ExternalMemory.Markdown), 0o600); err != nil {
+		t.Fatalf("WriteFile external: %v", err)
+	}
+
+	status, err := sut.ActivationStatus(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("State = %q, want stale (host stale, external in_sync)", status.State)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusStale {
+		t.Fatalf("HostContext.State = %q, want stale", status.HostContext.State)
+	}
+	if status.ExternalMemory.State != apptypes.MemoryActivationStatusInSync {
+		t.Fatalf("ExternalMemory.State = %q, want in_sync", status.ExternalMemory.State)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_GeminiInvalidStubBeginsWithoutEnd(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	if err := os.WriteFile(hostPath, []byte("<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/gemini.md\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-invalid", domtypes.MemoryTypePreference, scope, "prefer invalid pair detection"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	status, err := sut.ActivationStatus(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("State = %q, want invalid", status.State)
+	}
+	if status.HostContext.State != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("HostContext.State = %q, want invalid", status.HostContext.State)
+	}
+	if !strings.Contains(status.HostContext.Message, "without end marker") {
+		t.Fatalf("HostContext.Message = %q, want orphan-begin reason", status.HostContext.Message)
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_GeminiInvalidSymlinkHostContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	missingTarget := filepath.Join(root, "missing-target.md")
+	if err := os.Symlink(missingTarget, hostPath); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-symlink", domtypes.MemoryTypePreference, scope, "prefer symlink refusal"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+
+	status, err := sut.ActivationStatus(context.Background(), apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
+		Root:   root,
+		Scopes: []domtypes.MemoryScope{scope},
+	})
+	if err != nil {
+		t.Fatalf("ActivationStatus: %v", err)
+	}
+	if status.State != apptypes.MemoryActivationStatusInvalid {
+		t.Fatalf("State = %q, want invalid", status.State)
+	}
+	if status.HostContext == nil || !strings.Contains(status.HostContext.Message, "symlinks are not supported") {
+		t.Fatalf("HostContext.Message = %q, want symlink rejection", status.HostContext.Message)
+	}
+	info, statErr := os.Lstat(hostPath)
+	if statErr != nil {
+		t.Fatalf("Lstat: %v", statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("status must not replace dangling symlink, got mode %s", info.Mode())
+	}
+}
+
+func TestMemoryUsecase_ActivationStatus_GeminiInSyncAfterPlanWriteback(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	scope := mustWorkspaceScope(t, "github.com/example/repo")
+	query := &stubExportMemoryQuery{
+		summaries: []apptypes.MemorySummary{
+			mustAcceptedSummary(t, "m-gemini-insync", domtypes.MemoryTypePreference, scope, "prefer in_sync gemini pair"),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.MemoryActivationCriteria{
+		Target: apptypes.MemoryBridgeTargetGemini,
 		Root:   root,
 		Scopes: []domtypes.MemoryScope{scope},
 	}

--- a/docs/architecture/host-native-memory-activation.ja.md
+++ b/docs/architecture/host-native-memory-activation.ja.md
@@ -135,6 +135,13 @@ Claude については、v0.13.0-4 の read-only PR が以下 2 つの artefact 
 
 Claude `--apply` PR (#893) でも同じ 2 つの artefact をスコープに保持します。script の structural section は `--apply` を end-to-end で実行するように更新済みで、初回 apply で 2 ファイルが created になり、再 apply は noop へ収束し、apply 後の `--status` が `in_sync` になることを CI 側で検査します。ライブ launch を含む `TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` 実行記録は引き続き maintainer が保持するか、別 gate を採用するときはその根拠を ADR に追記します。
 
+Gemini については、v0.13.0-6 の read-only PR が以下 2 つの artefact を組み合わせて、ライブ launch のフレーキネスに依存しない readiness 証跡を残します。
+
+- `application/usecase/gemini_import_readiness_internal_test.go` は、rendering 済み import line・marker layout・external file 解決を Gemini 公式 Memory Import Processor documentation の `@<relative-path>` フォーマット（`GEMINI.md` のあるディレクトリ基準）に固定します。さらに、render される DO NOT EDIT 警告が `--target gemini` を含むことを検査するため、誤って Claude 向け remediation を出してしまう regression が CI で捕捉されます。
+- `scripts/smoke_test_gemini_activation.sh` は `traceary memory activate --target gemini --dry-run --json` の生成 plan を使って一時プロジェクト (`.git`、`GEMINI.md`、`.traceary/memories/gemini.md`) を materialize します。Gemini `--apply` はまだ実装されていない (#895 で導入) ため、現時点の script は dry-run pair contract のみ検証します。`--apply` 経路は #895 で同 script を拡張してカバーします。manual runtime probe のために一時プロジェクトを保持して、そのディレクトリで `gemini` を起動する場合は `TRACEARY_KEEP_SMOKE_TEMP=1` を指定します。Gemini CLI の階層的 context loading と認証状態のため無人ランタイム probe は非決定的なので、ライブ launch は `TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1` を指定したときだけ実行します。
+
+Gemini `--apply` PR (#895) は `scripts/smoke_test_gemini_activation.sh` を end-to-end まで拡張し（初回 apply で 2 ファイルが created、再 apply は noop、apply 後の status が `in_sync`）、apply 経路にも CI 側 regression coverage を備えさせる必要があります。さらに、事前に `GEMINI.md` 内に存在する `## Gemini Added Memories` section が `--apply` 後も byte-for-byte で保持されることを確認します。`TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1` を指定した maintainer 実行記録は、代替 gate が無い場合は引き続き必須です。
+
 ## apply semantics
 
 `--status` と `--dry-run` は read-only です。変更するのは `--apply` だけです。

--- a/docs/architecture/host-native-memory-activation.md
+++ b/docs/architecture/host-native-memory-activation.md
@@ -135,6 +135,13 @@ For Claude, the v0.13.0-4 read-only PR records that evidence in two artefacts th
 
 The Claude `--apply` PR (#893) keeps the live runtime evidence in scope through the same two artefacts. The script's structural section now exercises `--apply` end-to-end (first apply creates both files, a second apply converges to noop, and `--status` reports `in_sync` afterwards), so a CI-side regression in the apply path is detected without launching Claude. A maintainer-recorded `smoke_test_claude_activation.sh` run with `TRACEARY_ENABLE_CLAUDE_RUNTIME_SMOKE=1` is still required when an alternative gate is not available, or the ADR must be updated explaining why a different gate is acceptable.
 
+For Gemini, the v0.13.0-6 read-only PR records the same two artefacts that together stand in for a flaky live launch:
+
+- `application/usecase/gemini_import_readiness_internal_test.go` pins the rendered import line, marker layout, and external-file resolution to the form Gemini's official Memory Import Processor documentation specifies (`@<relative-path>` resolved against the directory containing `GEMINI.md`). The test additionally asserts that the rendered DO NOT EDIT warning carries `--target gemini` so the remediation command points at the right host. It runs in CI, so a refactor cannot silently move the import path or mis-target the warning.
+- `scripts/smoke_test_gemini_activation.sh` materialises a temp project (`.git`, `GEMINI.md`, `.traceary/memories/gemini.md`) using the live `traceary memory activate --target gemini --dry-run --json` plan. The Gemini `--apply` path is not yet implemented (it lands in #895), so the script does not exercise apply: it only validates the dry-run pair contract today and is expanded by #895 to cover the apply ordering. Set `TRACEARY_KEEP_SMOKE_TEMP=1` to retain the temp project for a manual `gemini` runtime probe; the live launch is gated behind `TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1` because Gemini CLI's hierarchical context loading and authentication state make an unattended runtime probe non-deterministic.
+
+The Gemini `--apply` PR (#895) must extend `scripts/smoke_test_gemini_activation.sh` end-to-end (first apply creates both files, a second apply converges to noop, post-apply status reports `in_sync`) so the apply path inherits the CI-side regression coverage Claude already has. The PR must also ensure the existing `## Gemini Added Memories` section in any pre-existing `GEMINI.md` is preserved byte-for-byte after `--apply`. A maintainer-recorded run with `TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1` is still required when an alternative gate is not available.
+
 ## Apply semantics
 
 `--status` and `--dry-run` are read-only. `--apply` is the only mutating mode.

--- a/presentation/cli/memory_activate.go
+++ b/presentation/cli/memory_activate.go
@@ -25,8 +25,8 @@ func (c *RootCLI) newMemoryActivateCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
-	cmd.Flags().StringVar(&input.target, "target", "", Localize("activation target host (codex, claude)", "activation 対象ホスト (codex, claude)"))
-	cmd.Flags().StringVar(&input.root, "root", "", Localize("host memory root override (Codex default: ~/.codex/memories; Claude default: nearest .git ancestor or cwd)", "host memory root の上書き (Codex 既定: ~/.codex/memories; Claude 既定: 直近の .git 祖先または cwd)"))
+	cmd.Flags().StringVar(&input.target, "target", "", Localize("activation target host (codex, claude, gemini)", "activation 対象ホスト (codex, claude, gemini)"))
+	cmd.Flags().StringVar(&input.root, "root", "", Localize("host memory root override (Codex default: ~/.codex/memories; Claude/Gemini default: nearest .git ancestor or cwd)", "host memory root の上書き (Codex 既定: ~/.codex/memories; Claude/Gemini 既定: 直近の .git 祖先または cwd)"))
 	cmd.Flags().StringVar(&input.path, "path", "", Localize("explicit activation target file path override", "activation 対象ファイルパスを明示的に上書き"))
 	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("workspace scope to activate (defaults to env/detected workspace)", "activation 対象の workspace scope (未指定時は env/検出 workspace)"))
 	cmd.Flags().BoolVar(&input.includeGlobal, "include-global", true, Localize("include global memories alongside a workspace activation (default true)", "workspace activation に global memory も含める (default true)"))
@@ -55,13 +55,18 @@ func (c *RootCLI) runMemoryActivate(ctx context.Context, output io.Writer, input
 	}
 	target, ok := apptypes.MemoryBridgeTargetOf(strings.ToLower(strings.TrimSpace(input.target)))
 	if !ok {
-		return xerrors.Errorf(Localize("--target must be codex or claude", "--target は codex または claude を指定してください"))
+		return xerrors.Errorf(Localize("--target must be codex, claude, or gemini", "--target は codex, claude, gemini のいずれかを指定してください"))
 	}
 	switch target {
 	case apptypes.MemoryBridgeTargetCodex, apptypes.MemoryBridgeTargetClaude:
 		// fully supported (status / dry-run / apply)
+	case apptypes.MemoryBridgeTargetGemini:
+		// status / dry-run / diff supported in v0.13.0-6; --apply lands in v0.13.0-7 (#895).
+		if input.apply {
+			return xerrors.Errorf(Localize("memory activate --apply is not supported yet for target gemini", "memory activate --apply は target gemini ではまだサポートされていません"))
+		}
 	default:
-		return xerrors.Errorf(Localize("--target must be codex or claude", "--target は codex または claude を指定してください"))
+		return xerrors.Errorf(Localize("--target must be codex, claude, or gemini", "--target は codex, claude, gemini のいずれかを指定してください"))
 	}
 	if err := c.initializeStore(ctx, input.dbPath); err != nil {
 		return err
@@ -301,7 +306,7 @@ func writeMemoryActivationStatus(output io.Writer, result apptypes.MemoryActivat
 			payload.DryRunCommand = commands.DryRun
 			payload.ApplyCommand = commands.Apply
 			// commands.Apply is empty for targets where --apply is not
-			// supported yet (Claude until #893). The JSON field uses
+			// supported yet (Gemini until #895). The JSON field uses
 			// `omitempty` so the payload simply drops `apply_command`
 			// instead of advertising a command the CLI would refuse.
 		}

--- a/presentation/cli/memory_activate_test.go
+++ b/presentation/cli/memory_activate_test.go
@@ -777,3 +777,286 @@ func assertMemoryApplyCall(t *testing.T, stub *memoryUsecaseStub, wantIncludeGlo
 		t.Fatalf("Scopes[0] = %s:%s, want workspace:github.com/duck8823/traceary", call.Scopes[0].Kind(), call.Scopes[0].Key())
 	}
 }
+
+func TestRootCLI_MemoryActivateGeminiDryRunRendersComponents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	memoryStub := &memoryUsecaseStub{
+		activationPlan: apptypes.MemoryActivationPlan{
+			Target:     apptypes.MemoryBridgeTargetGemini,
+			TargetPath: hostPath,
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:     hostPath,
+				Existing: false,
+				Markdown: "<!-- traceary-memory-import:begin:v1 -->\n@./.traceary/memories/gemini.md\n<!-- traceary-memory-import:end -->\n",
+				Action:   apptypes.MemoryActivationApplyCreated,
+				State:    apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:     externalPath,
+				Existing: false,
+				Markdown: "<!-- traceary-memories:begin:v1 -->\nplanned\n<!-- traceary-memories:end -->\n",
+				Action:   apptypes.MemoryActivationApplyCreated,
+				State:    apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "gemini",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--dry-run",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"target: gemini",
+		"external_memory: " + externalPath,
+		"host_context: " + hostPath,
+		"# external memory plan",
+		"# host context plan",
+		"@./.traceary/memories/gemini.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q: %q", want, out)
+		}
+	}
+	if len(memoryStub.activationPlanCalls) != 1 {
+		t.Fatalf("activation plan calls = %d, want 1", len(memoryStub.activationPlanCalls))
+	}
+	if memoryStub.activationPlanCalls[0].Target != apptypes.MemoryBridgeTargetGemini {
+		t.Fatalf("Target = %q, want gemini", memoryStub.activationPlanCalls[0].Target)
+	}
+}
+
+func TestRootCLI_MemoryActivateGeminiDryRunDiffOrdersExternalFirst(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	memoryStub := &memoryUsecaseStub{
+		activationPlan: apptypes.MemoryActivationPlan{
+			Target:     apptypes.MemoryBridgeTargetGemini,
+			TargetPath: hostPath,
+			Diff:       "--- " + externalPath + "\n+++ " + externalPath + " (planned)\n--- " + hostPath + "\n+++ " + hostPath + " (planned)\n",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:     hostPath,
+				Existing: true,
+				Diff:     "--- " + hostPath + "\n+++ " + hostPath + " (planned)\n",
+				State:    apptypes.MemoryActivationStatusStale,
+				Action:   apptypes.MemoryActivationApplyUpdated,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:     externalPath,
+				Existing: true,
+				Diff:     "--- " + externalPath + "\n+++ " + externalPath + " (planned)\n",
+				State:    apptypes.MemoryActivationStatusStale,
+				Action:   apptypes.MemoryActivationApplyUpdated,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "gemini",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--dry-run",
+		"--diff",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	externalIdx := strings.Index(out, "# external memory diff")
+	hostIdx := strings.Index(out, "# host context diff")
+	if externalIdx < 0 || hostIdx < 0 || externalIdx >= hostIdx {
+		t.Fatalf("diff output must order external before host, externalIdx=%d hostIdx=%d out=%q", externalIdx, hostIdx, out)
+	}
+	if !memoryStub.activationPlanCalls[0].Diff {
+		t.Fatalf("plan call did not propagate Diff=true")
+	}
+}
+
+func TestRootCLI_MemoryActivateGeminiStatusJSONOmitsApplyCommand(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	memoryStub := &memoryUsecaseStub{
+		activationStatus: apptypes.MemoryActivationStatusResult{
+			Target:         apptypes.MemoryBridgeTargetGemini,
+			TargetPath:     hostPath,
+			State:          apptypes.MemoryActivationStatusMissing,
+			Existing:       false,
+			ActivatedCount: 1,
+			Message:        "host context import stub and external memory file are missing",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:  hostPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:  externalPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "gemini",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--status",
+		"--json",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var payload struct {
+		Target         string `json:"target"`
+		TargetPath     string `json:"target_path"`
+		State          string `json:"state"`
+		ActivatedCount int    `json:"activated_count"`
+		DryRunCommand  string `json:"dry_run_command"`
+		ApplyCommand   string `json:"apply_command"`
+		HostContext    *struct {
+			Path  string `json:"path"`
+			State string `json:"state"`
+		} `json:"host_context"`
+		ExternalMemory *struct {
+			Path  string `json:"path"`
+			State string `json:"state"`
+		} `json:"external_memory"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout=%s", err, stdout.String())
+	}
+	if payload.Target != "gemini" || payload.State != "missing" {
+		t.Fatalf("payload = %+v, want gemini/missing", payload)
+	}
+	if !strings.Contains(payload.DryRunCommand, "--target gemini") || !strings.Contains(payload.DryRunCommand, "--dry-run --diff") {
+		t.Fatalf("dry_run_command = %q, want gemini dry-run command", payload.DryRunCommand)
+	}
+	if payload.ApplyCommand != "" {
+		t.Fatalf("apply_command = %q, want empty until #895 wires gemini --apply", payload.ApplyCommand)
+	}
+	if payload.HostContext == nil || payload.HostContext.Path != hostPath {
+		t.Fatalf("host_context = %+v, want gemini host", payload.HostContext)
+	}
+	if payload.ExternalMemory == nil || payload.ExternalMemory.Path != externalPath {
+		t.Fatalf("external_memory = %+v, want gemini external", payload.ExternalMemory)
+	}
+}
+
+func TestRootCLI_MemoryActivateGeminiStatusTextOmitsApplyRemediation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hostPath := filepath.Join(root, "GEMINI.md")
+	externalPath := filepath.Join(root, ".traceary", "memories", "gemini.md")
+	memoryStub := &memoryUsecaseStub{
+		activationStatus: apptypes.MemoryActivationStatusResult{
+			Target:         apptypes.MemoryBridgeTargetGemini,
+			TargetPath:     hostPath,
+			State:          apptypes.MemoryActivationStatusMissing,
+			Existing:       false,
+			ActivatedCount: 1,
+			Message:        "host context import stub and external memory file are missing",
+			HostContext: &apptypes.MemoryActivationComponent{
+				Path:  hostPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+			ExternalMemory: &apptypes.MemoryActivationComponent{
+				Path:  externalPath,
+				State: apptypes.MemoryActivationStatusMissing,
+			},
+		},
+	}
+	stdout := &bytes.Buffer{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "gemini",
+		"--root", root,
+		"--workspace", "github.com/duck8823/traceary",
+		"--status",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "next_dry_run:") {
+		t.Fatalf("stdout missing next_dry_run remediation: %q", out)
+	}
+	if strings.Contains(out, "next_apply:") {
+		t.Fatalf("stdout must omit next_apply for gemini until #895: %q", out)
+	}
+	if !strings.Contains(out, "--target gemini") {
+		t.Fatalf("next_dry_run must reference --target gemini: %q", out)
+	}
+}
+
+func TestRootCLI_MemoryActivateGeminiApplyRefused(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"memory", "activate",
+		"--target", "gemini",
+		"--apply",
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected --target gemini --apply to be refused")
+	}
+	if !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("err = %v, want 'not supported yet' refusal", err)
+	}
+	if len(memoryStub.activationCalls) != 0 {
+		t.Fatalf("Activate must not be called when --target gemini --apply is refused, got %d calls", len(memoryStub.activationCalls))
+	}
+}

--- a/scripts/smoke_test_gemini_activation.sh
+++ b/scripts/smoke_test_gemini_activation.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# smoke_test_gemini_activation.sh runs
+# `traceary memory activate --target gemini --dry-run` and materialises
+# that returned plan into a temp project without using the product
+# `--apply` path. This gives operators a concrete GEMINI.md +
+# `.traceary/memories/gemini.md` pair for manual runtime probes while
+# keeping v0.13.0-6 itself read-only. The real `--apply` path is wired
+# in v0.13.0-7 (#895), so this script intentionally confirms `--apply`
+# is still refused today. When #895 lands, this script must be
+# extended end-to-end (apply creates both files, second apply converges
+# to noop, post-apply status is in_sync) so Gemini inherits the same
+# CI-side regression coverage Claude already has.
+#
+# Launching Gemini CLI from CI is non-deterministic (auth state, model
+# availability, hierarchical context load order), so the live runtime
+# probe is gated behind TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1 and
+# falls through to a printed manual verification when gemini is not
+# available. The structural checks (file paths, marker layout,
+# import-line format) always run regardless of gemini availability.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TMP_PROJECT="$(mktemp -d)"
+KEEP_TEMP="${TRACEARY_KEEP_SMOKE_TEMP:-0}"
+if [[ "${KEEP_TEMP}" != "1" ]]; then
+  trap 'rm -rf "${TMP_PROJECT}"' EXIT
+fi
+
+mkdir -p "${TMP_PROJECT}/.git"
+echo 'ref: refs/heads/main' > "${TMP_PROJECT}/.git/HEAD"
+
+(cd "${ROOT_DIR}" && go run . memory activate \
+  --target gemini \
+  --db-path "${TMP_PROJECT}/traceary.db" \
+  --root "${TMP_PROJECT}" \
+  --workspace github.com/duck8823/traceary-gemini-smoke \
+  --dry-run \
+  --json) > "${TMP_PROJECT}/plan.json"
+
+python3 - "${TMP_PROJECT}" "${TMP_PROJECT}/plan.json" <<'PY'
+import json
+import os
+import sys
+
+tmp_project = os.path.realpath(sys.argv[1])
+plan_path = sys.argv[2]
+with open(plan_path, encoding="utf-8") as fp:
+    plan = json.load(fp)
+
+target = plan.get("target")
+assert target == "gemini", f"unexpected target: {target}"
+
+host = plan.get("host_context")
+external = plan.get("external_memory")
+assert host is not None, "host_context component missing"
+assert external is not None, "external_memory component missing"
+
+assert host["path"].endswith(os.sep + "GEMINI.md"), f"host path not GEMINI.md: {host['path']}"
+assert external["path"].endswith(os.path.join(".traceary", "memories", "gemini.md")), f"unexpected external path: {external['path']}"
+
+stub = host["markdown"]
+assert "<!-- traceary-memory-import:begin:v1 -->" in stub, "missing begin marker"
+assert "<!-- traceary-memory-import:end -->" in stub, "missing end marker"
+assert "@./.traceary/memories/gemini.md" in stub, f"missing relative import line: {stub}"
+assert "--target gemini" in stub, f"DO NOT EDIT warning must reference --target gemini: {stub}"
+
+for component in (host, external):
+    component_path = os.path.realpath(component["path"])
+    assert os.path.commonpath([tmp_project, component_path]) == tmp_project, (
+        f"refusing to materialise path outside temp project: {component['path']}"
+    )
+    os.makedirs(os.path.dirname(component_path), exist_ok=True)
+    with open(component_path, "w", encoding="utf-8") as fp:
+        fp.write(component["markdown"])
+
+print("ok: traceary memory activate --target gemini --dry-run produced and materialised the expected pair plan")
+PY
+
+(cd "${ROOT_DIR}" && go run . memory activate \
+  --target gemini \
+  --db-path "${TMP_PROJECT}/traceary.db" \
+  --root "${TMP_PROJECT}" \
+  --workspace github.com/duck8823/traceary-gemini-smoke \
+  --status \
+  --json) > "${TMP_PROJECT}/status.json"
+
+python3 - "${TMP_PROJECT}/status.json" <<'PY'
+import json
+import sys
+
+status_path = sys.argv[1]
+with open(status_path, encoding="utf-8") as fp:
+    status = json.load(fp)
+
+assert status.get("target") == "gemini", f"unexpected target: {status.get('target')}"
+assert status.get("state") == "in_sync", f"status after materialising plan must be in_sync: {status}"
+assert "apply_command" not in status, f"gemini status must not advertise apply until #895: {status}"
+assert status.get("host_context", {}).get("state") == "in_sync", f"host not in_sync: {status}"
+assert status.get("external_memory", {}).get("state") == "in_sync", f"external not in_sync: {status}"
+
+print("ok: materialised gemini dry-run plan is recognised as in_sync by --status")
+PY
+
+# v0.13.0-6 ships read-only surfaces. The apply path lands in #895, so
+# this script only calls `traceary memory activate --target gemini
+# --apply` to assert the command is refused today; #895 must replace
+# this refusal assertion with the same end-to-end checks the Claude
+# smoke script performs (first apply creates both files, second apply
+# converges to noop, post-apply status is in_sync), and must
+# additionally assert that any pre-existing `## Gemini Added Memories`
+# section in GEMINI.md survives byte-for-byte after apply.
+
+# Confirm `--apply` is currently refused for gemini so a regression
+# that silently enables apply is caught immediately.
+if (cd "${ROOT_DIR}" && go run . memory activate \
+  --target gemini \
+  --db-path "${TMP_PROJECT}/traceary.db" \
+  --root "${TMP_PROJECT}" \
+  --workspace github.com/duck8823/traceary-gemini-smoke \
+  --apply >/dev/null 2>&1); then
+  echo 'fail: gemini --apply must be refused until #895 lands.' >&2
+  exit 1
+fi
+
+if [[ "${TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE:-0}" != "1" ]]; then
+  if [[ "${KEEP_TEMP}" == "1" ]]; then
+    echo "manual runtime probe: cd \"${TMP_PROJECT}\" and run \`gemini\` to confirm the @./.traceary/memories/gemini.md import loads."
+  else
+    echo 'set TRACEARY_KEEP_SMOKE_TEMP=1 to retain the temp project for a manual `gemini` probe (default: temp project is removed at exit).'
+  fi
+  echo 'ok: structural smoke test passed (set TRACEARY_ENABLE_GEMINI_RUNTIME_SMOKE=1 for an authenticated live probe).'
+  exit 0
+fi
+
+if ! command -v gemini >/dev/null 2>&1; then
+  echo 'skip: gemini binary not found; structural checks already passed.'
+  exit 0
+fi
+
+# Live probe: v0.13.0-6 leaves Gemini launch as an operator-run
+# readiness check because authenticated Gemini CLI startup is
+# environment-dependent. The materialised temp project is ready for
+# that manual probe when TRACEARY_KEEP_SMOKE_TEMP=1.
+echo 'skip: automated live gemini probe is reserved for #895; structural materialisation already passed.'


### PR DESCRIPTION
## Motivation

Gemini host-native memory activation needs the same read-only planning surface as Claude before the public apply path can be enabled safely. This PR wires `--target gemini` for status/dry-run/diff only, preserving the v0.13 contract while keeping `--apply` refused until #895.

## Changes

- Resolve Gemini activation targets to `GEMINI.md` plus `.traceary/memories/gemini.md` with `@./.traceary/memories/gemini.md`.
- Reuse the two-file import-stub planner for Gemini status, dry-run, and deterministic diffs.
- Keep Gemini `--apply` refused at both CLI and usecase boundaries.
- Add usecase/CLI tests for missing, stale, in_sync, invalid, no-mutation, and remediation output.
- Add Gemini import readiness evidence and structural smoke coverage.
- Document the Gemini readiness gate in the host-native activation ADR.

## Verification

- `go test ./application/usecase -run 'Gemini|Activation|ImportStub|Claude|Codex'`\n- `go test ./presentation/cli -run 'MemoryActivate.*Gemini|MemoryActivate|Doctor.*Activation'`\n- `go test ./...`\n- `go build ./...`\n- `go tool golangci-lint run`\n- `python3 scripts/verify_docs_i18n.py`\n- `bash scripts/smoke_test_gemini_activation.sh`\n- `git diff --check`\n\nCloses #894