### PR TITLE
fix: normalize broken-pipe snapshot exits

### DIFF
--- a/broken_pipe_signal_other.go
+++ b/broken_pipe_signal_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package main
+
+func configureBrokenPipeSignalHandling() {}

--- a/broken_pipe_signal_unix.go
+++ b/broken_pipe_signal_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package main
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+func configureBrokenPipeSignalHandling() {
+	signal.Ignore(syscall.SIGPIPE)
+}

--- a/docs/operations/json-contract-tests.ja.md
+++ b/docs/operations/json-contract-tests.ja.md
@@ -14,6 +14,8 @@ contract surface は次の 3 種類です。
 
 v0.19.0 以降、`traceary sessions --snapshot`（および恒久的な互換 alias の `traceary top --snapshot`）の text snapshot は raw な `workspace=` / `agent=` metadata の前に `name="..."` を含みます。この形状は text golden fixture で固定されています。位置ベースの安定性が必要な機械 consumer は、変更のない JSON envelope を使ってください。
 
+v0.20.1 以降、JSON / text snapshot writer は downstream の broken pipe を通常の early-close として扱います。`traceary sessions --snapshot --json | head -c 1` のような command は、誤解を招く Traceary error を出さずに silent に終了します。一方で、query や JSON encoding の失敗は従来どおり loud に失敗します。
+
 CLI コマンドの公開出力に対応する fixture が無い場合は、ad-hoc な string assertion ではなく、merge 前に fixture を追加してください。同様に、MCP tool を追加 / 削除 / 改名するときは同じ変更で registry snapshot も再生成してください。
 
 ## golden test の実行

--- a/docs/operations/json-contract-tests.md
+++ b/docs/operations/json-contract-tests.md
@@ -14,6 +14,8 @@ The contract surfaces are:
 
 Starting in v0.19.0, the text snapshot for `traceary sessions --snapshot` (and permanent compatibility `traceary top --snapshot`) includes `name="..."` before the raw `workspace=` / `agent=` metadata. This is covered by the text golden fixture; machine consumers that need positional stability should use the unchanged JSON envelope.
 
+Starting in v0.20.1, JSON and text snapshot writers treat a downstream broken pipe as a normal early-close outcome. Commands such as `traceary sessions --snapshot --json | head -c 1` should exit silently instead of printing a misleading Traceary error, while query and JSON-encoding failures remain loud.
+
 If a CLI command has no fixture for one of its public outputs, add one before merging rather than relying on ad-hoc string assertions. Likewise, do not add or remove an MCP tool without regenerating the registry snapshot in the same change.
 
 ## Run golden tests

--- a/main.go
+++ b/main.go
@@ -228,7 +228,11 @@ type cliExitCoder interface {
 }
 
 func main() {
+	configureBrokenPipeSignalHandling()
 	if err := run(); err != nil {
+		if isSilentCLIExitError(err) {
+			return
+		}
 		if writeErr := writeCLIError(os.Stderr, err); writeErr != nil {
 			log.Printf("%s: %v", cli.Localize("failed to print CLI error", "CLI error の出力に失敗しました"), writeErr)
 		}
@@ -239,6 +243,10 @@ func main() {
 		}
 		os.Exit(exitCode)
 	}
+}
+
+func isSilentCLIExitError(err error) bool {
+	return cli.IsBrokenPipeError(err)
 }
 
 func writeCLIError(output io.Writer, err error) error {

--- a/main_test.go
+++ b/main_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"os"
 	"runtime/debug"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
 )
 
 func TestWriteCLIError(t *testing.T) {
@@ -40,6 +42,27 @@ func TestWriteCLIError(t *testing.T) {
 type testError string
 
 func (e testError) Error() string { return string(e) }
+
+func TestIsSilentCLIExitError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("recognizes wrapped broken pipe", func(t *testing.T) {
+		t.Parallel()
+
+		err := xerrors.Errorf("failed to execute CLI command: %w", syscall.EPIPE)
+		if !isSilentCLIExitError(err) {
+			t.Fatal("isSilentCLIExitError() = false, want true")
+		}
+	})
+
+	t.Run("keeps ordinary errors loud", func(t *testing.T) {
+		t.Parallel()
+
+		if isSilentCLIExitError(testError("database query failed")) {
+			t.Fatal("isSilentCLIExitError() = true, want false")
+		}
+	})
+}
 
 func TestSetupLogger(t *testing.T) {
 	t.Run("valid LOG_LEVEL is set without error", func(t *testing.T) {

--- a/presentation/cli/broken_pipe.go
+++ b/presentation/cli/broken_pipe.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// IsBrokenPipeError reports whether err represents an output stream closed by
+// the downstream reader. This is normal for scripted inspection commands piped
+// into early-closing consumers such as head, jq filters, or byte limiters.
+func IsBrokenPipeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
+		return true
+	}
+
+	// Some callers surface SIGPIPE as text rather than an unwrap-friendly errno.
+	// Keep this fallback narrow so ordinary generation/query errors remain loud.
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "signal: broken pipe") ||
+		(strings.Contains(message, "write") && strings.Contains(message, "broken pipe"))
+}

--- a/presentation/cli/top_json_truncation_test.go
+++ b/presentation/cli/top_json_truncation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -78,6 +79,26 @@ func TestWriteTopSnapshotJSON_TruncatesLargeRecentCommandBody(t *testing.T) {
 	if want := apptypes.DefaultTopSnapshotBodyLimit + 1; len([]rune(got.Message)) != want { // limit runes + ellipsis
 		t.Fatalf("len(message) in runes = %d, want %d", len([]rune(got.Message)), want)
 	}
+}
+
+func TestWriteTopSnapshotJSON_RecognizesBrokenPipeWriter(t *testing.T) {
+	t.Parallel()
+
+	err := writeTopSnapshotJSON(brokenPipeWriter{}, topDataSnapshot{
+		Now: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("writeTopSnapshotJSON() error = nil, want broken pipe")
+	}
+	if !IsBrokenPipeError(err) {
+		t.Fatalf("IsBrokenPipeError(%v) = false, want true", err)
+	}
+}
+
+type brokenPipeWriter struct{}
+
+func (brokenPipeWriter) Write(_ []byte) (int, error) {
+	return 0, syscall.EPIPE
 }
 
 func TestWriteTopSnapshotJSON_LeavesSmallBodiesUntouched(t *testing.T) {


### PR DESCRIPTION
## Motivation

Downstream consumers such as `head`, `jq`, or byte-limiters may close a pipe before Traceary finishes writing snapshot output. That is a normal scripted inspection outcome, not a Traceary operational failure.

## Changes

- Ignore SIGPIPE on Unix so stdout writes can surface as ordinary write errors.
- Classify broken-pipe/closed-pipe output errors and let the CLI entrypoint exit silently.
- Cover `sessions/top --snapshot --json` writer behavior with a simulated broken-pipe writer.
- Document the v0.20.1 pipe behavior in the JSON/snapshot contract docs.

## Verification

- `rtk go test ./presentation/cli -run 'TestWriteTopSnapshotJSON_RecognizesBrokenPipeWriter|TestIsBrokenPipeError'`
- `rtk go test . -run 'TestIsSilentCLIExitError|TestWriteCLIError'`
- `rtk go test . ./presentation/cli`
- `rtk go run ./cmd/repo-tooling docs verify-i18n`
- `rtk go test ./...`
- `go tool golangci-lint run`
- `rtk go build ./...`
- `rtk git diff --check`

Closes #1154
