### PR TITLE
v0.16-7: add dogfood reliability metrics to top snapshot

### DIFF
--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -36,6 +36,17 @@ func ResetGCNowFunc() {
 	gcNowFunc = time.Now
 }
 
+// SetTopNowFunc replaces the current-time function used by top snapshot and
+// dashboard loading for tests.
+func SetTopNowFunc(f func() time.Time) {
+	topNowFunc = f
+}
+
+// ResetTopNowFunc restores the default top current-time function for tests.
+func ResetTopNowFunc() {
+	topNowFunc = time.Now
+}
+
 // SetDetectRepoContextFunc replaces the work-context resolver for tests.
 func SetDetectRepoContextFunc(f func(context.Context) (string, error)) {
 	detectRepoContextFunc = f

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -80,11 +80,12 @@ type sessionTreeNode struct {
 // that already destructure `sessions[*]` keep working — only the
 // outer wrapping is new.
 type topSnapshotPayload struct {
-	Sessions       []*topSnapshotNode    `json:"sessions"`
-	Failures       []event               `json:"failures"`
-	RecentCommands []event               `json:"recent_commands"`
-	Candidates     topSnapshotCandidates `json:"candidates"`
-	StaleMemories  topSnapshotStale      `json:"stale_memories"`
+	Sessions       []*topSnapshotNode     `json:"sessions"`
+	Failures       []event                `json:"failures"`
+	RecentCommands []event                `json:"recent_commands"`
+	Candidates     topSnapshotCandidates  `json:"candidates"`
+	StaleMemories  topSnapshotStale       `json:"stale_memories"`
+	Reliability    topSnapshotReliability `json:"reliability"`
 }
 
 // topSnapshotCandidates wraps the durable-memory inbox slice with an
@@ -103,6 +104,41 @@ type topSnapshotCandidates struct {
 type topSnapshotStale struct {
 	Count int                 `json:"count"`
 	Items []staleMemoryOutput `json:"items"`
+}
+
+// topSnapshotReliability groups additive dogfood reliability signals for
+// operator cockpit and script consumers. Counts are derived from the same
+// filtered snapshot window as the dashboard so existing consumers can ignore
+// the key without changing their session / event parsing.
+type topSnapshotReliability struct {
+	StaleActiveSessionCount int                          `json:"stale_active_session_count"`
+	Memory                  topSnapshotReliabilityMemory `json:"memory"`
+	CandidateAge            topSnapshotCandidateAge      `json:"candidate_age"`
+	LargePayloads           topSnapshotLargePayloads     `json:"large_payloads"`
+}
+
+type topSnapshotReliabilityMemory struct {
+	AcceptedCount    int      `json:"accepted_count"`
+	CandidateCount   int      `json:"candidate_count"`
+	AcceptedRatio    *float64 `json:"accepted_ratio,omitempty"`
+	ScanLimit        int      `json:"scan_limit"`
+	ScanLimitReached bool     `json:"scan_limit_reached"`
+}
+
+type topSnapshotCandidateAge struct {
+	Count             int     `json:"count"`
+	OldestUpdatedAt   *string `json:"oldest_updated_at,omitempty"`
+	NewestUpdatedAt   *string `json:"newest_updated_at,omitempty"`
+	OldestAgeSeconds  *int64  `json:"oldest_age_seconds,omitempty"`
+	AverageAgeSeconds *int64  `json:"average_age_seconds,omitempty"`
+}
+
+type topSnapshotLargePayloads struct {
+	Count              int `json:"count"`
+	RecentCommandCount int `json:"recent_command_count"`
+	RecentFailureCount int `json:"recent_failure_count"`
+	SampledEventCount  int `json:"sampled_event_count"`
+	BodyLimitRunes     int `json:"body_limit_runes"`
 }
 
 // topSnapshotNode is the JSON shape of a single node in the

--- a/presentation/cli/testdata/top/snapshot_empty_json.golden.json
+++ b/presentation/cli/testdata/top/snapshot_empty_json.golden.json
@@ -10,5 +10,24 @@
   "stale_memories": {
     "count": 0,
     "items": []
+  },
+  "reliability": {
+    "stale_active_session_count": 0,
+    "memory": {
+      "accepted_count": 0,
+      "candidate_count": 0,
+      "scan_limit": 2000,
+      "scan_limit_reached": false
+    },
+    "candidate_age": {
+      "count": 0
+    },
+    "large_payloads": {
+      "count": 0,
+      "recent_command_count": 0,
+      "recent_failure_count": 0,
+      "sampled_event_count": 0,
+      "body_limit_runes": 500
+    }
   }
 }

--- a/presentation/cli/testdata/top/snapshot_json.golden.json
+++ b/presentation/cli/testdata/top/snapshot_json.golden.json
@@ -107,5 +107,29 @@
         "reason": "superseded"
       }
     ]
+  },
+  "reliability": {
+    "stale_active_session_count": 0,
+    "memory": {
+      "accepted_count": 0,
+      "candidate_count": 1,
+      "accepted_ratio": 0,
+      "scan_limit": 2000,
+      "scan_limit_reached": false
+    },
+    "candidate_age": {
+      "count": 1,
+      "oldest_updated_at": "2026-04-10T12:00:00Z",
+      "newest_updated_at": "2026-04-10T12:00:00Z",
+      "oldest_age_seconds": 21600,
+      "average_age_seconds": 21600
+    },
+    "large_payloads": {
+      "count": 0,
+      "recent_command_count": 0,
+      "recent_failure_count": 0,
+      "sampled_event_count": 2,
+      "body_limit_runes": 500
+    }
   }
 }

--- a/presentation/cli/testdata/top/snapshot_text.golden
+++ b/presentation/cli/testdata/top/snapshot_text.golden
@@ -1,3 +1,9 @@
+RELIABILITY:
+- stale_active_sessions=0 hint="ok"
+- memory_counts accepted=0 candidate=1 accepted_ratio=0% hint="review candidates with `traceary memory inbox review` and cleanup old candidates with `traceary memory inbox cleanup --dry-run`"
+- candidate_age count=1 oldest=2026-04-10T12:00:00Z newest=2026-04-10T12:00:00Z avg_age=6h0m hint="prioritize older candidate memories first"
+- large_payloads count=0 recent_commands=0 recent_failures=0 sampled=2 body_limit=500 hint="inspect full payloads with `traceary show <event_id>`; keep command output concise for handoff/top surfaces"
+
 ACTIVE SESSIONS:
 ws-long workspace=…g/path/github.com/duck8823/traceary agent=codex client=claude started=12:00:00 latest=12:15:00 events=165 last=command_executed: go test ./... idle
 ws-empty workspace=duck8823/traceary agent=- client=claude started=14:00:00 latest=14:00:00 events=0 last=- idle

--- a/presentation/cli/testdata/top/snapshot_text_empty.golden
+++ b/presentation/cli/testdata/top/snapshot_text_empty.golden
@@ -1,3 +1,9 @@
+RELIABILITY:
+- stale_active_sessions=0 hint="ok"
+- memory_counts accepted=0 candidate=0 accepted_ratio=- hint="review candidates with `traceary memory inbox review` and cleanup old candidates with `traceary memory inbox cleanup --dry-run`"
+- candidate_age count=0 hint="ok"
+- large_payloads count=0 recent_commands=0 recent_failures=0 sampled=0 body_limit=500 hint="inspect full payloads with `traceary show <event_id>`; keep command output concise for handoff/top surfaces"
+
 ACTIVE SESSIONS:
 No active sessions found.
 

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -32,6 +32,8 @@ func init() {
 
 const defaultTopLimit = 500
 
+var topNowFunc = time.Now
+
 type topCommandOptions struct {
 	dbPath     string
 	workspace  string
@@ -115,7 +117,7 @@ func (c *RootCLI) runTop(ctx context.Context, output io.Writer, opts topCommandO
 		if opts.asJSON {
 			return writeTopSnapshotJSON(output, snap)
 		}
-		return writeTopSnapshotText(output, snap, opts.idle, time.Now())
+		return writeTopSnapshotText(output, snap, opts.idle, snap.Now)
 	}
 	if opts.asJSON {
 		return xerrors.Errorf("%s", Localize("--json requires --snapshot", "--json には --snapshot が必要です"))
@@ -140,6 +142,7 @@ func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (
 		StaleMemoryLimit:   topPaneStaleMemoryLimit,
 		StaleAfter:         opts.staleAfter,
 		AllowStale:         opts.allowStale,
+		Now:                topNowFunc(),
 	}
 	return c.newTopDataLoader().loadSnapshot(ctx, criteria)
 }
@@ -231,6 +234,9 @@ func sessionSummaryHasAgent(summary apptypes.SessionSummary, agent string) bool 
 }
 
 func writeTopSnapshotText(output io.Writer, snap topDataSnapshot, idle time.Duration, now time.Time) error {
+	if err := writeTopSnapshotTextReliability(output, snap.Reliability); err != nil {
+		return err
+	}
 	if err := writeTopSnapshotTextSessions(output, snap.Sessions, idle, now); err != nil {
 		return err
 	}
@@ -244,6 +250,77 @@ func writeTopSnapshotText(output io.Writer, snap topDataSnapshot, idle time.Dura
 		return err
 	}
 	return writeTopSnapshotTextStaleMemories(output, snap.StaleMemories)
+}
+
+func writeTopSnapshotTextReliability(output io.Writer, metrics topReliabilityMetrics) error {
+	if _, err := fmt.Fprintln(output, "RELIABILITY:"); err != nil {
+		return xerrors.Errorf("failed to print reliability header: %w", err)
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		"- stale_active_sessions=%d",
+		metrics.StaleActiveSessionCount,
+	); err != nil {
+		return xerrors.Errorf("failed to print stale session reliability metric: %w", err)
+	}
+	if metrics.StaleActiveSessionCount > 0 {
+		if _, err := fmt.Fprint(output, " hint=\"run `traceary session gc --stale-after 24h --dry-run`, then drop --dry-run after confirming\""); err != nil {
+			return xerrors.Errorf("failed to print stale session reliability hint: %w", err)
+		}
+	} else if _, err := fmt.Fprint(output, " hint=\"ok\""); err != nil {
+		return xerrors.Errorf("failed to print stale session reliability hint: %w", err)
+	}
+	if _, err := fmt.Fprintln(output); err != nil {
+		return xerrors.Errorf("failed to finish stale session reliability metric: %w", err)
+	}
+
+	acceptedRatio := "-"
+	totalMemories := metrics.AcceptedMemoryCount + metrics.CandidateMemoryCount
+	if totalMemories > 0 {
+		acceptedRatio = fmt.Sprintf("%.0f%%", float64(metrics.AcceptedMemoryCount)*100/float64(totalMemories))
+	}
+	limitNote := ""
+	if metrics.MemoryScanLimited {
+		limitNote = fmt.Sprintf(" scan_limit_reached=%d", metrics.MemoryScanLimit)
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		"- memory_counts accepted=%d candidate=%d accepted_ratio=%s%s hint=\"review candidates with `traceary memory inbox review` and cleanup old candidates with `traceary memory inbox cleanup --dry-run`\"\n",
+		metrics.AcceptedMemoryCount,
+		metrics.CandidateMemoryCount,
+		acceptedRatio,
+		limitNote,
+	); err != nil {
+		return xerrors.Errorf("failed to print memory reliability metric: %w", err)
+	}
+
+	if metrics.CandidateAge.Count == 0 {
+		if _, err := fmt.Fprintln(output, "- candidate_age count=0 hint=\"ok\""); err != nil {
+			return xerrors.Errorf("failed to print empty candidate age reliability metric: %w", err)
+		}
+	} else if _, err := fmt.Fprintf(
+		output,
+		"- candidate_age count=%d oldest=%s newest=%s avg_age=%s hint=\"prioritize older candidate memories first\"\n",
+		metrics.CandidateAge.Count,
+		formatJSONTime(metrics.CandidateAge.Oldest),
+		formatJSONTime(metrics.CandidateAge.Newest),
+		formatDuration(metrics.CandidateAge.AverageAge),
+	); err != nil {
+		return xerrors.Errorf("failed to print candidate age reliability metric: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(
+		output,
+		"- large_payloads count=%d recent_commands=%d recent_failures=%d sampled=%d body_limit=%d hint=\"inspect full payloads with `traceary show <event_id>`; keep command output concise for handoff/top surfaces\"\n\n",
+		metrics.LargePayloads.Count,
+		metrics.LargePayloads.RecentCommandCount,
+		metrics.LargePayloads.RecentFailureCount,
+		metrics.LargePayloads.SampledEventCount,
+		metrics.LargePayloads.BodyLimitRunes,
+	); err != nil {
+		return xerrors.Errorf("failed to print large payload reliability metric: %w", err)
+	}
+	return nil
 }
 
 func writeTopSnapshotTextSessions(output io.Writer, roots []*sessionNode, idle time.Duration, now time.Time) error {
@@ -475,6 +552,7 @@ func (c *RootCLI) runTopTUI(ctx context.Context, output io.Writer, opts topComma
 		Detail:          loader,
 		Criteria:        criteria,
 		Idle:            opts.idle,
+		Now:             topNowFunc,
 		RefreshInterval: topDashboardRefreshInterval,
 		LoaderCtx:       ctx,
 	})
@@ -488,7 +566,7 @@ func (c *RootCLI) runTopTUI(ctx context.Context, output io.Writer, opts topComma
 		if loadErr != nil {
 			return loadErr
 		}
-		return writeTopSnapshotText(output, snap, opts.idle, time.Now())
+		return writeTopSnapshotText(output, snap, opts.idle, snap.Now)
 	}
 	if err := tui.Run(model, tui.RunOptions{Input: stdin, Output: stdout, AltScreen: true}); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to run top dashboard", "top ダッシュボードの実行に失敗しました"), err)

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -185,6 +185,7 @@ type topDataSnapshot struct {
 	Candidates                   []apptypes.MemorySummary
 	RememberIntentCandidateCount int
 	StaleMemories                apptypes.StaleMemoryListResult
+	Reliability                  topReliabilityMetrics
 
 	// StaleAfter is the threshold the loader used to evaluate session
 	// staleness; a zero or negative value means the check was disabled.
@@ -197,6 +198,36 @@ type topDataSnapshot struct {
 	// Now is the reference time staleness was evaluated against.
 	Now time.Time
 }
+
+type topReliabilityMetrics struct {
+	StaleActiveSessionCount int
+
+	AcceptedMemoryCount  int
+	CandidateMemoryCount int
+	MemoryScanLimit      int
+	MemoryScanLimited    bool
+
+	CandidateAge  topCandidateAgeMetrics
+	LargePayloads topLargePayloadMetrics
+}
+
+type topCandidateAgeMetrics struct {
+	Count      int
+	Oldest     time.Time
+	Newest     time.Time
+	OldestAge  time.Duration
+	AverageAge time.Duration
+}
+
+type topLargePayloadMetrics struct {
+	Count              int
+	RecentCommandCount int
+	RecentFailureCount int
+	SampledEventCount  int
+	BodyLimitRunes     int
+}
+
+const topReliabilityMemoryScanLimit = 2000
 
 // topDataLoader fetches every data slice the redesigned `traceary top`
 // dashboard needs (active session tree, recent failures, recent
@@ -227,8 +258,13 @@ func newTopDataLoader(session usecase.SessionUsecase, event usecase.EventUsecase
 // can swap the previous inline implementation for this call without
 // changing user-visible output.
 func (l *topDataLoader) loadSessions(ctx context.Context, c topDataCriteria) ([]*sessionNode, error) {
+	roots, _, err := l.loadSessionsWithReliability(ctx, c)
+	return roots, err
+}
+
+func (l *topDataLoader) loadSessionsWithReliability(ctx context.Context, c topDataCriteria) ([]*sessionNode, int, error) {
 	if l.session == nil || c.SessionLimit <= 0 {
-		return nil, nil
+		return nil, 0, nil
 	}
 	workspace := strings.TrimSpace(c.Workspace)
 	client := strings.TrimSpace(c.Client)
@@ -241,13 +277,14 @@ func (l *topDataLoader) loadSessions(ctx context.Context, c topDataCriteria) ([]
 		Build()
 	summaries, err := l.session.List(ctx, criteria)
 	if err != nil {
-		return nil, xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
+		return nil, 0, xerrors.Errorf("%s: %w", Localize("failed to list sessions", "セッション一覧の取得に失敗しました"), err)
 	}
+	now := topDataNow(c)
+	staleActiveCount := countStaleActiveSummaries(summaries, c.StaleAfter, now)
 	// Drop stale active leaves before lineage expansion when the caller
 	// did not opt in. We filter before expansion so retained ended
 	// ancestors do not stay around for a leaf the operator never sees.
 	if !c.AllowStale && c.StaleAfter > 0 {
-		now := topDataNow(c)
 		filtered := summaries[:0]
 		for _, summary := range summaries {
 			if topDataSummaryIsStale(summary, c.StaleAfter, now) {
@@ -259,14 +296,13 @@ func (l *topDataLoader) loadSessions(ctx context.Context, c topDataCriteria) ([]
 	}
 	expanded, err := l.expandSessionLineages(ctx, summaries)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	now := topDataNow(c)
 	return filterTopSessionTree(buildActiveSessionTreeWithOptions(expanded, c.AllowStale, c.StaleAfter, now), topCommandOptions{
 		workspace: workspace,
 		client:    client,
 		agent:     agent,
-	}), nil
+	}), staleActiveCount, nil
 }
 
 // topDataNow returns the reference time the loader should use for
@@ -291,6 +327,16 @@ func topDataSummaryIsStale(summary apptypes.SessionSummary, staleAfter time.Dura
 		return false
 	}
 	return summary.StartedAt().Before(now.Add(-staleAfter))
+}
+
+func countStaleActiveSummaries(summaries []apptypes.SessionSummary, staleAfter time.Duration, now time.Time) int {
+	count := 0
+	for _, summary := range summaries {
+		if topDataSummaryIsStale(summary, staleAfter, now) {
+			count++
+		}
+	}
+	return count
 }
 
 // expandSessionLineages walks every active session's lineage so root
@@ -420,7 +466,7 @@ func (l *topDataLoader) loadStaleMemories(ctx context.Context, c topDataCriteria
 // current `traceary top` (sessions only) and the upcoming multi-pane
 // dashboard share one entry point.
 func (l *topDataLoader) loadSnapshot(ctx context.Context, c topDataCriteria) (topDataSnapshot, error) {
-	sessions, err := l.loadSessions(ctx, c)
+	sessions, staleActiveCount, err := l.loadSessionsWithReliability(ctx, c)
 	if err != nil {
 		return topDataSnapshot{}, err
 	}
@@ -440,6 +486,14 @@ func (l *topDataLoader) loadSnapshot(ctx context.Context, c topDataCriteria) (to
 	if err != nil {
 		return topDataSnapshot{}, err
 	}
+	reliability, err := l.loadReliabilityMetrics(ctx, c, topReliabilityInputs{
+		StaleActiveSessionCount: staleActiveCount,
+		Failures:                failures,
+		RecentCommands:          commands,
+	})
+	if err != nil {
+		return topDataSnapshot{}, err
+	}
 	return topDataSnapshot{
 		Sessions:                     sessions,
 		Failures:                     failures,
@@ -447,10 +501,102 @@ func (l *topDataLoader) loadSnapshot(ctx context.Context, c topDataCriteria) (to
 		Candidates:                   candidates,
 		RememberIntentCandidateCount: countCandidatesBySource(candidates, domtypes.MemorySourceRememberIntent),
 		StaleMemories:                staleMemories,
+		Reliability:                  reliability,
 		StaleAfter:                   c.StaleAfter,
 		AllowStale:                   c.AllowStale,
 		Now:                          topDataNow(c),
 	}, nil
+}
+
+type topReliabilityInputs struct {
+	StaleActiveSessionCount int
+	Failures                []*model.Event
+	RecentCommands          []*model.Event
+}
+
+func (l *topDataLoader) loadReliabilityMetrics(ctx context.Context, c topDataCriteria, inputs topReliabilityInputs) (topReliabilityMetrics, error) {
+	metrics := topReliabilityMetrics{
+		StaleActiveSessionCount: inputs.StaleActiveSessionCount,
+		LargePayloads:           topLargePayloadMetricsOf(inputs.Failures, inputs.RecentCommands, apptypes.DefaultTopSnapshotBodyLimit),
+	}
+	if l.memory == nil {
+		return metrics, nil
+	}
+	memories, err := l.memory.List(ctx, topReliabilityMemoryCriteria(c))
+	if err != nil {
+		return topReliabilityMetrics{}, xerrors.Errorf("%s: %w", Localize("failed to list memories for reliability metrics", "reliability metrics 用 memory 一覧の取得に失敗しました"), err)
+	}
+	metrics.MemoryScanLimit = topReliabilityMemoryScanLimit
+	metrics.MemoryScanLimited = len(memories) >= topReliabilityMemoryScanLimit
+	for _, summary := range memories {
+		switch summary.Status() {
+		case domtypes.MemoryStatusAccepted:
+			metrics.AcceptedMemoryCount++
+		case domtypes.MemoryStatusCandidate:
+			metrics.CandidateMemoryCount++
+			metrics.CandidateAge = topCandidateAgeMetricsAdd(metrics.CandidateAge, summary.UpdatedAt(), topDataNow(c))
+		}
+	}
+	return metrics, nil
+}
+
+func topReliabilityMemoryCriteria(c topDataCriteria) apptypes.MemoryListCriteria {
+	builder := apptypes.NewMemoryListCriteriaBuilder(topReliabilityMemoryScanLimit).
+		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted, domtypes.MemoryStatusCandidate})
+	builder = applyTopMemoryScopes(builder, c)
+	return builder.Build()
+}
+
+func applyTopMemoryScopes(builder *apptypes.MemoryListCriteriaBuilder, c topDataCriteria) *apptypes.MemoryListCriteriaBuilder {
+	if workspace := strings.TrimSpace(c.Workspace); workspace != "" {
+		builder = builder.Scope(domtypes.WorkspaceScopeOf(domtypes.Workspace(workspace)))
+	}
+	if agent := strings.TrimSpace(c.Agent); agent != "" {
+		builder = builder.Scope(domtypes.AgentScopeOf(domtypes.Agent(agent)))
+	}
+	return builder
+}
+
+func topCandidateAgeMetricsAdd(metrics topCandidateAgeMetrics, updatedAt time.Time, now time.Time) topCandidateAgeMetrics {
+	age := now.Sub(updatedAt)
+	if age < 0 {
+		age = 0
+	}
+	if metrics.Count == 0 || updatedAt.Before(metrics.Oldest) {
+		metrics.Oldest = updatedAt
+		metrics.OldestAge = age
+	}
+	if metrics.Count == 0 || updatedAt.After(metrics.Newest) {
+		metrics.Newest = updatedAt
+	}
+	totalAge := metrics.AverageAge*time.Duration(metrics.Count) + age
+	metrics.Count++
+	metrics.AverageAge = totalAge / time.Duration(metrics.Count)
+	return metrics
+}
+
+func topLargePayloadMetricsOf(failures []*model.Event, commands []*model.Event, limit int) topLargePayloadMetrics {
+	metrics := topLargePayloadMetrics{
+		SampledEventCount: len(failures) + len(commands),
+		BodyLimitRunes:    limit,
+	}
+	metrics.RecentFailureCount = countLargePayloadEvents(failures, limit)
+	metrics.RecentCommandCount = countLargePayloadEvents(commands, limit)
+	metrics.Count = metrics.RecentFailureCount + metrics.RecentCommandCount
+	return metrics
+}
+
+func countLargePayloadEvents(events []*model.Event, limit int) int {
+	count := 0
+	for _, ev := range events {
+		if ev == nil {
+			continue
+		}
+		if apptypes.TruncateCommandPayload(apptypes.ExtractPlainBody(ev.Body()), limit).Truncated {
+			count++
+		}
+	}
+	return count
 }
 
 func countCandidatesBySource(candidates []apptypes.MemorySummary, source domtypes.MemorySource) int {

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -83,8 +83,10 @@ type topDataMemoryStub struct {
 	usecase.MemoryUsecase
 
 	listResult          []apptypes.MemorySummary
+	listFunc            func(apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error)
 	listErr             error
 	listCriteria        apptypes.MemoryListCriteria
+	listCriteriaCalls   []apptypes.MemoryListCriteria
 	listCalls           int
 	staleResult         apptypes.StaleMemoryListResult
 	staleErr            error
@@ -98,7 +100,11 @@ type topDataMemoryStub struct {
 
 func (s *topDataMemoryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
 	s.listCriteria = criteria
+	s.listCriteriaCalls = append(s.listCriteriaCalls, criteria)
 	s.listCalls++
+	if s.listFunc != nil {
+		return s.listFunc(criteria)
+	}
 	return s.listResult, s.listErr
 }
 
@@ -949,6 +955,161 @@ func TestTopDataLoader_LoadSnapshot_AggregatesEveryPane(t *testing.T) {
 	}
 }
 
+func TestTopDataLoader_LoadSnapshot_ComputesReliabilityMetrics(t *testing.T) {
+	t.Parallel()
+
+	now := fixedStartedAt.Add(48 * time.Hour)
+	fresh := sessionSummaryFixture("fresh", "", now.Add(-time.Hour), "active", domtypes.EventKindTranscript, "fresh")
+	stale := sessionSummaryFixture("stale", "", now.Add(-30*time.Hour), "stale", domtypes.EventKindTranscript, "stale")
+	session := &topDataSessionStub{
+		listResult: []apptypes.SessionSummary{fresh, stale},
+		lineageByID: map[domtypes.SessionID][]apptypes.SessionSummary{
+			domtypes.SessionID("fresh"): {fresh},
+			domtypes.SessionID("stale"): {stale},
+		},
+	}
+
+	hugeFailure := mustEvent(t, "evt-huge-fail", domtypes.EventKindCommandExecuted, strings.Repeat("f", apptypes.DefaultTopSnapshotBodyLimit+1))
+	hugeCommand := mustEvent(t, "evt-huge-cmd", domtypes.EventKindCommandExecuted, strings.Repeat("c", apptypes.DefaultTopSnapshotBodyLimit+1))
+	event := &snapshotEventStub{failures: []*model.Event{hugeFailure}, commands: []*model.Event{hugeCommand}}
+
+	accepted := memorySummaryWithUpdatedAt(t, "mem-accepted", domtypes.MemoryStatusAccepted, now.Add(-2*time.Hour))
+	oldCandidate := memorySummaryWithUpdatedAt(t, "mem-old-candidate", domtypes.MemoryStatusCandidate, now.Add(-25*time.Hour))
+	newCandidate := memorySummaryWithUpdatedAt(t, "mem-new-candidate", domtypes.MemoryStatusCandidate, now.Add(-3*time.Hour))
+	memory := &topDataMemoryStub{
+		listFunc: func(criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+			statuses := criteria.Statuses()
+			if len(statuses) == 1 && statuses[0] == domtypes.MemoryStatusCandidate {
+				return []apptypes.MemorySummary{oldCandidate}, nil
+			}
+			return []apptypes.MemorySummary{accepted, oldCandidate, newCandidate}, nil
+		},
+	}
+	loader := newTopDataLoader(session, event, memory)
+
+	snap, err := loader.loadSnapshot(context.Background(), topDataCriteria{
+		SessionLimit:       10,
+		FailureLimit:       1,
+		RecentCommandLimit: 1,
+		CandidateLimit:     1,
+		StaleMemoryLimit:   1,
+		StaleAfter:         24 * time.Hour,
+		Now:                now,
+	})
+	if err != nil {
+		t.Fatalf("loadSnapshot() error = %v", err)
+	}
+
+	if got := snap.Reliability.StaleActiveSessionCount; got != 1 {
+		t.Fatalf("StaleActiveSessionCount = %d, want 1", got)
+	}
+	if len(snap.Sessions) != 1 || snap.Sessions[0].summary.SessionID() != "fresh" {
+		t.Fatalf("Sessions = %#v, want stale session filtered while still counted", snap.Sessions)
+	}
+	if got, want := snap.Reliability.AcceptedMemoryCount, 1; got != want {
+		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := snap.Reliability.CandidateMemoryCount, 2; got != want {
+		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := snap.Reliability.CandidateAge.Count, 2; got != want {
+		t.Fatalf("CandidateAge.Count = %d, want %d", got, want)
+	}
+	if !snap.Reliability.CandidateAge.Oldest.Equal(oldCandidate.UpdatedAt()) {
+		t.Fatalf("CandidateAge.Oldest = %s, want %s", snap.Reliability.CandidateAge.Oldest, oldCandidate.UpdatedAt())
+	}
+	if got, want := snap.Reliability.CandidateAge.OldestAge, 25*time.Hour; got != want {
+		t.Fatalf("CandidateAge.OldestAge = %s, want %s", got, want)
+	}
+	if got, want := snap.Reliability.CandidateAge.AverageAge, 14*time.Hour; got != want {
+		t.Fatalf("CandidateAge.AverageAge = %s, want %s", got, want)
+	}
+	if got, want := snap.Reliability.LargePayloads.Count, 2; got != want {
+		t.Fatalf("LargePayloads.Count = %d, want %d", got, want)
+	}
+	if got, want := snap.Reliability.LargePayloads.RecentCommandCount, 1; got != want {
+		t.Fatalf("LargePayloads.RecentCommandCount = %d, want %d", got, want)
+	}
+	if got, want := snap.Reliability.LargePayloads.RecentFailureCount, 1; got != want {
+		t.Fatalf("LargePayloads.RecentFailureCount = %d, want %d", got, want)
+	}
+	if got, want := len(memory.listCriteriaCalls), 2; got != want {
+		t.Fatalf("memory.List calls = %d, want %d (candidate pane + reliability scan)", got, want)
+	}
+}
+
+func TestWriteTopSnapshotJSON_EmitsReliabilityShape(t *testing.T) {
+	t.Parallel()
+
+	oldest := fixedStartedAt
+	newest := fixedStartedAt.Add(2 * time.Hour)
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		Reliability: topReliabilityMetrics{
+			StaleActiveSessionCount: 2,
+			AcceptedMemoryCount:     3,
+			CandidateMemoryCount:    1,
+			MemoryScanLimit:         topReliabilityMemoryScanLimit,
+			CandidateAge: topCandidateAgeMetrics{
+				Count:      1,
+				Oldest:     oldest,
+				Newest:     newest,
+				OldestAge:  4 * time.Hour,
+				AverageAge: 4 * time.Hour,
+			},
+			LargePayloads: topLargePayloadMetrics{
+				Count:              2,
+				RecentCommandCount: 1,
+				RecentFailureCount: 1,
+				SampledEventCount:  3,
+				BodyLimitRunes:     apptypes.DefaultTopSnapshotBodyLimit,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("writeTopSnapshotJSON() error = %v", err)
+	}
+
+	var payload struct {
+		Reliability struct {
+			StaleActiveSessionCount int `json:"stale_active_session_count"`
+			Memory                  struct {
+				AcceptedCount  int      `json:"accepted_count"`
+				CandidateCount int      `json:"candidate_count"`
+				AcceptedRatio  *float64 `json:"accepted_ratio"`
+			} `json:"memory"`
+			CandidateAge struct {
+				Count             int    `json:"count"`
+				OldestUpdatedAt   string `json:"oldest_updated_at"`
+				NewestUpdatedAt   string `json:"newest_updated_at"`
+				OldestAgeSeconds  int64  `json:"oldest_age_seconds"`
+				AverageAgeSeconds int64  `json:"average_age_seconds"`
+			} `json:"candidate_age"`
+			LargePayloads struct {
+				Count              int `json:"count"`
+				RecentCommandCount int `json:"recent_command_count"`
+				RecentFailureCount int `json:"recent_failure_count"`
+				SampledEventCount  int `json:"sampled_event_count"`
+				BodyLimitRunes     int `json:"body_limit_runes"`
+			} `json:"large_payloads"`
+		} `json:"reliability"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal(top snapshot) error = %v\n%s", err, buf.String())
+	}
+	if got, want := payload.Reliability.StaleActiveSessionCount, 2; got != want {
+		t.Fatalf("stale_active_session_count = %d, want %d", got, want)
+	}
+	if payload.Reliability.Memory.AcceptedRatio == nil || *payload.Reliability.Memory.AcceptedRatio != 0.75 {
+		t.Fatalf("accepted_ratio = %v, want 0.75", payload.Reliability.Memory.AcceptedRatio)
+	}
+	if got, want := payload.Reliability.CandidateAge.OldestAgeSeconds, int64((4 * time.Hour).Seconds()); got != want {
+		t.Fatalf("oldest_age_seconds = %d, want %d", got, want)
+	}
+	if got, want := payload.Reliability.LargePayloads.SampledEventCount, 3; got != want {
+		t.Fatalf("sampled_event_count = %d, want %d", got, want)
+	}
+}
+
 // snapshotEventStub returns separate fixtures for the failures call and
 // the recent-commands call so loadSnapshot's two EventUsecase.List
 // invocations can be distinguished by the FailuresOnly / Kind criteria.
@@ -990,6 +1151,16 @@ func TestTopDataLoader_LoadSnapshot_NoUsecasesReturnsEmpty(t *testing.T) {
 
 func memorySummaryFixture(t *testing.T, id string, status domtypes.MemoryStatus, fact string) apptypes.MemorySummary {
 	t.Helper()
+	return memorySummaryWithFactAndUpdatedAt(t, id, status, fact, fixedStartedAt)
+}
+
+func memorySummaryWithUpdatedAt(t *testing.T, id string, status domtypes.MemoryStatus, updatedAt time.Time) apptypes.MemorySummary {
+	t.Helper()
+	return memorySummaryWithFactAndUpdatedAt(t, id, status, "reliability metric fixture "+id, updatedAt)
+}
+
+func memorySummaryWithFactAndUpdatedAt(t *testing.T, id string, status domtypes.MemoryStatus, fact string, updatedAt time.Time) apptypes.MemorySummary {
+	t.Helper()
 	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
 	if err != nil {
 		t.Fatalf("WorkspaceFrom: %v", err)
@@ -1007,7 +1178,7 @@ func memorySummaryFixture(t *testing.T, id string, status domtypes.MemoryStatus,
 		fixedStartedAt,
 		domtypes.None[time.Time](),
 		fixedStartedAt,
-		fixedStartedAt,
+		updatedAt,
 	)
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)

--- a/presentation/cli/top_json.go
+++ b/presentation/cli/top_json.go
@@ -65,8 +65,55 @@ func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 			Count: snap.StaleMemories.Count(),
 			Items: staleItems,
 		},
+		Reliability: topSnapshotReliabilityFromMetrics(snap.Reliability),
 	}
 	return writeJSON(output, payload)
+}
+
+func topSnapshotReliabilityFromMetrics(metrics topReliabilityMetrics) topSnapshotReliability {
+	return topSnapshotReliability{
+		StaleActiveSessionCount: metrics.StaleActiveSessionCount,
+		Memory:                  topSnapshotReliabilityMemoryFromMetrics(metrics),
+		CandidateAge:            topSnapshotCandidateAgeFromMetrics(metrics.CandidateAge),
+		LargePayloads: topSnapshotLargePayloads{
+			Count:              metrics.LargePayloads.Count,
+			RecentCommandCount: metrics.LargePayloads.RecentCommandCount,
+			RecentFailureCount: metrics.LargePayloads.RecentFailureCount,
+			SampledEventCount:  metrics.LargePayloads.SampledEventCount,
+			BodyLimitRunes:     metrics.LargePayloads.BodyLimitRunes,
+		},
+	}
+}
+
+func topSnapshotReliabilityMemoryFromMetrics(metrics topReliabilityMetrics) topSnapshotReliabilityMemory {
+	out := topSnapshotReliabilityMemory{
+		AcceptedCount:    metrics.AcceptedMemoryCount,
+		CandidateCount:   metrics.CandidateMemoryCount,
+		ScanLimit:        metrics.MemoryScanLimit,
+		ScanLimitReached: metrics.MemoryScanLimited,
+	}
+	total := metrics.AcceptedMemoryCount + metrics.CandidateMemoryCount
+	if total > 0 {
+		ratio := float64(metrics.AcceptedMemoryCount) / float64(total)
+		out.AcceptedRatio = &ratio
+	}
+	return out
+}
+
+func topSnapshotCandidateAgeFromMetrics(metrics topCandidateAgeMetrics) topSnapshotCandidateAge {
+	out := topSnapshotCandidateAge{Count: metrics.Count}
+	if metrics.Count == 0 {
+		return out
+	}
+	oldest := formatJSONTime(metrics.Oldest)
+	newest := formatJSONTime(metrics.Newest)
+	oldestAge := int64(metrics.OldestAge.Seconds())
+	averageAge := int64(metrics.AverageAge.Seconds())
+	out.OldestUpdatedAt = &oldest
+	out.NewestUpdatedAt = &newest
+	out.OldestAgeSeconds = &oldestAge
+	out.AverageAgeSeconds = &averageAge
+	return out
 }
 
 // snapshotStaleContext carries the per-snapshot stale-evaluation inputs

--- a/presentation/cli/top_test.go
+++ b/presentation/cli/top_test.go
@@ -41,6 +41,8 @@ func (s *topPaneEventStub) List(_ context.Context, criteria apptypes.EventListCr
 func TestRootCLI_TopCommand_SnapshotJSONGolden(t *testing.T) {
 	startedAt := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	endedAt := startedAt.Add(30 * time.Minute)
+	cli.SetTopNowFunc(func() time.Time { return startedAt.Add(6 * time.Hour) })
+	t.Cleanup(cli.ResetTopNowFunc)
 
 	stub := &sessionUsecaseStub{listResult: []apptypes.SessionSummary{
 		apptypes.SessionSummaryOf(
@@ -224,6 +226,8 @@ func TestRootCLI_TopCommand_SnapshotTextGolden(t *testing.T) {
 	t.Cleanup(func() { time.Local = prevLocal })
 
 	startedAt := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	cli.SetTopNowFunc(func() time.Time { return startedAt.Add(6 * time.Hour) })
+	t.Cleanup(cli.ResetTopNowFunc)
 
 	stub := &sessionUsecaseStub{listResult: []apptypes.SessionSummary{
 		apptypes.SessionSummaryOf(


### PR DESCRIPTION
## Motivation

Dogfooding surfaced reliability signals that were available only indirectly: stale active sessions, poor accepted/candidate memory balance, old inbox candidates, and large payloads that bloat top/handoff surfaces. The top snapshot needs an additive, script-friendly reliability block that can become the input for the later operator cockpit TUI.

Closes #988

## Changes

- Add a `reliability` section to `traceary top --snapshot --json` with:
  - stale active session count
  - accepted/candidate memory counts and accepted ratio
  - candidate memory age summary
  - large payload counts for the loaded recent command/failure panes
- Add a `RELIABILITY` section to text snapshots with actionable remediation hints.
- Keep active-session stale filtering behavior unchanged while still counting filtered stale active sessions.
- Add deterministic top clock test seams and coverage for metric calculation and JSON shape.

## Claude delegation

Requested Claude implementation delegation was attempted, but Claude CLI did not produce a usable non-interactive result in this session and was terminated after hanging. Implementation proceeded locally with the same issue scope and validation evidence below.

## Validation

```json
{
  "source": "codex-verifier",
  "validated_commands": [
    "rtk proxy git diff --check",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py"
  ],
  "results": {
    "passed": [
      "diff whitespace check",
      "Go test suite",
      "golangci-lint",
      "go build",
      "integration manifest/package verification"
    ],
    "failed": []
  },
  "residual_risks": [
    "External AI review gates are unavailable in this session due local/auth/repo configuration; relying on local verification and CI."
  ],
  "findings": []
}
```
