### PR TITLE
refactor: remove the unreferenced session-top alias

### DIFF
--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -79,8 +79,7 @@ func (c *RootCLI) newSessionsCommand() *cobra.Command {
 			"Show a live, auto-refreshing Sessions dashboard for active sessions, failures, commands, memory review, and health. Press q or Ctrl-C to quit. Use --snapshot --json for a one-shot Sessions JSON snapshot with latest-event metadata.",
 			"active session、失敗、コマンド、メモリ確認、状態をまとめた Sessions ダッシュボードをライブ自動更新で表示します。q または Ctrl-C で終了します。--snapshot --json で latest event metadata を含む Sessions JSON snapshot を一回出力します。",
 		),
-		Aliases: []string{"session-top"},
-		Args:    noArgsLocalized(),
+		Args: noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runSessions(cmd.Context(), cmd.OutOrStdout(), opts)
 		},


### PR DESCRIPTION
## Summary

Remove the unreferenced `session-top` alias from `newSessionsCommand`.

## Problem

`presentation/cli/top.go` declared `Aliases: []string{"session-top"}` on the `sessions` command. `session-top` is referenced **nowhere else** in the repo (verified by `rg "session-top" .` → only that one definition line): no doc, test, skill pack, changelog, or integration manifest. It is an undiscoverable third name for `sessions` that duplicates the documented permanent `traceary top` compatibility command, and it is not part of the `docs/operations/cli-stability.md` contract (which lists only `sessions` and `top`).

## Change

- Drop the `Aliases` entry. `traceary session-top` no longer resolves (falls back to Cobra's unknown-command); `traceary sessions` and the top-level `traceary top` compatibility command are unchanged.

## Verification

- `rg "session-top" .` → only the removed line (no other references).
- `gofmt -l presentation/cli/top.go` → clean; `go build ./...` → Success; `env -u TRACEARY_LANG go test ./...` → no failures; `go vet ./...` → no issues; `git diff --check` → clean.
- golangci-lint skipped for this single-line alias removal (provably lint-neutral and gofmt-clean); build/vet/test cover it.

Out of scope (kept): `traceary top` is a **permanent** compat alias per `cli-stability.md:50` and is not touched.

Closes #1108
