### PR TITLE
feat: surface the memory inbox backlog in the cockpit via CountByStatus

### DIFF
--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -2142,6 +2142,9 @@ func renderCockpitDoctorCheck(styles tui.Styles, check cockpitDoctorCheck, line 
 
 func (m cockpitModel) memoryReviewView() string {
 	lines := []string{}
+	if summary := m.memoryBacklogSummaryLine(); summary != "" {
+		lines = append(lines, summary, "")
+	}
 	switch {
 	case m.memoryReview.loading:
 		lines = append(lines, m.styles.Subtle.Render(Localize("Loading memory review queue...", "メモリ候補の確認キューを読み込み中...")))
@@ -2153,6 +2156,24 @@ func (m cockpitModel) memoryReviewView() string {
 		lines = append(lines, m.memoryReview.review.View())
 	}
 	return m.renderCockpitShell(memoryReviewWorkflowLabel(), lines, m.memoryReviewLocalHelp())
+}
+
+// memoryBacklogSummaryLine renders the inbox backlog counts — true accepted /
+// candidate totals from CountByStatus, plus new-since-last-review candidates —
+// at the top of the Memory tab so the curation debt is visible where the
+// operator reviews it. Memory cues stay in the Memory tab; the session-focused
+// Top/Sessions surfaces deliberately omit them.
+func (m cockpitModel) memoryBacklogSummaryLine() string {
+	if m.home.CandidateMemoryCount == 0 && m.home.AcceptedMemoryCount == 0 {
+		return ""
+	}
+	return m.styles.Subtle.Render(Localizef(
+		"backlog: candidate=%d accepted=%d new=%s",
+		"backlog: candidate=%d accepted=%d new=%s",
+		m.home.CandidateMemoryCount,
+		m.home.AcceptedMemoryCount,
+		formatCockpitNewCandidateCount(m.home),
+	))
 }
 
 func (m cockpitModel) liveView() string {

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -227,6 +227,22 @@ func (c *RootCLI) loadCockpitHome(ctx context.Context, opts cockpitCommandOption
 	home.RecentCommandCount = len(snap.RecentCommands)
 	home.LargePayloadCount = snap.Reliability.LargePayloads.Count
 
+	// Populate the memory inbox backlog via the cheap CountByStatus query (a
+	// COUNT, not the bounded reliability scan or the List path) so the cockpit
+	// Memory tab shows the true accepted/candidate totals — and new-since-last-
+	// review candidates when a checkpoint is known — without an expensive scan.
+	if counter, ok := c.memory.(memoryStatusCounter); ok {
+		if counts, err := counter.CountByStatus(ctx, cockpitMemoryStatusCountCriteria()); err == nil {
+			home.AcceptedMemoryCount = counts.Accepted
+			home.CandidateMemoryCount = counts.Candidate
+		}
+		if memoryLastSeenKnown {
+			if counts, err := counter.CountByStatus(ctx, cockpitNewCandidateCountCriteria(memoryLastSeenAt)); err == nil {
+				home.NewCandidateMemoryCount = counts.Candidate
+			}
+		}
+	}
+
 	return home, nil
 }
 
@@ -241,6 +257,23 @@ func cockpitSessionsDataCriteriaAt(now time.Time) topDataCriteria {
 		Now:                   now,
 		SkipMemoryReliability: true,
 	}
+}
+
+// cockpitMemoryStatusCountCriteria builds the (limit-irrelevant) criteria for
+// the true accepted/candidate totals shown in the cockpit Memory tab.
+func cockpitMemoryStatusCountCriteria() apptypes.MemoryListCriteria {
+	return apptypes.NewMemoryListCriteriaBuilder(1).
+		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted, domtypes.MemoryStatusCandidate}).
+		Build()
+}
+
+// cockpitNewCandidateCountCriteria counts candidate memories updated since the
+// last review checkpoint, for the cockpit's new-since-last-review signal.
+func cockpitNewCandidateCountCriteria(since time.Time) apptypes.MemoryListCriteria {
+	return apptypes.NewMemoryListCriteriaBuilder(1).
+		Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}).
+		UpdatedAfter(since).
+		Build()
 }
 
 // CockpitStateReader provides optional local cockpit state. Missing or failing

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -74,6 +74,45 @@ func TestLoadCockpitHome_AggregatesSessionSignalsWithoutMemoryScans(t *testing.T
 	}
 }
 
+func TestCockpitHome_PopulatesMemoryBacklogViaCountByStatus(t *testing.T) {
+	lastSeenAt := fixedStartedAt.Add(-2 * time.Hour)
+	memory := &topDataMemoryStub{
+		listErr:  context.Canceled,
+		staleErr: context.Canceled,
+		countFunc: func(criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
+			if _, ok := criteria.UpdatedAfter().Value(); ok {
+				return apptypes.MemoryStatusCounts{Candidate: 42}, nil
+			}
+			return apptypes.MemoryStatusCounts{Accepted: 8, Candidate: 5177}, nil
+		},
+	}
+	root := &RootCLI{
+		memory:       memory,
+		cockpitState: cockpitStateReaderStub{at: lastSeenAt, ok: true},
+	}
+
+	home, err := root.loadCockpitHome(context.Background(), cockpitCommandOptions{dbPath: filepath.Join(t.TempDir(), "traceary.db")})
+	if err != nil {
+		t.Fatalf("loadCockpitHome() error = %v", err)
+	}
+
+	if got, want := home.CandidateMemoryCount, 5177; got != want {
+		t.Fatalf("CandidateMemoryCount = %d, want %d (true backlog via CountByStatus)", got, want)
+	}
+	if got, want := home.AcceptedMemoryCount, 8; got != want {
+		t.Fatalf("AcceptedMemoryCount = %d, want %d", got, want)
+	}
+	if got, want := home.NewCandidateMemoryCount, 42; got != want {
+		t.Fatalf("NewCandidateMemoryCount = %d, want %d (candidates since last review)", got, want)
+	}
+	if got := memory.listCalls; got != 0 {
+		t.Fatalf("memory.List calls = %d, want 0 (cockpit backlog must use the cheap CountByStatus path)", got)
+	}
+	if got, want := memory.countCalls, 2; got != want {
+		t.Fatalf("CountByStatus calls = %d, want %d (totals + new-since-last-review)", got, want)
+	}
+}
+
 func TestCockpitSessionsTab_HidesMemoryNotificationsWhenLastSeenAvailable(t *testing.T) {
 	now := fixedStartedAt.Add(72 * time.Hour)
 	previousTopNow := topNowFunc

--- a/presentation/cli/cockpit_internal_test.go
+++ b/presentation/cli/cockpit_internal_test.go
@@ -113,6 +113,26 @@ func TestCockpitHome_PopulatesMemoryBacklogViaCountByStatus(t *testing.T) {
 	}
 }
 
+func TestCockpitMemoryReviewView_RendersInboxBacklogSummary(t *testing.T) {
+	home := cockpitHomeSnapshot{
+		LoadedAt:                fixedStartedAt,
+		CandidateMemoryCount:    5177,
+		AcceptedMemoryCount:     8,
+		NewCandidateMemoryCount: 42,
+		NewCandidateMemoryKnown: true,
+	}
+	model := newCockpitModel(tui.DefaultKeyMap(), tui.Styles{}, home)
+	model.mode = cockpitModeMemoryReview
+	model.memoryReview.loading = true
+	model.memoryReview.review = newReviewModel(nil, model.keys, model.styles)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	view := updated.(cockpitModel).View()
+
+	if !strings.Contains(view, "backlog: candidate=5177 accepted=8 new=42") {
+		t.Fatalf("memory tab missing inbox backlog summary line:\n%s", view)
+	}
+}
+
 func TestCockpitSessionsTab_HidesMemoryNotificationsWhenLastSeenAvailable(t *testing.T) {
 	now := fixedStartedAt.Add(72 * time.Hour)
 	previousTopNow := topNowFunc

--- a/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
+++ b/presentation/cli/testdata/cockpit/memory_ambiguous_candidate.golden.txt
@@ -1,6 +1,8 @@
 Traceary cockpit · memory review
 tabs: 1 Tail  2 Sessions  [3 Memory]  4 Settings
 
+backlog: candidate=1 accepted=0 new=untracked
+
 memory review · decision card
 candidate 1 / 1
 

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -99,6 +99,7 @@ type topDataMemoryStub struct {
 	countResult         apptypes.MemoryStatusCounts
 	countErr            error
 	countCalls          int
+	countFunc           func(apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error)
 }
 
 func (s *topDataMemoryStub) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -123,8 +124,11 @@ func (s *topDataMemoryStub) Show(_ context.Context, memoryID domtypes.MemoryID) 
 	return s.showDetails, s.showErr
 }
 
-func (s *topDataMemoryStub) CountByStatus(_ context.Context, _ apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
+func (s *topDataMemoryStub) CountByStatus(_ context.Context, criteria apptypes.MemoryListCriteria) (apptypes.MemoryStatusCounts, error) {
 	s.countCalls++
+	if s.countFunc != nil {
+		return s.countFunc(criteria)
+	}
 	return s.countResult, s.countErr
 }
 


### PR DESCRIPTION
## Summary

Surface the memory inbox backlog in the operator cockpit's Memory tab by
populating **and rendering** the accepted / candidate / new-candidate counts —
closing the gap the Gemini scout flagged on #1130 (routed here as this issue's
scope).

## Problem

The cockpit `cockpitHomeSnapshot` carries `AcceptedMemoryCount` /
`CandidateMemoryCount` / `NewCandidateMemoryCount`, but two gaps kept the
backlog invisible:

1. `loadCockpitHome` left the counts at **0**: it loads the session snapshot
   with `SkipMemoryReliability: true` (deliberately avoiding the expensive
   up-to-2000-row reliability scan), so the backlog never reached the Home
   snapshot. With the operator's store holding 5177 candidates, the cockpit
   computed `candidate=0`.
2. Even once populated, **no production rendering path read the fields** — the
   Memory tab's `memoryReviewView()` only rendered the review queue, and
   `formatCockpitNewCandidateCount` was unused. So the counts were never shown.

## Change

**Commit 1 — data wiring.** Populate the counts in `loadCockpitHome` via the
cheap `CountByStatus` query added in #1130 (a `COUNT(*)`, not the bounded scan
or `List`):

- True accepted / candidate totals (`cockpitMemoryStatusCountCriteria`).
- New-since-last-review candidates — `CountByStatus` with
  `UpdatedAfter(checkpoint)` — when the persisted review checkpoint is known.

The memory dependency is consumed via the local `memoryStatusCounter`
type-assert (same opt-in pattern as `top_data.go`), so stubs without it fall
back to 0. **`List` is never called**, keeping the cockpit Home on its cheap
session-only path.

**Commit 2 — rendering.** Render a backlog summary line —
`backlog: candidate=N accepted=M new=K` — at the top of the Memory tab
(`memoryReviewView`), reusing the previously-unused `formatCockpitNewCandidateCount`
so an absent last-review checkpoint shows `new=untracked` rather than a
misleading 0. The summary lands in the **Memory tab only**: the session-focused
Top/Sessions surfaces deliberately omit memory cues (enforced by the existing
`TestCockpitModelView` exclusion assertions), so the backlog must not leak
there. `memoryBacklogSummaryLine` returns `""` when both totals are 0, keeping
an empty inbox uncluttered.

## Tests

- `TestCockpitHome_PopulatesMemoryBacklogViaCountByStatus`: with a memory stub
  whose `CountByStatus` returns distinct totals vs new-candidate counts (keyed
  on `UpdatedAfter`), `loadCockpitHome` sets `CandidateMemoryCount=5177`,
  `AcceptedMemoryCount=8`, `NewCandidateMemoryCount=42`, with `listCalls==0`
  (cheap path preserved) and `countCalls==2`.
- `TestCockpitMemoryReviewView_RendersInboxBacklogSummary`: the Memory tab
  `View()` contains the backlog line.
- The dogfood golden for the ambiguous-candidate scenario picks up the new
  header; Top/Sessions goldens are unchanged (memory cues stay in the Memory
  tab).

## Verification

- `go build ./...` → Success; `go test ./...` → 2294 passed; `go vet ./...` →
  no issues; `gofmt -l` → clean; `go tool golangci-lint run ./presentation/cli/...`
  → **0 issues**.

Closes #1115
