### PR TITLE
test: pin cli locale to English via TestMain

### DIFF
--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain pins the CLI locale to English for this package's tests unless the
+// environment already sets TRACEARY_LANG. Locale resolution falls back to the
+// operator's ~/.config/traceary/config.json ui.language when TRACEARY_LANG is
+// unset (see i18n.go), so golden-snapshot tests that assert English View()
+// output otherwise fail on a machine configured for Japanese even though CI
+// (which has no such config) stays green. Pinning here makes `go test` for the
+// package hermetic with respect to the operator's config and OS locale.
+//
+// Per-test overrides via t.Setenv(cliLanguageEnvKey, ...) still take effect:
+// they run after this default is applied and restore the prior value when the
+// test completes.
+func TestMain(m *testing.M) {
+	if _, ok := os.LookupEnv(cliLanguageEnvKey); !ok {
+		_ = os.Setenv(cliLanguageEnvKey, "en")
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

Make `presentation/cli` tests hermetic with respect to the operator's locale so `go test` is trustworthy locally regardless of `~/.config/traceary/config.json` ui.language.

## Problem

`presentation/cli` golden-snapshot tests resolve the CLI locale in `i18n.go` via `TRACEARY_LANG`, falling back to the operator's config `ui.language` when the env var is unset. On a machine configured for Japanese, the English-expecting snapshots fail locally (~221 failures) even though CI — which has no such config — stays green. Local `go test ./...` was therefore untrustworthy for any ja-configured maintainer.

## Change

Add `presentation/cli/main_test.go` with a package `TestMain` that sets `TRACEARY_LANG=en` **only when it is not already set**, then runs the suite. Per-test `t.Setenv(cliLanguageEnvKey, ...)` overrides (the explicit ja/en cases) still take effect, since they run after the default and restore the prior value on completion.

## Verification

- `env -u TRACEARY_LANG go test ./presentation/cli/` → `ok` (this previously failed under a ja operator config)
- `env -u TRACEARY_LANG go test ./...` → all packages `ok`
- `go build ./...` → Success
- `go vet ./...` → no issues
- `go tool golangci-lint run` → 0 issues

Closes #1105
