### PR TITLE
v0.21.0-5: capture Gemini prompt/transcript/tool events

### DIFF
--- a/application/hooks_inspector.go
+++ b/application/hooks_inspector.go
@@ -65,9 +65,10 @@ type HooksInspector interface {
 	// re-implementing the command parsing.
 	ExtractManagedKeyFromEntry(name, command string) string
 	// ManagedCoverage reports which Traceary-managed enrichment surfaces
-	// (prompt, transcript, shell audit, compact) are wired in the given
-	// hook configuration content. Missing hooks fields or a payload with
-	// no Traceary-managed entries return a zero HookManagedCoverage.
-	// Returned errors are the same sentinels as Inspect.
-	ManagedCoverage(content []byte) (HookManagedCoverage, error)
+	// (prompt, transcript, shell audit, compact) are wired for the given
+	// client in the hook configuration content. Missing hooks fields or a
+	// payload with no matching Traceary-managed entries return a zero
+	// HookManagedCoverage. Returned errors are the same sentinels as
+	// Inspect.
+	ManagedCoverage(content []byte, client string) (HookManagedCoverage, error)
 }

--- a/application/hooks_inspector.go
+++ b/application/hooks_inspector.go
@@ -9,6 +9,36 @@ type HookDuplicate struct {
 	Count      int
 }
 
+// HookManagedCoverage summarizes which Traceary-managed enrichment surfaces
+// are wired into a host's hook configuration. Boundary coverage (session
+// start/end) is intentionally omitted — the existing `<client>-config` check
+// already covers the "no Traceary hooks at all" state, while this value
+// answers the narrower question doctor's coverage diagnostics need: do
+// installed hooks actually capture prompt, transcript, and shell audit?
+type HookManagedCoverage struct {
+	HasPrompt     bool
+	HasTranscript bool
+	HasAudit      bool
+	HasCompact    bool
+}
+
+// MissingEnrichment returns the enrichment surfaces (prompt, transcript,
+// audit) that are not wired by the installed hook config. The list is
+// deterministic so the doctor remediation message is stable across runs.
+func (c HookManagedCoverage) MissingEnrichment() []string {
+	missing := make([]string, 0, 3)
+	if !c.HasPrompt {
+		missing = append(missing, "prompt")
+	}
+	if !c.HasTranscript {
+		missing = append(missing, "transcript")
+	}
+	if !c.HasAudit {
+		missing = append(missing, "audit")
+	}
+	return missing
+}
+
 // HooksInspector inspects a hook configuration JSON payload and reports
 // high-level state relevant to diagnostics. Implementations live in the
 // infrastructure layer so presentation code can depend only on this
@@ -34,4 +64,10 @@ type HooksInspector interface {
 	// code uses this to recognise installed hook entries without
 	// re-implementing the command parsing.
 	ExtractManagedKeyFromEntry(name, command string) string
+	// ManagedCoverage reports which Traceary-managed enrichment surfaces
+	// (prompt, transcript, shell audit, compact) are wired in the given
+	// hook configuration content. Missing hooks fields or a payload with
+	// no Traceary-managed entries return a zero HookManagedCoverage.
+	// Returned errors are the same sentinels as Inspect.
+	ManagedCoverage(content []byte) (HookManagedCoverage, error)
 }

--- a/application/usecase/session_event_coverage.go
+++ b/application/usecase/session_event_coverage.go
@@ -1,0 +1,99 @@
+package usecase
+
+import "github.com/duck8823/traceary/domain/types"
+
+// EventCoverageInput is one observation fed to SummarizeSessionEventCoverage.
+// It carries just enough state for the classifier to attribute the event to a
+// session and decide whether it enriches that session beyond pure boundary
+// metadata.
+type EventCoverageInput struct {
+	SessionID string
+	Kind      types.EventKind
+}
+
+// SessionEventCoverage reports how many recent sessions captured prompt,
+// transcript, and command_executed events versus boundaries only. It is the
+// summary surfaced by the `<client>-event-coverage` doctor diagnostic that
+// flags hook installs which only wire session start/end.
+type SessionEventCoverage struct {
+	// Sessions counts only sessions whose session_started event was
+	// observed in the scanned window. List queries return newest-first, so
+	// observing the start means every subsequent event of that session is
+	// also in the window — this avoids misclassifying a truncated session
+	// (start out of window) as boundary-only.
+	Sessions       int
+	BoundaryOnly   int
+	Enriched       int
+	WithPrompt     int
+	WithTranscript int
+	WithCommand    int
+}
+
+// BoundaryOnlyRatio returns BoundaryOnly / Sessions, or 0 when no sessions
+// were counted (so callers can compare against a threshold without guarding
+// against division by zero).
+func (s SessionEventCoverage) BoundaryOnlyRatio() float64 {
+	if s.Sessions == 0 {
+		return 0
+	}
+	return float64(s.BoundaryOnly) / float64(s.Sessions)
+}
+
+// SummarizeSessionEventCoverage classifies the given event observations into
+// per-session coverage counts. Enrichment kinds are
+// {prompt, transcript, command_executed}; everything else (session boundaries,
+// compact summaries, notes, …) is neutral. The function is pure and
+// client-agnostic so the same classifier can back the gemini and claude
+// coverage diagnostics.
+func SummarizeSessionEventCoverage(events []EventCoverageInput) SessionEventCoverage {
+	type sessionState struct {
+		started    bool
+		prompt     bool
+		transcript bool
+		command    bool
+	}
+	states := map[string]*sessionState{}
+	for _, e := range events {
+		if e.SessionID == "" {
+			continue
+		}
+		state, ok := states[e.SessionID]
+		if !ok {
+			state = &sessionState{}
+			states[e.SessionID] = state
+		}
+		switch e.Kind {
+		case types.EventKindSessionStarted:
+			state.started = true
+		case types.EventKindPrompt:
+			state.prompt = true
+		case types.EventKindTranscript:
+			state.transcript = true
+		case types.EventKindCommandExecuted:
+			state.command = true
+		}
+	}
+
+	summary := SessionEventCoverage{}
+	for _, state := range states {
+		if !state.started {
+			continue
+		}
+		summary.Sessions++
+		if state.prompt {
+			summary.WithPrompt++
+		}
+		if state.transcript {
+			summary.WithTranscript++
+		}
+		if state.command {
+			summary.WithCommand++
+		}
+		if state.prompt || state.transcript || state.command {
+			summary.Enriched++
+		} else {
+			summary.BoundaryOnly++
+		}
+	}
+	return summary
+}

--- a/application/usecase/session_event_coverage.go
+++ b/application/usecase/session_event_coverage.go
@@ -11,16 +11,17 @@ type EventCoverageInput struct {
 	Kind      types.EventKind
 }
 
-// SessionEventCoverage reports how many recent sessions captured prompt,
-// transcript, and command_executed events versus boundaries only. It is the
-// summary surfaced by the `<client>-event-coverage` doctor diagnostic that
-// flags hook installs which only wire session start/end.
+// SessionEventCoverage reports how many recent sessions captured prompt or
+// transcript events versus sessions that only have non-conversation metadata.
+// Command audits are counted separately, but they do not make a session healthy
+// for this diagnostic: a stale install that wires only session boundaries plus
+// AfterTool still misses the core prompt/transcript capture.
 type SessionEventCoverage struct {
 	// Sessions counts only sessions whose session_started event was
 	// observed in the scanned window. List queries return newest-first, so
 	// observing the start means every subsequent event of that session is
 	// also in the window — this avoids misclassifying a truncated session
-	// (start out of window) as boundary-only.
+	// (start out of window) as prompt/transcript-missing.
 	Sessions       int
 	BoundaryOnly   int
 	Enriched       int
@@ -40,11 +41,13 @@ func (s SessionEventCoverage) BoundaryOnlyRatio() float64 {
 }
 
 // SummarizeSessionEventCoverage classifies the given event observations into
-// per-session coverage counts. Enrichment kinds are
-// {prompt, transcript, command_executed}; everything else (session boundaries,
-// compact summaries, notes, …) is neutral. The function is pure and
-// client-agnostic so the same classifier can back the gemini and claude
-// coverage diagnostics.
+// per-session coverage counts. Prompt and transcript are the conversation
+// enrichment kinds. Command audits are useful evidence and are counted in
+// WithCommand, but command-only sessions are still reported as prompt/transcript-missing
+// for the coverage ratio because they lack the prompt/transcript data this
+// diagnostic is meant to protect. Everything else (session boundaries, compact
+// summaries, notes, …) is neutral. The function is pure and client-agnostic so
+// the same classifier can back the gemini and claude coverage diagnostics.
 func SummarizeSessionEventCoverage(events []EventCoverageInput) SessionEventCoverage {
 	type sessionState struct {
 		started    bool
@@ -89,7 +92,7 @@ func SummarizeSessionEventCoverage(events []EventCoverageInput) SessionEventCove
 		if state.command {
 			summary.WithCommand++
 		}
-		if state.prompt || state.transcript || state.command {
+		if state.prompt || state.transcript {
 			summary.Enriched++
 		} else {
 			summary.BoundaryOnly++

--- a/application/usecase/session_event_coverage_test.go
+++ b/application/usecase/session_event_coverage_test.go
@@ -1,0 +1,143 @@
+package usecase_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestSummarizeSessionEventCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		events    []usecase.EventCoverageInput
+		want      usecase.SessionEventCoverage
+		wantRatio float64
+	}{
+		{
+			name:      "empty input yields zero counts and zero ratio",
+			events:    nil,
+			want:      usecase.SessionEventCoverage{},
+			wantRatio: 0,
+		},
+		{
+			name: "session without observed start is excluded as truncated",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindPrompt},
+				{SessionID: "s1", Kind: types.EventKindTranscript},
+			},
+			want:      usecase.SessionEventCoverage{},
+			wantRatio: 0,
+		},
+		{
+			name: "boundary only session is counted but not enriched",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindSessionStarted},
+				{SessionID: "s1", Kind: types.EventKindSessionEnded},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:     1,
+				BoundaryOnly: 1,
+			},
+			wantRatio: 1,
+		},
+		{
+			name: "prompt only counts as enriched with prompt",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindSessionStarted},
+				{SessionID: "s1", Kind: types.EventKindPrompt},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:   1,
+				Enriched:   1,
+				WithPrompt: 1,
+			},
+			wantRatio: 0,
+		},
+		{
+			name: "transcript only counts as enriched with transcript",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindSessionStarted},
+				{SessionID: "s1", Kind: types.EventKindTranscript},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:       1,
+				Enriched:       1,
+				WithTranscript: 1,
+			},
+		},
+		{
+			name: "command only counts as enriched with command",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindSessionStarted},
+				{SessionID: "s1", Kind: types.EventKindCommandExecuted},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:    1,
+				Enriched:    1,
+				WithCommand: 1,
+			},
+		},
+		{
+			name: "neutral events do not enrich a boundary only session",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "s1", Kind: types.EventKindSessionStarted},
+				{SessionID: "s1", Kind: types.EventKindCompactSummary},
+				{SessionID: "s1", Kind: types.EventKindNote},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:     1,
+				BoundaryOnly: 1,
+			},
+			wantRatio: 1,
+		},
+		{
+			name: "mixed sessions report ratio",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "boundary-a", Kind: types.EventKindSessionStarted},
+				{SessionID: "boundary-a", Kind: types.EventKindSessionEnded},
+				{SessionID: "boundary-b", Kind: types.EventKindSessionStarted},
+				{SessionID: "enriched-a", Kind: types.EventKindSessionStarted},
+				{SessionID: "enriched-a", Kind: types.EventKindPrompt},
+				{SessionID: "enriched-a", Kind: types.EventKindTranscript},
+				{SessionID: "enriched-a", Kind: types.EventKindCommandExecuted},
+				{SessionID: "truncated", Kind: types.EventKindPrompt},
+			},
+			want: usecase.SessionEventCoverage{
+				Sessions:       3,
+				BoundaryOnly:   2,
+				Enriched:       1,
+				WithPrompt:     1,
+				WithTranscript: 1,
+				WithCommand:    1,
+			},
+			wantRatio: float64(2) / float64(3),
+		},
+		{
+			name: "events with empty session id are ignored",
+			events: []usecase.EventCoverageInput{
+				{SessionID: "", Kind: types.EventKindSessionStarted},
+				{SessionID: "", Kind: types.EventKindPrompt},
+			},
+			want: usecase.SessionEventCoverage{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := usecase.SummarizeSessionEventCoverage(tt.events)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("SummarizeSessionEventCoverage() mismatch (-want +got):\n%s", diff)
+			}
+			if gotRatio := got.BoundaryOnlyRatio(); gotRatio != tt.wantRatio {
+				t.Fatalf("BoundaryOnlyRatio() = %v, want %v", gotRatio, tt.wantRatio)
+			}
+		})
+	}
+}

--- a/application/usecase/session_event_coverage_test.go
+++ b/application/usecase/session_event_coverage_test.go
@@ -71,16 +71,17 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 			},
 		},
 		{
-			name: "command only counts as enriched with command",
+			name: "command only is counted but does not satisfy prompt transcript coverage",
 			events: []usecase.EventCoverageInput{
 				{SessionID: "s1", Kind: types.EventKindSessionStarted},
 				{SessionID: "s1", Kind: types.EventKindCommandExecuted},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:    1,
-				Enriched:    1,
-				WithCommand: 1,
+				Sessions:     1,
+				BoundaryOnly: 1,
+				WithCommand:  1,
 			},
+			wantRatio: 1,
 		},
 		{
 			name: "neutral events do not enrich a boundary only session",

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -380,7 +380,7 @@ func checkGemini(root, version string) error {
 	if err := checkNoDuplicateTracearyHookEntries("integrations/gemini-extension/hooks/hooks.json", hooks); err != nil {
 		return err
 	}
-	for _, event := range []string{"SessionStart", "SessionEnd", "AfterTool", "BeforeAgent", "PreCompress"} {
+	for _, event := range []string{"SessionStart", "SessionEnd", "BeforeAgent", "AfterAgent", "AfterTool", "PreCompress"} {
 		if _, ok := hooks.Hooks[event]; !ok {
 			return xerrors.Errorf("gemini hooks must include %s", event)
 		}
@@ -389,6 +389,7 @@ func checkGemini(root, version string) error {
 		{"'hook' 'session' 'gemini'", "Gemini packaged hooks must invoke traceary hook session directly"},
 		{"'hook' 'audit' 'gemini'", "Gemini packaged hooks must invoke traceary hook audit directly"},
 		{"'hook' 'prompt' 'gemini'", "Gemini packaged hooks must invoke traceary hook prompt directly"},
+		{"'hook' 'transcript' 'gemini'", "Gemini packaged hooks must invoke traceary hook transcript directly"},
 		{"'hook' 'compact' 'gemini' 'pre-compact'", "Gemini packaged hooks must invoke traceary hook compact pre-compact directly"},
 	} {
 		if !strings.Contains(hooksRaw, fragment.sub) {

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -373,11 +373,12 @@ func checkGemini(root, version string) error {
 		return xerrors.Errorf("gemini extension must expose GEMINI.md as context file")
 	}
 
-	hooks, hooksRaw, err := readHookFile(root, "integrations/gemini-extension/hooks/hooks.json")
+	hooksPath := "integrations/gemini-extension/hooks/hooks.json"
+	hooks, _, err := readHookFile(root, hooksPath)
 	if err != nil {
 		return err
 	}
-	if err := checkNoDuplicateTracearyHookEntries("integrations/gemini-extension/hooks/hooks.json", hooks); err != nil {
+	if err := checkNoDuplicateTracearyHookEntries(hooksPath, hooks); err != nil {
 		return err
 	}
 	for _, event := range []string{"SessionStart", "SessionEnd", "BeforeAgent", "AfterAgent", "AfterTool", "PreCompress"} {
@@ -385,15 +386,21 @@ func checkGemini(root, version string) error {
 			return xerrors.Errorf("gemini hooks must include %s", event)
 		}
 	}
-	for _, fragment := range []struct{ sub, msg string }{
-		{"'hook' 'session' 'gemini'", "Gemini packaged hooks must invoke traceary hook session directly"},
-		{"'hook' 'audit' 'gemini'", "Gemini packaged hooks must invoke traceary hook audit directly"},
-		{"'hook' 'prompt' 'gemini'", "Gemini packaged hooks must invoke traceary hook prompt directly"},
-		{"'hook' 'transcript' 'gemini'", "Gemini packaged hooks must invoke traceary hook transcript directly"},
-		{"'hook' 'compact' 'gemini' 'pre-compact'", "Gemini packaged hooks must invoke traceary hook compact pre-compact directly"},
+	for _, required := range []struct {
+		event           string
+		matcher         string
+		name            string
+		commandFragment string
+	}{
+		{"SessionStart", "*", "traceary-session-start", "'hook' 'session' 'gemini' 'start'"},
+		{"SessionEnd", "*", "traceary-session-end", "'hook' 'session' 'gemini' 'end'"},
+		{"BeforeAgent", "*", "traceary-prompt", "'hook' 'prompt' 'gemini'"},
+		{"AfterAgent", "*", "traceary-transcript", "'hook' 'transcript' 'gemini'"},
+		{"AfterTool", "run_shell_command", "traceary-audit", "'hook' 'audit' 'gemini'"},
+		{"PreCompress", "*", "traceary-pre-compress", "'hook' 'compact' 'gemini' 'pre-compact'"},
 	} {
-		if !strings.Contains(hooksRaw, fragment.sub) {
-			return xerrors.Errorf("%s", fragment.msg)
+		if err := requirePackagedHookCommand(hooksPath, hooks, required.event, required.matcher, required.name, required.commandFragment); err != nil {
+			return err
 		}
 	}
 	for _, rel := range []struct{ path, msg string }{
@@ -451,6 +458,38 @@ func hookMatchers(entries []hookEntry) []string {
 		matchers = append(matchers, entry.Matcher)
 	}
 	return matchers
+}
+
+func requirePackagedHookCommand(rel string, hooks hookFile, event, matcher, name, commandFragment string) error {
+	entries, ok := hooks.Hooks[event]
+	if !ok {
+		return xerrors.Errorf("%s must include %s", rel, event)
+	}
+	for _, entry := range entries {
+		if entry.Matcher != matcher {
+			continue
+		}
+		for _, command := range entry.Hooks {
+			if command.Name != name {
+				continue
+			}
+			if command.Type != "command" {
+				return xerrors.Errorf("%s %s/%s must use command hook type, got %q", rel, event, name, command.Type)
+			}
+			if strings.Contains(command.Command, commandFragment) {
+				return nil
+			}
+		}
+	}
+	return xerrors.Errorf(
+		"%s must include %s matcher %q hook %q invoking %s (got matchers %v)",
+		rel,
+		event,
+		matcher,
+		name,
+		commandFragment,
+		hookMatchers(entries),
+	)
 }
 
 func readHookFile(root, rel string) (hookFile, string, error) {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -78,3 +78,46 @@ func TestCheckNoDuplicateTracearyHookEntries_AllowsDistinctMatchers(t *testing.T
 		t.Fatalf("checkNoDuplicateTracearyHookEntries() error = %v, want nil for distinct matchers", err)
 	}
 }
+
+func TestRequirePackagedHookCommand_FailsOnMatcherDrift(t *testing.T) {
+	t.Parallel()
+
+	err := requirePackagedHookCommand("integrations/gemini-extension/hooks/hooks.json", hookFile{
+		Hooks: map[string][]hookEntry{
+			"AfterTool": {
+				{
+					Matcher: "*",
+					Hooks: []hookCommand{
+						{Name: "traceary-audit", Type: "command", Command: "'traceary' 'hook' 'audit' 'gemini'"},
+					},
+				},
+			},
+		},
+	}, "AfterTool", "run_shell_command", "traceary-audit", "'hook' 'audit' 'gemini'")
+	if err == nil {
+		t.Fatal("requirePackagedHookCommand() error = nil, want matcher drift error")
+	}
+	if !strings.Contains(err.Error(), "AfterTool") || !strings.Contains(err.Error(), "run_shell_command") {
+		t.Fatalf("error = %v, want AfterTool/run_shell_command drift message", err)
+	}
+}
+
+func TestRequirePackagedHookCommand_PassesOnExpectedCommand(t *testing.T) {
+	t.Parallel()
+
+	err := requirePackagedHookCommand("integrations/gemini-extension/hooks/hooks.json", hookFile{
+		Hooks: map[string][]hookEntry{
+			"AfterTool": {
+				{
+					Matcher: "run_shell_command",
+					Hooks: []hookCommand{
+						{Name: "traceary-audit", Type: "command", Command: "'traceary' 'hook' 'audit' 'gemini'"},
+					},
+				},
+			},
+		},
+	}, "AfterTool", "run_shell_command", "traceary-audit", "'hook' 'audit' 'gemini'")
+	if err != nil {
+		t.Fatalf("requirePackagedHookCommand() error = %v, want nil", err)
+	}
+}

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -8,8 +8,10 @@ Gemini 向け package は `integrations/gemini-extension/` にあります。Gem
 
 - `traceary mcp-server` を使う `traceary` MCP server
 - `SessionStart` / `SessionEnd` hook
+- `BeforeAgent` prompt hook（送信された user prompt を `prompt` event として記録）
 - `AfterAgent` transcript hook（agent の応答を `transcript` event として記録）
 - `run_shell_command` 向け `AfterTool` audit hook
+- `PreCompress` compact marker hook（Gemini に post-compress summary hook がないため、圧縮前の境界だけを記録）
 - slash command の `/traceary-help` と `/traceary-doctor`
 - 文脈で効く `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。
 
@@ -91,6 +93,18 @@ gemini extensions uninstall traceary
 ```sh
 traceary doctor --client gemini --json
 ```
+
+`doctor` は Gemini capture について次の 2 つを確認します。
+
+- `gemini-config`: Traceary 管理の hook が一部だけ（例: 旧式の
+  SessionStart / SessionEnd / AfterTool のみ）になっている場合に警告します。
+  settings.json へ入れている場合は `traceary doctor --client gemini --fix`
+  で修復できます。
+- `gemini-event-coverage`: recent Gemini session を見て、boundary-only の
+  session 比率が `--coverage-threshold`（既定 `0.5`）を超えると警告します。
+  settings.json ではなく Gemini extension package を使っている場合は、
+  `gemini extensions update traceary` で package 側の BeforeAgent /
+  AfterAgent hook を更新してください。
 
 package 自体の validate は次です。
 

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -100,8 +100,8 @@ traceary doctor --client gemini --json
   SessionStart / SessionEnd / AfterTool のみ）になっている場合に警告します。
   settings.json へ入れている場合は `traceary doctor --client gemini --fix`
   で修復できます。
-- `gemini-event-coverage`: recent Gemini session を見て、boundary-only の
-  session 比率が `--coverage-threshold`（既定 `0.5`）を超えると警告します。
+- `gemini-event-coverage`: recent Gemini session を見て、prompt/transcript が欠けた
+  session 比率が `--coverage-threshold`（既定 `0.5`）を超えると警告します。audit のみの session も会話内容の coverage がないため警告対象です。
   settings.json ではなく Gemini extension package を使っている場合は、
   `gemini extensions update traceary` で package 側の BeforeAgent /
   AfterAgent hook を更新してください。

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -122,7 +122,7 @@ traceary doctor --client gemini --json
   repaired with `traceary doctor --client gemini --fix` for settings.json
   installs.
 - `gemini-event-coverage` scans recent Gemini sessions and warns when the
-  boundary-only session ratio is above `--coverage-threshold` (default `0.5`).
+  prompt/transcript-missing session ratio is above `--coverage-threshold` (default `0.5`). Audit-only sessions still warn because they lack conversation coverage.
   If you rely on the Gemini extension package instead of settings.json, update
   it with `gemini extensions update traceary` so the packaged BeforeAgent /
   AfterAgent hooks are refreshed.

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -8,8 +8,10 @@ The Gemini package lives under `integrations/gemini-extension/`. Gemini CLI expe
 
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart` / `SessionEnd` hooks
+- `BeforeAgent` prompt hook — records the submitted user prompt as a `prompt` event
 - `AfterAgent` transcript hook — records the agent response as a `transcript` event
 - `AfterTool` shell-audit hook for `run_shell_command`
+- `PreCompress` compact marker hook — records the pre-compress boundary (Gemini exposes no post-compress summary hook)
 - slash commands: `/traceary-help` and `/traceary-doctor`
 - contextual skills: `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember`. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて").
 
@@ -112,6 +114,18 @@ Primary runtime check:
 ```sh
 traceary doctor --client gemini --json
 ```
+
+`doctor` now checks two Gemini capture failure modes:
+
+- `gemini-config` warns when the installed Traceary-managed hooks are partial
+  (for example, legacy SessionStart / SessionEnd / AfterTool only) and can be
+  repaired with `traceary doctor --client gemini --fix` for settings.json
+  installs.
+- `gemini-event-coverage` scans recent Gemini sessions and warns when the
+  boundary-only session ratio is above `--coverage-threshold` (default `0.5`).
+  If you rely on the Gemini extension package instead of settings.json, update
+  it with `gemini extensions update traceary` so the packaged BeforeAgent /
+  AfterAgent hooks are refreshed.
 
 Package validation:
 

--- a/examples/hooks/gemini.settings.json
+++ b/examples/hooks/gemini.settings.json
@@ -28,6 +28,34 @@
         ]
       }
     ],
+    "BeforeAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-prompt",
+            "type": "command",
+            "command": "'traceary' 'hook' 'prompt' 'gemini'",
+            "timeout": 5000,
+            "description": "Record user prompt as a prompt event"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-transcript",
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'gemini'",
+            "timeout": 5000,
+            "description": "Record agent response as a transcript event"
+          }
+        ]
+      }
+    ],
     "AfterTool": [
       {
         "matcher": "run_shell_command",
@@ -38,6 +66,20 @@
             "command": "'traceary' 'hook' 'audit' 'gemini'",
             "timeout": 5000,
             "description": "Record shell command audits in Traceary"
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-pre-compress",
+            "type": "command",
+            "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'",
+            "timeout": 5000,
+            "description": "Record a pre-compact marker (Gemini exposes no post-compress hook)"
           }
         ]
       }

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -106,6 +107,38 @@ func (i *HooksInspector) DuplicateManagedHooks(content []byte) ([]application.Ho
 // infrastructure package directly.
 func (i *HooksInspector) ExtractManagedKeyFromEntry(name, command string) string {
 	return ExtractTracearyManagedKeyFromEntry(name, command)
+}
+
+// ManagedCoverage reports which Traceary-managed enrichment surfaces are wired
+// in a hook configuration. It uses the same canonical-key extraction as
+// duplicate detection so dev-build installs with a non-`traceary` binary name
+// are still recognized through their Traceary-managed entry names.
+func (i *HooksInspector) ManagedCoverage(content []byte) (application.HookManagedCoverage, error) {
+	hooksMap, ok, err := parseHooksMap(content)
+	if err != nil || !ok {
+		return application.HookManagedCoverage{}, err
+	}
+
+	coverage := application.HookManagedCoverage{}
+	for _, matchers := range hooksMap {
+		for _, matcher := range matchers {
+			for _, command := range matcher.Hooks {
+				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
+				switch {
+				case strings.HasPrefix(managedKey, "traceary-prompt.sh:"):
+					coverage.HasPrompt = true
+				case strings.HasPrefix(managedKey, "traceary-transcript.sh:"):
+					coverage.HasTranscript = true
+				case strings.HasPrefix(managedKey, "traceary-audit.sh:"):
+					coverage.HasAudit = true
+				case strings.HasPrefix(managedKey, "traceary-compact.sh:"):
+					coverage.HasCompact = true
+				}
+			}
+		}
+	}
+
+	return coverage, nil
 }
 
 func parseHooksMap(content []byte) (map[string][]hookMatcherDocument, bool, error) {

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -124,18 +124,22 @@ func (i *HooksInspector) ManagedCoverage(content []byte, client string) (applica
 	}
 
 	coverage := application.HookManagedCoverage{}
-	for _, matchers := range hooksMap {
+	for event, matchers := range hooksMap {
 		for _, matcher := range matchers {
+			matcherValue := ""
+			if matcher.Matcher != nil {
+				matcherValue = *matcher.Matcher
+			}
 			for _, command := range matcher.Hooks {
 				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
 				switch {
-				case managedKey == managedKeyOf("traceary-prompt.sh", targetClient):
+				case event == "BeforeAgent" && managedKey == managedKeyOf("traceary-prompt.sh", targetClient):
 					coverage.HasPrompt = true
-				case managedKey == managedKeyOf("traceary-transcript.sh", targetClient):
+				case event == "AfterAgent" && managedKey == managedKeyOf("traceary-transcript.sh", targetClient):
 					coverage.HasTranscript = true
-				case managedKey == managedKeyOf("traceary-audit.sh", targetClient):
+				case event == "AfterTool" && matcherValue == "run_shell_command" && managedKey == managedKeyOf("traceary-audit.sh", targetClient):
 					coverage.HasAudit = true
-				case strings.HasPrefix(managedKey, managedKeyOf("traceary-compact.sh", targetClient)+":"):
+				case event == "PreCompress" && strings.HasPrefix(managedKey, managedKeyOf("traceary-compact.sh", targetClient)+":"):
 					coverage.HasCompact = true
 				}
 			}

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -110,13 +110,17 @@ func (i *HooksInspector) ExtractManagedKeyFromEntry(name, command string) string
 }
 
 // ManagedCoverage reports which Traceary-managed enrichment surfaces are wired
-// in a hook configuration. It uses the same canonical-key extraction as
-// duplicate detection so dev-build installs with a non-`traceary` binary name
-// are still recognized through their Traceary-managed entry names.
-func (i *HooksInspector) ManagedCoverage(content []byte) (application.HookManagedCoverage, error) {
+// for the given client in a hook configuration. It uses the same canonical-key
+// extraction as duplicate detection so dev-build installs with a non-`traceary`
+// binary name are still recognized through their Traceary-managed entry names.
+func (i *HooksInspector) ManagedCoverage(content []byte, client string) (application.HookManagedCoverage, error) {
 	hooksMap, ok, err := parseHooksMap(content)
 	if err != nil || !ok {
 		return application.HookManagedCoverage{}, err
+	}
+	targetClient := strings.TrimSpace(client)
+	if targetClient == "" {
+		return application.HookManagedCoverage{}, nil
 	}
 
 	coverage := application.HookManagedCoverage{}
@@ -125,13 +129,13 @@ func (i *HooksInspector) ManagedCoverage(content []byte) (application.HookManage
 			for _, command := range matcher.Hooks {
 				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
 				switch {
-				case strings.HasPrefix(managedKey, "traceary-prompt.sh:"):
+				case managedKey == managedKeyOf("traceary-prompt.sh", targetClient):
 					coverage.HasPrompt = true
-				case strings.HasPrefix(managedKey, "traceary-transcript.sh:"):
+				case managedKey == managedKeyOf("traceary-transcript.sh", targetClient):
 					coverage.HasTranscript = true
-				case strings.HasPrefix(managedKey, "traceary-audit.sh:"):
+				case managedKey == managedKeyOf("traceary-audit.sh", targetClient):
 					coverage.HasAudit = true
-				case strings.HasPrefix(managedKey, "traceary-compact.sh:"):
+				case strings.HasPrefix(managedKey, managedKeyOf("traceary-compact.sh", targetClient)+":"):
 					coverage.HasCompact = true
 				}
 			}

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -296,6 +296,17 @@ func TestHooksInspector_ManagedCoverage(t *testing.T) {
 			}`,
 			want: application.HookManagedCoverage{},
 		},
+		{
+			name: "ignores Traceary managed hooks for another client",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'codex'"}]}],
+			    "AfterAgent": [{"hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'codex'"}]}],
+			    "AfterTool": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -303,7 +314,7 @@ func TestHooksInspector_ManagedCoverage(t *testing.T) {
 			t.Parallel()
 
 			inspector := filesystem.NewHooksInspector()
-			got, err := inspector.ManagedCoverage([]byte(tt.payload))
+			got, err := inspector.ManagedCoverage([]byte(tt.payload), "gemini")
 			if err != nil {
 				t.Fatalf("ManagedCoverage() error = %v", err)
 			}

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -258,7 +258,7 @@ func TestHooksInspector_ManagedCoverage(t *testing.T) {
 			  "hooks": {
 			    "BeforeAgent": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'prompt' 'gemini'"}]}],
 			    "AfterAgent": [{"hooks": [{"name": "traceary-transcript", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'transcript' 'gemini'"}]}],
-			    "AfterTool": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'audit' 'gemini'"}]}]
+			    "AfterTool": [{"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'audit' 'gemini'"}]}]
 			  }
 			}`,
 			want: application.HookManagedCoverage{
@@ -268,7 +268,7 @@ func TestHooksInspector_ManagedCoverage(t *testing.T) {
 			},
 		},
 		{
-			name: "recognizes legacy script-form transcript hooks",
+			name: "recognizes legacy script-form prompt and transcript hooks",
 			payload: `{
 			  "hooks": {
 			    "BeforeAgent": [{"hooks": [{"type": "command", "command": "bash '/scripts/traceary-prompt.sh' 'gemini'"}]}],
@@ -279,7 +279,21 @@ func TestHooksInspector_ManagedCoverage(t *testing.T) {
 			want: application.HookManagedCoverage{
 				HasPrompt:     true,
 				HasTranscript: true,
-				HasAudit:      true,
+			},
+		},
+
+		{
+			name: "ignores stale wildcard Gemini audit matcher",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'gemini'"}]}],
+			    "AfterAgent": [{"hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'gemini'"}]}],
+			    "AfterTool": [{"matcher": "*", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'gemini'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
 			},
 		},
 		{

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -212,3 +212,114 @@ func TestHooksInspector_DuplicateManagedHooks_AllowsDistinctMatchers(t *testing.
 		t.Fatalf("duplicates = %+v, want none for distinct matchers", duplicates)
 	}
 }
+
+func TestHooksInspector_ManagedCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+		want    application.HookManagedCoverage
+	}{
+		{
+			name: "reports complete Gemini enrichment coverage",
+			payload: `{
+			  "hooks": {
+			    "SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'start'"}]}],
+			    "BeforeAgent": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'gemini'"}]}],
+			    "AfterAgent": [{"hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'gemini'"}]}],
+			    "AfterTool": [{"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'gemini'"}]}],
+			    "PreCompress": [{"hooks": [{"name": "traceary-pre-compress", "type": "command", "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
+				HasAudit:      true,
+				HasCompact:    true,
+			},
+		},
+		{
+			name: "reports legacy boundary and audit only config as missing prompt and transcript",
+			payload: `{
+			  "hooks": {
+			    "SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'start'"}]}],
+			    "SessionEnd": [{"hooks": [{"name": "traceary-session-end", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'end'"}]}],
+			    "AfterTool": [{"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'gemini'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasAudit: true,
+			},
+		},
+		{
+			name: "recognizes non-canonical traceary binary through entry names",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'prompt' 'gemini'"}]}],
+			    "AfterAgent": [{"hooks": [{"name": "traceary-transcript", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'transcript' 'gemini'"}]}],
+			    "AfterTool": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "'/tmp/traceary-qa' 'hook' 'audit' 'gemini'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
+				HasAudit:      true,
+			},
+		},
+		{
+			name: "recognizes legacy script-form transcript hooks",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"hooks": [{"type": "command", "command": "bash '/scripts/traceary-prompt.sh' 'gemini'"}]}],
+			    "AfterAgent": [{"hooks": [{"type": "command", "command": "bash '/scripts/traceary-transcript.sh' 'gemini'"}]}],
+			    "AfterTool": [{"hooks": [{"type": "command", "command": "bash '/scripts/traceary-audit.sh' 'gemini'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
+				HasAudit:      true,
+			},
+		},
+		{
+			name:    "missing hooks field has zero coverage",
+			payload: `{"theme":"dark"}`,
+			want:    application.HookManagedCoverage{},
+		},
+		{
+			name: "ignores user managed commands",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"hooks": [{"name": "user-prompt", "type": "command", "command": "'/tmp/custom' 'hook' 'prompt' 'gemini'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inspector := filesystem.NewHooksInspector()
+			got, err := inspector.ManagedCoverage([]byte(tt.payload))
+			if err != nil {
+				t.Fatalf("ManagedCoverage() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("coverage mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHookManagedCoverage_MissingEnrichment(t *testing.T) {
+	t.Parallel()
+
+	got := (application.HookManagedCoverage{HasAudit: true}).MissingEnrichment()
+	want := []string{"prompt", "transcript"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("MissingEnrichment() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -247,7 +247,7 @@ func isTracearyManagedHookCommandDocument(command hookCommandDocument, desiredDi
 	return managed
 }
 
-var tracearyHookScriptPattern = regexp.MustCompile(`traceary-(session|audit|compact|prompt)\.sh`)
+var tracearyHookScriptPattern = regexp.MustCompile(`traceary-(session|audit|compact|prompt|transcript)\.sh`)
 
 // ExtractTracearyManagedKey is the exported counterpart of
 // extractTracearyManagedKey. Higher-level diagnostics (for example

--- a/integrations/gemini-extension/hooks/hooks.json
+++ b/integrations/gemini-extension/hooks/hooks.json
@@ -58,14 +58,14 @@
     ],
     "AfterTool": [
       {
-        "matcher": "*",
+        "matcher": "run_shell_command",
         "hooks": [
           {
             "name": "traceary-audit",
             "type": "command",
             "command": "'traceary' 'hook' 'audit' 'gemini'",
             "timeout": 5000,
-            "description": "Record tool execution audits in Traceary"
+            "description": "Record shell command audits in Traceary"
           }
         ]
       }

--- a/presentation/cli/cockpit.go
+++ b/presentation/cli/cockpit.go
@@ -418,8 +418,9 @@ func (c *RootCLI) loadCockpitDoctorReport(ctx context.Context, opts cockpitComma
 		return nil, xerrors.New(Localize("hooks orchestrator is not configured", "hooks orchestrator が設定されていません"))
 	}
 	return c.buildDoctorReport(ctx, doctorCommandInput{
-		dbPath:         opts.dbPath,
-		currentVersion: "",
+		dbPath:            opts.dbPath,
+		currentVersion:    "",
+		coverageThreshold: defaultDoctorCoverageThreshold,
 	})
 }
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/duck8823/traceary/application"
 	apptypes "github.com/duck8823/traceary/application/types"
+	appusecase "github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -31,6 +33,10 @@ const (
 	doctorSeverityPass = "PASS"
 	doctorSeverityWarn = "WARN"
 	doctorSeverityFail = "FAIL"
+
+	defaultDoctorCoverageThreshold = 0.5
+	doctorEventCoverageScanLimit   = 500
+	doctorEventCoverageMinSample   = 3
 )
 
 type doctorCheck struct {
@@ -86,13 +92,14 @@ func (e doctorExitError) ExitCode() int { return e.exitCode }
 
 func (c *RootCLI) newDoctorCommand() *cobra.Command {
 	var (
-		dbPath     string
-		client     string
-		projectDir string
-		asJSON     bool
-		fix        bool
-		dryRun     bool
-		strict     bool
+		dbPath            string
+		client            string
+		projectDir        string
+		asJSON            bool
+		fix               bool
+		dryRun            bool
+		strict            bool
+		coverageThreshold float64
 	)
 
 	doctorCmd := &cobra.Command{
@@ -102,14 +109,15 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 		Args:    noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.runDoctor(cmd.Context(), cmd.OutOrStdout(), doctorCommandInput{
-				dbPath:         dbPath,
-				client:         client,
-				projectDir:     projectDir,
-				currentVersion: cmd.Root().Version,
-				asJSON:         asJSON,
-				fix:            fix,
-				dryRun:         dryRun,
-				strict:         strict,
+				dbPath:            dbPath,
+				client:            client,
+				projectDir:        projectDir,
+				currentVersion:    cmd.Root().Version,
+				asJSON:            asJSON,
+				fix:               fix,
+				dryRun:            dryRun,
+				strict:            strict,
+				coverageThreshold: coverageThreshold,
 			})
 		},
 	}
@@ -120,6 +128,7 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 	doctorCmd.Flags().BoolVar(&fix, "fix", false, Localize("apply known safe remediations for warning and failing checks", "警告・失敗チェックに対して既知の安全な修復を適用する"))
 	doctorCmd.Flags().BoolVar(&dryRun, "dry-run", false, Localize("preview --fix actions without writing files", "ファイルを書き込まずに --fix の処理をプレビューする"))
 	doctorCmd.Flags().BoolVar(&strict, "strict", false, Localize("audit-reliability: report every exact duplicate group regardless of time, not only near-simultaneous writes", "audit-reliability: 時間に関係なく完全一致する duplicate group をすべて報告する（near-simultaneous な書き込みだけに限定しない）"))
+	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("gemini-event-coverage: warn when the recent boundary-only session ratio is above this value (0.0 to 1.0)", "gemini-event-coverage: recent session の boundary-only 比率がこの値を超えたら警告する (0.0 から 1.0)"))
 
 	return doctorCmd
 }
@@ -127,6 +136,9 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 func (c *RootCLI) runDoctor(ctx context.Context, output io.Writer, input doctorCommandInput) error {
 	if c.storeManagement == nil {
 		return xerrors.New(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if err := validateDoctorCoverageThreshold(input.coverageThreshold); err != nil {
+		return err
 	}
 
 	report, err := c.buildDoctorReport(ctx, input)
@@ -154,6 +166,17 @@ func (c *RootCLI) runDoctor(ctx context.Context, output io.Writer, input doctorC
 		return doctorExitError{message: message, exitCode: report.ExitCode}
 	}
 
+	return nil
+}
+
+func validateDoctorCoverageThreshold(value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > 1 {
+		return xerrors.Errorf(
+			"%s: %g",
+			Localize("--coverage-threshold must be between 0.0 and 1.0", "--coverage-threshold は 0.0 から 1.0 の範囲で指定してください"),
+			value,
+		)
+	}
 	return nil
 }
 
@@ -281,6 +304,9 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		check := c.inspectClaudeOrConfigFile(targetClient, outputPath, resolvedProjectDir)
 		c.attachDoctorConfigFix(&check, targetClient, outputPath, resolvedProjectDir)
 		report.Checks = append(report.Checks, check)
+		if targetClient == "gemini" {
+			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
+		}
 		report.Checks = append(report.Checks, c.inspectMCPRegistrationForClient(targetClient, outputPath))
 
 		if globalCheck := c.inspectGlobalConfigForClient(targetClient); globalCheck != nil {
@@ -721,6 +747,149 @@ func formatCommandAuditWorkspaceDriftSamples(samples []commandAuditWorkspaceDrif
 	return strings.Join(parts, "; ")
 }
 
+func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, outputPath, projectDir string, threshold float64) doctorCheck {
+	checkName := client + "-event-coverage"
+	if c.event == nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusSkip,
+			Message: localizef("event usecase is not configured", "event usecase が設定されていません"),
+		}
+	}
+
+	events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(doctorEventCoverageScanLimit).
+		Agent(types.Agent(client)).
+		Build())
+	if err != nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to list recent %s events: %v", "recent %s event の取得に失敗しました: %v", client, err),
+		}
+	}
+
+	inputs := make([]appusecase.EventCoverageInput, 0, len(events))
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		inputs = append(inputs, appusecase.EventCoverageInput{
+			SessionID: event.SessionID().String(),
+			Kind:      event.Kind(),
+		})
+	}
+	coverage := appusecase.SummarizeSessionEventCoverage(inputs)
+	ratio := coverage.BoundaryOnlyRatio()
+	if coverage.Sessions < doctorEventCoverageMinSample {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"scanned %d recent %s event(s); only %d complete session(s) observed (minimum sample %d), so event coverage is not judged yet",
+				"%d 件の recent %s event を検査しました。完全に観測できた session は %d 件だけです (minimum sample %d) のため、event coverage はまだ判定しません",
+				len(events),
+				client,
+				coverage.Sessions,
+				doctorEventCoverageMinSample,
+			),
+		}
+	}
+	if ratio <= threshold {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"scanned %d recent %s event(s); event coverage is healthy (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				"%d 件の recent %s event を検査しました。event coverage は健全です (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				len(events),
+				client,
+				coverage.Sessions,
+				coverage.BoundaryOnly,
+				coverage.Enriched,
+				coverage.WithPrompt,
+				coverage.WithTranscript,
+				coverage.WithCommand,
+				ratio,
+				threshold,
+			),
+		}
+	}
+
+	configCoverage, configCoverageKnown := c.managedCoverageForConfigFile(outputPath)
+	if configCoverageKnown {
+		if missing := configCoverage.MissingEnrichment(); len(missing) > 0 {
+			fixCommand := fmt.Sprintf("traceary doctor --client %s --project-dir %s --fix", client, shellQuote(projectDir))
+			return doctorCheck{
+				Name:       checkName,
+				Status:     doctorStatusWarn,
+				FixCommand: fixCommand,
+				Hint: localizef(
+					"the installed hook config is missing %s coverage; run `%s` to refresh Traceary-managed hooks without touching user hooks",
+					"インストール済み hook config に %s coverage がありません。`%s` で Traceary 管理 hook を更新できます (user hook は保持)",
+					strings.Join(missing, ", "),
+					fixCommand,
+				),
+				Message: localizef(
+					"scanned %d recent %s event(s); %.0f%% of complete sessions are boundary-only (sessions=%d boundary_only=%d enriched=%d, threshold=%.0f%%). The installed config is missing Traceary-managed %s hooks: %s",
+					"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% が boundary-only です (sessions=%d boundary_only=%d enriched=%d, threshold=%.0f%%)。インストール済み config に Traceary 管理の %s hook がありません: %s",
+					len(events),
+					client,
+					ratio*100,
+					coverage.Sessions,
+					coverage.BoundaryOnly,
+					coverage.Enriched,
+					threshold*100,
+					strings.Join(missing, ", "),
+					outputPath,
+				),
+			}
+		}
+	}
+
+	hint := Localize(
+		"hook config appears to include enrichment coverage; inspect hook timeouts, host hook behavior, and recent event IDs with `traceary list --agent gemini`",
+		"hook config には enrichment coverage が含まれているようです。hook timeout、host 側の hook 挙動、recent event ID を `traceary list --agent gemini` で確認してください",
+	)
+	if !configCoverageKnown {
+		hint = localizef(
+			"the project hook config could not be inspected; first fix %s-config, then rerun doctor",
+			"project hook config を検査できませんでした。先に %s-config を修復してから doctor を再実行してください",
+			client,
+		)
+	}
+	return doctorCheck{
+		Name:   checkName,
+		Status: doctorStatusWarn,
+		Hint:   hint,
+		Message: localizef(
+			"scanned %d recent %s event(s); %.0f%% of complete sessions are boundary-only (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% が boundary-only です (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			len(events),
+			client,
+			ratio*100,
+			coverage.Sessions,
+			coverage.BoundaryOnly,
+			coverage.Enriched,
+			coverage.WithPrompt,
+			coverage.WithTranscript,
+			coverage.WithCommand,
+			threshold*100,
+		),
+	}
+}
+
+func (c *RootCLI) managedCoverageForConfigFile(path string) (application.HookManagedCoverage, bool) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return application.HookManagedCoverage{}, false
+	}
+	coverage, err := c.hooksInspector.ManagedCoverage(content)
+	if err != nil {
+		return application.HookManagedCoverage{}, false
+	}
+	return coverage, true
+}
+
 // inspectClaudePluginCacheStatus compares the cached Traceary Claude
 // Code plugin version against the marketplace manifest the plugin was
 // registered from. A stale cache is the exact failure mode v0.8.0
@@ -1095,6 +1264,20 @@ func (c *RootCLI) inspectGlobalConfigForClient(client string) *doctorCheck {
 		}
 	}
 	if hasTracearyHook {
+		if client == "gemini" {
+			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content)
+			if coverageErr != nil {
+				return &doctorCheck{
+					Name:    checkName,
+					Status:  doctorStatusFail,
+					Message: localizef("global %s config is not a valid hooks-shaped JSON object: %s", "global %s config は hooks 形式の JSON として解釈できません: %s", client, globalPath),
+				}
+			}
+			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
+				check := missingGeminiHookCoverageCheck(checkName, globalPath, home, missing, false)
+				return &check
+			}
+		}
 		return &doctorCheck{
 			Name:   checkName,
 			Status: doctorStatusPass,
@@ -1220,6 +1403,19 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 				}
 			}
 		}
+		if client == "gemini" {
+			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content)
+			if coverageErr != nil {
+				return doctorCheck{
+					Name:    client + "-config",
+					Status:  doctorStatusFail,
+					Message: localizef("%s config file must be a hooks-shaped JSON object: %s", "%s の設定ファイルは hooks 形式の JSON object である必要があります: %s", client, outputPath),
+				}
+			}
+			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
+				return missingGeminiHookCoverageCheck(client+"-config", outputPath, projectDir, missing, true)
+			}
+		}
 		return doctorCheck{
 			Name:    client + "-config",
 			Status:  doctorStatusPass,
@@ -1264,6 +1460,36 @@ func duplicateTracearyHookCheck(client, checkName, outputPath, projectDir string
 			client,
 			summary,
 			dryRunCommand,
+			outputPath,
+		),
+	}
+}
+
+func missingGeminiHookCoverageCheck(checkName, outputPath, projectDir string, missing []string, projectConfig bool) doctorCheck {
+	joinedMissing := strings.Join(missing, ", ")
+	fixCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client gemini --project-dir %s", shellQuote(projectDir))
+	hint := localizef(
+		"preview the non-destructive refresh with `%s`; it rewrites only Traceary-managed entries and preserves non-Traceary hooks",
+		"`%s` で非破壊 refresh をプレビューしてください。Traceary 管理エントリだけを更新し、Traceary 以外の hook は保持します",
+		fixCommand,
+	)
+	if !projectConfig {
+		fixCommand = "traceary hooks install --client gemini --global --upgrade"
+		hint = localizef(
+			"refresh the user-level Gemini settings with `%s`; if you use the Gemini extension package instead, run `gemini extensions update traceary`",
+			"`%s` で user-level Gemini settings を更新してください。Gemini extension package を使っている場合は `gemini extensions update traceary` を実行してください",
+			fixCommand,
+		)
+	}
+	return doctorCheck{
+		Name:       checkName,
+		Status:     doctorStatusWarn,
+		FixCommand: fixCommand,
+		Hint:       hint,
+		Message: localizef(
+			"gemini config contains Traceary-managed hooks but is missing enrichment coverage (%s). Prompt/transcript gaps make sessions look boundary-only; refresh the managed hooks: %s",
+			"gemini config に Traceary 管理 hook はありますが enrichment coverage (%s) が不足しています。prompt/transcript が欠けると session が boundary-only に見えます。管理 hook を更新してください: %s",
+			joinedMissing,
 			outputPath,
 		),
 	}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -128,7 +128,7 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 	doctorCmd.Flags().BoolVar(&fix, "fix", false, Localize("apply known safe remediations for warning and failing checks", "警告・失敗チェックに対して既知の安全な修復を適用する"))
 	doctorCmd.Flags().BoolVar(&dryRun, "dry-run", false, Localize("preview --fix actions without writing files", "ファイルを書き込まずに --fix の処理をプレビューする"))
 	doctorCmd.Flags().BoolVar(&strict, "strict", false, Localize("audit-reliability: report every exact duplicate group regardless of time, not only near-simultaneous writes", "audit-reliability: 時間に関係なく完全一致する duplicate group をすべて報告する（near-simultaneous な書き込みだけに限定しない）"))
-	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("gemini-event-coverage: warn when the recent boundary-only session ratio is above this value (0.0 to 1.0)", "gemini-event-coverage: recent session の boundary-only 比率がこの値を超えたら警告する (0.0 から 1.0)"))
+	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("gemini-event-coverage: warn when the recent prompt/transcript-missing session ratio is above this value (0.0 to 1.0)", "gemini-event-coverage: recent session の prompt/transcript 欠落比率がこの値を超えたら警告する (0.0 から 1.0)"))
 
 	return doctorCmd
 }
@@ -803,8 +803,8 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 			Name:   checkName,
 			Status: doctorStatusPass,
 			Message: localizef(
-				"scanned %d recent %s event(s); event coverage is healthy (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
-				"%d 件の recent %s event を検査しました。event coverage は健全です (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				"scanned %d recent %s event(s); prompt/transcript coverage is healthy (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				"%d 件の recent %s event を検査しました。prompt/transcript coverage は健全です (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
 				len(events),
 				client,
 				coverage.Sessions,
@@ -834,8 +834,8 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 					fixCommand,
 				),
 				Message: localizef(
-					"scanned %d recent %s event(s); %.0f%% of complete sessions are boundary-only (sessions=%d boundary_only=%d enriched=%d, threshold=%.0f%%). The installed config is missing Traceary-managed %s hooks: %s",
-					"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% が boundary-only です (sessions=%d boundary_only=%d enriched=%d, threshold=%.0f%%)。インストール済み config に Traceary 管理の %s hook がありません: %s",
+					"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%). The installed config is missing Traceary-managed %s hooks: %s",
+					"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%)。インストール済み config に Traceary 管理の %s hook がありません: %s",
 					len(events),
 					client,
 					ratio*100,
@@ -866,8 +866,8 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		Status: doctorStatusWarn,
 		Hint:   hint,
 		Message: localizef(
-			"scanned %d recent %s event(s); %.0f%% of complete sessions are boundary-only (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
-			"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% が boundary-only です (sessions=%d boundary_only=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
 			len(events),
 			client,
 			ratio*100,
@@ -1501,8 +1501,8 @@ func missingGeminiHookCoverageCheck(checkName, outputPath, projectDir string, mi
 		FixCommand: fixCommand,
 		Hint:       hint,
 		Message: localizef(
-			"gemini config contains Traceary-managed hooks but is missing enrichment coverage (%s). Prompt/transcript gaps make sessions look boundary-only; refresh the managed hooks: %s",
-			"gemini config に Traceary 管理 hook はありますが enrichment coverage (%s) が不足しています。prompt/transcript が欠けると session が boundary-only に見えます。管理 hook を更新してください: %s",
+			"gemini config contains Traceary-managed hooks but is missing enrichment coverage (%s). Prompt/transcript gaps leave sessions without conversation coverage; refresh the managed hooks: %s",
+			"gemini config に Traceary 管理 hook はありますが enrichment coverage (%s) が不足しています。prompt/transcript が欠けると session に会話内容の coverage が残りません。管理 hook を更新してください: %s",
 			joinedMissing,
 			outputPath,
 		),

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -819,7 +819,7 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		}
 	}
 
-	configCoverage, configCoverageKnown := c.managedCoverageForConfigFile(outputPath)
+	configCoverage, configCoverageKnown := c.managedCoverageForConfigFile(outputPath, client)
 	if configCoverageKnown {
 		if missing := configCoverage.MissingEnrichment(); len(missing) > 0 {
 			fixCommand := fmt.Sprintf("traceary doctor --client %s --project-dir %s --fix", client, shellQuote(projectDir))
@@ -892,12 +892,12 @@ func resolveDoctorEventCoverageWorkspace(ctx context.Context, projectDir string)
 	return types.Workspace(normalizeLocalWorkContextPath(projectDir))
 }
 
-func (c *RootCLI) managedCoverageForConfigFile(path string) (application.HookManagedCoverage, bool) {
+func (c *RootCLI) managedCoverageForConfigFile(path string, client string) (application.HookManagedCoverage, bool) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return application.HookManagedCoverage{}, false
 	}
-	coverage, err := c.hooksInspector.ManagedCoverage(content)
+	coverage, err := c.hooksInspector.ManagedCoverage(content, client)
 	if err != nil {
 		return application.HookManagedCoverage{}, false
 	}
@@ -1279,7 +1279,7 @@ func (c *RootCLI) inspectGlobalConfigForClient(client string) *doctorCheck {
 	}
 	if hasTracearyHook {
 		if client == "gemini" {
-			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content)
+			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content, client)
 			if coverageErr != nil {
 				return &doctorCheck{
 					Name:    checkName,
@@ -1418,7 +1418,7 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 			}
 		}
 		if client == "gemini" {
-			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content)
+			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content, client)
 			if coverageErr != nil {
 				return doctorCheck{
 					Name:    client + "-config",

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -757,9 +757,13 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		}
 	}
 
-	events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(doctorEventCoverageScanLimit).
-		Agent(types.Agent(client)).
-		Build())
+	workspace := resolveDoctorEventCoverageWorkspace(ctx, projectDir)
+	criteria := apptypes.NewEventListCriteriaBuilder(doctorEventCoverageScanLimit).
+		Agent(types.Agent(client))
+	if workspace.String() != "" {
+		criteria.Workspace(workspace)
+	}
+	events, err := c.event.List(ctx, criteria.Build())
 	if err != nil {
 		return doctorCheck{
 			Name:    checkName,
@@ -876,6 +880,16 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 			threshold*100,
 		),
 	}
+}
+
+func resolveDoctorEventCoverageWorkspace(ctx context.Context, projectDir string) types.Workspace {
+	if explicit := resolveExplicitWorkspaceValue(""); explicit != "" {
+		return types.Workspace(explicit)
+	}
+	if detected, err := detectRepoContextFromDir(ctx, projectDir); err == nil {
+		return types.Workspace(detected)
+	}
+	return types.Workspace(normalizeLocalWorkContextPath(projectDir))
 }
 
 func (c *RootCLI) managedCoverageForConfigFile(path string) (application.HookManagedCoverage, bool) {

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -217,6 +217,28 @@ func TestRootCLI_Doctor_GeminiGlobalConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("reports partial gemini global config as warn", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		writeGeminiPartialGlobalHooksSettings(t, homeDir)
+
+		report := runDoctorForClient(t, "gemini", projectDir)
+		globalCfg := statusByName(report, "gemini-global-config")
+		if globalCfg.Status != "warn" {
+			t.Fatalf("gemini-global-config status = %q, want warn; msg = %q", globalCfg.Status, globalCfg.Message)
+		}
+		if !strings.Contains(globalCfg.Message, "prompt") || !strings.Contains(globalCfg.Message, "transcript") {
+			t.Fatalf("gemini-global-config message = %q; want prompt/transcript gap", globalCfg.Message)
+		}
+		if !strings.Contains(globalCfg.FixCommand, "--global --upgrade") {
+			t.Fatalf("gemini-global-config FixCommand = %q; want global upgrade command", globalCfg.FixCommand)
+		}
+	})
+
 	t.Run("reports missing gemini global config as skip", func(t *testing.T) {
 		homeDir := t.TempDir()
 		projectDir := t.TempDir()
@@ -338,8 +360,85 @@ func writeGeminiGlobalHooksSettings(t *testing.T, home string) {
         "matcher": "*",
         "hooks": [
           {
+            "name": "traceary-session-start",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'gemini' 'start'"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-prompt",
+            "type": "command",
+            "command": "'traceary' 'hook' 'prompt' 'gemini'"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-transcript",
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'gemini'"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'gemini'"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeGeminiPartialGlobalHooksSettings(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".gemini")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-session-start",
+            "type": "command",
+            "command": "'traceary' 'hook' 'session' 'gemini' 'start'"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'gemini'"
           }
         ]
       }

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -3,14 +3,17 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
@@ -894,6 +897,154 @@ func TestRootCLI_DoctorGeminiMemoryActivationInvalid(t *testing.T) {
 	}
 }
 
+func TestRootCLI_DoctorGeminiCoverage(t *testing.T) {
+	t.Run("partial gemini config warns with autofix", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeLegacyGeminiProjectHookSettings(t, projectDir)
+
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "gemini-config")
+		if check.Status != "warn" {
+			t.Fatalf("gemini-config status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "prompt") || !strings.Contains(check.Message, "transcript") {
+			t.Fatalf("gemini-config message = %q; want prompt/transcript gap", check.Message)
+		}
+		if !check.AutoFixAvailable {
+			t.Fatalf("gemini-config AutoFixAvailable = false, want true")
+		}
+		if !strings.Contains(check.FixCommand, "doctor --fix --dry-run") {
+			t.Fatalf("gemini-config FixCommand = %q, want doctor dry-run preview", check.FixCommand)
+		}
+	})
+
+	t.Run("boundary only recent sessions warn when above threshold", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteGeminiProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: geminiCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "gemini-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("gemini-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "boundary-only") || !strings.Contains(check.Message, "67%") {
+			t.Fatalf("gemini-event-coverage message = %q; want ratio evidence", check.Message)
+		}
+		if eventStub.listCriteria.Agent() != types.Agent("gemini") {
+			t.Fatalf("List criteria agent = %q, want gemini", eventStub.listCriteria.Agent())
+		}
+		if eventStub.listCriteria.Limit() != 500 {
+			t.Fatalf("List criteria limit = %d, want 500", eventStub.listCriteria.Limit())
+		}
+	})
+
+	t.Run("coverage threshold flag can suppress expected warning", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteGeminiProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: geminiCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--coverage-threshold", "0.75", "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "gemini-event-coverage")
+		if check.Status != "pass" {
+			t.Fatalf("gemini-event-coverage status = %q, want pass (message=%q)", check.Status, check.Message)
+		}
+	})
+
+	t.Run("small samples are reported as pass", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteGeminiProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: geminiCoverageEvents(2, 0)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "gemini-event-coverage")
+		if check.Status != "pass" {
+			t.Fatalf("gemini-event-coverage status = %q, want pass for small sample (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "minimum sample") {
+			t.Fatalf("gemini-event-coverage message = %q; want minimum sample explanation", check.Message)
+		}
+	})
+
+	t.Run("invalid threshold is rejected", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--coverage-threshold", "1.5", "--json"})
+
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("Execute() error = nil, want invalid threshold error")
+		}
+		if !strings.Contains(err.Error(), "--coverage-threshold") {
+			t.Fatalf("Execute() error = %v, want --coverage-threshold", err)
+		}
+	})
+}
+
 func TestRootCLI_DoctorStaleActiveSessions(t *testing.T) {
 	projectDir := t.TempDir()
 	homeDir := t.TempDir()
@@ -1045,6 +1196,100 @@ func writeClaudeHookSettings(t *testing.T, projectDir string) {
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+}
+
+func writeLegacyGeminiProjectHookSettings(t *testing.T, projectDir string) {
+	t.Helper()
+	settingsPath := filepath.Join(projectDir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'start'"}]}
+    ],
+    "SessionEnd": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-end", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'end'"}]}
+    ],
+    "AfterTool": [
+      {"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'gemini'"}]}
+    ]
+  }
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(gemini legacy settings) error = %v", err)
+	}
+}
+
+func writeCompleteGeminiProjectHookSettings(t *testing.T, projectDir string) {
+	t.Helper()
+	settingsPath := filepath.Join(projectDir, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "mcpServers": {
+    "traceary": {
+      "command": "traceary",
+      "args": ["mcp-server"]
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'start'"}]}
+    ],
+    "SessionEnd": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-end", "type": "command", "command": "'traceary' 'hook' 'session' 'gemini' 'end'"}]}
+    ],
+    "BeforeAgent": [
+      {"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'gemini'"}]}
+    ],
+    "AfterAgent": [
+      {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'gemini'"}]}
+    ],
+    "AfterTool": [
+      {"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'gemini'"}]}
+    ],
+    "PreCompress": [
+      {"matcher": "*", "hooks": [{"name": "traceary-pre-compress", "type": "command", "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'"}]}
+    ]
+  }
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(gemini settings) error = %v", err)
+	}
+}
+
+func geminiCoverageEvents(boundaryOnly, enriched int) []*model.Event {
+	events := make([]*model.Event, 0, boundaryOnly*2+enriched*3)
+	createdAt := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	appendEvent := func(id string, kind types.EventKind, sessionID string) {
+		events = append(events, model.EventOf(
+			types.EventID(id),
+			kind,
+			types.Client("hook"),
+			types.Agent("gemini"),
+			types.SessionID(sessionID),
+			types.Workspace("duck8823/traceary"),
+			"body",
+			createdAt,
+		))
+	}
+	for i := 0; i < boundaryOnly; i++ {
+		sessionID := fmt.Sprintf("boundary-%d", i)
+		appendEvent(fmt.Sprintf("boundary-%d-start", i), types.EventKindSessionStarted, sessionID)
+		appendEvent(fmt.Sprintf("boundary-%d-end", i), types.EventKindSessionEnded, sessionID)
+	}
+	for i := 0; i < enriched; i++ {
+		sessionID := fmt.Sprintf("enriched-%d", i)
+		appendEvent(fmt.Sprintf("enriched-%d-start", i), types.EventKindSessionStarted, sessionID)
+		appendEvent(fmt.Sprintf("enriched-%d-prompt", i), types.EventKindPrompt, sessionID)
+		appendEvent(fmt.Sprintf("enriched-%d-transcript", i), types.EventKindTranscript, sessionID)
+	}
+	return events
 }
 
 func setTracearyPathToCurrentExecutable(t *testing.T) {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -961,6 +961,9 @@ func TestRootCLI_DoctorGeminiCoverage(t *testing.T) {
 		if eventStub.listCriteria.Agent() != types.Agent("gemini") {
 			t.Fatalf("List criteria agent = %q, want gemini", eventStub.listCriteria.Agent())
 		}
+		if wantWorkspace := types.Workspace(filepath.ToSlash(filepath.Clean(projectDir))); eventStub.listCriteria.Workspace() != wantWorkspace {
+			t.Fatalf("List criteria workspace = %q, want %q", eventStub.listCriteria.Workspace(), wantWorkspace)
+		}
 		if eventStub.listCriteria.Limit() != 500 {
 			t.Fatalf("List criteria limit = %d, want 500", eventStub.listCriteria.Limit())
 		}

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -955,7 +955,7 @@ func TestRootCLI_DoctorGeminiCoverage(t *testing.T) {
 		if check.Status != "warn" {
 			t.Fatalf("gemini-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
 		}
-		if !strings.Contains(check.Message, "boundary-only") || !strings.Contains(check.Message, "67%") {
+		if !strings.Contains(check.Message, "prompt/transcript") || !strings.Contains(check.Message, "67%") {
 			t.Fatalf("gemini-event-coverage message = %q; want ratio evidence", check.Message)
 		}
 		if eventStub.listCriteria.Agent() != types.Agent("gemini") {
@@ -993,6 +993,36 @@ func TestRootCLI_DoctorGeminiCoverage(t *testing.T) {
 		check := statusByName(report, "gemini-event-coverage")
 		if check.Status != "pass" {
 			t.Fatalf("gemini-event-coverage status = %q, want pass (message=%q)", check.Status, check.Message)
+		}
+	})
+
+	t.Run("audit only sessions still warn because prompt transcript coverage is missing", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteGeminiProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: geminiAuditOnlyCoverageEvents(3)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "gemini", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "gemini-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("gemini-event-coverage status = %q, want warn for audit-only sessions (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "prompt/transcript") || !strings.Contains(check.Message, "with_command=3") {
+			t.Fatalf("gemini-event-coverage message = %q; want prompt/transcript gap and command evidence", check.Message)
 		}
 	})
 
@@ -1291,6 +1321,37 @@ func geminiCoverageEvents(boundaryOnly, enriched int) []*model.Event {
 		appendEvent(fmt.Sprintf("enriched-%d-start", i), types.EventKindSessionStarted, sessionID)
 		appendEvent(fmt.Sprintf("enriched-%d-prompt", i), types.EventKindPrompt, sessionID)
 		appendEvent(fmt.Sprintf("enriched-%d-transcript", i), types.EventKindTranscript, sessionID)
+	}
+	return events
+}
+
+func geminiAuditOnlyCoverageEvents(count int) []*model.Event {
+	events := make([]*model.Event, 0, count*2)
+	createdAt := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < count; i++ {
+		sessionID := fmt.Sprintf("audit-only-%d", i)
+		events = append(events,
+			model.EventOf(
+				types.EventID(fmt.Sprintf("audit-only-%d-start", i)),
+				types.EventKindSessionStarted,
+				types.Client("hook"),
+				types.Agent("gemini"),
+				types.SessionID(sessionID),
+				types.Workspace("duck8823/traceary"),
+				"body",
+				createdAt,
+			),
+			model.EventOf(
+				types.EventID(fmt.Sprintf("audit-only-%d-command", i)),
+				types.EventKindCommandExecuted,
+				types.Client("hook"),
+				types.Agent("gemini"),
+				types.SessionID(sessionID),
+				types.Workspace("duck8823/traceary"),
+				"body",
+				createdAt,
+			),
+		)
 	}
 	return events
 }

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -65,14 +65,15 @@ type contextCommandInput struct {
 
 // doctorCommandInput is the resolved input to the `traceary doctor` command.
 type doctorCommandInput struct {
-	dbPath         string
-	client         string
-	projectDir     string
-	currentVersion string
-	asJSON         bool
-	fix            bool
-	dryRun         bool
-	strict         bool
+	dbPath            string
+	client            string
+	projectDir        string
+	currentVersion    string
+	asJSON            bool
+	fix               bool
+	dryRun            bool
+	strict            bool
+	coverageThreshold float64
 }
 
 // gcCommandInput is the resolved input to the `traceary gc` command.

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -27,6 +27,7 @@ type eventUsecaseStub struct {
 	contextErr       error
 	timelineBlocks   []apptypes.TimelineBlock
 	timelineErr      error
+	listCriteria     apptypes.EventListCriteria
 	timelineCriteria apptypes.TimelineCriteria
 
 	logCall struct {
@@ -80,7 +81,8 @@ func (s *eventUsecaseStub) Audit(_ context.Context, in apptypes.AuditInput, audi
 func (s *eventUsecaseStub) Search(_ context.Context, _ apptypes.EventSearchCriteria) ([]*model.Event, error) {
 	return s.searchEvents, s.searchErr
 }
-func (s *eventUsecaseStub) List(_ context.Context, _ apptypes.EventListCriteria) ([]*model.Event, error) {
+func (s *eventUsecaseStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
+	s.listCriteria = criteria
 	return s.listEvents, s.listErr
 }
 func (s *eventUsecaseStub) ListWindow(_ context.Context, _ apptypes.EventListCriteria) ([]*model.Event, error) {


### PR DESCRIPTION
## Motivation

Closes #1171.

Recent Gemini dogfood showed sessions that contained only `session_started` / `session_ended` even though normal interactions should also record prompt, transcript, and shell-command audit events. The root cause was stale or incomplete Gemini hook coverage: older installs wired only session boundaries and sometimes a broad `AfterTool` audit hook, while `traceary doctor` treated "at least one Traceary-managed hook exists" as healthy.

## Changes

- Add a reusable session event coverage classifier that treats prompt/transcript capture as the healthy conversation coverage signal and keeps command audits as separate evidence.
- Extend the hook inspector to report Traceary-managed prompt / transcript / audit / compact coverage for the requested client only.
- Make Gemini config checks coverage-aware, including `AfterTool` + `run_shell_command` validation for shell audit coverage.
- Add `gemini-event-coverage` with configurable `--coverage-threshold` (default `0.5`) and a small-sample guard.
- Update the packaged Gemini extension, example settings, and integration docs to include BeforeAgent / AfterAgent / PreCompress coverage and the new diagnostics.

## Verification

- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./application/usecase`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./infrastructure/filesystem`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./presentation/cli`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./cmd/repo-tooling`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./presentation/cli ./cmd/repo-tooling`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go build ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling integrations verify`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling docs verify-i18n`
- `rtk proxy git diff --check HEAD`
