### PR TITLE
fix: normalize SQLite timestamp comparisons

### DIFF
--- a/.ai/spec/1185.md
+++ b/.ai/spec/1185.md
@@ -1,0 +1,66 @@
+# Spec 1185: Normalize RFC3339Nano Timestamps for SQLite TEXT Comparisons
+
+## Requirement summary
+
+SQLite stores event timestamps as RFC3339Nano TEXT. Because Go's `time.Format(time.RFC3339Nano)` trims trailing zeros in the fractional second, the stored width varies (e.g. `2026-06-20T10:00:00Z` vs `2026-06-20T10:00:00.5Z` vs `...000001Z`). Lexical `<`/`>`/`BETWEEN` comparisons over these variable-width strings are incorrect at sub-second boundaries, corrupting:
+
+- **command hook audit dedup** — the boundary that decides whether a hook event is a duplicate,
+- **read-side period filters** — `ListRecent`, `Search`, `ListWindow`, including the legacy `source_hook` path,
+- **session late-event detection** — sub-second "did this event arrive after the cutoff" checks.
+
+Fix is **per-comparison normalization at read/compare time**, not a storage migration. No rewrite of persisted rows.
+
+## Conceptual model
+
+A timestamp has two representations:
+
+- **Stored form** — raw RFC3339Nano TEXT, variable width, unchanged.
+- **Comparable form** — a canonical, fixed-width, lexically-monotonic key derived deterministically from the stored form *at comparison time*.
+
+The invariant: for any two valid instants `a`, `b`, `comparable(a) < comparable(b)` iff `a` is strictly before `b`. Two code paths produce the comparable form:
+
+- **SQL path** — a deterministic registered SQLite function `ts_norm(text) -> text` that pads/canonicalizes the fractional second (and zone) to fixed width, applied to *both operands* of every range comparison.
+- **Go path** — exact instant comparison via `time.Parse(time.RFC3339Nano, …)` then `time.Time.Before/After/Equal`, used where the comparison happens in Go rather than SQL.
+
+Hook dedup uses a hybrid: a **coarse second-prefix SQL predicate** to cheaply narrow candidate rows (index-friendly, no per-row Go parse over the whole table), then an **exact Go `time.Parse` comparison** to resolve the sub-second boundary on the narrowed set.
+
+## Responsibility assignment
+
+| Concern | Owner |
+|---|---|
+| Register deterministic `ts_norm` on every connection | `infrastructure/sqlite/database.go` |
+| Wrap range operands in `ts_norm(...)` in read SQL | `sql/search_events.sql`, `sql/select_recent_events.sql`, `sql/select_recent_events_by_source_hook.sql` |
+| Coarse second-prefix candidate query + exact Go boundary check for hook dedup | `infrastructure/sqlite/event_datasource.go` |
+| Session late-event sub-second detection via parsed-instant comparison | session/read path in `event_datasource.go` (Go-side) |
+| Normalization helper (single source of truth for the canonical form) | shared func in `event_datasource.go` / `database.go`, reused by both `ts_norm` body and any Go-side formatting |
+
+`ts_norm` must be registered `Deterministic` so SQLite may use it in indexed/optimized contexts and so results are stable within a statement.
+
+## Boundaries / interfaces
+
+- **SQL ↔ Go**: `ts_norm` is the sanctioned way to compare/order timestamp TEXT inside correctness-sensitive SQL paths; raw column-vs-literal range comparisons on timestamp columns are disallowed for user-facing read/session boundaries.
+- **Stored data untouched**: writers keep emitting RFC3339Nano; readers normalize. No schema/migration change.
+- **Out of scope (documented, deliberately left raw)**: GC / retention pruning continues to compare raw TEXT. This is acceptable only because retention boundaries are coarse (cut at whole-second or larger granularity) and an off-by-sub-second prune is harmless. This exemption is recorded here so it is a documented decision, not an oversight; if retention ever needs sub-second precision it must adopt `ts_norm` too.
+
+## Behavior tests
+
+1. **Hook dedup boundary** — two hook events whose timestamps differ only in trailing-zero width but represent the same instant dedup as one; two events one nanosecond apart do **not** dedup. Covers a stored `...00Z` vs `...00.000Z` collision case.
+2. **ListRecent / Search / ListWindow period filter** — an event at `T.5` is included/excluded correctly when the window edge is `T` vs `T.5` vs `T.6`; assert no event is dropped or leaked solely due to fractional-width differences. Run the same assertions through the **legacy `source_hook`** query path.
+3. **Session late-event sub-second detection** — an event arriving fractionally after a session cutoff is detected as late; one fractionally before is not. Drive via parsed-instant comparison, with mixed-width stored timestamps.
+4. **`ts_norm` ordering property** — table-level: insert variable-width timestamps spanning equal/adjacent instants; `ORDER BY ts_norm(col)` matches true chronological order while `ORDER BY col` (raw) demonstrably does not (regression guard).
+
+## TDD plan
+
+1. Write failing test (4) — `ts_norm` ordering / equivalence — to pin the canonical-form contract before implementing the function.
+2. Implement `ts_norm` + register deterministically in `database.go`; make (4) pass.
+3. Write failing read-filter tests (2) for all three queries incl. `source_hook`; wrap operands in `ts_norm`; make pass.
+4. Write failing hook-dedup boundary test (1); implement coarse second-prefix SQL + exact Go `time.Parse` resolution; make pass.
+5. Write failing session late-event test (3); implement Go-side parsed comparison; make pass.
+6. Add the GC/retention exemption note and a test asserting retention still functions (coarse), documenting intentionally-raw behavior.
+
+## Risks / rollback
+
+- **`ts_norm` mis-canonicalization** (zone offsets, varying fractional digits, missing fraction) silently reorders rows. Mitigated by the ordering property test over a matrix of widths/zones; the helper is the single source of truth shared by SQL and Go.
+- **Performance**: wrapping columns in `ts_norm(col)` can defeat raw timestamp index ordering. We deliberately do not add expression indexes over the application-defined function because external SQLite tooling would not know `ts_norm`; if large-database performance becomes a release blocker, add a persisted normalized timestamp column in a follow-up.
+- **Determinism not declared** would break optimizer assumptions — registration flag is asserted in test 4's setup.
+- **Rollback**: change is isolated to read-side SQL, the `ts_norm` registration, and two Go comparison sites. Reverting the three SQL files + the registration + the dedup/session diffs restores prior behavior with zero data-format impact, since storage was never altered.

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -459,3 +459,70 @@ CREATE TABLE command_audits (
 		t.Fatalf("failuresOnly returned a success row; got %v", got)
 	}
 }
+
+func TestDatasource_SaveWithAudit_SuppressesDuplicateAcrossFractionalSecondBoundary(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	agent, err := types.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	sessionID, err := types.SessionIDFrom("session-1")
+	if err != nil {
+		t.Fatalf("SessionIDFrom() error = %v", err)
+	}
+	workspace := types.Workspace("github.com/duck8823/dotfiles")
+	output := "On branch main\n"
+
+	base := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC).Add(500 * time.Millisecond)
+
+	save := func(id string, at time.Time) {
+		t.Helper()
+		eventID, err := types.EventIDFrom(id)
+		if err != nil {
+			t.Fatalf("EventIDFrom(%q) error = %v", id, err)
+		}
+		event := model.EventOfWithSourceHook(eventID, types.EventKindCommandExecuted, types.Client("hook"), agent, sessionID, workspace, "git status\n\nINPUT:\n{}\n\nOUTPUT:\n"+output, at, "post_tool_use")
+		audit, err := model.NewCommandAudit(eventID, "git status", "", output, false, false)
+		if err != nil {
+			t.Fatalf("NewCommandAudit() error = %v", err)
+		}
+		if err := sut.SaveWithAudit(ctx, event, audit); err != nil {
+			t.Fatalf("SaveWithAudit() error = %v", err)
+		}
+	}
+
+	countAudits := func() int {
+		t.Helper()
+		db, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("sql.Open() error = %v", err)
+		}
+		defer func() { _ = db.Close() }()
+		var count int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM command_audits").Scan(&count); err != nil {
+			t.Fatalf("QueryRowContext() error = %v", err)
+		}
+		return count
+	}
+
+	save("event-1", base)
+	save("event-2", base.Add(1500*time.Millisecond))
+
+	if diff := cmp.Diff(1, countAudits()); diff != "" {
+		t.Errorf("command_audits count after duplicate mismatch (-want +got):\n%s", diff)
+	}
+
+	save("event-3", base.Add(2500*time.Millisecond))
+
+	if diff := cmp.Diff(2, countAudits()); diff != "" {
+		t.Errorf("command_audits count after distinct entry mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -13,10 +14,63 @@ import (
 	"sync"
 	"time"
 
-	_ "modernc.org/sqlite" // Required to register the SQLite driver.
+	"modernc.org/sqlite" // Registers the SQLite driver and the ts_norm scalar function (see init).
 
 	"golang.org/x/xerrors"
 )
+
+// sqlTimestampNormalizeFunc is the name of the SQLite scalar function that
+// normalizes a stored RFC3339Nano timestamp to a lexically-orderable
+// fixed-width form for boundary-correct TEXT comparisons. See
+// normalizeRFC3339NanoForCompare and #1185.
+const sqlTimestampNormalizeFunc = "ts_norm"
+
+// init registers ts_norm on the modernc SQLite driver. Registration is global
+// and applies to every connection opened afterwards, so the per-operation
+// connections this package opens all expose the function. It is registered as
+// deterministic so the query planner may cache its result for identical inputs.
+func init() {
+	sqlite.MustRegisterDeterministicScalarFunction(
+		sqlTimestampNormalizeFunc,
+		1,
+		normalizeTimestampSQLFunc,
+	)
+}
+
+// normalizeTimestampSQLFunc adapts normalizeRFC3339NanoForCompare to the
+// SQLite scalar-function signature. NULL and non-text arguments are returned
+// unchanged so wrapping a column in ts_norm never alters its NULL-ness or
+// errors a query over historical/malformed rows.
+func normalizeTimestampSQLFunc(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+	if len(args) != 1 {
+		return nil, xerrors.Errorf("ts_norm expects exactly one argument, got %d", len(args))
+	}
+	raw, ok := args[0].(string)
+	if !ok {
+		return args[0], nil
+	}
+	return normalizeRFC3339NanoForCompare(raw), nil
+}
+
+// normalizeRFC3339NanoForCompare rewrites a variable-width RFC3339Nano
+// timestamp (the shape formatTimestamp emits, which trims trailing fractional
+// zeros) into the fixed-width nine-fractional-digit form used by
+// formatMemoryValidityTimestamp. Variable-width RFC3339Nano is NOT
+// lexicographically ordered the same as real time — e.g. "…00.5Z" sorts before
+// "…00Z" because '.' (0x2E) < 'Z' (0x5A) — so a plain TEXT comparison over
+// created_at / started_at / ended_at can drop an in-range row or include an
+// out-of-range one near a fractional-second boundary. The fixed-width form is
+// lexicographically ordered the same as real time, so TEXT comparisons over it
+// are boundary-correct (see #1185). A value that does not parse as RFC3339 is
+// returned unchanged so historical/malformed rows degrade to the previous
+// lexical behavior rather than erroring the whole query.
+func normalizeRFC3339NanoForCompare(raw string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return raw
+	}
+	return formatMemoryValidityTimestamp(parsed)
+}
 
 // Database wraps a SQLite path and provides connection and migration
 // utilities shared by all per-aggregate datasources in this package.

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -347,6 +347,20 @@ func (d *EventDatasource) SaveWithAudit(
 	return nil
 }
 
+// hookCommandAuditDuplicateExists reports whether an identical hook command
+// audit already exists within duplicateHookCommandAuditWindow of the new
+// event's created_at.
+//
+// events.created_at is stored as variable-width RFC3339Nano (see
+// formatTimestamp), which is NOT lexically ordered the same as real time: e.g.
+// "…00.5Z" sorts before "…00Z". A plain TEXT range over created_at can thus
+// miss a genuine duplicate or over-suppress near fractional-second boundaries.
+// We therefore coarsely pre-filter on the fixed-width whole-second prefix
+// (substr 1..19 is always "YYYY-MM-DDTHH:MM:SS" for the UTC timestamps
+// formatTimestamp emits), widened by an extra second so it is a guaranteed
+// superset of the true window, then compare parsed timestamps exactly in Go.
+// This mirrors hookContentEventDuplicateExists so the two write-path dedup
+// guards stay in lockstep (#1185).
 func hookCommandAuditDuplicateExists(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -363,13 +377,15 @@ func hookCommandAuditDuplicateExists(
 		exitCodeSQL = &exitCode
 		hasExitCode = 1
 	}
-	from := formatTimestamp(event.CreatedAt().Add(-duplicateHookCommandAuditWindow))
-	to := formatTimestamp(event.CreatedAt().Add(duplicateHookCommandAuditWindow))
 
-	var value int
-	err := tx.QueryRowContext(
+	const secondPrefixLayout = "2006-01-02T15:04:05"
+	coarse := duplicateHookCommandAuditWindow + time.Second
+	lowerPrefix := event.CreatedAt().Add(-coarse).UTC().Format(secondPrefixLayout)
+	upperPrefix := event.CreatedAt().Add(coarse).UTC().Format(secondPrefixLayout)
+
+	rows, err := tx.QueryContext(
 		ctx,
-		`SELECT 1
+		`SELECT e.created_at
 		   FROM events e
 		   JOIN command_audits ca ON ca.event_id = e.id
 		  WHERE e.kind = ?
@@ -387,9 +403,8 @@ func hookCommandAuditDuplicateExists(
 		    AND ca.output_original_bytes = ?
 		    AND ((? = 0 AND ca.exit_code IS NULL) OR (? = 1 AND ca.exit_code = ?))
 		    AND ca.failed = ?
-		    AND e.created_at >= ?
-		    AND e.created_at <= ?
-		  LIMIT 1`,
+		    AND substr(e.created_at, 1, 19) >= ?
+		    AND substr(e.created_at, 1, 19) <= ?`,
 		event.Kind().String(),
 		event.Client().String(),
 		event.Agent().String(),
@@ -407,16 +422,38 @@ func hookCommandAuditDuplicateExists(
 		hasExitCode,
 		exitCodeSQL,
 		audit.Failed(),
-		from,
-		to,
-	).Scan(&value)
-	if err == nil {
-		return true, nil
+		lowerPrefix,
+		upperPrefix,
+	)
+	if err != nil {
+		return false, xerrors.Errorf("failed to query duplicate hook command audit candidates: %w", err)
 	}
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	for rows.Next() {
+		var createdAtText string
+		if err := rows.Scan(&createdAtText); err != nil {
+			return false, xerrors.Errorf("failed to scan duplicate hook command audit candidate: %w", err)
+		}
+		candidateAt, err := time.Parse(time.RFC3339Nano, createdAtText)
+		if err != nil {
+			// A malformed historical timestamp must not block the write; skip it
+			// and keep checking the remaining candidates.
+			slog.Debug("skipping unparseable candidate timestamp", "created_at", createdAtText, "error", err)
+			continue
+		}
+		if event.CreatedAt().Sub(candidateAt).Abs() <= duplicateHookCommandAuditWindow {
+			return true, nil
+		}
 	}
-	return false, xerrors.Errorf("failed to check duplicate hook command audit: %w", err)
+	if err := rows.Err(); err != nil {
+		return false, xerrors.Errorf("failed to iterate duplicate hook command audit candidates: %w", err)
+	}
+	return false, nil
 }
 
 // ListRecent returns events in descending time order.

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -780,7 +780,7 @@ func TestDatasource_ListSummariesEndedWithLateEvents(t *testing.T) {
 	const workspace = "duck8823/traceary"
 	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	endMarker := started.Add(2 * time.Minute)
-	lateEvent := started.Add(5 * time.Minute)
+	lateEvent := endMarker.Add(500 * time.Millisecond)
 
 	newScenario := func(t *testing.T) *listSessionsFixture {
 		t.Helper()

--- a/infrastructure/sqlite/sql/find_latest_session.sql
+++ b/infrastructure/sqlite/sql/find_latest_session.sql
@@ -16,7 +16,7 @@ WITH candidate_sessions AS (
                  AND boundary.agent = started.agent
                  AND boundary.workspace = started.workspace
                  AND boundary.kind IN (?, ?)
-               ORDER BY boundary.created_at DESC, boundary.id DESC
+               ORDER BY ts_norm(boundary.created_at) DESC, boundary.id DESC
                LIMIT 1
             ) AS latest_boundary_created_at,
             (
@@ -27,7 +27,7 @@ WITH candidate_sessions AS (
                  AND boundary.agent = started.agent
                  AND boundary.workspace = started.workspace
                  AND boundary.kind IN (?, ?)
-               ORDER BY boundary.created_at DESC, boundary.id DESC
+               ORDER BY ts_norm(boundary.created_at) DESC, boundary.id DESC
                LIMIT 1
             ) AS latest_boundary_id
        FROM events started
@@ -44,8 +44,8 @@ WITH candidate_sessions AS (
                 AND newer_started.agent = started.agent
                 AND newer_started.workspace = started.workspace
                 AND (
-                     newer_started.created_at > started.created_at OR
-                     (newer_started.created_at = started.created_at AND newer_started.id > started.id)
+                     ts_norm(newer_started.created_at) > ts_norm(started.created_at) OR
+                     (ts_norm(newer_started.created_at) = ts_norm(started.created_at) AND newer_started.id > started.id)
                 )
         )
         AND (
@@ -67,8 +67,8 @@ WITH candidate_sessions AS (
                         AND ended.agent = started.agent
                         AND ended.workspace = started.workspace
                         AND (
-                             ended.created_at > started.created_at OR
-                             (ended.created_at = started.created_at AND ended.id > started.id)
+                             ts_norm(ended.created_at) > ts_norm(started.created_at) OR
+                             (ts_norm(ended.created_at) = ts_norm(started.created_at) AND ended.id > started.id)
                         )
                         -- The "later event" check is session_id-only so it
                         -- matches list_sessions.sql's late-event rule exactly.
@@ -80,8 +80,8 @@ WITH candidate_sessions AS (
                                FROM events later_ev
                               WHERE later_ev.session_id = started.session_id
                                 AND (
-                                     later_ev.created_at > ended.created_at OR
-                                     (later_ev.created_at = ended.created_at AND later_ev.id > ended.id)
+                                     ts_norm(later_ev.created_at) > ts_norm(ended.created_at) OR
+                                     (ts_norm(later_ev.created_at) = ts_norm(ended.created_at) AND later_ev.id > ended.id)
                                 )
                         )
                  )
@@ -98,7 +98,7 @@ WITH candidate_sessions AS (
                              SELECT 1
                                FROM events row_later
                               WHERE row_later.session_id = started.session_id
-                                AND row_later.created_at > ended_row.ended_at
+                                AND ts_norm(row_later.created_at) > ts_norm(ended_row.ended_at)
                         )
                  )
              )
@@ -114,6 +114,6 @@ SELECT id,
        source_hook,
        created_at
   FROM candidate_sessions
- ORDER BY CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END DESC,
+ ORDER BY ts_norm(CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END) DESC,
           CASE WHEN ? THEN id ELSE latest_boundary_id END DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/get_context_events.sql
+++ b/infrastructure/sqlite/sql/get_context_events.sql
@@ -2,5 +2,5 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
   FROM events
  WHERE (? = '' OR workspace = ?)
    AND (? = '' OR session_id = ?)
- ORDER BY created_at DESC, id DESC
+ ORDER BY ts_norm(created_at) DESC, id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -20,22 +20,22 @@ WITH RECURSIVE
       e.session_id,
       COUNT(*) AS total_events,
       SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-      GROUP_CONCAT(DISTINCT e.agent) AS agents,
-      MAX(e.created_at) AS latest_event_at
+      GROUP_CONCAT(DISTINCT e.agent) AS agents
     FROM events e
     JOIN selected_ids ON selected_ids.session_id = e.session_id
     GROUP BY e.session_id
   ),
   latest_events AS (
-    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    SELECT session_id, created_at AS latest_event_at, kind AS latest_event_kind, body AS latest_event_body
     FROM (
       SELECT
         e.session_id,
+        e.created_at,
         e.kind,
         e.body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY e.created_at DESC, e.id DESC
+          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
         ) AS rn
       FROM events e
       JOIN selected_ids ON selected_ids.session_id = e.session_id
@@ -50,7 +50,7 @@ SELECT
   s.ended_at,
   COALESCE(agg.total_events, 0) AS total_events,
   COALESCE(agg.command_count, 0) AS command_count,
-  COALESCE(agg.latest_event_at, s.started_at) AS latest_event_at,
+  COALESCE(latest.latest_event_at, s.started_at) AS latest_event_at,
   COALESCE(agg.agents, '') AS agents,
   s.label,
   s.summary,

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -11,10 +11,10 @@ WITH
             SELECT 1
               FROM events late_ev
              WHERE late_ev.session_id = s.session_id
-               AND late_ev.created_at > s.ended_at
+               AND ts_norm(late_ev.created_at) > ts_norm(s.ended_at)
           ))
-      AND (? = '' OR s.started_at >= ?)
-      AND (? = '' OR s.started_at < ?)
+      AND (? = '' OR ts_norm(s.started_at) >= ts_norm(?))
+      AND (? = '' OR ts_norm(s.started_at) < ts_norm(?))
     ORDER BY s.started_at DESC
     LIMIT ? OFFSET ?
   ),
@@ -23,22 +23,22 @@ WITH
       e.session_id,
       COUNT(*) AS total_events,
       SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-      GROUP_CONCAT(DISTINCT e.agent) AS agents,
-      MAX(e.created_at) AS latest_event_at
+      GROUP_CONCAT(DISTINCT e.agent) AS agents
     FROM events e
     JOIN filtered_sessions fs ON fs.session_id = e.session_id
     GROUP BY e.session_id
   ),
   latest_events AS (
-    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    SELECT session_id, created_at AS latest_event_at, kind AS latest_event_kind, body AS latest_event_body
     FROM (
       SELECT
         e.session_id,
+        e.created_at,
         e.kind,
         e.body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY e.created_at DESC, e.id DESC
+          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
         ) AS rn
       FROM events e
       JOIN filtered_sessions fs ON fs.session_id = e.session_id
@@ -53,7 +53,7 @@ SELECT
   s.ended_at,
   COALESCE(agg.total_events, 0) AS total_events,
   COALESCE(agg.command_count, 0) AS command_count,
-  COALESCE(agg.latest_event_at, s.started_at) AS latest_event_at,
+  COALESCE(latest.latest_event_at, s.started_at) AS latest_event_at,
   COALESCE(agg.agents, '') AS agents,
   s.label,
   s.summary,

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -24,11 +24,12 @@ WITH ordered_events AS (
     e.workspace,
     e.body,
     e.created_at,
-    LAG(e.created_at) OVER (ORDER BY e.created_at, e.id) AS prev_created_at
+    ts_norm(e.created_at) AS created_at_norm,
+    LAG(e.created_at) OVER (ORDER BY ts_norm(e.created_at), e.id) AS prev_created_at
   FROM events e
   WHERE (? = '' OR e.workspace = ?)
-    AND (? = '' OR e.created_at >= ?)
-    AND (? = '' OR e.created_at < ?)
+    AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+    AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
 ),
 blocks AS (
   SELECT
@@ -37,14 +38,14 @@ blocks AS (
       WHEN prev_created_at IS NULL THEN 1
       WHEN (julianday(created_at) - julianday(prev_created_at)) * 86400 > ? THEN 1
       ELSE 0
-    END) OVER (ORDER BY created_at, id) AS block_num
+    END) OVER (ORDER BY created_at_norm, id) AS block_num
   FROM ordered_events
 ),
 block_summary AS (
   SELECT
     block_num,
-    MIN(created_at) AS block_start,
-    MAX(created_at) AS block_end,
+    MIN(created_at_norm) AS block_start,
+    MAX(created_at_norm) AS block_end,
     COUNT(*) AS block_event_count,
     GROUP_CONCAT(DISTINCT agent) AS agents
   FROM blocks
@@ -61,7 +62,7 @@ prompt_ranked AS (
     block_num,
     workspace,
     body,
-    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at, id) AS rn
+    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
   WHERE kind = 'prompt'
     AND TRIM(body) != ''
@@ -76,7 +77,7 @@ compact_ranked AS (
     block_num,
     workspace,
     body,
-    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at DESC, id DESC) AS rn
+    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm DESC, id DESC) AS rn
   FROM blocks
   WHERE kind = 'compact_summary'
     AND TRIM(body) != ''
@@ -91,7 +92,7 @@ transcript_ranked AS (
     block_num,
     workspace,
     body,
-    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at, id) AS rn
+    ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
   WHERE kind = 'transcript'
     AND TRIM(body) != ''

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -33,8 +33,11 @@ SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.bo
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.kind = ?)
-   AND (? = '' OR e.created_at >= ?)
-   AND (? = '' OR e.created_at < ?)
+   -- created_at is variable-width RFC3339Nano, which is not lexically ordered
+   -- the same as real time; ts_norm() rewrites both sides to a fixed-width
+   -- form so the period bound is boundary-correct (#1185).
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
    AND (? = 0 OR a.failed = 1 OR (a.exit_code IS NOT NULL AND a.exit_code != 0))
- ORDER BY e.created_at DESC, e.id DESC
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_events.sql
+++ b/infrastructure/sqlite/sql/select_recent_events.sql
@@ -1,8 +1,6 @@
--- No source_hook filter: planner picks idx_events_created_at for the
--- ORDER BY. When a source_hook filter is set, the Go datasource
--- dispatches to select_recent_events_by_source_hook.sql instead so the
--- compound `(source_hook, created_at DESC, id DESC)` partial index can
--- cover the query without a post-filter scan. See #683.
+-- No source_hook filter. When a source_hook filter is set, the Go datasource
+-- dispatches to select_recent_events_by_source_hook.sql so hook-specific
+-- predicates stay isolated from the general recent-events path. See #683.
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
@@ -12,7 +10,9 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.sou
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR e.created_at >= ?)
-   AND (? = '' OR e.created_at < ?)
- ORDER BY e.created_at DESC, e.id DESC
+   -- created_at is variable-width RFC3339Nano; ts_norm() makes the period
+   -- bound and ordering boundary-correct (#1185).
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
@@ -1,7 +1,6 @@
 -- Source_hook filtered query (primary-only path). `e.source_hook = ?`
--- is the top-level conjunct so the planner serves WHERE + ORDER BY
--- from the compound partial index
--- `idx_events_source_hook_time (source_hook, created_at DESC, id DESC)`.
+-- is the top-level conjunct so hook-specific filtering stays out of the
+-- general recent-events path.
 --
 -- Used for hook names that have no legacy body-prefix equivalent
 -- (everything except subagent_stop / pre_compact). For those two names
@@ -19,7 +18,9 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.sou
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR e.created_at >= ?)
-   AND (? = '' OR e.created_at < ?)
- ORDER BY e.created_at DESC, e.id DESC
+   -- created_at is variable-width RFC3339Nano; ts_norm() makes the period
+   -- bound and ordering boundary-correct (#1185).
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
@@ -1,7 +1,6 @@
 -- Source_hook filtered query: the primary branch uses
--- `e.source_hook = ?` as a top-level conjunct so the planner can serve
--- the WHERE + ORDER BY from the compound partial index
--- `idx_events_source_hook_time (source_hook, created_at DESC, id DESC)`.
+-- `e.source_hook = ?` as a top-level conjunct so hook-specific filtering stays
+-- out of the general recent-events path.
 -- A UNION ALL branch matches pre-#672 legacy rows via the body prefix
 -- so migration-window data keeps working. See #683.
 --
@@ -19,8 +18,8 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
            AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR e.created_at >= ?)
-           AND (? = '' OR e.created_at < ?)
+           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
         UNION ALL
         SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
           FROM events e
@@ -38,8 +37,8 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
            AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR e.created_at >= ?)
-           AND (? = '' OR e.created_at < ?)
+           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
        ) events_union
- ORDER BY created_at DESC, id DESC
+ ORDER BY ts_norm(created_at) DESC, id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -31,22 +31,22 @@ WITH RECURSIVE
       e.session_id,
       COUNT(*) AS total_events,
       SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
-      GROUP_CONCAT(DISTINCT e.agent) AS agents,
-      MAX(e.created_at) AS latest_event_at
+      GROUP_CONCAT(DISTINCT e.agent) AS agents
     FROM events e
     JOIN lineage ON lineage.session_id = e.session_id
     GROUP BY e.session_id
   ),
   latest_events AS (
-    SELECT session_id, kind AS latest_event_kind, body AS latest_event_body
+    SELECT session_id, created_at AS latest_event_at, kind AS latest_event_kind, body AS latest_event_body
     FROM (
       SELECT
         e.session_id,
+        e.created_at,
         e.kind,
         e.body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY e.created_at DESC, e.id DESC
+          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
         ) AS rn
       FROM events e
       JOIN lineage ON lineage.session_id = e.session_id
@@ -61,7 +61,7 @@ SELECT
   s.ended_at,
   COALESCE(agg.total_events, 0) AS total_events,
   COALESCE(agg.command_count, 0) AS command_count,
-  COALESCE(agg.latest_event_at, s.started_at) AS latest_event_at,
+  COALESCE(latest.latest_event_at, s.started_at) AS latest_event_at,
   COALESCE(agg.agents, '') AS agents,
   s.label,
   s.summary,


### PR DESCRIPTION
## Motivation

Variable-width RFC3339Nano timestamps are stored as SQLite TEXT. Plain lexical comparisons can misclassify rows around fractional-second boundaries, which affects hook command audit dedup, read-side period filters/orderings, and session late-event detection.

Closes #1185

## Changes

- Register deterministic `ts_norm()` for boundary-correct timestamp TEXT comparisons.
- Normalize correctness-sensitive SQLite timestamp comparisons/orderings in recent/search/context/timeline/session reads.
- Keep command hook audit dedup index-friendly by using a widened whole-second candidate prefilter plus exact Go timestamp comparison.
- Add Structure-Behavior design note and fractional-boundary regression tests.

## Verification

- `rtk git diff --check`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./infrastructure/sqlite`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go build ./...`
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling docs verify-i18n`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling integrations verify`
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go run ./cmd/repo-tooling release verify-changelog`

## Review

- Claude reviewer: APPROVE after the expression-index tradeoff was documented and no blocking finding remained.
- Gemini/Antigravity: skipped; Gemini CLI is retired and Antigravity migration is tracked for v0.22.0.
- Codex review: skipped per operator instruction.
