### PR TITLE
v0.16-2: normalize workspace resolution across sessions, events, and memories

### DIFF
--- a/application/queryservice/workspace_resolution.go
+++ b/application/queryservice/workspace_resolution.go
@@ -1,0 +1,192 @@
+package queryservice
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// WorkspaceResolutionCriteria describes the common filters used when resolving
+// a requested workspace to the session row that should back read-side context
+// assembly. It deliberately stays independent of any specific usecase criteria
+// type so session, event, and memory context surfaces can share the same
+// parent/child fallback contract.
+type WorkspaceResolutionCriteria struct {
+	sessionID  domtypes.SessionID
+	workspace  domtypes.Workspace
+	activeOnly bool
+}
+
+// WorkspaceResolutionCriteriaOf creates criteria for ResolveSessionWorkspace.
+func WorkspaceResolutionCriteriaOf(sessionID domtypes.SessionID, workspace domtypes.Workspace, activeOnly bool) WorkspaceResolutionCriteria {
+	return WorkspaceResolutionCriteria{
+		sessionID:  sessionID,
+		workspace:  workspace,
+		activeOnly: activeOnly,
+	}
+}
+
+// SessionID returns the optional exact session ID filter.
+func (c WorkspaceResolutionCriteria) SessionID() domtypes.SessionID { return c.sessionID }
+
+// Workspace returns the originally requested workspace.
+func (c WorkspaceResolutionCriteria) Workspace() domtypes.Workspace { return c.workspace }
+
+// ActiveOnly reports whether session lookup should only consider active
+// sessions.
+func (c WorkspaceResolutionCriteria) ActiveOnly() bool { return c.activeOnly }
+
+// WorkspaceResolution carries the outcome of canonical workspace resolution
+// used by session, event, and memory query paths. matchedSession is the
+// session selected for the requested workspace (either exact match or via
+// ancestor fallback when the requested workspace is a child path). When
+// fallbackApplied is true, matchedSession.Workspace() is an ancestor of the
+// requested workspace and at least one event for the session was recorded
+// under the requested workspace.
+type WorkspaceResolution struct {
+	matchedSession  apptypes.SessionSummary
+	matchedFound    bool
+	fallbackApplied bool
+}
+
+// MatchedSession returns the selected session summary.
+func (r WorkspaceResolution) MatchedSession() apptypes.SessionSummary { return r.matchedSession }
+
+// MatchedFound reports whether resolution selected a session.
+func (r WorkspaceResolution) MatchedFound() bool { return r.matchedFound }
+
+// FallbackApplied reports whether resolution selected an ancestor workspace
+// session after finding event evidence under the originally requested
+// workspace.
+func (r WorkspaceResolution) FallbackApplied() bool { return r.fallbackApplied }
+
+// ResolveSessionWorkspace selects the session that best matches the requested
+// workspace. The contract is:
+//
+//  1. If the requested workspace has at least one matching session row, that
+//     session wins (exact-match path — preserves existing behavior including
+//     the github.com/org/repo git remote case).
+//  2. Otherwise, when the requested workspace looks like a filesystem path,
+//     walk its ancestors (closest parent first, up to "/"). For each ancestor
+//     workspace, accept the most recent matching session whose event history
+//     contains at least one event recorded under the requested workspace. This
+//     is the parent/child fallback used when an agent recorded the session
+//     under a parent project root but recorded events under a child subdir.
+//  3. If no fallback candidate qualifies, return matchedFound=false so the
+//     caller can render "no matching session".
+//
+// The helper deliberately ignores client/agent/label filters during fallback
+// because dogfooding showed they are usually unset for handoff and the goal
+// is to surface evidence of work under <requested>, regardless of which agent
+// recorded the parent session.
+func ResolveSessionWorkspace(
+	ctx context.Context,
+	sessionQuery SessionQueryService,
+	eventQuery EventQueryService,
+	criteria WorkspaceResolutionCriteria,
+) (WorkspaceResolution, error) {
+	if sessionQuery == nil {
+		return WorkspaceResolution{}, xerrors.Errorf("session query service is not configured")
+	}
+
+	requested := criteria.Workspace()
+	sessions, err := sessionQuery.ListSummaries(
+		ctx,
+		1,
+		0,
+		criteria.SessionID(),
+		requested,
+		domtypes.Client(""),
+		domtypes.Agent(""),
+		"",
+		criteria.ActiveOnly(),
+		domtypes.None[time.Time](),
+		domtypes.None[time.Time](),
+	)
+	if err != nil {
+		return WorkspaceResolution{}, xerrors.Errorf("failed to list sessions for workspace resolution: %w", err)
+	}
+	if len(sessions) > 0 {
+		return WorkspaceResolution{matchedSession: sessions[0], matchedFound: true}, nil
+	}
+
+	if eventQuery == nil || !requested.IsLocalPath() {
+		return WorkspaceResolution{}, nil
+	}
+
+	for _, ancestor := range requested.AncestorWorkspaces() {
+		const ancestorCandidatePageSize = 50
+		for offset := 0; ; offset += ancestorCandidatePageSize {
+			candidates, err := sessionQuery.ListSummaries(
+				ctx,
+				ancestorCandidatePageSize,
+				offset,
+				criteria.SessionID(),
+				ancestor,
+				domtypes.Client(""),
+				domtypes.Agent(""),
+				"",
+				criteria.ActiveOnly(),
+				domtypes.None[time.Time](),
+				domtypes.None[time.Time](),
+			)
+			if err != nil {
+				return WorkspaceResolution{}, xerrors.Errorf("failed to list ancestor sessions for workspace resolution: %w", err)
+			}
+			if len(candidates) == 0 {
+				break
+			}
+			for _, candidate := range candidates {
+				hasEvidence, err := sessionHasEventsUnderWorkspace(ctx, eventQuery, candidate.SessionID(), requested)
+				if err != nil {
+					return WorkspaceResolution{}, err
+				}
+				if hasEvidence {
+					return WorkspaceResolution{
+						matchedSession:  candidate,
+						matchedFound:    true,
+						fallbackApplied: true,
+					}, nil
+				}
+			}
+			if len(candidates) < ancestorCandidatePageSize {
+				break
+			}
+		}
+	}
+
+	return WorkspaceResolution{}, nil
+}
+
+// sessionHasEventsUnderWorkspace reports whether any event for sessionID was
+// recorded under the supplied workspace. We pull one row because existence is
+// the only signal needed for fallback acceptance.
+func sessionHasEventsUnderWorkspace(
+	ctx context.Context,
+	eventQuery EventQueryService,
+	sessionID domtypes.SessionID,
+	workspace domtypes.Workspace,
+) (bool, error) {
+	events, err := eventQuery.ListRecent(
+		ctx,
+		1,
+		0,
+		domtypes.EventKind(""),
+		domtypes.Client(""),
+		domtypes.Agent(""),
+		sessionID,
+		workspace,
+		false,
+		time.Time{},
+		time.Time{},
+		"",
+	)
+	if err != nil {
+		return false, xerrors.Errorf("failed to verify event evidence under requested workspace: %w", err)
+	}
+	return len(events) > 0, nil
+}

--- a/application/types/context_pack.go
+++ b/application/types/context_pack.go
@@ -9,16 +9,17 @@ import (
 // ContextPack is the structured working-memory bundle shared by CLI and MCP
 // handoff surfaces.
 type ContextPack struct {
-	sessionID      domtypes.SessionID
-	workspace      domtypes.Workspace
-	label          string
-	status         string
-	totalEvents    int
-	commandCount   int
-	agents         []string
-	workingState   WorkingState
-	recentCommands []string
-	memories       []MemorySummary
+	sessionID          domtypes.SessionID
+	workspace          domtypes.Workspace
+	requestedWorkspace domtypes.Workspace
+	label              string
+	status             string
+	totalEvents        int
+	commandCount       int
+	agents             []string
+	workingState       WorkingState
+	recentCommands     []string
+	memories           []MemorySummary
 }
 
 // ContextPackOf creates a ContextPack.
@@ -46,6 +47,30 @@ func ContextPackOf(
 		recentCommands: slices.Clone(recentCommands),
 		memories:       slices.Clone(memories),
 	}
+}
+
+// WithRequestedWorkspace returns a copy of the pack with the originally
+// requested workspace recorded. When the requested value differs from the
+// matched session workspace, callers can surface a parent-fallback hint via
+// WorkspaceFallbackUsed.
+func (c ContextPack) WithRequestedWorkspace(requested domtypes.Workspace) ContextPack {
+	c.requestedWorkspace = requested
+	return c
+}
+
+// RequestedWorkspace returns the workspace the caller asked for, which may
+// differ from the matched session workspace when parent fallback was applied.
+// Returns an empty workspace when the caller did not request any specific
+// workspace.
+func (c ContextPack) RequestedWorkspace() domtypes.Workspace { return c.requestedWorkspace }
+
+// WorkspaceFallbackUsed reports whether the pack was assembled by walking up
+// to a parent workspace because no session existed under the requested one.
+func (c ContextPack) WorkspaceFallbackUsed() bool {
+	if c.requestedWorkspace.String() == "" {
+		return false
+	}
+	return c.requestedWorkspace != c.workspace
 }
 
 // SessionID returns the session ID.

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -46,27 +46,20 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 		return domtypes.None[apptypes.ContextPack](), xerrors.Errorf("memory limit must be greater than or equal to 0")
 	}
 
-	sessions, err := b.sessionQuery.ListSummaries(
+	resolution, err := queryservice.ResolveSessionWorkspace(
 		ctx,
-		1,
-		0,
-		criteria.SessionID(),
-		criteria.Workspace(),
-		domtypes.Client(""),
-		domtypes.Agent(""),
-		"",
-		false,
-		domtypes.None[time.Time](),
-		domtypes.None[time.Time](),
+		b.sessionQuery,
+		b.eventQuery,
+		queryservice.WorkspaceResolutionCriteriaOf(criteria.SessionID(), criteria.Workspace(), false),
 	)
 	if err != nil {
-		return domtypes.None[apptypes.ContextPack](), xerrors.Errorf("failed to list sessions for context pack: %w", err)
+		return domtypes.None[apptypes.ContextPack](), xerrors.Errorf("failed to resolve session workspace for context pack: %w", err)
 	}
-	if len(sessions) == 0 {
+	if !resolution.MatchedFound() {
 		return domtypes.None[apptypes.ContextPack](), nil
 	}
 
-	session := sessions[0]
+	session := resolution.MatchedSession()
 	if !criteria.AllowStale() && criteria.StaleAfter() > 0 && isStaleActiveSession(session, criteria.StaleAfter(), time.Now()) {
 		return domtypes.None[apptypes.ContextPack](), nil
 	}
@@ -78,7 +71,14 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 	if err != nil {
 		compactSummary = ""
 	}
-	memories, err := b.loadMemories(ctx, session, criteria.MemoryLimit(), criteria.MemoryPreset(), criteria.MemoryAsOf())
+	memories, err := b.loadMemories(
+		ctx,
+		session,
+		criteria.Workspace(),
+		criteria.MemoryLimit(),
+		criteria.MemoryPreset(),
+		criteria.MemoryAsOf(),
+	)
 	if err != nil {
 		return domtypes.None[apptypes.ContextPack](), err
 	}
@@ -94,7 +94,7 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 		apptypes.WorkingStateOf(session.Summary(), compactSummary),
 		recentCommands,
 		memories,
-	)
+	).WithRequestedWorkspace(criteria.Workspace())
 	return domtypes.Some(pack), nil
 }
 
@@ -169,6 +169,7 @@ func (b *contextPackBuilder) loadCompactSummary(ctx context.Context, session app
 func (b *contextPackBuilder) loadMemories(
 	ctx context.Context,
 	session apptypes.SessionSummary,
+	requestedWorkspace domtypes.Workspace,
 	limit int,
 	preset apptypes.MemoryRetrievalPreset,
 	asOf domtypes.Optional[time.Time],
@@ -177,7 +178,7 @@ func (b *contextPackBuilder) loadMemories(
 		return nil, nil
 	}
 
-	scopes := relevantMemoryScopes(session)
+	scopes := relevantMemoryScopes(session, requestedWorkspace)
 	if len(scopes) == 0 {
 		return nil, nil
 	}
@@ -211,14 +212,14 @@ func (b *contextPackBuilder) loadMemories(
 	return memories, nil
 }
 
-func relevantMemoryScopes(session apptypes.SessionSummary) []domtypes.MemoryScope {
+func relevantMemoryScopes(session apptypes.SessionSummary, requestedWorkspace domtypes.Workspace) []domtypes.MemoryScope {
 	type scopeKey struct {
 		kind string
 		key  string
 	}
 
 	seen := make(map[scopeKey]struct{})
-	scopes := make([]domtypes.MemoryScope, 0, len(session.Agents())+2)
+	scopes := make([]domtypes.MemoryScope, 0, len(session.Agents())+3)
 	appendScope := func(scope domtypes.MemoryScope) {
 		if scope == nil {
 			return
@@ -233,6 +234,13 @@ func relevantMemoryScopes(session apptypes.SessionSummary) []domtypes.MemoryScop
 
 	if session.Workspace().String() != "" {
 		appendScope(domtypes.WorkspaceScopeOf(session.Workspace()))
+	}
+	// When parent fallback selected a session under an ancestor workspace,
+	// also surface memories scoped to the originally requested child
+	// workspace so the canonical resolution covers all three surfaces
+	// (sessions, events, memories) consistently.
+	if requestedWorkspace.String() != "" && requestedWorkspace != session.Workspace() {
+		appendScope(domtypes.WorkspaceScopeOf(requestedWorkspace))
 	}
 	if session.SessionID().String() != "" {
 		appendScope(domtypes.SessionFamilyScopeOf(session.SessionID()))

--- a/application/usecase/context_usecase_impl_test.go
+++ b/application/usecase/context_usecase_impl_test.go
@@ -484,3 +484,279 @@ func TestContextUsecase_Handoff(t *testing.T) {
 		}
 	})
 }
+
+func TestContextUsecase_Handoff_WorkspaceFallback(t *testing.T) {
+	t.Parallel()
+
+	parentWorkspace := domtypes.Workspace("/Users/duck/repos/project")
+	childWorkspace := domtypes.Workspace("/Users/duck/repos/project/sub")
+	siblingWorkspace := domtypes.Workspace("/Users/duck/repos/project/other")
+
+	newParentSession := func() apptypes.SessionSummary {
+		return apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-parent"),
+			parentWorkspace,
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			5,
+			3,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+	}
+
+	newChildEvent := func(t *testing.T, workspace domtypes.Workspace) *model.Event {
+		t.Helper()
+		event, err := model.NewEvent(
+			domtypes.EventID("event-child"),
+			domtypes.EventKindCommandExecuted,
+			domtypes.Client("cli"),
+			domtypes.Agent("claude"),
+			domtypes.SessionID("session-parent"),
+			workspace,
+			"go test ./...",
+		)
+		if err != nil {
+			t.Fatalf("NewEvent() error = %v", err)
+		}
+		return event
+	}
+
+	t.Run("parent session matches when child workspace has event evidence", func(t *testing.T) {
+		t.Parallel()
+
+		parent := newParentSession()
+		evidence := newChildEvent(t, childWorkspace)
+
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{
+				parentWorkspace: {parent},
+			},
+		}
+		eventQuery := &eventQueryServiceStub{
+			listRecentResultByEvidence: map[eventEvidenceKey][]*model.Event{
+				{sessionID: domtypes.SessionID("session-parent"), workspace: childWorkspace}: {evidence},
+			},
+			listRecentResultByKind: map[domtypes.EventKind][]*model.Event{
+				domtypes.EventKindCommandExecuted: {evidence},
+			},
+		}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(childWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack, want parent-fallback match")
+		}
+		if diff := cmp.Diff(parentWorkspace, pack.Workspace()); diff != "" {
+			t.Errorf("Workspace() mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(childWorkspace, pack.RequestedWorkspace()); diff != "" {
+			t.Errorf("RequestedWorkspace() mismatch (-want +got):\n%s", diff)
+		}
+		if !pack.WorkspaceFallbackUsed() {
+			t.Errorf("WorkspaceFallbackUsed() = false, want true after parent fallback")
+		}
+	})
+
+	t.Run("windows drive parent session matches when child workspace has event evidence", func(t *testing.T) {
+		t.Parallel()
+
+		windowsParentWorkspace := domtypes.Workspace("C:/Users/duck/repos/project")
+		windowsChildWorkspace := domtypes.Workspace("C:/Users/duck/repos/project/sub")
+		windowsSessionID := domtypes.SessionID("session-windows")
+		parent := apptypes.SessionSummaryOf(
+			windowsSessionID,
+			windowsParentWorkspace,
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			5,
+			3,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+		evidence, err := model.NewEvent(
+			domtypes.EventID("event-windows-child"),
+			domtypes.EventKindCommandExecuted,
+			domtypes.Client("cli"),
+			domtypes.Agent("claude"),
+			windowsSessionID,
+			windowsChildWorkspace,
+			"go test ./...",
+		)
+		if err != nil {
+			t.Fatalf("NewEvent() error = %v", err)
+		}
+
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{
+				windowsParentWorkspace: {parent},
+			},
+		}
+		eventQuery := &eventQueryServiceStub{
+			listRecentResultByEvidence: map[eventEvidenceKey][]*model.Event{
+				{sessionID: windowsSessionID, workspace: windowsChildWorkspace}: {evidence},
+			},
+		}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(windowsChildWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack, want Windows parent-fallback match")
+		}
+		if diff := cmp.Diff(windowsParentWorkspace, pack.Workspace()); diff != "" {
+			t.Errorf("Workspace() mismatch (-want +got):\n%s", diff)
+		}
+		if !pack.WorkspaceFallbackUsed() {
+			t.Errorf("WorkspaceFallbackUsed() = false, want true after Windows parent fallback")
+		}
+	})
+
+	t.Run("exact workspace match wins without fallback", func(t *testing.T) {
+		t.Parallel()
+
+		exactSession := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-exact"),
+			childWorkspace,
+			time.Now(),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{
+				childWorkspace:  {exactSession},
+				parentWorkspace: {newParentSession()},
+			},
+		}
+		eventQuery := &eventQueryServiceStub{}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(childWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack, want exact match")
+		}
+		if diff := cmp.Diff(domtypes.SessionID("session-exact"), pack.SessionID()); diff != "" {
+			t.Errorf("SessionID() mismatch (-want +got):\n%s", diff)
+		}
+		if pack.WorkspaceFallbackUsed() {
+			t.Errorf("WorkspaceFallbackUsed() = true, want false on exact match")
+		}
+	})
+
+	t.Run("sibling workspace with events does not satisfy fallback", func(t *testing.T) {
+		t.Parallel()
+
+		parent := newParentSession()
+		siblingEvent := newChildEvent(t, siblingWorkspace)
+
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{
+				parentWorkspace: {parent},
+			},
+		}
+		// Events exist under the sibling workspace only — the fallback
+		// helper queries ListRecent with the *requested* workspace
+		// (childWorkspace), so this evidence must not be visible there.
+		eventQuery := &eventQueryServiceStub{
+			listRecentResultByEvidence: map[eventEvidenceKey][]*model.Event{
+				{sessionID: domtypes.SessionID("session-parent"), workspace: siblingWorkspace}: {siblingEvent},
+			},
+		}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(childWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		if _, ok := got.Value(); ok {
+			t.Errorf("Handoff() returned a pack, want empty when only sibling has evidence")
+		}
+	})
+
+	t.Run("no matching session under any ancestor returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{},
+		}
+		eventQuery := &eventQueryServiceStub{}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(childWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		if _, ok := got.Value(); ok {
+			t.Errorf("Handoff() returned a pack, want empty when no session matches")
+		}
+	})
+
+	t.Run("git remote URL workspace skips fallback walk", func(t *testing.T) {
+		t.Parallel()
+
+		// Sessions exist neither at the requested URL workspace nor at
+		// any URL "ancestor". The helper must not walk url path segments
+		// for non-filesystem workspaces, so the result stays empty.
+		remoteWorkspace := domtypes.Workspace("github.com/duck/traceary/sub")
+		sessionQuery := &sessionQueryServiceStub{
+			listSummariesResultByWorkspace: map[domtypes.Workspace][]apptypes.SessionSummary{
+				domtypes.Workspace("github.com/duck/traceary"): {newParentSession()},
+			},
+		}
+		eventQuery := &eventQueryServiceStub{}
+		sut := usecase.NewContextUsecase(sessionQuery, eventQuery, nil)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().Workspace(remoteWorkspace).Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		if _, ok := got.Value(); ok {
+			t.Errorf("Handoff() returned a pack, want empty for URL workspace fallback skip")
+		}
+		// Only the exact workspace should have been queried; no walk.
+		if got := len(sessionQuery.listSummariesWorkspaceCalls); got != 1 {
+			t.Errorf("ListSummaries calls = %d, want 1 (no ancestor walk for URL workspace)", got)
+		}
+	})
+}

--- a/application/usecase/session_usecase_impl_test.go
+++ b/application/usecase/session_usecase_impl_test.go
@@ -23,19 +23,21 @@ type sessionQueryServiceStub struct {
 	findLatestWS     types.Workspace
 	findLatestActive bool
 
-	listSummariesResult []apptypes.SessionSummary
-	listSummariesErr    error
-	listSummariesCalls  int
-	listLimit           int
-	listOffset          int
-	listSessionID       types.SessionID
-	listWorkspace       types.Workspace
-	listClient          types.Client
-	listAgent           types.Agent
-	listLabel           string
-	listActiveOnly      bool
-	listFrom            types.Optional[time.Time]
-	listTo              types.Optional[time.Time]
+	listSummariesResult            []apptypes.SessionSummary
+	listSummariesResultByWorkspace map[types.Workspace][]apptypes.SessionSummary
+	listSummariesErr               error
+	listSummariesCalls             int
+	listSummariesWorkspaceCalls    []types.Workspace
+	listLimit                      int
+	listOffset                     int
+	listSessionID                  types.SessionID
+	listWorkspace                  types.Workspace
+	listClient                     types.Client
+	listAgent                      types.Agent
+	listLabel                      string
+	listActiveOnly                 bool
+	listFrom                       types.Optional[time.Time]
+	listTo                         types.Optional[time.Time]
 
 	lineageResult    []apptypes.SessionSummary
 	lineageErr       error
@@ -83,8 +85,15 @@ func (s *sessionQueryServiceStub) ListSummaries(
 	s.listActiveOnly = activeOnly
 	s.listFrom = from
 	s.listTo = to
+	s.listSummariesWorkspaceCalls = append(s.listSummariesWorkspaceCalls, workspace)
 	if s.listSummariesErr != nil {
 		return nil, s.listSummariesErr
+	}
+	if s.listSummariesResultByWorkspace != nil {
+		if result, ok := s.listSummariesResultByWorkspace[workspace]; ok {
+			return result, nil
+		}
+		return nil, nil
 	}
 	return s.listSummariesResult, nil
 }
@@ -122,16 +131,26 @@ func (s *sessionQueryServiceStub) LineageOf(_ context.Context, sessionID types.S
 }
 
 type eventQueryServiceStub struct {
-	listRecentResult          []*model.Event
-	listRecentResultByKind    map[types.EventKind][]*model.Event
-	listRecentErr             error
-	listRecentErrByKind       map[types.EventKind]error
-	listRecentCalls           int
-	listRecentCallsByKind     map[types.EventKind]int
-	listRecentLimit           int
-	listRecentLimitByKind     map[types.EventKind]int
-	listRecentWorkspace       types.Workspace
-	listRecentWorkspaceByKind map[types.EventKind]types.Workspace
+	listRecentResult           []*model.Event
+	listRecentResultByKind     map[types.EventKind][]*model.Event
+	listRecentResultByEvidence map[eventEvidenceKey][]*model.Event
+	listRecentErr              error
+	listRecentErrByKind        map[types.EventKind]error
+	listRecentCalls            int
+	listRecentCallsByKind      map[types.EventKind]int
+	listRecentLimit            int
+	listRecentLimitByKind      map[types.EventKind]int
+	listRecentWorkspace        types.Workspace
+	listRecentWorkspaceByKind  map[types.EventKind]types.Workspace
+}
+
+// eventEvidenceKey lets tests stub ListRecent results that depend on the
+// combination of session ID and workspace passed by the workspace fallback
+// helper. It is intentionally distinct from listRecentResultByKind so the
+// existing kind-based tests keep working unchanged.
+type eventEvidenceKey struct {
+	sessionID types.SessionID
+	workspace types.Workspace
 }
 
 func (s *eventQueryServiceStub) ListRecent(
@@ -140,7 +159,7 @@ func (s *eventQueryServiceStub) ListRecent(
 	kind types.EventKind,
 	_ types.Client,
 	_ types.Agent,
-	_ types.SessionID,
+	sessionID types.SessionID,
 	workspace types.Workspace,
 	_ bool,
 	_, _ time.Time,
@@ -167,6 +186,11 @@ func (s *eventQueryServiceStub) ListRecent(
 	}
 	if s.listRecentErr != nil {
 		return nil, s.listRecentErr
+	}
+	if s.listRecentResultByEvidence != nil {
+		if result, ok := s.listRecentResultByEvidence[eventEvidenceKey{sessionID: sessionID, workspace: workspace}]; ok {
+			return result, nil
+		}
 	}
 	if result, ok := s.listRecentResultByKind[kind]; ok {
 		return result, nil

--- a/domain/types/workspace.go
+++ b/domain/types/workspace.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"path"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -22,3 +23,94 @@ func WorkspaceFrom(value string) (Workspace, error) {
 
 // String returns the string representation.
 func (w Workspace) String() string { return string(w) }
+
+// IsLocalPath reports whether the workspace value looks like an absolute
+// filesystem path. Only filesystem-style workspaces participate in
+// parent/child fallback; values that look like remote URLs
+// (e.g. github.com/org/repo) are kept as exact matches because their path
+// segments do not represent filesystem ancestry.
+func (w Workspace) IsLocalPath() bool {
+	value := string(w)
+	return strings.HasPrefix(value, "/") || isWindowsDriveAbsolute(value)
+}
+
+// AncestorWorkspaces returns the ancestor workspaces of w in order from
+// the closest parent to the filesystem root. For non-filesystem workspaces
+// (e.g. github.com/org/repo) the result is empty so callers always get
+// exact-match behavior. The receiver itself is never included.
+func (w Workspace) AncestorWorkspaces() []Workspace {
+	if !w.IsLocalPath() {
+		return nil
+	}
+	if isWindowsDriveAbsolute(string(w)) {
+		return windowsDriveAncestorWorkspaces(string(w))
+	}
+	cleaned := path.Clean(string(w))
+	if cleaned == "/" || cleaned == "." {
+		return nil
+	}
+
+	ancestors := make([]Workspace, 0)
+	for {
+		parent := path.Dir(cleaned)
+		if parent == cleaned {
+			break
+		}
+		ancestors = append(ancestors, Workspace(parent))
+		if parent == "/" {
+			break
+		}
+		cleaned = parent
+	}
+	return ancestors
+}
+
+func isWindowsDriveAbsolute(value string) bool {
+	if len(value) < 3 {
+		return false
+	}
+	drive := value[0]
+	if !isASCIIAlpha(drive) {
+		return false
+	}
+	return value[1] == ':' && isPathSeparator(value[2])
+}
+
+func isASCIIAlpha(value byte) bool {
+	return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z')
+}
+
+func isPathSeparator(value byte) bool {
+	return value == '/' || value == '\\'
+}
+
+func windowsDriveAncestorWorkspaces(value string) []Workspace {
+	separator := "/"
+	if value[2] == '\\' {
+		separator = "\\"
+	}
+	slashValue := strings.ReplaceAll(value, "\\", "/")
+	volume := slashValue[:2]
+	cleanedRest := path.Clean(slashValue[2:])
+	if cleanedRest == "." {
+		cleanedRest = "/"
+	}
+	if cleanedRest == "/" {
+		return nil
+	}
+
+	ancestors := make([]Workspace, 0)
+	for {
+		parentRest := path.Dir(cleanedRest)
+		parent := volume + parentRest
+		if separator == "\\" {
+			parent = strings.ReplaceAll(parent, "/", "\\")
+		}
+		ancestors = append(ancestors, Workspace(parent))
+		if parentRest == "/" {
+			break
+		}
+		cleanedRest = parentRest
+	}
+	return ancestors
+}

--- a/domain/types/workspace_test.go
+++ b/domain/types/workspace_test.go
@@ -3,8 +3,111 @@ package types_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/duck8823/traceary/domain/types"
 )
+
+func TestWorkspace_IsLocalPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workspace types.Workspace
+		want      bool
+	}{
+		{name: "absolute path is local", workspace: types.Workspace("/Users/duck/project"), want: true},
+		{name: "windows drive slash path is local", workspace: types.Workspace("C:/Users/duck/project"), want: true},
+		{name: "windows drive backslash path is local", workspace: types.Workspace(`C:\Users\duck\project`), want: true},
+		{name: "windows drive relative path is not local", workspace: types.Workspace(`C:Users\duck\project`), want: false},
+		{name: "git remote URL is not local", workspace: types.Workspace("github.com/duck/traceary"), want: false},
+		{name: "relative path is not local", workspace: types.Workspace("project"), want: false},
+		{name: "empty workspace is not local", workspace: types.Workspace(""), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.workspace.IsLocalPath(); got != tt.want {
+				t.Errorf("IsLocalPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspace_AncestorWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workspace types.Workspace
+		want      []types.Workspace
+	}{
+		{
+			name:      "absolute child path returns ancestors up to root",
+			workspace: types.Workspace("/Users/duck/repos/project/sub"),
+			want: []types.Workspace{
+				types.Workspace("/Users/duck/repos/project"),
+				types.Workspace("/Users/duck/repos"),
+				types.Workspace("/Users/duck"),
+				types.Workspace("/Users"),
+				types.Workspace("/"),
+			},
+		},
+		{
+			name:      "windows drive slash path returns ancestors up to drive root",
+			workspace: types.Workspace("C:/Users/duck/repos/project/sub"),
+			want: []types.Workspace{
+				types.Workspace("C:/Users/duck/repos/project"),
+				types.Workspace("C:/Users/duck/repos"),
+				types.Workspace("C:/Users/duck"),
+				types.Workspace("C:/Users"),
+				types.Workspace("C:/"),
+			},
+		},
+		{
+			name:      "windows drive backslash path preserves separators",
+			workspace: types.Workspace(`C:\Users\duck\repos\project\sub`),
+			want: []types.Workspace{
+				types.Workspace(`C:\Users\duck\repos\project`),
+				types.Workspace(`C:\Users\duck\repos`),
+				types.Workspace(`C:\Users\duck`),
+				types.Workspace(`C:\Users`),
+				types.Workspace(`C:\`),
+			},
+		},
+		{
+			name:      "windows drive root has no ancestors",
+			workspace: types.Workspace("C:/"),
+			want:      nil,
+		},
+		{
+			name:      "filesystem root has no ancestors",
+			workspace: types.Workspace("/"),
+			want:      nil,
+		},
+		{
+			name:      "git remote URL has no ancestors",
+			workspace: types.Workspace("github.com/duck/traceary"),
+			want:      nil,
+		},
+		{
+			name:      "empty workspace has no ancestors",
+			workspace: types.Workspace(""),
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.workspace.AncestorWorkspaces()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("AncestorWorkspaces() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestWorkspaceFrom(t *testing.T) {
 	t.Parallel()

--- a/presentation/cli/handoff.go
+++ b/presentation/cli/handoff.go
@@ -213,6 +213,16 @@ func writeHandoffText(output io.Writer, result types.Optional[apptypes.ContextPa
 	if _, err := fmt.Fprintf(output, "WORKSPACE: %s\n", formatOptionalColumn(pack.Workspace().String())); err != nil {
 		return xerrors.Errorf("failed to print handoff workspace: %w", err)
 	}
+	if pack.WorkspaceFallbackUsed() {
+		if _, err := fmt.Fprintf(
+			output,
+			"NOTE: matched through parent workspace %s (requested %s)\n",
+			pack.Workspace().String(),
+			pack.RequestedWorkspace().String(),
+		); err != nil {
+			return xerrors.Errorf("failed to print handoff workspace fallback note: %w", err)
+		}
+	}
 	if _, err := fmt.Fprintf(output, "LABEL: %s\n", formatOptionalColumn(pack.Label())); err != nil {
 		return xerrors.Errorf("failed to print handoff label: %w", err)
 	}

--- a/presentation/cli/handoff_test.go
+++ b/presentation/cli/handoff_test.go
@@ -338,6 +338,44 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("workspace fallback note surfaces when matched through parent workspace", func(t *testing.T) {
+		t.Parallel()
+
+		parent := types.Workspace("/Users/duck/repos/project")
+		child := types.Workspace("/Users/duck/repos/project/sub")
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithContext(&contextUsecaseStub{
+				handoff: types.Some(apptypes.ContextPackOf(
+					types.SessionID("session-parent"),
+					parent,
+					"",
+					"active",
+					3,
+					1,
+					nil,
+					apptypes.WorkingStateOf("", ""),
+					nil,
+					nil,
+				).WithRequestedWorkspace(child)),
+			}),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "handoff", "--db-path", filepath.Join(t.TempDir(), "traceary.db")})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		out := stdout.String()
+		wantNote := "NOTE: matched through parent workspace " + parent.String() + " (requested " + child.String() + ")"
+		if !strings.Contains(out, wantNote) {
+			t.Fatalf("output missing parent-workspace fallback note %q:\n%s", wantNote, out)
+		}
+	})
+
 	t.Run("session handoff subcommand reuses the same structured output", func(t *testing.T) {
 		t.Parallel()
 

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -57,17 +57,20 @@ type eventOutput struct {
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.
 type sessionHandoffOutput struct {
-	SessionID      string                `json:"session_id,omitempty"`
-	Workspace      string                `json:"workspace,omitempty"`
-	Label          string                `json:"label,omitempty"`
-	Status         string                `json:"status,omitempty"`
-	TotalEvents    int                   `json:"total_events"`
-	CommandCount   int                   `json:"command_count"`
-	Agents         []string              `json:"agents,omitempty"`
-	Summary        string                `json:"summary,omitempty" jsonschema:"legacy compatibility mirror of working_state.combined_summary"`
-	WorkingState   workingStateOutput    `json:"working_state"`
-	RecentCommands []string              `json:"recent_commands,omitempty"`
-	Memories       []memorySummaryOutput `json:"memories,omitempty"`
+	SessionID             string                `json:"session_id,omitempty"`
+	Workspace             string                `json:"workspace,omitempty"`
+	RequestedWorkspace    string                `json:"requested_workspace,omitempty" jsonschema:"workspace originally requested by the caller when it differs from the matched session workspace"`
+	WorkspaceFallbackUsed bool                  `json:"workspace_fallback_used,omitempty" jsonschema:"true when Traceary matched a parent workspace session using event evidence under the requested workspace"`
+	WorkspaceMatchNote    string                `json:"workspace_match_note,omitempty" jsonschema:"human-readable explanation of parent-workspace fallback"`
+	Label                 string                `json:"label,omitempty"`
+	Status                string                `json:"status,omitempty"`
+	TotalEvents           int                   `json:"total_events"`
+	CommandCount          int                   `json:"command_count"`
+	Agents                []string              `json:"agents,omitempty"`
+	Summary               string                `json:"summary,omitempty" jsonschema:"legacy compatibility mirror of working_state.combined_summary"`
+	WorkingState          workingStateOutput    `json:"working_state"`
+	RecentCommands        []string              `json:"recent_commands,omitempty"`
+	Memories              []memorySummaryOutput `json:"memories,omitempty"`
 }
 
 // sessionLineageOutput is the MCP output for session_status action=lineage.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1243,7 +1243,7 @@ func buildContextPackCriteria(sessionID string, workspace string, recentCommands
 }
 
 func newContextPackOutput(pack apptypes.ContextPack) sessionHandoffOutput {
-	return sessionHandoffOutput{
+	out := sessionHandoffOutput{
 		SessionID:      pack.SessionID().String(),
 		Workspace:      pack.Workspace().String(),
 		Label:          pack.Label(),
@@ -1256,6 +1256,13 @@ func newContextPackOutput(pack apptypes.ContextPack) sessionHandoffOutput {
 		RecentCommands: pack.RecentCommands(),
 		Memories:       convertMemorySummaries(pack.Memories()),
 	}
+	if pack.WorkspaceFallbackUsed() {
+		out.RequestedWorkspace = pack.RequestedWorkspace().String()
+		out.WorkspaceFallbackUsed = true
+		out.WorkspaceMatchNote = "matched through parent workspace " + pack.Workspace().String() +
+			" (requested " + pack.RequestedWorkspace().String() + ")"
+	}
+	return out
 }
 
 func newWorkingStateOutput(state apptypes.WorkingState) workingStateOutput {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -975,6 +975,66 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("session_handoff surfaces workspace fallback in MCP output", func(t *testing.T) {
+		parentWorkspace := "/tmp/traceary-mcp-parent"
+		childWorkspace := "/tmp/traceary-mcp-parent/sub"
+		startResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "manage_session",
+			Arguments: map[string]any{
+				"action":    "start",
+				"agent":     "claude",
+				"workspace": parentWorkspace,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(start_session) error = %v", err)
+		}
+		sessionID := extractJSONStringValue(t, startResult, "session_id")
+
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "record_event",
+			Arguments: map[string]any{
+				"type":       "audit",
+				"command":    "go test ./...",
+				"agent":      "claude",
+				"session_id": sessionID,
+				"workspace":  childWorkspace,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(add_audit child workspace) error = %v", err)
+		}
+
+		handoffResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action":    "handoff",
+				"workspace": childWorkspace,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_handoff child workspace) error = %v", err)
+		}
+		if handoffResult.IsError {
+			t.Fatalf("CallTool(session_handoff child workspace) returned tool error")
+		}
+
+		payload := decodeJSONPayload(t, handoffResult)
+		if diff := cmp.Diff(parentWorkspace, payload["workspace"]); diff != "" {
+			t.Fatalf("workspace mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(childWorkspace, payload["requested_workspace"]); diff != "" {
+			t.Fatalf("requested_workspace mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(true, payload["workspace_fallback_used"]); diff != "" {
+			t.Fatalf("workspace_fallback_used mismatch (-want +got):\n%s", diff)
+		}
+		wantNote := "matched through parent workspace " + parentWorkspace + " (requested " + childWorkspace + ")"
+		if diff := cmp.Diff(wantNote, payload["workspace_match_note"]); diff != "" {
+			t.Fatalf("workspace_match_note mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("supersede and expire memory return updated memory details", func(t *testing.T) {
 		rememberResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "manage_memory",


### PR DESCRIPTION
## Motivation\n\nDogfooding found that session rows can be recorded under a parent workspace while command/event evidence is recorded under a child project workspace. Workspace-scoped handoff then reported no matching session even though relevant event evidence existed.\n\n## Changes\n\n- Add a shared queryservice workspace-resolution helper for exact-match-first parent/child fallback.\n- Keep git remote style workspaces exact-match only.\n- Include requested child workspace memories when a parent session is selected by fallback.\n- Surface fallback decisions in CLI handoff and MCP session_handoff/memory_pack output.\n- Add regression coverage for parent session + child event, exact match, sibling isolation, no-match, URL skip, and MCP/CLI fallback hints.\n\n## Validation\n\n- `git diff --check origin/main...HEAD`\n- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`\n- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`\n- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`\n- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`\n\nCloses #983