### PR TITLE
fix(cli): diagnose Codex plugin hook fallback

### DIFF
--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -3,7 +3,7 @@
 [English](./codex-plugin.md)
 
 Traceary の Codex 向け plugin は `plugins/traceary/` にあり、Codex CLI 公式の `/plugins` flow に乗せて使えます。
-MCP server / slash command / session-history skill / session・prompt・transcript・audit の hook は、公式 flow で plugin を install した時点で自動配線されます。
+MCP server / slash command / session-history skill は、公式 flow で plugin を install した時点で自動配線されます。hook 登録は条件付きで、Codex 側の `plugin_hooks` feature が stable + 有効なビルドでのみ自動配線されます。`codex features list` で `plugin_hooks` が `under development` のままだったり、`~/.codex/config.toml` に `[features].plugin_hooks = false` が明示されているビルドでは、plugin 配下の hook manifest は `~/.codex/hooks.json` に展開されないため、手動 install による fallback が必要です。詳細は下記の **Hook fallback (plugin_hooks が利用できない環境向け)** セクションを参照してください。
 
 ## Codex 公式 /plugins flow で入れる (primary)
 
@@ -40,9 +40,42 @@ traceary doctor --client codex --json
 ## 公式 flow が自動で組み込むもの
 
 - `traceary mcp-server` を呼ぶ `traceary` MCP server
-- `SessionStart`, `UserPromptSubmit`, `Stop`（session 終了 + transcript）, `PostToolUse` hook（`plugins/traceary/hooks.json` で宣言、manifest から参照）
+- `SessionStart`, `UserPromptSubmit`, `Stop`（session 終了 + transcript）, `PostToolUse` hook（`plugins/traceary/hooks.json` で宣言、manifest から参照） — **Codex 側の `plugin_hooks` feature が有効なビルドに限る**。それ以外は下記 **Hook fallback (plugin_hooks が利用できない環境向け)** セクションを参照
 - slash command: `/traceary:help`, `/traceary:doctor`
 - 文脈に効く skill: `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember`。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。
+
+## Hook fallback (plugin_hooks が利用できない環境向け)
+
+Codex 側の plugin-managed hook サポートは `plugin_hooks` feature flag に紐付いており、ビルドによってはまだ `under development` のままです。feature が利用できない環境では、`/plugins` で Traceary plugin が enabled になっていても Codex は plugin manifest の hook 宣言を `~/.codex/hooks.json` に展開しないため、`traceary tail` や durable-memory extraction に Codex の event が一切流れません。
+
+診断手順:
+
+```sh
+codex features list                          # plugin_hooks は stable + on か
+cat ~/.codex/config.toml                     # [features].plugin_hooks = false が無いか
+traceary doctor --client codex --json        # plugin_hooks fallback 用の actionable warning が表示される
+```
+
+`plugin_hooks` が利用できない場合は、event を捕捉するために hook を手動 install してください:
+
+```sh
+traceary hooks install --client codex --upgrade --traceary-bin "$(command -v traceary)"
+traceary doctor --client codex --json
+```
+
+fallback は `~/.codex/hooks.json` に Traceary 管理のエントリ (`traceary-session-start` / `traceary-prompt` / `traceary-transcript` / `traceary-session-stop` / `traceary-audit`) を直接書き込みます。Traceary 以外のエントリは保持されます。
+
+### 二重記録の注意点
+
+将来 Codex 側で `plugin_hooks` が有効化されると、plugin manifest 経由の hook が自動で発火するようになります。このとき `~/.codex/hooks.json` に fallback で書き込まれた手動エントリがそのまま残っていると、**session / prompt / transcript / audit の各 event が二重に記録されます**。fallback を経由した install で plugin-managed hook を改めて有効化する前に、手動エントリを削除してください:
+
+```sh
+# ~/.codex/hooks.json を開き、fallback が追加した次の名前付きエントリを削除:
+#   traceary-session-start / traceary-prompt / traceary-transcript /
+#   traceary-session-stop / traceary-audit
+```
+
+cleanup 後に `traceary doctor --client codex --json` を再実行し、登録経路が一つだけになっていることを確認してください。
 
 ## Memory activation strategy
 

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -3,7 +3,7 @@
 [日本語](./codex-plugin.ja.md)
 
 Traceary ships a Codex plugin under `plugins/traceary/` that plugs into Codex CLI's official `/plugins` flow.
-Codex picks up the MCP server, the slash commands, the session-history skill, and the session / prompt / transcript / audit hooks automatically as soon as the plugin is installed through the official flow.
+Codex picks up the MCP server, the slash commands, and the session-history skill automatically as soon as the plugin is installed through the official flow. Hook registration is conditional: it works on Codex builds where the `plugin_hooks` feature is enabled and stable. On builds where `plugin_hooks` is still under development or explicitly disabled (`codex features list` shows `plugin_hooks` as `under development`, or `~/.codex/config.toml` has `[features].plugin_hooks = false`), the plugin's hook manifest is not materialized into `~/.codex/hooks.json` and a manual hook install is required — see the **Hook fallback when plugin_hooks is unavailable** section below.
 
 ## Install via Codex's official /plugins flow (primary)
 
@@ -40,9 +40,42 @@ traceary doctor --client codex --json
 ## What the official flow wires automatically
 
 - `traceary` MCP server via `traceary mcp-server`
-- `SessionStart`, `UserPromptSubmit`, `Stop` (session end + transcript), and `PostToolUse` hooks (declared in `plugins/traceary/hooks.json` and referenced from the plugin manifest)
+- `SessionStart`, `UserPromptSubmit`, `Stop` (session end + transcript), and `PostToolUse` hooks (declared in `plugins/traceary/hooks.json` and referenced from the plugin manifest) — **only when `plugin_hooks` is enabled on your Codex build**; otherwise see the fallback below
 - slash commands: `/traceary:help` and `/traceary:doctor`
 - contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて").
+
+## Hook fallback when plugin_hooks is unavailable
+
+Codex's plugin-managed hook support shipped behind the `plugin_hooks` feature flag and is still marked `under development` on some builds. When the feature is unavailable, Codex will not materialize the plugin manifest's hook declarations into `~/.codex/hooks.json`, so `traceary tail` and durable-memory extraction will see no Codex events even though `/plugins` lists the Traceary plugin as enabled.
+
+Diagnose with:
+
+```sh
+codex features list                          # is plugin_hooks stable + on?
+cat ~/.codex/config.toml                     # does [features].plugin_hooks = false exist?
+traceary doctor --client codex --json        # surfaces the actionable fallback warning
+```
+
+If `plugin_hooks` is unavailable, install the hooks manually so events are still captured:
+
+```sh
+traceary hooks install --client codex --upgrade --traceary-bin "$(command -v traceary)"
+traceary doctor --client codex --json
+```
+
+The fallback writes Traceary-managed entries directly into `~/.codex/hooks.json` (named `traceary-session-start`, `traceary-prompt`, `traceary-transcript`, `traceary-session-stop`, `traceary-audit`). Existing non-Traceary entries are preserved.
+
+### Duplicate-capture warning
+
+If a future Codex build enables `plugin_hooks` for your install (the plugin manifest's hooks start firing automatically) while these manual entries remain in `~/.codex/hooks.json`, **every session/prompt/transcript/audit event will be recorded twice**. Before enabling plugin-managed hooks on an install that previously used the fallback, remove the manual entries:
+
+```sh
+# Inspect ~/.codex/hooks.json and delete the named entries the fallback created:
+#   traceary-session-start, traceary-prompt, traceary-transcript,
+#   traceary-session-stop, traceary-audit
+```
+
+After cleanup, re-run `traceary doctor --client codex --json` to confirm only one registration path is active.
 
 ## Memory activation strategy
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -689,6 +689,11 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 	content, err := os.ReadFile(outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if client == "codex" {
+				if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+					return codexPluginHookFallbackCheck(state, outputPath, localizef("does not exist", "が存在しません"))
+				}
+			}
 			return doctorCheck{
 				Name:   client + "-config",
 				Status: doctorStatusWarn,
@@ -726,6 +731,11 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 	}
 
 	if !hasHooksField {
+		if client == "codex" {
+			if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+				return codexPluginHookFallbackCheck(state, outputPath, localizef("has no hooks field", "には hooks フィールドがありません"))
+			}
+		}
 		return doctorCheck{
 			Name:   client + "-config",
 			Status: doctorStatusWarn,
@@ -758,6 +768,12 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 			Name:    client + "-config",
 			Status:  doctorStatusPass,
 			Message: localizef("%s config contains Traceary-managed hooks: %s", "%s の設定には Traceary 管理下の hook があります: %s", client, outputPath),
+		}
+	}
+
+	if client == "codex" {
+		if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+			return codexPluginHookFallbackCheck(state, outputPath, localizef("has hook entries but none are Traceary-managed", "には hook エントリはありますが Traceary 管理のものがありません"))
 		}
 	}
 

--- a/presentation/cli/doctor_codex_plugin.go
+++ b/presentation/cli/doctor_codex_plugin.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// codexPluginHookFallbackState captures the subset of ~/.codex/config.toml
+// that doctor needs to surface the v0.15.1 plugin_hooks fallback warning.
+// PluginKey is the first matching `traceary@<marketplace>` table key that
+// is enabled; PluginHooksFeature is the literal value of `[features].plugin_hooks`
+// (nil when the key is absent). ConfigTOMLPath is always populated so callers
+// can reference the file in user-facing messages even when the read fails.
+type codexPluginHookFallbackState struct {
+	ConfigTOMLPath     string
+	PluginEnabled      bool
+	PluginKey          string
+	PluginHooksFeature *bool
+}
+
+// detectCodexPluginHookFallback returns the state of the Codex plugin
+// entry and the `[features].plugin_hooks` flag in `~/.codex/config.toml`.
+// Missing file, unreadable file, and invalid TOML all return a zero-value
+// state so the doctor falls back to the existing generic warning.
+func (c *RootCLI) detectCodexPluginHookFallback() codexPluginHookFallbackState {
+	home, err := userHomeDirFunc()
+	if err != nil {
+		return codexPluginHookFallbackState{}
+	}
+	path := filepath.Join(home, ".codex", "config.toml")
+	state := codexPluginHookFallbackState{ConfigTOMLPath: path}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return state
+	}
+	var root struct {
+		Plugins map[string]struct {
+			Enabled bool `toml:"enabled"`
+		} `toml:"plugins"`
+		Features struct {
+			PluginHooks *bool `toml:"plugin_hooks"`
+		} `toml:"features"`
+	}
+	if err := toml.Unmarshal(content, &root); err != nil {
+		return state
+	}
+	state.PluginHooksFeature = root.Features.PluginHooks
+	for key, plugin := range root.Plugins {
+		if strings.HasPrefix(key, "traceary@") && plugin.Enabled {
+			state.PluginEnabled = true
+			state.PluginKey = key
+			break
+		}
+	}
+	return state
+}
+
+// codexPluginHookFallbackCheck builds the actionable doctor warning that
+// fires when the Traceary Codex plugin is enabled in config.toml but the
+// effective hooks.json does not register any Traceary-managed hook entry.
+// The reason argument explains the observed shape of hooks.json (missing,
+// no hooks field, or no Traceary entry) so users can correlate the warning
+// with what they see on disk.
+func codexPluginHookFallbackCheck(state codexPluginHookFallbackState, hooksPath, reason string) doctorCheck {
+	pluginKey := state.PluginKey
+	if pluginKey == "" {
+		pluginKey = "traceary@<marketplace>"
+	}
+	featureNote := ""
+	if state.PluginHooksFeature != nil && !*state.PluginHooksFeature {
+		featureNote = localizef(
+			" `[features].plugin_hooks = false` in %s confirms the Codex build is not delivering plugin-managed hooks for this install.",
+			" %s では `[features].plugin_hooks = false` が明示されており、この install では plugin-managed hook が配信されません。",
+			state.ConfigTOMLPath,
+		)
+	}
+	message := localizef(
+		"codex plugin %q is enabled in %s but %s %s; Codex builds where plugin-managed hooks are unavailable (e.g. `plugin_hooks=false` or `codex features list` showing `plugin_hooks` under development) need a manual hook install to record events.%s Run the fallback below; if you later enable plugin-managed hooks, remove the manual entries first to avoid duplicate event capture.",
+		"codex plugin %q は %s で有効になっていますが %s %s。Codex 側で plugin-managed hook が配信されないビルド (`plugin_hooks=false` や `codex features list` で `plugin_hooks` が development 状態など) では、event を記録するために fallback の hook install が必要です。%s 下記の fallback を実行してください。後で plugin-managed hook を有効化する場合は、二重記録を避けるために事前に手動 hook を削除してください。",
+		pluginKey,
+		state.ConfigTOMLPath,
+		hooksPath,
+		reason,
+		featureNote,
+	)
+	return doctorCheck{
+		Name:       "codex-config",
+		Status:     doctorStatusWarn,
+		Hint:       "fall back to a manual hook install while plugin-managed hooks are unavailable; remove the manual entries before re-enabling plugin hooks to avoid duplicate capture",
+		Message:    message,
+		FixCommand: "traceary hooks install --client codex --upgrade --traceary-bin $(command -v traceary)",
+	}
+}

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -379,6 +379,80 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("codex plugin enabled but hooks.json lacks Traceary entries warns about plugin_hooks fallback", func(t *testing.T) {
+		// Regression for #967: Codex builds with `plugin_hooks=false`
+		// (or any plugin host that does not materialize plugin-managed
+		// hooks) leave hooks.json without Traceary entries even when
+		// the Traceary plugin is enabled in config.toml. The doctor
+		// must surface the manual fallback, not the generic "no
+		// Traceary-managed hook" warning.
+		codexDir := filepath.Join(homeDir, ".codex")
+		if err := os.MkdirAll(codexDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		configTOML := `[features]
+plugin_hooks = false
+
+[plugins."traceary@local-traceary-plugins"]
+enabled = true
+`
+		if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(configTOML), 0o644); err != nil {
+			t.Fatalf("WriteFile(codex config.toml) error = %v", err)
+		}
+		// Non-Traceary user hooks already present in hooks.json.
+		nonTraceary := `{
+			"hooks": {
+				"SessionStart": [{"hooks": [{"type": "command", "command": "'/usr/local/bin/custom' 'hook' 'session' 'start'"}]}],
+				"Stop": [{"hooks": [{"type": "command", "command": "'/usr/local/bin/custom' 'hook' 'session' 'stop'"}]}]
+			}
+		}`
+		if err := os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(nonTraceary), 0o644); err != nil {
+			t.Fatalf("WriteFile(codex hooks.json) error = %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(codexDir) })
+
+		initStub := &storeManagementUsecaseStub{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(initStub)).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "codex", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		var codex doctorCheck
+		for _, check := range report.Checks {
+			if check.Name == "codex-config" {
+				codex = check
+			}
+		}
+		if codex.Status != "warn" {
+			t.Fatalf("codex-config status = %q, want warn (message: %q)", codex.Status, codex.Message)
+		}
+		if !strings.Contains(codex.Message, "traceary@local-traceary-plugins") {
+			t.Fatalf("expected message to identify the enabled plugin key, got %q", codex.Message)
+		}
+		if !strings.Contains(codex.Message, "plugin_hooks") {
+			t.Fatalf("expected message to mention plugin_hooks fallback path, got %q", codex.Message)
+		}
+		if !strings.Contains(codex.Message, "manual hook install") {
+			t.Fatalf("expected message to explain manual hook install fallback, got %q", codex.Message)
+		}
+		if !strings.Contains(codex.Message, "duplicate event capture") {
+			t.Fatalf("expected message to warn about duplicate event capture, got %q", codex.Message)
+		}
+		if !strings.Contains(codex.Message, "plugin_hooks = false") {
+			t.Fatalf("expected message to surface the explicit [features].plugin_hooks=false flag, got %q", codex.Message)
+		}
+		if codex.Hint == "" {
+			t.Fatalf("expected hint to be set, got empty (check=%+v)", codex)
+		}
+		if !strings.Contains(codex.FixCommand, "traceary hooks install --client codex --upgrade") {
+			t.Fatalf("FixCommand = %q, want the manual fallback install command", codex.FixCommand)
+		}
+	})
+
 	t.Run("invalid Traceary config fails doctor", func(t *testing.T) {
 		configDir := filepath.Join(homeDir, ".config", "traceary")
 		if err := os.MkdirAll(configDir, 0o755); err != nil {


### PR DESCRIPTION
## Motivation

Codex plugin installs can expose MCP/skills while plugin-managed hooks are unavailable when `plugin_hooks` is disabled or still under development. In that state, `traceary tail --agent codex` stays stale even though the plugin appears enabled.

Closes #967

## Changes

- Clarify Codex plugin docs in English/Japanese that hook registration depends on `plugin_hooks` support.
- Document the manual `traceary hooks install --client codex --upgrade` fallback and duplicate-capture cleanup risk.
- Add a Codex-specific doctor warning when the Traceary plugin is enabled but no effective Traceary hooks are present.
- Add a regression test for plugin enabled + `plugin_hooks = false` + non-Traceary hooks only.

## Implementation delegation

- Design/implementation was delegated to Claude Code CLI per release-operating instruction.
- Claude edited the branch but the headless session hung during its final build/check phase, so Codex terminated the worker and performed verification/integration locally.

## Verification

- `rtk proxy gofmt -w presentation/cli/doctor.go presentation/cli/doctor_codex_plugin.go presentation/cli/doctor_test.go`
- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./presentation/cli -run 'TestRootCLI_DoctorCommand|TestRootCLI_DoctorCodex'`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy python3 scripts/verify_integrations.py`

## Residual risks

- Doctor cannot directly observe `codex features list` in a portable way; the warning infers the fallback condition from enabled plugin + missing effective hooks and surfaces `[features].plugin_hooks = false` when present.
