### PR TITLE
v0.18-1: audit cockpit usability against reference TUIs

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -30,6 +30,7 @@
 - [運用上の前提](./operations/README.ja.md): SQLite の同時実行、hook 状態管理、既知の制約
 - [Python 依存の縮小計画](./operations/python-dependencies.ja.md): 現在の Python helper、影響範囲、移行順
 - [repository tooling の方針](./operations/repo-tooling.ja.md): maintainer-only helper をまとめる Go entrypoint の方針
+- [Cockpit UI/UX design baseline](./operations/cockpit-ui-ux-design.ja.md): v0.18 で `traceary tui` を reference-driven に再設計する方針
 - [Memory コマンド体系の整理計画](./operations/memory-command-surface.ja.md): v0.14 で導入する `memory inbox` / `memory store` / `memory admin` と、v0.15 まで残す hidden deprecated alias の方針
 - [リリースガイド](./release/README.ja.md): リリース手順、GitHub Actions、ローカルでの確認方法
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 - [Operational assumptions](./operations/README.md): SQLite concurrency, hook-state assumptions, and known limits
 - [Python dependency plan](./operations/python-dependencies.md): current Python-backed helpers, audience impact, and reduction order
 - [Repository tooling plan](./operations/repo-tooling.md): the planned Go entrypoint for maintainer-only repository helpers
+- [Cockpit UI/UX design baseline](./operations/cockpit-ui-ux-design.md): v0.18 reference-driven redesign target for `traceary tui`
 - [Memory command surface plan](./operations/memory-command-surface.md): v0.14 plan for `memory inbox`, `memory store`, and `memory admin` plus the hidden deprecated aliases retained until v0.15
 - [Release guide](./release/README.md): release packaging, GitHub Actions, and local snapshot builds
 

--- a/docs/operations/cockpit-ui-ux-design.ja.md
+++ b/docs/operations/cockpit-ui-ux-design.ja.md
@@ -1,0 +1,244 @@
+# Cockpit UI/UX design baseline (v0.18)
+
+[English](./cockpit-ui-ux-design.md)
+
+この文書は #1030 と v0.18 cockpit usability overhaul の設計ベースラインです。実装より先に固定します。v0.17 の cockpit は `top`、`tail`、`doctor`、`memory inbox review` という必要な面を集めましたが、日常利用に耐える interaction model にはまだ届いていません。
+
+## ユーザーフィードバック
+
+`traceary tui` は使いにくい。問題は underlying data の価値ではなく、TUI が自分自身の操作方法を説明できておらず、navigation が安定せず、mode ごとの隠れた key を覚えさせている点です。
+
+## 設計原則
+
+1. **コマンド一覧ではなく cockpit にする。** TUI 内では `top`、`tail`、`doctor`、`memory inbox review` を覚えなくてもよい operator console にする。
+2. **常に現在地が分かる。** すべての画面で「どこにいるか」「何が選択されているか」「何が変わったか」「次に何ができるか」を分かるようにする。
+3. **shortcut は覚える前に見つけられる。** single-key shortcut は残すが、contextual action list と現在画面向けの `?` help を必ず用意する。
+4. **Home は triage board。** count を並べるだけではなく、今 attention が必要なものを優先する。
+5. **CLI escape hatch は残す。** direct subcommand は script、専用 terminal pane、power user のために安定させる。
+6. **破壊的な魔法はしない。** memory accept/reject や session GC のようなデータ変更は明示的にし、可能な限り確認・取り消し可能性を持たせる。
+
+## 参考にするパターン
+
+これは reference であり、見た目を clone するという意味ではありません。
+
+| Product / guide | 採用するパターン | 避けるパターン |
+|---|---|---|
+| lazygit | persistent panel、常時 `?`、context-specific key hint、`Tab`/number navigation、`/` filter | Git 固有の mental model、初期画面から shortcut が多すぎる密度 |
+| k9s | command/filter mode、`?` help、素早い view switch、予測しやすい Esc/cancel | Kubernetes 固有の resource grammar、破壊的な one-key action |
+| btop / htop | glanceable な status region、安定した screen zone、明確な selected row | next action のない telemetry wall |
+| Apple HIG keyboard guidance | 一般的な keyboard 期待値を尊重し、驚きの少ない shortcut と keyboard-only 操作にする | 画面ごとに共通 key の意味を変える |
+| Material accessibility guidance | focus、state、feedback を明確にし、navigation/menu label は action を説明する | focus が隠れる・状態変化が曖昧 |
+| Bubble Tea | model/update/view を明示し、小さい state machine を合成する | 1 つの巨大 model に screen-specific behavior が漏れる構造 |
+
+参考リンク:
+
+- lazygit keybindings: https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Keybindings_en.md
+- lazygit configuration/keybinding reference: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+- k9s commands/key bindings: https://k9scli.io/topics/commands/
+- btop interactive tutorial/key bindings: https://btop.one/
+- Apple keyboard HIG: https://developer.apple.com/design/human-interface-guidelines/keyboards/
+- Material accessibility: https://m2.material.io/design/usability/accessibility.html
+- Bubble Tea: https://github.com/charmbracelet/bubbletea
+
+## 現状 cockpit audit
+
+確認対象: `presentation/cli/cockpit.go` と `presentation/cli/tui/` の shared TUI primitives。
+
+### できていること
+
+- 明示 entrypoint (`traceary tui`) は正しい。bare `traceary` は CLI help のままでよい。
+- 最初の surface はある: home、live tail、doctor、event detail、memory review。
+- local last-seen state を使って new memory / event count を出せる。
+- 既存の direct command は script や fallback として残っている。
+
+### 主な usability failure
+
+| Failure | Current behavior | 問題 |
+|---|---|---|
+| navigation model が隠れている | Home は `d`、`t`/`l`、`m`; 他画面は `h`; memory review は独自 nested keys | operator が visible structure ではなく mode を記憶する必要がある |
+| persistent shell がない | 各 mode が独自 title/footer を描画する | 現在地と global action が画面間で安定しない |
+| Home が count dump | `ATTENTION`、`OVERVIEW`、`Cockpit surfaces` が text section | count が next action や priority に結びつきにくい |
+| Help が fallback command 寄り | Home の `?` は CLI fallback command を表示する | TUI の操作モデルを学べない |
+| Esc semantics が衝突 | shared keymap では `esc` が quit | lazygit/k9s 風の back/cancel 期待と違い、誤終了リスクがある |
+| live tail に filter/search affordance がない | shared keymap に `/` はあるが cockpit live では使っていない | noisy な event stream を TUI 内で絞れない |
+| doctor pane が read-only text | fix command は出るが action menu/copy/run affordance がない | cockpit が remediation を手伝えるか分からない |
+| detail screen で origin context が薄い | detail は home/live に戻れるが breadcrumb が弱い | list/detail の関係を見失いやすい |
+
+## 目標 information architecture
+
+Cockpit は persistent global chrome を持つ tabbed operator console にする。
+
+```text
+┌ Traceary cockpit ─ workspace=github.com/duck8823/traceary ─ db=... ─ 12:34:56 ┐
+│ [1 Home] [2 Live] [3 Health] [4 Memory] [5 Sessions]                         │
+├───────────────────────────────────────────────────────────────────────────────┤
+│ screen-specific content                                                       │
+├───────────────────────────────────────────────────────────────────────────────┤
+│ ? help  : actions  / filter  tab next  esc back  q quit                       │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Sections
+
+| Section | 目的 | Primary actions |
+|---|---|---|
+| Home | 今 attention が必要なものの triage board | open problem, mark seen, refresh |
+| Live | recent/new event stream と detail drill-down | follow/pause, filter, detail, mark seen |
+| Health | doctor summary と remediation hints | refresh, copy fix command, open details |
+| Memory | candidate memory review | accept, reject, skip, edit/distill, evidence |
+| Sessions | active/stale/recent sessions と handoff | open session, handoff, close stale sessions after confirmation |
+
+`Sessions` は v0.18 scope を小さくするなら placeholder から始めてもよい。ただし cockpit の方向性を明確にするため、shell 上の section として予約する。
+
+## Global keyboard model
+
+| Key | Global meaning | Notes |
+|---|---|---|
+| `?` | contextual help | 常に利用可能。global keys と screen actions を分けて表示する |
+| `:` | action palette / command mode | arbitrary shell command ではなく cockpit action を一覧する |
+| `/` | current list の filter/search | filter できない画面では理由を説明する |
+| `Tab` / `Shift-Tab` | 次/前の section または focus region | lazygit 風の transfer を狙う |
+| `1`-`5` | section へ jump | header に常時表示する |
+| `Esc` | back/cancel/overlay close | nested screen からは quit しない。Home では overlay/filter clear 後 no-op |
+| `q` / `Ctrl-C` | cockpit を終了 | quit key はこの 2 つだけ |
+| `r` | current screen refresh | loading と last refreshed timestamp を表示する |
+| `Enter` | selected item open / dialog confirm | 確認 dialog なしに破壊的 action をしない |
+| `j/k`, `↑/↓` | selection 移動 | 現行 TUI surface と共有 |
+| `g/G`, `PgUp/PgDn` | jump/scroll | 現行 TUI surface と共有 |
+
+### Screen-local keys
+
+Local key は footer/help/action palette に表示される場合だけ許可する。例:
+
+- Live: `f` follow/pause、`m` mark seen
+- Health: `c` copy fix command。`x` execute fix は confirmation UX ができるまで scope 外
+- Memory: `a` accept はよいが、`r` reject は global `r` refresh と衝突するため避ける。最終 shortcut は action palette や明示 label を先に設計する
+- Sessions: `H` handoff は可。`g` GC は `g` top と衝突するため不可。palette + confirmation にする
+
+## Home screen design
+
+Home は actionable card の priority queue にする。
+
+```text
+HOME · 3 items need attention
+
+Problems
+  [FAIL] doctor failures=1             Enter: Health · fix: traceary doctor --fix --dry-run
+  [WARN] stale sessions=4              Enter: Sessions · action: close stale after preview
+
+New activity
+  [NEW] 12 events since last seen       Enter: Live · m mark seen
+  [NEW] 2 memory candidates             Enter: Memory · review now
+
+All clear
+  hidden unless there are no Problems/New activity cards
+```
+
+### Priority order
+
+1. Doctor failures
+2. Hook/MCP failures
+3. Stale active sessions
+4. New candidate memories, remember-intent first
+5. New events / recent failures
+6. Large payload warnings
+7. Informational healthy status
+
+## Live screen design
+
+Live は static list ではなく focused tail viewer にする。
+
+必須要素:
+
+- follow/pause state が header で分かる
+- filter query が active 時に見える
+- selected row count、total row count、truncation indicator
+- detail は breadcrumb 付き pane/modal として Live に戻れる
+- new events がある場合は mark-seen action が見える
+
+Empty state:
+
+```text
+No recent events.
+Actions: r refresh · f follow · / filter · h Home
+```
+
+## Health screen design
+
+Health は doctor status summary を先に出し、その後 severity ごとに check を group する。
+
+必須要素:
+
+- `fail`、`warn`、`pass` の summary chip
+- failure/warning check を pass より上に出す
+- 各 check は name、short message、remediation command を表示する
+- action palette には copy command を入れる。execution は confirmation/safety rule が設計されるまで scope 外
+
+## Memory screen design
+
+Memory screen は standalone `memory inbox review` view をそのまま埋め込むだけでは不十分。decision flow は review model を再利用しつつ、cockpit shell と help を共有する。
+
+必須要素:
+
+- inbox queue position (`2/7`)、source (`remember-intent`, `extracted`, `hidden`)、可能なら confidence/quality marker
+- evidence / edit mode は overlay として扱い、Esc behavior を明確にする
+- finish/apply step で accepted/rejected/distilled/skipped counts をまとめる
+- empty state は “candidate memories なし” を説明し、accepted memory search/list command は secondary fallback としてだけ示す
+
+## Sessions screen design
+
+Sessions は `top` と `handoff` から implied されている missing cockpit surface。
+
+初期 v0.18 option:
+
+- existing top snapshot data を使って active sessions と stale sessions を表示する
+- Enter で session detail / handoff preview を開く
+- stale cleanup は guided action として表示するが、confirmation 必須、default は dry-run preview
+
+scope が厳しい場合、Sessions はまず read-only section として出し、cleanup action は defer する。
+
+## Layout behavior
+
+| Terminal size | Behavior |
+|---|---|
+| `<80 cols` | single-column。header/footer は短くし、secondary metadata は help/detail 側へ逃がす |
+| `80-119 cols` | compact metadata 付き single-column cards/lists |
+| `>=120 cols` | 有効な場所だけ two-pane。list left、detail/summary right |
+
+色だけに依存しない。selection は color に加えて prefix、border、glyph のいずれかで表現する。
+
+## State and feedback rules
+
+- action dispatch から 100 ms 以内に loading state を出す。
+- refresh は `loaded=` または `refreshed=` timestamp を更新する。
+- error は current screen に残し、retry/back action を表示する。
+- mark-seen は state write 成功後に count を即時更新する。
+- user が tail end から離れて scroll したとき follow mode を visible に pause する、または selection と follow が独立していることを UI で明示する。
+- 長い list は viewport/windowing し、操作できない量の row をそのまま描画しない。
+
+## v0.18 の非目標
+
+- mouse support
+- cockpit 内から arbitrary shell command を実行すること
+- 明示確認なしの doctor auto-remediation
+- direct CLI subcommand の置き換え
+- full theming / configurable keybindings
+
+## Implementation waves
+
+1. **Design/audit (#1030):** この design baseline と dogfood note を land する。
+2. **Shell (#1031):** persistent header/footer、sections、global key semantics、Esc/back behavior。
+3. **Discoverability (#1032):** contextual help と action palette。
+4. **Home triage (#1033):** actionable cards と zero states。
+5. **Dogfood/regression (#1034):** scripted task scenarios と layout snapshots。
+
+## v0.18 acceptance checklist
+
+- 新規ユーザーが Home を見て「次に何をすべきか」を docs なしで判断できる。
+- `?` は fallback CLI command ではなく current screen を説明する。
+- `Esc` は nested screen から予期せず終了しない。
+- visible warning には必ず visible action target がある。
+- Live tail は 1 画面内で pause、filter、refresh、detail drill-down ができる。
+- Memory review への導線と finish/apply semantics が明確。
+- Doctor warnings は severity ごとにまとまり、remediation hints が actionable。
+- narrow terminal snapshot でも使える。

--- a/docs/operations/cockpit-ui-ux-design.ja.md
+++ b/docs/operations/cockpit-ui-ux-design.ja.md
@@ -15,7 +15,7 @@
 3. **shortcut は覚える前に見つけられる。** single-key shortcut は残すが、contextual action list と現在画面向けの `?` help を必ず用意する。
 4. **Home は triage board。** count を並べるだけではなく、今 attention が必要なものを優先する。
 5. **CLI escape hatch は残す。** direct subcommand は script、専用 terminal pane、power user のために安定させる。
-6. **破壊的な魔法はしない。** memory accept/reject や session GC のようなデータ変更は明示的にし、可能な限り確認・取り消し可能性を持たせる。
+6. **破壊的な魔法はしない。** `memory inbox accept` / `memory inbox reject` や session GC のようなデータ変更は明示的にし、可能な限り確認・取り消し可能性を持たせる。
 
 ## 参考にするパターン
 

--- a/docs/operations/cockpit-ui-ux-design.ja.md
+++ b/docs/operations/cockpit-ui-ux-design.ja.md
@@ -160,7 +160,7 @@ Empty state:
 
 ```text
 No recent events.
-Actions: r refresh · f follow · / filter · h Home
+Actions: r refresh · f follow · / filter · 1 Home
 ```
 
 ## Health screen design

--- a/docs/operations/cockpit-ui-ux-design.md
+++ b/docs/operations/cockpit-ui-ux-design.md
@@ -15,7 +15,7 @@ This document is the design baseline for issue #1030 and the v0.18 cockpit usabi
 3. **Actions are discoverable before they are memorized.** Single-key shortcuts remain, but the UI must expose a contextual action list and `?` help for the current screen.
 4. **Home is a triage board.** The home screen should prioritize what needs attention, not only print counts.
 5. **Keep CLI escape hatches.** Direct subcommands remain stable for scripts, dedicated terminal panes, and power users.
-6. **No destructive magic.** Any action that changes data, such as memory acceptance/rejection or session GC, must be explicit and reversible where possible.
+6. **No destructive magic.** Any action that changes data, such as `memory inbox accept` / `memory inbox reject` decisions or session GC, must be explicit and reversible where possible.
 
 ## Reference patterns
 

--- a/docs/operations/cockpit-ui-ux-design.md
+++ b/docs/operations/cockpit-ui-ux-design.md
@@ -1,0 +1,244 @@
+# Cockpit UI/UX design baseline (v0.18)
+
+[日本語](./cockpit-ui-ux-design.ja.md)
+
+This document is the design baseline for issue #1030 and the v0.18 cockpit usability overhaul. It intentionally precedes implementation. The v0.17 cockpit collected the right surfaces (`top`, `tail`, `doctor`, `memory inbox review`), but the interaction model is not yet good enough for daily use.
+
+## User feedback
+
+`traceary tui` is too hard to use. The issue is not the value of the underlying data; it is that the TUI does not yet explain itself, does not keep navigation stable, and forces the operator to remember hidden mode-specific keys.
+
+## Design principles
+
+1. **One cockpit, not a menu of commands.** The TUI should feel like a persistent operator console. Operators should not have to remember `top`, `tail`, `doctor`, or `memory inbox review` while inside it.
+2. **Visible orientation at all times.** Every screen must answer: where am I, what is selected, what changed, and what can I do next?
+3. **Actions are discoverable before they are memorized.** Single-key shortcuts remain, but the UI must expose a contextual action list and `?` help for the current screen.
+4. **Home is a triage board.** The home screen should prioritize what needs attention, not only print counts.
+5. **Keep CLI escape hatches.** Direct subcommands remain stable for scripts, dedicated terminal panes, and power users.
+6. **No destructive magic.** Any action that changes data, such as memory acceptance/rejection or session GC, must be explicit and reversible where possible.
+
+## Reference patterns
+
+These are references, not clone targets.
+
+| Product / guide | Pattern to adopt | Pattern to avoid |
+|---|---|---|
+| lazygit | Persistent panels, always-available `?`, context-specific key hints, `Tab`/number navigation, `/` filter | Git-specific mental model, too many dense shortcuts on first screen |
+| k9s | Command/filter mode, `?` help, quick view switching, predictable Esc/cancel behavior | Kubernetes-specific resource grammar, destructive one-key actions |
+| btop / htop | Glanceable status regions, stable screen zones, obvious selected row | Dense telemetry wall without next actions |
+| Apple HIG keyboard guidance | Respect common keyboard expectations, avoid surprising shortcuts, support keyboard-only operation | Repurposing common keys differently by screen |
+| Material accessibility guidance | Clear focus, state, and feedback; navigation/menu labels should describe the action | Hidden focus and ambiguous state changes |
+| Bubble Tea | Keep model/update/view explicit; use small composable state machines for modes | One large model where screen-specific behavior leaks everywhere |
+
+Reference links:
+
+- lazygit keybindings: https://github.com/jesseduffield/lazygit/blob/master/docs/keybindings/Keybindings_en.md
+- lazygit configuration/keybinding reference: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+- k9s commands/key bindings: https://k9scli.io/topics/commands/
+- btop interactive tutorial/key bindings: https://btop.one/
+- Apple keyboard HIG: https://developer.apple.com/design/human-interface-guidelines/keyboards/
+- Material accessibility: https://m2.material.io/design/usability/accessibility.html
+- Bubble Tea: https://github.com/charmbracelet/bubbletea
+
+## Current cockpit audit
+
+Current implementation inspected: `presentation/cli/cockpit.go` and shared TUI primitives under `presentation/cli/tui/`.
+
+### What works
+
+- The explicit entrypoint (`traceary tui`) is correct; bare `traceary` should still show CLI help.
+- The first set of surfaces exists: home, live tail, doctor, event detail, memory review.
+- The cockpit can surface new memory and event counts using local last-seen state.
+- Existing direct commands remain available for scripts and fallback.
+
+### Main usability failures
+
+| Failure | Current behavior | Why it hurts |
+|---|---|---|
+| Hidden navigation model | Home uses `d`, `t`/`l`, `m`; other screens use `h`; memory review has its own nested keys | The operator must remember modes instead of following visible UI structure |
+| No persistent shell | Each mode renders its own title/footer | Location and global actions are not stable across screens |
+| Home is a count dump | `ATTENTION`, `OVERVIEW`, and `Cockpit surfaces` are text sections | Counts do not clearly map to next actions or workflow priority |
+| Help is fallback-command oriented | `?` on home lists CLI fallback commands | Help does not teach the current TUI interaction model |
+| Esc semantics conflict | Shared keymap binds `esc` to quit; many TUIs use Esc for back/cancel | Accidental exit risk and poor transfer from lazygit/k9s-style TUIs |
+| Live tail lacks filter/search affordance | `/` exists in shared keymap but cockpit live does not use it | Operators cannot narrow noisy event streams inside the cockpit |
+| Doctor pane is read-only text | Fix commands are shown, but no action menu or copy/run affordance | It is not obvious whether the cockpit can help remediate |
+| Detail screen loses origin context | Detail can go home or live, but the breadcrumb is minimal | Users can forget what list/detail relationship they are in |
+
+## Target information architecture
+
+The cockpit becomes a tabbed operator console with persistent global chrome.
+
+```text
+┌ Traceary cockpit ─ workspace=github.com/duck8823/traceary ─ db=... ─ 12:34:56 ┐
+│ [1 Home] [2 Live] [3 Health] [4 Memory] [5 Sessions]                         │
+├───────────────────────────────────────────────────────────────────────────────┤
+│ screen-specific content                                                       │
+├───────────────────────────────────────────────────────────────────────────────┤
+│ ? help  : actions  / filter  tab next  esc back  q quit                       │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Sections
+
+| Section | Purpose | Primary actions |
+|---|---|---|
+| Home | Triage board: what needs attention now | open problem, mark seen, refresh |
+| Live | Stream recent/new events and drill into detail | follow/pause, filter, detail, mark seen |
+| Health | Doctor summary and remediation hints | refresh, copy fix command, open details |
+| Memory | Review candidate memories | accept, reject, skip, edit/distill, evidence |
+| Sessions | Active/stale/recent sessions and handoff | open session, handoff, close stale sessions after confirmation |
+
+`Sessions` can start as a placeholder if v0.18 scope needs to stay small, but the shell should reserve the section so the cockpit direction is clear.
+
+## Global keyboard model
+
+| Key | Global meaning | Notes |
+|---|---|---|
+| `?` | Contextual help | Always available; first line shows global keys, second section shows screen actions |
+| `:` | Action palette / command mode | Lists available cockpit actions, not arbitrary shell commands |
+| `/` | Filter/search current list | No-op screens must explain why filtering is unavailable |
+| `Tab` / `Shift-Tab` | Next / previous section or focus region | Mirrors lazygit-style transfer |
+| `1`-`5` | Jump to section | Visible in header |
+| `Esc` | Back/cancel/close overlay | Never quits from a nested screen; from Home it clears overlay/filter first, then no-op |
+| `q` / `Ctrl-C` | Quit cockpit | The only quit keys |
+| `r` | Refresh current screen | Shows loading and last refreshed timestamp |
+| `Enter` | Open selected item / confirm in dialog | Never destructive without a confirmation dialog |
+| `j/k`, `↑/↓` | Move selection | Shared with current TUI surfaces |
+| `g/G`, `PgUp/PgDn` | Jump/scroll | Shared with current TUI surfaces |
+
+### Screen-local keys
+
+Local keys are allowed only when they are also shown in the footer/help/action palette. Examples:
+
+- Live: `f` follow/pause, `m` mark seen
+- Health: `c` copy fix command, `x` execute fix is out of scope for now unless confirmation UX exists
+- Memory: `a` accept, `r` reject should be avoided because global `r` refresh already exists; use an action palette or explicit labels before choosing final memory shortcuts
+- Sessions: `H` handoff, `g` GC is not acceptable because `g` already means top; use palette + confirmation
+
+## Home screen design
+
+Home should show a prioritized queue of actionable cards.
+
+```text
+HOME · 3 items need attention
+
+Problems
+  [FAIL] doctor failures=1             Enter: Health · fix: traceary doctor --fix --dry-run
+  [WARN] stale sessions=4              Enter: Sessions · action: close stale after preview
+
+New activity
+  [NEW] 12 events since last seen       Enter: Live · m mark seen
+  [NEW] 2 memory candidates             Enter: Memory · review now
+
+All clear
+  hidden unless there are no Problems/New activity cards
+```
+
+### Priority order
+
+1. Doctor failures
+2. Hook/MCP failures
+3. Stale active sessions
+4. New candidate memories, remember-intent first
+5. New events / recent failures
+6. Large payload warnings
+7. Informational healthy status
+
+## Live screen design
+
+Live should behave like a focused tail viewer, not a static list.
+
+Required elements:
+
+- follow/pause state visible in the header
+- filter query visible when active
+- selected row count, total row count, and truncation indicator
+- detail opens as a pane/modal with a breadcrumb back to Live
+- mark-seen action visible when there are new events
+
+Empty state:
+
+```text
+No recent events.
+Actions: r refresh · f follow · / filter · h Home
+```
+
+## Health screen design
+
+Health should summarize doctor status first, then group checks by severity.
+
+Required elements:
+
+- summary chips: `fail`, `warn`, `pass`
+- failure/warning checks above passes
+- each check shows name, short message, and remediation command if available
+- action palette includes copy command; execution remains out of scope until confirmation and safety rules are designed
+
+## Memory screen design
+
+The memory screen should not simply embed the standalone `memory inbox review` view unchanged. It should share cockpit shell and help while reusing the review model for the decision flow.
+
+Required elements:
+
+- inbox queue position (`2/7`), source (`remember-intent`, `extracted`, `hidden`), confidence/quality marker if available
+- evidence and edit modes as overlays with clear Esc behavior
+- explicit finish/apply step that summarizes accepted/rejected/distilled/skipped counts
+- empty state that explains “no candidate memories” and points to accepted memory search/list commands only as secondary fallback
+
+## Sessions screen design
+
+Sessions is the missing cockpit surface implied by `top` and `handoff`.
+
+Initial v0.18 option:
+
+- Show active sessions and stale sessions using existing top snapshot data.
+- Enter opens session detail/handoff preview.
+- Stale cleanup is shown as a guided action but requires confirmation and should default to dry-run preview.
+
+If implementation scope is tight, ship Sessions as a read-only section first and defer cleanup actions.
+
+## Layout behavior
+
+| Terminal size | Behavior |
+|---|---|
+| `<80 cols` | Single-column content; keep header/footer short; hide secondary metadata behind help/detail |
+| `80-119 cols` | Single-column cards/lists with compact metadata |
+| `>=120 cols` | Two-pane layout where useful: list left, detail/summary right |
+
+The layout must not rely only on color. Selection should use a prefix, border, or glyph in addition to color.
+
+## State and feedback rules
+
+- Loading state must appear within 100 ms of action dispatch.
+- Refresh updates `loaded=` or `refreshed=` timestamp.
+- Errors stay in the current screen and expose retry/back actions.
+- Mark-seen changes counts immediately after successful state write.
+- Follow mode must be visibly paused when the user scrolls away from the tail end, or the UI must make it clear that selection and follow are independent.
+- No screen should render more rows than can be navigated predictably; use viewport/windowing for long lists.
+
+## Non-goals for v0.18
+
+- Mouse support
+- Running arbitrary shell commands from inside the cockpit
+- Auto-remediating doctor warnings without explicit confirmation
+- Replacing direct CLI subcommands
+- Full theming/configurable keybindings
+
+## Implementation waves
+
+1. **Design/audit (#1030):** land this design baseline and dogfood notes.
+2. **Shell (#1031):** persistent header/footer, sections, global key semantics, Esc/back behavior.
+3. **Discoverability (#1032):** contextual help and action palette.
+4. **Home triage (#1033):** actionable cards and zero states.
+5. **Dogfood/regression (#1034):** scripted task scenarios and layout snapshots.
+
+## Acceptance checklist for v0.18
+
+- A new user can answer “what should I do next?” from Home without reading docs.
+- `?` explains the current screen, not only fallback CLI commands.
+- `Esc` never unexpectedly exits from nested screens.
+- Every visible warning has a visible action target.
+- Live tail can be paused, filtered, refreshed, and drilled into from one screen.
+- Memory review is reachable and finish/apply semantics are clear.
+- Doctor warnings are grouped by severity with actionable remediation hints.
+- Narrow terminal snapshots remain usable.

--- a/docs/operations/cockpit-ui-ux-design.md
+++ b/docs/operations/cockpit-ui-ux-design.md
@@ -160,7 +160,7 @@ Empty state:
 
 ```text
 No recent events.
-Actions: r refresh · f follow · / filter · h Home
+Actions: r refresh · f follow · / filter · 1 Home
 ```
 
 ## Health screen design


### PR DESCRIPTION
## Motivation

`traceary tui` currently exposes the right v0.17 surfaces, but the interaction model is still hard to use: navigation is hidden, screen chrome is inconsistent, `Esc` can unexpectedly quit, and Home does not clearly answer what to do next. This PR establishes the v0.18 UI/UX design baseline before implementation.

Closes #1030

## Summary

- Add bilingual cockpit UI/UX design baseline docs for v0.18.
- Capture reference-driven patterns from lazygit, k9s, btop/htop-style monitors, Apple HIG, Material accessibility, and Bubble Tea.
- Audit current cockpit usability failures and define the target cockpit information architecture.
- Define global keyboard semantics, Home/Live/Health/Memory/Sessions screen behavior, layout rules, state feedback rules, non-goals, implementation waves, and v0.18 acceptance checklist.
- Link the design baseline from the English and Japanese docs index.

## Validation

- `python3 scripts/verify_docs_i18n.py`
- `python3 scripts/verify_docs_no_removed_aliases.py`
- `git diff --check`
- `grep -R "cockpit-ui-ux-design" -n docs`
- `GOCACHE=/private/tmp/traceary-go-build-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`

## AI review note

- Claude/Gemini external review: not run. The local escalation reviewer rejected sending repository documentation content to external AI services as external data disclosure. This PR therefore uses local validation plus the normal GitHub review gates.
