### PR TITLE
fix: align Gemini compact instrumentation with Claude compact boundaries

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -43,7 +43,7 @@
 | AfterTool | `*` | ツール監査を記録 |
 | PreCompress | `*` | `compact_summary` marker として記録（`trigger` のみ。Gemini には post-compress digest がない） |
 
-**制限**: post-compress digest はなし（Gemini の `PreCompress` は async marker のみ）、failure 専用イベントなし。Gemini には Stop event が存在しないため、transcript 取得は `AfterAgent` に紐付けている。失敗捕捉は部分的: `AfterTool` の nested `tool_response.error` は spawn/OS レベルエラー時のみ出る（その場合は `failed` とマーク）。通常の非ゼロ終了は `tool_response.llmContent` 内の `Exit Code: N` テキストとしてのみ現れ、Traceary は意図的に parse しないため、それらはフラグなしのまま。
+**制限**: post-compress digest はなし — Gemini の `PreCompress` は advisory-only で compression 前に非同期で発火し、gemini-cli 0.43.0 同梱 hook reference の hook surface 全体（`BeforeTool` / `AfterTool` / `BeforeAgent` / `AfterAgent` / `BeforeModel` / `BeforeToolSelection` / `AfterModel` / `SessionStart` / `SessionEnd` / `Notification` / `PreCompress`）に post-compress event は存在しない。failure 専用イベントなし、PostCompact/SessionStart(compact) なし。Gemini には Stop event が存在しないため、transcript 取得は `AfterAgent` に紐付けている。失敗捕捉は部分的: `AfterTool` の nested `tool_response.error` は spawn/OS レベルエラー時のみ出る（その場合は `failed` とマーク）。通常の非ゼロ終了は `tool_response.llmContent` 内の `Exit Code: N` テキストとしてのみ現れ、Traceary は意図的に parse しないため、それらはフラグなしのまま。
 
 ## 共通動作
 
@@ -80,6 +80,6 @@ Traceary の managed hook 集合は、リリースをまたいで安定させる
 | Gemini CLI | `AfterAgent.prompt_response` | wire 済み | Gemini `AfterAgent` event 上で `traceary hook transcript gemini` が起動し `transcript` event として記録 (Gemini には Stop event が存在しない) |
 | Gemini CLI | `BeforeAgent.prompt` | wire 済み | Gemini `BeforeAgent` event 上で `traceary hook prompt gemini` が起動し `prompt` event として記録 (Claude / Codex の `UserPromptSubmit` と同等) |
 | Gemini CLI | `PreCompress.trigger` | wire 済み (marker のみ) | Gemini `PreCompress` event 上で `traceary hook compact gemini pre-compact` が起動し、`source_hook=pre_compact` で `trigger` 値を body にした `compact_summary` event として記録 (Gemini に post-compress digest はない) |
-| Gemini CLI 0.38.x | Memory manager agent / auto-memory | プレビュー | Traceary Tier 3 surface はまだこれらの preview 信号を subscribe していない |
+| Gemini CLI | Memory manager agent / auto-memory | experimental (0.43.0 で再確認済) | Traceary Tier 3 surface はまだこれらの experimental 信号を subscribe していない |
 
 これらの preview 機能を有効化したいオペレーターはクライアント側の公式ドキュメントを参照してください。Traceary は Tier 1-3 表に記載した安定 capability のみを記録し、`doctor` の informational check はギャップを可視化するためのものであり、有効化を強制するものではありません。

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -43,7 +43,7 @@ This document defines the hook capability tiers across AI agent clients.
 | AfterTool | `*` | Record tool audit |
 | PreCompress | `*` | Record a `compact_summary` marker (`trigger` field only — Gemini exposes no post-compress digest) |
 
-**Limitations**: No post-compress digest (Gemini's `PreCompress` is advisory and fires asynchronously), no failure-specific event, no PostCompact/SessionStart(compact). Gemini has no Stop event, so transcript capture is attached to `AfterAgent` instead. Failure capture is partial: `AfterTool` exposes a nested `tool_response.error` object only for spawn/OS-level errors (Traceary marks those `failed`); a plain non-zero shell exit surfaces only as `Exit Code: N` text inside `tool_response.llmContent`, which Traceary deliberately does not parse, so those runs stay unflagged.
+**Limitations**: No post-compress digest — Gemini's `PreCompress` is advisory-only and fires asynchronously before compression, and the gemini-cli 0.43.0 bundled hook reference exposes no post-compress event anywhere in its hook surface (`BeforeTool` / `AfterTool` / `BeforeAgent` / `AfterAgent` / `BeforeModel` / `BeforeToolSelection` / `AfterModel` / `SessionStart` / `SessionEnd` / `Notification` / `PreCompress`). No failure-specific event, no PostCompact/SessionStart(compact). Gemini has no Stop event, so transcript capture is attached to `AfterAgent` instead. Failure capture is partial: `AfterTool` exposes a nested `tool_response.error` object only for spawn/OS-level errors (Traceary marks those `failed`); a plain non-zero shell exit surfaces only as `Exit Code: N` text inside `tool_response.llmContent`, which Traceary deliberately does not parse, so those runs stay unflagged.
 
 ## Shared Behavior
 
@@ -84,7 +84,7 @@ runtime under the `<client>-host-capabilities` check.
 | Gemini CLI | `AfterAgent.prompt_response` | wired | persisted as `transcript` event via `traceary hook transcript gemini` on the Gemini `AfterAgent` event (Gemini has no Stop event) |
 | Gemini CLI | `BeforeAgent.prompt` | wired | persisted as `prompt` event via `traceary hook prompt gemini` on the Gemini `BeforeAgent` event (parity with Claude / Codex `UserPromptSubmit`) |
 | Gemini CLI | `PreCompress.trigger` | wired (marker only) | persisted as `compact_summary` event with `source_hook=pre_compact` and the `trigger` value as body via `traceary hook compact gemini pre-compact` (Gemini exposes no post-compress digest) |
-| Gemini CLI 0.38.x | Memory manager agent / auto-memory | preview | Traceary's Tier 3 surface does not yet subscribe to the preview signals |
+| Gemini CLI | Memory manager agent / auto-memory | experimental (re-verified on 0.43.0) | Traceary's Tier 3 surface does not yet subscribe to the experimental signals |
 
 Operators who want to enable any of the preview features above should
 follow the upstream docs for their client. Traceary continues to record

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -10,7 +10,7 @@
 - `○` ホスト側に hook はあるが Traceary 未配線
 - `✕` ホスト自体が公開していない
 
-**最終確認日: 2026-04-27.** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
+**最終確認日: 2026-04-27 (Gemini CLI は 2026-06-10 に 0.43.0 で再確認済).** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
 
 ## ライフサイクルイベント → ホスト hook マトリクス
 
@@ -39,7 +39,7 @@
 
 - Claude Code: https://code.claude.com/docs/en/hooks · パッケージ config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
 - Codex CLI: upstream binary `codex-cli 0.125.0` — hook surface はローカルインストールのバイナリ文字列 (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionRequest`, `UserPromptSubmit`) から推定。compact hook tracking: openai/codex#16098. パッケージ config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
-- Gemini CLI: ローカルインストール同梱の hooks reference (`/opt/homebrew/Cellar/gemini-cli/0.38.2/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`). パッケージ config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+- Gemini CLI: ローカルインストール同梱の hooks reference (`/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`。文書化された hook surface に post-compress event はなく、`PreCompress` は compression 前に非同期で発火する advisory-only hook). パッケージ config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
 
 ## 更新方法
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -10,7 +10,7 @@ Legend:
 - `○` available in the host but not wired by Traceary yet
 - `✕` not exposed by this host
 
-**Last verified: 2026-04-27.** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
+**Last verified: 2026-04-27 (Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
 
 ## Lifecycle event → host hook matrix
 
@@ -39,7 +39,7 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 
 - Claude Code: https://code.claude.com/docs/en/hooks · packaged config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
 - Codex CLI: upstream binary `codex-cli 0.125.0` — hook surface inferred from local install strings (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionRequest`, `UserPromptSubmit`). Compact hook tracking: openai/codex#16098. Packaged config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
-- Gemini CLI: hooks reference shipped with the local install at `/opt/homebrew/Cellar/gemini-cli/0.38.2/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`. Packaged config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+- Gemini CLI: hooks reference shipped with the local install at `/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md` (no post-compress event in the documented hook surface; `PreCompress` is advisory-only and fires asynchronously before compression). Packaged config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
 
 ## Maintenance
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -289,9 +289,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			}
 		}
 
-		if hostCheck := inspectHostCapabilityGaps(targetClient, outputPath); hostCheck != nil {
-			report.Checks = append(report.Checks, *hostCheck)
-		}
+		report.Checks = append(report.Checks, inspectHostCapabilityGaps(targetClient, outputPath)...)
 		if targetClient == "codex" {
 			if activationCheck := c.inspectCodexMemoryActivationStatus(ctx, resolvedProjectDir); activationCheck != nil {
 				report.Checks = append(report.Checks, *activationCheck)
@@ -744,16 +742,16 @@ func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
 	}
 }
 
-// inspectHostCapabilityGaps surfaces informational notes about 2026 Q2 host
+// inspectHostCapabilityGaps surfaces informational notes about host
 // capabilities that Traceary does not yet wire into its managed hook set.
-// The check intentionally returns pass status with a descriptive message so
+// The checks intentionally return pass status with descriptive messages so
 // the operator sees the gap without treating it as a regression — the
-// content was verified against each host's current official docs during
-// v0.7-4.
-func inspectHostCapabilityGaps(client, configPath string) *doctorCheck {
+// content was verified against each host's bundled hook reference docs
+// (gemini-cli 0.43.0 as of v0.21.0).
+func inspectHostCapabilityGaps(client, configPath string) []doctorCheck {
 	switch client {
 	case "claude":
-		return &doctorCheck{
+		return []doctorCheck{{
 			Name:   "claude-host-capabilities",
 			Status: doctorStatusPass,
 			Message: localizef(
@@ -761,10 +759,10 @@ func inspectHostCapabilityGaps(client, configPath string) *doctorCheck {
 				"claude ホスト: SubagentStop と PreCompact は既存の SessionStart / SessionEnd / Stop / PostCompact と並んで Traceary 管理の hook config に組み込み済みです (hooks config: %s)",
 				configPath,
 			),
-		}
+		}}
 	case "codex":
 		codexConfigPath := describeCodexConfigPath()
-		return &doctorCheck{
+		return []doctorCheck{{
 			Name:   "codex-host-capabilities",
 			Status: doctorStatusPass,
 			Message: localizef(
@@ -772,16 +770,26 @@ func inspectHostCapabilityGaps(client, configPath string) *doctorCheck {
 				"codex ホスト: memory 機能は per-install な feature flag (%s) の背後にあります。flag 名と有効化状態の確認方法は Codex のリリースノートを参照してください。Traceary は flag 状態に関わらず `memory import codex` で取り込み可能です",
 				codexConfigPath,
 			),
-		}
+		}}
 	case "gemini":
-		return &doctorCheck{
-			Name:   "gemini-host-capabilities",
-			Status: doctorStatusPass,
-			Message: localizef(
-				"gemini host: memory manager agent and auto-memory are preview-flag features on Gemini CLI 0.38.x; Traceary's Tier 3 hook coverage (SessionStart / SessionEnd / AfterAgent / AfterTool) does not yet surface those preview signals (hooks config: %s)",
-				"gemini ホスト: memory manager agent / auto-memory は Gemini CLI 0.38.x のプレビュー機能です。Traceary の Tier 3 hook (SessionStart / SessionEnd / AfterAgent / AfterTool) は現時点でそれらの preview 信号を surface しません (hooks config: %s)",
-				configPath,
-			),
+		return []doctorCheck{
+			{
+				Name:   "gemini-host-capabilities",
+				Status: doctorStatusPass,
+				Message: localizef(
+					"gemini host: memory manager agent and auto-memory remain experimental features on Gemini CLI (verified against 0.43.0); Traceary's Tier 3 hook coverage (SessionStart / SessionEnd / BeforeAgent / AfterAgent / AfterTool / PreCompress) does not yet surface those experimental signals (hooks config: %s)",
+					"gemini ホスト: memory manager agent / auto-memory は Gemini CLI の experimental 機能です (0.43.0 で確認済)。Traceary の Tier 3 hook (SessionStart / SessionEnd / BeforeAgent / AfterAgent / AfterTool / PreCompress) は現時点でそれらの experimental 信号を surface しません (hooks config: %s)",
+					configPath,
+				),
+			},
+			{
+				Name:   "gemini-compact-coverage",
+				Status: doctorStatusPass,
+				Message: Localize(
+					"gemini host: compact summaries are captured at the pre-compact boundary only (PreCompress marker). Gemini CLI exposes no post-compress hook — PreCompress is advisory-only and fires asynchronously before compression (verified against the gemini-cli 0.43.0 hook reference) — so a missing post-compact digest is expected upstream behavior, not a broken install",
+					"gemini ホスト: compact summary は pre-compact 境界のみで捕捉します (PreCompress marker)。Gemini CLI に post-compress hook は存在せず、PreCompress は compression 前に非同期で発火する advisory-only hook です (gemini-cli 0.43.0 の hook reference で確認済)。post-compact digest が無いのは upstream の想定挙動であり、インストール不良ではありません",
+				),
+			},
 		}
 	}
 	return nil

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -72,6 +72,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 	t.Cleanup(cli.ResetUserHomeDirFunc)
 
 	t.Run("all clients without config only warns", func(t *testing.T) {
+		t.Setenv("TRACEARY_LANG", "en")
 		initStub := &storeManagementUsecaseStub{}
 		rootCmd := newTestRootCLI(cli.WithStoreManagement(initStub)).Command()
 		stdout := &bytes.Buffer{}
@@ -100,6 +101,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 			"claude-host-capabilities": gotStatuses["claude-host-capabilities"],
 			"codex-host-capabilities":  gotStatuses["codex-host-capabilities"],
 			"gemini-host-capabilities": gotStatuses["gemini-host-capabilities"],
+			"gemini-compact-coverage":  gotStatuses["gemini-compact-coverage"],
 		}
 		wantStatuses := map[string]string{
 			"config":                   "pass",
@@ -109,9 +111,21 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 			"claude-host-capabilities": "pass",
 			"codex-host-capabilities":  "pass",
 			"gemini-host-capabilities": "pass",
+			"gemini-compact-coverage":  "pass",
 		}
 		if diff := cmp.Diff(wantStatuses, gotSubset); diff != "" {
 			t.Fatalf("doctor statuses mismatch (-want +got):\n%s", diff)
+		}
+
+		gotMessages := map[string]string{}
+		for _, check := range report.Checks {
+			gotMessages[check.Name] = check.Message
+		}
+		if msg := gotMessages["gemini-compact-coverage"]; !strings.Contains(msg, "no post-compress hook") || !strings.Contains(msg, "PreCompress") {
+			t.Fatalf("gemini-compact-coverage message should explain the missing post-compress hook, got: %q", msg)
+		}
+		if msg := gotMessages["gemini-host-capabilities"]; !strings.Contains(msg, "BeforeAgent") || !strings.Contains(msg, "PreCompress") {
+			t.Fatalf("gemini-host-capabilities message should list the wired BeforeAgent / PreCompress hooks, got: %q", msg)
 		}
 	})
 


### PR DESCRIPTION
Closes #1176

## Summary

Aligns Gemini compact instrumentation expectations with Claude compact boundaries by verifying the Gemini hook surface from primary source and documenting/diagnosing the asymmetry, per the acceptance criteria.

### Primary-source verification (acceptance criterion 1)

Verified against the hook reference bundled with the local gemini-cli **0.43.0** install (`/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`):

- The documented hook surface is exactly: `BeforeTool` / `AfterTool` / `BeforeAgent` / `AfterAgent` / `BeforeModel` / `BeforeToolSelection` / `AfterModel` / `SessionStart` / `SessionEnd` / `Notification` / `PreCompress` — **no post-compress event exists**.
- `PreCompress` is documented as *"Advisory Only: Fired asynchronously. It cannot block or modify the compression process."* with input `trigger: "auto" | "manual"`.
- Cross-checked against the minified bundle source: the `HookEventName` enum matches the reference doc, and `ChatCompressed` is an internal `GeminiEventType` only ("Internal concerns — no AgentEvent emitted"), so there is nothing to map (acceptance criterion 2 → N/A by evidence).

### Changes (acceptance criterion 3)

- **doctor**: new `gemini-compact-coverage` informational pass check explaining that compact summaries are captured at the pre-compact boundary only, and that a missing post-compact digest is expected upstream behavior rather than a broken install. `inspectHostCapabilityGaps` now returns a slice so a client can surface multiple notes.
- **doctor**: fixed the stale `gemini-host-capabilities` message — the wired Tier 3 hook list was missing `BeforeAgent` / `PreCompress`, and the memory manager / auto-memory note cited 0.38.x preview; it now cites 0.43.0 (still experimental per the bundled `docs/cli/auto-memory.md`).
- **docs**: `docs/hooks/contract.md` (+ja) Tier 3 limitations now record the full verified 0.43.0 hook surface; the host capability table drops the 0.38.x pin. `docs/hooks/host-coverage.md` (+ja) provenance updated from 0.38.2 to 0.43.0 with the no-post-compress finding, and the Gemini re-verification date added.
- **tests**: doctor test asserts the new check's status and message content (post-compress explanation, updated hook list), with `TRACEARY_LANG=en` pinned for the message assertions.

### Session lineage / context output (acceptance criterion 4)

No change needed: `loadCompactSummary` (`application/usecase/context_pack_builder.go`) already filters `source_hook=pre_compact` markers and the pre-snapshot body prefix, so handoff / context output remains correct when only a pre-compress marker exists. Verified by existing tests.

## Verification

- `go build ./...` — pass
- `go test ./...` — 2342 passed in 21 packages
- `go tool golangci-lint run` — 0 issues
- `go run ./cmd/repo-tooling docs verify-i18n` — pass

## Non-goals (unchanged)

- Compact summary content storage semantics untouched.
- Gemini experimental memory-manager signals not wired (documented only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
