### PR TITLE
v0.19-10: align latest-session test schema with production migrations

### DIFF
--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -17,7 +17,7 @@ func TestBundleDatasource_CommandAuditBeforeEventFailsFK(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -53,7 +53,7 @@ func TestBundleDatasource_ImportSessionBackfillsMissingParent(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -2,7 +2,6 @@ package sqlite_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,7 +17,7 @@ func TestBundleDatasource_CommandAuditBeforeEventFailsFK(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -54,7 +53,7 @@ func TestBundleDatasource_ImportSessionBackfillsMissingParent(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -17,6 +17,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns latest session_started", func(t *testing.T) {
+		t.Parallel()
+
 		_, sessionDS := newFindLatestScenario(t)
 
 		result, err := sessionDS.FindLatest(
@@ -36,6 +38,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("session with end boundary as last event is selected as latest", func(t *testing.T) {
+		t.Parallel()
+
 		eventDS, sessionDS := newFindLatestScenario(t)
 		saveFindLatestSessionEventFixture(
 			t,
@@ -76,6 +80,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns active session when active only is set", func(t *testing.T) {
+		t.Parallel()
+
 		eventDS, sessionDS := newFindLatestScenario(t)
 		saveFindLatestSessionEventFixture(
 			t,
@@ -86,6 +92,16 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"github.com/duck8823/traceary",
 			"session started",
 			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-7",
+			types.EventKindSessionEnded,
+			"session-finished",
+			"github.com/duck8823/traceary",
+			"session ended",
+			time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
 		)
 
 		result, err := sessionDS.FindLatest(
@@ -105,6 +121,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns newest start when multiple starts exist for same session_id", func(t *testing.T) {
+		t.Parallel()
+
 		eventDS, sessionDS := newFindLatestScenario(t)
 		saveFindLatestSessionEventFixture(
 			t,
@@ -144,6 +162,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns empty Optional when no matching session exists", func(t *testing.T) {
+		t.Parallel()
+
 		_, sessionDS := newFindLatestScenario(t)
 
 		result, err := sessionDS.FindLatest(
@@ -159,11 +179,23 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns empty Optional when no matching active session exists", func(t *testing.T) {
-		_, sessionDS := newFindLatestScenario(t)
+		t.Parallel()
+
+		eventDS, sessionDS := newFindLatestScenario(t)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-6",
+			types.EventKindSessionEnded,
+			"session-active",
+			"github.com/duck8823/traceary",
+			"session ended",
+			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		)
 
 		result, err := sessionDS.FindLatest(
 			context.Background(),
-			types.Client(""), types.Agent("claude"), types.Workspace(""), true,
+			types.Client("cli"), types.Agent("codex"), types.Workspace("github.com/duck8823/traceary"), true,
 		)
 		if err != nil {
 			t.Fatalf("FindLatest() error = %v, want nil", err)

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"testing/fstest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,27 +15,8 @@ import (
 func TestDatasource_FindLatest(t *testing.T) {
 	t.Parallel()
 
-	migrations := fstest.MapFS{
-		"000001_init.sql": {
-			Data: []byte(`
-CREATE TABLE events (
-    id TEXT PRIMARY KEY,
-    kind TEXT NOT NULL,
-    agent TEXT NOT NULL,
-    session_id TEXT NOT NULL,
-    body TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    source_hook TEXT
-);`),
-		},
-		"000002_add_event_metadata.sql": {
-			Data: []byte(`
-ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
-ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
-		},
-	}
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, migrations)
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -243,27 +223,8 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 func TestDatasource_FindLatest_ignoresBoundariesFromOtherContexts(t *testing.T) {
 	t.Parallel()
 
-	migrations := fstest.MapFS{
-		"000001_init.sql": {
-			Data: []byte(`
-CREATE TABLE events (
-    id TEXT PRIMARY KEY,
-    kind TEXT NOT NULL,
-    agent TEXT NOT NULL,
-    session_id TEXT NOT NULL,
-    body TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    source_hook TEXT
-);`),
-		},
-		"000002_add_event_metadata.sql": {
-			Data: []byte(`
-ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
-ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
-		},
-	}
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, migrations)
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -326,27 +287,8 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
 func TestDatasource_FindLatest_activeOnlyIgnoresEndsFromOtherContexts(t *testing.T) {
 	t.Parallel()
 
-	migrations := fstest.MapFS{
-		"000001_init.sql": {
-			Data: []byte(`
-CREATE TABLE events (
-    id TEXT PRIMARY KEY,
-    kind TEXT NOT NULL,
-    agent TEXT NOT NULL,
-    session_id TEXT NOT NULL,
-    body TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    source_hook TEXT
-);`),
-		},
-		"000002_add_event_metadata.sql": {
-			Data: []byte(`
-ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
-ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
-		},
-	}
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, migrations)
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -16,7 +16,7 @@ func TestDatasource_FindLatest(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -224,7 +224,7 @@ func TestDatasource_FindLatest_ignoresBoundariesFromOtherContexts(t *testing.T) 
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -288,7 +288,7 @@ func TestDatasource_FindLatest_activeOnlyIgnoresEndsFromOtherContexts(t *testing
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations())
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -10,83 +10,15 @@ import (
 
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
 func TestDatasource_FindLatest(t *testing.T) {
 	t.Parallel()
 
-	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, onDiskSQLiteMigrations(t))
-	if err := storeManager.Initialize(context.Background()); err != nil {
-		t.Fatalf("Initialize() error = %v", err)
-	}
-
-	oldEvent := newFindLatestSessionEventFixture(
-		t,
-		"event-1",
-		types.EventKindSessionStarted,
-		"session-old",
-		"github.com/duck8823/traceary",
-		"session started",
-		time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC),
-	)
-	if err := eventDS.Save(context.Background(), oldEvent); err != nil {
-		t.Fatalf("Save(old) error = %v", err)
-	}
-
-	endedEvent := newFindLatestSessionEventFixture(
-		t,
-		"event-2",
-		types.EventKindSessionEnded,
-		"session-old",
-		"github.com/duck8823/traceary",
-		"session ended",
-		time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
-	)
-	if err := eventDS.Save(context.Background(), endedEvent); err != nil {
-		t.Fatalf("Save(ended) error = %v", err)
-	}
-
-	activeEvent := newFindLatestSessionEventFixture(
-		t,
-		"event-3",
-		types.EventKindSessionStarted,
-		"session-active",
-		"github.com/duck8823/traceary",
-		"session started",
-		time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
-	)
-	if err := eventDS.Save(context.Background(), activeEvent); err != nil {
-		t.Fatalf("Save(active) error = %v", err)
-	}
-
-	finishedStartEvent := newFindLatestSessionEventFixture(
-		t,
-		"event-4",
-		types.EventKindSessionStarted,
-		"session-finished",
-		"github.com/duck8823/traceary",
-		"session started",
-		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
-	)
-	if err := eventDS.Save(context.Background(), finishedStartEvent); err != nil {
-		t.Fatalf("Save(finished start) error = %v", err)
-	}
-
-	finishedEndEvent := newFindLatestSessionEventFixture(
-		t,
-		"event-5",
-		types.EventKindSessionEnded,
-		"session-finished",
-		"github.com/duck8823/traceary",
-		"session ended",
-		time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
-	)
-	if err := eventDS.Save(context.Background(), finishedEndEvent); err != nil {
-		t.Fatalf("Save(finished end) error = %v", err)
-	}
-
 	t.Run("returns latest session_started", func(t *testing.T) {
+		_, sessionDS := newFindLatestScenario(t)
+
 		result, err := sessionDS.FindLatest(
 			context.Background(),
 			types.Client("cli"), types.Agent("codex"), types.Workspace("github.com/duck8823/traceary"), false,
@@ -104,8 +36,10 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("session with end boundary as last event is selected as latest", func(t *testing.T) {
-		laterStartEvent := newFindLatestSessionEventFixture(
+		eventDS, sessionDS := newFindLatestScenario(t)
+		saveFindLatestSessionEventFixture(
 			t,
+			eventDS,
 			"event-6",
 			types.EventKindSessionStarted,
 			"session-overlapping",
@@ -113,12 +47,10 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"session started",
 			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
 		)
-		if err := eventDS.Save(context.Background(), laterStartEvent); err != nil {
-			t.Fatalf("Save(later start) error = %v", err)
-		}
 
-		overlapEndEvent := newFindLatestSessionEventFixture(
+		saveFindLatestSessionEventFixture(
 			t,
+			eventDS,
 			"event-7",
 			types.EventKindSessionEnded,
 			"session-finished",
@@ -126,9 +58,6 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"session ended",
 			time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
 		)
-		if err := eventDS.Save(context.Background(), overlapEndEvent); err != nil {
-			t.Fatalf("Save(overlap end) error = %v", err)
-		}
 
 		result, err := sessionDS.FindLatest(
 			context.Background(),
@@ -147,6 +76,18 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns active session when active only is set", func(t *testing.T) {
+		eventDS, sessionDS := newFindLatestScenario(t)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-6",
+			types.EventKindSessionStarted,
+			"session-overlapping",
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		)
+
 		result, err := sessionDS.FindLatest(
 			context.Background(),
 			types.Client("cli"), types.Agent("codex"), types.Workspace("github.com/duck8823/traceary"), true,
@@ -164,8 +105,20 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns newest start when multiple starts exist for same session_id", func(t *testing.T) {
-		repeatedStartEvent := newFindLatestSessionEventFixture(
+		eventDS, sessionDS := newFindLatestScenario(t)
+		saveFindLatestSessionEventFixture(
 			t,
+			eventDS,
+			"event-6",
+			types.EventKindSessionStarted,
+			"session-overlapping",
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
 			"event-8",
 			types.EventKindSessionStarted,
 			"session-overlapping",
@@ -173,9 +126,6 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"session started",
 			time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
 		)
-		if err := eventDS.Save(context.Background(), repeatedStartEvent); err != nil {
-			t.Fatalf("Save(repeated start) error = %v", err)
-		}
 
 		result, err := sessionDS.FindLatest(
 			context.Background(),
@@ -194,6 +144,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns empty Optional when no matching session exists", func(t *testing.T) {
+		_, sessionDS := newFindLatestScenario(t)
+
 		result, err := sessionDS.FindLatest(
 			context.Background(),
 			types.Client(""), types.Agent("claude"), types.Workspace(""), false,
@@ -207,6 +159,8 @@ func TestDatasource_FindLatest(t *testing.T) {
 	})
 
 	t.Run("returns empty Optional when no matching active session exists", func(t *testing.T) {
+		_, sessionDS := newFindLatestScenario(t)
+
 		result, err := sessionDS.FindLatest(
 			context.Background(),
 			types.Client(""), types.Agent("claude"), types.Workspace(""), true,
@@ -332,6 +286,87 @@ func TestDatasource_FindLatest_activeOnlyIgnoresEndsFromOtherContexts(t *testing
 	event, _ := result.Value()
 	if diff := cmp.Diff("event-1", event.EventID().String()); diff != "" {
 		t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func newFindLatestScenario(t *testing.T) (*sqlite.EventDatasource, *sqlite.SessionDatasource) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	saveFindLatestSessionEventFixture(
+		t,
+		eventDS,
+		"event-1",
+		types.EventKindSessionStarted,
+		"session-old",
+		"github.com/duck8823/traceary",
+		"session started",
+		time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC),
+	)
+	saveFindLatestSessionEventFixture(
+		t,
+		eventDS,
+		"event-2",
+		types.EventKindSessionEnded,
+		"session-old",
+		"github.com/duck8823/traceary",
+		"session ended",
+		time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+	)
+	saveFindLatestSessionEventFixture(
+		t,
+		eventDS,
+		"event-3",
+		types.EventKindSessionStarted,
+		"session-active",
+		"github.com/duck8823/traceary",
+		"session started",
+		time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+	)
+	saveFindLatestSessionEventFixture(
+		t,
+		eventDS,
+		"event-4",
+		types.EventKindSessionStarted,
+		"session-finished",
+		"github.com/duck8823/traceary",
+		"session started",
+		time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	)
+	saveFindLatestSessionEventFixture(
+		t,
+		eventDS,
+		"event-5",
+		types.EventKindSessionEnded,
+		"session-finished",
+		"github.com/duck8823/traceary",
+		"session ended",
+		time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	)
+
+	return eventDS, sessionDS
+}
+
+func saveFindLatestSessionEventFixture(
+	t *testing.T,
+	eventDS *sqlite.EventDatasource,
+	eventIDValue string,
+	kind types.EventKind,
+	sessionIDValue string,
+	workspace string,
+	body string,
+	createdAt time.Time,
+) {
+	t.Helper()
+
+	event := newFindLatestSessionEventFixture(t, eventIDValue, kind, sessionIDValue, workspace, body, createdAt)
+	if err := eventDS.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save(%s) error = %v", eventIDValue, err)
 	}
 }
 

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -16,7 +16,7 @@ func TestDatasource_FindLatest(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -224,7 +224,7 @@ func TestDatasource_FindLatest_ignoresBoundariesFromOtherContexts(t *testing.T) 
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -288,7 +288,7 @@ func TestDatasource_FindLatest_activeOnlyIgnoresEndsFromOtherContexts(t *testing
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
-	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, productionSQLiteMigrations(t))
+	eventDS, sessionDS, storeManager := newFullDatasources(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := storeManager.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -60,7 +60,7 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"session-ended-last",
 			"github.com/duck8823/traceary",
 			"session started",
-			time.Date(2026, 4, 11, 13, 30, 0, 0, time.UTC),
+			time.Date(2026, 4, 11, 12, 30, 0, 0, time.UTC),
 		)
 		saveFindLatestSessionEventFixture(
 			t,
@@ -111,7 +111,7 @@ func TestDatasource_FindLatest(t *testing.T) {
 			"session-ended-later",
 			"github.com/duck8823/traceary",
 			"session started",
-			time.Date(2026, 4, 11, 13, 30, 0, 0, time.UTC),
+			time.Date(2026, 4, 11, 12, 30, 0, 0, time.UTC),
 		)
 		saveFindLatestSessionEventFixture(
 			t,

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -56,8 +56,18 @@ func TestDatasource_FindLatest(t *testing.T) {
 			t,
 			eventDS,
 			"event-7",
+			types.EventKindSessionStarted,
+			"session-ended-last",
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 11, 13, 30, 0, 0, time.UTC),
+		)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-8",
 			types.EventKindSessionEnded,
-			"session-finished",
+			"session-ended-last",
 			"github.com/duck8823/traceary",
 			"session ended",
 			time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
@@ -74,7 +84,7 @@ func TestDatasource_FindLatest(t *testing.T) {
 			t.Fatalf("FindLatest() returned empty, want present")
 		}
 		event, _ := result.Value()
-		if diff := cmp.Diff("event-4", event.EventID().String()); diff != "" {
+		if diff := cmp.Diff("event-7", event.EventID().String()); diff != "" {
 			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -97,8 +107,18 @@ func TestDatasource_FindLatest(t *testing.T) {
 			t,
 			eventDS,
 			"event-7",
+			types.EventKindSessionStarted,
+			"session-ended-later",
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 11, 13, 30, 0, 0, time.UTC),
+		)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-8",
 			types.EventKindSessionEnded,
-			"session-finished",
+			"session-ended-later",
 			"github.com/duck8823/traceary",
 			"session ended",
 			time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),

--- a/infrastructure/sqlite/find_latest_session_test.go
+++ b/infrastructure/sqlite/find_latest_session_test.go
@@ -224,6 +224,64 @@ func TestDatasource_FindLatest(t *testing.T) {
 			t.Fatalf("FindLatest() returned present, want empty")
 		}
 	})
+
+	t.Run("returns empty Optional when active-only context has no matching session", func(t *testing.T) {
+		t.Parallel()
+
+		_, sessionDS := newFindLatestScenario(t)
+
+		result, err := sessionDS.FindLatest(
+			context.Background(),
+			types.Client(""), types.Agent("claude"), types.Workspace(""), true,
+		)
+		if err != nil {
+			t.Fatalf("FindLatest() error = %v, want nil", err)
+		}
+		if _, ok := result.Value(); ok {
+			t.Fatalf("FindLatest() returned present, want empty")
+		}
+	})
+
+	t.Run("handles repeated end boundary for already ended session", func(t *testing.T) {
+		t.Parallel()
+
+		eventDS, sessionDS := newFindLatestScenario(t)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-6",
+			types.EventKindSessionStarted,
+			"session-overlapping",
+			"github.com/duck8823/traceary",
+			"session started",
+			time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		)
+		saveFindLatestSessionEventFixture(
+			t,
+			eventDS,
+			"event-7",
+			types.EventKindSessionEnded,
+			"session-finished",
+			"github.com/duck8823/traceary",
+			"session ended again",
+			time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		)
+
+		result, err := sessionDS.FindLatest(
+			context.Background(),
+			types.Client("cli"), types.Agent("codex"), types.Workspace("github.com/duck8823/traceary"), false,
+		)
+		if err != nil {
+			t.Fatalf("FindLatest() error = %v", err)
+		}
+		if _, ok := result.Value(); !ok {
+			t.Fatalf("FindLatest() returned empty, want present")
+		}
+		event, _ := result.Value()
+		if diff := cmp.Diff("event-4", event.EventID().String()); diff != "" {
+			t.Fatalf("EventID() mismatch (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestDatasource_FindLatest_ignoresBoundariesFromOtherContexts(t *testing.T) {

--- a/infrastructure/sqlite/memory_tool_file_datasource_test.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource_test.go
@@ -15,7 +15,7 @@ func TestMemoryToolFileDatasource_roundTripThroughRepository(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -125,7 +125,7 @@ func mustMemoryToolPath(t *testing.T, raw string) types.MemoryToolPath {
 func newTestMemoryToolFileDatasource(t *testing.T) *sqlite.MemoryToolFileDatasource {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)

--- a/infrastructure/sqlite/memory_tool_file_datasource_test.go
+++ b/infrastructure/sqlite/memory_tool_file_datasource_test.go
@@ -2,7 +2,6 @@ package sqlite_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -16,7 +15,7 @@ func TestMemoryToolFileDatasource_roundTripThroughRepository(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -126,7 +125,7 @@ func mustMemoryToolPath(t *testing.T, raw string) types.MemoryToolPath {
 func newTestMemoryToolFileDatasource(t *testing.T) *sqlite.MemoryToolFileDatasource {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	db := sqlite.NewDatabase(dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	db := sqlite.NewDatabase(dbPath, productionSQLiteMigrations(t))
 	store := sqlite.NewStoreManagementDatasource(db)
 	if err := store.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -153,7 +152,7 @@ func countOnDiskSQLiteMigrations(t *testing.T) int {
 	}
 	count := 0
 	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) == ".sql" {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".sql" {
 			count++
 		}
 	}
@@ -175,13 +174,9 @@ func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.Ma
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
 			continue
 		}
-		versionText, _, ok := strings.Cut(entry.Name(), "_")
-		if !ok {
-			t.Fatalf("migration filename %q missing version separator", entry.Name())
-		}
-		version, parseErr := strconv.Atoi(versionText)
-		if parseErr != nil {
-			t.Fatalf("migration filename %q has invalid version: %v", entry.Name(), parseErr)
+		version, err := sqliteMigrationVersion(entry.Name())
+		if err != nil {
+			t.Fatal(err)
 		}
 		if version == maxVersion {
 			foundMaxVersion = true

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -53,7 +54,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
+	ds := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
 
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -77,7 +78,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	}
 
 	// Count migration files dynamically
-	entries, err := os.ReadDir(productionSQLiteMigrationDir(t))
+	entries, err := os.ReadDir(onDiskSQLiteMigrationDir(t))
 	if err != nil {
 		t.Fatalf("ReadDir() error = %v", err)
 	}
@@ -103,13 +104,13 @@ func TestMigration014_addsSessionSpawnMetadataToUpgradedDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	preV010 := migrationsWithout(t, productionSQLiteMigrationDir(t), "000014_add_session_spawn_metadata.sql")
+	preV010 := migrationsBeforeVersion(t, onDiskSQLiteMigrationDir(t), 14)
 	ds := newStoreManagementDatasource(t, dbPath, preV010)
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(pre-v0.10) error = %v", err)
 	}
 
-	ds = newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
+	ds = newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(upgrade) error = %v", err)
 	}
@@ -127,7 +128,7 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
+	ds := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
 
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() first error = %v", err)
@@ -142,7 +143,7 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	entries, err := os.ReadDir(productionSQLiteMigrationDir(t))
+	entries, err := os.ReadDir(onDiskSQLiteMigrationDir(t))
 	if err != nil {
 		t.Fatalf("ReadDir() error = %v", err)
 	}
@@ -162,13 +163,8 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 }
 
-func migrationsWithout(t *testing.T, dir string, excludedNames ...string) fstest.MapFS {
+func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.MapFS {
 	t.Helper()
-
-	excluded := make(map[string]struct{}, len(excludedNames))
-	for _, name := range excludedNames {
-		excluded[name] = struct{}{}
-	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -179,7 +175,15 @@ func migrationsWithout(t *testing.T, dir string, excludedNames ...string) fstest
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
 			continue
 		}
-		if _, ok := excluded[entry.Name()]; ok {
+		versionText, _, ok := strings.Cut(entry.Name(), "_")
+		if !ok {
+			t.Fatalf("migration filename %q missing version separator", entry.Name())
+		}
+		version, err := strconv.Atoi(versionText)
+		if err != nil {
+			t.Fatalf("migration filename %q has invalid version: %v", entry.Name(), err)
+		}
+		if version >= maxVersion {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
@@ -292,7 +296,7 @@ func TestMigrations_backfillPopulatesSessionsFromEvents(t *testing.T) {
 	_ = db.Close()
 
 	// Apply remaining migrations via Initialize
-	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
+	ds := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -113,6 +113,30 @@ func TestMigrations_upgradeFromPreV014DatabaseAddsSessionSpawnMetadata(t *testin
 	assertSessionSpawnMetadataSchema(t, db)
 }
 
+func TestMigrations_applyMissingMidSequenceMigration(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	withoutV014 := migrationsWithoutVersion(t, onDiskSQLiteMigrationDir(t), 14)
+	ds := newStoreManagementDatasource(t, dbPath, withoutV014)
+	if err := ds.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(without v0.14) error = %v", err)
+	}
+
+	ds = newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := ds.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(upgrade) error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	assertSessionSpawnMetadataSchema(t, db)
+}
+
 func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	t.Parallel()
 
@@ -157,6 +181,39 @@ func countOnDiskSQLiteMigrations(t *testing.T) int {
 		}
 	}
 	return count
+}
+
+func migrationsWithoutVersion(t *testing.T, dir string, excludedVersion int) fstest.MapFS {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	migrations := fstest.MapFS{}
+	foundExcludedVersion := false
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		version, err := sqliteMigrationVersion(entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if version == excludedVersion {
+			foundExcludedVersion = true
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", entry.Name(), err)
+		}
+		migrations[entry.Name()] = &fstest.MapFile{Data: data}
+	}
+	if !foundExcludedVersion {
+		t.Fatalf("migration version %d not found in %s", excludedVersion, dir)
+	}
+	return migrations
 }
 
 // migrationsBeforeVersion returns on-disk migrations whose numeric version is

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -77,17 +77,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 		}
 	}
 
-	// Count migration files dynamically
-	entries, err := os.ReadDir(onDiskSQLiteMigrationDir(t))
-	if err != nil {
-		t.Fatalf("ReadDir() error = %v", err)
-	}
-	wantMigrations := 0
-	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) == ".sql" {
-			wantMigrations++
-		}
-	}
+	wantMigrations := countOnDiskSQLiteMigrations(t)
 
 	var migrationCount int
 	if err := db.QueryRow("SELECT count(*) FROM schema_migrations").Scan(&migrationCount); err != nil {
@@ -100,14 +90,14 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	assertSessionSpawnMetadataSchema(t, db)
 }
 
-func TestMigration014_addsSessionSpawnMetadataToUpgradedDatabase(t *testing.T) {
+func TestMigrations_upgradeFromPreV014DatabaseAddsSessionSpawnMetadata(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	preV010 := migrationsBeforeVersion(t, onDiskSQLiteMigrationDir(t), 14)
-	ds := newStoreManagementDatasource(t, dbPath, preV010)
+	preV014 := migrationsBeforeVersion(t, onDiskSQLiteMigrationDir(t), 14)
+	ds := newStoreManagementDatasource(t, dbPath, preV014)
 	if err := ds.Initialize(context.Background()); err != nil {
-		t.Fatalf("Initialize(pre-v0.10) error = %v", err)
+		t.Fatalf("Initialize(pre-v0.14) error = %v", err)
 	}
 
 	ds = newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
@@ -143,16 +133,7 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	entries, err := os.ReadDir(onDiskSQLiteMigrationDir(t))
-	if err != nil {
-		t.Fatalf("ReadDir() error = %v", err)
-	}
-	wantMigrations := 0
-	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) == ".sql" {
-			wantMigrations++
-		}
-	}
+	wantMigrations := countOnDiskSQLiteMigrations(t)
 
 	var count int
 	if err := db.QueryRow("SELECT count(*) FROM schema_migrations").Scan(&count); err != nil {
@@ -161,6 +142,22 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	if count != wantMigrations {
 		t.Errorf("schema_migrations count = %d, want %d", count, wantMigrations)
 	}
+}
+
+func countOnDiskSQLiteMigrations(t *testing.T) int {
+	t.Helper()
+
+	entries, err := os.ReadDir(onDiskSQLiteMigrationDir(t))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".sql" {
+			count++
+		}
+	}
+	return count
 }
 
 // migrationsBeforeVersion returns on-disk migrations whose numeric version is
@@ -179,11 +176,13 @@ func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.Ma
 		}
 		versionText, _, ok := strings.Cut(entry.Name(), "_")
 		if !ok {
-			t.Fatalf("migration filename %q missing version separator", entry.Name())
+			t.Logf("skip migration filename %q: missing version separator", entry.Name())
+			continue
 		}
-		version, err := strconv.Atoi(versionText)
-		if err != nil {
-			t.Fatalf("migration filename %q has invalid version: %v", entry.Name(), err)
+		version, parseErr := strconv.Atoi(versionText)
+		if parseErr != nil {
+			t.Logf("skip migration filename %q: invalid version: %v", entry.Name(), parseErr)
+			continue
 		}
 		if version >= maxVersion {
 			continue

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -170,19 +170,21 @@ func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.Ma
 		t.Fatalf("ReadDir() error = %v", err)
 	}
 	migrations := fstest.MapFS{}
+	foundMaxVersion := false
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
 			continue
 		}
 		versionText, _, ok := strings.Cut(entry.Name(), "_")
 		if !ok {
-			t.Logf("skip migration filename %q: missing version separator", entry.Name())
-			continue
+			t.Fatalf("migration filename %q missing version separator", entry.Name())
 		}
 		version, parseErr := strconv.Atoi(versionText)
 		if parseErr != nil {
-			t.Logf("skip migration filename %q: invalid version: %v", entry.Name(), parseErr)
-			continue
+			t.Fatalf("migration filename %q has invalid version: %v", entry.Name(), parseErr)
+		}
+		if version == maxVersion {
+			foundMaxVersion = true
 		}
 		if version >= maxVersion {
 			continue
@@ -192,6 +194,9 @@ func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.Ma
 			t.Fatalf("ReadFile(%s) error = %v", entry.Name(), err)
 		}
 		migrations[entry.Name()] = &fstest.MapFile{Data: data}
+	}
+	if !foundMaxVersion {
+		t.Fatalf("migration version %d not found in %s", maxVersion, dir)
 	}
 	return migrations
 }

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -99,6 +99,8 @@ func TestMigrations_upgradeFromPreV014DatabaseAddsSessionSpawnMetadata(t *testin
 		t.Fatalf("Initialize(pre-v0.14) error = %v", err)
 	}
 
+	seedPreV014SessionRow(t, dbPath)
+
 	ds = newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(upgrade) error = %v", err)
@@ -111,6 +113,7 @@ func TestMigrations_upgradeFromPreV014DatabaseAddsSessionSpawnMetadata(t *testin
 	defer func() { _ = db.Close() }()
 
 	assertSessionSpawnMetadataSchema(t, db)
+	assertPreV014SessionMetadataDefaults(t, db)
 }
 
 func TestMigrations_applyMissingMidSequenceMigration(t *testing.T) {
@@ -181,6 +184,73 @@ func countOnDiskSQLiteMigrations(t *testing.T) int {
 		}
 	}
 	return count
+}
+
+func seedPreV014SessionRow(t *testing.T, dbPath string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("Open(pre-v0.14 seed) error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+INSERT INTO sessions (
+    session_id,
+    started_at,
+    client,
+    agent,
+    workspace,
+    label,
+    summary,
+    parent_session_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
+		"pre-v014-session",
+		"2026-04-11T12:00:00Z",
+		"cli",
+		"codex",
+		"github.com/duck8823/traceary",
+		"pre v0.14 row",
+		"existing summary",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("seed pre-v0.14 session row error = %v", err)
+	}
+}
+
+func assertPreV014SessionMetadataDefaults(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	var (
+		spawnEventID sql.NullString
+		subagentKind string
+		spawnOrder   sql.NullInt64
+	)
+	if err := db.QueryRow(`
+SELECT spawn_event_id, subagent_kind, spawn_order
+  FROM sessions
+ WHERE session_id = ?;`, "pre-v014-session").Scan(&spawnEventID, &subagentKind, &spawnOrder); err != nil {
+		t.Fatalf("query upgraded pre-v0.14 session row error = %v", err)
+	}
+	if spawnEventID.Valid {
+		t.Errorf("spawn_event_id = %q, want NULL", spawnEventID.String)
+	}
+	if subagentKind != "" {
+		t.Errorf("subagent_kind = %q, want empty string", subagentKind)
+	}
+	if spawnOrder.Valid {
+		t.Errorf("spawn_order = %d, want NULL", spawnOrder.Int64)
+	}
+
+	var applied int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = 14;`).Scan(&applied); err != nil {
+		t.Fatalf("query migration 14 application error = %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("schema_migrations version 14 count = %d, want 1", applied)
+	}
 }
 
 func migrationsWithoutVersion(t *testing.T, dir string, excludedVersion int) fstest.MapFS {

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -53,7 +53,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	ds := newStoreManagementDatasource(t, dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
 
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
@@ -77,7 +77,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	}
 
 	// Count migration files dynamically
-	entries, err := os.ReadDir("../../schema/sqlite/migrations")
+	entries, err := os.ReadDir(productionSQLiteMigrationDir(t))
 	if err != nil {
 		t.Fatalf("ReadDir() error = %v", err)
 	}
@@ -103,13 +103,13 @@ func TestMigration014_addsSessionSpawnMetadataToUpgradedDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	preV010 := migrationsWithout(t, "../../schema/sqlite/migrations", "000014_add_session_spawn_metadata.sql")
+	preV010 := migrationsWithout(t, productionSQLiteMigrationDir(t), "000014_add_session_spawn_metadata.sql")
 	ds := newStoreManagementDatasource(t, dbPath, preV010)
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(pre-v0.10) error = %v", err)
 	}
 
-	ds = newStoreManagementDatasource(t, dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	ds = newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(upgrade) error = %v", err)
 	}
@@ -127,7 +127,7 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	ds := newStoreManagementDatasource(t, dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
 
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() first error = %v", err)
@@ -142,7 +142,7 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	entries, err := os.ReadDir("../../schema/sqlite/migrations")
+	entries, err := os.ReadDir(productionSQLiteMigrationDir(t))
 	if err != nil {
 		t.Fatalf("ReadDir() error = %v", err)
 	}
@@ -292,7 +292,7 @@ func TestMigrations_backfillPopulatesSessionsFromEvents(t *testing.T) {
 	_ = db.Close()
 
 	// Apply remaining migrations via Initialize
-	ds := newStoreManagementDatasource(t, dbPath, os.DirFS("../../schema/sqlite/migrations"))
+	ds := newStoreManagementDatasource(t, dbPath, productionSQLiteMigrations(t))
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -116,11 +116,11 @@ func TestMigrations_upgradeFromPreV014DatabaseAddsSessionSpawnMetadata(t *testin
 	assertPreV014SessionMetadataDefaults(t, db)
 }
 
-func TestMigrations_applyMissingMidSequenceMigration(t *testing.T) {
+func TestMigrations_appliesGapInVersionHistory(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	withoutV014 := migrationsWithoutVersion(t, onDiskSQLiteMigrationDir(t), 14)
+	withoutV014 := migrationsInRangeExcluding(t, onDiskSQLiteMigrationDir(t), 1, 16, 14)
 	ds := newStoreManagementDatasource(t, dbPath, withoutV014)
 	if err := ds.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize(without v0.14) error = %v", err)
@@ -138,6 +138,7 @@ func TestMigrations_applyMissingMidSequenceMigration(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	assertSessionSpawnMetadataSchema(t, db)
+	assertMigrationApplied(t, db, 14)
 }
 
 func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
@@ -195,6 +196,9 @@ func seedPreV014SessionRow(t *testing.T, dbPath string) {
 	}
 	defer func() { _ = db.Close() }()
 
+	// This intentionally freezes the sessions table shape after migrations
+	// 000001..000013 so the v14 upgrade path proves existing rows survive
+	// the new nullable/defaulted metadata columns.
 	_, err = db.Exec(`
 INSERT INTO sessions (
     session_id,
@@ -244,16 +248,22 @@ SELECT spawn_event_id, subagent_kind, spawn_order
 		t.Errorf("spawn_order = %d, want NULL", spawnOrder.Int64)
 	}
 
+	assertMigrationApplied(t, db, 14)
+}
+
+func assertMigrationApplied(t *testing.T, db *sql.DB, version int) {
+	t.Helper()
+
 	var applied int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = 14;`).Scan(&applied); err != nil {
-		t.Fatalf("query migration 14 application error = %v", err)
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?;`, version).Scan(&applied); err != nil {
+		t.Fatalf("query migration %d application error = %v", version, err)
 	}
 	if applied != 1 {
-		t.Errorf("schema_migrations version 14 count = %d, want 1", applied)
+		t.Errorf("schema_migrations version %d count = %d, want 1", version, applied)
 	}
 }
 
-func migrationsWithoutVersion(t *testing.T, dir string, excludedVersion int) fstest.MapFS {
+func migrationsInRangeExcluding(t *testing.T, dir string, minVersion, maxVersion, excludedVersion int) fstest.MapFS {
 	t.Helper()
 
 	entries, err := os.ReadDir(dir)
@@ -269,6 +279,9 @@ func migrationsWithoutVersion(t *testing.T, dir string, excludedVersion int) fst
 		version, err := sqliteMigrationVersion(entry.Name())
 		if err != nil {
 			t.Fatal(err)
+		}
+		if version < minVersion || version > maxVersion {
+			continue
 		}
 		if version == excludedVersion {
 			foundExcludedVersion = true

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -163,6 +163,8 @@ func TestMigrations_idempotentOnExistingDatabase(t *testing.T) {
 	}
 }
 
+// migrationsBeforeVersion returns on-disk migrations whose numeric version is
+// lower than maxVersion, preserving the history shape of an older database.
 func migrationsBeforeVersion(t *testing.T, dir string, maxVersion int) fstest.MapFS {
 	t.Helper()
 

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -1,7 +1,6 @@
 package sqlite_test
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -15,6 +14,8 @@ import (
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
+
+const tracearyRepoRootEnv = "TRACEARY_REPO_ROOT"
 
 var (
 	sqliteMigrationDirMu sync.Mutex
@@ -47,15 +48,9 @@ func onDiskSQLiteMigrationDir(t testing.TB) string {
 }
 
 func resolveOnDiskSQLiteMigrationDir() (string, error) {
-	starts, startErrs := sqliteMigrationSearchStarts()
-	searchErrs := append([]error(nil), startErrs...)
-	for _, start := range starts {
-		root, err := findTracearyRepositoryRoot(start)
-		if err != nil {
-			searchErrs = append(searchErrs, err)
-			continue
-		}
-		dir := filepath.Join(root, "schema", "sqlite", "migrations")
+	candidates, candidateErrs := sqliteMigrationDirCandidates()
+	searchErrs := append([]error(nil), candidateErrs...)
+	for _, dir := range candidates {
 		if err := validateSQLiteMigrationDir(dir); err != nil {
 			searchErrs = append(searchErrs, err)
 			continue
@@ -63,85 +58,44 @@ func resolveOnDiskSQLiteMigrationDir() (string, error) {
 		return dir, nil
 	}
 	if len(searchErrs) == 0 {
-		return "", errors.New("no traceary repository search roots available")
+		return "", errors.New("no SQLite migration directory candidates available")
 	}
 	return "", fmt.Errorf("resolve SQLite migrations directory: %w", errors.Join(searchErrs...))
 }
 
-func sqliteMigrationSearchStarts() ([]string, []error) {
-	var starts []string
+func sqliteMigrationDirCandidates() ([]string, []error) {
+	var candidates []string
 	var errs []error
 
+	if root := os.Getenv(tracearyRepoRootEnv); root != "" {
+		candidates = appendUniquePath(candidates, filepath.Join(root, "schema", "sqlite", "migrations"))
+	}
+
 	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
-		starts = appendSearchStart(starts, filepath.Dir(file))
+		candidates = appendUniquePath(
+			candidates,
+			filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations"),
+		)
 	}
 
 	if cwd, err := os.Getwd(); err == nil {
-		starts = appendSearchStart(starts, cwd)
+		candidates = appendUniquePath(candidates, filepath.Join(cwd, "..", "..", "schema", "sqlite", "migrations"))
+		candidates = appendUniquePath(candidates, filepath.Join(cwd, "schema", "sqlite", "migrations"))
 	} else {
 		errs = append(errs, fmt.Errorf("get working directory: %w", err))
 	}
 
-	return starts, errs
-}
-
-func appendSearchStart(starts []string, start string) []string {
-	start = filepath.Clean(start)
-	starts = appendUniquePath(starts, start)
-	if resolved, err := filepath.EvalSymlinks(start); err == nil {
-		starts = appendUniquePath(starts, resolved)
-	}
-	return starts
+	return candidates, errs
 }
 
 func appendUniquePath(paths []string, candidate string) []string {
+	candidate = filepath.Clean(candidate)
 	for _, path := range paths {
 		if path == candidate {
 			return paths
 		}
 	}
 	return append(paths, candidate)
-}
-
-func findTracearyRepositoryRoot(start string) (string, error) {
-	dir := filepath.Clean(start)
-	for {
-		goModPath := filepath.Join(dir, "go.mod")
-		data, err := os.ReadFile(goModPath)
-		switch {
-		case err == nil:
-			if isTracearyModule(data) {
-				return dir, nil
-			}
-		case errors.Is(err, os.ErrNotExist):
-			// Continue walking upward.
-		default:
-			return "", fmt.Errorf("read %s: %w", goModPath, err)
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", errors.New("traceary go.mod not found from " + start)
-		}
-		dir = parent
-	}
-}
-
-func isTracearyModule(data []byte) bool {
-	for _, line := range bytes.Split(data, []byte("\n")) {
-		fields := bytes.Fields(line)
-		if len(fields) < 2 || !bytes.Equal(fields[0], []byte("module")) {
-			continue
-		}
-		modulePath := string(fields[1])
-		if unquoted, err := strconv.Unquote(modulePath); err == nil {
-			modulePath = unquoted
-		}
-		if modulePath == "github.com/duck8823/traceary" ||
-			strings.HasPrefix(modulePath, "github.com/duck8823/traceary/v") {
-			return true
-		}
-	}
-	return false
 }
 
 func validateSQLiteMigrationDir(dir string) error {
@@ -156,12 +110,53 @@ func validateSQLiteMigrationDir(dir string) error {
 	if err != nil {
 		return fmt.Errorf("read SQLite migrations in %s: %w", dir, err)
 	}
+	seenVersions := map[int]struct{}{}
+	foundSQL := false
+	foundInitialMigration := false
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".sql" {
-			return nil
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		foundSQL = true
+		version, err := sqliteMigrationVersion(entry.Name())
+		if err != nil {
+			return err
+		}
+		if _, exists := seenVersions[version]; exists {
+			return fmt.Errorf("duplicate SQLite migration version %d in %s", version, dir)
+		}
+		seenVersions[version] = struct{}{}
+		if entry.Name() == "000001_init.sql" {
+			foundInitialMigration = true
 		}
 	}
-	return errors.New("SQLite migrations path has no .sql files: " + dir)
+	if !foundSQL {
+		return errors.New("SQLite migrations path has no .sql files: " + dir)
+	}
+	if !foundInitialMigration {
+		return errors.New("SQLite migrations path is missing 000001_init.sql: " + dir)
+	}
+	return nil
+}
+
+func sqliteMigrationVersion(name string) (int, error) {
+	versionText, _, ok := strings.Cut(name, "_")
+	if !ok {
+		return 0, fmt.Errorf("migration filename %q missing version separator", name)
+	}
+	if len(versionText) != 6 {
+		return 0, fmt.Errorf("migration filename %q must use a six-digit version prefix", name)
+	}
+	for _, digit := range versionText {
+		if digit < '0' || digit > '9' {
+			return 0, fmt.Errorf("migration filename %q has non-numeric version prefix", name)
+		}
+	}
+	version, err := strconv.Atoi(versionText)
+	if err != nil {
+		return 0, fmt.Errorf("migration filename %q has invalid version: %w", name, err)
+	}
+	return version, nil
 }
 
 // newEventDatasource returns an EventDatasource plus a matching

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -43,10 +43,9 @@ func findTracearyRepositoryRoot(start string) (string, error) {
 		data, err := os.ReadFile(goModPath)
 		switch {
 		case err == nil:
-			if bytes.Contains(data, []byte("module github.com/duck8823/traceary")) {
+			if isTracearyModule(data) {
 				return dir, nil
 			}
-			return "", errors.New("found go.mod with unexpected module at " + goModPath)
 		case errors.Is(err, os.ErrNotExist):
 			// Continue walking upward.
 		default:
@@ -60,19 +59,29 @@ func findTracearyRepositoryRoot(start string) (string, error) {
 	}
 }
 
+func isTracearyModule(data []byte) bool {
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if bytes.Equal(bytes.TrimSpace(line), []byte("module github.com/duck8823/traceary")) {
+			return true
+		}
+	}
+	return false
+}
+
 func validateSQLiteMigrationDir(dir string) error {
-	info, err := os.Lstat(dir)
+	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("stat SQLite migrations path %s: %w", dir, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return errors.New("SQLite migrations path is a symlink: " + dir)
 	}
 	if !info.IsDir() {
 		return errors.New("SQLite migrations path is not a directory: " + dir)
 	}
-	if _, err := os.Lstat(filepath.Join(dir, "000001_init.sql")); err != nil {
-		return fmt.Errorf("stat initial SQLite migration in %s: %w", dir, err)
+	migrations, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	if err != nil {
+		return fmt.Errorf("glob SQLite migrations in %s: %w", dir, err)
+	}
+	if len(migrations) == 0 {
+		return errors.New("SQLite migrations path has no .sql files: " + dir)
 	}
 	return nil
 }

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -16,9 +17,8 @@ import (
 )
 
 var (
-	sqliteMigrationDirOnce sync.Once
-	sqliteMigrationDir     string
-	sqliteMigrationDirErr  error
+	sqliteMigrationDirMu sync.Mutex
+	sqliteMigrationDir   string
 )
 
 // onDiskSQLiteMigrations returns the repository's on-disk migration set for
@@ -30,12 +30,19 @@ func onDiskSQLiteMigrations(t testing.TB) fs.FS {
 
 func onDiskSQLiteMigrationDir(t testing.TB) string {
 	t.Helper()
-	sqliteMigrationDirOnce.Do(func() {
-		sqliteMigrationDir, sqliteMigrationDirErr = resolveOnDiskSQLiteMigrationDir()
-	})
-	if sqliteMigrationDirErr != nil {
-		t.Fatal(sqliteMigrationDirErr)
+
+	sqliteMigrationDirMu.Lock()
+	defer sqliteMigrationDirMu.Unlock()
+
+	if sqliteMigrationDir != "" {
+		return sqliteMigrationDir
 	}
+
+	dir, err := resolveOnDiskSQLiteMigrationDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqliteMigrationDir = dir
 	return sqliteMigrationDir
 }
 
@@ -65,14 +72,14 @@ func sqliteMigrationSearchStarts() ([]string, []error) {
 	var starts []string
 	var errs []error
 
+	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
+		starts = appendSearchStart(starts, filepath.Dir(file))
+	}
+
 	if cwd, err := os.Getwd(); err == nil {
 		starts = appendSearchStart(starts, cwd)
 	} else {
 		errs = append(errs, fmt.Errorf("get working directory: %w", err))
-	}
-
-	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
-		starts = appendSearchStart(starts, filepath.Dir(file))
 	}
 
 	return starts, errs
@@ -129,7 +136,8 @@ func isTracearyModule(data []byte) bool {
 		if unquoted, err := strconv.Unquote(modulePath); err == nil {
 			modulePath = unquoted
 		}
-		if modulePath == "github.com/duck8823/traceary" {
+		if modulePath == "github.com/duck8823/traceary" ||
+			strings.HasPrefix(modulePath, "github.com/duck8823/traceary/v") {
 			return true
 		}
 	}

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -1,7 +1,6 @@
 package sqlite_test
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -13,6 +12,8 @@ import (
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
+
+const sqliteMigrationVersionDigits = 6
 
 // onDiskSQLiteMigrations returns the repository's on-disk migration set for
 // tests that intentionally exercise full-schema compatibility.
@@ -57,7 +58,7 @@ func validateSQLiteMigrationDir(dir string) error {
 		return fmt.Errorf("stat SQLite migrations path %s: %w", dir, err)
 	}
 	if !info.IsDir() {
-		return errors.New("SQLite migrations path is not a directory: " + dir)
+		return fmt.Errorf("SQLite migrations path is not a directory: %s", dir)
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -84,10 +85,10 @@ func validateSQLiteMigrationDir(dir string) error {
 		}
 	}
 	if !foundSQL {
-		return errors.New("SQLite migrations path has no .sql files: " + dir)
+		return fmt.Errorf("SQLite migrations path has no .sql files: %s", dir)
 	}
 	if !foundVersionOne {
-		return errors.New("SQLite migrations path is missing migration version 1: " + dir)
+		return fmt.Errorf("SQLite migrations path is missing migration version 1: %s", dir)
 	}
 	return nil
 }
@@ -97,8 +98,8 @@ func sqliteMigrationVersion(name string) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("migration filename %q missing version separator", name)
 	}
-	if len(versionText) != 6 {
-		return 0, fmt.Errorf("migration filename %q must use a six-digit version prefix", name)
+	if len(versionText) != sqliteMigrationVersionDigits {
+		return 0, fmt.Errorf("migration filename %q must use a %d-digit version prefix", name, sqliteMigrationVersionDigits)
 	}
 	for _, digit := range versionText {
 		if digit < '0' || digit > '9' {

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -4,7 +4,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
@@ -19,19 +18,30 @@ func productionSQLiteMigrations(t testing.TB) fs.FS {
 
 func productionSQLiteMigrationDir(t testing.TB) string {
 	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("runtime.Caller(0) failed")
-	}
-	dir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations"))
-	info, err := os.Stat(dir)
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("stat production SQLite migrations dir %s: %v", dir, err)
+		t.Fatalf("get working directory: %v", err)
 	}
-	if !info.IsDir() {
-		t.Fatalf("production SQLite migrations path %s is not a directory", dir)
+	dir, ok := findProductionSQLiteMigrationDir(cwd)
+	if !ok {
+		t.Fatalf("production SQLite migrations dir not found from %s", cwd)
 	}
 	return dir
+}
+
+func findProductionSQLiteMigrationDir(start string) (string, bool) {
+	dir := filepath.Clean(start)
+	for {
+		candidate := filepath.Join(dir, "schema", "sqlite", "migrations")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
 }
 
 // newEventDatasource returns an EventDatasource plus a matching

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -2,10 +2,15 @@ package sqlite_test
 
 import (
 	"io/fs"
+	"os"
 	"testing"
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
+
+func productionSQLiteMigrations() fs.FS {
+	return os.DirFS("../../schema/sqlite/migrations")
+}
 
 // newEventDatasource returns an EventDatasource plus a matching
 // StoreManagementDatasource for initialize/migrate operations.

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -3,13 +3,35 @@ package sqlite_test
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
-func productionSQLiteMigrations() fs.FS {
-	return os.DirFS("../../schema/sqlite/migrations")
+// productionSQLiteMigrations returns the on-disk production migration set for
+// tests that intentionally exercise full-schema compatibility.
+func productionSQLiteMigrations(t testing.TB) fs.FS {
+	t.Helper()
+	return os.DirFS(productionSQLiteMigrationDir(t))
+}
+
+func productionSQLiteMigrationDir(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller(0) failed")
+	}
+	dir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations"))
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat production SQLite migrations dir %s: %v", dir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("production SQLite migrations path %s is not a directory", dir)
+	}
+	return dir
 }
 
 // newEventDatasource returns an EventDatasource plus a matching

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -1,6 +1,9 @@
 package sqlite_test
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -9,39 +12,69 @@ import (
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
-// productionSQLiteMigrations returns the on-disk production migration set for
+// onDiskSQLiteMigrations returns the repository's on-disk migration set for
 // tests that intentionally exercise full-schema compatibility.
-func productionSQLiteMigrations(t testing.TB) fs.FS {
+func onDiskSQLiteMigrations(t testing.TB) fs.FS {
 	t.Helper()
-	return os.DirFS(productionSQLiteMigrationDir(t))
+	return os.DirFS(onDiskSQLiteMigrationDir(t))
 }
 
-func productionSQLiteMigrationDir(t testing.TB) string {
+func onDiskSQLiteMigrationDir(t testing.TB) string {
 	t.Helper()
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	dir, ok := findProductionSQLiteMigrationDir(cwd)
-	if !ok {
-		t.Fatalf("production SQLite migrations dir not found from %s", cwd)
+	root, err := findTracearyRepositoryRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "schema", "sqlite", "migrations")
+	if err := validateSQLiteMigrationDir(dir); err != nil {
+		t.Fatal(err)
 	}
 	return dir
 }
 
-func findProductionSQLiteMigrationDir(start string) (string, bool) {
+func findTracearyRepositoryRoot(start string) (string, error) {
 	dir := filepath.Clean(start)
 	for {
-		candidate := filepath.Join(dir, "schema", "sqlite", "migrations")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate, true
+		goModPath := filepath.Join(dir, "go.mod")
+		data, err := os.ReadFile(goModPath)
+		switch {
+		case err == nil:
+			if bytes.Contains(data, []byte("module github.com/duck8823/traceary")) {
+				return dir, nil
+			}
+			return "", errors.New("found go.mod with unexpected module at " + goModPath)
+		case errors.Is(err, os.ErrNotExist):
+			// Continue walking upward.
+		default:
+			return "", fmt.Errorf("read %s: %w", goModPath, err)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return "", errors.New("traceary go.mod not found from " + start)
 		}
 		dir = parent
 	}
+}
+
+func validateSQLiteMigrationDir(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("stat SQLite migrations path %s: %w", dir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("SQLite migrations path is a symlink: " + dir)
+	}
+	if !info.IsDir() {
+		return errors.New("SQLite migrations path is not a directory: " + dir)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "000001_init.sql")); err != nil {
+		return fmt.Errorf("stat initial SQLite migration in %s: %w", dir, err)
+	}
+	return nil
 }
 
 // newEventDatasource returns an EventDatasource plus a matching

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -9,17 +9,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
-)
-
-const tracearyRepoRootEnv = "TRACEARY_REPO_ROOT"
-
-var (
-	sqliteMigrationDirMu sync.Mutex
-	sqliteMigrationDir   string
 )
 
 // onDiskSQLiteMigrations returns the repository's on-disk migration set for
@@ -32,70 +24,31 @@ func onDiskSQLiteMigrations(t testing.TB) fs.FS {
 func onDiskSQLiteMigrationDir(t testing.TB) string {
 	t.Helper()
 
-	sqliteMigrationDirMu.Lock()
-	defer sqliteMigrationDirMu.Unlock()
-
-	if sqliteMigrationDir != "" {
-		return sqliteMigrationDir
-	}
-
 	dir, err := resolveOnDiskSQLiteMigrationDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	sqliteMigrationDir = dir
-	return sqliteMigrationDir
+	return dir
 }
 
 func resolveOnDiskSQLiteMigrationDir() (string, error) {
-	candidates, candidateErrs := sqliteMigrationDirCandidates()
-	searchErrs := append([]error(nil), candidateErrs...)
-	for _, dir := range candidates {
+	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
+		dir := filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations")
 		if err := validateSQLiteMigrationDir(dir); err != nil {
-			searchErrs = append(searchErrs, err)
-			continue
+			return "", err
 		}
 		return dir, nil
 	}
-	if len(searchErrs) == 0 {
-		return "", errors.New("no SQLite migration directory candidates available")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
 	}
-	return "", fmt.Errorf("resolve SQLite migrations directory: %w", errors.Join(searchErrs...))
-}
-
-func sqliteMigrationDirCandidates() ([]string, []error) {
-	var candidates []string
-	var errs []error
-
-	if root := os.Getenv(tracearyRepoRootEnv); root != "" {
-		candidates = appendUniquePath(candidates, filepath.Join(root, "schema", "sqlite", "migrations"))
+	dir := filepath.Join(cwd, "..", "..", "schema", "sqlite", "migrations")
+	if err := validateSQLiteMigrationDir(dir); err != nil {
+		return "", err
 	}
-
-	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
-		candidates = appendUniquePath(
-			candidates,
-			filepath.Join(filepath.Dir(file), "..", "..", "schema", "sqlite", "migrations"),
-		)
-	}
-
-	if cwd, err := os.Getwd(); err == nil {
-		candidates = appendUniquePath(candidates, filepath.Join(cwd, "..", "..", "schema", "sqlite", "migrations"))
-		candidates = appendUniquePath(candidates, filepath.Join(cwd, "schema", "sqlite", "migrations"))
-	} else {
-		errs = append(errs, fmt.Errorf("get working directory: %w", err))
-	}
-
-	return candidates, errs
-}
-
-func appendUniquePath(paths []string, candidate string) []string {
-	candidate = filepath.Clean(candidate)
-	for _, path := range paths {
-		if path == candidate {
-			return paths
-		}
-	}
-	return append(paths, candidate)
+	return dir, nil
 }
 
 func validateSQLiteMigrationDir(dir string) error {
@@ -112,7 +65,7 @@ func validateSQLiteMigrationDir(dir string) error {
 	}
 	seenVersions := map[int]struct{}{}
 	foundSQL := false
-	foundInitialMigration := false
+	foundVersionOne := false
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
 			continue
@@ -126,15 +79,15 @@ func validateSQLiteMigrationDir(dir string) error {
 			return fmt.Errorf("duplicate SQLite migration version %d in %s", version, dir)
 		}
 		seenVersions[version] = struct{}{}
-		if entry.Name() == "000001_init.sql" {
-			foundInitialMigration = true
+		if version == 1 {
+			foundVersionOne = true
 		}
 	}
 	if !foundSQL {
 		return errors.New("SQLite migrations path has no .sql files: " + dir)
 	}
-	if !foundInitialMigration {
-		return errors.New("SQLite migrations path is missing 000001_init.sql: " + dir)
+	if !foundVersionOne {
+		return errors.New("SQLite migrations path is missing migration version 1: " + dir)
 	}
 	return nil
 }

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -7,9 +7,18 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+var (
+	sqliteMigrationDirOnce sync.Once
+	sqliteMigrationDir     string
+	sqliteMigrationDirErr  error
 )
 
 // onDiskSQLiteMigrations returns the repository's on-disk migration set for
@@ -21,19 +30,70 @@ func onDiskSQLiteMigrations(t testing.TB) fs.FS {
 
 func onDiskSQLiteMigrationDir(t testing.TB) string {
 	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get working directory: %v", err)
+	sqliteMigrationDirOnce.Do(func() {
+		sqliteMigrationDir, sqliteMigrationDirErr = resolveOnDiskSQLiteMigrationDir()
+	})
+	if sqliteMigrationDirErr != nil {
+		t.Fatal(sqliteMigrationDirErr)
 	}
-	root, err := findTracearyRepositoryRoot(cwd)
-	if err != nil {
-		t.Fatal(err)
+	return sqliteMigrationDir
+}
+
+func resolveOnDiskSQLiteMigrationDir() (string, error) {
+	starts, startErrs := sqliteMigrationSearchStarts()
+	searchErrs := append([]error(nil), startErrs...)
+	for _, start := range starts {
+		root, err := findTracearyRepositoryRoot(start)
+		if err != nil {
+			searchErrs = append(searchErrs, err)
+			continue
+		}
+		dir := filepath.Join(root, "schema", "sqlite", "migrations")
+		if err := validateSQLiteMigrationDir(dir); err != nil {
+			searchErrs = append(searchErrs, err)
+			continue
+		}
+		return dir, nil
 	}
-	dir := filepath.Join(root, "schema", "sqlite", "migrations")
-	if err := validateSQLiteMigrationDir(dir); err != nil {
-		t.Fatal(err)
+	if len(searchErrs) == 0 {
+		return "", errors.New("no traceary repository search roots available")
 	}
-	return dir
+	return "", fmt.Errorf("resolve SQLite migrations directory: %w", errors.Join(searchErrs...))
+}
+
+func sqliteMigrationSearchStarts() ([]string, []error) {
+	var starts []string
+	var errs []error
+
+	if cwd, err := os.Getwd(); err == nil {
+		starts = appendSearchStart(starts, cwd)
+	} else {
+		errs = append(errs, fmt.Errorf("get working directory: %w", err))
+	}
+
+	if _, file, _, ok := runtime.Caller(0); ok && filepath.IsAbs(file) {
+		starts = appendSearchStart(starts, filepath.Dir(file))
+	}
+
+	return starts, errs
+}
+
+func appendSearchStart(starts []string, start string) []string {
+	start = filepath.Clean(start)
+	starts = appendUniquePath(starts, start)
+	if resolved, err := filepath.EvalSymlinks(start); err == nil {
+		starts = appendUniquePath(starts, resolved)
+	}
+	return starts
+}
+
+func appendUniquePath(paths []string, candidate string) []string {
+	for _, path := range paths {
+		if path == candidate {
+			return paths
+		}
+	}
+	return append(paths, candidate)
 }
 
 func findTracearyRepositoryRoot(start string) (string, error) {
@@ -61,7 +121,15 @@ func findTracearyRepositoryRoot(start string) (string, error) {
 
 func isTracearyModule(data []byte) bool {
 	for _, line := range bytes.Split(data, []byte("\n")) {
-		if bytes.Equal(bytes.TrimSpace(line), []byte("module github.com/duck8823/traceary")) {
+		fields := bytes.Fields(line)
+		if len(fields) < 2 || !bytes.Equal(fields[0], []byte("module")) {
+			continue
+		}
+		modulePath := string(fields[1])
+		if unquoted, err := strconv.Unquote(modulePath); err == nil {
+			modulePath = unquoted
+		}
+		if modulePath == "github.com/duck8823/traceary" {
 			return true
 		}
 	}
@@ -76,14 +144,16 @@ func validateSQLiteMigrationDir(dir string) error {
 	if !info.IsDir() {
 		return errors.New("SQLite migrations path is not a directory: " + dir)
 	}
-	migrations, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("glob SQLite migrations in %s: %w", dir, err)
+		return fmt.Errorf("read SQLite migrations in %s: %w", dir, err)
 	}
-	if len(migrations) == 0 {
-		return errors.New("SQLite migrations path has no .sql files: " + dir)
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".sql" {
+			return nil
+		}
 	}
-	return nil
+	return errors.New("SQLite migrations path has no .sql files: " + dir)
 }
 
 // newEventDatasource returns an EventDatasource plus a matching


### PR DESCRIPTION
## Motivation

PR #1067 review found that `find_latest_session_test.go` hand-rolled a minimal events schema. That let the latest-session tests pass against a schema that could drift from production migrations.

## Changes

- Replace duplicated `fstest.MapFS` migration fixtures in latest-session tests with the real `schema/sqlite/migrations` directory.
- Add a shared `productionSQLiteMigrations()` test helper for tests that intentionally need production schema parity.

## Audit note

Covered #1067 review finding: latest-session tests now initialize with the full production migration set, including downstream tables, columns, and indexes that the write/read datasources expect. The fixture event ordering remains unchanged so the test intent stays focused on `FindLatest` behavior.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache go test ./infrastructure/sqlite`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `git diff --check`

Closes #1068
