### PR TITLE
fix(cli): return error for inbox review failures

### DIFF
--- a/presentation/cli/memory_inbox_review.go
+++ b/presentation/cli/memory_inbox_review.go
@@ -109,7 +109,11 @@ func (c *RootCLI) runMemoryInboxReview(ctx context.Context, output io.Writer, in
 		return xerrors.Errorf("%s", Localize("review model returned unexpected final state", "review model が想定外の最終状態を返しました"))
 	}
 
-	result, applyErr := applyInboxReviewDecisions(ctx, c.memory, final.Decisions(), items)
+	return finishMemoryInboxReview(ctx, output, c.memory, final, items)
+}
+
+func finishMemoryInboxReview(ctx context.Context, output io.Writer, writer inboxReviewWriter, final reviewModel, items []apptypes.MemoryDetails) error {
+	result, applyErr := applyInboxReviewDecisions(ctx, writer, final.Decisions(), items)
 	if applyErr != nil {
 		return applyErr
 	}
@@ -285,7 +289,18 @@ func writeMemoryInboxReviewSummary(output io.Writer, result memoryInboxReviewRes
 			return xerrors.Errorf("%s: %w", Localize("failed to print review failure row", "review 失敗行の出力に失敗しました"), err)
 		}
 	}
+	if len(result.Failures) > 0 {
+		return memoryInboxReviewFailureError(result)
+	}
 	return nil
+}
+
+func memoryInboxReviewFailureError(result memoryInboxReviewResult) error {
+	return xerrors.Errorf(Localizef(
+		"inbox review failed for %d memory id(s)",
+		"inbox review が %d 件の memory id で失敗しました",
+		len(result.Failures),
+	))
 }
 
 // reviewDecisionKind enumerates the post-quit operations the CLI dispatches

--- a/presentation/cli/memory_inbox_review_internal_test.go
+++ b/presentation/cli/memory_inbox_review_internal_test.go
@@ -525,6 +525,62 @@ func TestInboxReviewExitError_CarriesExitCodeTwo(t *testing.T) {
 	}
 }
 
+func TestWriteMemoryInboxReviewSummary_FailureReturnsError(t *testing.T) {
+	t.Parallel()
+	candidate := buildReviewCandidate(t, "id-ok", "accepted fact")
+
+	okResult := memoryInboxReviewResult{Accepted: []apptypes.MemoryDetails{candidate}}
+	okOut := &strings.Builder{}
+	if err := writeMemoryInboxReviewSummary(okOut, okResult); err != nil {
+		t.Fatalf("writeMemoryInboxReviewSummary(success) error = %v, want nil", err)
+	}
+
+	failureResult := memoryInboxReviewResult{
+		Accepted: []apptypes.MemoryDetails{candidate},
+		Failures: []memoryInboxFailure{
+			{ID: "id-fail", Error: "synthetic failure"},
+		},
+	}
+	out := &strings.Builder{}
+	err := writeMemoryInboxReviewSummary(out, failureResult)
+	if err == nil {
+		t.Fatalf("writeMemoryInboxReviewSummary(failure) error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "inbox review failed for 1 memory id(s)") {
+		t.Fatalf("unexpected failure error: %v", err)
+	}
+	want := "review accepted=1 rejected=0 distilled=0 failures=1\nACCEPT\tid-ok\tcandidate\nFAILED\tid-fail\tsynthetic failure\n"
+	if got := out.String(); got != want {
+		t.Fatalf("summary output changed:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestFinishMemoryInboxReview_ReturnsFailureError(t *testing.T) {
+	t.Parallel()
+	candidate := buildReviewCandidate(t, "id-1", "accepted fact")
+	final := newReviewTestModel(candidate)
+	final.decisions = []reviewDecision{
+		{kind: reviewDecisionAccept, memoryID: candidate.Summary().MemoryID()},
+	}
+	stub := &reviewWriterStub{acceptErr: errors.New("synthetic accept failure")}
+	out := &strings.Builder{}
+
+	err := finishMemoryInboxReview(context.Background(), out, stub, final, []apptypes.MemoryDetails{candidate})
+	if err == nil {
+		t.Fatal("finishMemoryInboxReview error = nil, want failure summary error")
+	}
+	if !strings.Contains(err.Error(), "inbox review failed for 1 memory id(s)") {
+		t.Fatalf("unexpected failure error: %v", err)
+	}
+	if stub.acceptCalls != 1 {
+		t.Fatalf("acceptCalls = %d, want 1", stub.acceptCalls)
+	}
+	want := "review accepted=0 rejected=0 distilled=0 failures=1\nFAILED\tid-1\tsynthetic accept failure\n"
+	if got := out.String(); got != want {
+		t.Fatalf("summary output changed:\n got %q\nwant %q", got, want)
+	}
+}
+
 // TestApplyInboxReviewDecisions_DispatchesToUsecases drives the post-quit
 // runner directly with a list of decisions and verifies each one routes
 // to the correct usecase method exactly once. The corresponding stubs


### PR DESCRIPTION
## Motivation

`traceary memory inbox review` printed per-id `FAILED` rows when queued accept/reject/distill operations failed, but still returned success. That made automation and shell callers treat partially failed reviews as successful.

Closes #963

## Changes

- Keep applying all queued review decisions and preserve the existing stdout summary/`FAILED` row format.
- Return a localized non-nil error after printing the summary when any per-id failure is present.
- Factor the post-TUI finish path so the runner path can be tested without a real TTY.
- Add regression tests for summary errors and propagated finish-path failures.

## Delegation notes

- Requested Claude Code Opus 4.7 with `effort=auto`; the local CLI rejected `--effort auto` as invalid.
- Retried Claude Code without explicit effort; the headless command produced no actionable output before timeout and was terminated. Implementation was completed by Codex with the same issue scope.

## Validation

- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./presentation/cli -run 'TestWriteMemoryInboxReviewSummary_FailureReturnsError|TestFinishMemoryInboxReview_ReturnsFailureError|TestApplyInboxReviewDecisions_FailureIsRecordedNotPropagated'`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go test ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp go build ./...`
- `rtk env GOCACHE=/private/tmp/traceary-gocache GOMODCACHE=/private/tmp/traceary-gomodcache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `rtk git diff --check`