### PR TITLE
fix: suppress traceary self-inspection audits

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -73,6 +73,9 @@ host ごとのネイティブ連携パッケージを使いたい場合は、ま
 - `traceary` が入っていない
 - hook payload に `tool_input.command` が無い
 - まだ session ID を解決できない
+- `TRACEARY_NO_AUDIT` が truthy、または対象 tool が `traceary list --json`、`traceary sessions --snapshot --json`、MCP `list_events`、MCP `search` のような Traceary の read / self-inspection command
+
+巨大な JSON を Traceary 自身の command audit に戻したくない ad-hoc 調査では `TRACEARY_NO_AUDIT=1` を付けてください。既知の read-only self-inspection surface は既定でも skip します。一方で、MCP `record_event` / `manage_memory` のような write 系 tool は引き続き audit 対象です。
 
 ### Prompt hooks
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -73,6 +73,9 @@ The hook exits successfully without recording anything when:
 - `traceary` is not installed
 - the hook payload has no `tool_input.command`
 - a session ID cannot be resolved yet
+- `TRACEARY_NO_AUDIT` is truthy, or the audited tool is a Traceary read/self-inspection command such as `traceary list --json`, `traceary sessions --snapshot --json`, MCP `list_events`, or MCP `search`
+
+Use `TRACEARY_NO_AUDIT=1` when running ad-hoc Traceary investigations that would otherwise feed large JSON back into Traceary's own command-audit table. Traceary also skips known read-only self-inspection surfaces by default; write-like tools such as MCP `record_event` / `manage_memory` are still auditable.
 
 ### Prompt hooks
 

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -22,7 +22,10 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-const hookStateDirEnvKey = "TRACEARY_HOOK_STATE_DIR"
+const (
+	hookStateDirEnvKey         = "TRACEARY_HOOK_STATE_DIR"
+	hookAuditSuppressionEnvKey = "TRACEARY_NO_AUDIT"
+)
 
 const hookActiveSubagentStateTTL = 24 * time.Hour
 
@@ -404,6 +407,9 @@ func (c *RootCLI) runHookAudit(
 	if command == "" {
 		return nil
 	}
+	if shouldSuppressHookAudit(payload, command) {
+		return nil
+	}
 
 	sessionID, err := resolveHookSessionID(payload, client)
 	if err != nil {
@@ -473,6 +479,158 @@ func (c *RootCLI) runHookAudit(
 	}
 
 	return nil
+}
+
+func shouldSuppressHookAudit(payload []byte, command string) bool {
+	if hookAuditSuppressionEnabled(os.Getenv(hookAuditSuppressionEnvKey)) {
+		return true
+	}
+	if commandCarriesHookAuditSuppression(command) {
+		return true
+	}
+	if isTracearySelfInspectionCommand(command) {
+		return true
+	}
+	toolName := hookPayloadString(payload, "tool_name", "")
+	return isTracearyReadMCPToolName(toolName)
+}
+
+func hookAuditSuppressionEnabled(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(trimmed)
+	if err == nil {
+		return parsed
+	}
+	switch strings.ToLower(trimmed) {
+	case "yes", "y", "on":
+		return true
+	case "no", "n", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+func commandCarriesHookAuditSuppression(command string) bool {
+	for _, token := range hookAuditCommandTokens(command) {
+		if token == "env" || isShellEnvAssignment(token) && !strings.HasPrefix(token, hookAuditSuppressionEnvKey+"=") {
+			continue
+		}
+		if value, ok := strings.CutPrefix(token, hookAuditSuppressionEnvKey+"="); ok {
+			return hookAuditSuppressionEnabled(value)
+		}
+		return false
+	}
+	return false
+}
+
+func isTracearySelfInspectionCommand(command string) bool {
+	tokens := tracearyCommandTokens(command)
+	if len(tokens) == 0 {
+		return false
+	}
+	switch tokens[0] {
+	case "list", "search", "show", "tail", "timeline", "context", "sessions", "top", "doctor", "status":
+		return true
+	case "session":
+		if len(tokens) < 2 {
+			return false
+		}
+		switch tokens[1] {
+		case "active", "latest", "tree", "handoff":
+			return true
+		}
+	case "memory":
+		if len(tokens) < 2 {
+			return false
+		}
+		switch tokens[1] {
+		case "list", "search", "show":
+			return true
+		case "inbox":
+			return len(tokens) >= 3 && (tokens[2] == "list" || tokens[2] == "show")
+		}
+	case "hooks":
+		return len(tokens) >= 2 && (tokens[1] == "print" || tokens[1] == "guide")
+	}
+	return false
+}
+
+func tracearyCommandTokens(command string) []string {
+	tokens := hookAuditCommandTokens(command)
+	for len(tokens) > 0 {
+		token := tokens[0]
+		switch {
+		case token == "env" || token == "command":
+			tokens = tokens[1:]
+			continue
+		case isShellEnvAssignment(token):
+			tokens = tokens[1:]
+			continue
+		case isTracearyCommandToken(token):
+			return tokens[1:]
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func hookAuditCommandTokens(command string) []string {
+	fields := strings.Fields(command)
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		token := strings.Trim(field, `"'`)
+		if token == "" {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+func isShellEnvAssignment(token string) bool {
+	key, _, ok := strings.Cut(token, "=")
+	if !ok || key == "" {
+		return false
+	}
+	for i, r := range key {
+		if i == 0 {
+			if r != '_' && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+				return false
+			}
+			continue
+		}
+		if r != '_' && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func isTracearyCommandToken(token string) bool {
+	return filepath.Base(strings.TrimSpace(token)) == "traceary"
+}
+
+func isTracearyReadMCPToolName(toolName string) bool {
+	normalized := strings.TrimSpace(toolName)
+	if normalized == "" {
+		return false
+	}
+	tracearyQualified := strings.HasPrefix(normalized, "mcp__traceary__") || strings.HasPrefix(normalized, "traceary.")
+	normalized = strings.TrimPrefix(normalized, "mcp__traceary__")
+	normalized = strings.TrimPrefix(normalized, "traceary.")
+	switch normalized {
+	case "list_events", "get_context", "session_status", "query_memory":
+		return true
+	case "search":
+		return tracearyQualified
+	default:
+		return false
+	}
 }
 
 func (c *RootCLI) runHookCompact(

--- a/presentation/cli/hook_runtime_self_inspection_test.go
+++ b/presentation/cli/hook_runtime_self_inspection_test.go
@@ -1,0 +1,85 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestRootCLI_HookAuditCommand_SuppressesSelfInspectionNoise(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		payload string
+	}{
+		{
+			name:    "environment opt-out suppresses normal command audit",
+			env:     "1",
+			payload: `{"session_id":"generated-session","tool_input":{"command":"go test ./..."},"tool_response":{"stdout":"ok"}}`,
+		},
+		{
+			name:    "command prefix opt-out suppresses traceary read command",
+			payload: `{"session_id":"generated-session","tool_input":{"command":"TRACEARY_NO_AUDIT=1 traceary list --json"},"tool_response":{"stdout":"[]"}}`,
+		},
+		{
+			name:    "traceary read MCP list_events suppresses large tool output",
+			payload: `{"session_id":"generated-session","tool_name":"mcp__traceary__list_events","tool_input":{"limit":1000},"tool_response":{"content":"large JSON omitted from audits"}}`,
+		},
+		{
+			name:    "traceary CLI self-inspection read command suppresses audit",
+			payload: `{"session_id":"generated-session","tool_input":{"command":"traceary sessions --snapshot --json"},"tool_response":{"stdout":"{\"sessions\":[]}"}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TRACEARY_HOOK_STATE_KEY", "self-noise-key")
+			if tc.env != "" {
+				t.Setenv("TRACEARY_NO_AUDIT", tc.env)
+			}
+
+			homeDir := t.TempDir()
+			cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+			t.Cleanup(cli.ResetUserHomeDirFunc)
+
+			eventStub := &eventUsecaseStub{auditErr: errors.New("audit should not be called")}
+			rootCmd := newTestRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithEvent(eventStub),
+			).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetIn(strings.NewReader(tc.payload))
+			rootCmd.SetArgs([]string{"hook", "audit", "codex"})
+
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if eventStub.auditCall.command != "" {
+				t.Fatalf("audit command = %q, want no audit call", eventStub.auditCall.command)
+			}
+		})
+	}
+}
+
+func TestRootCLI_HookAuditCommand_RecordsGenericSearchTool(t *testing.T) {
+	eventStub := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"generated-session","tool_name":"search","tool_input":{"query":"traceary"},"tool_response":{"content":"ok"}}`))
+	rootCmd.SetArgs([]string{"hook", "audit", "codex"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := eventStub.auditCall.command, "search"; got != want {
+		t.Fatalf("audit command = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Motivation

Dogfood/process review should not be distorted by Traceary investigations recursively recording large Traceary read outputs as command audits.

## Changes

- Add hook-audit suppression for `TRACEARY_NO_AUDIT`.
- Recognize command-prefix opt-out such as `TRACEARY_NO_AUDIT=1 traceary list --json`.
- Skip known Traceary read/self-inspection CLI commands and read-only MCP tools (`list_events`, `search`, `get_context`, `session_status`, `query_memory`) before recording command audits.
- Keep write-like Traceary tools auditable by default.
- Document the suppression behavior in the hooks guide.

## Verification

- `rtk go test ./presentation/cli -run 'TestRootCLI_HookAuditCommand_(SuppressesSelfInspectionNoise|UsesSessionStateAndToolPayload|FlagsFailureFromErrorPayload)'`
- `rtk go run ./cmd/repo-tooling docs verify-i18n`
- `rtk go test ./...`
- `go tool golangci-lint run`
- `rtk go build ./...`
- `rtk git diff --check`

Closes #1150
