### PR TITLE
v0.17-3: integrate live tail pane into cockpit

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -13,10 +14,14 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli/tui"
 )
 
 const cockpitExitCodeNotInteractive = 2
+const cockpitLiveMaxEvents = 200
 
 type cockpitExitError struct {
 	message  string
@@ -59,6 +64,8 @@ func (c *RootCLI) runCockpit(ctx context.Context, output io.Writer, opts cockpit
 		return err
 	}
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
+	model.loader = c
+	model.loaderCtx = ctx
 	if err := tui.Run(model, tui.RunOptions{Input: stdin, Output: stdout, AltScreen: true}); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to run cockpit TUI", "cockpit TUI の実行に失敗しました"), err)
 	}
@@ -169,6 +176,55 @@ func countCockpitHookIssues(report *doctorReport) (warn int, fail int) {
 	return warn, fail
 }
 
+type cockpitLoader interface {
+	loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error)
+	loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error)
+}
+
+type cockpitLiveSnapshot struct {
+	Events   []*model.Event
+	Cursor   tailCursor
+	LoadedAt time.Time
+}
+
+func (c *RootCLI) loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
+	if c.event == nil {
+		return cockpitLiveSnapshot{}, xerrors.Errorf(Localize("list events query service is not configured", "イベント一覧クエリサービスが設定されていません"))
+	}
+	now := topNowFunc().UTC()
+	if initial || cursor.timestamp.IsZero() {
+		events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(defaultTailInitialLimit).Build())
+		if err != nil {
+			return cockpitLiveSnapshot{}, xerrors.Errorf("%s: %w", Localize("failed to list live events", "live event の一覧取得に失敗しました"), err)
+		}
+		slices.Reverse(events)
+		if len(events) > 0 {
+			cursor = newTailCursor(events[len(events)-1].CreatedAt())
+			cursor.Advance(events)
+		} else {
+			cursor = newTailCursor(now)
+		}
+		return cockpitLiveSnapshot{Events: events, Cursor: cursor, LoadedAt: now}, nil
+	}
+	base := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build()
+	events, err := c.pollTailEvents(ctx, base, cursor, now)
+	if err != nil {
+		return cockpitLiveSnapshot{}, err
+	}
+	cursor.Advance(events)
+	return cockpitLiveSnapshot{Events: events, Cursor: cursor, LoadedAt: now}, nil
+}
+
+func (c *RootCLI) loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error) {
+	return c.newTopDataLoader().loadDetail(ctx, topDetailRequest{
+		target: topDetailTarget{
+			kind:    topDetailEvent,
+			title:   fmt.Sprintf("EVENT %s", eventID.String()),
+			eventID: eventID,
+		},
+	})
+}
+
 type cockpitWarning struct {
 	severity string
 	label    string
@@ -219,10 +275,19 @@ func newCockpitNonInteractiveError(output io.Writer) error {
 }
 
 type cockpitModel struct {
-	keys     tui.KeyMap
-	styles   tui.Styles
+	keys   tui.KeyMap
+	styles tui.Styles
+
+	loader    cockpitLoader
+	loaderCtx context.Context
+
 	showHelp bool
+	mode     cockpitMode
 	home     cockpitHomeSnapshot
+
+	live         cockpitLiveState
+	detail       topDetailState
+	detailOffset int
 }
 
 func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapshot) cockpitModel {
@@ -231,21 +296,266 @@ func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapsho
 
 func (m cockpitModel) Init() tea.Cmd { return nil }
 
+type cockpitMode int
+
+const (
+	cockpitModeHome cockpitMode = iota
+	cockpitModeLive
+	cockpitModeDetail
+)
+
+type cockpitLiveState struct {
+	events     []*model.Event
+	cursor     tailCursor
+	loadedAt   time.Time
+	loading    bool
+	follow     bool
+	selected   int
+	requestSeq uint64
+	err        error
+}
+
+type cockpitLiveMsg struct {
+	snapshot cockpitLiveSnapshot
+	initial  bool
+	seq      uint64
+	err      error
+}
+
+type cockpitLiveTickMsg struct{}
+
+type cockpitDetailLoadedMsg struct {
+	request topDetailRequest
+	content topDetailContent
+	err     error
+}
+
 func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case cockpitLiveMsg:
+		if msg.seq != m.live.requestSeq {
+			return m, nil
+		}
+		m.live.loading = false
+		m.live.err = msg.err
+		if msg.err == nil {
+			if msg.initial {
+				m.live.events = msg.snapshot.Events
+			} else {
+				m.live.events = append(m.live.events, msg.snapshot.Events...)
+				if len(m.live.events) > cockpitLiveMaxEvents {
+					m.live.events = m.live.events[len(m.live.events)-cockpitLiveMaxEvents:]
+				}
+			}
+			m.live.cursor = msg.snapshot.Cursor
+			m.live.loadedAt = msg.snapshot.LoadedAt
+			m.clampLiveSelection()
+		}
+		if m.mode == cockpitModeLive && m.live.follow {
+			return m, m.cockpitLiveTickCmd()
+		}
+		return m, nil
+	case cockpitLiveTickMsg:
+		if m.mode == cockpitModeLive && m.live.follow && !m.live.loading {
+			return m, m.startCockpitLiveLoad(false)
+		}
+		return m, nil
+	case cockpitDetailLoadedMsg:
+		if m.mode != cockpitModeDetail || msg.request != m.detail.request {
+			return m, nil
+		}
+		m.detail.loading = false
+		m.detail.err = msg.err
+		m.detail.title = msg.content.title
+		m.detail.lines = msg.content.lines
+		m.clampDetailOffset()
+		return m, nil
 	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, m.keys.Quit):
-			return m, tea.Quit
-		case key.Matches(msg, m.keys.Help):
-			m.showHelp = !m.showHelp
+		return m.updateKey(msg)
+	}
+	return m, nil
+}
+
+func (m cockpitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Quit):
+		return m, tea.Quit
+	case key.Matches(msg, m.keys.Help):
+		m.showHelp = !m.showHelp
+		return m, nil
+	}
+	switch m.mode {
+	case cockpitModeDetail:
+		return m.updateDetailKey(msg)
+	case cockpitModeLive:
+		return m.updateLiveKey(msg)
+	default:
+		return m.updateHomeKey(msg)
+	}
+}
+
+func (m cockpitModel) updateHomeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type == tea.KeyRunes {
+		switch strings.ToLower(string(msg.Runes)) {
+		case "t", "l":
+			m.mode = cockpitModeLive
+			return m, m.startCockpitLiveLoad(true)
+		}
+	}
+	return m, nil
+}
+
+func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Up):
+		m.live.selected--
+		m.clampLiveSelection()
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.live.selected++
+		m.clampLiveSelection()
+		return m, nil
+	case key.Matches(msg, m.keys.Refresh):
+		return m, m.startCockpitLiveLoad(true)
+	case key.Matches(msg, m.keys.Select):
+		return m.openCockpitLiveDetail()
+	}
+	if msg.Type == tea.KeyRunes {
+		switch strings.ToLower(string(msg.Runes)) {
+		case "h":
+			m.mode = cockpitModeHome
+			return m, nil
+		case "f":
+			m.live.follow = !m.live.follow
+			if m.live.follow {
+				return m, m.cockpitLiveTickCmd()
+			}
 			return m, nil
 		}
 	}
 	return m, nil
 }
 
+func (m cockpitModel) updateDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Up):
+		m.detailOffset--
+		m.clampDetailOffset()
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.detailOffset++
+		m.clampDetailOffset()
+		return m, nil
+	}
+	if msg.Type == tea.KeyRunes {
+		switch strings.ToLower(string(msg.Runes)) {
+		case "h":
+			m.mode = cockpitModeHome
+			m.detail = topDetailState{}
+			m.detailOffset = 0
+			return m, nil
+		case "t", "l":
+			m.mode = cockpitModeLive
+			m.detail = topDetailState{}
+			m.detailOffset = 0
+			if m.live.follow {
+				return m, m.cockpitLiveTickCmd()
+			}
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m *cockpitModel) startCockpitLiveLoad(initial bool) tea.Cmd {
+	m.live.loading = true
+	m.live.requestSeq++
+	return m.fetchCockpitLiveCmd(initial, m.live.requestSeq)
+}
+
+func (m cockpitModel) fetchCockpitLiveCmd(initial bool, seq uint64) tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	cursor := m.live.cursor
+	return func() tea.Msg {
+		if loader == nil {
+			return cockpitLiveMsg{initial: initial, seq: seq, err: xerrors.Errorf("cockpit live loader is not configured")}
+		}
+		snapshot, err := loader.loadCockpitLive(ctx, cursor, initial)
+		return cockpitLiveMsg{snapshot: snapshot, initial: initial, seq: seq, err: err}
+	}
+}
+
+func (m cockpitModel) cockpitLiveTickCmd() tea.Cmd {
+	return tea.Tick(defaultTailPollInterval, func(time.Time) tea.Msg {
+		return cockpitLiveTickMsg{}
+	})
+}
+
+func (m cockpitModel) openCockpitLiveDetail() (tea.Model, tea.Cmd) {
+	if len(m.live.events) == 0 || m.live.selected < 0 || m.live.selected >= len(m.live.events) {
+		return m, nil
+	}
+	event := m.live.events[m.live.selected]
+	if event == nil {
+		return m, nil
+	}
+	req := topDetailRequest{target: topDetailTarget{kind: topDetailEvent, title: fmt.Sprintf("EVENT %s", event.EventID()), eventID: event.EventID()}}
+	m.mode = cockpitModeDetail
+	m.detailOffset = 0
+	m.detail = topDetailState{request: req, title: req.target.title, lines: []string{Localize("Loading...", "読み込み中...")}, loading: true}
+	return m, m.fetchCockpitDetailCmd(req)
+}
+
+func (m cockpitModel) fetchCockpitDetailCmd(req topDetailRequest) tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	return func() tea.Msg {
+		if loader == nil {
+			return cockpitDetailLoadedMsg{request: req, err: xerrors.Errorf("cockpit detail loader is not configured")}
+		}
+		content, err := loader.loadCockpitEventDetail(ctx, req.target.eventID)
+		return cockpitDetailLoadedMsg{request: req, content: content, err: err}
+	}
+}
+
+func (m *cockpitModel) clampLiveSelection() {
+	if len(m.live.events) == 0 {
+		m.live.selected = 0
+		return
+	}
+	if m.live.selected < 0 {
+		m.live.selected = 0
+	}
+	if m.live.selected >= len(m.live.events) {
+		m.live.selected = len(m.live.events) - 1
+	}
+}
+
+func (m *cockpitModel) clampDetailOffset() {
+	maxOffset := len(m.detailLines()) - 1
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.detailOffset < 0 {
+		m.detailOffset = 0
+	}
+	if m.detailOffset > maxOffset {
+		m.detailOffset = maxOffset
+	}
+}
+
 func (m cockpitModel) View() string {
+	switch m.mode {
+	case cockpitModeLive:
+		return m.liveView()
+	case cockpitModeDetail:
+		return m.detailView()
+	}
+	return m.homeView()
+}
+
+func (m cockpitModel) homeView() string {
 	lines := []string{
 		m.styles.Title.Render("Traceary cockpit"),
 		"",
@@ -280,7 +590,7 @@ func (m cockpitModel) View() string {
 		"• memory: inbox notifications and review launcher",
 		"• doctor: warnings and remediation commands",
 		"",
-		m.styles.Help.Render("q/esc/ctrl+c quit · ? help"),
+		m.styles.Help.Render("t/l live tail · q/esc/ctrl+c quit · ? help"),
 	)
 	if m.showHelp {
 		lines = append(lines,
@@ -294,6 +604,87 @@ func (m cockpitModel) View() string {
 		)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m cockpitModel) liveView() string {
+	lines := []string{
+		m.styles.Title.Render("Traceary cockpit · live tail"),
+		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s follow=%t rows=%d", formatJSONTime(m.live.loadedAt), m.live.follow, len(m.live.events))),
+		"",
+	}
+	if m.live.err != nil {
+		lines = append(lines, m.styles.Error.Render(m.live.err.Error()))
+	} else if len(m.live.events) == 0 {
+		if m.live.loading {
+			lines = append(lines, m.styles.Subtle.Render("Loading live events..."))
+		} else {
+			lines = append(lines, m.styles.Subtle.Render("No recent events. Press r to refresh or f to follow."))
+		}
+	} else {
+		for i, event := range m.live.events {
+			prefix := "  "
+			if i == m.live.selected {
+				prefix = "> "
+			}
+			line := prefix + formatCockpitLiveEventRow(event, time.Local)
+			if i == m.live.selected {
+				line = m.styles.Active.Render(line)
+			}
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, "", m.styles.Help.Render("h home · r refresh · f follow · enter detail · q quit"))
+	return strings.Join(lines, "\n")
+}
+
+func (m cockpitModel) detailView() string {
+	lines := []string{m.styles.Title.Render("Traceary cockpit · " + m.detail.title), ""}
+	if m.detail.err != nil {
+		lines = append(lines, m.styles.Error.Render(m.detail.err.Error()))
+	} else {
+		detailLines := m.detailLines()
+		if len(detailLines) == 0 {
+			detailLines = []string{m.styles.Subtle.Render("No detail lines.")}
+		}
+		lines = append(lines, detailLines[m.detailOffset:]...)
+	}
+	lines = append(lines, "", m.styles.Help.Render("t/l live · h home · ↑/↓ scroll · q quit"))
+	return strings.Join(lines, "\n")
+}
+
+func (m cockpitModel) detailLines() []string {
+	if m.detail.loading {
+		return []string{Localize("Loading...", "読み込み中...")}
+	}
+	return m.detail.lines
+}
+
+func formatCockpitLiveEventRow(event *model.Event, loc *time.Location) string {
+	if event == nil {
+		return "-"
+	}
+	displayEvent := event
+	truncated := false
+	out := newTruncatedEventOutput(event, apptypes.DefaultTopSnapshotBodyLimit)
+	if out.Truncated {
+		truncated = true
+		displayEvent = model.EventOfWithSourceHook(
+			event.EventID(),
+			event.Kind(),
+			event.Client(),
+			event.Agent(),
+			event.SessionID(),
+			event.Workspace(),
+			out.Message,
+			event.CreatedAt(),
+			event.SourceHook(),
+		)
+	}
+	row := formatEventCompactRow(displayEvent, eventTextFormatOptions{location: loc}, compactRowExtras{})
+	if truncated {
+		row += " [truncated]"
+	}
+	return row
 }
 
 // cockpitIO resolves the stdin/stdout pair the cockpit TUI should drive. Tests

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
@@ -143,4 +145,221 @@ func TestCockpitModelView_RendersStableEmptyStateAndOverview(t *testing.T) {
 			t.Fatalf("cockpit view missing %q:\n%s", must, view)
 		}
 	}
+}
+
+func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
+	t.Parallel()
+
+	initialEvent := mustEvent(t, "evt-initial", domtypes.EventKindNote, "initial live event")
+	followEvent := mustEvent(t, "evt-follow", domtypes.EventKindCommandExecuted, "followed live event")
+	loader := &cockpitLoaderStub{
+		liveResponses: []cockpitLiveSnapshot{
+			{Events: []*model.Event{initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt},
+			{Events: []*model.Event{initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(time.Minute)},
+			{Events: []*model.Event{followEvent}, Cursor: newTailCursor(followEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(2 * time.Minute)},
+		},
+		detailContent: topDetailContent{
+			title: "EVENT evt-initial",
+			lines: []string{"shared detail renderer line", "full event payload"},
+		},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("t"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeLive || !model.live.loading {
+		t.Fatalf("opening live pane mode/loading = %v/%v, want live/loading", model.mode, model.live.loading)
+	}
+	if cmd == nil {
+		t.Fatalf("opening live pane returned nil command")
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("initial load command returned follow-up cmd = %T, want nil when follow is disabled", cmd)
+	}
+	if got, want := len(model.live.events), 1; got != want {
+		t.Fatalf("live events after initial load = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "live tail") || !strings.Contains(got, "initial live event") {
+		t.Fatalf("live view missing loaded event:\n%s", got)
+	}
+	if got := loader.liveCalls[0].initial; !got {
+		t.Fatalf("first live call initial = false, want true")
+	}
+
+	updated, cmd = model.Update(cockpitRuneKey("r"))
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("refresh returned nil command")
+	}
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if got := len(loader.liveCalls); got != 2 {
+		t.Fatalf("live calls after refresh = %d, want 2", got)
+	}
+	if got := loader.liveCalls[1].initial; !got {
+		t.Fatalf("refresh live call initial = false, want true")
+	}
+
+	updated, cmd = model.Update(cockpitRuneKey("f"))
+	model = updated.(cockpitModel)
+	if !model.live.follow || cmd == nil {
+		t.Fatalf("follow toggle follow/cmd = %v/%T, want enabled/tick command", model.live.follow, cmd)
+	}
+	updated, cmd = model.Update(cockpitLiveTickMsg{})
+	model = updated.(cockpitModel)
+	if !model.live.loading || cmd == nil {
+		t.Fatalf("follow tick loading/cmd = %v/%T, want loading/fetch command", model.live.loading, cmd)
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if got := len(model.live.events); got != 2 {
+		t.Fatalf("live events after follow poll = %d, want 2", got)
+	}
+	if got := model.View(); !strings.Contains(got, "followed live event") {
+		t.Fatalf("live view missing followed event:\n%s", got)
+	}
+	if got := loader.liveCalls[2].initial; got {
+		t.Fatalf("follow poll live call initial = true, want false")
+	}
+	if cmd == nil {
+		t.Fatalf("follow poll should schedule the next tick while follow is enabled")
+	}
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeDetail || !model.detail.loading {
+		t.Fatalf("opening detail mode/loading = %v/%v, want detail/loading", model.mode, model.detail.loading)
+	}
+	if cmd == nil {
+		t.Fatalf("opening detail returned nil command")
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("detail load returned unexpected follow-up command = %T", cmd)
+	}
+	if got, want := loader.detailCalls, []domtypes.EventID{initialEvent.EventID()}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("detail calls = %v, want %v", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "shared detail renderer line") {
+		t.Fatalf("detail view missing shared renderer output:\n%s", got)
+	}
+
+	updated, cmd = model.Update(cockpitRuneKey("t"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeLive || cmd == nil {
+		t.Fatalf("returning to live with follow mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+	}
+}
+
+func TestCockpitModel_IgnoresStaleLiveLoadResponses(t *testing.T) {
+	t.Parallel()
+
+	staleEvent := mustEvent(t, "evt-stale", domtypes.EventKindNote, "stale live event")
+	freshEvent := mustEvent(t, "evt-fresh", domtypes.EventKindNote, "fresh live event")
+	cockpit := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	cockpit.loader = &cockpitLoaderStub{}
+	cockpit.loaderCtx = context.Background()
+
+	updated, _ := cockpit.Update(cockpitRuneKey("t"))
+	cockpit = updated.(cockpitModel)
+	firstSeq := cockpit.live.requestSeq
+
+	updated, _ = cockpit.Update(cockpitRuneKey("r"))
+	cockpit = updated.(cockpitModel)
+	secondSeq := cockpit.live.requestSeq
+	if firstSeq == secondSeq {
+		t.Fatalf("live request sequence did not advance: first=%d second=%d", firstSeq, secondSeq)
+	}
+
+	updated, _ = cockpit.Update(cockpitLiveMsg{
+		seq:     firstSeq,
+		initial: true,
+		snapshot: cockpitLiveSnapshot{
+			Events:   []*model.Event{staleEvent},
+			Cursor:   newTailCursor(staleEvent.CreatedAt()),
+			LoadedAt: fixedStartedAt,
+		},
+	})
+	cockpit = updated.(cockpitModel)
+	if len(cockpit.live.events) != 0 {
+		t.Fatalf("stale response mutated live events: %#v", cockpit.live.events)
+	}
+	if !cockpit.live.loading {
+		t.Fatalf("stale response cleared loading for the newer request")
+	}
+
+	updated, _ = cockpit.Update(cockpitLiveMsg{
+		seq:     secondSeq,
+		initial: true,
+		snapshot: cockpitLiveSnapshot{
+			Events:   []*model.Event{freshEvent},
+			Cursor:   newTailCursor(freshEvent.CreatedAt()),
+			LoadedAt: fixedStartedAt.Add(time.Minute),
+		},
+	})
+	cockpit = updated.(cockpitModel)
+	if got, want := len(cockpit.live.events), 1; got != want {
+		t.Fatalf("current response live events = %d, want %d", got, want)
+	}
+	if got := cockpit.live.events[0].EventID(); got != freshEvent.EventID() {
+		t.Fatalf("live event after current response = %s, want %s", got, freshEvent.EventID())
+	}
+	if cockpit.live.loading {
+		t.Fatalf("current response left loading true")
+	}
+}
+
+func TestFormatCockpitLiveEventRow_TruncatesLargePayload(t *testing.T) {
+	t.Parallel()
+
+	event := mustEvent(t, "evt-large", domtypes.EventKindCommandExecuted, strings.Repeat("x", apptypes.DefaultTopSnapshotBodyLimit+20))
+	row := formatCockpitLiveEventRow(event, time.UTC)
+	if !strings.Contains(row, "[truncated]") {
+		t.Fatalf("row = %q, want truncation marker", row)
+	}
+	if got, limit := len([]rune(row)), apptypes.DefaultTopSnapshotBodyLimit; got >= limit {
+		t.Fatalf("row length = %d, want compact row below body limit %d", got, limit)
+	}
+}
+
+type cockpitLoaderStub struct {
+	liveResponses []cockpitLiveSnapshot
+	liveCalls     []cockpitLiveCall
+	liveErr       error
+
+	detailContent topDetailContent
+	detailErr     error
+	detailCalls   []domtypes.EventID
+}
+
+type cockpitLiveCall struct {
+	cursor  tailCursor
+	initial bool
+}
+
+func (s *cockpitLoaderStub) loadCockpitLive(_ context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
+	s.liveCalls = append(s.liveCalls, cockpitLiveCall{cursor: cursor, initial: initial})
+	if s.liveErr != nil {
+		return cockpitLiveSnapshot{}, s.liveErr
+	}
+	if len(s.liveResponses) == 0 {
+		return cockpitLiveSnapshot{LoadedAt: fixedStartedAt}, nil
+	}
+	next := s.liveResponses[0]
+	s.liveResponses = s.liveResponses[1:]
+	return next, nil
+}
+
+func (s *cockpitLoaderStub) loadCockpitEventDetail(_ context.Context, eventID domtypes.EventID) (topDetailContent, error) {
+	s.detailCalls = append(s.detailCalls, eventID)
+	return s.detailContent, s.detailErr
+}
+
+func cockpitRuneKey(value string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(value)}
 }


### PR DESCRIPTION
## Motivation

Operators should be able to enter `traceary tui` and inspect live hook/event activity without remembering the standalone `traceary tail` command.

## Changes

- Adds a cockpit live-tail pane reachable with `t`/`l` from the cockpit home screen.
- Supports refresh, follow polling, row selection, and event detail drilldown.
- Reuses tail compact row formatting and the shared top detail renderer for event details.
- Applies the v0.16 list-surface body truncation limit to large live payloads.
- Adds cockpit model tests for live pane loading, refresh/follow, detail routing, and truncation rendering.

Closes #992

## Validation

- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`
