### PR TITLE
feat: hide fix-instruction label fragments from the extraction inbox

### DIFF
--- a/application/usecase/memory_extraction_quality.go
+++ b/application/usecase/memory_extraction_quality.go
@@ -10,12 +10,13 @@ import (
 // stable string suitable for surfacing through `memory extract --debug-signals`
 // and the candidate hygiene scan (#864).
 const (
-	extractionNoiseDiffFragment      = "diff_fragment"
-	extractionNoiseGeneratedCode     = "generated_code"
-	extractionNoiseStandaloneCommand = "standalone_command"
-	extractionNoiseReviewConclusion  = "review_conclusion"
-	extractionNoiseWorkDeclaration   = "work_declaration"
-	extractionNoiseTransientPRRound  = "transient_pr_round"
+	extractionNoiseDiffFragment         = "diff_fragment"
+	extractionNoiseGeneratedCode        = "generated_code"
+	extractionNoiseStandaloneCommand    = "standalone_command"
+	extractionNoiseReviewConclusion     = "review_conclusion"
+	extractionNoiseWorkDeclaration      = "work_declaration"
+	extractionNoiseTransientPRRound     = "transient_pr_round"
+	extractionNoiseReviewFixInstruction = "review_fix_instruction"
 )
 
 var (
@@ -56,6 +57,14 @@ var (
 			`|^承認(?:済み|済|しました)?[。\.]?\s*$` +
 			`|^異常なし(?:です)?[。\.]?\s*$`,
 	)
+
+	// reviewFixInstructionPattern matches a line that opens with a review-style
+	// "fix instruction" label (`修正:` / `修正案:` / `Fix:`, optionally wrapped in
+	// markdown bold). The colon immediately after the label is required so prose
+	// that merely mentions 修正 / fix in a sentence (e.g. "Fixed the test",
+	// "修正は必ずレビューを通す") is never hidden. These fragments are transient review
+	// actions tied to a specific diff, not durable facts.
+	reviewFixInstructionPattern = regexp.MustCompile(`(?i)^\s*\*{0,2}\s*(?:修正案|修正|fix)\s*\*{0,2}\s*[:：]`)
 
 	workDeclarationEnglishPattern = regexp.MustCompile(`(?i)^` +
 		`(?:` +
@@ -150,6 +159,9 @@ func classifyExtractionNoise(fact string) []string {
 	if isReviewConclusion(trimmed) {
 		reasons = append(reasons, extractionNoiseReviewConclusion)
 	}
+	if isReviewFixInstruction(trimmed) {
+		reasons = append(reasons, extractionNoiseReviewFixInstruction)
+	}
 	if isWorkDeclaration(trimmed) {
 		reasons = append(reasons, extractionNoiseWorkDeclaration)
 	}
@@ -160,6 +172,20 @@ func classifyExtractionNoise(fact string) []string {
 		return nil
 	}
 	return reasons
+}
+
+func isReviewFixInstruction(value string) bool {
+	if !reviewFixInstructionPattern.MatchString(value) {
+		return false
+	}
+	// A fix-instruction label that also carries a durable signal
+	// (must/always/never/...) or durable choice phrasing states a long-lived
+	// constraint, not a throwaway review action — keep it visible, mirroring
+	// the isWorkDeclaration guard.
+	if hasDurableSignalMarker(value) || hasDurableChoicePhrasing(value) {
+		return false
+	}
+	return true
 }
 
 func isDiffFragment(value string) bool {

--- a/application/usecase/memory_extraction_quality_test.go
+++ b/application/usecase/memory_extraction_quality_test.go
@@ -76,6 +76,27 @@ func TestClassifyExtractionNoise(t *testing.T) {
 		{name: "ship it", fact: "Ship it", want: []string{"review_conclusion"}},
 		{name: "japanese problem none", fact: "問題なし", want: []string{"review_conclusion"}},
 		{name: "japanese confirmed problem none with desu", fact: "確認済み・問題なしです", want: []string{"review_conclusion"}},
+
+		// Review fix-instruction fragments (transient review actions tied to a diff)
+		{name: "japanese fix instruction bold", fact: "**修正:** help 文言を bare interactive cockpit only と明示する", want: []string{"review_fix_instruction"}},
+		{name: "japanese fix instruction plain", fact: "修正: filterMigrations を導入する", want: []string{"review_fix_instruction"}},
+		{name: "japanese fix proposal", fact: "修正案: v0.19 の挙動に更新する", want: []string{"review_fix_instruction"}},
+		{name: "japanese fix instruction fullwidth colon", fact: "修正：accept で確認を要求する", want: []string{"review_fix_instruction"}},
+		{name: "english fix instruction bold", fact: "**Fix:** split the refspec by colon", want: []string{"review_fix_instruction"}},
+		{name: "english fix instruction plain", fact: "Fix: validate the PR ticket reference", want: []string{"review_fix_instruction"}},
+		// Prose that mentions 修正 / fix without the label colon must stay visible
+		{name: "japanese fix prose no colon", fact: "修正は必ずレビューを通してからマージする", want: nil},
+		{name: "english fixed past tense prose", fact: "Fixed the flaky test by pinning the locale", want: nil},
+		{name: "english fixes prose", fact: "This PR fixes the memory extraction regression", want: nil},
+		// Bold-wrapped label only (colon outside the bold) must still match
+		{name: "english fix bold label only", fact: "**Fix**: split the refspec by colon", want: []string{"review_fix_instruction"}},
+		{name: "japanese fix bold label only", fact: "**修正**: accept をブロックする", want: []string{"review_fix_instruction"}},
+		// A fix-instruction label that carries a durable signal is a constraint,
+		// not a throwaway action — keep it visible (mirrors isWorkDeclaration).
+		{name: "english fix with durable signal", fact: "Fix: we must always use context.Context", want: nil},
+		{name: "japanese fix with durable signal", fact: "修正: 必ず context.Context を使う", want: nil},
+		// Words that merely contain "fix" must not match the label
+		{name: "affix label is not a fix instruction", fact: "affix: special handling for prefixes", want: nil},
 		{name: "japanese OK desu", fact: "OKです", want: []string{"review_conclusion"}},
 		// Durable continuations after a review-conclusion phrase must NOT be hidden
 		{name: "lgtm with durable continuation", fact: "LGTM and we should also reorganize the test layout", want: nil},


### PR DESCRIPTION
## Summary

Conservatively tighten the auto-extraction quality gate: classify review-style **fix-instruction label** fragments (`修正:` / `修正案:` / `Fix:`) as noise so they route to the hidden inbox source instead of cluttering the visible candidate queue.

## Evidence (dogfood DB)

The live store has **5177 candidate memories, all low-confidence, with a 0% extraction accept rate** — every one of the 8 accepted memories is `manual`. Source split: `extracted` 4030, `extracted-hidden` 934, `remember-intent` 207, `compact-summary` 6. Sampling the visible `extracted` candidates surfaced many transient review/work fragments slipping past the classifier; the most prevalent and clearly-transient were fix-instruction labels (`**修正:** …`, `修正案: …`, `Fix: …`) — a reviewer's suggested action tied to a specific diff, not a durable fact.

This is the **conservative gate-tightening** direction chosen for the inbox-scaling work. (The planned cross-page dedup work was dropped as an invalid premise — extraction already dedups across all pages, and the store has only 2 duplicates out of 5177.)

## Change

`application/usecase/memory_extraction_quality.go`:
- New `review_fix_instruction` noise category + `isReviewFixInstruction` detector.
- `reviewFixInstructionPattern = (?i)^\s*\*{0,2}\s*(?:修正案|修正|fix)\s*[:：]` — the label must be at the start and **immediately followed by a colon** (optionally inside markdown bold).

### False-positive guards
- The required colon means prose that merely mentions 修正 / fix stays visible: "Fixed the test", "This PR fixes …", "修正は必ずレビューを通す" → not classified (test-covered).
- Like every existing noise reason, the classifier result only routes `extracted` candidates to the hidden source; candidates with **explicit remember intent are never hidden** (unchanged).

## Tests

`TestClassifyExtractionNoise` (now 108 cases) adds 6 matching cases (JP/EN, bold/plain, full-width colon) and 3 prose false-positive cases.

## Verification

- `go build ./...` → Success; `env -u TRACEARY_LANG go test ./...` → no failures; `go vet ./...` → no issues; `gofmt -l` → clean; `go tool golangci-lint run` → **0 issues**; `git diff --check` → clean.

Closes #1113
