### PR TITLE
v0.19-22: keep Sessions tab focused on sessions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Traceary ships complementary inspection views so you can switch between "what's 
 
 | When | Command | Use it to |
 |---|---|---|
-| Starting from one operator cockpit | `traceary` (`traceary tui` explicitly) | notice new events / memory candidates and jump into live tail, doctor details, or memory review |
+| Starting from one operator cockpit | `traceary` (`traceary tui` explicitly) | follow live tail, session health, and jump into doctor details or memory review |
 | Watching the workspace dashboard | `traceary top` | browse active sessions, recent failures / commands, memory candidates, and stale memories in one TUI |
 | Following what is happening now | `traceary tail` | confirm hooks are firing, watch failures in real time |
 | Understanding what happened across a span | `traceary timeline` | see gap-separated work blocks with a per-workspace activity summary |
@@ -172,7 +172,7 @@ Traceary ships complementary inspection views so you can switch between "what's 
 traceary tui
 ```
 
-`traceary` opens the Tail-first operator cockpit in an interactive terminal. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit: a TTY-only surface for new events, memory candidates, doctor warnings, and recent failures, with jumps into live tail, doctor details, and memory review. In non-interactive shells, bare `traceary` prints deterministic help/fallback guidance so scripts should continue calling explicit commands such as `traceary list`, `traceary top --snapshot [--json]`, and `traceary doctor --json`.
+`traceary` opens the Tail-first operator cockpit in an interactive terminal. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit: a TTY-only surface for live tail, session health, doctor warnings, and recent failures, with a dedicated Memory tab for candidate review. The cockpit Sessions tab intentionally stays session-centric (sessions, failures, commands, and health); memory candidate and stale-memory review belong in the Memory tab. In non-interactive shells, bare `traceary` prints deterministic help/fallback guidance so scripts should continue calling explicit commands such as `traceary list`, `traceary sessions --snapshot [--json]`, `traceary top --snapshot [--json]`, and `traceary doctor --json`.
 
 ### `traceary top`
 
@@ -180,7 +180,7 @@ traceary tui
 traceary top
 ```
 
-`top` opens a five-pane Bubble Tea dashboard for active sessions, recent failures, recent commands, memory candidates, and stale memories. Use `tab` / `shift+tab` to move between panes, `/` to filter the focused pane incrementally, and Enter to drill into the highlighted session, event, or memory detail. In non-TTY shells, `traceary top --snapshot` and `traceary top --snapshot --json` expose the same data for scripts, including the `stale_memories` envelope key.
+`top` remains the compatibility alias for the standalone Sessions dashboard. It opens a five-pane Bubble Tea dashboard for active sessions, recent failures, recent commands, memory candidates, and stale memories; those memory panes remain here and in `traceary sessions --snapshot [--json]` / `traceary top --snapshot [--json]` for compatibility while the cockpit Sessions tab is narrower. Use `tab` / `shift+tab` to move between panes, `/` to filter the focused pane incrementally, and Enter to drill into the highlighted session, event, or memory detail. In non-TTY shells, `traceary top --snapshot` and `traceary top --snapshot --json` expose the same data for scripts, including the `stale_memories` envelope key.
 
 ### `traceary tail`
 

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -75,9 +75,9 @@ session 解決ルールは `traceary log` と同じです。
 
 Traceary operator cockpit TUI を開きます。
 
-個別の subcommand を覚える代わりに、operator loop を 1 つのターミナル画面から始めたいときは、対話 terminal で bare `traceary` を使います。`traceary tui` は同じ cockpit を明示的に開く互換 entrypoint として残ります。cockpit は Tail-first で開き、active work、直近の失敗、doctor status、前回 live-tail 以降の新着 event、前回 memory review 以降のメモリ候補をまとめて表示します。cockpit から live tail、doctor details、memory inbox review へ移動できます。
+個別の subcommand を覚える代わりに、operator loop を 1 つのターミナル画面から始めたいときは、対話 terminal で bare `traceary` を使います。`traceary tui` は同じ cockpit を明示的に開く互換 entrypoint として残ります。cockpit は Tail-first で開き、active work、直近の失敗、doctor status、前回 live-tail 以降の新着 event をまとめて表示します。Sessions タブは session 中心 (session、失敗、コマンド、状態) に保ち、メモリ候補や stale memory cleanup は専用の Memory タブに置きます。cockpit から live tail、doctor details、memory inbox review へ移動できます。
 
-`traceary tui` は対話 terminal が必要です。非 TTY で起動した場合は exit code `2` で拒否し、script 向け command (`list`、`top --snapshot [--json]`、`doctor --json`、`session handoff`、`memory inbox list`) の利用を案内します。非 TTY の bare `traceary` は cockpit を起動せず、help と fallback guidance を表示します。
+`traceary tui` は対話 terminal が必要です。非 TTY で起動した場合は exit code `2` で拒否し、script 向け command (`list`、`sessions --snapshot [--json]`、`top --snapshot [--json]`、`doctor --json`、`session handoff`、`memory inbox list`) の利用を案内します。非 TTY の bare `traceary` は cockpit を起動せず、help と fallback guidance を表示します。
 
 主な flag:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -75,9 +75,9 @@ Session resolution follows the same rules as `traceary log`.
 
 Open the Traceary operator cockpit TUI.
 
-Use bare `traceary` in an interactive terminal when you want one terminal surface for the operator loop instead of remembering individual subcommands. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit. The cockpit opens Tail-first and summarizes active work, recent failures, doctor status, new events since the last live-tail visit, and memory candidates queued since the last memory review. From the cockpit you can jump into live tail, doctor details, and memory inbox review.
+Use bare `traceary` in an interactive terminal when you want one terminal surface for the operator loop instead of remembering individual subcommands. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit. The cockpit opens Tail-first and summarizes active work, recent failures, doctor status, and new events since the last live-tail visit. The Sessions tab stays session-centric (sessions, failures, commands, and health); memory candidates and stale-memory cleanup belong in the dedicated Memory tab. From the cockpit you can jump into live tail, doctor details, and memory inbox review.
 
-`traceary tui` requires an interactive terminal. Non-TTY callers receive a refusal with exit code `2` and guidance to use the script-friendly commands instead (`list`, `top --snapshot [--json]`, `doctor --json`, `session handoff`, and `memory inbox list`). Bare non-TTY `traceary` prints help plus fallback guidance rather than starting the cockpit.
+`traceary tui` requires an interactive terminal. Non-TTY callers receive a refusal with exit code `2` and guidance to use the script-friendly commands instead (`list`, `sessions --snapshot [--json]`, `top --snapshot [--json]`, `doctor --json`, `session handoff`, and `memory inbox list`). Bare non-TTY `traceary` prints help plus fallback guidance rather than starting the cockpit.
 
 Useful flags:
 

--- a/docs/interactive/README.ja.md
+++ b/docs/interactive/README.ja.md
@@ -22,7 +22,7 @@
 
 ### 1. 「まず1か所から始めたい」 → `traceary`
 
-対話 terminal で Traceary の Tail-first operator cockpit を開きたいときは bare `traceary` を使います。`traceary tui` は同じ cockpit を明示的に開く互換 entrypoint として残ります。cockpit は active work、doctor の warning/failure、直近の失敗、前回 live tail 以降の新着 event、前回 memory review 以降のメモリ候補をまとめて表示します。そこから次の画面へ移動できます。
+対話 terminal で Traceary の Tail-first operator cockpit を開きたいときは bare `traceary` を使います。`traceary tui` は同じ cockpit を明示的に開く互換 entrypoint として残ります。cockpit は active work、doctor の warning/failure、直近の失敗、前回 live tail 以降の新着 event をまとめて表示します。Sessions タブは session 中心 (session、失敗、コマンド、状態) に保ち、メモリ候補や stale memory cleanup は専用の Memory タブに置きます。そこから次の画面へ移動できます。
 
 - live event tail
 - doctor details
@@ -62,7 +62,7 @@ traceary top --snapshot
 traceary top --snapshot --json
 ```
 
-dashboard 内では `tab` / `shift+tab` でフォーカスペインを切り替え、`↑/↓` (`k/j`) で 1 行ずつスクロール、`pgup/pgdn` でページング、`g/G` で先頭 / 末尾、`r` で snapshot 再取得、`?` でヘルプ切替、`q` / Ctrl-C / Esc は共通の安全網を経由して終了します。非 TTY (パイプ / CI ログ) では自動的に snapshot text 出力にフォールバックします。`--snapshot` / `--snapshot --json` も dashboard の 5 ペインに合わせて拡張されており、テキスト出力は `ACTIVE SESSIONS` / `RECENT FAILURES` / `RECENT COMMANDS` / `CANDIDATE MEMORIES (count=N)` / `STALE MEMORIES (count=N)` のセクション、JSON 出力は `sessions` / `failures` / `recent_commands` / `candidates` (`{ count, items }`) / `stale_memories` (`{ count, items }`) を持つ envelope オブジェクトを返します。
+dashboard 内では `tab` / `shift+tab` でフォーカスペインを切り替え、`↑/↓` (`k/j`) で 1 行ずつスクロール、`pgup/pgdn` でページング、`g/G` で先頭 / 末尾、`r` で snapshot 再取得、`?` でヘルプ切替、`q` / Ctrl-C / Esc は共通の安全網を経由して終了します。この standalone dashboard と非 TTY snapshot は、cockpit の Sessions タブを session-only にした後も互換性のため memory pane を維持します。非 TTY (パイプ / CI ログ) では自動的に snapshot text 出力にフォールバックします。`--snapshot` / `--snapshot --json` も dashboard の 5 ペインに合わせて拡張されており、テキスト出力は `ACTIVE SESSIONS` / `RECENT FAILURES` / `RECENT COMMANDS` / `CANDIDATE MEMORIES (count=N)` / `STALE MEMORIES (count=N)` のセクション、JSON 出力は `sessions` / `failures` / `recent_commands` / `candidates` (`{ count, items }`) / `stale_memories` (`{ count, items }`) を持つ envelope オブジェクトを返します。
 
 ### 4. 「今まさに書き込まれているか」を追いたい → `traceary tail`
 

--- a/docs/interactive/README.md
+++ b/docs/interactive/README.md
@@ -22,7 +22,7 @@ Use the commands below according to the question you are trying to answer.
 
 ### 1. "I want one place to start" → `traceary`
 
-Use bare `traceary` when you are at an interactive terminal and want Traceary to show the Tail-first operator cockpit first. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit. The cockpit summarizes active work, doctor warnings/failures, recent failures, new events since the last live-tail visit, and memory candidates queued since the last memory review. From there you can jump into:
+Use bare `traceary` when you are at an interactive terminal and want Traceary to show the Tail-first operator cockpit first. `traceary tui` remains the explicit compatibility entrypoint for the same cockpit. The cockpit summarizes active work, doctor warnings/failures, recent failures, and new events since the last live-tail visit. The Sessions tab stays session-centric (sessions, failures, commands, and health); memory candidates and stale-memory cleanup belong in the dedicated Memory tab. From there you can jump into:
 
 - live event tail
 - doctor details
@@ -62,7 +62,7 @@ traceary top --snapshot
 traceary top --snapshot --json
 ```
 
-Inside the dashboard `tab` / `shift+tab` cycle the focused pane, `↑/↓` (or `k/j`) scroll it by one row, `pgup/pgdn` page through it, `g/G` jump to the top/bottom, `r` forces a refresh, `?` toggles help, and `q` / Ctrl-C / Esc quit cleanly. Non-TTY callers (pipes, CI logs) fall back to the snapshot text writer automatically. `--snapshot` and `--snapshot --json` mirror the five panes for scripts: the text snapshot prints `ACTIVE SESSIONS`, `RECENT FAILURES`, `RECENT COMMANDS`, `CANDIDATE MEMORIES (count=N)`, and `STALE MEMORIES (count=N)` sections; the JSON snapshot is wrapped in an envelope with `sessions`, `failures`, `recent_commands`, `candidates` (`{ count, items }`), and `stale_memories` (`{ count, items }`) keys.
+Inside the dashboard `tab` / `shift+tab` cycle the focused pane, `↑/↓` (or `k/j`) scroll it by one row, `pgup/pgdn` page through it, `g/G` jump to the top/bottom, `r` forces a refresh, `?` toggles help, and `q` / Ctrl-C / Esc quit cleanly. This standalone dashboard and its non-TTY snapshots intentionally keep the memory panes for compatibility even though the cockpit Sessions tab is session-only. Non-TTY callers (pipes, CI logs) fall back to the snapshot text writer automatically. `--snapshot` and `--snapshot --json` mirror the five panes for scripts: the text snapshot prints `ACTIVE SESSIONS`, `RECENT FAILURES`, `RECENT COMMANDS`, `CANDIDATE MEMORIES (count=N)`, and `STALE MEMORIES (count=N)` sections; the JSON snapshot is wrapped in an envelope with `sessions`, `failures`, `recent_commands`, `candidates` (`{ count, items }`), and `stale_memories` (`{ count, items }`) keys.
 
 ### 4. "Is the system writing events right now?" → `traceary tail`
 

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -206,18 +206,7 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 		home.MemoryLastSeenAt = memoryLastSeenAt
 		home.NewCandidateMemoryKnown = true
 	}
-	criteria := topDataCriteria{
-		SessionLimit:       defaultTopLimit,
-		FailureLimit:       topPaneFailureLimit,
-		RecentCommandLimit: topPaneRecentCommandLimit,
-		CandidateLimit:     topPaneCandidateLimit,
-		StaleMemoryLimit:   topPaneStaleMemoryLimit,
-		StaleAfter:         defaultActiveSessionStaleAfter,
-		Now:                loadedAt,
-	}
-	if home.NewCandidateMemoryKnown {
-		criteria.MemoryLastSeenAt = domtypes.Some(home.MemoryLastSeenAt)
-	}
+	criteria := cockpitSessionsDataCriteriaAt(loadedAt)
 	if eventLastSeen, eventLastSeenKnown, err := c.loadCockpitEventLastSeen(ctx); err == nil && eventLastSeenKnown {
 		home.EventLastSeenAt = eventLastSeen.at
 		home.NewEventCount, home.NewEventScanLimited, home.NewEventKnown = c.countCockpitNewEvents(ctx, eventLastSeen)
@@ -227,19 +216,24 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 		return cockpitHomeSnapshot{}, err
 	}
 	home.StaleActiveSessionCount = snap.Reliability.StaleActiveSessionCount
-	home.AcceptedMemoryCount = snap.Reliability.AcceptedMemoryCount
-	home.CandidateMemoryCount = snap.Reliability.CandidateMemoryCount
-	home.NewCandidateMemoryCount = snap.Reliability.NewCandidateCount
-	home.NewCandidateMemoryKnown = snap.Reliability.NewCandidateKnown
-	home.RememberIntentCount = snap.Reliability.RememberIntentCount
-	home.LowQualityMemoryCount = snap.Reliability.LowQualityCount
-	home.MemoryScanLimited = snap.Reliability.MemoryScanLimited
-	home.StaleMemoryCount = snap.StaleMemories.Count()
 	home.RecentFailureCount = len(snap.Failures)
 	home.RecentCommandCount = len(snap.RecentCommands)
 	home.LargePayloadCount = snap.Reliability.LargePayloads.Count
 
 	return home, nil
+}
+
+func cockpitSessionsDataCriteriaAt(now time.Time) topDataCriteria {
+	return topDataCriteria{
+		SessionLimit:          defaultTopLimit,
+		FailureLimit:          topPaneFailureLimit,
+		RecentCommandLimit:    topPaneRecentCommandLimit,
+		CandidateLimit:        0,
+		StaleMemoryLimit:      0,
+		StaleAfter:            defaultActiveSessionStaleAfter,
+		Now:                   now,
+		SkipMemoryReliability: true,
+	}
 }
 
 // CockpitStateReader provides optional local cockpit state. Missing or failing
@@ -1445,19 +1439,7 @@ func (m cockpitModel) fetchCockpitTopCmd(seq uint64) tea.Cmd {
 }
 
 func (m cockpitModel) cockpitTopCriteriaAt(now time.Time) topDataCriteria {
-	criteria := topDataCriteria{
-		SessionLimit:       defaultTopLimit,
-		FailureLimit:       topPaneFailureLimit,
-		RecentCommandLimit: topPaneRecentCommandLimit,
-		CandidateLimit:     topPaneCandidateLimit,
-		StaleMemoryLimit:   topPaneStaleMemoryLimit,
-		StaleAfter:         defaultActiveSessionStaleAfter,
-		Now:                now,
-	}
-	if m.home.NewCandidateMemoryKnown {
-		criteria.MemoryLastSeenAt = domtypes.Some(m.home.MemoryLastSeenAt)
-	}
-	return criteria
+	return cockpitSessionsDataCriteriaAt(now)
 }
 
 func (m *cockpitModel) startCockpitDoctorLoad() tea.Cmd {
@@ -2206,15 +2188,6 @@ func (m cockpitModel) topSignals() []cockpitTopSignal {
 			actionLabel: Localize("open Doctor checks", "Doctor check を開く"),
 		})
 	}
-	if home.CandidateMemoryCount > 0 || home.NewCandidateMemoryCount > 0 || home.RememberIntentCount > 0 || home.LowQualityMemoryCount > 0 {
-		signals = append(signals, cockpitTopSignal{
-			severity:    cockpitSignalWarning,
-			label:       Localize("Memory review queue needs attention", "メモリ候補の確認が必要"),
-			description: Localizef("candidate=%d new=%s remember-intent=%d low-quality=%d", "candidate=%d new=%s remember-intent=%d low-quality=%d", home.CandidateMemoryCount, formatCockpitNewCandidateCount(home), home.RememberIntentCount, home.LowQualityMemoryCount),
-			actionKey:   "3",
-			actionLabel: Localize("open Memory review", "メモリ確認を開く"),
-		})
-	}
 	if home.RecentFailureCount > 0 {
 		signals = append(signals, cockpitTopSignal{
 			severity:    cockpitSignalWarning,
@@ -2293,21 +2266,21 @@ func (m cockpitModel) topTabView() string {
 	if m.cockpitTopDetailOpen() {
 		return m.cockpitTopDetailView()
 	}
-	memoryScanSuffix := ""
-	if m.home.MemoryScanLimited {
-		memoryScanSuffix = " scan_limited=true"
-	}
 	eventScanSuffix := ""
 	if m.home.NewEventScanLimited {
 		eventScanSuffix = " scan_limited=true"
 	}
 	// Keep metric identifiers in English for copy/paste parity with CLI output, docs, and issue search.
+	// The cockpit Sessions tab is intentionally session-focused; memory candidate
+	// and stale memory surfaces belong to the Memory tab (cockpit section 3).
+	// `traceary sessions --snapshot [--json]` and the compatibility
+	// `traceary top --snapshot [--json]` keep their full memory sections for
+	// script consumers and are unaffected by this view.
 	lines := []string{
 		m.styles.Subtle.Render(fmt.Sprintf("loaded=%s db=%s", formatJSONTime(m.home.LoadedAt), formatOptionalColumn(m.home.DBPath))),
 		"",
 		m.styles.Subtle.Render(Localize("Sessions summary", "Sessions 概要")),
 		Localizef("• sessions: stale_active=%d recent_failures=%d recent_commands=%d new_events=%s%s", "• セッション: stale_active=%d recent_failures=%d recent_commands=%d new_events=%s%s", m.home.StaleActiveSessionCount, m.home.RecentFailureCount, m.home.RecentCommandCount, formatCockpitNewEventCount(m.home), eventScanSuffix),
-		Localizef("• memories: accepted(reviewed)=%d candidate(inbox)=%d new=%s remember-intent=%d low-quality=%d stale=%d%s", "• メモリ: accepted(reviewed)=%d candidate(inbox)=%d new=%s remember-intent=%d low-quality=%d stale=%d%s", m.home.AcceptedMemoryCount, m.home.CandidateMemoryCount, formatCockpitNewCandidateCount(m.home), m.home.RememberIntentCount, m.home.LowQualityMemoryCount, m.home.StaleMemoryCount, memoryScanSuffix),
 		Localizef("• doctor: pass=%d warn=%d fail=%d", "• doctor: pass=%d warn=%d fail=%d", m.home.DoctorPassCount, m.home.DoctorWarnCount, m.home.DoctorFailCount),
 		Localizef("• hooks/mcp: warn=%d fail=%d", "• hooks/mcp: warn=%d fail=%d", m.home.HookWarnCount, m.home.HookFailCount),
 		Localizef("• payloads: large=%d", "• payloads: large=%d", m.home.LargePayloadCount),
@@ -2328,21 +2301,6 @@ func (m cockpitModel) topTabView() string {
 		lines = append(lines, Localizef("• no unseen events since %s", "• %s 以降の未確認イベントはありません", formatCockpitCheckpoint(m.home.EventLastSeenAt)))
 	default:
 		lines = append(lines, Localize("• new events=untracked until cockpit state is initialized", "• cockpit state 初期化まで新着イベントは未追跡"))
-	}
-	switch {
-	case m.home.NewCandidateMemoryKnown && m.home.NewCandidateMemoryCount > 0:
-		lines = append(lines, Localizef("• new memory candidates=%d", "• 新着メモリ候補=%d", m.home.NewCandidateMemoryCount))
-	case m.home.NewCandidateMemoryKnown:
-		lines = append(lines, Localizef("• no unseen candidates since %s", "• %s 以降の未確認メモリ候補はありません", formatCockpitCheckpoint(m.home.MemoryLastSeenAt)))
-	default:
-		lines = append(lines, Localize("• memory candidate new count=untracked", "• メモリ候補の新着数=未追跡"))
-	}
-	lines = append(lines, Localizef("• memory candidates=%d", "• メモリ候補=%d", m.home.CandidateMemoryCount))
-	if m.home.RememberIntentCount > 0 {
-		lines = append(lines, Localizef("• remember-intent candidates=%d", "• remember-intent メモリ候補=%d", m.home.RememberIntentCount))
-	}
-	if m.home.LowQualityMemoryCount > 0 {
-		lines = append(lines, Localizef("• low-quality candidates=%d", "• 低品質メモリ候補=%d", m.home.LowQualityMemoryCount))
 	}
 	if m.home.RecentFailureCount > 0 {
 		lines = append(lines, Localizef("• recent failures=%d", "• 最近の失敗=%d", m.home.RecentFailureCount))
@@ -2425,7 +2383,7 @@ func (m cockpitModel) cockpitTopRows() []cockpitTopRow {
 func buildCockpitTopRows(snapshot topDataSnapshot, criteria topDataCriteria, loadedAt time.Time, width int, styles tui.Styles) []cockpitTopRow {
 	renderer := newCockpitTopRowRenderer(snapshot, criteria, loadedAt, width, styles)
 	rows := make([]cockpitTopRow, 0)
-	for _, pane := range []topPane{topPaneSessions, topPaneFailures, topPaneRecentCommands, topPaneCandidates, topPaneStaleMemories} {
+	for _, pane := range cockpitSessionsPanes() {
 		rows = append(rows, cockpitTopRow{
 			line:   styles.Subtle.Render(cockpitTopSectionLabel(pane, snapshot)),
 			pane:   pane,
@@ -2441,6 +2399,15 @@ func buildCockpitTopRows(snapshot topDataSnapshot, criteria topDataCriteria, loa
 		}
 	}
 	return rows
+}
+
+// cockpitSessionsPanes intentionally keeps the cockpit Sessions tab
+// session-centric. Memory candidates / stale memories surface through the
+// dedicated Memory tab. Script-facing snapshots are written by
+// writeTopSnapshotText/writeTopSnapshotJSON and keep their public memory
+// sections for compatibility.
+func cockpitSessionsPanes() []topPane {
+	return []topPane{topPaneSessions, topPaneFailures, topPaneRecentCommands}
 }
 
 func newCockpitTopRowRenderer(snapshot topDataSnapshot, criteria topDataCriteria, loadedAt time.Time, width int, styles tui.Styles) topModel {

--- a/presentation/cli/cockpit_dogfood_internal_test.go
+++ b/presentation/cli/cockpit_dogfood_internal_test.go
@@ -51,7 +51,7 @@ func TestCockpitDogfoodJapaneseNarrowGoldenSnapshot(t *testing.T) {
 	model.mode = cockpitModeTop
 	model.showHelp = true
 	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	assertCockpitDogfoodGolden(t, "top_candidate_memories_ja_narrow", updated.(cockpitModel).View())
+	assertCockpitDogfoodGolden(t, "top_candidate_memories_suppressed_ja_narrow", updated.(cockpitModel).View())
 }
 
 func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
@@ -75,7 +75,6 @@ func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
 		"top_all_green": {
 			"Sessions summary",
 			"doctor: pass=4 warn=0 fail=0",
-			"memories: accepted(reviewed)=2 candidate(inbox)=0 new=0",
 		},
 		"top_doctor_failure": {
 			"doctor: pass=2 warn=1 fail=1",
@@ -85,9 +84,10 @@ func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
 			"[FAIL] Doctor unavailable",
 			"doctor dependency unavailable",
 		},
-		"top_candidate_memories": {
-			"new memory candidates=2",
-			"remember-intent candidates=1",
+		"top_candidate_memories_suppressed": {
+			"Sessions summary",
+			"[OK] No active signals",
+			"3 Memory",
 		},
 		"top_stale_sessions": {
 			"stale active sessions=2",
@@ -120,6 +120,13 @@ func TestCockpitDogfoodTerminalSizesKeepTaskCues(t *testing.T) {
 				for _, globalCue := range []string{"tabs:", "quit"} {
 					if !strings.Contains(view, globalCue) {
 						t.Fatalf("%s %dx%d missing global cue %q:\n%s", scenario.name, size.width, size.height, globalCue, view)
+					}
+				}
+				if strings.HasPrefix(scenario.name, "top_") {
+					for _, memoryCue := range []string{"memories:", "Memory review queue", "new memory candidates", "remember-intent candidates", "low-quality candidates"} {
+						if strings.Contains(view, memoryCue) {
+							t.Fatalf("%s %dx%d should not render memory status %q in Sessions tab:\n%s", scenario.name, size.width, size.height, memoryCue, view)
+						}
 					}
 				}
 				sizeCue := "terminal " + strconv.Itoa(size.width) + "x" + strconv.Itoa(size.height)
@@ -458,7 +465,7 @@ func cockpitDogfoodSnapshotScenarios(t *testing.T) []cockpitDogfoodSnapshotScena
 		{name: "top_all_green", model: topModel(allGreen)},
 		{name: "top_doctor_failure", model: topModel(doctorFailure)},
 		{name: "top_doctor_unavailable", model: topModel(doctorUnavailable)},
-		{name: "top_candidate_memories", model: topModel(candidateMemories)},
+		{name: "top_candidate_memories_suppressed", model: topModel(candidateMemories)},
 		{name: "top_stale_sessions", model: topModel(staleSessions)},
 		{name: "top_new_events_and_failure", model: topModel(newEventsAndFailure)},
 		{name: "memory_ambiguous_candidate", model: memoryModel},

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/duck8823/traceary/presentation/cli/tui"
 )
 
-func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
+func TestLoadCockpitHome_AggregatesSessionSignalsWithoutMemoryScans(t *testing.T) {
 	now := fixedStartedAt.Add(48 * time.Hour)
 	previousTopNow := topNowFunc
 	topNowFunc = func() time.Time { return now }
@@ -40,28 +40,7 @@ func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
 	hugeFailure := mustEvent(t, "evt-fail", domtypes.EventKindCommandExecuted, strings.Repeat("f", apptypes.DefaultTopSnapshotBodyLimit+1))
 	command := mustEvent(t, "evt-cmd", domtypes.EventKindCommandExecuted, "go test ./...")
 	event := &snapshotEventStub{failures: []*model.Event{hugeFailure}, commands: []*model.Event{command}}
-
-	accepted := memorySummaryWithUpdatedAt(t, "mem-accepted", domtypes.MemoryStatusAccepted, now.Add(-2*time.Hour))
-	candidate := memorySummaryWithUpdatedAt(t, "mem-candidate", domtypes.MemoryStatusCandidate, now.Add(-3*time.Hour))
-	staleSummary := memorySummaryFixture(t, "mem-stale", domtypes.MemoryStatusSuperseded, "stale cockpit fixture")
-	staleRow, err := apptypes.StaleMemoryRowOf(staleSummary, apptypes.StaleMemoryReasonSuperseded)
-	if err != nil {
-		t.Fatalf("StaleMemoryRowOf: %v", err)
-	}
-	staleResult, err := apptypes.StaleMemoryListResultOf(2, []apptypes.StaleMemoryRow{staleRow})
-	if err != nil {
-		t.Fatalf("StaleMemoryListResultOf: %v", err)
-	}
-	memory := &topDataMemoryStub{
-		listFunc: func(criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
-			statuses := criteria.Statuses()
-			if len(statuses) == 1 && statuses[0] == domtypes.MemoryStatusCandidate {
-				return []apptypes.MemorySummary{candidate}, nil
-			}
-			return []apptypes.MemorySummary{accepted, candidate}, nil
-		},
-		staleResult: staleResult,
-	}
+	memory := &topDataMemoryStub{listErr: context.Canceled, staleErr: context.Canceled}
 
 	root := &RootCLI{session: session, event: event, memory: memory}
 	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
@@ -75,17 +54,14 @@ func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
 	if got, want := home.StaleActiveSessionCount, 1; got != want {
 		t.Fatalf("StaleActiveSessionCount = %d, want %d", got, want)
 	}
-	if got, want := home.AcceptedMemoryCount, 1; got != want {
-		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
-	}
-	if got, want := home.CandidateMemoryCount, 1; got != want {
-		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
-	}
 	if home.NewCandidateMemoryKnown {
 		t.Fatalf("NewCandidateMemoryKnown = true, want false when cockpit state is not configured")
 	}
-	if got, want := home.StaleMemoryCount, 2; got != want {
-		t.Fatalf("StaleMemoryCount = %d, want %d", got, want)
+	if got := memory.listCalls; got != 0 {
+		t.Fatalf("memory.List calls = %d, want 0 for session-only cockpit summary", got)
+	}
+	if got := memory.staleMemoryCalls; got != 0 {
+		t.Fatalf("memory.ListStale calls = %d, want 0 for session-only cockpit summary", got)
 	}
 	if got, want := home.RecentFailureCount, 1; got != want {
 		t.Fatalf("RecentFailureCount = %d, want %d", got, want)
@@ -98,27 +74,14 @@ func TestLoadCockpitHome_AggregatesTopSignalsWithoutTTY(t *testing.T) {
 	}
 }
 
-func TestLoadCockpitHome_MemoryNotificationsUseLastSeenWhenAvailable(t *testing.T) {
+func TestCockpitSessionsTab_HidesMemoryNotificationsWhenLastSeenAvailable(t *testing.T) {
 	now := fixedStartedAt.Add(72 * time.Hour)
 	previousTopNow := topNowFunc
 	topNowFunc = func() time.Time { return now }
 	t.Cleanup(func() { topNowFunc = previousTopNow })
 
 	lastSeenAt := now.Add(-2 * time.Hour)
-	accepted := memorySummaryWithSourceAndUpdatedAt(t, "mem-accepted", domtypes.MemoryStatusAccepted, domtypes.MemorySourceManual, now.Add(-30*time.Minute))
-	oldCandidate := memorySummaryWithSourceAndUpdatedAt(t, "mem-old", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtracted, now.Add(-3*time.Hour))
-	newRemember := memorySummaryWithSourceAndUpdatedAt(t, "mem-remember", domtypes.MemoryStatusCandidate, domtypes.MemorySourceRememberIntent, now.Add(-90*time.Minute))
-	newLowQuality := memorySummaryWithSourceAndUpdatedAt(t, "mem-low", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtractedHidden, now.Add(-15*time.Minute))
-	candidates := []apptypes.MemorySummary{oldCandidate, newRemember, newLowQuality}
-	memory := &topDataMemoryStub{
-		listFunc: func(criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
-			statuses := criteria.Statuses()
-			if len(statuses) == 1 && statuses[0] == domtypes.MemoryStatusCandidate {
-				return candidates, nil
-			}
-			return []apptypes.MemorySummary{accepted, oldCandidate, newRemember, newLowQuality}, nil
-		},
-	}
+	memory := &topDataMemoryStub{listErr: context.Canceled, staleErr: context.Canceled}
 	root := &RootCLI{
 		memory:       memory,
 		cockpitState: cockpitStateReaderStub{at: lastSeenAt, ok: true},
@@ -135,33 +98,28 @@ func TestLoadCockpitHome_MemoryNotificationsUseLastSeenWhenAvailable(t *testing.
 	if got, want := home.MemoryLastSeenAt, lastSeenAt; !got.Equal(want) {
 		t.Fatalf("MemoryLastSeenAt = %v, want %v", got, want)
 	}
-	if got, want := home.AcceptedMemoryCount, 1; got != want {
-		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
+	if got := memory.listCalls; got != 0 {
+		t.Fatalf("memory.List calls = %d, want 0 for session-only cockpit summary", got)
 	}
-	if got, want := home.CandidateMemoryCount, 3; got != want {
-		t.Fatalf("CandidateMemoryCount = %d, want %d", got, want)
-	}
-	if got, want := home.NewCandidateMemoryCount, 2; got != want {
-		t.Fatalf("NewCandidateMemoryCount = %d, want %d", got, want)
-	}
-	if got, want := home.RememberIntentCount, 1; got != want {
-		t.Fatalf("RememberIntentCount = %d, want %d", got, want)
-	}
-	if got, want := home.LowQualityMemoryCount, 1; got != want {
-		t.Fatalf("LowQualityMemoryCount = %d, want %d", got, want)
+	if got := memory.staleMemoryCalls; got != 0 {
+		t.Fatalf("memory.ListStale calls = %d, want 0 for session-only cockpit summary", got)
 	}
 
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
 	model.mode = cockpitModeTop
 	view := model.View()
-	for _, must := range []string{
+	if !strings.Contains(view, "3 Memory") {
+		t.Fatalf("cockpit navigation should keep Memory tab discoverable:\n%s", view)
+	}
+	for _, mustNot := range []string{
 		"new memory candidates=2",
 		"remember-intent candidates=1",
 		"low-quality candidates=1",
-		"memories: accepted(reviewed)=1 candidate(inbox)=3 new=2 remember-intent=1 low-quality=1 stale=0",
+		"memories:",
+		"Memory review queue needs attention",
 	} {
-		if !strings.Contains(view, must) {
-			t.Fatalf("cockpit view missing %q:\n%s", must, view)
+		if strings.Contains(view, mustNot) {
+			t.Fatalf("sessions tab should not render memory status %q:\n%s", mustNot, view)
 		}
 	}
 }
@@ -228,15 +186,10 @@ func TestLoadCockpitHome_EventNotificationsScanPastSeenBoundaryIDs(t *testing.T)
 	}
 }
 
-func TestLoadCockpitHome_MemoryNotificationsFallbackWhenLastSeenUnavailable(t *testing.T) {
+func TestCockpitSessionsTab_HidesMemoryNotificationsWhenLastSeenUnavailable(t *testing.T) {
 	t.Parallel()
 
-	candidate := memorySummaryWithSourceAndUpdatedAt(t, "mem-candidate", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtracted, fixedStartedAt)
-	memory := &topDataMemoryStub{
-		listFunc: func(_ apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
-			return []apptypes.MemorySummary{candidate}, nil
-		},
-	}
+	memory := &topDataMemoryStub{listErr: context.Canceled, staleErr: context.Canceled}
 	root := &RootCLI{memory: memory}
 
 	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
@@ -249,24 +202,26 @@ func TestLoadCockpitHome_MemoryNotificationsFallbackWhenLastSeenUnavailable(t *t
 	if got, want := formatCockpitNewCandidateCount(home), "untracked"; got != want {
 		t.Fatalf("formatCockpitNewCandidateCount() = %q, want %q", got, want)
 	}
+	if got := memory.listCalls; got != 0 {
+		t.Fatalf("memory.List calls = %d, want 0 for session-only cockpit summary", got)
+	}
+	if got := memory.staleMemoryCalls; got != 0 {
+		t.Fatalf("memory.ListStale calls = %d, want 0 for session-only cockpit summary", got)
+	}
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
 	model.mode = cockpitModeTop
 	view := model.View()
-	if !strings.Contains(view, "memory candidates=1") {
-		t.Fatalf("fallback view should still surface total candidates:\n%s", view)
+	if !strings.Contains(view, "3 Memory") {
+		t.Fatalf("cockpit navigation should keep Memory tab discoverable:\n%s", view)
 	}
-	if strings.Contains(view, "new memory candidates=") {
-		t.Fatalf("fallback view should not claim a new count without last-seen state:\n%s", view)
-	}
-	if !strings.Contains(view, "memory candidate new count=untracked") {
-		t.Fatalf("fallback view should explain untracked memory notification state:\n%s", view)
-	}
-	if !strings.Contains(view, "new=untracked") {
-		t.Fatalf("fallback view missing untracked new-count state:\n%s", view)
+	for _, mustNot := range []string{"memory candidates=1", "new memory candidates=", "memory candidate new count=untracked", "new=untracked", "memories:"} {
+		if strings.Contains(view, mustNot) {
+			t.Fatalf("sessions tab should not render fallback memory status %q:\n%s", mustNot, view)
+		}
 	}
 }
 
-func TestCockpitModelView_MemoryNotificationsNoneState(t *testing.T) {
+func TestCockpitSessionsTab_HidesMemoryNotificationsWhenNone(t *testing.T) {
 	t.Parallel()
 
 	home := cockpitHomeSnapshot{
@@ -277,14 +232,36 @@ func TestCockpitModelView_MemoryNotificationsNoneState(t *testing.T) {
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), home)
 	model.mode = cockpitModeTop
 	view := model.View()
-	if !strings.Contains(view, "memories: accepted(reviewed)=2 candidate(inbox)=0 new=0 remember-intent=0 low-quality=0 stale=0") {
-		t.Fatalf("none-state view missing zero notification summary:\n%s", view)
+	for _, mustNot := range []string{"memories:", "[WARN] Memory review", "new memory candidates=", "no unseen candidates since"} {
+		if strings.Contains(view, mustNot) {
+			t.Fatalf("sessions tab should not render memory none-state %q:\n%s", mustNot, view)
+		}
 	}
-	if strings.Contains(view, "[WARN] Memory review") || strings.Contains(view, "new memory candidates=") {
-		t.Fatalf("none-state view should not show candidate warnings:\n%s", view)
+}
+
+func TestCockpitTopCriteria_IsSessionOnly(t *testing.T) {
+	t.Parallel()
+
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{
+		LoadedAt:                fixedStartedAt,
+		NewCandidateMemoryKnown: true,
+		MemoryLastSeenAt:        fixedStartedAt.Add(-time.Hour),
+	})
+	got := model.cockpitTopCriteriaAt(fixedStartedAt)
+	if got.CandidateLimit != 0 {
+		t.Fatalf("CandidateLimit = %d, want 0 for cockpit Sessions", got.CandidateLimit)
 	}
-	if !strings.Contains(view, "no unseen candidates since not recorded") {
-		t.Fatalf("none-state view should explain seen memory checkpoint:\n%s", view)
+	if got.StaleMemoryLimit != 0 {
+		t.Fatalf("StaleMemoryLimit = %d, want 0 for cockpit Sessions", got.StaleMemoryLimit)
+	}
+	if !got.SkipMemoryReliability {
+		t.Fatalf("SkipMemoryReliability = false, want true for cockpit Sessions")
+	}
+	if _, ok := got.MemoryLastSeenAt.Value(); ok {
+		t.Fatalf("MemoryLastSeenAt should not be forwarded to session-only cockpit criteria")
+	}
+	if got.SessionLimit <= 0 || got.FailureLimit <= 0 || got.RecentCommandLimit <= 0 {
+		t.Fatalf("session/failure/command limits should stay enabled: %#v", got)
 	}
 }
 
@@ -318,21 +295,15 @@ func TestCockpitModelView_RendersActionableTriageBoard(t *testing.T) {
 		"Traceary cockpit · sessions",
 		"Sessions summary",
 		"sessions: stale_active=2 recent_failures=2 recent_commands=5 new_events=3",
-		"memories: accepted(reviewed)=0 candidate(inbox)=4 new=2 remember-intent=1 low-quality=1 stale=0",
 		"doctor: pass=3 warn=1 fail=1",
 		"hooks/mcp: warn=0 fail=1",
 		"Actionable signals",
 		"[FAIL] Health failures",
 		"(d open Doctor checks)",
-		"[WARN] Memory review queue needs attention",
-		"(3 open Memory review)",
 		"[WARN] Recent command failures",
 		"[WARN] Stale active sessions",
 		"[INFO] New Tail events",
 		"new events=3 since 2026-05-07T11:30:00Z",
-		"new memory candidates=2",
-		"remember-intent candidates=1",
-		"low-quality candidates=1",
 		"stale active sessions=2",
 		"recent failures=2",
 	} {
@@ -340,7 +311,7 @@ func TestCockpitModelView_RendersActionableTriageBoard(t *testing.T) {
 			t.Fatalf("top summary missing %q:\n%s", must, view)
 		}
 	}
-	for _, mustNot := range []string{"TRIAGE BOARD", "1 Home"} {
+	for _, mustNot := range []string{"TRIAGE BOARD", "1 Home", "memories:", "Memory review queue", "new memory candidates", "remember-intent candidates", "low-quality candidates"} {
 		if strings.Contains(view, mustNot) {
 			t.Fatalf("top summary should not render removed Home triage cue %q:\n%s", mustNot, view)
 		}
@@ -368,11 +339,13 @@ func TestCockpitModelView_RendersStableEmptyStateAndOverview(t *testing.T) {
 		"[OK] No active signals",
 		"Signal details",
 		"doctor: pass=4 warn=0 fail=0",
-		"memories: accepted(reviewed)=2 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0",
 	} {
 		if !strings.Contains(view, must) {
 			t.Fatalf("cockpit view missing %q:\n%s", must, view)
 		}
+	}
+	if strings.Contains(view, "memories:") {
+		t.Fatalf("sessions tab should not render memory summary:\n%s", view)
 	}
 }
 
@@ -436,11 +409,14 @@ func TestCockpitModelTopTab_LoadsDashboardAndOpensDetail(t *testing.T) {
 		"SESSIONS (1)",
 		"RECENT FAILURES (1)",
 		"go test failed in top tab",
-		"MEMORY CANDIDATES (1)",
-		"use the dedicated top dashboard",
 	} {
 		if !strings.Contains(view, must) {
 			t.Fatalf("top dashboard view missing %q:\n%s", must, view)
+		}
+	}
+	for _, mustNot := range []string{"MEMORY CANDIDATES", "STALE MEMORIES", "use the dedicated top dashboard"} {
+		if strings.Contains(view, mustNot) {
+			t.Fatalf("sessions dashboard should not render memory row %q:\n%s", mustNot, view)
 		}
 	}
 	if strings.Contains(view, "run `traceary top`") {
@@ -2199,7 +2175,7 @@ func TestCockpitModel_NavigationLinesAlignByDisplayWidth(t *testing.T) {
 			wantWidth: 11,
 			descriptions: []string{
 				"live event stream",
-				"session dashboard for failures, commands, memory, and health",
+				"session dashboard for sessions, failures, commands, and health",
 				"memory review queue",
 				"language, read defaults, redaction diagnostics",
 			},
@@ -2209,7 +2185,7 @@ func TestCockpitModel_NavigationLinesAlignByDisplayWidth(t *testing.T) {
 			wantWidth: 13,
 			descriptions: []string{
 				"イベントのライブ表示",
-				"セッション・失敗・コマンド・メモリ・状態の一覧",
+				"セッション・失敗・コマンド・状態の一覧",
 				"メモリ候補の確認キュー",
 				"言語・表示既定・redaction 診断",
 			},
@@ -2256,7 +2232,7 @@ func TestCockpitNavigationSectionsCoverKnownSectionIDs(t *testing.T) {
 		japaneseDescription string
 	}{
 		{cockpitSectionLive, "1", "Tail", "Tail", "live event stream", "イベントのライブ表示"},
-		{cockpitSectionTop, "2", "Sessions", "セッション", "session dashboard for failures, commands, memory, and health", "セッション・失敗・コマンド・メモリ・状態の一覧"},
+		{cockpitSectionTop, "2", "Sessions", "セッション", "session dashboard for sessions, failures, commands, and health", "セッション・失敗・コマンド・状態の一覧"},
 		{cockpitSectionMemory, "3", "Memory", "メモリ", "memory review queue", "メモリ候補の確認キュー"},
 		{cockpitSectionSettings, "4", "Settings", "設定", "language, read defaults, redaction diagnostics", "言語・表示既定・redaction 診断"},
 	}
@@ -3341,33 +3317,6 @@ func (s cockpitStateReaderStub) EventLastSeenAt(context.Context) (time.Time, boo
 
 func (s cockpitStateReaderStub) EventLastSeenIDs(context.Context) ([]string, bool, error) {
 	return slices.Clone(s.eventSeenIDs), len(s.eventSeenIDs) > 0, s.err
-}
-
-func memorySummaryWithSourceAndUpdatedAt(t *testing.T, id string, status domtypes.MemoryStatus, source domtypes.MemorySource, updatedAt time.Time) apptypes.MemorySummary {
-	t.Helper()
-	workspace, err := domtypes.WorkspaceFrom("duck8823/traceary")
-	if err != nil {
-		t.Fatalf("WorkspaceFrom: %v", err)
-	}
-	summary, err := apptypes.MemorySummaryOf(
-		domtypes.MemoryID(id),
-		domtypes.MemoryTypePreference,
-		domtypes.WorkspaceScopeOf(workspace),
-		"cockpit notification fixture "+id,
-		status,
-		domtypes.ConfidenceMedium,
-		source,
-		domtypes.None[domtypes.MemoryID](),
-		domtypes.None[time.Time](),
-		fixedStartedAt,
-		domtypes.None[time.Time](),
-		fixedStartedAt,
-		updatedAt,
-	)
-	if err != nil {
-		t.Fatalf("MemorySummaryOf: %v", err)
-	}
-	return summary
 }
 
 func cockpitMemoryDetailsFixture(t *testing.T, id string, fact string, status domtypes.MemoryStatus) apptypes.MemoryDetails {

--- a/presentation/cli/cockpit_localization.go
+++ b/presentation/cli/cockpit_localization.go
@@ -27,8 +27,8 @@ var cockpitNavigationSections = [...]cockpitNavigationSection{
 		key:                 "2",
 		englishLabel:        "Sessions",
 		japaneseLabel:       "セッション",
-		englishDescription:  "session dashboard for failures, commands, memory, and health",
-		japaneseDescription: "セッション・失敗・コマンド・メモリ・状態の一覧",
+		englishDescription:  "session dashboard for sessions, failures, commands, and health",
+		japaneseDescription: "セッション・失敗・コマンド・状態の一覧",
 	},
 	{
 		id:                  cockpitSectionMemory,

--- a/presentation/cli/testdata/cockpit/top_all_green.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_all_green.golden.txt
@@ -5,7 +5,6 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=0 recent_failures=0 recent_commands=0 new_events=0
-• memories: accepted(reviewed)=2 candidate(inbox)=0 new=0 remember-intent=0 low-quality=0 stale=0
 • doctor: pass=4 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
@@ -15,8 +14,6 @@ Actionable signals
 
 Signal details
 • no unseen events since 2026-05-07T11:30:00Z
-• no unseen candidates since 2026-05-07T11:00:00Z
-• memory candidates=0
 
 Sessions dashboard
 Sessions dashboard has not loaded yet. Press r to refresh.

--- a/presentation/cli/testdata/cockpit/top_candidate_memories_suppressed.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_candidate_memories_suppressed.golden.txt
@@ -5,20 +5,15 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=0 recent_failures=0 recent_commands=0 new_events=untracked
-• memories: accepted(reviewed)=3 candidate(inbox)=4 new=2 remember-intent=1 low-quality=1 stale=0
 • doctor: pass=0 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
 
 Actionable signals
-• [WARN] Memory review queue needs attention — candidate=4 new=2 remember-intent=1 low-quality=1 (3 open Memory review)
+• [OK] No active signals — Tail and Sessions summaries have no review cues.
 
 Signal details
 • new events=untracked until cockpit state is initialized
-• new memory candidates=2
-• memory candidates=4
-• remember-intent candidates=1
-• low-quality candidates=1
 
 Sessions dashboard
 Sessions dashboard has not loaded yet. Press r to refresh.

--- a/presentation/cli/testdata/cockpit/top_candidate_memories_suppressed_ja_narrow.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_candidate_memories_suppressed_ja_narrow.golden.txt
@@ -5,20 +5,15 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions 概要
 • セッション: stale_active=0 recent_failures=0 recent_commands=0 new_events=未追跡
-• メモリ: accepted(reviewed)=3 candidate(inbox)=4 new=2 remember-intent=1 low-quality=1 stale=0
 • doctor: pass=0 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
 
 対応が必要な通知
-• [WARN] メモリ候補の確認が必要 — candidate=4 new=2 remember-intent=1 low-quality=1 (3 メモリ確認を開く)
+• [OK] 対応が必要な通知なし — Tail と Sessions 概要に確認が必要な項目はありません。
 
 通知の詳細
 • cockpit state 初期化まで新着イベントは未追跡
-• 新着メモリ候補=2
-• メモリ候補=4
-• remember-intent メモリ候補=1
-• 低品質メモリ候補=1
 
 Sessions ダッシュボード
 Sessions ダッシュボードはまだ読み込まれていません。r で再取得します。
@@ -31,7 +26,7 @@ Sessions ダッシュボードはまだ読み込まれていません。r で再
 
 全体ナビゲーション
 1 Tail       イベントのライブ表示
-2 セッション セッション・失敗・コマンド・メモリ・状態の一覧
+2 セッション セッション・失敗・コマンド・状態の一覧
 3 メモリ     メモリ候補の確認キュー
 4 設定       言語・表示既定・redaction 診断
 ← / → でタブ移動。tab / shift+tab も利用可能

--- a/presentation/cli/testdata/cockpit/top_doctor_failure.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_doctor_failure.golden.txt
@@ -5,7 +5,6 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=0 recent_failures=0 recent_commands=0 new_events=untracked
-• memories: accepted(reviewed)=0 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0
 • doctor: pass=2 warn=1 fail=1
 • hooks/mcp: warn=0 fail=1
 • payloads: large=0
@@ -15,8 +14,6 @@ Actionable signals
 
 Signal details
 • new events=untracked until cockpit state is initialized
-• memory candidate new count=untracked
-• memory candidates=0
 
 Sessions dashboard
 Sessions dashboard has not loaded yet. Press r to refresh.

--- a/presentation/cli/testdata/cockpit/top_doctor_unavailable.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_doctor_unavailable.golden.txt
@@ -5,7 +5,6 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=0 recent_failures=0 recent_commands=0 new_events=untracked
-• memories: accepted(reviewed)=0 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0
 • doctor: pass=0 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
@@ -15,8 +14,6 @@ Actionable signals
 
 Signal details
 • new events=untracked until cockpit state is initialized
-• memory candidate new count=untracked
-• memory candidates=0
 
 Sessions dashboard
 Sessions dashboard has not loaded yet. Press r to refresh.

--- a/presentation/cli/testdata/cockpit/top_new_events_and_failure.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_new_events_and_failure.golden.txt
@@ -5,7 +5,6 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=0 recent_failures=1 recent_commands=2 new_events=3
-• memories: accepted(reviewed)=0 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0
 • doctor: pass=0 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
@@ -16,8 +15,6 @@ Actionable signals
 
 Signal details
 • new events=3 since 2026-05-07T11:30:00Z
-• memory candidate new count=untracked
-• memory candidates=0
 • recent failures=1
 
 Sessions dashboard

--- a/presentation/cli/testdata/cockpit/top_stale_sessions.golden.txt
+++ b/presentation/cli/testdata/cockpit/top_stale_sessions.golden.txt
@@ -5,7 +5,6 @@ loaded=2026-05-07T12:00:00Z db=/tmp/traceary.db
 
 Sessions summary
 • sessions: stale_active=2 recent_failures=0 recent_commands=0 new_events=untracked
-• memories: accepted(reviewed)=0 candidate(inbox)=0 new=untracked remember-intent=0 low-quality=0 stale=0
 • doctor: pass=0 warn=0 fail=0
 • hooks/mcp: warn=0 fail=0
 • payloads: large=0
@@ -15,8 +14,6 @@ Actionable signals
 
 Signal details
 • new events=untracked until cockpit state is initialized
-• memory candidate new count=untracked
-• memory candidates=0
 • stale active sessions=2
 
 Sessions dashboard

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -50,6 +50,11 @@ type topDataCriteria struct {
 	// this checkpoint is intentionally outside topDataLoader; callers that do
 	// not have state leave it empty and get total-count metrics only.
 	MemoryLastSeenAt domtypes.Optional[time.Time]
+	// SkipMemoryReliability keeps session/failure/command reliability metrics
+	// while bypassing accepted/candidate memory scans. Interactive cockpit
+	// Sessions uses this because Memory review has its own tab and hidden
+	// memory query failures must not break the session dashboard.
+	SkipMemoryReliability bool
 }
 
 func (l *topDataLoader) loadDetail(ctx context.Context, req topDetailRequest) (topDetailContent, error) {
@@ -528,7 +533,7 @@ func (l *topDataLoader) loadReliabilityMetrics(ctx context.Context, c topDataCri
 		StaleActiveSessionCount: inputs.StaleActiveSessionCount,
 		LargePayloads:           topLargePayloadMetricsOf(inputs.Failures, inputs.RecentCommands, apptypes.DefaultTopSnapshotBodyLimit),
 	}
-	if l.memory == nil {
+	if l.memory == nil || c.SkipMemoryReliability {
 		return metrics, nil
 	}
 	memories, err := l.memory.List(ctx, topReliabilityMemoryCriteria(c))

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -78,7 +78,7 @@ func (s *topDataEventStub) Show(_ context.Context, eventID domtypes.EventID) (ap
 }
 
 // topDataMemoryStub satisfies usecase.MemoryUsecase via the embedded
-// interface trick. Only List is exercised by topDataLoader.
+// interface trick. Tests opt into List/ListStale/Show behavior per surface.
 type topDataMemoryStub struct {
 	usecase.MemoryUsecase
 
@@ -1035,6 +1035,39 @@ func TestTopDataLoader_LoadSnapshot_ComputesReliabilityMetrics(t *testing.T) {
 	}
 	if got, want := len(memory.listCriteriaCalls), 2; got != want {
 		t.Fatalf("memory.List calls = %d, want %d (candidate pane + reliability scan)", got, want)
+	}
+}
+
+func TestTopDataLoader_LoadSnapshot_SkipsMemoryReliabilityWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	hugeFailure := mustEvent(t, "evt-skip-huge-fail", domtypes.EventKindCommandExecuted, strings.Repeat("f", apptypes.DefaultTopSnapshotBodyLimit+1))
+	command := mustEvent(t, "evt-skip-cmd", domtypes.EventKindCommandExecuted, "go test ./...")
+	event := &snapshotEventStub{failures: []*model.Event{hugeFailure}, commands: []*model.Event{command}}
+	memory := &topDataMemoryStub{listErr: context.Canceled, staleErr: context.Canceled}
+	loader := newTopDataLoader(nil, event, memory)
+
+	snap, err := loader.loadSnapshot(context.Background(), topDataCriteria{
+		FailureLimit:          1,
+		RecentCommandLimit:    1,
+		CandidateLimit:        0,
+		StaleMemoryLimit:      0,
+		SkipMemoryReliability: true,
+	})
+	if err != nil {
+		t.Fatalf("loadSnapshot() error = %v", err)
+	}
+	if got := memory.listCalls; got != 0 {
+		t.Fatalf("memory.List calls = %d, want 0 when memory reliability is skipped", got)
+	}
+	if got := memory.staleMemoryCalls; got != 0 {
+		t.Fatalf("memory.ListStale calls = %d, want 0 when stale memory pane is disabled", got)
+	}
+	if got, want := snap.Reliability.LargePayloads.Count, 1; got != want {
+		t.Fatalf("LargePayloads.Count = %d, want %d", got, want)
+	}
+	if got := snap.Reliability.CandidateMemoryCount; got != 0 {
+		t.Fatalf("CandidateMemoryCount = %d, want 0 when memory reliability is skipped", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Dogfood feedback says the cockpit Sessions tab should not include Memory status. Sessions should stay focused on session/work activity, while Memory review remains available from the dedicated Memory tab.

Closes #1092

## Changes

- Removed Memory review queue signals and memory count/detail lines from the cockpit Sessions tab.
- Changed the cockpit Sessions dashboard row builder to render only session-centric panes: sessions, recent failures, and recent commands.
- Kept public non-TTY `traceary sessions/top --snapshot [--json]` contracts unchanged; this only changes the cockpit Sessions tab.
- Updated navigation copy so Sessions no longer claims to cover memory/status.
- Updated cockpit behavior tests and dogfood snapshots.

## Review / delegation notes

- Claude implementation delegation was attempted for this issue first, but the headless `claude -p` run hung without output and was terminated after no file changes were produced for several minutes.
- Codex implemented the scoped fallback and ran local verification.

## Validation

```sh
TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'CockpitModelTopTab|LoadCockpitHome|CockpitModelView|CockpitDogfood|CockpitNavigation'
TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci
git diff --check
```
