### PR TITLE
docs: add Clean My Agent relay compatibility design note

### DIFF
--- a/docs/architecture/README.ja.md
+++ b/docs/architecture/README.ja.md
@@ -133,6 +133,7 @@ Traceary では、`internal/` を既定では要求しません。
 - [ドキュメント索引](../README.ja.md)
 - [Optional API 移行方針](./optional-api.ja.md)
 - [Memory blocks: 評価と決定](./memory-blocks.ja.md)
+- [Clean My Agent relay 互換性: 評価と決定](./clean-my-agent-compatibility.ja.md)
 - [Host-native memory activation contract](./host-native-memory-activation.ja.md)
 - [Hook contract](../hooks/contract.ja.md)
 - [イベントライフサイクル](../lifecycle.ja.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -128,6 +128,7 @@ If the answer to any of these is "no", document the exception explicitly before 
 - [Documentation index](../README.md)
 - [Optional API migration policy](./optional-api.md)
 - [Memory blocks: evaluation and decision](./memory-blocks.md)
+- [Clean My Agent relay compatibility: evaluation and decision](./clean-my-agent-compatibility.md)
 - [Host-native memory activation contract](./host-native-memory-activation.md)
 - [Hook contract](../hooks/contract.md)
 - [Event lifecycle](../lifecycle.md)

--- a/docs/architecture/clean-my-agent-compatibility.ja.md
+++ b/docs/architecture/clean-my-agent-compatibility.ja.md
@@ -1,0 +1,106 @@
+# Clean My Agent relay 互換性: 評価と決定
+
+[English](./clean-my-agent-compatibility.md)
+
+このドキュメントは、Traceary の session / event / bundle / replay の各サーフェスを [Clean My Agent](https://github.com/blain3white/clean-my-agent) の universal relay schema に揃えるべきかを評価し、決定を記録します。このリファレンスは Clean My Agent のメンテナーが #1170 からプロジェクトをリンクしたことで浮上しました。比較をこの 1 箇所に閉じることで、実装イシュー (#1170, #1171, #1172, #1173, #1169) を実装に集中させます。
+
+**結論**: **参照のみ（reference-only）**。Traceary は下記のマッピングを文書化し、Clean My Agent のストレージ形式ドキュメントを host 側 session ストレージの外部 ground truth として利用します（#1170 の回帰フィクスチャ、#1171/#1174 の診断）。しかし v0.21.0 では `clean-my-agent.universal-session.v1` のエクスポートは**行いません**。upstream のスキーマが独立した versioned spec として安定した時点で再評価します。
+
+## Clean My Agent とは
+
+Clean My Agent は local-first のデスクトップアプリです（MIT ライセンス。確認済み最新リリース `v0.1.3`、2026-06-09 公開）。Codex / Claude Code / Cursor / Gemini / OpenCode の session データをスキャンし、利用分析・バックアップ・エクスポート・クリーンアップ提案・アプリ管理の Trash・リストアを提供します。
+
+Traceary に関係する成果物は 2 つです。
+
+1. **`docs/agent-storage-formats.md`** — host の session ストレージのルートとレコード形状を schema-only で文書化したもの。プロンプト本文・ツール出力・認証データ・ユーザーファイル内容のコピーを明示的に避けています。
+2. **`UniversalRelayDocument`** (`src/shared/types.ts`) — アプリの relay/export 機能が生成する、`clean-my-agent.universal-session.v1` という識別子を持つエクスポートスキーマ。
+
+一次情報の検証（2026-06-10）で判明した正確性に関する注意が 2 点あります。
+
+- universal relay schema は `docs/agent-storage-formats.md` には**定義されていません**。アプリの TypeScript 型と relay view コンポーネントの中にのみ存在します。独立した JSON Schema や互換性ポリシーはまだありません。
+- `docs/agent-storage-formats.md` は Codex / Claude Code / Cursor / OpenCode を文書化していますが、**Gemini のセクションはありません**。#1171 から参照されている Gemini ストレージルート（`~/.gemini`, `~/.config/gemini`, `~/Library/Application Support/Gemini`）は、同ドキュメントではなくアプリの Gemini scanner provider のコード由来です。
+
+## universal relay schema（v0.1.3 時点）
+
+`UniversalRelayDocument` のフィールド（`src/shared/types.ts` より）:
+
+| フィールド | 形状 |
+| --- | --- |
+| `schema` | `"clean-my-agent.universal-session.v1"` |
+| `exportedAt` | timestamp |
+| `source` | agent 識別子（例: `codex`） |
+| `session` | `SessionRecord`: `id`, `source`, `title`, `projectName`, `projectPath`, `branch`, `storagePath`, `storageKind` (`file`/`directory`/`database`), `storageState`, `createdAt`, `lastUpdated`, `messageCount`, `tokens`, `sizeBytes`, `backupStatus`, `tags`, `searchText`, `metadata` |
+| `messages` | `UniversalRelayMessage` の配列: `id`, `role` (`system`/`user`/`assistant`/`tool`/`unknown`), `createdAt`, `text`, `raw` |
+| `files` | `{path, reason, lastSeenAt}` の配列 |
+| `commands` | `{command, cwd, createdAt}` の配列 |
+| `git` | `{branch, projectPath, diff}` |
+| `attachments` | `{path, mediaType, sizeBytes}` の配列 |
+| `warnings` | 文字列の配列 |
+
+## マッピング: Traceary サーフェスと relay 概念
+
+| Traceary サーフェス | relay 概念 | 適合度 | 備考 |
+| --- | --- | --- | --- |
+| `Session` (`session_id`, `started_at`, `ended_at`, `client`, `agent`, `workspace`, `label`, `summary`) | `session` (`id`, `createdAt`, `lastUpdated`, `source`, `projectPath`/`projectName`, `title`) | 部分的 | `ended_at` に対応する relay スロットはありません（最も近いのは `lastUpdated`）。`summary` にもありません（強いて言えば `session.metadata`）。relay の `tokens`, `sizeBytes`, `storageState`, `backupStatus` には Traceary 側の情報源がありません。 |
+| `Session` の subagent 系譜 (`parent_session_id`, `spawn_event_id`, `subagent_kind`, `spawn_order`) | なし | なし | relay ドキュメントはフラットな session 単位エクスポートです。Traceary の session ツリー（親子の spawn 系譜）には relay 上の表現がなく、エクスポートすると subagent session が親から切り離されます。 |
+| `Event` `kind=prompt` | `messages[]` の `role=user` | 良好 | Traceary は `id`, `createdAt`, `text` を埋められます。 |
+| `Event` `kind=transcript` | `messages[]` の `role=assistant` | 良好 | 同上。 |
+| `Event` `kind=compact_summary` | `warnings[]`（または `messages[]` の `role=system`） | 欠損あり | compaction 境界は Traceary のライフサイクル概念で、relay に等価物はありません。 |
+| `Event` `kind=note` / `reviewed` / `session_started` / `session_ended` | なし（強いて言えば `warnings[]`） | なし | ライフサイクル・レビューイベントに relay 側の置き場はありません。 |
+| `CommandAudit` / `Event` `kind=command_executed` | `commands[]` (`{command, cwd, createdAt}`) | 欠損あり | relay は Traceary の最も豊かな監査データ（`exit_code`, `failed`, `input`, `output`, truncation/redaction フラグ）を落とします。`cwd` は workspace がローカルパスの場合にのみ近似できます。 |
+| workspace メタデータ (`workspace`) | `git.projectPath` / `session.projectPath` | 部分的 | workspace がファイルシステムパスの場合は対応します。リモート URL workspace に対応するスロットはありません。 |
+| branch メタデータ | `git.branch` / `session.branch` | ギャップ | Traceary は git branch を永続化していません。host payload には含まれます（例: Codex `session_meta.payload.git.branch`）が、その捕捉は v0.21.0 のスコープ外です。 |
+| body truncation/redaction メタデータ (`input_truncated`, `output_truncated`, `input_redacted`, `output_redacted`。#1173 で拡張予定) | `warnings[]` | 良好（先例として） | relay の `warnings` は有用な先例です: ingest 時の truncation は下流の消費者から見えるべきで、無言であるべきではありません。 |
+| durable memory (`Memory`: type/scope/status/confidence) | なし | なし | relay は session 単位の会話エクスポートで、durable memory は session 横断の知識です。役割が異なります。 |
+| bundle export (`manifest_version=2`、NDJSON テーブルの tar.gz) | なし | なし | Traceary の bundle は conflict policy を持つストア全体のバックアップ/移送形式で、session 単位の relay ドキュメントではありません。 |
+| replay (`traceary replay` の HTML) | なし | なし | replay はオペレーター向けのレビュービューで、機械可読の交換形式ではありません。 |
+
+## 決定
+
+**スキーマを参照する。ただし v0.21.0 ではエクスポートしない。**
+
+理由:
+
+1. **スキーマの成熟度。** スキーマは `v0.1.x` のアプリケーションの TypeScript 型の中にインラインでのみ存在します。独立した versioned spec も JSON Schema も互換性ポリシーの文書もありません。今これをターゲットにすると churn を追いかけることになります。
+2. **サーフェス規律。** Traceary の MCP tool 数は凍結されており、CLI サーフェスも意図的に厳格です。（bundle と replay に続く）3 つ目のエクスポートサーフェスには「スキーマが存在する」以上の正当化が必要です。
+3. **情報形状のミスマッチ。** relay ドキュメントの半分は空になり（`branch`, `tokens`, `sizeBytes`, `files`, `attachments` には Traceary 側の情報源がない）、Traceary が最も豊かな半分（exit code・失敗フラグ・truncation メタデータ付きの command audit）は `{command, cwd, createdAt}` に平坦化されます。
+4. **消費者需要の不在。** サードパーティの `universal-session.v1` ドキュメントを消費するツールは現在存在しません。
+
+再評価のトリガー（いずれか）:
+
+- upstream がスキーマを互換性ポリシー付きの独立した versioned spec（JSON Schema 等）として公開する
+- このフォーマットの 2 つ目の producer または consumer が現れる
+- Traceary が branch メタデータを永続化し始め、最大のマッピングギャップが解消される
+- Traceary の session を中立形式で別ツールに渡す具体的なオペレーターワークフローが生まれる
+
+互換エクスポートを後日実装する場合でも、MCP tool は追加してはなりません（tool サーフェスは凍結）。その時点で明示的な additive CLI サーフェスとして設計します — この note は意図的にコマンド形状を事前確約しません。
+
+## v0.21.0 がこのリファレンスから採用するもの
+
+- **フィクスチャと診断のための host ストレージ ground truth。** Codex ルート（`~/.codex/sessions/YYYY/MM/DD/*.jsonl`, `~/.codex/archived_sessions/*.jsonl`, `~/.codex/session_index.jsonl`。レコードは `session_meta` / `response_item` / `event_msg` / `turn_context` の union）は #1170 の回帰フィクスチャの根拠になります。Claude Code ルート（`~/.claude/projects/<encoded-project-path>/*.jsonl`, `~/.claude/transcripts/*.jsonl`）は #1174 の coverage gap 診断を支えます。Gemini scanner ルートは #1171 の root-cause 比較を支えます。
+- **フィクスチャポリシー。** フィクスチャは schema-shaped のみ: 実際のプロンプト本文・ツール出力・認証情報・ユーザーファイル内容を含めません。これは Clean My Agent のドキュメント方針とも #1170/#1171 の受け入れ基準とも一致します。
+- **memory hygiene (#1169) のための安全セマンティクスの参照。** Clean My Agent のモデル — read-before-write、明示的なクリーンアップ提案、リスクあるクリーンアップ前のバックアップ、アプリ管理の Trash/リストア — は Traceary の dry-run-first クリーンアップと evidence-first レビューに対応します。Traceary は既存の姿勢を維持します: bulk accept はせず、この比較を理由に破壊的クリーンアップを追加しません。
+- **truncation 可視性の先例 (#1173)。** relay は変換上の注意を `warnings` で表面化します。Traceary の ingest 時 truncation メタデータも同様に、無言ではなく CLI/MCP 出力で見えるべきです。
+- **session liveness 語彙の確認 (#1172)。** relay の `session.storageState` は、下流の消費者が明示的な liveness/state フィールドを求めることを示しています。#1170/#1172 の status 語彙（例: 終了後の late events）も同じ理由で明示的であるべきです。
+
+## 非ゴール（#1177 から変更なし）
+
+- Clean My Agent を vendor しない。
+- デスクトップのクリーンアップ UI を実装しない。
+- 破壊的なクリーンアップ挙動を追加しない。
+- 実際のローカル agent ログをテストに取り込まない。
+
+## 情報源
+
+- リポジトリ: <https://github.com/blain3white/clean-my-agent>（MIT、`v0.1.3` 2026-06-09 リリース。2026-06-10 検証）
+- `docs/agent-storage-formats.md`（ストレージルートとレコード形状）
+- `src/shared/types.ts`（`UniversalRelayDocument`, `SessionRecord`, `UniversalRelayMessage`, `ExportFormat`）
+- `src/features/relay/RelayView.tsx`（relay/export 機能）
+
+## 関連文書
+
+- [アーキテクチャ原則](./README.ja.md)
+- [イベントライフサイクル](../lifecycle.ja.md)
+- [Hook contract](../hooks/contract.ja.md)
+- [バックアップガイド](../backup/README.ja.md)
+- 実装イシュー: #1170, #1171, #1172, #1173, #1169

--- a/docs/architecture/clean-my-agent-compatibility.md
+++ b/docs/architecture/clean-my-agent-compatibility.md
@@ -1,0 +1,106 @@
+# Clean My Agent relay compatibility: evaluation and decision
+
+[日本語](./clean-my-agent-compatibility.ja.md)
+
+This document evaluates whether Traceary should align its session/event/bundle/replay surfaces with [Clean My Agent](https://github.com/blain3white/clean-my-agent)'s universal relay schema, and records the decision. The reference surfaced when the Clean My Agent maintainer linked the project from #1170; this note keeps the implementation issues (#1170, #1171, #1172, #1173, #1169) focused by capturing the comparison in one bounded place.
+
+**TL;DR**: **reference-only**. Traceary documents the mapping below and uses Clean My Agent's storage-format documentation as external ground truth for host-side session storage (regression fixtures in #1170, diagnosis in #1171/#1174), but does **not** export `clean-my-agent.universal-session.v1` in v0.21.0. The decision is revisited when the upstream schema stabilizes into a standalone versioned spec.
+
+## What Clean My Agent is
+
+Clean My Agent is a local-first desktop app (MIT license; latest checked release `v0.1.3`, published 2026-06-09) that scans Codex, Claude Code, Cursor, Gemini, and OpenCode session data and provides usage analytics, backups, exports, cleanup suggestions, an app-managed Trash, and restore.
+
+Two of its artifacts are relevant to Traceary:
+
+1. **`docs/agent-storage-formats.md`** — schema-only documentation of host session storage roots and record shapes. It explicitly avoids copying prompt text, tool output, auth data, or user file contents.
+2. **`UniversalRelayDocument`** (`src/shared/types.ts`) — an export schema identified as `clean-my-agent.universal-session.v1`, produced by the app's relay/export feature.
+
+Two accuracy notes from primary-source verification (2026-06-10):
+
+- The universal relay schema is **not** defined in `docs/agent-storage-formats.md`; it lives only in the app's TypeScript types and the relay view component. There is no standalone JSON Schema or compatibility policy yet.
+- `docs/agent-storage-formats.md` documents Codex, Claude Code, Cursor, and OpenCode, but **has no Gemini section**. The Gemini storage roots referenced from #1171 (`~/.gemini`, `~/.config/gemini`, `~/Library/Application Support/Gemini`) come from the app's Gemini scanner provider code, not from that document.
+
+## The universal relay schema (as of v0.1.3)
+
+`UniversalRelayDocument` fields, verbatim from `src/shared/types.ts`:
+
+| Field | Shape |
+| --- | --- |
+| `schema` | `"clean-my-agent.universal-session.v1"` |
+| `exportedAt` | timestamp |
+| `source` | agent identifier (e.g. `codex`) |
+| `session` | `SessionRecord`: `id`, `source`, `title`, `projectName`, `projectPath`, `branch`, `storagePath`, `storageKind` (`file`/`directory`/`database`), `storageState`, `createdAt`, `lastUpdated`, `messageCount`, `tokens`, `sizeBytes`, `backupStatus`, `tags`, `searchText`, `metadata` |
+| `messages` | array of `UniversalRelayMessage`: `id`, `role` (`system`/`user`/`assistant`/`tool`/`unknown`), `createdAt`, `text`, `raw` |
+| `files` | array of `{path, reason, lastSeenAt}` |
+| `commands` | array of `{command, cwd, createdAt}` |
+| `git` | `{branch, projectPath, diff}` |
+| `attachments` | array of `{path, mediaType, sizeBytes}` |
+| `warnings` | array of strings |
+
+## Mapping: Traceary surfaces to relay concepts
+
+| Traceary surface | Relay concept | Fit | Notes |
+| --- | --- | --- | --- |
+| `Session` (`session_id`, `started_at`, `ended_at`, `client`, `agent`, `workspace`, `label`, `summary`) | `session` (`id`, `createdAt`, `lastUpdated`, `source`, `projectPath`/`projectName`, `title`) | Partial | `ended_at` has no relay slot (`lastUpdated` is the closest), and `summary` has none either (`session.metadata` at best). Relay's `tokens`, `sizeBytes`, `storageState`, `backupStatus` have no Traceary source of truth. |
+| `Session` subagent lineage (`parent_session_id`, `spawn_event_id`, `subagent_kind`, `spawn_order`) | none | None | Relay documents are flat per-session exports. Traceary's session tree (parent/child spawn lineage) has no relay representation, so an export would sever subagent sessions from their parents. |
+| `Event` `kind=prompt` | `messages[]` with `role=user` | Good | Traceary can fill `id`, `createdAt`, `text`. |
+| `Event` `kind=transcript` | `messages[]` with `role=assistant` | Good | Same as above. |
+| `Event` `kind=compact_summary` | `warnings[]` (or `messages[]` with `role=system`) | Lossy | Compaction boundaries are a Traceary lifecycle concept; relay has no equivalent. |
+| `Event` `kind=note` / `reviewed` / `session_started` / `session_ended` | none (`warnings[]` at best) | None | Lifecycle and review events have no relay home. |
+| `CommandAudit` / `Event` `kind=command_executed` | `commands[]` (`{command, cwd, createdAt}`) | Lossy | Relay drops Traceary's richest audit data: `exit_code`, `failed`, `input`, `output`, truncation/redaction flags. `cwd` is only approximated by `workspace` when it is a local path. |
+| Workspace metadata (`workspace`) | `git.projectPath` / `session.projectPath` | Partial | Maps when the workspace is a filesystem path; remote-URL workspaces have no relay slot. |
+| Branch metadata | `git.branch` / `session.branch` | Gap | Traceary does not persist a git branch. Host payloads contain it (e.g. Codex `session_meta.payload.git.branch`), but capturing it is out of scope for v0.21.0. |
+| Body truncation/redaction metadata (`input_truncated`, `output_truncated`, `input_redacted`, `output_redacted`; extended by #1173) | `warnings[]` | Good (as precedent) | Relay's `warnings` is a useful precedent: ingest-time truncation should be visible to any downstream consumer, not silent. |
+| Durable memory (`Memory`: type/scope/status/confidence) | none | None | Relay is a per-session conversation export; durable memory is cross-session knowledge. Different jobs. |
+| Bundle export (`manifest_version=2` tar.gz of NDJSON tables) | none | None | Traceary's bundle is a whole-store backup/transfer format with conflict policies, not a per-session relay document. |
+| Replay (`traceary replay` HTML) | none | None | Replay is an operator-facing review view, not a machine-readable interchange format. |
+
+## Decision
+
+**Reference the schema; do not export it in v0.21.0.**
+
+Rationale:
+
+1. **Schema maturity.** The schema exists only inline in a `v0.1.x` application's TypeScript types. There is no standalone versioned spec, no JSON Schema, and no documented compatibility policy. Targeting it now means chasing churn.
+2. **Surface discipline.** Traceary's MCP tool count is frozen and the CLI surface is deliberately strict. A third export surface (next to bundle and replay) needs a stronger justification than "a schema exists".
+3. **Information shape mismatch.** Half of the relay document would be empty (`branch`, `tokens`, `sizeBytes`, `files`, `attachments` have no Traceary source), and the half Traceary is richest in (command audits with exit codes, failure flags, truncation metadata) would be flattened to `{command, cwd, createdAt}`.
+4. **No consumer demand.** No tool currently consumes `universal-session.v1` documents from third parties.
+
+Revisit triggers (any of):
+
+- upstream publishes the schema as a standalone versioned spec (JSON Schema or equivalent) with a compatibility policy
+- a second producer or consumer of the format appears
+- Traceary starts persisting branch metadata, closing the largest mapping gap
+- a concrete operator workflow needs to hand a Traceary session to another tool in a neutral format
+
+If a compatible export is implemented later, it must not add an MCP tool (the tool surface is frozen) and should be designed as an explicit additive CLI surface at that time — this note deliberately does not pre-commit a command shape.
+
+## What v0.21.0 adopts from the reference
+
+- **Host storage ground truth for fixtures and diagnosis.** Codex roots (`~/.codex/sessions/YYYY/MM/DD/*.jsonl`, `~/.codex/archived_sessions/*.jsonl`, `~/.codex/session_index.jsonl`; record union of `session_meta` / `response_item` / `event_msg` / `turn_context`) ground the #1170 regression fixtures. Claude Code roots (`~/.claude/projects/<encoded-project-path>/*.jsonl`, `~/.claude/transcripts/*.jsonl`) support the #1174 coverage-gap diagnosis. Gemini scanner roots support the #1171 root-cause comparison.
+- **Fixture policy.** Fixtures stay schema-shaped only: no real prompt text, tool output, credentials, or user file contents. This matches both Clean My Agent's documentation approach and the acceptance criteria on #1170/#1171.
+- **Safety semantics as a reference for memory hygiene (#1169).** Clean My Agent's model — read-before-write, explicit cleanup suggestions, backup before risky cleanup, app-managed Trash/restore — maps to Traceary's dry-run-first cleanup and evidence-first review. Traceary keeps its existing stance: no bulk accept, no destructive cleanup added by this comparison.
+- **Truncation visibility precedent (#1173).** Relay surfaces conversion caveats in `warnings`; Traceary's ingest-time truncation metadata should likewise be visible in CLI/MCP output rather than silent.
+- **Session liveness vocabulary check (#1172).** Relay's `session.storageState` shows that downstream consumers want an explicit liveness/state field. The #1170/#1172 status vocabulary (e.g. late events after an end) should stay explicit for the same reason.
+
+## Non-goals (unchanged from #1177)
+
+- Do not vendor Clean My Agent.
+- Do not implement a desktop cleanup UI.
+- Do not add destructive cleanup behavior.
+- Do not import real local agent logs into tests.
+
+## Sources
+
+- Repository: <https://github.com/blain3white/clean-my-agent> (MIT, `v0.1.3` released 2026-06-09; verified 2026-06-10)
+- `docs/agent-storage-formats.md` (storage roots and record shapes)
+- `src/shared/types.ts` (`UniversalRelayDocument`, `SessionRecord`, `UniversalRelayMessage`, `ExportFormat`)
+- `src/features/relay/RelayView.tsx` (relay/export feature)
+
+## Related docs
+
+- [Architecture principles](./README.md)
+- [Event lifecycle](../lifecycle.md)
+- [Hook contract](../hooks/contract.md)
+- [Backup guide](../backup/README.md)
+- Implementation issues: #1170, #1171, #1172, #1173, #1169


### PR DESCRIPTION
Closes #1177

## Summary

Adds `docs/architecture/clean-my-agent-compatibility.md` (+ `.ja.md` pair), a bounded design note that evaluates Clean My Agent's universal relay schema (`clean-my-agent.universal-session.v1`) against Traceary's session/event/bundle/replay surfaces and records the decision.

## Decision

**Reference-only for v0.21.0** — Traceary uses Clean My Agent's storage-format documentation as external ground truth (fixtures for #1170, diagnosis for #1171/#1174) but does not export the relay schema. Rationale: the schema exists only inline in a v0.1.x app's TypeScript types (no standalone spec / JSON Schema / compatibility policy), MCP/CLI surfaces are frozen/strict, and the mapping is heavily lossy in both directions. Revisit triggers are documented.

## Primary-source corrections captured in the note

Verified against the upstream repository (2026-06-10):

- The universal relay schema is **not** in `docs/agent-storage-formats.md`; it is defined in `src/shared/types.ts` (`UniversalRelayDocument`) and the relay view component.
- `docs/agent-storage-formats.md` has **no Gemini section**; the Gemini storage roots referenced from #1171 come from the app's Gemini scanner provider code.

## Acceptance criteria mapping (#1177)

- [x] Design note comparing Traceary surfaces with relay concepts
- [x] Mapping table (Session→session, prompt/transcript/compact_summary→messages/warnings, CommandAudit→commands, workspace→git.projectPath, truncation/redaction→warnings)
- [x] Explicit decision with rationale (reference-only; export deferred with revisit triggers)
- [x] No fixtures added (none needed for a docs-only note; fixture *policy* documented for #1170/#1171)
- [x] Cross-links to #1170, #1171, #1172, #1173, #1169

## Verification

- `go run ./cmd/repo-tooling docs verify-i18n` — passed
- `go run ./cmd/repo-tooling docs verify-landing` — passed (no landing impact)
- Docs-only change; no Go code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
