### PR TITLE
maintenance: version host-native memory activation files

### DIFF
--- a/.traceary/memories/claude.md
+++ b/.traceary/memories/claude.md
@@ -1,0 +1,17 @@
+<!-- traceary-memories:begin:v1 -->
+<!-- DO NOT EDIT: this block is managed by Traceary. Hand edits will be overwritten by `traceary memory export` or `traceary memory activate`. -->
+
+# Traceary-managed claude memories
+
+## Workspace memories: github.com/duck8823/traceary
+
+### Constraints
+
+- v0.8 の新 hook (transcript / built-in tool matcher) を実環境で効かせるには、brew upgrade traceary + ~/.claude/plugins/marketplaces/traceary-plugins の git pull + claude plugins update が必要。片方だけでは古い hooks.json が残る (memory_id: memory-825f38352ae0d99128bab1162c33e9d7, scope: workspace=github.com/duck8823/traceary)
+
+### Lessons
+
+- Codex GitHub reviews can take several minutes to complete; keep polling PR review/check state instead of assuming a missing response means the review failed or should be skipped. (memory_id: memory-beb524035b13bf7ea877001a36b8ccbc, scope: workspace=github.com/duck8823/traceary)
+- replay UI の HTML は GitHub で render できないので、Markdown format の追加が必要。follow-up で format フラグを検討 (memory_id: memory-9663a7faa775387ea03aca34892284c2, scope: workspace=github.com/duck8823/traceary)
+
+<!-- traceary-memories:end -->

--- a/.traceary/memories/gemini.md
+++ b/.traceary/memories/gemini.md
@@ -1,0 +1,17 @@
+<!-- traceary-memories:begin:v1 -->
+<!-- DO NOT EDIT: this block is managed by Traceary. Hand edits will be overwritten by `traceary memory export` or `traceary memory activate`. -->
+
+# Traceary-managed gemini memories
+
+## Workspace memories: github.com/duck8823/traceary
+
+### Constraints
+
+- v0.8 の新 hook (transcript / built-in tool matcher) を実環境で効かせるには、brew upgrade traceary + ~/.claude/plugins/marketplaces/traceary-plugins の git pull + claude plugins update が必要。片方だけでは古い hooks.json が残る (memory_id: memory-825f38352ae0d99128bab1162c33e9d7, scope: workspace=github.com/duck8823/traceary)
+
+### Lessons
+
+- Codex GitHub reviews can take several minutes to complete; keep polling PR review/check state instead of assuming a missing response means the review failed or should be skipped. (memory_id: memory-beb524035b13bf7ea877001a36b8ccbc, scope: workspace=github.com/duck8823/traceary)
+- replay UI の HTML は GitHub で render できないので、Markdown format の追加が必要。follow-up で format フラグを検討 (memory_id: memory-9663a7faa775387ea03aca34892284c2, scope: workspace=github.com/duck8823/traceary)
+
+<!-- traceary-memories:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,8 @@ Memory capture in v0.11.0+ is split into two narrow skills plus hook-driven auto
 - `traceary-memory-remember` — write durable memory **only** when the user explicitly asks ("remember that", "覚えておいて"). Lands in `status=candidate` for review, never auto-accepted.
 
 Hook-driven auto-extraction (planned in v0.11.0 #810 / #811) populates the inbox so the LLM does not have to.
+
+<!-- traceary-memory-import:begin:v1 -->
+<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target claude --dry-run --diff` before applying updates. -->
+@./.traceary/memories/claude.md
+<!-- traceary-memory-import:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -77,3 +77,8 @@ go tool golangci-lint run
 - `go test ./...` must pass before committing
 - Test names use English descriptions (table-driven with subtests)
 - No `panic()` in runtime paths — reserved only for programming errors in init-time assertions
+
+<!-- traceary-memory-import:begin:v1 -->
+<!-- DO NOT EDIT: this import is managed by Traceary. Run `traceary memory activate --target gemini --dry-run --diff` before applying updates. -->
+@./.traceary/memories/gemini.md
+<!-- traceary-memory-import:end -->


### PR DESCRIPTION
## Motivation

The v0.18 dogfood/update flow activated Traceary host-native memory for this repository. The resulting Claude/Gemini import stubs and external memory projections are intentionally shared project context, so they should be versioned instead of remaining as local dirty state.

Closes #1050

## Changes

- Add the Traceary-managed Claude memory import stub to `CLAUDE.md`.
- Add the Traceary-managed Gemini memory import stub to `GEMINI.md`.
- Commit the generated `.traceary/memories/claude.md` and `.traceary/memories/gemini.md` projection files.

## Validation

- `traceary memory admin activate --target claude --status --json` → `state: in_sync`, `activated_count: 3`
- `traceary memory admin activate --target gemini --status --json` → `state: in_sync`, `activated_count: 3`
- `git diff --check`
- `grep -R "traceary-memory-import:begin:v1" -n CLAUDE.md GEMINI.md`
- `grep -R "traceary-memories:begin:v1" -n .traceary/memories/claude.md .traceary/memories/gemini.md`
