### PR TITLE
feat(cli): add top detail modal

### DIFF
--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -440,6 +440,7 @@ func (c *RootCLI) runTopTUI(ctx context.Context, output io.Writer, opts topComma
 		Actions:         defaultTopPaneActionKeys(),
 		Styles:          tui.DefaultStyles(),
 		Loader:          loader,
+		Detail:          loader,
 		Criteria:        criteria,
 		Idle:            opts.idle,
 		RefreshInterval: topDashboardRefreshInterval,

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattn/go-runewidth"
 
 	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli/tui"
 )
 
@@ -55,7 +56,56 @@ type topMode int
 const (
 	topModeBrowse topMode = iota
 	topModeHelp
+	topModeDetail
 )
+
+const topDetailRecentEventLimit = 10
+
+type topDetailKind int
+
+const (
+	topDetailNone topDetailKind = iota
+	topDetailSession
+	topDetailEvent
+	topDetailMemory
+)
+
+type topDetailTarget struct {
+	kind      topDetailKind
+	title     string
+	sessionID domtypes.SessionID
+	eventID   domtypes.EventID
+	memoryID  domtypes.MemoryID
+}
+
+type topDetailRequest struct {
+	pane   topPane
+	target topDetailTarget
+}
+
+type topDetailContent struct {
+	title string
+	lines []string
+}
+
+type topDetailMsg struct {
+	request topDetailRequest
+	content topDetailContent
+	err     error
+}
+
+type topDetailState struct {
+	request topDetailRequest
+	title   string
+	lines   []string
+	err     error
+	loading bool
+}
+
+type topPaneRow struct {
+	line   string
+	target topDetailTarget
+}
 
 // topPaneActionKeys extends the shared tui.KeyMap with bindings that are
 // dashboard-specific (pane switching). Quit / Help / Refresh / movement
@@ -86,6 +136,10 @@ type topSnapshotLoader interface {
 	loadSnapshot(ctx context.Context, c topDataCriteria) (topDataSnapshot, error)
 }
 
+type topDetailLoader interface {
+	loadDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error)
+}
+
 // topRefreshTickMsg is delivered by the periodic ticker; the model reacts
 // by issuing a fetch command and scheduling the next tick.
 type topRefreshTickMsg struct{}
@@ -108,6 +162,7 @@ type topModel struct {
 	styles  tui.Styles
 
 	loader   topSnapshotLoader
+	detail   topDetailLoader
 	criteria topDataCriteria
 	idle     time.Duration
 
@@ -119,10 +174,12 @@ type topModel struct {
 	searchOpen  bool
 	searchQuery string
 
-	snapshot topDataSnapshot
-	loadedAt time.Time
-	loadErr  error
-	loaded   bool
+	snapshot     topDataSnapshot
+	loadedAt     time.Time
+	loadErr      error
+	loaded       bool
+	detailUI     topDetailState
+	detailOffset int
 
 	mode topMode
 
@@ -150,6 +207,7 @@ type topModelConfig struct {
 	Actions  topPaneActionKeys
 	Styles   tui.Styles
 	Loader   topSnapshotLoader
+	Detail   topDetailLoader
 	Criteria topDataCriteria
 	Idle     time.Duration
 	// Now defaults to time.Now when nil.
@@ -189,6 +247,7 @@ func newTopModel(cfg topModelConfig) topModel {
 		actions:         cfg.Actions,
 		styles:          cfg.Styles,
 		loader:          cfg.Loader,
+		detail:          cfg.Detail,
 		criteria:        cfg.Criteria,
 		idle:            cfg.Idle,
 		now:             now,
@@ -217,6 +276,7 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.clampOffsets()
+		m.clampDetailOffset()
 		return m, nil
 	case topRefreshTickMsg:
 		if m.refreshInterval <= 0 {
@@ -230,6 +290,17 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loaded = true
 		m.clampOffsets()
 		return m, nil
+	case topDetailMsg:
+		if m.mode != topModeDetail || msg.request != m.detailUI.request {
+			return m, nil
+		}
+		m.detailUI.request = msg.request
+		m.detailUI.loading = false
+		m.detailUI.err = msg.err
+		m.detailUI.title = msg.content.title
+		m.detailUI.lines = msg.content.lines
+		m.clampDetailOffset()
+		return m, nil
 	case tea.KeyMsg:
 		return m.updateKey(msg)
 	}
@@ -237,6 +308,9 @@ func (m topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.mode == topModeDetail {
+		return m.updateDetailKey(msg)
+	}
 	if m.searchOpen {
 		return m.updateSearchKey(msg)
 	}
@@ -271,6 +345,8 @@ func (m topModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.searchOpen = true
 		m.offsets[m.pane] = 0
 		return m, nil
+	case key.Matches(msg, m.keys.Select):
+		return m.openDetail()
 	case key.Matches(msg, m.keys.Up):
 		m.scrollBy(-1)
 		return m, nil
@@ -341,6 +417,77 @@ func (m topModel) updateSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m topModel) updateDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case msg.Type == tea.KeyCtrlC:
+		return m, tea.Quit
+	case msg.Type == tea.KeyEsc || (msg.Type == tea.KeyRunes && string(msg.Runes) == "q"):
+		m.mode = topModeBrowse
+		m.detailUI = topDetailState{}
+		m.detailOffset = 0
+		return m, nil
+	case key.Matches(msg, m.keys.Up):
+		m.scrollDetailBy(-1)
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.scrollDetailBy(1)
+		return m, nil
+	case key.Matches(msg, m.keys.PageUp):
+		m.scrollDetailBy(-m.detailViewportRows())
+		return m, nil
+	case key.Matches(msg, m.keys.PageDown):
+		m.scrollDetailBy(m.detailViewportRows())
+		return m, nil
+	case key.Matches(msg, m.keys.Home):
+		m.detailOffset = 0
+		return m, nil
+	case key.Matches(msg, m.keys.End):
+		m.detailOffset = max(len(m.detailLines())-m.detailViewportRows(), 0)
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m topModel) openDetail() (tea.Model, tea.Cmd) {
+	rows := m.paneRows(m.pane, m.paneInteriorWidth())
+	if len(rows) == 0 {
+		return m, nil
+	}
+	index := m.offsets[m.pane]
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(rows) {
+		index = len(rows) - 1
+	}
+	target := rows[index].target
+	if target.kind == topDetailNone {
+		return m, nil
+	}
+	req := topDetailRequest{pane: m.pane, target: target}
+	m.mode = topModeDetail
+	m.detailOffset = 0
+	m.detailUI = topDetailState{
+		request: req,
+		title:   target.title,
+		lines:   []string{Localize("Loading...", "読み込み中...")},
+		loading: true,
+	}
+	return m, m.fetchDetailCmd(req)
+}
+
+func (m topModel) fetchDetailCmd(req topDetailRequest) tea.Cmd {
+	loader := m.detail
+	ctx := m.loaderCtx
+	return func() tea.Msg {
+		if loader == nil {
+			return topDetailMsg{request: req, err: fmt.Errorf("detail loader is not configured")}
+		}
+		content, err := loader.loadDetail(ctx, req)
+		return topDetailMsg{request: req, content: content, err: err}
+	}
+}
+
 func (m *topModel) switchPane(next topPane) {
 	if next == m.pane {
 		return
@@ -392,6 +539,21 @@ func (m *topModel) clampOffsets() {
 		if m.offsets[i] < 0 {
 			m.offsets[i] = 0
 		}
+	}
+}
+
+func (m *topModel) scrollDetailBy(delta int) {
+	m.detailOffset += delta
+	m.clampDetailOffset()
+}
+
+func (m *topModel) clampDetailOffset() {
+	maxOffset := max(len(m.detailLines())-m.detailViewportRows(), 0)
+	if m.detailOffset > maxOffset {
+		m.detailOffset = maxOffset
+	}
+	if m.detailOffset < 0 {
+		m.detailOffset = 0
 	}
 }
 
@@ -455,39 +617,56 @@ func (m topModel) paneContentViewportRows(pane topPane) int {
 // last snapshot — caching would require invalidation on resize and on
 // snapshot apply, which the periodic ticker would race with.
 func (m topModel) paneLines(pane topPane, width int) []string {
-	var lines []string
+	rows := m.paneRows(pane, width)
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		lines = append(lines, row.line)
+	}
+	return lines
+}
+
+func (m topModel) paneRows(pane topPane, width int) []topPaneRow {
+	var rows []topPaneRow
 	switch pane {
 	case topPaneSessions:
-		lines = m.sessionLines(width)
+		rows = m.sessionRows(width)
 	case topPaneFailures:
-		lines = m.eventLines(m.snapshot.Failures, width)
+		rows = m.eventRows(m.snapshot.Failures, width)
 	case topPaneRecentCommands:
-		lines = m.eventLines(m.snapshot.RecentCommands, width)
+		rows = m.eventRows(m.snapshot.RecentCommands, width)
 	case topPaneCandidates:
-		lines = m.candidateLines(width)
+		rows = m.candidateRows(width)
 	case topPaneStaleMemories:
-		lines = m.staleMemoryLines(width)
+		rows = m.staleMemoryRows(width)
 	default:
 		return nil
 	}
-	return m.applyPaneSearchFilter(pane, lines)
+	return m.applyPaneSearchFilter(pane, rows)
 }
 
-func (m topModel) applyPaneSearchFilter(pane topPane, lines []string) []string {
+func (m topModel) applyPaneSearchFilter(pane topPane, rows []topPaneRow) []topPaneRow {
 	if pane != m.pane || m.searchQuery == "" {
-		return lines
+		return rows
 	}
 	query := strings.ToLower(m.searchQuery)
-	filtered := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if strings.Contains(strings.ToLower(line), query) {
-			filtered = append(filtered, line)
+	filtered := make([]topPaneRow, 0, len(rows))
+	for _, row := range rows {
+		if strings.Contains(strings.ToLower(row.line), query) {
+			filtered = append(filtered, row)
 		}
 	}
 	if len(filtered) == 0 {
-		return []string{m.styles.Subtle.Render(Localize("No rows match search.", "search に一致する行はありません。"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("No rows match search.", "search に一致する行はありません。"))}}
 	}
 	return filtered
+}
+
+func topPaneRowLines(rows []topPaneRow) []string {
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		lines = append(lines, row.line)
+	}
+	return lines
 }
 
 // sessionLines renders the active session tree to one line per node so
@@ -496,24 +675,28 @@ func (m topModel) applyPaneSearchFilter(pane topPane, lines []string) []string {
 // look identical to `traceary top --snapshot` output, modulo the pane
 // width truncation that the Bubble Tea renderer applies on display.
 func (m topModel) sessionLines(width int) []string {
+	return topPaneRowLines(m.sessionRows(width))
+}
+
+func (m topModel) sessionRows(width int) []topPaneRow {
 	if m.loadErr != nil {
-		return []string{m.styles.Error.Render(m.loadErr.Error())}
+		return []topPaneRow{{line: m.styles.Error.Render(m.loadErr.Error())}}
 	}
 	if !m.loaded {
-		return []string{m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}}
 	}
 	if len(m.snapshot.Sessions) == 0 {
-		return []string{m.styles.Subtle.Render(Localize("No active sessions found.", "active session が見つかりません"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("No active sessions found.", "active session が見つかりません"))}}
 	}
 	now := m.now()
-	out := make([]string, 0)
+	out := make([]topPaneRow, 0)
 	for _, root := range m.snapshot.Sessions {
-		out = appendSessionLines(out, root, "", true, false, m.idle, now, m.location, width)
+		out = appendSessionRows(out, root, "", true, false, m.idle, now, m.location, width)
 	}
 	return out
 }
 
-func appendSessionLines(out []string, node *sessionNode, prefix string, isLast bool, hasParent bool, idle time.Duration, now time.Time, loc *time.Location, width int) []string {
+func appendSessionRows(out []topPaneRow, node *sessionNode, prefix string, isLast bool, hasParent bool, idle time.Duration, now time.Time, loc *time.Location, width int) []topPaneRow {
 	connector := "├── "
 	if isLast {
 		connector = "└── "
@@ -523,7 +706,15 @@ func appendSessionLines(out []string, node *sessionNode, prefix string, isLast b
 	}
 	linePrefix := prefix + connector
 	line := formatTopNodeLineIn(node, linePrefix, idle, now, loc)
-	out = append(out, truncateToWidth(line, width))
+	summary := node.summary
+	out = append(out, topPaneRow{
+		line: truncateToWidth(line, width),
+		target: topDetailTarget{
+			kind:      topDetailSession,
+			title:     fmt.Sprintf("SESSION %s", summary.SessionID()),
+			sessionID: summary.SessionID(),
+		},
+	})
 	childPrefix := prefix
 	if hasParent {
 		if isLast {
@@ -533,7 +724,7 @@ func appendSessionLines(out []string, node *sessionNode, prefix string, isLast b
 		}
 	}
 	for i, child := range node.children {
-		out = appendSessionLines(out, child, childPrefix, i == len(node.children)-1, true, idle, now, loc, width)
+		out = appendSessionRows(out, child, childPrefix, i == len(node.children)-1, true, idle, now, loc, width)
 	}
 	return out
 }
@@ -542,23 +733,30 @@ func appendSessionLines(out []string, node *sessionNode, prefix string, isLast b
 // panes. The format keeps timestamps and kinds aligned and truncates the
 // body to fit the pane width so a single noisy event cannot wrap and shove
 // the rest of the rows off-screen.
-func (m topModel) eventLines(events []*model.Event, width int) []string {
+func (m topModel) eventRows(events []*model.Event, width int) []topPaneRow {
 	if m.loadErr != nil {
-		return []string{m.styles.Error.Render(m.loadErr.Error())}
+		return []topPaneRow{{line: m.styles.Error.Render(m.loadErr.Error())}}
 	}
 	if !m.loaded {
-		return []string{m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}}
 	}
 	if len(events) == 0 {
-		return []string{m.styles.Subtle.Render(Localize("No matching records.", "一致する記録はありません"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("No matching records.", "一致する記録はありません"))}}
 	}
-	out := make([]string, 0, len(events))
+	out := make([]topPaneRow, 0, len(events))
 	for _, ev := range events {
 		ts := ev.CreatedAt().In(m.location).Format(eventCompactTimeLayout)
 		kind := ev.Kind().String()
 		body := truncateMessage(ev.Body())
 		line := fmt.Sprintf("%s %s %s", ts, kind, body)
-		out = append(out, truncateToWidth(line, width))
+		out = append(out, topPaneRow{
+			line: truncateToWidth(line, width),
+			target: topDetailTarget{
+				kind:    topDetailEvent,
+				title:   fmt.Sprintf("EVENT %s", ev.EventID()),
+				eventID: ev.EventID(),
+			},
+		})
 	}
 	return out
 }
@@ -567,19 +765,30 @@ func (m topModel) eventLines(events []*model.Event, width int) []string {
 // candidate-list ordering set by the loader (remember-intent priority) so
 // inbox and dashboard agree on which row is "next up".
 func (m topModel) candidateLines(width int) []string {
+	return topPaneRowLines(m.candidateRows(width))
+}
+
+func (m topModel) candidateRows(width int) []topPaneRow {
 	if m.loadErr != nil {
-		return []string{m.styles.Error.Render(m.loadErr.Error())}
+		return []topPaneRow{{line: m.styles.Error.Render(m.loadErr.Error())}}
 	}
 	if !m.loaded {
-		return []string{m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}}
 	}
 	if len(m.snapshot.Candidates) == 0 {
-		return []string{m.styles.Subtle.Render(Localize("No candidate durable memories in the inbox.", "inbox に candidate durable memory はありません"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("No candidate durable memories in the inbox.", "inbox に candidate durable memory はありません"))}}
 	}
-	out := make([]string, 0, len(m.snapshot.Candidates))
+	out := make([]topPaneRow, 0, len(m.snapshot.Candidates))
 	for _, candidate := range m.snapshot.Candidates {
 		line := fmt.Sprintf("%s %s %s", candidate.MemoryID(), candidate.MemoryType(), truncateMessage(candidate.Fact()))
-		out = append(out, truncateToWidth(line, width))
+		out = append(out, topPaneRow{
+			line: truncateToWidth(line, width),
+			target: topDetailTarget{
+				kind:     topDetailMemory,
+				title:    fmt.Sprintf("MEMORY %s", candidate.MemoryID()),
+				memoryID: candidate.MemoryID(),
+			},
+		})
 	}
 	return out
 }
@@ -589,17 +798,21 @@ func (m topModel) candidateLines(width int) []string {
 // human-readable fact so operators can quickly decide whether the stale row
 // should be pruned or investigated from the dedicated memory commands.
 func (m topModel) staleMemoryLines(width int) []string {
+	return topPaneRowLines(m.staleMemoryRows(width))
+}
+
+func (m topModel) staleMemoryRows(width int) []topPaneRow {
 	if m.loadErr != nil {
-		return []string{m.styles.Error.Render(m.loadErr.Error())}
+		return []topPaneRow{{line: m.styles.Error.Render(m.loadErr.Error())}}
 	}
 	if !m.loaded {
-		return []string{m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("loading…", "読み込み中…"))}}
 	}
 	items := m.snapshot.StaleMemories.Items()
 	if len(items) == 0 {
-		return []string{m.styles.Subtle.Render(Localize("No stale memories.", "stale な memory はありません。"))}
+		return []topPaneRow{{line: m.styles.Subtle.Render(Localize("No stale memories.", "stale な memory はありません。"))}}
 	}
-	out := make([]string, 0, len(items))
+	out := make([]topPaneRow, 0, len(items))
 	for _, row := range items {
 		summary := row.Summary()
 		line := fmt.Sprintf(
@@ -610,7 +823,14 @@ func (m topModel) staleMemoryLines(width int) []string {
 			row.Reason(),
 			truncateMessage(summary.Fact()),
 		)
-		out = append(out, truncateToWidth(line, width))
+		out = append(out, topPaneRow{
+			line: truncateToWidth(line, width),
+			target: topDetailTarget{
+				kind:     topDetailMemory,
+				title:    fmt.Sprintf("MEMORY %s", summary.MemoryID()),
+				memoryID: summary.MemoryID(),
+			},
+		})
 	}
 	return out
 }
@@ -656,6 +876,9 @@ func (m topModel) View() string {
 	if m.mode == topModeHelp {
 		return m.renderHelp()
 	}
+	if m.mode == topModeDetail {
+		return m.renderDetail()
+	}
 	var b strings.Builder
 	b.WriteString(m.renderHeader())
 	b.WriteString("\n")
@@ -665,6 +888,66 @@ func (m topModel) View() string {
 	}
 	b.WriteString(m.renderFooter())
 	return b.String()
+}
+
+func (m topModel) renderDetail() string {
+	width := m.paneInteriorWidth()
+	lines := m.detailLines()
+	viewport := m.detailViewportRows()
+	start := m.detailOffset
+	if start > len(lines) {
+		start = len(lines)
+	}
+	end := start + viewport
+	if end > len(lines) {
+		end = len(lines)
+	}
+	visible := make([]string, 0, end-start)
+	for _, line := range lines[start:end] {
+		visible = append(visible, truncateToWidth(line, width))
+	}
+	title := m.detailUI.title
+	if title == "" {
+		title = Localize("detail", "detail")
+	}
+	scroll := ""
+	if len(lines) > viewport {
+		scroll = fmt.Sprintf(" %d-%d/%d", start+1, min(start+viewport, len(lines)), len(lines))
+	} else if len(lines) > 0 {
+		scroll = fmt.Sprintf(" %d", len(lines))
+	}
+	header := m.styles.Title.Render(fmt.Sprintf("traceary top · detail · %s%s", title, scroll))
+	body := strings.Join(visible, "\n")
+	if body == "" {
+		body = m.styles.Subtle.Render(Localize("(empty)", "(空)"))
+	}
+	help := m.styles.Help.Render(Localize("↑/↓ scroll · pgup/pgdn page · g/G top/bottom · esc/q close · ctrl+c quit", "↑/↓ スクロール · pgup/pgdn ページ · g/G 先頭/末尾 · esc/q 閉じる · ctrl+c quit"))
+	return header + "\n\n" + body + "\n\n" + help
+}
+
+func (m topModel) detailLines() []string {
+	if m.detailUI.loading {
+		return []string{Localize("Loading...", "読み込み中...")}
+	}
+	if m.detailUI.err != nil {
+		return []string{m.styles.Error.Render(m.detailUI.err.Error())}
+	}
+	if len(m.detailUI.lines) == 0 {
+		return []string{Localize("(empty)", "(空)")}
+	}
+	return m.detailUI.lines
+}
+
+func (m topModel) detailViewportRows() int {
+	if m.height <= 0 {
+		return 12
+	}
+	const detailChromeRows = 4
+	rows := m.height - detailChromeRows
+	if rows < 1 {
+		return 1
+	}
+	return rows
 }
 
 func (m topModel) renderHeader() string {
@@ -695,8 +978,8 @@ func (m topModel) renderFooter() string {
 		status += " " + m.styles.Error.Render(Localize("load error", "load error"))
 	}
 	help := Localize(
-		"tab/shift+tab pane · / search · ↑/↓ scroll · pgup/pgdn page · g/G top/bottom · r refresh · ? help · q quit",
-		"tab/shift+tab pane · / search · ↑/↓ スクロール · pgup/pgdn ページ · g/G 先頭/末尾 · r 更新 · ? help · q quit",
+		"tab/shift+tab pane · enter detail · / search · ↑/↓ scroll · pgup/pgdn page · g/G top/bottom · r refresh · ? help · q quit",
+		"tab/shift+tab pane · enter detail · / search · ↑/↓ スクロール · pgup/pgdn ページ · g/G 先頭/末尾 · r 更新 · ? help · q quit",
 	)
 	return m.styles.Subtle.Render(status) + "\n" + m.styles.Help.Render(help)
 }
@@ -717,8 +1000,9 @@ func (m topModel) renderHelp() string {
 	b.WriteString("  ↑ / ↓ (k / j)    " + Localize("scroll the focused pane by one row", "フォーカス中のペインを1行スクロール") + "\n")
 	b.WriteString("  pgup / pgdn      " + Localize("page through the focused pane", "フォーカス中のペインをページ移動") + "\n")
 	b.WriteString("  g / G            " + Localize("jump to top / bottom of the pane", "ペインの先頭 / 末尾へ") + "\n")
+	b.WriteString("  enter            " + Localize("open detail for the highlighted row", "highlight 中の行の detail を開く") + "\n")
 	b.WriteString("  /                " + Localize("open / edit pane search filter", "ペイン内 search filter を開く / 編集") + "\n")
-	b.WriteString("  enter            " + Localize("keep the current search filter and return to pane navigation", "現在の search filter を保持してペイン操作へ戻る") + "\n")
+	b.WriteString("  enter (search)   " + Localize("keep the current search filter and return to pane navigation", "現在の search filter を保持してペイン操作へ戻る") + "\n")
 	b.WriteString("  esc              " + Localize("clear the active search filter while editing search", "search 編集中の filter をクリア") + "\n")
 	b.WriteString("  r                " + Localize("force a snapshot refresh", "スナップショットを再取得") + "\n")
 	b.WriteString("  ?                " + Localize("toggle this help", "ヘルプの表示を切替") + "\n")
@@ -733,30 +1017,39 @@ func (m topModel) renderHelp() string {
 // operator can tell at a glance which pane keys are bound to.
 func (m topModel) renderPane(pane topPane) string {
 	width := m.paneInteriorWidth()
-	lines := m.paneLines(pane, width)
+	rows := m.paneRows(pane, width)
 	viewport := m.paneContentViewportRows(pane)
-	if m.offsets[pane] > 0 && m.offsets[pane] >= len(lines) {
+	if m.offsets[pane] > 0 && m.offsets[pane] >= len(rows) {
 		// Snapshot shrunk under the cursor; rewind to the last visible row
 		// so the pane never renders an empty window after a refresh.
-		m.offsets[pane] = max(len(lines)-viewport, 0)
+		m.offsets[pane] = max(len(rows)-viewport, 0)
 	}
 	start := m.offsets[pane]
 	end := start + viewport
-	if end > len(lines) {
-		end = len(lines)
+	if end > len(rows) {
+		end = len(rows)
 	}
-	visible := lines[start:end]
-	header := m.renderPaneHeader(pane, len(lines))
+	visible := rows[start:end]
+	header := m.renderPaneHeader(pane, len(rows))
 	bodyLines := make([]string, 0, len(visible)+1)
 	if m.searchOpen && pane == m.pane {
 		bodyLines = append(bodyLines, m.renderSearchPrompt(width))
 	}
-	bodyLines = append(bodyLines, visible...)
+	for i, row := range visible {
+		bodyLines = append(bodyLines, m.renderPaneRow(pane, start+i, row, width))
+	}
 	body := strings.Join(bodyLines, "\n")
 	if body == "" {
 		body = m.styles.Subtle.Render(Localize("(empty)", "(空)"))
 	}
 	return header + "\n" + body
+}
+
+func (m topModel) renderPaneRow(pane topPane, index int, row topPaneRow, width int) string {
+	if pane == m.pane && index == m.offsets[pane] && row.target.kind != topDetailNone {
+		return m.styles.Active.Render(truncateToWidth("› "+row.line, width))
+	}
+	return row.line
 }
 
 func (m topModel) renderSearchPrompt(width int) string {

--- a/presentation/cli/top_dashboard_internal_test.go
+++ b/presentation/cli/top_dashboard_internal_test.go
@@ -20,14 +20,24 @@ import (
 // returned tea.Cmd, so wrapping it lets tests assert on Update transitions
 // without spinning up the application use cases.
 type stubTopLoader struct {
-	snapshot topDataSnapshot
-	err      error
-	calls    int
+	snapshot    topDataSnapshot
+	err         error
+	calls       int
+	detail      topDetailContent
+	detailErr   error
+	detailCalls int
+	detailReqs  []topDetailRequest
 }
 
 func (s *stubTopLoader) loadSnapshot(_ context.Context, _ topDataCriteria) (topDataSnapshot, error) {
 	s.calls++
 	return s.snapshot, s.err
+}
+
+func (s *stubTopLoader) loadDetail(_ context.Context, req topDetailRequest) (topDetailContent, error) {
+	s.detailCalls++
+	s.detailReqs = append(s.detailReqs, req)
+	return s.detail, s.detailErr
 }
 
 // fixedDashboardNow pins "now" so idle markers and last-event timestamps
@@ -41,6 +51,7 @@ func newDashboardTestModel(t *testing.T, loader topSnapshotLoader) topModel {
 		Actions:         defaultTopPaneActionKeys(),
 		Styles:          tui.DefaultStyles(),
 		Loader:          loader,
+		Detail:          loader.(topDetailLoader),
 		Criteria:        topDataCriteria{},
 		Idle:            10 * time.Minute,
 		Now:             func() time.Time { return fixedDashboardNow },
@@ -181,6 +192,18 @@ func sendKey(m topModel, key tea.KeyMsg) topModel {
 func sendRunes(m topModel, runes string) topModel {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(runes)})
 	return updated.(topModel)
+}
+
+func detailTargetID(target topDetailTarget) string {
+	switch target.kind {
+	case topDetailSession:
+		return target.sessionID.String()
+	case topDetailEvent:
+		return target.eventID.String()
+	case topDetailMemory:
+		return target.memoryID.String()
+	}
+	return ""
 }
 
 func TestTopModel_InitialFetchPopulatesSnapshot(t *testing.T) {
@@ -398,6 +421,9 @@ func TestTopModel_HelpModeTogglesAndSwallowsNavigation(t *testing.T) {
 	view := m.View()
 	if !strings.Contains(view, "help") {
 		t.Fatalf("help view did not contain `help` marker:\n%s", view)
+	}
+	if !strings.Contains(view, "open detail") {
+		t.Fatalf("help view did not document Enter detail binding:\n%s", view)
 	}
 
 	// Tab should not change the focused pane while help is up.
@@ -682,6 +708,168 @@ func TestTopModel_SearchPromptQuitKeysStillQuit(t *testing.T) {
 		if msg := cmd(); msg == nil {
 			t.Fatalf("quit cmd for key %v returned nil msg", keyMsg)
 		}
+	}
+}
+
+func TestTopModel_DetailModalOpensFromEachPane(t *testing.T) {
+	t.Parallel()
+	candidate := dashboardCandidate(t, "mem-candidate", "candidate detail fact")
+	stale := dashboardStaleMemory(t, "mem-stale", apptypes.StaleMemoryReasonExpired, "stale detail fact")
+	staleResult := dashboardStaleResult(t, 1, stale)
+	cases := []struct {
+		name       string
+		pane       topPane
+		snapshot   topDataSnapshot
+		wantKind   topDetailKind
+		wantTarget string
+	}{
+		{
+			name:       "sessions",
+			pane:       topPaneSessions,
+			snapshot:   topDataSnapshot{Sessions: []*sessionNode{dashboardSessionNode("session-detail", fixedDashboardNow)}},
+			wantKind:   topDetailSession,
+			wantTarget: "session-detail",
+		},
+		{
+			name:       "failures",
+			pane:       topPaneFailures,
+			snapshot:   topDataSnapshot{Failures: []*model.Event{dashboardEvent("evt-fail", domtypes.EventKindCommandExecuted, "failure detail body")}},
+			wantKind:   topDetailEvent,
+			wantTarget: "evt-fail",
+		},
+		{
+			name:       "recent commands",
+			pane:       topPaneRecentCommands,
+			snapshot:   topDataSnapshot{RecentCommands: []*model.Event{dashboardEvent("evt-cmd", domtypes.EventKindCommandExecuted, "command detail body")}},
+			wantKind:   topDetailEvent,
+			wantTarget: "evt-cmd",
+		},
+		{
+			name:       "candidates",
+			pane:       topPaneCandidates,
+			snapshot:   topDataSnapshot{Candidates: []apptypes.MemorySummary{candidate}},
+			wantKind:   topDetailMemory,
+			wantTarget: "mem-candidate",
+		},
+		{
+			name:       "stale memories",
+			pane:       topPaneStaleMemories,
+			snapshot:   topDataSnapshot{StaleMemories: staleResult},
+			wantKind:   topDetailMemory,
+			wantTarget: "mem-stale",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loader := &stubTopLoader{
+				snapshot: tc.snapshot,
+				detail:   topDetailContent{title: "DETAIL", lines: []string{"full detail body"}},
+			}
+			m := newDashboardTestModel(t, loader)
+			m = applySnapshot(t, m)
+			m = resize(m, 120, 40)
+			m.pane = tc.pane
+
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			if cmd == nil {
+				t.Fatalf("Enter on pane %v returned nil detail cmd", tc.pane)
+			}
+			m = updated.(topModel)
+			if m.mode != topModeDetail || !m.detailUI.loading {
+				t.Fatalf("mode/loading = %v/%v, want detail/loading", m.mode, m.detailUI.loading)
+			}
+			if view := m.View(); !strings.Contains(view, "Loading...") {
+				t.Fatalf("detail loading view missing placeholder:\n%s", view)
+			}
+
+			msg := cmd()
+			detailMsg, ok := msg.(topDetailMsg)
+			if !ok {
+				t.Fatalf("detail cmd returned %T, want topDetailMsg", msg)
+			}
+			if detailMsg.request.target.kind != tc.wantKind {
+				t.Fatalf("detail kind = %v, want %v", detailMsg.request.target.kind, tc.wantKind)
+			}
+			if got := detailTargetID(detailMsg.request.target); got != tc.wantTarget {
+				t.Fatalf("detail target id = %q, want %q", got, tc.wantTarget)
+			}
+			updated, _ = m.Update(detailMsg)
+			m = updated.(topModel)
+			if view := m.View(); !strings.Contains(view, "full detail body") {
+				t.Fatalf("loaded detail view missing body:\n%s", view)
+			}
+		})
+	}
+}
+
+func TestTopModel_DetailModalRendersErrorAndEscCloses(t *testing.T) {
+	t.Parallel()
+	loader := &stubTopLoader{
+		snapshot:  topDataSnapshot{Failures: []*model.Event{dashboardEvent("evt-fail", domtypes.EventKindCommandExecuted, "failure detail body")}},
+		detailErr: errors.New("detail boom"),
+	}
+	m := newDashboardTestModel(t, loader)
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 40)
+	m.pane = topPaneFailures
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(topModel)
+	updated, _ = m.Update(cmd())
+	m = updated.(topModel)
+	if view := m.View(); !strings.Contains(view, "detail boom") {
+		t.Fatalf("detail error view missing error:\n%s", view)
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("Esc in detail modal returned cmd, want nil")
+	}
+	m = updated.(topModel)
+	if m.mode != topModeBrowse {
+		t.Fatalf("mode = %v, want browse after Esc", m.mode)
+	}
+}
+
+func TestTopModel_DetailModalScrollsAndQCloses(t *testing.T) {
+	t.Parallel()
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = "detail line " + string(rune('a'+i))
+	}
+	loader := &stubTopLoader{
+		snapshot: topDataSnapshot{Failures: []*model.Event{dashboardEvent("evt-fail", domtypes.EventKindCommandExecuted, "failure detail body")}},
+		detail:   topDetailContent{title: "EVENT evt-fail", lines: lines},
+	}
+	m := newDashboardTestModel(t, loader)
+	m = applySnapshot(t, m)
+	m = resize(m, 120, 8)
+	m.pane = topPaneFailures
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(topModel)
+	updated, _ = m.Update(cmd())
+	m = updated.(topModel)
+
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.detailOffset == 0 {
+		t.Fatalf("detailOffset = 0 after PgDown, want scrolled")
+	}
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnd})
+	if got, want := m.detailOffset, len(lines)-m.detailViewportRows(); got != want {
+		t.Fatalf("detailOffset after End = %d, want %d", got, want)
+	}
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyUp})
+	if got, want := m.detailOffset, len(lines)-m.detailViewportRows()-1; got != want {
+		t.Fatalf("detailOffset after Up = %d, want %d", got, want)
+	}
+
+	updated, closeCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if closeCmd != nil {
+		t.Fatalf("q in detail modal returned cmd, want nil")
+	}
+	m = updated.(topModel)
+	if m.mode != topModeBrowse {
+		t.Fatalf("mode = %v, want browse after q", m.mode)
 	}
 }
 

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -19,10 +22,8 @@ import (
 // underlying usecases.
 //
 // Limit fields use the convention that a non-positive value disables the
-// corresponding load: callers wire the `traceary top` session limit on
-// the command surface today and leave the failures / recent-commands /
-// candidates / stale-memory limits at zero so the loader stays a no-op
-// for those panes until the multi-pane redesign (#928) needs them.
+// corresponding load. The live dashboard and snapshot paths opt in pane by
+// pane by setting the relevant limits.
 type topDataCriteria struct {
 	Workspace string
 	Client    string
@@ -33,6 +34,134 @@ type topDataCriteria struct {
 	RecentCommandLimit int
 	CandidateLimit     int
 	StaleMemoryLimit   int
+}
+
+func (l *topDataLoader) loadDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
+	switch req.target.kind {
+	case topDetailSession:
+		return l.loadSessionDetail(ctx, req)
+	case topDetailEvent:
+		return l.loadEventDetail(ctx, req)
+	case topDetailMemory:
+		return l.loadMemoryDetail(ctx, req)
+	default:
+		return topDetailContent{}, xerrors.Errorf("unsupported detail target")
+	}
+}
+
+func (l *topDataLoader) loadSessionDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
+	if l.session == nil {
+		return topDetailContent{}, xerrors.Errorf("session detail loader is not configured")
+	}
+	lineage, err := l.session.Lineage(ctx, req.target.sessionID)
+	if err != nil {
+		return topDetailContent{}, xerrors.Errorf("%s: %w", Localize("failed to load session detail", "session detail の取得に失敗しました"), err)
+	}
+	var events []*model.Event
+	if l.event != nil {
+		events, err = l.event.List(ctx, apptypes.NewEventListCriteriaBuilder(topDetailRecentEventLimit).
+			SessionID(req.target.sessionID).
+			Build())
+		if err != nil {
+			return topDetailContent{}, xerrors.Errorf("%s: %w", Localize("failed to load session events", "session event の取得に失敗しました"), err)
+		}
+	}
+	return topDetailContent{
+		title: req.target.title,
+		lines: formatTopSessionDetailLines(req.target.sessionID, lineage, events),
+	}, nil
+}
+
+func (l *topDataLoader) loadEventDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
+	if l.event == nil {
+		return topDetailContent{}, xerrors.Errorf("event detail loader is not configured")
+	}
+	details, err := l.event.Show(ctx, req.target.eventID)
+	if err != nil {
+		return topDetailContent{}, xerrors.Errorf("%s: %w", Localize("failed to load event detail", "event detail の取得に失敗しました"), err)
+	}
+	var buf bytes.Buffer
+	if err := writeEventDetails(&buf, details); err != nil {
+		return topDetailContent{}, err
+	}
+	return topDetailContent{title: req.target.title, lines: splitTopDetailText(buf.String())}, nil
+}
+
+func (l *topDataLoader) loadMemoryDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
+	if l.memory == nil {
+		return topDetailContent{}, xerrors.Errorf("memory detail loader is not configured")
+	}
+	details, err := l.memory.Show(ctx, req.target.memoryID)
+	if err != nil {
+		return topDetailContent{}, xerrors.Errorf("%s: %w", Localize("failed to load memory detail", "memory detail の取得に失敗しました"), err)
+	}
+	var buf bytes.Buffer
+	if err := writeMemoryDetails(&buf, details); err != nil {
+		return topDetailContent{}, err
+	}
+	return topDetailContent{title: req.target.title, lines: splitTopDetailText(buf.String())}, nil
+}
+
+func formatTopSessionDetailLines(sessionID domtypes.SessionID, lineage []apptypes.SessionSummary, events []*model.Event) []string {
+	lines := []string{
+		fmt.Sprintf("SESSION_ID: %s", sessionID),
+	}
+	var selected apptypes.SessionSummary
+	for _, summary := range lineage {
+		if summary.SessionID() == sessionID {
+			selected = summary
+			break
+		}
+	}
+	if selected.SessionID() != "" {
+		lines = append(lines,
+			fmt.Sprintf("ROW: %s", formatTopNodeLineIn(&sessionNode{summary: selected}, "", 0, selected.LatestEventAt(), timeUTC())),
+			fmt.Sprintf("LABEL: %s", formatOptionalColumn(selected.Label())),
+			fmt.Sprintf("SUMMARY: %s", formatOptionalColumn(selected.Summary())),
+		)
+	}
+	lines = append(lines, "", "LINEAGE:")
+	if len(lineage) == 0 {
+		lines = append(lines, "- -")
+	} else {
+		for i, summary := range lineage {
+			lines = append(lines, fmt.Sprintf("- %d. %s status=%s workspace=%s agent=%s parent=%s", i+1, summary.SessionID(), summary.Status(), summary.Workspace(), extractSubagentType(summary.Agents()), formatOptionalColumn(summary.ParentSessionID().String())))
+		}
+	}
+	lines = append(lines, "", fmt.Sprintf("RECENT_EVENTS (limit=%d):", topDetailRecentEventLimit))
+	if len(events) == 0 {
+		lines = append(lines, "- -")
+	} else {
+		for _, ev := range events {
+			lines = appendSessionEventDetailLines(lines, ev)
+		}
+	}
+	return lines
+}
+
+func appendSessionEventDetailLines(lines []string, ev *model.Event) []string {
+	bodyLines := splitTopDetailText(apptypes.ExtractPlainBody(ev.Body()))
+	prefix := fmt.Sprintf("- %s %s %s", ev.CreatedAt().UTC().Format(eventCompactTimeLayout), ev.EventID(), ev.Kind())
+	if len(bodyLines) == 0 {
+		return append(lines, prefix)
+	}
+	lines = append(lines, fmt.Sprintf("%s %s", prefix, bodyLines[0]))
+	for _, line := range bodyLines[1:] {
+		lines = append(lines, "  "+line)
+	}
+	return lines
+}
+
+func splitTopDetailText(text string) []string {
+	trimmed := strings.TrimRight(text, "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+func timeUTC() *time.Location {
+	return time.UTC
 }
 
 // topDataSnapshot bundles every data slice the redesigned top dashboard

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,12 +57,22 @@ type topDataEventStub struct {
 	listErr      error
 	listCriteria apptypes.EventListCriteria
 	listCalls    int
+	showDetails  apptypes.EventDetails
+	showErr      error
+	showEventID  domtypes.EventID
+	showCalls    int
 }
 
 func (s *topDataEventStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
 	s.listCriteria = criteria
 	s.listCalls++
 	return s.listEvents, s.listErr
+}
+
+func (s *topDataEventStub) Show(_ context.Context, eventID domtypes.EventID) (apptypes.EventDetails, error) {
+	s.showEventID = eventID
+	s.showCalls++
+	return s.showDetails, s.showErr
 }
 
 // topDataMemoryStub satisfies usecase.MemoryUsecase via the embedded
@@ -77,6 +88,10 @@ type topDataMemoryStub struct {
 	staleErr            error
 	staleMemoryCriteria apptypes.StaleMemoryListCriteria
 	staleMemoryCalls    int
+	showDetails         apptypes.MemoryDetails
+	showErr             error
+	showMemoryID        domtypes.MemoryID
+	showCalls           int
 }
 
 func (s *topDataMemoryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -89,6 +104,12 @@ func (s *topDataMemoryStub) ListStale(_ context.Context, criteria apptypes.Stale
 	s.staleMemoryCriteria = criteria
 	s.staleMemoryCalls++
 	return s.staleResult, s.staleErr
+}
+
+func (s *topDataMemoryStub) Show(_ context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	s.showMemoryID = memoryID
+	s.showCalls++
+	return s.showDetails, s.showErr
 }
 
 // fixedStartedAt is the deterministic anchor every fixture in this file
@@ -505,6 +526,113 @@ func TestTopDataLoader_LoadStaleMemories_ZeroLimitIsNoOp(t *testing.T) {
 	}
 	if memory.staleMemoryCalls != 0 {
 		t.Fatalf("memory.ListStale calls = %d, want 0", memory.staleMemoryCalls)
+	}
+}
+
+func TestTopDataLoader_LoadDetail_SessionUsesLineageAndRecentEvents(t *testing.T) {
+	t.Parallel()
+
+	root := sessionSummaryFixture("root", "", fixedStartedAt, "ended", domtypes.EventKindSessionEnded, "root ended")
+	child := sessionSummaryFixture("child", "root", fixedStartedAt.Add(10*time.Minute), "active", domtypes.EventKindTranscript, "child active")
+	event := mustEvent(t, "evt-session", domtypes.EventKindTranscript, "first session event line\nsecond session event line")
+	session := &topDataSessionStub{lineageByID: map[domtypes.SessionID][]apptypes.SessionSummary{
+		domtypes.SessionID("child"): {root, child},
+	}}
+	events := &topDataEventStub{listEvents: []*model.Event{event}}
+	loader := newTopDataLoader(session, events, nil)
+
+	got, err := loader.loadDetail(context.Background(), topDetailRequest{
+		target: topDetailTarget{kind: topDetailSession, title: "SESSION child", sessionID: domtypes.SessionID("child")},
+	})
+	if err != nil {
+		t.Fatalf("loadDetail(session) error = %v", err)
+	}
+	joined := strings.Join(got.lines, "\n")
+	for _, expect := range []string{"SESSION_ID: child", "LINEAGE:", "root", "child", "RECENT_EVENTS", "first session event line", "  second session event line"} {
+		if !strings.Contains(joined, expect) {
+			t.Fatalf("session detail missing %q:\n%s", expect, joined)
+		}
+	}
+	for _, line := range got.lines {
+		if strings.Contains(line, "first session event line") && strings.Contains(line, "second session event line") {
+			t.Fatalf("multiline event body should be split into modal rows, got combined line %q", line)
+		}
+	}
+	if len(session.lineageCalls) != 1 || session.lineageCalls[0] != "child" {
+		t.Fatalf("Lineage calls = %#v, want child", session.lineageCalls)
+	}
+	if events.listCriteria.SessionID() != "child" || events.listCriteria.Limit() != topDetailRecentEventLimit {
+		t.Fatalf("event List criteria = session %q limit %d, want child/%d", events.listCriteria.SessionID(), events.listCriteria.Limit(), topDetailRecentEventLimit)
+	}
+}
+
+func TestTopDataLoader_LoadDetail_EventUsesShowAndFormatsAudit(t *testing.T) {
+	t.Parallel()
+
+	event := mustEvent(t, "evt-detail", domtypes.EventKindCommandExecuted, "full event body")
+	audit := model.CommandAuditOf(
+		event.EventID(),
+		"go test ./...",
+		"stdin payload",
+		"stdout payload",
+		false,
+		false,
+		domtypes.Some(1),
+	)
+	details, err := apptypes.EventDetailsOf(event, domtypes.Some(audit))
+	if err != nil {
+		t.Fatalf("EventDetailsOf: %v", err)
+	}
+	events := &topDataEventStub{showDetails: details}
+	loader := newTopDataLoader(nil, events, nil)
+
+	got, err := loader.loadDetail(context.Background(), topDetailRequest{
+		target: topDetailTarget{kind: topDetailEvent, title: "EVENT evt-detail", eventID: event.EventID()},
+	})
+	if err != nil {
+		t.Fatalf("loadDetail(event) error = %v", err)
+	}
+	joined := strings.Join(got.lines, "\n")
+	for _, expect := range []string{"EVENT_ID: evt-detail", "MESSAGE: full event body", "COMMAND: go test ./...", "EXIT_CODE: 1", "stdout payload"} {
+		if !strings.Contains(joined, expect) {
+			t.Fatalf("event detail missing %q:\n%s", expect, joined)
+		}
+	}
+	if events.showCalls != 1 || events.showEventID != "evt-detail" {
+		t.Fatalf("Show calls/id = %d/%q, want 1/evt-detail", events.showCalls, events.showEventID)
+	}
+}
+
+func TestTopDataLoader_LoadDetail_MemoryUsesShowAndFormatsRefs(t *testing.T) {
+	t.Parallel()
+
+	summary := memorySummaryFixture(t, "mem-detail", domtypes.MemoryStatusCandidate, "full memory fact")
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindEvent, "evt-detail")
+	if err != nil {
+		t.Fatalf("EvidenceRefFrom: %v", err)
+	}
+	artifact, err := domtypes.ArtifactRefFrom(domtypes.ArtifactRefKindFile, "docs/plan.md")
+	if err != nil {
+		t.Fatalf("ArtifactRefFrom: %v", err)
+	}
+	details := apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{evidence}, []domtypes.ArtifactRef{artifact})
+	memory := &topDataMemoryStub{showDetails: details}
+	loader := newTopDataLoader(nil, nil, memory)
+
+	got, err := loader.loadDetail(context.Background(), topDetailRequest{
+		target: topDetailTarget{kind: topDetailMemory, title: "MEMORY mem-detail", memoryID: summary.MemoryID()},
+	})
+	if err != nil {
+		t.Fatalf("loadDetail(memory) error = %v", err)
+	}
+	joined := strings.Join(got.lines, "\n")
+	for _, expect := range []string{"MEMORY_ID: mem-detail", "FACT: full memory fact", "EVIDENCE_REFS:", "event:evt-detail", "ARTIFACT_REFS:", "file:docs/plan.md"} {
+		if !strings.Contains(joined, expect) {
+			t.Fatalf("memory detail missing %q:\n%s", expect, joined)
+		}
+	}
+	if memory.showCalls != 1 || memory.showMemoryID != "mem-detail" {
+		t.Fatalf("Show calls/id = %d/%q, want 1/mem-detail", memory.showCalls, memory.showMemoryID)
 	}
 }
 


### PR DESCRIPTION
## Motivation

`traceary top` should let operators drill into the highlighted row without leaving the live dashboard to copy IDs into separate commands.

Closes #962

## Changes

- Adds Enter-driven detail modal state to the top dashboard.
- Maps rendered pane rows to detail targets for sessions, failures, recent commands, candidate memories, and stale memories.
- Reuses existing application-layer queries:
  - `SessionUsecase.Lineage` + `EventUsecase.List` for session details.
  - `EventUsecase.Show` for failure/recent-command event details and command audit details.
  - `MemoryUsecase.Show` for candidate/stale memory details.
- Adds loading/error detail states plus modal scrolling and Esc/q close behavior.
- Documents Enter detail in footer/help.
- Adds TUI tests for opening details from every pane, stale memory coverage, error path, scrolling, and close behavior, plus data-loader detail tests.

## Delegation notes

- Claude Code Opus 4.7 delegation was attempted. The local Claude CLI rejected `--effort auto` (`low|medium|high|xhigh|max` only), and a retry without explicit effort produced no output and had to be interrupted. Codex completed the implementation fallback to keep the autonomous flow moving.

## Validation

- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./presentation/cli -run 'TestTopModel_|TestTopDataLoader_LoadDetail'`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go build ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache GOTMPDIR=/private/tmp go tool golangci-lint run`
- `rtk git diff --check`