### PR TITLE
feat: add a composition summary to memory inbox cleanup

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -391,6 +391,10 @@ durable memory を一覧表示します。scope flag を明示しない場合は
 
 主な flag: `--workspace`, `--agent`, `--session-family`, `--type`, `--source`, `--include-hidden`, `--limit`。
 
+#### `traceary memory inbox cleanup`
+
+古い / 低品質のメモリ候補を一括でプレビューまたは reject します。既定は dry-run で、`--apply` を付けると一致した候補を reject します。フィルタ: `--quality {low|normal|any}`（既定 `low`。`--quality any` はキュー全体の reject を避けるため `--older-than` が必須）、`--source`、`--type`、`--workspace`、`--agent`、`--session-family`、`--older-than` / `--newer-than`、`--include-hidden`、`--limit`。text と `--json` の出力には composition `summary`（`total` と `by_source` / `by_type` の内訳）が含まれ、`--apply` 前に batch の構成が分かります。cleanup は候補を reject するだけで、accept は evidence-first の rails を保つため上記の個別 review 系に委ねます。
+
 ### `traceary memory store` — deliberate writes
 
 `memory store` 配下の verb はすべて durable memory row を書き込みます。row が `accepted` で着地するか `candidate` で着地するかは問いません。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -391,6 +391,10 @@ The command refuses to start without a TTY and exits with code `2`, printing fal
 
 Useful flags: `--workspace`, `--agent`, `--session-family`, `--type`, `--source`, `--include-hidden`, `--limit`.
 
+#### `traceary memory inbox cleanup`
+
+Bulk preview or reject stale / low-quality memory candidates. Dry-run by default; pass `--apply` to reject the matched candidates. Filters: `--quality {low|normal|any}` (default `low`; `--quality any` requires `--older-than` so the whole queue is not rejected), `--source`, `--type`, `--workspace`, `--agent`, `--session-family`, `--older-than` / `--newer-than`, `--include-hidden`, `--limit`. The text and `--json` output include a composition `summary` — `total` plus counts `by_source` and `by_type` — so the batch makeup is visible before `--apply`. Cleanup only rejects candidates; accepting stays on the per-candidate review surfaces above to keep the evidence-first rails intact.
+
 ### `traceary memory store` — deliberate writes
 
 Every command under `memory store` writes a durable-memory row, regardless of whether the row lands as `accepted` or `candidate`.

--- a/presentation/cli/memory_inbox.go
+++ b/presentation/cli/memory_inbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -351,6 +352,7 @@ func (c *RootCLI) runMemoryInboxCleanup(ctx context.Context, output io.Writer, i
 	result := memoryInboxCleanupResult{
 		Action:  "cleanup-reject",
 		DryRun:  !input.apply,
+		Summary: summarizeMemoryInboxCleanup(items),
 		Matched: items,
 	}
 	if !input.apply {
@@ -609,9 +611,49 @@ type memoryInboxBatchResult struct {
 type memoryInboxCleanupResult struct {
 	Action    string
 	DryRun    bool
+	Summary   memoryInboxCleanupSummary
 	Matched   []apptypes.MemoryDetails
 	Processed []apptypes.MemoryDetails
 	Failures  []memoryInboxFailure
+}
+
+// memoryInboxCleanupSummary is the aggregate composition of the matched memory
+// candidates, surfaced before --apply so an operator triaging a large backlog
+// sees the source / type breakdown at a glance instead of scanning every row.
+type memoryInboxCleanupSummary struct {
+	Total    int            `json:"total"`
+	BySource map[string]int `json:"by_source,omitempty"`
+	ByType   map[string]int `json:"by_type,omitempty"`
+}
+
+func summarizeMemoryInboxCleanup(matched []apptypes.MemoryDetails) memoryInboxCleanupSummary {
+	summary := memoryInboxCleanupSummary{Total: len(matched)}
+	if len(matched) == 0 {
+		return summary
+	}
+	summary.BySource = make(map[string]int)
+	summary.ByType = make(map[string]int)
+	for _, details := range matched {
+		s := details.Summary()
+		summary.BySource[s.Source().String()]++
+		summary.ByType[s.MemoryType().String()]++
+	}
+	return summary
+}
+
+// formatMemoryCountMap renders a count map as sorted "key=value" pairs so the
+// text summary is deterministic.
+func formatMemoryCountMap(counts map[string]int) string {
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, counts[key]))
+	}
+	return strings.Join(parts, " ")
 }
 
 type memoryInboxFailureCode string
@@ -794,6 +836,7 @@ func writeMemoryInboxCleanupResult(output io.Writer, result memoryInboxCleanupRe
 		payload := memoryInboxCleanupOutput{
 			Action:    result.Action,
 			DryRun:    result.DryRun,
+			Summary:   result.Summary,
 			Matched:   make([]memoryDetailsOutput, 0, len(result.Matched)),
 			Processed: make([]memoryDetailsOutput, 0, len(result.Processed)),
 			Failures:  result.Failures,
@@ -817,6 +860,11 @@ func writeMemoryInboxCleanupResult(output io.Writer, result memoryInboxCleanupRe
 	}
 	if _, err := fmt.Fprintf(output, "action=%s dry_run=%t matched=%d processed=%d failures=%d\n", result.Action, result.DryRun, len(result.Matched), len(result.Processed), len(result.Failures)); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue cleanup summary", "メモリ候補の確認キュー cleanup サマリの出力に失敗しました"), err)
+	}
+	if result.Summary.Total > 0 {
+		if _, err := fmt.Fprintf(output, "summary total=%d by_source[%s] by_type[%s]\n", result.Summary.Total, formatMemoryCountMap(result.Summary.BySource), formatMemoryCountMap(result.Summary.ByType)); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print memory review queue cleanup composition summary", "メモリ候補の確認キュー cleanup 構成サマリの出力に失敗しました"), err)
+		}
 	}
 	if result.DryRun {
 		for _, details := range result.Matched {

--- a/presentation/cli/memory_inbox_test.go
+++ b/presentation/cli/memory_inbox_test.go
@@ -506,6 +506,50 @@ func TestMemoryInboxCleanup_DryRunDoesNotReject(t *testing.T) {
 	}
 }
 
+func TestMemoryInboxCleanup_DryRunReportsCompositionSummary(t *testing.T) {
+	t.Parallel()
+
+	a := buildInboxCandidateDetails(t, "memory-sum-a", "git status", domtypes.MemorySourceExtracted)
+	b := buildInboxCandidateDetails(t, "memory-sum-b", "go test ./...", domtypes.MemorySourceExtracted)
+	memoryStub := &memoryUsecaseStub{
+		listResult: []apptypes.MemorySummary{a.Summary(), b.Summary()},
+		showDetailsByID: map[domtypes.MemoryID]apptypes.MemoryDetails{
+			a.Summary().MemoryID(): a,
+			b.Summary().MemoryID(): b,
+		},
+		scanResult: apptypes.MemoryHygieneScanResult{
+			LowQualityCandidateCount: 2,
+			Suggestions: []apptypes.MemoryHygieneSuggestion{
+				{MemoryID: a.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+				{MemoryID: b.Summary().MemoryID(), Kind: apptypes.MemoryHygieneSuggestionLowQualityCandidate},
+			},
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"memory", "inbox", "cleanup", "--db-path", t.TempDir() + "/t.db"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "summary total=2") {
+		t.Fatalf("cleanup dry-run missing composition summary total:\n%s", out)
+	}
+	if !strings.Contains(out, "by_source[extracted=2]") {
+		t.Fatalf("cleanup dry-run missing by_source breakdown:\n%s", out)
+	}
+	if !strings.Contains(out, "by_type[preference=2]") {
+		t.Fatalf("cleanup dry-run missing by_type breakdown:\n%s", out)
+	}
+}
+
 func TestMemoryInboxCleanup_ApplyRejectsCandidatesAndReportsFailures(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -328,11 +328,12 @@ type memoryInboxBatchOutput struct {
 
 // memoryInboxCleanupOutput is the JSON shape of an inbox cleanup preview/apply run.
 type memoryInboxCleanupOutput struct {
-	Action    string                `json:"action"`
-	DryRun    bool                  `json:"dry_run"`
-	Matched   []memoryDetailsOutput `json:"matched,omitempty"`
-	Processed []memoryDetailsOutput `json:"processed,omitempty"`
-	Failures  []memoryInboxFailure  `json:"failures,omitempty"`
+	Action    string                    `json:"action"`
+	DryRun    bool                      `json:"dry_run"`
+	Summary   memoryInboxCleanupSummary `json:"summary"`
+	Matched   []memoryDetailsOutput     `json:"matched,omitempty"`
+	Processed []memoryDetailsOutput     `json:"processed,omitempty"`
+	Failures  []memoryInboxFailure      `json:"failures,omitempty"`
 }
 
 // memoryImportOutput is the JSON shape of a memory import result.


### PR DESCRIPTION
## Summary

Add an aggregate **composition summary** to `memory inbox cleanup` so an operator triaging a large backlog sees what `--apply` would reject — totals plus a breakdown by source and by type — at a glance, instead of scanning per-row preview output.

## Context

`memory inbox cleanup` **already** bulk-rejects candidates by quality / source / age (`--quality`, `--source`, `--older-than` / `--newer-than`, `--type`, scopes, `--limit`) with a dry-run-by-default preview and `--apply`. So the bulk-triage filter surface this issue called for is largely present; the genuine gap at scale (the dogfood store holds 5177 candidates) is a composition summary. (The sibling cross-page-dedup issue was dropped earlier as an invalid premise — extraction already dedups across all pages.)

## Change

- `memoryInboxCleanupSummary{Total, BySource, ByType}` computed from the matched set.
- Text: a deterministic `summary total=N by_source[...] by_type[...]` line (sorted keys) after the existing header.
- JSON: an **additive** `summary` field on the cleanup `--json` output (existing fields unchanged; additive between minors per cli-stability).

### Deliberately out of scope
- **Bulk accept** is not added: accepting candidates without per-candidate judgment conflicts with the evidence-first review rails, so cleanup stays reject/preview-only.

## Tests

`TestMemoryInboxCleanup_DryRunReportsCompositionSummary` asserts the dry-run output reports `summary total=2` and `by_source[extracted=2]`. Existing cleanup tests (dry-run / apply / non-candidate) still pass — the new field is additive.

## Verification

- `go build ./...` → Success; `env -u TRACEARY_LANG go test ./...` → no failures; `go vet ./...` → no issues; `gofmt -l` → clean; `go tool golangci-lint run` → **0 issues**; `git diff --check` → clean.

Closes #1114
