### PR TITLE
v0.19-23: remove cockpit Tail truncation marker

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -3068,10 +3068,8 @@ func formatCockpitLiveEventRow(event *model.Event, loc *time.Location, targetWid
 		return "-"
 	}
 	displayEvent := event
-	truncationMarker := ""
 	out := newTruncatedEventOutput(event, apptypes.DefaultTopSnapshotBodyLimit)
 	if out.Truncated {
-		truncationMarker = " [truncated]"
 		displayEvent = model.EventOfWithSourceHook(
 			event.EventID(),
 			event.Kind(),
@@ -3084,12 +3082,7 @@ func formatCockpitLiveEventRow(event *model.Event, loc *time.Location, targetWid
 			event.SourceHook(),
 		)
 	}
-	rowWidth := targetWidth
-	if rowWidth > runeLen(truncationMarker)+8 {
-		rowWidth -= runeLen(truncationMarker)
-	}
-	row := formatEventCompactRow(displayEvent, eventTextFormatOptions{location: loc, targetWidth: rowWidth, messageMinWidth: 8, hardTargetWidth: true, colorEnabled: colorEnabled}, extras)
-	return row + truncationMarker
+	return formatEventCompactRow(displayEvent, eventTextFormatOptions{location: loc, targetWidth: targetWidth, messageMinWidth: 8, hardTargetWidth: true, colorEnabled: colorEnabled}, extras)
 }
 
 func cockpitLiveSeenAt(snapshot cockpitLiveSnapshot) time.Time {

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -1797,13 +1797,16 @@ func TestCockpitModel_IgnoresStaleHomeRefreshResponses(t *testing.T) {
 	}
 }
 
-func TestFormatCockpitLiveEventRow_TruncatesLargePayload(t *testing.T) {
+func TestFormatCockpitLiveEventRow_OmitsTruncationMarkerForLargePayload(t *testing.T) {
 	t.Parallel()
 
 	event := mustEvent(t, "evt-large", domtypes.EventKindCommandExecuted, strings.Repeat("x", apptypes.DefaultTopSnapshotBodyLimit+20))
 	row := formatCockpitLiveEventRow(event, time.UTC, 100, compactRowExtras{}, false)
-	if !strings.Contains(row, "[truncated]") {
-		t.Fatalf("row = %q, want truncation marker", row)
+	if strings.Contains(row, "[truncated]") {
+		t.Fatalf("row = %q, want no visible truncation marker", row)
+	}
+	if got, limit := runeLen(row), 100; got > limit {
+		t.Fatalf("row length = %d, want <= viewport width %d: %q", got, limit, row)
 	}
 	if got, limit := len([]rune(row)), apptypes.DefaultTopSnapshotBodyLimit; got >= limit {
 		t.Fatalf("row length = %d, want compact row below body limit %d", got, limit)


### PR DESCRIPTION
## Motivation
The cockpit Tail stream still rendered a literal `[truncated]` suffix for large payloads. User feedback was that this marker is unnecessary noise in the live TUI and consumes limited horizontal space.

Closes #1097

## Changes
- Keep large Tail event payloads compacted before row formatting.
- Remove the visible `[truncated]` suffix from cockpit Tail rows.
- Update the large-payload behavior test to assert the marker is omitted while compactness remains preserved.

## Verification
- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'TestFormatCockpitLiveEventRow'`
- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci`
- `git diff --check`
