### PR TITLE
v0.19-5: make Memory review evidence-first

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -2842,14 +2842,22 @@ func (m cockpitModel) memoryReviewContextualActions() []cockpitAction {
 		}
 	default:
 		acceptDescription := Localize("Accept as-is only when the checklist passes", "checklist を満たす場合だけ accept as-is")
-		if len(m.memoryReview.items) > 0 && m.memoryReview.review.cursor >= 0 && m.memoryReview.review.cursor < len(m.memoryReview.items) && memoryReviewRequiresAcceptConfirmation(m.memoryReview.items[m.memoryReview.review.cursor]) {
-			acceptDescription = Localize("Accept as-is (requires pressing a twice; prefer edit/distill if unsure)", "accept as-is には a を 2 回押す必要があります。不明なら edit/distill を優先")
+		editDescription := Localize("Edit/distill into an operator-authored fact when wording is unclear", "文言が曖昧なら operator-authored fact に edit/distill")
+		if len(m.memoryReview.items) > 0 && m.memoryReview.review.cursor >= 0 && m.memoryReview.review.cursor < len(m.memoryReview.items) {
+			current := m.memoryReview.items[m.memoryReview.review.cursor]
+			switch {
+			case memoryReviewBlocksAccept(current):
+				acceptDescription = Localize("Accept as-is unavailable until evidence exists", "evidence が追加されるまで accept as-is は利用できません")
+				editDescription = Localize("Edit/distill unavailable without source evidence", "source evidence がないため edit/distill は利用できません")
+			case memoryReviewRequiresAcceptConfirmation(current):
+				acceptDescription = Localize("Accept as-is (requires pressing a twice; prefer edit/distill if unsure)", "accept as-is には a を 2 回押す必要があります。不明なら edit/distill を優先")
+			}
 		}
 		actions := []cockpitAction{
 			{key: "a", description: acceptDescription},
 			{key: "x", description: Localize("Reject current candidate", "現在の candidate を reject")},
 			{key: "s", description: Localize("Skip when more context is needed", "追加 context が必要なら skip")},
-			{key: "e", description: Localize("Edit/distill into an operator-authored fact when wording is unclear", "文言が曖昧なら operator-authored fact に edit/distill")},
+			{key: "e", description: editDescription},
 			{key: "v", description: Localize("View evidence and artifact refs", "evidence と artifact refs を表示")},
 			{key: "q", description: Localize("Finish review and apply queued decisions", "review を終了し予約済み判断を適用")},
 			{description: Localize("Accept checklist: factual, stable, useful later, scoped correctly, evidence-backed, not duplicate/stale.", "Accept checklist: 事実で安定、将来有用、scope が正しい、evidence あり、重複/古さなし。")},
@@ -2923,6 +2931,9 @@ func (m cockpitModel) memoryReviewLocalHelp() string {
 	case reviewModeHelp:
 		return Localize("?/esc close help · q finish/apply", "?/esc help を閉じる · q 終了/適用")
 	default:
+		if m.memoryReview.review.cursor >= 0 && m.memoryReview.review.cursor < len(m.memoryReview.items) && memoryReviewBlocksAccept(m.memoryReview.items[m.memoryReview.review.cursor]) {
+			return Localize("a unavailable (evidence required) · x reject · s skip · v evidence · q finish/apply", "a 不可 (evidence 必須) · x reject · s skip · v evidence · q 終了/適用")
+		}
 		return Localize("a accept as-is · x reject · s skip · e edit/distill · v evidence · q finish/apply", "a accept as-is · x reject · s skip · e edit/distill · v evidence · q 終了/適用")
 	}
 }

--- a/presentation/cli/cockpit_dogfood_internal_test.go
+++ b/presentation/cli/cockpit_dogfood_internal_test.go
@@ -97,8 +97,10 @@ func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
 			"new events=3",
 		},
 		"memory_ambiguous_candidate": {
-			"accept requires confirmation",
-			"e edit/distill",
+			"accept blocked until evidence exists",
+			"a unavailable (evidence required)",
+			"EVIDENCE-FIRST REVIEW",
+			"GUIDANCE: accepted memory requires evidence",
 			"EVIDENCE_REFS:          0",
 		},
 	}
@@ -206,8 +208,8 @@ func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 		if cmd != nil || len(model.memoryReview.review.Decisions()) != 0 {
 			t.Fatalf("first accept should not queue ambiguous candidate, cmd=%T decisions=%+v", cmd, model.memoryReview.review.Decisions())
 		}
-		if !strings.Contains(model.View(), "accept confirmation armed") {
-			t.Fatalf("ambiguous memory view missing confirmation guard:\n%s", model.View())
+		if !strings.Contains(model.View(), "accept as-is unavailable") {
+			t.Fatalf("ambiguous memory view missing accept block:\n%s", model.View())
 		}
 	})
 
@@ -361,7 +363,8 @@ func TestCockpitDogfoodJapaneseNarrowSmoke(t *testing.T) {
 		"判断カード",
 		"判断 context",
 		"信頼度が低い",
-		"accept には確認が必要",
+		"evidence 追加まで accept 不可",
+		"evidence 優先 review",
 		"事実で安定している",
 		"q 終了/適用",
 	} {

--- a/presentation/cli/memory_inbox_review.go
+++ b/presentation/cli/memory_inbox_review.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,6 +24,12 @@ import (
 // callers branch (run the batch alternatives) without having to grep
 // stderr, mirroring the doctor command's exit-code contract.
 const reviewExitCodeNotInteractive = 2
+
+const (
+	memoryReviewRefPreviewLimit    = 5
+	memoryReviewRefDisplayMaxRunes = 160
+	memoryReviewTruncatedRefSuffix = "…"
+)
 
 // inboxReviewExitError carries a process exit code through cli.run() so the
 // non-TTY refusal returns 2 instead of the default 1. The pattern matches
@@ -488,6 +495,14 @@ func (m reviewModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.acceptConfirmID = ""
 		return m, nil
 	case key.Matches(msg, actions.Accept):
+		if m.currentCandidateBlocksAccept() {
+			m.acceptConfirmID = ""
+			m.statusMsg = Localize(
+				"accept as-is is unavailable because accepted memory requires evidence; skip, reject, or add evidence outside this review and retry",
+				"accepted memory には evidence が必要なため accept as-is は利用できません。skip / reject するか、review 外で evidence を追加してから再実行してください",
+			)
+			return m, nil
+		}
 		if m.currentCandidateNeedsAcceptConfirmation() && !m.acceptConfirmationMatchesCurrent() {
 			m.acceptConfirmID = m.items[m.cursor].Summary().MemoryID()
 			m.statusMsg = Localize(
@@ -517,6 +532,14 @@ func (m reviewModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case key.Matches(msg, actions.Edit):
 		if len(m.items) == 0 {
+			return m, nil
+		}
+		if m.currentCandidateBlocksAccept() {
+			m.statusMsg = Localize(
+				"edit/distill is unavailable because the source candidate has no evidence to preserve; skip, reject, or recreate with evidence outside this review",
+				"source candidate に引き継ぐ evidence がないため edit/distill は利用できません。skip / reject するか、review 外で evidence 付きで作り直してください",
+			)
+			m.acceptConfirmID = ""
 			return m, nil
 		}
 		m.mode = reviewModeEdit
@@ -678,6 +701,14 @@ func (m reviewModel) renderBrowse() string {
 	b.WriteString("\n")
 	b.WriteString(summary.Fact())
 	b.WriteString("\n\n")
+	b.WriteString(m.styles.Subtle.Render(Localize("EVIDENCE-FIRST REVIEW", "evidence 優先 review")))
+	b.WriteString("\n")
+	for _, line := range memoryReviewEvidencePreview(current) {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	b.WriteString(memoryReviewDecisionGuidance(current))
+	b.WriteString("\n\n")
 	b.WriteString(m.styles.Subtle.Render(Localize("ACCEPT AS-IS CHECKLIST", "accept as-is checklist")))
 	b.WriteString("\n")
 	for _, item := range memoryReviewAcceptChecklist(current) {
@@ -685,7 +716,7 @@ func (m reviewModel) renderBrowse() string {
 		b.WriteString(item)
 		b.WriteString("\n")
 	}
-	if m.currentCandidateNeedsAcceptConfirmation() {
+	if !m.currentCandidateBlocksAccept() && m.currentCandidateNeedsAcceptConfirmation() {
 		b.WriteString(m.styles.Warning.Render(Localize("• This weak candidate requires pressing `a` twice to accept as-is; prefer edit/distill when wording is unclear.", "• この弱い候補を accept as-is するには `a` を 2 回押す必要があります。文言が曖昧なら edit/distill を優先してください。")))
 		b.WriteString("\n")
 	}
@@ -698,15 +729,16 @@ func (m reviewModel) renderBrowse() string {
 		b.WriteString(m.styles.Warning.Render(Localize("accept confirmation armed: press a again to accept this candidate as-is", "accept 確認中: この候補をそのまま accept するにはもう一度 a")))
 		b.WriteString("\n")
 	}
+	if m.currentCandidateBlocksAccept() {
+		b.WriteString(m.styles.Warning.Render(Localize("accept as-is unavailable: accepted memory requires at least one evidence ref", "accept as-is 不可: accepted memory には 1 件以上の evidence ref が必要です")))
+		b.WriteString("\n")
+	}
 	if m.statusMsg != "" {
 		b.WriteString(m.styles.Subtle.Render(m.statusMsg))
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(m.styles.Help.Render(Localize(
-		"a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ navigate · ? help · q quit",
-		"a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ 移動 · ? ヘルプ · q 終了",
-	)))
+	b.WriteString(m.styles.Help.Render(memoryReviewBrowseHelp(current)))
 	return b.String()
 }
 
@@ -721,7 +753,7 @@ func (m reviewModel) renderEvidence() string {
 		b.WriteString("- -\n")
 	} else {
 		for _, ref := range current.EvidenceRefs() {
-			fmt.Fprintf(&b, "- %s:%s\n", ref.Kind(), ref.Value())
+			fmt.Fprintf(&b, "- %s\n", formatMemoryReviewRefLine(ref.Kind().String(), ref.Value()))
 		}
 	}
 	b.WriteString("\n")
@@ -731,7 +763,7 @@ func (m reviewModel) renderEvidence() string {
 		b.WriteString("- -\n")
 	} else {
 		for _, ref := range current.ArtifactRefs() {
-			fmt.Fprintf(&b, "- %s:%s\n", ref.Kind(), ref.Value())
+			fmt.Fprintf(&b, "- %s\n", formatMemoryReviewRefLine(ref.Kind().String(), ref.Value()))
 		}
 	}
 	b.WriteString("\n")
@@ -808,11 +840,22 @@ func (m reviewModel) currentCandidateNeedsAcceptConfirmation() bool {
 	return memoryReviewRequiresAcceptConfirmation(m.items[m.cursor])
 }
 
+func (m reviewModel) currentCandidateBlocksAccept() bool {
+	if len(m.items) == 0 || m.cursor < 0 || m.cursor >= len(m.items) {
+		return false
+	}
+	return memoryReviewBlocksAccept(m.items[m.cursor])
+}
+
 func (m reviewModel) acceptConfirmationMatchesCurrent() bool {
 	if len(m.items) == 0 || m.cursor < 0 || m.cursor >= len(m.items) {
 		return false
 	}
 	return m.acceptConfirmID != "" && m.acceptConfirmID == m.items[m.cursor].Summary().MemoryID()
+}
+
+func memoryReviewBlocksAccept(details apptypes.MemoryDetails) bool {
+	return len(details.EvidenceRefs()) == 0
 }
 
 func memoryReviewRequiresAcceptConfirmation(details apptypes.MemoryDetails) bool {
@@ -846,7 +889,9 @@ func memoryReviewQualitySignal(details apptypes.MemoryDetails) string {
 	if len(details.EvidenceRefs()) == 0 {
 		signals = append(signals, Localize("no evidence refs", "evidence ref なし"))
 	}
-	if memoryReviewRequiresAcceptConfirmation(details) {
+	if memoryReviewBlocksAccept(details) {
+		signals = append(signals, Localize("accept blocked until evidence exists", "evidence 追加まで accept 不可"))
+	} else if memoryReviewRequiresAcceptConfirmation(details) {
 		signals = append(signals, Localize("accept requires confirmation", "accept には確認が必要"))
 	}
 	return strings.Join(signals, "; ")
@@ -873,6 +918,82 @@ func memoryReviewDuplicateSupersedeHint(summary apptypes.MemorySummary) string {
 	return Localize("not checked in cockpit yet; use edit/distill or skip if duplicate risk is unclear", "cockpit では未チェック。重複リスクが不明なら edit/distill または skip")
 }
 
+func memoryReviewEvidencePreview(details apptypes.MemoryDetails) []string {
+	lines := []string{}
+	evidence := details.EvidenceRefs()
+	if len(evidence) == 0 {
+		lines = append(lines, Localize("• evidence: none recorded; accept as-is is unavailable until evidence exists", "• evidence: 記録なし。evidence が追加されるまで accept as-is は利用できません"))
+	} else {
+		lines = append(lines, Localizef("• evidence: %d ref(s)", "• evidence: %d 件", len(evidence)))
+		for i, ref := range evidence {
+			if i >= memoryReviewRefPreviewLimit {
+				lines = append(lines, Localizef("  + %d more (press v to inspect)", "  + 他 %d 件 (v で確認)", len(evidence)-i))
+				break
+			}
+			lines = append(lines, "  - "+formatMemoryReviewRefLine(ref.Kind().String(), ref.Value()))
+		}
+	}
+	artifacts := details.ArtifactRefs()
+	if len(artifacts) == 0 {
+		lines = append(lines, Localize("• artifacts: none", "• artifacts: なし"))
+	} else {
+		lines = append(lines, Localizef("• artifacts: %d ref(s)", "• artifacts: %d 件", len(artifacts)))
+		for i, ref := range artifacts {
+			if i >= memoryReviewRefPreviewLimit {
+				lines = append(lines, Localizef("  + %d more (press v to inspect)", "  + 他 %d 件 (v で確認)", len(artifacts)-i))
+				break
+			}
+			lines = append(lines, "  - "+formatMemoryReviewRefLine(ref.Kind().String(), ref.Value()))
+		}
+	}
+	return lines
+}
+
+func memoryReviewDecisionGuidance(details apptypes.MemoryDetails) string {
+	if memoryReviewBlocksAccept(details) {
+		return Localize(
+			"GUIDANCE: accepted memory requires evidence; skip or reject now, or recreate this memory with evidence outside this review.",
+			"判断ガイド: accepted memory には evidence が必要です。ここでは skip / reject するか、review 外で evidence 付きで作り直してください。",
+		)
+	}
+	if memoryReviewRequiresAcceptConfirmation(details) {
+		return Localize(
+			"GUIDANCE: prefer edit/distill or skip until evidence, wording, and scope are clear; accept as-is requires a second confirmation.",
+			"判断ガイド: evidence・文言・scope が明確になるまでは edit/distill または skip を優先。accept as-is には再確認が必要です。",
+		)
+	}
+	return Localize(
+		"GUIDANCE: accept as-is only if the evidence supports the exact wording; use edit/distill to tighten ambiguous wording.",
+		"判断ガイド: evidence が文言をそのまま支える場合だけ accept as-is。曖昧なら edit/distill で整えます。",
+	)
+}
+
+func formatMemoryReviewRefLine(kind string, value string) string {
+	return fmt.Sprintf("%s:%s", kind, sanitizeMemoryReviewRefValue(value))
+}
+
+func sanitizeMemoryReviewRefValue(value string) string {
+	value = strings.ToValidUTF8(value, "�")
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case unicode.IsControl(r), unicode.Is(unicode.Cf, r), r == '\u2028', r == '\u2029':
+			if b.Len() > 0 {
+				b.WriteRune(' ')
+			}
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	safe := strings.Join(strings.Fields(b.String()), " ")
+	runes := []rune(safe)
+	if len(runes) <= memoryReviewRefDisplayMaxRunes {
+		return safe
+	}
+	return string(runes[:memoryReviewRefDisplayMaxRunes-len([]rune(memoryReviewTruncatedRefSuffix))]) + memoryReviewTruncatedRefSuffix
+}
+
 func memoryReviewAcceptChecklist(details apptypes.MemoryDetails) []string {
 	checks := []string{
 		Localize("factual and stable", "事実で安定している"),
@@ -882,10 +1003,23 @@ func memoryReviewAcceptChecklist(details apptypes.MemoryDetails) []string {
 	if len(details.EvidenceRefs()) > 0 {
 		checks = append(checks, Localize("supported by evidence refs", "evidence refs に支えられている"))
 	} else {
-		checks = append(checks, Localize("evidence not shown; inspect before accepting", "evidence 未表示。accept 前に確認してください"))
+		checks = append(checks, Localize("evidence missing; accept as-is is unavailable", "evidence がないため accept as-is は利用できません"))
 	}
 	checks = append(checks, Localize("not duplicate, stale, or superseded", "重複・古い・supersede 済みではない"))
 	return checks
+}
+
+func memoryReviewBrowseHelp(details apptypes.MemoryDetails) string {
+	if memoryReviewBlocksAccept(details) {
+		return Localize(
+			"a unavailable (evidence required) · x reject · s skip · v evidence · ↑/↓ navigate · ? help · q quit",
+			"a 不可 (evidence 必須) · x reject · s skip · v evidence · ↑/↓ 移動 · ? ヘルプ · q 終了",
+		)
+	}
+	return Localize(
+		"a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ navigate · ? help · q quit",
+		"a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ 移動 · ? ヘルプ · q 終了",
+	)
 }
 
 // inboxReviewIO resolves the stdin/stdout pair the review TUI should drive.

--- a/presentation/cli/memory_inbox_review_internal_test.go
+++ b/presentation/cli/memory_inbox_review_internal_test.go
@@ -25,12 +25,13 @@ func buildReviewCandidate(t *testing.T, id string, fact string) apptypes.MemoryD
 }
 
 type reviewCandidateOptions struct {
-	id         string
-	fact       string
-	confidence domtypes.Confidence
-	source     domtypes.MemorySource
-	supersedes domtypes.Optional[domtypes.MemoryID]
-	noEvidence bool
+	id            string
+	fact          string
+	confidence    domtypes.Confidence
+	source        domtypes.MemorySource
+	supersedes    domtypes.Optional[domtypes.MemoryID]
+	noEvidence    bool
+	evidenceValue string
 }
 
 func buildReviewCandidateWithOptions(t *testing.T, opts reviewCandidateOptions) apptypes.MemoryDetails {
@@ -69,7 +70,11 @@ func buildReviewCandidateWithOptions(t *testing.T, opts reviewCandidateOptions) 
 	if opts.noEvidence {
 		return apptypes.MemoryDetailsOf(summary, nil, nil)
 	}
-	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L2")
+	evidenceValue := opts.evidenceValue
+	if evidenceValue == "" {
+		evidenceValue = "/tmp/MEMORY.md#L1-L2"
+	}
+	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, evidenceValue)
 	if err != nil {
 		t.Fatalf("EvidenceRefFrom: %v", err)
 	}
@@ -137,6 +142,10 @@ func TestReviewModel_DecisionCardShowsAcceptEvidenceContext(t *testing.T) {
 		"CREATED_AT:             2026-05-07T00:00:00Z",
 		"CANDIDATE_AGE:          48h0m",
 		"DUPLICATE_SUPERSEDE:    supersedes old-memory",
+		"EVIDENCE-FIRST REVIEW",
+		"• evidence: 1 ref(s)",
+		"file:/tmp/MEMORY.md#L1-L2",
+		"GUIDANCE: accept as-is only if the evidence supports the exact wording",
 		"ACCEPT AS-IS CHECKLIST",
 		"factual and stable",
 		"not duplicate, stale, or superseded",
@@ -145,6 +154,68 @@ func TestReviewModel_DecisionCardShowsAcceptEvidenceContext(t *testing.T) {
 		if !strings.Contains(view, must) {
 			t.Fatalf("decision card missing %q:\n%s", must, view)
 		}
+	}
+}
+
+func TestReviewModel_NoEvidenceCandidateBlocksAcceptAsIs(t *testing.T) {
+	t.Parallel()
+
+	model := newReviewTestModel(buildReviewCandidateWithOptions(t, reviewCandidateOptions{
+		id:         "id-no-evidence",
+		fact:       "fact without evidence",
+		confidence: domtypes.ConfidenceHigh,
+		source:     domtypes.MemorySourceManual,
+		noEvidence: true,
+	}))
+
+	first, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	firstM := first.(reviewModel)
+	if len(firstM.Decisions()) != 0 {
+		t.Fatalf("first accept without evidence must not queue decisions, got %+v", firstM.Decisions())
+	}
+	if firstM.acceptConfirmationMatchesCurrent() {
+		t.Fatalf("first accept without evidence must not arm accept confirmation")
+	}
+	view := firstM.View()
+	for _, must := range []string{
+		"evidence: none recorded; accept as-is is unavailable",
+		"accept as-is unavailable",
+		"accepted memory requires evidence",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("no-evidence accept guard missing %q:\n%s", must, view)
+		}
+	}
+	second, _ := firstM.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	secondM := second.(reviewModel)
+	if len(secondM.Decisions()) != 0 || secondM.acceptConfirmationMatchesCurrent() {
+		t.Fatalf("second accept without evidence must remain blocked, decisions=%+v confirm=%q", secondM.Decisions(), secondM.acceptConfirmID)
+	}
+	edit, _ := secondM.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	editM := edit.(reviewModel)
+	if editM.mode != reviewModeBrowse || len(editM.Decisions()) != 0 {
+		t.Fatalf("edit/distill without evidence must stay in browse without queuing decisions, mode=%v decisions=%+v", editM.mode, editM.Decisions())
+	}
+	if !strings.Contains(editM.statusMsg, "edit/distill is unavailable") {
+		t.Fatalf("edit/distill block status = %q", editM.statusMsg)
+	}
+}
+
+func TestFormatMemoryReviewRefLineSanitizesAndTruncates(t *testing.T) {
+	t.Parallel()
+
+	line := formatMemoryReviewRefLine("file", "path\n\x1b[31m\u009b32m\u202e\u2066\u200b"+strings.Repeat("x", memoryReviewRefDisplayMaxRunes+20))
+	for _, forbidden := range []string{"\n", "\x1b", "\u009b", "\u202e", "\u2066", "\u200b", "\r", "\t"} {
+		if strings.Contains(line, forbidden) {
+			t.Fatalf("ref line contains control sequence %q: %q", forbidden, line)
+		}
+	}
+	if !strings.HasSuffix(line, memoryReviewTruncatedRefSuffix) {
+		t.Fatalf("ref line should be truncated with suffix: %q", line)
+	}
+	value := strings.TrimPrefix(line, "file:")
+	if got := len([]rune(value)); got != memoryReviewRefDisplayMaxRunes {
+		t.Fatalf("sanitized ref value length = %d, want %d: %q", got, memoryReviewRefDisplayMaxRunes, value)
 	}
 }
 
@@ -546,6 +617,25 @@ func TestReviewModel_EvidenceToggle(t *testing.T) {
 	}
 	if !strings.Contains(view, "/tmp/MEMORY.md") {
 		t.Fatalf("evidence view missing ref value, got:\n%s", view)
+	}
+}
+
+func TestReviewModel_EvidenceViewSanitizesRefs(t *testing.T) {
+	t.Parallel()
+
+	model := newReviewTestModel(buildReviewCandidateWithOptions(t, reviewCandidateOptions{
+		id:            "id-unsafe-ref",
+		evidenceValue: "safe\n\x1b[31m\u202eunsafe",
+	}))
+	on, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	view := on.(reviewModel).View()
+	for _, forbidden := range []string{"\n\x1b", "\u202e"} {
+		if strings.Contains(view, forbidden) {
+			t.Fatalf("evidence view contains unsafe ref sequence %q:\n%s", forbidden, view)
+		}
+	}
+	if !strings.Contains(view, "file:safe [31m unsafe") {
+		t.Fatalf("evidence view missing sanitized ref:\n%s", view)
 	}
 }
 

--- a/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
+++ b/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
@@ -10,7 +10,7 @@ TYPE:                   preference
 SCOPE:                  workspace:github.com/example/repo
 SOURCE:                 extracted-hidden
 CONFIDENCE:             low
-QUALITY_SIGNAL:         low confidence; hidden extraction; no evidence refs; accept requires confirmation
+QUALITY_SIGNAL:         low confidence; hidden extraction; no evidence refs; accept blocked until evidence exists
 REMEMBERED_BY_OPERATOR: no
 EVIDENCE_REFS:          0 (press v to inspect)
 ARTIFACT_REFS:          0 (press v to inspect)
@@ -22,15 +22,20 @@ DUPLICATE_SUPERSEDE:    not checked in cockpit yet; use edit/distill or skip if 
 CANDIDATE FACT:
 Maybe the operator prefers short summaries
 
+EVIDENCE-FIRST REVIEW
+• evidence: none recorded; accept as-is is unavailable until evidence exists
+• artifacts: none
+GUIDANCE: accepted memory requires evidence; skip or reject now, or recreate this memory with evidence outside this review.
+
 ACCEPT AS-IS CHECKLIST
 • factual and stable
 • useful for future sessions
 • scope/type are correct
-• evidence not shown; inspect before accepting
+• evidence missing; accept as-is is unavailable
 • not duplicate, stale, or superseded
-• This weak candidate requires pressing `a` twice to accept as-is; prefer edit/distill when wording is unclear.
 
+accept as-is unavailable: accepted memory requires at least one evidence ref
 
-a accept as-is · x reject · s skip · e edit/distill · v evidence · ↑/↓ navigate · ? help · q quit
+a unavailable (evidence required) · x reject · s skip · v evidence · ↑/↓ navigate · ? help · q quit
 
-1-5 tabs · ←/→ tabs · tab/shift+tab next/prev · esc back · ctrl+c quit · ? help · a accept as-is · x reject · s skip · e edit/distill · v evidence · q finish/apply
+1-5 tabs · ←/→ tabs · tab/shift+tab next/prev · esc back · ctrl+c quit · ? help · a unavailable (evidence required) · x reject · s skip · v evidence · q finish/apply


### PR DESCRIPTION
## Motivation

Closes #1057.

Memory review should help operators decide accept/reject/edit without leaving the TUI. The previous card showed counts and a checklist, but evidence refs were not visible in the main decision flow and no-evidence candidates could still be accepted too easily unless they were low-confidence/hidden.

## Changes

- Adds an evidence-first review block to the Memory review decision card with inline evidence/artifact refs and decision guidance.
- Treats candidates with no evidence refs as requiring accept-as-is confirmation, even when confidence/source look otherwise strong.
- Keeps edit/distill as the recommended path when evidence, wording, or scope is unclear.
- Updates dogfood golden and terminal-size cues for ambiguous candidates.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `git diff --check`

## Notes

This is intentionally a focused Issue #1057 PR. Broader Memory review layout restructuring can remain follow-up work if reviewers want a richer card layout.