### PR TITLE
v0.18-8: add cockpit Settings for language and safe config updates

### DIFF
--- a/docs/environment/README.ja.md
+++ b/docs/environment/README.ja.md
@@ -39,6 +39,7 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 
 | キー | 型 | 用途 |
 | --- | --- | --- |
+| `ui.language` | string | `TRACEARY_LANG` が未設定のときに使う operator 向け CLI/TUI language。利用可能な値: `en`, `ja`。`TRACEARY_LANG` は引き続き process-local override として優先されます。 |
 | `redact.extra_patterns` | 文字列配列 | 後方互換の追加正規表現パターン。各エントリは Go の `regexp` パターンとしてコンパイルされ、マッチした内容が `[REDACTED]` に置換されます。CLI（`traceary audit`、`traceary log --kind transcript`、Claude Stop-hook の transcript capture）と MCP サーバー（`record_event(type="audit")`、`kind=transcript` を指定した `record_event(type="log")`）の両方で、組み込みルールの後に適用されます。 |
 | `redact.rules` | object 配列 | `extra_patterns` と併用できる構造化 redaction rule。rule には `name`、target scope（`audit.input`, `audit.output`, `log.message`）、独自 `replacement` を設定できます。対応 type は `regex`（`pattern`）、`field`（`fields` または dotted JSON `paths`）、`url`（`query_params` と URL credential masking）、`context`（`fields` + JWT / 長い hex / 長い base64 などの secret 形状、任意の `min_length`）です。組み込み redaction は安全床として常に残り、無効化できません。 |
 | `read.fields` | 文字列配列 | `traceary tail` / `list` / `search` のテキスト出力で `--fields` が指定されなかった場合に使用されるコンパクトカラムのデフォルト順。利用可能なフィールド名: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`。未知・空・重複エントリはコマンド実行時に拒否されます。`--fields` フラグが指定された場合は常にこの設定を上書きします。`--wide` や `--json` 出力には影響しません。 |
@@ -49,6 +50,9 @@ Traceary はオプションの JSON 設定ファイルを `~/.config/traceary/co
 
 ```json
 {
+  "ui": {
+    "language": "en"
+  },
   "redact": {
     "extra_patterns": ["my_custom_secret", "internal_auth_header:\\s*\\S+"]
   },

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -39,6 +39,7 @@ Traceary reads an optional JSON configuration file from `~/.config/traceary/conf
 
 | Key | Type | Purpose |
 | --- | --- | --- |
+| `ui.language` | string | Default operator-facing CLI/TUI language when `TRACEARY_LANG` is not set. Supported values: `en`, `ja`. `TRACEARY_LANG` remains the process-local override. |
 | `redact.extra_patterns` | string array | Backward-compatible extra regex patterns for audit and transcript redaction. Each entry is compiled as a Go `regexp` pattern and matched content is replaced with `[REDACTED]`. Applied after the built-in redaction rules in both the CLI (`traceary audit`, `traceary log --kind transcript`, Claude Stop-hook transcript capture) and MCP server (`record_event(type="audit")`, `record_event(type="log")` with `kind=transcript`). |
 | `redact.rules` | object array | Structured redaction rules applied alongside `extra_patterns`. Rules may be named, scoped to targets (`audit.input`, `audit.output`, `log.message`), and may set a custom `replacement`. Supported types: `regex` (`pattern`), `field` (`fields` or dotted JSON `paths`), `url` (`query_params` plus built-in URL credential masking), and `context` (`fields` + secret-shaped values such as JWT / long hex / long base64, with optional `min_length`). Built-in redaction remains a safety floor and cannot be disabled. |
 | `read.fields` | string array | Default compact column order for `traceary tail` / `list` / `search` text output when `--fields` is omitted. Accepted field names: `ts`, `kind`, `session`, `ws`, `client`, `agent`, `message`, `exit_code`, `id`. Unknown / empty / duplicate entries are rejected at command runtime; the `--fields` flag always overrides this setting. Does not affect `--wide` or `--json` output. |
@@ -49,6 +50,9 @@ Example:
 
 ```json
 {
+  "ui": {
+    "language": "en"
+  },
   "redact": {
     "extra_patterns": ["my_custom_secret", "internal_auth_header:\\s*\\S+"]
   },

--- a/docs/operations/cockpit-dogfood.ja.md
+++ b/docs/operations/cockpit-dogfood.ja.md
@@ -26,6 +26,7 @@ dogfood テストで確認する内容:
   - 曖昧な memory の evidence を確認し、誤って accept しない。
   - Doctor を開き remediation command を見つける。
 - `TRACEARY_LANG=ja` と 80x24 での Japanese cockpit smoke。
+- `ui.language` の切り替え、安全な read setting の cycle、保存前の redaction regex 検証を含む Settings coverage。
 
 Golden snapshot は `presentation/cli/testdata/cockpit/` にあります。意図した cockpit 文言・layout 変更時だけ更新してください:
 
@@ -58,6 +59,10 @@ cockpit release の tag 前に、実 terminal で以下を確認します:
 8. `TRACEARY_LANG=ja traceary tui --reset-state` を実行。
    - shell / footer / help・action menu / Home labels / Memory review の判断補助が日本語で理解できること。
    - `traceary doctor --json` などの literal command は、copy できる英語 command 名のまま残ること。
+9. `6` で Settings へ移動。
+   - config path/status、`TRACEARY_LANG` override の説明、environment diagnostics、read-only の preset/rule list が見えること。
+   - `ui.language` を English から Japanese へ、さらに戻す操作と、`read.color` または `read.fields` の cycle を staged にし、保存前 diff を確認できること。
+   - 不正な `redact.extra_patterns` regex を入力し、config 書き込み前に拒否されること。
 
 ## Release gate
 

--- a/docs/operations/cockpit-dogfood.md
+++ b/docs/operations/cockpit-dogfood.md
@@ -26,6 +26,7 @@ The dogfood tests cover:
   - inspecting evidence for an ambiguous memory without accidentally accepting it,
   - opening Doctor and finding a remediation command.
 - Japanese cockpit smoke coverage with `TRACEARY_LANG=ja` at 80x24.
+- Settings coverage for switching `ui.language`, cycling one safe read setting, and validating redaction regex input before save.
 
 Golden snapshots live under `presentation/cli/testdata/cockpit/`. Update them only when the intended cockpit copy/layout changes:
 
@@ -58,6 +59,10 @@ Run each task in a real terminal before tagging a cockpit release:
 8. Run `TRACEARY_LANG=ja traceary tui --reset-state`.
    - Confirm the shell, footer, help/action menu, Home labels, and Memory review decision aids are understandable in Japanese.
    - Confirm literal commands such as `traceary doctor --json` remain copyable as English command names.
+9. Press `6` for Settings.
+   - Confirm the config path/status, `TRACEARY_LANG` override explanation, environment diagnostics, and read-only preset/rule lists are visible.
+   - Stage `ui.language` from English to Japanese and back, cycle `read.color` or `read.fields`, then review the diff before confirming save.
+   - Try an invalid `redact.extra_patterns` regex and confirm it is rejected before any config write.
 
 ## Release gate
 

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -788,6 +788,7 @@ type cockpitModel struct {
 	doctorRequestSeq       uint64
 	memoryReview           cockpitMemoryReviewState
 	memoryReviewRequestSeq uint64
+	settings               cockpitSettingsState
 }
 
 func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapshot) cockpitModel {
@@ -805,6 +806,7 @@ const (
 	cockpitModeDetail
 	cockpitModeMemoryReview
 	cockpitModeSessions
+	cockpitModeSettings
 )
 
 type cockpitSectionID int
@@ -815,6 +817,7 @@ const (
 	cockpitSectionDoctor
 	cockpitSectionMemory
 	cockpitSectionSessions
+	cockpitSectionSettings
 )
 
 type cockpitNavigationSection struct {
@@ -833,6 +836,7 @@ var cockpitNavigationSections = []cockpitNavigationSection{
 	{id: cockpitSectionDoctor, key: "3"},
 	{id: cockpitSectionMemory, key: "4"},
 	{id: cockpitSectionSessions, key: "5"},
+	{id: cockpitSectionSettings, key: "6"},
 }
 
 // cockpitNavigationSectionLabel returns the localized label for a cockpit
@@ -851,6 +855,8 @@ func cockpitNavigationSectionLabel(id cockpitSectionID) string {
 		return Localize("Memory", "メモリ")
 	case cockpitSectionSessions:
 		return Localize("Sessions", "セッション")
+	case cockpitSectionSettings:
+		return Localize("Settings", "設定")
 	}
 	return ""
 }
@@ -1030,6 +1036,9 @@ func (m cockpitModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.mode == cockpitModeMemoryReview {
 		return m.updateMemoryReviewKey(msg)
 	}
+	if m.mode == cockpitModeSettings {
+		return m.updateSettingsKey(msg)
+	}
 	switch {
 	case isCockpitQuitKey(msg):
 		return m, tea.Quit
@@ -1085,6 +1094,8 @@ func cockpitSectionFromKey(msg tea.KeyMsg) (cockpitSectionID, bool) {
 		return cockpitSectionMemory, true
 	case '5':
 		return cockpitSectionSessions, true
+	case '6':
+		return cockpitSectionSettings, true
 	default:
 		return 0, false
 	}
@@ -1126,6 +1137,8 @@ func (m cockpitModel) activeCockpitSection() cockpitSectionID {
 		return cockpitSectionMemory
 	case cockpitModeSessions:
 		return cockpitSectionSessions
+	case cockpitModeSettings:
+		return cockpitSectionSettings
 	default:
 		return cockpitSectionHome
 	}
@@ -1160,6 +1173,8 @@ func (m cockpitModel) openCockpitSection(section cockpitSectionID) (tea.Model, t
 	case cockpitSectionSessions:
 		m.mode = cockpitModeSessions
 		return m, nil
+	case cockpitSectionSettings:
+		return m.openCockpitSettings()
 	default:
 		return m, nil
 	}
@@ -1196,6 +1211,8 @@ func (m cockpitModel) updateHomeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.openCockpitSection(cockpitSectionLive)
 		case "m":
 			return m.openCockpitSection(cockpitSectionMemory)
+		case "s":
+			return m.openCockpitSection(cockpitSectionSettings)
 		}
 	}
 	return m, nil
@@ -1610,6 +1627,8 @@ func (m cockpitModel) View() string {
 		return m.memoryReviewView()
 	case cockpitModeSessions:
 		return m.sessionsView()
+	case cockpitModeSettings:
+		return m.settingsView()
 	}
 	return m.homeView()
 }
@@ -1651,7 +1670,7 @@ func (m cockpitModel) homeView() string {
 			"",
 			m.styles.Success.Render(Localize("ALL GREEN", "すべて正常")),
 			"• "+Localize("No immediate cockpit warnings or tracked new activity.", "直近の cockpit warning や追跡済みの新着 activity はありません。"),
-			"• "+Localize("Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff.", "次: 作業中は 2 Live、定期確認は 4 Memory、release 前は 3 Doctor、handoff は 5 Sessions。"),
+			"• "+Localize("Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff, 6 Settings for configuration.", "次: 作業中は 2 Live、定期確認は 4 Memory、release 前は 3 Doctor、handoff は 5 Sessions、設定は 6 Settings。"),
 		)
 	}
 	lines = append(lines,
@@ -1935,10 +1954,12 @@ func (m cockpitModel) cockpitGlobalFooter(localHelp string) string {
 		if m.memoryReview.applying {
 			quitHelp = Localize("quit disabled while applying", "適用中は終了できません")
 		}
+	} else if m.mode == cockpitModeSettings && m.settings.editingPattern {
+		quitHelp = Localize("ctrl+c quit", "ctrl+c 終了")
 	}
 	parts := []string{}
 	if m.cockpitSectionNavigationAvailable() {
-		parts = append(parts, Localize("1-5 sections", "1-5 セクション"), Localize("tab/shift+tab next/prev", "tab/shift+tab 次/前"))
+		parts = append(parts, Localize("1-6 sections", "1-6 セクション"), Localize("tab/shift+tab next/prev", "tab/shift+tab 次/前"))
 	}
 	if m.width > 0 && m.height > 0 {
 		parts = append(parts, Localizef("terminal %dx%d", "端末 %dx%d", m.width, m.height))
@@ -1959,6 +1980,9 @@ func (m cockpitModel) cockpitGlobalFooter(localHelp string) string {
 }
 
 func (m cockpitModel) cockpitSectionNavigationAvailable() bool {
+	if m.mode == cockpitModeSettings && (m.settings.editingPattern || m.settings.confirmSave) {
+		return false
+	}
 	if m.mode != cockpitModeMemoryReview {
 		return true
 	}
@@ -1969,6 +1993,9 @@ func (m cockpitModel) cockpitSectionNavigationAvailable() bool {
 }
 
 func (m cockpitModel) cockpitBackAvailable() bool {
+	if m.mode == cockpitModeSettings && (m.settings.editingPattern || m.settings.confirmSave) {
+		return false
+	}
 	if m.mode == cockpitModeHome {
 		return false
 	}
@@ -1986,6 +2013,9 @@ func (m cockpitModel) cockpitBackAvailable() bool {
 }
 
 func (m cockpitModel) cockpitHelpAvailable() bool {
+	if m.mode == cockpitModeSettings && (m.settings.editingPattern || m.settings.confirmSave) {
+		return false
+	}
 	if m.mode != cockpitModeMemoryReview {
 		return true
 	}
@@ -2014,6 +2044,7 @@ func (m cockpitModel) cockpitContextualHelp() []string {
 		Localize("3 Doctor    health checks and remediation hints", "3 Doctor    health check と修復 hint"),
 		Localize("4 Memory    inbox review queue", "4 メモリ      inbox review queue"),
 		Localize("5 Sessions  session and handoff entry points", "5 セッション  session と handoff 導線"),
+		Localize("6 Settings  language, read defaults, redaction diagnostics", "6 設定        language / read 既定 / redaction 診断"),
 		Localize("tab / shift+tab cycle sections", "tab / shift+tab で section を移動"),
 		Localize("esc backs out to the previous cockpit level; q exits the TUI", "esc で前の cockpit 階層へ戻り、q で TUI を終了"),
 		"",
@@ -2064,15 +2095,18 @@ func (m cockpitModel) cockpitContextualActions() []cockpitAction {
 			{key: "r", description: Localize("Refresh session summary", "session summary を再取得")},
 			{description: Localize("Use `traceary session handoff` for the full handoff outside the cockpit.", "完全な handoff は cockpit 外で `traceary session handoff` を使ってください。")},
 		}
+	case cockpitModeSettings:
+		return m.settingsContextualActions()
 	default:
 		actions := []cockpitAction{
 			{key: "2", description: Localize("Open Live tail", "Live tail を開く")},
 			{key: "3", description: Localize("Run Doctor checks", "Doctor check を実行")},
 			{key: "4", description: Localize("Open Memory review", "Memory review を開く")},
 			{key: "5", description: Localize("Open Sessions and handoff entry points", "Sessions と handoff 導線を開く")},
+			{key: "6", description: Localize("Open Settings", "Settings を開く")},
 		}
 		if m.home.allGreen() {
-			actions = append(actions, cockpitAction{description: Localize("All green: use Live for ongoing work, Memory for periodic review, Doctor before release, Sessions for handoff.", "すべて正常: 作業中は Live、定期確認は Memory、release 前は Doctor、handoff は Sessions を使います。")})
+			actions = append(actions, cockpitAction{description: Localize("All green: use Live for ongoing work, Memory for periodic review, Doctor before release, Sessions for handoff, Settings for config changes.", "すべて正常: 作業中は Live、定期確認は Memory、release 前は Doctor、handoff は Sessions、設定変更は Settings を使います。")})
 		} else {
 			actions = append(actions, cockpitAction{description: Localize("Home cards are ordered by urgency; each card shows its next action target.", "Home card は緊急度順です。各 card に次の action target が表示されます。")})
 		}

--- a/presentation/cli/cockpit_dogfood_internal_test.go
+++ b/presentation/cli/cockpit_dogfood_internal_test.go
@@ -232,6 +232,74 @@ func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 			t.Fatalf("doctor dogfood view missing remediation command:\n%s", view)
 		}
 	})
+
+	t.Run("stage settings language read color and validated regex before save", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "config.json")
+		model := newCockpitModel(tui.DefaultKeyMap(), tui.Styles{}, cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+		model.mode = cockpitModeSettings
+		model.settings = cockpitSettingsState{
+			loaded: true,
+			snapshot: cockpitSettingsSnapshot{
+				Path:   configPath,
+				Status: cockpitSettingsConfigMissing,
+				Env: cockpitSettingsEnv{
+					TracearyLang:    "en",
+					TracearyLangSet: true,
+				},
+			},
+		}
+		model.settings.draft = model.settings.snapshot.Values.clone()
+
+		updated, _ := model.Update(cockpitRuneKey("l"))
+		model = updated.(cockpitModel)
+		if view := model.View(); !strings.Contains(view, "ui.language: ja") || !strings.Contains(view, "ui.language: en (default) -> ja") {
+			t.Fatalf("settings dogfood missing staged Japanese language diff:\n%s", view)
+		}
+		updated, _ = model.Update(cockpitRuneKey("l"))
+		model = updated.(cockpitModel)
+		if view := model.View(); !strings.Contains(view, "ui.language: en") || !strings.Contains(view, "ui.language: en (default) -> en") {
+			t.Fatalf("settings dogfood missing staged English language diff:\n%s", view)
+		}
+		updated, _ = model.Update(cockpitRuneKey("c"))
+		model = updated.(cockpitModel)
+		updated, _ = model.Update(cockpitRuneKey("n"))
+		model = updated.(cockpitModel)
+		for _, r := range "SECRET-[" {
+			updated, _ = model.Update(cockpitRuneKey(string(r)))
+			model = updated.(cockpitModel)
+		}
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		model = updated.(cockpitModel)
+		if view := model.View(); !strings.Contains(view, "Invalid regex") {
+			t.Fatalf("settings dogfood should reject invalid regex before save:\n%s", view)
+		}
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		model = updated.(cockpitModel)
+		updated, _ = model.Update(cockpitRuneKey("n"))
+		model = updated.(cockpitModel)
+		for _, r := range `SECRET-[0-9]+` {
+			updated, _ = model.Update(cockpitRuneKey(string(r)))
+			model = updated.(cockpitModel)
+		}
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		model = updated.(cockpitModel)
+		updated, _ = model.Update(cockpitRuneKey("w"))
+		model = updated.(cockpitModel)
+		if view := model.View(); !strings.Contains(view, "Confirm config write") || !strings.Contains(view, "read.color: auto (default) -> always") {
+			t.Fatalf("settings dogfood missing confirmation diff:\n%s", view)
+		}
+		updated, _ = model.Update(cockpitRuneKey("y"))
+		model = updated.(cockpitModel)
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("settings dogfood expected saved config: %v", err)
+		}
+		for _, must := range []string{`"language": "en"`, `"color": "always"`, `SECRET-[0-9]+`} {
+			if !strings.Contains(string(data), must) {
+				t.Fatalf("settings dogfood saved config missing %q:\n%s", must, data)
+			}
+		}
+	})
 }
 
 func TestCockpitDogfoodJapaneseNarrowSmoke(t *testing.T) {
@@ -263,6 +331,7 @@ func TestCockpitDogfoodJapaneseNarrowSmoke(t *testing.T) {
 		"アクション menu",
 		"Global navigation",
 		"1 ホーム",
+		"6 設定",
 		"? ヘルプ",
 	} {
 		if !strings.Contains(view, must) {
@@ -294,6 +363,36 @@ func TestCockpitDogfoodJapaneseNarrowSmoke(t *testing.T) {
 	} {
 		if !strings.Contains(memoryView, must) {
 			t.Fatalf("Japanese memory review smoke missing %q:\n%s", must, memoryView)
+		}
+	}
+
+	settingsModel := newCockpitModel(tui.DefaultKeyMap(), tui.Styles{}, cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	settingsModel.mode = cockpitModeSettings
+	settingsModel.settings = cockpitSettingsState{
+		loaded: true,
+		snapshot: cockpitSettingsSnapshot{
+			Path:   "/tmp/config.json",
+			Status: cockpitSettingsConfigMissing,
+			Env: cockpitSettingsEnv{
+				TracearyLang:    "ja",
+				TracearyLangSet: true,
+			},
+		},
+	}
+	settingsModel.settings.draft = settingsModel.settings.snapshot.Values.clone()
+	settingsView := settingsModel.View()
+	for _, must := range []string{
+		"Traceary cockpit · 設定",
+		"config backed settings",
+		"編集可能な settings",
+		"読み取り専用 diagnostics",
+		"TRACEARY_LANG=ja",
+		"ui.language:",
+		"redact.extra_patterns:",
+		"regex 追加",
+	} {
+		if !strings.Contains(settingsView, must) {
+			t.Fatalf("Japanese settings smoke missing %q:\n%s", must, settingsView)
 		}
 	}
 }

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -355,7 +357,7 @@ func TestCockpitModelView_RendersStableEmptyStateAndOverview(t *testing.T) {
 		"PROBLEMS",
 		"No immediate cockpit warnings",
 		"ALL GREEN",
-		"Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff.",
+		"Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff, 6 Settings for configuration.",
 		"SIGNAL COUNTS",
 		"doctor: pass=4 warn=0 fail=0",
 		"memories: accepted(reviewed)=2 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0",
@@ -1281,8 +1283,8 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			model: model,
 			expect: []string{
 				"Traceary cockpit · home",
-				"sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions",
-				"1-5 sections",
+				"sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings",
+				"1-6 sections",
 				"q/ctrl+c quit",
 			},
 		},
@@ -1296,7 +1298,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}(),
 			expect: []string{
 				"Traceary cockpit · doctor",
-				"sections: 1 Home  2 Live  [3 Doctor]  4 Memory  5 Sessions",
+				"sections: 1 Home  2 Live  [3 Doctor]  4 Memory  5 Sessions  6 Settings",
 				"r refresh",
 			},
 		},
@@ -1310,7 +1312,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}(),
 			expect: []string{
 				"Traceary cockpit · live tail",
-				"sections: 1 Home  [2 Live]  3 Doctor  4 Memory  5 Sessions",
+				"sections: 1 Home  [2 Live]  3 Doctor  4 Memory  5 Sessions  6 Settings",
 				"r refresh",
 			},
 		},
@@ -1325,7 +1327,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}(),
 			expect: []string{
 				"Traceary cockpit · EVENT evt-shell",
-				"sections: 1 Home  [2 Live]  3 Doctor  4 Memory  5 Sessions",
+				"sections: 1 Home  [2 Live]  3 Doctor  4 Memory  5 Sessions  6 Settings",
 				"esc back",
 			},
 		},
@@ -1339,7 +1341,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}(),
 			expect: []string{
 				"Traceary cockpit · memory review",
-				"sections: 1 Home  2 Live  3 Doctor  [4 Memory]  5 Sessions",
+				"sections: 1 Home  2 Live  3 Doctor  [4 Memory]  5 Sessions  6 Settings",
 				"Loading memory inbox review queue",
 			},
 		},
@@ -1352,8 +1354,29 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 			}(),
 			expect: []string{
 				"Traceary cockpit · sessions",
-				"sections: 1 Home  2 Live  3 Doctor  4 Memory  [5 Sessions]",
+				"sections: 1 Home  2 Live  3 Doctor  4 Memory  [5 Sessions]  6 Settings",
 				"traceary session handoff",
+			},
+		},
+		{
+			name: "settings",
+			model: func() cockpitModel {
+				next := model
+				next.mode = cockpitModeSettings
+				next.settings = cockpitSettingsState{
+					loaded: true,
+					snapshot: cockpitSettingsSnapshot{
+						Path:   "/tmp/config.json",
+						Status: cockpitSettingsConfigMissing,
+					},
+				}
+				next.settings.draft = next.settings.snapshot.Values.clone()
+				return next
+			}(),
+			expect: []string{
+				"Traceary cockpit · settings",
+				"sections: 1 Home  2 Live  3 Doctor  4 Memory  5 Sessions  [6 Settings]",
+				"config status: missing",
 			},
 		},
 	}
@@ -1516,6 +1539,336 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 	})
 }
 
+func TestCockpitSettingsViewShowsConfigStatusAndEnvOverrides(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(cliLanguageEnvKey, "en")
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{
+		"ui": {"language": "ja"},
+		"read": {
+			"color": "never",
+			"fields": ["ts", "kind", "message"],
+			"presets": {"mine": {"fields": ["ts"], "filters": {"kind": "prompt"}}}
+		},
+		"redact": {
+			"extra_patterns": ["SECRET-[0-9]+"],
+			"rules": [{"name": "token", "type": "regex"}]
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, cmd := model.Update(cockpitRuneKey("6"))
+	model = updated.(cockpitModel)
+	if cmd != nil {
+		t.Fatalf("opening settings returned cmd = %T, want nil", cmd)
+	}
+	view := model.View()
+	for _, must := range []string{
+		"Traceary cockpit · settings",
+		"config status: loaded",
+		"TRACEARY_LANG=en overrides ui.language",
+		"ui.language: ja",
+		"read.color: never",
+		"read.fields: ts,kind,message",
+		"redact.extra_patterns: SECRET-[0-9]+",
+		"TRACEARY_DB_PATH=unset",
+		"read.presets (view only in v0.18)",
+		"mine fields=ts filters=kind=prompt",
+		"redact.rules (view only in v0.18)",
+		"token(regex)",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("settings view missing %q:\n%s", must, view)
+		}
+	}
+}
+
+func TestCockpitSettingsStagesValidatesAndSavesConfigAtomically(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	previousLang, hadLang := os.LookupEnv(cliLanguageEnvKey)
+	if err := os.Unsetenv(cliLanguageEnvKey); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if hadLang {
+			_ = os.Setenv(cliLanguageEnvKey, previousLang)
+		} else {
+			_ = os.Unsetenv(cliLanguageEnvKey)
+		}
+	})
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("6"))
+	model = updated.(cockpitModel)
+
+	updated, _ = model.Update(cockpitRuneKey("l"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("c"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("f"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("n"))
+	model = updated.(cockpitModel)
+	for _, r := range "SECRET-[" {
+		updated, _ = model.Update(cockpitRuneKey(string(r)))
+		model = updated.(cockpitModel)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if !strings.Contains(model.View(), "Invalid regex") {
+		t.Fatalf("invalid regex should be rejected before save:\n%s", model.View())
+	}
+	configPath := filepath.Join(home, ".config", "traceary", "config.json")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("invalid regex should not create config, stat err=%v", err)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("n"))
+	model = updated.(cockpitModel)
+	for _, r := range `SECRET-[0-9]+` {
+		updated, _ = model.Update(cockpitRuneKey(string(r)))
+		model = updated.(cockpitModel)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("w"))
+	model = updated.(cockpitModel)
+	if !strings.Contains(model.View(), "Confirm config write") || !strings.Contains(model.View(), "redact.extra_patterns") {
+		t.Fatalf("settings save should require confirmation with diff:\n%s", model.View())
+	}
+	updated, _ = model.Update(cockpitRuneKey("y"))
+	model = updated.(cockpitModel)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config) error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("saved config invalid JSON: %v\n%s", err, data)
+	}
+	ui := got["ui"].(map[string]any)
+	read := got["read"].(map[string]any)
+	redact := got["redact"].(map[string]any)
+	if ui["language"] != "ja" {
+		t.Fatalf("ui.language = %v, want ja", ui["language"])
+	}
+	if read["color"] != "always" {
+		t.Fatalf("read.color = %v, want always", read["color"])
+	}
+	if len(read["fields"].([]any)) == 0 {
+		t.Fatalf("read.fields not saved: %#v", read["fields"])
+	}
+	if gotPatterns := redact["extra_patterns"].([]any); len(gotPatterns) != 1 || gotPatterns[0] != "SECRET-[0-9]+" {
+		t.Fatalf("redact.extra_patterns = %#v, want valid staged regex", gotPatterns)
+	}
+	if !strings.Contains(model.View(), "設定") {
+		t.Fatalf("saved ui.language should refresh current cockpit language when TRACEARY_LANG is unset:\n%s", model.View())
+	}
+}
+
+func TestCockpitSettingsInvalidConfigIsRecoverableAndNotOverwritten(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configPath, []byte("{invalid}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("6"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("l"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("w"))
+	model = updated.(cockpitModel)
+
+	view := model.View()
+	for _, must := range []string{"config status: invalid JSON", "Config edits are disabled", "Fix config readability/JSON"} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("invalid config settings view missing %q:\n%s", must, view)
+		}
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "{invalid}" {
+		t.Fatalf("invalid config was overwritten: %q", string(data))
+	}
+}
+
+func TestCockpitSettingsSaveHandlesNullSectionsAndPreservesUnknownKeys(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	initial := `{"ui": null, "read": null, "redact": null, "unknown": {"keep": true}}`
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := cockpitSettingsSnapshot{
+		Path:   configPath,
+		Status: cockpitSettingsConfigLoaded,
+		Values: cockpitSettingsValues{
+			UILanguage:    "",
+			ReadColor:     "",
+			ReadFields:    nil,
+			ExtraPatterns: nil,
+		},
+	}
+	values := snapshot.Values.clone()
+	values.UILanguage = "ja"
+	values.ReadColor = "never"
+	values.ReadFields = []string{"ts", "kind", "message"}
+	values.ExtraPatterns = []string{"SECRET-[0-9]+"}
+
+	if err := saveCockpitSettingsDraft(snapshot, values); err != nil {
+		t.Fatalf("saveCockpitSettingsDraft() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("saved config invalid JSON: %v\n%s", err, data)
+	}
+	if got["unknown"].(map[string]any)["keep"] != true {
+		t.Fatalf("unknown key not preserved: %s", data)
+	}
+	if got["ui"].(map[string]any)["language"] != "ja" {
+		t.Fatalf("ui section not replaced from null: %s", data)
+	}
+	if got["read"].(map[string]any)["color"] != "never" {
+		t.Fatalf("read section not replaced from null: %s", data)
+	}
+	if gotPatterns := got["redact"].(map[string]any)["extra_patterns"].([]any); len(gotPatterns) != 1 || gotPatterns[0] != "SECRET-[0-9]+" {
+		t.Fatalf("redact section not replaced from null: %s", data)
+	}
+}
+
+func TestCockpitSettingsLanguageStagedMarkerUsesNormalizedDiff(t *testing.T) {
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.mode = cockpitModeSettings
+	model.settings = cockpitSettingsState{
+		loaded: true,
+		snapshot: cockpitSettingsSnapshot{
+			Path:   filepath.Join(t.TempDir(), "config.json"),
+			Status: cockpitSettingsConfigLoaded,
+			Values: cockpitSettingsValues{
+				UILanguage: "ja-JP",
+			},
+		},
+	}
+	model.settings.draft = model.settings.snapshot.Values.clone()
+
+	updated, _ := model.Update(cockpitRuneKey("l"))
+	model = updated.(cockpitModel)
+	if !model.settings.dirty() || !strings.Contains(model.View(), "[staged]") {
+		t.Fatalf("language toggle should stage a normalized diff:\n%s", model.View())
+	}
+	updated, _ = model.Update(cockpitRuneKey("l"))
+	model = updated.(cockpitModel)
+	view := model.View()
+	if model.settings.dirty() {
+		t.Fatalf("language toggled back to equivalent value should not be dirty")
+	}
+	if strings.Contains(view, "[staged]") {
+		t.Fatalf("language row showed staged marker for equivalent normalized value:\n%s", view)
+	}
+	updated, _ = model.Update(cockpitRuneKey("w"))
+	model = updated.(cockpitModel)
+	if !strings.Contains(model.View(), "No pending settings changes to save.") {
+		t.Fatalf("save prompt should match normalized clean state:\n%s", model.View())
+	}
+}
+
+func TestCockpitSettingsSaveConfirmationHidesUnavailableGlobalShortcuts(t *testing.T) {
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.mode = cockpitModeSettings
+	model.settings = cockpitSettingsState{
+		loaded: true,
+		snapshot: cockpitSettingsSnapshot{
+			Path:   filepath.Join(t.TempDir(), "config.json"),
+			Status: cockpitSettingsConfigMissing,
+		},
+	}
+	model.settings.draft = model.settings.snapshot.Values.clone()
+
+	updated, _ := model.Update(cockpitRuneKey("l"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cockpitRuneKey("w"))
+	model = updated.(cockpitModel)
+	view := model.View()
+	if !strings.Contains(view, "y save · n/esc cancel") {
+		t.Fatalf("save confirmation local help missing:\n%s", view)
+	}
+	for _, hidden := range []string{"1-6 sections", "tab/shift+tab", "? help", "esc back"} {
+		if strings.Contains(view, hidden) {
+			t.Fatalf("save confirmation footer advertised unavailable global shortcut %q:\n%s", hidden, view)
+		}
+	}
+}
+
+func TestCockpitSettingsPatternInputKeepsQuitContract(t *testing.T) {
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.mode = cockpitModeSettings
+	model.settings = cockpitSettingsState{
+		loaded: true,
+		snapshot: cockpitSettingsSnapshot{
+			Path:   filepath.Join(t.TempDir(), "config.json"),
+			Status: cockpitSettingsConfigMissing,
+		},
+	}
+	model.settings.draft = model.settings.snapshot.Values.clone()
+
+	updated, cmd := model.Update(cockpitRuneKey("n"))
+	model = updated.(cockpitModel)
+	if cmd != nil || !model.settings.editingPattern {
+		t.Fatalf("n mode/cmd = editing:%v/%T, want editing/nil", model.settings.editingPattern, cmd)
+	}
+	view := model.View()
+	if !strings.Contains(view, "ctrl+c quit") || strings.Contains(view, "q/ctrl+c quit") {
+		t.Fatalf("pattern input footer should advertise ctrl+c quit only:\n%s", view)
+	}
+	for _, hidden := range []string{"1-6 sections", "tab/shift+tab", "? help", "esc back"} {
+		if strings.Contains(view, hidden) {
+			t.Fatalf("pattern input footer advertised unavailable global shortcut %q:\n%s", hidden, view)
+		}
+	}
+	updated, cmd = model.Update(cockpitRuneKey("q"))
+	model = updated.(cockpitModel)
+	if cmd != nil || model.settings.patternInput != "q" {
+		t.Fatalf("q should remain available as regex input, pattern=%q cmd=%T", model.settings.patternInput, cmd)
+	}
+	_, cmd = model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatalf("ctrl+c in pattern input returned nil command, want quit")
+	}
+}
+
 func TestCockpitModel_MemoryReviewSubmodeFootersDoNotAdvertiseBrowseActions(t *testing.T) {
 	t.Parallel()
 
@@ -1563,7 +1916,7 @@ func TestCockpitModel_MemoryReviewSubmodeFootersDoNotAdvertiseBrowseActions(t *t
 		}
 		for _, mustNot := range []string{
 			"a accept as-is · x reject",
-			"1-5 sections",
+			"1-6 sections",
 		} {
 			if strings.Contains(view, mustNot) {
 				t.Fatalf("evidence footer advertised disabled %q:\n%s", mustNot, view)
@@ -1622,16 +1975,24 @@ func TestCockpitModel_GlobalSectionKeysSwitchWithoutReturningToCLI(t *testing.T)
 		t.Fatalf("5 mode/cmd = %v/%T, want sessions/nil", model.mode, cmd)
 	}
 
-	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
 	model = updated.(cockpitModel)
-	if model.mode != cockpitModeHome || cmd != nil {
-		t.Fatalf("tab from sessions mode/cmd = %v/%T, want home/nil", model.mode, cmd)
+	if model.mode != cockpitModeSettings || cmd != nil {
+		t.Fatalf("tab from sessions mode/cmd = %v/%T, want settings/nil", model.mode, cmd)
 	}
 
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeSessions || cmd != nil {
-		t.Fatalf("shift+tab from home mode/cmd = %v/%T, want sessions/nil", model.mode, cmd)
+		t.Fatalf("shift+tab from settings mode/cmd = %v/%T, want sessions/nil", model.mode, cmd)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(cockpitModel)
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(cockpitModel)
+	if model.mode != cockpitModeHome || cmd != nil {
+		t.Fatalf("tab from settings mode/cmd = %v/%T, want home/nil", model.mode, cmd)
 	}
 
 	updated, cmd = model.Update(cockpitRuneKey("4"))

--- a/presentation/cli/cockpit_settings.go
+++ b/presentation/cli/cockpit_settings.go
@@ -1,0 +1,932 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/presentation"
+)
+
+const (
+	cockpitSettingsConfigMissing    = "missing"
+	cockpitSettingsConfigLoaded     = "loaded"
+	cockpitSettingsConfigInvalid    = "invalid"
+	cockpitSettingsConfigUnreadable = "unreadable"
+	cockpitSettingsConfigPathError  = "path_error"
+)
+
+type cockpitSettingsState struct {
+	loaded         bool
+	snapshot       cockpitSettingsSnapshot
+	draft          cockpitSettingsValues
+	cursor         int
+	confirmSave    bool
+	editingPattern bool
+	patternInput   string
+	info           string
+	err            string
+}
+
+type cockpitSettingsSnapshot struct {
+	Path   string
+	Status string
+	Error  string
+	Values cockpitSettingsValues
+	Env    cockpitSettingsEnv
+}
+
+type cockpitSettingsEnv struct {
+	TracearyLang         string
+	TracearyLangSet      bool
+	TracearyDBPath       string
+	TracearyDBPathSet    bool
+	TracearyWorkspace    string
+	TracearyWorkspaceSet bool
+	TracearyClient       string
+	TracearyClientSet    bool
+	TracearyAgent        string
+	TracearyAgentSet     bool
+	TracearySessionID    string
+	TracearySessionIDSet bool
+	HookStateDir         string
+	HookStateDirSet      bool
+	HookStateKey         string
+	HookStateKeySet      bool
+	HookDebug            string
+	HookDebugSet         bool
+}
+
+type cockpitSettingsValues struct {
+	UILanguage      string
+	ReadColor       string
+	ReadFields      []string
+	ReadPresets     []cockpitSettingsPresetSummary
+	ExtraPatterns   []string
+	RedactRuleCount int
+	RedactRuleNames []string
+}
+
+type cockpitSettingsPresetSummary struct {
+	Name    string
+	Fields  []string
+	Filters []string
+}
+
+type cockpitSettingsConfigFile struct {
+	UI     cockpitSettingsUISection     `json:"ui"`
+	Read   cockpitSettingsReadSection   `json:"read"`
+	Redact cockpitSettingsRedactSection `json:"redact"`
+}
+
+type cockpitSettingsUISection struct {
+	Language string `json:"language"`
+}
+
+type cockpitSettingsReadSection struct {
+	Fields  []string                                `json:"fields"`
+	Color   string                                  `json:"color"`
+	Presets map[string]cockpitSettingsReadPresetDoc `json:"presets"`
+}
+
+type cockpitSettingsReadPresetDoc struct {
+	Fields  []string                        `json:"fields"`
+	Filters cockpitSettingsReadPresetFilter `json:"filters"`
+}
+
+type cockpitSettingsReadPresetFilter struct {
+	Kind      string `json:"kind"`
+	Failures  *bool  `json:"failures"`
+	Workspace string `json:"workspace"`
+	SessionID string `json:"session_id"`
+	Client    string `json:"client"`
+	Agent     string `json:"agent"`
+}
+
+type cockpitSettingsRedactSection struct {
+	ExtraPatterns []string                        `json:"extra_patterns"`
+	Rules         []cockpitSettingsRedactRuleView `json:"rules"`
+}
+
+type cockpitSettingsRedactRuleView struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func (m cockpitModel) openCockpitSettings() (tea.Model, tea.Cmd) {
+	m.mode = cockpitModeSettings
+	m.showHelp = false
+	if !m.settings.loaded {
+		m.settings = newCockpitSettingsState()
+	}
+	return m, nil
+}
+
+func newCockpitSettingsState() cockpitSettingsState {
+	snapshot := loadCockpitSettingsSnapshot()
+	return cockpitSettingsState{
+		loaded:   true,
+		snapshot: snapshot,
+		draft:    snapshot.Values.clone(),
+	}
+}
+
+func loadCockpitSettingsSnapshot() cockpitSettingsSnapshot {
+	path, err := presentation.DefaultConfigPath()
+	snapshot := cockpitSettingsSnapshot{Env: readCockpitSettingsEnv()}
+	if err != nil {
+		snapshot.Status = cockpitSettingsConfigPathError
+		snapshot.Error = err.Error()
+		return snapshot
+	}
+	snapshot.Path = path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			snapshot.Status = cockpitSettingsConfigMissing
+			return snapshot
+		}
+		snapshot.Status = cockpitSettingsConfigUnreadable
+		snapshot.Error = err.Error()
+		return snapshot
+	}
+	var file cockpitSettingsConfigFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		snapshot.Status = cockpitSettingsConfigInvalid
+		snapshot.Error = err.Error()
+		return snapshot
+	}
+	snapshot.Status = cockpitSettingsConfigLoaded
+	snapshot.Values = cockpitSettingsValues{
+		UILanguage:      strings.TrimSpace(file.UI.Language),
+		ReadColor:       strings.TrimSpace(file.Read.Color),
+		ReadFields:      slices.Clone(file.Read.Fields),
+		ReadPresets:     summarizeCockpitSettingsPresets(file.Read.Presets),
+		ExtraPatterns:   slices.Clone(file.Redact.ExtraPatterns),
+		RedactRuleCount: len(file.Redact.Rules),
+		RedactRuleNames: summarizeCockpitSettingsRedactRules(file.Redact.Rules),
+	}
+	return snapshot
+}
+
+func readCockpitSettingsEnv() cockpitSettingsEnv {
+	return cockpitSettingsEnv{
+		TracearyLang:         envValue(cliLanguageEnvKey),
+		TracearyLangSet:      envSet(cliLanguageEnvKey),
+		TracearyDBPath:       envValue("TRACEARY_DB_PATH"),
+		TracearyDBPathSet:    envSet("TRACEARY_DB_PATH"),
+		TracearyWorkspace:    envValue("TRACEARY_WORKSPACE"),
+		TracearyWorkspaceSet: envSet("TRACEARY_WORKSPACE"),
+		TracearyClient:       envValue("TRACEARY_CLIENT"),
+		TracearyClientSet:    envSet("TRACEARY_CLIENT"),
+		TracearyAgent:        envValue("TRACEARY_AGENT"),
+		TracearyAgentSet:     envSet("TRACEARY_AGENT"),
+		TracearySessionID:    envValue("TRACEARY_SESSION_ID"),
+		TracearySessionIDSet: envSet("TRACEARY_SESSION_ID"),
+		HookStateDir:         envValue("TRACEARY_HOOK_STATE_DIR"),
+		HookStateDirSet:      envSet("TRACEARY_HOOK_STATE_DIR"),
+		HookStateKey:         envValue("TRACEARY_HOOK_STATE_KEY"),
+		HookStateKeySet:      envSet("TRACEARY_HOOK_STATE_KEY"),
+		HookDebug:            envValue("TRACEARY_HOOK_DEBUG"),
+		HookDebugSet:         envSet("TRACEARY_HOOK_DEBUG"),
+	}
+}
+
+func envValue(name string) string {
+	value, _ := os.LookupEnv(name)
+	return value
+}
+
+func envSet(name string) bool {
+	_, ok := os.LookupEnv(name)
+	return ok
+}
+
+func summarizeCockpitSettingsPresets(raw map[string]cockpitSettingsReadPresetDoc) []cockpitSettingsPresetSummary {
+	if len(raw) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(raw))
+	for name := range raw {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]cockpitSettingsPresetSummary, 0, len(names))
+	for _, name := range names {
+		doc := raw[name]
+		out = append(out, cockpitSettingsPresetSummary{Name: name, Fields: slices.Clone(doc.Fields), Filters: summarizeCockpitSettingsPresetFilters(doc.Filters)})
+	}
+	return out
+}
+
+func summarizeCockpitSettingsPresetFilters(filters cockpitSettingsReadPresetFilter) []string {
+	out := []string{}
+	if strings.TrimSpace(filters.Kind) != "" {
+		out = append(out, "kind="+strings.TrimSpace(filters.Kind))
+	}
+	if filters.Failures != nil {
+		out = append(out, fmt.Sprintf("failures=%t", *filters.Failures))
+	}
+	if strings.TrimSpace(filters.Workspace) != "" {
+		out = append(out, "workspace="+strings.TrimSpace(filters.Workspace))
+	}
+	if strings.TrimSpace(filters.SessionID) != "" {
+		out = append(out, "session_id="+strings.TrimSpace(filters.SessionID))
+	}
+	if strings.TrimSpace(filters.Client) != "" {
+		out = append(out, "client="+strings.TrimSpace(filters.Client))
+	}
+	if strings.TrimSpace(filters.Agent) != "" {
+		out = append(out, "agent="+strings.TrimSpace(filters.Agent))
+	}
+	return out
+}
+
+func summarizeCockpitSettingsRedactRules(rules []cockpitSettingsRedactRuleView) []string {
+	out := make([]string, 0, len(rules))
+	for i, rule := range rules {
+		name := strings.TrimSpace(rule.Name)
+		if name == "" {
+			name = fmt.Sprintf("rule-%d", i+1)
+		}
+		kind := strings.TrimSpace(rule.Type)
+		if kind == "" {
+			kind = "regex"
+		}
+		out = append(out, fmt.Sprintf("%s(%s)", name, kind))
+	}
+	return out
+}
+
+func (v cockpitSettingsValues) clone() cockpitSettingsValues {
+	out := v
+	out.ReadFields = slices.Clone(v.ReadFields)
+	out.ExtraPatterns = slices.Clone(v.ExtraPatterns)
+	out.RedactRuleNames = slices.Clone(v.RedactRuleNames)
+	out.ReadPresets = slices.Clone(v.ReadPresets)
+	for i := range out.ReadPresets {
+		out.ReadPresets[i].Fields = slices.Clone(out.ReadPresets[i].Fields)
+		out.ReadPresets[i].Filters = slices.Clone(out.ReadPresets[i].Filters)
+	}
+	return out
+}
+
+func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.settings.editingPattern {
+		return m.updateSettingsPatternInputKey(msg)
+	}
+	if m.settings.confirmSave {
+		return m.updateSettingsConfirmKey(msg)
+	}
+	if isCockpitQuitKey(msg) {
+		return m, tea.Quit
+	}
+	if key.Matches(msg, m.keys.Help) {
+		m.showHelp = !m.showHelp
+		return m, nil
+	}
+	if isCockpitBackKey(msg) {
+		return m.backCockpitSection()
+	}
+	if section, ok := cockpitSectionFromKey(msg); ok {
+		return m.openCockpitSection(section)
+	}
+	if section, ok := m.cockpitAdjacentSectionFromKey(msg); ok {
+		return m.openCockpitSection(section)
+	}
+	switch {
+	case key.Matches(msg, m.keys.Up):
+		m.settings.cursor--
+		m.clampSettingsCursor()
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.settings.cursor++
+		m.clampSettingsCursor()
+		return m, nil
+	case key.Matches(msg, m.keys.Refresh):
+		m.settings = newCockpitSettingsState()
+		m.settings.info = Localize("Settings reloaded from disk.", "Settings を disk から再読み込みしました。")
+		return m, nil
+	}
+	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
+		return m, nil
+	}
+	switch strings.ToLower(string(msg.Runes)) {
+	case "l":
+		return m.stageSettingsLanguageToggle()
+	case "c":
+		return m.stageSettingsColorCycle()
+	case "f":
+		return m.stageSettingsFieldsCycle()
+	case "+", "n":
+		return m.startSettingsPatternInput()
+	case "-", "x":
+		return m.stageSettingsPatternRemove()
+	case "w":
+		return m.startSettingsSaveConfirmation()
+	case "d":
+		m.settings.draft = m.settings.snapshot.Values.clone()
+		m.settings.info = Localize("Discarded pending settings changes.", "未保存の設定変更を破棄しました。")
+		m.settings.err = ""
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m cockpitModel) updateSettingsPatternInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type == tea.KeyCtrlC {
+		return m, tea.Quit
+	}
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.settings.editingPattern = false
+		m.settings.patternInput = ""
+		m.settings.info = Localize("Cancelled redaction pattern input.", "redaction pattern 入力をキャンセルしました。")
+		m.settings.err = ""
+		return m, nil
+	case tea.KeyEnter:
+		pattern := strings.TrimSpace(m.settings.patternInput)
+		if pattern == "" {
+			m.settings.err = Localize("Redaction pattern cannot be empty.", "redaction pattern は空にできません。")
+			return m, nil
+		}
+		if _, err := regexp.Compile(pattern); err != nil {
+			m.settings.err = Localizef("Invalid regex: %v", "regex が不正です: %v", err)
+			return m, nil
+		}
+		m.settings.draft.ExtraPatterns = append(m.settings.draft.ExtraPatterns, pattern)
+		m.settings.editingPattern = false
+		m.settings.patternInput = ""
+		m.settings.info = Localize("Staged redaction pattern. Press w to review and save.", "redaction pattern を staged にしました。w で確認して保存します。")
+		m.settings.err = ""
+		return m, nil
+	case tea.KeyBackspace, tea.KeyDelete:
+		runes := []rune(m.settings.patternInput)
+		if len(runes) > 0 {
+			m.settings.patternInput = string(runes[:len(runes)-1])
+		}
+		return m, nil
+	case tea.KeySpace:
+		m.settings.patternInput += " "
+		return m, nil
+	case tea.KeyRunes:
+		m.settings.patternInput += string(msg.Runes)
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m cockpitModel) updateSettingsConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type == tea.KeyEsc {
+		m.settings.confirmSave = false
+		m.settings.info = Localize("Save confirmation cancelled.", "保存確認をキャンセルしました。")
+		return m, nil
+	}
+	if isCockpitQuitKey(msg) {
+		return m, tea.Quit
+	}
+	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
+		return m, nil
+	}
+	switch strings.ToLower(string(msg.Runes)) {
+	case "y":
+		return m.applySettingsSave()
+	case "n":
+		m.settings.confirmSave = false
+		m.settings.info = Localize("Save confirmation cancelled.", "保存確認をキャンセルしました。")
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m cockpitModel) stageSettingsLanguageToggle() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	current := normalizeSettingsLanguage(m.settings.draft.UILanguage)
+	if current == "ja" {
+		m.settings.draft.UILanguage = "en"
+	} else {
+		m.settings.draft.UILanguage = "ja"
+	}
+	m.settings.info = Localize("Staged UI language change. Press w to review and save.", "UI language 変更を staged にしました。w で確認して保存します。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) stageSettingsColorCycle() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	m.settings.draft.ReadColor = nextSettingsColor(m.settings.draft.ReadColor)
+	m.settings.info = Localize("Staged read.color change. Press w to review and save.", "read.color 変更を staged にしました。w で確認して保存します。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) stageSettingsFieldsCycle() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	m.settings.draft.ReadFields = nextSettingsFieldSet(m.settings.draft.ReadFields)
+	m.settings.info = Localize("Staged read.fields change. Press w to review and save.", "read.fields 変更を staged にしました。w で確認して保存します。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) startSettingsPatternInput() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	m.settings.editingPattern = true
+	m.settings.patternInput = ""
+	m.settings.info = Localize("Enter a Go regexp for redact.extra_patterns; enter stages, esc cancels.", "redact.extra_patterns に追加する Go regexp を入力。enter で staged、esc でキャンセル。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) stageSettingsPatternRemove() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	if len(m.settings.draft.ExtraPatterns) == 0 {
+		m.settings.err = Localize("No redact.extra_patterns entry to remove.", "削除できる redact.extra_patterns はありません。")
+		return m, nil
+	}
+	removed := m.settings.draft.ExtraPatterns[len(m.settings.draft.ExtraPatterns)-1]
+	m.settings.draft.ExtraPatterns = m.settings.draft.ExtraPatterns[:len(m.settings.draft.ExtraPatterns)-1]
+	m.settings.info = Localizef("Staged removal of redact.extra_patterns entry %q. Press w to review and save.", "redact.extra_patterns %q の削除を staged にしました。w で確認して保存します。", removed)
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) startSettingsSaveConfirmation() (tea.Model, tea.Cmd) {
+	if !m.settings.canEditConfig() {
+		m.settings.err = Localize("Fix config readability/JSON before saving settings.", "設定を保存する前に config の読み込み/JSON を修復してください。")
+		return m, nil
+	}
+	if !m.settings.dirty() {
+		m.settings.err = Localize("No pending settings changes to save.", "保存する未反映の設定変更はありません。")
+		return m, nil
+	}
+	if err := validateCockpitSettingsDraft(m.settings.draft); err != nil {
+		m.settings.err = err.Error()
+		return m, nil
+	}
+	m.settings.confirmSave = true
+	m.settings.info = Localize("Review the pending config diff, then press y to save or n/esc to cancel.", "未保存 config diff を確認し、y で保存 / n・esc でキャンセルします。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) applySettingsSave() (tea.Model, tea.Cmd) {
+	if err := saveCockpitSettingsDraft(m.settings.snapshot, m.settings.draft); err != nil {
+		m.settings.err = err.Error()
+		m.settings.confirmSave = false
+		return m, nil
+	}
+	if !m.settings.snapshot.Env.TracearyLangSet {
+		setConfiguredCLILanguageForProcess(m.settings.draft.UILanguage)
+	}
+	m.settings = newCockpitSettingsState()
+	m.settings.info = Localize("Settings saved. Current cockpit language refreshed where no TRACEARY_LANG override is set.", "Settings を保存しました。TRACEARY_LANG override がない場合は現在の cockpit language も更新しました。")
+	return m, nil
+}
+
+func (m cockpitModel) settingsView() string {
+	if !m.settings.loaded {
+		m.settings = newCockpitSettingsState()
+	}
+	lines := []string{
+		m.styles.Subtle.Render(Localize("Config-backed settings", "config backed settings")),
+		Localize("config path: ", "config path: ") + formatOptionalColumn(m.settings.snapshot.Path),
+		Localize("config status: ", "config status: ") + m.settings.configStatusLabel(),
+	}
+	if m.settings.snapshot.Error != "" {
+		lines = append(lines, m.styles.Error.Render(Localize("config error: ", "config error: ")+m.settings.snapshot.Error))
+	}
+	if m.settings.info != "" {
+		lines = append(lines, m.styles.Success.Render("• "+m.settings.info))
+	}
+	if m.settings.err != "" {
+		lines = append(lines, m.styles.Error.Render("• "+m.settings.err))
+	}
+	if m.settings.snapshot.Env.TracearyLangSet {
+		lines = append(lines, m.styles.Warning.Render(Localizef("TRACEARY_LANG=%s overrides ui.language until the env var is unset.", "TRACEARY_LANG=%s が設定されているため、解除するまで ui.language より優先されます。", m.settings.snapshot.Env.TracearyLang)))
+	}
+	if !m.settings.canEditConfig() {
+		lines = append(lines, m.styles.Warning.Render(Localize("Config edits are disabled to avoid silently overwriting invalid or unreadable JSON.", "invalid / unreadable JSON を黙って上書きしないため、config 編集は無効です。")))
+	}
+	lines = append(lines, "", m.styles.Subtle.Render(Localize("Editable settings", "編集可能な settings")))
+	for i, row := range m.settings.settingsRows() {
+		prefix := "  "
+		if i == m.settings.cursor {
+			prefix = "> "
+		}
+		lines = append(lines, prefix+row)
+	}
+	lines = append(lines, "", m.styles.Subtle.Render(Localize("Read-only diagnostics", "読み取り専用 diagnostics")))
+	lines = append(lines, m.settings.settingsEnvLines()...)
+	if len(m.settings.draft.ReadPresets) > 0 {
+		lines = append(lines, "", m.styles.Subtle.Render(Localize("read.presets (view only in v0.18)", "read.presets (v0.18 では表示のみ)")))
+		for _, preset := range m.settings.draft.ReadPresets {
+			fields := strings.Join(preset.Fields, ",")
+			if fields == "" {
+				fields = Localize("default fields", "default fields")
+			}
+			filters := strings.Join(preset.Filters, ",")
+			if filters == "" {
+				filters = Localize("no filters", "filter なし")
+			}
+			lines = append(lines, fmt.Sprintf("• %s fields=%s filters=%s", preset.Name, fields, filters))
+		}
+	}
+	if m.settings.draft.RedactRuleCount > 0 {
+		lines = append(lines, "", m.styles.Subtle.Render(Localize("redact.rules (view only in v0.18)", "redact.rules (v0.18 では表示のみ)")))
+		for _, name := range m.settings.draft.RedactRuleNames {
+			lines = append(lines, "• "+name)
+		}
+	}
+	if m.settings.editingPattern {
+		lines = append(lines, "", m.styles.Active.Render(Localize("Add redact.extra_patterns regex:", "redact.extra_patterns regex を追加:")), m.settings.patternInput)
+	}
+	if m.settings.confirmSave {
+		lines = append(lines, "", m.styles.Warning.Render(Localize("Confirm config write", "config 書き込み確認")))
+		lines = append(lines, m.settingsDiffLines()...)
+		lines = append(lines, m.styles.Help.Render(Localize("y save atomically · n/esc cancel", "y atomic save · n/esc キャンセル")))
+	} else if m.settings.dirty() {
+		lines = append(lines, "", m.styles.Warning.Render(Localize("Pending changes are not written yet. Press w to review and save, d to discard.", "未保存の変更があります。w で確認して保存、d で破棄します。")))
+		lines = append(lines, m.settingsDiffLines()...)
+	}
+	return m.renderCockpitShell(Localize("settings", "設定"), lines, m.settingsLocalHelp())
+}
+
+func (s cockpitSettingsState) settingsRows() []string {
+	return []string{
+		Localize("ui.language: ", "ui.language: ") + formatSettingValue(effectiveSettingsLanguage(s.draft.UILanguage)) + s.languageDirtyMarker(),
+		Localize("read.color: ", "read.color: ") + formatSettingValue(effectiveSettingsColor(s.draft.ReadColor)) + s.settingDirtyMarker(s.snapshot.Values.ReadColor, s.draft.ReadColor),
+		Localize("read.fields: ", "read.fields: ") + formatSettingValue(formatSettingsFields(s.draft.ReadFields)) + s.settingDirtyMarker(strings.Join(s.snapshot.Values.ReadFields, ","), strings.Join(s.draft.ReadFields, ",")),
+		Localize("redact.extra_patterns: ", "redact.extra_patterns: ") + formatSettingValue(formatSettingsPatterns(s.draft.ExtraPatterns)) + s.settingDirtyMarker(strings.Join(s.snapshot.Values.ExtraPatterns, "\x00"), strings.Join(s.draft.ExtraPatterns, "\x00")),
+	}
+}
+
+func (s cockpitSettingsState) settingsEnvLines() []string {
+	env := s.snapshot.Env
+	return []string{
+		formatSettingsEnvLine(cliLanguageEnvKey, env.TracearyLang, env.TracearyLangSet),
+		formatSettingsEnvLine("TRACEARY_DB_PATH", env.TracearyDBPath, env.TracearyDBPathSet),
+		formatSettingsEnvLine("TRACEARY_WORKSPACE", env.TracearyWorkspace, env.TracearyWorkspaceSet),
+		formatSettingsEnvLine("TRACEARY_CLIENT", env.TracearyClient, env.TracearyClientSet),
+		formatSettingsEnvLine("TRACEARY_AGENT", env.TracearyAgent, env.TracearyAgentSet),
+		formatSettingsEnvLine("TRACEARY_SESSION_ID", env.TracearySessionID, env.TracearySessionIDSet),
+		formatSettingsEnvLine("TRACEARY_HOOK_STATE_DIR", env.HookStateDir, env.HookStateDirSet),
+		formatSettingsEnvLine("TRACEARY_HOOK_STATE_KEY", env.HookStateKey, env.HookStateKeySet),
+		formatSettingsEnvLine("TRACEARY_HOOK_DEBUG", env.HookDebug, env.HookDebugSet),
+	}
+}
+
+func (s cockpitSettingsState) configStatusLabel() string {
+	switch s.snapshot.Status {
+	case cockpitSettingsConfigMissing:
+		return Localize("missing (will be created on save)", "missing (保存時に作成)")
+	case cockpitSettingsConfigLoaded:
+		return Localize("loaded", "loaded")
+	case cockpitSettingsConfigInvalid:
+		return Localize("invalid JSON", "invalid JSON")
+	case cockpitSettingsConfigUnreadable:
+		return Localize("unreadable", "unreadable")
+	case cockpitSettingsConfigPathError:
+		return Localize("path error", "path error")
+	default:
+		return s.snapshot.Status
+	}
+}
+
+func (s cockpitSettingsState) canEditConfig() bool {
+	return s.snapshot.Status == cockpitSettingsConfigMissing || s.snapshot.Status == cockpitSettingsConfigLoaded
+}
+
+func (s cockpitSettingsState) dirty() bool {
+	return normalizeSettingsLanguage(s.snapshot.Values.UILanguage) != normalizeSettingsLanguage(s.draft.UILanguage) ||
+		strings.TrimSpace(s.snapshot.Values.ReadColor) != strings.TrimSpace(s.draft.ReadColor) ||
+		!slices.Equal(s.snapshot.Values.ReadFields, s.draft.ReadFields) ||
+		!slices.Equal(s.snapshot.Values.ExtraPatterns, s.draft.ExtraPatterns)
+}
+
+func (s cockpitSettingsState) settingDirtyMarker(oldValue string, newValue string) string {
+	if strings.TrimSpace(oldValue) == strings.TrimSpace(newValue) {
+		return ""
+	}
+	return Localize("  [staged]", "  [staged]")
+}
+
+func (s cockpitSettingsState) languageDirtyMarker() string {
+	if normalizeSettingsLanguage(s.snapshot.Values.UILanguage) == normalizeSettingsLanguage(s.draft.UILanguage) {
+		return ""
+	}
+	return Localize("  [staged]", "  [staged]")
+}
+
+func (m cockpitModel) settingsDiffLines() []string {
+	old := m.settings.snapshot.Values
+	draft := m.settings.draft
+	lines := []string{}
+	appendDiff := func(label string, before string, after string) {
+		if strings.TrimSpace(before) == strings.TrimSpace(after) {
+			return
+		}
+		lines = append(lines, fmt.Sprintf("• %s: %s -> %s", label, formatSettingValue(before), formatSettingValue(after)))
+	}
+	appendDiff("ui.language", effectiveSettingsLanguage(old.UILanguage), effectiveSettingsLanguage(draft.UILanguage))
+	appendDiff("read.color", effectiveSettingsColor(old.ReadColor), effectiveSettingsColor(draft.ReadColor))
+	appendDiff("read.fields", formatSettingsFields(old.ReadFields), formatSettingsFields(draft.ReadFields))
+	appendDiff("redact.extra_patterns", formatSettingsPatterns(old.ExtraPatterns), formatSettingsPatterns(draft.ExtraPatterns))
+	if len(lines) == 0 {
+		return []string{Localize("• no effective diff", "• 有効な差分はありません")}
+	}
+	return lines
+}
+
+func (m *cockpitModel) clampSettingsCursor() {
+	maxIndex := len(m.settings.settingsRows()) - 1
+	if maxIndex < 0 {
+		maxIndex = 0
+	}
+	if m.settings.cursor < 0 {
+		m.settings.cursor = 0
+	}
+	if m.settings.cursor > maxIndex {
+		m.settings.cursor = maxIndex
+	}
+}
+
+func (m cockpitModel) settingsLocalHelp() string {
+	if m.settings.editingPattern {
+		return Localize("enter stage regex · esc cancel · backspace edit", "enter regex を staged · esc キャンセル · backspace 編集")
+	}
+	if m.settings.confirmSave {
+		return Localize("y save · n/esc cancel", "y 保存 · n/esc キャンセル")
+	}
+	return Localize("↑/↓ select · l language · c color · f fields · n/+ add regex · x/- remove regex · w save · d discard · r reload", "↑/↓ 選択 · l language · c color · f fields · n/+ regex 追加 · x/- regex 削除 · w 保存 · d 破棄 · r 再読込")
+}
+
+func (m cockpitModel) settingsContextualActions() []cockpitAction {
+	if m.settings.editingPattern {
+		return []cockpitAction{
+			{key: "enter", description: Localize("Validate regex and stage redact.extra_patterns addition", "regex を検証して redact.extra_patterns 追加を staged")},
+			{key: "esc", description: Localize("Cancel regex input", "regex 入力をキャンセル")},
+		}
+	}
+	if m.settings.confirmSave {
+		return []cockpitAction{
+			{key: "y", description: Localize("Write config atomically", "config を atomic に書き込み")},
+			{key: "n / esc", description: Localize("Cancel config write", "config 書き込みをキャンセル")},
+		}
+	}
+	return []cockpitAction{
+		{key: "l", description: Localize("Toggle ui.language between en and ja", "ui.language を en / ja で切替")},
+		{key: "c", description: Localize("Cycle read.color auto / always / never", "read.color を auto / always / never で切替")},
+		{key: "f", description: Localize("Cycle safe read.fields presets", "安全な read.fields preset を切替")},
+		{key: "n / +", description: Localize("Add a regex to redact.extra_patterns after validation", "検証後に regex を redact.extra_patterns へ追加")},
+		{key: "x / -", description: Localize("Remove the last redact.extra_patterns entry", "最後の redact.extra_patterns を削除")},
+		{key: "w", description: Localize("Review diff and confirm before writing config", "diff を確認してから config 書き込み")},
+		{key: "d", description: Localize("Discard pending settings changes", "未保存の settings 変更を破棄")},
+		{key: "r", description: Localize("Reload settings from config file", "config file から settings を再読込")},
+	}
+}
+
+func validateCockpitSettingsDraft(values cockpitSettingsValues) error {
+	lang := normalizeSettingsLanguage(values.UILanguage)
+	if lang != "" && lang != "en" && lang != "ja" {
+		return xerrors.Errorf(Localize("ui.language must be en or ja", "ui.language は en または ja にしてください"))
+	}
+	if _, err := validateColorValue(values.ReadColor); err != nil {
+		return err
+	}
+	if len(values.ReadFields) > 0 {
+		if _, err := parseReadFields(values.ReadFields); err != nil {
+			return err
+		}
+	}
+	for _, pattern := range values.ExtraPatterns {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			return xerrors.Errorf(Localize("redact.extra_patterns cannot contain an empty regex", "redact.extra_patterns に空の regex は保存できません"))
+		}
+		if _, err := regexp.Compile(trimmed); err != nil {
+			return xerrors.Errorf(Localizef("invalid redact.extra_patterns regex %q: %v", "redact.extra_patterns regex %q が不正です: %v", pattern, err))
+		}
+	}
+	return nil
+}
+
+func saveCockpitSettingsDraft(snapshot cockpitSettingsSnapshot, values cockpitSettingsValues) error {
+	if snapshot.Path == "" {
+		return xerrors.Errorf(Localize("config path is unavailable", "config path を利用できません"))
+	}
+	if err := validateCockpitSettingsDraft(values); err != nil {
+		return err
+	}
+	raw := map[string]json.RawMessage{}
+	data, err := os.ReadFile(snapshot.Path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return xerrors.Errorf(Localizef("failed to read config before saving: %v", "保存前の config 読み込みに失敗しました: %v", err))
+		}
+	} else if len(bytes.TrimSpace(data)) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return xerrors.Errorf(Localizef("config JSON is invalid; refusing to overwrite: %v", "config JSON が不正なため上書きを拒否します: %v", err))
+		}
+	}
+	if raw == nil {
+		raw = map[string]json.RawMessage{}
+	}
+	if normalizeSettingsLanguage(snapshot.Values.UILanguage) != normalizeSettingsLanguage(values.UILanguage) {
+		if err := updateCockpitSettingsSection(raw, "ui", map[string]any{"language": normalizeSettingsLanguage(values.UILanguage)}); err != nil {
+			return err
+		}
+	}
+	readUpdates := map[string]any{}
+	if strings.TrimSpace(snapshot.Values.ReadColor) != strings.TrimSpace(values.ReadColor) {
+		readUpdates["color"] = strings.TrimSpace(values.ReadColor)
+	}
+	if !slices.Equal(snapshot.Values.ReadFields, values.ReadFields) {
+		readUpdates["fields"] = values.ReadFields
+	}
+	if len(readUpdates) > 0 {
+		if err := updateCockpitSettingsSection(raw, "read", readUpdates); err != nil {
+			return err
+		}
+	}
+	if !slices.Equal(snapshot.Values.ExtraPatterns, values.ExtraPatterns) {
+		if err := updateCockpitSettingsSection(raw, "redact", map[string]any{"extra_patterns": values.ExtraPatterns}); err != nil {
+			return err
+		}
+	}
+	encoded, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return xerrors.Errorf(Localizef("failed to encode config JSON: %v", "config JSON の encode に失敗しました: %v", err))
+	}
+	encoded = append(encoded, '\n')
+	return writeCockpitSettingsConfigAtomically(snapshot.Path, encoded)
+}
+
+func updateCockpitSettingsSection(raw map[string]json.RawMessage, section string, updates map[string]any) error {
+	sectionMap := map[string]any{}
+	if existing, ok := raw[section]; ok && len(bytes.TrimSpace(existing)) > 0 {
+		if err := json.Unmarshal(existing, &sectionMap); err != nil {
+			return xerrors.Errorf(Localizef("config section %s is invalid; refusing to overwrite: %v", "config section %s が不正なため上書きを拒否します: %v", section, err))
+		}
+		if sectionMap == nil {
+			sectionMap = map[string]any{}
+		}
+	}
+	for key, value := range updates {
+		sectionMap[key] = value
+	}
+	encoded, err := json.Marshal(sectionMap)
+	if err != nil {
+		return xerrors.Errorf(Localizef("failed to encode config section %s: %v", "config section %s の encode に失敗しました: %v", section, err))
+	}
+	raw[section] = encoded
+	return nil
+}
+
+func writeCockpitSettingsConfigAtomically(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return xerrors.Errorf(Localizef("failed to create config directory: %v", "config directory の作成に失敗しました: %v", err))
+	}
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config.json.tmp-*")
+	if err != nil {
+		return xerrors.Errorf(Localizef("failed to create temp config file: %v", "一時 config file の作成に失敗しました: %v", err))
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf(Localizef("failed to write temp config file: %v", "一時 config file の書き込みに失敗しました: %v", err))
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf(Localizef("failed to chmod temp config file: %v", "一時 config file の chmod に失敗しました: %v", err))
+	}
+	if err := tmp.Close(); err != nil {
+		return xerrors.Errorf(Localizef("failed to close temp config file: %v", "一時 config file の close に失敗しました: %v", err))
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return xerrors.Errorf(Localizef("failed to replace config atomically: %v", "config の atomic replace に失敗しました: %v", err))
+	}
+	return nil
+}
+
+func normalizeSettingsLanguage(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if strings.HasPrefix(value, "ja") {
+		return "ja"
+	}
+	if strings.HasPrefix(value, "en") {
+		return "en"
+	}
+	return value
+}
+
+func effectiveSettingsLanguage(value string) string {
+	lang := normalizeSettingsLanguage(value)
+	if lang == "" {
+		return "en (default)"
+	}
+	return lang
+}
+
+func effectiveSettingsColor(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "auto (default)"
+	}
+	return trimmed
+}
+
+func formatSettingsFields(fields []string) string {
+	if len(fields) == 0 {
+		return strings.Join(readFieldIDsToStrings(defaultReadFields), ",") + " (default)"
+	}
+	return strings.Join(fields, ",")
+}
+
+func formatSettingsPatterns(patterns []string) string {
+	if len(patterns) == 0 {
+		return Localize("none", "なし")
+	}
+	return strings.Join(patterns, ", ")
+}
+
+func formatSettingValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return Localize("unset", "未設定")
+	}
+	return value
+}
+
+func formatSettingsEnvLine(name string, value string, set bool) string {
+	if !set {
+		return "• " + name + "=" + Localize("unset", "未設定")
+	}
+	if value == "" {
+		return "• " + name + "=" + Localize("set empty", "空で設定")
+	}
+	return "• " + name + "=" + value
+}
+
+func nextSettingsColor(current string) string {
+	switch strings.TrimSpace(current) {
+	case "auto", "":
+		return "always"
+	case "always":
+		return "never"
+	default:
+		return "auto"
+	}
+}
+
+func nextSettingsFieldSet(current []string) []string {
+	sets := [][]string{
+		readFieldIDsToStrings(defaultReadFields),
+		{"ts", "kind", "exit_code", "session", "ws", "message"},
+		{"ts", "kind", "client", "agent", "id", "message"},
+		{"ts", "kind", "message"},
+	}
+	currentLabel := strings.Join(current, ",")
+	for i, set := range sets {
+		if currentLabel == strings.Join(set, ",") {
+			return slices.Clone(sets[(i+1)%len(sets)])
+		}
+	}
+	return slices.Clone(sets[0])
+}
+
+func readFieldIDsToStrings(fields []readFieldID) []string {
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, string(field))
+	}
+	return out
+}

--- a/presentation/cli/i18n.go
+++ b/presentation/cli/i18n.go
@@ -4,9 +4,18 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+
+	"github.com/duck8823/traceary/presentation"
 )
 
 const cliLanguageEnvKey = "TRACEARY_LANG"
+
+var cliLanguageCache = struct {
+	sync.RWMutex
+	loaded bool
+	value  string
+}{}
 
 // Localize returns the English or Japanese string for the active CLI locale.
 func Localize(english string, japanese string) string {
@@ -27,7 +36,55 @@ func localizef(english string, japanese string, args ...any) string {
 }
 
 func isJapaneseCLI() bool {
-	value := strings.ToLower(strings.TrimSpace(os.Getenv(cliLanguageEnvKey)))
+	value, ok := explicitCLILanguageOverride()
+	if !ok {
+		value = configuredCLILanguage()
+	}
 
 	return strings.HasPrefix(value, "ja")
+}
+
+func explicitCLILanguageOverride() (string, bool) {
+	value, ok := os.LookupEnv(cliLanguageEnvKey)
+	if !ok {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimSpace(value)), true
+}
+
+func configuredCLILanguage() string {
+	cliLanguageCache.RLock()
+	if cliLanguageCache.loaded {
+		value := cliLanguageCache.value
+		cliLanguageCache.RUnlock()
+		return value
+	}
+	cliLanguageCache.RUnlock()
+
+	cfg := presentation.LoadConfig()
+	value := normalizeCLILanguage(cfg.UILanguage)
+
+	cliLanguageCache.Lock()
+	cliLanguageCache.loaded = true
+	cliLanguageCache.value = value
+	cliLanguageCache.Unlock()
+	return value
+}
+
+func setConfiguredCLILanguageForProcess(value string) {
+	cliLanguageCache.Lock()
+	cliLanguageCache.loaded = true
+	cliLanguageCache.value = normalizeCLILanguage(value)
+	cliLanguageCache.Unlock()
+}
+
+func resetConfiguredCLILanguageCacheForTest() {
+	cliLanguageCache.Lock()
+	cliLanguageCache.loaded = false
+	cliLanguageCache.value = ""
+	cliLanguageCache.Unlock()
+}
+
+func normalizeCLILanguage(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }

--- a/presentation/cli/i18n_test.go
+++ b/presentation/cli/i18n_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalizeUsesConfigLanguageWhenEnvUnset(t *testing.T) {
+	t.Setenv(cliLanguageEnvKey, "")
+	if err := os.Unsetenv(cliLanguageEnvKey); err != nil {
+		t.Fatal(err)
+	}
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"ui":{"language":"ja"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := Localize("English", "日本語"); got != "日本語" {
+		t.Fatalf("Localize() = %q, want Japanese from config", got)
+	}
+}
+
+func TestLocalizeEnvOverridesConfigLanguage(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"ui":{"language":"ja"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(cliLanguageEnvKey, "en")
+
+	if got := Localize("English", "日本語"); got != "English" {
+		t.Fatalf("Localize() = %q, want env override to keep English", got)
+	}
+}

--- a/presentation/cli/testdata/cockpit/home_all_green.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_all_green.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · home
-sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions
+sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -35,7 +35,7 @@ HEALTH
 
 ALL GREEN
 • No immediate cockpit warnings or tracked new activity.
-• Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff.
+• Next: 2 Live for ongoing work, 4 Memory for periodic review, 3 Doctor before release, 5 Sessions for handoff, 6 Settings for configuration.
 
 SIGNAL COUNTS
 • doctor: pass=4 warn=0 fail=0
@@ -44,4 +44,4 @@ SIGNAL COUNTS
 • memories: accepted(reviewed)=2 candidate(inbox)=0 new=0 remember-intent=0 low-quality=0 stale=0
 • payloads: large=0
 
-1-5 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help
+1-6 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help

--- a/presentation/cli/testdata/cockpit/home_candidate_memories.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_candidate_memories.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · home
-sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions
+sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -48,4 +48,4 @@ NEXT ACTIONS
 • 3 Doctor: check health and remediation commands
 • 5 Sessions: session list and handoff entry points
 
-1-5 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help
+1-6 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help

--- a/presentation/cli/testdata/cockpit/home_candidate_memories_ja_narrow.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_candidate_memories_ja_narrow.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · ホーム
-セクション: [1 ホーム]  2 ライブ  3 ドクター  4 メモリ  5 セッション
+セクション: [1 ホーム]  2 ライブ  3 ドクター  4 メモリ  5 セッション  6 設定
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -48,13 +48,14 @@ signal 件数
 • 3 Doctor: health と修復 command を確認
 • 5 Sessions: session 一覧と handoff 導線を確認
 
-1-5 セクション · tab/shift+tab 次/前 · 端末 80x24 · q/ctrl+c 終了 · ? ヘルプ
+1-6 セクション · tab/shift+tab 次/前 · 端末 80x24 · q/ctrl+c 終了 · ? ヘルプ
 
 アクション menu
 • 2            Live tail を開く
 • 3            Doctor check を実行
 • 4            Memory review を開く
 • 5            Sessions と handoff 導線を開く
+• 6            Settings を開く
 • Home card は緊急度順です。各 card に次の action target が表示されます。
 
 Global navigation
@@ -63,6 +64,7 @@ Global navigation
 3 Doctor    health check と修復 hint
 4 メモリ      inbox review queue
 5 セッション  session と handoff 導線
+6 設定        language / read 既定 / redaction 診断
 tab / shift+tab で section を移動
 esc で前の cockpit 階層へ戻り、q で TUI を終了
 

--- a/presentation/cli/testdata/cockpit/home_doctor_failure.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_doctor_failure.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · home
-sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions
+sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -48,4 +48,4 @@ NEXT ACTIONS
 • 3 Doctor: check health and remediation commands
 • 5 Sessions: session list and handoff entry points
 
-1-5 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help
+1-6 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help

--- a/presentation/cli/testdata/cockpit/home_new_events_and_failure.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_new_events_and_failure.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · home
-sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions
+sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -47,4 +47,4 @@ NEXT ACTIONS
 • 3 Doctor: check health and remediation commands
 • 5 Sessions: session list and handoff entry points
 
-1-5 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help
+1-6 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help

--- a/presentation/cli/testdata/cockpit/home_stale_sessions.golden.txt
+++ b/presentation/cli/testdata/cockpit/home_stale_sessions.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · home
-sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions
+sections: [1 Home]  2 Live  3 Doctor  4 Memory  5 Sessions  6 Settings
 
 loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
@@ -46,4 +46,4 @@ NEXT ACTIONS
 • 3 Doctor: check health and remediation commands
 • 5 Sessions: session list and handoff entry points
 
-1-5 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help
+1-6 sections · tab/shift+tab next/prev · q/ctrl+c quit · ? help

--- a/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
+++ b/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
@@ -1,5 +1,5 @@
 Traceary cockpit · memory review
-sections: 1 Home  2 Live  3 Doctor  [4 Memory]  5 Sessions
+sections: 1 Home  2 Live  3 Doctor  [4 Memory]  5 Sessions  6 Settings
 
 inbox review · decision card
 candidate 1 / 1
@@ -33,4 +33,4 @@ ACCEPT AS-IS CHECKLIST
 
 a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ navigate · ? help · q quit
 
-1-5 sections · tab/shift+tab next/prev · esc back · ctrl+c quit · ? help · a accept as-is · x reject · s skip · e edit/distill · v evidence · q finish/apply
+1-6 sections · tab/shift+tab next/prev · esc back · ctrl+c quit · ? help · a accept as-is · x reject · s skip · e edit/distill · v evidence · q finish/apply

--- a/presentation/config.go
+++ b/presentation/config.go
@@ -7,13 +7,19 @@ import (
 	"path/filepath"
 
 	"github.com/duck8823/traceary/application/redaction"
+	"golang.org/x/xerrors"
 )
 
 // configFile mirrors the on-disk JSON layout. It is intentionally unexported
 // because callers receive the loaded values through Config.
 type configFile struct {
+	UI     uiSection     `json:"ui"`
 	Redact redactSection `json:"redact"`
 	Read   readSection   `json:"read"`
+}
+
+type uiSection struct {
+	Language string `json:"language"`
 }
 
 type redactSection struct {
@@ -51,6 +57,11 @@ type readPresetFilters struct {
 // MCP server. Zero values mean "fall back to the built-in default" so callers
 // do not need to distinguish between "file missing" and "key missing".
 type Config struct {
+	// UILanguage is the operator-facing CLI/TUI language (en / ja). Empty
+	// string means "fall back to the built-in default language". Runtime
+	// environment overrides such as TRACEARY_LANG are resolved by the CLI
+	// layer because they are process-local, not persisted config.
+	UILanguage string
 	// ExtraRedactPatterns are additional regex patterns applied on top of the
 	// built-in audit redaction rules. Nil / empty means "no extras".
 	ExtraRedactPatterns []string
@@ -101,6 +112,7 @@ func LoadConfig() Config {
 		return Config{}
 	}
 	return Config{
+		UILanguage:            file.UI.Language,
 		ExtraRedactPatterns:   file.Redact.ExtraPatterns,
 		StructuredRedactRules: file.Redact.Rules,
 		ReadFields:            file.Read.Fields,
@@ -137,7 +149,7 @@ func LoadExtraRedactPatterns() []string {
 }
 
 func loadConfigFile() *configFile {
-	homeDir, err := os.UserHomeDir()
+	configPath, err := DefaultConfigPath()
 	if err != nil {
 		slog.Warn(
 			"Traceary config path could not be resolved; config-backed features fall back to built-in defaults",
@@ -146,7 +158,6 @@ func loadConfigFile() *configFile {
 		return nil
 	}
 
-	configPath := filepath.Join(homeDir, ".config", "traceary", "config.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -169,4 +180,14 @@ func loadConfigFile() *configFile {
 	}
 
 	return &file
+}
+
+// DefaultConfigPath returns the canonical per-user Traceary config path.
+func DefaultConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", xerrors.Errorf("resolve home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".config", "traceary", "config.json"), nil
 }

--- a/presentation/config_test.go
+++ b/presentation/config_test.go
@@ -89,6 +89,26 @@ func TestLoadConfig_returnsReadFieldsAlongsideRedact(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_returnsUILanguage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"ui": {"language": "ja"}}`
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := presentation.LoadConfig()
+
+	if cfg.UILanguage != "ja" {
+		t.Fatalf("UILanguage = %q, want ja", cfg.UILanguage)
+	}
+}
+
 func TestLoadConfig_returnsStructuredRedactRules(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Motivation\n\nCloses #1039. The cockpit should make key Traceary settings discoverable and safely editable, especially UI language, without requiring operators to memorize environment variables or hand-edit config JSON.\n\n## Changes\n\n- Add a global `6 Settings` cockpit section with config status/path, environment override diagnostics, read-only preset/rule summaries, and contextual help.\n- Add persistent `ui.language` config support with precedence `TRACEARY_LANG` > config > built-in English, plus current-session refresh after save when no env override is set.\n- Support staged/confirmed atomic writes for `ui.language`, `read.color`, safe `read.fields` presets, and validated `redact.extra_patterns` additions/removals while refusing to overwrite invalid/unreadable config.\n- Update dogfood coverage, goldens, and environment docs.\n\n## Verification\n\n- `go test ./...`\n- `go build ./...`\n- `go tool golangci-lint run`\n- `python3 scripts/verify_docs_i18n.py`\n- `git diff --check`\n