### PR TITLE
v0.17-7: persist cockpit last-seen timestamps

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,6 +205,7 @@ func run() error {
 		cli.WithHooksInspector(hooksInspector),
 		cli.WithPluginCacheInspector(pluginCacheInspector),
 		cli.WithClaudePluginDetector(pluginDetector),
+		cli.WithCockpitStateReader(cli.NewFileCockpitStateStore()),
 		cli.WithExtraRedactPatterns(extraRedactPatterns),
 		cli.WithStructuredRedactRules(structuredRedactRules),
 		cli.WithDefaultReadFields(defaultReadFields),

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -23,6 +23,7 @@ import (
 const cockpitExitCodeNotInteractive = 2
 const cockpitLiveMaxEvents = 200
 const cockpitDoctorMessageWidth = 160
+const cockpitNewEventLimit = 200
 
 type cockpitExitError struct {
 	message  string
@@ -33,7 +34,8 @@ func (e cockpitExitError) Error() string { return e.message }
 func (e cockpitExitError) ExitCode() int { return e.exitCode }
 
 type cockpitCommandOptions struct {
-	dbPath string
+	dbPath     string
+	resetState bool
 }
 
 func (c *RootCLI) newCockpitCommand() *cobra.Command {
@@ -52,6 +54,7 @@ func (c *RootCLI) newCockpitCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.dbPath, "db-path", "", dbPathFlagUsage())
+	cmd.Flags().BoolVar(&opts.resetState, "reset-state", false, Localize("reset local cockpit last-seen state before opening", "起動前に cockpit の local last-seen state をリセットする"))
 	return cmd
 }
 
@@ -59,6 +62,11 @@ func (c *RootCLI) runCockpit(ctx context.Context, output io.Writer, opts cockpit
 	stdin, stdout := cockpitIO(output)
 	if !tui.Interactive(stdin, stdout) {
 		return newCockpitNonInteractiveError(output)
+	}
+	if opts.resetState {
+		if err := c.resetCockpitState(ctx); err != nil {
+			return err
+		}
 	}
 	home, err := c.loadCockpitHome(ctx, opts)
 	if err != nil {
@@ -94,6 +102,10 @@ type cockpitHomeSnapshot struct {
 	LowQualityMemoryCount   int
 	MemoryScanLimited       bool
 	MemoryLastSeenAt        time.Time
+	EventLastSeenAt         time.Time
+	NewEventCount           int
+	NewEventKnown           bool
+	NewEventScanLimited     bool
 	StaleMemoryCount        int
 	RecentFailureCount      int
 	RecentCommandCount      int
@@ -171,6 +183,10 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 	if home.NewCandidateMemoryKnown {
 		criteria.MemoryLastSeenAt = domtypes.Some(home.MemoryLastSeenAt)
 	}
+	if eventLastSeen, eventLastSeenKnown, err := c.loadCockpitEventLastSeen(ctx); err == nil && eventLastSeenKnown {
+		home.EventLastSeenAt = eventLastSeen.at
+		home.NewEventCount, home.NewEventScanLimited, home.NewEventKnown = c.countCockpitNewEvents(ctx, eventLastSeen)
+	}
 	snap, err := c.newTopDataLoader().loadSnapshot(ctx, criteria)
 	if err != nil {
 		return cockpitHomeSnapshot{}, err
@@ -198,6 +214,25 @@ type CockpitStateReader interface {
 	MemoryLastSeenAt(ctx context.Context) (time.Time, bool, error)
 }
 
+type cockpitEventStateReader interface {
+	EventLastSeenAt(ctx context.Context) (time.Time, bool, error)
+}
+
+type cockpitEventSeenIDsReader interface {
+	EventLastSeenIDs(ctx context.Context) ([]string, bool, error)
+}
+
+type cockpitEventLastSeenCheckpoint struct {
+	at     time.Time
+	seenID map[string]struct{}
+}
+
+type cockpitStateWriter interface {
+	MarkMemoryLastSeenAt(ctx context.Context, at time.Time) error
+	MarkEventLastSeenAt(ctx context.Context, at time.Time, seenIDs []string) error
+	ResetCockpitState(ctx context.Context) error
+}
+
 func (c *RootCLI) loadCockpitMemoryLastSeenAt(ctx context.Context) (time.Time, bool, error) {
 	if c.cockpitState == nil {
 		return time.Time{}, false, nil
@@ -207,6 +242,103 @@ func (c *RootCLI) loadCockpitMemoryLastSeenAt(ctx context.Context) (time.Time, b
 		return time.Time{}, false, xerrors.Errorf("%s: %w", Localize("failed to load cockpit memory last-seen state", "cockpit memory last-seen state の読み込みに失敗しました"), err)
 	}
 	return lastSeenAt, ok, nil
+}
+
+func (c *RootCLI) loadCockpitEventLastSeen(ctx context.Context) (cockpitEventLastSeenCheckpoint, bool, error) {
+	reader, ok := c.cockpitState.(cockpitEventStateReader)
+	if !ok {
+		return cockpitEventLastSeenCheckpoint{}, false, nil
+	}
+	lastSeenAt, ok, err := reader.EventLastSeenAt(ctx)
+	if err != nil {
+		return cockpitEventLastSeenCheckpoint{}, false, xerrors.Errorf("%s: %w", Localize("failed to load cockpit event last-seen state", "cockpit event last-seen state の読み込みに失敗しました"), err)
+	}
+	if !ok {
+		return cockpitEventLastSeenCheckpoint{}, false, nil
+	}
+	checkpoint := cockpitEventLastSeenCheckpoint{at: lastSeenAt, seenID: make(map[string]struct{})}
+	if idsReader, ok := c.cockpitState.(cockpitEventSeenIDsReader); ok {
+		seenIDs, _, err := idsReader.EventLastSeenIDs(ctx)
+		if err != nil {
+			return cockpitEventLastSeenCheckpoint{}, false, xerrors.Errorf("%s: %w", Localize("failed to load cockpit event last-seen IDs", "cockpit event last-seen ID の読み込みに失敗しました"), err)
+		}
+		for _, id := range seenIDs {
+			checkpoint.seenID[id] = struct{}{}
+		}
+	}
+	return checkpoint, true, nil
+}
+
+func (c *RootCLI) countCockpitNewEvents(ctx context.Context, checkpoint cockpitEventLastSeenCheckpoint) (int, bool, bool) {
+	if c.event == nil {
+		return 0, false, false
+	}
+	events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(cockpitNewEventScanLimit(checkpoint)).From(checkpoint.at).Build())
+	if err != nil {
+		return 0, false, false
+	}
+	count := 0
+	for _, event := range events {
+		if isCockpitEventNewSinceCheckpoint(event, checkpoint) {
+			count++
+		}
+	}
+	limited := count > cockpitNewEventLimit
+	if limited {
+		count = cockpitNewEventLimit
+	}
+	return count, limited, true
+}
+
+func isCockpitEventNewSinceCheckpoint(event *model.Event, checkpoint cockpitEventLastSeenCheckpoint) bool {
+	if event == nil {
+		return false
+	}
+	if event.CreatedAt().After(checkpoint.at) {
+		return true
+	}
+	if !event.CreatedAt().Equal(checkpoint.at) {
+		return false
+	}
+	_, seen := checkpoint.seenID[event.EventID().String()]
+	return !seen
+}
+
+func cockpitNewEventScanLimit(checkpoint cockpitEventLastSeenCheckpoint) int {
+	return cockpitNewEventLimit + len(checkpoint.seenID) + 1
+}
+
+func (c *RootCLI) markCockpitMemorySeen(ctx context.Context, at time.Time) error {
+	writer, ok := c.cockpitState.(cockpitStateWriter)
+	if !ok {
+		return nil
+	}
+	if err := writer.MarkMemoryLastSeenAt(ctx, at); err != nil {
+		return xerrors.Errorf("failed to mark cockpit memory last-seen state: %w", err)
+	}
+	return nil
+}
+
+func (c *RootCLI) markCockpitEventsSeen(ctx context.Context, at time.Time, seenIDs []string) error {
+	writer, ok := c.cockpitState.(cockpitStateWriter)
+	if !ok {
+		return nil
+	}
+	if err := writer.MarkEventLastSeenAt(ctx, at, seenIDs); err != nil {
+		return xerrors.Errorf("failed to mark cockpit event last-seen state: %w", err)
+	}
+	return nil
+}
+
+func (c *RootCLI) resetCockpitState(ctx context.Context) error {
+	writer, ok := c.cockpitState.(cockpitStateWriter)
+	if !ok {
+		return nil
+	}
+	if err := writer.ResetCockpitState(ctx); err != nil {
+		return xerrors.Errorf("failed to reset cockpit state: %w", err)
+	}
+	return nil
 }
 
 func (c *RootCLI) loadCockpitDoctorReport(ctx context.Context, opts cockpitCommandOptions) (*doctorReport, error) {
@@ -276,6 +408,8 @@ type cockpitLoader interface {
 	loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error)
 	loadCockpitMemoryReviewItems(ctx context.Context) ([]apptypes.MemoryDetails, error)
 	finishCockpitMemoryReview(ctx context.Context, final reviewModel, items []apptypes.MemoryDetails) (memoryInboxReviewResult, error)
+	markCockpitMemorySeen(ctx context.Context, at time.Time) error
+	markCockpitEventsSeen(ctx context.Context, at time.Time, seenIDs []string) error
 }
 
 type cockpitLiveSnapshot struct {
@@ -339,6 +473,14 @@ func (l cockpitRuntimeLoader) finishCockpitMemoryReview(ctx context.Context, fin
 		return result, memoryInboxReviewFailureError(result)
 	}
 	return result, nil
+}
+
+func (l cockpitRuntimeLoader) markCockpitMemorySeen(ctx context.Context, at time.Time) error {
+	return l.root.markCockpitMemorySeen(ctx, at)
+}
+
+func (l cockpitRuntimeLoader) markCockpitEventsSeen(ctx context.Context, at time.Time, seenIDs []string) error {
+	return l.root.markCockpitEventsSeen(ctx, at, seenIDs)
 }
 
 func (c *RootCLI) loadCockpitLive(ctx context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
@@ -413,6 +555,13 @@ func (s cockpitHomeSnapshot) warnings() []cockpitWarning {
 	}
 	if s.LowQualityMemoryCount > 0 {
 		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("low-quality candidates=%d", s.LowQualityMemoryCount), hint: "inspect with `traceary memory inbox cleanup --include-hidden`"})
+	}
+	if s.NewEventKnown && s.NewEventCount > 0 {
+		hint := "press `t` or `l` to open live tail"
+		if s.NewEventScanLimited {
+			hint = "open live tail; count is capped at the cockpit scan limit"
+		}
+		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("new events=%d", s.NewEventCount), hint: hint})
 	}
 	if s.CandidateMemoryCount > 0 {
 		warnings = append(warnings, cockpitWarning{severity: "WARN", label: fmt.Sprintf("candidate memories=%d", s.CandidateMemoryCount), hint: "review with `traceary memory inbox review`"})
@@ -533,9 +682,10 @@ type cockpitMemoryReviewState struct {
 }
 
 type cockpitMemoryReviewLoadedMsg struct {
-	items []apptypes.MemoryDetails
-	seq   uint64
-	err   error
+	items  []apptypes.MemoryDetails
+	seq    uint64
+	seenAt time.Time
+	err    error
 }
 
 type cockpitMemoryReviewAppliedMsg struct {
@@ -588,10 +738,14 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.live.loadedAt = msg.snapshot.LoadedAt
 			m.clampLiveSelection()
 		}
-		if m.mode == cockpitModeLive && m.live.follow {
-			return m, m.cockpitLiveTickCmd()
+		var markCmd tea.Cmd
+		if msg.err == nil && m.mode == cockpitModeLive {
+			markCmd = m.markCockpitEventsSeenCmd(msg.snapshot)
 		}
-		return m, nil
+		if m.mode == cockpitModeLive && m.live.follow {
+			return m, tea.Batch(markCmd, m.cockpitLiveTickCmd())
+		}
+		return m, markCmd
 	case cockpitLiveTickMsg:
 		if m.mode == cockpitModeLive && m.live.follow && !m.live.loading {
 			return m, m.startCockpitLiveLoad(false)
@@ -618,7 +772,7 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.memoryReview.items = msg.items
 		m.memoryReview.review = newReviewModel(msg.items, m.keys, m.styles)
-		return m, nil
+		return m, m.markCockpitMemorySeenCmd(msg.seenAt)
 	case cockpitMemoryReviewAppliedMsg:
 		m.memoryReview.applying = false
 		m.memoryReview.result = msg.result
@@ -877,12 +1031,37 @@ func (m cockpitModel) fetchCockpitMemoryReviewCmd() tea.Cmd {
 	loader := m.loader
 	ctx := m.loaderCtx
 	seq := m.memoryReview.requestSeq
+	seenAt := topNowFunc().UTC()
 	return func() tea.Msg {
 		if loader == nil {
-			return cockpitMemoryReviewLoadedMsg{seq: seq, err: xerrors.Errorf("cockpit memory review loader is not configured")}
+			return cockpitMemoryReviewLoadedMsg{seq: seq, seenAt: seenAt, err: xerrors.Errorf("cockpit memory review loader is not configured")}
 		}
 		items, err := loader.loadCockpitMemoryReviewItems(ctx)
-		return cockpitMemoryReviewLoadedMsg{items: items, seq: seq, err: err}
+		return cockpitMemoryReviewLoadedMsg{items: items, seq: seq, seenAt: seenAt, err: err}
+	}
+}
+
+func (m cockpitModel) markCockpitMemorySeenCmd(at time.Time) tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	return func() tea.Msg {
+		if loader != nil {
+			_ = loader.markCockpitMemorySeen(ctx, at)
+		}
+		return nil
+	}
+}
+
+func (m cockpitModel) markCockpitEventsSeenCmd(snapshot cockpitLiveSnapshot) tea.Cmd {
+	loader := m.loader
+	ctx := m.loaderCtx
+	at := cockpitLiveSeenAt(snapshot)
+	seenIDs := cockpitLiveSeenIDs(snapshot)
+	return func() tea.Msg {
+		if loader != nil && !at.IsZero() {
+			_ = loader.markCockpitEventsSeen(ctx, at, seenIDs)
+		}
+		return nil
 	}
 }
 
@@ -1019,6 +1198,10 @@ func (m cockpitModel) homeView() string {
 	if m.home.MemoryScanLimited {
 		memoryScanSuffix = " scan_limited=true"
 	}
+	eventScanSuffix := ""
+	if m.home.NewEventScanLimited {
+		eventScanSuffix = " scan_limited=true"
+	}
 	lines := []string{
 		m.styles.Title.Render("Traceary cockpit"),
 		"",
@@ -1049,7 +1232,7 @@ func (m cockpitModel) homeView() string {
 		m.styles.Subtle.Render("OVERVIEW"),
 		fmt.Sprintf("• doctor: pass=%d warn=%d fail=%d", m.home.DoctorPassCount, m.home.DoctorWarnCount, m.home.DoctorFailCount),
 		fmt.Sprintf("• hooks/mcp: warn=%d fail=%d", m.home.HookWarnCount, m.home.HookFailCount),
-		fmt.Sprintf("• sessions: stale_active=%d recent_failures=%d recent_commands=%d", m.home.StaleActiveSessionCount, m.home.RecentFailureCount, m.home.RecentCommandCount),
+		fmt.Sprintf("• sessions: stale_active=%d recent_failures=%d recent_commands=%d new_events=%s%s", m.home.StaleActiveSessionCount, m.home.RecentFailureCount, m.home.RecentCommandCount, formatCockpitNewEventCount(m.home), eventScanSuffix),
 		fmt.Sprintf("• memories: accepted(reviewed)=%d candidate(inbox)=%d new=%s remember-intent=%d low-quality=%d stale=%d%s", m.home.AcceptedMemoryCount, m.home.CandidateMemoryCount, formatCockpitNewCandidateCount(m.home), m.home.RememberIntentCount, m.home.LowQualityMemoryCount, m.home.StaleMemoryCount, memoryScanSuffix),
 		fmt.Sprintf("• payloads: large=%d", m.home.LargePayloadCount),
 		"",
@@ -1070,6 +1253,7 @@ func (m cockpitModel) homeView() string {
 			"traceary doctor --json",
 			"traceary session handoff",
 			"traceary memory inbox review",
+			"traceary tui --reset-state",
 		)
 	}
 	return strings.Join(lines, "\n")
@@ -1080,6 +1264,13 @@ func formatCockpitNewCandidateCount(home cockpitHomeSnapshot) string {
 		return "untracked"
 	}
 	return fmt.Sprintf("%d", home.NewCandidateMemoryCount)
+}
+
+func formatCockpitNewEventCount(home cockpitHomeSnapshot) string {
+	if !home.NewEventKnown {
+		return "untracked"
+	}
+	return fmt.Sprintf("%d", home.NewEventCount)
 }
 
 func formatCockpitMemoryReviewResult(result memoryInboxReviewResult) string {
@@ -1269,6 +1460,25 @@ func formatCockpitLiveEventRow(event *model.Event, loc *time.Location) string {
 		row += " [truncated]"
 	}
 	return row
+}
+
+func cockpitLiveSeenAt(snapshot cockpitLiveSnapshot) time.Time {
+	if !snapshot.Cursor.timestamp.IsZero() {
+		return snapshot.Cursor.timestamp
+	}
+	return snapshot.LoadedAt
+}
+
+func cockpitLiveSeenIDs(snapshot cockpitLiveSnapshot) []string {
+	if snapshot.Cursor.timestamp.IsZero() {
+		return nil
+	}
+	seenIDs := make([]string, 0, len(snapshot.Cursor.seenIDs))
+	for id := range snapshot.Cursor.seenIDs {
+		seenIDs = append(seenIDs, id)
+	}
+	slices.Sort(seenIDs)
+	return seenIDs
 }
 
 // cockpitIO resolves the stdin/stdout pair the cockpit TUI should drive. Tests

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -155,6 +157,66 @@ func TestLoadCockpitHome_MemoryNotificationsUseLastSeenWhenAvailable(t *testing.
 		if !strings.Contains(view, must) {
 			t.Fatalf("cockpit view missing %q:\n%s", must, view)
 		}
+	}
+}
+
+func TestLoadCockpitHome_EventNotificationsUseLastSeenWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	lastSeenAt := fixedStartedAt.Add(-2 * time.Hour)
+	oldEvent := mustEvent(t, "evt-old", domtypes.EventKindNote, "old event")
+	oldEvent = model.EventOfWithSourceHook(oldEvent.EventID(), oldEvent.Kind(), oldEvent.Client(), oldEvent.Agent(), oldEvent.SessionID(), oldEvent.Workspace(), oldEvent.Body(), lastSeenAt, oldEvent.SourceHook())
+	newEvent := mustEvent(t, "evt-new", domtypes.EventKindNote, "new event")
+	event := &snapshotEventStub{events: []*model.Event{newEvent, oldEvent}}
+	root := &RootCLI{
+		event:        event,
+		cockpitState: cockpitStateReaderStub{eventAt: lastSeenAt, eventOk: true, eventSeenIDs: []string{oldEvent.EventID().String()}},
+	}
+
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+	if !home.NewEventKnown {
+		t.Fatalf("NewEventKnown = false, want true")
+	}
+	if got, want := home.NewEventCount, 1; got != want {
+		t.Fatalf("NewEventCount = %d, want %d", got, want)
+	}
+	view := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home).View()
+	if !strings.Contains(view, "new events=1") || !strings.Contains(view, "new_events=1") {
+		t.Fatalf("cockpit view missing new event notification:\n%s", view)
+	}
+}
+
+func TestLoadCockpitHome_EventNotificationsScanPastSeenBoundaryIDs(t *testing.T) {
+	t.Parallel()
+
+	lastSeenAt := fixedStartedAt.Add(-2 * time.Hour)
+	seenIDs := make([]string, 0, cockpitNewEventLimit+5)
+	events := make([]*model.Event, 0, (cockpitNewEventLimit*2)+6)
+	for i := range cockpitNewEventLimit + 5 {
+		event := cockpitEventFixtureAt(t, fmt.Sprintf("evt-seen-%03d", i), lastSeenAt)
+		seenIDs = append(seenIDs, event.EventID().String())
+		events = append(events, event)
+	}
+	for i := range cockpitNewEventLimit + 1 {
+		events = append(events, cockpitEventFixtureAt(t, fmt.Sprintf("evt-new-%03d", i), lastSeenAt))
+	}
+	root := &RootCLI{
+		event:        &snapshotEventStub{events: events},
+		cockpitState: cockpitStateReaderStub{eventAt: lastSeenAt, eventOk: true, eventSeenIDs: seenIDs},
+	}
+
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+	if got, want := home.NewEventCount, cockpitNewEventLimit; got != want {
+		t.Fatalf("NewEventCount = %d, want capped %d", got, want)
+	}
+	if !home.NewEventScanLimited {
+		t.Fatalf("NewEventScanLimited = false, want true")
 	}
 }
 
@@ -469,8 +531,14 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	}
 	updated, cmd = model.Update(cmd())
 	model = updated.(cockpitModel)
-	if cmd != nil {
-		t.Fatalf("initial load command returned follow-up cmd = %T, want nil when follow is disabled", cmd)
+	if cmd == nil {
+		t.Fatalf("initial load should mark events seen")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("event seen marker returned message = %T, want nil", msg)
+	}
+	if got, want := len(loader.eventSeenCalls), 1; got != want {
+		t.Fatalf("event seen calls after initial load = %d, want %d", got, want)
 	}
 	if got, want := len(model.live.events), 1; got != want {
 		t.Fatalf("live events after initial load = %d, want %d", got, want)
@@ -545,6 +613,39 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeLive || cmd == nil {
 		t.Fatalf("returning to live with follow mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+	}
+}
+
+func TestCockpitModel_LiveLoadDoesNotMarkAfterLeavingLive(t *testing.T) {
+	t.Parallel()
+
+	event := mustEvent(t, "evt-leave-live", domtypes.EventKindNote, "leave live before load completes")
+	loader := &cockpitLoaderStub{
+		liveResponses: []cockpitLiveSnapshot{
+			{Events: []*model.Event{event}, Cursor: newTailCursor(event.CreatedAt()), LoadedAt: fixedStartedAt},
+		},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("t"))
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("opening live pane returned nil command")
+	}
+	updated, homeCmd := model.Update(cockpitRuneKey("h"))
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome || homeCmd != nil {
+		t.Fatalf("leaving live mode/cmd = %v/%T, want home/nil", model.mode, homeCmd)
+	}
+	updated, markCmd := model.Update(cmd())
+	model = updated.(cockpitModel)
+	if markCmd != nil {
+		t.Fatalf("stale live load returned mark command = %T, want nil after leaving live", markCmd)
+	}
+	if got := len(loader.eventSeenCalls); got != 0 {
+		t.Fatalf("event seen calls after leaving live = %d, want 0", got)
 	}
 }
 
@@ -642,8 +743,14 @@ func TestCockpitModel_MemoryReviewLaunchAndFinishRefreshesHome(t *testing.T) {
 	}
 	updated, cmd = model.Update(cmd())
 	model = updated.(cockpitModel)
-	if cmd != nil {
-		t.Fatalf("memory review load returned unexpected follow-up command = %T", cmd)
+	if cmd == nil {
+		t.Fatalf("memory review load should mark memory seen")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("memory seen marker returned message = %T, want nil", msg)
+	}
+	if got, want := len(loader.memorySeenCalls), 1; got != want {
+		t.Fatalf("memory seen calls after review load = %d, want %d", got, want)
 	}
 	if got, want := loader.reviewLoadCalls, 1; got != want {
 		t.Fatalf("review load calls = %d, want %d", got, want)
@@ -690,6 +797,37 @@ func TestCockpitModel_MemoryReviewLaunchAndFinishRefreshesHome(t *testing.T) {
 	}
 	if got := model.View(); !strings.Contains(got, "memory review applied: accepted=1 rejected=0 distilled=0 failures=0") || !strings.Contains(got, "candidate(inbox)=0") {
 		t.Fatalf("home view missing review result/refreshed counts:\n%s", got)
+	}
+}
+
+func TestCockpitModel_MemoryReviewMarksLoadStartAsSeen(t *testing.T) {
+	candidate := cockpitMemoryDetailsFixture(t, "mem-review-checkpoint", "review checkpoint candidate", domtypes.MemoryStatusCandidate)
+	loader := &cockpitLoaderStub{reviewItems: []apptypes.MemoryDetails{candidate}}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{
+		LoadedAt:             fixedStartedAt,
+		CandidateMemoryCount: 1,
+	})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+
+	updated, cmd := model.Update(cockpitRuneKey("m"))
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("memory review launch returned nil command")
+	}
+	updated, cmd = model.Update(cmd())
+	model = updated.(cockpitModel)
+	if cmd == nil {
+		t.Fatalf("memory review load should mark memory seen")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("memory seen marker returned message = %T, want nil", msg)
+	}
+	if got, want := len(loader.memorySeenCalls), 1; got != want {
+		t.Fatalf("memory seen calls after review load = %d, want %d", got, want)
+	}
+	if seenAt := loader.memorySeenCalls[0]; seenAt.After(loader.reviewLoadStartedAt) {
+		t.Fatalf("memory seen checkpoint = %v, want not after loader start %v", seenAt, loader.reviewLoadStartedAt)
 	}
 }
 
@@ -1060,6 +1198,9 @@ type cockpitLoaderStub struct {
 	doctorCalls     int
 	doctorErr       error
 
+	memorySeenCalls []time.Time
+	eventSeenCalls  []time.Time
+
 	liveResponses []cockpitLiveSnapshot
 	liveCalls     []cockpitLiveCall
 	liveErr       error
@@ -1068,12 +1209,13 @@ type cockpitLoaderStub struct {
 	detailErr     error
 	detailCalls   []domtypes.EventID
 
-	reviewItems        []apptypes.MemoryDetails
-	reviewLoadCalls    int
-	reviewLoadErr      error
-	reviewFinishCalls  []reviewDecision
-	reviewFinishResult memoryInboxReviewResult
-	reviewFinishErr    error
+	reviewItems         []apptypes.MemoryDetails
+	reviewLoadCalls     int
+	reviewLoadStartedAt time.Time
+	reviewLoadErr       error
+	reviewFinishCalls   []reviewDecision
+	reviewFinishResult  memoryInboxReviewResult
+	reviewFinishErr     error
 }
 
 type cockpitLiveCall struct {
@@ -1108,13 +1250,24 @@ func (s *cockpitLoaderStub) loadCockpitDoctor(context.Context) (cockpitDoctorSna
 }
 
 type cockpitStateReaderStub struct {
-	at  time.Time
-	ok  bool
-	err error
+	at           time.Time
+	ok           bool
+	err          error
+	eventAt      time.Time
+	eventOk      bool
+	eventSeenIDs []string
 }
 
 func (s cockpitStateReaderStub) MemoryLastSeenAt(context.Context) (time.Time, bool, error) {
 	return s.at, s.ok, s.err
+}
+
+func (s cockpitStateReaderStub) EventLastSeenAt(context.Context) (time.Time, bool, error) {
+	return s.eventAt, s.eventOk, s.err
+}
+
+func (s cockpitStateReaderStub) EventLastSeenIDs(context.Context) ([]string, bool, error) {
+	return slices.Clone(s.eventSeenIDs), len(s.eventSeenIDs) > 0, s.err
 }
 
 func memorySummaryWithSourceAndUpdatedAt(t *testing.T, id string, status domtypes.MemoryStatus, source domtypes.MemorySource, updatedAt time.Time) apptypes.MemorySummary {
@@ -1175,6 +1328,12 @@ func cockpitMemoryDetailsFixture(t *testing.T, id string, fact string, status do
 	return apptypes.MemoryDetailsOf(summary, []domtypes.EvidenceRef{evidence}, nil)
 }
 
+func cockpitEventFixtureAt(t *testing.T, id string, createdAt time.Time) *model.Event {
+	t.Helper()
+	event := mustEvent(t, id, domtypes.EventKindNote, "cockpit event notification fixture "+id)
+	return model.EventOfWithSourceHook(event.EventID(), event.Kind(), event.Client(), event.Agent(), event.SessionID(), event.Workspace(), event.Body(), createdAt, event.SourceHook())
+}
+
 func (s *cockpitLoaderStub) loadCockpitLive(_ context.Context, cursor tailCursor, initial bool) (cockpitLiveSnapshot, error) {
 	s.liveCalls = append(s.liveCalls, cockpitLiveCall{cursor: cursor, initial: initial})
 	if s.liveErr != nil {
@@ -1194,6 +1353,7 @@ func (s *cockpitLoaderStub) loadCockpitEventDetail(_ context.Context, eventID do
 }
 
 func (s *cockpitLoaderStub) loadCockpitMemoryReviewItems(context.Context) ([]apptypes.MemoryDetails, error) {
+	s.reviewLoadStartedAt = time.Now()
 	s.reviewLoadCalls++
 	if s.reviewLoadErr != nil {
 		return nil, s.reviewLoadErr
@@ -1204,6 +1364,16 @@ func (s *cockpitLoaderStub) loadCockpitMemoryReviewItems(context.Context) ([]app
 func (s *cockpitLoaderStub) finishCockpitMemoryReview(_ context.Context, final reviewModel, _ []apptypes.MemoryDetails) (memoryInboxReviewResult, error) {
 	s.reviewFinishCalls = append(s.reviewFinishCalls, final.Decisions()...)
 	return s.reviewFinishResult, s.reviewFinishErr
+}
+
+func (s *cockpitLoaderStub) markCockpitMemorySeen(_ context.Context, at time.Time) error {
+	s.memorySeenCalls = append(s.memorySeenCalls, at)
+	return nil
+}
+
+func (s *cockpitLoaderStub) markCockpitEventsSeen(_ context.Context, at time.Time, _ []string) error {
+	s.eventSeenCalls = append(s.eventSeenCalls, at)
+	return nil
 }
 
 func cockpitRuneKey(value string) tea.KeyMsg {

--- a/presentation/cli/cockpit_state_file.go
+++ b/presentation/cli/cockpit_state_file.go
@@ -1,0 +1,269 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	cockpitStateLockRetryLimit = 100
+	cockpitStateLockRetryDelay = 10 * time.Millisecond
+	cockpitStateStaleLockAfter = 5 * time.Minute
+)
+
+type fileCockpitStateStore struct {
+	path string
+}
+
+type cockpitStateFile struct {
+	MemoryLastSeenAt string   `json:"memory_last_seen_at,omitempty"`
+	EventLastSeenAt  string   `json:"event_last_seen_at,omitempty"`
+	EventLastSeenIDs []string `json:"event_last_seen_ids,omitempty"`
+}
+
+// NewFileCockpitStateStore returns the local-first cockpit state store used by
+// the default CLI wiring. Missing or unreadable state is treated as non-critical
+// by cockpit callers; writes use an atomic replace under the user's state dir.
+func NewFileCockpitStateStore() CockpitStateReader {
+	return fileCockpitStateStore{path: defaultCockpitStatePath()}
+}
+
+func newFileCockpitStateStoreAt(path string) fileCockpitStateStore {
+	return fileCockpitStateStore{path: path}
+}
+
+func defaultCockpitStatePath() string {
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return filepath.Join(stateHome, "traceary", "cockpit.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".traceary", "cockpit.json")
+	}
+	return filepath.Join(home, ".local", "state", "traceary", "cockpit.json")
+}
+
+func (s fileCockpitStateStore) MemoryLastSeenAt(context.Context) (time.Time, bool, error) {
+	state, err := s.read()
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return parseCockpitStateTime(state.MemoryLastSeenAt)
+}
+
+func (s fileCockpitStateStore) EventLastSeenAt(context.Context) (time.Time, bool, error) {
+	state, err := s.read()
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return parseCockpitStateTime(state.EventLastSeenAt)
+}
+
+func (s fileCockpitStateStore) EventLastSeenIDs(context.Context) ([]string, bool, error) {
+	state, err := s.read()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(state.EventLastSeenIDs) == 0 {
+		return nil, false, nil
+	}
+	return normalizeCockpitStateIDs(state.EventLastSeenIDs), true, nil
+}
+
+func (s fileCockpitStateStore) MarkMemoryLastSeenAt(_ context.Context, at time.Time) error {
+	return s.update(func(state *cockpitStateFile) (bool, error) {
+		if shouldAdvanceCockpitStateTime(state.MemoryLastSeenAt, at) {
+			state.MemoryLastSeenAt = at.UTC().Format(time.RFC3339Nano)
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func (s fileCockpitStateStore) MarkEventLastSeenAt(_ context.Context, at time.Time, seenIDs []string) error {
+	return s.update(func(state *cockpitStateFile) (bool, error) {
+		parsed, ok, err := parseCockpitStateTime(state.EventLastSeenAt)
+		if err != nil || !ok || at.After(parsed) {
+			state.EventLastSeenAt = at.UTC().Format(time.RFC3339Nano)
+			state.EventLastSeenIDs = normalizeCockpitStateIDs(seenIDs)
+			return true, nil
+		}
+		if at.Equal(parsed) {
+			mergedIDs := mergeCockpitStateIDs(state.EventLastSeenIDs, seenIDs)
+			if !slices.Equal(mergedIDs, normalizeCockpitStateIDs(state.EventLastSeenIDs)) {
+				state.EventLastSeenIDs = mergedIDs
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func (s fileCockpitStateStore) ResetCockpitState(context.Context) error {
+	if s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return xerrors.Errorf("failed to create cockpit state directory: %w", err)
+	}
+	unlock, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to reset cockpit state: %w", err)
+	}
+	return nil
+}
+
+func (s fileCockpitStateStore) read() (cockpitStateFile, error) {
+	if s.path == "" {
+		return cockpitStateFile{}, nil
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cockpitStateFile{}, nil
+		}
+		return cockpitStateFile{}, xerrors.Errorf("failed to read cockpit state: %w", err)
+	}
+	var state cockpitStateFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return cockpitStateFile{}, xerrors.Errorf("failed to parse cockpit state: %w", err)
+	}
+	return state, nil
+}
+
+func (s fileCockpitStateStore) update(update func(*cockpitStateFile) (bool, error)) error {
+	if s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return xerrors.Errorf("failed to create cockpit state directory: %w", err)
+	}
+	unlock, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	state, err := s.read()
+	if err != nil {
+		return err
+	}
+	changed, err := update(&state)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode cockpit state: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".cockpit-*.json")
+	if err != nil {
+		return xerrors.Errorf("failed to create cockpit state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to write cockpit state temp file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to chmod cockpit state temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return xerrors.Errorf("failed to close cockpit state temp file: %w", err)
+	}
+	if err := replaceCockpitStateFile(tmpPath, s.path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s fileCockpitStateStore) lock() (func(), error) {
+	lockPath := s.path + ".lock"
+	for i := 0; ; i++ {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			return func() { _ = os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, xerrors.Errorf("failed to lock cockpit state: %w", err)
+		}
+		if err := removeStaleCockpitStateLock(lockPath); err != nil {
+			return nil, err
+		}
+		if i >= cockpitStateLockRetryLimit {
+			return nil, xerrors.Errorf("failed to lock cockpit state: timed out")
+		}
+		time.Sleep(cockpitStateLockRetryDelay)
+	}
+}
+
+func removeStaleCockpitStateLock(lockPath string) error {
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return xerrors.Errorf("failed to inspect cockpit state lock: %w", err)
+	}
+	if time.Since(info.ModTime()) <= cockpitStateStaleLockAfter {
+		return nil
+	}
+	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to remove stale cockpit state lock: %w", err)
+	}
+	return nil
+}
+
+func parseCockpitStateTime(value string) (time.Time, bool, error) {
+	if value == "" {
+		return time.Time{}, false, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, false, xerrors.Errorf("invalid cockpit state timestamp %q: %w", value, err)
+	}
+	return parsed, true, nil
+}
+
+func shouldAdvanceCockpitStateTime(existing string, candidate time.Time) bool {
+	parsed, ok, err := parseCockpitStateTime(existing)
+	if err != nil {
+		return true
+	}
+	return !ok || candidate.After(parsed)
+}
+
+func normalizeCockpitStateIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	normalized := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+	slices.Sort(normalized)
+	return normalized
+}
+
+func mergeCockpitStateIDs(existing []string, incoming []string) []string {
+	return normalizeCockpitStateIDs(append(slices.Clone(existing), incoming...))
+}

--- a/presentation/cli/cockpit_state_file_replace_unix.go
+++ b/presentation/cli/cockpit_state_file_replace_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/xerrors"
+)
+
+func replaceCockpitStateFile(tmpPath string, path string) error {
+	if err := os.Rename(tmpPath, path); err != nil {
+		return xerrors.Errorf("failed to replace cockpit state: %w", err)
+	}
+	return nil
+}

--- a/presentation/cli/cockpit_state_file_replace_windows.go
+++ b/presentation/cli/cockpit_state_file_replace_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package cli
+
+import (
+	"golang.org/x/sys/windows"
+	"golang.org/x/xerrors"
+)
+
+func replaceCockpitStateFile(tmpPath string, path string) error {
+	from, err := windows.UTF16PtrFromString(tmpPath)
+	if err != nil {
+		return xerrors.Errorf("failed to encode cockpit state temp path: %w", err)
+	}
+	to, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return xerrors.Errorf("failed to encode cockpit state path: %w", err)
+	}
+	if err := windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
+		return xerrors.Errorf("failed to replace cockpit state: %w", err)
+	}
+	return nil
+}

--- a/presentation/cli/cockpit_state_file_test.go
+++ b/presentation/cli/cockpit_state_file_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestFileCockpitStateStorePersistsAndResetsLastSeen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "cockpit.json")
+	store := newFileCockpitStateStoreAt(path)
+	memorySeen := time.Date(2026, 5, 23, 1, 2, 3, 4, time.UTC)
+	eventSeen := memorySeen.Add(time.Minute)
+
+	if _, ok, err := store.MemoryLastSeenAt(context.Background()); err != nil || ok {
+		t.Fatalf("initial MemoryLastSeenAt ok/err = %v/%v, want false/nil", ok, err)
+	}
+	if err := store.MarkMemoryLastSeenAt(context.Background(), memorySeen); err != nil {
+		t.Fatalf("MarkMemoryLastSeenAt() error = %v", err)
+	}
+	if err := store.MarkEventLastSeenAt(context.Background(), eventSeen, []string{"evt-2", "evt-1"}); err != nil {
+		t.Fatalf("MarkEventLastSeenAt() error = %v", err)
+	}
+
+	gotMemory, ok, err := store.MemoryLastSeenAt(context.Background())
+	if err != nil || !ok || !gotMemory.Equal(memorySeen) {
+		t.Fatalf("MemoryLastSeenAt = %v/%v/%v, want %v/true/nil", gotMemory, ok, err, memorySeen)
+	}
+	gotEvent, ok, err := store.EventLastSeenAt(context.Background())
+	if err != nil || !ok || !gotEvent.Equal(eventSeen) {
+		t.Fatalf("EventLastSeenAt = %v/%v/%v, want %v/true/nil", gotEvent, ok, err, eventSeen)
+	}
+	gotEventIDs, ok, err := store.EventLastSeenIDs(context.Background())
+	if err != nil || !ok || !slices.Equal(gotEventIDs, []string{"evt-1", "evt-2"}) {
+		t.Fatalf("EventLastSeenIDs = %v/%v/%v, want [evt-1 evt-2]/true/nil", gotEventIDs, ok, err)
+	}
+
+	if err := store.ResetCockpitState(context.Background()); err != nil {
+		t.Fatalf("ResetCockpitState() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("state file still exists or stat failed with unexpected error: %v", err)
+	}
+}
+
+func TestFileCockpitStateStoreKeepsLastSeenMonotonic(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "cockpit.json")
+	store := newFileCockpitStateStoreAt(path)
+	newer := time.Date(2026, 5, 23, 3, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+
+	if err := store.MarkMemoryLastSeenAt(context.Background(), newer); err != nil {
+		t.Fatalf("MarkMemoryLastSeenAt(newer) error = %v", err)
+	}
+	if err := store.MarkMemoryLastSeenAt(context.Background(), older); err != nil {
+		t.Fatalf("MarkMemoryLastSeenAt(older) error = %v", err)
+	}
+	if err := store.MarkEventLastSeenAt(context.Background(), newer, []string{"evt-newer"}); err != nil {
+		t.Fatalf("MarkEventLastSeenAt(newer) error = %v", err)
+	}
+	if err := store.MarkEventLastSeenAt(context.Background(), older, []string{"evt-older"}); err != nil {
+		t.Fatalf("MarkEventLastSeenAt(older) error = %v", err)
+	}
+	if err := store.MarkEventLastSeenAt(context.Background(), newer, []string{"evt-equal"}); err != nil {
+		t.Fatalf("MarkEventLastSeenAt(equal) error = %v", err)
+	}
+
+	gotMemory, ok, err := store.MemoryLastSeenAt(context.Background())
+	if err != nil || !ok || !gotMemory.Equal(newer) {
+		t.Fatalf("MemoryLastSeenAt = %v/%v/%v, want %v/true/nil", gotMemory, ok, err, newer)
+	}
+	gotEvent, ok, err := store.EventLastSeenAt(context.Background())
+	if err != nil || !ok || !gotEvent.Equal(newer) {
+		t.Fatalf("EventLastSeenAt = %v/%v/%v, want %v/true/nil", gotEvent, ok, err, newer)
+	}
+	gotEventIDs, ok, err := store.EventLastSeenIDs(context.Background())
+	if err != nil || !ok || !slices.Equal(gotEventIDs, []string{"evt-equal", "evt-newer"}) {
+		t.Fatalf("EventLastSeenIDs = %v/%v/%v, want [evt-equal evt-newer]/true/nil", gotEventIDs, ok, err)
+	}
+}
+
+func TestFileCockpitStateStoreRecoversStaleLock(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "cockpit.json")
+	store := newFileCockpitStateStoreAt(path)
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("MkdirAll(lockPath) error = %v", err)
+	}
+	staleAt := time.Now().Add(-cockpitStateStaleLockAfter - time.Minute)
+	if err := os.Chtimes(lockPath, staleAt, staleAt); err != nil {
+		t.Fatalf("Chtimes(lockPath) error = %v", err)
+	}
+	seenAt := time.Date(2026, 5, 23, 4, 0, 0, 0, time.UTC)
+
+	if err := store.MarkEventLastSeenAt(context.Background(), seenAt, []string{"evt-seen"}); err != nil {
+		t.Fatalf("MarkEventLastSeenAt() error = %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock still exists or stat failed with unexpected error: %v", err)
+	}
+	got, ok, err := store.EventLastSeenAt(context.Background())
+	if err != nil || !ok || !got.Equal(seenAt) {
+		t.Fatalf("EventLastSeenAt = %v/%v/%v, want %v/true/nil", got, ok, err, seenAt)
+	}
+}

--- a/presentation/cli/cockpit_test.go
+++ b/presentation/cli/cockpit_test.go
@@ -2,9 +2,11 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/presentation/cli"
 )
@@ -39,6 +41,24 @@ func TestCockpitCommand_RefusesNonTTYThroughCobra(t *testing.T) {
 	}
 }
 
+func TestCockpitCommand_ResetStateDoesNotRunForNonTTY(t *testing.T) {
+	t.Parallel()
+
+	state := &cockpitStateSpy{}
+	rootCmd := cli.NewRootCLI(cli.WithCockpitStateReader(state)).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"tui", "--reset-state"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute(tui --reset-state) error = nil, want non-TTY refusal")
+	}
+	if state.resetCalls != 0 {
+		t.Fatalf("ResetCockpitState() calls = %d, want 0 for non-TTY execution", state.resetCalls)
+	}
+}
+
 func TestCockpitCommand_HelpAndAliasAreDiscoverable(t *testing.T) {
 	t.Parallel()
 
@@ -52,7 +72,7 @@ func TestCockpitCommand_HelpAndAliasAreDiscoverable(t *testing.T) {
 		t.Fatalf("Execute(tui --help) error = %v", err)
 	}
 	help := stdout.String()
-	for _, must := range []string{"operator cockpit", "dashboard", "--db-path", "top", "tail", "doctor", "memory review"} {
+	for _, must := range []string{"operator cockpit", "dashboard", "--db-path", "--reset-state", "top", "tail", "doctor", "memory review"} {
 		if !strings.Contains(help, must) {
 			t.Fatalf("tui --help missing %q:\n%s", must, help)
 		}
@@ -69,6 +89,35 @@ func TestCockpitCommand_HelpAndAliasAreDiscoverable(t *testing.T) {
 	if !strings.Contains(rootHelp.String(), "tui") {
 		t.Fatalf("root help does not list tui command:\n%s", rootHelp.String())
 	}
+}
+
+type cockpitStateSpy struct {
+	resetCalls int
+}
+
+func (s *cockpitStateSpy) MemoryLastSeenAt(context.Context) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
+
+func (s *cockpitStateSpy) EventLastSeenAt(context.Context) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
+
+func (s *cockpitStateSpy) EventLastSeenIDs(context.Context) ([]string, bool, error) {
+	return nil, false, nil
+}
+
+func (s *cockpitStateSpy) MarkMemoryLastSeenAt(context.Context, time.Time) error {
+	return nil
+}
+
+func (s *cockpitStateSpy) MarkEventLastSeenAt(context.Context, time.Time, []string) error {
+	return nil
+}
+
+func (s *cockpitStateSpy) ResetCockpitState(context.Context) error {
+	s.resetCalls++
+	return nil
 }
 
 func TestCockpitCommand_NoArgsCompatibility(t *testing.T) {

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -120,7 +120,7 @@ func WithClaudePluginDetector(detector application.ClaudePluginDetector) RootCLI
 }
 
 // WithCockpitStateReader injects optional local cockpit state used for
-// non-critical notification checkpoints such as memory inbox last-seen time.
+// non-critical notification checkpoints such as memory/event last-seen time.
 func WithCockpitStateReader(reader CockpitStateReader) RootCLIOption {
 	return func(c *RootCLI) { c.cockpitState = reader }
 }

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -1116,6 +1116,7 @@ func TestWriteTopSnapshotJSON_EmitsReliabilityShape(t *testing.T) {
 type snapshotEventStub struct {
 	usecase.EventUsecase
 
+	events   []*model.Event
 	failures []*model.Event
 	commands []*model.Event
 }
@@ -1127,7 +1128,16 @@ func (s *snapshotEventStub) List(_ context.Context, criteria apptypes.EventListC
 	if criteria.Kind() == domtypes.EventKindCommandExecuted {
 		return s.commands, nil
 	}
-	return nil, nil
+	events := make([]*model.Event, 0, len(s.events))
+	for _, event := range s.events {
+		if event == nil || criteria.From().IsZero() || !event.CreatedAt().Before(criteria.From()) {
+			events = append(events, event)
+		}
+	}
+	if criteria.Limit() > 0 && len(events) > criteria.Limit() {
+		return events[:criteria.Limit()], nil
+	}
+	return events, nil
 }
 
 func TestTopDataLoader_LoadSnapshot_NoUsecasesReturnsEmpty(t *testing.T) {


### PR DESCRIPTION
## Motivation

Closes #996.

The cockpit already surfaces candidate memory and live event activity, but the notification counts need durable local checkpoints so operators can distinguish total backlog from newly observed work since the last cockpit interaction.

Claude delegation note: Claude CLI delegation was attempted for the preceding v0.17 cockpit work, but the tenant policy rejected external code disclosure. This PR proceeds with local Codex implementation and verification instead.

## Summary

- Add a local-first cockpit state store at `$XDG_STATE_HOME/traceary/cockpit.json` or `~/.local/state/traceary/cockpit.json` with atomic writes.
- Persist memory review and live event last-seen timestamps without blocking read-only cockpit views when state is unavailable.
- Surface new event counts on the cockpit home screen and add `traceary tui --reset-state` for reset behavior.
- Cover persisted state, reset behavior, non-TTY compatibility, and new event notification behavior in tests.

## Validation

- `git diff --check`
- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./presentation/cli/...`
- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go test ./...`
- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run --timeout=5m`
- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp go build ./...`
- `env GOCACHE=/private/tmp/traceary-gocache GOTMPDIR=/private/tmp python3 scripts/verify_integrations.py`
