### PR TITLE
refactor: replace the EventUsecase.Audit positional signature with AuditInput

### DIFF
--- a/application/types/audit_input.go
+++ b/application/types/audit_input.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// AuditInput carries the fields the Audit usecase records for a single
+// command / tool execution. Grouping them as a named value object keeps the
+// Audit call safe: every field is set by name, so the attribution strings,
+// ExitCode, and Failed flag cannot be silently transposed the way a long
+// positional signature allowed. The redaction policy is passed separately
+// because it is a capture policy, not audit data.
+type AuditInput struct {
+	Command   string
+	Input     string
+	Output    string
+	Client    domtypes.Client
+	Agent     domtypes.Agent
+	SessionID domtypes.SessionID
+	Workspace domtypes.Workspace
+	// ExitCode is the captured process exit code when a host provides one.
+	ExitCode domtypes.Optional[int]
+	// Failed marks a structural failure even when no numeric exit code is
+	// available (e.g. Claude's PostToolUseFailure payload).
+	Failed bool
+}

--- a/application/usecase/event_usecase.go
+++ b/application/usecase/event_usecase.go
@@ -18,10 +18,10 @@ type EventUsecase interface {
 	// to re-implement that policy in the presentation layer.
 	Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error)
 
-	// Audit records a command execution audit event. failed marks a
-	// structural failure (e.g. Claude's PostToolUseFailure) independently of
-	// exitCode, since some hosts report failure without a numeric exit code.
-	Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)
+	// Audit records a command execution audit event. The AuditInput value
+	// object carries the command, attribution, exit code, and structural
+	// failure flag; auditCfg carries the redaction policy.
+	Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error)
 
 	// Search performs full-text search across events.
 	Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error)

--- a/application/usecase/event_usecase_impl.go
+++ b/application/usecase/event_usecase_impl.go
@@ -105,15 +105,15 @@ func (u *eventUsecase) Log(ctx context.Context, message string, kind types.Event
 	return event, nil
 }
 
-func (u *eventUsecase) Audit(ctx context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (u *eventUsecase) Audit(ctx context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	if u.eventRepo == nil {
 		return nil, nil, xerrors.Errorf("event repository is not configured")
 	}
 
-	if _, err := types.AgentFrom(agent.String()); err != nil {
+	if _, err := types.AgentFrom(in.Agent.String()); err != nil {
 		return nil, nil, xerrors.Errorf("failed to resolve agent: %w", err)
 	}
-	if _, err := types.SessionIDFrom(sessionID.String()); err != nil {
+	if _, err := types.SessionIDFrom(in.SessionID.String()); err != nil {
 		return nil, nil, xerrors.Errorf("failed to resolve session ID: %w", err)
 	}
 	eventID, err := newEventID()
@@ -135,8 +135,8 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 		return nil, nil, xerrors.Errorf("failed to compile redaction rules: %w", err)
 	}
 
-	normalizedInput := input
-	normalizedOutput := output
+	normalizedInput := in.Input
+	normalizedOutput := in.Output
 	var inputRedacted bool
 	var outputRedacted bool
 	if !auditCfg.AllowSecrets() {
@@ -148,7 +148,7 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 	normalizedOutput, outputTruncated := truncateAuditPayload(normalizedOutput, maxOutputBytes)
 	commandAudit, err := model.NewCommandAudit(
 		eventID,
-		command,
+		in.Command,
 		normalizedInput,
 		normalizedOutput,
 		inputTruncated,
@@ -158,16 +158,16 @@ func (u *eventUsecase) Audit(ctx context.Context, command string, input string, 
 		return nil, nil, xerrors.Errorf("failed to build command audit: %w", err)
 	}
 	commandAudit.SetRedaction(inputRedacted, outputRedacted)
-	commandAudit.SetExitCode(exitCode)
-	commandAudit.SetFailed(failed)
+	commandAudit.SetExitCode(in.ExitCode)
+	commandAudit.SetFailed(in.Failed)
 
 	event, err := model.NewEvent(
 		eventID,
 		types.EventKindCommandExecuted,
-		client,
-		agent,
-		sessionID,
-		workspace,
+		in.Client,
+		in.Agent,
+		in.SessionID,
+		in.Workspace,
 		commandAuditEventBody(commandAudit),
 	)
 	if err != nil {

--- a/application/usecase/record_command_audit_test.go
+++ b/application/usecase/record_command_audit_test.go
@@ -44,15 +44,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		event, commandAudit, err := sut.Audit(context.Background(),
-			"go test ./...",
-			"stdin",
-			"stdout",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace("duck8823/traceary"),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "go test ./...",
+				Input:     "stdin",
+				Output:    "stdout",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace("duck8823/traceary"),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -85,15 +87,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		longOutput := strings.Repeat("o", 70*1024)
 
 		_, commandAudit, err := sut.Audit(context.Background(),
-			"go test ./...",
-			longInput,
-			longOutput,
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "go test ./...",
+				Input:     longInput,
+				Output:    longOutput,
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -120,15 +124,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, commandAudit, err := sut.Audit(context.Background(),
-			"go test ./...",
-			strings.Repeat("i", 32),
-			strings.Repeat("o", 32),
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "go test ./...",
+				Input:     strings.Repeat("i", 32),
+				Output:    strings.Repeat("o", 32),
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().
 				MaxInputBytes(16).
 				MaxOutputBytes(20).
@@ -155,15 +161,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, commandAudit, err := sut.Audit(context.Background(),
-			"curl https://example.test",
-			`{"access_token":"top-secret","note":"keep"}`,
-			"Authorization: Bearer token-value\nexport API_KEY=\"abc123\"",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "curl https://example.test",
+				Input:     `{"access_token":"top-secret","note":"keep"}`,
+				Output:    "Authorization: Bearer token-value\nexport API_KEY=\"abc123\"",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().Build(),
 		)
 		if err != nil {
@@ -196,15 +204,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, commandAudit, err := sut.Audit(context.Background(),
-			"curl https://example.test",
-			`{"access_token":"top-secret"}`,
-			"Authorization: Bearer token-value",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "curl https://example.test",
+				Input:     `{"access_token":"top-secret"}`,
+				Output:    "Authorization: Bearer token-value",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().
 				AllowSecrets(true).
 				MaxInputBytes(256).
@@ -234,15 +244,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, commandAudit, err := sut.Audit(context.Background(),
-			"curl https://example.test",
-			"my_custom_secret=hunter2",
-			"internal_token: abc123",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "curl https://example.test",
+				Input:     "my_custom_secret=hunter2",
+				Output:    "internal_token: abc123",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().
 				ExtraRedactPatterns([]string{"my_custom_secret=\\S+", "internal_token:\\s*\\S+"}).
 				Build(),
@@ -268,15 +280,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, _, err := sut.Audit(context.Background(),
-			"test",
-			"",
-			"",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "test",
+				Input:     "",
+				Output:    "",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().
 				ExtraRedactPatterns([]string{"[invalid"}).
 				Build(),
@@ -293,15 +307,17 @@ func TestEventUsecase_Audit(t *testing.T) {
 		sut := usecase.NewEventUsecase(stub, nil)
 
 		_, _, err := sut.Audit(context.Background(),
-			"go test ./...",
-			"stdin",
-			"stdout",
-			types.Client("cli"),
-			types.Agent("codex"),
-			types.SessionID("session-1"),
-			types.Workspace(""),
-			types.None[int](),
-			false,
+			apptypes.AuditInput{
+				Command:   "go test ./...",
+				Input:     "stdin",
+				Output:    "stdout",
+				Client:    types.Client("cli"),
+				Agent:     types.Agent("codex"),
+				SessionID: types.SessionID("session-1"),
+				Workspace: types.Workspace(""),
+				ExitCode:  types.None[int](),
+				Failed:    false,
+			},
 			apptypes.NewAuditRedactionBuilder().
 				MaxInputBytes(-1).
 				Build(),

--- a/presentation/cli/audit.go
+++ b/presentation/cli/audit.go
@@ -186,10 +186,18 @@ func (c *RootCLI) runAudit(ctx context.Context, output io.Writer, input auditCom
 		StructuredRules(c.structuredRedactRules).
 		Build()
 	event, commandAudit, err := c.event.Audit(ctx,
-		input.command, input.input, input.output,
-		client, agent, sid, types.Workspace(resolvedRepo),
-		input.exitCode,
-		false, // manual audits carry an explicit exit code; the failure flag is for hosts that omit it
+		apptypes.AuditInput{
+			Command:   input.command,
+			Input:     input.input,
+			Output:    input.output,
+			Client:    client,
+			Agent:     agent,
+			SessionID: sid,
+			Workspace: types.Workspace(resolvedRepo),
+			ExitCode:  input.exitCode,
+			// Failed stays false: manual audits carry an explicit exit code;
+			// the failure flag is for hosts that omit one.
+		},
 		auditCfg,
 	)
 	if err != nil {

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -454,15 +454,17 @@ func (c *RootCLI) runHookAudit(
 		Build()
 	_, _, err = c.event.Audit(
 		ctx,
-		command,
-		auditInput,
-		auditOutput,
-		types.Client("hook"),
-		agent,
-		sessionID,
-		workspace,
-		hookPayloadExitCode(payload),
-		hookPayloadFailed(payload),
+		apptypes.AuditInput{
+			Command:   command,
+			Input:     auditInput,
+			Output:    auditOutput,
+			Client:    types.Client("hook"),
+			Agent:     agent,
+			SessionID: sessionID,
+			Workspace: workspace,
+			ExitCode:  hookPayloadExitCode(payload),
+			Failed:    hookPayloadFailed(payload),
+		},
 		auditCfg,
 	)
 

--- a/presentation/cli/tail_test.go
+++ b/presentation/cli/tail_test.go
@@ -27,7 +27,7 @@ func (s *tailEventUsecaseStub) Log(context.Context, string, types.EventKind, typ
 	return nil, nil
 }
 
-func (s *tailEventUsecaseStub) Audit(context.Context, string, string, string, types.Client, types.Agent, types.SessionID, types.Workspace, types.Optional[int], bool, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+func (s *tailEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
 	return nil, nil, nil
 }
 

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -64,16 +64,16 @@ func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.E
 	s.logCall.sourceHook = apptypes.SourceHookFromContext(ctx)
 	return s.logEvent, s.logErr
 }
-func (s *eventUsecaseStub) Audit(_ context.Context, command string, input string, output string, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, exitCode types.Optional[int], failed bool, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
-	s.auditCall.command = command
-	s.auditCall.input = input
-	s.auditCall.output = output
-	s.auditCall.client = client
-	s.auditCall.agent = agent
-	s.auditCall.sessionID = sessionID
-	s.auditCall.workspace = workspace
-	s.auditCall.exitCode = exitCode
-	s.auditCall.failed = failed
+func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, auditCfg apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+	s.auditCall.command = in.Command
+	s.auditCall.input = in.Input
+	s.auditCall.output = in.Output
+	s.auditCall.client = in.Client
+	s.auditCall.agent = in.Agent
+	s.auditCall.sessionID = in.SessionID
+	s.auditCall.workspace = in.Workspace
+	s.auditCall.exitCode = in.ExitCode
+	s.auditCall.failed = in.Failed
 	s.auditCall.auditCfg = auditCfg
 	return s.auditEvent, s.auditAudit, s.auditErr
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -375,7 +375,16 @@ func (s *Server) recordEvent() mcp.ToolHandlerFor[recordEventInput, recordEventO
 				return nil, recordEventOutput{}, xerrors.Errorf("record_event type audit requires command")
 			}
 			auditCfg := apptypes.NewAuditRedactionBuilder().ExtraRedactPatterns(s.extraRedactPatterns).StructuredRules(s.structuredRedactRules).Build()
-			event, audit, err := s.event.Audit(ctx, input.Command, input.Input, input.Output, types.Client(resolveValue(input.Client, defaultClientValue)), types.Agent(resolveValue(input.Agent, defaultAgentValue)), types.SessionID(resolveValue(input.SessionID, defaultSessionValue)), types.Workspace(strings.TrimSpace(input.Workspace)), types.None[int](), false, auditCfg)
+			event, audit, err := s.event.Audit(ctx, apptypes.AuditInput{
+				Command:   input.Command,
+				Input:     input.Input,
+				Output:    input.Output,
+				Client:    types.Client(resolveValue(input.Client, defaultClientValue)),
+				Agent:     types.Agent(resolveValue(input.Agent, defaultAgentValue)),
+				SessionID: types.SessionID(resolveValue(input.SessionID, defaultSessionValue)),
+				Workspace: types.Workspace(strings.TrimSpace(input.Workspace)),
+				ExitCode:  types.None[int](),
+			}, auditCfg)
 			if err != nil {
 				return nil, recordEventOutput{}, xerrors.Errorf("failed to record command audit: %w", err)
 			}


### PR DESCRIPTION
## Summary

Tech-debt follow-up from the v0.20 capture-parity work (folded into v0.20.0 per
maintainer request): the `failed bool` added to `EventUsecase.Audit` pushed it
to 11 positional parameters, which both reviewers flagged as a transposition
risk. Replace the positional tail with an `apptypes.AuditInput` value object.

## Change

- **`application/types/audit_input.go`** — `AuditInput{Command, Input, Output,
  Client, Agent, SessionID, Workspace, ExitCode, Failed}`, an exported-field
  value object (matching the existing `ImportedMemoryCandidate` precedent). The
  redaction policy stays a separate argument — it is a capture policy, not audit
  data.
- **`EventUsecase.Audit`** interface + impl now take `(ctx, AuditInput,
  AuditRedaction)`; the body reads `in.Field` directly.
- **Call sites** rewritten as named-field literals so fields can no longer be
  transposed: `presentation/cli/audit.go`, `presentation/cli/hook_runtime.go`,
  `presentation/mcpserver/server.go`. The `eventUsecaseStub` /
  `tailEventUsecaseStub` test stubs and the `record_command_audit_test.go` cases
  follow.

## Behavior

Purely a signature refactor — **no CLI / MCP / JSON / schema change**, so no
changelog entry. The existing Audit tests (truncation, redaction, exit-code,
failure-flag capture) are unchanged in intent and still pass.

## Verification

`go build ./...` ok; `go test ./...` → 2312 passed; `go vet ./...` clean;
`go tool golangci-lint run ./...` → **0 issues**; touched files `gofmt`-clean.

Closes #1141
