### PR TITLE
v0.19-4: make Settings editable with arrow-key form controls

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -2597,7 +2597,11 @@ func (m cockpitModel) cockpitGlobalFooter(localHelp string) string {
 	}
 	parts := []string{}
 	if m.cockpitSectionNavigationAvailable() {
-		parts = append(parts, Localize("1-5 tabs", "1-5 タブ"), Localize("←/→ tabs", "←/→ タブ"), Localize("tab/shift+tab next/prev", "tab/shift+tab 次/前"))
+		parts = append(parts, Localize("1-5 tabs", "1-5 タブ"))
+		if m.mode != cockpitModeSettings {
+			parts = append(parts, Localize("←/→ tabs", "←/→ タブ"))
+		}
+		parts = append(parts, Localize("tab/shift+tab next/prev", "tab/shift+tab 次/前"))
 	}
 	if m.width > 0 && m.height > 0 {
 		parts = append(parts, Localizef("terminal %dx%d", "端末 %dx%d", m.width, m.height))
@@ -2674,16 +2678,9 @@ func (m cockpitModel) cockpitContextualHelp() []string {
 			lines = append(lines, fmt.Sprintf("• %-12s %s", action.key, action.description))
 		}
 	}
+	lines = append(lines, "", m.styles.Subtle.Render(m.cockpitContextualNavigationTitle()))
+	lines = append(lines, m.cockpitContextualNavigationLines()...)
 	lines = append(lines,
-		"",
-		m.styles.Subtle.Render(Localize("Global navigation", "Global navigation")),
-		Localize("1 Tail      live event stream and event details", "1 Tail      live event stream と event 詳細"),
-		Localize("2 Top       dashboard for sessions, failures, commands, memory, and health", "2 Top       session / failure / command / memory / health の dashboard"),
-		Localize("3 Memory    inbox review queue", "3 メモリ      inbox review queue"),
-		Localize("4 Sessions  session and handoff entry points", "4 セッション  session と handoff 導線"),
-		Localize("5 Settings  language, read defaults, redaction diagnostics", "5 設定        language / read 既定 / redaction 診断"),
-		Localize("← / → cycle tabs; tab / shift+tab remain supported", "← / → でタブ移動。tab / shift+tab も利用可能"),
-		Localize("esc backs out to Tail; q exits the TUI", "esc で Tail に戻り、q で TUI を終了"),
 		"",
 		m.styles.Subtle.Render(Localize("Fallback commands available today:", "現在利用できる fallback command:")),
 		"traceary top --snapshot [--json]",
@@ -2693,6 +2690,36 @@ func (m cockpitModel) cockpitContextualHelp() []string {
 		"traceary memory inbox review",
 		"traceary tui --reset-state",
 	)
+	return lines
+}
+
+func (m cockpitModel) cockpitContextualNavigationTitle() string {
+	if m.mode == cockpitModeSettings && (m.settings.editingPattern || m.settings.confirmSave) {
+		return Localize("Navigation paused", "Navigation paused")
+	}
+	return Localize("Global navigation", "Global navigation")
+}
+
+func (m cockpitModel) cockpitContextualNavigationLines() []string {
+	if m.mode == cockpitModeSettings && m.settings.editingPattern {
+		return []string{Localize("Navigation is paused while regex input is active; enter stages the regex and esc cancels.", "regex 入力中は navigation を一時停止します。enter で staged、esc でキャンセルします。")}
+	}
+	if m.mode == cockpitModeSettings && m.settings.confirmSave {
+		return []string{Localize("Navigation is paused while config write confirmation is active; y saves and n/esc cancels.", "config 書き込み確認中は navigation を一時停止します。y で保存、n/esc でキャンセルします。")}
+	}
+	lines := []string{
+		Localize("1 Tail      live event stream and event details", "1 Tail      live event stream と event 詳細"),
+		Localize("2 Top       dashboard for sessions, failures, commands, memory, and health", "2 Top       session / failure / command / memory / health の dashboard"),
+		Localize("3 Memory    inbox review queue", "3 メモリ      inbox review queue"),
+		Localize("4 Sessions  session and handoff entry points", "4 セッション  session と handoff 導線"),
+		Localize("5 Settings  language, read defaults, redaction diagnostics", "5 設定        language / read 既定 / redaction 診断"),
+	}
+	if m.mode == cockpitModeSettings {
+		lines = append(lines, Localize("tab / shift+tab cycle tabs; 1-5 jump tabs; ← / → edit selected value rows", "tab / shift+tab でタブ移動。1-5 でタブ選択。← / → は選択中の値 row を編集"))
+	} else {
+		lines = append(lines, Localize("← / → cycle tabs; tab / shift+tab remain supported", "← / → でタブ移動。tab / shift+tab も利用可能"))
+	}
+	lines = append(lines, Localize("esc backs out to Tail; q exits the TUI", "esc で Tail に戻り、q で TUI を終了"))
 	return lines
 }
 

--- a/presentation/cli/cockpit_dogfood_internal_test.go
+++ b/presentation/cli/cockpit_dogfood_internal_test.go
@@ -260,8 +260,8 @@ func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 		}
 		updated, _ = model.Update(cockpitRuneKey("l"))
 		model = updated.(cockpitModel)
-		if view := model.View(); !strings.Contains(view, "ui.language: en") || !strings.Contains(view, "ui.language: en (default) -> en") {
-			t.Fatalf("settings dogfood missing staged English language diff:\n%s", view)
+		if view := model.View(); !strings.Contains(view, "ui.language: en") || strings.Contains(view, "ui.language: en (default) -> en") {
+			t.Fatalf("settings dogfood should treat explicit English as the default, not a staged diff:\n%s", view)
 		}
 		updated, _ = model.Update(cockpitRuneKey("c"))
 		model = updated.(cockpitModel)
@@ -297,10 +297,13 @@ func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 		if err != nil {
 			t.Fatalf("settings dogfood expected saved config: %v", err)
 		}
-		for _, must := range []string{`"language": "en"`, `"color": "always"`, `SECRET-[0-9]+`} {
+		for _, must := range []string{`"color": "always"`, `SECRET-[0-9]+`} {
 			if !strings.Contains(string(data), must) {
 				t.Fatalf("settings dogfood saved config missing %q:\n%s", must, data)
 			}
+		}
+		if strings.Contains(string(data), `"language": "en"`) {
+			t.Fatalf("settings dogfood should not write explicit default language:\n%s", data)
 		}
 	})
 }
@@ -388,9 +391,9 @@ func TestCockpitDogfoodJapaneseNarrowSmoke(t *testing.T) {
 		"編集可能な settings",
 		"読み取り専用 diagnostics",
 		"TRACEARY_LANG=ja",
-		"ui.language:",
-		"redact.extra_patterns:",
-		"regex 追加",
+		"UI 言語",
+		"redact.extra_patterns",
+		"を追加",
 	} {
 		if !strings.Contains(settingsView, must) {
 			t.Fatalf("Japanese settings smoke missing %q:\n%s", must, settingsView)

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1706,6 +1706,7 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 				"Traceary cockpit · settings",
 				"tabs: 1 Tail  2 Top  3 Memory  4 Sessions  [5 Settings]",
 				"config status: missing",
+				"tab/shift+tab next/prev",
 			},
 		},
 	}
@@ -1717,6 +1718,9 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 				if !strings.Contains(view, must) {
 					t.Fatalf("%s view missing %q:\n%s", tc.name, must, view)
 				}
+			}
+			if tc.name == "settings" && strings.Contains(view, "←/→ tabs") {
+				t.Fatalf("settings footer should reserve ←/→ for value rows, not tabs:\n%s", view)
 			}
 		})
 	}
@@ -1870,6 +1874,74 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("settings", func(t *testing.T) {
+		model := base
+		model.mode = cockpitModeSettings
+		model.settings = cockpitSettingsState{
+			loaded: true,
+			snapshot: cockpitSettingsSnapshot{
+				Path:   "/tmp/config.json",
+				Status: cockpitSettingsConfigMissing,
+			},
+		}
+		model.settings.draft = model.settings.snapshot.Values.clone()
+		view := model.View()
+		for _, must := range []string{
+			"Change ui.language, read.color, or read.fields when those rows are selected",
+			"tab / shift+tab",
+			"← / → edit selected value rows",
+		} {
+			if !strings.Contains(view, must) {
+				t.Fatalf("settings help missing %q:\n%s", must, view)
+			}
+		}
+		if strings.Contains(view, "← / → cycle tabs") {
+			t.Fatalf("settings help should not advertise ←/→ as tab navigation:\n%s", view)
+		}
+	})
+
+	t.Run("settings modal help", func(t *testing.T) {
+		model := base
+		model.mode = cockpitModeSettings
+		model.showHelp = true
+		model.settings = cockpitSettingsState{
+			loaded: true,
+			snapshot: cockpitSettingsSnapshot{
+				Path:   "/tmp/config.json",
+				Status: cockpitSettingsConfigMissing,
+			},
+		}
+		model.settings.draft = model.settings.snapshot.Values.clone()
+
+		updated, _ := model.Update(cockpitRuneKey("n"))
+		model = updated.(cockpitModel)
+		view := model.View()
+		if !strings.Contains(view, "Navigation is paused while regex input is active") {
+			t.Fatalf("settings regex modal help missing paused-navigation copy:\n%s", view)
+		}
+		for _, mustNot := range []string{"\n1 Tail      ", "← / → cycle tabs", "← / → edit selected value rows"} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("settings regex modal help advertised unavailable navigation %q:\n%s", mustNot, view)
+			}
+		}
+
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		model = updated.(cockpitModel)
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+		model = updated.(cockpitModel)
+		updated, _ = model.Update(cockpitRuneKey("w"))
+		model = updated.(cockpitModel)
+		view = model.View()
+		if !strings.Contains(view, "Navigation is paused while config write confirmation is active") {
+			t.Fatalf("settings save-confirmation help missing paused-navigation copy:\n%s", view)
+		}
+		for _, mustNot := range []string{"\n1 Tail      ", "← / → cycle tabs", "← / → edit selected value rows"} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("settings confirmation help advertised unavailable navigation %q:\n%s", mustNot, view)
+			}
+		}
+	})
 }
 
 func TestCockpitSettingsViewShowsConfigStatusAndEnvOverrides(t *testing.T) {
@@ -1913,16 +1985,42 @@ func TestCockpitSettingsViewShowsConfigStatusAndEnvOverrides(t *testing.T) {
 		"ui.language: ja",
 		"read.color: never",
 		"read.fields: ts,kind,message",
-		"redact.extra_patterns: SECRET-[0-9]+",
+		"redact.extra_patterns add: SECRET-[0-9]+",
 		"TRACEARY_DB_PATH=unset",
-		"read.presets (view only in v0.18)",
+		"read.presets (view only in this release)",
 		"mine fields=ts filters=kind=prompt",
-		"redact.rules (view only in v0.18)",
+		"redact.rules (view only in this release)",
 		"token(regex)",
 	} {
 		if !strings.Contains(view, must) {
 			t.Fatalf("settings view missing %q:\n%s", must, view)
 		}
+	}
+}
+
+func TestCockpitSettingsRowsMatchDispatchConstants(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+	t.Setenv(cliLanguageEnvKey, "en")
+
+	rows := cockpitSettingsState{}.settingsRows()
+	if got, want := len(rows), cockpitSettingsRowCount; got != want {
+		t.Fatalf("settings row count = %d, want %d", got, want)
+	}
+	if got := rows[cockpitSettingsRowLanguage]; !strings.Contains(got, "ui.language") {
+		t.Fatalf("language row = %q, want ui.language marker", got)
+	}
+	if got := rows[cockpitSettingsRowReadColor]; !strings.Contains(got, "read.color") {
+		t.Fatalf("read color row = %q, want read.color marker", got)
+	}
+	if got := rows[cockpitSettingsRowReadFields]; !strings.Contains(got, "read.fields") {
+		t.Fatalf("read fields row = %q, want read.fields marker", got)
+	}
+	if got := rows[cockpitSettingsRowAddPattern]; !strings.Contains(got, "redact.extra_patterns add") {
+		t.Fatalf("add pattern row = %q, want redact.extra_patterns add marker", got)
+	}
+	if got := rows[cockpitSettingsRowRemovePattern]; !strings.Contains(got, "redact.extra_patterns remove last") {
+		t.Fatalf("remove pattern row = %q, want redact.extra_patterns remove marker", got)
 	}
 }
 
@@ -1995,24 +2093,283 @@ func TestCockpitSettingsStagesValidatesAndSavesConfigAtomically(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("saved config invalid JSON: %v\n%s", err, data)
 	}
-	ui := got["ui"].(map[string]any)
-	read := got["read"].(map[string]any)
-	redact := got["redact"].(map[string]any)
+	ui := settingsJSONSection(t, got, "ui")
+	read := settingsJSONSection(t, got, "read")
+	redact := settingsJSONSection(t, got, "redact")
 	if ui["language"] != "ja" {
 		t.Fatalf("ui.language = %v, want ja", ui["language"])
 	}
 	if read["color"] != "always" {
 		t.Fatalf("read.color = %v, want always", read["color"])
 	}
-	if len(read["fields"].([]any)) == 0 {
-		t.Fatalf("read.fields not saved: %#v", read["fields"])
+	fields := settingsJSONArray(t, read, "fields")
+	if len(fields) == 0 {
+		t.Fatalf("read.fields not saved: %#v", fields)
 	}
-	if gotPatterns := redact["extra_patterns"].([]any); len(gotPatterns) != 1 || gotPatterns[0] != "SECRET-[0-9]+" {
+	if gotPatterns := settingsJSONArray(t, redact, "extra_patterns"); len(gotPatterns) != 1 || gotPatterns[0] != "SECRET-[0-9]+" {
 		t.Fatalf("redact.extra_patterns = %#v, want valid staged regex", gotPatterns)
 	}
 	if !strings.Contains(model.View(), "設定") {
 		t.Fatalf("saved ui.language should refresh current cockpit language when TRACEARY_LANG is unset:\n%s", model.View())
 	}
+}
+
+func TestCockpitSettingsArrowKeyWorkflowStagesAndConfirmsSave(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(cliLanguageEnvKey, "en")
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("5"))
+	model = updated.(cockpitModel)
+
+	// Row 0: ui.language, Row 1: read.color, Row 2: read.fields.
+	for _, keyMsg := range []tea.KeyMsg{
+		{Type: tea.KeyRight},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyRight},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyRight},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+	} {
+		updated, _ = model.Update(keyMsg)
+		model = updated.(cockpitModel)
+	}
+	if !model.settings.editingPattern {
+		t.Fatalf("enter on add-pattern row should open regex editor:\n%s", model.View())
+	}
+	for _, r := range `TOKEN-[A-Z]+` {
+		updated, _ = model.Update(cockpitRuneKey(string(r)))
+		model = updated.(cockpitModel)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	for range 2 {
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+		model = updated.(cockpitModel)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if !model.settings.confirmSave || !strings.Contains(model.View(), "Confirm config write") {
+		t.Fatalf("enter on save row should require explicit confirmation:\n%s", model.View())
+	}
+	updated, _ = model.Update(cockpitRuneKey("y"))
+	model = updated.(cockpitModel)
+
+	configPath := filepath.Join(home, ".config", "traceary", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config) error = %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("saved config invalid JSON: %v\n%s", err, data)
+	}
+	ui := settingsJSONSection(t, got, "ui")
+	read := settingsJSONSection(t, got, "read")
+	redact := settingsJSONSection(t, got, "redact")
+	if ui["language"] != "ja" {
+		t.Fatalf("ui.language = %v, want ja", ui["language"])
+	}
+	if read["color"] != "always" {
+		t.Fatalf("read.color = %v, want always", read["color"])
+	}
+	fields := settingsJSONArray(t, read, "fields")
+	wantFields := []any{"ts", "kind", "exit_code", "session", "ws", "message"}
+	if !slices.Equal(fields, wantFields) {
+		t.Fatalf("read.fields = %#v, want first non-default preset %#v", fields, wantFields)
+	}
+	if gotPatterns := settingsJSONArray(t, redact, "extra_patterns"); len(gotPatterns) != 1 || gotPatterns[0] != "TOKEN-[A-Z]+" {
+		t.Fatalf("redact.extra_patterns = %#v, want valid staged regex", gotPatterns)
+	}
+	view := model.View()
+	if !strings.Contains(view, "TRACEARY_LANG=en") {
+		t.Fatalf("TRACEARY_LANG override message should remain visible after save:\n%s", view)
+	}
+}
+
+func TestCockpitSettingsLeftArrowCyclesEditableRowsBackward(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("5"))
+	model = updated.(cockpitModel)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	model = updated.(cockpitModel)
+	if got, want := model.settings.draft.UILanguage, "ja"; got != want {
+		t.Fatalf("left on ui.language = %q, want %q", got, want)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	model = updated.(cockpitModel)
+	if got, want := model.settings.draft.ReadColor, "never"; got != want {
+		t.Fatalf("left on read.color = %q, want %q", got, want)
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	model = updated.(cockpitModel)
+	wantFields := []string{"ts", "kind", "message"}
+	if !slices.Equal(model.settings.draft.ReadFields, wantFields) {
+		t.Fatalf("left on read.fields = %#v, want %#v", model.settings.draft.ReadFields, wantFields)
+	}
+}
+
+func TestCockpitSettingsArrowsStayInsideSettingsRows(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for row := range cockpitSettingsRowCount {
+		for _, keyMsg := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}} {
+			model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+			updated, _ := model.Update(cockpitRuneKey("5"))
+			model = updated.(cockpitModel)
+			model.settings.cursor = row
+
+			updated, cmd := model.Update(keyMsg)
+			model = updated.(cockpitModel)
+			if model.mode != cockpitModeSettings || cmd != nil {
+				t.Fatalf("row %d key %v mode/cmd = %v/%T, want settings/nil", row, keyMsg.Type, model.mode, cmd)
+			}
+		}
+	}
+}
+
+func TestCockpitSettingsDefaultCyclesAreSemanticallyReversible(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("5"))
+	model = updated.(cockpitModel)
+
+	for _, step := range []struct {
+		name        string
+		row         int
+		defaultText string
+	}{
+		{name: "ui.language", row: cockpitSettingsRowLanguage, defaultText: "ui.language: en (default)"},
+		{name: "read.color", row: cockpitSettingsRowReadColor, defaultText: "read.color: auto (default)"},
+		{name: "read.fields", row: cockpitSettingsRowReadFields, defaultText: "read.fields: ts,kind,agent,session,ws,message (default)"},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			cycleModel := model
+			cycleModel.settings.cursor = step.row
+			updated, _ := cycleModel.Update(tea.KeyMsg{Type: tea.KeyRight})
+			cycleModel = updated.(cockpitModel)
+			if !cycleModel.settings.dirty() {
+				t.Fatalf("%s right arrow should stage a non-default value", step.name)
+			}
+			updated, _ = cycleModel.Update(tea.KeyMsg{Type: tea.KeyLeft})
+			cycleModel = updated.(cockpitModel)
+			if cycleModel.settings.dirty() {
+				t.Fatalf("%s right then left should return to the semantic default:\n%s", step.name, cycleModel.View())
+			}
+			view := cycleModel.View()
+			if !strings.Contains(view, step.defaultText) || strings.Contains(view, "Staged") {
+				t.Fatalf("%s revert should restore default display and clear staged info:\n%s", step.name, view)
+			}
+		})
+	}
+}
+
+func TestSettingsFieldSetAtOffsetCustomSetRespectsDirection(t *testing.T) {
+	custom := []string{"ts", "kind", "custom"}
+	if got, want := settingsFieldSetAtOffset(custom, 1), readFieldIDsToStrings(defaultReadFields); !slices.Equal(got, want) {
+		t.Fatalf("right from custom read.fields = %#v, want default %#v", got, want)
+	}
+	if got, want := settingsFieldSetAtOffset(custom, -1), []string{"ts", "kind", "message"}; !slices.Equal(got, want) {
+		t.Fatalf("left from custom read.fields = %#v, want final preset %#v", got, want)
+	}
+}
+
+func TestCockpitSettingsEnterActionsRemoveDiscardAndReload(t *testing.T) {
+	resetConfiguredCLILanguageCacheForTest()
+	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "traceary")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"ui":{"language":"en"},"redact":{"extra_patterns":["SECRET","TOKEN"]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	updated, _ := model.Update(cockpitRuneKey("5"))
+	model = updated.(cockpitModel)
+
+	model.settings.cursor = cockpitSettingsRowRemovePattern
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if got, want := model.settings.draft.ExtraPatterns, []string{"SECRET"}; !slices.Equal(got, want) {
+		t.Fatalf("enter remove pattern = %#v, want %#v", got, want)
+	}
+
+	model.settings.cursor = cockpitSettingsRowDiscard
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if got, want := model.settings.draft.ExtraPatterns, []string{"SECRET", "TOKEN"}; !slices.Equal(got, want) {
+		t.Fatalf("enter discard = %#v, want %#v", got, want)
+	}
+
+	if err := os.WriteFile(configPath, []byte(`{"ui":{"language":"ja"},"redact":{"extra_patterns":["UPDATED"]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	model.settings.cursor = cockpitSettingsRowReload
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	if got, want := model.settings.draft.UILanguage, "ja"; got != want {
+		t.Fatalf("enter reload ui.language = %q, want %q", got, want)
+	}
+	if got, want := model.settings.draft.ExtraPatterns, []string{"UPDATED"}; !slices.Equal(got, want) {
+		t.Fatalf("enter reload redact.extra_patterns = %#v, want %#v", got, want)
+	}
+}
+
+func settingsJSONSection(t *testing.T, doc map[string]any, name string) map[string]any {
+	t.Helper()
+	raw, ok := doc[name]
+	if !ok {
+		t.Fatalf("saved config missing %q section: %#v", name, doc)
+	}
+	section, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("saved config %q section type = %T, want object: %#v", name, raw, raw)
+	}
+	return section
+}
+
+func settingsJSONArray(t *testing.T, section map[string]any, name string) []any {
+	t.Helper()
+	raw, ok := section[name]
+	if !ok {
+		t.Fatalf("saved config missing %q field: %#v", name, section)
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("saved config %q field type = %T, want array: %#v", name, raw, raw)
+	}
+	return values
 }
 
 func TestCockpitSettingsInvalidConfigIsRecoverableAndNotOverwritten(t *testing.T) {
@@ -2352,10 +2709,10 @@ func TestCockpitModel_GlobalSectionKeysSwitchWithoutReturningToCLI(t *testing.T)
 	if model.mode != cockpitModeSettings || cmd != nil {
 		t.Fatalf("right from sessions mode/cmd = %v/%T, want settings/nil", model.mode, cmd)
 	}
-	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyTab})
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeLive || cmd == nil {
-		t.Fatalf("right from settings mode/cmd = %v/%T, want tail/load", model.mode, cmd)
+		t.Fatalf("tab from settings mode/cmd = %v/%T, want tail/load", model.mode, cmd)
 	}
 }
 

--- a/presentation/cli/cockpit_settings.go
+++ b/presentation/cli/cockpit_settings.go
@@ -26,6 +26,18 @@ const (
 	cockpitSettingsConfigPathError  = "path_error"
 )
 
+const (
+	cockpitSettingsRowLanguage = iota
+	cockpitSettingsRowReadColor
+	cockpitSettingsRowReadFields
+	cockpitSettingsRowAddPattern
+	cockpitSettingsRowRemovePattern
+	cockpitSettingsRowSave
+	cockpitSettingsRowDiscard
+	cockpitSettingsRowReload
+	cockpitSettingsRowCount
+)
+
 type cockpitSettingsState struct {
 	loaded         bool
 	snapshot       cockpitSettingsSnapshot
@@ -301,9 +313,6 @@ func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if section, ok := cockpitSectionFromKey(msg); ok {
 		return m.openCockpitSection(section)
 	}
-	if section, ok := m.cockpitAdjacentSectionFromKey(msg); ok {
-		return m.openCockpitSection(section)
-	}
 	switch {
 	case key.Matches(msg, m.keys.Up):
 		m.settings.cursor--
@@ -313,10 +322,17 @@ func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.settings.cursor++
 		m.clampSettingsCursor()
 		return m, nil
+	case msg.Type == tea.KeyLeft:
+		return m.adjustSelectedSettingsRow(-1)
+	case msg.Type == tea.KeyRight:
+		return m.adjustSelectedSettingsRow(1)
+	case key.Matches(msg, m.keys.Select):
+		return m.activateSelectedSettingsRow()
 	case key.Matches(msg, m.keys.Refresh):
-		m.settings = newCockpitSettingsState()
-		m.settings.info = Localize("Settings reloaded from disk.", "Settings を disk から再読み込みしました。")
-		return m, nil
+		return m.reloadSettings()
+	}
+	if section, ok := m.cockpitAdjacentSectionFromKey(msg); ok {
+		return m.openCockpitSection(section)
 	}
 	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
 		return m, nil
@@ -335,10 +351,7 @@ func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "w":
 		return m.startSettingsSaveConfirmation()
 	case "d":
-		m.settings.draft = m.settings.snapshot.Values.clone()
-		m.settings.info = Localize("Discarded pending settings changes.", "未保存の設定変更を破棄しました。")
-		m.settings.err = ""
-		return m, nil
+		return m.discardSettingsChanges()
 	}
 	return m, nil
 }
@@ -367,7 +380,7 @@ func (m cockpitModel) updateSettingsPatternInputKey(msg tea.KeyMsg) (tea.Model, 
 		m.settings.draft.ExtraPatterns = append(m.settings.draft.ExtraPatterns, pattern)
 		m.settings.editingPattern = false
 		m.settings.patternInput = ""
-		m.settings.info = Localize("Staged redaction pattern. Press w to review and save.", "redaction pattern を staged にしました。w で確認して保存します。")
+		m.settings.info = Localize("Staged redaction pattern. Select Save changes or press w to review and save.", "redaction pattern を staged にしました。「変更を保存」を選ぶか w で確認して保存します。")
 		m.settings.err = ""
 		return m, nil
 	case tea.KeyBackspace, tea.KeyDelete:
@@ -409,41 +422,121 @@ func (m cockpitModel) updateSettingsConfirmKey(msg tea.KeyMsg) (tea.Model, tea.C
 	return m, nil
 }
 
+func (m cockpitModel) adjustSelectedSettingsRow(delta int) (tea.Model, tea.Cmd) {
+	switch m.settings.cursor {
+	case cockpitSettingsRowLanguage:
+		return m.stageSettingsLanguageCycle(delta)
+	case cockpitSettingsRowReadColor:
+		return m.stageSettingsColorCycleBy(delta)
+	case cockpitSettingsRowReadFields:
+		return m.stageSettingsFieldsCycleBy(delta)
+	default:
+		return m, nil
+	}
+}
+
+func (m cockpitModel) activateSelectedSettingsRow() (tea.Model, tea.Cmd) {
+	switch m.settings.cursor {
+	case cockpitSettingsRowLanguage:
+		return m.stageSettingsLanguageCycle(1)
+	case cockpitSettingsRowReadColor:
+		return m.stageSettingsColorCycleBy(1)
+	case cockpitSettingsRowReadFields:
+		return m.stageSettingsFieldsCycleBy(1)
+	case cockpitSettingsRowAddPattern:
+		return m.startSettingsPatternInput()
+	case cockpitSettingsRowRemovePattern:
+		return m.stageSettingsPatternRemove()
+	case cockpitSettingsRowSave:
+		return m.startSettingsSaveConfirmation()
+	case cockpitSettingsRowDiscard:
+		return m.discardSettingsChanges()
+	case cockpitSettingsRowReload:
+		return m.reloadSettings()
+	default:
+		return m, nil
+	}
+}
+
 func (m cockpitModel) stageSettingsLanguageToggle() (tea.Model, tea.Cmd) {
+	return m.stageSettingsLanguageCycle(1)
+}
+
+func (m cockpitModel) stageSettingsLanguageCycle(delta int) (tea.Model, tea.Cmd) {
 	if !m.settings.canEditConfig() {
 		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
 		return m, nil
 	}
 	current := normalizeSettingsLanguage(m.settings.draft.UILanguage)
-	if current == "ja" {
-		m.settings.draft.UILanguage = "en"
-	} else {
-		m.settings.draft.UILanguage = "ja"
+	values := []string{"en", "ja"}
+	index := 0
+	for i, value := range values {
+		if current == value {
+			index = i
+			break
+		}
 	}
-	m.settings.info = Localize("Staged UI language change. Press w to review and save.", "UI language 変更を staged にしました。w で確認して保存します。")
+	m.settings.draft.UILanguage = values[cycleSettingsIndex(index, delta, len(values))]
+	if settingsLanguageEquivalent(m.settings.snapshot.Values.UILanguage, m.settings.draft.UILanguage) {
+		m.settings.draft.UILanguage = m.settings.snapshot.Values.UILanguage
+		m.settings.info = ""
+	} else {
+		m.settings.info = Localize("Staged UI language change. Select Save changes to review and save.", "UI language 変更を staged にしました。「変更を保存」を選んで確認・保存します。")
+	}
 	m.settings.err = ""
 	return m, nil
 }
 
 func (m cockpitModel) stageSettingsColorCycle() (tea.Model, tea.Cmd) {
+	return m.stageSettingsColorCycleBy(1)
+}
+
+func (m cockpitModel) stageSettingsColorCycleBy(delta int) (tea.Model, tea.Cmd) {
 	if !m.settings.canEditConfig() {
 		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
 		return m, nil
 	}
-	m.settings.draft.ReadColor = nextSettingsColor(m.settings.draft.ReadColor)
-	m.settings.info = Localize("Staged read.color change. Press w to review and save.", "read.color 変更を staged にしました。w で確認して保存します。")
+	m.settings.draft.ReadColor = settingsColorAtOffset(m.settings.draft.ReadColor, delta)
+	if settingsColorEquivalent(m.settings.snapshot.Values.ReadColor, m.settings.draft.ReadColor) {
+		m.settings.draft.ReadColor = m.settings.snapshot.Values.ReadColor
+		m.settings.info = ""
+	} else {
+		m.settings.info = Localize("Staged read.color change. Select Save changes to review and save.", "read.color 変更を staged にしました。「変更を保存」を選んで確認・保存します。")
+	}
 	m.settings.err = ""
 	return m, nil
 }
 
 func (m cockpitModel) stageSettingsFieldsCycle() (tea.Model, tea.Cmd) {
+	return m.stageSettingsFieldsCycleBy(1)
+}
+
+func (m cockpitModel) stageSettingsFieldsCycleBy(delta int) (tea.Model, tea.Cmd) {
 	if !m.settings.canEditConfig() {
 		m.settings.err = Localize("Fix config readability/JSON before editing settings.", "設定を編集する前に config の読み込み/JSON を修復してください。")
 		return m, nil
 	}
-	m.settings.draft.ReadFields = nextSettingsFieldSet(m.settings.draft.ReadFields)
-	m.settings.info = Localize("Staged read.fields change. Press w to review and save.", "read.fields 変更を staged にしました。w で確認して保存します。")
+	m.settings.draft.ReadFields = settingsFieldSetAtOffset(m.settings.draft.ReadFields, delta)
+	if settingsFieldSetEquivalent(m.settings.snapshot.Values.ReadFields, m.settings.draft.ReadFields) {
+		m.settings.draft.ReadFields = slices.Clone(m.settings.snapshot.Values.ReadFields)
+		m.settings.info = ""
+	} else {
+		m.settings.info = Localize("Staged read.fields change. Select Save changes to review and save.", "read.fields 変更を staged にしました。「変更を保存」を選んで確認・保存します。")
+	}
 	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) discardSettingsChanges() (tea.Model, tea.Cmd) {
+	m.settings.draft = m.settings.snapshot.Values.clone()
+	m.settings.info = Localize("Discarded pending settings changes.", "未保存の設定変更を破棄しました。")
+	m.settings.err = ""
+	return m, nil
+}
+
+func (m cockpitModel) reloadSettings() (tea.Model, tea.Cmd) {
+	m.settings = newCockpitSettingsState()
+	m.settings.info = Localize("Settings reloaded from disk.", "Settings を disk から再読み込みしました。")
 	return m, nil
 }
 
@@ -470,7 +563,7 @@ func (m cockpitModel) stageSettingsPatternRemove() (tea.Model, tea.Cmd) {
 	}
 	removed := m.settings.draft.ExtraPatterns[len(m.settings.draft.ExtraPatterns)-1]
 	m.settings.draft.ExtraPatterns = m.settings.draft.ExtraPatterns[:len(m.settings.draft.ExtraPatterns)-1]
-	m.settings.info = Localizef("Staged removal of redact.extra_patterns entry %q. Press w to review and save.", "redact.extra_patterns %q の削除を staged にしました。w で確認して保存します。", removed)
+	m.settings.info = Localizef("Staged removal of redact.extra_patterns entry %q. Select Save changes or press w to review and save.", "redact.extra_patterns %q の削除を staged にしました。「変更を保存」を選ぶか w で確認して保存します。", removed)
 	m.settings.err = ""
 	return m, nil
 }
@@ -543,7 +636,7 @@ func (m cockpitModel) settingsView() string {
 	lines = append(lines, "", m.styles.Subtle.Render(Localize("Read-only diagnostics", "読み取り専用 diagnostics")))
 	lines = append(lines, m.settings.settingsEnvLines()...)
 	if len(m.settings.draft.ReadPresets) > 0 {
-		lines = append(lines, "", m.styles.Subtle.Render(Localize("read.presets (view only in v0.18)", "read.presets (v0.18 では表示のみ)")))
+		lines = append(lines, "", m.styles.Subtle.Render(Localize("read.presets (view only in this release)", "read.presets (このリリースでは表示のみ)")))
 		for _, preset := range m.settings.draft.ReadPresets {
 			fields := strings.Join(preset.Fields, ",")
 			if fields == "" {
@@ -557,7 +650,7 @@ func (m cockpitModel) settingsView() string {
 		}
 	}
 	if m.settings.draft.RedactRuleCount > 0 {
-		lines = append(lines, "", m.styles.Subtle.Render(Localize("redact.rules (view only in v0.18)", "redact.rules (v0.18 では表示のみ)")))
+		lines = append(lines, "", m.styles.Subtle.Render(Localize("redact.rules (view only in this release)", "redact.rules (このリリースでは表示のみ)")))
 		for _, name := range m.settings.draft.RedactRuleNames {
 			lines = append(lines, "• "+name)
 		}
@@ -570,18 +663,25 @@ func (m cockpitModel) settingsView() string {
 		lines = append(lines, m.settingsDiffLines()...)
 		lines = append(lines, m.styles.Help.Render(Localize("y save atomically · n/esc cancel", "y atomic save · n/esc キャンセル")))
 	} else if m.settings.dirty() {
-		lines = append(lines, "", m.styles.Warning.Render(Localize("Pending changes are not written yet. Press w to review and save, d to discard.", "未保存の変更があります。w で確認して保存、d で破棄します。")))
+		lines = append(lines, "", m.styles.Warning.Render(Localize("Pending changes are not written yet. Select Save changes or press w to review and save; select Discard or press d to discard.", "未保存の変更があります。「変更を保存」を選ぶか w で確認して保存、「破棄」を選ぶか d で破棄します。")))
 		lines = append(lines, m.settingsDiffLines()...)
 	}
 	return m.renderCockpitShell(Localize("settings", "設定"), lines, m.settingsLocalHelp())
 }
 
 func (s cockpitSettingsState) settingsRows() []string {
+	// Keep this order aligned with cockpitSettingsRow* constants and the
+	// dispatch switches below; TestCockpitSettingsRowsMatchDispatchConstants
+	// guards the contract.
 	return []string{
-		Localize("ui.language: ", "ui.language: ") + formatSettingValue(effectiveSettingsLanguage(s.draft.UILanguage)) + s.languageDirtyMarker(),
-		Localize("read.color: ", "read.color: ") + formatSettingValue(effectiveSettingsColor(s.draft.ReadColor)) + s.settingDirtyMarker(s.snapshot.Values.ReadColor, s.draft.ReadColor),
-		Localize("read.fields: ", "read.fields: ") + formatSettingValue(formatSettingsFields(s.draft.ReadFields)) + s.settingDirtyMarker(strings.Join(s.snapshot.Values.ReadFields, ","), strings.Join(s.draft.ReadFields, ",")),
-		Localize("redact.extra_patterns: ", "redact.extra_patterns: ") + formatSettingValue(formatSettingsPatterns(s.draft.ExtraPatterns)) + s.settingDirtyMarker(strings.Join(s.snapshot.Values.ExtraPatterns, "\x00"), strings.Join(s.draft.ExtraPatterns, "\x00")),
+		Localize("ui.language: ", "ui.language (UI 言語): ") + formatSettingValue(effectiveSettingsLanguage(s.draft.UILanguage)) + s.languageDirtyMarker(),
+		Localize("read.color: ", "read.color (色): ") + formatSettingValue(effectiveSettingsColor(s.draft.ReadColor)) + s.readColorDirtyMarker(),
+		Localize("read.fields: ", "read.fields (表示項目): ") + formatSettingValue(formatSettingsFields(s.draft.ReadFields)) + s.readFieldsDirtyMarker(),
+		Localize("redact.extra_patterns add: ", "redact.extra_patterns を追加: ") + formatSettingValue(formatSettingsPatterns(s.draft.ExtraPatterns)) + s.settingDirtyMarker(strings.Join(s.snapshot.Values.ExtraPatterns, "\x00"), strings.Join(s.draft.ExtraPatterns, "\x00")),
+		Localize("redact.extra_patterns remove last", "最後の redact.extra_patterns を削除"),
+		Localize("save changes", "変更を保存"),
+		Localize("discard pending changes", "未保存の変更を破棄"),
+		Localize("reload settings from disk", "settings を disk から再読み込み"),
 	}
 }
 
@@ -622,9 +722,13 @@ func (s cockpitSettingsState) canEditConfig() bool {
 }
 
 func (s cockpitSettingsState) dirty() bool {
-	return normalizeSettingsLanguage(s.snapshot.Values.UILanguage) != normalizeSettingsLanguage(s.draft.UILanguage) ||
-		strings.TrimSpace(s.snapshot.Values.ReadColor) != strings.TrimSpace(s.draft.ReadColor) ||
-		!slices.Equal(s.snapshot.Values.ReadFields, s.draft.ReadFields) ||
+	// ui.language/read.color/read.fields treat omitted config values as their
+	// runtime defaults so a cycle back to the default does not write noisy
+	// explicit defaults. redact.extra_patterns has no implicit default beyond
+	// the literal empty list, so raw slice equality is intentional there.
+	return !settingsLanguageEquivalent(s.snapshot.Values.UILanguage, s.draft.UILanguage) ||
+		!settingsColorEquivalent(s.snapshot.Values.ReadColor, s.draft.ReadColor) ||
+		!settingsFieldSetEquivalent(s.snapshot.Values.ReadFields, s.draft.ReadFields) ||
 		!slices.Equal(s.snapshot.Values.ExtraPatterns, s.draft.ExtraPatterns)
 }
 
@@ -636,7 +740,21 @@ func (s cockpitSettingsState) settingDirtyMarker(oldValue string, newValue strin
 }
 
 func (s cockpitSettingsState) languageDirtyMarker() string {
-	if normalizeSettingsLanguage(s.snapshot.Values.UILanguage) == normalizeSettingsLanguage(s.draft.UILanguage) {
+	if settingsLanguageEquivalent(s.snapshot.Values.UILanguage, s.draft.UILanguage) {
+		return ""
+	}
+	return Localize("  [staged]", "  [staged]")
+}
+
+func (s cockpitSettingsState) readColorDirtyMarker() string {
+	if settingsColorEquivalent(s.snapshot.Values.ReadColor, s.draft.ReadColor) {
+		return ""
+	}
+	return Localize("  [staged]", "  [staged]")
+}
+
+func (s cockpitSettingsState) readFieldsDirtyMarker() string {
+	if settingsFieldSetEquivalent(s.snapshot.Values.ReadFields, s.draft.ReadFields) {
 		return ""
 	}
 	return Localize("  [staged]", "  [staged]")
@@ -652,10 +770,18 @@ func (m cockpitModel) settingsDiffLines() []string {
 		}
 		lines = append(lines, fmt.Sprintf("• %s: %s -> %s", label, formatSettingValue(before), formatSettingValue(after)))
 	}
-	appendDiff("ui.language", effectiveSettingsLanguage(old.UILanguage), effectiveSettingsLanguage(draft.UILanguage))
-	appendDiff("read.color", effectiveSettingsColor(old.ReadColor), effectiveSettingsColor(draft.ReadColor))
-	appendDiff("read.fields", formatSettingsFields(old.ReadFields), formatSettingsFields(draft.ReadFields))
-	appendDiff("redact.extra_patterns", formatSettingsPatterns(old.ExtraPatterns), formatSettingsPatterns(draft.ExtraPatterns))
+	if !settingsLanguageEquivalent(old.UILanguage, draft.UILanguage) {
+		appendDiff("ui.language", effectiveSettingsLanguage(old.UILanguage), effectiveSettingsLanguage(draft.UILanguage))
+	}
+	if !settingsColorEquivalent(old.ReadColor, draft.ReadColor) {
+		appendDiff("read.color", effectiveSettingsColor(old.ReadColor), effectiveSettingsColor(draft.ReadColor))
+	}
+	if !settingsFieldSetEquivalent(old.ReadFields, draft.ReadFields) {
+		appendDiff("read.fields", formatSettingsFields(old.ReadFields), formatSettingsFields(draft.ReadFields))
+	}
+	if !slices.Equal(old.ExtraPatterns, draft.ExtraPatterns) {
+		appendDiff("redact.extra_patterns", formatSettingsPatterns(old.ExtraPatterns), formatSettingsPatterns(draft.ExtraPatterns))
+	}
 	if len(lines) == 0 {
 		return []string{Localize("• no effective diff", "• 有効な差分はありません")}
 	}
@@ -663,10 +789,7 @@ func (m cockpitModel) settingsDiffLines() []string {
 }
 
 func (m *cockpitModel) clampSettingsCursor() {
-	maxIndex := len(m.settings.settingsRows()) - 1
-	if maxIndex < 0 {
-		maxIndex = 0
-	}
+	maxIndex := cockpitSettingsRowCount - 1
 	if m.settings.cursor < 0 {
 		m.settings.cursor = 0
 	}
@@ -682,7 +805,7 @@ func (m cockpitModel) settingsLocalHelp() string {
 	if m.settings.confirmSave {
 		return Localize("y save · n/esc cancel", "y 保存 · n/esc キャンセル")
 	}
-	return Localize("↑/↓ select · l language · c color · f fields · n/+ add regex · x/- remove regex · w save · d discard · r reload", "↑/↓ 選択 · l language · c color · f fields · n/+ regex 追加 · x/- regex 削除 · w 保存 · d 破棄 · r 再読込")
+	return Localize("↑/↓ select · ←/→ change value rows · enter action · tab/shift+tab tabs · w save · d discard · r reload", "↑/↓ 選択 · ←/→ 値 row を変更 · enter 実行 · tab/shift+tab タブ · w 保存 · d 破棄 · r 再読込")
 }
 
 func (m cockpitModel) settingsContextualActions() []cockpitAction {
@@ -699,14 +822,15 @@ func (m cockpitModel) settingsContextualActions() []cockpitAction {
 		}
 	}
 	return []cockpitAction{
-		{key: "l", description: Localize("Toggle ui.language between en and ja", "ui.language を en / ja で切替")},
-		{key: "c", description: Localize("Cycle read.color auto / always / never", "read.color を auto / always / never で切替")},
-		{key: "f", description: Localize("Cycle safe read.fields presets", "安全な read.fields preset を切替")},
-		{key: "n / +", description: Localize("Add a regex to redact.extra_patterns after validation", "検証後に regex を redact.extra_patterns へ追加")},
-		{key: "x / -", description: Localize("Remove the last redact.extra_patterns entry", "最後の redact.extra_patterns を削除")},
+		{key: "↑/↓", description: Localize("Select a settings row", "settings row を選択")},
+		{key: "←/→", description: Localize("Change ui.language, read.color, or read.fields when those rows are selected", "ui.language / read.color / read.fields の row 選択時に値を変更")},
+		{key: "tab / shift+tab", description: Localize("Move between cockpit tabs while editing settings", "settings 編集中に cockpit タブ間を移動")},
+		{key: "enter", description: Localize("Run the selected settings action", "選択中の settings action を実行")},
 		{key: "w", description: Localize("Review diff and confirm before writing config", "diff を確認してから config 書き込み")},
 		{key: "d", description: Localize("Discard pending settings changes", "未保存の settings 変更を破棄")},
 		{key: "r", description: Localize("Reload settings from config file", "config file から settings を再読込")},
+		{key: "l/c/f", description: Localize("Change language, color, and field presets", "language / color / field preset を変更")},
+		{key: "n/+ x/-", description: Localize("Add or remove redact.extra_patterns entries", "redact.extra_patterns を追加 / 削除")},
 	}
 }
 
@@ -756,16 +880,16 @@ func saveCockpitSettingsDraft(snapshot cockpitSettingsSnapshot, values cockpitSe
 	if raw == nil {
 		raw = map[string]json.RawMessage{}
 	}
-	if normalizeSettingsLanguage(snapshot.Values.UILanguage) != normalizeSettingsLanguage(values.UILanguage) {
+	if !settingsLanguageEquivalent(snapshot.Values.UILanguage, values.UILanguage) {
 		if err := updateCockpitSettingsSection(raw, "ui", map[string]any{"language": normalizeSettingsLanguage(values.UILanguage)}); err != nil {
 			return err
 		}
 	}
 	readUpdates := map[string]any{}
-	if strings.TrimSpace(snapshot.Values.ReadColor) != strings.TrimSpace(values.ReadColor) {
+	if !settingsColorEquivalent(snapshot.Values.ReadColor, values.ReadColor) {
 		readUpdates["color"] = strings.TrimSpace(values.ReadColor)
 	}
-	if !slices.Equal(snapshot.Values.ReadFields, values.ReadFields) {
+	if !settingsFieldSetEquivalent(snapshot.Values.ReadFields, values.ReadFields) {
 		readUpdates["fields"] = values.ReadFields
 	}
 	if len(readUpdates) > 0 {
@@ -857,6 +981,21 @@ func effectiveSettingsLanguage(value string) string {
 	return lang
 }
 
+func comparableSettingsLanguage(value string) string {
+	lang := normalizeSettingsLanguage(value)
+	if lang == "" {
+		// The CLI falls back to English when neither TRACEARY_LANG nor
+		// ui.language is configured; keep this equivalent to
+		// effectiveSettingsLanguage's display default.
+		return "en"
+	}
+	return lang
+}
+
+func settingsLanguageEquivalent(left string, right string) bool {
+	return comparableSettingsLanguage(left) == comparableSettingsLanguage(right)
+}
+
 func effectiveSettingsColor(value string) string {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -865,11 +1004,34 @@ func effectiveSettingsColor(value string) string {
 	return trimmed
 }
 
+func comparableSettingsColor(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "auto"
+	}
+	return trimmed
+}
+
+func settingsColorEquivalent(left string, right string) bool {
+	return comparableSettingsColor(left) == comparableSettingsColor(right)
+}
+
 func formatSettingsFields(fields []string) string {
 	if len(fields) == 0 {
 		return strings.Join(readFieldIDsToStrings(defaultReadFields), ",") + " (default)"
 	}
 	return strings.Join(fields, ",")
+}
+
+func comparableSettingsFieldSet(fields []string) []string {
+	if len(fields) == 0 {
+		return readFieldIDsToStrings(defaultReadFields)
+	}
+	return fields
+}
+
+func settingsFieldSetEquivalent(left []string, right []string) bool {
+	return slices.Equal(comparableSettingsFieldSet(left), comparableSettingsFieldSet(right))
 }
 
 func formatSettingsPatterns(patterns []string) string {
@@ -896,31 +1058,63 @@ func formatSettingsEnvLine(name string, value string, set bool) string {
 	return "• " + name + "=" + value
 }
 
-func nextSettingsColor(current string) string {
-	switch strings.TrimSpace(current) {
-	case "auto", "":
-		return "always"
-	case "always":
-		return "never"
-	default:
-		return "auto"
+func settingsColorAtOffset(current string, delta int) string {
+	values := []string{"auto", "always", "never"}
+	normalized := strings.TrimSpace(current)
+	if normalized == "" {
+		normalized = "auto"
 	}
+	index := 0
+	for i, value := range values {
+		if normalized == value {
+			index = i
+			break
+		}
+	}
+	return values[cycleSettingsIndex(index, delta, len(values))]
 }
 
-func nextSettingsFieldSet(current []string) []string {
+func settingsFieldSetAtOffset(current []string, delta int) []string {
 	sets := [][]string{
 		readFieldIDsToStrings(defaultReadFields),
 		{"ts", "kind", "exit_code", "session", "ws", "message"},
 		{"ts", "kind", "client", "agent", "id", "message"},
 		{"ts", "kind", "message"},
 	}
-	currentLabel := strings.Join(current, ",")
-	for i, set := range sets {
-		if currentLabel == strings.Join(set, ",") {
-			return slices.Clone(sets[(i+1)%len(sets)])
+	index := 0
+	if len(current) > 0 {
+		currentLabel := strings.Join(current, ",")
+		matched := false
+		for i, set := range sets {
+			if currentLabel == strings.Join(set, ",") {
+				index = i
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			// Custom field lists are order-sensitive because read.fields itself is
+			// an ordered column list. They are not part of the finite preset cycle;
+			// right enters the preset cycle from the start, left from the end, and
+			// repeated keypresses then move through known presets predictably.
+			if delta < 0 {
+				return slices.Clone(sets[len(sets)-1])
+			}
+			return slices.Clone(sets[0])
 		}
 	}
-	return slices.Clone(sets[0])
+	return slices.Clone(sets[cycleSettingsIndex(index, delta, len(sets))])
+}
+
+func cycleSettingsIndex(index int, delta int, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	next := (index + delta) % total
+	if next < 0 {
+		next += total
+	}
+	return next
 }
 
 func readFieldIDsToStrings(fields []readFieldID) []string {


### PR DESCRIPTION
## Motivation
Closes #1056.

Settings should be editable with list/form controls instead of requiring operators to memorize `l/c/f/n/x/w/d` shortcuts.

## Changes
- Adds selectable Settings action rows for language, read color, read fields, pattern add/remove, save, discard, and reload.
- Uses `←/→` to cycle enum-like values (`ui.language`, `read.color`, `read.fields`).
- Uses `Enter` to run selected actions, including opening the regex editor and starting explicit save confirmation.
- Keeps existing mnemonic shortcuts as optional fallbacks.
- Updates Japanese labels/help to make the arrow-key workflow understandable.
- Keeps invalid JSON/unreadable config safeguards and atomic save behavior intact.

## Structure-Behavior Design Note
- **Concepts:** Settings row selection now represents a form cursor; enum rows adjust values; action rows run explicit operations.
- **Boundaries:** config read/write logic remains unchanged; this PR changes only cockpit interaction mapping and labels.
- **Safety:** Save still requires the existing confirmation screen; invalid config states still block editing/saving.

## Validation
- `GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'TestCockpitSettings'`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `git diff --check`
