### PR TITLE
fix: make hook prompt/transcript writes idempotent within a window

### DIFF
--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -46,6 +46,15 @@ var listTimelineBlocksQuery string
 
 const duplicateHookCommandAuditWindow = 2 * time.Second
 
+// duplicateHookContentEventWindow bounds the duplicate-suppression window for
+// hook-originated content events (prompt / transcript). Hosts occasionally
+// re-fire these hooks in immediate succession (~1ms apart), producing identical
+// rows that double the noise in context retrieval, memory extraction, and
+// operator review. It is intentionally a separate constant from
+// duplicateHookCommandAuditWindow: command audits keep their own semantics
+// (command re-runs are meaningful), so the two windows must be able to diverge.
+const duplicateHookContentEventWindow = 2 * time.Second
+
 // EventDatasource is the SQLite-backed implementation of the event
 // repository and event query service.
 type EventDatasource struct {
@@ -81,6 +90,10 @@ func (d *EventDatasource) Save(ctx context.Context, event *model.Event) error {
 		}
 	}()
 
+	if isDedupEligibleHookContentEvent(event) {
+		return d.saveDedupedHookContentEvent(ctx, db, event)
+	}
+
 	if _, err := db.ExecContext(
 		ctx,
 		insertEventQuery,
@@ -98,6 +111,124 @@ func (d *EventDatasource) Save(ctx context.Context, event *model.Event) error {
 	}
 
 	return nil
+}
+
+// isDedupEligibleHookContentEvent reports whether an event should pass through
+// the duplicate-window guard. Only hook-originated prompt/transcript content is
+// eligible: direct CLI / MCP writes (non-"hook" client) and other kinds
+// (note, session boundaries, compact_summary, reviewed, command_executed) keep
+// the unconditional insert path. Command audits are handled separately by
+// SaveWithAudit and are deliberately excluded here.
+func isDedupEligibleHookContentEvent(event *model.Event) bool {
+	if event.Client().String() != "hook" {
+		return false
+	}
+	switch event.Kind() {
+	case types.EventKindPrompt, types.EventKindTranscript:
+		return true
+	default:
+		return false
+	}
+}
+
+// saveDedupedHookContentEvent inserts a hook-originated content event unless an
+// identical one already exists within duplicateHookContentEventWindow. The
+// duplicate check and the insert run in a single transaction, mirroring
+// SaveWithAudit, so the guard and the write are atomic.
+func (d *EventDatasource) saveDedupedHookContentEvent(ctx context.Context, db *sql.DB, event *model.Event) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return xerrors.Errorf("failed to begin hook content event transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			slog.Debug("failed to rollback transaction", "error", err)
+		}
+	}()
+
+	duplicate, err := hookContentEventDuplicateExists(ctx, tx, event)
+	if err != nil {
+		return err
+	}
+	if duplicate {
+		slog.Debug(
+			"suppressed duplicate hook content event within window",
+			"kind", event.Kind().String(),
+			"client", event.Client().String(),
+			"agent", event.Agent().String(),
+			"session_id", event.SessionID().String(),
+			"workspace", event.Workspace().String(),
+			"source_hook", event.SourceHook(),
+			"window", duplicateHookContentEventWindow.String(),
+		)
+		return nil
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		insertEventQuery,
+		event.EventID().String(),
+		event.Kind().String(),
+		event.Client().String(),
+		event.Agent().String(),
+		event.SessionID().String(),
+		event.Workspace().String(),
+		event.Body(),
+		formatTimestamp(event.CreatedAt()),
+		nullableString(event.SourceHook()),
+	); err != nil {
+		return xerrors.Errorf("failed to insert event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit hook content event transaction: %w", err)
+	}
+
+	return nil
+}
+
+// hookContentEventDuplicateExists reports whether an identical hook content
+// event already exists within duplicateHookContentEventWindow of the new
+// event's created_at. The identity tuple matches the audit guard's shape minus
+// the command_audits join: kind, client, agent, session_id, workspace,
+// source_hook, and body. kind is bound to the event's own kind, so a prompt
+// never deduplicates a transcript.
+func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *model.Event) (bool, error) {
+	from := formatTimestamp(event.CreatedAt().Add(-duplicateHookContentEventWindow))
+	to := formatTimestamp(event.CreatedAt().Add(duplicateHookContentEventWindow))
+
+	var value int
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT 1
+		   FROM events e
+		  WHERE e.kind = ?
+		    AND e.client = ?
+		    AND e.agent = ?
+		    AND e.session_id = ?
+		    AND e.workspace = ?
+		    AND COALESCE(e.source_hook, '') = ?
+		    AND e.body = ?
+		    AND e.created_at >= ?
+		    AND e.created_at <= ?
+		  LIMIT 1`,
+		event.Kind().String(),
+		event.Client().String(),
+		event.Agent().String(),
+		event.SessionID().String(),
+		event.Workspace().String(),
+		event.SourceHook(),
+		event.Body(),
+		from,
+		to,
+	).Scan(&value)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, xerrors.Errorf("failed to check duplicate hook content event: %w", err)
 }
 
 // SaveWithAudit persists an event together with its command audit.

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -193,14 +193,24 @@ func (d *EventDatasource) saveDedupedHookContentEvent(ctx context.Context, db *s
 // the command_audits join: kind, client, agent, session_id, workspace,
 // source_hook, and body. kind is bound to the event's own kind, so a prompt
 // never deduplicates a transcript.
+//
+// events.created_at is stored as variable-width RFC3339Nano (see
+// formatTimestamp), which is NOT lexically ordered the same as real time: e.g.
+// "…00.5Z" sorts before "…00Z". A plain TEXT range over created_at can thus
+// miss a genuine duplicate or over-suppress near fractional-second boundaries.
+// We therefore coarsely pre-filter on the fixed-width whole-second prefix
+// (substr 1..19 is always "YYYY-MM-DDTHH:MM:SS" for the UTC timestamps
+// formatTimestamp emits), widened by an extra second so it is a guaranteed
+// superset of the true window, then compare parsed timestamps exactly in Go.
 func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *model.Event) (bool, error) {
-	from := formatTimestamp(event.CreatedAt().Add(-duplicateHookContentEventWindow))
-	to := formatTimestamp(event.CreatedAt().Add(duplicateHookContentEventWindow))
+	const secondPrefixLayout = "2006-01-02T15:04:05"
+	coarse := duplicateHookContentEventWindow + time.Second
+	lowerPrefix := event.CreatedAt().Add(-coarse).UTC().Format(secondPrefixLayout)
+	upperPrefix := event.CreatedAt().Add(coarse).UTC().Format(secondPrefixLayout)
 
-	var value int
-	err := tx.QueryRowContext(
+	rows, err := tx.QueryContext(
 		ctx,
-		`SELECT 1
+		`SELECT e.created_at
 		   FROM events e
 		  WHERE e.kind = ?
 		    AND e.client = ?
@@ -209,9 +219,8 @@ func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *mod
 		    AND e.workspace = ?
 		    AND COALESCE(e.source_hook, '') = ?
 		    AND e.body = ?
-		    AND e.created_at >= ?
-		    AND e.created_at <= ?
-		  LIMIT 1`,
+		    AND substr(e.created_at, 1, 19) >= ?
+		    AND substr(e.created_at, 1, 19) <= ?`,
 		event.Kind().String(),
 		event.Client().String(),
 		event.Agent().String(),
@@ -219,16 +228,46 @@ func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *mod
 		event.Workspace().String(),
 		event.SourceHook(),
 		event.Body(),
-		from,
-		to,
-	).Scan(&value)
-	if err == nil {
-		return true, nil
+		lowerPrefix,
+		upperPrefix,
+	)
+	if err != nil {
+		return false, xerrors.Errorf("failed to query duplicate hook content event candidates: %w", err)
 	}
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	for rows.Next() {
+		var createdAtText string
+		if err := rows.Scan(&createdAtText); err != nil {
+			return false, xerrors.Errorf("failed to scan duplicate hook content event candidate: %w", err)
+		}
+		candidateAt, err := time.Parse(time.RFC3339Nano, createdAtText)
+		if err != nil {
+			// A malformed historical timestamp must not block the write; skip it
+			// and keep checking the remaining candidates.
+			slog.Debug("skipping unparseable candidate timestamp", "created_at", createdAtText, "error", err)
+			continue
+		}
+		if absDuration(event.CreatedAt().Sub(candidateAt)) <= duplicateHookContentEventWindow {
+			return true, nil
+		}
 	}
-	return false, xerrors.Errorf("failed to check duplicate hook content event: %w", err)
+	if err := rows.Err(); err != nil {
+		return false, xerrors.Errorf("failed to iterate duplicate hook content event candidates: %w", err)
+	}
+	return false, nil
+}
+
+// absDuration returns the absolute value of d.
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
 }
 
 // SaveWithAudit persists an event together with its command audit.

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -252,7 +252,7 @@ func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *mod
 			slog.Debug("skipping unparseable candidate timestamp", "created_at", createdAtText, "error", err)
 			continue
 		}
-		if absDuration(event.CreatedAt().Sub(candidateAt)) <= duplicateHookContentEventWindow {
+		if event.CreatedAt().Sub(candidateAt).Abs() <= duplicateHookContentEventWindow {
 			return true, nil
 		}
 	}
@@ -260,14 +260,6 @@ func hookContentEventDuplicateExists(ctx context.Context, tx *sql.Tx, event *mod
 		return false, xerrors.Errorf("failed to iterate duplicate hook content event candidates: %w", err)
 	}
 	return false, nil
-}
-
-// absDuration returns the absolute value of d.
-func absDuration(d time.Duration) time.Duration {
-	if d < 0 {
-		return -d
-	}
-	return d
 }
 
 // SaveWithAudit persists an event together with its command audit.

--- a/infrastructure/sqlite/event_dedup_store_test.go
+++ b/infrastructure/sqlite/event_dedup_store_test.go
@@ -1,0 +1,259 @@
+package sqlite_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	_ "modernc.org/sqlite"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+// saveDedupTestEvent persists an event through EventDatasource.Save, the path
+// that carries the hook content-event duplicate-window guard.
+func saveDedupTestEvent(
+	ctx context.Context,
+	t *testing.T,
+	sut *sqlite.EventDatasource,
+	id string,
+	kind types.EventKind,
+	client string,
+	sourceHook string,
+	body string,
+	at time.Time,
+) {
+	t.Helper()
+
+	eventID, err := types.EventIDFrom(id)
+	if err != nil {
+		t.Fatalf("EventIDFrom(%s) error = %v", id, err)
+	}
+	agent, err := types.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	sessionID, err := types.SessionIDFrom("session-1")
+	if err != nil {
+		t.Fatalf("SessionIDFrom() error = %v", err)
+	}
+	event := model.EventOfWithSourceHook(
+		eventID,
+		kind,
+		types.Client(client),
+		agent,
+		sessionID,
+		types.Workspace("github.com/duck8823/dotfiles"),
+		body,
+		at,
+		sourceHook,
+	)
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatalf("Save(%s) error = %v", id, err)
+	}
+}
+
+func countEventsByKind(t *testing.T, dbPath string, kind types.EventKind) int {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE kind = ?`, kind.String()).Scan(&count); err != nil {
+		t.Fatalf("count query error = %v", err)
+	}
+	return count
+}
+
+func eventRowExists(t *testing.T, dbPath, id string) bool {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE id = ?`, id).Scan(&count); err != nil {
+		t.Fatalf("id count query error = %v", err)
+	}
+	return count > 0
+}
+
+// TestDatasource_Save_SkipsDuplicateHookContentEventsWithinWindow covers the
+// prompt and transcript duplicate windows separately (#1167 criteria 1, 2, 4).
+// For each kind: the original is kept, an identical body within the window is
+// suppressed, a different body within the window is kept, and an identical body
+// outside the window is kept.
+func TestDatasource_Save_SkipsDuplicateHookContentEventsWithinWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		kind       types.EventKind
+		sourceHook string
+	}{
+		{name: "prompt", kind: types.EventKindPrompt, sourceHook: "user_prompt_submit"},
+		{name: "transcript", kind: types.EventKindTranscript, sourceHook: "stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+			sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+			if err := storeManager.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+
+			base := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+			saveDedupTestEvent(ctx, t, sut, "event-original", tt.kind, "hook", tt.sourceHook, "same body", base)
+			saveDedupTestEvent(ctx, t, sut, "event-duplicate", tt.kind, "hook", tt.sourceHook, "same body", base.Add(time.Second))
+			saveDedupTestEvent(ctx, t, sut, "event-different-body", tt.kind, "hook", tt.sourceHook, "different body", base.Add(time.Second))
+			saveDedupTestEvent(ctx, t, sut, "event-later-rerun", tt.kind, "hook", tt.sourceHook, "same body", base.Add(10*time.Second))
+
+			if diff := cmp.Diff(3, countEventsByKind(t, dbPath, tt.kind)); diff != "" {
+				t.Fatalf("persisted %s event count mismatch (-want +got):\n%s", tt.name, diff)
+			}
+			if eventRowExists(t, dbPath, "event-duplicate") {
+				t.Fatalf("duplicate %s within window was persisted, want suppressed", tt.name)
+			}
+			if !eventRowExists(t, dbPath, "event-different-body") {
+				t.Fatalf("different-body %s within window was suppressed, want persisted", tt.name)
+			}
+			if !eventRowExists(t, dbPath, "event-later-rerun") {
+				t.Fatalf("identical %s outside window was suppressed, want persisted", tt.name)
+			}
+		})
+	}
+}
+
+// TestDatasource_Save_DoesNotDeduplicateNonHookContentEvents proves the guard is
+// gated on hook origin: a direct CLI/MCP write (client != "hook") is never
+// suppressed even with an identical body within the window.
+func TestDatasource_Save_DoesNotDeduplicateNonHookContentEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "cli-original", types.EventKindPrompt, "cli", "", "same body", base)
+	saveDedupTestEvent(ctx, t, sut, "cli-duplicate", types.EventKindPrompt, "cli", "", "same body", base.Add(time.Second))
+
+	if diff := cmp.Diff(2, countEventsByKind(t, dbPath, types.EventKindPrompt)); diff != "" {
+		t.Fatalf("non-hook prompt count mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestDatasource_Save_DoesNotDeduplicateNonContentHookEvents proves the guard is
+// gated on kind: a hook-originated note (a non prompt/transcript kind) is never
+// suppressed. This protects the non-goal — only prompt/transcript are eligible.
+func TestDatasource_Save_DoesNotDeduplicateNonContentHookEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "note-original", types.EventKindNote, "hook", "", "same body", base)
+	saveDedupTestEvent(ctx, t, sut, "note-duplicate", types.EventKindNote, "hook", "", "same body", base.Add(time.Second))
+
+	if diff := cmp.Diff(2, countEventsByKind(t, dbPath, types.EventKindNote)); diff != "" {
+		t.Fatalf("hook note count mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestDatasource_Save_DoesNotDeduplicateAcrossKinds proves a prompt never
+// deduplicates a transcript: the duplicate query binds the event's own kind, so
+// identical bodies of different kinds at the same instant both persist.
+func TestDatasource_Save_DoesNotDeduplicateAcrossKinds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	at := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "prompt-row", types.EventKindPrompt, "hook", "user_prompt_submit", "identical body", at)
+	saveDedupTestEvent(ctx, t, sut, "transcript-row", types.EventKindTranscript, "hook", "stop", "identical body", at)
+
+	if diff := cmp.Diff(1, countEventsByKind(t, dbPath, types.EventKindPrompt)); diff != "" {
+		t.Fatalf("prompt count mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, countEventsByKind(t, dbPath, types.EventKindTranscript)); diff != "" {
+		t.Fatalf("transcript count mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// lockedBuffer is a concurrency-safe io.Writer for capturing slog output.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	//nolint:wrapcheck // io.Writer contract: forward the underlying writer's result verbatim.
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestDatasource_Save_LogsSuppressedDuplicateHookContentEvent verifies the
+// suppression is observable via debug output (#1167 criterion 3). It swaps the
+// global slog default, so it must run in the sequential (non-parallel) phase to
+// avoid interleaving with other tests' debug logs.
+func TestDatasource_Save_LogsSuppressedDuplicateHookContentEvent(t *testing.T) {
+	buf := &lockedBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "log-original", types.EventKindPrompt, "hook", "user_prompt_submit", "same body", base)
+	saveDedupTestEvent(ctx, t, sut, "log-duplicate", types.EventKindPrompt, "hook", "user_prompt_submit", "same body", base.Add(time.Second))
+
+	if !strings.Contains(buf.String(), "suppressed duplicate hook content event within window") {
+		t.Fatalf("expected suppression debug log, got:\n%s", buf.String())
+	}
+}

--- a/infrastructure/sqlite/event_dedup_store_test.go
+++ b/infrastructure/sqlite/event_dedup_store_test.go
@@ -144,6 +144,44 @@ func TestDatasource_Save_SkipsDuplicateHookContentEventsWithinWindow(t *testing.
 	}
 }
 
+// TestDatasource_Save_SuppressesDuplicateAcrossFractionalSecondBoundary is a
+// regression test for the variable-width RFC3339Nano comparison bug: a plain
+// TEXT range over created_at sorts "…00.5Z" before "…00Z", so a genuine
+// duplicate 1.5s apart could slip through (and a row just outside 2s could be
+// wrongly suppressed). The fix compares parsed timestamps in Go.
+func TestDatasource_Save_SuppressesDuplicateAcrossFractionalSecondBoundary(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	// Original at .5s (variable-width "…00.5Z"); duplicate at a whole second
+	// 1.5s later ("…02Z"). Lexically "…00.5Z" < "…02Z" but also "…00.5Z" < the
+	// naive lower bound "…00Z", so the buggy TEXT range missed it. 1.5s <= 2s,
+	// so it must be suppressed.
+	original := time.Date(2026, 5, 31, 1, 0, 0, 500_000_000, time.UTC)
+	duplicate := time.Date(2026, 5, 31, 1, 0, 2, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "frac-original", types.EventKindPrompt, "hook", "user_prompt_submit", "same body", original)
+	saveDedupTestEvent(ctx, t, sut, "frac-duplicate", types.EventKindPrompt, "hook", "user_prompt_submit", "same body", duplicate)
+
+	if diff := cmp.Diff(1, countEventsByKind(t, dbPath, types.EventKindPrompt)); diff != "" {
+		t.Fatalf("fractional-boundary duplicate not suppressed (-want +got):\n%s", diff)
+	}
+
+	// A row 2.5s after the original is outside the window and must be kept,
+	// proving the Go comparison does not over-suppress near the boundary.
+	outside := time.Date(2026, 5, 31, 1, 0, 3, 0, time.UTC)
+	saveDedupTestEvent(ctx, t, sut, "frac-outside", types.EventKindPrompt, "hook", "user_prompt_submit", "same body", outside)
+
+	if diff := cmp.Diff(2, countEventsByKind(t, dbPath, types.EventKindPrompt)); diff != "" {
+		t.Fatalf("out-of-window row across fractional boundary was suppressed (-want +got):\n%s", diff)
+	}
+}
+
 // TestDatasource_Save_DoesNotDeduplicateNonHookContentEvents proves the guard is
 // gated on hook origin: a direct CLI/MCP write (client != "hook") is never
 // suppressed even with an identical body within the window.

--- a/presentation/cli/hook_dedup_test.go
+++ b/presentation/cli/hook_dedup_test.go
@@ -1,0 +1,125 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	usecase "github.com/duck8823/traceary/application/usecase"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
+	cli "github.com/duck8823/traceary/presentation/cli"
+)
+
+// TestRootCLI_HookContent_SuppressesDuplicateCodexWriteWithinWindow drives the
+// real `hook prompt codex` / `hook transcript codex` commands end-to-end against
+// a temp SQLite DB, reproducing the #1167 bug: a host re-firing the same hook in
+// immediate succession recorded duplicate rows. After the fix, the second
+// identical fire is suppressed, while a distinct body is preserved. It also
+// asserts the persisted client/source_hook the hook stamps — the exact inputs
+// the datasource eligibility gate keys on.
+func TestRootCLI_HookContent_SuppressesDuplicateCodexWriteWithinWindow(t *testing.T) {
+	tests := []struct {
+		name         string
+		subcommand   string
+		kind         string
+		sourceHook   string
+		sessionID    string
+		payloadSame  string
+		payloadOther string
+	}{
+		{
+			name:         "prompt",
+			subcommand:   "prompt",
+			kind:         "prompt",
+			sourceHook:   "user_prompt_submit",
+			sessionID:    "codex-e2e-prompt",
+			payloadSame:  `{"prompt":"summarize the diff and run the tests","session_id":"codex-e2e-prompt","cwd":"/tmp"}`,
+			payloadOther: `{"prompt":"now open a draft PR","session_id":"codex-e2e-prompt","cwd":"/tmp"}`,
+		},
+		{
+			name:         "transcript",
+			subcommand:   "transcript",
+			kind:         "transcript",
+			sourceHook:   "stop",
+			sessionID:    "codex-e2e-transcript",
+			payloadSame:  `{"last_assistant_message":"I ran the tests and they pass.","session_id":"codex-e2e-transcript","cwd":"/tmp"}`,
+			payloadOther: `{"last_assistant_message":"I opened the draft PR.","session_id":"codex-e2e-transcript","cwd":"/tmp"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Isolate hook state and pin the workspace so resolution is
+			// deterministic and never reads a developer's real hook state.
+			t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+			t.Setenv("TRACEARY_WORKSPACE", "github.com/dogfood/test")
+
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "traceary.db")
+			db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+			eventDS := sqliteinfra.NewEventDatasource(db)
+			storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+			eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+			if err := storeUC.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+
+			fire := func(payload string) {
+				t.Helper()
+				rootCmd := cli.NewRootCLI(
+					cli.WithStoreManagement(storeUC),
+					cli.WithEvent(eventUC),
+					cli.WithDatabasePathSetter(db.SetPath),
+				).Command()
+				rootCmd.SetIn(strings.NewReader(payload))
+				rootCmd.SetOut(&bytes.Buffer{})
+				rootCmd.SetErr(&bytes.Buffer{})
+				rootCmd.SetArgs([]string{"hook", tt.subcommand, "codex", "--db-path", dbPath})
+				if err := rootCmd.Execute(); err != nil {
+					t.Fatalf("Execute(%s) error = %v", tt.subcommand, err)
+				}
+			}
+
+			fire(tt.payloadSame)  // original
+			fire(tt.payloadSame)  // identical re-fire within window -> suppressed
+			fire(tt.payloadOther) // distinct body -> preserved
+
+			sqldb, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatalf("sql.Open() error = %v", err)
+			}
+			defer func() { _ = sqldb.Close() }()
+
+			var count int
+			if err := sqldb.QueryRow(
+				`SELECT COUNT(*) FROM events WHERE kind = ? AND session_id = ?`,
+				tt.kind, tt.sessionID,
+			).Scan(&count); err != nil {
+				t.Fatalf("count query error = %v", err)
+			}
+			if count != 2 {
+				t.Fatalf("%s rows = %d, want 2 (identical re-fire suppressed, distinct body kept)", tt.kind, count)
+			}
+
+			var client, sourceHook string
+			if err := sqldb.QueryRow(
+				`SELECT client, COALESCE(source_hook, '') FROM events WHERE kind = ? AND session_id = ? LIMIT 1`,
+				tt.kind, tt.sessionID,
+			).Scan(&client, &sourceHook); err != nil {
+				t.Fatalf("metadata query error = %v", err)
+			}
+			if client != "hook" {
+				t.Fatalf("persisted client = %q, want hook (eligibility-gate input)", client)
+			}
+			if sourceHook != tt.sourceHook {
+				t.Fatalf("persisted source_hook = %q, want %q", sourceHook, tt.sourceHook)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Hosts (notably Codex) occasionally re-fire the `prompt` / `transcript` hooks in immediate succession (~1ms apart), recording identical rows. This doubles the noise in context retrieval, memory extraction, and operator review.

`EventDatasource.Save` now routes **hook-originated prompt/transcript content** through a duplicate-window guard that mirrors the existing command-audit guard (`SaveWithAudit` / `hookCommandAuditDuplicateExists`): a query-then-insert in a single transaction, gated on `client == "hook"` AND `kind ∈ {prompt, transcript}`. An identical event — keyed on `{kind, client, agent, session_id, workspace, source_hook, body}` — recorded within `duplicateHookContentEventWindow` (2s) is suppressed and logged at debug level. Every other `Save` caller (note / session boundaries / compact_summary / reviewed, and any non-hook client such as MCP `record_event` or direct CLI) keeps the unconditional insert path — no behavior change, no transaction overhead.

The usecase (`eventUsecase.Log`) and `EventRepository` interface are unchanged: dedup stays a persistence-layer concern, consistent with how the audit dedup is invisible above the datasource.

## Acceptance criteria

- [x] Prompt/transcript writes idempotent for the same `{session_id, workspace, kind, source_hook, body}` within a short window
- [x] Legitimate repeats preserved: different body within window, or identical body outside the window, both persist
- [x] Suppression observable via debug output (`slog.Debug("suppressed duplicate hook content event within window", …)`)
- [x] Tests cover the prompt and transcript windows separately

## Non-goal honored

Command audits are **not** suppressed by this rule. They keep their own `duplicateHookCommandAuditWindow` and the `command_audits`-joined guard in `SaveWithAudit` (command re-runs are meaningful). The new window is a deliberately separate constant so the two can diverge.

## Design Note

Posted on the issue: https://github.com/duck8823/traceary/issues/1167#issuecomment-4739101615 (S/B risk Medium — concept model, responsibility placement, boundary/IF, behavior tests, rollback).

## Tests / verification

- `infrastructure/sqlite/event_dedup_store_test.go` — datasource guard:
  - `..._SkipsDuplicateHookContentEventsWithinWindow` (table over **prompt** + **transcript**): original kept, identical body within window suppressed, different body within window kept, identical body outside window kept → 3 rows.
  - `..._DoesNotDeduplicateNonHookContentEvents` (client `cli`), `..._DoesNotDeduplicateNonContentHookEvents` (`note`), `..._DoesNotDeduplicateAcrossKinds` (prompt vs transcript) — gate proofs.
  - `..._LogsSuppressedDuplicateHookContentEvent` — observability.
- `presentation/cli/hook_dedup_test.go` — end-to-end through the real `hook prompt codex` / `hook transcript codex` cobra commands against a temp SQLite DB (the in-tree dogfood): identical re-fire suppressed, distinct body kept, persisted `client="hook"` + `source_hook` asserted.
- `go build ./...` ✅ · `go test ./...` ✅ 2369 passed · `go vet ./...` ✅ · `go tool golangci-lint run` ✅ 0 issues · docs i18n ✅

No schema change, no migration.

Closes #1167
