### PR TITLE
fix: correct hook audit workspace attribution

### DIFF
--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -129,6 +129,79 @@ SELECT e.kind, a.command_text, a.input_truncated, a.output_truncated
 	}
 }
 
+func TestDatasource_SaveWithAudit_SkipsDuplicateHookAuditsWithinWindow(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	save := func(id string, at time.Time, output string) {
+		t.Helper()
+
+		eventID, err := types.EventIDFrom(id)
+		if err != nil {
+			t.Fatalf("EventIDFrom(%s) error = %v", id, err)
+		}
+		agent, err := types.AgentFrom("codex")
+		if err != nil {
+			t.Fatalf("AgentFrom() error = %v", err)
+		}
+		sessionID, err := types.SessionIDFrom("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDFrom() error = %v", err)
+		}
+		event := model.EventOfWithSourceHook(
+			eventID,
+			types.EventKindCommandExecuted,
+			types.Client("hook"),
+			agent,
+			sessionID,
+			types.Workspace("github.com/duck8823/dotfiles"),
+			"git status\n\nINPUT:\n{\"command\":\"git status\"}\n\nOUTPUT:\n"+output,
+			at,
+			"post_tool_use",
+		)
+		audit, err := model.NewCommandAudit(eventID, "git status", `{"command":"git status"}`, output, false, false)
+		if err != nil {
+			t.Fatalf("NewCommandAudit(%s) error = %v", id, err)
+		}
+		if err := sut.SaveWithAudit(context.Background(), event, audit); err != nil {
+			t.Fatalf("SaveWithAudit(%s) error = %v", id, err)
+		}
+	}
+
+	save("event-original", base, "same output")
+	save("event-duplicate", base.Add(time.Second), "same output")
+	save("event-different-output", base.Add(2*time.Second), "different output")
+	save("event-later-rerun", base.Add(10*time.Second), "same output")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM command_audits`).Scan(&count); err != nil {
+		t.Fatalf("command audit count query error = %v", err)
+	}
+	if diff := cmp.Diff(3, count); diff != "" {
+		t.Fatalf("command audit count mismatch (-want +got):\n%s", diff)
+	}
+
+	var duplicateRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE id = 'event-duplicate'`).Scan(&duplicateRows); err != nil {
+		t.Fatalf("duplicate event count query error = %v", err)
+	}
+	if diff := cmp.Diff(0, duplicateRows); diff != "" {
+		t.Fatalf("duplicate event persisted mismatch (-want +got):\n%s", diff)
+	}
+}
+
 // TestDatasource_ListRecent_FailuresOnly_IncludesFailedFlag verifies the
 // failures filter treats the structural failed flag as a failure even when no
 // numeric exit code was captured — the Claude PostToolUseFailure case, where

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -44,6 +44,8 @@ var getEventDetailsQuery string
 //go:embed sql/list_timeline_blocks.sql
 var listTimelineBlocksQuery string
 
+const duplicateHookCommandAuditWindow = 2 * time.Second
+
 // EventDatasource is the SQLite-backed implementation of the event
 // repository and event query service.
 type EventDatasource struct {
@@ -131,6 +133,14 @@ func (d *EventDatasource) SaveWithAudit(
 		}
 	}()
 
+	duplicate, err := hookCommandAuditDuplicateExists(ctx, tx, event, audit)
+	if err != nil {
+		return err
+	}
+	if duplicate {
+		return nil
+	}
+
 	if _, err := tx.ExecContext(
 		ctx,
 		insertEventQuery,
@@ -171,6 +181,74 @@ func (d *EventDatasource) SaveWithAudit(
 	}
 
 	return nil
+}
+
+func hookCommandAuditDuplicateExists(
+	ctx context.Context,
+	tx *sql.Tx,
+	event *model.Event,
+	audit *model.CommandAudit,
+) (bool, error) {
+	if event.Client().String() != "hook" {
+		return false, nil
+	}
+
+	var exitCodeSQL *int
+	hasExitCode := 0
+	if exitCode, ok := audit.ExitCode().Value(); ok {
+		exitCodeSQL = &exitCode
+		hasExitCode = 1
+	}
+	from := formatTimestamp(event.CreatedAt().Add(-duplicateHookCommandAuditWindow))
+	to := formatTimestamp(event.CreatedAt().Add(duplicateHookCommandAuditWindow))
+
+	var value int
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT 1
+		   FROM events e
+		   JOIN command_audits ca ON ca.event_id = e.id
+		  WHERE e.kind = ?
+		    AND e.client = ?
+		    AND e.agent = ?
+		    AND e.session_id = ?
+		    AND e.workspace = ?
+		    AND COALESCE(e.source_hook, '') = ?
+		    AND ca.command_text = ?
+		    AND ca.input_text = ?
+		    AND ca.output_text = ?
+		    AND ca.input_truncated = ?
+		    AND ca.output_truncated = ?
+		    AND ((? = 0 AND ca.exit_code IS NULL) OR (? = 1 AND ca.exit_code = ?))
+		    AND ca.failed = ?
+		    AND e.created_at >= ?
+		    AND e.created_at <= ?
+		  LIMIT 1`,
+		event.Kind().String(),
+		event.Client().String(),
+		event.Agent().String(),
+		event.SessionID().String(),
+		event.Workspace().String(),
+		event.SourceHook(),
+		audit.Command(),
+		audit.Input(),
+		audit.Output(),
+		audit.InputTruncated(),
+		audit.OutputTruncated(),
+		hasExitCode,
+		hasExitCode,
+		exitCodeSQL,
+		audit.Failed(),
+		from,
+		to,
+	).Scan(&value)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, xerrors.Errorf("failed to check duplicate hook command audit: %w", err)
 }
 
 // ListRecent returns events in descending time order.
@@ -612,18 +690,18 @@ func (d *EventDatasource) ListTimelineBlocks(
 
 	for rows.Next() {
 		var (
-			blockNum             int
-			blockStart           string
-			blockEnd             string
-			blockEventCount      int
-			agents               string
-			workspace            string
-			wsEventCount         int
-			kinds                string
-			wsAgents             string
-			firstPromptBody      string
-			compactSummaryBody   string
-			firstTranscriptBody  string
+			blockNum            int
+			blockStart          string
+			blockEnd            string
+			blockEventCount     int
+			agents              string
+			workspace           string
+			wsEventCount        int
+			kinds               string
+			wsAgents            string
+			firstPromptBody     string
+			compactSummaryBody  string
+			firstTranscriptBody string
 		)
 		if err := rows.Scan(
 			&blockNum,

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -412,7 +412,7 @@ func (c *RootCLI) runHookAudit(
 	if sessionID == "" {
 		return nil
 	}
-	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+	workspace, err := resolveHookWorkspaceForAudit(ctx, payload, client)
 	if err != nil {
 		return err
 	}
@@ -1298,6 +1298,28 @@ func resolveHookWorkspace(ctx context.Context, payload []byte, client string, pr
 		return types.Workspace(explicit), nil
 	}
 
+	return resolveHookWorkspaceFromPayload(ctx, payload)
+}
+
+func resolveHookWorkspaceForAudit(ctx context.Context, payload []byte, client string) (types.Workspace, error) {
+	if explicit := strings.TrimSpace(os.Getenv("TRACEARY_WORKSPACE")); explicit != "" {
+		return types.Workspace(explicit), nil
+	}
+
+	if workspace, err := resolveHookWorkspaceFromPayload(ctx, payload); err != nil {
+		return "", err
+	} else if workspace != "" {
+		return workspace, nil
+	}
+
+	workspace, err := readHookWorkspaceState(client)
+	if err != nil {
+		return "", err
+	}
+	return workspace, nil
+}
+
+func resolveHookWorkspaceFromPayload(ctx context.Context, payload []byte) (types.Workspace, error) {
 	cwd := hookPayloadString(payload, "cwd", "")
 	if cwd == "" {
 		return "", nil

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -585,6 +587,45 @@ func TestRootCLI_HookAuditCommand_UsesSessionStateAndToolPayload(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HookAuditCommand_PrefersToolCWDWorkspaceOverSessionState(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "workspace-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-workspace-key"), []byte("generated-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-workspace-key-repo"), []byte("github.com/duck8823/calorie-balance"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	repoDir := initGitRepoForHookRuntimeTest(t)
+	runGitCommandForHookRuntimeTest(t, repoDir, "remote", "add", "origin", "git@github.com:duck8823/dotfiles.git")
+
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"cwd":` + quoteJSONStringForHookRuntimeTest(repoDir) + `,"tool_input":{"command":"git status"},"tool_response":{"stdout":"ok"}}`))
+	rootCmd.SetArgs([]string{"hook", "audit", "codex"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := eventStub.auditCall.workspace, types.Workspace("github.com/duck8823/dotfiles"); got != want {
+		t.Fatalf("audit workspace = %q, want %q", got, want)
+	}
+}
+
 // TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload verifies the
 // failure-derivation logic: no host exposes a numeric exit code in the
 // post-tool payload, so a Claude PostToolUseFailure (top-level "error") and a
@@ -685,6 +726,32 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			}
 		})
 	}
+}
+
+func initGitRepoForHookRuntimeTest(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	runGitCommandForHookRuntimeTest(t, repoDir, "init")
+	return repoDir
+}
+
+func runGitCommandForHookRuntimeTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v error = %v, output = %s", args, err, string(output))
+	}
+}
+
+func quoteJSONStringForHookRuntimeTest(value string) string {
+	encodedValue, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(encodedValue)
 }
 
 func TestRootCLI_HookCompactCommand_SupportsPostCompactAndResume(t *testing.T) {


### PR DESCRIPTION
## Motivation

Codex command audits can be recorded under the session-start workspace even when the tool payload carries a different `cwd`. Dogfood analysis also found duplicate hook audit rows, which distorts process review and failure-rate analysis.

## Change

- Prefer the tool payload `cwd` for hook audit workspace attribution, while keeping the persisted session workspace as a fallback when the payload does not include a cwd.
- Keep explicit `TRACEARY_WORKSPACE` as the audit override.
- Skip duplicate hook command-audit writes when the same hook payload is delivered twice within a small window.
- Preserve legitimate reruns when output differs or the rerun happens outside the duplicate window.

## Verification

- `go build ./...`
- `go test ./...`
- `go tool golangci-lint run`

Closes #1149