### PR TITLE
v0.16-5: add memory inbox backlog controls and TTL/hygiene actions

### DIFF
--- a/application/types/memory_list_criteria.go
+++ b/application/types/memory_list_criteria.go
@@ -28,6 +28,8 @@ type MemoryListCriteria struct {
 	memoryTypes            []domtypes.MemoryType
 	sources                []domtypes.MemorySource
 	asOf                   domtypes.Optional[time.Time]
+	updatedBefore          domtypes.Optional[time.Time]
+	updatedAfter           domtypes.Optional[time.Time]
 	includeExpired         bool
 	rememberIntentPriority bool
 }
@@ -55,6 +57,12 @@ func (c MemoryListCriteria) Sources() []domtypes.MemorySource { return slices.Cl
 // (validTo is null or validTo > AsOf). The zero value (None) means
 // "use the current wall clock at query time".
 func (c MemoryListCriteria) AsOf() domtypes.Optional[time.Time] { return c.asOf }
+
+// UpdatedBefore returns an optional updated_at upper bound.
+func (c MemoryListCriteria) UpdatedBefore() domtypes.Optional[time.Time] { return c.updatedBefore }
+
+// UpdatedAfter returns an optional updated_at lower bound.
+func (c MemoryListCriteria) UpdatedAfter() domtypes.Optional[time.Time] { return c.updatedAfter }
 
 // IncludeExpiredByValidity returns true when the caller asked to bypass
 // the validity-window filter and return memories whose validTo is in
@@ -145,6 +153,24 @@ func (b *MemoryListCriteriaBuilder) Sources(sources []domtypes.MemorySource) *Me
 func (b *MemoryListCriteriaBuilder) AsOf(asOf time.Time) *MemoryListCriteriaBuilder {
 	if !asOf.IsZero() {
 		b.criteria.asOf = domtypes.Some(asOf)
+	}
+	return b
+}
+
+// UpdatedBefore filters rows whose updated_at is earlier than or equal
+// to the supplied timestamp. Zero values are ignored.
+func (b *MemoryListCriteriaBuilder) UpdatedBefore(updatedBefore time.Time) *MemoryListCriteriaBuilder {
+	if !updatedBefore.IsZero() {
+		b.criteria.updatedBefore = domtypes.Some(updatedBefore)
+	}
+	return b
+}
+
+// UpdatedAfter filters rows whose updated_at is later than or equal to
+// the supplied timestamp. Zero values are ignored.
+func (b *MemoryListCriteriaBuilder) UpdatedAfter(updatedAfter time.Time) *MemoryListCriteriaBuilder {
+	if !updatedAfter.IsZero() {
+		b.criteria.updatedAfter = domtypes.Some(updatedAfter)
 	}
 	return b
 }

--- a/application/types/memory_list_criteria_test.go
+++ b/application/types/memory_list_criteria_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"testing"
+	"time"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	domtypes "github.com/duck8823/traceary/domain/types"
@@ -23,11 +24,15 @@ func TestMemoryListCriteriaBuilder(t *testing.T) {
 	t.Parallel()
 
 	workspace, _ := domtypes.WorkspaceFrom("github.com/duck8823/traceary")
+	updatedBefore := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	updatedAfter := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	criteria := apptypes.NewMemoryListCriteriaBuilder(20).
 		Offset(5).
 		Scope(domtypes.WorkspaceScopeOf(workspace)).
 		Status(domtypes.MemoryStatusAccepted).
 		MemoryType(domtypes.MemoryTypeDecision).
+		UpdatedBefore(updatedBefore).
+		UpdatedAfter(updatedAfter).
 		Build()
 
 	if got := criteria.Limit(); got != 20 {
@@ -44,5 +49,11 @@ func TestMemoryListCriteriaBuilder(t *testing.T) {
 	}
 	if got := len(criteria.MemoryTypes()); got != 1 {
 		t.Fatalf("len(MemoryTypes()) = %d, want 1", got)
+	}
+	if got, ok := criteria.UpdatedBefore().Value(); !ok || !got.Equal(updatedBefore) {
+		t.Fatalf("UpdatedBefore() = %v ok=%v, want %v", got, ok, updatedBefore)
+	}
+	if got, ok := criteria.UpdatedAfter().Value(); !ok || !got.Equal(updatedAfter) {
+		t.Fatalf("UpdatedAfter() = %v ok=%v, want %v", got, ok, updatedAfter)
 	}
 }

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -808,6 +808,7 @@ func buildMemoryListQuery(criteria apptypes.MemoryListCriteria, clock types.Cloc
 		return "", nil, err
 	}
 	args = appendMemoryValidityWindowFilter(&builder, args, criteria.AsOf(), criteria.IncludeExpiredByValidity(), clock)
+	args = appendMemoryUpdatedAtFilter(&builder, args, criteria.UpdatedBefore(), criteria.UpdatedAfter())
 	builder.WriteString(" ORDER BY ")
 	if criteria.RememberIntentPriority() {
 		// Pin prioritized inbox sources to the top of the result set BEFORE
@@ -822,6 +823,23 @@ func buildMemoryListQuery(criteria apptypes.MemoryListCriteria, clock types.Cloc
 	builder.WriteString("m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
 	args = append(args, criteria.Limit(), criteria.Offset())
 	return builder.String(), args, nil
+}
+
+func appendMemoryUpdatedAtFilter(
+	builder *strings.Builder,
+	args []any,
+	updatedBefore types.Optional[time.Time],
+	updatedAfter types.Optional[time.Time],
+) []any {
+	if before, ok := updatedBefore.Value(); ok {
+		builder.WriteString(" AND m.updated_at <= ?")
+		args = append(args, formatMemoryValidityTimestamp(before))
+	}
+	if after, ok := updatedAfter.Value(); ok {
+		builder.WriteString(" AND m.updated_at >= ?")
+		args = append(args, formatMemoryValidityTimestamp(after))
+	}
+	return args
 }
 
 func buildMemorySearchQuery(criteria apptypes.MemorySearchCriteria, clock types.Clock) (string, []any, error) {

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -633,6 +633,36 @@ func TestMemoryDatasource_List(t *testing.T) {
 			t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
 		}
 	})
+
+	t.Run("updated_at filters narrow candidate age windows", func(t *testing.T) {
+		t.Parallel()
+
+		summaries, err := sut.List(ctx, apptypes.NewMemoryListCriteriaBuilder(10).
+			Status(types.MemoryStatusCandidate).
+			UpdatedBefore(time.Date(2026, 4, 12, 9, 45, 0, 0, time.UTC)).
+			UpdatedAfter(time.Date(2026, 4, 12, 9, 15, 0, 0, time.UTC)).
+			Build())
+		if err != nil {
+			t.Fatalf("List(updated_at window) error = %v", err)
+		}
+		if got := len(summaries); got != 1 {
+			t.Fatalf("len(List(updated_at window)) = %d, want 1", got)
+		}
+		if diff := cmp.Diff("mem-candidate", summaries[0].MemoryID().String()); diff != "" {
+			t.Fatalf("MemoryID mismatch (-want +got):\n%s", diff)
+		}
+
+		summaries, err = sut.List(ctx, apptypes.NewMemoryListCriteriaBuilder(10).
+			Status(types.MemoryStatusCandidate).
+			UpdatedBefore(time.Date(2026, 4, 12, 9, 0, 0, 0, time.UTC)).
+			Build())
+		if err != nil {
+			t.Fatalf("List(updated_before miss) error = %v", err)
+		}
+		if len(summaries) != 0 {
+			t.Fatalf("List(updated_before miss) returned %d rows, want 0", len(summaries))
+		}
+	})
 }
 
 func TestMemoryDatasource_List_RememberIntentPriorityAppliesBeforePagination(t *testing.T) {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -414,6 +414,9 @@ type memoryInboxListCommandInput struct {
 	memoryTypes   []string
 	sources       []string
 	includeHidden bool
+	olderThan     time.Duration
+	newerThan     time.Duration
+	quality       string
 	limit         int
 	offset        int
 	asJSON        bool
@@ -429,6 +432,25 @@ type memoryInboxBatchCommandInput struct {
 	confidence string
 	idOnly     bool
 	asJSON     bool
+}
+
+// memoryInboxCleanupCommandInput is the resolved input to `traceary memory
+// inbox cleanup`. The command defaults to dry-run and requires --apply before
+// it rejects any candidate rows.
+type memoryInboxCleanupCommandInput struct {
+	dbPath        string
+	workspace     string
+	agent         string
+	sessionFamily string
+	memoryTypes   []string
+	sources       []string
+	includeHidden bool
+	olderThan     time.Duration
+	newerThan     time.Duration
+	quality       string
+	limit         int
+	apply         bool
+	asJSON        bool
 }
 
 // memoryExportCommandInput is the resolved input to `traceary memory

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -27,6 +28,7 @@ func (c *RootCLI) newMemoryInboxCommand() *cobra.Command {
 	cmd.AddCommand(c.newMemoryInboxListCommand())
 	cmd.AddCommand(c.newMemoryInboxAcceptCommand())
 	cmd.AddCommand(c.newMemoryInboxRejectCommand())
+	cmd.AddCommand(c.newMemoryInboxCleanupCommand())
 	cmd.AddCommand(c.newMemoryInboxReviewCommand())
 	return cmd
 }
@@ -48,6 +50,9 @@ func (c *RootCLI) newMemoryInboxListCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
 	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / remember-intent / compact-summary / imported)", "memory source (manual / extracted / extracted-hidden / remember-intent / compact-summary / imported) で絞り込む"))
 	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates (low-quality auto-extractions kept for audit)", "extracted-hidden の候補も含める (audit 用に保存された低品質自動抽出)"))
+	cmd.Flags().DurationVar(&input.olderThan, "older-than", 0, Localize("only include candidates not updated within this duration (for example 168h)", "この duration 以内に更新されていない候補だけを含める (例: 168h)"))
+	cmd.Flags().DurationVar(&input.newerThan, "newer-than", 0, Localize("only include candidates updated within this duration (for example 24h)", "この duration 以内に更新された候補だけを含める (例: 24h)"))
+	cmd.Flags().StringVar(&input.quality, "quality", "any", Localize("filter by quality category (any / low / normal)", "品質カテゴリで絞り込む (any / low / normal)"))
 	cmd.Flags().IntVar(&input.limit, "limit", defaultMemoryInboxLimit, Localize("maximum number of candidates to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of candidates to skip before listing", "一覧表示前にスキップする件数"))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
@@ -77,6 +82,35 @@ func (c *RootCLI) newMemoryInboxAcceptCommand() *cobra.Command {
 	))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	cmd.MarkFlagsMutuallyExclusive("id-only", "json")
+	return cmd
+}
+
+func (c *RootCLI) newMemoryInboxCleanupCommand() *cobra.Command {
+	input := memoryInboxCleanupCommandInput{
+		quality: "low",
+		limit:   defaultMemoryInboxLimit,
+	}
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: Localize("Preview or reject stale/low-quality candidate durable memories in bulk", "古い/低品質の candidate durable memory を一括プレビューまたは reject する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runMemoryInboxCleanup(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().StringVar(&input.workspace, "workspace", "", Localize("filter by workspace scope (defaults to env/detected workspace)", "workspace scope で絞り込む (未指定時は env/検出 workspace)"))
+	cmd.Flags().StringVar(&input.agent, "agent", "", Localize("filter by agent scope", "agent scope で絞り込む"))
+	cmd.Flags().StringVar(&input.sessionFamily, "session-family", "", Localize("filter by session-family scope", "session-family scope で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.memoryTypes, "type", nil, Localize("filter by memory type", "memory type で絞り込む"))
+	cmd.Flags().StringSliceVar(&input.sources, "source", nil, Localize("filter by memory source (manual / extracted / extracted-hidden / remember-intent / compact-summary / imported)", "memory source (manual / extracted / extracted-hidden / remember-intent / compact-summary / imported) で絞り込む"))
+	cmd.Flags().BoolVar(&input.includeHidden, "include-hidden", false, Localize("include extracted-hidden candidates", "extracted-hidden の候補も含める"))
+	cmd.Flags().DurationVar(&input.olderThan, "older-than", 0, Localize("only target candidates not updated within this duration (for example 168h)", "この duration 以内に更新されていない候補だけを対象にする (例: 168h)"))
+	cmd.Flags().DurationVar(&input.newerThan, "newer-than", 0, Localize("only target candidates updated within this duration (for example 24h)", "この duration 以内に更新された候補だけを対象にする (例: 24h)"))
+	cmd.Flags().StringVar(&input.quality, "quality", "low", Localize("target quality category (low / any / normal); default low", "対象の品質カテゴリ (low / any / normal); 既定は low"))
+	cmd.Flags().IntVar(&input.limit, "limit", defaultMemoryInboxLimit, Localize("maximum number of candidates to target", "対象候補数"))
+	cmd.Flags().BoolVar(&input.apply, "apply", false, Localize("reject the matched candidates; omit for dry-run preview", "一致した候補を reject する。省略時は dry-run preview"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
 
@@ -140,6 +174,13 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	if input.offset < 0 {
 		return xerrors.Errorf(Localize("offset must be greater than or equal to 0", "offset は 0 以上である必要があります"))
 	}
+	if input.olderThan < 0 || input.newerThan < 0 {
+		return xerrors.Errorf(Localize("--older-than and --newer-than must be greater than or equal to 0", "--older-than と --newer-than は 0 以上である必要があります"))
+	}
+	quality, err := parseMemoryInboxQuality(input.quality)
+	if err != nil {
+		return err
+	}
 	if err := c.initializeStore(ctx, input.dbPath); err != nil {
 		return err
 	}
@@ -153,6 +194,10 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		return err
 	}
 	sources, err := parseMemorySources(input.sources)
+	if err != nil {
+		return err
+	}
+	lowQualityIDs, err := c.loadLowQualityCandidateIDs(ctx, scopes, input.includeHidden || memorySourcesContain(sources, domtypes.MemorySourceExtractedHidden), quality)
 	if err != nil {
 		return err
 	}
@@ -176,14 +221,15 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 	// sort would only re-order the current page and could let a prioritized
 	// row that lives just past the page boundary stay hidden until later pages
 	// (#856/#857).
-	criteria := apptypes.NewMemoryListCriteriaBuilder(input.limit).
+	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).
 		Offset(input.offset).
 		Scopes(scopes).
 		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
 		MemoryTypes(memoryTypes).
 		Sources(sources).
-		RememberIntentPriority(true).
-		Build()
+		RememberIntentPriority(true)
+	criteriaBuilder = applyMemoryInboxAgeFilters(criteriaBuilder, input.olderThan, input.newerThan, time.Now())
+	criteria := criteriaBuilder.Build()
 	summaries, err := c.memory.List(ctx, criteria)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to list candidate memories", "candidate memory の一覧取得に失敗しました"), err)
@@ -195,9 +241,191 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		if err != nil {
 			return xerrors.Errorf("failed to load memory %s: %w", summary.MemoryID().String(), err)
 		}
-		items = append(items, details)
+		if memoryInboxDetailsMatchesQuality(details, quality, lowQualityIDs) {
+			items = append(items, details)
+		}
 	}
 	return writeMemoryInboxList(output, items, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryInboxCleanup(ctx context.Context, output io.Writer, input memoryInboxCleanupCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if input.limit <= 0 {
+		return xerrors.Errorf(Localize("limit must be greater than or equal to 1", "limit は 1 以上である必要があります"))
+	}
+	if input.olderThan < 0 || input.newerThan < 0 {
+		return xerrors.Errorf(Localize("--older-than and --newer-than must be greater than or equal to 0", "--older-than と --newer-than は 0 以上である必要があります"))
+	}
+	quality, err := parseMemoryInboxQuality(input.quality)
+	if err != nil {
+		return err
+	}
+	if quality == memoryInboxQualityAny && input.olderThan == 0 {
+		return xerrors.Errorf(Localize("cleanup with --quality any requires --older-than to avoid rejecting the whole inbox", "--quality any の cleanup では inbox 全体の reject を避けるため --older-than が必要です"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+
+	items, err := c.loadMemoryInboxCleanupCandidates(ctx, input, quality, time.Now())
+	if err != nil {
+		return err
+	}
+	result := memoryInboxCleanupResult{
+		Action:  "cleanup-reject",
+		DryRun:  !input.apply,
+		Matched: items,
+	}
+	if !input.apply {
+		return writeMemoryInboxCleanupResult(output, result, input.asJSON)
+	}
+
+	for _, item := range items {
+		summary := item.Summary()
+		if summary.Status() != domtypes.MemoryStatusCandidate {
+			result.Failures = append(result.Failures, memoryInboxFailure{
+				ID:    summary.MemoryID().String(),
+				Error: "cleanup only modifies candidate memories",
+			})
+			continue
+		}
+		details, err := c.memory.Reject(ctx, summary.MemoryID())
+		if err != nil {
+			result.Failures = append(result.Failures, memoryInboxFailure{
+				ID:    summary.MemoryID().String(),
+				Error: err.Error(),
+			})
+			continue
+		}
+		result.Processed = append(result.Processed, details)
+	}
+	return writeMemoryInboxCleanupResult(output, result, input.asJSON)
+}
+
+func (c *RootCLI) loadMemoryInboxCleanupCandidates(ctx context.Context, input memoryInboxCleanupCommandInput, quality memoryInboxQuality, now time.Time) ([]apptypes.MemoryDetails, error) {
+	scopes, err := resolveMemoryFilterScopes(ctx, input.workspace, input.agent, input.sessionFamily, true)
+	if err != nil {
+		return nil, err
+	}
+	memoryTypes, err := parseMemoryTypes(input.memoryTypes)
+	if err != nil {
+		return nil, err
+	}
+	sources, err := parseMemorySources(input.sources)
+	if err != nil {
+		return nil, err
+	}
+	lowQualityIDs, err := c.loadLowQualityCandidateIDs(ctx, scopes, input.includeHidden || memorySourcesContain(sources, domtypes.MemorySourceExtractedHidden), quality)
+	if err != nil {
+		return nil, err
+	}
+	sources = applyExtractedHiddenDefault(sources, input.includeHidden)
+	criteriaBuilder := apptypes.NewMemoryListCriteriaBuilder(input.limit).
+		Scopes(scopes).
+		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
+		MemoryTypes(memoryTypes).
+		Sources(sources).
+		RememberIntentPriority(true)
+	criteriaBuilder = applyMemoryInboxAgeFilters(criteriaBuilder, input.olderThan, input.newerThan, now)
+	summaries, err := c.memory.List(ctx, criteriaBuilder.Build())
+	if err != nil {
+		return nil, xerrors.Errorf("%s: %w", Localize("failed to list cleanup candidates", "cleanup 対象 candidate の一覧取得に失敗しました"), err)
+	}
+	items := make([]apptypes.MemoryDetails, 0, len(summaries))
+	for _, summary := range summaries {
+		details, err := c.memory.Show(ctx, summary.MemoryID())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to load memory %s: %w", summary.MemoryID().String(), err)
+		}
+		if memoryInboxDetailsMatchesQuality(details, quality, lowQualityIDs) {
+			items = append(items, details)
+		}
+	}
+	return items, nil
+}
+
+type memoryInboxQuality string
+
+const (
+	memoryInboxQualityAny    memoryInboxQuality = "any"
+	memoryInboxQualityLow    memoryInboxQuality = "low"
+	memoryInboxQualityNormal memoryInboxQuality = "normal"
+)
+
+func parseMemoryInboxQuality(value string) (memoryInboxQuality, error) {
+	switch memoryInboxQuality(strings.ToLower(strings.TrimSpace(value))) {
+	case "", memoryInboxQualityAny:
+		return memoryInboxQualityAny, nil
+	case memoryInboxQualityLow:
+		return memoryInboxQualityLow, nil
+	case memoryInboxQualityNormal:
+		return memoryInboxQualityNormal, nil
+	default:
+		return "", xerrors.Errorf("unknown memory inbox quality %q (allowed values: any, low, normal)", value)
+	}
+}
+
+func (c *RootCLI) loadLowQualityCandidateIDs(ctx context.Context, scopes []domtypes.MemoryScope, includeHidden bool, quality memoryInboxQuality) (map[string]struct{}, error) {
+	if quality == memoryInboxQualityAny {
+		return nil, nil
+	}
+	result, err := c.memory.Scan(ctx, apptypes.MemoryHygieneScanCriteria{
+		Scopes:                  scopes,
+		IncludeHiddenCandidates: includeHidden,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("%s: %w", Localize("failed to scan low-quality candidates", "低品質 candidate のスキャンに失敗しました"), err)
+	}
+	ids := make(map[string]struct{}, result.LowQualityCandidateCount)
+	for _, suggestion := range result.Suggestions {
+		if suggestion.Kind != apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+			continue
+		}
+		ids[suggestion.MemoryID.String()] = struct{}{}
+	}
+	return ids, nil
+}
+
+func memoryInboxDetailsMatchesQuality(details apptypes.MemoryDetails, quality memoryInboxQuality, lowQualityIDs map[string]struct{}) bool {
+	switch quality {
+	case memoryInboxQualityAny:
+		return true
+	case memoryInboxQualityLow:
+		_, ok := lowQualityIDs[details.Summary().MemoryID().String()]
+		return ok
+	case memoryInboxQualityNormal:
+		_, ok := lowQualityIDs[details.Summary().MemoryID().String()]
+		return !ok
+	default:
+		return true
+	}
+}
+
+func applyMemoryInboxAgeFilters(builder *apptypes.MemoryListCriteriaBuilder, olderThan time.Duration, newerThan time.Duration, now time.Time) *apptypes.MemoryListCriteriaBuilder {
+	if builder == nil {
+		return builder
+	}
+	if olderThan > 0 {
+		builder = builder.UpdatedBefore(now.Add(-olderThan))
+	}
+	if newerThan > 0 {
+		builder = builder.UpdatedAfter(now.Add(-newerThan))
+	}
+	return builder
+}
+
+func memorySourcesContain(sources []domtypes.MemorySource, target domtypes.MemorySource) bool {
+	for _, source := range sources {
+		if source == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *RootCLI) runMemoryInboxBatch(ctx context.Context, output io.Writer, errOutput io.Writer, input memoryInboxBatchCommandInput, action memoryInboxAction) error {
@@ -253,6 +481,14 @@ func (c *RootCLI) runMemoryInboxBatch(ctx context.Context, output io.Writer, err
 // same success / failure breakdown.
 type memoryInboxBatchResult struct {
 	Action    string
+	Processed []apptypes.MemoryDetails
+	Failures  []memoryInboxFailure
+}
+
+type memoryInboxCleanupResult struct {
+	Action    string
+	DryRun    bool
+	Matched   []apptypes.MemoryDetails
 	Processed []apptypes.MemoryDetails
 	Failures  []memoryInboxFailure
 }
@@ -419,10 +655,72 @@ func writeMemoryInboxBatch(output io.Writer, result memoryInboxBatchResult, asJS
 	return nil
 }
 
+func writeMemoryInboxCleanupResult(output io.Writer, result memoryInboxCleanupResult, asJSON bool) error {
+	if asJSON {
+		payload := memoryInboxCleanupOutput{
+			Action:    result.Action,
+			DryRun:    result.DryRun,
+			Matched:   make([]memoryDetailsOutput, 0, len(result.Matched)),
+			Processed: make([]memoryDetailsOutput, 0, len(result.Processed)),
+			Failures:  result.Failures,
+		}
+		for _, details := range result.Matched {
+			payload.Matched = append(payload.Matched, newMemoryDetailsOutput(details))
+		}
+		for _, details := range result.Processed {
+			payload.Processed = append(payload.Processed, newMemoryDetailsOutput(details))
+		}
+		encoder := json.NewEncoder(output)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to encode inbox cleanup result", "inbox cleanup 結果の JSON 出力に失敗しました"), err)
+		}
+		if len(result.Failures) > 0 {
+			return memoryInboxCleanupFailureError(result)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(output, "action=%s dry_run=%t matched=%d processed=%d failures=%d\n", result.Action, result.DryRun, len(result.Matched), len(result.Processed), len(result.Failures)); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print inbox cleanup summary", "inbox cleanup サマリの出力に失敗しました"), err)
+	}
+	if result.DryRun {
+		for _, details := range result.Matched {
+			summary := details.Summary()
+			if _, err := fmt.Fprintf(output, "DRY_RUN\t%s\t%s\t%s\t%s\n", summary.MemoryID(), summary.Status(), summary.Source(), summary.Fact()); err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to print inbox cleanup dry-run row", "inbox cleanup dry-run 行の出力に失敗しました"), err)
+			}
+		}
+	}
+	for _, details := range result.Processed {
+		summary := details.Summary()
+		if _, err := fmt.Fprintf(output, "%s\t%s\t%s\n", summary.MemoryID(), summary.Status(), summary.Fact()); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print inbox cleanup processed row", "inbox cleanup 処理済み行の出力に失敗しました"), err)
+		}
+	}
+	for _, failure := range result.Failures {
+		if _, err := fmt.Fprintf(output, "FAILED\t%s\t%s\n", failure.ID, failure.Error); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print inbox cleanup failure row", "inbox cleanup 失敗行の出力に失敗しました"), err)
+		}
+	}
+	if len(result.Failures) > 0 {
+		return memoryInboxCleanupFailureError(result)
+	}
+	return nil
+}
+
 func memoryInboxBatchFailureError(result memoryInboxBatchResult) error {
 	return xerrors.Errorf(Localizef(
 		"inbox %s failed for %d memory id(s)",
 		"inbox %s が %d 件の memory id で失敗しました",
 		result.Action, len(result.Failures),
+	))
+}
+
+func memoryInboxCleanupFailureError(result memoryInboxCleanupResult) error {
+	return xerrors.Errorf(Localizef(
+		"inbox cleanup failed for %d memory id(s)",
+		"inbox cleanup が %d 件の memory id で失敗しました",
+		len(result.Failures),
 	))
 }

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -19,6 +19,10 @@ var (
 )
 
 func buildInboxCandidateDetails(t *testing.T, id string, fact string, source domtypes.MemorySource) apptypes.MemoryDetails {
+	return buildInboxMemoryDetails(t, id, fact, domtypes.MemoryStatusCandidate, source)
+}
+
+func buildInboxMemoryDetails(t *testing.T, id string, fact string, status domtypes.MemoryStatus, source domtypes.MemorySource) apptypes.MemoryDetails {
 	t.Helper()
 	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
@@ -29,7 +33,7 @@ func buildInboxCandidateDetails(t *testing.T, id string, fact string, source dom
 		domtypes.MemoryTypePreference,
 		domtypes.WorkspaceScopeOf(workspace),
 		fact,
-		domtypes.MemoryStatusCandidate,
+		status,
 		domtypes.ConfidenceMedium,
 		source,
 		domtypes.None[domtypes.MemoryID](),
@@ -118,6 +122,186 @@ func TestMemoryInboxList_SourceFilterPropagatesToCriteria(t *testing.T) {
 	}
 	if got := memoryStub.listCriteria.Sources(); len(got) != 1 || got[0] != domtypes.MemorySourceImported {
 		t.Fatalf("inbox list should pass --source into criteria, got %v", got)
+	}
+}
+
+func TestMemoryInboxList_AgeAndQualityFilters(t *testing.T) {
+	t.Parallel()
+
+	low := buildInboxCandidateDetails(t, "memory-low", "git status", domtypes.MemorySourceExtracted)
+	normal := buildInboxCandidateDetails(t, "memory-normal", "Keep release notes concise", domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{low.Summary(), normal.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			low.Summary().MemoryID():    low,
+			normal.Summary().MemoryID(): normal,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 1,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{{
+				MemoryID: low.Summary().MemoryID(),
+				Kind:     apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+			}},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"memory", "inbox", "list",
+		"--db-path", t.TempDir() + "/t.db",
+		"--quality", "low",
+		"--older-than", "24h",
+		"--newer-than", "720h",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "memory-low") {
+		t.Fatalf("low-quality row missing from inbox list:\n%s", out)
+	}
+	if strings.Contains(out, "memory-normal") {
+		t.Fatalf("normal-quality row leaked into --quality low list:\n%s", out)
+	}
+	if _, ok := memoryStub.listCriteria.UpdatedBefore().Value(); !ok {
+		t.Fatalf("--older-than should set UpdatedBefore in list criteria")
+	}
+	if _, ok := memoryStub.listCriteria.UpdatedAfter().Value(); !ok {
+		t.Fatalf("--newer-than should set UpdatedAfter in list criteria")
+	}
+}
+
+func TestMemoryInboxCleanup_DryRunDoesNotReject(t *testing.T) {
+	t.Parallel()
+
+	low := buildInboxCandidateDetails(t, "memory-low-cleanup", "git status", domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{low.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			low.Summary().MemoryID(): low,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 1,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{{
+				MemoryID: low.Summary().MemoryID(),
+				Kind:     apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+			}},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if memoryStub.rejectCallCount != 0 {
+		t.Fatalf("dry-run cleanup called Reject %d time(s), want 0", memoryStub.rejectCallCount)
+	}
+	if out := stdout.String(); !strings.Contains(out, "dry_run=true") || !strings.Contains(out, "memory-low-cleanup") {
+		t.Fatalf("dry-run output missing preview row:\n%s", out)
+	}
+}
+
+func TestMemoryInboxCleanup_ApplyRejectsCandidatesAndReportsFailures(t *testing.T) {
+	t.Parallel()
+
+	okCandidate := buildInboxCandidateDetails(t, "memory-cleanup-ok", "git status", domtypes.MemorySourceExtracted)
+	failCandidate := buildInboxCandidateDetails(t, "memory-cleanup-fail", "gh pr checks", domtypes.MemorySourceExtracted)
+	rejectedDetails := buildInboxMemoryDetails(t, "memory-cleanup-ok", "git status", domtypes.MemoryStatusRejected, domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{okCandidate.Summary(), failCandidate.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			okCandidate.Summary().MemoryID():   okCandidate,
+			failCandidate.Summary().MemoryID(): failCandidate,
+		},
+		rejectDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			okCandidate.Summary().MemoryID(): rejectedDetails,
+		},
+		rejectErrByID: map[domtypes.MemoryID]error{
+			failCandidate.Summary().MemoryID(): errSyntheticRejectFailure,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 2,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{
+				{MemoryID: okCandidate.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+				{MemoryID: failCandidate.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+			},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--apply", "--db-path", t.TempDir() + "/t.db"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("cleanup apply error = nil, want partial failure")
+	}
+	if !strings.Contains(err.Error(), "inbox cleanup failed for 1 memory id") {
+		t.Fatalf("cleanup apply error = %v", err)
+	}
+	if memoryStub.rejectCallCount != 2 {
+		t.Fatalf("Reject call count = %d, want 2", memoryStub.rejectCallCount)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "memory-cleanup-ok") || !strings.Contains(out, "FAILED\tmemory-cleanup-fail") {
+		t.Fatalf("cleanup output missing success/failure rows:\n%s", out)
+	}
+}
+
+func TestMemoryInboxCleanup_DoesNotModifyAcceptedMemories(t *testing.T) {
+	t.Parallel()
+
+	accepted := buildInboxMemoryDetails(t, "memory-accepted-safe", "Accepted memory must remain safe", domtypes.MemoryStatusAccepted, domtypes.MemorySourceManual)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{accepted.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			accepted.Summary().MemoryID(): accepted,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 1,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{{
+				MemoryID: accepted.Summary().MemoryID(),
+				Kind:     apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+			}},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--apply", "--quality", "low", "--db-path", t.TempDir() + "/t.db"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("cleanup apply error = nil, want accepted safety failure")
+	}
+	if memoryStub.rejectCallCount != 0 {
+		t.Fatalf("accepted safety path called Reject %d time(s), want 0", memoryStub.rejectCallCount)
+	}
+	if !strings.Contains(stdout.String(), "cleanup only modifies candidate memories") {
+		t.Fatalf("accepted safety failure missing from output:\n%s", stdout.String())
 	}
 }
 

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -289,6 +289,15 @@ type memoryInboxBatchOutput struct {
 	Failures  []memoryInboxFailure  `json:"failures,omitempty"`
 }
 
+// memoryInboxCleanupOutput is the JSON shape of an inbox cleanup preview/apply run.
+type memoryInboxCleanupOutput struct {
+	Action    string                `json:"action"`
+	DryRun    bool                  `json:"dry_run"`
+	Matched   []memoryDetailsOutput `json:"matched,omitempty"`
+	Processed []memoryDetailsOutput `json:"processed,omitempty"`
+	Failures  []memoryInboxFailure  `json:"failures,omitempty"`
+}
+
 // memoryImportOutput is the JSON shape of a memory import result.
 type memoryImportOutput struct {
 	Imported              []memoryDetailsOutput `json:"imported"`

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -300,6 +300,7 @@ type memoryUsecaseStub struct {
 	searchResult        []apptypes.MemorySummary
 	searchErr           error
 	showDetails         apptypes.MemoryDetails
+	showDetailsByID     map[types.MemoryID]apptypes.MemoryDetails
 	showErr             error
 	rememberDetails     apptypes.MemoryDetails
 	rememberErr         error
@@ -310,7 +311,9 @@ type memoryUsecaseStub struct {
 	distillResult       apptypes.MemoryDistillResult
 	distillErr          error
 	rejectDetails       apptypes.MemoryDetails
+	rejectDetailsByID   map[types.MemoryID]apptypes.MemoryDetails
 	rejectErr           error
+	rejectErrByID       map[types.MemoryID]error
 	supersedeDetails    apptypes.MemoryDetails
 	supersedeErr        error
 	expireDetails       apptypes.MemoryDetails
@@ -412,6 +415,12 @@ func (s *memoryUsecaseStub) Distill(_ context.Context, criteria apptypes.MemoryD
 func (s *memoryUsecaseStub) Reject(_ context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error) {
 	s.rejectCall.memoryID = memoryID
 	s.rejectCallCount++
+	if err, ok := s.rejectErrByID[memoryID]; ok {
+		return apptypes.MemoryDetails{}, err
+	}
+	if details, ok := s.rejectDetailsByID[memoryID]; ok {
+		return details, nil
+	}
 	return s.rejectDetails, s.rejectErr
 }
 
@@ -453,6 +462,9 @@ func (s *memoryUsecaseStub) Search(_ context.Context, criteria apptypes.MemorySe
 
 func (s *memoryUsecaseStub) Show(_ context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error) {
 	s.showMemoryID = memoryID
+	if details, ok := s.showDetailsByID[memoryID]; ok {
+		return details, s.showErr
+	}
 	return s.showDetails, s.showErr
 }
 


### PR DESCRIPTION
## Motivation

Candidate durable memories accumulate faster than review. Operators need a safe backlog-control path that can filter stale/low-quality candidates and preview destructive cleanup before applying it.

## Changes

- Add updated_at age filters to memory list criteria and SQLite list queries.
- Extend `memory inbox list` with `--older-than`, `--newer-than`, and `--quality any|low|normal` while preserving source filters.
- Add `memory inbox cleanup` as a dry-run-by-default bulk reject workflow with explicit `--apply`.
- Reuse hygiene low-quality suggestions for quality filtering and keep extracted-hidden opt-in behavior.
- Guard cleanup so only candidate rows can be modified; accepted rows produce per-id failures and are not rejected.
- Add regression tests for age/quality list filters, dry-run, apply partial failure, and accepted-memory safety.

## Delegation note

Claude implementation delegation remains unavailable in this session (`Not logged in · Please run /login`), so implementation proceeded locally to avoid blocking the autonomous flow.

## Validation

- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`

Closes #986
