### PR TITLE
v0.19-19: align cockpit Tail rendering with tail command

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -451,6 +451,7 @@ type cockpitLoader interface {
 
 type cockpitLiveSnapshot struct {
 	Events   []*model.Event
+	Extras   map[domtypes.EventID]compactRowExtras
 	Cursor   tailCursor
 	LoadedAt time.Time
 }
@@ -555,7 +556,7 @@ func (c *RootCLI) loadCockpitLive(ctx context.Context, cursor tailCursor, initia
 		} else {
 			cursor = newTailCursor(now)
 		}
-		return cockpitLiveSnapshot{Events: events, Cursor: cursor, LoadedAt: now}, nil
+		return cockpitLiveSnapshot{Events: events, Extras: c.cockpitLiveExtras(ctx, events), Cursor: cursor, LoadedAt: now}, nil
 	}
 	base := apptypes.NewEventListCriteriaBuilder(defaultTailBatchSize).Build()
 	events, err := c.pollTailEvents(ctx, base, cursor, now)
@@ -563,7 +564,25 @@ func (c *RootCLI) loadCockpitLive(ctx context.Context, cursor tailCursor, initia
 		return cockpitLiveSnapshot{}, err
 	}
 	cursor.Advance(events)
-	return cockpitLiveSnapshot{Events: events, Cursor: cursor, LoadedAt: now}, nil
+	return cockpitLiveSnapshot{Events: events, Extras: c.cockpitLiveExtras(ctx, events), Cursor: cursor, LoadedAt: now}, nil
+}
+
+func (c *RootCLI) cockpitLiveExtras(ctx context.Context, events []*model.Event) map[domtypes.EventID]compactRowExtras {
+	resolver := c.makeCompactExtrasResolver(ctx, defaultReadFields, true)
+	if resolver == nil || len(events) == 0 {
+		return nil
+	}
+	extras := make(map[domtypes.EventID]compactRowExtras)
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		extras[event.EventID()] = resolver(event)
+	}
+	if len(extras) == 0 {
+		return nil
+	}
+	return extras
 }
 
 func (c *RootCLI) loadCockpitEventDetail(ctx context.Context, eventID domtypes.EventID) (topDetailContent, error) {
@@ -694,6 +713,7 @@ type cockpitTopSignal struct {
 
 type cockpitLiveState struct {
 	events         []*model.Event
+	extras         map[domtypes.EventID]compactRowExtras
 	cursor         tailCursor
 	loadedAt       time.Time
 	loading        bool
@@ -845,12 +865,14 @@ func (m cockpitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err == nil {
 			if msg.initial {
 				m.live.events = msg.snapshot.Events
+				m.live.extras = cloneCockpitLiveExtras(msg.snapshot.Extras)
 				m.live.pausedNewCount = 0
 			} else {
 				if !m.live.follow && len(msg.snapshot.Events) > 0 {
 					m.live.pausedNewCount += len(msg.snapshot.Events)
 				}
 				m.live.events = append(m.live.events, msg.snapshot.Events...)
+				m.mergeCockpitLiveExtras(msg.snapshot.Extras)
 				m.trimCockpitLiveEventsToLimit()
 			}
 			m.live.cursor = msg.snapshot.Cursor
@@ -1802,12 +1824,14 @@ func (m *cockpitModel) ensureCockpitTopSelectionVisible(rows []cockpitTopRow) {
 }
 
 func (m *cockpitModel) trimCockpitLiveEventsToLimit() {
+	before := len(m.live.events)
 	overflow := len(m.live.events) - cockpitLiveMaxEvents
 	if overflow <= 0 {
 		return
 	}
 	if m.live.follow {
 		m.live.events = m.live.events[overflow:]
+		m.pruneCockpitLiveExtras()
 		return
 	}
 	m.clampLiveSelection()
@@ -1822,6 +1846,52 @@ func (m *cockpitModel) trimCockpitLiveEventsToLimit() {
 			return
 		}
 		overflow--
+	}
+	if len(m.live.events) != before {
+		m.pruneCockpitLiveExtras()
+	}
+}
+
+func cloneCockpitLiveExtras(in map[domtypes.EventID]compactRowExtras) map[domtypes.EventID]compactRowExtras {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[domtypes.EventID]compactRowExtras, len(in))
+	for id, extras := range in {
+		out[id] = extras
+	}
+	return out
+}
+
+func (m *cockpitModel) mergeCockpitLiveExtras(in map[domtypes.EventID]compactRowExtras) {
+	if len(in) == 0 {
+		return
+	}
+	if m.live.extras == nil {
+		m.live.extras = make(map[domtypes.EventID]compactRowExtras, len(in))
+	}
+	for id, extras := range in {
+		m.live.extras[id] = extras
+	}
+}
+
+func (m *cockpitModel) pruneCockpitLiveExtras() {
+	if len(m.live.extras) == 0 {
+		return
+	}
+	visible := make(map[domtypes.EventID]struct{}, len(m.live.events))
+	for _, event := range m.live.events {
+		if event != nil {
+			visible[event.EventID()] = struct{}{}
+		}
+	}
+	for id := range m.live.extras {
+		if _, ok := visible[id]; !ok {
+			delete(m.live.extras, id)
+		}
+	}
+	if len(m.live.extras) == 0 {
+		m.live.extras = nil
 	}
 }
 
@@ -2092,7 +2162,7 @@ func (m cockpitModel) liveView() string {
 		}
 		start, end := m.cockpitLiveVisibleRange(viewport)
 		for _, event := range m.live.events[start:end] {
-			lines = append(lines, formatCockpitLiveEventRow(event, time.Local))
+			lines = append(lines, m.formatCockpitLiveEventRow(event, time.Local))
 		}
 	}
 	return m.renderCockpitShell(Localize("live tail", "live tail"), lines, m.liveLocalHelp())
@@ -2111,6 +2181,13 @@ func (m cockpitModel) cockpitLiveViewportRows(preludeRows int) int {
 
 func (m cockpitModel) cockpitLiveKeyViewportRows() int {
 	return m.cockpitLiveViewportRows(cockpitLiveBasePreludeRows)
+}
+
+func (m cockpitModel) cockpitLiveRowWidth() int {
+	if m.width <= 0 {
+		return 0
+	}
+	return max(m.width-1, 1)
 }
 
 func (m cockpitModel) cockpitLiveVisibleRange(viewport int) (int, int) {
@@ -2965,15 +3042,23 @@ func (m cockpitModel) detailLines() []string {
 	return m.detail.lines
 }
 
-func formatCockpitLiveEventRow(event *model.Event, loc *time.Location) string {
+func (m cockpitModel) formatCockpitLiveEventRow(event *model.Event, loc *time.Location) string {
+	extras := compactRowExtras{}
+	if event != nil && m.live.extras != nil {
+		extras = m.live.extras[event.EventID()]
+	}
+	return formatCockpitLiveEventRow(event, loc, m.cockpitLiveRowWidth(), extras, true)
+}
+
+func formatCockpitLiveEventRow(event *model.Event, loc *time.Location, targetWidth int, extras compactRowExtras, colorEnabled bool) string {
 	if event == nil {
 		return "-"
 	}
 	displayEvent := event
-	truncated := false
+	truncationMarker := ""
 	out := newTruncatedEventOutput(event, apptypes.DefaultTopSnapshotBodyLimit)
 	if out.Truncated {
-		truncated = true
+		truncationMarker = " [truncated]"
 		displayEvent = model.EventOfWithSourceHook(
 			event.EventID(),
 			event.Kind(),
@@ -2986,11 +3071,12 @@ func formatCockpitLiveEventRow(event *model.Event, loc *time.Location) string {
 			event.SourceHook(),
 		)
 	}
-	row := formatEventCompactRow(displayEvent, eventTextFormatOptions{location: loc}, compactRowExtras{})
-	if truncated {
-		row += " [truncated]"
+	rowWidth := targetWidth
+	if rowWidth > runeLen(truncationMarker)+8 {
+		rowWidth -= runeLen(truncationMarker)
 	}
-	return row
+	row := formatEventCompactRow(displayEvent, eventTextFormatOptions{location: loc, targetWidth: rowWidth, messageMinWidth: 8, hardTargetWidth: true, colorEnabled: colorEnabled}, extras)
+	return row + truncationMarker
 }
 
 func cockpitLiveSeenAt(snapshot cockpitLiveSnapshot) time.Time {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1740,12 +1740,69 @@ func TestFormatCockpitLiveEventRow_TruncatesLargePayload(t *testing.T) {
 	t.Parallel()
 
 	event := mustEvent(t, "evt-large", domtypes.EventKindCommandExecuted, strings.Repeat("x", apptypes.DefaultTopSnapshotBodyLimit+20))
-	row := formatCockpitLiveEventRow(event, time.UTC)
+	row := formatCockpitLiveEventRow(event, time.UTC, 100, compactRowExtras{}, false)
 	if !strings.Contains(row, "[truncated]") {
 		t.Fatalf("row = %q, want truncation marker", row)
 	}
 	if got, limit := len([]rune(row)), apptypes.DefaultTopSnapshotBodyLimit; got >= limit {
 		t.Fatalf("row length = %d, want compact row below body limit %d", got, limit)
+	}
+}
+
+func TestFormatCockpitLiveEventRow_UsesViewportWidth(t *testing.T) {
+	t.Parallel()
+
+	event := mustEvent(t, "evt-long-tail", domtypes.EventKindCommandExecuted, "go test ./presentation/cli -run TestCockpitLiveTailKeepsUsefulContext --count=1 --timeout=30s")
+	widths := []int{80, 100, 120}
+	rows := make([]string, 0, len(widths))
+	for _, width := range widths {
+		row := formatCockpitLiveEventRow(event, time.UTC, width, compactRowExtras{}, false)
+		rows = append(rows, row)
+		if got := runeLen(row); got > width {
+			t.Fatalf("row width at target %d = %d, want <= target:\n%s", width, got, row)
+		}
+		for _, must := range []string{"12:00:00", "command_executed", "sess=", "ws=traceary", "go test"} {
+			if !strings.Contains(row, must) {
+				t.Fatalf("row at width %d missing %q:\n%s", width, must, row)
+			}
+		}
+	}
+	if runeLen(rows[0]) >= runeLen(rows[1]) || runeLen(rows[1]) >= runeLen(rows[2]) {
+		t.Fatalf("rows should preserve more context as width grows:\n80=%q\n100=%q\n120=%q", rows[0], rows[1], rows[2])
+	}
+	if strings.Contains(rows[0], "TestCockpitLiveTa") {
+		t.Fatalf("80-column row unexpectedly kept wide-only context:\n%s", rows[0])
+	}
+	if !strings.Contains(rows[2], "TestCockpitLiveTa") {
+		t.Fatalf("120-column row should keep useful command context:\n%s", rows[2])
+	}
+}
+
+func TestFormatCockpitLiveEventRow_ColorSemanticsMatchTail(t *testing.T) {
+	t.Parallel()
+
+	failed := mustEvent(t, "evt-live-failed-color", domtypes.EventKindCommandExecuted, "go test ./...")
+	failedRow := formatCockpitLiveEventRow(failed, time.UTC, 120, compactRowExtras{exitCode: domtypes.Some(1)}, true)
+	if !strings.HasPrefix(failedRow, ansiRedBold) || !strings.HasSuffix(failedRow, ansiReset) {
+		t.Fatalf("failed command row color = %q, want red/bold wrapper", failedRow)
+	}
+
+	success := mustEvent(t, "evt-live-success-color", domtypes.EventKindCommandExecuted, "go test ./...")
+	successRow := formatCockpitLiveEventRow(success, time.UTC, 120, compactRowExtras{exitCode: domtypes.Some(0)}, true)
+	if strings.Contains(successRow, ansiRedBold) || strings.Contains(successRow, ansiReset) {
+		t.Fatalf("successful command row should stay plain, got %q", successRow)
+	}
+
+	promptBase := mustEvent(t, "evt-live-prompt-color", domtypes.EventKindPrompt, "review this")
+	promptRow := formatCockpitLiveEventRow(promptBase, time.UTC, 120, compactRowExtras{}, true)
+	if !strings.HasPrefix(promptRow, ansiCyan) || !strings.HasSuffix(promptRow, ansiReset) {
+		t.Fatalf("prompt row color = %q, want cyan wrapper", promptRow)
+	}
+
+	summary := mustEvent(t, "evt-live-summary-color", domtypes.EventKindCompactSummary, "summary")
+	summaryRow := formatCockpitLiveEventRow(summary, time.UTC, 120, compactRowExtras{}, true)
+	if !strings.HasPrefix(summaryRow, ansiMagenta) || !strings.HasSuffix(summaryRow, ansiReset) {
+		t.Fatalf("compact summary row color = %q, want magenta wrapper", summaryRow)
 	}
 }
 

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -48,6 +48,13 @@ type eventTextFormatOptions struct {
 	// fixed eventCompactTargetWidth default so non-interactive output (pipes,
 	// golden tests) stays byte-stable.
 	targetWidth int
+	// messageMinWidth overrides the compact message floor used when metadata
+	// columns consume most of targetWidth. 0 means use the historical default.
+	messageMinWidth int
+	// hardTargetWidth caps the final compact row at targetWidth. It is opt-in
+	// so legacy non-interactive compact output keeps its historical minimum
+	// message floor even when metadata columns are unusually wide.
+	hardTargetWidth bool
 }
 
 // compactRowExtras carries hydrated data that a specific field needs but is
@@ -132,12 +139,16 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 	if targetWidth <= 0 {
 		targetWidth = eventCompactTargetWidth
 	}
+	messageMinWidth := opts.messageMinWidth
+	if messageMinWidth <= 0 {
+		messageMinWidth = eventCompactMessageMinRunes
+	}
 	prefix := strings.Join(tokens[:messageIndex], sep)
 	if messageIndex > 0 {
 		prefix += sep
 	}
 	remaining := targetWidth - runeLen(prefix)
-	if remaining < eventCompactMessageMinRunes {
+	if remaining < messageMinWidth {
 		for i := 0; i < messageIndex; i++ {
 			if fields[i] == readFieldWorkspace {
 				tokens[i] = "ws=" + truncateNormalized(compactWorkspace(event.Workspace().String()), eventCompactWorkspaceMaxRunes)
@@ -149,11 +160,14 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 			prefix += sep
 		}
 		remaining = targetWidth - runeLen(prefix)
-		if remaining < eventCompactMessageMinRunes {
-			remaining = eventCompactMessageMinRunes
+		if remaining < messageMinWidth {
+			remaining = messageMinWidth
 		}
 	}
 	plain := prefix + truncateNormalized(apptypes.ExtractPlainBody(event.Body()), remaining)
+	if opts.hardTargetWidth && targetWidth > 0 && runeLen(plain) > targetWidth {
+		plain = truncateNormalized(plain, targetWidth)
+	}
 	if opts.colorEnabled {
 		exitCode, exitCodeSet := extras.exitCode.Value()
 		return applyCompactRowHighlight(plain, string(event.Kind()), exitCode, exitCodeSet)


### PR DESCRIPTION
## Motivation

Closes #1089.

Dogfood feedback reported that the cockpit Tail tab truncated long rows too aggressively and visually diverged from `traceary tail`. This keeps Tail as a read-only stream while making rows use the same compact formatter/color semantics as the standalone tail command.

## Changes

- Use the cockpit terminal width as the compact Tail row target width so 80/100/120-column terminals preserve progressively more useful command/message context.
- Reuse compact event row highlighting semantics for prompt/transcript/compact-summary/failed command rows.
- Hydrate command exit-code extras for cockpit Tail rows so failed command emphasis matches `traceary tail` color behavior.
- Keep Tail stream-only; Enter still does not drill down from Tail.
- Add regression coverage for width-aware Tail rows, color semantics, and existing stream-only keyboard path.

## Structure / behavior notes

- Concept model: Tail rows are a view of the same compact event-row model used by non-TTY tail/list/search; cockpit only supplies the viewport width and command extras.
- Responsibility split: `event_text_formatter` owns compact row budgeting; cockpit owns live-stream state, viewport width, and retaining per-event extras.
- Snapshot compatibility: non-TTY `traceary tail` output remains unchanged because the new message floor override is only set by cockpit.

## Validation

- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'CockpitLive|FormatCockpitLiveEventRow|CockpitDogfoodKeyboardPaths|FormatEventCompactRow'`
- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci`
- `git diff --check`

## AI delegation / review

- Claude implementation delegation was attempted first, but the headless process produced no usable output before Codex fallback implementation.
- Claude/Gemini ai-review will be run before ready/merge per current autonomous flow.
