### PR TITLE
fix: warn on duplicate traceary hook entries

### DIFF
--- a/application/hooks_inspector.go
+++ b/application/hooks_inspector.go
@@ -1,5 +1,14 @@
 package application
 
+// HookDuplicate describes duplicate Traceary-managed hook registrations for
+// the same host event, matcher, and managed command key.
+type HookDuplicate struct {
+	Event      string
+	Matcher    string
+	ManagedKey string
+	Count      int
+}
+
 // HooksInspector inspects a hook configuration JSON payload and reports
 // high-level state relevant to diagnostics. Implementations live in the
 // infrastructure layer so presentation code can depend only on this
@@ -14,6 +23,11 @@ type HooksInspector interface {
 	// ErrHookConfigInvalidHooksField when the "hooks" field has the wrong
 	// shape.
 	Inspect(content []byte) (hasHooksField bool, hasTracearyManagedHook bool, err error)
+	// DuplicateManagedHooks reports Traceary-managed hook registrations that
+	// appear more than once for the same event, matcher, and managed key.
+	// Missing hooks fields return an empty slice. Returned errors are the
+	// same sentinels as Inspect.
+	DuplicateManagedHooks(content []byte) ([]HookDuplicate, error)
 	// ExtractManagedKeyFromEntry returns the canonical Traceary-managed
 	// key extracted from a hook entry's name / command pair, or an
 	// empty string if the entry is not Traceary-managed. Presentation

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -163,6 +163,9 @@ func checkClaude(root, version string) error {
 	if err != nil {
 		return err
 	}
+	if err := checkNoDuplicateTracearyHookEntries(hooksPath, hooks); err != nil {
+		return err
+	}
 	for _, event := range []string{"SessionStart", "SessionEnd", "PostToolUse", "PostCompact"} {
 		if _, ok := hooks.Hooks[event]; !ok {
 			return xerrors.Errorf("claude hooks must include %s", event)
@@ -261,6 +264,9 @@ func checkCodex(root, version string, runCLISmoke bool) error {
 
 	hooks, hooksRaw, err := readHookFile(root, "plugins/traceary/hooks.json")
 	if err != nil {
+		return err
+	}
+	if err := checkNoDuplicateTracearyHookEntries("plugins/traceary/hooks.json", hooks); err != nil {
 		return err
 	}
 	for _, event := range []string{"SessionStart", "UserPromptSubmit", "Stop", "PostToolUse"} {
@@ -371,6 +377,9 @@ func checkGemini(root, version string) error {
 	if err != nil {
 		return err
 	}
+	if err := checkNoDuplicateTracearyHookEntries("integrations/gemini-extension/hooks/hooks.json", hooks); err != nil {
+		return err
+	}
 	for _, event := range []string{"SessionStart", "SessionEnd", "AfterTool", "BeforeAgent", "PreCompress"} {
 		if _, ok := hooks.Hooks[event]; !ok {
 			return xerrors.Errorf("gemini hooks must include %s", event)
@@ -425,7 +434,14 @@ type hookFile struct {
 }
 
 type hookEntry struct {
-	Matcher string `json:"matcher"`
+	Matcher string        `json:"matcher"`
+	Hooks   []hookCommand `json:"hooks"`
+}
+
+type hookCommand struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Command string `json:"command"`
 }
 
 func hookMatchers(entries []hookEntry) []string {
@@ -446,6 +462,55 @@ func readHookFile(root, rel string) (hookFile, string, error) {
 		return hookFile{}, "", xerrors.Errorf("invalid json in %s: %w", rel, err)
 	}
 	return hf, string(data), nil
+}
+
+func checkNoDuplicateTracearyHookEntries(rel string, hooks hookFile) error {
+	for event, entries := range hooks.Hooks {
+		counts := map[string]int{}
+		for _, entry := range entries {
+			matcher := entry.Matcher
+			for _, command := range entry.Hooks {
+				key := packagedTracearyHookKey(command)
+				if key == "" {
+					continue
+				}
+				countKey := event + "\x00" + matcher + "\x00" + key
+				counts[countKey]++
+				if counts[countKey] > 1 {
+					displayMatcher := matcher
+					if displayMatcher == "" {
+						displayMatcher = "<default>"
+					}
+					return xerrors.Errorf(
+						"%s registers duplicate Traceary hook entry for event=%s matcher=%q command=%s",
+						rel,
+						event,
+						displayMatcher,
+						key,
+					)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func packagedTracearyHookKey(command hookCommand) string {
+	if command.Type != "" && command.Type != "command" {
+		return ""
+	}
+	name := strings.TrimSpace(command.Name)
+	commandText := strings.Join(strings.Fields(command.Command), " ")
+	if name == "" && commandText == "" {
+		return ""
+	}
+	if strings.HasPrefix(name, "traceary-") {
+		return name
+	}
+	if strings.Contains(commandText, "traceary") && strings.Contains(commandText, "hook") {
+		return commandText
+	}
+	return ""
 }
 
 func readJSON(root, rel string, dest any) error {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestVerifyIntegrations_PassesOnCurrentTree is the Go equivalent of running
 // scripts/verify_integrations.py against the repository: the current tree must
@@ -26,5 +29,52 @@ func TestVerifyIntegrations_FailsWhenRootIncomplete(t *testing.T) {
 
 	if err := verifyIntegrations(t.TempDir(), false); err == nil {
 		t.Fatal("verifyIntegrations() on an empty tree = nil, want an error")
+	}
+}
+
+func TestCheckNoDuplicateTracearyHookEntries_FailsOnDuplicateManagedEntry(t *testing.T) {
+	t.Parallel()
+
+	err := checkNoDuplicateTracearyHookEntries("plugins/traceary/hooks.json", hookFile{
+		Hooks: map[string][]hookEntry{
+			"PostToolUse": {
+				{
+					Matcher: "",
+					Hooks: []hookCommand{
+						{Name: "traceary-audit", Type: "command", Command: "'traceary' 'hook' 'audit' 'codex'"},
+						{Name: "traceary-audit", Type: "command", Command: "'traceary' 'hook' 'audit' 'codex'"},
+						{Name: "user-audit", Type: "command", Command: "echo user"},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("checkNoDuplicateTracearyHookEntries() error = nil, want duplicate error")
+	}
+	if !strings.Contains(err.Error(), "PostToolUse") || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want duplicate PostToolUse message", err)
+	}
+}
+
+func TestCheckNoDuplicateTracearyHookEntries_AllowsDistinctMatchers(t *testing.T) {
+	t.Parallel()
+
+	err := checkNoDuplicateTracearyHookEntries("integrations/claude-plugin/hooks/hooks.json", hookFile{
+		Hooks: map[string][]hookEntry{
+			"PostToolUse": {
+				{
+					Matcher: "Bash",
+					Hooks:   []hookCommand{{Type: "command", Command: "'traceary' 'hook' 'audit' 'claude'"}},
+				},
+				{
+					Matcher: "mcp__.*",
+					Hooks:   []hookCommand{{Type: "command", Command: "'traceary' 'hook' 'audit' 'claude'"}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("checkNoDuplicateTracearyHookEntries() error = %v, want nil for distinct matchers", err)
 	}
 }

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"encoding/json"
+	"sort"
 
 	"golang.org/x/xerrors"
 
@@ -24,19 +25,12 @@ func NewHooksInspector() *HooksInspector {
 // application.ErrHookConfigInvalidHooksField when the "hooks" field has the
 // wrong shape.
 func (i *HooksInspector) Inspect(content []byte) (bool, bool, error) {
-	root := map[string]json.RawMessage{}
-	if err := json.Unmarshal(content, &root); err != nil {
-		return false, false, xerrors.Errorf("%w: %v", application.ErrHookConfigNotJSONObject, err)
+	hooksMap, ok, err := parseHooksMap(content)
+	if err != nil {
+		return ok, false, err
 	}
-
-	hooksValue, ok := root["hooks"]
 	if !ok {
 		return false, false, nil
-	}
-
-	hooksMap := map[string][]hookMatcherDocument{}
-	if err := json.Unmarshal(hooksValue, &hooksMap); err != nil {
-		return true, false, xerrors.Errorf("%w: %v", application.ErrHookConfigInvalidHooksField, err)
 	}
 
 	for _, matchers := range hooksMap {
@@ -52,10 +46,83 @@ func (i *HooksInspector) Inspect(content []byte) (bool, bool, error) {
 	return true, false, nil
 }
 
+// DuplicateManagedHooks reports Traceary-managed hook registrations that
+// appear more than once for the same host event, matcher, and managed key.
+func (i *HooksInspector) DuplicateManagedHooks(content []byte) ([]application.HookDuplicate, error) {
+	hooksMap, ok, err := parseHooksMap(content)
+	if err != nil || !ok {
+		return nil, err
+	}
+
+	counts := map[string]*application.HookDuplicate{}
+	for event, matchers := range hooksMap {
+		for _, matcher := range matchers {
+			matcherValue := ""
+			if matcher.Matcher != nil {
+				matcherValue = *matcher.Matcher
+			}
+			for _, command := range matcher.Hooks {
+				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
+				if managedKey == "" {
+					continue
+				}
+				id := event + "\x00" + matcherValue + "\x00" + managedKey
+				duplicate, ok := counts[id]
+				if !ok {
+					duplicate = &application.HookDuplicate{
+						Event:      event,
+						Matcher:    matcherValue,
+						ManagedKey: managedKey,
+					}
+					counts[id] = duplicate
+				}
+				duplicate.Count++
+			}
+		}
+	}
+
+	duplicates := make([]application.HookDuplicate, 0)
+	for _, duplicate := range counts {
+		if duplicate.Count > 1 {
+			duplicates = append(duplicates, *duplicate)
+		}
+	}
+	sort.Slice(duplicates, func(i, j int) bool {
+		if duplicates[i].Event != duplicates[j].Event {
+			return duplicates[i].Event < duplicates[j].Event
+		}
+		if duplicates[i].Matcher != duplicates[j].Matcher {
+			return duplicates[i].Matcher < duplicates[j].Matcher
+		}
+		return duplicates[i].ManagedKey < duplicates[j].ManagedKey
+	})
+
+	return duplicates, nil
+}
+
 // ExtractManagedKeyFromEntry delegates to the free ExtractTracearyManagedKeyFromEntry
 // function so presentation code can consume the canonical-key extraction
 // through the application.HooksInspector interface without importing the
 // infrastructure package directly.
 func (i *HooksInspector) ExtractManagedKeyFromEntry(name, command string) string {
 	return ExtractTracearyManagedKeyFromEntry(name, command)
+}
+
+func parseHooksMap(content []byte) (map[string][]hookMatcherDocument, bool, error) {
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(content, &root); err != nil {
+		return nil, false, xerrors.Errorf("%w: %v", application.ErrHookConfigNotJSONObject, err)
+	}
+
+	hooksValue, ok := root["hooks"]
+	if !ok {
+		return nil, false, nil
+	}
+
+	hooksMap := map[string][]hookMatcherDocument{}
+	if err := json.Unmarshal(hooksValue, &hooksMap); err != nil {
+		return nil, true, xerrors.Errorf("%w: %v", application.ErrHookConfigInvalidHooksField, err)
+	}
+
+	return hooksMap, true, nil
 }

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -146,3 +146,69 @@ func TestHooksInspector_Inspect(t *testing.T) {
 		})
 	}
 }
+
+func TestHooksInspector_DuplicateManagedHooks(t *testing.T) {
+	t.Parallel()
+
+	inspector := filesystem.NewHooksInspector()
+	duplicates, err := inspector.DuplicateManagedHooks([]byte(`{
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "",
+            "hooks": [
+              {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
+              {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
+              {"name": "user-audit", "type": "command", "command": "echo user"}
+            ]
+          }
+        ],
+        "SessionStart": [
+          {
+            "hooks": [
+              {"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'start'"}
+            ]
+          }
+        ]
+      }
+    }`))
+	if err != nil {
+		t.Fatalf("DuplicateManagedHooks() error = %v", err)
+	}
+
+	want := []application.HookDuplicate{{
+		Event:      "PostToolUse",
+		Matcher:    "",
+		ManagedKey: "traceary-audit.sh:codex",
+		Count:      2,
+	}}
+	if diff := cmp.Diff(want, duplicates); diff != "" {
+		t.Fatalf("duplicates mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestHooksInspector_DuplicateManagedHooks_AllowsDistinctMatchers(t *testing.T) {
+	t.Parallel()
+
+	inspector := filesystem.NewHooksInspector()
+	duplicates, err := inspector.DuplicateManagedHooks([]byte(`{
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]
+          },
+          {
+            "matcher": "mcp__.*",
+            "hooks": [{"type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]
+          }
+        ]
+      }
+    }`))
+	if err != nil {
+		t.Fatalf("DuplicateManagedHooks() error = %v", err)
+	}
+	if len(duplicates) != 0 {
+		t.Fatalf("duplicates = %+v, want none for distinct matchers", duplicates)
+	}
+}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -590,11 +590,11 @@ func inspectDoctorConfig() doctorCheck {
 // structurally valid.
 func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir string) doctorCheck {
 	if client != "claude" {
-		return c.inspectDoctorConfigFile(client, outputPath)
+		return c.inspectDoctorConfigFile(client, outputPath, projectDir)
 	}
 
 	detection := c.detectClaudeTracearyPluginForCLI()
-	configCheck := c.inspectDoctorConfigFile(client, outputPath)
+	configCheck := c.inspectDoctorConfigFile(client, outputPath, projectDir)
 
 	if detection.Active {
 		// Structural failures (invalid JSON, malformed hooks field) are
@@ -705,6 +705,29 @@ func (c *RootCLI) inspectGlobalConfigForClient(client string) *doctorCheck {
 			Message: localizef("global %s config is not a valid hooks-shaped JSON object: %s", "global %s config は hooks 形式の JSON として解釈できません: %s", client, globalPath),
 		}
 	}
+	if duplicates, duplicateErr := c.hooksInspector.DuplicateManagedHooks(content); duplicateErr != nil {
+		return &doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("global %s config is not a valid hooks-shaped JSON object: %s", "global %s config は hooks 形式の JSON として解釈できません: %s", client, globalPath),
+		}
+	} else if len(duplicates) > 0 {
+		return &doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusWarn,
+			Hint: Localize(
+				"remove the duplicate Traceary-managed entries manually or regenerate the global hooks after reviewing the file; keep non-Traceary hooks",
+				"ファイルを確認した上で Traceary 管理の重複エントリだけを手動削除するか、global hooks を再生成してください。Traceary 以外の hook は残してください",
+			),
+			Message: localizef(
+				"global %s config registers duplicate Traceary-managed hooks (%s). Matching host events can be recorded more than once: %s",
+				"global %s config に Traceary 管理 hook の重複があります (%s)。該当する host event が複数回記録される可能性があります: %s",
+				client,
+				formatHookDuplicateSummary(duplicates),
+				globalPath,
+			),
+		}
+	}
 	if hasTracearyHook {
 		return &doctorCheck{
 			Name:   checkName,
@@ -741,7 +764,7 @@ func (c *RootCLI) claudeConfigHasTracearyHooks(outputPath string) bool {
 	return hasTracearyHook
 }
 
-func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doctorCheck {
+func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, projectDir string) doctorCheck {
 	content, err := os.ReadFile(outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -806,6 +829,17 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 	}
 
 	if hasTracearyManagedHook {
+		duplicates, duplicateErr := c.hooksInspector.DuplicateManagedHooks(content)
+		if duplicateErr != nil {
+			return doctorCheck{
+				Name:    client + "-config",
+				Status:  doctorStatusFail,
+				Message: localizef("%s config file must be a hooks-shaped JSON object: %s", "%s の設定ファイルは hooks 形式の JSON object である必要があります: %s", client, outputPath),
+			}
+		}
+		if len(duplicates) > 0 {
+			return duplicateTracearyHookCheck(client, client+"-config", outputPath, projectDir, duplicates)
+		}
 		if client == "codex" {
 			if missing := c.missingTracearyManagedCodexEvents(content); len(missing) > 0 {
 				return doctorCheck{
@@ -844,6 +878,41 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string) doct
 			outputPath,
 		),
 	}
+}
+
+func duplicateTracearyHookCheck(client, checkName, outputPath, projectDir string, duplicates []application.HookDuplicate) doctorCheck {
+	summary := formatHookDuplicateSummary(duplicates)
+	dryRunCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client %s --project-dir %s", client, shellQuote(projectDir))
+	return doctorCheck{
+		Name:       checkName,
+		Status:     doctorStatusWarn,
+		FixCommand: dryRunCommand,
+		Hint: localizef(
+			"preview cleanup first with `%s`; the repair refreshes only Traceary-managed entries and preserves non-Traceary hooks",
+			"`%s` で先に cleanup をプレビューしてください。修復は Traceary 管理のエントリだけを更新し、Traceary 以外の hook は保持します",
+			dryRunCommand,
+		),
+		Message: localizef(
+			"%s config registers duplicate Traceary-managed hooks (%s). Matching host events can be recorded more than once. Preview the non-destructive cleanup with `%s`: %s",
+			"%s の設定に Traceary 管理 hook の重複があります (%s)。該当する host event が複数回記録される可能性があります。`%s` で非破壊 cleanup をプレビューしてください: %s",
+			client,
+			summary,
+			dryRunCommand,
+			outputPath,
+		),
+	}
+}
+
+func formatHookDuplicateSummary(duplicates []application.HookDuplicate) string {
+	parts := make([]string, 0, len(duplicates))
+	for _, duplicate := range duplicates {
+		matcher := duplicate.Matcher
+		if matcher == "" {
+			matcher = "<default>"
+		}
+		parts = append(parts, fmt.Sprintf("%s matcher=%q key=%s count=%d", duplicate.Event, matcher, duplicate.ManagedKey, duplicate.Count))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // codexManagedEvents is the canonical list of hook events Traceary installs

--- a/presentation/cli/doctor_fix_test.go
+++ b/presentation/cli/doctor_fix_test.go
@@ -148,6 +148,47 @@ func TestRootCLI_DoctorFix(t *testing.T) {
 			t.Fatalf("--fix unexpectedly removed project hooks:\n%s", content)
 		}
 	})
+
+	t.Run("duplicate codex hooks dry-run does not mutate user hooks", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		setDoctorFixHome(t, homeDir)
+		setTracearyPathToCurrentExecutableAt(t, filepath.Join(t.TempDir(), "bin"))
+		writeCodexDuplicateAuditHook(t, homeDir)
+		codexPath := filepath.Join(homeDir, ".codex", "hooks.json")
+		before, err := os.ReadFile(codexPath)
+		if err != nil {
+			t.Fatalf("ReadFile() error = %v", err)
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--fix", "--dry-run", "--client", "codex", "--project-dir", projectDir, "--json"})
+		executeDoctorAllowWarnings(t, rootCmd)
+		report := decodeDoctorReport(t, stdout.Bytes())
+
+		foundDryRun := false
+		for _, fix := range report.Fixes {
+			if fix.Name == "codex-config" && strings.HasPrefix(fix.Action, "would:") {
+				foundDryRun = true
+			}
+		}
+		if !foundDryRun {
+			t.Fatalf("fixes = %#v, want dry-run preview for codex-config", report.Fixes)
+		}
+		after, err := os.ReadFile(codexPath)
+		if err != nil {
+			t.Fatalf("ReadFile(after) error = %v", err)
+		}
+		if string(before) != string(after) {
+			t.Fatalf("doctor --fix --dry-run mutated codex hooks\nbefore:\n%s\nafter:\n%s", before, after)
+		}
+		if !strings.Contains(string(after), "echo user-hook") {
+			t.Fatalf("user hook disappeared from codex hooks:\n%s", after)
+		}
+	})
 }
 
 func setDoctorFixHome(t *testing.T, homeDir string) {

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -250,6 +250,33 @@ func TestRootCLI_Doctor_CodexHasNoGlobalCheck(t *testing.T) {
 	}
 }
 
+func TestRootCLI_Doctor_CodexDuplicateHooksWarns(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	writeCodexDuplicateAuditHook(t, homeDir)
+
+	report := runDoctorForClient(t, "codex", projectDir)
+	codexCfg := statusByName(report, "codex-config")
+	if codexCfg.Status != "warn" {
+		t.Fatalf("codex-config status = %q, want warn; msg = %q", codexCfg.Status, codexCfg.Message)
+	}
+	if !strings.Contains(codexCfg.Message, "duplicate") || !strings.Contains(codexCfg.Message, "PostToolUse") {
+		t.Fatalf("codex-config message = %q; want duplicate PostToolUse warning", codexCfg.Message)
+	}
+	if !strings.Contains(codexCfg.Hint, "--dry-run") {
+		t.Fatalf("codex-config hint = %q; want dry-run-first guidance", codexCfg.Hint)
+	}
+	if !codexCfg.AutoFixAvailable {
+		t.Fatal("codex-config AutoFixAvailable = false, want true for non-destructive doctor fix preview/apply")
+	}
+	if !strings.Contains(codexCfg.FixCommand, "doctor --fix --dry-run") {
+		t.Fatalf("codex-config FixCommand = %q, want doctor dry-run command", codexCfg.FixCommand)
+	}
+}
+
 func runDoctorForClient(t *testing.T, client, projectDir string) doctorReport {
 	t.Helper()
 	initStub := &storeManagementUsecaseStub{}
@@ -261,6 +288,41 @@ func runDoctorForClient(t *testing.T, client, projectDir string) doctorReport {
 
 	executeDoctorAllowWarnings(t, rootCmd)
 	return decodeDoctorReport(t, stdout.Bytes())
+}
+
+func writeCodexDuplicateAuditHook(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'start'"}]}
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'codex'"}]}
+    ],
+    "Stop": [
+      {"hooks": [
+        {"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'codex'"},
+        {"name": "traceary-session-stop", "type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'stop'"}
+      ]}
+    ],
+    "PostToolUse": [
+      {"matcher": "", "hooks": [
+        {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
+        {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
+        {"name": "user-audit", "type": "command", "command": "echo user-hook"}
+      ]}
+    ]
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "hooks.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 }
 
 func writeGeminiGlobalHooksSettings(t *testing.T, home string) {


### PR DESCRIPTION
## Motivation

Traceary can already make hook upgrades idempotent, but operators also need an early warning when the installed host hook config contains duplicate Traceary-managed entries that would double-record events.

## Changes

- Add duplicate managed-hook detection to the hook inspector using event + matcher + managed key identity.
- Surface duplicate hook registrations as `doctor` warnings with dry-run-first remediation guidance.
- Keep the repair path on the existing non-destructive upgrade flow, preserving non-Traceary hooks.
- Extend integration package verification so committed hook assets fail CI if duplicate Traceary entries are introduced.
- Add regression coverage for duplicated Codex audit-hook configuration and packaged verifier behavior.

## Verification

- `rtk go test ./infrastructure/filesystem -run 'TestHooksInspector_DuplicateManagedHooks'`
- `rtk go test ./presentation/cli -run 'TestRootCLI_Doctor_CodexDuplicateHooksWarns|TestRootCLI_DoctorFix/duplicate_codex_hooks_dry-run_does_not_mutate_user_hooks'`
- `rtk go test ./cmd/repo-tooling -run 'Test(CheckNoDuplicateTracearyHookEntries|VerifyIntegrations_PassesOnCurrentTree)'`
- `rtk go run ./cmd/repo-tooling integrations verify`
- `rtk go test ./presentation/cli ./infrastructure/filesystem ./cmd/repo-tooling`
- `rtk go test ./...`
- `go tool golangci-lint run`
- `rtk go build ./...`
- `rtk git diff --check`

Closes #1152
