### PR TITLE
feat: add stale memory snapshot data

### DIFF
--- a/application/queryservice/memory_query.go
+++ b/application/queryservice/memory_query.go
@@ -16,3 +16,12 @@ type MemoryQueryService interface {
 	// GetDetails returns the details for a single memory.
 	GetDetails(ctx context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error)
 }
+
+// StaleMemoryQueryService provides the additive read-side query used by
+// `traceary top --snapshot --json` to surface stale durable memories without
+// introducing a write-side use case.
+type StaleMemoryQueryService interface {
+	// ListStale returns stale durable-memory rows plus the total count before
+	// paging.
+	ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error)
+}

--- a/application/types/stale_memory.go
+++ b/application/types/stale_memory.go
@@ -1,0 +1,148 @@
+package types
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// StaleMemoryReason explains why a durable-memory row should be surfaced in
+// the operator-facing stale-memory pane.
+type StaleMemoryReason string
+
+const (
+	// StaleMemoryReasonExpired covers memories whose lifecycle status is
+	// expired or whose content-validity window has already closed.
+	StaleMemoryReasonExpired StaleMemoryReason = "expired"
+	// StaleMemoryReasonSuperseded covers memories that have been replaced but
+	// still exist in the local store for audit / pruning.
+	StaleMemoryReasonSuperseded StaleMemoryReason = "superseded"
+	// StaleMemoryReasonOverlap covers memories that are part of a deterministic
+	// dedupe overlap hygiene hit.
+	StaleMemoryReasonOverlap StaleMemoryReason = "overlap"
+)
+
+// StaleMemoryReasonFrom validates a serialized stale-memory reason.
+func StaleMemoryReasonFrom(value string) (StaleMemoryReason, error) {
+	trimmed := strings.TrimSpace(value)
+	switch StaleMemoryReason(trimmed) {
+	case StaleMemoryReasonExpired, StaleMemoryReasonSuperseded, StaleMemoryReasonOverlap:
+		return StaleMemoryReason(trimmed), nil
+	default:
+		return "", xerrors.Errorf("unknown stale memory reason: %s", value)
+	}
+}
+
+// StaleMemoryRow is the read-side row rendered by the stale-memory top pane.
+type StaleMemoryRow struct {
+	summary MemorySummary
+	reason  StaleMemoryReason
+}
+
+// StaleMemoryRowOf creates a stale-memory row from an existing memory summary.
+func StaleMemoryRowOf(summary MemorySummary, reason StaleMemoryReason) (StaleMemoryRow, error) {
+	if _, err := StaleMemoryReasonFrom(reason.String()); err != nil {
+		return StaleMemoryRow{}, err
+	}
+	return StaleMemoryRow{summary: summary, reason: reason}, nil
+}
+
+// Summary returns the durable-memory summary for this stale row.
+func (r StaleMemoryRow) Summary() MemorySummary { return r.summary }
+
+// Reason returns the staleness reason.
+func (r StaleMemoryRow) Reason() StaleMemoryReason { return r.reason }
+
+// String returns the serialized reason value.
+func (r StaleMemoryReason) String() string { return string(r) }
+
+// StaleMemoryListCriteria holds the filters for read-side stale-memory lists.
+type StaleMemoryListCriteria struct {
+	limit  int
+	offset int
+	scopes []domtypes.MemoryScope
+	asOf   domtypes.Optional[time.Time]
+}
+
+// Limit returns the maximum number of rows to return.
+func (c StaleMemoryListCriteria) Limit() int { return c.limit }
+
+// Offset returns the number of rows to skip after ordering.
+func (c StaleMemoryListCriteria) Offset() int { return c.offset }
+
+// Scopes returns the typed scope filters.
+func (c StaleMemoryListCriteria) Scopes() []domtypes.MemoryScope { return slices.Clone(c.scopes) }
+
+// AsOf returns the evaluation time for validity-window checks.
+func (c StaleMemoryListCriteria) AsOf() domtypes.Optional[time.Time] { return c.asOf }
+
+// StaleMemoryListCriteriaBuilder builds stale-memory list criteria.
+type StaleMemoryListCriteriaBuilder struct {
+	criteria StaleMemoryListCriteria
+}
+
+// NewStaleMemoryListCriteriaBuilder starts building with the given limit.
+func NewStaleMemoryListCriteriaBuilder(limit int) *StaleMemoryListCriteriaBuilder {
+	return &StaleMemoryListCriteriaBuilder{criteria: StaleMemoryListCriteria{limit: limit}}
+}
+
+// Offset sets the number of rows to skip.
+func (b *StaleMemoryListCriteriaBuilder) Offset(offset int) *StaleMemoryListCriteriaBuilder {
+	b.criteria.offset = offset
+	return b
+}
+
+// Scope appends a typed scope filter.
+func (b *StaleMemoryListCriteriaBuilder) Scope(scope domtypes.MemoryScope) *StaleMemoryListCriteriaBuilder {
+	if scope != nil {
+		b.criteria.scopes = append(b.criteria.scopes, scope)
+	}
+	return b
+}
+
+// Scopes replaces the typed scope filters.
+func (b *StaleMemoryListCriteriaBuilder) Scopes(scopes []domtypes.MemoryScope) *StaleMemoryListCriteriaBuilder {
+	b.criteria.scopes = slices.Clone(scopes)
+	return b
+}
+
+// AsOf sets the evaluation time for validity-window checks.
+func (b *StaleMemoryListCriteriaBuilder) AsOf(asOf time.Time) *StaleMemoryListCriteriaBuilder {
+	if !asOf.IsZero() {
+		b.criteria.asOf = domtypes.Some(asOf)
+	}
+	return b
+}
+
+// Build finalizes the criteria.
+func (b *StaleMemoryListCriteriaBuilder) Build() StaleMemoryListCriteria {
+	return b.criteria
+}
+
+// StaleMemoryListResult carries a paged stale-memory result plus the total
+// stale count before LIMIT/OFFSET are applied.
+type StaleMemoryListResult struct {
+	count int
+	items []StaleMemoryRow
+}
+
+// StaleMemoryListResultOf creates a stale-memory list result.
+func StaleMemoryListResultOf(count int, items []StaleMemoryRow) (StaleMemoryListResult, error) {
+	if count < 0 {
+		return StaleMemoryListResult{}, xerrors.Errorf("stale memory count must not be negative")
+	}
+	if count < len(items) {
+		return StaleMemoryListResult{}, xerrors.Errorf("stale memory count must be greater than or equal to item count")
+	}
+	return StaleMemoryListResult{count: count, items: slices.Clone(items)}, nil
+}
+
+// Count returns the total stale-memory count before paging.
+func (r StaleMemoryListResult) Count() int { return r.count }
+
+// Items returns the paged stale-memory rows.
+func (r StaleMemoryListResult) Items() []StaleMemoryRow { return slices.Clone(r.items) }

--- a/application/types/stale_memory_test.go
+++ b/application/types/stale_memory_test.go
@@ -1,0 +1,67 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestStaleMemoryReasonFrom(t *testing.T) {
+	t.Parallel()
+
+	got, err := apptypes.StaleMemoryReasonFrom("overlap")
+	if err != nil {
+		t.Fatalf("StaleMemoryReasonFrom() error = %v", err)
+	}
+	if got != apptypes.StaleMemoryReasonOverlap {
+		t.Fatalf("StaleMemoryReasonFrom() = %q, want overlap", got)
+	}
+
+	if _, err := apptypes.StaleMemoryReasonFrom("unknown"); err == nil {
+		t.Fatal("StaleMemoryReasonFrom(unknown) error = nil, want error")
+	}
+}
+
+func TestStaleMemoryListResultOfClonesItems(t *testing.T) {
+	t.Parallel()
+
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID("mem-stale"),
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("duck8823/traceary")),
+		"stale memory fact",
+		domtypes.MemoryStatusSuperseded,
+		domtypes.ConfidenceMedium,
+		domtypes.MemorySourceManual,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		domtypes.None[time.Time](),
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf() error = %v", err)
+	}
+	row, err := apptypes.StaleMemoryRowOf(summary, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf() error = %v", err)
+	}
+	items := []apptypes.StaleMemoryRow{row}
+	result, err := apptypes.StaleMemoryListResultOf(2, items)
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf() error = %v", err)
+	}
+	items[0], _ = apptypes.StaleMemoryRowOf(summary, apptypes.StaleMemoryReasonExpired)
+
+	gotItems := result.Items()
+	if gotItems[0].Reason() != apptypes.StaleMemoryReasonSuperseded {
+		t.Fatalf("result item reason = %q, want superseded", gotItems[0].Reason())
+	}
+	gotItems[0], _ = apptypes.StaleMemoryRowOf(summary, apptypes.StaleMemoryReasonExpired)
+	if result.Items()[0].Reason() != apptypes.StaleMemoryReasonSuperseded {
+		t.Fatalf("Items() did not return a defensive copy")
+	}
+}

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -90,6 +90,11 @@ type MemoryUsecase interface {
 	// List returns memory summaries matching the criteria.
 	List(ctx context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error)
 
+	// ListStale returns stale durable-memory rows and the total count before
+	// paging. It is a read-side helper for the top dashboard's stale-memory
+	// pane.
+	ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error)
+
 	// Search searches durable memories.
 	Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error)
 

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -545,6 +545,28 @@ func (u *memoryUsecase) List(ctx context.Context, criteria apptypes.MemoryListCr
 	return summaries, nil
 }
 
+func (u *memoryUsecase) ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
+	if u.memoryQuery == nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("memory query service is not configured")
+	}
+	staleQuery, ok := u.memoryQuery.(queryservice.StaleMemoryQueryService)
+	if !ok {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("stale memory query service is not configured")
+	}
+	if criteria.Limit() <= 0 {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	result, err := staleQuery.ListStale(ctx, criteria)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to list stale durable memories: %w", err)
+	}
+	return result, nil
+}
+
 func (u *memoryUsecase) Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
 	if u.memoryQuery == nil {
 		return nil, xerrors.Errorf("memory query service is not configured")

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -85,18 +85,26 @@ func (s *memoryRepositoryStub) FindByID(_ context.Context, memoryID domtypes.Mem
 }
 
 type memoryQueryStub struct {
-	listResult   []apptypes.MemorySummary
-	listErr      error
-	listCriteria apptypes.MemoryListCriteria
-	searchResult []apptypes.MemorySummary
-	searchErr    error
-	details      apptypes.MemoryDetails
-	detailsErr   error
+	listResult    []apptypes.MemorySummary
+	listErr       error
+	listCriteria  apptypes.MemoryListCriteria
+	staleResult   apptypes.StaleMemoryListResult
+	staleErr      error
+	staleCriteria apptypes.StaleMemoryListCriteria
+	searchResult  []apptypes.MemorySummary
+	searchErr     error
+	details       apptypes.MemoryDetails
+	detailsErr    error
 }
 
 func (s *memoryQueryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
 	return s.listResult, s.listErr
+}
+
+func (s *memoryQueryStub) ListStale(_ context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
+	s.staleCriteria = criteria
+	return s.staleResult, s.staleErr
 }
 
 func (s *memoryQueryStub) Search(_ context.Context, _ apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
@@ -720,6 +728,41 @@ func TestMemoryUsecase_SetValidity(t *testing.T) {
 			t.Fatalf("SetValidity() error = nil; want mutual-exclusion error")
 		}
 	})
+}
+
+func TestMemoryUsecase_ListStale(t *testing.T) {
+	t.Parallel()
+
+	memory := mustAcceptedMemory(t, "memory-stale", "stale fact")
+	summary, err := apptypes.MemorySummaryFrom(memory)
+	if err != nil {
+		t.Fatalf("MemorySummaryFrom() error = %v", err)
+	}
+	row, err := apptypes.StaleMemoryRowOf(summary, apptypes.StaleMemoryReasonOverlap)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf() error = %v", err)
+	}
+	want, err := apptypes.StaleMemoryListResultOf(9, []apptypes.StaleMemoryRow{row})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf() error = %v", err)
+	}
+	query := &memoryQueryStub{staleResult: want}
+	sut := usecase.NewMemoryUsecase(nil, query, nil)
+	criteria := apptypes.NewStaleMemoryListCriteriaBuilder(3).Build()
+
+	got, err := sut.ListStale(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListStale() error = %v", err)
+	}
+	if got.Count() != 9 {
+		t.Fatalf("ListStale().Count = %d, want 9", got.Count())
+	}
+	if items := got.Items(); len(items) != 1 || items[0].Summary().MemoryID() != memory.MemoryID() {
+		t.Fatalf("ListStale().Items = %#v, want one memory-stale row", items)
+	}
+	if query.staleCriteria.Limit() != 3 {
+		t.Fatalf("stale criteria Limit = %d, want 3", query.staleCriteria.Limit())
+	}
 }
 
 func TestMemoryUsecase_Show(t *testing.T) {

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -60,6 +60,30 @@ SELECT
 FROM memories m
 WHERE 1 = 1`
 
+const selectStaleMemoryColumnsQuery = `
+SELECT
+    m.id,
+    m.type,
+    m.scope_kind,
+    m.scope_value,
+    m.fact,
+    m.status,
+    m.confidence,
+    m.source,
+    m.supersedes_memory_id,
+    m.expires_at,
+    m.valid_from,
+    m.valid_to,
+    m.created_at,
+    m.updated_at,
+    CASE
+      WHEN m.status = 'expired' OR (m.status = 'accepted' AND m.valid_to IS NOT NULL AND m.valid_to <= ?) THEN 'expired'
+      WHEN m.status = 'superseded' THEN 'superseded'
+      ELSE 'overlap'
+    END AS stale_reason
+FROM memories m
+WHERE 1 = 1`
+
 // MemoryDatasource is the SQLite-backed implementation of the memory
 // repository and memory query service.
 type MemoryDatasource struct {
@@ -81,8 +105,9 @@ func NewMemoryDatasourceWithClock(db *Database, clock types.Clock) *MemoryDataso
 }
 
 var (
-	_ model.MemoryRepository          = (*MemoryDatasource)(nil)
-	_ queryservice.MemoryQueryService = (*MemoryDatasource)(nil)
+	_ model.MemoryRepository               = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryQueryService      = (*MemoryDatasource)(nil)
+	_ queryservice.StaleMemoryQueryService = (*MemoryDatasource)(nil)
 )
 
 // Save persists a memory aggregate together with its refs.
@@ -352,6 +377,68 @@ func (d *MemoryDatasource) List(ctx context.Context, criteria apptypes.MemoryLis
 	return summaries, nil
 }
 
+// ListStale returns stale memory rows plus the total count before paging.
+func (d *MemoryDatasource) ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
+	if criteria.Limit() <= 0 {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to open DB for stale memory list: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	evaluationTimestamp := staleMemoryEvaluationTimestamp(criteria, d.clock)
+	countQuery, countArgs, err := buildStaleMemoryCountQuery(criteria, evaluationTimestamp)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to build stale memory count query: %w", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&count); err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to count stale memories: %w", err)
+	}
+
+	listQuery, listArgs, err := buildStaleMemoryListQuery(criteria, evaluationTimestamp)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to build stale memory list query: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, listQuery, listArgs...)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to query stale memories: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	items := make([]apptypes.StaleMemoryRow, 0, criteria.Limit())
+	for rows.Next() {
+		item, err := scanStaleMemoryRow(rows)
+		if err != nil {
+			return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to scan stale memory row: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to iterate stale memory rows: %w", err)
+	}
+
+	result, err := apptypes.StaleMemoryListResultOf(count, items)
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("failed to build stale memory list result: %w", err)
+	}
+	return result, nil
+}
+
 // Search performs text search across durable memories and their refs.
 func (d *MemoryDatasource) Search(ctx context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
 	if criteria.Limit() <= 0 {
@@ -451,6 +538,45 @@ func scanMemorySummary(rowScanner interface {
 		return apptypes.MemorySummary{}, err
 	}
 	return restoreMemorySummary(row)
+}
+
+func scanStaleMemoryRow(rowScanner interface {
+	Scan(dest ...any) error
+}) (apptypes.StaleMemoryRow, error) {
+	var row memoryRow
+	var reasonValue string
+	if err := rowScanner.Scan(
+		&row.memoryID,
+		&row.memoryType,
+		&row.scopeKind,
+		&row.scopeValue,
+		&row.fact,
+		&row.status,
+		&row.confidence,
+		&row.source,
+		&row.supersedes,
+		&row.expiresAt,
+		&row.validFrom,
+		&row.validTo,
+		&row.createdAt,
+		&row.updatedAt,
+		&reasonValue,
+	); err != nil {
+		return apptypes.StaleMemoryRow{}, xerrors.Errorf("failed to scan stale memory row: %w", err)
+	}
+	summary, err := restoreMemorySummary(row)
+	if err != nil {
+		return apptypes.StaleMemoryRow{}, err
+	}
+	reason, err := apptypes.StaleMemoryReasonFrom(reasonValue)
+	if err != nil {
+		return apptypes.StaleMemoryRow{}, xerrors.Errorf("failed to restore stale memory reason: %w", err)
+	}
+	staleRow, err := apptypes.StaleMemoryRowOf(summary, reason)
+	if err != nil {
+		return apptypes.StaleMemoryRow{}, xerrors.Errorf("failed to build stale memory row: %w", err)
+	}
+	return staleRow, nil
 }
 
 func restoreMemorySummary(row memoryRow) (apptypes.MemorySummary, error) {
@@ -735,6 +861,86 @@ func buildMemorySearchQuery(criteria apptypes.MemorySearchCriteria, clock types.
 	return builder.String(), args, nil
 }
 
+func buildStaleMemoryCountQuery(criteria apptypes.StaleMemoryListCriteria, evaluationTimestamp string) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString("SELECT COUNT(*) FROM memories m WHERE 1 = 1")
+	args, err := appendStaleMemoryFilters(&builder, nil, criteria, evaluationTimestamp)
+	if err != nil {
+		return "", nil, err
+	}
+	return builder.String(), args, nil
+}
+
+func buildStaleMemoryListQuery(criteria apptypes.StaleMemoryListCriteria, evaluationTimestamp string) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString(selectStaleMemoryColumnsQuery)
+	args := []any{evaluationTimestamp}
+	args, err := appendStaleMemoryFilters(&builder, args, criteria, evaluationTimestamp)
+	if err != nil {
+		return "", nil, err
+	}
+	builder.WriteString(" ORDER BY m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return builder.String(), args, nil
+}
+
+func appendStaleMemoryFilters(
+	builder *strings.Builder,
+	args []any,
+	criteria apptypes.StaleMemoryListCriteria,
+	evaluationTimestamp string,
+) ([]any, error) {
+	builder.WriteString(`
+  AND (
+      m.status = ?
+      OR m.status = ?
+      OR (m.status = ? AND m.valid_to IS NOT NULL AND m.valid_to <= ?)
+      OR (
+          m.status = ?
+          AND m.valid_from <= ?
+          AND (m.valid_to IS NULL OR m.valid_to > ?)
+          AND EXISTS (
+              SELECT 1
+              FROM memories peer
+              WHERE peer.id <> m.id
+                AND peer.status = ?
+                AND peer.valid_from <= ?
+                AND (peer.valid_to IS NULL OR peer.valid_to > ?)
+                AND peer.scope_kind = m.scope_kind
+                AND peer.scope_value = m.scope_value
+                AND peer.fact = m.fact
+          )
+      )
+  )`)
+	args = append(args,
+		types.MemoryStatusExpired.String(),
+		types.MemoryStatusSuperseded.String(),
+		types.MemoryStatusAccepted.String(),
+		evaluationTimestamp,
+		types.MemoryStatusAccepted.String(),
+		evaluationTimestamp,
+		evaluationTimestamp,
+		types.MemoryStatusAccepted.String(),
+		evaluationTimestamp,
+		evaluationTimestamp,
+	)
+	if err := appendMemoryScopeFilter(builder, &args, criteria.Scopes()); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+func staleMemoryEvaluationTimestamp(criteria apptypes.StaleMemoryListCriteria, clock types.Clock) string {
+	if clock == nil {
+		clock = types.SystemClock{}
+	}
+	evaluationTime := clock.Now()
+	if explicit, ok := criteria.AsOf().Value(); ok {
+		evaluationTime = explicit
+	}
+	return formatMemoryValidityTimestamp(evaluationTime)
+}
+
 // appendMemoryValidityWindowFilter narrows results to memories whose
 // content validity window contains the evaluation timestamp, unless
 // includeExpired is true. When criteria.AsOf() is None we use the
@@ -792,19 +998,8 @@ func appendMemoryFilters(
 	}
 	builder.WriteString(")")
 
-	if len(scopes) > 0 {
-		builder.WriteString(" AND (")
-		for index, scope := range scopes {
-			if scope == nil {
-				return nil, xerrors.Errorf("memory scope must not be nil")
-			}
-			if index > 0 {
-				builder.WriteString(" OR ")
-			}
-			builder.WriteString("(m.scope_kind = ? AND m.scope_value = ?)")
-			args = append(args, scope.Kind().String(), scope.Key())
-		}
-		builder.WriteString(")")
+	if err := appendMemoryScopeFilter(builder, &args, scopes); err != nil {
+		return nil, err
 	}
 
 	if len(memoryTypes) > 0 {
@@ -832,6 +1027,25 @@ func appendMemoryFilters(
 	}
 
 	return args, nil
+}
+
+func appendMemoryScopeFilter(builder *strings.Builder, args *[]any, scopes []types.MemoryScope) error {
+	if len(scopes) == 0 {
+		return nil
+	}
+	builder.WriteString(" AND (")
+	for index, scope := range scopes {
+		if scope == nil {
+			return xerrors.Errorf("memory scope must not be nil")
+		}
+		if index > 0 {
+			builder.WriteString(" OR ")
+		}
+		builder.WriteString("(m.scope_kind = ? AND m.scope_value = ?)")
+		*args = append(*args, scope.Kind().String(), scope.Key())
+	}
+	builder.WriteString(")")
+	return nil
 }
 
 func normalizeMemoryStatuses(statuses []types.MemoryStatus) []types.MemoryStatus {

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -695,6 +695,191 @@ func TestMemoryDatasource_List_RememberIntentPriorityAppliesBeforePagination(t *
 	}
 }
 
+func TestMemoryDatasource_ListStale_ReturnsCountItemsAndReasons(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "stale.db")
+	evaluationTime := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	sut, store := newMemoryDatasourceWithClock(t, dbPath, memoryDatasourceTestMigrations(), fakeClock{now: evaluationTime})
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	scope := mustWorkspaceScope(t, "github.com/duck8823/traceary")
+	otherScope := mustWorkspaceScope(t, "github.com/example/other")
+	validFrom := evaluationTime.Add(-24 * time.Hour)
+	memories := []*model.Memory{
+		model.MemoryOf(
+			mustMemoryID(t, "mem-valid-expired"),
+			types.MemoryTypeDecision,
+			scope,
+			"validity window already closed",
+			types.MemoryStatusAccepted,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.Some(evaluationTime.Add(-time.Nanosecond)),
+			validFrom,
+			evaluationTime.Add(1*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-lifecycle-expired"),
+			types.MemoryTypeLesson,
+			scope,
+			"lifecycle expired but retained for audit",
+			types.MemoryStatusExpired,
+			types.ConfidenceMedium,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.Some(evaluationTime.Add(-time.Hour)),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(2*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-superseded"),
+			types.MemoryTypePreference,
+			scope,
+			"superseded preference",
+			types.MemoryStatusSuperseded,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(3*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-overlap-a"),
+			types.MemoryTypeConstraint,
+			scope,
+			"same fact in same scope",
+			types.MemoryStatusAccepted,
+			types.ConfidenceVerified,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(4*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-overlap-b"),
+			types.MemoryTypeConstraint,
+			scope,
+			"same fact in same scope",
+			types.MemoryStatusAccepted,
+			types.ConfidenceVerified,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(5*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-active"),
+			types.MemoryTypeDecision,
+			scope,
+			"active memory stays out of stale list",
+			types.MemoryStatusAccepted,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(6*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-rotated-active"),
+			types.MemoryTypeDecision,
+			scope,
+			"validity window already closed",
+			types.MemoryStatusAccepted,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			evaluationTime.Add(-time.Minute),
+			types.None[time.Time](),
+			evaluationTime.Add(-time.Minute),
+			evaluationTime.Add(7*time.Minute),
+		),
+		model.MemoryOf(
+			mustMemoryID(t, "mem-other-scope"),
+			types.MemoryTypeDecision,
+			otherScope,
+			"other scope stale memory",
+			types.MemoryStatusSuperseded,
+			types.ConfidenceHigh,
+			types.MemorySourceManual,
+			nil,
+			nil,
+			types.None[types.MemoryID](),
+			types.None[time.Time](),
+			validFrom,
+			types.None[time.Time](),
+			validFrom,
+			evaluationTime.Add(8*time.Minute),
+		),
+	}
+	for _, memory := range memories {
+		if err := sut.Save(ctx, memory); err != nil {
+			t.Fatalf("Save(%s) error = %v", memory.MemoryID(), err)
+		}
+	}
+
+	result, err := sut.ListStale(ctx, apptypes.NewStaleMemoryListCriteriaBuilder(3).
+		Scope(scope).
+		Build())
+	if err != nil {
+		t.Fatalf("ListStale() error = %v", err)
+	}
+	if got, want := result.Count(), 5; got != want {
+		t.Fatalf("ListStale().Count = %d, want %d", got, want)
+	}
+	items := result.Items()
+	if got, want := len(items), 3; got != want {
+		t.Fatalf("len(ListStale().Items) = %d, want %d", got, want)
+	}
+	gotRows := make([]string, 0, len(items))
+	for _, item := range items {
+		gotRows = append(gotRows, item.Summary().MemoryID().String()+":"+item.Reason().String())
+	}
+	wantRows := []string{
+		"mem-overlap-b:overlap",
+		"mem-overlap-a:overlap",
+		"mem-superseded:superseded",
+	}
+	if diff := cmp.Diff(wantRows, gotRows); diff != "" {
+		t.Fatalf("ListStale rows mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestMemoryDatasource_Search(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/memory_output.go
+++ b/presentation/cli/memory_output.go
@@ -233,6 +233,27 @@ func newMemorySummaryOutput(summary apptypes.MemorySummary) memorySummaryOutput 
 	}
 }
 
+func newStaleMemoryOutput(row apptypes.StaleMemoryRow) staleMemoryOutput {
+	summary := newMemorySummaryOutput(row.Summary())
+	return staleMemoryOutput{
+		MemoryID:   summary.MemoryID,
+		Type:       summary.Type,
+		ScopeKind:  summary.ScopeKind,
+		ScopeValue: summary.ScopeValue,
+		Fact:       summary.Fact,
+		Status:     summary.Status,
+		Confidence: summary.Confidence,
+		Source:     summary.Source,
+		Supersedes: summary.Supersedes,
+		ExpiresAt:  summary.ExpiresAt,
+		ValidFrom:  summary.ValidFrom,
+		ValidTo:    summary.ValidTo,
+		CreatedAt:  summary.CreatedAt,
+		UpdatedAt:  summary.UpdatedAt,
+		Reason:     row.Reason().String(),
+	}
+}
+
 func newMemoryDetailsOutput(details apptypes.MemoryDetails) memoryDetailsOutput {
 	evidenceRefs := make([]string, 0, len(details.EvidenceRefs()))
 	for _, ref := range details.EvidenceRefs() {

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -74,6 +74,7 @@ type topSnapshotPayload struct {
 	Failures       []event               `json:"failures"`
 	RecentCommands []event               `json:"recent_commands"`
 	Candidates     topSnapshotCandidates `json:"candidates"`
+	StaleMemories  topSnapshotStale      `json:"stale_memories"`
 }
 
 // topSnapshotCandidates wraps the durable-memory inbox slice with an
@@ -84,6 +85,13 @@ type topSnapshotPayload struct {
 type topSnapshotCandidates struct {
 	Count int                   `json:"count"`
 	Items []memorySummaryOutput `json:"items"`
+}
+
+// topSnapshotStale wraps stale durable-memory rows with the total stale count
+// before the per-pane item cap is applied.
+type topSnapshotStale struct {
+	Count int                 `json:"count"`
+	Items []staleMemoryOutput `json:"items"`
 }
 
 // topSnapshotNode is the JSON shape of a single node in the
@@ -131,6 +139,25 @@ type memorySummaryOutput struct {
 	ValidTo    *string `json:"valid_to,omitempty"`
 	CreatedAt  string  `json:"created_at"`
 	UpdatedAt  string  `json:"updated_at"`
+}
+
+// staleMemoryOutput is the JSON shape of a stale durable-memory top row.
+type staleMemoryOutput struct {
+	MemoryID   string  `json:"memory_id"`
+	Type       string  `json:"type"`
+	ScopeKind  string  `json:"scope_kind"`
+	ScopeValue string  `json:"scope_value"`
+	Fact       string  `json:"fact"`
+	Status     string  `json:"status"`
+	Confidence string  `json:"confidence"`
+	Source     string  `json:"source"`
+	Supersedes *string `json:"supersedes,omitempty"`
+	ExpiresAt  *string `json:"expires_at,omitempty"`
+	ValidFrom  string  `json:"valid_from"`
+	ValidTo    *string `json:"valid_to,omitempty"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
+	Reason     string  `json:"reason"`
 }
 
 // memoryDetailsOutput is the JSON shape of a durable memory with refs.

--- a/presentation/cli/testdata/top/snapshot_empty_json.golden.json
+++ b/presentation/cli/testdata/top/snapshot_empty_json.golden.json
@@ -5,5 +5,9 @@
   "candidates": {
     "count": 0,
     "items": []
+  },
+  "stale_memories": {
+    "count": 0,
+    "items": []
   }
 }

--- a/presentation/cli/testdata/top/snapshot_json.golden.json
+++ b/presentation/cli/testdata/top/snapshot_json.golden.json
@@ -87,5 +87,24 @@
         "updated_at": "2026-04-10T12:00:00Z"
       }
     ]
+  },
+  "stale_memories": {
+    "count": 3,
+    "items": [
+      {
+        "memory_id": "mem-stale-1",
+        "type": "decision",
+        "scope_kind": "workspace",
+        "scope_value": "duck8823/traceary",
+        "fact": "superseded rollout note",
+        "status": "superseded",
+        "confidence": "high",
+        "source": "manual",
+        "valid_from": "2026-04-10T12:00:00Z",
+        "created_at": "2026-04-10T12:00:00Z",
+        "updated_at": "2026-04-10T12:01:00Z",
+        "reason": "superseded"
+      }
+    ]
   }
 }

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -103,15 +103,15 @@ func (c *RootCLI) runTop(ctx context.Context, output io.Writer, opts topCommandO
 	return c.runTopTUI(ctx, output, opts)
 }
 
-// loadTopSnapshot fetches every data slice the redesigned snapshot
-// surfaces — active session tree, recent failures, recent commands,
-// and candidate durable memories — using the same per-pane caps the
-// live dashboard applies. The session pane reuses the operator-controlled
-// --limit flag; the secondary panes intentionally use the small dashboard
-// caps so the script-friendly snapshot does not balloon under a noisy
-// workspace.
+// loadTopSnapshot fetches the data slices the redesigned snapshot surfaces
+// using the same per-pane caps the live dashboard applies. The session pane
+// reuses the operator-controlled --limit flag; the secondary panes
+// intentionally use the small dashboard caps so the script-friendly snapshot
+// does not balloon under a noisy workspace. The stale-memory pane is enabled
+// for the JSON snapshot contract in #959 and remains disabled for text/TUI
+// paths until #960 renders it.
 func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (topDataSnapshot, error) {
-	return c.newTopDataLoader().loadSnapshot(ctx, topDataCriteria{
+	criteria := topDataCriteria{
 		Workspace:          opts.workspace,
 		Client:             opts.client,
 		Agent:              opts.agent,
@@ -119,7 +119,11 @@ func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (
 		FailureLimit:       topPaneFailureLimit,
 		RecentCommandLimit: topPaneRecentCommandLimit,
 		CandidateLimit:     topPaneCandidateLimit,
-	})
+	}
+	if opts.asJSON {
+		criteria.StaleMemoryLimit = topPaneStaleMemoryLimit
+	}
+	return c.newTopDataLoader().loadSnapshot(ctx, criteria)
 }
 
 // newTopDataLoader builds a topDataLoader bound to the RootCLI's

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -19,14 +19,15 @@ import (
 // idle dimming and "refresh=1s" advertised in the header line match.
 const topDashboardRefreshInterval = time.Second
 
-// topPaneFailureLimit / topPaneRecentCommandLimit / topPaneCandidateLimit
-// cap the per-pane rows the loader fetches. The session pane re-uses the
-// operator-controlled --limit flag (default 500); the secondary panes are
-// summary surfaces that only need a short window.
+// topPaneFailureLimit / topPaneRecentCommandLimit / topPaneCandidateLimit /
+// topPaneStaleMemoryLimit cap the per-pane rows the loader fetches. The
+// session pane re-uses the operator-controlled --limit flag (default 500);
+// the secondary panes are summary surfaces that only need a short window.
 const (
 	topPaneFailureLimit       = 50
 	topPaneRecentCommandLimit = 50
 	topPaneCandidateLimit     = 25
+	topPaneStaleMemoryLimit   = topPaneCandidateLimit
 )
 
 // topPane enumerates the focusable panes on the dashboard.

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -21,8 +21,8 @@ import (
 // Limit fields use the convention that a non-positive value disables the
 // corresponding load: callers wire the `traceary top` session limit on
 // the command surface today and leave the failures / recent-commands /
-// candidates limits at zero so the loader stays a no-op for those panes
-// until the multi-pane redesign (#928) needs them.
+// candidates / stale-memory limits at zero so the loader stays a no-op
+// for those panes until the multi-pane redesign (#928) needs them.
 type topDataCriteria struct {
 	Workspace string
 	Client    string
@@ -32,6 +32,7 @@ type topDataCriteria struct {
 	FailureLimit       int
 	RecentCommandLimit int
 	CandidateLimit     int
+	StaleMemoryLimit   int
 }
 
 // topDataSnapshot bundles every data slice the redesigned top dashboard
@@ -42,14 +43,15 @@ type topDataSnapshot struct {
 	Failures       []*model.Event
 	RecentCommands []*model.Event
 	Candidates     []apptypes.MemorySummary
+	StaleMemories  apptypes.StaleMemoryListResult
 }
 
 // topDataLoader fetches every data slice the redesigned `traceary top`
 // dashboard needs (active session tree, recent failures, recent
-// commands, and candidate memories). It is the testable seam between
-// the cobra command and the application layer; the cobra command keeps
-// its current snapshot output in this issue and routes its session
-// fetch through the loader so future panes can be added without
+// commands, candidate memories, and stale memories). It is the testable
+// seam between the cobra command and the application layer; the cobra
+// command keeps its current snapshot output in this issue and routes its
+// session fetch through the loader so future panes can be added without
 // re-wiring the command (#928 / #929).
 type topDataLoader struct {
 	session usecase.SessionUsecase
@@ -200,7 +202,29 @@ func (l *topDataLoader) loadCandidates(ctx context.Context, c topDataCriteria) (
 	return summaries, nil
 }
 
-// loadSnapshot fetches the four data slices in a single call. Each
+// loadStaleMemories returns stale durable memories for the future stale pane.
+// Workspace and Agent narrow the result to memory scopes, mirroring the
+// candidate pane; Client has no memory scope equivalent and is intentionally
+// ignored. A non-positive StaleMemoryLimit disables the load.
+func (l *topDataLoader) loadStaleMemories(ctx context.Context, c topDataCriteria) (apptypes.StaleMemoryListResult, error) {
+	if l.memory == nil || c.StaleMemoryLimit <= 0 {
+		return apptypes.StaleMemoryListResult{}, nil
+	}
+	builder := apptypes.NewStaleMemoryListCriteriaBuilder(c.StaleMemoryLimit)
+	if workspace := strings.TrimSpace(c.Workspace); workspace != "" {
+		builder = builder.Scope(domtypes.WorkspaceScopeOf(domtypes.Workspace(workspace)))
+	}
+	if agent := strings.TrimSpace(c.Agent); agent != "" {
+		builder = builder.Scope(domtypes.AgentScopeOf(domtypes.Agent(agent)))
+	}
+	result, err := l.memory.ListStale(ctx, builder.Build())
+	if err != nil {
+		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("%s: %w", Localize("failed to list stale memories", "stale memory の取得に失敗しました"), err)
+	}
+	return result, nil
+}
+
+// loadSnapshot fetches the five data slices in a single call. Each
 // pane is opt-in via its limit field on topDataCriteria, so the
 // current `traceary top` (sessions only) and the upcoming multi-pane
 // dashboard share one entry point.
@@ -221,10 +245,15 @@ func (l *topDataLoader) loadSnapshot(ctx context.Context, c topDataCriteria) (to
 	if err != nil {
 		return topDataSnapshot{}, err
 	}
+	staleMemories, err := l.loadStaleMemories(ctx, c)
+	if err != nil {
+		return topDataSnapshot{}, err
+	}
 	return topDataSnapshot{
 		Sessions:       sessions,
 		Failures:       failures,
 		RecentCommands: commands,
 		Candidates:     candidates,
+		StaleMemories:  staleMemories,
 	}, nil
 }

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -69,16 +69,26 @@ func (s *topDataEventStub) List(_ context.Context, criteria apptypes.EventListCr
 type topDataMemoryStub struct {
 	usecase.MemoryUsecase
 
-	listResult   []apptypes.MemorySummary
-	listErr      error
-	listCriteria apptypes.MemoryListCriteria
-	listCalls    int
+	listResult          []apptypes.MemorySummary
+	listErr             error
+	listCriteria        apptypes.MemoryListCriteria
+	listCalls           int
+	staleResult         apptypes.StaleMemoryListResult
+	staleErr            error
+	staleMemoryCriteria apptypes.StaleMemoryListCriteria
+	staleMemoryCalls    int
 }
 
 func (s *topDataMemoryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
 	s.listCalls++
 	return s.listResult, s.listErr
+}
+
+func (s *topDataMemoryStub) ListStale(_ context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
+	s.staleMemoryCriteria = criteria
+	s.staleMemoryCalls++
+	return s.staleResult, s.staleErr
 }
 
 // fixedStartedAt is the deterministic anchor every fixture in this file
@@ -427,6 +437,77 @@ func TestTopDataLoader_LoadCandidates_ClientDoesNotAddScope(t *testing.T) {
 	}
 }
 
+func TestTopDataLoader_LoadStaleMemories_ForwardsScopesAndLimit(t *testing.T) {
+	t.Parallel()
+
+	staleSummary := memorySummaryFixture(t, "mem-stale", domtypes.MemoryStatusSuperseded, "stale fixture")
+	staleRow, err := apptypes.StaleMemoryRowOf(staleSummary, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	staleResult, err := apptypes.StaleMemoryListResultOf(7, []apptypes.StaleMemoryRow{staleRow})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
+	memory := &topDataMemoryStub{staleResult: staleResult}
+	loader := newTopDataLoader(nil, nil, memory)
+
+	got, err := loader.loadStaleMemories(context.Background(), topDataCriteria{
+		Workspace:        "  duck8823/traceary  ",
+		Client:           "claude",
+		Agent:            "  codex  ",
+		StaleMemoryLimit: 4,
+	})
+	if err != nil {
+		t.Fatalf("loadStaleMemories() error = %v", err)
+	}
+	if got.Count() != 7 {
+		t.Fatalf("loadStaleMemories().Count = %d, want 7", got.Count())
+	}
+	if items := got.Items(); len(items) != 1 || items[0].Summary().MemoryID().String() != "mem-stale" {
+		t.Fatalf("loadStaleMemories().Items = %#v, want one mem-stale", items)
+	}
+	if got, want := memory.staleMemoryCriteria.Limit(), 4; got != want {
+		t.Fatalf("ListStale criteria Limit = %d, want %d", got, want)
+	}
+	scopes := memory.staleMemoryCriteria.Scopes()
+	if len(scopes) != 2 {
+		t.Fatalf("ListStale criteria Scopes length = %d, want 2 (workspace + agent)", len(scopes))
+	}
+	workspaceScope, ok := scopes[0].(domtypes.WorkspaceScope)
+	if !ok {
+		t.Fatalf("scopes[0] = %T, want WorkspaceScope", scopes[0])
+	}
+	if got, want := workspaceScope.Workspace().String(), "duck8823/traceary"; got != want {
+		t.Fatalf("scopes[0].Workspace = %q, want %q", got, want)
+	}
+	agentScope, ok := scopes[1].(domtypes.AgentScope)
+	if !ok {
+		t.Fatalf("scopes[1] = %T, want AgentScope", scopes[1])
+	}
+	if got, want := agentScope.Agent().String(), "codex"; got != want {
+		t.Fatalf("scopes[1].Agent = %q, want %q", got, want)
+	}
+}
+
+func TestTopDataLoader_LoadStaleMemories_ZeroLimitIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	memory := &topDataMemoryStub{}
+	loader := newTopDataLoader(nil, nil, memory)
+
+	got, err := loader.loadStaleMemories(context.Background(), topDataCriteria{StaleMemoryLimit: 0})
+	if err != nil {
+		t.Fatalf("loadStaleMemories() error = %v", err)
+	}
+	if got.Count() != 0 || len(got.Items()) != 0 {
+		t.Fatalf("loadStaleMemories() = %#v, want empty result when StaleMemoryLimit <= 0", got)
+	}
+	if memory.staleMemoryCalls != 0 {
+		t.Fatalf("memory.ListStale calls = %d, want 0", memory.staleMemoryCalls)
+	}
+}
+
 func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 	t.Parallel()
 
@@ -455,6 +536,15 @@ func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)
 	}
+	staleSummary := memorySummaryFixture(t, "mem-stale", domtypes.MemoryStatusSuperseded, "stale snapshot fixture")
+	staleRow, err := apptypes.StaleMemoryRowOf(staleSummary, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	staleResult, err := apptypes.StaleMemoryListResultOf(3, []apptypes.StaleMemoryRow{staleRow})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
 
 	session := &topDataSessionStub{
 		listResult: []apptypes.SessionSummary{root},
@@ -462,7 +552,7 @@ func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 			domtypes.SessionID("root"): {root},
 		},
 	}
-	memory := &topDataMemoryStub{listResult: []apptypes.MemorySummary{candidate}}
+	memory := &topDataMemoryStub{listResult: []apptypes.MemorySummary{candidate}, staleResult: staleResult}
 	// snapshotEventStub differentiates the two EventUsecase.List calls
 	// loadSnapshot makes (failures vs recent commands) by inspecting
 	// the FailuresOnly / Kind criteria, so each pane sees a distinct
@@ -475,6 +565,7 @@ func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 		FailureLimit:       3,
 		RecentCommandLimit: 3,
 		CandidateLimit:     2,
+		StaleMemoryLimit:   2,
 	})
 	if err != nil {
 		t.Fatalf("loadSnapshot() error = %v", err)
@@ -490,6 +581,12 @@ func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 	}
 	if len(snap.Candidates) != 1 || snap.Candidates[0].MemoryID().String() != "mem-1" {
 		t.Fatalf("snap.Candidates = %#v, want one mem-1", snap.Candidates)
+	}
+	if snap.StaleMemories.Count() != 3 {
+		t.Fatalf("snap.StaleMemories.Count = %d, want 3", snap.StaleMemories.Count())
+	}
+	if items := snap.StaleMemories.Items(); len(items) != 1 || items[0].Summary().MemoryID().String() != "mem-stale" {
+		t.Fatalf("snap.StaleMemories.Items = %#v, want one mem-stale", items)
 	}
 }
 
@@ -522,13 +619,41 @@ func TestTopDataLoader_LoadSnapshot_NoUsecasesReturnsEmpty(t *testing.T) {
 		FailureLimit:       10,
 		RecentCommandLimit: 10,
 		CandidateLimit:     10,
+		StaleMemoryLimit:   10,
 	})
 	if err != nil {
 		t.Fatalf("loadSnapshot() error = %v", err)
 	}
-	if snap.Sessions != nil || snap.Failures != nil || snap.RecentCommands != nil || snap.Candidates != nil {
+	if snap.Sessions != nil || snap.Failures != nil || snap.RecentCommands != nil || snap.Candidates != nil || snap.StaleMemories.Count() != 0 || len(snap.StaleMemories.Items()) != 0 {
 		t.Fatalf("loadSnapshot() = %#v, want zero-value snapshot when no usecases are wired", snap)
 	}
+}
+
+func memorySummaryFixture(t *testing.T, id string, status domtypes.MemoryStatus, fact string) apptypes.MemorySummary {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypePreference,
+		domtypes.WorkspaceScopeOf(workspace),
+		fact,
+		status,
+		domtypes.ConfidenceMedium,
+		domtypes.MemorySourceManual,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		fixedStartedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	return summary
 }
 
 func mustEvent(t *testing.T, id string, kind domtypes.EventKind, body string) *model.Event {

--- a/presentation/cli/top_json.go
+++ b/presentation/cli/top_json.go
@@ -7,9 +7,9 @@ import (
 // writeTopSnapshotJSON renders the top dashboard snapshot as the
 // envelope-wrapped JSON contract added in v0.14.0. The active session
 // tree continues to live under `sessions` with its existing field
-// shape; `failures`, `recent_commands`, and `candidates` mirror the
-// new dashboard panes so a script that consumes the snapshot has the
-// same data the live dashboard renders.
+// shape; `failures`, `recent_commands`, `candidates`, and `stale_memories`
+// mirror the new dashboard panes so a script that consumes the snapshot has
+// the same data the live dashboard renders.
 func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 	sessions := make([]*topSnapshotNode, 0, len(snap.Sessions))
 	for _, root := range snap.Sessions {
@@ -31,6 +31,11 @@ func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 		candidateItems = append(candidateItems, newMemorySummaryOutput(candidate))
 	}
 
+	staleItems := make([]staleMemoryOutput, 0, len(snap.StaleMemories.Items()))
+	for _, stale := range snap.StaleMemories.Items() {
+		staleItems = append(staleItems, newStaleMemoryOutput(stale))
+	}
+
 	payload := topSnapshotPayload{
 		Sessions:       sessions,
 		Failures:       failures,
@@ -38,6 +43,10 @@ func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 		Candidates: topSnapshotCandidates{
 			Count: len(candidateItems),
 			Items: candidateItems,
+		},
+		StaleMemories: topSnapshotStale{
+			Count: snap.StaleMemories.Count(),
+			Items: staleItems,
 		},
 	}
 	return writeJSON(output, payload)

--- a/presentation/cli/top_test.go
+++ b/presentation/cli/top_test.go
@@ -137,7 +137,36 @@ func TestRootCLI_TopCommand_SnapshotJSONGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)
 	}
-	memoryStub := &memoryUsecaseStub{listResult: []apptypes.MemorySummary{candidate}}
+	staleMemory, err := apptypes.MemorySummaryOf(
+		types.MemoryID("mem-stale-1"),
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("duck8823/traceary")),
+		"superseded rollout note",
+		types.MemoryStatusSuperseded,
+		types.ConfidenceHigh,
+		types.MemorySourceManual,
+		types.None[types.MemoryID](),
+		types.None[time.Time](),
+		startedAt,
+		types.None[time.Time](),
+		startedAt,
+		startedAt.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf(stale): %v", err)
+	}
+	staleRow, err := apptypes.StaleMemoryRowOf(staleMemory, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	staleResult, err := apptypes.StaleMemoryListResultOf(3, []apptypes.StaleMemoryRow{staleRow})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
+	memoryStub := &memoryUsecaseStub{
+		listResult:  []apptypes.MemorySummary{candidate},
+		staleResult: staleResult,
+	}
 
 	stdout := &bytes.Buffer{}
 	rootCmd := cli.NewRootCLI(
@@ -177,6 +206,12 @@ func TestRootCLI_TopCommand_SnapshotJSONGolden(t *testing.T) {
 	}
 	if got, want := stub.listCriteria.Agent().String(), "claude/explore"; got != want {
 		t.Fatalf("agent criteria = %q, want %q", got, want)
+	}
+	if got, want := memoryStub.staleCriteria.Limit(), 25; got != want {
+		t.Fatalf("stale memory limit criteria = %d, want %d", got, want)
+	}
+	if got, want := memoryStub.staleCalls, 1; got != want {
+		t.Fatalf("ListStale calls = %d, want %d for JSON snapshot", got, want)
 	}
 
 	assertJSONGolden(t, stdout.Bytes(), filepath.Join("testdata", "top", "snapshot_json.golden.json"))
@@ -323,6 +358,9 @@ func TestRootCLI_TopCommand_SnapshotTextGolden(t *testing.T) {
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+	if memoryStub.staleCalls != 0 {
+		t.Fatalf("ListStale calls = %d, want 0 for text snapshot until stale pane is rendered", memoryStub.staleCalls)
 	}
 
 	assertGolden(t, stdout.Bytes(), filepath.Join("testdata", "top", "snapshot_text.golden"))

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -288,6 +288,8 @@ func (s *bundleUsecaseStub) Import(_ context.Context, _ usecase.BundleImportOpti
 type memoryUsecaseStub struct {
 	listResult          []apptypes.MemorySummary
 	listErr             error
+	staleResult         apptypes.StaleMemoryListResult
+	staleErr            error
 	searchResult        []apptypes.MemorySummary
 	searchErr           error
 	showDetails         apptypes.MemoryDetails
@@ -337,6 +339,8 @@ type memoryUsecaseStub struct {
 		artifactRefs []types.ArtifactRef
 	}
 	listCriteria   apptypes.MemoryListCriteria
+	staleCriteria  apptypes.StaleMemoryListCriteria
+	staleCalls     int
 	searchCriteria apptypes.MemorySearchCriteria
 	showMemoryID   types.MemoryID
 	acceptCall     struct {
@@ -427,6 +431,12 @@ func (s *memoryUsecaseStub) SetValidity(_ context.Context, memoryID types.Memory
 func (s *memoryUsecaseStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
 	return s.listResult, s.listErr
+}
+
+func (s *memoryUsecaseStub) ListStale(_ context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
+	s.staleCriteria = criteria
+	s.staleCalls++
+	return s.staleResult, s.staleErr
 }
 
 func (s *memoryUsecaseStub) Search(_ context.Context, criteria apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {


### PR DESCRIPTION
## Motivation

v0.15 adds operator hygiene visibility to `traceary top`. This PR provides the data-source and snapshot JSON contract for the upcoming stale-memory pane without changing the live dashboard rendering yet.

Closes #959

## Changes

- Add read-side stale-memory criteria/row/result types and a SQLite-backed `ListStale` query.
- Surface expired, superseded, and deterministic overlap stale-memory reasons with total count separate from capped items.
- Wire `topDataLoader.loadStaleMemories` into `loadSnapshot` and `traceary top --snapshot --json` as additive `stale_memories: { count, items }`.
- Update snapshot JSON golden files and add deterministic application / SQLite / loader tests.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go build ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache GOTMPDIR=/private/tmp go tool golangci-lint run`
- `git diff --check`

## Review notes

- Claude Code Opus 4.7 was invoked for implementation delegation but the CLI produced no output and hung on both the issue prompt and a minimal prompt; Codex completed the implementation as the fallback worker/orchestrator.