### PR TITLE
fix: preserve session end attribution inheritance

### DIFF
--- a/presentation/cli/session.go
+++ b/presentation/cli/session.go
@@ -236,20 +236,24 @@ func (c *RootCLI) runSessionBoundary(
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 
+	shouldDefaultAttribution := input.kind != types.EventKindSessionEnded
 	client := types.Client(resolveSessionBoundaryClient(input))
-	if client == "" {
+	if client == "" && shouldDefaultAttribution {
 		client = types.Client(defaultClientValue)
 	}
 	agentStr := resolveSessionBoundaryAgent(input)
-	if agentStr == "" {
+	if agentStr == "" && shouldDefaultAttribution {
 		agentStr = defaultAgentValue
 	}
-	agent, _ := types.AgentFrom(agentStr)
-	sid := types.SessionID(input.sessionID)
-	ws := types.Workspace(resolveSessionBoundaryRepo(input))
-	if ws == "" {
-		ws = types.Workspace(resolveWorkspaceValue(ctx, input.repo))
+	var agent types.Agent
+	if agentStr != "" {
+		agent, err = types.AgentFrom(agentStr)
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to resolve agent", "作業主体の解決に失敗しました"), err)
+		}
 	}
+	sid := types.SessionID(input.sessionID)
+	ws := types.Workspace(resolveSessionBoundaryRepo(ctx, input))
 
 	var event *model.Event
 	switch input.kind {
@@ -267,9 +271,17 @@ func (c *RootCLI) runSessionBoundary(
 	// follow-up #830). Best-effort: an extraction failure must not
 	// block the session-end record from being reported.
 	if input.kind == types.EventKindSessionEnded && c.memory != nil {
+		// For session-end, an empty workspace is intentional: the
+		// application use case inherits attribution from the matching
+		// session start. Use the returned event workspace so auto-extract
+		// follows that inherited scope.
+		extractWorkspace := ws
+		if extractWorkspace == "" {
+			extractWorkspace = event.Workspace()
+		}
 		if _, extractErr := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
 			SessionID(sid).
-			Workspace(ws).
+			Workspace(extractWorkspace).
 			Build()); extractErr != nil {
 			slog.Debug("CLI session-end auto-extract failed", "session_id", sid, "error", extractErr)
 		}
@@ -317,12 +329,12 @@ func resolveSessionBoundaryAgent(input sessionBoundaryCommandInput) string {
 	return resolveOptionalValue(input.agent, "TRACEARY_AGENT", defaultAgentValue)
 }
 
-func resolveSessionBoundaryRepo(input sessionBoundaryCommandInput) string {
+func resolveSessionBoundaryRepo(ctx context.Context, input sessionBoundaryCommandInput) string {
 	if input.kind == types.EventKindSessionEnded {
 		return resolveExplicitWorkspaceValue(input.repo)
 	}
 
-	return resolveWorkspaceValue(context.Background(), input.repo)
+	return resolveWorkspaceValue(ctx, input.repo)
 }
 
 func (c *RootCLI) runSessionLatest(

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -278,6 +278,151 @@ func TestRootCLI_SessionEndCommand(t *testing.T) {
 	}
 }
 
+func TestRootCLI_SessionEndCommand_DefersOmittedAttributionToUsecaseInheritance(t *testing.T) {
+	t.Setenv("TRACEARY_SESSION_ID", "session-inherit")
+	t.Setenv("TRACEARY_CLIENT", "")
+	t.Setenv("TRACEARY_AGENT", "")
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "github.com/duck8823/traceary", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	sessionID := mustSessionID(t, "session-inherit")
+	sessionStub := &sessionUsecaseStub{
+		endEvent: model.EventOf(
+			mustEventID(t, "event-end-inherit"),
+			types.EventKindSessionEnded,
+			types.Client("claude"),
+			mustAgent(t, "qa-reviewer"),
+			sessionID,
+			types.Workspace("traceary"),
+			"session ended",
+			time.Date(2026, 4, 7, 13, 30, 0, 0, time.UTC),
+		),
+	}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"session", "end", "--db-path", filepath.Join(t.TempDir(), "traceary.db")})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := sessionStub.endCall.client; got != "" {
+		t.Fatalf("end client = %q, want empty so usecase inherits from session start", got)
+	}
+	if got := sessionStub.endCall.agent; got != "" {
+		t.Fatalf("end agent = %q, want empty so usecase inherits from session start", got)
+	}
+	if got := sessionStub.endCall.workspace; got != "" {
+		t.Fatalf("end workspace = %q, want empty so usecase inherits from session start", got)
+	}
+	if got := sessionStub.endCall.sessionID; got != sessionID {
+		t.Fatalf("end sessionID = %q, want %q", got, sessionID)
+	}
+}
+
+func TestRootCLI_SessionEndCommand_PreservesExplicitAttributionOverrides(t *testing.T) {
+	t.Setenv("TRACEARY_SESSION_ID", "session-override")
+	t.Setenv("TRACEARY_CLIENT", "env-client")
+	t.Setenv("TRACEARY_AGENT", "env-agent")
+	t.Setenv("TRACEARY_WORKSPACE", "env-workspace")
+
+	sessionID := mustSessionID(t, "session-override")
+	sessionStub := &sessionUsecaseStub{
+		endEvent: model.EventOf(
+			mustEventID(t, "event-end-override"),
+			types.EventKindSessionEnded,
+			types.Client("flag-client"),
+			mustAgent(t, "env-agent"),
+			sessionID,
+			types.Workspace("flag-workspace"),
+			"session ended",
+			time.Date(2026, 4, 7, 13, 30, 0, 0, time.UTC),
+		),
+	}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "end",
+		"--db-path", filepath.Join(t.TempDir(), "traceary.db"),
+		"--client", "flag-client",
+		"--agent", "flag-agent",
+		"--workspace", "flag-workspace",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := sessionStub.endCall.client, types.Client("flag-client"); got != want {
+		t.Fatalf("end client = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.endCall.agent, types.Agent("flag-agent"); got != want {
+		t.Fatalf("end agent = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.endCall.workspace, types.Workspace("flag-workspace"); got != want {
+		t.Fatalf("end workspace = %q, want %q", got, want)
+	}
+	if got := sessionStub.endCall.sessionID; got != sessionID {
+		t.Fatalf("end sessionID = %q, want %q", got, sessionID)
+	}
+}
+
+func TestRootCLI_SessionEndCommand_AutoExtractUsesInheritedEventWorkspace(t *testing.T) {
+	t.Setenv("TRACEARY_SESSION_ID", "session-extract")
+	t.Setenv("TRACEARY_CLIENT", "")
+	t.Setenv("TRACEARY_AGENT", "")
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) {
+		return "detected-workspace-should-not-be-used-for-session-end", nil
+	})
+	defer cli.ResetDetectRepoContextFunc()
+
+	sessionID := mustSessionID(t, "session-extract")
+	memoryStub := &memoryUsecaseStub{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{
+			endEvent: model.EventOf(
+				mustEventID(t, "event-end-extract"),
+				types.EventKindSessionEnded,
+				types.Client("claude"),
+				mustAgent(t, "qa-reviewer"),
+				sessionID,
+				types.Workspace("traceary"),
+				"session ended",
+				time.Date(2026, 4, 7, 13, 30, 0, 0, time.UTC),
+			),
+		}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "end",
+		"--db-path", filepath.Join(t.TempDir(), "traceary.db"),
+		"--session-id", "session-extract",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := memoryStub.extractCriteria.SessionID(), sessionID; got != want {
+		t.Fatalf("extract sessionID = %q, want %q", got, want)
+	}
+	if got, want := memoryStub.extractCriteria.Workspace(), types.Workspace("traceary"); got != want {
+		t.Fatalf("extract workspace = %q, want inherited event workspace %q", got, want)
+	}
+}
+
 func TestRootCLI_SessionEndCommand_IdOnly(t *testing.T) {
 	t.Setenv("TRACEARY_SESSION_ID", "session-env")
 


### PR DESCRIPTION
## Motivation

Release QA dogfooding found that `traceary session end` filled omitted client / agent / workspace with CLI defaults before calling the session use case. That prevented the application layer from inheriting attribution from the matching session start, so an explicitly attributed session could end as `client=cli`, `agent=manual`, and the detected workspace.

## Changes

- Keep omitted `session end` client / agent / workspace empty so the use case can inherit from the existing session.
- Preserve explicit flag / env overrides.
- Make CLI session-end auto-extract fall back to the recorded end event workspace after inheritance.
- Add CLI regression tests for omitted attribution, overrides, and auto-extract workspace selection.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go test ./presentation/cli -run 'TestRootCLI_SessionEndCommand' -count=1`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci`
- `git diff --check`
- Local v0.19.0 binary dogfood: start/end an explicitly attributed session and verify `list`, `list --failures`, `top --snapshot --json`, bare TUI, and `tui --reset-state` preserve `agent=qa-reviewer` / `workspace=traceary`.

Closes #1077