### PR TITLE
v0.16-3: truncate large command payloads in top, handoff, and MCP context

### DIFF
--- a/application/types/command_truncation.go
+++ b/application/types/command_truncation.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"unicode/utf8"
+)
+
+// Operator-facing recent-command renderers share the same rune-based
+// truncation policy so a single noisy command_executed payload does not
+// dominate either a terminal pane or an MCP context-window response.
+// Full content is preserved in the database and remains retrievable
+// through the explicit event detail / show surfaces, which bypass these
+// limits.
+const (
+	// DefaultListEventBodyLimit caps the per-event body projection on
+	// MCP list-style surfaces (list_events / search / get_context).
+	// Callers pass body_limit=0 / full_body=true to opt out. The 500-
+	// rune budget matches the historical default introduced in #799.
+	DefaultListEventBodyLimit = 500
+
+	// DefaultTopSnapshotBodyLimit caps recent-command and recent-failure
+	// rows on `traceary top --snapshot --json` so a multi-hundred-line
+	// command_executed payload does not balloon the script-friendly
+	// snapshot output. The text snapshot keeps using truncateMessage for
+	// tabular alignment.
+	DefaultTopSnapshotBodyLimit = 500
+
+	// DefaultHandoffRecentCommandLimit is the per-line summary cap used
+	// for the handoff RECENT_COMMANDS list. The output is single-line
+	// per row, so the budget is intentionally smaller than the list
+	// surfaces above.
+	DefaultHandoffRecentCommandLimit = 60
+
+	// TruncationEllipsis is the marker appended to a truncated payload.
+	// All operator-facing renderers use the same glyph so consumers can
+	// detect truncation textually if they ignore the structured flag.
+	TruncationEllipsis = "…"
+)
+
+// CommandPayloadTruncation carries the result of applying the shared
+// truncation policy to a recent-command body. Callers attach Truncated
+// and OriginalRuneCount / OriginalByteCount to JSON shapes so consumers
+// can tell that the value has been cut and can fetch the full event via
+// explicit detail lookups.
+type CommandPayloadTruncation struct {
+	Body              string
+	Truncated         bool
+	OriginalRuneCount int
+	OriginalByteCount int
+}
+
+// TruncateCommandPayload applies the shared rune-based truncation
+// policy. A non-positive limit disables truncation entirely; the
+// original body is returned with Truncated=false but the original
+// counts are still populated so callers can record size metadata even
+// when no cut occurred.
+func TruncateCommandPayload(body string, limit int) CommandPayloadTruncation {
+	originalRunes := utf8.RuneCountInString(body)
+	originalBytes := len(body)
+	if limit <= 0 || originalRunes <= limit {
+		return CommandPayloadTruncation{
+			Body:              body,
+			Truncated:         false,
+			OriginalRuneCount: originalRunes,
+			OriginalByteCount: originalBytes,
+		}
+	}
+	runes := []rune(body)
+	return CommandPayloadTruncation{
+		Body:              string(runes[:limit]) + TruncationEllipsis,
+		Truncated:         true,
+		OriginalRuneCount: originalRunes,
+		OriginalByteCount: originalBytes,
+	}
+}

--- a/application/types/command_truncation_test.go
+++ b/application/types/command_truncation_test.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateCommandPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		body              string
+		limit             int
+		wantBody          string
+		wantTruncated     bool
+		wantOriginalRunes int
+		wantOriginalBytes int
+	}{
+		"empty body keeps zero counts": {
+			body:              "",
+			limit:             10,
+			wantBody:          "",
+			wantTruncated:     false,
+			wantOriginalRunes: 0,
+			wantOriginalBytes: 0,
+		},
+		"short payload is returned untouched": {
+			body:              "go test ./...",
+			limit:             50,
+			wantBody:          "go test ./...",
+			wantTruncated:     false,
+			wantOriginalRunes: 13,
+			wantOriginalBytes: 13,
+		},
+		"boundary length matches limit and is not truncated": {
+			body:              strings.Repeat("a", 60),
+			limit:             60,
+			wantBody:          strings.Repeat("a", 60),
+			wantTruncated:     false,
+			wantOriginalRunes: 60,
+			wantOriginalBytes: 60,
+		},
+		"one rune over limit is truncated with ellipsis": {
+			body:              strings.Repeat("a", 61),
+			limit:             60,
+			wantBody:          strings.Repeat("a", 60) + TruncationEllipsis,
+			wantTruncated:     true,
+			wantOriginalRunes: 61,
+			wantOriginalBytes: 61,
+		},
+		"multibyte runes count by rune not byte": {
+			body:              strings.Repeat("あ", 5),
+			limit:             3,
+			wantBody:          strings.Repeat("あ", 3) + TruncationEllipsis,
+			wantTruncated:     true,
+			wantOriginalRunes: 5,
+			wantOriginalBytes: len(strings.Repeat("あ", 5)),
+		},
+		"non-positive limit disables truncation": {
+			body:              strings.Repeat("a", 200),
+			limit:             0,
+			wantBody:          strings.Repeat("a", 200),
+			wantTruncated:     false,
+			wantOriginalRunes: 200,
+			wantOriginalBytes: 200,
+		},
+		"negative limit disables truncation": {
+			body:              strings.Repeat("a", 200),
+			limit:             -5,
+			wantBody:          strings.Repeat("a", 200),
+			wantTruncated:     false,
+			wantOriginalRunes: 200,
+			wantOriginalBytes: 200,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateCommandPayload(tc.body, tc.limit)
+			if got.Body != tc.wantBody {
+				t.Errorf("Body = %q, want %q", got.Body, tc.wantBody)
+			}
+			if got.Truncated != tc.wantTruncated {
+				t.Errorf("Truncated = %v, want %v", got.Truncated, tc.wantTruncated)
+			}
+			if got.OriginalRuneCount != tc.wantOriginalRunes {
+				t.Errorf("OriginalRuneCount = %d, want %d", got.OriginalRuneCount, tc.wantOriginalRunes)
+			}
+			if got.OriginalByteCount != tc.wantOriginalBytes {
+				t.Errorf("OriginalByteCount = %d, want %d", got.OriginalByteCount, tc.wantOriginalBytes)
+			}
+		})
+	}
+}

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -279,10 +279,12 @@ func summarizeCommand(command string) string {
 	if trimmed == "" {
 		return "-"
 	}
-	if runes := []rune(trimmed); len(runes) > 60 {
-		return string(runes[:60]) + "\u2026"
-	}
-	return trimmed
+	// The handoff RECENT_COMMANDS list renders one row per command, so
+	// the shared single-line cap (DefaultHandoffRecentCommandLimit) is
+	// applied here. The truncation policy lives in application/types so
+	// list, snapshot, and handoff surfaces share the same ellipsis glyph
+	// and rune-counting semantics.
+	return apptypes.TruncateCommandPayload(trimmed, apptypes.DefaultHandoffRecentCommandLimit).Body
 }
 
 func extractCompactSummarySignal(body string) string {

--- a/application/usecase/context_pack_builder_internal_test.go
+++ b/application/usecase/context_pack_builder_internal_test.go
@@ -1,0 +1,63 @@
+package usecase
+
+import (
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// summarizeCommand drives the handoff RECENT_COMMANDS list, which feeds
+// both the CLI `traceary session handoff` text rendering and the MCP
+// session_handoff tool. The single-line cap is intentionally smaller
+// than the list-surface defaults (60 vs 500 runes) because each row
+// renders on its own line; truncation here keeps multi-hundred-line
+// command_executed bodies from blowing up the handoff output.
+
+func TestSummarizeCommand_TruncatesAtHandoffLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"empty input falls back to dash": {
+			input: "",
+			want:  "-",
+		},
+		"whitespace-only input falls back to dash": {
+			input: "   \t\n  ",
+			want:  "-",
+		},
+		"short command stays untouched": {
+			input: "go test ./...",
+			want:  "go test ./...",
+		},
+		"only first paragraph is kept": {
+			input: "go test ./...\n\ndetails: build cache hit",
+			want:  "go test ./...",
+		},
+		"runs of whitespace collapse to single spaces": {
+			input: "go    test\t./...",
+			want:  "go test ./...",
+		},
+		"boundary length matches limit and is not truncated": {
+			input: strings.Repeat("a", apptypes.DefaultHandoffRecentCommandLimit),
+			want:  strings.Repeat("a", apptypes.DefaultHandoffRecentCommandLimit),
+		},
+		"one rune over limit is truncated with ellipsis": {
+			input: strings.Repeat("a", apptypes.DefaultHandoffRecentCommandLimit+1),
+			want:  strings.Repeat("a", apptypes.DefaultHandoffRecentCommandLimit) + apptypes.TruncationEllipsis,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := summarizeCommand(tc.input); got != tc.want {
+				t.Fatalf("summarizeCommand(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -53,6 +53,28 @@ func newEventOutput(e *model.Event) event {
 	}
 }
 
+// newTruncatedEventOutput is the snapshot-friendly variant of
+// newEventOutput. It applies the shared recent-command truncation
+// policy so operator-facing list surfaces (top --snapshot --json,
+// candidate failure / recent-command panes) do not balloon a single
+// multi-hundred-line command_executed payload across the script's
+// output. A non-positive limit disables truncation while still
+// populating size metadata only when a cut actually happened — so the
+// JSON shape stays additive for callers that ignore the new fields.
+// Explicit detail surfaces (`traceary show`) intentionally route
+// through newEventOutput so the full body remains retrievable.
+func newTruncatedEventOutput(e *model.Event, limit int) event {
+	base := newEventOutput(e)
+	result := apptypes.TruncateCommandPayload(base.Message, limit)
+	base.Message = result.Body
+	if result.Truncated {
+		base.Truncated = true
+		base.MessageLength = result.OriginalRuneCount
+		base.MessageBytes = result.OriginalByteCount
+	}
+	return base
+}
+
 func newCommandAuditOutput(audit *model.CommandAudit) *commandAudit {
 	if audit == nil {
 		return nil

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -3,16 +3,26 @@ package cli
 import "time"
 
 // event is the JSON shape of an event in CLI output.
+//
+// Truncated / MessageLength / MessageBytes are additive metadata
+// introduced for the shared recent-command truncation policy. They are
+// populated only when the snapshot renderer cut the message, so legacy
+// consumers that destructure `message` continue to work and explicit
+// detail lookups (`traceary show`) that bypass truncation never emit
+// these keys.
 type event struct {
-	EventID    string `json:"event_id"`
-	Kind       string `json:"kind"`
-	Client     string `json:"client"`
-	Agent      string `json:"agent"`
-	SessionID  string `json:"session_id"`
-	Workspace  string `json:"workspace"`
-	Message    string `json:"message"`
-	SourceHook string `json:"source_hook,omitempty"`
-	CreatedAt  string `json:"created_at"`
+	EventID       string `json:"event_id"`
+	Kind          string `json:"kind"`
+	Client        string `json:"client"`
+	Agent         string `json:"agent"`
+	SessionID     string `json:"session_id"`
+	Workspace     string `json:"workspace"`
+	Message       string `json:"message"`
+	SourceHook    string `json:"source_hook,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	Truncated     bool   `json:"truncated,omitempty"`
+	MessageLength int    `json:"message_length,omitempty"`
+	MessageBytes  int    `json:"message_bytes,omitempty"`
 }
 
 // commandAudit is the JSON shape of a command audit in CLI output.

--- a/presentation/cli/top_json.go
+++ b/presentation/cli/top_json.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"io"
 	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
 )
 
 // writeTopSnapshotJSON renders the top dashboard snapshot as the
@@ -24,14 +26,20 @@ func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 		sessions = append(sessions, topSnapshotNodeFromSessionNode(root, 0, staleCtx))
 	}
 
+	// Recent failure / command panes feed the script-friendly snapshot,
+	// so apply the shared list-surface body cap. A multi-hundred-line
+	// command_executed payload would otherwise dominate the output and
+	// waste host-agent context window. Full content stays available
+	// through `traceary show <event_id>`, which intentionally bypasses
+	// this limit.
 	failures := make([]event, 0, len(snap.Failures))
 	for _, ev := range snap.Failures {
-		failures = append(failures, newEventOutput(ev))
+		failures = append(failures, newTruncatedEventOutput(ev, apptypes.DefaultTopSnapshotBodyLimit))
 	}
 
 	commands := make([]event, 0, len(snap.RecentCommands))
 	for _, ev := range snap.RecentCommands {
-		commands = append(commands, newEventOutput(ev))
+		commands = append(commands, newTruncatedEventOutput(ev, apptypes.DefaultTopSnapshotBodyLimit))
 	}
 
 	candidateItems := make([]memorySummaryOutput, 0, len(snap.Candidates))

--- a/presentation/cli/top_json_truncation_test.go
+++ b/presentation/cli/top_json_truncation_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// The top --snapshot JSON contract truncates large command bodies on
+// the recent-failure and recent-command panes so a single multi-hundred-
+// line command_executed payload does not balloon the script-friendly
+// snapshot. The tests below pin the shape contract: text rendering
+// stays line-tabular (covered elsewhere via truncateMessage), JSON adds
+// the additive metadata fields, boundary-length rows stay untruncated,
+// and small payloads stay byte-for-byte identical to the legacy shape.
+
+func newTopSnapshotEvent(id, body string, ts time.Time) *model.Event {
+	return model.EventOf(
+		domtypes.EventID(id),
+		domtypes.EventKindCommandExecuted,
+		domtypes.Client("claude"),
+		domtypes.Agent("claude/explore"),
+		domtypes.SessionID("session-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		body,
+		ts,
+	)
+}
+
+func TestWriteTopSnapshotJSON_TruncatesLargeRecentCommandBody(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	huge := strings.Repeat("x", apptypes.DefaultTopSnapshotBodyLimit+50)
+	ev := newTopSnapshotEvent("evt-cmd-huge", huge, createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		RecentCommands: []*model.Event{ev},
+		Now:            createdAt,
+	}); err != nil {
+		t.Fatalf("writeTopSnapshotJSON: %v", err)
+	}
+
+	var payload struct {
+		RecentCommands []struct {
+			Message       string `json:"message"`
+			Truncated     bool   `json:"truncated"`
+			MessageLength int    `json:"message_length"`
+			MessageBytes  int    `json:"message_bytes"`
+		} `json:"recent_commands"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, buf.String())
+	}
+	if len(payload.RecentCommands) != 1 {
+		t.Fatalf("recent_commands length = %d, want 1", len(payload.RecentCommands))
+	}
+	got := payload.RecentCommands[0]
+	if !got.Truncated {
+		t.Fatalf("Truncated = false, want true for a body of %d runes", len(huge))
+	}
+	if got.MessageLength != len(huge) {
+		t.Fatalf("message_length = %d, want %d", got.MessageLength, len(huge))
+	}
+	if got.MessageBytes != len(huge) {
+		t.Fatalf("message_bytes = %d, want %d", got.MessageBytes, len(huge))
+	}
+	if !strings.HasSuffix(got.Message, "…") {
+		t.Fatalf("truncated message must end with ellipsis: %q", got.Message)
+	}
+	if want := apptypes.DefaultTopSnapshotBodyLimit + 1; len([]rune(got.Message)) != want { // limit runes + ellipsis
+		t.Fatalf("len(message) in runes = %d, want %d", len([]rune(got.Message)), want)
+	}
+}
+
+func TestWriteTopSnapshotJSON_LeavesSmallBodiesUntouched(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	ev := newTopSnapshotEvent("evt-cmd-small", "go test ./...", createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		RecentCommands: []*model.Event{ev},
+		Now:            createdAt,
+	}); err != nil {
+		t.Fatalf("writeTopSnapshotJSON: %v", err)
+	}
+
+	// The additive metadata keys must be omitted (omitempty) when no
+	// truncation happened so v0.16-2 consumers see the same shape they
+	// did before.
+	if strings.Contains(buf.String(), "\"truncated\"") {
+		t.Fatalf("untruncated row must omit `truncated`: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "\"message_length\"") {
+		t.Fatalf("untruncated row must omit `message_length`: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "\"message_bytes\"") {
+		t.Fatalf("untruncated row must omit `message_bytes`: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "\"message\": \"go test ./...\"") {
+		t.Fatalf("message body was rewritten unexpectedly: %s", buf.String())
+	}
+}
+
+func TestWriteTopSnapshotJSON_BoundaryLengthIsNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	boundary := strings.Repeat("a", apptypes.DefaultTopSnapshotBodyLimit)
+	ev := newTopSnapshotEvent("evt-cmd-boundary", boundary, createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		RecentCommands: []*model.Event{ev},
+		Now:            createdAt,
+	}); err != nil {
+		t.Fatalf("writeTopSnapshotJSON: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "\"truncated\": true") {
+		t.Fatalf("boundary-length row must not be truncated: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), boundary) {
+		t.Fatalf("boundary message was rewritten unexpectedly")
+	}
+}
+
+func TestWriteTopSnapshotJSON_TruncatesRecentFailures(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	huge := strings.Repeat("y", apptypes.DefaultTopSnapshotBodyLimit+25)
+	ev := newTopSnapshotEvent("evt-fail-huge", huge, createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		Failures: []*model.Event{ev},
+		Now:      createdAt,
+	}); err != nil {
+		t.Fatalf("writeTopSnapshotJSON: %v", err)
+	}
+
+	var payload struct {
+		Failures []struct {
+			Truncated     bool `json:"truncated"`
+			MessageLength int  `json:"message_length"`
+		} `json:"failures"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(payload.Failures) != 1 || !payload.Failures[0].Truncated {
+		t.Fatalf("expected recent failures pane to truncate large payloads: %+v", payload.Failures)
+	}
+	if payload.Failures[0].MessageLength != len(huge) {
+		t.Fatalf("message_length = %d, want %d", payload.Failures[0].MessageLength, len(huge))
+	}
+}
+
+func TestWriteTopSnapshotTextEvents_TruncatesLongBody(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	huge := strings.Repeat("z", 400)
+	ev := newTopSnapshotEvent("evt-cmd-huge", huge, createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotTextEvents(&buf, "RECENT COMMANDS", []*model.Event{ev}, time.UTC); err != nil {
+		t.Fatalf("writeTopSnapshotTextEvents: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "…") {
+		t.Fatalf("text snapshot row must show truncation ellipsis: %q", out)
+	}
+	if strings.Contains(out, huge) {
+		t.Fatalf("text snapshot row leaked the full body: %q", out)
+	}
+}

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1710,7 +1710,10 @@ func parseFlexibleTimeOptional(value string) (types.Optional[time.Time], error) 
 // responses by default (in runes) so a single multi-hundred-line
 // command_executed payload does not dominate the listing. Callers that
 // need the full body pass body_limit=0 or full_body=true. See #799.
-const defaultListEventBodyLimit = 500
+// The value is sourced from the shared truncation policy in
+// application/types so MCP list surfaces and CLI snapshot renderers
+// stay aligned on the same recent-command budget.
+const defaultListEventBodyLimit = apptypes.DefaultListEventBodyLimit
 
 // convertEventsWithBodyLimit serializes events for MCP list_events with
 // body_blocks included (the canonical envelope form, thinking blocks
@@ -1738,16 +1741,14 @@ func convertEventsWithoutBlocksWithBodyLimit(events []*model.Event, bodyLimit in
 func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit int) []eventOutput {
 	outputs := make([]eventOutput, 0, len(events))
 	for _, event := range events {
-		body := apptypes.ExtractPlainBody(event.Body())
-		truncated := false
+		plain := apptypes.ExtractPlainBody(event.Body())
+		result := apptypes.TruncateCommandPayload(plain, bodyLimit)
+		// BodyLength is only meaningful when the row was actually
+		// truncated; emit zero otherwise so the omitempty contract
+		// documented on eventOutput.BodyLength stays correct.
 		fullLen := 0
-		if bodyLimit > 0 {
-			runes := []rune(body)
-			if len(runes) > bodyLimit {
-				truncated = true
-				fullLen = len(runes)
-				body = string(runes[:bodyLimit]) + "…"
-			}
+		if result.Truncated {
+			fullLen = result.OriginalRuneCount
 		}
 		// body_blocks duplicates the canonical envelope inline. When
 		// the plain-text body is truncated, returning the full
@@ -1756,7 +1757,7 @@ func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit 
 		// who need the canonical structure pass full_body=true.
 		// See #799.
 		var blocks []apptypes.EventBodyBlock
-		if includeBlocks && !truncated {
+		if includeBlocks && !result.Truncated {
 			blocks, _ = apptypes.DecodeCanonicalEnvelope(event.Body())
 		}
 		outputs = append(outputs, eventOutput{
@@ -1766,9 +1767,9 @@ func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit 
 			Agent:         event.Agent().String(),
 			SessionID:     event.SessionID().String(),
 			Workspace:     event.Workspace().String(),
-			Body:          body,
+			Body:          result.Body,
 			BodyBlocks:    blocks,
-			BodyTruncated: truncated,
+			BodyTruncated: result.Truncated,
 			BodyLength:    fullLen,
 			SourceHook:    event.SourceHook(),
 			CreatedAt:     event.CreatedAt().UTC().Format(time.RFC3339Nano),


### PR DESCRIPTION
## Motivation

Large captured command payloads can dominate top snapshots, handoff summaries, and MCP list/context responses. This makes operator views noisy and wastes host-agent context budget while the full audit content should still remain available through explicit detail lookup.

## Changes

- Add a shared command-payload truncation policy in application/types.
- Apply the policy to top snapshot JSON recent failures/recent commands with additive truncation metadata.
- Reuse the shared policy for session handoff recent-command summaries and MCP event body limits.
- Keep explicit event detail/show output on the full event body path.
- Add regression tests for truncation, boundary length, small payload compatibility, and text snapshot truncation.

## Validation

- 
- ok  	github.com/duck8823/traceary	(cached)
?   	github.com/duck8823/traceary/application	[no test files]
?   	github.com/duck8823/traceary/application/marketplace	[no test files]
?   	github.com/duck8823/traceary/application/queryservice	[no test files]
ok  	github.com/duck8823/traceary/application/redaction	(cached)
ok  	github.com/duck8823/traceary/application/types	(cached)
ok  	github.com/duck8823/traceary/application/usecase	(cached)
?   	github.com/duck8823/traceary/domain	[no test files]
ok  	github.com/duck8823/traceary/domain/model	(cached)
ok  	github.com/duck8823/traceary/domain/types	(cached)
?   	github.com/duck8823/traceary/examples/anthropic-memory	[no test files]
?   	github.com/duck8823/traceary/infrastructure	[no test files]
ok  	github.com/duck8823/traceary/infrastructure/filesystem	(cached)
ok  	github.com/duck8823/traceary/infrastructure/sqlite	(cached)
ok  	github.com/duck8823/traceary/pkg/anthropicmemory	(cached)
ok  	github.com/duck8823/traceary/presentation	(cached)
ok  	github.com/duck8823/traceary/presentation/cli	(cached)
ok  	github.com/duck8823/traceary/presentation/cli/tui	(cached)
ok  	github.com/duck8823/traceary/presentation/mcpserver	(cached)
ok  	github.com/duck8823/traceary/scripts/hooks	(cached)
- 0 issues.
- 
- ok: integration manifests and packaged assets are consistent

Closes #984