### PR TITLE
v0.19-2: make Tail auto-follow by default

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -571,6 +571,7 @@ func newCockpitModel(keys tui.KeyMap, styles tui.Styles, home cockpitHomeSnapsho
 		live: cockpitLiveState{
 			loadedAt: home.LoadedAt,
 			loading:  true,
+			follow:   true,
 		},
 	}
 }
@@ -663,14 +664,15 @@ func cockpitNavigationSectionLabel(id cockpitSectionID) string {
 }
 
 type cockpitLiveState struct {
-	events     []*model.Event
-	cursor     tailCursor
-	loadedAt   time.Time
-	loading    bool
-	follow     bool
-	selected   int
-	requestSeq uint64
-	err        error
+	events         []*model.Event
+	cursor         tailCursor
+	loadedAt       time.Time
+	loading        bool
+	follow         bool
+	pausedNewCount int
+	selected       int
+	requestSeq     uint64
+	err            error
 }
 
 type cockpitLiveMsg struct {
@@ -771,7 +773,11 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			if msg.initial {
 				m.live.events = msg.snapshot.Events
+				m.live.pausedNewCount = 0
 			} else {
+				if !m.live.follow && len(msg.snapshot.Events) > 0 {
+					m.live.pausedNewCount += len(msg.snapshot.Events)
+				}
 				m.live.events = append(m.live.events, msg.snapshot.Events...)
 				if len(m.live.events) > cockpitLiveMaxEvents {
 					m.live.events = m.live.events[len(m.live.events)-cockpitLiveMaxEvents:]
@@ -780,17 +786,21 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.live.cursor = msg.snapshot.Cursor
 			m.live.loadedAt = msg.snapshot.LoadedAt
 			m.clampLiveSelection()
+			if m.live.follow {
+				m.moveCockpitLiveSelectionToNewest()
+				m.live.pausedNewCount = 0
+			}
 		}
 		var markCmd tea.Cmd
 		if msg.err == nil && m.mode == cockpitModeLive {
 			markCmd = m.markCockpitEventsSeenCmd(msg.snapshot)
 		}
-		if m.mode == cockpitModeLive && m.live.follow {
+		if m.mode == cockpitModeLive {
 			return m, tea.Batch(markCmd, m.cockpitLiveTickCmd())
 		}
 		return m, markCmd
 	case cockpitLiveTickMsg:
-		if m.mode == cockpitModeLive && m.live.follow && !m.live.loading {
+		if m.mode == cockpitModeLive && !m.live.loading {
 			return m, m.startCockpitLiveLoad(false)
 		}
 		return m, nil
@@ -985,6 +995,7 @@ func (m cockpitModel) openCockpitSection(section cockpitSectionID) (tea.Model, t
 			m.detailOffset = 0
 		}
 		m.mode = cockpitModeLive
+		m.resumeCockpitLiveFollow()
 		return m, m.startCockpitLiveLoad(true)
 	case cockpitSectionTop:
 		m.mode = cockpitModeTop
@@ -1009,10 +1020,7 @@ func (m cockpitModel) backCockpitSection() (tea.Model, tea.Cmd) {
 		m.mode = cockpitModeLive
 		m.detail = topDetailState{}
 		m.detailOffset = 0
-		if m.live.follow {
-			return m, m.cockpitLiveTickCmd()
-		}
-		return m, nil
+		return m, m.cockpitLiveTickCmd()
 	case cockpitModeLive:
 		return m, nil
 	default:
@@ -1051,25 +1059,34 @@ func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Up):
 		m.live.selected--
 		m.clampLiveSelection()
+		if !m.live.isAtNewest() {
+			m.live.follow = false
+		}
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
 		m.live.selected++
 		m.clampLiveSelection()
+		if !m.live.isAtNewest() {
+			m.live.follow = false
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.Home):
+		m.live.selected = 0
+		m.clampLiveSelection()
+		if !m.live.isAtNewest() {
+			m.live.follow = false
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.End):
+		m.resumeCockpitLiveFollow()
+		if !m.live.loading {
+			return m, m.cockpitLiveTickCmd()
+		}
 		return m, nil
 	case key.Matches(msg, m.keys.Refresh):
 		return m, m.startCockpitLiveLoad(true)
 	case key.Matches(msg, m.keys.Select):
 		return m.openCockpitLiveDetail()
-	}
-	if msg.Type == tea.KeyRunes {
-		switch strings.ToLower(string(msg.Runes)) {
-		case "f":
-			m.live.follow = !m.live.follow
-			if m.live.follow {
-				return m, m.cockpitLiveTickCmd()
-			}
-			return m, nil
-		}
 	}
 	return m, nil
 }
@@ -1098,15 +1115,12 @@ func (m cockpitModel) updateDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.mode = cockpitModeLive
 			m.detail = topDetailState{}
 			m.detailOffset = 0
-			return m, nil
+			return m, m.cockpitLiveTickCmd()
 		case "t", "l":
 			m.mode = cockpitModeLive
 			m.detail = topDetailState{}
 			m.detailOffset = 0
-			if m.live.follow {
-				return m, m.cockpitLiveTickCmd()
-			}
-			return m, nil
+			return m, m.cockpitLiveTickCmd()
 		}
 	}
 	return m, nil
@@ -1235,6 +1249,7 @@ func (m *cockpitModel) startCockpitHomeLoad() tea.Cmd {
 }
 
 func (m *cockpitModel) startCockpitHomeAndLiveLoad() tea.Cmd {
+	m.resumeCockpitLiveFollow()
 	return tea.Batch(m.startCockpitHomeLoad(), m.startCockpitLiveLoad(true))
 }
 
@@ -1395,6 +1410,24 @@ func (m *cockpitModel) clampLiveSelection() {
 	if m.live.selected >= len(m.live.events) {
 		m.live.selected = len(m.live.events) - 1
 	}
+}
+
+func (m *cockpitModel) moveCockpitLiveSelectionToNewest() {
+	if len(m.live.events) == 0 {
+		m.live.selected = 0
+		return
+	}
+	m.live.selected = len(m.live.events) - 1
+}
+
+func (s cockpitLiveState) isAtNewest() bool {
+	return len(s.events) == 0 || s.selected >= len(s.events)-1
+}
+
+func (m *cockpitModel) resumeCockpitLiveFollow() {
+	m.live.follow = true
+	m.live.pausedNewCount = 0
+	m.moveCockpitLiveSelectionToNewest()
 }
 
 func (m *cockpitModel) clampDetailOffset() {
@@ -1566,7 +1599,7 @@ func (m cockpitModel) memoryReviewView() string {
 
 func (m cockpitModel) liveView() string {
 	lines := []string{
-		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s follow=%t rows=%d", formatJSONTime(m.live.loadedAt), m.live.follow, len(m.live.events))),
+		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s auto_follow=%t rows=%d", formatJSONTime(m.live.loadedAt), m.live.follow, len(m.live.events))),
 		"",
 	}
 	if m.statusMsg != "" {
@@ -1575,13 +1608,16 @@ func (m cockpitModel) liveView() string {
 	if m.statusErr != "" {
 		lines = append(lines, m.styles.Error.Render("• "+m.statusErr), "")
 	}
+	if pauseMessage := m.livePauseMessage(); pauseMessage != "" {
+		lines = append(lines, pauseMessage, "")
+	}
 	if m.live.err != nil {
 		lines = append(lines, m.styles.Error.Render(m.live.err.Error()))
 	} else if len(m.live.events) == 0 {
 		if m.live.loading {
 			lines = append(lines, m.styles.Subtle.Render(Localize("Loading live events...", "live event を読み込み中...")))
 		} else {
-			lines = append(lines, m.styles.Subtle.Render(Localize("No recent events. Press r to refresh or f to follow.", "最近の event はありません。r で再取得、f で follow します。")))
+			lines = append(lines, m.styles.Subtle.Render(Localize("No recent events. Press r to refresh.", "最近の event はありません。r で再取得します。")))
 		}
 	} else {
 		for i, event := range m.live.events {
@@ -1597,6 +1633,16 @@ func (m cockpitModel) liveView() string {
 		}
 	}
 	return m.renderCockpitShell(Localize("live tail", "live tail"), lines, m.liveLocalHelp())
+}
+
+func (m cockpitModel) livePauseMessage() string {
+	if m.live.follow {
+		return ""
+	}
+	if m.live.pausedNewCount > 0 {
+		return m.styles.Warning.Render(Localizef("Auto-follow paused · %d newer event(s) available · press End/G for newest", "auto-follow 停止中 · 新しい event %d 件 · End/G で最新へ", m.live.pausedNewCount))
+	}
+	return m.styles.Subtle.Render(Localize("Auto-follow paused · press End/G for newest", "auto-follow 停止中 · End/G で最新へ"))
 }
 
 func (m cockpitModel) detailView() string {
@@ -1958,8 +2004,8 @@ func (m cockpitModel) cockpitContextualActions() []cockpitAction {
 		return actions
 	case cockpitModeLive:
 		actions := []cockpitAction{
-			{key: "r", description: Localize("Refresh live events", "live event を再取得")},
-			{key: "f", description: m.liveFollowActionDescription()},
+			{key: "r", description: Localize("Refresh Tail events", "Tail event を再取得")},
+			{key: "End/G", description: Localize("Jump to newest and resume auto-follow", "最新へ移動して auto-follow を再開")},
 		}
 		if len(m.live.events) > 0 {
 			actions = append(actions, cockpitAction{key: "enter", description: Localize("Open selected event detail", "選択中 event の詳細を開く")})
@@ -2009,13 +2055,6 @@ func cockpitDoctorHasRemediation(snapshot cockpitDoctorSnapshot) bool {
 		}
 	}
 	return false
-}
-
-func (m cockpitModel) liveFollowActionDescription() string {
-	if m.live.follow {
-		return Localize("Pause follow mode", "follow mode を停止")
-	}
-	return Localize("Start follow mode", "follow mode を開始")
 }
 
 func (m cockpitModel) memoryReviewContextualActions() []cockpitAction {
@@ -2078,10 +2117,7 @@ func (m cockpitModel) memoryReviewContextualActions() []cockpitAction {
 }
 
 func (m cockpitModel) liveLocalHelp() string {
-	parts := []string{Localize("r refresh", "r 再取得"), Localize("f follow", "f follow")}
-	if m.live.follow {
-		parts[1] = Localize("f pause", "f 停止")
-	}
+	parts := []string{Localize("r refresh", "r 再取得"), Localize("End/G newest", "End/G 最新")}
 	if len(m.live.events) > 0 {
 		parts = append(parts, Localize("enter detail", "enter 詳細"))
 		if len(m.live.events) > 1 {

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -779,15 +779,7 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.live.pausedNewCount += len(msg.snapshot.Events)
 				}
 				m.live.events = append(m.live.events, msg.snapshot.Events...)
-				if overflow := len(m.live.events) - cockpitLiveMaxEvents; overflow > 0 {
-					m.live.events = m.live.events[overflow:]
-					if !m.live.follow {
-						m.live.selected -= overflow
-						if m.live.selected < 0 {
-							m.live.selected = 0
-						}
-					}
-				}
+				m.trimCockpitLiveEventsToLimit()
 			}
 			m.live.cursor = msg.snapshot.Cursor
 			m.live.loadedAt = msg.snapshot.LoadedAt
@@ -1414,6 +1406,30 @@ func (m *cockpitModel) clampLiveSelection() {
 	}
 	if m.live.selected >= len(m.live.events) {
 		m.live.selected = len(m.live.events) - 1
+	}
+}
+
+func (m *cockpitModel) trimCockpitLiveEventsToLimit() {
+	overflow := len(m.live.events) - cockpitLiveMaxEvents
+	if overflow <= 0 {
+		return
+	}
+	if m.live.follow {
+		m.live.events = m.live.events[overflow:]
+		return
+	}
+	m.clampLiveSelection()
+	for overflow > 0 && len(m.live.events) > cockpitLiveMaxEvents {
+		switch {
+		case m.live.selected > 0:
+			m.live.events = m.live.events[1:]
+			m.live.selected--
+		case len(m.live.events) > 1:
+			m.live.events = append(m.live.events[:1], m.live.events[2:]...)
+		default:
+			return
+		}
+		overflow--
 	}
 }
 

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -779,8 +779,14 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.live.pausedNewCount += len(msg.snapshot.Events)
 				}
 				m.live.events = append(m.live.events, msg.snapshot.Events...)
-				if len(m.live.events) > cockpitLiveMaxEvents {
-					m.live.events = m.live.events[len(m.live.events)-cockpitLiveMaxEvents:]
+				if overflow := len(m.live.events) - cockpitLiveMaxEvents; overflow > 0 {
+					m.live.events = m.live.events[overflow:]
+					if !m.live.follow {
+						m.live.selected -= overflow
+						if m.live.selected < 0 {
+							m.live.selected = 0
+						}
+					}
 				}
 			}
 			m.live.cursor = msg.snapshot.Cursor
@@ -792,7 +798,7 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		var markCmd tea.Cmd
-		if msg.err == nil && m.mode == cockpitModeLive {
+		if msg.err == nil && m.mode == cockpitModeLive && m.live.follow {
 			markCmd = m.markCockpitEventsSeenCmd(msg.snapshot)
 		}
 		if m.mode == cockpitModeLive {
@@ -1064,10 +1070,13 @@ func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
+		wasFollowing := m.live.follow
 		m.live.selected++
 		m.clampLiveSelection()
 		if !m.live.isAtNewest() {
 			m.live.follow = false
+		} else if !wasFollowing {
+			return m, m.resumeCockpitLiveFollowCmd()
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.Home):
@@ -1078,11 +1087,7 @@ func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.End):
-		m.resumeCockpitLiveFollow()
-		if !m.live.loading {
-			return m, m.cockpitLiveTickCmd()
-		}
-		return m, nil
+		return m, m.resumeCockpitLiveFollowCmd()
 	case key.Matches(msg, m.keys.Refresh):
 		return m, m.startCockpitLiveLoad(true)
 	case key.Matches(msg, m.keys.Select):
@@ -1430,6 +1435,21 @@ func (m *cockpitModel) resumeCockpitLiveFollow() {
 	m.moveCockpitLiveSelectionToNewest()
 }
 
+func (m *cockpitModel) resumeCockpitLiveFollowCmd() tea.Cmd {
+	m.resumeCockpitLiveFollow()
+	return tea.Batch(m.markCurrentCockpitLiveSeenCmd(), m.cockpitLiveTickCmd())
+}
+
+func (m cockpitModel) markCurrentCockpitLiveSeenCmd() tea.Cmd {
+	if len(m.live.events) == 0 {
+		return nil
+	}
+	return m.markCockpitEventsSeenCmd(cockpitLiveSnapshot{
+		Cursor:   m.live.cursor,
+		LoadedAt: m.live.loadedAt,
+	})
+}
+
 func (m *cockpitModel) clampDetailOffset() {
 	maxOffset := len(m.detailLines()) - 1
 	if maxOffset < 0 {
@@ -1640,9 +1660,16 @@ func (m cockpitModel) livePauseMessage() string {
 		return ""
 	}
 	if m.live.pausedNewCount > 0 {
-		return m.styles.Warning.Render(Localizef("Auto-follow paused · %d newer event(s) available · press End/G for newest", "auto-follow 停止中 · 新しい event %d 件 · End/G で最新へ", m.live.pausedNewCount))
+		return m.styles.Warning.Render(formatCockpitPausedNewEvents(m.live.pausedNewCount))
 	}
 	return m.styles.Subtle.Render(Localize("Auto-follow paused · press End/G for newest", "auto-follow 停止中 · End/G で最新へ"))
+}
+
+func formatCockpitPausedNewEvents(count int) string {
+	if count == 1 {
+		return Localize("Auto-follow paused · 1 newer event available · press End/G for newest", "auto-follow 停止中 · 新しい event 1 件 · End/G で最新へ")
+	}
+	return Localizef("Auto-follow paused · %d newer events available · press End/G for newest", "auto-follow 停止中 · 新しい event %d 件 · End/G で最新へ", count)
 }
 
 func (m cockpitModel) detailView() string {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -612,19 +612,20 @@ func TestCockpitModel_IgnoresStaleDoctorResponses(t *testing.T) {
 	}
 }
 
-func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
+func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 	t.Parallel()
 
+	olderEvent := mustEvent(t, "evt-older", domtypes.EventKindNote, "older live event")
 	initialEvent := mustEvent(t, "evt-initial", domtypes.EventKindNote, "initial live event")
 	followEvent := mustEvent(t, "evt-follow", domtypes.EventKindCommandExecuted, "followed live event")
 	loader := &cockpitLoaderStub{
 		liveResponses: []cockpitLiveSnapshot{
-			{Events: []*model.Event{initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt},
-			{Events: []*model.Event{initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(time.Minute)},
+			{Events: []*model.Event{olderEvent, initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt},
+			{Events: []*model.Event{olderEvent, initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(time.Minute)},
 			{Events: []*model.Event{followEvent}, Cursor: newTailCursor(followEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(2 * time.Minute)},
 		},
 		detailContent: topDetailContent{
-			title: "EVENT evt-initial",
+			title: "EVENT evt-follow",
 			lines: []string{"shared detail renderer line", "full event payload"},
 		},
 	}
@@ -635,8 +636,8 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 
 	updated, cmd := model.Update(cockpitRuneKey("t"))
 	model = updated.(cockpitModel)
-	if model.mode != cockpitModeLive || !model.live.loading {
-		t.Fatalf("opening live pane mode/loading = %v/%v, want live/loading", model.mode, model.live.loading)
+	if model.mode != cockpitModeLive || !model.live.loading || !model.live.follow {
+		t.Fatalf("opening live pane mode/loading/follow = %v/%v/%v, want live/loading/follow", model.mode, model.live.loading, model.live.follow)
 	}
 	if cmd == nil {
 		t.Fatalf("opening live pane returned nil command")
@@ -644,16 +645,13 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	updated, cmd = model.Update(cmd())
 	model = updated.(cockpitModel)
 	if cmd == nil {
-		t.Fatalf("initial load should mark events seen")
+		t.Fatalf("initial load should mark events and schedule next poll")
 	}
-	if msg := cmd(); msg != nil {
-		t.Fatalf("event seen marker returned message = %T, want nil", msg)
-	}
-	if got, want := len(loader.eventSeenCalls), 1; got != want {
-		t.Fatalf("event seen calls after initial load = %d, want %d", got, want)
-	}
-	if got, want := len(model.live.events), 1; got != want {
+	if got, want := len(model.live.events), 2; got != want {
 		t.Fatalf("live events after initial load = %d, want %d", got, want)
+	}
+	if got, want := model.live.selected, 1; got != want {
+		t.Fatalf("selected row after default follow load = %d, want newest %d", got, want)
 	}
 	if got := model.View(); !strings.Contains(got, "live tail") || !strings.Contains(got, "initial live event") {
 		t.Fatalf("live view missing loaded event:\n%s", got)
@@ -675,30 +673,55 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	if got := loader.liveCalls[1].initial; !got {
 		t.Fatalf("refresh live call initial = false, want true")
 	}
-
-	updated, cmd = model.Update(cockpitRuneKey("f"))
-	model = updated.(cockpitModel)
-	if !model.live.follow || cmd == nil {
-		t.Fatalf("follow toggle follow/cmd = %v/%T, want enabled/tick command", model.live.follow, cmd)
+	if !model.live.follow {
+		t.Fatalf("refresh disabled default auto-follow")
 	}
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyUp})
+	model = updated.(cockpitModel)
+	if model.live.follow || cmd != nil {
+		t.Fatalf("scroll up follow/cmd = %v/%T, want paused/nil", model.live.follow, cmd)
+	}
+	if got, want := model.live.selected, 0; got != want {
+		t.Fatalf("selected row after scroll up = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "Auto-follow paused") {
+		t.Fatalf("paused live view missing pause cue:\n%s", got)
+	}
+
 	updated, cmd = model.Update(cockpitLiveTickMsg{})
 	model = updated.(cockpitModel)
 	if !model.live.loading || cmd == nil {
-		t.Fatalf("follow tick loading/cmd = %v/%T, want loading/fetch command", model.live.loading, cmd)
+		t.Fatalf("paused poll tick loading/cmd = %v/%T, want loading/fetch command", model.live.loading, cmd)
 	}
 	updated, cmd = model.Update(cmd())
 	model = updated.(cockpitModel)
-	if got := len(model.live.events); got != 2 {
-		t.Fatalf("live events after follow poll = %d, want 2", got)
+	if got := len(model.live.events); got != 3 {
+		t.Fatalf("live events after paused poll = %d, want 3", got)
 	}
-	if got := model.View(); !strings.Contains(got, "followed live event") {
-		t.Fatalf("live view missing followed event:\n%s", got)
+	if got, want := model.live.selected, 0; got != want {
+		t.Fatalf("selected row after paused poll = %d, want paused row %d", got, want)
+	}
+	if got, want := model.live.pausedNewCount, 1; got != want {
+		t.Fatalf("paused new count = %d, want %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "1 newer event") && !strings.Contains(got, "1 newer event(s)") {
+		t.Fatalf("paused live view missing newer-event cue:\n%s", got)
 	}
 	if got := loader.liveCalls[2].initial; got {
-		t.Fatalf("follow poll live call initial = true, want false")
+		t.Fatalf("paused poll live call initial = true, want false")
 	}
 	if cmd == nil {
-		t.Fatalf("follow poll should schedule the next tick while follow is enabled")
+		t.Fatalf("paused poll should schedule the next tick")
+	}
+
+	updated, cmd = model.Update(cockpitRuneKey("G"))
+	model = updated.(cockpitModel)
+	if !model.live.follow || model.live.pausedNewCount != 0 || cmd == nil {
+		t.Fatalf("G resume follow/new/cmd = %v/%d/%T, want follow/0/tick", model.live.follow, model.live.pausedNewCount, cmd)
+	}
+	if got, want := model.live.selected, 2; got != want {
+		t.Fatalf("selected row after G = %d, want newest %d", got, want)
 	}
 
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -714,7 +737,7 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("detail load returned unexpected follow-up command = %T", cmd)
 	}
-	if got, want := loader.detailCalls, []domtypes.EventID{initialEvent.EventID()}; len(got) != len(want) || got[0] != want[0] {
+	if got, want := loader.detailCalls, []domtypes.EventID{followEvent.EventID()}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("detail calls = %v, want %v", got, want)
 	}
 	if got := model.View(); !strings.Contains(got, "shared detail renderer line") {
@@ -724,7 +747,7 @@ func TestCockpitModel_LivePaneRefreshFollowAndDetail(t *testing.T) {
 	updated, cmd = model.Update(cockpitRuneKey("t"))
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeLive || cmd == nil {
-		t.Fatalf("returning to live with follow mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+		t.Fatalf("returning to live mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
 	}
 }
 
@@ -898,23 +921,7 @@ func TestCockpitModel_MemoryReviewLaunchAndFinishRefreshesHome(t *testing.T) {
 		t.Fatalf("review finish decision = %v, want accept", got)
 	}
 
-	msg := cmd()
-	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("memory review apply refresh command = %T, want tea.BatchMsg", msg)
-	}
-	for _, batchedCmd := range batch {
-		if batchedCmd == nil {
-			continue
-		}
-		updated, followCmd := model.Update(batchedCmd())
-		model = updated.(cockpitModel)
-		if followCmd != nil {
-			if followMsg := followCmd(); followMsg != nil {
-				t.Fatalf("refresh follow-up returned message = %T, want nil", followMsg)
-			}
-		}
-	}
+	model = applyCockpitImmediateCommandForTest(t, model, cmd)
 	if got, want := loader.homeCalls, 1; got != want {
 		t.Fatalf("home refresh calls = %d, want %d", got, want)
 	}
@@ -1496,8 +1503,8 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 		view := base.View()
 		for _, must := range []string{
 			"Action menu",
-			"Refresh live events",
-			"Start follow mode",
+			"Refresh Tail events",
+			"Jump to newest and resume auto-follow",
 			"Global navigation",
 			"1 Tail",
 		} {
@@ -1517,8 +1524,8 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 		view := model.View()
 		for _, must := range []string{
 			"Action menu",
-			"Refresh live events",
-			"Start follow mode",
+			"Refresh Tail events",
+			"Jump to newest and resume auto-follow",
 			"Loading live events...",
 		} {
 			if !strings.Contains(view, must) {
@@ -2161,8 +2168,8 @@ func TestCockpitModel_EscBacksOutWithoutQuitting(t *testing.T) {
 
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model = updated.(cockpitModel)
-	if model.mode != cockpitModeLive || cmd != nil {
-		t.Fatalf("esc from detail mode/cmd = %v/%T, want live/nil", model.mode, cmd)
+	if model.mode != cockpitModeLive || cmd == nil {
+		t.Fatalf("esc from detail mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
 	}
 
 	_, cmd = model.Update(cockpitRuneKey("q"))

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -647,6 +647,10 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 	if cmd == nil {
 		t.Fatalf("initial load should mark events and schedule next poll")
 	}
+	runFirstCockpitBatchCommandForTest(t, cmd)
+	if got, want := len(loader.eventSeenCalls), 1; got != want {
+		t.Fatalf("event seen calls after initial follow load = %d, want %d", got, want)
+	}
 	if got, want := len(model.live.events), 2; got != want {
 		t.Fatalf("live events after initial load = %d, want %d", got, want)
 	}
@@ -705,7 +709,10 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 	if got, want := model.live.pausedNewCount, 1; got != want {
 		t.Fatalf("paused new count = %d, want %d", got, want)
 	}
-	if got := model.View(); !strings.Contains(got, "1 newer event") && !strings.Contains(got, "1 newer event(s)") {
+	if got, want := len(loader.eventSeenCalls), 1; got != want {
+		t.Fatalf("event seen calls after paused poll = %d, want still %d", got, want)
+	}
+	if got := model.View(); !strings.Contains(got, "1 newer event") {
 		t.Fatalf("paused live view missing newer-event cue:\n%s", got)
 	}
 	if got := loader.liveCalls[2].initial; got {
@@ -719,6 +726,10 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 	model = updated.(cockpitModel)
 	if !model.live.follow || model.live.pausedNewCount != 0 || cmd == nil {
 		t.Fatalf("G resume follow/new/cmd = %v/%d/%T, want follow/0/tick", model.live.follow, model.live.pausedNewCount, cmd)
+	}
+	runFirstCockpitBatchCommandForTest(t, cmd)
+	if got, want := len(loader.eventSeenCalls), 2; got != want {
+		t.Fatalf("event seen calls after G resume = %d, want %d", got, want)
 	}
 	if got, want := model.live.selected, 2; got != want {
 		t.Fatalf("selected row after G = %d, want newest %d", got, want)
@@ -748,6 +759,72 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeLive || cmd == nil {
 		t.Fatalf("returning to live mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+	}
+}
+
+func TestCockpitModel_LiveDownToNewestResumesAutoFollow(t *testing.T) {
+	t.Parallel()
+
+	olderEvent := mustEvent(t, "evt-down-older", domtypes.EventKindNote, "older event")
+	newerEvent := mustEvent(t, "evt-down-newer", domtypes.EventKindNote, "newer event")
+	loader := &cockpitLoaderStub{}
+	cockpit := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	cockpit.loader = loader
+	cockpit.loaderCtx = context.Background()
+	cockpit.live.events = []*model.Event{olderEvent, newerEvent}
+	cockpit.live.cursor = newTailCursor(newerEvent.CreatedAt())
+	cockpit.live.loadedAt = fixedStartedAt
+	cockpit.live.selected = 0
+	cockpit.live.follow = false
+	cockpit.live.pausedNewCount = 1
+
+	updated, cmd := cockpit.Update(tea.KeyMsg{Type: tea.KeyDown})
+	cockpit = updated.(cockpitModel)
+	if !cockpit.live.follow || cockpit.live.pausedNewCount != 0 || cmd == nil {
+		t.Fatalf("down to newest follow/new/cmd = %v/%d/%T, want follow/0/tick", cockpit.live.follow, cockpit.live.pausedNewCount, cmd)
+	}
+	if got, want := cockpit.live.selected, 1; got != want {
+		t.Fatalf("selected row after down = %d, want newest %d", got, want)
+	}
+	runFirstCockpitBatchCommandForTest(t, cmd)
+	if got, want := len(loader.eventSeenCalls), 1; got != want {
+		t.Fatalf("event seen calls after down resume = %d, want %d", got, want)
+	}
+}
+
+func TestCockpitModel_LivePausedAppendTruncationKeepsFocusedRow(t *testing.T) {
+	t.Parallel()
+
+	events := make([]*model.Event, 0, cockpitLiveMaxEvents)
+	base := fixedStartedAt.Add(-time.Hour)
+	for i := range cockpitLiveMaxEvents {
+		events = append(events, cockpitEventFixtureAt(t, fmt.Sprintf("evt-buffer-%03d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+	focused := events[50]
+	newEvents := []*model.Event{}
+	for i := range 5 {
+		newEvents = append(newEvents, cockpitEventFixtureAt(t, fmt.Sprintf("evt-new-%03d", i), base.Add(time.Duration(cockpitLiveMaxEvents+i)*time.Second)))
+	}
+	cursor := newTailCursor(newEvents[len(newEvents)-1].CreatedAt())
+	cursor.Advance(newEvents)
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.live.events = events
+	model.live.selected = 50
+	model.live.follow = false
+
+	updated, _ := model.Update(cockpitLiveMsg{
+		seq:      model.live.requestSeq,
+		snapshot: cockpitLiveSnapshot{Events: newEvents, Cursor: cursor, LoadedAt: fixedStartedAt.Add(time.Minute)},
+	})
+	model = updated.(cockpitModel)
+	if got, want := len(model.live.events), cockpitLiveMaxEvents; got != want {
+		t.Fatalf("live events after truncate = %d, want %d", got, want)
+	}
+	if got := model.live.events[model.live.selected].EventID(); got != focused.EventID() {
+		t.Fatalf("focused event after truncate = %s, want %s", got, focused.EventID())
+	}
+	if got, want := model.live.pausedNewCount, len(newEvents); got != want {
+		t.Fatalf("paused new count after truncate append = %d, want %d", got, want)
 	}
 }
 

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -800,31 +800,38 @@ func TestCockpitModel_LivePausedAppendTruncationKeepsFocusedRow(t *testing.T) {
 	for i := range cockpitLiveMaxEvents {
 		events = append(events, cockpitEventFixtureAt(t, fmt.Sprintf("evt-buffer-%03d", i), base.Add(time.Duration(i)*time.Second)))
 	}
-	focused := events[50]
 	newEvents := []*model.Event{}
 	for i := range 5 {
 		newEvents = append(newEvents, cockpitEventFixtureAt(t, fmt.Sprintf("evt-new-%03d", i), base.Add(time.Duration(cockpitLiveMaxEvents+i)*time.Second)))
 	}
 	cursor := newTailCursor(newEvents[len(newEvents)-1].CreatedAt())
 	cursor.Advance(newEvents)
-	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
-	model.live.events = events
-	model.live.selected = 50
-	model.live.follow = false
 
-	updated, _ := model.Update(cockpitLiveMsg{
-		seq:      model.live.requestSeq,
-		snapshot: cockpitLiveSnapshot{Events: newEvents, Cursor: cursor, LoadedAt: fixedStartedAt.Add(time.Minute)},
-	})
-	model = updated.(cockpitModel)
-	if got, want := len(model.live.events), cockpitLiveMaxEvents; got != want {
-		t.Fatalf("live events after truncate = %d, want %d", got, want)
-	}
-	if got := model.live.events[model.live.selected].EventID(); got != focused.EventID() {
-		t.Fatalf("focused event after truncate = %s, want %s", got, focused.EventID())
-	}
-	if got, want := model.live.pausedNewCount, len(newEvents); got != want {
-		t.Fatalf("paused new count after truncate append = %d, want %d", got, want)
+	for _, selected := range []int{0, 2, 50} {
+		selected := selected
+		t.Run(fmt.Sprintf("selected_%d", selected), func(t *testing.T) {
+			t.Parallel()
+			focused := events[selected]
+			model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+			model.live.events = slices.Clone(events)
+			model.live.selected = selected
+			model.live.follow = false
+
+			updated, _ := model.Update(cockpitLiveMsg{
+				seq:      model.live.requestSeq,
+				snapshot: cockpitLiveSnapshot{Events: newEvents, Cursor: cursor, LoadedAt: fixedStartedAt.Add(time.Minute)},
+			})
+			model = updated.(cockpitModel)
+			if got, want := len(model.live.events), cockpitLiveMaxEvents; got != want {
+				t.Fatalf("live events after truncate = %d, want %d", got, want)
+			}
+			if got := model.live.events[model.live.selected].EventID(); got != focused.EventID() {
+				t.Fatalf("focused event after truncate = %s, want %s", got, focused.EventID())
+			}
+			if got, want := model.live.pausedNewCount, len(newEvents); got != want {
+				t.Fatalf("paused new count after truncate append = %d, want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/presentation/cli/cockpit_test_helpers_test.go
+++ b/presentation/cli/cockpit_test_helpers_test.go
@@ -25,11 +25,33 @@ func applyCockpitImmediateMessageForTest(t *testing.T, model cockpitModel, msg t
 		}
 		return model
 	default:
+		// Deliberately ignore follow-up commands here: Tail auto-follow can
+		// return tea.Tick, and recursively draining it would create a polling
+		// loop. Tests that need follow-up side effects should inspect the
+		// returned command directly.
 		updated, _ := model.Update(msg)
 		next, ok := updated.(cockpitModel)
 		if !ok {
 			t.Fatalf("cockpit update returned %T, want cockpitModel", updated)
 		}
 		return next
+	}
+}
+
+func runFirstCockpitBatchCommandForTest(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("command = nil, want tea.BatchMsg")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("command message = %T, want tea.BatchMsg", msg)
+	}
+	if len(batch) == 0 || batch[0] == nil {
+		t.Fatalf("batch first command missing: %#v", batch)
+	}
+	if followMsg := batch[0](); followMsg != nil {
+		t.Fatalf("batch first command returned message = %T, want nil", followMsg)
 	}
 }

--- a/presentation/cli/cockpit_test_helpers_test.go
+++ b/presentation/cli/cockpit_test_helpers_test.go
@@ -25,16 +25,10 @@ func applyCockpitImmediateMessageForTest(t *testing.T, model cockpitModel, msg t
 		}
 		return model
 	default:
-		updated, followCmd := model.Update(msg)
+		updated, _ := model.Update(msg)
 		next, ok := updated.(cockpitModel)
 		if !ok {
 			t.Fatalf("cockpit update returned %T, want cockpitModel", updated)
-		}
-		if followCmd != nil {
-			followMsg := followCmd()
-			if followMsg != nil {
-				return applyCockpitImmediateMessageForTest(t, next, followMsg)
-			}
 		}
 		return next
 	}

--- a/presentation/cli/testdata/cockpit/tail_initial.golden.txt
+++ b/presentation/cli/testdata/cockpit/tail_initial.golden.txt
@@ -1,8 +1,8 @@
 Traceary cockpit · live tail
 tabs: [1 Tail]  2 Top  3 Memory  4 Sessions  5 Settings
 
-loaded=2026-05-07T12:00:00Z follow=false rows=0
+loaded=2026-05-07T12:00:00Z auto_follow=true rows=0
 
 Loading live events...
 
-1-5 tabs · ←/→ tabs · tab/shift+tab next/prev · q/ctrl+c quit · ? help · r refresh · f follow
+1-5 tabs · ←/→ tabs · tab/shift+tab next/prev · q/ctrl+c quit · ? help · r refresh · End/G newest


### PR DESCRIPTION
## Motivation

Closes #1054.

Operators should not need to remember a hidden `f` toggle to make the Tail tab behave like a live stream. Tail should follow by default, pause when the operator scrolls into history, and provide an obvious way back to the newest event.

## Structure-Behavior Design Note

### Requirement summary
- Purpose: make the Tail tab a single live stream with default auto-follow.
- Current state: Tail exposes a manual `f follow` toggle and starts with follow disabled.
- Expected behavior: Tail polls by default, scrolling into history pauses selection auto-follow, and `End`/`G` resumes at the newest event.
- Non-goals: no changes to the non-interactive `traceary tail --follow` command.

### Conceptual model
| Concept | State | Behavior | Constraint |
|---|---|---|---|
| Tail stream | events, cursor, loading | polls for new events | preserves event-detail behavior |
| Auto-follow | follow bool, selected index | moves selection to newest while enabled | disabled by historical navigation |
| Paused new-event cue | pausedNewCount | increments while paused and polling finds newer events | cleared when refreshing initial view or resuming |

### Responsibility assignment
| Responsibility | Owner | Reason |
|---|---|---|
| Auto-follow state transitions | cockpitModel live update/key handlers | state transition is local to Tail tab |
| Help/footer copy | cockpit view helpers | UI affordances must match available keys |
| Regression coverage | cockpit internal/golden tests | behavior is user-visible TUI state |

### Behavior tests
| Behavior | Given | When | Then |
|---|---|---|---|
| Default follow | Tail load returns multiple events | load completes | selected row is newest and polling continues |
| Scroll pause | Tail is at newest | Up/Home | auto-follow pauses |
| Paused new events | Tail is paused | poll returns new events | selection stays put and newer-event cue appears |
| Resume | Tail is paused | `G`/End | selection moves newest, count clears, polling continues |
| Detail | Tail has selected event | Enter | event detail still opens |

## Changes

- Tail auto-follow is enabled by default.
- Removed `f follow` from Tail key handling, footer, and contextual help.
- Polling continues while selection auto-follow is paused so new-event cues can be shown.
- `End`/`G` jumps to newest and resumes auto-follow.
- Tail golden snapshot now shows `auto_follow=true` and `End/G newest` help.

## Validation

- `TRACEARY_UPDATE_GOLDEN=1 GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `git diff --check`
