### PR TITLE
v0.17-5: launch memory review flow from cockpit

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -64,7 +64,7 @@ func (c *RootCLI) runCockpit(ctx context.Context, output io.Writer, opts cockpit
 		return err
 	}
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
-	model.loader = c
+	model.loader = cockpitRuntimeLoader{root: c, opts: opts}
 	model.loaderCtx = ctx
 	if err := tui.Run(model, tui.RunOptions{Input: stdin, Output: stdout, AltScreen: true}); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to run cockpit TUI", "cockpit TUI の実行に失敗しました"), err)
@@ -217,14 +217,63 @@ func countCockpitHookIssues(report *doctorReport) (warn int, fail int) {
 }
 
 type cockpitLoader interface {
+	loadCockpitHome(ctx context.Context) (cockpitHomeSnapshot, error)
 	loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error)
 	loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error)
+	loadCockpitMemoryReviewItems(ctx context.Context) ([]apptypes.MemoryDetails, error)
+	finishCockpitMemoryReview(ctx context.Context, final reviewModel, items []apptypes.MemoryDetails) (memoryInboxReviewResult, error)
 }
 
 type cockpitLiveSnapshot struct {
 	Events   []*model.Event
 	Cursor   tailCursor
 	LoadedAt time.Time
+}
+
+type cockpitRuntimeLoader struct {
+	root *RootCLI
+	opts cockpitCommandOptions
+}
+
+func (l cockpitRuntimeLoader) loadCockpitHome(ctx context.Context) (cockpitHomeSnapshot, error) {
+	return l.root.loadCockpitHome(ctx, l.opts)
+}
+
+func (l cockpitRuntimeLoader) loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
+	return l.root.loadCockpitLive(ctx, cursor, initial)
+}
+
+func (l cockpitRuntimeLoader) loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error) {
+	return l.root.loadCockpitEventDetail(ctx, eventID)
+}
+
+func (l cockpitRuntimeLoader) loadCockpitMemoryReviewItems(ctx context.Context) ([]apptypes.MemoryDetails, error) {
+	if l.root.memory == nil {
+		return nil, xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if l.root.storeManagement != nil {
+		if err := l.root.initializeStore(ctx, l.opts.dbPath); err != nil {
+			return nil, err
+		}
+	}
+	return l.root.loadInboxReviewItems(ctx, memoryInboxReviewCommandInput{
+		dbPath: l.opts.dbPath,
+		limit:  defaultMemoryInboxLimit,
+	})
+}
+
+func (l cockpitRuntimeLoader) finishCockpitMemoryReview(ctx context.Context, final reviewModel, items []apptypes.MemoryDetails) (memoryInboxReviewResult, error) {
+	if l.root.memory == nil {
+		return memoryInboxReviewResult{}, xerrors.Errorf(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	result, err := applyInboxReviewDecisions(ctx, l.root.memory, final.Decisions(), items)
+	if err != nil {
+		return result, err
+	}
+	if len(result.Failures) > 0 {
+		return result, memoryInboxReviewFailureError(result)
+	}
+	return result, nil
 }
 
 func (c *RootCLI) loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
@@ -330,13 +379,18 @@ type cockpitModel struct {
 	loader    cockpitLoader
 	loaderCtx context.Context
 
-	showHelp bool
-	mode     cockpitMode
-	home     cockpitHomeSnapshot
+	showHelp  bool
+	mode      cockpitMode
+	home      cockpitHomeSnapshot
+	statusMsg string
+	statusErr string
 
-	live         cockpitLiveState
-	detail       topDetailState
-	detailOffset int
+	live                   cockpitLiveState
+	detail                 topDetailState
+	detailOffset           int
+	homeRequestSeq         uint64
+	memoryReview           cockpitMemoryReviewState
+	memoryReviewRequestSeq uint64
 }
 
 func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapshot) cockpitModel {
@@ -351,6 +405,7 @@ const (
 	cockpitModeHome cockpitMode = iota
 	cockpitModeLive
 	cockpitModeDetail
+	cockpitModeMemoryReview
 )
 
 type cockpitLiveState struct {
@@ -373,14 +428,53 @@ type cockpitLiveMsg struct {
 
 type cockpitLiveTickMsg struct{}
 
+type cockpitHomeMsg struct {
+	home cockpitHomeSnapshot
+	seq  uint64
+	err  error
+}
+
 type cockpitDetailLoadedMsg struct {
 	request topDetailRequest
 	content topDetailContent
 	err     error
 }
 
+type cockpitMemoryReviewState struct {
+	items      []apptypes.MemoryDetails
+	review     reviewModel
+	loading    bool
+	applying   bool
+	requestSeq uint64
+	err        error
+	result     memoryInboxReviewResult
+}
+
+type cockpitMemoryReviewLoadedMsg struct {
+	items []apptypes.MemoryDetails
+	seq   uint64
+	err   error
+}
+
+type cockpitMemoryReviewAppliedMsg struct {
+	result memoryInboxReviewResult
+	err    error
+}
+
 func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case cockpitHomeMsg:
+		if msg.seq != m.homeRequestSeq {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.statusMsg = ""
+			m.statusErr = msg.err.Error()
+			return m, nil
+		}
+		m.home = msg.home
+		m.statusErr = ""
+		return m, nil
 	case cockpitLiveMsg:
 		if msg.seq != m.live.requestSeq {
 			return m, nil
@@ -419,6 +513,29 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.detail.lines = msg.content.lines
 		m.clampDetailOffset()
 		return m, nil
+	case cockpitMemoryReviewLoadedMsg:
+		if m.mode != cockpitModeMemoryReview || msg.seq != m.memoryReview.requestSeq {
+			return m, nil
+		}
+		m.memoryReview.loading = false
+		m.memoryReview.err = msg.err
+		if msg.err != nil {
+			return m, nil
+		}
+		m.memoryReview.items = msg.items
+		m.memoryReview.review = newReviewModel(msg.items, m.keys, m.styles)
+		return m, nil
+	case cockpitMemoryReviewAppliedMsg:
+		m.memoryReview.applying = false
+		m.memoryReview.result = msg.result
+		m.memoryReview.err = msg.err
+		if msg.err != nil {
+			return m, nil
+		}
+		m.statusMsg = formatCockpitMemoryReviewResult(msg.result)
+		m.statusErr = ""
+		m.mode = cockpitModeHome
+		return m, m.startCockpitHomeLoad()
 	case tea.KeyMsg:
 		return m.updateKey(msg)
 	}
@@ -426,6 +543,9 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m cockpitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.mode == cockpitModeMemoryReview {
+		return m.updateMemoryReviewKey(msg)
+	}
 	switch {
 	case key.Matches(msg, m.keys.Quit):
 		return m, tea.Quit
@@ -449,6 +569,9 @@ func (m cockpitModel) updateHomeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "t", "l":
 			m.mode = cockpitModeLive
 			return m, m.startCockpitLiveLoad(true)
+		case "m":
+			m.mode = cockpitModeMemoryReview
+			return m, m.startCockpitMemoryReviewLoad()
 		}
 	}
 	return m, nil
@@ -514,6 +637,130 @@ func (m cockpitModel) updateDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m cockpitModel) updateMemoryReviewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	actions := defaultReviewActionKeys()
+	if msg.Type == tea.KeyRunes && strings.ToLower(string(msg.Runes)) == "h" && (m.memoryReview.loading || m.memoryReview.err != nil) {
+		m.mode = cockpitModeHome
+		if m.memoryReview.err != nil {
+			m.memoryReview = cockpitMemoryReviewState{}
+			return m, m.startCockpitHomeLoad()
+		}
+		return m, nil
+	}
+	if m.memoryReview.applying {
+		return m, nil
+	}
+	if m.memoryReview.err != nil {
+		if key.Matches(msg, actions.Cancel) {
+			m.mode = cockpitModeHome
+			m.memoryReview = cockpitMemoryReviewState{}
+			return m, m.startCockpitHomeLoad()
+		}
+		if isCockpitMemoryReviewFinishKey(msg) || msg.Type == tea.KeyCtrlC {
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+	if msg.Type == tea.KeyCtrlC {
+		return m, tea.Quit
+	}
+	if m.memoryReview.loading {
+		if key.Matches(msg, actions.Cancel) {
+			m.mode = cockpitModeHome
+			m.memoryReview = cockpitMemoryReviewState{}
+			return m, nil
+		}
+		if isCockpitMemoryReviewFinishKey(msg) || msg.Type == tea.KeyCtrlC {
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
+	if key.Matches(msg, actions.Cancel) {
+		switch m.memoryReview.review.mode {
+		case reviewModeHelp, reviewModeViewEvidence, reviewModeEdit:
+			updated, _ := m.memoryReview.review.Update(msg)
+			m.memoryReview.review = updated.(reviewModel)
+			return m, nil
+		default:
+			m.mode = cockpitModeHome
+			m.memoryReview = cockpitMemoryReviewState{}
+			return m, m.startCockpitHomeLoad()
+		}
+	}
+	if m.memoryReview.review.mode != reviewModeEdit && isCockpitMemoryReviewFinishKey(msg) {
+		m.memoryReview.applying = true
+		return m, m.applyCockpitMemoryReviewCmd()
+	}
+
+	updated, cmd := m.memoryReview.review.Update(msg)
+	m.memoryReview.review = updated.(reviewModel)
+	// reviewModel returns tea.Quit for standalone `memory inbox review`; the
+	// cockpit owns the outer program, so finishing review is handled above and
+	// no delegated command should escape into the cockpit runtime.
+	if cmd != nil {
+		return m, nil
+	}
+	return m, nil
+}
+
+func isCockpitMemoryReviewFinishKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyRunes && strings.ToLower(string(msg.Runes)) == "q"
+}
+
+func (m *cockpitModel) startCockpitHomeLoad() tea.Cmd {
+	m.homeRequestSeq++
+	return m.fetchCockpitHomeCmd(m.homeRequestSeq)
+}
+
+func (m cockpitModel) fetchCockpitHomeCmd(seq uint64) tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	return func() tea.Msg {
+		if loader == nil {
+			return cockpitHomeMsg{seq: seq, err: xerrors.Errorf("cockpit home loader is not configured")}
+		}
+		home, err := loader.loadCockpitHome(ctx)
+		return cockpitHomeMsg{home: home, seq: seq, err: err}
+	}
+}
+
+func (m cockpitModel) fetchCockpitMemoryReviewCmd() tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	seq := m.memoryReview.requestSeq
+	return func() tea.Msg {
+		if loader == nil {
+			return cockpitMemoryReviewLoadedMsg{seq: seq, err: xerrors.Errorf("cockpit memory review loader is not configured")}
+		}
+		items, err := loader.loadCockpitMemoryReviewItems(ctx)
+		return cockpitMemoryReviewLoadedMsg{items: items, seq: seq, err: err}
+	}
+}
+
+func (m *cockpitModel) startCockpitMemoryReviewLoad() tea.Cmd {
+	m.memoryReviewRequestSeq++
+	m.memoryReview = cockpitMemoryReviewState{
+		loading:    true,
+		requestSeq: m.memoryReviewRequestSeq,
+	}
+	return m.fetchCockpitMemoryReviewCmd()
+}
+
+func (m cockpitModel) applyCockpitMemoryReviewCmd() tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	final := m.memoryReview.review
+	items := append([]apptypes.MemoryDetails(nil), m.memoryReview.items...)
+	return func() tea.Msg {
+		if loader == nil {
+			return cockpitMemoryReviewAppliedMsg{err: xerrors.Errorf("cockpit memory review loader is not configured")}
+		}
+		result, err := loader.finishCockpitMemoryReview(ctx, final, items)
+		return cockpitMemoryReviewAppliedMsg{result: result, err: err}
+	}
 }
 
 func (m *cockpitModel) startCockpitLiveLoad(initial bool) tea.Cmd {
@@ -600,6 +847,8 @@ func (m cockpitModel) View() string {
 		return m.liveView()
 	case cockpitModeDetail:
 		return m.detailView()
+	case cockpitModeMemoryReview:
+		return m.memoryReviewView()
 	}
 	return m.homeView()
 }
@@ -614,8 +863,14 @@ func (m cockpitModel) homeView() string {
 		"",
 		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s db=%s", formatJSONTime(m.home.LoadedAt), formatOptionalColumn(m.home.DBPath))),
 		"",
-		m.styles.Subtle.Render("ATTENTION"),
 	}
+	if m.statusMsg != "" {
+		lines = append(lines, m.styles.Success.Render("• "+m.statusMsg), "")
+	}
+	if m.statusErr != "" {
+		lines = append(lines, m.styles.Error.Render("• "+m.statusErr), "")
+	}
+	lines = append(lines, m.styles.Subtle.Render("ATTENTION"))
 	warnings := m.home.warnings()
 	if len(warnings) == 0 {
 		lines = append(lines, m.styles.Success.Render("• No immediate cockpit warnings."))
@@ -643,7 +898,7 @@ func (m cockpitModel) homeView() string {
 		"• memory: inbox notifications and review launcher",
 		"• doctor: warnings and remediation commands",
 		"",
-		m.styles.Help.Render("t/l live tail · q/esc/ctrl+c quit · ? help"),
+		m.styles.Help.Render("t/l live tail · m memory review · q/esc/ctrl+c quit · ? help"),
 	)
 	if m.showHelp {
 		lines = append(lines,
@@ -664,6 +919,28 @@ func formatCockpitNewCandidateCount(home cockpitHomeSnapshot) string {
 		return "untracked"
 	}
 	return fmt.Sprintf("%d", home.NewCandidateMemoryCount)
+}
+
+func formatCockpitMemoryReviewResult(result memoryInboxReviewResult) string {
+	return fmt.Sprintf("memory review applied: accepted=%d rejected=%d distilled=%d failures=%d", len(result.Accepted), len(result.Rejected), len(result.Distilled), len(result.Failures))
+}
+
+func (m cockpitModel) memoryReviewView() string {
+	lines := []string{
+		m.styles.Title.Render("Traceary cockpit · memory review"),
+		"",
+	}
+	switch {
+	case m.memoryReview.loading:
+		lines = append(lines, m.styles.Subtle.Render("Loading memory inbox review queue..."))
+	case m.memoryReview.applying:
+		lines = append(lines, m.styles.Subtle.Render("Applying memory review decisions..."))
+	case m.memoryReview.err != nil:
+		lines = append(lines, m.styles.Error.Render(m.memoryReview.err.Error()), "", m.styles.Help.Render("h home · q quit"))
+	default:
+		lines = append(lines, m.memoryReview.review.View(), "", m.styles.Help.Render("q finish review and refresh cockpit"))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m cockpitModel) liveView() string {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -433,6 +433,438 @@ func TestCockpitModel_IgnoresStaleLiveLoadResponses(t *testing.T) {
 	}
 }
 
+func TestCockpitModel_MemoryReviewLaunchAndFinishRefreshesHome(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-review", "review this candidate", domtypes.MemoryStatusCandidate)
+	accepted := cockpitMemoryDetailsFixture(t, "mem-review", "review this candidate", domtypes.MemoryStatusAccepted)
+	loader := &cockpitLoaderStub{
+		reviewItems: []apptypes.MemoryDetails{candidate},
+		reviewFinishResult: memoryInboxReviewResult{
+			Accepted: []apptypes.MemoryDetails{accepted},
+		},
+		homeResponses: []cockpitHomeSnapshot{
+			{
+				LoadedAt:                fixedStartedAt.Add(time.Minute),
+				AcceptedMemoryCount:     1,
+				CandidateMemoryCount:    0,
+				NewCandidateMemoryKnown: true,
+			},
+		},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{
+		LoadedAt:             fixedStartedAt,
+		CandidateMemoryCount: 1,
+	})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeMemoryReview || !model.memoryReview.loading {
+		t.Fatalf("memory review launch mode/loading = %v/%v, want memory review/loading", model.mode, model.memoryReview.loading)
+	}
+	if cmd == nil {
+		t.Fatalf("memory review launch returned nil command")
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("memory review load returned unexpected follow-up command = %T", cmd)
+	}
+	if got, want := loader.reviewLoadCalls, 1; got != want {
+		t.Fatalf("review load calls = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "review this candidate") {
+		t.Fatalf("memory review view missing candidate:\n%s", got)
+	}
+
+	updated, cmd = model.Update(cockpitRuneKey("a"))
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("accept key returned unexpected command = %T", cmd)
+	}
+	updated, cmd = model.Update(cockpitRuneKey("q"))
+	model = updated.(cockpitModel)
+	if !model.memoryReview.applying || cmd == nil {
+		t.Fatalf("finish review applying/cmd = %v/%T, want applying/apply command", model.memoryReview.applying, cmd)
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome {
+		t.Fatalf("after apply mode = %v, want home", model.mode)
+	}
+	if cmd == nil {
+		t.Fatalf("after apply should refresh cockpit home")
+	}
+	if got, want := len(loader.reviewFinishCalls), 1; got != want {
+		t.Fatalf("review finish decision count = %d, want %d", got, want)
+	}
+	if got := loader.reviewFinishCalls[0].kind; got != reviewDecisionAccept {
+		t.Fatalf("review finish decision = %v, want accept", got)
+	}
+
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("home refresh returned unexpected command = %T", cmd)
+	}
+	if got, want := loader.homeCalls, 1; got != want {
+		t.Fatalf("home refresh calls = %d, want %d", got, want)
+	}
+	if got, want := model.home.CandidateMemoryCount, 0; got != want {
+		t.Fatalf("refreshed CandidateMemoryCount = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "memory review applied: accepted=1 rejected=0 distilled=0 failures=0") || !strings.Contains(got, "candidate(inbox)=0") {
+		t.Fatalf("home view missing review result/refreshed counts:\n%s", got)
+	}
+}
+
+func TestCockpitModel_MemoryReviewEscDismissesEvidenceWithoutApplying(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-evidence", "check evidence", domtypes.MemoryStatusCandidate)
+	loader := &cockpitLoaderStub{reviewItems: []apptypes.MemoryDetails{candidate}}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("v"))
+	model = updated.(cockpitModel)
+	if model.memoryReview.review.mode != reviewModeViewEvidence {
+		t.Fatalf("review mode = %v, want evidence", model.memoryReview.review.mode)
+	}
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("esc from evidence returned command = %T, want nil", cmd)
+	}
+	if model.mode != cockpitModeMemoryReview || model.memoryReview.review.mode != reviewModeBrowse {
+		t.Fatalf("esc from evidence mode/reviewMode = %v/%v, want memory review/browse", model.mode, model.memoryReview.review.mode)
+	}
+	if len(loader.reviewFinishCalls) != 0 {
+		t.Fatalf("esc from evidence applied decisions unexpectedly: %#v", loader.reviewFinishCalls)
+	}
+}
+
+func TestCockpitModel_MemoryReviewEscBacksOutWithoutApplying(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-backout", "do not apply on escape", domtypes.MemoryStatusCandidate)
+	loader := &cockpitLoaderStub{
+		reviewItems: []apptypes.MemoryDetails{candidate},
+		homeResponses: []cockpitHomeSnapshot{
+			{
+				LoadedAt:             fixedStartedAt.Add(time.Minute),
+				CandidateMemoryCount: 1,
+			},
+		},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("a"))
+	model = updated.(cockpitModel)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome {
+		t.Fatalf("esc from review browse mode = %v, want home", model.mode)
+	}
+	if model.memoryReview.applying {
+		t.Fatalf("esc from review browse started applying decisions")
+	}
+	if len(loader.reviewFinishCalls) != 0 {
+		t.Fatalf("esc from review browse applied decisions unexpectedly: %#v", loader.reviewFinishCalls)
+	}
+	if cmd == nil {
+		t.Fatalf("esc from review browse returned nil command, want home refresh")
+	}
+
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("home refresh returned unexpected command = %T", cmd)
+	}
+	if got, want := loader.homeCalls, 1; got != want {
+		t.Fatalf("home refresh calls = %d, want %d", got, want)
+	}
+}
+
+func TestCockpitModel_MemoryReviewErrorAllowsHomeAndQuit(t *testing.T) {
+	t.Parallel()
+
+	home := cockpitHomeSnapshot{LoadedAt: fixedStartedAt}
+	loader := &cockpitLoaderStub{
+		homeResponses: []cockpitHomeSnapshot{
+			{
+				LoadedAt:             fixedStartedAt.Add(time.Minute),
+				CandidateMemoryCount: 3,
+			},
+			{
+				LoadedAt:             fixedStartedAt.Add(2 * time.Minute),
+				CandidateMemoryCount: 4,
+			},
+		},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
+	model.loader = loader
+	model.loaderCtx = context.Background()
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.err = context.Canceled
+
+	updated, cmd := model.Update(cockpitRuneKey("h"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome || cmd == nil {
+		t.Fatalf("h from review error mode/cmd = %v/%T, want home/refresh command", model.mode, cmd)
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("home refresh after h returned follow-up command = %T", cmd)
+	}
+	if got, want := model.home.CandidateMemoryCount, 3; got != want {
+		t.Fatalf("home refresh after h CandidateMemoryCount = %d, want %d", got, want)
+	}
+
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.err = context.Canceled
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome || cmd == nil {
+		t.Fatalf("esc from review error mode/cmd = %v/%T, want home/refresh command", model.mode, cmd)
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("home refresh after esc returned follow-up command = %T", cmd)
+	}
+	if got, want := model.home.CandidateMemoryCount, 4; got != want {
+		t.Fatalf("home refresh after esc CandidateMemoryCount = %d, want %d", got, want)
+	}
+
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.err = context.Canceled
+	_, cmd = model.Update(cockpitRuneKey("q"))
+	if cmd == nil {
+		t.Fatalf("q from review error returned nil command, want quit command")
+	}
+}
+
+func TestCockpitModel_MemoryReviewLoadingEscBacksOut(t *testing.T) {
+	t.Parallel()
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.loading = true
+	model.memoryReview.requestSeq = 1
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome || cmd != nil {
+		t.Fatalf("esc while review loading mode/cmd = %v/%T, want home/nil", model.mode, cmd)
+	}
+
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.loading = true
+	_, cmd = model.Update(cockpitRuneKey("q"))
+	if cmd == nil {
+		t.Fatalf("q while review loading returned nil command, want quit command")
+	}
+}
+
+func TestCockpitModel_MemoryReviewApplyFailureStaysInReview(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-fail-review", "review fails", domtypes.MemoryStatusCandidate)
+	result := memoryInboxReviewResult{Failures: []memoryInboxFailure{{ID: "mem-fail-review", Error: "conflict"}}}
+	loader := &cockpitLoaderStub{
+		reviewItems:        []apptypes.MemoryDetails{candidate},
+		reviewFinishResult: result,
+		reviewFinishErr:    memoryInboxReviewFailureError(result),
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("a"))
+	model = updated.(cockpitModel)
+	updated, cmd = model.Update(cockpitRuneKey("q"))
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("finish review returned nil command")
+	}
+
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("failed apply returned follow-up command = %T, want nil", cmd)
+	}
+	if model.mode != cockpitModeMemoryReview || model.memoryReview.err == nil {
+		t.Fatalf("failed apply mode/err = %v/%v, want memory review/error", model.mode, model.memoryReview.err)
+	}
+	if got, want := len(model.memoryReview.result.Failures), 1; got != want {
+		t.Fatalf("failed apply result failures = %d, want %d", got, want)
+	}
+}
+
+func TestCockpitModel_MemoryReviewBlocksQuitWhileApplying(t *testing.T) {
+	t.Parallel()
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.applying = true
+
+	_, cmd := model.Update(cockpitRuneKey("q"))
+	if cmd != nil {
+		t.Fatalf("q while review apply is in flight returned command = %T, want nil", cmd)
+	}
+	_, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("esc while review apply is in flight returned command = %T, want nil", cmd)
+	}
+}
+
+func TestCockpitModel_MemoryReviewCtrlCQuitsWithoutApplying(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-ctrlc-review", "do not apply on ctrl c", domtypes.MemoryStatusCandidate)
+	loader := &cockpitLoaderStub{reviewItems: []apptypes.MemoryDetails{candidate}}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("a"))
+	model = updated.(cockpitModel)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("ctrl+c during review returned nil command, want quit command")
+	}
+	if model.memoryReview.applying {
+		t.Fatalf("ctrl+c during review started applying decisions")
+	}
+	if len(loader.reviewFinishCalls) != 0 {
+		t.Fatalf("ctrl+c during review applied decisions unexpectedly: %#v", loader.reviewFinishCalls)
+	}
+}
+
+func TestCockpitModel_IgnoresStaleMemoryReviewLoadResponses(t *testing.T) {
+	t.Parallel()
+
+	oldCandidate := cockpitMemoryDetailsFixture(t, "mem-old-review", "old review queue", domtypes.MemoryStatusCandidate)
+	newCandidate := cockpitMemoryDetailsFixture(t, "mem-new-review", "new review queue", domtypes.MemoryStatusCandidate)
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+
+	updated, _ := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	firstSeq := model.memoryReview.requestSeq
+
+	updated, _ = model.Update(cockpitRuneKey("h"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome {
+		t.Fatalf("h while review loading mode = %v, want home", model.mode)
+	}
+
+	updated, _ = model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	secondSeq := model.memoryReview.requestSeq
+	if firstSeq == secondSeq {
+		t.Fatalf("memory review request sequence did not advance: first=%d second=%d", firstSeq, secondSeq)
+	}
+
+	updated, _ = model.Update(cockpitMemoryReviewLoadedMsg{seq: firstSeq, items: []apptypes.MemoryDetails{oldCandidate}})
+	model = updated.(cockpitModel)
+	if !model.memoryReview.loading {
+		t.Fatalf("stale review response cleared loading for the newer request")
+	}
+	if len(model.memoryReview.items) != 0 {
+		t.Fatalf("stale review response mutated items: %#v", model.memoryReview.items)
+	}
+
+	updated, _ = model.Update(cockpitMemoryReviewLoadedMsg{seq: secondSeq, items: []apptypes.MemoryDetails{newCandidate}})
+	model = updated.(cockpitModel)
+	if model.memoryReview.loading {
+		t.Fatalf("current review response left loading true")
+	}
+	if got, want := len(model.memoryReview.items), 1; got != want {
+		t.Fatalf("current review items = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "new review queue") || strings.Contains(got, "old review queue") {
+		t.Fatalf("review view did not use current queue only:\n%s", got)
+	}
+}
+
+func TestCockpitModel_HomeRefreshErrorUsesErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitHomeMsg{err: context.Canceled})
+	model = updated.(cockpitModel)
+	if model.statusMsg != "" {
+		t.Fatalf("statusMsg = %q, want empty for refresh errors", model.statusMsg)
+	}
+	if model.statusErr == "" {
+		t.Fatalf("statusErr = empty, want refresh error")
+	}
+	if got := model.View(); !strings.Contains(got, context.Canceled.Error()) {
+		t.Fatalf("home view missing refresh error:\n%s", got)
+	}
+}
+
+func TestCockpitModel_IgnoresStaleHomeRefreshResponses(t *testing.T) {
+	t.Parallel()
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{
+		LoadedAt:             fixedStartedAt,
+		CandidateMemoryCount: 10,
+	})
+	_ = model.startCockpitHomeLoad()
+	firstSeq := model.homeRequestSeq
+	_ = model.startCockpitHomeLoad()
+	secondSeq := model.homeRequestSeq
+	if firstSeq == secondSeq {
+		t.Fatalf("home request sequence did not advance: first=%d second=%d", firstSeq, secondSeq)
+	}
+
+	updated, _ := model.Update(cockpitHomeMsg{seq: firstSeq, err: context.Canceled})
+	model = updated.(cockpitModel)
+	if model.statusErr != "" {
+		t.Fatalf("stale home error set statusErr = %q", model.statusErr)
+	}
+	if got, want := model.home.CandidateMemoryCount, 10; got != want {
+		t.Fatalf("stale home error changed CandidateMemoryCount = %d, want %d", got, want)
+	}
+
+	updated, _ = model.Update(cockpitHomeMsg{seq: secondSeq, home: cockpitHomeSnapshot{
+		LoadedAt:             fixedStartedAt.Add(time.Minute),
+		CandidateMemoryCount: 2,
+	}})
+	model = updated.(cockpitModel)
+	if got, want := model.home.CandidateMemoryCount, 2; got != want {
+		t.Fatalf("current home response CandidateMemoryCount = %d, want %d", got, want)
+	}
+}
+
 func TestFormatCockpitLiveEventRow_TruncatesLargePayload(t *testing.T) {
 	t.Parallel()
 
@@ -447,6 +879,10 @@ func TestFormatCockpitLiveEventRow_TruncatesLargePayload(t *testing.T) {
 }
 
 type cockpitLoaderStub struct {
+	homeResponses []cockpitHomeSnapshot
+	homeCalls     int
+	homeErr       error
+
 	liveResponses []cockpitLiveSnapshot
 	liveCalls     []cockpitLiveCall
 	liveErr       error
@@ -454,11 +890,31 @@ type cockpitLoaderStub struct {
 	detailContent topDetailContent
 	detailErr     error
 	detailCalls   []domtypes.EventID
+
+	reviewItems        []apptypes.MemoryDetails
+	reviewLoadCalls    int
+	reviewLoadErr      error
+	reviewFinishCalls  []reviewDecision
+	reviewFinishResult memoryInboxReviewResult
+	reviewFinishErr    error
 }
 
 type cockpitLiveCall struct {
 	cursor  tailCursor
 	initial bool
+}
+
+func (s *cockpitLoaderStub) loadCockpitHome(context.Context) (cockpitHomeSnapshot, error) {
+	s.homeCalls++
+	if s.homeErr != nil {
+		return cockpitHomeSnapshot{}, s.homeErr
+	}
+	if len(s.homeResponses) == 0 {
+		return cockpitHomeSnapshot{LoadedAt: fixedStartedAt}, nil
+	}
+	next := s.homeResponses[0]
+	s.homeResponses = s.homeResponses[1:]
+	return next, nil
 }
 
 type cockpitStateReaderStub struct {
@@ -498,6 +954,37 @@ func memorySummaryWithSourceAndUpdatedAt(t *testing.T, id string, status domtype
 	return summary
 }
 
+func cockpitMemoryDetailsFixture(t *testing.T, id string, fact string, status domtypes.MemoryStatus) apptypes.MemoryDetails {
+	t.Helper()
+	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom: %v", err)
+	}
+	summary, err := apptypes.MemorySummaryOf(
+		domtypes.MemoryID(id),
+		domtypes.MemoryTypePreference,
+		domtypes.WorkspaceScopeOf(workspace),
+		fact,
+		status,
+		domtypes.ConfidenceMedium,
+		domtypes.MemorySourceRememberIntent,
+		domtypes.None[domtypes.MemoryID](),
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		domtypes.None[time.Time](),
+		fixedStartedAt,
+		fixedStartedAt,
+	)
+	if err != nil {
+		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L2")
+	if err != nil {
+		t.Fatalf("EvidenceRefFrom: %v", err)
+	}
+	return apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{evidence}, nil)
+}
+
 func (s *cockpitLoaderStub) loadCockpitLive(_ context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
 	s.liveCalls = append(s.liveCalls, cockpitLiveCall{cursor: cursor, initial: initial})
 	if s.liveErr != nil {
@@ -514,6 +1001,19 @@ func (s *cockpitLoaderStub) loadCockpitLive(_ context.Context, cursor tailCursor
 func (s *cockpitLoaderStub) loadCockpitEventDetail(_ context.Context, eventID domtypes.EventID) (topDetailContent, error) {
 	s.detailCalls = append(s.detailCalls, eventID)
 	return s.detailContent, s.detailErr
+}
+
+func (s *cockpitLoaderStub) loadCockpitMemoryReviewItems(context.Context) ([]apptypes.MemoryDetails, error) {
+	s.reviewLoadCalls++
+	if s.reviewLoadErr != nil {
+		return nil, s.reviewLoadErr
+	}
+	return s.reviewItems, nil
+}
+
+func (s *cockpitLoaderStub) finishCockpitMemoryReview(_ context.Context, final reviewModel, _ []apptypes.MemoryDetails) (memoryInboxReviewResult, error) {
+	s.reviewFinishCalls = append(s.reviewFinishCalls, final.Decisions()...)
+	return s.reviewFinishResult, s.reviewFinishErr
 }
 
 func cockpitRuneKey(value string) tea.KeyMsg {


### PR DESCRIPTION
## Motivation

`traceary memory inbox review` exists, but cockpit users should be able to reach the same review flow without leaving the operator dashboard or remembering a separate subcommand.

## Changes

- Adds `m` from cockpit home to load and enter the memory inbox review queue.
- Embeds the existing `reviewModel` and reuses `applyInboxReviewDecisions`, preserving accept/reject/edit/distill semantics from standalone `memory inbox review`.
- Adds a runtime loader seam that initializes the store, loads review items with the default inbox context, applies queued decisions, and refreshes cockpit home counts when review finishes.
- Adds cockpit status feedback after review application.
- Adds model tests for review launch, decision application, return-to-home refresh, and overlay escape behavior without accidentally applying decisions.

Closes #994

## Validation

- `rtk proxy git diff --check`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `rtk proxy env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`
