### PR TITLE
v0.17-1: add cockpit TUI entrypoint

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/presentation/cli/tui"
+)
+
+const cockpitExitCodeNotInteractive = 2
+
+type cockpitExitError struct {
+	message  string
+	exitCode int
+}
+
+func (e cockpitExitError) Error() string { return e.message }
+func (e cockpitExitError) ExitCode() int { return e.exitCode }
+
+type cockpitCommandOptions struct {
+	dbPath string
+}
+
+func (c *RootCLI) newCockpitCommand() *cobra.Command {
+	opts := cockpitCommandOptions{}
+	cmd := &cobra.Command{
+		Use:     "tui",
+		Aliases: []string{"dashboard"},
+		Short:   Localize("Open the Traceary operator cockpit TUI", "Traceary operator cockpit TUI を開く"),
+		Long: Localize(
+			"Open the Traceary operator cockpit TUI. The cockpit is the explicit interactive entrypoint that will gather top, tail, doctor, handoff, and memory review workflows behind one TTY-only shell. Bare `traceary` behavior is unchanged.",
+			"Traceary operator cockpit TUI を開きます。cockpit は top / tail / doctor / handoff / memory review を 1 つの TTY 専用 shell にまとめる明示的な対話 entrypoint です。bare `traceary` の挙動は変更しません。",
+		),
+		Args: noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runCockpit(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.dbPath, "db-path", "", dbPathFlagUsage())
+	return cmd
+}
+
+func (c *RootCLI) runCockpit(ctx context.Context, output io.Writer, opts cockpitCommandOptions) error {
+	_ = ctx
+	_ = opts
+	stdin, stdout := cockpitIO(output)
+	if !tui.Interactive(stdin, stdout) {
+		return newCockpitNonInteractiveError(output)
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles())
+	if err := tui.Run(model, tui.RunOptions{Input: stdin, Output: stdout, AltScreen: true}); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to run cockpit TUI", "cockpit TUI の実行に失敗しました"), err)
+	}
+	return nil
+}
+
+func newCockpitNonInteractiveError(output io.Writer) error {
+	guidance := Localize(
+		"Traceary cockpit requires an interactive terminal (TTY).\nUse the existing non-interactive commands instead:\n  traceary top --snapshot [--json]\n  traceary tail [--follow]\n  traceary doctor --json\n  traceary session handoff\n  traceary memory inbox list\nRun `traceary tui` from a terminal to open the cockpit.",
+		"Traceary cockpit には対話 terminal (TTY) が必要です。\n非対話 shell では既存 command を使ってください:\n  traceary top --snapshot [--json]\n  traceary tail [--follow]\n  traceary doctor --json\n  traceary session handoff\n  traceary memory inbox list\nterminal から `traceary tui` を実行すると cockpit を開けます。",
+	)
+	if output != nil {
+		_, _ = fmt.Fprintln(output, guidance)
+	}
+	return cockpitExitError{message: guidance, exitCode: cockpitExitCodeNotInteractive}
+}
+
+type cockpitModel struct {
+	keys     tui.KeyMap
+	styles   tui.Styles
+	showHelp bool
+}
+
+func newCockpitModel(keys tui.KeyMap, styles tui.Styles) cockpitModel {
+	return cockpitModel{keys: keys, styles: styles}
+}
+
+func (m cockpitModel) Init() tea.Cmd { return nil }
+
+func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.Quit):
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Help):
+			m.showHelp = !m.showHelp
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m cockpitModel) View() string {
+	lines := []string{
+		m.styles.Title.Render("Traceary cockpit"),
+		"",
+		"Home status model lands in v0.17-2. This shell pins the explicit TTY entrypoint first, without changing bare `traceary`.",
+		"",
+		m.styles.Subtle.Render("Planned cockpit surfaces:"),
+		"• home status: DB/hooks/doctor summary, stale sessions, memory counts",
+		"• sessions: top dashboard and detail drill-down",
+		"• tail: live event stream",
+		"• memory: inbox notifications and review launcher",
+		"• doctor: warnings and remediation commands",
+		"",
+		m.styles.Help.Render("q/esc/ctrl+c quit · ? help"),
+	}
+	if m.showHelp {
+		lines = append(lines,
+			"",
+			m.styles.Subtle.Render("Fallback commands available today:"),
+			"traceary top --snapshot [--json]",
+			"traceary tail [--follow]",
+			"traceary doctor --json",
+			"traceary session handoff",
+			"traceary memory inbox review",
+		)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// cockpitIO resolves the stdin/stdout pair the cockpit TUI should drive. Tests
+// pass a non-file writer (e.g. *bytes.Buffer), making tui.Interactive refuse
+// the run before any Bubble Tea program is spawned.
+func cockpitIO(output io.Writer) (*os.File, *os.File) {
+	stdout, _ := output.(*os.File)
+	return os.Stdin, stdout
+}

--- a/presentation/cli/cockpit_test.go
+++ b/presentation/cli/cockpit_test.go
@@ -1,0 +1,89 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestCockpitCommand_RefusesNonTTYThroughCobra(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"tui"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute(tui) error = nil, want non-TTY refusal")
+	}
+	var coder interface{ ExitCode() int }
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected error implementing ExitCode(); got %T (%v)", err, err)
+	}
+	if coder.ExitCode() != 2 {
+		t.Fatalf("ExitCode() = %d, want 2", coder.ExitCode())
+	}
+	for _, must := range []string{"requires an interactive terminal", "traceary top --snapshot", "traceary memory inbox list", "traceary tui"} {
+		if !strings.Contains(err.Error(), must) {
+			t.Fatalf("error guidance missing %q:\n%s", must, err.Error())
+		}
+		if !strings.Contains(stdout.String(), must) {
+			t.Fatalf("stdout guidance missing %q:\n%s", must, stdout.String())
+		}
+	}
+}
+
+func TestCockpitCommand_HelpAndAliasAreDiscoverable(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"tui", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(tui --help) error = %v", err)
+	}
+	help := stdout.String()
+	for _, must := range []string{"operator cockpit", "dashboard", "--db-path", "top", "tail", "doctor", "memory review"} {
+		if !strings.Contains(help, must) {
+			t.Fatalf("tui --help missing %q:\n%s", must, help)
+		}
+	}
+
+	rootHelp := &bytes.Buffer{}
+	rootCmd = newTestRootCLI().Command()
+	rootCmd.SetOut(rootHelp)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"--help"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(--help) error = %v", err)
+	}
+	if !strings.Contains(rootHelp.String(), "tui") {
+		t.Fatalf("root help does not list tui command:\n%s", rootHelp.String())
+	}
+}
+
+func TestCockpitCommand_NoArgsCompatibility(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := cli.NewRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(no args) error = %v", err)
+	}
+	if strings.Contains(stdout.String(), "Traceary cockpit requires") {
+		t.Fatalf("bare traceary should not launch or refuse the cockpit; stdout:\n%s", stdout.String())
+	}
+}

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -196,6 +196,7 @@ func (c *RootCLI) Command() *cobra.Command {
 	rootCmd.AddCommand(c.newSearchCommand())
 	rootCmd.AddCommand(c.newTailCommand())
 	rootCmd.AddCommand(c.newTopCommand())
+	rootCmd.AddCommand(c.newCockpitCommand())
 	rootCmd.AddCommand(c.newContextCommand())
 	rootCmd.AddCommand(c.newListCommand())
 	rootCmd.AddCommand(c.newShowCommand())


### PR DESCRIPTION
## Motivation

Operators currently have to remember separate entry points (`top`, `tail`, `doctor`, `session handoff`, `memory inbox review`). v0.17 starts the operator cockpit by adding an explicit TTY-only shell without changing bare `traceary` behavior.

Closes #990

## Changes

- Add `traceary tui` with alias `traceary dashboard`.
- Reuse the shared Bubble Tea TUI runner and key map.
- Refuse non-TTY execution with deterministic guidance and exit code 2.
- Add a lightweight placeholder cockpit view that documents planned v0.17 panes until the home status model lands in #991.
- Add tests for non-TTY guard, help/alias discoverability, root help, and no-args compatibility.

## Claude delegation

Requested Claude implementation delegation remains unavailable in this session: the Claude CLI did not provide a usable non-interactive path. Implementation proceeded locally with validation evidence below.

## Validation

```json
{
  "source": "codex-verifier",
  "validated_commands": [
    "rtk proxy git diff --check",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./presentation/cli",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py"
  ],
  "results": {
    "passed": ["diff whitespace check", "presentation/cli tests", "Go test suite", "golangci-lint", "go build", "integration manifest/package verification"],
    "failed": []
  },
  "residual_risks": ["External AI review gates are unavailable in this session due local/auth/repo configuration; relying on local verification and CI."],
  "findings": []
}
```
