### PR TITLE
feat: capture tool failures as a first-class flag, not via exit code

### DIFF
--- a/application/types/event_details_test.go
+++ b/application/types/event_details_test.go
@@ -30,6 +30,7 @@ func TestEventDetailsOf_HappyPath(t *testing.T) {
 		false,
 		false,
 		domtypes.Some(0),
+		false,
 	)
 	auditOpt := domtypes.Some(audit)
 

--- a/application/usecase/bundle_usecase.go
+++ b/application/usecase/bundle_usecase.go
@@ -1030,6 +1030,7 @@ type bundleCommandAuditRow struct {
 	InputTruncated  bool   `json:"input_truncated"`
 	OutputTruncated bool   `json:"output_truncated"`
 	ExitCode        *int   `json:"exit_code,omitempty"`
+	Failed          bool   `json:"failed,omitempty"`
 }
 
 type bundleRefRow struct {
@@ -1231,6 +1232,7 @@ func (r bundleCommandAuditRow) toCommandAudit() (*model.CommandAudit, error) {
 		r.InputTruncated,
 		r.OutputTruncated,
 		exitCode,
+		r.Failed,
 	), nil
 }
 
@@ -1347,6 +1349,7 @@ func encodeCommandAuditsNDJSON(audits []*model.CommandAudit) (*bytes.Buffer, err
 			Output:          audit.Output(),
 			InputTruncated:  audit.InputTruncated(),
 			OutputTruncated: audit.OutputTruncated(),
+			Failed:          audit.Failed(),
 		}
 		if exitCode, ok := audit.ExitCode().Value(); ok {
 			row.ExitCode = &exitCode

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -18,8 +18,10 @@ type EventUsecase interface {
 	// to re-implement that policy in the presentation layer.
 	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error)
 
-	// Audit records a command execution audit event.
-	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)
+	// Audit records a command execution audit event. failed marks a
+	// structural failure (e.g. Claude's PostToolUseFailure) independently of
+	// exitCode, since some hosts report failure without a numeric exit code.
+	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)
 
 	// Search performs full-text search across events.
 	Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error)

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -105,7 +105,7 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 	return event, nil
 }
 
-func (u *eventUsecase) Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (u *eventUsecase) Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	if u.eventRepo == nil {
 		return nil, nil, xerrors.Errorf("event repository is not configured")
 	}
@@ -159,6 +159,7 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 	}
 	commandAudit.SetRedaction(inputRedacted, outputRedacted)
 	commandAudit.SetExitCode(exitCode)
+	commandAudit.SetFailed(failed)
 
 	event, err := model.NewEvent(
 		eventID,

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -52,6 +52,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace("duck8823/traceary"),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -92,6 +93,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -126,6 +128,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().
 				MaxInputBytes(16).
 				MaxOutputBytes(20).
@@ -160,6 +163,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -200,6 +204,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().
 				AllowSecrets(true).
 				MaxInputBytes(256).
@@ -237,6 +242,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().
 				ExtraRedactPatterns([]string{"my_custom_secret=\\S+", "internal_token:\\s*\\S+"}).
 				Build(),
@@ -270,6 +276,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().
 				ExtraRedactPatterns([]string{"[invalid"}).
 				Build(),
@@ -294,6 +301,7 @@ func TestEventUsecase_Audit(t *testing.T) {
 			types.SessionID("session-1"),
 			types.Workspace(""),
 			types.None[int](),
+			false,
 			apptypes.NewAuditRedactionBuilder().
 				MaxInputBytes(-1).
 				Build(),

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -53,6 +53,7 @@ Traceary は、ローカル状態を 1 つの SQLite DB ファイルに保存し
 - `input_truncated`: input を切り詰めたかどうか
 - `output_truncated`: output を切り詰めたかどうか
 - `exit_code`: 取得できた場合の終了コード
+- `failed`: 構造的な失敗フラグ。host が hook payload に数値 exit code を出さずに tool/command の失敗を伝える場合（例: Claude の `PostToolUseFailure`）に立つ。`list --failures` は非ゼロ `exit_code` に加えて `failed = 1` も対象にする
 
 `command_audits.event_id` は `ON DELETE CASCADE` なので、`gc` で event を削除すると対応する audit payload も同時に消えます。
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -53,6 +53,7 @@ Key columns:
 - `input_truncated`: whether Traceary truncated the stored input
 - `output_truncated`: whether Traceary truncated the stored output
 - `exit_code`: captured exit code when available
+- `failed`: structural failure flag, set when a host reports a tool/command failure without a numeric exit code in the hook payload (e.g. Claude's `PostToolUseFailure`); `list --failures` matches `failed = 1` in addition to a non-zero `exit_code`
 
 Because `command_audits.event_id` uses `ON DELETE CASCADE`, deleting an event through `gc` also deletes its audit payload.
 

--- a/domain/model/command_audit.go
+++ b/domain/model/command_audit.go
@@ -19,6 +19,7 @@ type CommandAudit struct {
 	inputRedacted   bool
 	outputRedacted  bool
 	exitCode        types.Optional[int]
+	failed          bool
 }
 
 // NewCommandAudit creates a new CommandAudit.
@@ -54,6 +55,7 @@ func CommandAuditOf(
 	inputTruncated bool,
 	outputTruncated bool,
 	exitCode types.Optional[int],
+	failed bool,
 ) *CommandAudit {
 	return &CommandAudit{
 		eventID:         eventID,
@@ -63,6 +65,7 @@ func CommandAuditOf(
 		inputTruncated:  inputTruncated,
 		outputTruncated: outputTruncated,
 		exitCode:        exitCode,
+		failed:          failed,
 	}
 }
 
@@ -109,4 +112,18 @@ func (a *CommandAudit) SetExitCode(code types.Optional[int]) {
 		return
 	}
 	a.exitCode = code
+}
+
+// Failed reports whether the tool/command execution failed. This is a
+// structural failure signal captured independently of exitCode, because
+// some hosts (e.g. Claude Code's PostToolUseFailure payload) report failure
+// without a numeric exit code in the hook payload. See docs/hooks/contract.md.
+func (a *CommandAudit) Failed() bool { return a.failed }
+
+// SetFailed marks whether the tool/command execution failed.
+func (a *CommandAudit) SetFailed(failed bool) {
+	if a == nil {
+		return
+	}
+	a.failed = failed
 }

--- a/domain/model/command_audit_test.go
+++ b/domain/model/command_audit_test.go
@@ -64,7 +64,7 @@ func TestCommandAuditOf(t *testing.T) {
 
 	eventID, _ := types.EventIDFrom("event-2")
 
-	audit := model.CommandAuditOf(eventID, "go build", "input-data", "output-data", false, true, types.None[int]())
+	audit := model.CommandAuditOf(eventID, "go build", "input-data", "output-data", false, true, types.None[int](), false)
 
 	if diff := cmp.Diff(eventID, audit.EventID()); diff != "" {
 		t.Errorf("EventID() mismatch (-want +got):\n%s", diff)

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -119,7 +119,7 @@ func (d *BundleDatasource) ListBundleCommandAudits(ctx context.Context) ([]*mode
 		}
 	}()
 	rows, err := db.QueryContext(ctx, `
-SELECT event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code
+SELECT event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code, failed
 FROM command_audits
 ORDER BY event_id`)
 	if err != nil {
@@ -366,15 +366,16 @@ func (t *bundleImportTx) ImportCommandAudit(ctx context.Context, audit *model.Co
 	}
 	query := insertCommandAuditQuery
 	if policy == usecase.BundleConflictReplace {
-		query = `INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+		query = `INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code, failed)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(event_id) DO UPDATE SET
   command_text = excluded.command_text,
   input_text = excluded.input_text,
   output_text = excluded.output_text,
   input_truncated = excluded.input_truncated,
   output_truncated = excluded.output_truncated,
-  exit_code = excluded.exit_code`
+  exit_code = excluded.exit_code,
+  failed = excluded.failed`
 	}
 	var exitCodeSQL *int
 	if exitCode, ok := audit.ExitCode().Value(); ok {
@@ -390,6 +391,7 @@ ON CONFLICT(event_id) DO UPDATE SET
 		audit.InputTruncated(),
 		audit.OutputTruncated(),
 		exitCodeSQL,
+		audit.Failed(),
 	)
 	if err == nil {
 		return true, nil
@@ -718,6 +720,7 @@ func scanBundleCommandAudit(row interface {
 		inputTruncated  bool
 		outputTruncated bool
 		exitCode        sql.NullInt64
+		failed          sql.NullBool
 	)
 	if err := row.Scan(
 		&eventID,
@@ -727,6 +730,7 @@ func scanBundleCommandAudit(row interface {
 		&inputTruncated,
 		&outputTruncated,
 		&exitCode,
+		&failed,
 	); err != nil {
 		return nil, xerrors.Errorf("scan command audit: %w", err)
 	}
@@ -738,6 +742,7 @@ func scanBundleCommandAudit(row interface {
 		inputTruncated,
 		outputTruncated,
 		optionalIntFromNullInt64(exitCode),
+		failed.Bool,
 	), nil
 }
 

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -45,7 +45,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -125,5 +126,109 @@ SELECT e.kind, a.command_text, a.input_truncated, a.output_truncated
 	}
 	if outputTruncated {
 		t.Fatalf("output_truncated = true, want false")
+	}
+}
+
+// TestDatasource_ListRecent_FailuresOnly_IncludesFailedFlag verifies the
+// failures filter treats the structural failed flag as a failure even when no
+// numeric exit code was captured — the Claude PostToolUseFailure case, where
+// the hook payload carries an "error" string but no exit code. The legacy
+// non-zero exit_code path must still match, and successes must be excluded.
+func TestDatasource_ListRecent_FailuresOnly_IncludesFailedFlag(t *testing.T) {
+	t.Parallel()
+
+	migrations := fstest.MapFS{
+		"000001_init.sql": {
+			Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    source_hook TEXT
+);`),
+		},
+		"000002_add_event_metadata.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN client TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
+		},
+		"000003_create_command_audits.sql": {
+			Data: []byte(`
+CREATE TABLE command_audits (
+    event_id TEXT PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    command_text TEXT NOT NULL,
+    input_text TEXT NOT NULL,
+    output_text TEXT NOT NULL,
+    input_truncated INTEGER NOT NULL DEFAULT 0,
+    output_truncated INTEGER NOT NULL DEFAULT 0,
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
+);`),
+		},
+	}
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, migrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	save := func(id, command string, exitCode types.Optional[int], failed bool) {
+		eventID, err := types.EventIDFrom(id)
+		if err != nil {
+			t.Fatalf("EventIDFrom(%s) error = %v", id, err)
+		}
+		agent, err := types.AgentFrom("claude")
+		if err != nil {
+			t.Fatalf("AgentFrom() error = %v", err)
+		}
+		sessionID, err := types.SessionIDFrom("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDFrom() error = %v", err)
+		}
+		event := model.EventOf(
+			eventID,
+			types.EventKindCommandExecuted,
+			"hook",
+			agent,
+			sessionID,
+			"duck8823/traceary",
+			command,
+			time.Date(2026, 4, 7, 14, 0, 0, 0, time.UTC),
+		)
+		audit, err := model.NewCommandAudit(eventID, command, "stdin", "stdout", false, false)
+		if err != nil {
+			t.Fatalf("NewCommandAudit(%s) error = %v", id, err)
+		}
+		audit.SetExitCode(exitCode)
+		audit.SetFailed(failed)
+		if err := sut.SaveWithAudit(context.Background(), event, audit); err != nil {
+			t.Fatalf("SaveWithAudit(%s) error = %v", id, err)
+		}
+	}
+
+	save("event-failed-flag", "failed tool without exit code", types.None[int](), true)
+	save("event-nonzero-exit", "command with nonzero exit", types.Some(1), false)
+	save("event-success", "successful command", types.None[int](), false)
+
+	events, err := sut.ListRecent(context.Background(), 50, 0, "", "", "", "", "", true, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListRecent(failuresOnly) error = %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, e := range events {
+		got[e.EventID().String()] = true
+	}
+	if !got["event-failed-flag"] {
+		t.Fatalf("failuresOnly omitted failed-flag row (failed=true, exit_code NULL); got %v", got)
+	}
+	if !got["event-nonzero-exit"] {
+		t.Fatalf("failuresOnly omitted nonzero-exit row; got %v", got)
+	}
+	if got["event-success"] {
+		t.Fatalf("failuresOnly returned a success row; got %v", got)
 	}
 }

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -161,6 +161,7 @@ func (d *EventDatasource) SaveWithAudit(
 		audit.InputTruncated(),
 		audit.OutputTruncated(),
 		exitCodeSQL,
+		audit.Failed(),
 	); err != nil {
 		return xerrors.Errorf("failed to insert command audit: %w", err)
 	}
@@ -503,6 +504,7 @@ func (d *EventDatasource) GetDetails(
 		inputTruncatedValue  sql.NullBool
 		outputTruncatedValue sql.NullBool
 		exitCodeValue        sql.NullInt64
+		failedValue          sql.NullBool
 	)
 
 	event, err := scanEventWithAudit(
@@ -513,6 +515,7 @@ func (d *EventDatasource) GetDetails(
 		&inputTruncatedValue,
 		&outputTruncatedValue,
 		&exitCodeValue,
+		&failedValue,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -535,6 +538,7 @@ func (d *EventDatasource) GetDetails(
 			inputTruncatedValue.Bool,
 			outputTruncatedValue.Bool,
 			exitCode,
+			failedValue.Bool,
 		)
 		commandAuditOpt = types.Some(commandAudit)
 	}
@@ -762,6 +766,7 @@ func scanEventWithAudit(
 	inputTruncatedValue *sql.NullBool,
 	outputTruncatedValue *sql.NullBool,
 	exitCodeValue *sql.NullInt64,
+	failedValue *sql.NullBool,
 ) (*model.Event, error) {
 	var (
 		eventIDValue    string
@@ -791,6 +796,7 @@ func scanEventWithAudit(
 		inputTruncatedValue,
 		outputTruncatedValue,
 		exitCodeValue,
+		failedValue,
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event details row: %w", err)
 	}

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -49,7 +49,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -146,7 +147,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -215,7 +217,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -287,7 +290,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -355,7 +359,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -536,7 +541,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -642,7 +648,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -691,7 +698,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -763,7 +771,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -101,7 +101,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}

--- a/infrastructure/sqlite/get_event_details_test.go
+++ b/infrastructure/sqlite/get_event_details_test.go
@@ -42,7 +42,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -59,7 +59,8 @@ ALTER TABLE events ADD COLUMN workspace TEXT NOT NULL DEFAULT '';`),
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 		"000004_create_sessions.sql": {

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -43,7 +43,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}
@@ -326,7 +327,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 	}

--- a/infrastructure/sqlite/sql/get_event_details.sql
+++ b/infrastructure/sqlite/sql/get_event_details.sql
@@ -1,5 +1,5 @@
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at,
-       ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code
+       ca.command_text, ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated, ca.exit_code, ca.failed
   FROM events AS e
   LEFT JOIN command_audits AS ca
     ON ca.event_id = e.id

--- a/infrastructure/sqlite/sql/insert_command_audit.sql
+++ b/infrastructure/sqlite/sql/insert_command_audit.sql
@@ -1,2 +1,2 @@
-INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code, failed)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -35,6 +35,6 @@ SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.bo
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.created_at >= ?)
    AND (? = '' OR e.created_at < ?)
-   AND (? = 0 OR (a.exit_code IS NOT NULL AND a.exit_code != 0))
+   AND (? = 0 OR a.failed = 1 OR (a.exit_code IS NOT NULL AND a.exit_code != 0))
  ORDER BY e.created_at DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_events.sql
+++ b/infrastructure/sqlite/sql/select_recent_events.sql
@@ -11,7 +11,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.sou
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
    AND (? = '' OR e.created_at >= ?)
    AND (? = '' OR e.created_at < ?)
  ORDER BY e.created_at DESC, e.id DESC

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
@@ -18,7 +18,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.sou
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
    AND (? = '' OR e.created_at >= ?)
    AND (? = '' OR e.created_at < ?)
  ORDER BY e.created_at DESC, e.id DESC

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
@@ -18,7 +18,7 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
            AND (? = '' OR e.agent = ?)
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
-           AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
            AND (? = '' OR e.created_at >= ?)
            AND (? = '' OR e.created_at < ?)
         UNION ALL
@@ -37,7 +37,7 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
            AND (? = '' OR e.agent = ?)
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
-           AND (? = 0 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
            AND (? = '' OR e.created_at >= ?)
            AND (? = '' OR e.created_at < ?)
        ) events_union

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -189,6 +189,7 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		input.command, input.input, input.output,
 		client, agent, sid, types.Workspace(resolvedRepo),
 		input.exitCode,
+		false, // manual audits carry an explicit exit code; the failure flag is for hosts that omit it
 		auditCfg,
 	)
 	if err != nil {

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -91,6 +91,7 @@ func newCommandAuditOutput(audit *model.CommandAudit) *commandAudit {
 		InputTruncated:  audit.InputTruncated(),
 		OutputTruncated: audit.OutputTruncated(),
 		ExitCode:        exitCode,
+		Failed:          audit.Failed(),
 	}
 }
 

--- a/presentation/cli/golden_test.go
+++ b/presentation/cli/golden_test.go
@@ -92,6 +92,7 @@ func TestEventShow_JSON_Golden(t *testing.T) {
 			false,
 			false,
 			types.Some(0),
+			false,
 		)),
 	)
 	if err != nil {
@@ -177,6 +178,7 @@ func TestCoreReadJSONGoldens(t *testing.T) {
 			false,
 			true,
 			types.Some(1),
+			false,
 		)
 		audit.SetRedaction(true, true)
 		auditEvent := mustGoldenEvent(t, eventID.String(), types.EventKindCommandExecuted, "cli", "codex", "session-golden-audit", "duck8823/traceary", "curl https://example.test", time.Date(2026, 4, 8, 14, 30, 0, 0, time.UTC), "")

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -462,6 +462,7 @@ func (c *RootCLI) runHookAudit(
 		sessionID,
 		workspace,
 		hookPayloadExitCode(payload),
+		hookPayloadFailed(payload),
 		auditCfg,
 	)
 
@@ -1354,6 +1355,33 @@ func hookPayloadExitCode(payload []byte) types.Optional[int] {
 	default:
 		return types.None[int]()
 	}
+}
+
+// hookPayloadFailed derives a structural failure signal from a post-tool hook
+// payload. No host exposes a numeric exit code in the post-tool payload, so
+// failure is detected from the failure-shaped fields each host does provide:
+//
+//   - Claude Code: a top-level "error" string on the PostToolUseFailure
+//     payload (the success PostToolUse payload has no "error" field).
+//   - Gemini CLI: a nested "tool_response.error" object, set only for
+//     spawn/OS-level errors (a plain non-zero shell exit is NOT reported here,
+//     so Gemini failure capture is partial — see docs/hooks/contract.md).
+//
+// Codex exposes no structured failure field, so its failures are not flagged.
+func hookPayloadFailed(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	if hookPayloadString(payload, "error", "") != "" {
+		return true
+	}
+	if value, ok := lookupHookPayloadValue(payload, "tool_response.error"); ok && value != nil {
+		if errString, isString := value.(string); isString {
+			return strings.TrimSpace(errString) != ""
+		}
+		return true
+	}
+	return false
 }
 
 func buildHookFailureOutput(payload []byte) (string, error) {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -545,6 +545,7 @@ func TestRootCLI_HookAuditCommand_UsesSessionStateAndToolPayload(t *testing.T) {
 			false,
 			false,
 			types.Some(0),
+			false,
 		),
 	}
 
@@ -578,6 +579,93 @@ func TestRootCLI_HookAuditCommand_UsesSessionStateAndToolPayload(t *testing.T) {
 	}
 	if got, ok := eventStub.auditCall.exitCode.Value(); !ok || got != 0 {
 		t.Fatalf("audit exitCode = (%d, %t), want (0, true)", got, ok)
+	}
+	if eventStub.auditCall.failed {
+		t.Fatalf("audit failed = true, want false for a success payload")
+	}
+}
+
+// TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload verifies the
+// failure-derivation logic: no host exposes a numeric exit code in the
+// post-tool payload, so a Claude PostToolUseFailure (top-level "error") and a
+// Gemini spawn error (nested "tool_response.error") must each be recorded as a
+// first-class failure (failed=true) even though exitCode stays unset.
+func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
+	cases := []struct {
+		name       string
+		client     string
+		payload    string
+		wantFailed bool
+	}{
+		{
+			name:       "claude post-tool-use failure with top-level error",
+			client:     "claude",
+			payload:    `{"tool_input":{"command":"go test ./..."},"error":"Exit code 7\nFAIL","is_interrupt":false}`,
+			wantFailed: true,
+		},
+		{
+			name:       "claude success payload is not flagged",
+			client:     "claude",
+			payload:    `{"tool_input":{"command":"go test ./..."},"tool_response":{"interrupted":false,"stdout":"ok","stderr":""}}`,
+			wantFailed: false,
+		},
+		{
+			name:       "gemini spawn error in tool_response.error",
+			client:     "gemini",
+			payload:    `{"tool_input":{"command":"missing-binary"},"tool_response":{"llmContent":"failed","error":{"type":"shell_execute_error","message":"spawn failed"}}}`,
+			wantFailed: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+			homeDir := t.TempDir()
+			cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+			t.Cleanup(cli.ResetUserHomeDirFunc)
+
+			stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(stateDir, tc.client+"-test-key"), []byte("generated-session"), 0o600); err != nil {
+				t.Fatalf("WriteFile(session state) error = %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(stateDir, tc.client+"-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+				t.Fatalf("WriteFile(workspace state) error = %v", err)
+			}
+
+			eventStub := &eventUsecaseStub{
+				auditEvent: model.EventOf(
+					types.EventID("evt-audit"),
+					types.EventKindCommandExecuted,
+					types.Client("hook"),
+					types.Agent(tc.client),
+					types.SessionID("generated-session"),
+					types.Workspace("github.com/duck8823/traceary"),
+					"command executed",
+					time.Now(),
+				),
+			}
+
+			rootCmd := newTestRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithEvent(eventStub),
+			).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetIn(strings.NewReader(tc.payload))
+			rootCmd.SetArgs([]string{"hook", "audit", tc.client})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if got := eventStub.auditCall.failed; got != tc.wantFailed {
+				t.Fatalf("audit failed = %t, want %t", got, tc.wantFailed)
+			}
+		})
 	}
 }
 

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -615,6 +615,24 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			payload:    `{"tool_input":{"command":"missing-binary"},"tool_response":{"llmContent":"failed","error":{"type":"shell_execute_error","message":"spawn failed"}}}`,
 			wantFailed: true,
 		},
+		{
+			name:       "empty top-level error is not a failure",
+			client:     "claude",
+			payload:    `{"tool_input":{"command":"go test ./..."},"error":""}`,
+			wantFailed: false,
+		},
+		{
+			name:       "gemini empty tool_response.error is not a failure",
+			client:     "gemini",
+			payload:    `{"tool_input":{"command":"go test ./..."},"tool_response":{"llmContent":"ok","error":""}}`,
+			wantFailed: false,
+		},
+		{
+			name:       "codex raw-string tool_response mentioning error is not flagged",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"go test ./..."},"tool_response":"error: a test logged the word error but exited 0"}`,
+			wantFailed: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -33,6 +33,7 @@ type commandAudit struct {
 	InputTruncated  bool   `json:"input_truncated"`
 	OutputTruncated bool   `json:"output_truncated"`
 	ExitCode        *int   `json:"exit_code,omitempty"`
+	Failed          bool   `json:"failed,omitempty"`
 }
 
 // eventDetails is the JSON shape of an event-with-audit pair in CLI output.

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -51,6 +51,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 				true,
 				false,
 				types.None[int](),
+				false,
 			)),
 		)
 		if err != nil {
@@ -151,6 +152,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 				true,
 				false,
 				types.None[int](),
+				false,
 			)),
 		)
 		if err != nil {
@@ -216,6 +218,7 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 				false,
 				false,
 				types.Some(1),
+				false,
 			)),
 		)
 		if err != nil {

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -27,7 +27,7 @@ func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, typ
 	return nil, nil
 }
 
-func (s *tailEventUsecaseStub) Audit(context.Context, string, string, string, types.Client, types.Agent, types.SessionID, types.Workspace, types.Optional[int], apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (s *tailEventUsecaseStub) Audit(context.Context, string, string, string, types.Client, types.Agent, types.SessionID, types.Workspace, types.Optional[int], bool, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	return nil, nil, nil
 }
 

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -870,6 +870,7 @@ func TestTopDataLoader_LoadDetail_EventUsesShowAndFormatsAudit(t *testing.T) {
 		false,
 		false,
 		domtypes.Some(1),
+		false,
 	)
 	details, err := apptypes.EventDetailsOf(event, domtypes.Some(audit))
 	if err != nil {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -48,6 +48,7 @@ type eventUsecaseStub struct {
 		sessionID types.SessionID
 		workspace types.Workspace
 		exitCode  types.Optional[int]
+		failed    bool
 		auditCfg  apptypes.AuditRedaction
 	}
 }
@@ -63,7 +64,7 @@ func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.E
 	s.logCall.sourceHook = apptypes.SourceHookFromContext(ctx)
 	return s.logEvent, s.logErr
 }
-func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	s.auditCall.command = command
 	s.auditCall.input = input
 	s.auditCall.output = output
@@ -72,6 +73,7 @@ func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string
 	s.auditCall.sessionID = sessionID
 	s.auditCall.workspace = workspace
 	s.auditCall.exitCode = exitCode
+	s.auditCall.failed = failed
 	s.auditCall.auditCfg = auditCfg
 	return s.auditEvent, s.auditAudit, s.auditErr
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -375,7 +375,7 @@ func (s *Server) recordEvent() mcp.ToolHandlerFor[recordEventInput, recordEventO
 				return nil, recordEventOutput{}, xerrors.Errorf("record_event type audit requires command")
 			}
 			auditCfg := apptypes.NewAuditRedactionBuilder().ExtraRedactPatterns(s.extraRedactPatterns).StructuredRules(s.structuredRedactRules).Build()
-			event, audit, err := s.event.Audit(ctx, input.Command, input.Input, input.Output, types.Client(resolveValue(input.Client, defaultClientValue)), types.Agent(resolveValue(input.Agent, defaultAgentValue)), types.SessionID(resolveValue(input.SessionID, defaultSessionValue)), types.Workspace(strings.TrimSpace(input.Workspace)), types.None[int](), auditCfg)
+			event, audit, err := s.event.Audit(ctx, input.Command, input.Input, input.Output, types.Client(resolveValue(input.Client, defaultClientValue)), types.Agent(resolveValue(input.Agent, defaultAgentValue)), types.SessionID(resolveValue(input.SessionID, defaultSessionValue)), types.Workspace(strings.TrimSpace(input.Workspace)), types.None[int](), false, auditCfg)
 			if err != nil {
 				return nil, recordEventOutput{}, xerrors.Errorf("failed to record command audit: %w", err)
 			}

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -1452,7 +1452,8 @@ CREATE TABLE command_audits (
     output_text TEXT NOT NULL,
     input_truncated INTEGER NOT NULL DEFAULT 0,
     output_truncated INTEGER NOT NULL DEFAULT 0,
-    exit_code INTEGER
+    exit_code INTEGER,
+    failed INTEGER NOT NULL DEFAULT 0
 );`),
 		},
 		"000004_create_sessions.sql": {

--- a/schema/sqlite/migrations/000017_add_command_audits_failed.sql
+++ b/schema/sqlite/migrations/000017_add_command_audits_failed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE command_audits ADD COLUMN failed INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

Define a failure-event capture path that works against what the AI hosts
**actually** expose. Issue #1116 asked to first verify the host payloads — that
verification overturned the issue's stated premise (derive failure from
`tool_response`/exitCode), so this PR captures failures via a structural
`failed` flag instead of a numeric exit code the hosts do not emit.

## What the hosts actually expose (verified)

`list --failures` filtered on `exit_code != 0`, but no host puts a numeric exit
code in its post-tool hook payload, so the column was effectively always NULL.
Live evidence: 111k+ shell-command audits in the operator store, **0** with a
non-zero exit code. Per-host (live payloads + upstream source):

| Host | Failure signal in the post-tool payload | Numeric exit code? |
|---|---|---|
| Claude Code | top-level `error` string on `PostToolUseFailure` (no `tool_response`) | no |
| Codex | `tool_response` is a bare formatted string | no — no structured signal |
| Gemini | nested `tool_response.error` **only** for spawn/OS-level errors | no (plain non-zero exit is text-only) |

A failed Bash command and a successful one were previously **indistinguishable**
in the store (both `source_hook=post_tool_use`, both `exit_code` NULL).

## Change (capture path — #1116)

- **migration 000017** adds `command_audits.failed` (`NOT NULL DEFAULT 0`).
- **domain** `CommandAudit` carries `failed` (`CommandAuditOf` param +
  `Failed()` / `SetFailed()`), independent of `exitCode`.
- **usecase** `Audit(...)` takes a `failed` argument.
- **hook runtime** derives failure via `hookPayloadFailed`: top-level `error`
  (Claude `PostToolUseFailure`) or nested `tool_response.error` (Gemini spawn
  error). Manual `traceary audit` and MCP `record_event` pass `false` — they
  already carry an explicit exit code.
- **failures filter** becomes `failed = 1 OR (exit_code IS NOT NULL AND
  exit_code != 0)` across the four list/search queries, so both flagged
  failures and legacy non-zero exits match.
- **restore + surface**: `failed` is read back in get-event-details, surfaced
  in the JSON / audit output (additive, `omitempty`), and round-tripped through
  bundle export/import.

**Honest bounds**: Codex stays unflagged (no structured signal); Gemini is
partial (spawn errors only). No fragile output-text parsing. The contract.md /
docs reality update is the follow-up host-wiring issue (next in the wave).

## Tests

- `TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload`: end-to-end via
  the `hook audit` command — Claude top-level `error` ⇒ `failed=true`, Gemini
  nested `tool_response.error` ⇒ `failed=true`, success payload ⇒ `failed=false`.
- `TestDatasource_ListRecent_FailuresOnly_IncludesFailedFlag`: failures-only
  query returns a `failed=true` row with a NULL exit code and the legacy
  non-zero-exit row, while excluding successes.
- Existing audit/bundle/golden tests updated for the new field.

## Verification

`go build ./...` → ok; `go test ./...` → 2299 passed; `go vet ./...` → clean;
`go tool golangci-lint run ./domain/... ./application/... ./infrastructure/... ./presentation/...` → **0 issues**.

Closes #1116
