### PR TITLE
v0.19-20: keep Sessions usable with many sessions

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -2400,6 +2400,9 @@ func (m cockpitModel) cockpitTopDashboardLines() []string {
 		scroll = fmt.Sprintf(" rows=%d", len(rows))
 	}
 	lines = append(lines, m.styles.Subtle.Render(fmt.Sprintf("loaded=%s%s", formatJSONTime(m.top.loadedAt), scroll)))
+	if sticky := cockpitTopStickyHeaderLine(rows, start, m.top.snapshot); sticky != "" {
+		lines = append(lines, m.styles.Subtle.Render(sticky))
+	}
 	for i := start; i < end; i++ {
 		row := rows[i]
 		prefix := "  "
@@ -2486,6 +2489,49 @@ func cockpitTopSectionLabel(pane topPane, snapshot topDataSnapshot) string {
 	default:
 		return ""
 	}
+}
+
+// cockpitTopStickyHeaderLine returns a one-line sticky breadcrumb the
+// Sessions dashboard prepends to its visible window when the operator
+// has scrolled past the section header that owns the topmost visible
+// row. With many nested sessions on an 80x24 terminal the SESSIONS
+// pane easily exceeds the ~6-row viewport, so without a sticky cue the
+// operator loses track of which pane they are scrolled into and how
+// far down the section they are. Returns "" when no sticky is needed
+// (window already shows the section header).
+func cockpitTopStickyHeaderLine(rows []cockpitTopRow, start int, snapshot topDataSnapshot) string {
+	if start <= 0 || start >= len(rows) {
+		return ""
+	}
+	if rows[start].header {
+		return ""
+	}
+	headerIdx := -1
+	for i := start - 1; i >= 0; i-- {
+		if rows[i].header {
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx < 0 {
+		return ""
+	}
+	sectionTotal := 0
+	for i := headerIdx + 1; i < len(rows); i++ {
+		if rows[i].header {
+			break
+		}
+		sectionTotal++
+	}
+	label := cockpitTopSectionLabel(rows[headerIdx].pane, snapshot)
+	if label == "" {
+		return ""
+	}
+	position := start - headerIdx
+	if sectionTotal > 0 {
+		return Localizef("↑ %s · row %d/%d", "↑ %s · 行 %d/%d", label, position, sectionTotal)
+	}
+	return "↑ " + label
 }
 
 func countCockpitTopSessionRows(nodes []*sessionNode) int {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -548,6 +548,87 @@ func TestCockpitModelTopTab_IgnoresStaleDetailAfterLeavingTop(t *testing.T) {
 	}
 }
 
+func TestCockpitTopStickyHeaderLine_BreadcrumbsScrolledSection(t *testing.T) {
+	t.Parallel()
+	rows := []cockpitTopRow{
+		{line: "SESSIONS (3)", pane: topPaneSessions, header: true},
+		{line: "ws-1 ...", pane: topPaneSessions, selectable: true},
+		{line: "ws-2 ...", pane: topPaneSessions, selectable: true},
+		{line: "ws-3 ...", pane: topPaneSessions, selectable: true},
+		{line: "RECENT FAILURES (2)", pane: topPaneFailures, header: true},
+		{line: "fail-1 ...", pane: topPaneFailures, selectable: true},
+		{line: "fail-2 ...", pane: topPaneFailures, selectable: true},
+	}
+	root := sessionSummaryFixture("ws-1", "", fixedStartedAt, "active", domtypes.EventKindNote, "")
+	mid := sessionSummaryFixture("ws-2", "", fixedStartedAt.Add(time.Minute), "active", domtypes.EventKindNote, "")
+	tail := sessionSummaryFixture("ws-3", "", fixedStartedAt.Add(2*time.Minute), "active", domtypes.EventKindNote, "")
+	snapshot := topDataSnapshot{
+		Sessions: buildActiveSessionTreeWithOptions(
+			[]apptypes.SessionSummary{root, mid, tail},
+			false, defaultActiveSessionStaleAfter, fixedStartedAt.Add(time.Hour),
+		),
+	}
+
+	if got := cockpitTopStickyHeaderLine(rows, 0, snapshot); got != "" {
+		t.Fatalf("offset=0 sticky = %q, want empty", got)
+	}
+	if got := cockpitTopStickyHeaderLine(rows, 4, snapshot); got != "" {
+		t.Fatalf("offset at FAILURES header sticky = %q, want empty (header visible)", got)
+	}
+	if got, want := cockpitTopStickyHeaderLine(rows, 2, snapshot), "↑ SESSIONS (3) · row 2/3"; got != want {
+		t.Fatalf("offset within SESSIONS sticky = %q, want %q", got, want)
+	}
+	if got, want := cockpitTopStickyHeaderLine(rows, 6, snapshot), "↑ RECENT FAILURES (0) · row 2/2"; got != want {
+		t.Fatalf("offset within FAILURES sticky = %q, want %q", got, want)
+	}
+}
+
+func TestCockpitModelTopTab_StickyHeaderSurfacesPaneWhenScrolled(t *testing.T) {
+	t.Parallel()
+
+	const sessionCount = 50
+	summaries := make([]apptypes.SessionSummary, 0, sessionCount)
+	for i := 0; i < sessionCount; i++ {
+		summaries = append(summaries, sessionSummaryFixture(
+			fmt.Sprintf("sess-%02d", i),
+			"",
+			fixedStartedAt.Add(time.Duration(i)*time.Minute),
+			"active",
+			domtypes.EventKindNote,
+			fmt.Sprintf("row %d", i),
+		))
+	}
+	now := fixedStartedAt.Add(time.Hour)
+	snapshot := topDataSnapshot{
+		Sessions: buildActiveSessionTreeWithOptions(summaries, false, defaultActiveSessionStaleAfter, now),
+		Now:      now,
+	}
+
+	cockpit := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	cockpit.mode = cockpitModeTop
+	cockpit.top.loaded = true
+	cockpit.top.snapshot = snapshot
+	cockpit.top.criteria = topDataCriteria{Now: now, SessionLimit: defaultTopLimit}
+	cockpit.top.loadedAt = now
+	updated, _ := cockpit.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cockpit = updated.(cockpitModel)
+
+	initial := cockpit.View()
+	if strings.Contains(initial, "↑ SESSIONS") {
+		t.Fatalf("unscrolled view should not include sticky cue:\n%s", initial)
+	}
+	if !strings.Contains(initial, "SESSIONS (50)") {
+		t.Fatalf("unscrolled view should still surface SESSIONS (50) header:\n%s", initial)
+	}
+
+	cockpit.top.offset = 20
+	cockpit.top.selected = 21
+	scrolled := cockpit.View()
+	if !strings.Contains(scrolled, "↑ SESSIONS (50) · row 20/50") {
+		t.Fatalf("scrolled view missing sticky breadcrumb:\n%s", scrolled)
+	}
+}
+
 func TestCockpitModel_InitLoadsTailEvenWhenTopSummaryFails(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -567,6 +567,10 @@ func TestCockpitTopStickyHeaderLine_BreadcrumbsScrolledSection(t *testing.T) {
 			[]apptypes.SessionSummary{root, mid, tail},
 			false, defaultActiveSessionStaleAfter, fixedStartedAt.Add(time.Hour),
 		),
+		Failures: []*model.Event{
+			mustEvent(t, "evt-sticky-fail-1", domtypes.EventKindCommandExecuted, "failure one"),
+			mustEvent(t, "evt-sticky-fail-2", domtypes.EventKindCommandExecuted, "failure two"),
+		},
 	}
 
 	if got := cockpitTopStickyHeaderLine(rows, 0, snapshot); got != "" {
@@ -578,7 +582,7 @@ func TestCockpitTopStickyHeaderLine_BreadcrumbsScrolledSection(t *testing.T) {
 	if got, want := cockpitTopStickyHeaderLine(rows, 2, snapshot), "↑ SESSIONS (3) · row 2/3"; got != want {
 		t.Fatalf("offset within SESSIONS sticky = %q, want %q", got, want)
 	}
-	if got, want := cockpitTopStickyHeaderLine(rows, 6, snapshot), "↑ RECENT FAILURES (0) · row 2/2"; got != want {
+	if got, want := cockpitTopStickyHeaderLine(rows, 6, snapshot), "↑ RECENT FAILURES (2) · row 2/2"; got != want {
 		t.Fatalf("offset within FAILURES sticky = %q, want %q", got, want)
 	}
 }

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -588,7 +588,7 @@ func TestCockpitModelTopTab_StickyHeaderSurfacesPaneWhenScrolled(t *testing.T) {
 
 	const sessionCount = 50
 	summaries := make([]apptypes.SessionSummary, 0, sessionCount)
-	for i := 0; i < sessionCount; i++ {
+	for i := range sessionCount {
 		summaries = append(summaries, sessionSummaryFixture(
 			fmt.Sprintf("sess-%02d", i),
 			"",

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -776,37 +776,63 @@ func cloneDashboardSessionNode(node *sessionNode) *sessionNode {
 }
 
 func sortDashboardSessionNodes(nodes []*sessionNode) {
+	priorities := make(map[*sessionNode]dashboardSessionPriority, len(nodes))
+	for _, node := range nodes {
+		dashboardSessionPriorityFor(node, priorities)
+	}
+	sortDashboardSessionNodesWithPriorities(nodes, priorities)
+}
+
+func sortDashboardSessionNodesWithPriorities(nodes []*sessionNode, priorities map[*sessionNode]dashboardSessionPriority) {
 	sort.SliceStable(nodes, func(i, j int) bool {
-		return dashboardSessionNodeLess(nodes[i], nodes[j])
+		return dashboardSessionNodeLess(nodes[i], nodes[j], priorities)
 	})
 	for _, node := range nodes {
-		sortDashboardSessionNodes(node.children)
+		sortDashboardSessionNodesWithPriorities(node.children, priorities)
 	}
 }
 
-func dashboardSessionNodeLess(left, right *sessionNode) bool {
-	leftRank := dashboardSubtreeStatusRank(left)
-	rightRank := dashboardSubtreeStatusRank(right)
+type dashboardSessionPriority struct {
+	statusRank int
+	latest     time.Time
+}
+
+func dashboardSessionPriorityFor(node *sessionNode, priorities map[*sessionNode]dashboardSessionPriority) dashboardSessionPriority {
+	if node == nil {
+		return dashboardSessionPriority{}
+	}
+	if priority, ok := priorities[node]; ok {
+		return priority
+	}
+	priority := dashboardSessionPriority{
+		statusRank: dashboardStatusRank(node.summary.Status()),
+		latest:     node.summary.LatestEventAt(),
+	}
+	for _, child := range node.children {
+		childPriority := dashboardSessionPriorityFor(child, priorities)
+		priority.statusRank = max(priority.statusRank, childPriority.statusRank)
+		if childPriority.latest.After(priority.latest) {
+			priority.latest = childPriority.latest
+		}
+	}
+	priorities[node] = priority
+	return priority
+}
+
+func dashboardSessionNodeLess(left, right *sessionNode, priorities map[*sessionNode]dashboardSessionPriority) bool {
+	leftPriority := priorities[left]
+	rightPriority := priorities[right]
+	leftRank := leftPriority.statusRank
+	rightRank := rightPriority.statusRank
 	if leftRank != rightRank {
 		return leftRank > rightRank
 	}
-	leftLatest := dashboardSubtreeLatestAt(left)
-	rightLatest := dashboardSubtreeLatestAt(right)
+	leftLatest := leftPriority.latest
+	rightLatest := rightPriority.latest
 	if !leftLatest.Equal(rightLatest) {
 		return leftLatest.After(rightLatest)
 	}
 	return sessionNodeLess(left, right)
-}
-
-func dashboardSubtreeStatusRank(node *sessionNode) int {
-	if node == nil {
-		return 0
-	}
-	rank := dashboardStatusRank(node.summary.Status())
-	for _, child := range node.children {
-		rank = max(rank, dashboardSubtreeStatusRank(child))
-	}
-	return rank
 }
 
 func dashboardStatusRank(status string) int {
@@ -820,19 +846,6 @@ func dashboardStatusRank(status string) int {
 	default:
 		return 0
 	}
-}
-
-func dashboardSubtreeLatestAt(node *sessionNode) time.Time {
-	if node == nil {
-		return time.Time{}
-	}
-	latest := node.summary.LatestEventAt()
-	for _, child := range node.children {
-		if childLatest := dashboardSubtreeLatestAt(child); childLatest.After(latest) {
-			latest = childLatest
-		}
-	}
-	return latest
 }
 
 func formatTopDashboardNodeLineIn(node *sessionNode, prefix string, idle time.Duration, now time.Time, loc *time.Location, width int) string {

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -33,6 +33,12 @@ const (
 	topPaneStaleMemoryLimit   = topPaneCandidateLimit
 )
 
+const (
+	dashboardSessionStatusActive = "active"
+	dashboardSessionStatusStale  = "stale"
+	dashboardSessionStatusEnded  = "ended"
+)
+
 // topPane enumerates the focusable panes on the dashboard.
 //
 // The numeric order matches the visual order so iteration helpers can stay
@@ -837,11 +843,11 @@ func dashboardSessionNodeLess(left, right *sessionNode, priorities map[*sessionN
 
 func dashboardStatusRank(status string) int {
 	switch status {
-	case "active":
+	case dashboardSessionStatusActive:
 		return 3
-	case "stale":
+	case dashboardSessionStatusStale:
 		return 2
-	case "ended":
+	case dashboardSessionStatusEnded:
 		return 1
 	default:
 		return 0

--- a/presentation/cli/top_dashboard.go
+++ b/presentation/cli/top_dashboard.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli/tui"
@@ -702,7 +704,7 @@ func (m topModel) sessionRows(width int) []topPaneRow {
 	}
 	now := m.now()
 	out := make([]topPaneRow, 0)
-	for _, root := range m.snapshot.Sessions {
+	for _, root := range dashboardSessionRoots(m.snapshot.Sessions) {
 		out = appendSessionRows(out, root, "", true, false, m.idle, now, m.location, width)
 	}
 	return out
@@ -717,7 +719,7 @@ func appendSessionRows(out []topPaneRow, node *sessionNode, prefix string, isLas
 		connector = ""
 	}
 	linePrefix := prefix + connector
-	line := formatTopNodeLineIn(node, linePrefix, idle, now, loc)
+	line := formatTopDashboardNodeLineIn(node, linePrefix, idle, now, loc, width)
 	summary := node.summary
 	out = append(out, topPaneRow{
 		line: truncateToWidth(line, width),
@@ -739,6 +741,165 @@ func appendSessionRows(out []topPaneRow, node *sessionNode, prefix string, isLas
 		out = appendSessionRows(out, child, childPrefix, i == len(node.children)-1, true, idle, now, loc, width)
 	}
 	return out
+}
+
+func dashboardSessionRoots(roots []*sessionNode) []*sessionNode {
+	if len(roots) == 0 {
+		return nil
+	}
+	cloned := make([]*sessionNode, 0, len(roots))
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+		cloned = append(cloned, cloneDashboardSessionNode(root))
+	}
+	sortDashboardSessionNodes(cloned)
+	return cloned
+}
+
+func cloneDashboardSessionNode(node *sessionNode) *sessionNode {
+	if node == nil {
+		return nil
+	}
+	cloned := &sessionNode{summary: node.summary}
+	if len(node.children) > 0 {
+		cloned.children = make([]*sessionNode, 0, len(node.children))
+		for _, child := range node.children {
+			if child == nil {
+				continue
+			}
+			cloned.children = append(cloned.children, cloneDashboardSessionNode(child))
+		}
+	}
+	return cloned
+}
+
+func sortDashboardSessionNodes(nodes []*sessionNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return dashboardSessionNodeLess(nodes[i], nodes[j])
+	})
+	for _, node := range nodes {
+		sortDashboardSessionNodes(node.children)
+	}
+}
+
+func dashboardSessionNodeLess(left, right *sessionNode) bool {
+	leftRank := dashboardSubtreeStatusRank(left)
+	rightRank := dashboardSubtreeStatusRank(right)
+	if leftRank != rightRank {
+		return leftRank > rightRank
+	}
+	leftLatest := dashboardSubtreeLatestAt(left)
+	rightLatest := dashboardSubtreeLatestAt(right)
+	if !leftLatest.Equal(rightLatest) {
+		return leftLatest.After(rightLatest)
+	}
+	return sessionNodeLess(left, right)
+}
+
+func dashboardSubtreeStatusRank(node *sessionNode) int {
+	if node == nil {
+		return 0
+	}
+	rank := dashboardStatusRank(node.summary.Status())
+	for _, child := range node.children {
+		rank = max(rank, dashboardSubtreeStatusRank(child))
+	}
+	return rank
+}
+
+func dashboardStatusRank(status string) int {
+	switch status {
+	case "active":
+		return 3
+	case "stale":
+		return 2
+	case "ended":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func dashboardSubtreeLatestAt(node *sessionNode) time.Time {
+	if node == nil {
+		return time.Time{}
+	}
+	latest := node.summary.LatestEventAt()
+	for _, child := range node.children {
+		if childLatest := dashboardSubtreeLatestAt(child); childLatest.After(latest) {
+			latest = childLatest
+		}
+	}
+	return latest
+}
+
+func formatTopDashboardNodeLineIn(node *sessionNode, prefix string, idle time.Duration, now time.Time, loc *time.Location, width int) string {
+	s := node.summary
+	latest := s.LatestEventAt()
+	idleFor := now.Sub(latest)
+	idleMarker := ""
+	if idle > 0 && idleFor >= idle {
+		idleMarker = " idle"
+	}
+	agent := extractSubagentType(s.Agents())
+	if agent == "" {
+		agent = "-"
+	}
+	client := s.Client().String()
+	if client == "" {
+		client = "-"
+	}
+	sessionID := s.SessionID().String()
+	if width > 0 && width < 120 {
+		sessionID = shortTopSessionID(sessionID)
+	}
+	displayName := formatTopDashboardSessionDisplayName(s)
+	latestText := "-"
+	if !latest.IsZero() {
+		latestText = latest.In(loc).Format("15:04")
+	}
+	return fmt.Sprintf("%s%s [%s] %s latest=%s ws=%s via=%s/%s last=%s%s",
+		prefix,
+		displayName,
+		sessionID,
+		normalizeTabularColumn(s.Status()),
+		latestText,
+		compactWorkspace(s.Workspace().String()),
+		client,
+		agent,
+		formatTopLatestEvent(s),
+		idleMarker,
+	)
+}
+
+func formatTopDashboardSessionDisplayName(s apptypes.SessionSummary) string {
+	for _, candidate := range []string{s.Label(), s.Summary()} {
+		if name := truncateTopDashboardDisplayName(candidate); name != "" {
+			return name
+		}
+	}
+
+	workspace := compactWorkspace(s.Workspace().String())
+	agent := extractSubagentType(s.Agents())
+	if agent == "" {
+		agent = strings.TrimSpace(s.SubagentKind())
+	}
+	switch {
+	case workspace != "-" && agent != "":
+		return truncateTopDashboardDisplayName(workspace + " · " + agent)
+	case workspace != "-":
+		return truncateTopDashboardDisplayName(workspace)
+	case agent != "":
+		return truncateTopDashboardDisplayName(agent)
+	default:
+		return shortTopSessionID(s.SessionID().String())
+	}
+}
+
+func truncateTopDashboardDisplayName(value string) string {
+	return truncateToWidth(normalizeTabularColumn(value), 24)
 }
 
 // eventLines renders one row per event for the failures and recent-commands

--- a/presentation/cli/top_dashboard_internal_test.go
+++ b/presentation/cli/top_dashboard_internal_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
@@ -76,6 +78,30 @@ func dashboardSessionNode(id string, latest time.Time) *sessionNode {
 		"",
 		"",
 		domtypes.SessionID(""),
+		domtypes.Client("claude"),
+		latest,
+		apptypes.SessionSummaryLatestEventOf(domtypes.EventKindTranscript, "row "+id),
+	)
+	return &sessionNode{summary: summary}
+}
+
+func dashboardSessionNodeWith(id string, parent string, started time.Time, status string, label string, latest time.Time) *sessionNode {
+	endedAt := domtypes.None[time.Time]()
+	if status == "ended" {
+		endedAt = domtypes.Some(latest)
+	}
+	summary := apptypes.SessionSummaryOf(
+		domtypes.SessionID(id),
+		domtypes.Workspace("duck8823/traceary"),
+		started,
+		endedAt,
+		status,
+		3,
+		1,
+		[]string{"claude"},
+		label,
+		"",
+		domtypes.SessionID(parent),
 		domtypes.Client("claude"),
 		latest,
 		apptypes.SessionSummaryLatestEventOf(domtypes.EventKindTranscript, "row "+id),
@@ -254,6 +280,121 @@ func TestTopModel_InitialFetchPopulatesSnapshot(t *testing.T) {
 	}
 	if len(m.snapshot.Sessions) != 1 {
 		t.Fatalf("snapshot.Sessions length = %d, want 1", len(m.snapshot.Sessions))
+	}
+}
+
+func TestTopModelSessionRows_PrioritizesRecentActiveSessionsWithManySessions(t *testing.T) {
+	t.Parallel()
+
+	sessions := make([]*sessionNode, 0, 55)
+	for i := 0; i < 55; i++ {
+		id := fmt.Sprintf("session-%03d", i)
+		latest := fixedDashboardNow.Add(time.Duration(i-55) * time.Minute)
+		sessions = append(sessions, dashboardSessionNodeWith(id, "", latest.Add(-10*time.Minute), "active", fmt.Sprintf("work-%03d", i), latest))
+	}
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Sessions: sessions}})
+	m = applySnapshot(t, m)
+	m = resize(m, 80, 24)
+
+	rows := m.sessionRows(80)
+	if len(rows) != 55 {
+		t.Fatalf("sessionRows length = %d, want 55", len(rows))
+	}
+	if !strings.Contains(rows[0].line, "session-054") || !strings.Contains(rows[0].line, "work-054") {
+		t.Fatalf("first row should surface newest active session, got %q", rows[0].line)
+	}
+	if strings.Contains(rows[0].line, "session-000") {
+		t.Fatalf("oldest session dominated first row: %q", rows[0].line)
+	}
+	view := m.View()
+	if !strings.Contains(view, "session-054") {
+		t.Fatalf("80x24 view should show newest active session above the fold:\n%s", view)
+	}
+	if !strings.Contains(view, "1-3/55") {
+		t.Fatalf("80x24 view should keep session scroll orientation, got:\n%s", view)
+	}
+}
+
+func TestTopModelSessionRows_KeepsIdentityFieldsAtNarrowWidth(t *testing.T) {
+	t.Parallel()
+
+	node := dashboardSessionNodeWith("session-id-abcdef123456", "", fixedDashboardNow.Add(-20*time.Minute), "active", "QA", fixedDashboardNow.Add(-time.Minute))
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Sessions: []*sessionNode{node}}})
+	m = applySnapshot(t, m)
+
+	rows := m.sessionRows(80)
+	if len(rows) != 1 {
+		t.Fatalf("sessionRows length = %d, want 1", len(rows))
+	}
+	line := rows[0].line
+	if got := runewidth.StringWidth(line); got > 80 {
+		t.Fatalf("row width = %d, want <= 80: %q", got, line)
+	}
+	for _, want := range []string{"QA", "[session-id-", "active", "latest=", "ws=traceary", "via=claude/claude"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("narrow session row missing %q: %q", want, line)
+		}
+	}
+}
+
+func TestTopModelSessionRows_PreservesNestedHierarchyAfterPrioritizingChildren(t *testing.T) {
+	t.Parallel()
+
+	root := dashboardSessionNodeWith("root", "", fixedDashboardNow.Add(-2*time.Hour), "ended", "root", fixedDashboardNow.Add(-90*time.Minute))
+	oldChild := dashboardSessionNodeWith("child-old", "root", fixedDashboardNow.Add(-80*time.Minute), "active", "old child", fixedDashboardNow.Add(-70*time.Minute))
+	recentChild := dashboardSessionNodeWith("child-recent", "root", fixedDashboardNow.Add(-30*time.Minute), "active", "recent child", fixedDashboardNow.Add(-time.Minute))
+	grandchild := dashboardSessionNodeWith("grandchild", "child-recent", fixedDashboardNow.Add(-20*time.Minute), "active", "grandchild", fixedDashboardNow.Add(-30*time.Second))
+	recentChild.children = []*sessionNode{grandchild}
+	root.children = []*sessionNode{oldChild, recentChild}
+
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Sessions: []*sessionNode{root}}})
+	m = applySnapshot(t, m)
+
+	rows := m.sessionRows(120)
+	if len(rows) != 4 {
+		t.Fatalf("sessionRows length = %d, want 4: %#v", len(rows), rows)
+	}
+	expectations := []struct {
+		index int
+		want  string
+	}{
+		{0, "root"},
+		{1, "├── recent child"},
+		{2, "│   └── grandchild"},
+		{3, "└── old child"},
+	}
+	for _, e := range expectations {
+		if !strings.Contains(rows[e.index].line, e.want) {
+			t.Fatalf("row[%d] = %q, want to contain %q", e.index, rows[e.index].line, e.want)
+		}
+	}
+}
+
+func TestTopModelSessionRows_LongListPageNavigationIsPredictable(t *testing.T) {
+	t.Parallel()
+
+	sessions := make([]*sessionNode, 0, 55)
+	for i := 0; i < 55; i++ {
+		id := fmt.Sprintf("session-%03d", i)
+		latest := fixedDashboardNow.Add(time.Duration(i-55) * time.Minute)
+		sessions = append(sessions, dashboardSessionNodeWith(id, "", latest.Add(-10*time.Minute), "active", fmt.Sprintf("work-%03d", i), latest))
+	}
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Sessions: sessions}})
+	m = applySnapshot(t, m)
+	m = resize(m, 80, 24)
+
+	viewport := m.paneContentViewportRows(topPaneSessions)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyPgDown})
+	if got, want := m.offsets[topPaneSessions], viewport; got != want {
+		t.Fatalf("offset after PgDown = %d, want viewport %d", got, want)
+	}
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnd})
+	if got, want := m.offsets[topPaneSessions], len(sessions)-viewport; got != want {
+		t.Fatalf("offset after End = %d, want %d", got, want)
+	}
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got, want := m.offsets[topPaneSessions], len(sessions)-viewport; got != want {
+		t.Fatalf("offset after Down at bottom = %d, want clamp %d", got, want)
 	}
 }
 

--- a/presentation/cli/top_dashboard_internal_test.go
+++ b/presentation/cli/top_dashboard_internal_test.go
@@ -315,6 +315,33 @@ func TestTopModelSessionRows_PrioritizesRecentActiveSessionsWithManySessions(t *
 	}
 }
 
+func TestTopModelSessionRows_DoesNotMutateSnapshotOrder(t *testing.T) {
+	t.Parallel()
+
+	oldChild := dashboardSessionNodeWith("child-old", "root", fixedDashboardNow.Add(-80*time.Minute), "active", "old child", fixedDashboardNow.Add(-70*time.Minute))
+	recentChild := dashboardSessionNodeWith("child-recent", "root", fixedDashboardNow.Add(-30*time.Minute), "active", "recent child", fixedDashboardNow.Add(-time.Minute))
+	root := dashboardSessionNodeWith("root", "", fixedDashboardNow.Add(-2*time.Hour), "ended", "root", fixedDashboardNow.Add(-90*time.Minute))
+	root.children = []*sessionNode{oldChild, recentChild}
+	sessions := []*sessionNode{
+		dashboardSessionNodeWith("session-old", "", fixedDashboardNow.Add(-2*time.Hour), "active", "old root", fixedDashboardNow.Add(-90*time.Minute)),
+		dashboardSessionNodeWith("session-new", "", fixedDashboardNow.Add(-time.Hour), "active", "new root", fixedDashboardNow.Add(-30*time.Second)),
+		root,
+	}
+	m := newDashboardTestModel(t, &stubTopLoader{snapshot: topDataSnapshot{Sessions: sessions}})
+	m = applySnapshot(t, m)
+
+	rows := m.sessionRows(120)
+	if !strings.Contains(rows[0].line, "session-new") {
+		t.Fatalf("rendered rows should prioritize newest root, first row = %q", rows[0].line)
+	}
+	if got, want := m.snapshot.Sessions[0].summary.SessionID().String(), "session-old"; got != want {
+		t.Fatalf("snapshot root order mutated: first root = %q, want %q", got, want)
+	}
+	if got, want := root.children[0].summary.SessionID().String(), "child-old"; got != want {
+		t.Fatalf("snapshot child order mutated: first child = %q, want %q", got, want)
+	}
+}
+
 func TestTopModelSessionRows_KeepsIdentityFieldsAtNarrowWidth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Closes #1090.

Dogfood feedback showed that the Sessions tab becomes hard to use when many sessions/subsessions exist: active/recent work can fall below the fold, row identity is dense, and cockpit scrolling can lose pane orientation.

## Changes

- Sort dashboard-only session roots/children by subtree live status and latest activity, without mutating the snapshot tree or changing snapshot text/JSON contracts.
- Render Sessions dashboard rows with compact identity-first fields: display name, session id, status, latest time, workspace, and client/agent before noisy latest-event text.
- Add a cockpit sticky breadcrumb when the Sessions dashboard is scrolled past a section header, so operators keep orientation in long lists.
- Add behavior tests for 55-session lists, 80-column identity visibility, nested hierarchy ordering, long-list navigation, and cockpit sticky breadcrumbs.

## Structure / behavior notes

- Dashboard-specific ordering is kept in `top_dashboard.go`; `session_tree.go` and snapshot output keep their existing ordering/contracts.
- Sorting clones the session tree first, so rendering does not mutate `topDataSnapshot`.
- Navigation continues to use the existing pane offset/viewport model; this PR adds tests around the expected long-list behavior.

## Validation

```json
{
  "source": "codex-worker",
  "validated_commands": [
    "TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'CockpitTopStickyHeaderLine|CockpitModelTopTab_StickyHeader|TopModelSessionRows' -count=1 -v",
    "TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci",
    "git diff --check"
  ],
  "results": {
    "passed": [
      "targeted Sessions/cockpit behavior tests",
      "full make ci",
      "whitespace check"
    ],
    "failed": []
  },
  "residual_risks": [
    "Operator preference for chronological ordering may differ; this PR keeps the change dashboard-only so it is easy to revert without data/schema impact."
  ],
  "findings": []
}
```

## AI review

- Claude implementation delegation was attempted for this single issue. The headless process produced no terminal output, but a scoped cockpit sticky-breadcrumb change was verified and amended locally.
- Claude/Gemini review will be posted as a follow-up PR comment before marking ready.
