### PR TITLE
feat: add command audit reliability diagnostics

### DIFF
--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -74,6 +74,12 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 多くの場合、既定の PPID ベース grouping がローカル client process topology に合っていません。
 より安定した grouping key が必要なら、hook 環境で `TRACEARY_HOOK_STATE_KEY` を明示してください。
 
+### Audit reliability の dogfood signal
+
+`traceary doctor` は bounded な recent command-audit window に対して `audit-reliability` check を出します。ここでは duplicate command-audit candidate group と、保存された audit input 内の `cwd` evidence が event の workspace metadata と食い違う workspace-drift candidate を報告します。
+
+これは自動 cleanup ではなく dogfood review の信号として扱ってください。check は count と sample event ID だけを表示し、command input/output body は出しません。process-review の指標に使う前に、sample row を `traceary show <event_id>` で確認し、本当に duplicate / drift なのか、正当な繰り返し作業なのかを切り分けてください。
+
 ### active ingestion 中に cleanup を強く走らせる
 
 `traceary store gc` は古い row を削除したあとに `VACUUM` を実行します。

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -74,6 +74,12 @@ If session-end fidelity matters, prefer the client integrations that expose an e
 This usually means the default PPID-based grouping does not match your local client process topology.
 Set `TRACEARY_HOOK_STATE_KEY` explicitly in the hook environment when you need a more stable grouping key.
 
+### Audit reliability dogfood signal
+
+`traceary doctor` includes an `audit-reliability` check over a bounded recent command-audit window. It reports duplicate command-audit candidate groups and workspace-drift candidates when `cwd` evidence in the stored audit input conflicts with the event workspace metadata.
+
+Treat this as a dogfood review signal, not as automatic cleanup. The check intentionally prints counts and sampled event IDs only; it does not dump command input/output bodies. Before using process-review metrics, inspect the sampled rows with `traceary show <event_id>` and confirm whether they are real duplicates/drift or legitimate repeated work.
+
 ### Concurrent cleanup versus active ingestion
 
 `traceary store gc` deletes old rows and then runs `VACUUM`.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -8,12 +8,16 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -241,6 +245,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			Message: localizef("initialized SQLite store: %s", "SQLite ストアを初期化しました: %s", resolvedDBPath),
 		})
 		report.Checks = append(report.Checks, c.inspectStaleActiveSessions(ctx))
+		report.Checks = append(report.Checks, c.inspectCommandAuditReliability(ctx))
 	}
 
 	resolvedProjectDir, err := resolveHooksProjectDir(input.projectDir)
@@ -363,6 +368,283 @@ func (c *RootCLI) inspectStaleActiveSessions(ctx context.Context) doctorCheck {
 			fixCommand,
 		),
 	}
+}
+
+const commandAuditReliabilityScanLimit = 200
+
+type commandAuditReliabilityFindings struct {
+	ScannedAuditCount     int
+	DuplicateGroups       []commandAuditDuplicateGroup
+	WorkspaceDriftSamples []commandAuditWorkspaceDriftSample
+}
+
+type commandAuditDuplicateGroup struct {
+	EventIDs []string
+	Count    int
+}
+
+type commandAuditDuplicateGroupKey struct {
+	SessionID       string
+	Workspace       string
+	Command         string
+	Input           string
+	Output          string
+	InputTruncated  bool
+	OutputTruncated bool
+	ExitCode        string
+	Failed          bool
+}
+
+type commandAuditWorkspaceDriftSample struct {
+	EventID           string
+	StoredWorkspace   string
+	EvidenceWorkspace string
+	CWD               string
+}
+
+func (c *RootCLI) inspectCommandAuditReliability(ctx context.Context) doctorCheck {
+	const checkName = "audit-reliability"
+	if c.event == nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusSkip,
+			Message: localizef("event usecase is not configured", "event usecase が設定されていません"),
+		}
+	}
+	events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(commandAuditReliabilityScanLimit).
+		Kind(types.EventKindCommandExecuted).
+		Build())
+	if err != nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to list recent command audits: %v", "recent command audit の取得に失敗しました: %v", err),
+		}
+	}
+	details := make([]apptypes.EventDetails, 0, len(events))
+	for _, event := range events {
+		detail, err := c.event.Show(ctx, event.EventID())
+		if err != nil {
+			return doctorCheck{
+				Name:    checkName,
+				Status:  doctorStatusFail,
+				Message: localizef("failed to inspect command audit %s: %v", "command audit %s の検査に失敗しました: %v", event.EventID(), err),
+			}
+		}
+		details = append(details, detail)
+	}
+	return commandAuditReliabilityCheckFromFindings(commandAuditReliabilityFindingsFromDetails(ctx, details))
+}
+
+func commandAuditReliabilityCheckFromFindings(findings commandAuditReliabilityFindings) doctorCheck {
+	const checkName = "audit-reliability"
+	duplicateRecordCount := 0
+	for _, group := range findings.DuplicateGroups {
+		duplicateRecordCount += group.Count
+	}
+	if len(findings.DuplicateGroups) == 0 && len(findings.WorkspaceDriftSamples) == 0 {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"scanned %d recent command audit(s); no duplicate groups or workspace-drift candidates found",
+				"%d 件の recent command audit を検査しました。duplicate group / workspace drift candidate はありません",
+				findings.ScannedAuditCount,
+			),
+		}
+	}
+
+	return doctorCheck{
+		Name:   checkName,
+		Status: doctorStatusWarn,
+		Hint: Localize(
+			"use this as a dogfood review signal; inspect the sampled event IDs with `traceary show <event_id>` before drawing process conclusions",
+			"dogfood review の信号として扱い、process の結論を出す前に sample event ID を `traceary show <event_id>` で確認してください",
+		),
+		Message: localizef(
+			"scanned %d recent command audit(s); duplicate_groups=%d duplicate_records=%d workspace_drift_candidates=%d samples: duplicates=[%s] drift=[%s]",
+			"%d 件の recent command audit を検査しました。duplicate_groups=%d duplicate_records=%d workspace_drift_candidates=%d samples: duplicates=[%s] drift=[%s]",
+			findings.ScannedAuditCount,
+			len(findings.DuplicateGroups),
+			duplicateRecordCount,
+			len(findings.WorkspaceDriftSamples),
+			formatCommandAuditDuplicateSamples(findings.DuplicateGroups),
+			formatCommandAuditWorkspaceDriftSamples(findings.WorkspaceDriftSamples),
+		),
+	}
+}
+
+func commandAuditReliabilityFindingsFromDetails(ctx context.Context, details []apptypes.EventDetails) commandAuditReliabilityFindings {
+	findings := commandAuditReliabilityFindings{}
+	type groupAccumulator struct {
+		eventIDs []string
+		count    int
+	}
+	groups := map[commandAuditDuplicateGroupKey]*groupAccumulator{}
+	for _, detail := range details {
+		event := detail.Event()
+		audit, ok := detail.CommandAudit().Value()
+		if event == nil || !ok || audit == nil {
+			continue
+		}
+		findings.ScannedAuditCount++
+		key := newCommandAuditDuplicateGroupKey(event, audit)
+		group := groups[key]
+		if group == nil {
+			group = &groupAccumulator{}
+			groups[key] = group
+		}
+		group.count++
+		group.eventIDs = append(group.eventIDs, event.EventID().String())
+
+		if drift, ok := commandAuditWorkspaceDriftFromDetail(ctx, event, audit); ok {
+			findings.WorkspaceDriftSamples = append(findings.WorkspaceDriftSamples, drift)
+		}
+	}
+	for _, group := range groups {
+		if group.count <= 1 {
+			continue
+		}
+		sort.Strings(group.eventIDs)
+		findings.DuplicateGroups = append(findings.DuplicateGroups, commandAuditDuplicateGroup{
+			EventIDs: group.eventIDs,
+			Count:    group.count,
+		})
+	}
+	sort.Slice(findings.DuplicateGroups, func(i, j int) bool {
+		return findings.DuplicateGroups[i].EventIDs[0] < findings.DuplicateGroups[j].EventIDs[0]
+	})
+	sort.Slice(findings.WorkspaceDriftSamples, func(i, j int) bool {
+		return findings.WorkspaceDriftSamples[i].EventID < findings.WorkspaceDriftSamples[j].EventID
+	})
+	return findings
+}
+
+func newCommandAuditDuplicateGroupKey(event *model.Event, audit *model.CommandAudit) commandAuditDuplicateGroupKey {
+	exitCode := "-"
+	if value, ok := audit.ExitCode().Value(); ok {
+		exitCode = strconv.Itoa(value)
+	}
+	return commandAuditDuplicateGroupKey{
+		SessionID:       event.SessionID().String(),
+		Workspace:       event.Workspace().String(),
+		Command:         audit.Command(),
+		Input:           audit.Input(),
+		Output:          audit.Output(),
+		InputTruncated:  audit.InputTruncated(),
+		OutputTruncated: audit.OutputTruncated(),
+		ExitCode:        exitCode,
+		Failed:          audit.Failed(),
+	}
+}
+
+func commandAuditWorkspaceDriftFromDetail(ctx context.Context, event *model.Event, audit *model.CommandAudit) (commandAuditWorkspaceDriftSample, bool) {
+	cwd, ok := commandAuditInputCWD(audit.Input())
+	if !ok {
+		return commandAuditWorkspaceDriftSample{}, false
+	}
+	evidenceWorkspace := commandAuditWorkspaceEvidenceFromCWD(ctx, cwd)
+	storedWorkspace := event.Workspace().String()
+	if storedWorkspace == "" || evidenceWorkspace == "" || storedWorkspace == evidenceWorkspace {
+		return commandAuditWorkspaceDriftSample{}, false
+	}
+	return commandAuditWorkspaceDriftSample{
+		EventID:           event.EventID().String(),
+		StoredWorkspace:   storedWorkspace,
+		EvidenceWorkspace: evidenceWorkspace,
+		CWD:               cwd,
+	}, true
+}
+
+func commandAuditInputCWD(input string) (string, bool) {
+	var value any
+	if err := json.Unmarshal([]byte(input), &value); err != nil {
+		return "", false
+	}
+	return findCWDInJSONValue(value)
+}
+
+func findCWDInJSONValue(value any) (string, bool) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		switch typed := value.(type) {
+		case []any:
+			for _, item := range typed {
+				if cwd, ok := findCWDInJSONValue(item); ok {
+					return cwd, true
+				}
+			}
+		}
+		return "", false
+	}
+	for _, key := range []string{"cwd", "workdir", "working_directory"} {
+		if raw, ok := object[key]; ok {
+			if cwd, ok := raw.(string); ok && strings.TrimSpace(cwd) != "" {
+				return strings.TrimSpace(cwd), true
+			}
+		}
+	}
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if cwd, ok := findCWDInJSONValue(object[key]); ok {
+			return cwd, true
+		}
+	}
+	return "", false
+}
+
+func commandAuditWorkspaceEvidenceFromCWD(ctx context.Context, cwd string) string {
+	trimmed := strings.TrimSpace(cwd)
+	if trimmed == "" {
+		return ""
+	}
+	if workspace, err := detectRepoContextFromDir(ctx, trimmed); err == nil && strings.TrimSpace(workspace) != "" {
+		return workspace
+	}
+	return normalizeLocalWorkContextPath(trimmed)
+}
+
+func formatCommandAuditDuplicateSamples(groups []commandAuditDuplicateGroup) string {
+	if len(groups) == 0 {
+		return "-"
+	}
+	limit := len(groups)
+	if limit > 3 {
+		limit = 3
+	}
+	parts := make([]string, 0, limit)
+	for _, group := range groups[:limit] {
+		eventIDs := group.EventIDs
+		if len(eventIDs) > 4 {
+			eventIDs = eventIDs[:4]
+		}
+		parts = append(parts, fmt.Sprintf("count=%d event_ids=%s", group.Count, strings.Join(eventIDs, ",")))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func formatCommandAuditWorkspaceDriftSamples(samples []commandAuditWorkspaceDriftSample) string {
+	if len(samples) == 0 {
+		return "-"
+	}
+	limit := len(samples)
+	if limit > 3 {
+		limit = 3
+	}
+	parts := make([]string, 0, limit)
+	for _, sample := range samples[:limit] {
+		parts = append(parts, fmt.Sprintf(
+			"event_id=%s stored=%q cwd_workspace=%q",
+			sample.EventID,
+			sample.StoredWorkspace,
+			sample.EvidenceWorkspace,
+		))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // inspectClaudePluginCacheStatus compares the cached Traceary Claude
@@ -1113,7 +1395,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "stale-active-sessions":
+	case name == "db-path" || name == "db-write" || name == "stale-active-sessions" || name == "audit-reliability":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/doctor_audit_reliability_internal_test.go
+++ b/presentation/cli/doctor_audit_reliability_internal_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestCommandAuditReliabilityFindingsDetectDuplicateGroups(t *testing.T) {
+	largeOutput := strings.Repeat("x", 2048)
+	details := []apptypes.EventDetails{
+		mustAuditDetailForReliability(t, "evt-a", "session-1", "workspace-1", "go test ./...", `{"command":"go test ./..."}`, largeOutput),
+		mustAuditDetailForReliability(t, "evt-b", "session-1", "workspace-1", "go test ./...", `{"command":"go test ./..."}`, largeOutput),
+	}
+
+	findings := commandAuditReliabilityFindingsFromDetails(context.Background(), details)
+	if findings.ScannedAuditCount != 2 {
+		t.Fatalf("ScannedAuditCount = %d, want 2", findings.ScannedAuditCount)
+	}
+	if len(findings.DuplicateGroups) != 1 {
+		t.Fatalf("DuplicateGroups = %+v, want one group", findings.DuplicateGroups)
+	}
+	if findings.DuplicateGroups[0].Count != 2 {
+		t.Fatalf("duplicate count = %d, want 2", findings.DuplicateGroups[0].Count)
+	}
+
+	check := commandAuditReliabilityCheckFromFindings(findings)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check status = %q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "evt-a") || !strings.Contains(check.Message, "evt-b") {
+		t.Fatalf("check message = %q, want sampled event IDs", check.Message)
+	}
+	if strings.Contains(check.Message, largeOutput) {
+		t.Fatalf("check message leaked full audit output body")
+	}
+}
+
+func TestCommandAuditReliabilityFindingsDetectWorkspaceDrift(t *testing.T) {
+	cwd := filepath.Join(t.TempDir(), "traceary")
+	details := []apptypes.EventDetails{
+		mustAuditDetailForReliability(t, "evt-drift", "session-1", "stored-workspace", "pwd", `{"cwd":`+quoteJSONStringForReliability(cwd)+`}`, "ok"),
+	}
+
+	findings := commandAuditReliabilityFindingsFromDetails(context.Background(), details)
+	if len(findings.WorkspaceDriftSamples) != 1 {
+		t.Fatalf("WorkspaceDriftSamples = %+v, want one drift candidate", findings.WorkspaceDriftSamples)
+	}
+	drift := findings.WorkspaceDriftSamples[0]
+	if drift.EventID != "evt-drift" || drift.StoredWorkspace != "stored-workspace" {
+		t.Fatalf("drift sample = %+v", drift)
+	}
+	if drift.EvidenceWorkspace == "" || drift.EvidenceWorkspace == "stored-workspace" {
+		t.Fatalf("EvidenceWorkspace = %q, want cwd-derived workspace different from stored", drift.EvidenceWorkspace)
+	}
+}
+
+func mustAuditDetailForReliability(t *testing.T, eventID, sessionID, workspace, command, input, output string) apptypes.EventDetails {
+	t.Helper()
+	event := model.EventOf(
+		types.EventID(eventID),
+		types.EventKindCommandExecuted,
+		types.Client("hook"),
+		types.Agent("codex"),
+		types.SessionID(sessionID),
+		types.Workspace(workspace),
+		"command executed",
+		time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+	)
+	audit := model.CommandAuditOf(
+		types.EventID(eventID),
+		command,
+		input,
+		output,
+		false,
+		false,
+		types.None[int](),
+		false,
+	)
+	details, err := apptypes.EventDetailsOf(event, types.Some(audit))
+	if err != nil {
+		t.Fatalf("EventDetailsOf() error = %v", err)
+	}
+	return details
+}
+
+func quoteJSONStringForReliability(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -170,6 +170,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
     ]
   }
 }
+
 `), 0o644); err != nil {
 			t.Fatalf("WriteFile() error = %v", err)
 		}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -55,6 +55,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "audit-reliability",
+      "status": "skip",
+      "severity": "PASS",
+      "section": "Database",
+      "message": "event usecase is not configured",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "project-dir",
       "status": "pass",
       "severity": "PASS",
@@ -183,6 +193,16 @@
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false
+        },
+        {
+          "name": "audit-reliability",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "event usecase is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
         }
       ]
     },
@@ -232,7 +252,7 @@
     }
   ],
   "summary": {
-    "pass": 8,
+    "pass": 9,
     "warn": 2,
     "fail": 0
   },


### PR DESCRIPTION
## Motivation

`traceary doctor` currently does not surface dogfood signals for the command-audit duplicate/workspace-drift issues that v0.20.1 is fixing. Maintainers have to discover those signals with ad-hoc exports and grep, which makes audit correctness regressions hard to spot before release.

## Changes

- Add a bounded `audit-reliability` doctor check over recent `command_executed` audits.
- Report duplicate command-audit candidate groups and cwd-derived workspace drift candidates using counts plus sampled event IDs only.
- Keep command input/output bodies out of doctor messages.
- Document the signal as dogfood review guidance in operations docs.
- Update doctor JSON golden coverage and pure helper tests.

## Verification

- `rtk go test ./presentation/cli -run TestDoctor_JSON_Golden -update`
- `rtk go test ./presentation/cli -run 'TestCommandAuditReliabilityFindings|TestRootCLI_DoctorCommand'`
- `rtk go test ./...`
- `go tool golangci-lint run`
- `rtk go build ./...`
- `rtk go run ./cmd/repo-tooling docs verify-i18n`
- `rtk git diff --check`

Closes #1153
