### PR TITLE
v0.17-2: add cockpit home status model

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -49,17 +50,161 @@ func (c *RootCLI) newCockpitCommand() *cobra.Command {
 }
 
 func (c *RootCLI) runCockpit(ctx context.Context, output io.Writer, opts cockpitCommandOptions) error {
-	_ = ctx
-	_ = opts
 	stdin, stdout := cockpitIO(output)
 	if !tui.Interactive(stdin, stdout) {
 		return newCockpitNonInteractiveError(output)
 	}
-	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles())
+	home, err := c.loadCockpitHome(ctx, opts)
+	if err != nil {
+		return err
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
 	if err := tui.Run(model, tui.RunOptions{Input: stdin, Output: stdout, AltScreen: true}); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to run cockpit TUI", "cockpit TUI の実行に失敗しました"), err)
 	}
 	return nil
+}
+
+type cockpitHomeSnapshot struct {
+	LoadedAt time.Time
+	DBPath   string
+
+	DoctorPassCount int
+	DoctorWarnCount int
+	DoctorFailCount int
+	DoctorError     string
+
+	HookWarnCount int
+	HookFailCount int
+
+	StaleActiveSessionCount int
+	AcceptedMemoryCount     int
+	CandidateMemoryCount    int
+	StaleMemoryCount        int
+	RecentFailureCount      int
+	RecentCommandCount      int
+	LargePayloadCount       int
+}
+
+func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOptions) (cockpitHomeSnapshot, error) {
+	loadedAt := topNowFunc()
+	home := cockpitHomeSnapshot{LoadedAt: loadedAt}
+
+	report, reportErr := c.loadCockpitDoctorReport(ctx, opts)
+	if reportErr != nil {
+		home.DoctorError = reportErr.Error()
+	} else if report != nil {
+		home.DBPath = report.DBPath
+		home.DoctorPassCount = report.Summary.Pass
+		home.DoctorWarnCount = report.Summary.Warn
+		home.DoctorFailCount = report.Summary.Fail
+		home.HookWarnCount, home.HookFailCount = countCockpitHookIssues(report)
+	}
+	if home.DBPath == "" {
+		resolvedDBPath, err := resolveDBPath(opts.dbPath)
+		if err != nil {
+			home.DoctorError = err.Error()
+		} else {
+			c.applyDatabasePath(resolvedDBPath)
+			home.DBPath = resolvedDBPath
+			if c.storeManagement != nil {
+				if err := c.storeManagement.Initialize(ctx); err != nil {
+					home.DoctorError = err.Error()
+				}
+			}
+		}
+	}
+
+	snap, err := c.newTopDataLoader().loadSnapshot(ctx, topDataCriteria{
+		SessionLimit:       defaultTopLimit,
+		FailureLimit:       topPaneFailureLimit,
+		RecentCommandLimit: topPaneRecentCommandLimit,
+		CandidateLimit:     topPaneCandidateLimit,
+		StaleMemoryLimit:   topPaneStaleMemoryLimit,
+		StaleAfter:         defaultActiveSessionStaleAfter,
+		Now:                loadedAt,
+	})
+	if err != nil {
+		return cockpitHomeSnapshot{}, err
+	}
+	home.StaleActiveSessionCount = snap.Reliability.StaleActiveSessionCount
+	home.AcceptedMemoryCount = snap.Reliability.AcceptedMemoryCount
+	home.CandidateMemoryCount = snap.Reliability.CandidateMemoryCount
+	home.StaleMemoryCount = snap.StaleMemories.Count()
+	home.RecentFailureCount = len(snap.Failures)
+	home.RecentCommandCount = len(snap.RecentCommands)
+	home.LargePayloadCount = snap.Reliability.LargePayloads.Count
+
+	return home, nil
+}
+
+func (c *RootCLI) loadCockpitDoctorReport(ctx context.Context, opts cockpitCommandOptions) (*doctorReport, error) {
+	if c.storeManagement == nil {
+		return nil, xerrors.Errorf(Localize("store management usecase is not configured", "ストア管理ユースケースが設定されていません"))
+	}
+	if c.hooksOrchestrator == nil {
+		return nil, xerrors.Errorf(Localize("hooks orchestrator is not configured", "hooks orchestrator が設定されていません"))
+	}
+	return c.buildDoctorReport(ctx, doctorCommandInput{
+		dbPath:         opts.dbPath,
+		currentVersion: "",
+	})
+}
+
+func countCockpitHookIssues(report *doctorReport) (warn int, fail int) {
+	if report == nil {
+		return 0, 0
+	}
+	for _, check := range report.Checks {
+		if check.Section != "Hooks" && check.Section != "MCP" {
+			continue
+		}
+		switch check.Severity {
+		case doctorSeverityWarn:
+			warn++
+		case doctorSeverityFail:
+			fail++
+		}
+	}
+	return warn, fail
+}
+
+type cockpitWarning struct {
+	severity string
+	label    string
+	hint     string
+}
+
+func (s cockpitHomeSnapshot) warnings() []cockpitWarning {
+	warnings := make([]cockpitWarning, 0, 6)
+	if s.DoctorError != "" {
+		warnings = append(warnings, cockpitWarning{severity: "FAIL", label: "doctor unavailable", hint: s.DoctorError})
+	}
+	if s.DoctorFailCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "FAIL", label: fmt.Sprintf("doctor failures=%d", s.DoctorFailCount), hint: "run `traceary doctor` for remediation details"})
+	}
+	if s.HookFailCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "FAIL", label: fmt.Sprintf("hook/MCP failures=%d", s.HookFailCount), hint: "run `traceary doctor --json` and inspect Hooks/MCP sections"})
+	}
+	if s.StaleActiveSessionCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("stale active sessions=%d", s.StaleActiveSessionCount), hint: "run `traceary session gc --stale-after 24h --dry-run`"})
+	}
+	if s.DoctorWarnCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("doctor warnings=%d", s.DoctorWarnCount), hint: "run `traceary doctor`"})
+	}
+	if s.HookWarnCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("hook/MCP warnings=%d", s.HookWarnCount), hint: "run `traceary doctor --json` and inspect Hooks/MCP sections"})
+	}
+	if s.CandidateMemoryCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("candidate memories=%d", s.CandidateMemoryCount), hint: "review with `traceary memory inbox review`"})
+	}
+	if s.RecentFailureCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("recent failures=%d", s.RecentFailureCount), hint: "open `traceary top` or `traceary tail` for details"})
+	}
+	if s.LargePayloadCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("large payloads=%d", s.LargePayloadCount), hint: "inspect full events with `traceary show <event_id>`"})
+	}
+	return warnings
 }
 
 func newCockpitNonInteractiveError(output io.Writer) error {
@@ -77,10 +222,11 @@ type cockpitModel struct {
 	keys     tui.KeyMap
 	styles   tui.Styles
 	showHelp bool
+	home     cockpitHomeSnapshot
 }
 
-func newCockpitModel(keys tui.KeyMap, styles tui.Styles) cockpitModel {
-	return cockpitModel{keys: keys, styles: styles}
+func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapshot) cockpitModel {
+	return cockpitModel{keys: keys, styles: styles, home: home}
 }
 
 func (m cockpitModel) Init() tea.Cmd { return nil }
@@ -103,17 +249,39 @@ func (m cockpitModel) View() string {
 	lines := []string{
 		m.styles.Title.Render("Traceary cockpit"),
 		"",
-		"Home status model lands in v0.17-2. This shell pins the explicit TTY entrypoint first, without changing bare `traceary`.",
+		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s db=%s", formatJSONTime(m.home.LoadedAt), formatOptionalColumn(m.home.DBPath))),
+		"",
+		m.styles.Subtle.Render("ATTENTION"),
+	}
+	warnings := m.home.warnings()
+	if len(warnings) == 0 {
+		lines = append(lines, m.styles.Success.Render("• No immediate cockpit warnings."))
+	} else {
+		for _, warning := range warnings {
+			style := m.styles.Warning
+			if warning.severity == "FAIL" {
+				style = m.styles.Error
+			}
+			lines = append(lines, style.Render(fmt.Sprintf("• [%s] %s — %s", warning.severity, warning.label, warning.hint)))
+		}
+	}
+	lines = append(lines,
+		"",
+		m.styles.Subtle.Render("OVERVIEW"),
+		fmt.Sprintf("• doctor: pass=%d warn=%d fail=%d", m.home.DoctorPassCount, m.home.DoctorWarnCount, m.home.DoctorFailCount),
+		fmt.Sprintf("• hooks/mcp: warn=%d fail=%d", m.home.HookWarnCount, m.home.HookFailCount),
+		fmt.Sprintf("• sessions: stale_active=%d recent_failures=%d recent_commands=%d", m.home.StaleActiveSessionCount, m.home.RecentFailureCount, m.home.RecentCommandCount),
+		fmt.Sprintf("• memories: accepted=%d candidate=%d stale=%d", m.home.AcceptedMemoryCount, m.home.CandidateMemoryCount, m.home.StaleMemoryCount),
+		fmt.Sprintf("• payloads: large=%d", m.home.LargePayloadCount),
 		"",
 		m.styles.Subtle.Render("Planned cockpit surfaces:"),
-		"• home status: DB/hooks/doctor summary, stale sessions, memory counts",
 		"• sessions: top dashboard and detail drill-down",
 		"• tail: live event stream",
 		"• memory: inbox notifications and review launcher",
 		"• doctor: warnings and remediation commands",
 		"",
 		m.styles.Help.Render("q/esc/ctrl+c quit · ? help"),
-	}
+	)
 	if m.showHelp {
 		lines = append(lines,
 			"",

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/presentation/cli/tui"
+)
+
+func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
+	now := fixedStartedAt.Add(48 * time.Hour)
+	previousTopNow := topNowFunc
+	topNowFunc = func() time.Time { return now }
+	t.Cleanup(func() { topNowFunc = previousTopNow })
+
+	fresh := sessionSummaryFixture("fresh", "", now.Add(-time.Hour), "active", domtypes.EventKindTranscript, "fresh")
+	stale := sessionSummaryFixture("stale", "", now.Add(-30*time.Hour), "stale", domtypes.EventKindTranscript, "stale")
+	session := &topDataSessionStub{
+		listResult: []apptypes.SessionSummary{fresh, stale},
+		lineageByID: map[domtypes.SessionID][]apptypes.SessionSummary{
+			domtypes.SessionID("fresh"): {fresh},
+			domtypes.SessionID("stale"): {stale},
+		},
+	}
+
+	hugeFailure := mustEvent(t, "evt-fail", domtypes.EventKindCommandExecuted, strings.Repeat("f", apptypes.DefaultTopSnapshotBodyLimit+1))
+	command := mustEvent(t, "evt-cmd", domtypes.EventKindCommandExecuted, "go test ./...")
+	event := &snapshotEventStub{failures: []*model.Event{hugeFailure}, commands: []*model.Event{command}}
+
+	accepted := memorySummaryWithUpdatedAt(t, "mem-accepted", domtypes.MemoryStatusAccepted, now.Add(-2*time.Hour))
+	candidate := memorySummaryWithUpdatedAt(t, "mem-candidate", domtypes.MemoryStatusCandidate, now.Add(-3*time.Hour))
+	staleSummary := memorySummaryFixture(t, "mem-stale", domtypes.MemoryStatusSuperseded, "stale cockpit fixture")
+	staleRow, err := apptypes.StaleMemoryRowOf(staleSummary, apptypes.StaleMemoryReasonSuperseded)
+	if err != nil {
+		t.Fatalf("StaleMemoryRowOf: %v", err)
+	}
+	staleResult, err := apptypes.StaleMemoryListResultOf(2, []apptypes.StaleMemoryRow{staleRow})
+	if err != nil {
+		t.Fatalf("StaleMemoryListResultOf: %v", err)
+	}
+	memory := &topDataMemoryStub{
+		listFunc: func(criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+			statuses := criteria.Statuses()
+			if len(statuses) == 1 && statuses[0] == domtypes.MemoryStatusCandidate {
+				return []apptypes.MemorySummary{candidate}, nil
+			}
+			return []apptypes.MemorySummary{accepted, candidate}, nil
+		},
+		staleResult: staleResult,
+	}
+
+	root := &RootCLI{session: session, event: event, memory: memory}
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+
+	if home.DoctorError == "" {
+		t.Fatalf("DoctorError = empty, want explicit dependency/configuration signal when doctor cannot run")
+	}
+	if got, want := home.StaleActiveSessionCount, 1; got != want {
+		t.Fatalf("StaleActiveSessionCount = %d, want %d", got, want)
+	}
+	if got, want := home.AcceptedMemoryCount, 1; got != want {
+		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.CandidateMemoryCount, 1; got != want {
+		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.StaleMemoryCount, 2; got != want {
+		t.Fatalf("StaleMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.RecentFailureCount, 1; got != want {
+		t.Fatalf("RecentFailureCount = %d, want %d", got, want)
+	}
+	if got, want := home.RecentCommandCount, 1; got != want {
+		t.Fatalf("RecentCommandCount = %d, want %d", got, want)
+	}
+	if got, want := home.LargePayloadCount, 1; got != want {
+		t.Fatalf("LargePayloadCount = %d, want %d", got, want)
+	}
+}
+
+func TestCockpitHomeWarnings_ActionableWarningsFirst(t *testing.T) {
+	t.Parallel()
+
+	home := cockpitHomeSnapshot{
+		DoctorFailCount:         1,
+		HookFailCount:           1,
+		DoctorWarnCount:         2,
+		HookWarnCount:           1,
+		StaleActiveSessionCount: 3,
+		CandidateMemoryCount:    5,
+		RecentFailureCount:      2,
+		LargePayloadCount:       1,
+	}
+	warnings := home.warnings()
+	if len(warnings) < 8 {
+		t.Fatalf("warnings length = %d, want all actionable signals: %#v", len(warnings), warnings)
+	}
+	for i, warning := range warnings[:2] {
+		if warning.severity != "FAIL" {
+			t.Fatalf("warnings[%d].severity = %q, want FAIL first: %#v", i, warning.severity, warnings)
+		}
+	}
+	for i, warning := range warnings[2:] {
+		if warning.severity == "FAIL" {
+			t.Fatalf("warnings[%d] is FAIL after WARN boundary: %#v", i+2, warnings)
+		}
+	}
+	if !strings.Contains(warnings[0].hint, "doctor") {
+		t.Fatalf("first warning should tell operator how to act, got %#v", warnings[0])
+	}
+}
+
+func TestCockpitModelView_RendersStableEmptyStateAndOverview(t *testing.T) {
+	t.Parallel()
+
+	home := cockpitHomeSnapshot{
+		LoadedAt:            fixedStartedAt,
+		DBPath:              "/tmp/traceary.db",
+		DoctorPassCount:     4,
+		AcceptedMemoryCount: 2,
+		RecentCommandCount:  1,
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
+	view := model.View()
+	for _, must := range []string{
+		"Traceary cockpit",
+		"ATTENTION",
+		"No immediate cockpit warnings",
+		"OVERVIEW",
+		"doctor: pass=4 warn=0 fail=0",
+		"memories: accepted=2 candidate=0 stale=0",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("cockpit view missing %q:\n%s", must, view)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

The cockpit entrypoint needs an immediate home surface that tells operators what needs attention before they choose a sub-view. This wires a testable home status model behind `traceary tui` using existing doctor/top signals.

Closes #991

## Changes

- Load a cockpit home snapshot before launching the TUI.
- Include DB path, doctor pass/warn/fail summary, Hooks/MCP issue counts, stale active session count, accepted/candidate/stale memory counts, recent failure/command counts, and large-payload count.
- Render actionable warnings before overview counts.
- Keep non-TTY refusal behavior from #990 unchanged.
- Add tests for home aggregation without a TTY, warning ordering, and stable empty-state/overview rendering.

## Claude delegation

Requested Claude implementation delegation remains unavailable in this session: the Claude CLI did not provide a usable non-interactive path. Implementation proceeded locally with validation evidence below.

## Validation

```json
{
  "source": "codex-verifier",
  "validated_commands": [
    "rtk proxy git diff --check",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./presentation/cli",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...",
    "rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py"
  ],
  "results": {
    "passed": ["diff whitespace check", "presentation/cli tests", "Go test suite", "golangci-lint", "go build", "integration manifest/package verification"],
    "failed": []
  },
  "residual_risks": ["External AI review gates are unavailable in this session due local/auth/repo configuration; relying on local verification and CI."],
  "findings": []
}
```
