### PR TITLE
v0.18-3: add discoverable command palette and contextual help

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -643,6 +643,11 @@ type cockpitNavigationSection struct {
 	label string
 }
 
+type cockpitAction struct {
+	key         string
+	description string
+}
+
 var cockpitNavigationSections = []cockpitNavigationSection{
 	{id: cockpitSectionHome, key: "1", label: "Home"},
 	{id: cockpitSectionLive, key: "2", label: "Live"},
@@ -1166,7 +1171,7 @@ func (m cockpitModel) updateMemoryReviewGlobalNavigationKey(msg tea.KeyMsg) (boo
 		}
 		return true, m, nil
 	}
-	reviewModeAllowsSectionJump := m.memoryReview.loading || m.memoryReview.err != nil || m.memoryReview.review.mode == reviewModeBrowse
+	reviewModeAllowsSectionJump := m.memoryReview.loading || m.memoryReview.err != nil || m.memoryReview.review.mode == reviewModeBrowse || m.memoryReview.review.mode == reviewModeHelp
 	if !reviewModeAllowsSectionJump {
 		return false, m, nil
 	}
@@ -1482,7 +1487,7 @@ func (m cockpitModel) doctorView() string {
 		offset = len(content)
 	}
 	lines = append(lines, content[offset:]...)
-	return m.renderCockpitShell("doctor", lines, "r refresh · ↑/↓ scroll")
+	return m.renderCockpitShell("doctor", lines, m.doctorLocalHelp())
 }
 
 func (m cockpitModel) doctorLines() []string {
@@ -1499,7 +1504,10 @@ func (m cockpitModel) doctorLines() []string {
 		"",
 	}
 	if len(snapshot.Sections) == 0 {
-		return append(lines, m.styles.Success.Render("No doctor checks reported."))
+		return append(lines,
+			m.styles.Success.Render("No doctor checks reported."),
+			m.styles.Subtle.Render("Press r to refresh checks or 1 to return Home."),
+		)
 	}
 	rendered := 0
 	for _, section := range snapshot.Sections {
@@ -1525,7 +1533,10 @@ func (m cockpitModel) doctorLines() []string {
 		lines = append(lines, "")
 	}
 	if rendered == 0 {
-		lines = append(lines, m.styles.Success.Render("No doctor checks reported."))
+		lines = append(lines,
+			m.styles.Success.Render("No doctor checks reported."),
+			m.styles.Subtle.Render("Press r to refresh checks or 1 to return Home."),
+		)
 	}
 	return lines
 }
@@ -1555,21 +1566,17 @@ func renderCockpitDoctorCheck(styles tui.Styles, check cockpitDoctorCheck, line 
 
 func (m cockpitModel) memoryReviewView() string {
 	lines := []string{}
-	localHelp := "q quit"
 	switch {
 	case m.memoryReview.loading:
 		lines = append(lines, m.styles.Subtle.Render("Loading memory inbox review queue..."))
 	case m.memoryReview.applying:
 		lines = append(lines, m.styles.Subtle.Render("Applying memory review decisions..."))
-		localHelp = "applying decisions"
 	case m.memoryReview.err != nil:
 		lines = append(lines, m.styles.Error.Render(m.memoryReview.err.Error()))
-		localHelp = "q quit"
 	default:
 		lines = append(lines, m.memoryReview.review.View())
-		localHelp = "a accept · x reject · s skip · e edit · v evidence · q finish/apply"
 	}
-	return m.renderCockpitShell("memory review", lines, localHelp)
+	return m.renderCockpitShell("memory review", lines, m.memoryReviewLocalHelp())
 }
 
 func (m cockpitModel) liveView() string {
@@ -1598,7 +1605,7 @@ func (m cockpitModel) liveView() string {
 			lines = append(lines, line)
 		}
 	}
-	return m.renderCockpitShell("live tail", lines, "r refresh · f follow · enter detail · ↑/↓ select")
+	return m.renderCockpitShell("live tail", lines, m.liveLocalHelp())
 }
 
 func (m cockpitModel) detailView() string {
@@ -1612,7 +1619,7 @@ func (m cockpitModel) detailView() string {
 		}
 		lines = append(lines, detailLines[m.detailOffset:]...)
 	}
-	return m.renderCockpitShell(m.detail.title, lines, "↑/↓ scroll")
+	return m.renderCockpitShell(m.detail.title, lines, m.detailLocalHelp())
 }
 
 func (m cockpitModel) sessionsView() string {
@@ -1648,7 +1655,7 @@ func (m cockpitModel) renderCockpitShell(title string, body []string, localHelp 
 	lines = append(lines, "", m.styles.Help.Render(m.cockpitGlobalFooter(localHelp)))
 	if m.showHelp {
 		lines = append(lines, "")
-		lines = append(lines, m.cockpitGlobalHelp()...)
+		lines = append(lines, m.cockpitContextualHelp()...)
 	}
 	return strings.Join(lines, "\n")
 }
@@ -1674,15 +1681,75 @@ func (m cockpitModel) cockpitGlobalFooter(localHelp string) string {
 			quitHelp = "quit disabled while applying"
 		}
 	}
-	parts := []string{"1-5 sections", "tab/shift+tab next/prev", "esc back", quitHelp, "? help"}
+	parts := []string{}
+	if m.cockpitSectionNavigationAvailable() {
+		parts = append(parts, "1-5 sections", "tab/shift+tab next/prev")
+	}
+	if m.cockpitBackAvailable() {
+		parts = append(parts, "esc back")
+	}
+	if quitHelp != "" {
+		parts = append(parts, quitHelp)
+	}
+	if m.cockpitHelpAvailable() {
+		parts = append(parts, "? help")
+	}
 	if localHelp != "" {
 		parts = append(parts, localHelp)
 	}
 	return strings.Join(parts, " · ")
 }
 
-func (m cockpitModel) cockpitGlobalHelp() []string {
-	lines := []string{
+func (m cockpitModel) cockpitSectionNavigationAvailable() bool {
+	if m.mode != cockpitModeMemoryReview {
+		return true
+	}
+	if m.memoryReview.applying {
+		return false
+	}
+	return m.memoryReview.loading || m.memoryReview.err != nil || m.memoryReview.review.mode == reviewModeBrowse || m.memoryReview.review.mode == reviewModeHelp
+}
+
+func (m cockpitModel) cockpitBackAvailable() bool {
+	if m.mode == cockpitModeHome {
+		return false
+	}
+	if m.mode == cockpitModeMemoryReview {
+		switch {
+		case m.memoryReview.applying:
+			return false
+		case m.memoryReview.loading, m.memoryReview.err != nil:
+			return true
+		default:
+			return m.memoryReview.review.mode == reviewModeBrowse
+		}
+	}
+	return true
+}
+
+func (m cockpitModel) cockpitHelpAvailable() bool {
+	if m.mode != cockpitModeMemoryReview {
+		return true
+	}
+	return !m.memoryReview.applying && m.memoryReview.review.mode != reviewModeEdit
+}
+
+func (m cockpitModel) cockpitContextualHelp() []string {
+	lines := []string{m.styles.Subtle.Render("Action menu")}
+	actions := m.cockpitContextualActions()
+	if len(actions) == 0 {
+		lines = append(lines, "• No local actions are available while this operation is in progress.")
+	} else {
+		for _, action := range actions {
+			if action.key == "" {
+				lines = append(lines, "• "+action.description)
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("• %-12s %s", action.key, action.description))
+		}
+	}
+	lines = append(lines,
+		"",
 		m.styles.Subtle.Render("Global navigation"),
 		"1 Home      triage overview and notifications",
 		"2 Live      event stream and event details",
@@ -1699,8 +1766,176 @@ func (m cockpitModel) cockpitGlobalHelp() []string {
 		"traceary session handoff",
 		"traceary memory inbox review",
 		"traceary tui --reset-state",
-	}
+	)
 	return lines
+}
+
+func (m cockpitModel) cockpitContextualActions() []cockpitAction {
+	switch m.mode {
+	case cockpitModeDoctor:
+		actions := []cockpitAction{{key: "r", description: "Refresh doctor checks"}}
+		if len(m.doctorLines()) > 3 {
+			actions = append(actions, cockpitAction{key: "↑/↓", description: "Scroll doctor output"})
+		}
+		if !m.doctor.loading && m.doctor.err == nil && cockpitDoctorHasRemediation(m.doctor.snapshot) {
+			actions = append(actions, cockpitAction{description: "Remediation commands are shown inline; copy and run them outside the cockpit."})
+		}
+		return actions
+	case cockpitModeLive:
+		actions := []cockpitAction{
+			{key: "r", description: "Refresh live events"},
+			{key: "f", description: m.liveFollowActionDescription()},
+		}
+		if len(m.live.events) > 0 {
+			actions = append(actions, cockpitAction{key: "enter", description: "Open selected event detail"})
+			if len(m.live.events) > 1 {
+				actions = append(actions, cockpitAction{key: "↑/↓", description: "Select an event"})
+			}
+		}
+		return actions
+	case cockpitModeDetail:
+		actions := []cockpitAction{{key: "esc", description: "Return to Live"}}
+		if len(m.detailLines()) > 1 {
+			actions = append(actions, cockpitAction{key: "↑/↓", description: "Scroll event detail"})
+		}
+		return actions
+	case cockpitModeMemoryReview:
+		return m.memoryReviewContextualActions()
+	case cockpitModeSessions:
+		return []cockpitAction{
+			{key: "r", description: "Refresh session summary"},
+			{description: "Use `traceary session handoff` for the full handoff outside the cockpit."},
+		}
+	default:
+		return []cockpitAction{
+			{key: "2", description: "Open Live tail"},
+			{key: "3", description: "Run Doctor checks"},
+			{key: "4", description: "Open Memory review"},
+			{key: "5", description: "Open Sessions and handoff entry points"},
+		}
+	}
+}
+
+func cockpitDoctorHasRemediation(snapshot cockpitDoctorSnapshot) bool {
+	for _, section := range snapshot.Sections {
+		for _, check := range section.Checks {
+			if check.FixCommand != "" || check.AutoFixAvailable {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m cockpitModel) liveFollowActionDescription() string {
+	if m.live.follow {
+		return "Pause follow mode"
+	}
+	return "Start follow mode"
+}
+
+func (m cockpitModel) memoryReviewContextualActions() []cockpitAction {
+	switch {
+	case m.memoryReview.loading:
+		return []cockpitAction{
+			{key: "esc", description: "Return to Home while the inbox loads"},
+			{key: "q", description: "Quit without applying decisions"},
+		}
+	case m.memoryReview.applying:
+		return nil
+	case m.memoryReview.err != nil:
+		return []cockpitAction{
+			{key: "esc", description: "Return to Home"},
+			{key: "q", description: "Quit without applying decisions"},
+		}
+	}
+	if len(m.memoryReview.items) == 0 {
+		return []cockpitAction{
+			{key: "q", description: "Finish review and refresh Home"},
+			{key: "esc", description: "Return to Home without applying"},
+		}
+	}
+	switch m.memoryReview.review.mode {
+	case reviewModeEdit:
+		return []cockpitAction{
+			{key: "enter", description: "Commit operator-authored fact"},
+			{key: "esc", description: "Cancel edit"},
+			{key: "backspace", description: "Edit text"},
+		}
+	case reviewModeViewEvidence:
+		return []cockpitAction{
+			{key: "v / esc", description: "Close evidence view"},
+			{key: "q", description: "Finish review and apply queued decisions"},
+		}
+	case reviewModeHelp:
+		return []cockpitAction{
+			{key: "? / esc", description: "Close memory review help"},
+			{key: "q", description: "Finish review and apply queued decisions"},
+		}
+	default:
+		actions := []cockpitAction{
+			{key: "a", description: "Accept current candidate"},
+			{key: "x", description: "Reject current candidate"},
+			{key: "s", description: "Skip current candidate"},
+			{key: "e", description: "Edit/distill into an operator-authored fact"},
+			{key: "v", description: "View evidence and artifact refs"},
+			{key: "q", description: "Finish review and apply queued decisions"},
+		}
+		if len(m.memoryReview.items) > 1 {
+			actions = append(actions, cockpitAction{key: "↑/↓", description: "Navigate candidates"})
+		}
+		return actions
+	}
+}
+
+func (m cockpitModel) liveLocalHelp() string {
+	parts := []string{"r refresh", "f follow"}
+	if m.live.follow {
+		parts[1] = "f pause"
+	}
+	if len(m.live.events) > 0 {
+		parts = append(parts, "enter detail")
+		if len(m.live.events) > 1 {
+			parts = append(parts, "↑/↓ select")
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (m cockpitModel) doctorLocalHelp() string {
+	parts := []string{"r refresh"}
+	if len(m.doctorLines()) > 3 {
+		parts = append(parts, "↑/↓ scroll")
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (m cockpitModel) detailLocalHelp() string {
+	if len(m.detailLines()) > 1 {
+		return "↑/↓ scroll"
+	}
+	return ""
+}
+
+func (m cockpitModel) memoryReviewLocalHelp() string {
+	switch {
+	case m.memoryReview.loading, m.memoryReview.err != nil:
+		return "q quit"
+	case m.memoryReview.applying:
+		return "applying decisions"
+	case len(m.memoryReview.items) == 0:
+		return "q finish review"
+	}
+	switch m.memoryReview.review.mode {
+	case reviewModeEdit:
+		return "enter commit · esc cancel · backspace edit"
+	case reviewModeViewEvidence:
+		return "v/esc close evidence · q finish/apply"
+	case reviewModeHelp:
+		return "?/esc close help · q finish/apply"
+	default:
+		return "a accept · x reject · s skip · e edit · v evidence · q finish/apply"
+	}
 }
 
 func (m cockpitModel) detailLines() []string {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1245,7 +1245,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 				"Traceary cockpit · home",
 				"sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions",
 				"1-5 sections",
-				"esc back",
+				"q/ctrl+c quit",
 			},
 		},
 		{
@@ -1273,7 +1273,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			expect: []string{
 				"Traceary cockpit · live tail",
 				"sections: 1 Home  [2 Live]  3 Doctor  4 Memory  5 Sessions",
-				"enter detail",
+				"r refresh",
 			},
 		},
 		{
@@ -1330,6 +1330,230 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
+	t.Parallel()
+
+	home := cockpitHomeSnapshot{
+		LoadedAt:                fixedStartedAt,
+		NewCandidateMemoryKnown: true,
+		CandidateMemoryCount:    1,
+	}
+	base := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
+	base.showHelp = true
+
+	t.Run("home", func(t *testing.T) {
+		view := base.View()
+		for _, must := range []string{
+			"Action menu",
+			"Open Live tail",
+			"Run Doctor checks",
+			"Open Memory review",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("home help missing %q:\n%s", must, view)
+			}
+		}
+	})
+
+	t.Run("live empty", func(t *testing.T) {
+		model := base
+		model.mode = cockpitModeLive
+		model.live.loadedAt = fixedStartedAt
+		view := model.View()
+		for _, must := range []string{
+			"Action menu",
+			"Refresh live events",
+			"Start follow mode",
+			"No recent events. Press r to refresh or f to follow.",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("live empty help missing %q:\n%s", must, view)
+			}
+		}
+		for _, mustNot := range []string{"enter detail", "Open selected event detail"} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("live empty help advertised unavailable %q:\n%s", mustNot, view)
+			}
+		}
+	})
+
+	t.Run("live with selection", func(t *testing.T) {
+		event := mustEvent(t, "evt-help-live", domtypes.EventKindNote, "help live event")
+		cockpit := base
+		cockpit.mode = cockpitModeLive
+		cockpit.live.loadedAt = fixedStartedAt
+		cockpit.live.events = []*model.Event{event}
+		view := cockpit.View()
+		for _, must := range []string{
+			"enter detail",
+			"Open selected event detail",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("live selection help missing %q:\n%s", must, view)
+			}
+		}
+	})
+
+	t.Run("live refresh error with cached selection", func(t *testing.T) {
+		event := mustEvent(t, "evt-help-live-error", domtypes.EventKindNote, "cached help live event")
+		cockpit := base
+		cockpit.mode = cockpitModeLive
+		cockpit.live.loadedAt = fixedStartedAt
+		cockpit.live.events = []*model.Event{event}
+		cockpit.live.err = context.Canceled
+		view := cockpit.View()
+		for _, must := range []string{
+			"enter detail",
+			"Open selected event detail",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("live cached-error help missing %q:\n%s", must, view)
+			}
+		}
+	})
+
+	t.Run("doctor", func(t *testing.T) {
+		model := base
+		model.mode = cockpitModeDoctor
+		model.doctor.snapshot = cockpitDoctorSnapshot{
+			LoadedAt: fixedStartedAt,
+			Summary:  doctorSummary{Warn: 1},
+			Sections: []cockpitDoctorSection{{Name: "Hooks", Checks: []cockpitDoctorCheck{
+				{Name: "codex-config", Status: doctorStatusWarn, Severity: doctorSeverityWarn, Message: "missing hook", FixCommand: "traceary hooks install --client codex"},
+			}}},
+		}
+		view := model.View()
+		for _, must := range []string{
+			"Refresh doctor checks",
+			"Remediation commands are shown inline",
+			"traceary hooks install --client codex",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("doctor help missing %q:\n%s", must, view)
+			}
+		}
+	})
+
+	t.Run("doctor error with stale remediation snapshot", func(t *testing.T) {
+		model := base
+		model.mode = cockpitModeDoctor
+		model.doctor.err = context.Canceled
+		model.doctor.snapshot = cockpitDoctorSnapshot{
+			LoadedAt: fixedStartedAt,
+			Summary:  doctorSummary{Warn: 1},
+			Sections: []cockpitDoctorSection{{Name: "Hooks", Checks: []cockpitDoctorCheck{
+				{Name: "codex-config", Status: doctorStatusWarn, Severity: doctorSeverityWarn, Message: "missing hook", FixCommand: "traceary hooks install --client codex"},
+			}}},
+		}
+		view := model.View()
+		if !strings.Contains(view, "Refresh doctor checks") {
+			t.Fatalf("doctor error help missing refresh action:\n%s", view)
+		}
+		if strings.Contains(view, "Remediation commands are shown inline") {
+			t.Fatalf("doctor error help advertised stale remediation:\n%s", view)
+		}
+	})
+
+	t.Run("memory", func(t *testing.T) {
+		candidate := cockpitMemoryDetailsFixture(t, "mem-help-menu", "review from contextual menu", domtypes.MemoryStatusCandidate)
+		model := base
+		model.mode = cockpitModeMemoryReview
+		model.memoryReview.items = []apptypes.MemoryDetails{candidate}
+		model.memoryReview.review = newReviewModel(model.memoryReview.items, model.keys, model.styles)
+		view := model.View()
+		for _, must := range []string{
+			"Accept current candidate",
+			"Reject current candidate",
+			"Skip current candidate",
+			"Edit/distill into an operator-authored fact",
+			"View evidence and artifact refs",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("memory help missing %q:\n%s", must, view)
+			}
+		}
+	})
+}
+
+func TestCockpitModel_MemoryReviewSubmodeFootersDoNotAdvertiseBrowseActions(t *testing.T) {
+	t.Parallel()
+
+	candidate := cockpitMemoryDetailsFixture(t, "mem-submode-footer", "submode footer candidate", domtypes.MemoryStatusCandidate)
+	base := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	base.mode = cockpitModeMemoryReview
+	base.memoryReview.items = []apptypes.MemoryDetails{candidate}
+	base.memoryReview.review = newReviewModel(base.memoryReview.items, base.keys, base.styles)
+
+	t.Run("edit", func(t *testing.T) {
+		model := base
+		model.memoryReview.review.mode = reviewModeEdit
+		model.memoryReview.review.editIndex = 0
+		view := model.View()
+		for _, must := range []string{
+			"enter commit · esc cancel · backspace edit",
+			"ctrl+c quit",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("edit footer missing %q:\n%s", must, view)
+			}
+		}
+		for _, mustNot := range []string{
+			"a accept · x reject",
+			"esc back",
+			"? help",
+		} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("edit footer advertised disabled %q:\n%s", mustNot, view)
+			}
+		}
+	})
+
+	t.Run("evidence", func(t *testing.T) {
+		model := base
+		model.memoryReview.review.mode = reviewModeViewEvidence
+		view := model.View()
+		for _, must := range []string{
+			"v/esc close evidence · q finish/apply",
+			"ctrl+c quit",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("evidence footer missing %q:\n%s", must, view)
+			}
+		}
+		for _, mustNot := range []string{
+			"a accept · x reject",
+			"1-5 sections",
+		} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("evidence footer advertised disabled %q:\n%s", mustNot, view)
+			}
+		}
+	})
+
+	t.Run("help", func(t *testing.T) {
+		model := base
+		model.showHelp = true
+		model.memoryReview.review.mode = reviewModeHelp
+		view := model.View()
+		for _, must := range []string{
+			"?/esc close help · q finish/apply",
+			"Close memory review help",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("help footer/menu missing %q:\n%s", must, view)
+			}
+		}
+		for _, mustNot := range []string{
+			"Accept current candidate",
+			"Reject current candidate",
+		} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("help action menu advertised disabled %q:\n%s", mustNot, view)
+			}
+		}
+	})
 }
 
 func TestCockpitModel_GlobalSectionKeysSwitchWithoutReturningToCLI(t *testing.T) {


### PR DESCRIPTION
## Motivation

The cockpit TUI now has stable global sections, but operators still need a discoverable way to understand which actions are available in the current screen. Hidden shortcuts make Live, Doctor, and Memory workflows difficult to learn.

## Changes

- Replace the generic help block with a contextual `Action menu` in `?` help.
- List only actions that are valid for the current cockpit screen/state.
- Hide unavailable Live detail actions when no event is selected/available.
- Surface Memory Review actions (`accept`, `reject`, `skip`, `edit`, `evidence`, finish/apply) in contextual help.
- Add useful empty-state next actions for Doctor no-check output.
- Keep global navigation and fallback command guidance in the help view.
- Add regression coverage for Home, Live, Doctor, and Memory action rendering.

## Verification

- `GOCACHE=/private/tmp/traceary-go-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go build ./...`
- `GOCACHE=/private/tmp/traceary-go-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `git diff --check`

Closes #1032
