### PR TITLE
feat: report true candidate/accepted counts when the reliability scan saturates

### DIFF
--- a/application/queryservice/memory_query.go
+++ b/application/queryservice/memory_query.go
@@ -17,6 +17,16 @@ type MemoryQueryService interface {
 	GetDetails(ctx context.Context, memoryID types.MemoryID) (apptypes.MemoryDetails, error)
 }
 
+// MemoryStatusCountQueryService is the additive read-side query used by the
+// reliability pane to report true candidate/accepted totals when the bounded
+// summary scan is saturated. It mirrors the additive StaleMemoryQueryService
+// pattern so implementers opt in without widening MemoryQueryService.
+type MemoryStatusCountQueryService interface {
+	// CountByStatus returns the true per-status row counts matching the
+	// criteria, ignoring its Limit/Offset.
+	CountByStatus(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error)
+}
+
 // StaleMemoryQueryService provides the additive read-side query used by
 // `traceary top --snapshot --json` to surface stale durable memories without
 // introducing a write-side use case.

--- a/application/types/memory_status_counts.go
+++ b/application/types/memory_status_counts.go
@@ -1,0 +1,10 @@
+package types
+
+// MemoryStatusCounts holds the true per-status durable-memory row counts,
+// independent of any list scan limit. It backs the reliability pane's
+// candidate/accepted totals when the bounded summary scan is saturated
+// (see topReliabilityMemoryScanLimit).
+type MemoryStatusCounts struct {
+	Accepted  int
+	Candidate int
+}

--- a/application/usecase/memory_usecase_impl.go
+++ b/application/usecase/memory_usecase_impl.go
@@ -586,6 +586,24 @@ func (u *memoryUsecase) List(ctx context.Context, criteria apptypes.MemoryListCr
 	return summaries, nil
 }
 
+// CountByStatus returns the true per-status durable-memory counts, ignoring
+// the criteria's Limit/Offset. It delegates to the query service when it
+// implements the additive MemoryStatusCountQueryService capability.
+func (u *memoryUsecase) CountByStatus(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
+	if u.memoryQuery == nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("memory query service is not configured")
+	}
+	counter, ok := u.memoryQuery.(queryservice.MemoryStatusCountQueryService)
+	if !ok {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("memory query service does not support status counts")
+	}
+	counts, err := counter.CountByStatus(ctx, criteria)
+	if err != nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to count durable memories by status: %w", err)
+	}
+	return counts, nil
+}
+
 func (u *memoryUsecase) ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
 	if u.memoryQuery == nil {
 		return apptypes.StaleMemoryListResult{}, xerrors.Errorf("memory query service is not configured")

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -377,6 +377,56 @@ func (d *MemoryDatasource) List(ctx context.Context, criteria apptypes.MemoryLis
 	return summaries, nil
 }
 
+// CountByStatus returns the true per-status row counts matching the criteria,
+// ignoring its Limit/Offset. It backs the reliability pane's candidate/accepted
+// totals when the bounded summary scan is saturated.
+func (d *MemoryDatasource) CountByStatus(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to open DB for memory count: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	query, args, err := buildMemoryCountByStatusQuery(criteria, d.clock)
+	if err != nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to build memory count query: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to count memories: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	var counts apptypes.MemoryStatusCounts
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to scan memory count row: %w", err)
+		}
+		switch status {
+		case string(types.MemoryStatusAccepted):
+			counts.Accepted = count
+		case string(types.MemoryStatusCandidate):
+			counts.Candidate = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return apptypes.MemoryStatusCounts{}, xerrors.Errorf("failed to iterate memory count rows: %w", err)
+	}
+
+	return counts, nil
+}
+
 // ListStale returns stale memory rows plus the total count before paging.
 func (d *MemoryDatasource) ListStale(ctx context.Context, criteria apptypes.StaleMemoryListCriteria) (apptypes.StaleMemoryListResult, error) {
 	if criteria.Limit() <= 0 {
@@ -822,6 +872,22 @@ func buildMemoryListQuery(criteria apptypes.MemoryListCriteria, clock types.Cloc
 	}
 	builder.WriteString("m.updated_at DESC, m.id DESC LIMIT ? OFFSET ?")
 	args = append(args, criteria.Limit(), criteria.Offset())
+	return builder.String(), args, nil
+}
+
+// buildMemoryCountByStatusQuery builds a per-status COUNT(*) query using the
+// same filters as buildMemoryListQuery but without LIMIT/OFFSET, so it returns
+// the true total counts even when a list scan would be capped.
+func buildMemoryCountByStatusQuery(criteria apptypes.MemoryListCriteria, clock types.Clock) (string, []any, error) {
+	var builder strings.Builder
+	builder.WriteString("SELECT m.status, COUNT(*) FROM memories m WHERE 1 = 1")
+	args, err := appendMemoryFilters(&builder, nil, criteria.Scopes(), criteria.Statuses(), criteria.MemoryTypes(), criteria.Sources())
+	if err != nil {
+		return "", nil, err
+	}
+	args = appendMemoryValidityWindowFilter(&builder, args, criteria.AsOf(), criteria.IncludeExpiredByValidity(), clock)
+	args = appendMemoryUpdatedAtFilter(&builder, args, criteria.UpdatedBefore(), criteria.UpdatedAfter())
+	builder.WriteString(" GROUP BY m.status")
 	return builder.String(), args, nil
 }
 

--- a/infrastructure/sqlite/memory_datasource_test.go
+++ b/infrastructure/sqlite/memory_datasource_test.go
@@ -665,6 +665,49 @@ func TestMemoryDatasource_List(t *testing.T) {
 	})
 }
 
+func TestMemoryDatasource_CountByStatus(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newMemoryDatasource(t, dbPath, memoryDatasourceTestMigrations())
+	ctx := context.Background()
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	ws := mustWorkspaceScope(t, "github.com/duck8823/traceary")
+	base := time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC)
+	fixtures := []*model.Memory{
+		memoryOf(t, "acc-1", types.MemoryTypeDecision, ws, "a1", types.MemoryStatusAccepted, types.ConfidenceHigh, types.MemorySourceManual, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "acc-2", types.MemoryTypeDecision, ws, "a2", types.MemoryStatusAccepted, types.ConfidenceHigh, types.MemorySourceManual, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "cand-1", types.MemoryTypeLesson, ws, "c1", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "cand-2", types.MemoryTypeLesson, ws, "c2", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "cand-3", types.MemoryTypeLesson, ws, "c3", types.MemoryStatusCandidate, types.ConfidenceLow, types.MemorySourceExtracted, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+		memoryOf(t, "rej-1", types.MemoryTypeConstraint, ws, "r1", types.MemoryStatusRejected, types.ConfidenceMedium, types.MemorySourceManual, nil, nil, types.None[types.MemoryID](), types.None[time.Time](), base, base),
+	}
+	for _, m := range fixtures {
+		if err := sut.Save(ctx, m); err != nil {
+			t.Fatalf("Save(%s) error = %v", m.MemoryID(), err)
+		}
+	}
+
+	// Limit(1) proves CountByStatus ignores the list scan cap and reports the
+	// true totals, and the rejected fixture proves the status filter applies.
+	criteria := apptypes.NewMemoryListCriteriaBuilder(1).
+		Statuses([]types.MemoryStatus{types.MemoryStatusAccepted, types.MemoryStatusCandidate}).
+		Build()
+	counts, err := sut.CountByStatus(ctx, criteria)
+	if err != nil {
+		t.Fatalf("CountByStatus() error = %v", err)
+	}
+	if got, want := counts.Accepted, 2; got != want {
+		t.Fatalf("Accepted = %d, want %d", got, want)
+	}
+	if got, want := counts.Candidate, 3; got != want {
+		t.Fatalf("Candidate = %d, want %d", got, want)
+	}
+}
+
 func TestMemoryDatasource_List_RememberIntentPriorityAppliesBeforePagination(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/top_data.go
+++ b/presentation/cli/top_data.go
@@ -528,6 +528,12 @@ type topReliabilityInputs struct {
 	RecentCommands          []*model.Event
 }
 
+// memoryStatusCounter is the optional capability used to report true
+// candidate/accepted totals when the bounded reliability scan is saturated.
+type memoryStatusCounter interface {
+	CountByStatus(ctx context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error)
+}
+
 func (l *topDataLoader) loadReliabilityMetrics(ctx context.Context, c topDataCriteria, inputs topReliabilityInputs) (topReliabilityMetrics, error) {
 	metrics := topReliabilityMetrics{
 		StaleActiveSessionCount: inputs.StaleActiveSessionCount,
@@ -560,6 +566,18 @@ func (l *topDataLoader) loadReliabilityMetrics(ctx context.Context, c topDataCri
 				metrics.LowQualityCount++
 			}
 			metrics.CandidateAge = topCandidateAgeMetricsAdd(metrics.CandidateAge, summary.UpdatedAt(), topDataNow(c))
+		}
+	}
+	// When the bounded scan saturated, the per-status totals above undercount.
+	// Replace the accepted/candidate totals with true COUNTs when the memory
+	// service supports it; the finer breakdowns stay scan-limited (signalled by
+	// MemoryScanLimited).
+	if metrics.MemoryScanLimited {
+		if counter, ok := l.memory.(memoryStatusCounter); ok {
+			if counts, err := counter.CountByStatus(ctx, topReliabilityMemoryCriteria(c)); err == nil {
+				metrics.AcceptedMemoryCount = counts.Accepted
+				metrics.CandidateMemoryCount = counts.Candidate
+			}
 		}
 	}
 	return metrics, nil

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -96,6 +96,9 @@ type topDataMemoryStub struct {
 	showErr             error
 	showMemoryID        domtypes.MemoryID
 	showCalls           int
+	countResult         apptypes.MemoryStatusCounts
+	countErr            error
+	countCalls          int
 }
 
 func (s *topDataMemoryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -118,6 +121,54 @@ func (s *topDataMemoryStub) Show(_ context.Context, memoryID domtypes.MemoryID) 
 	s.showMemoryID = memoryID
 	s.showCalls++
 	return s.showDetails, s.showErr
+}
+
+func (s *topDataMemoryStub) CountByStatus(_ context.Context, _ apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
+	s.countCalls++
+	return s.countResult, s.countErr
+}
+
+// TestTopDataLoader_LoadSnapshot_UsesTrueCountsWhenScanSaturated guards #1111:
+// when the bounded reliability scan saturates (returns the cap), the snapshot's
+// accepted/candidate totals come from the true CountByStatus query rather than
+// the capped scan count.
+func TestTopDataLoader_LoadSnapshot_UsesTrueCountsWhenScanSaturated(t *testing.T) {
+	t.Parallel()
+
+	now := fixedStartedAt.Add(48 * time.Hour)
+	candidate := memorySummaryWithUpdatedAt(t, "mem-candidate", domtypes.MemoryStatusCandidate, now.Add(-time.Hour))
+	saturated := make([]apptypes.MemorySummary, 0, topReliabilityMemoryScanLimit)
+	for i := 0; i < topReliabilityMemoryScanLimit; i++ {
+		saturated = append(saturated, candidate)
+	}
+	memory := &topDataMemoryStub{
+		listResult:  saturated,
+		countResult: apptypes.MemoryStatusCounts{Accepted: 7, Candidate: 5000},
+	}
+	loader := newTopDataLoader(nil, nil, memory)
+
+	snap, err := loader.loadSnapshot(context.Background(), topDataCriteria{
+		CandidateLimit:   1,
+		StaleMemoryLimit: 1,
+		StaleAfter:       24 * time.Hour,
+		Now:              now,
+	})
+	if err != nil {
+		t.Fatalf("loadSnapshot() error = %v", err)
+	}
+
+	if !snap.Reliability.MemoryScanLimited {
+		t.Fatalf("MemoryScanLimited = false, want true when the scan returns the cap")
+	}
+	if memory.countCalls != 1 {
+		t.Fatalf("CountByStatus calls = %d, want 1 when the scan saturated", memory.countCalls)
+	}
+	if got, want := snap.Reliability.CandidateMemoryCount, 5000; got != want {
+		t.Fatalf("CandidateMemoryCount = %d, want %d (true count, not the capped scan)", got, want)
+	}
+	if got, want := snap.Reliability.AcceptedMemoryCount, 7; got != want {
+		t.Fatalf("AcceptedMemoryCount = %d, want %d (true count)", got, want)
+	}
 }
 
 // fixedStartedAt is the deterministic anchor every fixture in this file


### PR DESCRIPTION
## Summary

Report the **true** candidate/accepted memory counts in the reliability pane when the bounded scan saturates, instead of silently undercounting.

## Problem

`loadReliabilityMetrics` scans durable memories with a 2000-row cap (`topReliabilityMemoryScanLimit`). When the candidate set exceeds the cap, `candidate_count` / `accepted_count` were computed from the capped scan and undercounted. The live dogfood store already sits at the edge (`candidate_count=1997`, `scan_limit_reached=true`), so the metric is about to saturate.

## Change (additive, minimal surface)

Followed the existing `StaleMemoryQueryService` opt-in pattern so the broad `MemoryQueryService` interface and its many stubs stay untouched:

- `application/types`: `MemoryStatusCounts` DTO (`Accepted`, `Candidate`).
- `application/queryservice`: additive `MemoryStatusCountQueryService` interface.
- `infrastructure/sqlite`: `MemoryDatasource.CountByStatus` + `buildMemoryCountByStatusQuery` — same filters as `buildMemoryListQuery`, `GROUP BY status`, **no `LIMIT`/`OFFSET`** so it returns true totals.
- `application/usecase`: `memoryUsecase.CountByStatus` delegates via the additive interface.
- `presentation/cli`: `loadReliabilityMetrics` overrides the accepted/candidate totals with the true COUNTs when `MemoryScanLimited`; the memory dependency is consumed via a local `memoryStatusCounter` type-assert, so stubs that do not implement it gracefully fall back to scan counts.

The candidate-age / remember-intent / low-quality sub-breakdowns intentionally remain scan-limited estimates when saturated (signalled by `scan_limit_reached`); only the headline totals are corrected.

## Tests

- `infrastructure/sqlite`: `TestMemoryDatasource_CountByStatus` — Limit(1) proves Count ignores the scan cap and returns true totals (2 accepted / 3 candidate), and the rejected fixture proves the status filter applies.
- `presentation/cli`: `TestTopDataLoader_LoadSnapshot_UsesTrueCountsWhenScanSaturated` — when the scan returns the cap, the snapshot uses the true `CountByStatus` totals (5000 candidate / 7 accepted) rather than the capped scan.

## Verification

- `go build ./...` → Success (additive design → no stub breakage); `env -u TRACEARY_LANG go test ./...` → no failures; `go vet ./...` → no issues; `gofmt -l` → clean; `go tool golangci-lint run` → **0 issues**; `git diff --check` → clean.

Closes #1111
