### PR TITLE
v0.19-24: keep Sessions summary visible with detail

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -32,8 +32,15 @@ const cockpitTopUnknownWidth = 120
 const cockpitTopShellHorizontalPadding = 6
 const cockpitTopRowPrefixWidth = 2
 const cockpitTopDefaultViewportRows = 12
-const cockpitTopSummaryChromeRows = 18
+const cockpitTopDashboardChromeRows = 3
 const cockpitTopMinViewportRows = 5
+const cockpitTopDetailOpenMinViewportRows = 1
+
+// Inline detail viewport rows are capped so detail can share the Sessions tab
+// with the summary and dashboard instead of monopolizing tall terminals.
+const cockpitTopInlineDetailDefaultViewportRows = 6
+const cockpitTopInlineDetailMinViewportRows = 1
+const cockpitTopInlineDetailMaxViewportRows = 8
 const cockpitTopDetailDefaultViewportRows = 16
 const cockpitTopDetailChromeRows = 6
 
@@ -1594,6 +1601,7 @@ func (m cockpitModel) openCockpitTopDetail() (tea.Model, tea.Cmd) {
 		lines:   []string{Localize("Loading...", "読み込み中...")},
 		loading: true,
 	}
+	m.ensureCockpitTopSelectionVisible(rows)
 	return m, m.fetchCockpitTopDetailCmd(req, m.top.detailSeq)
 }
 
@@ -2337,12 +2345,26 @@ func (m *cockpitModel) closeCockpitTopDetail() {
 	m.top.detailOpen = false
 	m.top.detailSeq++
 	m.top.detailOffset = 0
+	m.ensureCockpitTopSelectionVisible(m.cockpitTopRows())
 }
 
 func (m cockpitModel) topTabView() string {
+	lines := m.cockpitTopSummaryLines()
 	if m.cockpitTopDetailOpen() {
-		return m.cockpitTopDetailView()
+		lines = append(lines, m.cockpitTopInlineDetailLines()...)
+		lines = append(lines, "")
 	}
+	lines = append(lines, m.cockpitTopDashboardLines()...)
+	if m.statusMsg != "" {
+		lines = append([]string{m.styles.Success.Render("• " + m.statusMsg), ""}, lines...)
+	}
+	if m.statusErr != "" {
+		lines = append([]string{m.styles.Error.Render("• " + m.statusErr), ""}, lines...)
+	}
+	return m.renderCockpitShell(Localize("sessions", "セッション"), lines, m.topLocalHelp())
+}
+
+func (m cockpitModel) cockpitTopSummaryLines() []string {
 	eventScanSuffix := ""
 	if m.home.NewEventScanLimited {
 		eventScanSuffix = " scan_limited=true"
@@ -2388,14 +2410,7 @@ func (m cockpitModel) topTabView() string {
 	lines = append(lines,
 		"",
 	)
-	lines = append(lines, m.cockpitTopDashboardLines()...)
-	if m.statusMsg != "" {
-		lines = append([]string{m.styles.Success.Render("• " + m.statusMsg), ""}, lines...)
-	}
-	if m.statusErr != "" {
-		lines = append([]string{m.styles.Error.Render("• " + m.statusErr), ""}, lines...)
-	}
-	return m.renderCockpitShell(Localize("sessions", "セッション"), lines, m.topLocalHelp())
+	return lines
 }
 
 func (m cockpitModel) cockpitTopDashboardLines() []string {
@@ -2605,39 +2620,71 @@ func (m cockpitModel) cockpitTopViewportRows() int {
 	if m.height <= 0 {
 		return cockpitTopDefaultViewportRows
 	}
-	rows := m.height - cockpitTopSummaryChromeRows
+	rows := m.height - cockpitShellChromeRows - len(m.cockpitTopSummaryLines()) - cockpitTopDashboardChromeRows
+	if m.cockpitTopDetailOpen() {
+		// The inline detail block is part of the Sessions tab body. Reserve its
+		// actual rendered height plus the blank separator so opening detail does
+		// not silently push the dashboard out of view on taller terminals.
+		rows -= len(m.cockpitTopInlineDetailLines()) + 1
+		if rows < cockpitTopDetailOpenMinViewportRows {
+			return cockpitTopDetailOpenMinViewportRows
+		}
+		return rows
+	}
 	if rows < cockpitTopMinViewportRows {
 		return cockpitTopMinViewportRows
 	}
 	return rows
 }
 
-func (m cockpitModel) cockpitTopDetailView() string {
+func (m cockpitModel) cockpitTopInlineDetailLines() []string {
 	title := m.top.detail.title
 	if title == "" {
-		title = Localize("sessions detail", "Sessions detail")
+		title = Localize("Sessions detail", "セッション詳細")
 	}
-	lines := m.cockpitTopDetailLines()
-	if len(lines) == 0 {
-		lines = []string{m.styles.Subtle.Render(Localize("(empty)", "(空)"))}
+	lines := []string{
+		m.styles.Subtle.Render(Localize("Sessions detail · ", "セッション詳細 · ") + title),
+	}
+	if contextLine := m.cockpitTopSelectedContextLine(); contextLine != "" {
+		lines = append(lines, contextLine)
+	}
+	detailLines := m.cockpitTopDetailLines()
+	if len(detailLines) == 0 {
+		detailLines = []string{m.styles.Subtle.Render(Localize("(empty)", "(空)"))}
 	}
 	viewport := m.cockpitTopDetailViewportRows()
 	start := m.top.detailOffset
 	if start < 0 {
 		start = 0
 	}
-	if start > len(lines) {
-		start = len(lines)
+	if start > len(detailLines) {
+		start = len(detailLines)
 	}
 	end := start + viewport
-	if end > len(lines) {
-		end = len(lines)
+	if end > len(detailLines) {
+		end = len(detailLines)
 	}
-	body := append([]string{}, lines[start:end]...)
-	if len(lines) > viewport {
-		body = append([]string{m.styles.Subtle.Render(fmt.Sprintf("rows=%d-%d/%d", start+1, end, len(lines)))}, body...)
+	if len(detailLines) > viewport {
+		lines = append(lines, m.styles.Subtle.Render(fmt.Sprintf("rows=%d-%d/%d", start+1, end, len(detailLines))))
 	}
-	return m.renderCockpitShell(Localize("sessions detail · ", "Sessions detail · ")+title, body, m.topLocalHelp())
+	lines = append(lines, detailLines[start:end]...)
+	return lines
+}
+
+func (m cockpitModel) cockpitTopSelectedContextLine() string {
+	rows := m.cockpitTopRows()
+	if len(rows) == 0 {
+		return ""
+	}
+	selected := m.top.selected
+	if selected < 0 || selected >= len(rows) {
+		return ""
+	}
+	row := rows[selected]
+	if !row.selectable {
+		return ""
+	}
+	return m.styles.Subtle.Render(Localize("Selected: ", "選択: ")) + row.line
 }
 
 func (m cockpitModel) cockpitTopDetailLines() []string {
@@ -2651,12 +2698,33 @@ func (m cockpitModel) cockpitTopDetailLines() []string {
 }
 
 func (m cockpitModel) cockpitTopDetailViewportRows() int {
+	if m.cockpitTopDetailOpen() {
+		return m.cockpitTopInlineDetailViewportRows()
+	}
 	if m.height <= 0 {
 		return cockpitTopDetailDefaultViewportRows
 	}
 	rows := m.height - cockpitTopDetailChromeRows
 	if rows < 1 {
 		return 1
+	}
+	return rows
+}
+
+func (m cockpitModel) cockpitTopInlineDetailViewportRows() int {
+	if m.height <= 0 {
+		return cockpitTopInlineDetailDefaultViewportRows
+	}
+	// Split the rows that remain after fixed Sessions summary/dashboard chrome
+	// between inline detail and dashboard rows. The dashboard keeps at least one
+	// row via cockpitTopDetailOpenMinViewportRows.
+	available := m.height - cockpitShellChromeRows - len(m.cockpitTopSummaryLines()) - cockpitTopDashboardChromeRows - cockpitTopDetailOpenMinViewportRows - 1
+	rows := available / 2
+	if rows < cockpitTopInlineDetailMinViewportRows {
+		return cockpitTopInlineDetailMinViewportRows
+	}
+	if rows > cockpitTopInlineDetailMaxViewportRows {
+		return cockpitTopInlineDetailMaxViewportRows
 	}
 	return rows
 }

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -392,6 +392,8 @@ func TestCockpitModelTopTab_LoadsDashboardAndOpensDetail(t *testing.T) {
 	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
 	model.loader = loader
 	model.loaderCtx = context.Background()
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(cockpitModel)
 
 	updated, cmd := model.Update(cockpitRuneKey("2"))
 	model = updated.(cockpitModel)
@@ -442,13 +444,72 @@ func TestCockpitModelTopTab_LoadsDashboardAndOpensDetail(t *testing.T) {
 		t.Fatalf("top detail kind = %v, want event", got)
 	}
 	view = model.View()
-	if !strings.Contains(view, "Traceary cockpit · sessions detail") || !strings.Contains(view, "failure detail") {
-		t.Fatalf("top detail view missing loaded detail:\n%s", view)
+	for _, must := range []string{
+		"Traceary cockpit · sessions",
+		"Sessions summary",
+		"Sessions detail · EVENT evt-top-fail",
+		"Selected:",
+		"failure detail",
+		"Sessions dashboard",
+		"go test failed in top tab",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("top detail view missing %q:\n%s", must, view)
+		}
+	}
+	if strings.Contains(view, "Traceary cockpit · sessions detail") {
+		t.Fatalf("top detail should stay inside the sessions tab instead of replacing it:\n%s", view)
 	}
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model = updated.(cockpitModel)
 	if model.mode != cockpitModeTop || model.cockpitTopDetailOpen() {
 		t.Fatalf("esc from top detail mode/detailOpen = %v/%v, want top/false", model.mode, model.cockpitTopDetailOpen())
+	}
+}
+
+func TestCockpitModelTopTab_InlineDetailBudgetsTallViewport(t *testing.T) {
+	t.Parallel()
+
+	failure := mustEvent(t, "evt-top-budget-fail", domtypes.EventKindCommandExecuted, "go test failed with a long detail")
+	longDetail := make([]string, 20)
+	for i := range longDetail {
+		longDetail[i] = fmt.Sprintf("detail line %02d", i+1)
+	}
+	loader := &cockpitLoaderStub{
+		topResponses: []topDataSnapshot{{
+			Failures: []*model.Event{failure},
+			Now:      fixedStartedAt,
+		}},
+		topDetail: topDetailContent{title: "EVENT evt-top-budget-fail", lines: longDetail},
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.DefaultStyles(), cockpitHomeSnapshot{LoadedAt: fixedStartedAt})
+	model.loader = loader
+	model.loaderCtx = context.Background()
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+	model = updated.(cockpitModel)
+	updated, cmd := model.Update(cockpitRuneKey("2"))
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(cockpitModel)
+	updated, _ = model.Update(cmd())
+	model = updated.(cockpitModel)
+
+	view := model.View()
+	for _, must := range []string{
+		"Sessions summary",
+		"Sessions detail · EVENT evt-top-budget-fail",
+		"rows=1-8/20",
+		"Sessions dashboard",
+		"go test failed with a long detail",
+	} {
+		if !strings.Contains(view, must) {
+			t.Fatalf("inline detail budget view missing %q:\n%s", must, view)
+		}
+	}
+	if got, limit := len(strings.Split(view, "\n")), model.height; got > limit {
+		t.Fatalf("inline detail view lines = %d, want <= terminal height %d:\n%s", got, limit, view)
 	}
 }
 


### PR DESCRIPTION
## Motivation
Opening a detail from the cockpit Sessions tab replaced the whole tab with a detail-only screen. User feedback was that this makes the Sessions summary and dashboard context disappear while inspecting a selected row.

Closes #1098

## Changes
- Keep detail rendering inside the Sessions tab instead of switching the shell to a separate detail title.
- Show an inline Sessions detail panel with the selected dashboard row as context.
- Reserve a smaller dashboard viewport while detail is open so the summary/detail/dashboard remain in the same tab context.
- Update behavior coverage to assert summary, detail, selected context, and dashboard content remain visible together.

## Verification
- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli -run 'TestCockpitModelTopTab_LoadsDashboardAndOpensDetail|TestCockpitModelTopTab_StickyHeaderSurfacesPaneWhenScrolled'`
- `TRACEARY_LANG=en GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache make ci`
- `git diff --check`
