### PR TITLE
v0.21.0-8: diagnose Claude event coverage gaps

### DIFF
--- a/application/usecase/session_event_coverage.go
+++ b/application/usecase/session_event_coverage.go
@@ -11,23 +11,25 @@ type EventCoverageInput struct {
 	Kind      types.EventKind
 }
 
-// SessionEventCoverage reports how many recent sessions captured prompt or
-// transcript events versus sessions that only have non-conversation metadata.
-// Command audits are counted separately, but they do not make a session healthy
-// for this diagnostic: a stale install that wires only session boundaries plus
-// AfterTool still misses the core prompt/transcript capture.
+// SessionEventCoverage reports how many recent sessions captured prompt and
+// transcript events versus sessions that are missing either conversation
+// surface. Command audits are counted separately, but they do not make a
+// session healthy for this diagnostic: a stale install that wires only session
+// boundaries plus AfterTool still misses the core prompt/transcript capture.
 type SessionEventCoverage struct {
 	// Sessions counts only sessions whose session_started event was
 	// observed in the scanned window. List queries return newest-first, so
 	// observing the start means every subsequent event of that session is
 	// also in the window — this avoids misclassifying a truncated session
 	// (start out of window) as prompt/transcript-missing.
-	Sessions       int
-	BoundaryOnly   int
-	Enriched       int
-	WithPrompt     int
-	WithTranscript int
-	WithCommand    int
+	Sessions                int
+	BoundaryOnly            int
+	Enriched                int
+	Complete                int
+	PromptTranscriptMissing int
+	WithPrompt              int
+	WithTranscript          int
+	WithCommand             int
 }
 
 // BoundaryOnlyRatio returns BoundaryOnly / Sessions, or 0 when no sessions
@@ -40,14 +42,27 @@ func (s SessionEventCoverage) BoundaryOnlyRatio() float64 {
 	return float64(s.BoundaryOnly) / float64(s.Sessions)
 }
 
+// PromptTranscriptMissingRatio returns the fraction of observed complete
+// sessions that are missing either the prompt or transcript event. This is the
+// stricter health signal used by doctor: a prompt-only or transcript-only
+// session still indicates a hook coverage gap even though it is not boundary
+// only.
+func (s SessionEventCoverage) PromptTranscriptMissingRatio() float64 {
+	if s.Sessions == 0 {
+		return 0
+	}
+	return float64(s.PromptTranscriptMissing) / float64(s.Sessions)
+}
+
 // SummarizeSessionEventCoverage classifies the given event observations into
 // per-session coverage counts. Prompt and transcript are the conversation
 // enrichment kinds. Command audits are useful evidence and are counted in
-// WithCommand, but command-only sessions are still reported as prompt/transcript-missing
-// for the coverage ratio because they lack the prompt/transcript data this
-// diagnostic is meant to protect. Everything else (session boundaries, compact
-// summaries, notes, …) is neutral. The function is pure and client-agnostic so
-// the same classifier can back the gemini and claude coverage diagnostics.
+// WithCommand, but command-only, prompt-only, and transcript-only sessions are
+// still reported as prompt/transcript-missing for the strict coverage ratio
+// because they lack part of the data this diagnostic is meant to protect.
+// Everything else (session boundaries, compact summaries, notes, …) is neutral.
+// The function is pure and client-agnostic so the same classifier can back the
+// gemini and claude coverage diagnostics.
 func SummarizeSessionEventCoverage(events []EventCoverageInput) SessionEventCoverage {
 	type sessionState struct {
 		started    bool
@@ -96,6 +111,11 @@ func SummarizeSessionEventCoverage(events []EventCoverageInput) SessionEventCove
 			summary.Enriched++
 		} else {
 			summary.BoundaryOnly++
+		}
+		if state.prompt && state.transcript {
+			summary.Complete++
+		} else {
+			summary.PromptTranscriptMissing++
 		}
 	}
 	return summary

--- a/application/usecase/session_event_coverage_test.go
+++ b/application/usecase/session_event_coverage_test.go
@@ -13,10 +13,11 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		events    []usecase.EventCoverageInput
-		want      usecase.SessionEventCoverage
-		wantRatio float64
+		name                             string
+		events                           []usecase.EventCoverageInput
+		want                             usecase.SessionEventCoverage
+		wantRatio                        float64
+		wantPromptTranscriptMissingRatio float64
 	}{
 		{
 			name:      "empty input yields zero counts and zero ratio",
@@ -40,35 +41,41 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 				{SessionID: "s1", Kind: types.EventKindSessionEnded},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:     1,
-				BoundaryOnly: 1,
+				Sessions:                1,
+				BoundaryOnly:            1,
+				PromptTranscriptMissing: 1,
 			},
-			wantRatio: 1,
+			wantRatio:                        1,
+			wantPromptTranscriptMissingRatio: 1,
 		},
 		{
-			name: "prompt only counts as enriched with prompt",
+			name: "prompt only counts as enriched but still misses transcript",
 			events: []usecase.EventCoverageInput{
 				{SessionID: "s1", Kind: types.EventKindSessionStarted},
 				{SessionID: "s1", Kind: types.EventKindPrompt},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:   1,
-				Enriched:   1,
-				WithPrompt: 1,
+				Sessions:                1,
+				Enriched:                1,
+				PromptTranscriptMissing: 1,
+				WithPrompt:              1,
 			},
-			wantRatio: 0,
+			wantRatio:                        0,
+			wantPromptTranscriptMissingRatio: 1,
 		},
 		{
-			name: "transcript only counts as enriched with transcript",
+			name: "transcript only counts as enriched but still misses prompt",
 			events: []usecase.EventCoverageInput{
 				{SessionID: "s1", Kind: types.EventKindSessionStarted},
 				{SessionID: "s1", Kind: types.EventKindTranscript},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:       1,
-				Enriched:       1,
-				WithTranscript: 1,
+				Sessions:                1,
+				Enriched:                1,
+				PromptTranscriptMissing: 1,
+				WithTranscript:          1,
 			},
+			wantPromptTranscriptMissingRatio: 1,
 		},
 		{
 			name: "command only is counted but does not satisfy prompt transcript coverage",
@@ -77,11 +84,13 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 				{SessionID: "s1", Kind: types.EventKindCommandExecuted},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:     1,
-				BoundaryOnly: 1,
-				WithCommand:  1,
+				Sessions:                1,
+				BoundaryOnly:            1,
+				PromptTranscriptMissing: 1,
+				WithCommand:             1,
 			},
-			wantRatio: 1,
+			wantRatio:                        1,
+			wantPromptTranscriptMissingRatio: 1,
 		},
 		{
 			name: "neutral events do not enrich a boundary only session",
@@ -91,10 +100,12 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 				{SessionID: "s1", Kind: types.EventKindNote},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:     1,
-				BoundaryOnly: 1,
+				Sessions:                1,
+				BoundaryOnly:            1,
+				PromptTranscriptMissing: 1,
 			},
-			wantRatio: 1,
+			wantRatio:                        1,
+			wantPromptTranscriptMissingRatio: 1,
 		},
 		{
 			name: "mixed sessions report ratio",
@@ -109,14 +120,17 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 				{SessionID: "truncated", Kind: types.EventKindPrompt},
 			},
 			want: usecase.SessionEventCoverage{
-				Sessions:       3,
-				BoundaryOnly:   2,
-				Enriched:       1,
-				WithPrompt:     1,
-				WithTranscript: 1,
-				WithCommand:    1,
+				Sessions:                3,
+				BoundaryOnly:            2,
+				Enriched:                1,
+				Complete:                1,
+				PromptTranscriptMissing: 2,
+				WithPrompt:              1,
+				WithTranscript:          1,
+				WithCommand:             1,
 			},
-			wantRatio: float64(2) / float64(3),
+			wantRatio:                        float64(2) / float64(3),
+			wantPromptTranscriptMissingRatio: float64(2) / float64(3),
 		},
 		{
 			name: "events with empty session id are ignored",
@@ -138,6 +152,9 @@ func TestSummarizeSessionEventCoverage(t *testing.T) {
 			}
 			if gotRatio := got.BoundaryOnlyRatio(); gotRatio != tt.wantRatio {
 				t.Fatalf("BoundaryOnlyRatio() = %v, want %v", gotRatio, tt.wantRatio)
+			}
+			if gotRatio := got.PromptTranscriptMissingRatio(); gotRatio != tt.wantPromptTranscriptMissingRatio {
+				t.Fatalf("PromptTranscriptMissingRatio() = %v, want %v", gotRatio, tt.wantPromptTranscriptMissingRatio)
 			}
 		})
 	}

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -191,7 +191,10 @@ func managedCoverageMatchesAudit(event, matcherValue, managedKey, client string)
 	}
 	switch client {
 	case "claude":
-		return event == "PostToolUse" || event == "PostToolUseFailure"
+		if event != "PostToolUse" && event != "PostToolUseFailure" {
+			return false
+		}
+		return claudeAuditMatcherCoversBash(matcherValue)
 	case "codex":
 		return event == "PostToolUse"
 	case "gemini":
@@ -199,6 +202,19 @@ func managedCoverageMatchesAudit(event, matcherValue, managedKey, client string)
 	default:
 		return false
 	}
+}
+
+func claudeAuditMatcherCoversBash(matcherValue string) bool {
+	matcher := strings.TrimSpace(matcherValue)
+	if matcher == "" || matcher == "*" || matcher == "Bash" {
+		return true
+	}
+	for _, part := range strings.Split(matcher, "|") {
+		if strings.TrimSpace(part) == "Bash" {
+			return true
+		}
+	}
+	return false
 }
 
 func managedCoverageMatchesCompact(event, managedKey, client string) bool {

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -133,13 +133,13 @@ func (i *HooksInspector) ManagedCoverage(content []byte, client string) (applica
 			for _, command := range matcher.Hooks {
 				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
 				switch {
-				case event == "BeforeAgent" && managedKey == managedKeyOf("traceary-prompt.sh", targetClient):
+				case managedCoverageMatchesPrompt(event, managedKey, targetClient):
 					coverage.HasPrompt = true
-				case event == "AfterAgent" && managedKey == managedKeyOf("traceary-transcript.sh", targetClient):
+				case managedCoverageMatchesTranscript(event, managedKey, targetClient):
 					coverage.HasTranscript = true
-				case event == "AfterTool" && matcherValue == "run_shell_command" && managedKey == managedKeyOf("traceary-audit.sh", targetClient):
+				case managedCoverageMatchesAudit(event, matcherValue, managedKey, targetClient):
 					coverage.HasAudit = true
-				case event == "PreCompress" && strings.HasPrefix(managedKey, managedKeyOf("traceary-compact.sh", targetClient)+":"):
+				case managedCoverageMatchesCompact(event, managedKey, targetClient):
 					coverage.HasCompact = true
 				}
 			}
@@ -147,6 +147,64 @@ func (i *HooksInspector) ManagedCoverage(content []byte, client string) (applica
 	}
 
 	return coverage, nil
+}
+
+func managedCoverageMatchesPrompt(event, managedKey, client string) bool {
+	if managedKey != managedKeyOf("traceary-prompt.sh", client) {
+		return false
+	}
+	switch client {
+	case "claude", "codex":
+		return event == "UserPromptSubmit"
+	case "gemini":
+		return event == "BeforeAgent"
+	default:
+		return false
+	}
+}
+
+func managedCoverageMatchesTranscript(event, managedKey, client string) bool {
+	if managedKey != managedKeyOf("traceary-transcript.sh", client) {
+		return false
+	}
+	switch client {
+	case "claude", "codex":
+		return event == "Stop"
+	case "gemini":
+		return event == "AfterAgent"
+	default:
+		return false
+	}
+}
+
+func managedCoverageMatchesAudit(event, matcherValue, managedKey, client string) bool {
+	if managedKey != managedKeyOf("traceary-audit.sh", client) {
+		return false
+	}
+	switch client {
+	case "claude":
+		return event == "PostToolUse" || event == "PostToolUseFailure"
+	case "codex":
+		return event == "PostToolUse"
+	case "gemini":
+		return event == "AfterTool" && matcherValue == "run_shell_command"
+	default:
+		return false
+	}
+}
+
+func managedCoverageMatchesCompact(event, managedKey, client string) bool {
+	if !strings.HasPrefix(managedKey, managedKeyOf("traceary-compact.sh", client)+":") {
+		return false
+	}
+	switch client {
+	case "claude":
+		return event == "PreCompact" || event == "PostCompact" || event == "SessionStart"
+	case "gemini":
+		return event == "PreCompress"
+	default:
+		return false
+	}
 }
 
 func parseHooksMap(content []byte) (map[string][]hookMatcherDocument, bool, error) {

--- a/infrastructure/filesystem/hooks_inspector.go
+++ b/infrastructure/filesystem/hooks_inspector.go
@@ -124,6 +124,7 @@ func (i *HooksInspector) ManagedCoverage(content []byte, client string) (applica
 	}
 
 	coverage := application.HookManagedCoverage{}
+	claudeAuditEvents := map[string]bool{}
 	for event, matchers := range hooksMap {
 		for _, matcher := range matchers {
 			matcherValue := ""
@@ -138,12 +139,19 @@ func (i *HooksInspector) ManagedCoverage(content []byte, client string) (applica
 				case managedCoverageMatchesTranscript(event, managedKey, targetClient):
 					coverage.HasTranscript = true
 				case managedCoverageMatchesAudit(event, matcherValue, managedKey, targetClient):
-					coverage.HasAudit = true
+					if targetClient == "claude" {
+						claudeAuditEvents[event] = true
+					} else {
+						coverage.HasAudit = true
+					}
 				case managedCoverageMatchesCompact(event, managedKey, targetClient):
 					coverage.HasCompact = true
 				}
 			}
 		}
+	}
+	if targetClient == "claude" {
+		coverage.HasAudit = claudeAuditEvents["PostToolUse"] && claudeAuditEvents["PostToolUseFailure"]
 	}
 
 	return coverage, nil

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -393,6 +393,21 @@ func TestHooksInspector_ManagedCoverage_Claude(t *testing.T) {
 			},
 		},
 		{
+			name: "Claude audit under non-shell matcher is incomplete",
+			payload: `{
+			  "hooks": {
+			    "UserPromptSubmit": [{"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}],
+			    "Stop": [{"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}],
+			    "PostToolUse": [{"matcher": "Read", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}],
+			    "PostToolUseFailure": [{"matcher": "Read", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
+			},
+		},
+		{
 			name: "rejects Gemini event names for Claude",
 			payload: `{
 			  "hooks": {

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -366,6 +366,7 @@ func TestHooksInspector_ManagedCoverage_Claude(t *testing.T) {
 			    "UserPromptSubmit": [{"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}],
 			    "Stop": [{"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}],
 			    "PostToolUse": [{"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}],
+			    "PostToolUseFailure": [{"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}],
 			    "PreCompact": [{"matcher": "*", "hooks": [{"name": "traceary-compact-pre-compact", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'pre-compact'"}]}],
 			    "PostCompact": [{"matcher": "*", "hooks": [{"name": "traceary-compact-post-compact", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'post-compact'"}]}]
 			  }
@@ -375,6 +376,20 @@ func TestHooksInspector_ManagedCoverage_Claude(t *testing.T) {
 				HasTranscript: true,
 				HasAudit:      true,
 				HasCompact:    true,
+			},
+		},
+		{
+			name: "single Claude audit event is incomplete",
+			payload: `{
+			  "hooks": {
+			    "UserPromptSubmit": [{"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}],
+			    "Stop": [{"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}],
+			    "PostToolUse": [{"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
 			},
 		},
 		{

--- a/infrastructure/filesystem/hooks_inspector_test.go
+++ b/infrastructure/filesystem/hooks_inspector_test.go
@@ -348,3 +348,87 @@ func TestHookManagedCoverage_MissingEnrichment(t *testing.T) {
 		t.Fatalf("MissingEnrichment() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestHooksInspector_ManagedCoverage_Claude(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    application.HookManagedCoverage
+	}{
+		{
+			name: "complete generated Claude coverage",
+			payload: `{
+			  "hooks": {
+			    "SessionStart": [
+			      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}]},
+			      {"matcher": "compact", "hooks": [{"name": "traceary-compact-session-start", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'session-start-compact'"}]}
+			    ],
+			    "UserPromptSubmit": [{"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}],
+			    "Stop": [{"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}],
+			    "PostToolUse": [{"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}],
+			    "PreCompact": [{"matcher": "*", "hooks": [{"name": "traceary-compact-pre-compact", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'pre-compact'"}]}],
+			    "PostCompact": [{"matcher": "*", "hooks": [{"name": "traceary-compact-post-compact", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'post-compact'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{
+				HasPrompt:     true,
+				HasTranscript: true,
+				HasAudit:      true,
+				HasCompact:    true,
+			},
+		},
+		{
+			name: "rejects Gemini event names for Claude",
+			payload: `{
+			  "hooks": {
+			    "BeforeAgent": [{"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}],
+			    "AfterAgent": [{"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}],
+			    "AfterTool": [{"matcher": "run_shell_command", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}],
+			    "PreCompress": [{"matcher": "*", "hooks": [{"name": "traceary-pre-compress", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'pre-compact'"}]}]
+			  }
+			}`,
+			want: application.HookManagedCoverage{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inspector := filesystem.NewHooksInspector()
+			got, err := inspector.ManagedCoverage([]byte(tt.payload), "claude")
+			if err != nil {
+				t.Fatalf("ManagedCoverage() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("coverage mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHooksInspector_ManagedCoverage_Codex(t *testing.T) {
+	t.Parallel()
+
+	payload := `{
+	  "hooks": {
+	    "UserPromptSubmit": [{"matcher": "", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'codex'"}]}],
+	    "Stop": [{"matcher": "", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'codex'"}]}],
+	    "PostToolUse": [{"matcher": "", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"}]}]
+	  }
+	}`
+
+	inspector := filesystem.NewHooksInspector()
+	got, err := inspector.ManagedCoverage([]byte(payload), "codex")
+	if err != nil {
+		t.Fatalf("ManagedCoverage() error = %v", err)
+	}
+	want := application.HookManagedCoverage{
+		HasPrompt:     true,
+		HasTranscript: true,
+		HasAudit:      true,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("coverage mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -947,7 +947,7 @@ func (c *RootCLI) managedCoverageForConfigFile(path string, client string) (appl
 func (c *RootCLI) managedCoverageForEventCoverage(outputPath, client string) (application.HookManagedCoverage, bool, bool, string) {
 	if client == "claude" {
 		detection := c.detectClaudeTracearyPluginForCLI()
-		if detection.Active && !c.claudeConfigHasTracearyHooks(outputPath) {
+		if detection.Active {
 			coverage, known := c.managedCoverageForInstalledClaudePlugin(detection.PluginKey)
 			return coverage, known, true, detection.PluginKey
 		}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -1015,7 +1015,7 @@ func (c *RootCLI) attachDoctorConfigFix(check *doctorCheck, client, outputPath, 
 	}
 	if client == "claude" {
 		detection := c.detectClaudeTracearyPluginForCLI()
-		if detection.Active && c.claudeConfigHasTracearyHooks(outputPath) {
+		if detection.Active {
 			return
 		}
 	}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -957,28 +957,40 @@ func (c *RootCLI) managedCoverageForEventCoverage(outputPath, client string) (ap
 }
 
 func (c *RootCLI) managedCoverageForInstalledClaudePlugin(pluginKey string) (application.HookManagedCoverage, bool) {
+	result := c.inspectInstalledClaudePluginHookCoverage(pluginKey)
+	return result.coverage, result.known
+}
+
+type installedClaudePluginHookCoverage struct {
+	coverage  application.HookManagedCoverage
+	known     bool
+	cachePath string
+}
+
+func (c *RootCLI) inspectInstalledClaudePluginHookCoverage(pluginKey string) installedClaudePluginHookCoverage {
 	if c.pluginCacheInspector == nil || pluginKey == "" {
-		return application.HookManagedCoverage{}, false
+		return installedClaudePluginHookCoverage{}
 	}
 	home, err := userHomeDirFunc()
 	if err != nil {
-		return application.HookManagedCoverage{}, false
+		return installedClaudePluginHookCoverage{}
 	}
 	status := c.pluginCacheInspector.DetectClaudePluginCacheStatus(home, pluginKey)
 	if status.CachePath != "" && status.CachedVersion != "" {
 		cacheHooksPath := filepath.Join(status.CachePath, status.CachedVersion, "hooks", "hooks.json")
 		if coverage, known := c.managedCoverageForConfigFile(cacheHooksPath, "claude"); known {
-			return coverage, true
+			return installedClaudePluginHookCoverage{coverage: coverage, known: true, cachePath: cacheHooksPath}
 		}
+		return installedClaudePluginHookCoverage{cachePath: cacheHooksPath}
 	}
 	if status.MarketplacePath != "" {
 		pluginRoot := filepath.Dir(filepath.Dir(status.MarketplacePath))
 		marketplaceHooksPath := filepath.Join(pluginRoot, "hooks", "hooks.json")
 		if coverage, known := c.managedCoverageForConfigFile(marketplaceHooksPath, "claude"); known {
-			return coverage, true
+			return installedClaudePluginHookCoverage{coverage: coverage, known: true}
 		}
 	}
-	return application.HookManagedCoverage{}, false
+	return installedClaudePluginHookCoverage{}
 }
 
 func claudePluginUpdateCommand(pluginKey string) string {
@@ -1250,8 +1262,9 @@ func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir strin
 				),
 			}
 		}
-		if coverage, known := c.managedCoverageForInstalledClaudePlugin(detection.PluginKey); known {
-			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
+		pluginCoverage := c.inspectInstalledClaudePluginHookCoverage(detection.PluginKey)
+		if pluginCoverage.known {
+			if missing := pluginCoverage.coverage.MissingEnrichment(); len(missing) > 0 {
 				updateCommand := claudePluginUpdateCommand(detection.PluginKey)
 				return doctorCheck{
 					Name:       "claude-config",
@@ -1271,6 +1284,27 @@ func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir strin
 						updateCommand,
 					),
 				}
+			}
+		}
+		if !pluginCoverage.known && pluginCoverage.cachePath != "" {
+			updateCommand := claudePluginUpdateCommand(detection.PluginKey)
+			return doctorCheck{
+				Name:       "claude-config",
+				Status:     doctorStatusWarn,
+				FixCommand: updateCommand,
+				Hint: localizef(
+					"the plugin-managed Claude hook config could not be inspected at %s; update the Claude plugin instead of trusting marketplace source hooks",
+					"plugin-managed Claude hook config を %s で検査できませんでした。marketplace source hook ではなく Claude plugin を更新してください",
+					pluginCoverage.cachePath,
+				),
+				Message: localizef(
+					"claude hooks are delivered by plugin %q (%s), but the installed cached hook config could not be inspected at %s. Update the plugin with `%s`",
+					"claude hooks は plugin %q によって提供されています (%s) が、installed cache の hook config を %s で検査できませんでした。`%s` で plugin を更新してください",
+					detection.PluginKey,
+					detection.SettingsPath,
+					pluginCoverage.cachePath,
+					updateCommand,
+				),
 			}
 		}
 		return doctorCheck{

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -783,7 +783,7 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		})
 	}
 	coverage := appusecase.SummarizeSessionEventCoverage(inputs)
-	ratio := coverage.BoundaryOnlyRatio()
+	ratio := coverage.PromptTranscriptMissingRatio()
 	if coverage.Sessions < doctorEventCoverageMinSample {
 		return doctorCheck{
 			Name:   checkName,
@@ -803,12 +803,13 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 			Name:   checkName,
 			Status: doctorStatusPass,
 			Message: localizef(
-				"scanned %d recent %s event(s); prompt/transcript coverage is healthy (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
-				"%d 件の recent %s event を検査しました。prompt/transcript coverage は健全です (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				"scanned %d recent %s event(s); prompt/transcript coverage is healthy (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
+				"%d 件の recent %s event を検査しました。prompt/transcript coverage は健全です (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d ratio=%.2f threshold=%.2f)",
 				len(events),
 				client,
 				coverage.Sessions,
-				coverage.BoundaryOnly,
+				coverage.PromptTranscriptMissing,
+				coverage.Complete,
 				coverage.Enriched,
 				coverage.WithPrompt,
 				coverage.WithTranscript,
@@ -834,13 +835,14 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 						strings.Join(missing, ", "),
 					),
 					Message: localizef(
-						"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%). The plugin-managed config is missing Traceary-managed %s hooks",
-						"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%)。plugin-managed config に Traceary 管理の %s hook がありません",
+						"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d, threshold=%.0f%%). The plugin-managed config is missing Traceary-managed %s hooks",
+						"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d, threshold=%.0f%%)。plugin-managed config に Traceary 管理の %s hook がありません",
 						len(events),
 						client,
 						ratio*100,
 						coverage.Sessions,
-						coverage.BoundaryOnly,
+						coverage.PromptTranscriptMissing,
+						coverage.Complete,
 						coverage.Enriched,
 						threshold*100,
 						strings.Join(missing, ", "),
@@ -859,13 +861,14 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 					fixCommand,
 				),
 				Message: localizef(
-					"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%). The installed config is missing Traceary-managed %s hooks: %s",
-					"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%)。インストール済み config に Traceary 管理の %s hook がありません: %s",
+					"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d, threshold=%.0f%%). The installed config is missing Traceary-managed %s hooks: %s",
+					"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d, threshold=%.0f%%)。インストール済み config に Traceary 管理の %s hook がありません: %s",
 					len(events),
 					client,
 					ratio*100,
 					coverage.Sessions,
-					coverage.BoundaryOnly,
+					coverage.PromptTranscriptMissing,
+					coverage.Complete,
 					coverage.Enriched,
 					threshold*100,
 					strings.Join(missing, ", "),
@@ -902,13 +905,14 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		Status: doctorStatusWarn,
 		Hint:   hint,
 		Message: localizef(
-			"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
-			"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
+			"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d complete=%d enriched=%d with_prompt=%d with_transcript=%d with_command=%d, threshold=%.0f%%)",
 			len(events),
 			client,
 			ratio*100,
 			coverage.Sessions,
-			coverage.BoundaryOnly,
+			coverage.PromptTranscriptMissing,
+			coverage.Complete,
 			coverage.Enriched,
 			coverage.WithPrompt,
 			coverage.WithTranscript,

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -128,7 +128,7 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 	doctorCmd.Flags().BoolVar(&fix, "fix", false, Localize("apply known safe remediations for warning and failing checks", "警告・失敗チェックに対して既知の安全な修復を適用する"))
 	doctorCmd.Flags().BoolVar(&dryRun, "dry-run", false, Localize("preview --fix actions without writing files", "ファイルを書き込まずに --fix の処理をプレビューする"))
 	doctorCmd.Flags().BoolVar(&strict, "strict", false, Localize("audit-reliability: report every exact duplicate group regardless of time, not only near-simultaneous writes", "audit-reliability: 時間に関係なく完全一致する duplicate group をすべて報告する（near-simultaneous な書き込みだけに限定しない）"))
-	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("gemini-event-coverage: warn when the recent prompt/transcript-missing session ratio is above this value (0.0 to 1.0)", "gemini-event-coverage: recent session の prompt/transcript 欠落比率がこの値を超えたら警告する (0.0 から 1.0)"))
+	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("client event coverage: warn when the recent prompt/transcript-missing session ratio is above this value (0.0 to 1.0)", "client event coverage: recent session の prompt/transcript 欠落比率がこの値を超えたら警告する (0.0 から 1.0)"))
 
 	return doctorCmd
 }
@@ -304,7 +304,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		check := c.inspectClaudeOrConfigFile(targetClient, outputPath, resolvedProjectDir)
 		c.attachDoctorConfigFix(&check, targetClient, outputPath, resolvedProjectDir)
 		report.Checks = append(report.Checks, check)
-		if targetClient == "gemini" {
+		if targetClient == "gemini" || targetClient == "claude" {
 			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
 		}
 		report.Checks = append(report.Checks, c.inspectMCPRegistrationForClient(targetClient, outputPath))
@@ -819,9 +819,34 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 		}
 	}
 
-	configCoverage, configCoverageKnown := c.managedCoverageForConfigFile(outputPath, client)
+	configCoverage, configCoverageKnown, pluginManaged, pluginKey := c.managedCoverageForEventCoverage(outputPath, client)
 	if configCoverageKnown {
 		if missing := configCoverage.MissingEnrichment(); len(missing) > 0 {
+			if pluginManaged {
+				updateCommand := claudePluginUpdateCommand(pluginKey)
+				return doctorCheck{
+					Name:       checkName,
+					Status:     doctorStatusWarn,
+					FixCommand: updateCommand,
+					Hint: localizef(
+						"the plugin-managed Claude hook config is missing %s coverage; update the Claude plugin instead of writing project settings hooks",
+						"plugin-managed Claude hook config に %s coverage がありません。project settings hook を書き込まず Claude plugin を更新してください",
+						strings.Join(missing, ", "),
+					),
+					Message: localizef(
+						"scanned %d recent %s event(s); %.0f%% of complete sessions lack prompt/transcript coverage (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%). The plugin-managed config is missing Traceary-managed %s hooks",
+						"%d 件の recent %s event を検査しました。完全に観測できた session の %.0f%% で prompt/transcript coverage が不足しています (sessions=%d prompt_transcript_missing=%d enriched=%d, threshold=%.0f%%)。plugin-managed config に Traceary 管理の %s hook がありません",
+						len(events),
+						client,
+						ratio*100,
+						coverage.Sessions,
+						coverage.BoundaryOnly,
+						coverage.Enriched,
+						threshold*100,
+						strings.Join(missing, ", "),
+					),
+				}
+			}
 			fixCommand := fmt.Sprintf("traceary doctor --client %s --project-dir %s --fix", client, shellQuote(projectDir))
 			return doctorCheck{
 				Name:       checkName,
@@ -851,15 +876,26 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 	}
 
 	hint := Localize(
-		"hook config appears to include enrichment coverage; inspect hook timeouts, host hook behavior, and recent event IDs with `traceary list --agent gemini`",
-		"hook config には enrichment coverage が含まれているようです。hook timeout、host 側の hook 挙動、recent event ID を `traceary list --agent gemini` で確認してください",
+		fmt.Sprintf("hook config appears to include enrichment coverage; inspect hook timeouts, host hook cancellations, host behavior, and recent event IDs with `traceary list --agent %s`", client),
+		fmt.Sprintf("hook config には enrichment coverage が含まれているようです。hook timeout、host 側の hook cancellation、host 側の挙動、recent event ID を `traceary list --agent %s` で確認してください", client),
 	)
 	if !configCoverageKnown {
-		hint = localizef(
-			"the project hook config could not be inspected; first fix %s-config, then rerun doctor",
-			"project hook config を検査できませんでした。先に %s-config を修復してから doctor を再実行してください",
-			client,
-		)
+		if pluginManaged {
+			updateCommand := claudePluginUpdateCommand(pluginKey)
+			hint = localizef(
+				"Claude hooks appear to be plugin-managed by %q; project settings hooks are intentionally absent. Inspect plugin cache/update state (`%s`), host hook cancellations/timeouts, and recent event IDs with `traceary list --agent %s`",
+				"Claude hooks は plugin %q によって管理されているようです。project settings hook がないのは意図された状態です。plugin cache/update 状態 (`%s`)、host 側の hook cancellation/timeout、recent event ID を `traceary list --agent %s` で確認してください",
+				pluginKey,
+				updateCommand,
+				client,
+			)
+		} else {
+			hint = localizef(
+				"the project hook config could not be inspected; first fix %s-config, then rerun doctor",
+				"project hook config を検査できませんでした。先に %s-config を修復してから doctor を再実行してください",
+				client,
+			)
+		}
 	}
 	return doctorCheck{
 		Name:   checkName,
@@ -902,6 +938,50 @@ func (c *RootCLI) managedCoverageForConfigFile(path string, client string) (appl
 		return application.HookManagedCoverage{}, false
 	}
 	return coverage, true
+}
+
+func (c *RootCLI) managedCoverageForEventCoverage(outputPath, client string) (application.HookManagedCoverage, bool, bool, string) {
+	if client == "claude" {
+		detection := c.detectClaudeTracearyPluginForCLI()
+		if detection.Active && !c.claudeConfigHasTracearyHooks(outputPath) {
+			coverage, known := c.managedCoverageForInstalledClaudePlugin(detection.PluginKey)
+			return coverage, known, true, detection.PluginKey
+		}
+	}
+	coverage, known := c.managedCoverageForConfigFile(outputPath, client)
+	return coverage, known, false, ""
+}
+
+func (c *RootCLI) managedCoverageForInstalledClaudePlugin(pluginKey string) (application.HookManagedCoverage, bool) {
+	if c.pluginCacheInspector == nil || pluginKey == "" {
+		return application.HookManagedCoverage{}, false
+	}
+	home, err := userHomeDirFunc()
+	if err != nil {
+		return application.HookManagedCoverage{}, false
+	}
+	status := c.pluginCacheInspector.DetectClaudePluginCacheStatus(home, pluginKey)
+	if status.CachePath != "" && status.CachedVersion != "" {
+		cacheHooksPath := filepath.Join(status.CachePath, status.CachedVersion, "hooks", "hooks.json")
+		if coverage, known := c.managedCoverageForConfigFile(cacheHooksPath, "claude"); known {
+			return coverage, true
+		}
+	}
+	if status.MarketplacePath != "" {
+		pluginRoot := filepath.Dir(filepath.Dir(status.MarketplacePath))
+		marketplaceHooksPath := filepath.Join(pluginRoot, "hooks", "hooks.json")
+		if coverage, known := c.managedCoverageForConfigFile(marketplaceHooksPath, "claude"); known {
+			return coverage, true
+		}
+	}
+	return application.HookManagedCoverage{}, false
+}
+
+func claudePluginUpdateCommand(pluginKey string) string {
+	if pluginKey == "" {
+		return "claude plugins update"
+	}
+	return "claude plugins update " + pluginKey
 }
 
 // inspectClaudePluginCacheStatus compares the cached Traceary Claude
@@ -1166,6 +1246,29 @@ func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir strin
 				),
 			}
 		}
+		if coverage, known := c.managedCoverageForInstalledClaudePlugin(detection.PluginKey); known {
+			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
+				updateCommand := claudePluginUpdateCommand(detection.PluginKey)
+				return doctorCheck{
+					Name:       "claude-config",
+					Status:     doctorStatusWarn,
+					FixCommand: updateCommand,
+					Hint: localizef(
+						"the plugin-managed Claude hook config is missing %s coverage; update the Claude plugin instead of writing project settings hooks",
+						"plugin-managed Claude hook config に %s coverage がありません。project settings hook を書き込まず Claude plugin を更新してください",
+						strings.Join(missing, ", "),
+					),
+					Message: localizef(
+						"claude hooks are delivered by plugin %q (%s), but the installed plugin hook config is missing Traceary-managed enrichment coverage (%s). Update the plugin with `%s`",
+						"claude hooks は plugin %q によって提供されています (%s) が、installed plugin hook config に Traceary 管理の enrichment coverage (%s) がありません。`%s` で plugin を更新してください",
+						detection.PluginKey,
+						detection.SettingsPath,
+						strings.Join(missing, ", "),
+						updateCommand,
+					),
+				}
+			}
+		}
 		return doctorCheck{
 			Name:   "claude-config",
 			Status: doctorStatusPass,
@@ -1278,7 +1381,7 @@ func (c *RootCLI) inspectGlobalConfigForClient(client string) *doctorCheck {
 		}
 	}
 	if hasTracearyHook {
-		if client == "gemini" {
+		if client == "gemini" || client == "claude" {
 			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content, client)
 			if coverageErr != nil {
 				return &doctorCheck{
@@ -1288,7 +1391,7 @@ func (c *RootCLI) inspectGlobalConfigForClient(client string) *doctorCheck {
 				}
 			}
 			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
-				check := missingGeminiHookCoverageCheck(checkName, globalPath, home, missing, false)
+				check := missingClientHookCoverageCheck(client, checkName, globalPath, home, missing, false)
 				return &check
 			}
 		}
@@ -1417,7 +1520,7 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 				}
 			}
 		}
-		if client == "gemini" {
+		if client == "gemini" || client == "claude" {
 			coverage, coverageErr := c.hooksInspector.ManagedCoverage(content, client)
 			if coverageErr != nil {
 				return doctorCheck{
@@ -1427,7 +1530,7 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 				}
 			}
 			if missing := coverage.MissingEnrichment(); len(missing) > 0 {
-				return missingGeminiHookCoverageCheck(client+"-config", outputPath, projectDir, missing, true)
+				return missingClientHookCoverageCheck(client, client+"-config", outputPath, projectDir, missing, true)
 			}
 		}
 		return doctorCheck{
@@ -1479,21 +1582,30 @@ func duplicateTracearyHookCheck(client, checkName, outputPath, projectDir string
 	}
 }
 
-func missingGeminiHookCoverageCheck(checkName, outputPath, projectDir string, missing []string, projectConfig bool) doctorCheck {
+func missingClientHookCoverageCheck(client, checkName, outputPath, projectDir string, missing []string, projectConfig bool) doctorCheck {
 	joinedMissing := strings.Join(missing, ", ")
-	fixCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client gemini --project-dir %s", shellQuote(projectDir))
+	fixCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client %s --project-dir %s", client, shellQuote(projectDir))
 	hint := localizef(
 		"preview the non-destructive refresh with `%s`; it rewrites only Traceary-managed entries and preserves non-Traceary hooks",
 		"`%s` で非破壊 refresh をプレビューしてください。Traceary 管理エントリだけを更新し、Traceary 以外の hook は保持します",
 		fixCommand,
 	)
 	if !projectConfig {
-		fixCommand = "traceary hooks install --client gemini --global --upgrade"
-		hint = localizef(
-			"refresh the user-level Gemini settings with `%s`; if you use the Gemini extension package instead, run `gemini extensions update traceary`",
-			"`%s` で user-level Gemini settings を更新してください。Gemini extension package を使っている場合は `gemini extensions update traceary` を実行してください",
-			fixCommand,
-		)
+		fixCommand = fmt.Sprintf("traceary hooks install --client %s --global --upgrade", client)
+		if client == "gemini" {
+			hint = localizef(
+				"refresh the user-level Gemini settings with `%s`; if you use the Gemini extension package instead, run `gemini extensions update traceary`",
+				"`%s` で user-level Gemini settings を更新してください。Gemini extension package を使っている場合は `gemini extensions update traceary` を実行してください",
+				fixCommand,
+			)
+		} else {
+			hint = localizef(
+				"refresh the user-level %s settings with `%s`; if the host uses plugin-managed hooks instead, update the plugin package",
+				"user-level %s settings を `%s` で更新してください。host が plugin-managed hooks を使う場合は plugin package を更新してください",
+				client,
+				fixCommand,
+			)
+		}
 	}
 	return doctorCheck{
 		Name:       checkName,
@@ -1501,8 +1613,9 @@ func missingGeminiHookCoverageCheck(checkName, outputPath, projectDir string, mi
 		FixCommand: fixCommand,
 		Hint:       hint,
 		Message: localizef(
-			"gemini config contains Traceary-managed hooks but is missing enrichment coverage (%s). Prompt/transcript gaps leave sessions without conversation coverage; refresh the managed hooks: %s",
-			"gemini config に Traceary 管理 hook はありますが enrichment coverage (%s) が不足しています。prompt/transcript が欠けると session に会話内容の coverage が残りません。管理 hook を更新してください: %s",
+			"%s config contains Traceary-managed hooks but is missing enrichment coverage (%s). Prompt/transcript gaps leave sessions without conversation coverage; refresh the managed hooks: %s",
+			"%s config に Traceary 管理 hook はありますが enrichment coverage (%s) が不足しています。prompt/transcript が欠けると session に会話内容の coverage が残りません。管理 hook を更新してください: %s",
+			client,
 			joinedMissing,
 			outputPath,
 		),

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -85,6 +85,9 @@ func TestRootCLI_Doctor_ClaudePluginInteractions(t *testing.T) {
     ],
     "PostToolUse": [
       {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ],
+    "PostToolUseFailure": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
     ]
   }
 }`)
@@ -119,6 +122,9 @@ func TestRootCLI_Doctor_ClaudePluginInteractions(t *testing.T) {
       {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}
     ],
     "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ],
+    "PostToolUseFailure": [
       {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
     ]
   }
@@ -561,6 +567,18 @@ func writeClaudeGlobalHooksSettings(t *testing.T, home string) {
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
       {
         "matcher": "Bash",
         "hooks": [

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -66,6 +66,71 @@ func TestRootCLI_Doctor_ClaudePluginInteractions(t *testing.T) {
 		}
 	})
 
+	t.Run("plugin active with unreadable cached hooks warns without marketplace fallback", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		writePluginEnabledSettings(t, homeDir)
+		cacheDir := writeClaudePluginCacheVersionDir(t, homeDir)
+		writeClaudePluginMarketplaceHooks(t, homeDir, `{
+  "hooks": {
+    "UserPromptSubmit": [
+      {"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}
+    ],
+    "Stop": [
+      {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ]
+  }
+}`)
+
+		report := runDoctor(t, projectDir)
+		claudeCfg := statusByName(report, "claude-config")
+		if claudeCfg.Status != "warn" {
+			t.Fatalf("claude-config status = %q, want warn; msg = %q", claudeCfg.Status, claudeCfg.Message)
+		}
+		if !strings.Contains(claudeCfg.Message, filepath.Join(cacheDir, "hooks", "hooks.json")) {
+			t.Fatalf("claude-config message = %q; want cached hooks path", claudeCfg.Message)
+		}
+		if !strings.Contains(claudeCfg.Hint, "marketplace") || !strings.Contains(claudeCfg.FixCommand, "claude plugins update traceary@traceary-plugins") {
+			t.Fatalf("claude-config hint/fix = %q / %q; want no marketplace fallback and plugin update", claudeCfg.Hint, claudeCfg.FixCommand)
+		}
+	})
+
+	t.Run("plugin active with complete cached hooks passes", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		writePluginEnabledSettings(t, homeDir)
+		writeClaudePluginCacheHooks(t, homeDir, `{
+  "hooks": {
+    "UserPromptSubmit": [
+      {"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}
+    ],
+    "Stop": [
+      {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ]
+  }
+}`)
+
+		report := runDoctor(t, projectDir)
+		claudeCfg := statusByName(report, "claude-config")
+		if claudeCfg.Status != "pass" {
+			t.Fatalf("claude-config status = %q, want pass; msg = %q", claudeCfg.Status, claudeCfg.Message)
+		}
+	})
+
 	t.Run("plugin inactive with settings hooks passes", func(t *testing.T) {
 		homeDir := t.TempDir()
 		projectDir := t.TempDir()

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -464,8 +464,45 @@ func writeClaudeGlobalHooksSettings(t *testing.T, home string) {
         "matcher": "*",
         "hooks": [
           {
+            "name": "traceary-session-start",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'claude' 'start'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-prompt",
+            "type": "command",
+            "command": "'traceary' 'hook' 'prompt' 'claude'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-transcript",
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'claude'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
           }
         ]
       }
@@ -507,29 +544,7 @@ func writePluginEnabledSettings(t *testing.T, home string) {
 
 func writeClaudeProjectHook(t *testing.T, projectDir string) {
 	t.Helper()
-	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	content := `{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "'traceary' 'hook' 'session' 'claude' 'start'"
-          }
-        ]
-      }
-    ]
-  }
-}
-`
-	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
+	writeCompleteClaudeProjectHookSettings(t, projectDir)
 }
 
 func runDoctor(t *testing.T, projectDir string) doctorReport {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1202,6 +1202,51 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		}
 	})
 
+	t.Run("plugin active with stale settings hooks does not suggest settings fix", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writePluginEnabledSettings(t, homeDir)
+		writeClaudeProjectSessionOnlyHook(t, projectDir)
+		writeClaudePluginCacheHooks(t, homeDir, `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}]}
+    ]
+  }
+}`)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		configCheck := statusByName(report, "claude-config")
+		if configCheck.Status != "warn" || !strings.Contains(configCheck.Message, "twice") {
+			t.Fatalf("claude-config status/message = %q/%q; want double-registration warning", configCheck.Status, configCheck.Message)
+		}
+		coverage := statusByName(report, "claude-event-coverage")
+		if coverage.Status != "warn" {
+			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", coverage.Status, coverage.Message)
+		}
+		if strings.Contains(coverage.FixCommand, "traceary doctor") {
+			t.Fatalf("claude-event-coverage remediation = hint %q fix %q; want plugin/double-registration path, not settings fix", coverage.Hint, coverage.FixCommand)
+		}
+		if !strings.Contains(coverage.FixCommand, "claude plugins update traceary@traceary-plugins") {
+			t.Fatalf("claude-event-coverage FixCommand = %q; want plugin update", coverage.FixCommand)
+		}
+	})
+
 	t.Run("plugin-managed cached hook gaps warn before sample gate", func(t *testing.T) {
 		homeDir := t.TempDir()
 		projectDir := t.TempDir()

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1509,6 +1509,18 @@ func writeClaudeHookSettings(t *testing.T, projectDir string) {
           }
         ]
       }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
+          }
+        ]
+      }
     ]
   }
 }
@@ -1565,6 +1577,9 @@ func writeCompleteClaudeProjectHookSettings(t *testing.T, projectDir string) {
       {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}
     ],
     "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ],
+    "PostToolUseFailure": [
       {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
     ],
     "PreCompact": [

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1531,12 +1531,33 @@ func writeCompleteClaudeProjectHookSettings(t *testing.T, projectDir string) {
 
 func writeClaudePluginCacheHooks(t *testing.T, homeDir, content string) {
 	t.Helper()
-	hooksPath := filepath.Join(homeDir, ".claude", "plugins", "cache", "traceary-plugins", "traceary", "0.20.1", "hooks", "hooks.json")
+	cacheDir := writeClaudePluginCacheVersionDir(t, homeDir)
+	hooksPath := filepath.Join(cacheDir, "hooks", "hooks.json")
 	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 	if err := os.WriteFile(hooksPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile(plugin cache hooks) error = %v", err)
+	}
+}
+
+func writeClaudePluginCacheVersionDir(t *testing.T, homeDir string) string {
+	t.Helper()
+	cacheDir := filepath.Join(homeDir, ".claude", "plugins", "cache", "traceary-plugins", "traceary", "0.20.1")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(plugin cache version) error = %v", err)
+	}
+	return cacheDir
+}
+
+func writeClaudePluginMarketplaceHooks(t *testing.T, homeDir, content string) {
+	t.Helper()
+	hooksPath := filepath.Join(homeDir, ".claude", "plugins", "marketplaces", "traceary-plugins", "integrations", "claude-plugin", "hooks", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(plugin marketplace hooks) error = %v", err)
+	}
+	if err := os.WriteFile(hooksPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin marketplace hooks) error = %v", err)
 	}
 }
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1096,6 +1096,39 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		}
 	})
 
+	t.Run("prompt only recent claude sessions warn about transcript gap", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: claudePromptOnlyCoverageEvents(3)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "claude-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "100%") || !strings.Contains(check.Message, "with_prompt=3") || !strings.Contains(check.Message, "with_transcript=0") {
+			t.Fatalf("claude-event-coverage message = %q; want prompt-only transcript gap evidence", check.Message)
+		}
+		if !strings.Contains(check.Hint, "hook cancellations") {
+			t.Fatalf("claude-event-coverage hint = %q; want hook cancellation diagnostic hint", check.Hint)
+		}
+	})
+
 	t.Run("plugin-managed hooks do not suggest writing project settings", func(t *testing.T) {
 		homeDir := t.TempDir()
 		projectDir := t.TempDir()
@@ -1578,6 +1611,37 @@ func geminiCoverageEvents(boundaryOnly, enriched int) []*model.Event {
 
 func claudeCoverageEvents(boundaryOnly, enriched int) []*model.Event {
 	return clientCoverageEvents(types.Agent("claude"), boundaryOnly, enriched)
+}
+
+func claudePromptOnlyCoverageEvents(count int) []*model.Event {
+	events := make([]*model.Event, 0, count*2)
+	createdAt := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < count; i++ {
+		sessionID := fmt.Sprintf("prompt-only-%d", i)
+		events = append(events,
+			model.EventOf(
+				types.EventID(fmt.Sprintf("prompt-only-%d-start", i)),
+				types.EventKindSessionStarted,
+				types.Client("hook"),
+				types.Agent("claude"),
+				types.SessionID(sessionID),
+				types.Workspace("duck8823/traceary"),
+				"body",
+				createdAt,
+			),
+			model.EventOf(
+				types.EventID(fmt.Sprintf("prompt-only-%d-prompt", i)),
+				types.EventKindPrompt,
+				types.Client("hook"),
+				types.Agent("claude"),
+				types.SessionID(sessionID),
+				types.Workspace("duck8823/traceary"),
+				"body",
+				createdAt,
+			),
+		)
+	}
+	return events
 }
 
 func clientCoverageEvents(agent types.Agent, boundaryOnly, enriched int) []*model.Event {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1200,6 +1200,10 @@ func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
 		if strings.Contains(check.FixCommand, "traceary doctor") {
 			t.Fatalf("claude-event-coverage FixCommand = %q; want no project settings fix", check.FixCommand)
 		}
+		claudeCfg := statusByName(report, "claude-config")
+		if claudeCfg.AutoFixAvailable {
+			t.Fatalf("claude-config AutoFixAvailable = true; plugin-managed remediation must not write project settings hooks")
+		}
 	})
 
 	t.Run("plugin active with stale settings hooks does not suggest settings fix", func(t *testing.T) {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -168,29 +168,7 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"redact":{"extra_patterns":["internal_token"]}}`), 0o644); err != nil {
 			t.Fatalf("WriteFile() error = %v", err)
 		}
-		settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-		if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-			t.Fatalf("MkdirAll() error = %v", err)
-		}
-		if err := os.WriteFile(settingsPath, []byte(`{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "'traceary' 'hook' 'session' 'claude' 'start'"
-          }
-        ]
-      }
-    ]
-  }
-}
-
-`), 0o644); err != nil {
-			t.Fatalf("WriteFile() error = %v", err)
-		}
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
 
 		initStub := &storeManagementUsecaseStub{}
 		rootCmd := newTestRootCLI(cli.WithStoreManagement(initStub)).Command()
@@ -1078,6 +1056,195 @@ func TestRootCLI_DoctorGeminiCoverage(t *testing.T) {
 	})
 }
 
+func TestRootCLI_DoctorClaudeCoverage(t *testing.T) {
+	t.Run("boundary only recent claude sessions warn in current workspace", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "claude-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "prompt/transcript") || !strings.Contains(check.Message, "67%") {
+			t.Fatalf("claude-event-coverage message = %q; want ratio evidence", check.Message)
+		}
+		if !strings.Contains(check.Hint, "hook cancellations") {
+			t.Fatalf("claude-event-coverage hint = %q; want hook cancellation diagnostic hint", check.Hint)
+		}
+		if eventStub.listCriteria.Agent() != types.Agent("claude") {
+			t.Fatalf("List criteria agent = %q, want claude", eventStub.listCriteria.Agent())
+		}
+		if wantWorkspace := types.Workspace(filepath.ToSlash(filepath.Clean(projectDir))); eventStub.listCriteria.Workspace() != wantWorkspace {
+			t.Fatalf("List criteria workspace = %q, want %q", eventStub.listCriteria.Workspace(), wantWorkspace)
+		}
+	})
+
+	t.Run("plugin-managed hooks do not suggest writing project settings", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writePluginEnabledSettings(t, homeDir)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "claude-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Hint, "plugin") {
+			t.Fatalf("claude-event-coverage hint = %q; want plugin-managed diagnostic", check.Hint)
+		}
+		if strings.Contains(check.Hint, "first fix claude-config") || check.FixCommand != "" {
+			t.Fatalf("claude-event-coverage remediation = hint %q fix %q; want no project-settings fix", check.Hint, check.FixCommand)
+		}
+	})
+
+	t.Run("plugin-managed cached hook gaps suggest plugin update", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writePluginEnabledSettings(t, homeDir)
+		writeClaudePluginCacheHooks(t, homeDir, `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}]}
+    ]
+  }
+}`)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(2, 1)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		check := statusByName(report, "claude-event-coverage")
+		if check.Status != "warn" {
+			t.Fatalf("claude-event-coverage status = %q, want warn (message=%q)", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Hint, "plugin-managed") || !strings.Contains(check.FixCommand, "claude plugins update traceary@traceary-plugins") {
+			t.Fatalf("claude-event-coverage remediation = hint %q fix %q; want plugin update", check.Hint, check.FixCommand)
+		}
+		if strings.Contains(check.FixCommand, "traceary doctor") {
+			t.Fatalf("claude-event-coverage FixCommand = %q; want no project settings fix", check.FixCommand)
+		}
+	})
+
+	t.Run("plugin-managed cached hook gaps warn before sample gate", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writePluginEnabledSettings(t, homeDir)
+		writeClaudePluginCacheHooks(t, homeDir, `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}]}
+    ]
+  }
+}`)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(1, 0)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		claudeCfg := statusByName(report, "claude-config")
+		if claudeCfg.Status != "warn" {
+			t.Fatalf("claude-config status = %q, want warn (message=%q)", claudeCfg.Status, claudeCfg.Message)
+		}
+		if !strings.Contains(claudeCfg.Message, "installed plugin hook config") || !strings.Contains(claudeCfg.FixCommand, "claude plugins update traceary@traceary-plugins") {
+			t.Fatalf("claude-config message/fix = %q / %q; want plugin cache remediation", claudeCfg.Message, claudeCfg.FixCommand)
+		}
+		coverage := statusByName(report, "claude-event-coverage")
+		if coverage.Status != "pass" || !strings.Contains(coverage.Message, "not judged yet") {
+			t.Fatalf("claude-event-coverage status/message = %q/%q; want sample gate pass while plugin config still warns", coverage.Status, coverage.Message)
+		}
+	})
+
+	t.Run("settings-managed hook gaps warn before sample gate", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeClaudeProjectSessionOnlyHook(t, projectDir)
+		eventStub := &eventUsecaseStub{listEvents: claudeCoverageEvents(1, 0)}
+
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(eventStub),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json"})
+
+		executeDoctorAllowWarnings(t, rootCmd)
+
+		report := decodeDoctorReport(t, stdout.Bytes())
+		claudeCfg := statusByName(report, "claude-config")
+		if claudeCfg.Status != "warn" {
+			t.Fatalf("claude-config status = %q, want warn (message=%q)", claudeCfg.Status, claudeCfg.Message)
+		}
+		if !strings.Contains(claudeCfg.Message, "missing enrichment coverage") || !strings.Contains(claudeCfg.FixCommand, "--client claude") {
+			t.Fatalf("claude-config message/fix = %q / %q; want static Claude enrichment remediation", claudeCfg.Message, claudeCfg.FixCommand)
+		}
+		coverage := statusByName(report, "claude-event-coverage")
+		if coverage.Status != "pass" || !strings.Contains(coverage.Message, "not judged yet") {
+			t.Fatalf("claude-event-coverage status/message = %q/%q; want sample gate pass while config still warns", coverage.Status, coverage.Message)
+		}
+	})
+}
+
 func TestRootCLI_DoctorStaleActiveSessions(t *testing.T) {
 	projectDir := t.TempDir()
 	homeDir := t.TempDir()
@@ -1218,8 +1385,45 @@ func writeClaudeHookSettings(t *testing.T, projectDir string) {
         "matcher": "*",
         "hooks": [
           {
+            "name": "traceary-session-start",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'claude' 'start'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-prompt",
+            "type": "command",
+            "command": "'traceary' 'hook' 'prompt' 'claude'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-transcript",
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'claude'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "name": "traceary-audit",
+            "type": "command",
+            "command": "'traceary' 'hook' 'audit' 'claude'"
           }
         ]
       }
@@ -1228,6 +1432,78 @@ func writeClaudeHookSettings(t *testing.T, projectDir string) {
 }
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeClaudeProjectSessionOnlyHook(t *testing.T, projectDir string) {
+	t.Helper()
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'session' 'claude' 'start'"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeCompleteClaudeProjectHookSettings(t *testing.T, projectDir string) {
+	t.Helper()
+	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'start'"}]}
+    ],
+    "SessionEnd": [
+      {"matcher": "*", "hooks": [{"name": "traceary-session-end", "type": "command", "command": "'traceary' 'hook' 'session' 'claude' 'end'"}]}
+    ],
+    "UserPromptSubmit": [
+      {"matcher": "*", "hooks": [{"name": "traceary-prompt", "type": "command", "command": "'traceary' 'hook' 'prompt' 'claude'"}]}
+    ],
+    "Stop": [
+      {"matcher": "*", "hooks": [{"name": "traceary-transcript", "type": "command", "command": "'traceary' 'hook' 'transcript' 'claude'"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'claude'"}]}
+    ],
+    "PreCompact": [
+      {"matcher": "*", "hooks": [{"name": "traceary-compact-pre-compact", "type": "command", "command": "'traceary' 'hook' 'compact' 'claude' 'pre-compact'"}]}
+    ]
+  }
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(claude settings) error = %v", err)
+	}
+}
+
+func writeClaudePluginCacheHooks(t *testing.T, homeDir, content string) {
+	t.Helper()
+	hooksPath := filepath.Join(homeDir, ".claude", "plugins", "cache", "traceary-plugins", "traceary", "0.20.1", "hooks", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(hooksPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin cache hooks) error = %v", err)
 	}
 }
 
@@ -1297,6 +1573,14 @@ func writeCompleteGeminiProjectHookSettings(t *testing.T, projectDir string) {
 }
 
 func geminiCoverageEvents(boundaryOnly, enriched int) []*model.Event {
+	return clientCoverageEvents(types.Agent("gemini"), boundaryOnly, enriched)
+}
+
+func claudeCoverageEvents(boundaryOnly, enriched int) []*model.Event {
+	return clientCoverageEvents(types.Agent("claude"), boundaryOnly, enriched)
+}
+
+func clientCoverageEvents(agent types.Agent, boundaryOnly, enriched int) []*model.Event {
 	events := make([]*model.Event, 0, boundaryOnly*2+enriched*3)
 	createdAt := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
 	appendEvent := func(id string, kind types.EventKind, sessionID string) {
@@ -1304,7 +1588,7 @@ func geminiCoverageEvents(boundaryOnly, enriched int) []*model.Event {
 			types.EventID(id),
 			kind,
 			types.Client("hook"),
-			types.Agent("gemini"),
+			agent,
 			types.SessionID(sessionID),
 			types.Workspace("duck8823/traceary"),
 			"body",


### PR DESCRIPTION
## Motivation

Closes #1174

Claude dogfood now shows fresh current-workspace prompt and command events, while transcript coverage is still incomplete in the latest sampled history. This PR makes that state observable through `traceary doctor --client claude` so future coverage gaps are diagnosed by workspace-scoped evidence instead of manual log inspection.

## Changes

- Extend managed hook coverage detection to understand Claude host hook events.
- Run the existing prompt/transcript coverage diagnostic for Claude as `claude-event-coverage`.
- Treat prompt-only / transcript-only sessions as incomplete for doctor coverage.
- Keep Claude plugin-managed installs on the plugin/package diagnostic path instead of suggesting project `settings.json` hook fixes.
- Inspect installed Claude plugin cache hooks before marketplace source hooks, and warn when cached hooks are missing or incomplete.
- Require Claude audit coverage to include Bash-covering hooks on both `PostToolUse` and `PostToolUseFailure`.
- Add hook-cancellation/timeouts hints when installed hooks look complete but recent sessions are missing prompt/transcript enrichment.
- Add regression coverage for Claude hook config detection, cross-client rejection, Codex managed coverage, plugin-managed Claude remediation, installed plugin cache inspection, static Claude/plugin checks before sample gating, and doctor workspace/agent filtering.

## Verification

- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./presentation/cli ./application/usecase ./infrastructure/filesystem` — passed, 1940 tests in 3 packages
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./...` — passed, 2478 tests in 21 packages
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go build ./...` — passed
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run` — passed, 0 issues
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling integrations verify` — passed
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling docs verify-i18n` — passed
- `rtk proxy git diff --check HEAD` — passed
- CI for PR head `3792142a` — Docs, Integrations, Lint, Test, autolabel passed; update_release_draft skipped

## Dogfood evidence

- `traceary list --workspace github.com/duck8823/traceary --agent claude --limit 100 --json` showed current Claude `prompt`, `command_executed`, and session boundary events.
- Local head binary `doctor --client claude --project-dir /Users/duck8823/Repositories/traceary --json` now reports `claude-event-coverage` as `warn` with `sessions=6 prompt_transcript_missing=5 complete=1 with_prompt=5 with_transcript=1`, surfacing the incomplete transcript coverage.
- A fresh Claude review session also surfaced `SessionEnd hook ['traceary' 'hook' 'session' 'claude' 'end'] failed: Hook cancelled`; durable capture of host-side cancellation details remains split to a follow-up issue.

## AI review

- Gemini CLI scout: blocked by upstream migration (`UNSUPPORTED_CLIENT`, migrate to Antigravity).
- Antigravity headless scout: skipped by local external-delegation policy because Antigravity is not currently in the allowed external AI delegation list.
- Claude Code reviewer: ✅ approve; non-blocking follow-ups were either covered by added tests or split to follow-up.
- Codex Review: all returned P1/P2 findings addressed through `3792142a`; final re-review was requested but returned no new review comment after the connector removed its in-progress reaction.
- Codex verifier: local verification above.
