### PR TITLE
v0.16-4: make accepted memories the default durable-memory context

### DIFF
--- a/application/types/context_pack.go
+++ b/application/types/context_pack.go
@@ -9,17 +9,20 @@ import (
 // ContextPack is the structured working-memory bundle shared by CLI and MCP
 // handoff surfaces.
 type ContextPack struct {
-	sessionID          domtypes.SessionID
-	workspace          domtypes.Workspace
-	requestedWorkspace domtypes.Workspace
-	label              string
-	status             string
-	totalEvents        int
-	commandCount       int
-	agents             []string
-	workingState       WorkingState
-	recentCommands     []string
-	memories           []MemorySummary
+	sessionID            domtypes.SessionID
+	workspace            domtypes.Workspace
+	requestedWorkspace   domtypes.Workspace
+	label                string
+	status               string
+	totalEvents          int
+	commandCount         int
+	agents               []string
+	workingState         WorkingState
+	recentCommands       []string
+	memories             []MemorySummary
+	memoryNeedsReview    []MemorySummary
+	acceptedMemoryCount  int
+	candidateMemoryCount int
 }
 
 // ContextPackOf creates a ContextPack.
@@ -35,17 +38,21 @@ func ContextPackOf(
 	recentCommands []string,
 	memories []MemorySummary,
 ) ContextPack {
+	trustedMemories, reviewMemories := splitContextPackMemories(memories)
 	return ContextPack{
-		sessionID:      sessionID,
-		workspace:      workspace,
-		label:          label,
-		status:         status,
-		totalEvents:    totalEvents,
-		commandCount:   commandCount,
-		agents:         slices.Clone(agents),
-		workingState:   workingState,
-		recentCommands: slices.Clone(recentCommands),
-		memories:       slices.Clone(memories),
+		sessionID:            sessionID,
+		workspace:            workspace,
+		label:                label,
+		status:               status,
+		totalEvents:          totalEvents,
+		commandCount:         commandCount,
+		agents:               slices.Clone(agents),
+		workingState:         workingState,
+		recentCommands:       slices.Clone(recentCommands),
+		memories:             trustedMemories,
+		memoryNeedsReview:    reviewMemories,
+		acceptedMemoryCount:  len(trustedMemories),
+		candidateMemoryCount: countMemoriesByStatus(reviewMemories, domtypes.MemoryStatusCandidate),
 	}
 }
 
@@ -102,3 +109,60 @@ func (c ContextPack) RecentCommands() []string { return slices.Clone(c.recentCom
 
 // Memories returns accepted durable memories relevant to the pack.
 func (c ContextPack) Memories() []MemorySummary { return slices.Clone(c.memories) }
+
+// MemoryNeedsReview returns candidate durable memories that were
+// explicitly included for review. They are intentionally separate from
+// Memories so host contexts do not treat unaccepted facts as trusted.
+func (c ContextPack) MemoryNeedsReview() []MemorySummary {
+	return slices.Clone(c.memoryNeedsReview)
+}
+
+// AcceptedMemoryCount returns the number of trusted accepted memories
+// represented by the pack. For query-built packs this count reflects
+// the accepted rows loaded under the context-pack limit.
+func (c ContextPack) AcceptedMemoryCount() int { return c.acceptedMemoryCount }
+
+// CandidateMemoryCount returns the number of candidate rows observed
+// under the context-pack limit. Candidate facts are only included in
+// MemoryNeedsReview when IncludeMemoryCandidates was requested.
+func (c ContextPack) CandidateMemoryCount() int { return c.candidateMemoryCount }
+
+// WithMemoryNeedsReview returns a copy of the pack with the candidate
+// review section and candidate count populated.
+func (c ContextPack) WithMemoryNeedsReview(candidates []MemorySummary, candidateCount int) ContextPack {
+	c.memoryNeedsReview = slices.Clone(candidates)
+	c.candidateMemoryCount = candidateCount
+	return c
+}
+
+// WithMemoryCounts returns a copy of the pack with explicit trust
+// counters. This is used by query-built packs to expose accepted and
+// candidate counts even when candidates are intentionally omitted.
+func (c ContextPack) WithMemoryCounts(acceptedCount int, candidateCount int) ContextPack {
+	c.acceptedMemoryCount = acceptedCount
+	c.candidateMemoryCount = candidateCount
+	return c
+}
+
+func countMemoriesByStatus(memories []MemorySummary, status domtypes.MemoryStatus) int {
+	count := 0
+	for _, memory := range memories {
+		if memory.Status() == status {
+			count++
+		}
+	}
+	return count
+}
+
+func splitContextPackMemories(memories []MemorySummary) ([]MemorySummary, []MemorySummary) {
+	trusted := make([]MemorySummary, 0, len(memories))
+	needsReview := make([]MemorySummary, 0)
+	for _, memory := range memories {
+		if memory.Status() == domtypes.MemoryStatusAccepted {
+			trusted = append(trusted, memory)
+			continue
+		}
+		needsReview = append(needsReview, memory)
+	}
+	return trusted, needsReview
+}

--- a/application/types/context_pack_criteria.go
+++ b/application/types/context_pack_criteria.go
@@ -18,6 +18,7 @@ type ContextPackCriteria struct {
 	recentCommandsLimit int
 	memoryLimit         int
 	memoryPreset        MemoryRetrievalPreset
+	includeCandidates   bool
 	memoryAsOf          domtypes.Optional[time.Time]
 	allowStale          bool
 	staleAfter          time.Duration
@@ -39,6 +40,12 @@ func (c ContextPackCriteria) MemoryLimit() int { return c.memoryLimit }
 // durable memories for the pack. Empty means "no preset — use the
 // default accepted-only behavior of the memory query path."
 func (c ContextPackCriteria) MemoryPreset() MemoryRetrievalPreset { return c.memoryPreset }
+
+// IncludeMemoryCandidates reports whether candidate durable memories
+// should be included in the review-oriented section of a context pack.
+// Defaults to false so handoff / MCP context treat only accepted
+// durable memories as trusted.
+func (c ContextPackCriteria) IncludeMemoryCandidates() bool { return c.includeCandidates }
 
 // MemoryAsOf returns the point-in-time at which content validity should
 // be evaluated when loading durable memories for the pack. A present
@@ -99,6 +106,15 @@ func (b *ContextPackCriteriaBuilder) MemoryLimit(limit int) *ContextPackCriteria
 // durable-memory filters for the pack.
 func (b *ContextPackCriteriaBuilder) MemoryPreset(preset MemoryRetrievalPreset) *ContextPackCriteriaBuilder {
 	b.criteria.memoryPreset = preset
+	return b
+}
+
+// IncludeMemoryCandidates opts in to including candidate memories in a
+// separate review-oriented section. Candidate backlog counts can still
+// be populated when this is false, but candidate facts are not mixed
+// into the trusted memory section.
+func (b *ContextPackCriteriaBuilder) IncludeMemoryCandidates(include bool) *ContextPackCriteriaBuilder {
+	b.criteria.includeCandidates = include
 	return b
 }
 

--- a/application/types/memory_preset.go
+++ b/application/types/memory_preset.go
@@ -147,6 +147,22 @@ func (p MemoryRetrievalPreset) ApplyToMemoryListCriteriaBuilder(builder *MemoryL
 	return builder
 }
 
+// ApplyMemoryTypeFiltersToMemoryListCriteriaBuilder applies only the
+// preset's type restrictions, leaving lifecycle status untouched. This
+// lets review-oriented surfaces ask for candidate memories in a separate
+// section while preserving the same resume / review / incident memory
+// type shape as the trusted accepted section.
+func (p MemoryRetrievalPreset) ApplyMemoryTypeFiltersToMemoryListCriteriaBuilder(builder *MemoryListCriteriaBuilder) *MemoryListCriteriaBuilder {
+	if builder == nil {
+		return builder
+	}
+	filters := p.filters()
+	if len(filters.memoryTypes) > 0 {
+		builder = builder.MemoryTypes(filters.memoryTypes)
+	}
+	return builder
+}
+
 // ApplyToMemorySearchCriteriaBuilder is the search-side counterpart
 // to ApplyToMemoryListCriteriaBuilder. Same defaults, same override
 // semantics.

--- a/application/types/memory_preset_test.go
+++ b/application/types/memory_preset_test.go
@@ -111,3 +111,24 @@ func TestMemoryRetrievalPreset_ExplicitFiltersOverride(t *testing.T) {
 		t.Fatalf("MemoryTypes mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestMemoryRetrievalPreset_ApplyMemoryTypeFiltersLeavesStatusUntouched(t *testing.T) {
+	t.Parallel()
+
+	builder := apptypes.NewMemoryListCriteriaBuilder(10).Status(domtypes.MemoryStatusCandidate)
+	criteria := apptypes.MemoryRetrievalPresetReview.
+		ApplyMemoryTypeFiltersToMemoryListCriteriaBuilder(builder).
+		Build()
+
+	if diff := cmp.Diff([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, criteria.Statuses()); diff != "" {
+		t.Fatalf("Statuses mismatch (-want +got):\n%s", diff)
+	}
+	wantTypes := []domtypes.MemoryType{
+		domtypes.MemoryTypeDecision,
+		domtypes.MemoryTypeConstraint,
+		domtypes.MemoryTypeArtifact,
+	}
+	if diff := cmp.Diff(wantTypes, criteria.MemoryTypes()); diff != "" {
+		t.Fatalf("MemoryTypes mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -77,6 +77,7 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 		criteria.Workspace(),
 		criteria.MemoryLimit(),
 		criteria.MemoryPreset(),
+		criteria.IncludeMemoryCandidates(),
 		criteria.MemoryAsOf(),
 	)
 	if err != nil {
@@ -93,8 +94,11 @@ func (b *contextPackBuilder) Build(ctx context.Context, criteria apptypes.Contex
 		session.Agents(),
 		apptypes.WorkingStateOf(session.Summary(), compactSummary),
 		recentCommands,
-		memories,
-	).WithRequestedWorkspace(criteria.Workspace())
+		memories.trusted,
+	).
+		WithRequestedWorkspace(criteria.Workspace()).
+		WithMemoryNeedsReview(memories.needsReview, memories.candidateCount).
+		WithMemoryCounts(memories.acceptedCount, memories.candidateCount)
 	return domtypes.Some(pack), nil
 }
 
@@ -172,44 +176,81 @@ func (b *contextPackBuilder) loadMemories(
 	requestedWorkspace domtypes.Workspace,
 	limit int,
 	preset apptypes.MemoryRetrievalPreset,
+	includeCandidates bool,
 	asOf domtypes.Optional[time.Time],
-) ([]apptypes.MemorySummary, error) {
+) (contextPackMemoryLoad, error) {
 	if b.memoryQuery == nil || limit == 0 {
-		return nil, nil
+		return contextPackMemoryLoad{}, nil
 	}
 
 	scopes := relevantMemoryScopes(session, requestedWorkspace)
 	if len(scopes) == 0 {
-		return nil, nil
+		return contextPackMemoryLoad{}, nil
 	}
 
-	builder := apptypes.NewMemoryListCriteriaBuilder(limit).Scopes(scopes)
+	acceptedBuilder := apptypes.NewMemoryListCriteriaBuilder(limit).Scopes(scopes)
 	if preset != "" {
 		// Preset wins for context packs: callers asked for a specific
 		// retrieval shape (resume / review / incident), so we honor
-		// its Statuses + MemoryTypes defaults. No preset falls back to
-		// the legacy accepted-only behavior so existing clients see
-		// the same pack shape as before.
-		builder = preset.ApplyToMemoryListCriteriaBuilder(builder)
+		// its Statuses + MemoryTypes defaults.
+		acceptedBuilder = preset.ApplyToMemoryListCriteriaBuilder(acceptedBuilder)
 	} else {
-		// Default handoff / get_context surface returns both accepted and
-		// candidate memories so the next session sees pending review
-		// items with a status marker rather than only the curated set.
-		// Callers that want strict accepted-only behavior should pass an
-		// explicit preset (resume / review / incident).
-		builder = builder.Statuses([]domtypes.MemoryStatus{
-			domtypes.MemoryStatusAccepted,
-			domtypes.MemoryStatusCandidate,
-		})
+		// Default handoff / MCP context is accepted-only. Candidate
+		// memories are untrusted backlog and must not be mixed into the
+		// durable-memory context unless the caller opts into the separate
+		// review section.
+		acceptedBuilder = acceptedBuilder.Status(domtypes.MemoryStatusAccepted)
 	}
 	if asOfValue, ok := asOf.Value(); ok {
-		builder = builder.AsOf(asOfValue)
+		acceptedBuilder = acceptedBuilder.AsOf(asOfValue)
 	}
-	memories, err := b.memoryQuery.List(ctx, builder.Build())
+	trusted, err := b.memoryQuery.List(ctx, acceptedBuilder.Build())
 	if err != nil {
-		return nil, xerrors.Errorf("failed to list durable memories for context pack: %w", err)
+		return contextPackMemoryLoad{}, xerrors.Errorf("failed to list accepted durable memories for context pack: %w", err)
 	}
-	return memories, nil
+
+	candidateBuilder := apptypes.NewMemoryListCriteriaBuilder(limit).
+		Scopes(scopes).
+		Status(domtypes.MemoryStatusCandidate).
+		Sources(contextPackCandidateMemorySources())
+	if preset != "" {
+		candidateBuilder = preset.ApplyMemoryTypeFiltersToMemoryListCriteriaBuilder(candidateBuilder)
+	}
+	if asOfValue, ok := asOf.Value(); ok {
+		candidateBuilder = candidateBuilder.AsOf(asOfValue)
+	}
+	candidates, err := b.memoryQuery.List(ctx, candidateBuilder.Build())
+	if err != nil {
+		return contextPackMemoryLoad{}, xerrors.Errorf("failed to list candidate durable memories for context pack: %w", err)
+	}
+
+	needsReview := []apptypes.MemorySummary(nil)
+	if includeCandidates {
+		needsReview = candidates
+	}
+	return contextPackMemoryLoad{
+		trusted:        trusted,
+		needsReview:    needsReview,
+		acceptedCount:  len(trusted),
+		candidateCount: len(candidates),
+	}, nil
+}
+
+type contextPackMemoryLoad struct {
+	trusted        []apptypes.MemorySummary
+	needsReview    []apptypes.MemorySummary
+	acceptedCount  int
+	candidateCount int
+}
+
+func contextPackCandidateMemorySources() []domtypes.MemorySource {
+	return []domtypes.MemorySource{
+		domtypes.MemorySourceManual,
+		domtypes.MemorySourceExtracted,
+		domtypes.MemorySourceRememberIntent,
+		domtypes.MemorySourceCompactSummary,
+		domtypes.MemorySourceImported,
+	}
 }
 
 func relevantMemoryScopes(session apptypes.SessionSummary, requestedWorkspace domtypes.Workspace) []domtypes.MemoryScope {

--- a/application/usecase/context_usecase_impl_test.go
+++ b/application/usecase/context_usecase_impl_test.go
@@ -211,6 +211,173 @@ func TestContextUsecase_Handoff(t *testing.T) {
 		}
 	})
 
+	t.Run("defaults durable memory context to accepted memories only with candidate counts", func(t *testing.T) {
+		t.Parallel()
+
+		session := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-memory-trust-default"),
+			domtypes.Workspace("duck8823/traceary"),
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+		accepted := contextPackMemorySummary(t, "memory-accepted", domtypes.MemoryStatusAccepted, "Trusted architectural decision")
+		candidate := contextPackMemorySummary(t, "memory-candidate", domtypes.MemoryStatusCandidate, "Unreviewed extracted note")
+		memoryQuery := &memoryQueryStub{listResultByStatus: map[domtypes.MemoryStatus][]apptypes.MemorySummary{
+			domtypes.MemoryStatusAccepted:  {accepted},
+			domtypes.MemoryStatusCandidate: {candidate},
+		}}
+		sut := usecase.NewContextUsecase(
+			&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+			&eventQueryServiceStub{},
+			memoryQuery,
+		)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().
+				SessionID(domtypes.SessionID("session-memory-trust-default")).
+				Workspace(domtypes.Workspace("duck8823/traceary")).
+				MemoryLimit(5).
+				Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack")
+		}
+		if diff := cmp.Diff([]domtypes.MemoryID{accepted.MemoryID()}, memoryIDs(pack.Memories())); diff != "" {
+			t.Fatalf("trusted memories mismatch (-want +got):\n%s", diff)
+		}
+		if len(pack.MemoryNeedsReview()) != 0 {
+			t.Fatalf("MemoryNeedsReview() length = %d, want 0 by default", len(pack.MemoryNeedsReview()))
+		}
+		if pack.AcceptedMemoryCount() != 1 || pack.CandidateMemoryCount() != 1 {
+			t.Fatalf("memory counts = accepted %d candidate %d, want 1/1", pack.AcceptedMemoryCount(), pack.CandidateMemoryCount())
+		}
+		acceptedStatuses := memoryQuery.listCriteriaByStatus[domtypes.MemoryStatusAccepted].Statuses()
+		if diff := cmp.Diff([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}, acceptedStatuses); diff != "" {
+			t.Fatalf("accepted query statuses mismatch (-want +got):\n%s", diff)
+		}
+		candidateStatuses := memoryQuery.listCriteriaByStatus[domtypes.MemoryStatusCandidate].Statuses()
+		if diff := cmp.Diff([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, candidateStatuses); diff != "" {
+			t.Fatalf("candidate query statuses mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("include candidates keeps review backlog separate from trusted memories", func(t *testing.T) {
+		t.Parallel()
+
+		session := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-memory-trust-review"),
+			domtypes.Workspace("duck8823/traceary"),
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+		accepted := contextPackMemorySummary(t, "memory-accepted-review", domtypes.MemoryStatusAccepted, "Trusted deployment invariant")
+		candidate := contextPackMemorySummary(t, "memory-candidate-review", domtypes.MemoryStatusCandidate, "Review this possible follow-up")
+		memoryQuery := &memoryQueryStub{listResultByStatus: map[domtypes.MemoryStatus][]apptypes.MemorySummary{
+			domtypes.MemoryStatusAccepted:  {accepted},
+			domtypes.MemoryStatusCandidate: {candidate},
+		}}
+		sut := usecase.NewContextUsecase(
+			&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+			&eventQueryServiceStub{},
+			memoryQuery,
+		)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().
+				SessionID(domtypes.SessionID("session-memory-trust-review")).
+				Workspace(domtypes.Workspace("duck8823/traceary")).
+				MemoryLimit(5).
+				IncludeMemoryCandidates(true).
+				Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack")
+		}
+		if diff := cmp.Diff([]domtypes.MemoryID{accepted.MemoryID()}, memoryIDs(pack.Memories())); diff != "" {
+			t.Fatalf("trusted memories mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff([]domtypes.MemoryID{candidate.MemoryID()}, memoryIDs(pack.MemoryNeedsReview())); diff != "" {
+			t.Fatalf("needs-review memories mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("no accepted memories still reports candidate backlog without trusting it", func(t *testing.T) {
+		t.Parallel()
+
+		session := apptypes.SessionSummaryOf(
+			domtypes.SessionID("session-memory-trust-empty"),
+			domtypes.Workspace("duck8823/traceary"),
+			time.Now().Add(-time.Hour),
+			domtypes.None[time.Time](),
+			"active",
+			1,
+			0,
+			[]string{"claude"},
+			"",
+			"",
+			domtypes.SessionID(""),
+		)
+		candidate := contextPackMemorySummary(t, "memory-candidate-only", domtypes.MemoryStatusCandidate, "Do not trust me yet")
+		memoryQuery := &memoryQueryStub{listResultByStatus: map[domtypes.MemoryStatus][]apptypes.MemorySummary{
+			domtypes.MemoryStatusAccepted:  nil,
+			domtypes.MemoryStatusCandidate: {candidate},
+		}}
+		sut := usecase.NewContextUsecase(
+			&sessionQueryServiceStub{listSummariesResult: []apptypes.SessionSummary{session}},
+			&eventQueryServiceStub{},
+			memoryQuery,
+		)
+
+		got, err := sut.Handoff(
+			context.Background(),
+			apptypes.NewContextPackCriteriaBuilder().
+				SessionID(domtypes.SessionID("session-memory-trust-empty")).
+				Workspace(domtypes.Workspace("duck8823/traceary")).
+				MemoryLimit(5).
+				Build(),
+		)
+		if err != nil {
+			t.Fatalf("Handoff() error = %v", err)
+		}
+		pack, ok := got.Value()
+		if !ok {
+			t.Fatalf("Handoff() returned empty pack")
+		}
+		if len(pack.Memories()) != 0 {
+			t.Fatalf("trusted memories length = %d, want 0", len(pack.Memories()))
+		}
+		if len(pack.MemoryNeedsReview()) != 0 {
+			t.Fatalf("needs-review memories length = %d, want 0 by default", len(pack.MemoryNeedsReview()))
+		}
+		if pack.AcceptedMemoryCount() != 0 || pack.CandidateMemoryCount() != 1 {
+			t.Fatalf("memory counts = accepted %d candidate %d, want 0/1", pack.AcceptedMemoryCount(), pack.CandidateMemoryCount())
+		}
+	})
+
 	t.Run("skips memory lookup when no scopes are available", func(t *testing.T) {
 		t.Parallel()
 
@@ -483,6 +650,38 @@ func TestContextUsecase_Handoff(t *testing.T) {
 			t.Errorf("context pack missing post-compact summary; compact = %q", compact)
 		}
 	})
+}
+
+func contextPackMemorySummary(t *testing.T, id string, status domtypes.MemoryStatus, fact string) apptypes.MemorySummary {
+	t.Helper()
+	now := time.Date(2026, 5, 23, 0, 0, 0, 0, time.UTC)
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("duck8823/traceary")),
+		fact,
+		status,
+		domtypes.ConfidenceVerified,
+		domtypes.MemorySourceManual,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		now,
+		domtypes.None[time.Time](),
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf(%s) error = %v", id, err)
+	}
+	return summary
+}
+
+func memoryIDs(memories []apptypes.MemorySummary) []domtypes.MemoryID {
+	ids := make([]domtypes.MemoryID, 0, len(memories))
+	for _, memory := range memories {
+		ids = append(ids, memory.MemoryID())
+	}
+	return ids
 }
 
 func TestContextUsecase_Handoff_WorkspaceFallback(t *testing.T) {

--- a/application/usecase/memory_usecase_impl_test.go
+++ b/application/usecase/memory_usecase_impl_test.go
@@ -85,20 +85,31 @@ func (s *memoryRepositoryStub) FindByID(_ context.Context, memoryID domtypes.Mem
 }
 
 type memoryQueryStub struct {
-	listResult    []apptypes.MemorySummary
-	listErr       error
-	listCriteria  apptypes.MemoryListCriteria
-	staleResult   apptypes.StaleMemoryListResult
-	staleErr      error
-	staleCriteria apptypes.StaleMemoryListCriteria
-	searchResult  []apptypes.MemorySummary
-	searchErr     error
-	details       apptypes.MemoryDetails
-	detailsErr    error
+	listResult           []apptypes.MemorySummary
+	listResultByStatus   map[domtypes.MemoryStatus][]apptypes.MemorySummary
+	listErr              error
+	listCriteria         apptypes.MemoryListCriteria
+	listCriteriaByStatus map[domtypes.MemoryStatus]apptypes.MemoryListCriteria
+	staleResult          apptypes.StaleMemoryListResult
+	staleErr             error
+	staleCriteria        apptypes.StaleMemoryListCriteria
+	searchResult         []apptypes.MemorySummary
+	searchErr            error
+	details              apptypes.MemoryDetails
+	detailsErr           error
 }
 
 func (s *memoryQueryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
+	if statuses := criteria.Statuses(); len(statuses) > 0 {
+		if s.listCriteriaByStatus == nil {
+			s.listCriteriaByStatus = make(map[domtypes.MemoryStatus]apptypes.MemoryListCriteria)
+		}
+		s.listCriteriaByStatus[statuses[0]] = criteria
+		if result, ok := s.listResultByStatus[statuses[0]]; ok {
+			return result, s.listErr
+		}
+	}
 	return s.listResult, s.listErr
 }
 

--- a/presentation/cli/compact_summary.go
+++ b/presentation/cli/compact_summary.go
@@ -26,14 +26,15 @@ const compactSummaryDefaultRecent = 3
 // --preset / --as-of through here so those flags are not silent
 // no-ops.
 type compactSummaryOptions struct {
-	sessionID   string
-	workspace   string
-	recentCount int
-	memoryLimit int
-	preset      apptypes.MemoryRetrievalPreset
-	asOf        types.Optional[time.Time]
-	staleAfter  time.Duration
-	allowStale  bool
+	sessionID         string
+	workspace         string
+	recentCount       int
+	memoryLimit       int
+	preset            apptypes.MemoryRetrievalPreset
+	includeCandidates bool
+	asOf              types.Optional[time.Time]
+	staleAfter        time.Duration
+	allowStale        bool
 }
 
 func (c *RootCLI) printCompactSummaryWithOptions(
@@ -53,6 +54,7 @@ func (c *RootCLI) printCompactSummaryWithOptions(
 			RecentCommandsLimit(opts.recentCount).
 			MemoryLimit(opts.memoryLimit).
 			MemoryPreset(opts.preset).
+			IncludeMemoryCandidates(opts.includeCandidates).
 			MemoryAsOf(opts.asOf).
 			StaleAfter(opts.staleAfter).
 			AllowStale(opts.allowStale).
@@ -119,6 +121,18 @@ func buildCompactSummaryText(result types.Optional[apptypes.ContextPack]) (strin
 			sb.WriteString(truncateCompactSummarySegment(memory.Fact(), 60))
 		}
 		sb.WriteString("\n")
+	}
+	if candidates := pack.MemoryNeedsReview(); len(candidates) > 0 {
+		sb.WriteString("  needs_review: ")
+		for index, memory := range candidates {
+			if index > 0 {
+				sb.WriteString(" | ")
+			}
+			sb.WriteString(truncateCompactSummarySegment(memory.Fact(), 60))
+		}
+		sb.WriteString("\n")
+	} else if pack.CandidateMemoryCount() > 0 {
+		fmt.Fprintf(&sb, "  needs_review: %d candidate memories omitted (run session handoff --include-candidates)\n", pack.CandidateMemoryCount())
 	}
 	sb.WriteString("  Run list_events for full history.\n")
 	text := sb.String()

--- a/presentation/cli/handoff.go
+++ b/presentation/cli/handoff.go
@@ -16,16 +16,17 @@ import (
 
 func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
 	var (
-		dbPath      string
-		sessionID   string
-		repo        string
-		recent      int
-		memories    int
-		preset      string
-		asOf        string
-		compactOnly bool
-		staleAfter  time.Duration
-		allowStale  bool
+		dbPath            string
+		sessionID         string
+		repo              string
+		recent            int
+		memories          int
+		preset            string
+		includeCandidates bool
+		asOf              string
+		compactOnly       bool
+		staleAfter        time.Duration
+		allowStale        bool
 	)
 
 	cmd := &cobra.Command{
@@ -75,26 +76,28 @@ func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
 					return xerrors.Errorf("%s: %w", Localize("failed to parse --as-of", "--as-of の解析に失敗しました"), err)
 				}
 				return c.printCompactSummaryWithOptions(cmd.Context(), cmd.OutOrStdout(), compactSummaryOptions{
-					sessionID:   resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", ""),
-					workspace:   resolveWorkspaceValue(cmd.Context(), repo),
-					recentCount: compactRecent,
-					memoryLimit: memoryLimit,
-					preset:      parsedPreset,
-					asOf:        parsedAsOf,
-					staleAfter:  staleAfter,
-					allowStale:  allowStale,
+					sessionID:         resolveOptionalValue(sessionID, "TRACEARY_SESSION_ID", ""),
+					workspace:         resolveWorkspaceValue(cmd.Context(), repo),
+					recentCount:       compactRecent,
+					memoryLimit:       memoryLimit,
+					preset:            parsedPreset,
+					includeCandidates: includeCandidates,
+					asOf:              parsedAsOf,
+					staleAfter:        staleAfter,
+					allowStale:        allowStale,
 				})
 			}
 			return c.runHandoff(cmd.Context(), cmd.OutOrStdout(), handoffCommandInput{
-				dbPath:     dbPath,
-				sessionID:  sessionID,
-				workspace:  repo,
-				recent:     recent,
-				memories:   memories,
-				preset:     preset,
-				asOf:       asOf,
-				staleAfter: staleAfter,
-				allowStale: allowStale,
+				dbPath:            dbPath,
+				sessionID:         sessionID,
+				workspace:         repo,
+				recent:            recent,
+				memories:          memories,
+				preset:            preset,
+				includeCandidates: includeCandidates,
+				asOf:              asOf,
+				staleAfter:        staleAfter,
+				allowStale:        allowStale,
 			})
 		},
 	}
@@ -105,6 +108,7 @@ func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
 	cmd.Flags().IntVar(&recent, "recent", 5, Localize("number of recent commands to show", "表示する直近コマンド数"))
 	cmd.Flags().IntVar(&memories, "memories", 5, Localize("number of durable memories to include", "含める durable memory 数"))
 	cmd.Flags().StringVar(&preset, "preset", "", Localize("apply a built-in retrieval preset to durable memories (resume | review | incident)", "durable memory 取得に built-in preset を適用する (resume | review | incident)"))
+	cmd.Flags().BoolVar(&includeCandidates, "include-candidates", false, Localize("include candidate durable memories in a separate needs-review section", "candidate durable memory を別の needs-review セクションに含める"))
 	cmd.Flags().StringVar(&asOf, "as-of", "", Localize("evaluate durable memory validity at the given timestamp (RFC3339 or YYYY-MM-DD)", "指定時刻 (RFC3339 または YYYY-MM-DD) の時点で durable memory の validity を評価する"))
 	cmd.Flags().BoolVar(&compactOnly, "compact-only", false, Localize("emit the short prompt-injection summary used on session resume (replaces the v0.8.x compact-summary command); implicitly sets --recent=3 unless --recent is given", "セッション再開時に使う短い prompt-injection summary を出力する (v0.8.x の compact-summary を置き換え); --recent 未指定時は 3 に自動設定"))
 	cmd.Flags().DurationVar(
@@ -119,15 +123,16 @@ func (c *RootCLI) newSessionHandoffCommand() *cobra.Command {
 }
 
 type handoffCommandInput struct {
-	dbPath     string
-	sessionID  string
-	workspace  string
-	recent     int
-	memories   int
-	preset     string
-	asOf       string
-	staleAfter time.Duration
-	allowStale bool
+	dbPath            string
+	sessionID         string
+	workspace         string
+	recent            int
+	memories          int
+	preset            string
+	includeCandidates bool
+	asOf              string
+	staleAfter        time.Duration
+	allowStale        bool
 }
 
 func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handoffCommandInput) error {
@@ -163,6 +168,7 @@ func (c *RootCLI) runHandoff(ctx context.Context, output io.Writer, input handof
 		RecentCommandsLimit(input.recent).
 		MemoryLimit(input.memories).
 		MemoryPreset(preset).
+		IncludeMemoryCandidates(input.includeCandidates).
 		MemoryAsOf(asOf).
 		StaleAfter(input.staleAfter).
 		AllowStale(input.allowStale)
@@ -260,6 +266,14 @@ func writeHandoffText(output io.Writer, result types.Optional[apptypes.ContextPa
 			return xerrors.Errorf("failed to print empty recent-commands item: %w", err)
 		}
 	}
+	if _, err := fmt.Fprintf(
+		output,
+		"MEMORY_COUNTS: accepted=%d candidate=%d\n",
+		pack.AcceptedMemoryCount(),
+		pack.CandidateMemoryCount(),
+	); err != nil {
+		return xerrors.Errorf("failed to print memory counts: %w", err)
+	}
 	if _, err := fmt.Fprintln(output, "MEMORIES:"); err != nil {
 		return xerrors.Errorf("failed to print memories heading: %w", err)
 	}
@@ -287,6 +301,28 @@ func writeHandoffText(output io.Writer, result types.Optional[apptypes.ContextPa
 	if len(pack.Memories()) == 0 {
 		if _, err := fmt.Fprintln(output, "-"); err != nil {
 			return xerrors.Errorf("failed to print empty memories item: %w", err)
+		}
+	}
+	if pack.CandidateMemoryCount() > 0 {
+		if _, err := fmt.Fprintln(output, "MEMORY_NEEDS_REVIEW:"); err != nil {
+			return xerrors.Errorf("failed to print memory needs-review heading: %w", err)
+		}
+		for _, memory := range pack.MemoryNeedsReview() {
+			if _, err := fmt.Fprintf(
+				output,
+				"- [%s][%s:%s] %s\n",
+				memory.MemoryType(),
+				memory.Scope().Kind(),
+				memory.Scope().Key(),
+				memory.Fact(),
+			); err != nil {
+				return xerrors.Errorf("failed to print handoff memory candidate: %w", err)
+			}
+		}
+		if len(pack.MemoryNeedsReview()) == 0 {
+			if _, err := fmt.Fprintln(output, "- (candidate backlog omitted; pass --include-candidates to review)"); err != nil {
+				return xerrors.Errorf("failed to print omitted memory candidates hint: %w", err)
+			}
 		}
 	}
 

--- a/presentation/cli/handoff_golden_test.go
+++ b/presentation/cli/handoff_golden_test.go
@@ -57,6 +57,23 @@ func TestSessionHandoff_TextGoldens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MemorySummaryOf(candidate) error = %v", err)
 	}
+	fullPack := apptypes.ContextPackOf(
+		types.SessionID("session-handoff-golden"),
+		types.Workspace("duck8823/traceary"),
+		"v0.14.0",
+		"active",
+		42,
+		9,
+		[]string{"claude", "codex"},
+		apptypes.WorkingStateOf(
+			"Lock CLI/MCP contract surfaces before v1.0.",
+			"Add MCP registry snapshot.",
+		),
+		[]string{"go test ./...", "go tool golangci-lint run"},
+		[]apptypes.MemorySummary{acceptedSummary},
+	).
+		WithMemoryNeedsReview([]apptypes.MemorySummary{candidateSummary}, 1).
+		WithMemoryCounts(1, 1)
 
 	cases := []struct {
 		name    string
@@ -64,22 +81,8 @@ func TestSessionHandoff_TextGoldens(t *testing.T) {
 		fixture string
 	}{
 		{
-			name: "full",
-			handoff: types.Some(apptypes.ContextPackOf(
-				types.SessionID("session-handoff-golden"),
-				types.Workspace("duck8823/traceary"),
-				"v0.14.0",
-				"active",
-				42,
-				9,
-				[]string{"claude", "codex"},
-				apptypes.WorkingStateOf(
-					"Lock CLI/MCP contract surfaces before v1.0.",
-					"Add MCP registry snapshot.",
-				),
-				[]string{"go test ./...", "go tool golangci-lint run"},
-				[]apptypes.MemorySummary{acceptedSummary, candidateSummary},
-			)),
+			name:    "full",
+			handoff: types.Some(fullPack),
 			fixture: "full.golden",
 		},
 		{

--- a/presentation/cli/handoff_test.go
+++ b/presentation/cli/handoff_test.go
@@ -82,7 +82,7 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("candidate memories surface with status marker", func(t *testing.T) {
+	t.Run("candidate memories surface in needs-review section when included", func(t *testing.T) {
 		t.Parallel()
 
 		acceptedSummary, err := apptypes.MemorySummaryOf(
@@ -122,22 +122,26 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 			t.Fatalf("MemorySummaryOf(candidate) error = %v", err)
 		}
 
+		pack := apptypes.ContextPackOf(
+			types.SessionID("session-marker"),
+			types.Workspace("duck8823/traceary"),
+			"",
+			"active",
+			0,
+			0,
+			nil,
+			apptypes.WorkingStateOf("", ""),
+			nil,
+			[]apptypes.MemorySummary{acceptedSummary},
+		).
+			WithMemoryNeedsReview([]apptypes.MemorySummary{candidateSummary}, 1).
+			WithMemoryCounts(1, 1)
+
 		stdout := &bytes.Buffer{}
 		rootCmd := cli.NewRootCLI(
 			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 			cli.WithContext(&contextUsecaseStub{
-				handoff: types.Some(apptypes.ContextPackOf(
-					types.SessionID("session-marker"),
-					types.Workspace("duck8823/traceary"),
-					"",
-					"active",
-					0,
-					0,
-					nil,
-					apptypes.WorkingStateOf("", ""),
-					nil,
-					[]apptypes.MemorySummary{acceptedSummary, candidateSummary},
-				)),
+				handoff: types.Some(pack),
 			}),
 		).Command()
 		rootCmd.SetOut(stdout)
@@ -148,8 +152,11 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 			t.Fatalf("Execute() error = %v", err)
 		}
 		out := stdout.String()
-		if !strings.Contains(out, "[candidate][lesson]") {
-			t.Fatalf("candidate memory should render with [candidate] status prefix:\n%s", out)
+		if !strings.Contains(out, "MEMORY_NEEDS_REVIEW:") {
+			t.Fatalf("candidate memory should render in needs-review section:\n%s", out)
+		}
+		if !strings.Contains(out, "[lesson][workspace:duck8823/traceary] Pending review item from extraction") {
+			t.Fatalf("candidate memory should render without being mixed into trusted memories:\n%s", out)
 		}
 		if strings.Contains(out, "[accepted][decision]") {
 			t.Fatalf("accepted memory must not get a status prefix (existing layout); output:\n%s", out)
@@ -195,6 +202,44 @@ func TestRootCLI_HandoffCommand(t *testing.T) {
 		}
 		if got, want := first.StaleAfter(), 24*time.Hour; got != want {
 			t.Fatalf("default StaleAfter = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("--include-candidates opts into review candidate section", func(t *testing.T) {
+		t.Parallel()
+
+		ctxStub := &contextUsecaseStub{
+			handoff: types.Some(apptypes.ContextPackOf(
+				types.SessionID("session-candidates-flag"),
+				types.Workspace("duck8823/traceary"),
+				"",
+				"active",
+				1,
+				0,
+				nil,
+				apptypes.WorkingStateOf("", ""),
+				nil,
+				nil,
+			)),
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithContext(ctxStub),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"session", "handoff", "--include-candidates", "--db-path", filepath.Join(t.TempDir(), "traceary.db")})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if len(ctxStub.handoffCalls) != 1 {
+			t.Fatalf("handoff calls = %d, want 1", len(ctxStub.handoffCalls))
+		}
+		if !ctxStub.handoffCalls[0].IncludeMemoryCandidates() {
+			t.Fatalf("IncludeMemoryCandidates() = false, want true")
 		}
 	})
 

--- a/presentation/cli/testdata/session_handoff/empty_pack.golden
+++ b/presentation/cli/testdata/session_handoff/empty_pack.golden
@@ -11,5 +11,6 @@ WORKING_STATE:
 - compact_summary: -
 RECENT_COMMANDS:
 -
+MEMORY_COUNTS: accepted=0 candidate=0
 MEMORIES:
 -

--- a/presentation/cli/testdata/session_handoff/full.golden
+++ b/presentation/cli/testdata/session_handoff/full.golden
@@ -12,6 +12,8 @@ WORKING_STATE:
 RECENT_COMMANDS:
 - go test ./...
 - go tool golangci-lint run
+MEMORY_COUNTS: accepted=1 candidate=1
 MEMORIES:
 - [decision][workspace:duck8823/traceary] Keep handoff format stable for downstream parsers
-- [candidate][lesson][workspace:duck8823/traceary] Mark non-accepted entries with a status prefix
+MEMORY_NEEDS_REVIEW:
+- [lesson][workspace:duck8823/traceary] Mark non-accepted entries with a status prefix

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -40,6 +40,7 @@ type queryMemoryInput struct {
 	AsOf                string   `json:"as_of,omitempty" jsonschema:"evaluate content validity at this timestamp"`
 	IncludeExpired      bool     `json:"include_expired,omitempty" jsonschema:"include memories whose valid_to is in the past"`
 	Preset              string   `json:"preset,omitempty" jsonschema:"built-in retrieval preset: resume | review | incident"`
+	IncludeCandidates   bool     `json:"include_candidates,omitempty" jsonschema:"include candidate memories in a separate needs-review section for action=pack"`
 	SessionID           string   `json:"session_id,omitempty" jsonschema:"session identifier filter"`
 	RecentCommandsLimit *int     `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include"`
 	MemoryLimit         *int     `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
@@ -63,6 +64,7 @@ type sessionActionInput struct {
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories"`
+	IncludeCandidates   bool   `json:"include_candidates,omitempty" jsonschema:"include candidate durable memories in a separate needs-review section for action=handoff"`
 	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp"`
 	Depth               *int   `json:"depth,omitempty" jsonschema:"maximum descendant depth for action=tree (0 returns only the root)"`
 }
@@ -151,6 +153,7 @@ type sessionHandoffInput struct {
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
+	IncludeCandidates   bool   `json:"include_candidates,omitempty" jsonschema:"include candidate durable memories in a separate needs-review section"`
 	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`
 	AllowStale          bool   `json:"allow_stale,omitempty" jsonschema:"allow stale active sessions"`
 	StaleAfterSeconds   int    `json:"stale_after_seconds,omitempty" jsonschema:"mark active sessions older than this many seconds as stale (0 or omitted: 86400)"`
@@ -163,6 +166,7 @@ type memoryPackInput struct {
 	RecentCommandsLimit *int   `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include (default: 5; explicit 0 disables recent commands)"`
 	MemoryLimit         *int   `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include (default: 5; explicit 0 disables durable memories)"`
 	Preset              string `json:"preset,omitempty" jsonschema:"built-in retrieval preset applied to durable memories: resume | review | incident"`
+	IncludeCandidates   bool   `json:"include_candidates,omitempty" jsonschema:"include candidate durable memories in a separate needs-review section"`
 	AsOf                string `json:"as_of,omitempty" jsonschema:"evaluate durable memory validity at this timestamp (YYYY-MM-DD or RFC3339); defaults to now"`
 }
 

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -71,6 +71,9 @@ type sessionHandoffOutput struct {
 	WorkingState          workingStateOutput    `json:"working_state"`
 	RecentCommands        []string              `json:"recent_commands,omitempty"`
 	Memories              []memorySummaryOutput `json:"memories,omitempty"`
+	MemoryNeedsReview     []memorySummaryOutput `json:"memory_needs_review,omitempty" jsonschema:"candidate memories included only when include_candidates is true; review before trusting"`
+	AcceptedMemoryCount   int                   `json:"accepted_memory_count" jsonschema:"number of accepted memories loaded into trusted context"`
+	CandidateMemoryCount  int                   `json:"candidate_memory_count" jsonschema:"number of candidate memories observed under the context-pack limit"`
 }
 
 // sessionLineageOutput is the MCP output for session_status action=lineage.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -278,7 +278,7 @@ func (s *Server) queryMemory() mcp.ToolHandlerFor[queryMemoryInput, any] {
 			_, out, err := s.exportMemories()(ctx, req, exportMemoriesInput{Target: input.Target, Workspace: input.Workspace, IncludeGlobal: input.IncludeGlobal, NoGlobal: input.NoGlobal})
 			return nil, out, err
 		case "pack":
-			_, out, err := s.memoryPack()(ctx, req, memoryPackInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, AsOf: input.AsOf})
+			_, out, err := s.memoryPack()(ctx, req, memoryPackInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, IncludeCandidates: input.IncludeCandidates, AsOf: input.AsOf})
 			return nil, out, err
 		case "scan_hygiene":
 			_, out, err := s.scanMemoryHygiene()(ctx, req, scanMemoryHygieneInput{Workspace: input.Workspace, ExpiryDays: input.ExpiryDays, IncludeHidden: input.IncludeHidden})
@@ -315,7 +315,7 @@ func (s *Server) sessionStatus() mcp.ToolHandlerFor[sessionActionInput, any] {
 			_, out, err := s.latestSession()(ctx, req, sessionLookupInput{Client: input.Client, Agent: input.Agent, Workspace: input.Workspace, AllowStale: input.AllowStale, StaleAfterSeconds: input.StaleAfterSeconds})
 			return nil, out, err
 		case "handoff":
-			_, out, err := s.sessionHandoff()(ctx, req, sessionHandoffInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, AsOf: input.AsOf, AllowStale: input.AllowStale, StaleAfterSeconds: input.StaleAfterSeconds})
+			_, out, err := s.sessionHandoff()(ctx, req, sessionHandoffInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, IncludeCandidates: input.IncludeCandidates, AsOf: input.AsOf, AllowStale: input.AllowStale, StaleAfterSeconds: input.StaleAfterSeconds})
 			return nil, out, err
 		case "lineage":
 			out, err := s.sessionLineage(ctx, input.SessionID)
@@ -665,6 +665,7 @@ func (s *Server) sessionHandoff() mcp.ToolHandlerFor[sessionHandoffInput, sessio
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
 			preset,
+			input.IncludeCandidates,
 			asOf,
 			input.AllowStale,
 			staleAfter,
@@ -698,6 +699,7 @@ func (s *Server) memoryPack() mcp.ToolHandlerFor[memoryPackInput, memoryPackOutp
 			input.RecentCommandsLimit,
 			input.MemoryLimit,
 			preset,
+			input.IncludeCandidates,
 			asOf,
 			false,
 			0,
@@ -1221,10 +1223,11 @@ func resolveContextPackStaleAfter(staleAfterSeconds int) (time.Duration, error) 
 	return time.Duration(staleAfterSeconds) * time.Second, nil
 }
 
-func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int, preset apptypes.MemoryRetrievalPreset, asOf types.Optional[time.Time], allowStale bool, staleAfter time.Duration) apptypes.ContextPackCriteria {
+func buildContextPackCriteria(sessionID string, workspace string, recentCommandsLimit *int, memoryLimit *int, preset apptypes.MemoryRetrievalPreset, includeCandidates bool, asOf types.Optional[time.Time], allowStale bool, staleAfter time.Duration) apptypes.ContextPackCriteria {
 	builder := apptypes.NewContextPackCriteriaBuilder().
 		SessionID(types.SessionID(strings.TrimSpace(sessionID))).
 		Workspace(types.Workspace(strings.TrimSpace(workspace))).
+		IncludeMemoryCandidates(includeCandidates).
 		AllowStale(allowStale).
 		StaleAfter(staleAfter)
 	if recentCommandsLimit != nil {
@@ -1244,17 +1247,20 @@ func buildContextPackCriteria(sessionID string, workspace string, recentCommands
 
 func newContextPackOutput(pack apptypes.ContextPack) sessionHandoffOutput {
 	out := sessionHandoffOutput{
-		SessionID:      pack.SessionID().String(),
-		Workspace:      pack.Workspace().String(),
-		Label:          pack.Label(),
-		Status:         pack.Status(),
-		TotalEvents:    pack.TotalEvents(),
-		CommandCount:   pack.CommandCount(),
-		Agents:         pack.Agents(),
-		Summary:        pack.WorkingState().CombinedSummary(),
-		WorkingState:   newWorkingStateOutput(pack.WorkingState()),
-		RecentCommands: pack.RecentCommands(),
-		Memories:       convertMemorySummaries(pack.Memories()),
+		SessionID:            pack.SessionID().String(),
+		Workspace:            pack.Workspace().String(),
+		Label:                pack.Label(),
+		Status:               pack.Status(),
+		TotalEvents:          pack.TotalEvents(),
+		CommandCount:         pack.CommandCount(),
+		Agents:               pack.Agents(),
+		Summary:              pack.WorkingState().CombinedSummary(),
+		WorkingState:         newWorkingStateOutput(pack.WorkingState()),
+		RecentCommands:       pack.RecentCommands(),
+		Memories:             convertMemorySummaries(pack.Memories()),
+		MemoryNeedsReview:    convertMemorySummaries(pack.MemoryNeedsReview()),
+		AcceptedMemoryCount:  pack.AcceptedMemoryCount(),
+		CandidateMemoryCount: pack.CandidateMemoryCount(),
 	}
 	if pack.WorkspaceFallbackUsed() {
 		out.RequestedWorkspace = pack.RequestedWorkspace().String()

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -777,6 +777,18 @@ func TestServer_BuildAndTools(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CallTool(remember_memory) error = %v", err)
 		}
+		_, err = clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "manage_memory",
+			Arguments: map[string]any{
+				"action":    "propose",
+				"type":      "lesson",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      "Review candidate memories before using them as durable context",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(propose_memory) error = %v", err)
+		}
 
 		handoffResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "session_status",
@@ -809,6 +821,44 @@ func TestServer_BuildAndTools(t *testing.T) {
 		if !ok || len(memories) == 0 {
 			t.Fatalf("handoff memories = %T len=%d, want non-empty []any", handoffPayload["memories"], len(memories))
 		}
+		for _, raw := range memories {
+			memory, ok := raw.(map[string]any)
+			if !ok {
+				t.Fatalf("handoff memory item type = %T, want map[string]any", raw)
+			}
+			if got := memory["status"]; got != "accepted" {
+				t.Fatalf("default handoff memory status = %v, want accepted-only; payload=%v", got, memories)
+			}
+		}
+		if _, exists := handoffPayload["memory_needs_review"]; exists {
+			t.Fatalf("default handoff must omit memory_needs_review unless include_candidates=true: %v", handoffPayload["memory_needs_review"])
+		}
+		if got, ok := handoffPayload["accepted_memory_count"].(float64); !ok || got < 1 {
+			t.Fatalf("accepted_memory_count = %v (%T), want >= 1", handoffPayload["accepted_memory_count"], handoffPayload["accepted_memory_count"])
+		}
+		if got, ok := handoffPayload["candidate_memory_count"].(float64); !ok || got < 1 {
+			t.Fatalf("candidate_memory_count = %v (%T), want >= 1", handoffPayload["candidate_memory_count"], handoffPayload["candidate_memory_count"])
+		}
+
+		handoffWithCandidates, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "session_status",
+			Arguments: map[string]any{
+				"action":             "handoff",
+				"session_id":         sessionID,
+				"include_candidates": true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(session_handoff include_candidates) error = %v", err)
+		}
+		if handoffWithCandidates.IsError {
+			t.Fatalf("CallTool(session_handoff include_candidates) returned tool error")
+		}
+		handoffWithCandidatesPayload := decodeJSONPayload(t, handoffWithCandidates)
+		needsReview, ok := handoffWithCandidatesPayload["memory_needs_review"].([]any)
+		if !ok || !memoryListContainsFact(needsReview, "Review candidate memories before using them as durable context") {
+			t.Fatalf("memory_needs_review = %#v, want proposed candidate in separate section", handoffWithCandidatesPayload["memory_needs_review"])
+		}
 
 		packResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name: "query_memory",
@@ -829,6 +879,31 @@ func TestServer_BuildAndTools(t *testing.T) {
 		recentCommands, ok := packPayload["recent_commands"].([]any)
 		if !ok || len(recentCommands) != 1 {
 			t.Fatalf("recent_commands = %T len=%d, want 1", packPayload["recent_commands"], len(recentCommands))
+		}
+		if _, exists := packPayload["memory_needs_review"]; exists {
+			t.Fatalf("default memory_pack must omit memory_needs_review unless include_candidates=true: %v", packPayload["memory_needs_review"])
+		}
+
+		packWithCandidatesResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "query_memory",
+			Arguments: map[string]any{
+				"action":                "pack",
+				"session_id":            sessionID,
+				"recent_commands_limit": 1,
+				"memory_limit":          1,
+				"include_candidates":    true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(memory_pack include_candidates) error = %v", err)
+		}
+		if packWithCandidatesResult.IsError {
+			t.Fatalf("CallTool(memory_pack include_candidates) returned tool error")
+		}
+		packWithCandidatesPayload := decodeJSONPayload(t, packWithCandidatesResult)
+		packNeedsReview, ok := packWithCandidatesPayload["memory_needs_review"].([]any)
+		if !ok || !memoryListContainsFact(packNeedsReview, "Review candidate memories before using them as durable context") {
+			t.Fatalf("memory_pack memory_needs_review = %#v, want proposed candidate in separate section", packWithCandidatesPayload["memory_needs_review"])
 		}
 	})
 
@@ -1295,6 +1370,19 @@ func decodeJSONPayload(t *testing.T, result *mcp.CallToolResult) map[string]any 
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 	return payload
+}
+
+func memoryListContainsFact(memories []any, fact string) bool {
+	for _, raw := range memories {
+		memory, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if memory["fact"] == fact {
+			return true
+		}
+	}
+	return false
 }
 
 func decodeJSONArrayPayload(t *testing.T, result *mcp.CallToolResult) []any {

--- a/presentation/mcpserver/testdata/tool_registry.golden.json
+++ b/presentation/mcpserver/testdata/tool_registry.golden.json
@@ -262,6 +262,10 @@
             "integer"
           ]
         },
+        "include_candidates": {
+          "description": "include candidate durable memories in a separate needs-review section for action=handoff",
+          "type": "boolean"
+        },
         "infer_parent_session": {
           "description": "infer parent from the active session when parent_session_id is omitted (default: true for MCP starts)",
           "type": [
@@ -334,6 +338,10 @@
         "expiry_days": {
           "description": "staleness threshold in days (default 90)",
           "type": "integer"
+        },
+        "include_candidates": {
+          "description": "include candidate memories in a separate needs-review section for action=pack",
+          "type": "boolean"
         },
         "include_expired": {
           "description": "include memories whose valid_to is in the past",
@@ -576,6 +584,10 @@
             "null",
             "integer"
           ]
+        },
+        "include_candidates": {
+          "description": "include candidate durable memories in a separate needs-review section for action=handoff",
+          "type": "boolean"
         },
         "infer_parent_session": {
           "description": "infer parent from the active session when parent_session_id is omitted (default: true for MCP starts)",


### PR DESCRIPTION
## Motivation

Real Traceary stores can contain many unreviewed candidate memories. Handoff and MCP context surfaces should not mix those candidates into trusted durable-memory context by default, while still making candidate backlog visible and reviewable on explicit opt-in.

## Changes

- Default ContextUsecase memory loading to accepted memories only.
- Add explicit include-candidates criteria/CLI/MCP options that render candidates in a separate needs-review section.
- Add accepted/candidate memory counts to handoff text and MCP context-pack outputs.
- Keep retrieval presets accepted-only while reusing preset type filters for optional candidate review sections.
- Update CLI goldens, MCP tool registry, and regression tests for default, include-candidates, no accepted memories, and mixed stores.

## Delegation note

Claude implementation delegation was attempted but the local Claude CLI returned `Not logged in · Please run /login`; implementation proceeded locally to avoid blocking the autonomous flow.

## Validation

- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`

Closes #985
