### PR TITLE
[MAINTENANCE] expand tail/list/search compact rows to terminal width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/sys v0.43.0
+	golang.org/x/term v0.42.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	modernc.org/sqlite v1.49.1
 )
@@ -229,7 +230,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -44,6 +44,10 @@ type eventTextFormatOptions struct {
 	// Wide and JSON writers ignore this flag so their legacy / machine
 	// readable contract is preserved.
 	colorEnabled bool
+	// targetWidth overrides the compact row column budget. 0 means use the
+	// fixed eventCompactTargetWidth default so non-interactive output (pipes,
+	// golden tests) stays byte-stable.
+	targetWidth int
 }
 
 // compactRowExtras carries hydrated data that a specific field needs but is
@@ -124,11 +128,15 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 		return strings.Join(tokens, sep)
 	}
 
+	targetWidth := opts.targetWidth
+	if targetWidth <= 0 {
+		targetWidth = eventCompactTargetWidth
+	}
 	prefix := strings.Join(tokens[:messageIndex], sep)
 	if messageIndex > 0 {
 		prefix += sep
 	}
-	remaining := eventCompactTargetWidth - runeLen(prefix)
+	remaining := targetWidth - runeLen(prefix)
 	if remaining < eventCompactMessageMinRunes {
 		for i := 0; i < messageIndex; i++ {
 			if fields[i] == readFieldWorkspace {
@@ -140,7 +148,7 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 		if messageIndex > 0 {
 			prefix += sep
 		}
-		remaining = eventCompactTargetWidth - runeLen(prefix)
+		remaining = targetWidth - runeLen(prefix)
 		if remaining < eventCompactMessageMinRunes {
 			remaining = eventCompactMessageMinRunes
 		}

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -194,6 +194,7 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		location:     input.location,
 		fields:       resolvedFields,
 		colorEnabled: colorEnabled,
+		targetWidth:  terminalWidthOf(output),
 	}
 	extrasFor := c.makeCompactExtrasResolver(ctx, resolvedFields, colorEnabled)
 	if err := writeEventsByFormat(output, events, input.asJSON, textOpts, extrasFor); err != nil {

--- a/presentation/cli/read_color.go
+++ b/presentation/cli/read_color.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/term"
 	"golang.org/x/xerrors"
 )
 
@@ -126,6 +127,22 @@ func isTerminalWriter(w io.Writer) bool {
 		return false
 	}
 	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+// terminalWidthOf returns the visible column count of the terminal backing w,
+// or 0 when w is not a TTY (for example a pipe, buffer, or file). Callers
+// should fall back to a fixed width when 0 is returned so non-interactive
+// output stays deterministic.
+func terminalWidthOf(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0
+	}
+	width, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || width <= 0 {
+		return 0
+	}
+	return width
 }
 
 // applyCompactRowHighlight wraps a rendered compact row with ANSI sequences

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -203,6 +203,7 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		location:     input.location,
 		fields:       resolvedFields,
 		colorEnabled: colorEnabled,
+		targetWidth:  terminalWidthOf(output),
 	}
 	extrasFor := c.makeCompactExtrasResolver(ctx, resolvedFields, colorEnabled)
 	if err := writeEventsByFormat(output, events, input.asJSON, textOpts, extrasFor); err != nil {

--- a/presentation/cli/tail.go
+++ b/presentation/cli/tail.go
@@ -318,6 +318,7 @@ func (c *RootCLI) runTail(ctx context.Context, warnWriter io.Writer, output io.W
 		location:     input.location,
 		fields:       resolvedFields,
 		colorEnabled: colorEnabled,
+		targetWidth:  terminalWidthOf(output),
 	}
 	extrasFor := c.makeCompactExtrasResolver(ctx, resolvedFields, colorEnabled)
 	writer := newTailEventWriter(output, input.asJSON, textOpts, extrasFor)


### PR DESCRIPTION
## Summary

- compact event 行 (`tail` / `list` / `search`) が 100 col 固定で truncate されていたため、広い端末では message が無駄に切られていた
- 端末幅を `golang.org/x/term.GetSize` で検出し、`eventTextFormatOptions.targetWidth` 経由で formatter に伝搬する
- 非 TTY (pipe / リダイレクト / golden test buffer) のときは `targetWidth=0` → 既存の 100 col 固定にフォールバックするため、機械可読系の互換は維持

## Why

`top` は端末幅に追従して行が伸縮するのに、`tail` だけ 100 col で切られて見づらい、というユーザフィードバック。同じ formatter を使う `list` / `search` も同様に揃えた。

## Test plan

- [x] `go test ./...` (1612 / 19 packages 通過)
- [x] `go tool golangci-lint run ./...` (0 issues)
- [ ] 実端末で `traceary tail` を流して message が端末幅まで伸びることを確認
- [ ] `traceary tail | cat` でリダイレクト時に従来通り 100 col 固定であることを確認
- [ ] `--wide` / `--json` の出力が変化しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)