### PR TITLE
v0.19-16: make cockpit Tail a full-screen stream

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -22,6 +22,10 @@ import (
 
 const cockpitExitCodeNotInteractive = 2
 const cockpitLiveMaxEvents = 200
+const cockpitLiveDefaultViewportRows = 12
+const cockpitLiveMinViewportRows = 1
+const cockpitLiveBasePreludeRows = 2
+const cockpitShellChromeRows = 5
 const cockpitDoctorMessageWidth = 160
 const cockpitNewEventLimit = 200
 const cockpitTopUnknownWidth = 120
@@ -1183,19 +1187,18 @@ func (m cockpitModel) updateDoctorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Up):
-		m.live.selected--
-		m.clampLiveSelection()
-		if !m.live.isAtNewest() {
-			m.live.follow = false
-		}
+		m.scrollCockpitLiveStreamBy(-1)
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
-		wasFollowing := m.live.follow
-		m.live.selected++
-		m.clampLiveSelection()
-		if !m.live.isAtNewest() {
-			m.live.follow = false
-		} else if !wasFollowing {
+		if m.scrollCockpitLiveStreamBy(1) {
+			return m, m.resumeCockpitLiveFollowCmd()
+		}
+		return m, nil
+	case key.Matches(msg, m.keys.PageUp):
+		m.scrollCockpitLiveStreamBy(-m.cockpitLiveKeyViewportRows())
+		return m, nil
+	case key.Matches(msg, m.keys.PageDown):
+		if m.scrollCockpitLiveStreamBy(m.cockpitLiveKeyViewportRows()) {
 			return m, m.resumeCockpitLiveFollowCmd()
 		}
 		return m, nil
@@ -1210,8 +1213,6 @@ func (m cockpitModel) updateLiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.resumeCockpitLiveFollowCmd()
 	case key.Matches(msg, m.keys.Refresh):
 		return m, m.startCockpitLiveLoad(true)
-	case key.Matches(msg, m.keys.Select):
-		return m.openCockpitLiveDetail()
 	}
 	return m, nil
 }
@@ -1582,21 +1583,6 @@ func (m cockpitModel) cockpitLiveTickCmd() tea.Cmd {
 	})
 }
 
-func (m cockpitModel) openCockpitLiveDetail() (tea.Model, tea.Cmd) {
-	if len(m.live.events) == 0 || m.live.selected < 0 || m.live.selected >= len(m.live.events) {
-		return m, nil
-	}
-	event := m.live.events[m.live.selected]
-	if event == nil {
-		return m, nil
-	}
-	req := topDetailRequest{target: topDetailTarget{kind: topDetailEvent, title: fmt.Sprintf("EVENT %s", event.EventID()), eventID: event.EventID()}}
-	m.mode = cockpitModeDetail
-	m.detailOffset = 0
-	m.detail = topDetailState{request: req, title: req.target.title, lines: []string{Localize("Loading...", "読み込み中...")}, loading: true}
-	return m, m.fetchCockpitDetailCmd(req)
-}
-
 func (m cockpitModel) openCockpitTopDetail() (tea.Model, tea.Cmd) {
 	rows := m.cockpitTopRows()
 	if len(rows) == 0 {
@@ -1621,18 +1607,6 @@ func (m cockpitModel) openCockpitTopDetail() (tea.Model, tea.Cmd) {
 		loading: true,
 	}
 	return m, m.fetchCockpitTopDetailCmd(req, m.top.detailSeq)
-}
-
-func (m cockpitModel) fetchCockpitDetailCmd(req topDetailRequest) tea.Cmd {
-	loader := m.loader
-	ctx := m.loaderCtx
-	return func() tea.Msg {
-		if loader == nil {
-			return cockpitDetailLoadedMsg{request: req, err: xerrors.New(Localize("cockpit detail loader is not configured", "cockpit detail 用 loader が設定されていません"))}
-		}
-		content, err := loader.loadCockpitEventDetail(ctx, req.target.eventID)
-		return cockpitDetailLoadedMsg{request: req, content: content, err: err}
-	}
 }
 
 func (m cockpitModel) fetchCockpitTopDetailCmd(req topDetailRequest, seq uint64) tea.Cmd {
@@ -1865,6 +1839,32 @@ func (m *cockpitModel) trimCockpitLiveEventsToLimit() {
 		}
 		overflow--
 	}
+}
+
+func (m *cockpitModel) scrollCockpitLiveStreamBy(delta int) (resumeFollow bool) {
+	if len(m.live.events) == 0 || delta == 0 {
+		return false
+	}
+	viewport := m.cockpitLiveKeyViewportRows()
+	start, _ := m.cockpitLiveVisibleRange(viewport)
+	maxStart := max(len(m.live.events)-viewport, 0)
+	next := start + delta
+	if next <= 0 {
+		m.live.selected = 0
+		m.live.follow = false
+		return false
+	}
+	if next >= maxStart {
+		m.live.selected = maxStart
+		if delta > 0 {
+			return !m.live.follow
+		}
+		m.live.follow = false
+		return false
+	}
+	m.live.selected = next
+	m.live.follow = false
+	return false
 }
 
 func (m *cockpitModel) moveCockpitLiveSelectionToNewest() {
@@ -2103,19 +2103,66 @@ func (m cockpitModel) liveView() string {
 			lines = append(lines, m.styles.Subtle.Render(Localize("No recent events. Press r to refresh.", "最近のイベントはありません。r で再取得します。")))
 		}
 	} else {
-		for i, event := range m.live.events {
-			prefix := "  "
-			if i == m.live.selected {
-				prefix = "> "
-			}
-			line := prefix + formatCockpitLiveEventRow(event, time.Local)
-			if i == m.live.selected {
-				line = m.styles.Active.Render(line)
-			}
-			lines = append(lines, line)
+		viewport := m.cockpitLiveViewportRows(len(lines))
+		if viewport > cockpitLiveMinViewportRows && m.cockpitLiveScrollLine(viewport) != "" {
+			viewport = m.cockpitLiveViewportRows(len(lines) + 1)
+			lines = append(lines, m.cockpitLiveScrollLine(viewport))
+		}
+		start, end := m.cockpitLiveVisibleRange(viewport)
+		for _, event := range m.live.events[start:end] {
+			lines = append(lines, formatCockpitLiveEventRow(event, time.Local))
 		}
 	}
 	return m.renderCockpitShell(Localize("live tail", "live tail"), lines, m.liveLocalHelp())
+}
+
+func (m cockpitModel) cockpitLiveViewportRows(preludeRows int) int {
+	if m.height <= 0 {
+		return cockpitLiveDefaultViewportRows
+	}
+	rows := m.height - cockpitShellChromeRows - preludeRows
+	if rows < cockpitLiveMinViewportRows {
+		return cockpitLiveMinViewportRows
+	}
+	return rows
+}
+
+func (m cockpitModel) cockpitLiveKeyViewportRows() int {
+	return m.cockpitLiveViewportRows(cockpitLiveBasePreludeRows)
+}
+
+func (m cockpitModel) cockpitLiveVisibleRange(viewport int) (int, int) {
+	if viewport < 1 {
+		viewport = 1
+	}
+	total := len(m.live.events)
+	if total == 0 {
+		return 0, 0
+	}
+	if viewport >= total {
+		return 0, total
+	}
+	if m.live.follow {
+		return total - viewport, total
+	}
+	start := m.live.selected
+	if start < 0 {
+		start = 0
+	}
+	maxStart := total - viewport
+	if start > maxStart {
+		start = maxStart
+	}
+	return start, start + viewport
+}
+
+func (m cockpitModel) cockpitLiveScrollLine(viewport int) string {
+	total := len(m.live.events)
+	if total == 0 || viewport >= total {
+		return ""
+	}
+	start, end := m.cockpitLiveVisibleRange(viewport)
+	return m.styles.Subtle.Render(fmt.Sprintf("rows=%d-%d/%d", start+1, end, total))
 }
 
 func (m cockpitModel) livePauseMessage() string {
@@ -2761,12 +2808,10 @@ func (m cockpitModel) cockpitContextualActions() []cockpitAction {
 			{key: "r", description: Localize("Refresh Tail events", "Tail のイベントを再取得")},
 			{key: "End/G", description: Localize("Jump to newest and resume auto-follow", "最新へ移動して auto-follow を再開")},
 		}
-		if len(m.live.events) > 0 {
-			actions = append(actions, cockpitAction{key: "enter", description: Localize("Open selected event detail", "選択中イベントの詳細を開く")})
-			if len(m.live.events) > 1 {
-				actions = append(actions, cockpitAction{key: "↑/↓", description: Localize("Select an event", "イベントを選択")})
-			}
+		if len(m.live.events) > 1 {
+			actions = append(actions, cockpitAction{key: "↑/↓", description: Localize("Scroll Tail stream", "Tail stream をスクロール")})
 		}
+		actions = append(actions, cockpitAction{description: Localize("Tail is read-only; inspect full event payloads from Sessions detail or `traceary show <event_id>`.", "Tail は読み取り専用です。完全なイベント内容は Sessions detail または `traceary show <event_id>` で確認します。")})
 		return actions
 	case cockpitModeTop:
 		if m.cockpitTopDetailOpen() {
@@ -2893,11 +2938,8 @@ func (m cockpitModel) memoryReviewContextualActions() []cockpitAction {
 
 func (m cockpitModel) liveLocalHelp() string {
 	parts := []string{Localize("r refresh", "r 再取得"), Localize("End/G newest", "End/G 最新")}
-	if len(m.live.events) > 0 {
-		parts = append(parts, Localize("enter detail", "enter 詳細"))
-		if len(m.live.events) > 1 {
-			parts = append(parts, Localize("↑/↓ select", "↑/↓ 選択"))
-		}
+	if len(m.live.events) > 1 {
+		parts = append(parts, Localize("↑/↓ scroll", "↑/↓ スクロール"))
 	}
 	return strings.Join(parts, " · ")
 }

--- a/presentation/cli/cockpit_dogfood_internal_test.go
+++ b/presentation/cli/cockpit_dogfood_internal_test.go
@@ -134,12 +134,11 @@ func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
 func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 	t.Parallel()
 
-	t.Run("find latest failure from home", func(t *testing.T) {
+	t.Run("tail stream does not drill into latest failure", func(t *testing.T) {
 		t.Parallel()
 		failure := mustEvent(t, "evt-dogfood-failure", domtypes.EventKindCommandExecuted, "go test ./... failed")
 		loader := &cockpitLoaderStub{
 			liveResponses: []cockpitLiveSnapshot{{Events: []*model.Event{failure}, Cursor: newTailCursor(failure.CreatedAt()), LoadedAt: fixedStartedAt}},
-			detailContent: topDetailContent{title: "EVENT evt-dogfood-failure", lines: []string{"exit_code=1", "go test ./... failed"}},
 		}
 		model := newCockpitModel(tui.DefaultKeyMap(), tui.Styles{}, cockpitHomeSnapshot{LoadedAt: fixedStartedAt, RecentFailureCount: 1})
 		model.loader = loader
@@ -152,15 +151,13 @@ func TestCockpitDogfoodKeyboardPaths(t *testing.T) {
 		model = applyCockpitImmediateCommandForTest(t, model, cmd)
 		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		model = updated.(cockpitModel)
-		if model.mode != cockpitModeDetail || cmd == nil {
-			t.Fatalf("enter mode/cmd = %v/%T, want detail/load", model.mode, cmd)
+		if model.mode != cockpitModeLive || cmd != nil {
+			t.Fatalf("enter mode/cmd = %v/%T, want live/nil", model.mode, cmd)
 		}
-		updated, _ = model.Update(cmd())
-		model = updated.(cockpitModel)
 		view := model.View()
-		for _, must := range []string{"EVENT evt-dogfood-failure", "exit_code=1", "go test ./... failed"} {
+		for _, must := range []string{"Traceary cockpit · live tail", "go test ./... failed"} {
 			if !strings.Contains(view, must) {
-				t.Fatalf("failure detail missing %q:\n%s", must, view)
+				t.Fatalf("tail stream missing %q:\n%s", must, view)
 			}
 		}
 	})

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -764,7 +764,7 @@ func TestCockpitModel_IgnoresStaleDoctorResponses(t *testing.T) {
 	}
 }
 
-func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
+func TestCockpitModel_LivePaneRefreshPauseResumeAndIgnoresEnter(t *testing.T) {
 	t.Parallel()
 
 	olderEvent := mustEvent(t, "evt-older", domtypes.EventKindNote, "older live event")
@@ -775,10 +775,6 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 			{Events: []*model.Event{olderEvent, initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt},
 			{Events: []*model.Event{olderEvent, initialEvent}, Cursor: newTailCursor(initialEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(time.Minute)},
 			{Events: []*model.Event{followEvent}, Cursor: newTailCursor(followEvent.CreatedAt()), LoadedAt: fixedStartedAt.Add(2 * time.Minute)},
-		},
-		detailContent: topDetailContent{
-			title: "EVENT evt-follow",
-			lines: []string{"shared detail renderer line", "full event payload"},
 		},
 	}
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
@@ -889,28 +885,11 @@ func TestCockpitModel_LivePaneRefreshPauseResumeAndDetail(t *testing.T) {
 
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(cockpitModel)
-	if model.mode != cockpitModeDetail || !model.detail.loading {
-		t.Fatalf("opening detail mode/loading = %v/%v, want detail/loading", model.mode, model.detail.loading)
+	if model.mode != cockpitModeLive || cmd != nil {
+		t.Fatalf("enter on live stream mode/cmd = %v/%T, want live/nil", model.mode, cmd)
 	}
-	if cmd == nil {
-		t.Fatalf("opening detail returned nil command")
-	}
-	updated, cmd = model.Update(cmd())
-	model = updated.(cockpitModel)
-	if cmd != nil {
-		t.Fatalf("detail load returned unexpected follow-up command = %T", cmd)
-	}
-	if got, want := loader.detailCalls, []domtypes.EventID{followEvent.EventID()}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("detail calls = %v, want %v", got, want)
-	}
-	if got := model.View(); !strings.Contains(got, "shared detail renderer line") {
-		t.Fatalf("detail view missing shared renderer output:\n%s", got)
-	}
-
-	updated, cmd = model.Update(cockpitRuneKey("t"))
-	model = updated.(cockpitModel)
-	if model.mode != cockpitModeLive || cmd == nil {
-		t.Fatalf("returning to live mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+	if len(loader.detailCalls) != 0 {
+		t.Fatalf("enter on live stream opened detail unexpectedly: %#v", loader.detailCalls)
 	}
 }
 
@@ -941,6 +920,37 @@ func TestCockpitModel_LiveDownToNewestResumesAutoFollow(t *testing.T) {
 	runFirstCockpitBatchCommandForTest(t, cmd)
 	if got, want := len(loader.eventSeenCalls), 1; got != want {
 		t.Fatalf("event seen calls after down resume = %d, want %d", got, want)
+	}
+}
+
+func TestCockpitModel_LiveViewUsesTerminalViewportWithoutSelectionAffordance(t *testing.T) {
+	t.Parallel()
+
+	events := []*model.Event{
+		mustEvent(t, "evt-live-window-0", domtypes.EventKindNote, "tail row 0"),
+		mustEvent(t, "evt-live-window-1", domtypes.EventKindNote, "tail row 1"),
+		mustEvent(t, "evt-live-window-2", domtypes.EventKindNote, "tail row 2"),
+		mustEvent(t, "evt-live-window-3", domtypes.EventKindNote, "tail row 3"),
+		mustEvent(t, "evt-live-window-4", domtypes.EventKindNote, "tail row 4"),
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.width = 80
+	model.height = 10
+	model.live.events = events
+	model.live.loadedAt = fixedStartedAt
+	model.live.follow = true
+	model.moveCockpitLiveSelectionToNewest()
+
+	view := model.View()
+	for _, must := range []string{"rows=4-5/5", "tail row 3", "tail row 4"} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("live viewport missing %q:\n%s", must, view)
+		}
+	}
+	for _, mustNot := range []string{"tail row 0", "tail row 1", "tail row 2", "\n> "} {
+		if strings.Contains(view, mustNot) {
+			t.Fatalf("live viewport rendered unavailable/selected cue %q:\n%s", mustNot, view)
+		}
 	}
 }
 
@@ -1910,17 +1920,23 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 
 	t.Run("live with selection", func(t *testing.T) {
 		event := mustEvent(t, "evt-help-live", domtypes.EventKindNote, "help live event")
+		second := mustEvent(t, "evt-help-live-2", domtypes.EventKindNote, "second help live event")
 		cockpit := base
 		cockpit.mode = cockpitModeLive
 		cockpit.live.loadedAt = fixedStartedAt
-		cockpit.live.events = []*model.Event{event}
+		cockpit.live.events = []*model.Event{event, second}
 		view := cockpit.View()
 		for _, must := range []string{
-			"enter detail",
-			"Open selected event detail",
+			"↑/↓ scroll",
+			"Scroll Tail stream",
 		} {
 			if !strings.Contains(view, must) {
 				t.Fatalf("live selection help missing %q:\n%s", must, view)
+			}
+		}
+		for _, mustNot := range []string{"enter detail", "Open selected event detail"} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("live stream help advertised unavailable drill-down %q:\n%s", mustNot, view)
 			}
 		}
 	})
@@ -1933,12 +1949,9 @@ func TestCockpitModel_ContextualHelpActionMenuByScreen(t *testing.T) {
 		cockpit.live.events = []*model.Event{event}
 		cockpit.live.err = context.Canceled
 		view := cockpit.View()
-		for _, must := range []string{
-			"enter detail",
-			"Open selected event detail",
-		} {
-			if !strings.Contains(view, must) {
-				t.Fatalf("live cached-error help missing %q:\n%s", must, view)
+		for _, mustNot := range []string{"enter detail", "Open selected event detail"} {
+			if strings.Contains(view, mustNot) {
+				t.Fatalf("live cached-error help advertised unavailable drill-down %q:\n%s", mustNot, view)
 			}
 		}
 	})
@@ -3230,16 +3243,8 @@ func TestCockpitModel_EscBacksOutWithoutQuitting(t *testing.T) {
 	model.live.selected = 0
 	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(cockpitModel)
-	if model.mode != cockpitModeDetail || cmd == nil {
-		t.Fatalf("enter detail mode/cmd = %v/%T, want detail/load command", model.mode, cmd)
-	}
-	updated, _ = model.Update(cmd())
-	model = updated.(cockpitModel)
-
-	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	model = updated.(cockpitModel)
-	if model.mode != cockpitModeLive || cmd == nil {
-		t.Fatalf("esc from detail mode/cmd = %v/%T, want live/tick command", model.mode, cmd)
+	if model.mode != cockpitModeLive || cmd != nil {
+		t.Fatalf("enter from tail mode/cmd = %v/%T, want live/nil", model.mode, cmd)
 	}
 
 	_, cmd = model.Update(cockpitRuneKey("q"))


### PR DESCRIPTION
## Motivation

Tail should behave like a live stream, not a selectable event list. Operators should be able to keep it open full-screen, scroll the stream when needed, and avoid accidental drill-down from `Enter`.

Closes #1082

## Changes

- Render Tail through a terminal-height viewport with a `rows=start-end/total` scroll marker.
- Treat `↑/↓`, page keys, Home, and End/G as stream scrolling/follow controls.
- Make `Enter` on Tail a no-op and remove Tail detail affordances from help/action copy.
- Remove the now-unused Tail event-detail command path from the cockpit model.
- Update dogfood/internal tests for no-drill-down Tail behavior and dynamic viewport rendering.

## Validation

- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go test ./presentation/cli -run 'CockpitModel_Live|CockpitDogfoodKeyboardPaths|ContextualHelpActionMenu|EscBacksOut|FormatCockpitLive'`
- `git diff --check`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-gocache go build ./...` (exit 0; non-fatal Go stat-cache warning under `~/go/pkg/mod/cache/...` due sandbox permissions)
