### PR TITLE
feat(cli): add top pane search

### DIFF
--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -116,6 +116,9 @@ type topModel struct {
 	pane    topPane
 	offsets [topPaneCount]int
 
+	searchOpen  bool
+	searchQuery string
+
 	snapshot topDataSnapshot
 	loadedAt time.Time
 	loadErr  error
@@ -234,7 +237,14 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.searchOpen {
+		return m.updateSearchKey(msg)
+	}
 	switch {
+	case m.searchQuery != "" && msg.Type == tea.KeyEsc:
+		m.clearSearch()
+		m.clampOffsets()
+		return m, nil
 	case key.Matches(msg, m.keys.Quit):
 		return m, tea.Quit
 	case key.Matches(msg, m.keys.Help):
@@ -252,10 +262,14 @@ func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch {
 	case key.Matches(msg, m.actions.NextPane):
-		m.pane = topPane((int(m.pane) + 1) % topPaneCount)
+		m.switchPane(topPane((int(m.pane) + 1) % topPaneCount))
 		return m, nil
 	case key.Matches(msg, m.actions.PrevPane):
-		m.pane = topPane((int(m.pane) + topPaneCount - 1) % topPaneCount)
+		m.switchPane(topPane((int(m.pane) + topPaneCount - 1) % topPaneCount))
+		return m, nil
+	case key.Matches(msg, m.keys.Search):
+		m.searchOpen = true
+		m.offsets[m.pane] = 0
 		return m, nil
 	case key.Matches(msg, m.keys.Up):
 		m.scrollBy(-1)
@@ -264,17 +278,17 @@ func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.scrollBy(1)
 		return m, nil
 	case key.Matches(msg, m.keys.PageUp):
-		m.scrollBy(-m.paneViewportRows())
+		m.scrollBy(-m.paneContentViewportRows(m.pane))
 		return m, nil
 	case key.Matches(msg, m.keys.PageDown):
-		m.scrollBy(m.paneViewportRows())
+		m.scrollBy(m.paneContentViewportRows(m.pane))
 		return m, nil
 	case key.Matches(msg, m.keys.Home):
 		m.offsets[m.pane] = 0
 		return m, nil
 	case key.Matches(msg, m.keys.End):
 		lines := m.paneLineCount(m.pane)
-		viewport := m.paneViewportRows()
+		viewport := m.paneContentViewportRows(m.pane)
 		if lines > viewport {
 			m.offsets[m.pane] = lines - viewport
 		} else {
@@ -287,6 +301,60 @@ func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m topModel) updateSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case msg.Type == tea.KeyEsc:
+		m.clearSearch()
+		m.clampOffsets()
+		return m, nil
+	case key.Matches(msg, m.keys.Quit):
+		return m, tea.Quit
+	case key.Matches(msg, m.keys.Select):
+		m.searchOpen = false
+		m.clampOffsets()
+		return m, nil
+	case key.Matches(msg, m.actions.NextPane):
+		m.switchPane(topPane((int(m.pane) + 1) % topPaneCount))
+		return m, nil
+	case key.Matches(msg, m.actions.PrevPane):
+		m.switchPane(topPane((int(m.pane) + topPaneCount - 1) % topPaneCount))
+		return m, nil
+	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
+		runes := []rune(m.searchQuery)
+		if len(runes) > 0 {
+			m.searchQuery = string(runes[:len(runes)-1])
+			m.offsets[m.pane] = 0
+		}
+		m.clampOffsets()
+		return m, nil
+	case msg.Type == tea.KeySpace:
+		m.searchQuery += " "
+		m.offsets[m.pane] = 0
+		m.clampOffsets()
+		return m, nil
+	case msg.Type == tea.KeyRunes:
+		m.searchQuery += string(msg.Runes)
+		m.offsets[m.pane] = 0
+		m.clampOffsets()
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *topModel) switchPane(next topPane) {
+	if next == m.pane {
+		return
+	}
+	m.clearSearch()
+	m.pane = next
+	m.clampOffsets()
+}
+
+func (m *topModel) clearSearch() {
+	m.searchOpen = false
+	m.searchQuery = ""
+}
+
 // scrollBy adjusts the focused pane's offset, clamping to the legal range
 // so an over-scroll never wraps and so reaching the bottom of a short pane
 // stops cleanly instead of leaving a blank window.
@@ -296,7 +364,7 @@ func (m *topModel) scrollBy(delta int) {
 		offset = 0
 	}
 	lines := m.paneLineCount(m.pane)
-	viewport := m.paneViewportRows()
+	viewport := m.paneContentViewportRows(m.pane)
 	maxOffset := 0
 	if lines > viewport {
 		maxOffset = lines - viewport
@@ -311,8 +379,9 @@ func (m *topModel) scrollBy(delta int) {
 // so the focused window never points past the end of the available rows.
 func (m *topModel) clampOffsets() {
 	for i := range m.offsets {
-		viewport := m.paneViewportRows()
-		lines := m.paneLineCount(topPane(i))
+		pane := topPane(i)
+		viewport := m.paneContentViewportRows(pane)
+		lines := m.paneLineCount(pane)
 		maxOffset := 0
 		if lines > viewport {
 			maxOffset = lines - viewport
@@ -369,25 +438,56 @@ func (m topModel) paneViewportRows() int {
 	return rows
 }
 
+func (m topModel) paneContentViewportRows(pane topPane) int {
+	rows := m.paneViewportRows()
+	if m.searchOpen && pane == m.pane {
+		rows--
+	}
+	if rows < 1 {
+		return 1
+	}
+	return rows
+}
+
 // paneLines builds the slice of rendered rows for the given pane. Width
 // is the interior width (excluding pane border). The slice is recomputed
 // on every call rather than cached so the data stays in sync with the
 // last snapshot — caching would require invalidation on resize and on
 // snapshot apply, which the periodic ticker would race with.
 func (m topModel) paneLines(pane topPane, width int) []string {
+	var lines []string
 	switch pane {
 	case topPaneSessions:
-		return m.sessionLines(width)
+		lines = m.sessionLines(width)
 	case topPaneFailures:
-		return m.eventLines(m.snapshot.Failures, width)
+		lines = m.eventLines(m.snapshot.Failures, width)
 	case topPaneRecentCommands:
-		return m.eventLines(m.snapshot.RecentCommands, width)
+		lines = m.eventLines(m.snapshot.RecentCommands, width)
 	case topPaneCandidates:
-		return m.candidateLines(width)
+		lines = m.candidateLines(width)
 	case topPaneStaleMemories:
-		return m.staleMemoryLines(width)
+		lines = m.staleMemoryLines(width)
+	default:
+		return nil
 	}
-	return nil
+	return m.applyPaneSearchFilter(pane, lines)
+}
+
+func (m topModel) applyPaneSearchFilter(pane topPane, lines []string) []string {
+	if pane != m.pane || m.searchQuery == "" {
+		return lines
+	}
+	query := strings.ToLower(m.searchQuery)
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.Contains(strings.ToLower(line), query) {
+			filtered = append(filtered, line)
+		}
+	}
+	if len(filtered) == 0 {
+		return []string{m.styles.Subtle.Render(Localize("No rows match search.", "search に一致する行はありません。"))}
+	}
+	return filtered
 }
 
 // sessionLines renders the active session tree to one line per node so
@@ -585,12 +685,18 @@ func (m topModel) renderFooter() string {
 		loaded = m.loadedAt.In(m.location).Format(eventCompactTimeLayout)
 	}
 	status := fmt.Sprintf("loaded=%s pane=%s", loaded, paneLabel(m.pane))
+	if m.searchQuery != "" {
+		status += fmt.Sprintf(" search=%q", m.searchQuery)
+	}
+	if m.searchOpen {
+		status += " search-edit"
+	}
 	if m.loadErr != nil {
 		status += " " + m.styles.Error.Render(Localize("load error", "load error"))
 	}
 	help := Localize(
-		"tab/shift+tab pane · ↑/↓ scroll · pgup/pgdn page · g/G top/bottom · r refresh · ? help · q quit",
-		"tab/shift+tab pane · ↑/↓ スクロール · pgup/pgdn ページ · g/G 先頭/末尾 · r 更新 · ? help · q quit",
+		"tab/shift+tab pane · / search · ↑/↓ scroll · pgup/pgdn page · g/G top/bottom · r refresh · ? help · q quit",
+		"tab/shift+tab pane · / search · ↑/↓ スクロール · pgup/pgdn ページ · g/G 先頭/末尾 · r 更新 · ? help · q quit",
 	)
 	return m.styles.Subtle.Render(status) + "\n" + m.styles.Help.Render(help)
 }
@@ -611,8 +717,11 @@ func (m topModel) renderHelp() string {
 	b.WriteString("  ↑ / ↓ (k / j)    " + Localize("scroll the focused pane by one row", "フォーカス中のペインを1行スクロール") + "\n")
 	b.WriteString("  pgup / pgdn      " + Localize("page through the focused pane", "フォーカス中のペインをページ移動") + "\n")
 	b.WriteString("  g / G            " + Localize("jump to top / bottom of the pane", "ペインの先頭 / 末尾へ") + "\n")
+	b.WriteString("  /                " + Localize("open / edit pane search filter", "ペイン内 search filter を開く / 編集") + "\n")
+	b.WriteString("  enter            " + Localize("keep the current search filter and return to pane navigation", "現在の search filter を保持してペイン操作へ戻る") + "\n")
+	b.WriteString("  esc              " + Localize("clear the active search filter while editing search", "search 編集中の filter をクリア") + "\n")
 	b.WriteString("  r                " + Localize("force a snapshot refresh", "スナップショットを再取得") + "\n")
-	b.WriteString("  ? / esc          " + Localize("toggle this help", "ヘルプの表示を切替") + "\n")
+	b.WriteString("  ?                " + Localize("toggle this help", "ヘルプの表示を切替") + "\n")
 	b.WriteString("  q / ctrl+c       " + Localize("quit", "終了") + "\n")
 	b.WriteString("\n")
 	b.WriteString(m.styles.Help.Render(Localize("? close help · q quit", "? ヘルプを閉じる · q quit")))
@@ -625,7 +734,7 @@ func (m topModel) renderHelp() string {
 func (m topModel) renderPane(pane topPane) string {
 	width := m.paneInteriorWidth()
 	lines := m.paneLines(pane, width)
-	viewport := m.paneViewportRows()
+	viewport := m.paneContentViewportRows(pane)
 	if m.offsets[pane] > 0 && m.offsets[pane] >= len(lines) {
 		// Snapshot shrunk under the cursor; rewind to the last visible row
 		// so the pane never renders an empty window after a refresh.
@@ -638,11 +747,21 @@ func (m topModel) renderPane(pane topPane) string {
 	}
 	visible := lines[start:end]
 	header := m.renderPaneHeader(pane, len(lines))
-	body := strings.Join(visible, "\n")
+	bodyLines := make([]string, 0, len(visible)+1)
+	if m.searchOpen && pane == m.pane {
+		bodyLines = append(bodyLines, m.renderSearchPrompt(width))
+	}
+	bodyLines = append(bodyLines, visible...)
+	body := strings.Join(bodyLines, "\n")
 	if body == "" {
 		body = m.styles.Subtle.Render(Localize("(empty)", "(空)"))
 	}
 	return header + "\n" + body
+}
+
+func (m topModel) renderSearchPrompt(width int) string {
+	prompt := fmt.Sprintf("search: /%s", m.searchQuery)
+	return m.styles.Help.Render(truncateToWidth(prompt, width))
 }
 
 func (m topModel) renderPaneHeader(pane topPane, total int) string {
@@ -651,7 +770,7 @@ func (m topModel) renderPaneHeader(pane topPane, total int) string {
 		label = fmt.Sprintf("STALE MEMORIES (count=%d)", m.snapshot.StaleMemories.Count())
 	}
 	scroll := ""
-	viewport := m.paneViewportRows()
+	viewport := m.paneContentViewportRows(pane)
 	if total > viewport {
 		scroll = fmt.Sprintf(" %d-%d/%d", m.offsets[pane]+1, min(m.offsets[pane]+viewport, total), total)
 	} else if total > 0 {

--- a/presentation/cli/top_dashboard_internal_test.go
+++ b/presentation/cli/top_dashboard_internal_test.go
@@ -178,6 +178,11 @@ func sendKey(m topModel, key tea.KeyMsg) topModel {
 	return updated.(topModel)
 }
 
+func sendRunes(m topModel, runes string) topModel {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(runes)})
+	return updated.(topModel)
+}
+
 func TestTopModel_InitialFetchPopulatesSnapshot(t *testing.T) {
 	t.Parallel()
 	loader := &stubTopLoader{snapshot: topDataSnapshot{
@@ -405,6 +410,278 @@ func TestTopModel_HelpModeTogglesAndSwallowsNavigation(t *testing.T) {
 	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	if m.mode != topModeBrowse {
 		t.Fatalf("mode = %v after second `?`, want topModeBrowse", m.mode)
+	}
+}
+
+func TestTopModel_SearchPromptFiltersRowsIncrementally(t *testing.T) {
+	t.Parallel()
+	loader := &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha deploy failed"),
+		dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta deploy failed"),
+	}}}
+	m := newDashboardTestModel(t, loader)
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})                       // failures
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}) // search prompt
+	if !m.searchOpen {
+		t.Fatalf("searchOpen = false, want true after /")
+	}
+
+	m = sendRunes(m, "ALPHA")
+	view := m.View()
+	for _, expect := range []string{"search: /ALPHA", "Alpha deploy failed"} {
+		if !strings.Contains(view, expect) {
+			t.Fatalf("filtered view missing %q:\n%s", expect, view)
+		}
+	}
+	if strings.Contains(view, "Beta deploy failed") {
+		t.Fatalf("filtered view still contains non-matching row:\n%s", view)
+	}
+
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.searchOpen {
+		t.Fatalf("searchOpen = true, want false after Enter")
+	}
+	if got, want := m.searchQuery, "ALPHA"; got != want {
+		t.Fatalf("searchQuery = %q, want %q after Enter", got, want)
+	}
+	view = m.View()
+	if !strings.Contains(view, "Alpha deploy failed") || strings.Contains(view, "Beta deploy failed") {
+		t.Fatalf("Enter should keep the filter applied:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchFiltersEveryPaneByRenderedRows(t *testing.T) {
+	t.Parallel()
+	staleAlpha := dashboardStaleMemory(t, "mem-stale-alpha", apptypes.StaleMemoryReasonExpired, "Alpha stale fact")
+	staleBeta := dashboardStaleMemory(t, "mem-stale-beta", apptypes.StaleMemoryReasonSuperseded, "Beta stale fact")
+	cases := []struct {
+		name     string
+		pane     topPane
+		snapshot topDataSnapshot
+		want     string
+		reject   string
+	}{
+		{
+			name: "sessions",
+			pane: topPaneSessions,
+			snapshot: topDataSnapshot{Sessions: []*sessionNode{
+				dashboardSessionNode("session-alpha", fixedDashboardNow),
+				dashboardSessionNode("session-beta", fixedDashboardNow),
+			}},
+			want:   "session-alpha",
+			reject: "session-beta",
+		},
+		{
+			name: "failures",
+			pane: topPaneFailures,
+			snapshot: topDataSnapshot{Failures: []*model.Event{
+				dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha failure"),
+				dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta failure"),
+			}},
+			want:   "Alpha failure",
+			reject: "Beta failure",
+		},
+		{
+			name: "recent commands",
+			pane: topPaneRecentCommands,
+			snapshot: topDataSnapshot{RecentCommands: []*model.Event{
+				dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha command"),
+				dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta command"),
+			}},
+			want:   "Alpha command",
+			reject: "Beta command",
+		},
+		{
+			name: "candidates",
+			pane: topPaneCandidates,
+			snapshot: topDataSnapshot{Candidates: []apptypes.MemorySummary{
+				dashboardCandidate(t, "mem-alpha", "Alpha candidate fact"),
+				dashboardCandidate(t, "mem-beta", "Beta candidate fact"),
+			}},
+			want:   "Alpha candidate fact",
+			reject: "Beta candidate fact",
+		},
+		{
+			name: "stale memories",
+			pane: topPaneStaleMemories,
+			snapshot: topDataSnapshot{
+				StaleMemories: dashboardStaleResult(t, 2, staleAlpha, staleBeta),
+			},
+			want:   "Alpha stale fact",
+			reject: "Beta stale fact",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newDashboardTestModel(t, &stubTopLoader{snapshot: tc.snapshot})
+			m = applySnapshot(t, m)
+			m.pane = tc.pane
+			m.searchQuery = "alpha"
+
+			lines := m.paneLines(tc.pane, 160)
+			if len(lines) != 1 {
+				t.Fatalf("filtered lines = %d, want 1: %#v", len(lines), lines)
+			}
+			if !strings.Contains(lines[0], tc.want) || strings.Contains(lines[0], tc.reject) {
+				t.Fatalf("filtered line = %q, want %q and not %q", lines[0], tc.want, tc.reject)
+			}
+		})
+	}
+}
+
+func TestTopModel_SearchSlashReopensExistingFilterForEditing(t *testing.T) {
+	t.Parallel()
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha deploy failed"),
+	}}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})                       // failures
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}) // open prompt
+	m = sendRunes(m, "alpha")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.searchOpen {
+		t.Fatalf("searchOpen = true, want false after Enter")
+	}
+
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if !m.searchOpen {
+		t.Fatalf("searchOpen = false, want true after reopening /")
+	}
+	if got, want := m.searchQuery, "alpha"; got != want {
+		t.Fatalf("searchQuery = %q, want prior query %q", got, want)
+	}
+	if view := m.View(); !strings.Contains(view, "search: /alpha") {
+		t.Fatalf("reopened prompt missing prior query:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchEscClearsFilterWithoutQuitting(t *testing.T) {
+	t.Parallel()
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha deploy failed"),
+		dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta deploy failed"),
+	}}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = sendRunes(m, "alpha")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("Esc while search prompt is open should clear search, not quit")
+	}
+	m = updated.(topModel)
+	if m.searchOpen || m.searchQuery != "" {
+		t.Fatalf("searchOpen/searchQuery = %v/%q, want cleared", m.searchOpen, m.searchQuery)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Alpha deploy failed") || !strings.Contains(view, "Beta deploy failed") {
+		t.Fatalf("cleared search should render all rows:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchEscClearsCommittedFilterWithoutQuitting(t *testing.T) {
+	t.Parallel()
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha deploy failed"),
+		dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta deploy failed"),
+	}}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = sendRunes(m, "alpha")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("Esc with a committed search filter should clear search, not quit")
+	}
+	m = updated.(topModel)
+	if m.searchOpen || m.searchQuery != "" {
+		t.Fatalf("searchOpen/searchQuery = %v/%q, want cleared", m.searchOpen, m.searchQuery)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Alpha deploy failed") || !strings.Contains(view, "Beta deploy failed") {
+		t.Fatalf("cleared committed search should render all rows:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchRefreshPreservesFilter(t *testing.T) {
+	t.Parallel()
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha initial failure"),
+		dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta initial failure"),
+	}}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab})
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = sendRunes(m, "alpha")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	refreshed, _ := m.Update(topSnapshotMsg{
+		snapshot: topDataSnapshot{Failures: []*model.Event{
+			dashboardEvent("evt-alpha-2", domtypes.EventKindCommandExecuted, "Alpha refreshed failure"),
+			dashboardEvent("evt-gamma", domtypes.EventKindCommandExecuted, "Gamma refreshed failure"),
+		}},
+		at: fixedDashboardNow.Add(time.Second),
+	})
+	m = refreshed.(topModel)
+	if got, want := m.searchQuery, "alpha"; got != want {
+		t.Fatalf("searchQuery after refresh = %q, want %q", got, want)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Alpha refreshed failure") || strings.Contains(view, "Gamma refreshed failure") {
+		t.Fatalf("refresh should preserve active filter:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchFocusSwitchClearsFilter(t *testing.T) {
+	t.Parallel()
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Failures: []*model.Event{
+		dashboardEvent("evt-alpha", domtypes.EventKindCommandExecuted, "Alpha deploy failed"),
+		dashboardEvent("evt-beta", domtypes.EventKindCommandExecuted, "Beta deploy failed"),
+	}}})
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab}) // failures
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = sendRunes(m, "alpha")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyTab}) // recent commands
+	if m.searchOpen || m.searchQuery != "" {
+		t.Fatalf("searchOpen/searchQuery after focus switch = %v/%q, want cleared", m.searchOpen, m.searchQuery)
+	}
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyShiftTab}) // back to failures
+	view := m.View()
+	if !strings.Contains(view, "Alpha deploy failed") || !strings.Contains(view, "Beta deploy failed") {
+		t.Fatalf("focus switch should reset the previous pane filter:\n%s", view)
+	}
+}
+
+func TestTopModel_SearchPromptQuitKeysStillQuit(t *testing.T) {
+	t.Parallel()
+	for _, keyMsg := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'q'}},
+		{Type: tea.KeyCtrlC},
+	} {
+		m := newDashboardTestModel(t, &stubTopLoader{})
+		m = applySnapshot(t, m)
+		m = sendKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+		_, cmd := m.Update(keyMsg)
+		if cmd == nil {
+			t.Fatalf("key %v in search prompt should still quit", keyMsg)
+		}
+		if msg := cmd(); msg == nil {
+			t.Fatalf("quit cmd for key %v returned nil msg", keyMsg)
+		}
 	}
 }
 

--- a/presentation/cli/tui/keymap.go
+++ b/presentation/cli/tui/keymap.go
@@ -18,6 +18,7 @@ type KeyMap struct {
 	Home     key.Binding
 	End      key.Binding
 	Select   key.Binding
+	Search   key.Binding
 	Refresh  key.Binding
 	Help     key.Binding
 	Quit     key.Binding
@@ -57,6 +58,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("enter"),
 			key.WithHelp("enter", "select"),
 		),
+		Search: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "search"),
+		),
 		Refresh: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
@@ -74,13 +79,13 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp returns the bindings shown in the always-visible help line.
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Select, k.Quit, k.Help}
+	return []key.Binding{k.Up, k.Down, k.Select, k.Search, k.Quit, k.Help}
 }
 
 // FullHelp returns the bindings shown in the expanded help screen.
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.PageUp, k.PageDown, k.Home, k.End},
-		{k.Select, k.Refresh, k.Help, k.Quit},
+		{k.Select, k.Search, k.Refresh, k.Help, k.Quit},
 	}
 }

--- a/presentation/cli/tui/keymap_test.go
+++ b/presentation/cli/tui/keymap_test.go
@@ -27,6 +27,7 @@ func TestDefaultKeyMap_NavigationCovered(t *testing.T) {
 		{"down arrow", "down", km.Down},
 		{"vim j", "j", km.Down},
 		{"select", "enter", km.Select},
+		{"search", "/", km.Search},
 		{"refresh", "r", km.Refresh},
 		{"help", "?", km.Help},
 		{"home", "g", km.Home},


### PR DESCRIPTION
## Motivation

Long `traceary top` panes should be searchable in-place so operators can narrow a single pane without changing snapshot output or data-source filters.

Closes #961

## Changes

- Adds a shared `/` Search key binding to the TUI key map.
- Adds slash-search state to the top dashboard with incremental case-insensitive filtering against rendered row text.
- Supports Enter to keep the filter, Esc to clear it, `/` to reopen an existing filter for editing, and pane switches that clear the current pane filter.
- Preserves filters across snapshot refreshes and documents search in footer/help text.
- Adds TUI tests covering prompt open/type, all panes, Enter, Esc, refresh persistence, focus-switch clearing, and quit keys while searching.

## Delegation notes

- Claude Code Opus 4.7 delegation was attempted. The local Claude CLI rejected `--effort auto` (`low|medium|high|xhigh|max` only), and a retry without explicit effort produced no output and had to be interrupted. Codex completed the implementation fallback to keep the autonomous flow moving.

## Validation

- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./presentation/cli/tui ./presentation/cli -run 'TestDefaultKeyMap|TestTopModel_'`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go build ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache GOTMPDIR=/private/tmp go tool golangci-lint run`
- `rtk git diff --check`