### PR TITLE
feat(cli): add stale memory top pane

### DIFF
--- a/presentation/cli/testdata/top/snapshot_text.golden
+++ b/presentation/cli/testdata/top/snapshot_text.golden
@@ -12,3 +12,6 @@ RECENT COMMANDS:
 
 CANDIDATE MEMORIES (count=1):
 mem-1 preference prefer table-driven subtests
+
+STALE MEMORIES (count=3):
+mem-stale-1 decision workspace:duck8823/traceary superseded superseded rollout note

--- a/presentation/cli/testdata/top/snapshot_text_empty.golden
+++ b/presentation/cli/testdata/top/snapshot_text_empty.golden
@@ -9,3 +9,6 @@ No matching records.
 
 CANDIDATE MEMORIES (count=0):
 No candidate durable memories in the inbox.
+
+STALE MEMORIES (count=0):
+No stale memories.

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -107,9 +107,7 @@ func (c *RootCLI) runTop(ctx context.Context, output io.Writer, opts topCommandO
 // using the same per-pane caps the live dashboard applies. The session pane
 // reuses the operator-controlled --limit flag; the secondary panes
 // intentionally use the small dashboard caps so the script-friendly snapshot
-// does not balloon under a noisy workspace. The stale-memory pane is enabled
-// for the JSON snapshot contract in #959 and remains disabled for text/TUI
-// paths until #960 renders it.
+// does not balloon under a noisy workspace.
 func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (topDataSnapshot, error) {
 	criteria := topDataCriteria{
 		Workspace:          opts.workspace,
@@ -119,9 +117,7 @@ func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (
 		FailureLimit:       topPaneFailureLimit,
 		RecentCommandLimit: topPaneRecentCommandLimit,
 		CandidateLimit:     topPaneCandidateLimit,
-	}
-	if opts.asJSON {
-		criteria.StaleMemoryLimit = topPaneStaleMemoryLimit
+		StaleMemoryLimit:   topPaneStaleMemoryLimit,
 	}
 	return c.newTopDataLoader().loadSnapshot(ctx, criteria)
 }
@@ -214,7 +210,10 @@ func writeTopSnapshotText(output io.Writer, snap topDataSnapshot, idle time.Dura
 	if err := writeTopSnapshotTextEvents(output, "RECENT COMMANDS", snap.RecentCommands, now.Location()); err != nil {
 		return err
 	}
-	return writeTopSnapshotTextCandidates(output, snap.Candidates)
+	if err := writeTopSnapshotTextCandidates(output, snap.Candidates); err != nil {
+		return err
+	}
+	return writeTopSnapshotTextStaleMemories(output, snap.StaleMemories)
 }
 
 func writeTopSnapshotTextSessions(output io.Writer, roots []*sessionNode, idle time.Duration, now time.Time) error {
@@ -267,6 +266,34 @@ func writeTopSnapshotTextCandidates(output io.Writer, candidates []apptypes.Memo
 	for _, candidate := range candidates {
 		if _, err := fmt.Fprintf(output, "%s %s %s\n", candidate.MemoryID(), candidate.MemoryType(), truncateMessage(candidate.Fact())); err != nil {
 			return xerrors.Errorf("failed to print candidate row: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeTopSnapshotTextStaleMemories(output io.Writer, stale apptypes.StaleMemoryListResult) error {
+	if _, err := fmt.Fprintf(output, "\nSTALE MEMORIES (count=%d):\n", stale.Count()); err != nil {
+		return xerrors.Errorf("failed to print stale memories header: %w", err)
+	}
+	items := stale.Items()
+	if len(items) == 0 {
+		if _, err := fmt.Fprintln(output, Localize("No stale memories.", "stale な memory はありません。")); err != nil {
+			return xerrors.Errorf("failed to print empty stale memories message: %w", err)
+		}
+		return nil
+	}
+	for _, row := range items {
+		summary := row.Summary()
+		if _, err := fmt.Fprintf(
+			output,
+			"%s %s %s %s %s\n",
+			summary.MemoryID(),
+			summary.MemoryType(),
+			formatMemoryScope(summary.Scope()),
+			row.Reason(),
+			truncateMessage(summary.Fact()),
+		); err != nil {
+			return xerrors.Errorf("failed to print stale memory row: %w", err)
 		}
 	}
 	return nil
@@ -406,6 +433,7 @@ func (c *RootCLI) runTopTUI(ctx context.Context, output io.Writer, opts topComma
 		FailureLimit:       topPaneFailureLimit,
 		RecentCommandLimit: topPaneRecentCommandLimit,
 		CandidateLimit:     topPaneCandidateLimit,
+		StaleMemoryLimit:   topPaneStaleMemoryLimit,
 	}
 	model := newTopModel(topModelConfig{
 		Keys:            tui.DefaultKeyMap(),

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -42,9 +42,10 @@ const (
 	topPaneFailures
 	topPaneRecentCommands
 	topPaneCandidates
+	topPaneStaleMemories
 )
 
-const topPaneCount = 4
+const topPaneCount = 5
 
 // topMode encodes the sub-screen the model is showing. Browse is the
 // dashboard itself; Help is the overlay rendered when the operator presses
@@ -383,6 +384,8 @@ func (m topModel) paneLines(pane topPane, width int) []string {
 		return m.eventLines(m.snapshot.RecentCommands, width)
 	case topPaneCandidates:
 		return m.candidateLines(width)
+	case topPaneStaleMemories:
+		return m.staleMemoryLines(width)
 	}
 	return nil
 }
@@ -481,6 +484,37 @@ func (m topModel) candidateLines(width int) []string {
 	return out
 }
 
+// staleMemoryLines renders one row per stale durable memory. The row keeps
+// the audit identifiers first (memory id, type, scope, reason) and then the
+// human-readable fact so operators can quickly decide whether the stale row
+// should be pruned or investigated from the dedicated memory commands.
+func (m topModel) staleMemoryLines(width int) []string {
+	if m.loadErr != nil {
+		return []string{m.styles.Error.Render(m.loadErr.Error())}
+	}
+	if !m.loaded {
+		return []string{m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}
+	}
+	items := m.snapshot.StaleMemories.Items()
+	if len(items) == 0 {
+		return []string{m.styles.Subtle.Render(Localize("No stale memories.", "stale な memory はありません。"))}
+	}
+	out := make([]string, 0, len(items))
+	for _, row := range items {
+		summary := row.Summary()
+		line := fmt.Sprintf(
+			"%s %s %s %s %s",
+			summary.MemoryID(),
+			summary.MemoryType(),
+			formatMemoryScope(summary.Scope()),
+			row.Reason(),
+			truncateMessage(summary.Fact()),
+		)
+		out = append(out, truncateToWidth(line, width))
+	}
+	return out
+}
+
 // truncateToWidth clamps text to width visual columns by walking runes
 // and counting East Asian Wide characters as 2 columns. Width <= 0 falls
 // back to the original string so a degenerate viewport still shows
@@ -570,6 +604,7 @@ func (m topModel) renderHelp() string {
 	b.WriteString("  2 failures       " + Localize("recent failed command_executed events", "最新の失敗 command_executed イベント") + "\n")
 	b.WriteString("  3 commands       " + Localize("recent command_executed events", "最新の command_executed イベント") + "\n")
 	b.WriteString("  4 candidates     " + Localize("durable-memory inbox candidates", "durable memory inbox の候補") + "\n")
+	b.WriteString("  5 stale memories " + Localize("stale durable memories needing cleanup", "整理対象の stale durable memory") + "\n")
 	b.WriteString("\n")
 	b.WriteString(Localize("Navigation:\n", "操作:\n"))
 	b.WriteString("  tab / shift+tab  " + Localize("focus next / previous pane", "次 / 前のペインへフォーカス") + "\n")
@@ -612,6 +647,9 @@ func (m topModel) renderPane(pane topPane) string {
 
 func (m topModel) renderPaneHeader(pane topPane, total int) string {
 	label := paneLabel(pane)
+	if pane == topPaneStaleMemories {
+		label = fmt.Sprintf("STALE MEMORIES (count=%d)", m.snapshot.StaleMemories.Count())
+	}
 	scroll := ""
 	viewport := m.paneViewportRows()
 	if total > viewport {
@@ -638,7 +676,7 @@ func (m topModel) paneInteriorWidth() int {
 }
 
 // paneInteriorHeight returns the rows allocated to one pane's body. The
-// dashboard distributes the available terminal height between the four
+// dashboard distributes the available terminal height between the configured
 // panes after subtracting the title (2 rows), per-pane header (1 row each),
 // and footer (2 rows). The minimum is clamped to 1 so navigation stays
 // well-defined on a tiny terminal.
@@ -667,6 +705,8 @@ func paneLabel(pane topPane) string {
 		return Localize("recent commands", "recent commands")
 	case topPaneCandidates:
 		return Localize("candidates", "candidates")
+	case topPaneStaleMemories:
+		return Localize("stale memories", "stale memories")
 	}
 	return ""
 }

--- a/presentation/cli/top_dashboard_internal_test.go
+++ b/presentation/cli/top_dashboard_internal_test.go
@@ -110,6 +110,53 @@ func dashboardCandidate(t *testing.T, id string, fact string) apptypes.MemorySum
 	return summary
 }
 
+func dashboardStaleMemory(t *testing.T, id string, reason apptypes.StaleMemoryReason, fact string) apptypes.StaleMemoryRow {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	status := domtypes.MemoryStatusAccepted
+	switch reason {
+	case apptypes.StaleMemoryReasonExpired:
+		status = domtypes.MemoryStatusExpired
+	case apptypes.StaleMemoryReasonSuperseded:
+		status = domtypes.MemoryStatusSuperseded
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(workspace),
+		fact,
+		status,
+		domtypes.ConfidenceHigh,
+		domtypes.MemorySourceManual,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		fixedDashboardNow,
+		domtypes.None[time.Time](),
+		fixedDashboardNow,
+		fixedDashboardNow,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf(stale): %v", err)
+	}
+	row, err := apptypes.StaleMemoryRowOf(summary, reason)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	return row
+}
+
+func dashboardStaleResult(t *testing.T, count int, rows ...apptypes.StaleMemoryRow) apptypes.StaleMemoryListResult {
+	t.Helper()
+	result, err := apptypes.StaleMemoryListResultOf(count, rows)
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
+	return result
+}
+
 // applySnapshot is a test-only helper that drives the model through the
 // same path the production tea.Cmd takes: it calls the loader (synchronously
 // here) and feeds the resulting topSnapshotMsg back into Update.
@@ -216,6 +263,7 @@ func TestTopModel_TabCyclesPanesForward(t *testing.T) {
 		topPaneFailures,
 		topPaneRecentCommands,
 		topPaneCandidates,
+		topPaneStaleMemories,
 		topPaneSessions,
 	}
 	for i, expect := range want {
@@ -231,6 +279,7 @@ func TestTopModel_ShiftTabCyclesPanesBackward(t *testing.T) {
 	m := newDashboardTestModel(t, &stubTopLoader{})
 
 	want := []topPane{
+		topPaneStaleMemories,
 		topPaneCandidates,
 		topPaneRecentCommands,
 		topPaneFailures,
@@ -370,6 +419,7 @@ func TestTopModel_EmptySnapshotRendersPerPaneEmptyState(t *testing.T) {
 		"No active sessions found.",
 		"No matching records.",
 		"No candidate durable memories",
+		"No stale memories.",
 	} {
 		if !strings.Contains(view, expect) {
 			t.Fatalf("View() missing empty-state %q. Full view:\n%s", expect, view)
@@ -460,6 +510,48 @@ func TestTopModel_CandidateLinesRendersFactAndID(t *testing.T) {
 	}
 	if !strings.Contains(lines[0], "mem-1") || !strings.Contains(lines[0], "prefer table-driven subtests") {
 		t.Fatalf("candidateLines[0] = %q, want to contain id+fact", lines[0])
+	}
+}
+
+func TestTopModel_StaleMemoryLinesRendersReasonScopeAndFact(t *testing.T) {
+	t.Parallel()
+	stale := dashboardStaleMemory(t, "mem-stale-1", apptypes.StaleMemoryReasonSuperseded, "old rollout decision")
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{
+		StaleMemories: dashboardStaleResult(t, 3, stale),
+	}})
+	m = applySnapshot(t, m)
+
+	lines := m.staleMemoryLines(160)
+	if len(lines) != 1 {
+		t.Fatalf("staleMemoryLines = %d, want 1", len(lines))
+	}
+	for _, expect := range []string{"mem-stale-1", "decision", "workspace:duck8823/traceary", "superseded", "old rollout decision"} {
+		if !strings.Contains(lines[0], expect) {
+			t.Fatalf("staleMemoryLines[0] = %q, want to contain %q", lines[0], expect)
+		}
+	}
+}
+
+func TestTopModel_StaleMemoryPaneRendersHeaderCountAndRows(t *testing.T) {
+	t.Parallel()
+	stale := dashboardStaleMemory(t, "mem-stale-1", apptypes.StaleMemoryReasonExpired, "expired cleanup target")
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{
+		StaleMemories: dashboardStaleResult(t, 2, stale),
+	}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	for range 4 {
+		m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})
+	}
+	if m.pane != topPaneStaleMemories {
+		t.Fatalf("pane = %v, want stale memories", m.pane)
+	}
+
+	view := m.View()
+	for _, expect := range []string{"STALE MEMORIES (count=2)", "mem-stale-1", "expired cleanup target"} {
+		if !strings.Contains(view, expect) {
+			t.Fatalf("View() missing %q. Full view:\n%s", expect, view)
+		}
 	}
 }
 

--- a/presentation/cli/top_test.go
+++ b/presentation/cli/top_test.go
@@ -339,7 +339,36 @@ func TestRootCLI_TopCommand_SnapshotTextGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)
 	}
-	memoryStub := &memoryUsecaseStub{listResult: []apptypes.MemorySummary{candidate}}
+	staleMemory, err := apptypes.MemorySummaryOf(
+		types.MemoryID("mem-stale-1"),
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("duck8823/traceary")),
+		"superseded rollout note",
+		types.MemoryStatusSuperseded,
+		types.ConfidenceHigh,
+		types.MemorySourceManual,
+		types.None[types.MemoryID](),
+		types.None[time.Time](),
+		startedAt,
+		types.None[time.Time](),
+		startedAt,
+		startedAt.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf(stale): %v", err)
+	}
+	staleRow, err := apptypes.StaleMemoryRowOf(staleMemory, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	staleResult, err := apptypes.StaleMemoryListResultOf(3, []apptypes.StaleMemoryRow{staleRow})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
+	memoryStub := &memoryUsecaseStub{
+		listResult:  []apptypes.MemorySummary{candidate},
+		staleResult: staleResult,
+	}
 
 	stdout := &bytes.Buffer{}
 	rootCmd := cli.NewRootCLI(
@@ -359,17 +388,21 @@ func TestRootCLI_TopCommand_SnapshotTextGolden(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if memoryStub.staleCalls != 0 {
-		t.Fatalf("ListStale calls = %d, want 0 for text snapshot until stale pane is rendered", memoryStub.staleCalls)
+	if got, want := memoryStub.staleCriteria.Limit(), 25; got != want {
+		t.Fatalf("stale memory limit criteria = %d, want %d", got, want)
+	}
+	if got, want := memoryStub.staleCalls, 1; got != want {
+		t.Fatalf("ListStale calls = %d, want %d for text snapshot", got, want)
 	}
 
 	assertGolden(t, stdout.Bytes(), filepath.Join("testdata", "top", "snapshot_text.golden"))
 }
 
 // TestRootCLI_TopCommand_SnapshotEmptyTextGolden covers the empty-state
-// path where no active sessions, failures, recent commands, or candidate
-// memories are available. Each new section keeps its header and prints
-// a localized empty-state line so script consumers get a stable shape.
+// path where no active sessions, failures, recent commands, candidate
+// memories, or stale memories are available. Each new section keeps its
+// header and prints a localized empty-state line so script consumers get
+// a stable shape.
 func TestRootCLI_TopCommand_SnapshotEmptyTextGolden(t *testing.T) {
 	prevLocal := time.Local
 	time.Local = time.UTC


### PR DESCRIPTION
## Motivation

v0.15 adds stale-memory detection to the top snapshot data. The live `traceary top` dashboard and non-TTY snapshot text output should now expose the same stale-memory cleanup signal so operators can see stale rows without switching to JSON.

Closes #960

## Changes

- Adds a fifth `STALE MEMORIES (count=N)` pane to the Bubble Tea top dashboard.
- Wires stale-memory loading into live TUI criteria and text snapshot criteria.
- Adds text snapshot stale-memory output with stable empty-state handling.
- Extends dashboard focus cycle, help text, pane tests, and snapshot goldens.

## Delegation notes

- Attempted to delegate implementation to Claude Code Opus 4.7 (`effort=auto`) via the local Claude CLI, but the CLI produced no output and had to be interrupted. Codex completed the implementation fallback to keep the autonomous flow moving.

## Validation

- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./presentation/cli -run 'TestTopModel_|TestRootCLI_TopCommand_Snapshot(TextGolden|EmptyTextGolden|JSONGolden|EmptyJSONGolden)$'`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go build ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache GOTMPDIR=/private/tmp go tool golangci-lint run`
- `rtk git diff --check`