### PR TITLE
v0.19-15: normalize cockpit Settings navigation

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -2607,9 +2607,7 @@ func (m cockpitModel) cockpitGlobalFooter(localHelp string) string {
 	parts := []string{}
 	if m.cockpitSectionNavigationAvailable() {
 		parts = append(parts, Localize("1-5 tabs", "1-5 タブ"))
-		if m.mode != cockpitModeSettings {
-			parts = append(parts, Localize("←/→ tabs", "←/→ タブ"))
-		}
+		parts = append(parts, Localize("←/→ tabs", "←/→ タブ"))
 		parts = append(parts, Localize("tab/shift+tab next/prev", "tab/shift+tab 次/前"))
 	}
 	if m.width > 0 && m.height > 0 {
@@ -2722,11 +2720,7 @@ func (m cockpitModel) cockpitContextualNavigationLines() []string {
 	for _, item := range items {
 		lines = append(lines, cockpitNavigationLine(item, labelWidth))
 	}
-	if m.mode == cockpitModeSettings {
-		lines = append(lines, Localize("tab / shift+tab cycle tabs; 1-5 jump tabs; ← / → edit selected value rows", "tab / shift+tab でタブ移動。1-5 でタブ選択。← / → は選択中の設定値を編集"))
-	} else {
-		lines = append(lines, Localize("← / → cycle tabs; tab / shift+tab remain supported", "← / → でタブ移動。tab / shift+tab も利用可能"))
-	}
+	lines = append(lines, Localize("← / → cycle tabs; tab / shift+tab remain supported", "← / → でタブ移動。tab / shift+tab も利用可能"))
 	lines = append(lines, Localize("esc backs out to Tail; q exits the TUI", "esc で Tail に戻り、q で TUI を終了"))
 	return lines
 }

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1853,9 +1853,6 @@ func TestCockpitModel_GlobalNavigationShellRendersOnEveryScreen(t *testing.T) {
 					t.Fatalf("%s view missing %q:\n%s", tc.name, must, view)
 				}
 			}
-			if tc.name == "settings" && strings.Contains(view, "←/→ tabs") {
-				t.Fatalf("settings footer should reserve ←/→ for value rows, not tabs:\n%s", view)
-			}
 		})
 	}
 }
@@ -2022,16 +2019,16 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 		model.settings.draft = model.settings.snapshot.Values.clone()
 		view := model.View()
 		for _, must := range []string{
-			"Change ui.language, read.color, or read.fields when those rows are selected",
+			"Run the selected settings action or stage the selected value change",
 			"tab / shift+tab",
-			"← / → edit selected value rows",
+			"← / → cycle tabs",
 		} {
 			if !strings.Contains(view, must) {
 				t.Fatalf("settings help missing %q:\n%s", must, view)
 			}
 		}
-		if strings.Contains(view, "← / → cycle tabs") {
-			t.Fatalf("settings help should not advertise ←/→ as tab navigation:\n%s", view)
+		if strings.Contains(view, "← / → edit selected value rows") {
+			t.Fatalf("settings help should not advertise ←/→ as value editing:\n%s", view)
 		}
 	})
 
@@ -2062,7 +2059,7 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 
 		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 		model = updated.(cockpitModel)
-		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+		updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		model = updated.(cockpitModel)
 		updated, _ = model.Update(cockpitRuneKey("w"))
 		model = updated.(cockpitModel)
@@ -2609,11 +2606,11 @@ func TestCockpitSettingsArrowKeyWorkflowStagesAndConfirmsSave(t *testing.T) {
 
 	// Row 0: ui.language, Row 1: read.color, Row 2: read.fields.
 	for _, keyMsg := range []tea.KeyMsg{
-		{Type: tea.KeyRight},
+		{Type: tea.KeyEnter},
 		{Type: tea.KeyDown},
-		{Type: tea.KeyRight},
+		{Type: tea.KeyEnter},
 		{Type: tea.KeyDown},
-		{Type: tea.KeyRight},
+		{Type: tea.KeyEnter},
 		{Type: tea.KeyDown},
 		{Type: tea.KeyEnter},
 	} {
@@ -2673,7 +2670,7 @@ func TestCockpitSettingsArrowKeyWorkflowStagesAndConfirmsSave(t *testing.T) {
 	}
 }
 
-func TestCockpitSettingsLeftArrowCyclesEditableRowsBackward(t *testing.T) {
+func TestCockpitSettingsLeftRightMoveTabsWithoutStagingValues(t *testing.T) {
 	resetConfiguredCLILanguageCacheForTest()
 	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
 
@@ -2684,47 +2681,45 @@ func TestCockpitSettingsLeftArrowCyclesEditableRowsBackward(t *testing.T) {
 	updated, _ := model.Update(cockpitRuneKey("5"))
 	model = updated.(cockpitModel)
 
-	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	model = updated.(cockpitModel)
-	if got, want := model.settings.draft.UILanguage, "ja"; got != want {
-		t.Fatalf("left on ui.language = %q, want %q", got, want)
+	for _, row := range []int{cockpitSettingsRowLanguage, cockpitSettingsRowReadColor, cockpitSettingsRowReadFields} {
+		model.settings.cursor = row
+		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRight})
+		next := updated.(cockpitModel)
+		if next.mode != cockpitModeLive || cmd == nil {
+			t.Fatalf("right from settings row %d mode/cmd = %v/%T, want tail/load", row, next.mode, cmd)
+		}
+		if next.settings.dirty() {
+			t.Fatalf("right from settings row %d staged values unexpectedly:\n%s", row, next.View())
+		}
 	}
-	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
-	model = updated.(cockpitModel)
+
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
 	model = updated.(cockpitModel)
-	if got, want := model.settings.draft.ReadColor, "never"; got != want {
-		t.Fatalf("left on read.color = %q, want %q", got, want)
+	if model.mode != cockpitModeSessions {
+		t.Fatalf("left from settings mode = %v, want sessions", model.mode)
 	}
-	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
-	model = updated.(cockpitModel)
-	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	model = updated.(cockpitModel)
-	wantFields := []string{"ts", "kind", "message"}
-	if !slices.Equal(model.settings.draft.ReadFields, wantFields) {
-		t.Fatalf("left on read.fields = %#v, want %#v", model.settings.draft.ReadFields, wantFields)
+	if model.settings.dirty() {
+		t.Fatalf("left from settings staged values unexpectedly:\n%s", model.View())
 	}
 }
 
-func TestCockpitSettingsArrowsStayInsideSettingsRows(t *testing.T) {
+func TestCockpitSettingsEnterStagesEditableRows(t *testing.T) {
 	resetConfiguredCLILanguageCacheForTest()
 	t.Cleanup(resetConfiguredCLILanguageCacheForTest)
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	for row := range cockpitSettingsRowCount {
-		for _, keyMsg := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}} {
-			model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
-			updated, _ := model.Update(cockpitRuneKey("5"))
-			model = updated.(cockpitModel)
-			model.settings.cursor = row
+	for _, row := range []int{cockpitSettingsRowLanguage, cockpitSettingsRowReadColor, cockpitSettingsRowReadFields} {
+		model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+		updated, _ := model.Update(cockpitRuneKey("5"))
+		model = updated.(cockpitModel)
+		model.settings.cursor = row
 
-			updated, cmd := model.Update(keyMsg)
-			model = updated.(cockpitModel)
-			if model.mode != cockpitModeSettings || cmd != nil {
-				t.Fatalf("row %d key %v mode/cmd = %v/%T, want settings/nil", row, keyMsg.Type, model.mode, cmd)
-			}
+		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		model = updated.(cockpitModel)
+		if model.mode != cockpitModeSettings || cmd != nil || !model.settings.dirty() {
+			t.Fatalf("row %d enter mode/cmd/dirty = %v/%T/%v, want settings/nil/dirty", row, model.mode, cmd, model.settings.dirty())
 		}
 	}
 }
@@ -2743,28 +2738,31 @@ func TestCockpitSettingsDefaultCyclesAreSemanticallyReversible(t *testing.T) {
 	for _, step := range []struct {
 		name        string
 		row         int
+		cycles      int
 		defaultText string
 	}{
-		{name: "ui.language", row: cockpitSettingsRowLanguage, defaultText: "ui.language: en (default)"},
-		{name: "read.color", row: cockpitSettingsRowReadColor, defaultText: "read.color: auto (default)"},
-		{name: "read.fields", row: cockpitSettingsRowReadFields, defaultText: "read.fields: ts,kind,agent,session,ws,message (default)"},
+		{name: "ui.language", row: cockpitSettingsRowLanguage, cycles: 2, defaultText: "ui.language: en (default)"},
+		{name: "read.color", row: cockpitSettingsRowReadColor, cycles: 3, defaultText: "read.color: auto (default)"},
+		{name: "read.fields", row: cockpitSettingsRowReadFields, cycles: 4, defaultText: "read.fields: ts,kind,agent,session,ws,message (default)"},
 	} {
 		t.Run(step.name, func(t *testing.T) {
 			cycleModel := model
 			cycleModel.settings.cursor = step.row
-			updated, _ := cycleModel.Update(tea.KeyMsg{Type: tea.KeyRight})
+			updated, _ := cycleModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
 			cycleModel = updated.(cockpitModel)
 			if !cycleModel.settings.dirty() {
-				t.Fatalf("%s right arrow should stage a non-default value", step.name)
+				t.Fatalf("%s enter should stage a non-default value", step.name)
 			}
-			updated, _ = cycleModel.Update(tea.KeyMsg{Type: tea.KeyLeft})
-			cycleModel = updated.(cockpitModel)
+			for range step.cycles - 1 {
+				updated, _ = cycleModel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+				cycleModel = updated.(cockpitModel)
+			}
 			if cycleModel.settings.dirty() {
-				t.Fatalf("%s right then left should return to the semantic default:\n%s", step.name, cycleModel.View())
+				t.Fatalf("%s repeated enter should return to the semantic default:\n%s", step.name, cycleModel.View())
 			}
 			view := cycleModel.View()
 			if !strings.Contains(view, step.defaultText) || strings.Contains(view, "Staged") {
-				t.Fatalf("%s revert should restore default display and clear staged info:\n%s", step.name, view)
+				t.Fatalf("%s repeated enter should restore default display and clear staged info:\n%s", step.name, view)
 			}
 		})
 	}

--- a/presentation/cli/cockpit_settings.go
+++ b/presentation/cli/cockpit_settings.go
@@ -313,6 +313,9 @@ func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if section, ok := cockpitSectionFromKey(msg); ok {
 		return m.openCockpitSection(section)
 	}
+	if section, ok := m.cockpitAdjacentSectionFromKey(msg); ok {
+		return m.openCockpitSection(section)
+	}
 	switch {
 	case key.Matches(msg, m.keys.Up):
 		m.settings.cursor--
@@ -322,17 +325,10 @@ func (m cockpitModel) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.settings.cursor++
 		m.clampSettingsCursor()
 		return m, nil
-	case msg.Type == tea.KeyLeft:
-		return m.adjustSelectedSettingsRow(-1)
-	case msg.Type == tea.KeyRight:
-		return m.adjustSelectedSettingsRow(1)
 	case key.Matches(msg, m.keys.Select):
 		return m.activateSelectedSettingsRow()
 	case key.Matches(msg, m.keys.Refresh):
 		return m.reloadSettings()
-	}
-	if section, ok := m.cockpitAdjacentSectionFromKey(msg); ok {
-		return m.openCockpitSection(section)
 	}
 	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
 		return m, nil
@@ -420,19 +416,6 @@ func (m cockpitModel) updateSettingsConfirmKey(msg tea.KeyMsg) (tea.Model, tea.C
 		return m, nil
 	}
 	return m, nil
-}
-
-func (m cockpitModel) adjustSelectedSettingsRow(delta int) (tea.Model, tea.Cmd) {
-	switch m.settings.cursor {
-	case cockpitSettingsRowLanguage:
-		return m.stageSettingsLanguageCycle(delta)
-	case cockpitSettingsRowReadColor:
-		return m.stageSettingsColorCycleBy(delta)
-	case cockpitSettingsRowReadFields:
-		return m.stageSettingsFieldsCycleBy(delta)
-	default:
-		return m, nil
-	}
 }
 
 func (m cockpitModel) activateSelectedSettingsRow() (tea.Model, tea.Cmd) {
@@ -805,7 +788,7 @@ func (m cockpitModel) settingsLocalHelp() string {
 	if m.settings.confirmSave {
 		return Localize("y save · n/esc cancel", "y 保存 · n/esc キャンセル")
 	}
-	return Localize("↑/↓ select · ←/→ change value rows · enter action · tab/shift+tab tabs · w save · d discard · r reload", "↑/↓ 選択 · ←/→ 値 row を変更 · enter 実行 · tab/shift+tab タブ · w 保存 · d 破棄 · r 再読込")
+	return Localize("↑/↓ select · enter action/change · ←/→ or tab tabs · w save · d discard · r reload", "↑/↓ 選択 · enter 実行/変更 · ←/→ または tab でタブ · w 保存 · d 破棄 · r 再読込")
 }
 
 func (m cockpitModel) settingsContextualActions() []cockpitAction {
@@ -823,9 +806,9 @@ func (m cockpitModel) settingsContextualActions() []cockpitAction {
 	}
 	return []cockpitAction{
 		{key: "↑/↓", description: Localize("Select a settings row", "settings row を選択")},
-		{key: "←/→", description: Localize("Change ui.language, read.color, or read.fields when those rows are selected", "ui.language / read.color / read.fields の row 選択時に値を変更")},
+		{key: "enter", description: Localize("Run the selected settings action or stage the selected value change", "選択中の settings action を実行、または選択中の値変更を staged")},
+		{key: "←/→", description: Localize("Move between cockpit tabs without changing settings values", "settings 値を変更せず cockpit タブ間を移動")},
 		{key: "tab / shift+tab", description: Localize("Move between cockpit tabs while editing settings", "settings 編集中に cockpit タブ間を移動")},
-		{key: "enter", description: Localize("Run the selected settings action", "選択中の settings action を実行")},
 		{key: "w", description: Localize("Review diff and confirm before writing config", "diff を確認してから config 書き込み")},
 		{key: "d", description: Localize("Discard pending settings changes", "未保存の settings 変更を破棄")},
 		{key: "r", description: Localize("Reload settings from config file", "config file から settings を再読込")},


### PR DESCRIPTION
## Motivation

Settings currently consumes left/right before global tab navigation, so entering Settings and pressing `→` can silently stage the first setting instead of moving tabs. This PR makes Settings follow the same cockpit-wide movement model operators expect from Claude/Codex-like TUI flows.

Closes #1081

## Changes

- Route `←/→` through cockpit tab navigation in Settings when no modal input/confirmation is active.
- Keep Settings value staging explicit through `Enter` or existing mnemonic shortcuts (`l`, `c`, `f`, etc.).
- Update Settings footer/contextual help to describe `Enter` as the value/action key and left/right as tab navigation.
- Update regression coverage for accidental left/right staging and Enter-based Settings edits.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go test ./presentation/cli -run 'Cockpit|Settings|Navigation'`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-gocache go build ./...` (exited 0; Go emitted a non-fatal stat-cache write warning under `~/go/pkg/mod/cache/...` due sandbox permissions)

## Notes

- Claude design check was attempted with `claude --print`, but the headless command produced no output and appeared to hang; local tests and lint were used as the implementation gate for this PR.
