### PR TITLE
v0.21.0-13: capture Claude hook cancellation diagnostics

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -312,6 +312,9 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		if targetClient == "gemini" || targetClient == "claude" {
 			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
 		}
+		if targetClient == "claude" {
+			report.Checks = append(report.Checks, inspectClaudeHookCancellationDiagnostics(ctx, resolvedProjectDir))
+		}
 		report.Checks = append(report.Checks, c.inspectMCPRegistrationForClient(targetClient, outputPath))
 
 		if globalCheck := c.inspectGlobalConfigForClient(targetClient); globalCheck != nil {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -477,6 +478,84 @@ enabled = true
 		}
 		if diff := cmp.Diff(map[string]string{"config": "fail"}, map[string]string{"config": gotStatuses["config"]}); diff != "" {
 			t.Fatalf("doctor statuses mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {
+	t.Run("passes when no pending marker exists", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("TRACEARY_LANG", "en")
+		setTracearyPathToCurrentExecutable(t)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+
+		report, err := executeDoctorJSON(t, []string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json", "--warnings-ok"})
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		check := statusByName(report, "claude-hook-cancellations")
+		if got, want := check.Status, "pass"; got != want {
+			t.Fatalf("claude-hook-cancellations status = %q, want %q (message=%q)", got, want, check.Message)
+		}
+	})
+
+	t.Run("warns with durable marker evidence", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("TRACEARY_LANG", "en")
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "doctor-cancel-key")
+		setTracearyPathToCurrentExecutable(t)
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+		writeCompleteClaudeProjectHookSettings(t, projectDir)
+
+		stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(state) error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(stateDir, "claude-doctor-cancel-key"), []byte("doctor-cancelled-session"), 0o600); err != nil {
+			t.Fatalf("WriteFile(session state) error = %v", err)
+		}
+
+		hookCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithSession(&sessionUsecaseStub{endErr: errors.New("simulated cancellation")}),
+		).Command()
+		hookCmd.SetOut(&bytes.Buffer{})
+		hookCmd.SetErr(&bytes.Buffer{})
+		hookCmd.SetIn(strings.NewReader(fmt.Sprintf(`{"cwd":%q}`, projectDir)))
+		hookCmd.SetArgs([]string{"hook", "session", "claude", "end"})
+		if err := hookCmd.Execute(); err != nil {
+			t.Fatalf("hook Execute() error = %v", err)
+		}
+
+		report, err := executeDoctorJSON(t, []string{"doctor", "--client", "claude", "--project-dir", projectDir, "--json", "--warnings-ok"})
+		if err != nil {
+			t.Fatalf("doctor Execute() error = %v", err)
+		}
+		check := statusByName(report, "claude-hook-cancellations")
+		if got, want := check.Status, "warn"; got != want {
+			t.Fatalf("claude-hook-cancellations status = %q, want %q (message=%q)", got, want, check.Message)
+		}
+		for _, want := range []string{
+			"SessionEnd",
+			"'traceary' 'hook' 'session' 'claude' 'end'",
+			"doctor-cancelled-session",
+			"started_at=",
+			"path=",
+			filepath.Join(stateDir, "diagnostics"),
+		} {
+			if !strings.Contains(check.Message, want) {
+				t.Fatalf("claude-hook-cancellations message = %q, want substring %q", check.Message, want)
+			}
+		}
+		if check.Hint == "" || !strings.Contains(check.Hint, "Traceary reached Claude SessionEnd") {
+			t.Fatalf("claude-hook-cancellations hint = %q, want actionable cancellation hint", check.Hint)
 		}
 	})
 }

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -19,6 +21,11 @@ const (
 	hookCancellationDiagnosticSchemaVersion = 1
 	hookCancellationDiagnosticStatusStarted = "started"
 	hookDiagnosticsDirName                  = "diagnostics"
+	// hookCancellationDiagnosticSessionHashLen is the number of hex characters
+	// kept from the session hash embedded in diagnostic filenames. Twelve hex
+	// characters (48 bits) make accidental collisions between distinct sessions
+	// in a single diagnostics directory negligible while staying short.
+	hookCancellationDiagnosticSessionHashLen = 12
 )
 
 type hookCancellationDiagnostic struct {
@@ -209,17 +216,38 @@ func clearHookCancellationDiagnosticsForSession(client, hostEvent string, sessio
 	return nil
 }
 
+// hookCancellationDiagnosticPathMatchesSession reports whether an unreadable
+// diagnostic file belongs to the given (client, hostEvent, session) by matching
+// the stable hash segment embedded in the filename. Matching a delimited hash
+// segment — rather than a hyphenated client/event/session prefix — keeps cleanup
+// exact even when session IDs themselves contain hyphens, which a prefix match
+// would overmatch (e.g. session "cancelled" overmatching "cancelled-session").
 func hookCancellationDiagnosticPathMatchesSession(path, client, hostEvent string, sessionID types.SessionID) bool {
 	fileName := filepath.Base(strings.TrimSpace(path))
-	if fileName == "" {
+	if !strings.HasSuffix(fileName, ".json") {
 		return false
 	}
-	prefix := strings.Join([]string{
-		sanitizeHookStateKey(client),
-		sanitizeHookStateKey(hostEvent),
-		sanitizeHookStateKey(sessionID.String()),
-	}, "-") + "-"
-	return strings.HasPrefix(fileName, prefix) && strings.HasSuffix(fileName, ".json")
+	hash := hookCancellationDiagnosticSessionHash(client, hostEvent, sessionID.String())
+	for _, segment := range strings.Split(strings.TrimSuffix(fileName, ".json"), "-") {
+		if segment == hash {
+			return true
+		}
+	}
+	return false
+}
+
+// hookCancellationDiagnosticSessionHash derives the stable filename segment that
+// identifies a diagnostic's (client, hostEvent, session) tuple. The inputs are
+// trimmed to match the values stored on the record, so generation and cleanup
+// always agree on the same hash.
+func hookCancellationDiagnosticSessionHash(client, hostEvent, sessionID string) string {
+	seed := strings.Join([]string{
+		strings.TrimSpace(client),
+		strings.TrimSpace(hostEvent),
+		strings.TrimSpace(sessionID),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(seed))
+	return "s" + hex.EncodeToString(sum[:])[:hookCancellationDiagnosticSessionHashLen]
 }
 
 func emptyAsDash(value string) string {
@@ -321,6 +349,7 @@ func hookCancellationDiagnosticFileName(record hookCancellationDiagnostic, start
 		record.Client,
 		record.HostEvent,
 		record.SessionID,
+		hookCancellationDiagnosticSessionHash(record.Client, record.HostEvent, record.SessionID),
 		resolveHookStateKey(),
 		startedAt.UTC().Format("20060102T150405.000000000Z"),
 	}

--- a/presentation/cli/hook_diagnostics.go
+++ b/presentation/cli/hook_diagnostics.go
@@ -1,0 +1,338 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	hookCancellationDiagnosticSchemaVersion = 1
+	hookCancellationDiagnosticStatusStarted = "started"
+	hookDiagnosticsDirName                  = "diagnostics"
+)
+
+type hookCancellationDiagnostic struct {
+	SchemaVersion int       `json:"schema_version"`
+	Client        string    `json:"client"`
+	HostEvent     string    `json:"host_event"`
+	HookCommand   string    `json:"hook_command"`
+	HookPath      string    `json:"hook_path,omitempty"`
+	Workspace     string    `json:"workspace,omitempty"`
+	SessionID     string    `json:"session_id,omitempty"`
+	Status        string    `json:"status"`
+	StartedAt     time.Time `json:"started_at"`
+
+	Path string `json:"-"`
+}
+
+type hookCancellationDiagnosticScan struct {
+	Records    []hookCancellationDiagnostic
+	Unreadable []string
+}
+
+func inspectClaudeHookCancellationDiagnostics(ctx context.Context, projectDir string) doctorCheck {
+	const checkName = "claude-hook-cancellations"
+	workspace := resolveDoctorEventCoverageWorkspace(ctx, projectDir)
+	scan, err := scanHookCancellationDiagnostics("claude", "SessionEnd", workspace)
+	if err != nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to inspect Claude hook cancellation diagnostics: %v", "Claude hook cancellation diagnostic の検査に失敗しました: %v", err),
+		}
+	}
+	if len(scan.Records) == 0 && len(scan.Unreadable) == 0 {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"no pending Claude SessionEnd hook cancellation diagnostics found (workspace=%s)",
+				"未完了の Claude SessionEnd hook cancellation diagnostic は見つかりませんでした (workspace=%s)",
+				emptyAsDash(workspace.String()),
+			),
+		}
+	}
+
+	if len(scan.Records) == 0 {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusWarn,
+			Hint: Localize(
+				"inspect the unreadable diagnostic file(s); absence of readable diagnostics is not proof that Claude never cancelled a hook before Traceary started",
+				"読めない diagnostic file を確認してください。読める diagnostic が無いことは、Claude が Traceary 起動前に hook を cancel していない証明にはなりません",
+			),
+			Message: localizef(
+				"found unreadable Claude hook cancellation diagnostic file(s): %s",
+				"読めない Claude hook cancellation diagnostic file があります: %s",
+				strings.Join(scan.Unreadable, ", "),
+			),
+		}
+	}
+
+	latest := scan.Records[0]
+	return doctorCheck{
+		Name:   checkName,
+		Status: doctorStatusWarn,
+		Hint: Localize(
+			"the marker means Traceary reached Claude SessionEnd but did not complete cleanly; inspect the file and recent `traceary list --agent claude` output, then remove the marker after confirming it is stale. If Claude cancels before Traceary starts, no marker can be written.",
+			"この marker は Traceary が Claude SessionEnd まで到達したものの正常完了していないことを示します。file と最近の `traceary list --agent claude` を確認し、stale と判断できたら marker を削除してください。Claude が Traceary 起動前に cancel した場合、marker は書けません。",
+		),
+		Message: localizef(
+			"found %d pending Claude SessionEnd hook cancellation diagnostic(s); latest host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+			"未完了の Claude SessionEnd hook cancellation diagnostic が %d 件あります。latest host_event=%s hook_command=%s hook_path=%s workspace=%s session_id=%s started_at=%s path=%s%s",
+			len(scan.Records),
+			emptyAsDash(latest.HostEvent),
+			emptyAsDash(latest.HookCommand),
+			emptyAsDash(latest.HookPath),
+			emptyAsDash(latest.Workspace),
+			emptyAsDash(latest.SessionID),
+			formatHookDiagnosticTime(latest.StartedAt),
+			latest.Path,
+			formatUnreadableHookDiagnosticsSuffix(scan.Unreadable),
+		),
+	}
+}
+
+func beginHookCancellationDiagnostic(client, hostEvent, hookCommand string, sessionID types.SessionID, workspace types.Workspace) (string, error) {
+	startedAt := time.Now().UTC()
+	diagnosticsDir, err := hookDiagnosticsDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(diagnosticsDir, 0o755); err != nil {
+		return "", xerrors.Errorf("failed to create hook diagnostics directory: %w", err)
+	}
+
+	hookPath := ""
+	if executablePath, err := os.Executable(); err == nil {
+		hookPath = executablePath
+	}
+	record := hookCancellationDiagnostic{
+		SchemaVersion: hookCancellationDiagnosticSchemaVersion,
+		Client:        strings.TrimSpace(client),
+		HostEvent:     strings.TrimSpace(hostEvent),
+		HookCommand:   strings.TrimSpace(hookCommand),
+		HookPath:      hookPath,
+		Workspace:     workspace.String(),
+		SessionID:     sessionID.String(),
+		Status:        hookCancellationDiagnosticStatusStarted,
+		StartedAt:     startedAt,
+	}
+
+	path := filepath.Join(diagnosticsDir, hookCancellationDiagnosticFileName(record, startedAt))
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode hook cancellation diagnostic: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		return "", xerrors.Errorf("failed to write hook cancellation diagnostic: %w", err)
+	}
+
+	return path, nil
+}
+
+func clearHookCancellationDiagnostic(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear hook cancellation diagnostic: %w", err)
+	}
+	return nil
+}
+
+func updateHookCancellationDiagnosticWorkspace(path string, workspace types.Workspace) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return xerrors.Errorf("failed to read hook cancellation diagnostic: %w", err)
+	}
+	var record hookCancellationDiagnostic
+	if err := json.Unmarshal(data, &record); err != nil {
+		return xerrors.Errorf("failed to decode hook cancellation diagnostic: %w", err)
+	}
+	record.Workspace = workspace.String()
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode hook cancellation diagnostic: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		return xerrors.Errorf("failed to update hook cancellation diagnostic: %w", err)
+	}
+	return nil
+}
+
+func clearHookCancellationDiagnosticsForSession(client, hostEvent string, sessionID types.SessionID) error {
+	sessionIDValue := strings.TrimSpace(sessionID.String())
+	if sessionIDValue == "" {
+		return nil
+	}
+	scan, err := scanHookCancellationDiagnostics(client, hostEvent, "")
+	if err != nil {
+		return err
+	}
+	for _, record := range scan.Records {
+		if record.SessionID != sessionIDValue {
+			continue
+		}
+		if err := clearHookCancellationDiagnostic(record.Path); err != nil {
+			return err
+		}
+	}
+	for _, path := range scan.Unreadable {
+		if !hookCancellationDiagnosticPathMatchesSession(path, client, hostEvent, sessionID) {
+			continue
+		}
+		if err := clearHookCancellationDiagnostic(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hookCancellationDiagnosticPathMatchesSession(path, client, hostEvent string, sessionID types.SessionID) bool {
+	fileName := filepath.Base(strings.TrimSpace(path))
+	if fileName == "" {
+		return false
+	}
+	prefix := strings.Join([]string{
+		sanitizeHookStateKey(client),
+		sanitizeHookStateKey(hostEvent),
+		sanitizeHookStateKey(sessionID.String()),
+	}, "-") + "-"
+	return strings.HasPrefix(fileName, prefix) && strings.HasSuffix(fileName, ".json")
+}
+
+func emptyAsDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func formatHookDiagnosticTime(value time.Time) string {
+	if value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func formatUnreadableHookDiagnosticsSuffix(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("; unreadable=%s", strings.Join(paths, ","))
+}
+
+func scanHookCancellationDiagnostics(client, hostEvent string, workspace types.Workspace) (hookCancellationDiagnosticScan, error) {
+	diagnosticsDir, err := hookDiagnosticsDir()
+	if err != nil {
+		return hookCancellationDiagnosticScan{}, err
+	}
+	entries, err := os.ReadDir(diagnosticsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return hookCancellationDiagnosticScan{}, nil
+		}
+		return hookCancellationDiagnosticScan{}, xerrors.Errorf("failed to read hook diagnostics directory: %w", err)
+	}
+
+	client = strings.TrimSpace(client)
+	hostEvent = strings.TrimSpace(hostEvent)
+	workspaceValue := strings.TrimSpace(workspace.String())
+	scan := hookCancellationDiagnosticScan{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(diagnosticsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			scan.Unreadable = append(scan.Unreadable, path)
+			continue
+		}
+		var record hookCancellationDiagnostic
+		if err := json.Unmarshal(data, &record); err != nil {
+			scan.Unreadable = append(scan.Unreadable, path)
+			continue
+		}
+		if record.Status != hookCancellationDiagnosticStatusStarted {
+			continue
+		}
+		if client != "" && record.Client != client {
+			continue
+		}
+		if hostEvent != "" && record.HostEvent != hostEvent {
+			continue
+		}
+		// Empty-workspace records intentionally remain visible in every
+		// scoped doctor run: failing closed here would hide cancellation
+		// evidence from the exact cases where the host did not provide cwd
+		// or Traceary was interrupted before workspace resolution.
+		if workspaceValue != "" && strings.TrimSpace(record.Workspace) != "" && record.Workspace != workspaceValue {
+			continue
+		}
+		record.Path = path
+		scan.Records = append(scan.Records, record)
+	}
+
+	sort.Slice(scan.Records, func(i, j int) bool {
+		left := scan.Records[i]
+		right := scan.Records[j]
+		if !left.StartedAt.Equal(right.StartedAt) {
+			return left.StartedAt.After(right.StartedAt)
+		}
+		return left.Path < right.Path
+	})
+	sort.Strings(scan.Unreadable)
+	return scan, nil
+}
+
+func hookDiagnosticsDir() (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, hookDiagnosticsDirName), nil
+}
+
+func hookCancellationDiagnosticFileName(record hookCancellationDiagnostic, startedAt time.Time) string {
+	parts := []string{
+		record.Client,
+		record.HostEvent,
+		record.SessionID,
+		resolveHookStateKey(),
+		startedAt.UTC().Format("20060102T150405.000000000Z"),
+	}
+	sanitized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = sanitizeHookStateKey(part)
+		if part != "" && part != "default" {
+			sanitized = append(sanitized, part)
+		}
+	}
+	if len(sanitized) == 0 {
+		return "hook-diagnostic.json"
+	}
+	return strings.Join(sanitized, "-") + ".json"
+}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -317,11 +317,40 @@ func (c *RootCLI) runHookSession(
 			if clearErr := clearHookWorkspaceState(client); clearErr != nil {
 				return clearErr
 			}
+			if strings.TrimSpace(client) == "claude" {
+				if clearErr := clearHookCancellationDiagnosticsForSession(client, "SessionEnd", sessionID); clearErr != nil {
+					slog.Debug("hook already-ended cancellation diagnostic cleanup failed", "client", client, "session_id", sessionID, "error", clearErr)
+				}
+			}
 			return nil
 		} else if err != nil {
 			return err
 		}
 
+		hookCancellationDiagnosticPath := ""
+		shouldTrackClaudeCancellation := strings.TrimSpace(client) == "claude"
+		if shouldTrackClaudeCancellation {
+			if path, err := beginHookCancellationDiagnostic(
+				client,
+				"SessionEnd",
+				"'traceary' 'hook' 'session' 'claude' 'end'",
+				sessionID,
+				"",
+			); err != nil {
+				slog.Debug("hook session-end cancellation diagnostic failed", "client", client, "session_id", sessionID, "error", err)
+			} else {
+				hookCancellationDiagnosticPath = path
+			}
+		}
+		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
+		if err != nil {
+			return err
+		}
+		if shouldTrackClaudeCancellation {
+			if err := updateHookCancellationDiagnosticWorkspace(hookCancellationDiagnosticPath, workspace); err != nil {
+				slog.Debug("hook session-end cancellation diagnostic workspace update failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
+			}
+		}
 		resolvedDBPath, err := resolveDBPath(dbPath)
 		if err != nil {
 			return err
@@ -329,10 +358,6 @@ func (c *RootCLI) runHookSession(
 		c.applyDatabasePath(resolvedDBPath)
 		if err := c.storeManagement.Initialize(ctx); err != nil {
 			return xerrors.Errorf("failed to initialize store: %w", err)
-		}
-		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
-		if err != nil {
-			return err
 		}
 		if _, err := c.session.End(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to record hook session end: %w", err)
@@ -349,6 +374,12 @@ func (c *RootCLI) runHookSession(
 				Workspace(workspace).
 				Build()); err != nil {
 				slog.Debug("hook session-end auto-extract failed", "client", client, "session_id", sessionID, "error", err)
+			}
+		}
+		if shouldTrackClaudeCancellation {
+			if err := clearHookCancellationDiagnosticsForSession(client, "SessionEnd", sessionID); err != nil {
+				slog.Debug("hook session-end cancellation diagnostic cleanup failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
+				_ = clearHookCancellationDiagnostic(hookCancellationDiagnosticPath)
 			}
 		}
 		if err := clearHookSessionState(client); err != nil {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -301,6 +301,196 @@ func TestRootCLI_HookSessionCommand_EndUsesStateAndCreatesEndMarker(t *testing.T
 	if _, err := os.Stat(filepath.Join(stateDir, "ended", "claude-claude-session")); err != nil {
 		t.Fatalf("Stat(end marker) error = %v", err)
 	}
+	diagnosticsDir := filepath.Join(stateDir, "diagnostics")
+	if entries, err := os.ReadDir(diagnosticsDir); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadDir(diagnostics) error = %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("diagnostics entries = %d, want none after successful SessionEnd", len(entries))
+	}
+}
+
+func TestRootCLI_HookSessionCommand_EndLeavesCancellationDiagnosticOnFailure(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "cancel-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-cancel-key"), []byte("cancelled-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-cancel-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{endErr: errors.New("simulated hook cancellation")}),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"agent_type":"planner"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "end"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v (hook errors must stay best-effort)", err)
+	}
+
+	diagnosticsDir := filepath.Join(stateDir, "diagnostics")
+	entries, err := os.ReadDir(diagnosticsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(diagnostics) error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("diagnostics entries = %d, want 1", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(diagnosticsDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile(diagnostic) error = %v", err)
+	}
+	var diagnostic struct {
+		Client      string `json:"client"`
+		HostEvent   string `json:"host_event"`
+		HookCommand string `json:"hook_command"`
+		HookPath    string `json:"hook_path"`
+		Workspace   string `json:"workspace"`
+		SessionID   string `json:"session_id"`
+		Status      string `json:"status"`
+		StartedAt   string `json:"started_at"`
+	}
+	if err := json.Unmarshal(data, &diagnostic); err != nil {
+		t.Fatalf("json.Unmarshal(diagnostic) error = %v", err)
+	}
+	if got, want := diagnostic.Client, "claude"; got != want {
+		t.Fatalf("diagnostic client = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.HostEvent, "SessionEnd"; got != want {
+		t.Fatalf("diagnostic host_event = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.HookCommand, "'traceary' 'hook' 'session' 'claude' 'end'"; got != want {
+		t.Fatalf("diagnostic hook_command = %q, want %q", got, want)
+	}
+	if diagnostic.HookPath == "" {
+		t.Fatal("diagnostic hook_path is empty")
+	}
+	if got, want := diagnostic.Workspace, "github.com/duck8823/traceary"; got != want {
+		t.Fatalf("diagnostic workspace = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.SessionID, "cancelled-session"; got != want {
+		t.Fatalf("diagnostic session_id = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.Status, "started"; got != want {
+		t.Fatalf("diagnostic status = %q, want %q", got, want)
+	}
+	if diagnostic.StartedAt == "" {
+		t.Fatal("diagnostic started_at is empty")
+	}
+	malformedPath := filepath.Join(diagnosticsDir, "claude-SessionEnd-cancelled-session-malformed-20260619T000000.000000000Z.json")
+	if err := os.WriteFile(malformedPath, []byte(`{"client":"claude"`), 0o600); err != nil {
+		t.Fatalf("WriteFile(malformed diagnostic) error = %v", err)
+	}
+
+	successStub := &sessionUsecaseStub{
+		endEvent: model.EventOf(
+			types.EventID("evt-end-after-cancel"),
+			types.EventKindSessionEnded,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("cancelled-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"session ended",
+			time.Now(),
+		),
+	}
+	successCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(successStub),
+	).Command()
+	successCmd.SetOut(&bytes.Buffer{})
+	successCmd.SetErr(&bytes.Buffer{})
+	successCmd.SetIn(strings.NewReader(`{"agent_type":"planner"}`))
+	successCmd.SetArgs([]string{"hook", "session", "claude", "end"})
+
+	if err := successCmd.Execute(); err != nil {
+		t.Fatalf("success Execute() error = %v", err)
+	}
+	entries, err = os.ReadDir(diagnosticsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(diagnostics after retry) error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("diagnostics entries after successful retry = %d, want none", len(entries))
+	}
+}
+
+func TestRootCLI_HookSessionCommand_EndWritesCancellationDiagnosticBeforeWorkspaceResolution(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "workspace-error-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-workspace-error-key"), []byte("workspace-error-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(stateDir, "claude-workspace-error-key-repo"), 0o755); err != nil {
+		t.Fatalf("Mkdir(workspace state path) error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{}),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"cwd":"/tmp/project"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "end"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v (hook errors must stay best-effort)", err)
+	}
+
+	diagnosticsDir := filepath.Join(stateDir, "diagnostics")
+	entries, err := os.ReadDir(diagnosticsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(diagnostics) error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("diagnostics entries = %d, want 1", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(diagnosticsDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile(diagnostic) error = %v", err)
+	}
+	var diagnostic struct {
+		HostEvent string `json:"host_event"`
+		Workspace string `json:"workspace"`
+		SessionID string `json:"session_id"`
+		Status    string `json:"status"`
+	}
+	if err := json.Unmarshal(data, &diagnostic); err != nil {
+		t.Fatalf("json.Unmarshal(diagnostic) error = %v", err)
+	}
+	if got, want := diagnostic.HostEvent, "SessionEnd"; got != want {
+		t.Fatalf("diagnostic host_event = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.SessionID, "workspace-error-session"; got != want {
+		t.Fatalf("diagnostic session_id = %q, want %q", got, want)
+	}
+	if got, want := diagnostic.Status, "started"; got != want {
+		t.Fatalf("diagnostic status = %q, want %q", got, want)
+	}
+	if diagnostic.Workspace != "" {
+		t.Fatalf("diagnostic workspace = %q, want empty when workspace resolution fails after marker creation", diagnostic.Workspace)
+	}
 }
 
 func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -3,9 +3,12 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -389,7 +392,9 @@ func TestRootCLI_HookSessionCommand_EndLeavesCancellationDiagnosticOnFailure(t *
 	if diagnostic.StartedAt == "" {
 		t.Fatal("diagnostic started_at is empty")
 	}
-	malformedPath := filepath.Join(diagnosticsDir, "claude-SessionEnd-cancelled-session-malformed-20260619T000000.000000000Z.json")
+	malformedHash := hookCancellationDiagnosticSessionHashForTest("claude", "SessionEnd", "cancelled-session")
+	malformedName := fmt.Sprintf("claude-SessionEnd-cancelled-session-%s-malformed-20260619T000000.000000000Z.json", malformedHash)
+	malformedPath := filepath.Join(diagnosticsDir, malformedName)
 	if err := os.WriteFile(malformedPath, []byte(`{"client":"claude"`), 0o600); err != nil {
 		t.Fatalf("WriteFile(malformed diagnostic) error = %v", err)
 	}
@@ -425,6 +430,19 @@ func TestRootCLI_HookSessionCommand_EndLeavesCancellationDiagnosticOnFailure(t *
 	if len(entries) != 0 {
 		t.Fatalf("diagnostics entries after successful retry = %d, want none", len(entries))
 	}
+}
+
+// hookCancellationDiagnosticSessionHashForTest mirrors the production hash
+// embedded in diagnostic filenames so malformed-marker fixtures use the same
+// scheme that unreadable cleanup matches against.
+func hookCancellationDiagnosticSessionHashForTest(client, hostEvent, sessionID string) string {
+	seed := strings.Join([]string{
+		strings.TrimSpace(client),
+		strings.TrimSpace(hostEvent),
+		strings.TrimSpace(sessionID),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(seed))
+	return "s" + hex.EncodeToString(sum[:])[:12]
 }
 
 func TestRootCLI_HookSessionCommand_EndWritesCancellationDiagnosticBeforeWorkspaceResolution(t *testing.T) {


### PR DESCRIPTION
## Motivation
Claude Code can report `SessionEnd hook ['traceary' 'hook' 'session' 'claude' 'end'] failed: Hook cancelled` only on terminal stderr. Traceary should keep local, durable evidence once the SessionEnd hook reaches Traceary so `doctor --client claude` can guide operators later.

Closes #1190

## Summary
- Add a local hook diagnostic marker under the hook state directory for Claude SessionEnd.
- Write the marker before DB initialization/session-end/memory extraction, clear all markers for the session after successful end processing, and retain the marker on cancellation/suppressed errors.
- Add `claude-hook-cancellations` doctor check with host event, command/path, workspace, session, timestamp, and marker path.
- Cover failure marker, healthy cleanup, successful retry cleanup, and doctor pass/warn paths.

## Verification
- `rtk git diff --check HEAD`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./presentation/cli -run 'TestRootCLI_HookSessionCommand_End(UsesStateAndCreatesEndMarker|LeavesCancellationDiagnosticOnFailure)|TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics'`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go build ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling docs verify-i18n`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling integrations verify`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling release verify-changelog`

## Dogfood
- Built a dev binary in `/private/tmp` and simulated a Claude SessionEnd failure before DB initialization by using an invalid DB path.
- Confirmed one diagnostics JSON marker was written and `doctor --client claude --json --warnings-ok` reported `claude-hook-cancellations: warn` with host event, hook command/path, workspace, session, timestamp, and marker path.

## AI review
- Claude read-only review found marker-order and stale-marker cleanup issues; both were fixed before this PR.
- Gemini/Antigravity: skipped for now because headless `gemini -p ...` still prompts for browser authentication after login, so it is classified as auth_prompt rather than a transient fallback.
