### PR TITLE
docs: align the hook contract with verified host failure-capture reality

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -12,10 +12,10 @@
 |---|---|---|
 | SessionStart | `*` | セッション開始を記録 |
 | SessionEnd | `*` | セッション終了を記録 |
-| PostToolUse | `Bash` | シェルコマンド監査を exit code 付きで記録 |
+| PostToolUse | `Bash` | シェルコマンド監査を記録 |
 | PostToolUse | `mcp__.*` | MCP ツール監査を記録 |
 | PostToolUse | `Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode` | Claude Code 組み込みツール（ファイル I/O・検索・agent・web・plan モード終了）の呼び出しを記録（v0.8-6 で追加、v0.8-6b で `NotebookRead` と `ExitPlanMode` を追加） |
-| PostToolUseFailure | `Bash`, `mcp__.*`, 組み込みツール | 失敗したツール実行を記録 |
+| PostToolUseFailure | `Bash`, `mcp__.*`, 組み込みツール | 失敗フラグ付きのツール監査を記録。payload はトップレベル `error` 文字列を持ち（`tool_response` も数値 exit code も無い）、exit code を読む代わりに監査を `failed` とマークする。`list --failures` はこのフラグを対象にする |
 | PostCompact | `*` | compact サマリーを記録 |
 | UserPromptSubmit | `*` | ユーザーの指示テキストを記録 |
 | Stop | `*` | `transcript_path` から最後の assistant メッセージを読み取り `transcript` event として記録（既知 secret の redaction + オペレーター設定の `redact.rules` / `redact.extra_patterns` を適用） |
@@ -30,7 +30,7 @@
 | Stop | (全て) | セッション終了を記録し、`last_assistant_message` から最終 assistant メッセージを `transcript` event として記録（既知 secret の redaction + オペレーター設定の `redact.rules` / `redact.extra_patterns` を適用） |
 | PostToolUse | (全て) | ツール監査を記録 |
 
-**制限**: SessionEnd なし（Stop を使用）、compact hooks なし、failure 専用イベントなし。
+**制限**: SessionEnd なし（Stop を使用）、compact hooks なし、failure 専用イベントなし・構造化された失敗信号なし。Codex は非ゼロ終了でも `PostToolUse` を fire するが、`tool_response` は exit code も error フィールドも持たない素の整形済み文字列のため、失敗した実行は通常の（フラグなし）監査として記録される。
 
 ### Tier 3: 基本対応 (Gemini CLI)
 
@@ -43,14 +43,14 @@
 | AfterTool | `*` | ツール監査を記録 |
 | PreCompress | `*` | `compact_summary` marker として記録（`trigger` のみ。Gemini には post-compress digest がない） |
 
-**制限**: post-compress digest はなし（Gemini の `PreCompress` は async marker のみ）、failure 専用イベントなし。Gemini には Stop event が存在しないため、transcript 取得は `AfterAgent` に紐付けている。
+**制限**: post-compress digest はなし（Gemini の `PreCompress` は async marker のみ）、failure 専用イベントなし。Gemini には Stop event が存在しないため、transcript 取得は `AfterAgent` に紐付けている。失敗捕捉は部分的: `AfterTool` の nested `tool_response.error` は spawn/OS レベルエラー時のみ出る（その場合は `failed` とマーク）。通常の非ゼロ終了は `tool_response.llmContent` 内の `Exit Code: N` テキストとしてのみ現れ、Traceary は意図的に parse しないため、それらはフラグなしのまま。
 
 ## 共通動作
 
 全レベル共通:
 - セッション開始時に解決した workspace を state ファイルに保存し、audit はそこから workspace を読み取る
 - エージェントタイプ解決: `agent_type` フィールド → 階層的エージェント名（Claude のみ）
-- `tool_response.exitCode` から exit code を抽出（利用可能時）
+- host が提供する場合は `tool_response.exitCode` から exit code を抽出。ただし現行のどの host も post-tool payload にこのフィールドを出さないため、実際には exit code ではなく構造的に失敗を検出する（上記の失敗フラグ行と下記 fallback 表を参照）
 - MCP ツール名 fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:
@@ -64,7 +64,7 @@ Claude Task subagent capture:
 | 欠落機能 | フォールバック |
 |---|---|
 | Compact hooks | MCP `get_context` / `session_handoff` でオンデマンド取得 |
-| Failure イベント | audit スクリプトで tool_response の exit code を解析 |
+| Failure イベント | 失敗形状の payload から構造的な `failed` フラグを導出（Claude のトップレベル `error`、Gemini の `tool_response.error`）。`list --failures` は非ゼロ `exit_code` に加えて `failed = 1` も対象にする。構造化された失敗信号を出さない host（Codex、Gemini の通常の非ゼロ終了）はフラグなし監査として記録 |
 | エージェントタイプ | クライアント名のみ使用（例: `codex`, `gemini`） |
 
 ## 2026 Q2 ホスト別機能メモ

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -12,10 +12,10 @@ This document defines the hook capability tiers across AI agent clients.
 |---|---|---|
 | SessionStart | `*` | Record session start |
 | SessionEnd | `*` | Record session end |
-| PostToolUse | `Bash` | Record shell command audit with exit code |
+| PostToolUse | `Bash` | Record shell command audit |
 | PostToolUse | `mcp__.*` | Record MCP tool audit |
 | PostToolUse | `Read\|NotebookRead\|Edit\|MultiEdit\|Write\|NotebookEdit\|Grep\|Glob\|Agent\|Task\|TodoWrite\|WebFetch\|WebSearch\|ExitPlanMode` | Record built-in Claude Code tool invocations (file I/O, search, agent, web, plan-mode exit). Added in v0.8-6; expanded to include `NotebookRead` and `ExitPlanMode` in v0.8-6b |
-| PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | Record failed tool execution |
+| PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | Record a failure-flagged tool audit. The payload carries a top-level `error` string (no `tool_response`, no numeric exit code), so Traceary marks the audit `failed` rather than reading an exit code; `list --failures` matches the flag |
 | PostCompact | `*` | Record compact summary |
 | UserPromptSubmit | `*` | Record user prompt text |
 | Stop | `*` | Record last assistant message from `transcript_path` as a `transcript` event (built-in secret redaction + operator-configured `redact.rules` / `redact.extra_patterns` applied) |
@@ -30,7 +30,7 @@ This document defines the hook capability tiers across AI agent clients.
 | Stop | (all) | Record session end and the final assistant message (from `last_assistant_message`) as a `transcript` event (built-in secret redaction + operator-configured `redact.rules` / `redact.extra_patterns` applied) |
 | PostToolUse | (all) | Record tool audit |
 
-**Limitations**: No SessionEnd (uses Stop instead), no compact hooks, no failure-specific event.
+**Limitations**: No SessionEnd (uses Stop instead), no compact hooks, no failure-specific event and no structured failure signal — Codex fires `PostToolUse` for non-zero exits too, but its `tool_response` is a plain formatted string with no exit code or error field, so failed runs are recorded as ordinary (unflagged) audits.
 
 ### Tier 3: Basic (Gemini CLI)
 
@@ -43,14 +43,14 @@ This document defines the hook capability tiers across AI agent clients.
 | AfterTool | `*` | Record tool audit |
 | PreCompress | `*` | Record a `compact_summary` marker (`trigger` field only — Gemini exposes no post-compress digest) |
 
-**Limitations**: No post-compress digest (Gemini's `PreCompress` is advisory and fires asynchronously), no failure-specific event, no PostCompact/SessionStart(compact). Gemini has no Stop event, so transcript capture is attached to `AfterAgent` instead.
+**Limitations**: No post-compress digest (Gemini's `PreCompress` is advisory and fires asynchronously), no failure-specific event, no PostCompact/SessionStart(compact). Gemini has no Stop event, so transcript capture is attached to `AfterAgent` instead. Failure capture is partial: `AfterTool` exposes a nested `tool_response.error` object only for spawn/OS-level errors (Traceary marks those `failed`); a plain non-zero shell exit surfaces only as `Exit Code: N` text inside `tool_response.llmContent`, which Traceary deliberately does not parse, so those runs stay unflagged.
 
 ## Shared Behavior
 
 All tiers:
 - Session start persists the resolved workspace to the state file; audit reads the workspace from state
 - Agent type resolution: `agent_type` field → hierarchical agent name (Claude only)
-- Exit code extraction from `tool_response.exitCode` when available
+- Exit code extraction from `tool_response.exitCode` when a host provides it. In practice none of the current hosts populate this field in the post-tool payload, so failure is detected structurally instead (see the failure-flag rows above and the fallback table below) rather than from an exit code.
 - MCP tool name fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:
@@ -64,7 +64,7 @@ Claude Task subagent capture:
 | Missing Capability | Fallback |
 |---|---|
 | Compact hooks | MCP `get_context` / `session_handoff` on demand |
-| Failure event | Parse exit code from tool_response in audit script |
+| Failure event | Derive a structural `failed` flag from the failure-shaped payload (Claude's top-level `error`, Gemini's `tool_response.error`); `list --failures` matches `failed = 1` in addition to a non-zero `exit_code`. Hosts that expose no structured failure signal (Codex; Gemini plain non-zero exits) are recorded as unflagged audits |
 | Agent type | Use client name only (e.g., `codex`, `gemini`) |
 
 ## 2026 Q2 host capability notes

--- a/docs/hooks/lifecycle-events.ja.md
+++ b/docs/hooks/lifecycle-events.ja.md
@@ -12,7 +12,7 @@
 |---|---|---|---|
 | `session_started` | エージェントセッション開始 | `SessionStart` (Claude / Codex / Gemini) | workspace + agent 識別子 |
 | `prompt` | ユーザが指示を投入 | `UserPromptSubmit` (Claude / Codex) | 生プロンプト（redact 後） |
-| `command_executed` | tool / shell 呼び出しが成功または失敗で終わる | `PostToolUse`, `PostToolUseFailure`, `AfterTool` | input / output / exit code（compact JSON、redact 後） |
+| `command_executed` | tool / shell 呼び出しが成功または失敗で終わる | `PostToolUse`, `PostToolUseFailure`, `AfterTool` | input / output / 構造的な失敗フラグ（compact JSON、redact 後） |
 | `transcript` | アシスタント応答ターンが推論・説明テキストで閉じる | `Stop` (Claude / Codex) | 最後のアシスタントメッセージ本文（redact 後） |
 | `compact_summary` | ホスト側 context 圧縮で要約が生成される | `PostCompact`（現状 Claude のみ） | 構造化された compact summary |
 | `session_ended` | エージェントセッション終了 | `SessionEnd` (Claude / Gemini) または `Stop` (Codex) | 任意の reason marker |
@@ -41,7 +41,7 @@
   - `command`: `tool_input.command`（Bash 等にある場合）
   - `input`: `tool_input` の compact JSON
   - `output`: `tool_response` の compact JSON、失敗時は `{error, is_interrupt}`
-- 失敗 payload は Claude 側で `PostToolUseFailure` 経由となり、`traceary list events` の `failures_only` で絞り込める。
+- 失敗検出は exit code ベースではなく構造的: どの host も post-tool payload に数値 exit code を出さないため、失敗形状の payload から監査を `failed` とマークする — Claude の `PostToolUseFailure`（トップレベル `error`）と Gemini の `tool_response.error`（spawn エラーのみ）。`traceary list events` の `failures_only` はこのフラグを対象にする。Codex は構造化された失敗信号を出さないため、失敗した実行はフラグなし監査として記録される。
 - 通常セッションで最も件数が多いイベント。検索 / timeline はほぼここを触る。
 
 ### `transcript`

--- a/docs/hooks/lifecycle-events.md
+++ b/docs/hooks/lifecycle-events.md
@@ -12,7 +12,7 @@ The full enum lives in [`domain/types/event_kind.go`](../../domain/types/event_k
 |---|---|---|---|
 | `session_started` | A new agent session opens | `SessionStart` (Claude / Codex / Gemini) | workspace + agent identifier (free-text) |
 | `prompt` | The user submits an instruction | `UserPromptSubmit` (Claude / Codex) | raw prompt text (redacted) |
-| `command_executed` | A tool / shell call completes (success or failure) | `PostToolUse`, `PostToolUseFailure`, `AfterTool` | input / output / exit code (compact JSON, redacted) |
+| `command_executed` | A tool / shell call completes (success or failure) | `PostToolUse`, `PostToolUseFailure`, `AfterTool` | input / output / structural failure flag (compact JSON, redacted) |
 | `transcript` | Assistant turn ends with reasoning / explanation text | `Stop` (Claude / Codex) | last assistant-message text blocks (redacted) |
 | `compact_summary` | Host context compression produces a summary | `PostCompact` (Claude only today) | structured compact summary text |
 | `session_ended` | The agent session closes | `SessionEnd` (Claude / Gemini) or `Stop` (Codex) | optional reason marker |
@@ -41,7 +41,7 @@ All event bodies pass through built-in secret redaction plus operator-configured
   - `command`: `tool_input.command` when present (Bash etc.)
   - `input`: compact JSON of `tool_input`
   - `output`: compact JSON of `tool_response`, or `{error, is_interrupt}` for failure payloads
-- Failure payloads are routed via `PostToolUseFailure` (Claude) so they can be filtered with `failures_only` in `traceary list events`.
+- Failure detection is structural, not exit-code based: no host puts a numeric exit code in the post-tool payload, so Traceary marks an audit `failed` from the failure-shaped payload — Claude's `PostToolUseFailure` (top-level `error`) and Gemini's `tool_response.error` (spawn errors only). `failures_only` in `traceary list events` matches that flag. Codex exposes no structured failure signal, so its failed runs are recorded as unflagged audits.
 - This is the highest-volume event kind in a typical session — most search / timeline queries touch it.
 
 ### `transcript`

--- a/docs/lifecycle.ja.md
+++ b/docs/lifecycle.ja.md
@@ -17,7 +17,7 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | SessionStart | `*` | `session_started` | セッション開始。workspace 解決もここで行う |
 | SessionStart | `compact` | — | compact-summary を新しいコンテキストへ stdout 経由で注入 |
 | UserPromptSubmit | `*` | `prompt` | ユーザーが送った指示テキスト |
-| PostToolUse | `Bash` | `command_executed` | シェルコマンド（入出力・終了コード付き） |
+| PostToolUse | `Bash` | `command_executed` | シェルコマンド（入出力付き） |
 | PostToolUse | `mcp__.*` | `command_executed` | MCP ツール呼び出し |
 | PostToolUse | 組み込み tools | `command_executed` | ファイル I/O・検索・agent・web・plan モード終了 (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)。v0.8-6 で追加、v0.8-6b で拡張。 |
 | PostToolUseFailure | `Bash`, `mcp__.*`, 組み込み tools | `command_executed` | 失敗したツール実行（`failures_only` でフィルタ可能） |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -17,7 +17,7 @@ SessionStart → [UserPromptSubmit → PostToolUse]* → (PreCompact → PostCom
 | SessionStart | `*` | `session_started` | Session start with workspace resolution |
 | SessionStart | `compact` | — | Inject compact-summary into new context (stdout) |
 | UserPromptSubmit | `*` | `prompt` | User instruction text |
-| PostToolUse | `Bash` | `command_executed` | Shell command with input/output/exit code |
+| PostToolUse | `Bash` | `command_executed` | Shell command with input/output |
 | PostToolUse | `mcp__.*` | `command_executed` | MCP tool invocation |
 | PostToolUse | built-in tools | `command_executed` | File I/O / search / agent / web / plan-mode exit (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`). Added in v0.8-6; expanded in v0.8-6b. |
 | PostToolUseFailure | `Bash`, `mcp__.*`, built-in tools | `command_executed` | Failed tool execution (filterable via `failures_only`) |


### PR DESCRIPTION
## Summary

Align the hook contract and lifecycle docs with the verified host failure-capture
reality. Issue #1117 asked to wire the host configs for failure events and update
the contract — verification (in the failure-capture path PR) showed **no host config change is needed**,
so this PR is the honest documentation half: the contract now describes what the
hosts actually expose and how Traceary records failure (a structural `failed`
flag, not an exit code).

## Why no config change

The host hook configs already route the post-tool case to `traceary hook audit`:

- **Claude** `integrations/claude-plugin/hooks/hooks.json`: `PostToolUseFailure`
  (Bash / `mcp__.*` / built-in tools) → `hook audit claude`.
- **Codex** `plugins/traceary/hooks.json`: `PostToolUse` → `hook audit codex`.
- **Gemini** `integrations/gemini-extension/hooks/hooks.json`: `AfterTool` →
  `hook audit gemini`.

The detection added in the failure-capture path PR (`hookPayloadFailed`) marks the `failed` flag from
the payloads these existing hooks already deliver — Claude's top-level `error`,
Gemini's `tool_response.error` (spawn errors only). There is no failure event or
field to wire for Codex, and Gemini's plain non-zero exits are text-only, so no
config edit can change that. `verify_integrations.py` passes unchanged.

## Doc changes (en + ja)

- **`docs/hooks/contract.md`**: Tier 1 `PostToolUseFailure` records a
  failure-flagged audit from the top-level `error` (no exit code); the Bash
  `PostToolUse` row drops the exit-code claim. Codex/Gemini limitation notes
  spell out the structural-signal gap. Shared-behavior + fallback table now
  describe the `failed` flag instead of exit-code parsing.
- **`docs/hooks/lifecycle-events.md`, `docs/lifecycle.md`**: drop the stale
  "exit code" capture claim; describe the structural failure flag and host
  limits.
- en/ja kept in sync.

## Acceptance reality (honest)

> "Failed tool runs under Codex and Gemini show up as failure events end-to-end."

Corrected by verification: **Gemini** spawn/OS-level errors are flagged
end-to-end (covered by the the failure-capture path PR test); **Codex** failures cannot be flagged —
the host exposes no structured failure signal, so they are recorded as unflagged
audits. Both limits are now documented rather than promised. Claude failures
(the original Tier-1 case that was also silently broken) are flagged.

## Verification

`verify_docs_i18n.py` → passed; `verify_integrations.py` → ok (manifests/assets
consistent); no Go code changed.

Closes #1117
