### PR TITLE
v0.17-4: integrate memory inbox notifications

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -87,6 +87,12 @@ type cockpitHomeSnapshot struct {
 	StaleActiveSessionCount int
 	AcceptedMemoryCount     int
 	CandidateMemoryCount    int
+	NewCandidateMemoryCount int
+	NewCandidateMemoryKnown bool
+	RememberIntentCount     int
+	LowQualityMemoryCount   int
+	MemoryScanLimited       bool
+	MemoryLastSeenAt        time.Time
 	StaleMemoryCount        int
 	RecentFailureCount      int
 	RecentCommandCount      int
@@ -122,7 +128,14 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 		}
 	}
 
-	snap, err := c.newTopDataLoader().loadSnapshot(ctx, topDataCriteria{
+	memoryLastSeenAt, memoryLastSeenKnown, err := c.loadCockpitMemoryLastSeenAt(ctx)
+	if err != nil {
+		home.NewCandidateMemoryKnown = false
+	} else if memoryLastSeenKnown {
+		home.MemoryLastSeenAt = memoryLastSeenAt
+		home.NewCandidateMemoryKnown = true
+	}
+	criteria := topDataCriteria{
 		SessionLimit:       defaultTopLimit,
 		FailureLimit:       topPaneFailureLimit,
 		RecentCommandLimit: topPaneRecentCommandLimit,
@@ -130,19 +143,46 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 		StaleMemoryLimit:   topPaneStaleMemoryLimit,
 		StaleAfter:         defaultActiveSessionStaleAfter,
 		Now:                loadedAt,
-	})
+	}
+	if home.NewCandidateMemoryKnown {
+		criteria.MemoryLastSeenAt = domtypes.Some(home.MemoryLastSeenAt)
+	}
+	snap, err := c.newTopDataLoader().loadSnapshot(ctx, criteria)
 	if err != nil {
 		return cockpitHomeSnapshot{}, err
 	}
 	home.StaleActiveSessionCount = snap.Reliability.StaleActiveSessionCount
 	home.AcceptedMemoryCount = snap.Reliability.AcceptedMemoryCount
 	home.CandidateMemoryCount = snap.Reliability.CandidateMemoryCount
+	home.NewCandidateMemoryCount = snap.Reliability.NewCandidateCount
+	home.NewCandidateMemoryKnown = snap.Reliability.NewCandidateKnown
+	home.RememberIntentCount = snap.Reliability.RememberIntentCount
+	home.LowQualityMemoryCount = snap.Reliability.LowQualityCount
+	home.MemoryScanLimited = snap.Reliability.MemoryScanLimited
 	home.StaleMemoryCount = snap.StaleMemories.Count()
 	home.RecentFailureCount = len(snap.Failures)
 	home.RecentCommandCount = len(snap.RecentCommands)
 	home.LargePayloadCount = snap.Reliability.LargePayloads.Count
 
 	return home, nil
+}
+
+// CockpitStateReader provides optional local cockpit state. Missing or failing
+// state must not block read-only cockpit views; callers should treat it as a
+// notification enhancement rather than critical data.
+type CockpitStateReader interface {
+	MemoryLastSeenAt(ctx context.Context) (time.Time, bool, error)
+}
+
+func (c *RootCLI) loadCockpitMemoryLastSeenAt(ctx context.Context) (time.Time, bool, error) {
+	if c.cockpitState == nil {
+		return time.Time{}, false, nil
+	}
+	lastSeenAt, ok, err := c.cockpitState.MemoryLastSeenAt(ctx)
+	if err != nil {
+		return time.Time{}, false, xerrors.Errorf("%s: %w", Localize("failed to load cockpit memory last-seen state", "cockpit memory last-seen state の読み込みに失敗しました"), err)
+	}
+	return lastSeenAt, ok, nil
 }
 
 func (c *RootCLI) loadCockpitDoctorReport(ctx context.Context, opts cockpitCommandOptions) (*doctorReport, error) {
@@ -250,6 +290,15 @@ func (s cockpitHomeSnapshot) warnings() []cockpitWarning {
 	}
 	if s.HookWarnCount > 0 {
 		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("hook/MCP warnings=%d", s.HookWarnCount), hint: "run `traceary doctor --json` and inspect Hooks/MCP sections"})
+	}
+	if s.NewCandidateMemoryKnown && s.NewCandidateMemoryCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("new candidate memories=%d", s.NewCandidateMemoryCount), hint: "press memory review when available or run `traceary memory inbox review`"})
+	}
+	if s.RememberIntentCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("remember-intent candidates=%d", s.RememberIntentCount), hint: "prioritize with `traceary memory inbox review --remember-intent`"})
+	}
+	if s.LowQualityMemoryCount > 0 {
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("low-quality candidates=%d", s.LowQualityMemoryCount), hint: "inspect with `traceary memory inbox cleanup --include-hidden`"})
 	}
 	if s.CandidateMemoryCount > 0 {
 		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("candidate memories=%d", s.CandidateMemoryCount), hint: "review with `traceary memory inbox review`"})
@@ -556,6 +605,10 @@ func (m cockpitModel) View() string {
 }
 
 func (m cockpitModel) homeView() string {
+	memoryScanSuffix := ""
+	if m.home.MemoryScanLimited {
+		memoryScanSuffix = " scan_limited=true"
+	}
 	lines := []string{
 		m.styles.Title.Render("Traceary cockpit"),
 		"",
@@ -581,7 +634,7 @@ func (m cockpitModel) homeView() string {
 		fmt.Sprintf("• doctor: pass=%d warn=%d fail=%d", m.home.DoctorPassCount, m.home.DoctorWarnCount, m.home.DoctorFailCount),
 		fmt.Sprintf("• hooks/mcp: warn=%d fail=%d", m.home.HookWarnCount, m.home.HookFailCount),
 		fmt.Sprintf("• sessions: stale_active=%d recent_failures=%d recent_commands=%d", m.home.StaleActiveSessionCount, m.home.RecentFailureCount, m.home.RecentCommandCount),
-		fmt.Sprintf("• memories: accepted=%d candidate=%d stale=%d", m.home.AcceptedMemoryCount, m.home.CandidateMemoryCount, m.home.StaleMemoryCount),
+		fmt.Sprintf("• memories: accepted(reviewed)=%d candidate(inbox)=%d new=%s remember-intent=%d low-quality=%d stale=%d%s", m.home.AcceptedMemoryCount, m.home.CandidateMemoryCount, formatCockpitNewCandidateCount(m.home), m.home.RememberIntentCount, m.home.LowQualityMemoryCount, m.home.StaleMemoryCount, memoryScanSuffix),
 		fmt.Sprintf("• payloads: large=%d", m.home.LargePayloadCount),
 		"",
 		m.styles.Subtle.Render("Planned cockpit surfaces:"),
@@ -604,6 +657,13 @@ func (m cockpitModel) homeView() string {
 		)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatCockpitNewCandidateCount(home cockpitHomeSnapshot) string {
+	if !home.NewCandidateMemoryKnown {
+		return "untracked"
+	}
+	return fmt.Sprintf("%d", home.NewCandidateMemoryCount)
 }
 
 func (m cockpitModel) liveView() string {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -75,6 +75,9 @@ func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
 	if got, want := home.CandidateMemoryCount, 1; got != want {
 		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
 	}
+	if home.NewCandidateMemoryKnown {
+		t.Fatalf("NewCandidateMemoryKnown = true, want false when cockpit state is not configured")
+	}
 	if got, want := home.StaleMemoryCount, 2; got != want {
 		t.Fatalf("StaleMemoryCount = %d, want %d", got, want)
 	}
@@ -86,6 +89,122 @@ func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
 	}
 	if got, want := home.LargePayloadCount, 1; got != want {
 		t.Fatalf("LargePayloadCount = %d, want %d", got, want)
+	}
+}
+
+func TestLoadCockpitHome_MemoryNotificationsUseLastSeenWhenAvailable(t *testing.T) {
+	now := fixedStartedAt.Add(72 * time.Hour)
+	previousTopNow := topNowFunc
+	topNowFunc = func() time.Time { return now }
+	t.Cleanup(func() { topNowFunc = previousTopNow })
+
+	lastSeenAt := now.Add(-2 * time.Hour)
+	accepted := memorySummaryWithSourceAndUpdatedAt(t, "mem-accepted", domtypes.MemoryStatusAccepted, domtypes.MemorySourceManual, now.Add(-30*time.Minute))
+	oldCandidate := memorySummaryWithSourceAndUpdatedAt(t, "mem-old", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtracted, now.Add(-3*time.Hour))
+	newRemember := memorySummaryWithSourceAndUpdatedAt(t, "mem-remember", domtypes.MemoryStatusCandidate, domtypes.MemorySourceRememberIntent, now.Add(-90*time.Minute))
+	newLowQuality := memorySummaryWithSourceAndUpdatedAt(t, "mem-low", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtractedHidden, now.Add(-15*time.Minute))
+	candidates := []apptypes.MemorySummary{oldCandidate, newRemember, newLowQuality}
+	memory := &topDataMemoryStub{
+		listFunc: func(criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+			statuses := criteria.Statuses()
+			if len(statuses) == 1 && statuses[0] == domtypes.MemoryStatusCandidate {
+				return candidates, nil
+			}
+			return []apptypes.MemorySummary{accepted, oldCandidate, newRemember, newLowQuality}, nil
+		},
+	}
+	root := &RootCLI{
+		memory:       memory,
+		cockpitState: cockpitStateReaderStub{at: lastSeenAt, ok: true},
+	}
+
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+
+	if !home.NewCandidateMemoryKnown {
+		t.Fatalf("NewCandidateMemoryKnown = false, want true")
+	}
+	if got, want := home.MemoryLastSeenAt, lastSeenAt; !got.Equal(want) {
+		t.Fatalf("MemoryLastSeenAt = %v, want %v", got, want)
+	}
+	if got, want := home.AcceptedMemoryCount, 1; got != want {
+		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.CandidateMemoryCount, 3; got != want {
+		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.NewCandidateMemoryCount, 2; got != want {
+		t.Fatalf("NewCandidateMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.RememberIntentCount, 1; got != want {
+		t.Fatalf("RememberIntentCount = %d, want %d", got, want)
+	}
+	if got, want := home.LowQualityMemoryCount, 1; got != want {
+		t.Fatalf("LowQualityMemoryCount = %d, want %d", got, want)
+	}
+
+	view := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home).View()
+	for _, must := range []string{
+		"new candidate memories=2",
+		"remember-intent candidates=1",
+		"low-quality candidates=1",
+		"memories: accepted(reviewed)=1 candidate(inbox)=3 new=2 remember-intent=1 low-quality=1 stale=0",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("cockpit view missing %q:\n%s", must, view)
+		}
+	}
+}
+
+func TestLoadCockpitHome_MemoryNotificationsFallbackWhenLastSeenUnavailable(t *testing.T) {
+	t.Parallel()
+
+	candidate := memorySummaryWithSourceAndUpdatedAt(t, "mem-candidate", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtracted, fixedStartedAt)
+	memory := &topDataMemoryStub{
+		listFunc: func(_ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+			return []apptypes.MemorySummary{candidate}, nil
+		},
+	}
+	root := &RootCLI{memory: memory}
+
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+	if home.NewCandidateMemoryKnown {
+		t.Fatalf("NewCandidateMemoryKnown = true, want false")
+	}
+	if got, want := formatCockpitNewCandidateCount(home), "untracked"; got != want {
+		t.Fatalf("formatCockpitNewCandidateCount() = %q, want %q", got, want)
+	}
+	view := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home).View()
+	if !strings.Contains(view, "candidate memories=1") {
+		t.Fatalf("fallback view should still surface total candidates:\n%s", view)
+	}
+	if strings.Contains(view, "new candidate memories=") {
+		t.Fatalf("fallback view should not claim a new count without last-seen state:\n%s", view)
+	}
+	if !strings.Contains(view, "new=untracked") {
+		t.Fatalf("fallback view missing untracked new-count state:\n%s", view)
+	}
+}
+
+func TestCockpitModelView_MemoryNotificationsNoneState(t *testing.T) {
+	t.Parallel()
+
+	home := cockpitHomeSnapshot{
+		LoadedAt:                fixedStartedAt,
+		AcceptedMemoryCount:     2,
+		NewCandidateMemoryKnown: true,
+	}
+	view := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home).View()
+	if !strings.Contains(view, "memories: accepted(reviewed)=2 candidate(inbox)=0 new=0 remember-intent=0 low-quality=0 stale=0") {
+		t.Fatalf("none-state view missing zero notification summary:\n%s", view)
+	}
+	if strings.Contains(view, "candidate memories=") || strings.Contains(view, "new candidate memories=") {
+		t.Fatalf("none-state view should not show candidate warnings:\n%s", view)
 	}
 }
 
@@ -139,7 +258,7 @@ func TestCockpitModelView_RendersStableEmptyStateAndOverview(t *testing.T) {
 		"No immediate cockpit warnings",
 		"OVERVIEW",
 		"doctor: pass=4 warn=0 fail=0",
-		"memories: accepted=2 candidate=0 stale=0",
+		"memories: accepted(reviewed)=2 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0",
 	} {
 		if !strings.Contains(view, must) {
 			t.Fatalf("cockpit view missing %q:\n%s", must, view)
@@ -340,6 +459,43 @@ type cockpitLoaderStub struct {
 type cockpitLiveCall struct {
 	cursor  tailCursor
 	initial bool
+}
+
+type cockpitStateReaderStub struct {
+	at  time.Time
+	ok  bool
+	err error
+}
+
+func (s cockpitStateReaderStub) MemoryLastSeenAt(context.Context) (time.Time, bool, error) {
+	return s.at, s.ok, s.err
+}
+
+func memorySummaryWithSourceAndUpdatedAt(t *testing.T, id string, status domtypes.MemoryStatus, source domtypes.MemorySource, updatedAt time.Time) apptypes.MemorySummary {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypePreference,
+		domtypes.WorkspaceScopeOf(workspace),
+		"cockpit notification fixture "+id,
+		status,
+		domtypes.ConfidenceMedium,
+		source,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	return summary
 }
 
 func (s *cockpitLoaderStub) loadCockpitLive(_ context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -24,6 +24,7 @@ type RootCLI struct {
 	hooksInspector        application.HooksInspector
 	pluginCacheInspector  application.PluginCacheInspector
 	pluginDetector        application.ClaudePluginDetector
+	cockpitState          CockpitStateReader
 	extraRedactPatterns   []string
 	structuredRedactRules []redaction.RuleConfig
 	defaultReadFields     []string
@@ -116,6 +117,12 @@ func WithPluginCacheInspector(inspector application.PluginCacheInspector) RootCL
 // plugin is active in the user's global settings.
 func WithClaudePluginDetector(detector application.ClaudePluginDetector) RootCLIOption {
 	return func(c *RootCLI) { c.pluginDetector = detector }
+}
+
+// WithCockpitStateReader injects optional local cockpit state used for
+// non-critical notification checkpoints such as memory inbox last-seen time.
+func WithCockpitStateReader(reader CockpitStateReader) RootCLIOption {
+	return func(c *RootCLI) { c.cockpitState = reader }
 }
 
 // WithExtraRedactPatterns injects additional redaction regex patterns used

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -45,6 +45,11 @@ type topDataCriteria struct {
 	// Now is the reference time used to evaluate staleness. Zero falls
 	// back to time.Now() inside the loader so tests can pin it.
 	Now time.Time
+	// MemoryLastSeenAt is the optional cockpit/inbox checkpoint used to
+	// compute new-since-last-seen candidate counts. The persistence layer for
+	// this checkpoint is intentionally outside topDataLoader; callers that do
+	// not have state leave it empty and get total-count metrics only.
+	MemoryLastSeenAt domtypes.Optional[time.Time]
 }
 
 func (l *topDataLoader) loadDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
@@ -204,6 +209,10 @@ type topReliabilityMetrics struct {
 
 	AcceptedMemoryCount  int
 	CandidateMemoryCount int
+	NewCandidateCount    int
+	NewCandidateKnown    bool
+	RememberIntentCount  int
+	LowQualityCount      int
 	MemoryScanLimit      int
 	MemoryScanLimited    bool
 
@@ -528,12 +537,23 @@ func (l *topDataLoader) loadReliabilityMetrics(ctx context.Context, c topDataCri
 	}
 	metrics.MemoryScanLimit = topReliabilityMemoryScanLimit
 	metrics.MemoryScanLimited = len(memories) >= topReliabilityMemoryScanLimit
+	lastSeenAt, lastSeenKnown := c.MemoryLastSeenAt.Value()
+	metrics.NewCandidateKnown = lastSeenKnown
 	for _, summary := range memories {
 		switch summary.Status() {
 		case domtypes.MemoryStatusAccepted:
 			metrics.AcceptedMemoryCount++
 		case domtypes.MemoryStatusCandidate:
 			metrics.CandidateMemoryCount++
+			if lastSeenKnown && summary.UpdatedAt().After(lastSeenAt) {
+				metrics.NewCandidateCount++
+			}
+			switch summary.Source() {
+			case domtypes.MemorySourceRememberIntent:
+				metrics.RememberIntentCount++
+			case domtypes.MemorySourceExtractedHidden:
+				metrics.LowQualityCount++
+			}
 			metrics.CandidateAge = topCandidateAgeMetricsAdd(metrics.CandidateAge, summary.UpdatedAt(), topDataNow(c))
 		}
 	}


### PR DESCRIPTION
## Motivation

Operators should notice memory inbox work from the cockpit home screen instead of remembering to run `traceary memory inbox list` manually.

## Changes

- Adds cockpit memory notification fields for total candidates, new-since-last-seen candidates, remember-intent candidates, low-quality candidates, accepted memories, and scan-limited state.
- Extends top reliability memory metrics with candidate source and optional last-seen counts so cockpit can reuse the existing snapshot loader.
- Adds a safe `cockpitStateReader` seam: when no last-seen state is configured, cockpit displays `new=untracked` and still surfaces total candidates.
- Updates the home overview to visually distinguish `accepted(reviewed)` from `candidate(inbox)`.
- Adds tests for new, untracked/fallback, none, and mixed-source candidate states.

Closes #993

## Validation

- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`
