### PR TITLE
v0.19-21: make Memory review context evidence-rich

### DIFF
--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -423,6 +423,14 @@ type memoryInboxListCommandInput struct {
 	asJSON         bool
 }
 
+// memoryInboxShowCommandInput is the resolved input to `traceary memory
+// inbox show`.
+type memoryInboxShowCommandInput struct {
+	dbPath   string
+	memoryID string
+	asJSON   bool
+}
+
 // memoryInboxBatchCommandInput is the resolved input to `traceary memory
 // inbox accept` and `traceary memory inbox reject`. Batch operations walk
 // the id list in order and report per-id success/failure so the caller can

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -312,7 +312,7 @@ func (c *RootCLI) runMemoryInboxShow(ctx context.Context, output io.Writer, inpu
 		return xerrors.Errorf("%s: %w", Localize("failed to show memory candidate", "メモリ候補の取得に失敗しました"), err)
 	}
 	if details.Summary().Status() != domtypes.MemoryStatusCandidate {
-		return xerrors.Errorf("%s", Localize("memory inbox show only accepts memory candidates; use `traceary memory show` for other statuses", "memory inbox show は memory candidate のみ対象です。他の status は `traceary memory show` を使ってください"))
+		return xerrors.New(Localize("memory inbox show only accepts memory candidates; use `traceary memory show` for other statuses", "memory inbox show は memory candidate のみ対象です。他の status は `traceary memory show` を使ってください"))
 	}
 	if input.asJSON {
 		return writeJSON(output, newMemoryDetailsOutput(details))

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -26,6 +26,7 @@ func (c *RootCLI) newMemoryInboxCommand() *cobra.Command {
 		Short: Localize("Review memory candidates with provenance", "メモリ候補を provenance 付きで確認する"),
 	}
 	cmd.AddCommand(c.newMemoryInboxListCommand())
+	cmd.AddCommand(c.newMemoryInboxShowCommand())
 	cmd.AddCommand(c.newMemoryInboxAcceptCommand())
 	cmd.AddCommand(c.newMemoryInboxRejectCommand())
 	cmd.AddCommand(c.newMemoryInboxAttachCommand())
@@ -57,6 +58,22 @@ func (c *RootCLI) newMemoryInboxListCommand() *cobra.Command {
 	cmd.Flags().StringVar(&input.quality, "quality", "any", Localize("filter by quality category (any / low / normal)", "品質カテゴリで絞り込む (any / low / normal)"))
 	cmd.Flags().IntVar(&input.limit, "limit", defaultMemoryInboxLimit, Localize("maximum number of candidates to return", "表示件数"))
 	cmd.Flags().IntVar(&input.offset, "offset", 0, Localize("number of candidates to skip before listing", "一覧表示前にスキップする件数"))
+	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
+	return cmd
+}
+
+func (c *RootCLI) newMemoryInboxShowCommand() *cobra.Command {
+	input := memoryInboxShowCommandInput{}
+	cmd := &cobra.Command{
+		Use:   "show <memory-id>",
+		Short: Localize("Show an evidence-first decision card for a memory candidate", "メモリ候補の evidence 優先 decision card を表示する"),
+		Args:  exactArgsLocalized(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input.memoryID = args[0]
+			return c.runMemoryInboxShow(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	cmd.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -275,6 +292,32 @@ func (c *RootCLI) runMemoryInboxList(ctx context.Context, output io.Writer, inpu
 		}
 	}
 	return writeMemoryInboxList(output, items, input.asJSON)
+}
+
+func (c *RootCLI) runMemoryInboxShow(ctx context.Context, output io.Writer, input memoryInboxShowCommandInput) error {
+	if c.storeManagement == nil {
+		return xerrors.New(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.memory == nil {
+		return xerrors.New(Localize("memory usecase is not configured", "memory ユースケースが設定されていません"))
+	}
+	if strings.TrimSpace(input.memoryID) == "" {
+		return xerrors.New(Localize("memory id must not be empty", "memory id は空にできません"))
+	}
+	if err := c.initializeStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	details, err := c.memory.Show(ctx, domtypes.MemoryID(strings.TrimSpace(input.memoryID)))
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to show memory candidate", "メモリ候補の取得に失敗しました"), err)
+	}
+	if details.Summary().Status() != domtypes.MemoryStatusCandidate {
+		return xerrors.Errorf("%s", Localize("memory inbox show only accepts memory candidates; use `traceary memory show` for other statuses", "memory inbox show は memory candidate のみ対象です。他の status は `traceary memory show` を使ってください"))
+	}
+	if input.asJSON {
+		return writeJSON(output, newMemoryDetailsOutput(details))
+	}
+	return writeMemoryReviewDecisionCard(output, details)
 }
 
 func (c *RootCLI) runMemoryInboxCleanup(ctx context.Context, output io.Writer, input memoryInboxCleanupCommandInput) error {
@@ -657,20 +700,22 @@ func writeMemoryInboxList(output io.Writer, items []apptypes.MemoryDetails, asJS
 		}
 		return nil
 	}
-	if _, err := fmt.Fprintln(output, "MEMORY_ID\tTYPE\tSCOPE\tSOURCE\tEVIDENCE\tARTIFACT\tFACT"); err != nil {
+	if _, err := fmt.Fprintln(output, "MEMORY_ID\tTYPE\tSCOPE\tSOURCE\tCONFIDENCE\tEVIDENCE\tARTIFACT\tREVIEW\tFACT"); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue header", "メモリ候補の確認キューヘッダーの出力に失敗しました"), err)
 	}
 	for _, details := range items {
 		summary := details.Summary()
 		if _, err := fmt.Fprintf(
 			output,
-			"%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
 			summary.MemoryID(),
 			summary.MemoryType(),
 			formatMemoryScope(summary.Scope()),
 			summary.Source(),
+			summary.Confidence(),
 			len(details.EvidenceRefs()),
 			len(details.ArtifactRefs()),
+			memoryReviewDecisionStatus(details),
 			truncateMessage(summary.Fact()),
 		); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue row", "メモリ候補の確認キュー行の出力に失敗しました"), err)

--- a/presentation/cli/memory_inbox_review.go
+++ b/presentation/cli/memory_inbox_review.go
@@ -1120,6 +1120,17 @@ func memoryReviewRequiresAcceptConfirmation(details apptypes.MemoryDetails) bool
 	return summary.Source() == domtypes.MemorySourceExtractedHidden || summary.Confidence() == domtypes.ConfidenceLow
 }
 
+func memoryReviewDecisionStatus(details apptypes.MemoryDetails) string {
+	switch {
+	case memoryReviewBlocksAccept(details):
+		return "blocked:no-evidence"
+	case memoryReviewRequiresAcceptConfirmation(details):
+		return "needs-confirmation"
+	default:
+		return "ready"
+	}
+}
+
 func memoryReviewQualitySignal(details apptypes.MemoryDetails) string {
 	summary := details.Summary()
 	signals := make([]string, 0, 4)
@@ -1154,6 +1165,91 @@ func memoryReviewQualitySignal(details apptypes.MemoryDetails) string {
 		signals = append(signals, Localize("accept requires confirmation", "accept には確認が必要"))
 	}
 	return strings.Join(signals, "; ")
+}
+
+func writeMemoryReviewDecisionCard(output io.Writer, details apptypes.MemoryDetails) error {
+	summary := details.Summary()
+	if _, err := fmt.Fprintf(
+		output,
+		"DECISION_CONTEXT:\nMEMORY_ID: %s\nTYPE: %s\nSCOPE: %s\nSTATUS: %s\nCONFIDENCE: %s\nSOURCE: %s\nREVIEW_STATUS: %s\nQUALITY_SIGNAL: %s\nSUPERSEDES: %s\nEXPIRES_AT: %s\nVALID_FROM: %s\nVALID_TO: %s\nCREATED_AT: %s\nUPDATED_AT: %s\nFACT:\n%s\n",
+		summary.MemoryID(),
+		summary.MemoryType(),
+		formatMemoryScope(summary.Scope()),
+		summary.Status(),
+		summary.Confidence(),
+		summary.Source(),
+		memoryReviewDecisionStatus(details),
+		memoryReviewQualitySignal(details),
+		formatOptionalMemoryID(summary.Supersedes()),
+		formatOptionalTime(summary.ExpiresAt()),
+		formatTextTime(summary.ValidFrom()),
+		formatOptionalTime(summary.ValidTo()),
+		formatTextTime(summary.CreatedAt()),
+		formatTextTime(summary.UpdatedAt()),
+		summary.Fact(),
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory review decision context", "memory review decision context の出力に失敗しました"), err)
+	}
+	if err := writeMemoryReviewSourceContext(output, details); err != nil {
+		return err
+	}
+	if err := writeEvidenceRefSection(output, details.EvidenceRefs()); err != nil {
+		return err
+	}
+	if err := writeArtifactRefSection(output, details.ArtifactRefs()); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(output, "\nACCEPT_GUIDANCE:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory review guidance heading", "memory review guidance 見出しの出力に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintln(output, memoryReviewDecisionGuidance(details)); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory review guidance", "memory review guidance の出力に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintln(output, "\nACCEPT_AS_IS_CHECKLIST:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print memory review checklist heading", "memory review checklist 見出しの出力に失敗しました"), err)
+	}
+	for _, item := range memoryReviewAcceptChecklist(details) {
+		if _, err := fmt.Fprintln(output, "- "+item); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory review checklist item", "memory review checklist 項目の出力に失敗しました"), err)
+		}
+	}
+	if _, err := fmt.Fprintln(output, "\nRELATED_MEMORY:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print related memory heading", "related memory 見出しの出力に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintln(output, "- "+memoryReviewDuplicateSupersedeHint(summary)); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print related memory hint", "related memory hint の出力に失敗しました"), err)
+	}
+	return nil
+}
+
+func writeMemoryReviewSourceContext(output io.Writer, details apptypes.MemoryDetails) error {
+	if _, err := fmt.Fprintln(output, "\nSOURCE_CONTEXT:"); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print source context heading", "source context 見出しの出力に失敗しました"), err)
+	}
+	sourceRefs := memoryReviewSourceContextRefs(details)
+	if len(sourceRefs) == 0 {
+		if _, err := fmt.Fprintln(output, "- no event/session evidence refs recorded"); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty source context", "空の source context の出力に失敗しました"), err)
+		}
+		return nil
+	}
+	for _, ref := range sourceRefs {
+		if _, err := fmt.Fprintln(output, "- "+ref); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print source context ref", "source context ref の出力に失敗しました"), err)
+		}
+	}
+	return nil
+}
+
+func memoryReviewSourceContextRefs(details apptypes.MemoryDetails) []string {
+	refs := make([]string, 0)
+	for _, ref := range details.EvidenceRefs() {
+		switch ref.Kind() {
+		case domtypes.EvidenceRefKindEvent, domtypes.EvidenceRefKindSession:
+			refs = append(refs, formatMemoryReviewRefLine(ref.Kind().String(), ref.Value()))
+		}
+	}
+	return refs
 }
 
 func formatMemoryReviewRememberIntent(summary apptypes.MemorySummary) string {

--- a/presentation/cli/memory_inbox_review.go
+++ b/presentation/cli/memory_inbox_review.go
@@ -1228,7 +1228,7 @@ func writeMemoryReviewSourceContext(output io.Writer, details apptypes.MemoryDet
 	}
 	sourceRefs := memoryReviewSourceContextRefs(details)
 	if len(sourceRefs) == 0 {
-		if _, err := fmt.Fprintln(output, "- no event/session evidence refs recorded"); err != nil {
+		if _, err := fmt.Fprintln(output, "- "+Localize("no event/session evidence refs recorded", "event/session evidence ref は記録されていません")); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print empty source context", "空の source context の出力に失敗しました"), err)
 		}
 		return nil
@@ -1242,7 +1242,7 @@ func writeMemoryReviewSourceContext(output io.Writer, details apptypes.MemoryDet
 }
 
 func memoryReviewSourceContextRefs(details apptypes.MemoryDetails) []string {
-	refs := make([]string, 0)
+	var refs []string
 	for _, ref := range details.EvidenceRefs() {
 		switch ref.Kind() {
 		case domtypes.EvidenceRefKindEvent, domtypes.EvidenceRefKindSession:

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -24,6 +24,11 @@ func buildInboxCandidateDetails(t *testing.T, id string, fact string, source dom
 
 func buildInboxMemoryDetails(t *testing.T, id string, fact string, status domtypes.MemoryStatus, source domtypes.MemorySource) apptypes.MemoryDetails {
 	t.Helper()
+	return buildInboxMemoryDetailsWithRefs(t, id, fact, status, source, true)
+}
+
+func buildInboxMemoryDetailsWithRefs(t *testing.T, id string, fact string, status domtypes.MemoryStatus, source domtypes.MemorySource, withEvidence bool) apptypes.MemoryDetails {
+	t.Helper()
 	workspace, err := domtypes.WorkspaceFrom("github.com/example/repo")
 	if err != nil {
 		t.Fatalf("WorkspaceFrom: %v", err)
@@ -45,6 +50,9 @@ func buildInboxMemoryDetails(t *testing.T, id string, fact string, status domtyp
 	)
 	if err != nil {
 		t.Fatalf("MemorySummaryOf: %v", err)
+	}
+	if !withEvidence {
+		return apptypes.MemoryDetailsOf(summary, nil, nil)
 	}
 	evidence, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindFile, "/tmp/MEMORY.md#L1-L2")
 	if err != nil {
@@ -76,12 +84,118 @@ func TestMemoryInboxList_TextOutput(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !strings.Contains(out, "MEMORY_ID\tTYPE\tSCOPE\tSOURCE\tEVIDENCE\tARTIFACT\tFACT") {
+	if !strings.Contains(out, "MEMORY_ID\tTYPE\tSCOPE\tSOURCE\tCONFIDENCE\tEVIDENCE\tARTIFACT\tREVIEW\tFACT") {
 		t.Fatalf("expected inbox header, got %q", out)
 	}
 	// Status filter must be pinned to candidate on the list call.
 	if got := memoryStub.listCriteria.Statuses(); len(got) != 1 || got[0] != domtypes.MemoryStatusCandidate {
 		t.Fatalf("inbox list should filter to candidate status, got %v", got)
+	}
+}
+
+func TestMemoryInboxList_TextOutputSurfacesDecisionStatus(t *testing.T) {
+	t.Parallel()
+
+	evidenceRich := buildInboxMemoryDetailsWithRefs(t, "memory-rich", "supported memory", domtypes.MemoryStatusCandidate, domtypes.MemorySourceManual, true)
+	evidenceLess := buildInboxMemoryDetailsWithRefs(t, "memory-weak", "unsupported memory", domtypes.MemoryStatusCandidate, domtypes.MemorySourceExtracted, false)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{evidenceRich.Summary(), evidenceLess.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			evidenceRich.Summary().MemoryID(): evidenceRich,
+			evidenceLess.Summary().MemoryID(): evidenceLess,
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "list", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "memory-rich\tpreference\tworkspace:github.com/example/repo\tmanual\tmedium\t1\t0\tready\t") {
+		t.Fatalf("evidence-rich row missing ready signal:\n%s", out)
+	}
+	if !strings.Contains(out, "memory-weak\tpreference\tworkspace:github.com/example/repo\textracted\tmedium\t0\t0\tblocked:no-evidence\t") {
+		t.Fatalf("evidence-less row missing blocked signal:\n%s", out)
+	}
+}
+
+func TestMemoryInboxShow_TextOutputPrintsEvidenceFirstDecisionCard(t *testing.T) {
+	t.Parallel()
+
+	candidate := buildInboxMemoryDetailsWithRefs(t, "memory-show", "prefer evidence-first review", domtypes.MemoryStatusCandidate, domtypes.MemorySourceRememberIntent, true)
+	eventRef, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindEvent, "evt-123")
+	if err != nil {
+		t.Fatalf("EvidenceRefFrom(event): %v", err)
+	}
+	sessionRef, err := domtypes.EvidenceRefFrom(domtypes.EvidenceRefKindSession, "session-123")
+	if err != nil {
+		t.Fatalf("EvidenceRefFrom(session): %v", err)
+	}
+	candidate = apptypes.MemoryDetailsOf(candidate.Summary(), append(candidate.EvidenceRefs(), eventRef, sessionRef), nil)
+	memoryStub := &memoryUsecaseStub{showDetails: candidate}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "show", "memory-show", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"DECISION_CONTEXT:",
+		"REVIEW_STATUS: ready",
+		"QUALITY_SIGNAL:",
+		"FACT:\nprefer evidence-first review",
+		"SOURCE_CONTEXT:",
+		"- event:evt-123",
+		"- session:session-123",
+		"EVIDENCE_REFS:",
+		"ACCEPT_GUIDANCE:",
+		"ACCEPT_AS_IS_CHECKLIST:",
+		"RELATED_MEMORY:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("memory inbox show output missing %q:\n%s", want, out)
+		}
+	}
+	if got := memoryStub.showMemoryID.String(); got != "memory-show" {
+		t.Fatalf("Show memory id = %q, want memory-show", got)
+	}
+}
+
+func TestMemoryInboxShow_BlocksNonCandidate(t *testing.T) {
+	t.Parallel()
+
+	accepted := buildInboxMemoryDetailsWithRefs(t, "memory-accepted", "already accepted", domtypes.MemoryStatusAccepted, domtypes.MemorySourceManual, true)
+	memoryStub := &memoryUsecaseStub{showDetails: accepted}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "show", "memory-accepted", "--db-path", t.TempDir() + "/t.db"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("execute error = nil, want non-candidate rejection")
+	}
+	if !strings.Contains(err.Error(), "only accepts memory candidates") {
+		t.Fatalf("error = %v, want candidate-only message", err)
 	}
 }
 
@@ -161,6 +275,7 @@ func TestMemoryInboxHelp_JapaneseGlossary(t *testing.T) {
 	for _, args := range [][]string{
 		{"memory", "inbox", "--help"},
 		{"memory", "inbox", "list", "--help"},
+		{"memory", "inbox", "show", "--help"},
 		{"memory", "inbox", "accept", "--help"},
 		{"memory", "inbox", "reject", "--help"},
 		{"memory", "inbox", "cleanup", "--help"},


### PR DESCRIPTION
## Motivation

Closes #1091.

Dogfood feedback showed that memory review candidates need decision-grade context, especially in non-TTY workflows. Operators need to see evidence availability, confidence/source, exact refs, source context, guidance, and related/supersede hints before accept/reject.

## Changes

- Add `traceary memory inbox show <memory-id>` for an evidence-first decision card dedicated to memory candidates.
- Add decision-grade fields to `memory inbox list` text output: `CONFIDENCE` and `REVIEW` (`ready`, `needs-confirmation`, `blocked:no-evidence`).
- Reuse the existing evidence-first review invariants from the interactive review model for CLI decision cards.
- Surface source context when event/session evidence refs are available, otherwise state that no event/session evidence is recorded.
- Add tests for evidence-rich list rows, evidence-less blocked rows, evidence-first show output, candidate-only guard, and help coverage.

## Structure-Behavior Design Note

### Requirement summary
- Purpose: make memory accept/reject decisions evidence-first and understandable.
- Current: `memory inbox list` exposes counts but not a decision status; `memory show` is generic and not tailored to review safety.
- Expected: a candidate detail view answers what would be stored, what supports it, whether accept is blocked/warned, and where source context/related memory is available.
- Non-goals: no schema migration, no auto-accept, no LLM-only justification as evidence.

### Conceptual model
| Concept | State | Behavior | Invariant |
|---|---|---|---|
| Memory candidate decision card | MemoryDetails + refs | Presents fact, metadata, source context, evidence, guidance, checklist | Does not alter memory state |
| Review status | evidence presence + weak source/confidence | `blocked:no-evidence` / `needs-confirmation` / `ready` | Mirrors existing accept/edit blocking rules |
| Source context | event/session evidence refs | Printed when available, explicitly unavailable otherwise | No best-effort DB lookup in this PR |

### Responsibility assignment
| Responsibility | Owner | Not owner / reason |
|---|---|---|
| Decision status and guidance | `memory_inbox_review.go` | Usecase/domain already enforce evidence; presentation explains it |
| Candidate-specific CLI detail command | `memory_inbox.go` | Generic `memory show` remains status-agnostic |
| Ref persistence and accept blocking | existing memory usecase/review model | No schema/API rewrite |

### Behavior tests
| Behavior | Given | When | Then |
|---|---|---|---|
| evidence-rich candidate | refs exist | `memory inbox list/show` | ready signal + evidence/source context visible |
| evidence-less candidate | no refs | `memory inbox list` | blocked:no-evidence visible |
| non-candidate | accepted memory | `memory inbox show` | rejects and points to generic `memory show` |

### Risks / rollback
- Text table adds columns; JSON remains unchanged and still carries refs/summary.
- Related/conflict context is limited to existing `supersedes` data and explicit unavailable text; deeper conflict search should be a separate issue if needed.

## Validation

```json
{
  "source": "codex-worker",
  "validated_commands": [
    "TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'MemoryInbox(List|Show|Help|Review)|ProductionCliStringLiterals' -count=1",
    "TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci",
    "git diff --check"
  ],
  "results": {
    "passed": ["targeted memory inbox tests", "full make ci", "whitespace check"],
    "failed": []
  },
  "residual_risks": [
    "Text table now has additional columns; JSON output remains stable.",
    "Conflict/related memory context is limited to existing supersedes metadata; broader semantic conflict search is intentionally not added."
  ],
  "findings": []
}
```

## AI review

Claude/Gemini review will be posted before marking ready.
