### PR TITLE
fix(cli): fail memory inbox batch on per-id errors

### DIFF
--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -375,11 +375,7 @@ func writeMemoryInboxBatchIDOnly(output io.Writer, errOutput io.Writer, result m
 			return xerrors.Errorf("%s: %w", Localize("failed to print inbox failure row", "inbox 失敗行の出力に失敗しました"), err)
 		}
 	}
-	return xerrors.Errorf(Localizef(
-		"inbox %s failed for %d memory id(s)",
-		"inbox %s が %d 件の memory id で失敗しました",
-		result.Action, len(result.Failures),
-	))
+	return memoryInboxBatchFailureError(result)
 }
 
 func writeMemoryInboxBatch(output io.Writer, result memoryInboxBatchResult, asJSON bool) error {
@@ -398,6 +394,9 @@ func writeMemoryInboxBatch(output io.Writer, result memoryInboxBatchResult, asJS
 		if err := encoder.Encode(payload); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to encode inbox batch result", "inbox batch 結果の JSON 出力に失敗しました"), err)
 		}
+		if len(result.Failures) > 0 {
+			return memoryInboxBatchFailureError(result)
+		}
 		return nil
 	}
 	if _, err := fmt.Fprintf(output, "action=%s processed=%d failures=%d\n", result.Action, len(result.Processed), len(result.Failures)); err != nil {
@@ -414,5 +413,16 @@ func writeMemoryInboxBatch(output io.Writer, result memoryInboxBatchResult, asJS
 			return xerrors.Errorf("%s: %w", Localize("failed to print inbox failure row", "inbox 失敗行の出力に失敗しました"), err)
 		}
 	}
+	if len(result.Failures) > 0 {
+		return memoryInboxBatchFailureError(result)
+	}
 	return nil
+}
+
+func memoryInboxBatchFailureError(result memoryInboxBatchResult) error {
+	return xerrors.Errorf(Localizef(
+		"inbox %s failed for %d memory id(s)",
+		"inbox %s が %d 件の memory id で失敗しました",
+		result.Action, len(result.Failures),
+	))
 }

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
-var errSyntheticAcceptFailure = errors.New("synthetic accept failure")
+var (
+	errSyntheticAcceptFailure = errors.New("synthetic accept failure")
+	errSyntheticRejectFailure = errors.New("synthetic reject failure")
+)
 
 func buildInboxCandidateDetails(t *testing.T, id string, fact string, source domtypes.MemorySource) apptypes.MemoryDetails {
 	t.Helper()
@@ -514,6 +517,138 @@ func TestMemoryInboxAccept_IDOnlyFailureReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "FAILED\tmemory-fail\t") {
 		t.Fatalf("expected FAILED stderr line for the failing id, got %q", stderr.String())
+	}
+}
+
+func TestMemoryInboxBatch_TextFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		args        []string
+		memoryStub  *memoryUsecaseStub
+		wantAction  string
+		wantFailure string
+	}{
+		{
+			name:        "accept",
+			args:        []string{"memory", "inbox", "accept", "memory-fail"},
+			memoryStub:  &memoryUsecaseStub{acceptErr: errSyntheticAcceptFailure},
+			wantAction:  "accept",
+			wantFailure: "synthetic accept failure",
+		},
+		{
+			name:        "reject",
+			args:        []string{"memory", "inbox", "reject", "memory-fail"},
+			memoryStub:  &memoryUsecaseStub{rejectErr: errSyntheticRejectFailure},
+			wantAction:  "reject",
+			wantFailure: "synthetic reject failure",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithMemory(tc.memoryStub),
+			)
+			cmd := root.Command()
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			cmd.SetOut(stdout)
+			cmd.SetErr(stderr)
+			cmd.SetArgs(append(tc.args, "--db-path", t.TempDir()+"/t.db"))
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error when %s has per-id failures", tc.wantAction)
+			}
+			if !strings.Contains(err.Error(), "inbox "+tc.wantAction+" failed for 1 memory id(s)") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := stdout.String()
+			for _, want := range []string{
+				"action=" + tc.wantAction + " processed=0 failures=1",
+				"FAILED\tmemory-fail\t" + tc.wantFailure,
+			} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("stdout missing %q: %q", want, out)
+				}
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr for formatted text output, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestMemoryInboxBatch_JSONFailureReturnsErrorWithValidJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		args        []string
+		memoryStub  *memoryUsecaseStub
+		wantAction  string
+		wantFailure string
+	}{
+		{
+			name:        "accept",
+			args:        []string{"memory", "inbox", "accept", "memory-fail", "--json"},
+			memoryStub:  &memoryUsecaseStub{acceptErr: errSyntheticAcceptFailure},
+			wantAction:  "accept",
+			wantFailure: "synthetic accept failure",
+		},
+		{
+			name:        "reject",
+			args:        []string{"memory", "inbox", "reject", "memory-fail", "--json"},
+			memoryStub:  &memoryUsecaseStub{rejectErr: errSyntheticRejectFailure},
+			wantAction:  "reject",
+			wantFailure: "synthetic reject failure",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := cli.NewRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithMemory(tc.memoryStub),
+			)
+			cmd := root.Command()
+			stdout := &bytes.Buffer{}
+			cmd.SetOut(stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(append(tc.args, "--db-path", t.TempDir()+"/t.db"))
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error when %s JSON output has per-id failures", tc.wantAction)
+			}
+			if !strings.Contains(err.Error(), "inbox "+tc.wantAction+" failed for 1 memory id(s)") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var payload struct {
+				Action    string `json:"action"`
+				Processed []any  `json:"processed"`
+				Failures  []struct {
+					ID    string `json:"ID"`
+					Error string `json:"Error"`
+				} `json:"failures"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+				t.Fatalf("json.Unmarshal: %v (body=%s)", err, stdout.String())
+			}
+			if payload.Action != tc.wantAction {
+				t.Fatalf("payload.Action = %q, want %q", payload.Action, tc.wantAction)
+			}
+			if len(payload.Processed) != 0 {
+				t.Fatalf("expected no processed rows, got %+v", payload.Processed)
+			}
+			if len(payload.Failures) != 1 || payload.Failures[0].ID != "memory-fail" || payload.Failures[0].Error != tc.wantFailure {
+				t.Fatalf("unexpected failures payload: %+v", payload.Failures)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

Release QA dogfooding found that `traceary memory inbox accept` could report per-id failures in stdout while still exiting with status 0 for default text and JSON output. That makes release checks and scripts treat failed memory review decisions as successful.

Closes #950

## Summary

- return a non-zero error whenever memory inbox batch output contains per-id failures, including text and JSON modes
- keep stdout formatted first so operators/scripts still receive the full failure payload
- reuse the existing `--id-only` aggregate failure message
- cover accept/reject failures for text and JSON output

## Validation

- `GOCACHE=/private/tmp/traceary-go-build GOPATH=/private/tmp/traceary-gopath go test ./presentation/cli`
- `git diff --check`
- `python3 scripts/verify_changelog_releases.py`
- `python3 scripts/verify_release_manifests.py`
- `GOCACHE=/private/tmp/traceary-go-build GOPATH=/private/tmp/traceary-gopath python3 scripts/verify_integrations.py`
- `python3 scripts/verify_landing.py`
- `python3 scripts/verify_docs_i18n.py`
- `python3 scripts/verify_docs_no_removed_aliases.py`
- `GOCACHE=/private/tmp/traceary-go-build GOPATH=/private/tmp/traceary-gopath go build ./...`
- `GOCACHE=/private/tmp/traceary-go-build GOPATH=/private/tmp/traceary-gopath go test ./...`
- `GOCACHE=/private/tmp/traceary-go-build GOPATH=/private/tmp/traceary-gopath GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- dogfood smoke: no-evidence candidate `memory inbox accept` exits 1 for both `--json` and text, while JSON stdout remains valid
