### PR TITLE
docs: record v0.21 dogfood verification

### DIFF
--- a/.ai/spec/1178.md
+++ b/.ai/spec/1178.md
@@ -1,0 +1,337 @@
+# #1178 v0.21.0 final dogfood verification
+
+## Scope
+
+This file records the final dogfood evidence for the v0.21.0 parent gate (#1166). It uses the real local Traceary dogfood database and the v0.21.0 development binary built from `main` after the #1185 merge.
+
+- DB: `/Users/duck8823/.config/traceary/traceary.db`
+- Binary: `/private/tmp/traceary-dogfood`
+- Version: `traceary v0.20.2-0.20260619225739-4cd15c473563 (commit=4cd15c47356343e03858d076dc1f1e375a770712, date=2026-06-19T22:57:39Z, go=go1.26.3)`
+- Workspace: `github.com/duck8823/traceary`
+- Evidence time: 2026-06-19 23:10-23:30 UTC
+
+Historical rows are intentionally preserved. The original dogfood session still documents the pre-v0.21 failure mode, but the release gate below is based on fresh v0.21 hook writes into the same real DB.
+
+## Local setup note
+
+The live Codex host configuration still contains legacy pre-release state:
+
+- `~/.codex/hooks.json` registers Traceary hooks with `/opt/homebrew/bin/traceary`.
+- The Codex plugin cache also registers Traceary hooks from `traceary@traceary-marketplace` version `0.20.1`.
+- `/opt/homebrew/bin/traceary --version` reports `traceary 0.20.1`.
+
+That explains why historical/current live Codex rows can still show duplicate prompts and `source_hook=stop` session endings until the released binary is installed and legacy duplicate hook registration is cleaned up. It is not treated as a v0.21 code blocker because the fresh dev-binary evidence below exercises the v0.21 hook path against the real DB.
+
+## Evidence matrix
+
+### Codex stop is a turn boundary, not a session end (#1170)
+
+Fresh dogfood session:
+
+```text
+1178-v021-dogfood-20260619T232047Z
+```
+
+Command sequence:
+
+```sh
+TRACEARY_HOOK_STATE_DIR=/private/tmp/traceary-1178-hook-state \
+TRACEARY_WORKSPACE=github.com/duck8823/traceary \
+/private/tmp/traceary-dogfood hook session codex start --db-path /Users/duck8823/.config/traceary/traceary.db
+
+# Same prompt fired twice to verify idempotency.
+/private/tmp/traceary-dogfood hook prompt codex --db-path /Users/duck8823/.config/traceary/traceary.db
+/private/tmp/traceary-dogfood hook prompt codex --db-path /Users/duck8823/.config/traceary/traceary.db
+
+# Same transcript fired twice, followed by the Codex Stop turn-boundary hook.
+/private/tmp/traceary-dogfood hook transcript codex --db-path /Users/duck8823/.config/traceary/traceary.db
+/private/tmp/traceary-dogfood hook transcript codex --db-path /Users/duck8823/.config/traceary/traceary.db
+/private/tmp/traceary-dogfood hook session codex stop --db-path /Users/duck8823/.config/traceary/traceary.db
+
+# Later command audit under the same session.
+/private/tmp/traceary-dogfood hook audit codex --db-path /Users/duck8823/.config/traceary/traceary.db
+```
+
+Verification:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  list --json --workspace github.com/duck8823/traceary \
+  --session-id 1178-v021-dogfood-20260619T232047Z --limit 20
+```
+
+Sanitized result:
+
+```json
+{
+  "session_id": "1178-v021-dogfood-20260619T232047Z",
+  "event_count": 4,
+  "kind_counts": {
+    "session_started": 1,
+    "prompt": 1,
+    "transcript": 1,
+    "command_executed": 1
+  },
+  "source_counts": {
+    "session_started/session_start": 1,
+    "prompt/user_prompt_submit": 1,
+    "transcript/stop": 1,
+    "command_executed/post_tool_use": 1
+  }
+}
+```
+
+`session_ended` check:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  list --json --workspace github.com/duck8823/traceary \
+  --session-id 1178-v021-dogfood-20260619T232047Z \
+  --kind session_ended --limit 20
+```
+
+Result: `[]` (`session_ended_count=0`).
+
+Snapshot check:
+
+```json
+{
+  "session_id": "1178-v021-dogfood-20260619T232047Z",
+  "status": "active",
+  "latest_event_kind": "command_executed",
+  "total_events": 4,
+  "command_count": 1,
+  "agents": ["codex"]
+}
+```
+
+### Codex prompt/transcript writes are idempotent (#1167)
+
+The same prompt and the same transcript were each fired twice in the command sequence above. The real DB retained one prompt and one transcript:
+
+```json
+{
+  "dev_session_id": "1178-v021-dogfood-20260619T232047Z",
+  "dev_counts": {
+    "command_executed": 1,
+    "transcript": 1,
+    "prompt": 1,
+    "session_started": 1
+  },
+  "dev_duplicate_groups": {
+    "prompt": 0,
+    "transcript": 0
+  }
+}
+```
+
+Legacy pre-release rows remain visible and still show the original failure mode. For example, the historical session `019e7d06-3877-7b93-940c-b441df657de4` contains 22 duplicate prompt groups in the sampled prompt window. These rows are preserved as regression evidence, not as the release-gate result.
+
+### Codex doctor no longer reports misleading duplicate-audit warnings (#1168)
+
+After stale-session cleanup (see below):
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  doctor --client codex --json
+```
+
+Exit code: `2` because the dev binary differs from the PATH binary.
+
+Relevant checks:
+
+```json
+{
+  "path": "warn: PATH traceary resolves to /opt/homebrew/bin/traceary, while the tested binary is /private/tmp/traceary-dogfood",
+  "stale-active-sessions": "pass: no active sessions older than 24h0m0s",
+  "audit-reliability": "pass: 200 recent command audits inspected; no duplicate group / workspace drift candidate"
+}
+```
+
+Warnings-only automation mode:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  doctor --client codex --json --warnings-ok
+```
+
+Exit code: `0`.
+
+### Sessions snapshot is usable as the first resume surface (#1172)
+
+After stale-session cleanup:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  sessions --snapshot --json --workspace github.com/duck8823/traceary --allow-stale
+```
+
+Summary:
+
+```json
+{
+  "session_count": 108,
+  "status_counts": {
+    "active": 1,
+    "ended": 5,
+    "ended_with_late_events": 102
+  },
+  "active_session": "1178-v021-dogfood-20260619T232047Z"
+}
+```
+
+Codex-filtered snapshot:
+
+```json
+{
+  "session_count": 94,
+  "status_counts": {
+    "active": 1,
+    "ended_with_late_events": 93
+  },
+  "active_session": "1178-v021-dogfood-20260619T232047Z"
+}
+```
+
+The `ended_with_late_events` rows are historical rows from earlier dogfood runs and remain useful diagnostic evidence.
+
+### Gemini / Antigravity migration (#1171, #1176)
+
+Gemini CLI is no longer a v0.21 release gate. It is treated as retired/unavailable, and the replacement work is tracked as v0.22.0 follow-up:
+
+- #1194 — `v0.22.0: Antigravity migration and review orchestration`
+- #1195 — `v0.22.0-1: discover and wire Antigravity capability detection`
+- #1196 — `v0.22.0-2: add Antigravity hook and dogfood integration package`
+- #1197 — `v0.22.0-3: replace Gemini review guidance with Antigravity migration docs`
+
+This is an explicit deferral from v0.21 rather than an auth or tooling blocker.
+
+### Claude hook coverage gap is surfaced (#1174)
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  doctor --client claude --json
+```
+
+Relevant checks:
+
+```json
+{
+  "claude-config": "pass: hooks are provided by plugin traceary@traceary-plugins",
+  "claude-event-coverage": "warn: 500 recent claude events inspected; 58% of fully observed sessions lacked prompt/transcript coverage",
+  "claude-hook-cancellations": "pass: no pending Claude SessionEnd hook cancellation diagnostics for workspace github.com/duck8823/traceary",
+  "claude-host-capabilities": "pass: SubagentStop and PreCompact are wired alongside SessionStart / SessionEnd / Stop / PostCompact"
+}
+```
+
+#1174 is closed because the host behavior is now diagnosed and surfaced by doctor. The remaining warning is operator-visible and is not a silent coverage gap.
+
+### Memory candidate hygiene dry-run/apply path is verified (#1169, #1173)
+
+Initial snapshot reliability showed a large but bounded candidate backlog:
+
+```json
+{
+  "accepted_count": 3,
+  "candidate_count": 1856,
+  "candidate_hygiene": {
+    "stale_count": 1765,
+    "duplicate_count": 4,
+    "fragment_like_count": 214,
+    "extracted_hidden_count": 198,
+    "likely_actionable_count": 71
+  }
+}
+```
+
+Low-quality cleanup was safe but matched no rows for this workspace:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  memory inbox cleanup --quality low --limit 20 --json
+```
+
+Result: `summary.total=0`.
+
+The stale backlog path was then verified with a bounded dry-run and apply:
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  memory inbox cleanup --quality any --older-than 168h --limit 20 \
+  --workspace github.com/duck8823/traceary --json
+```
+
+Dry-run result:
+
+```json
+{
+  "action": "cleanup-reject",
+  "dry_run": true,
+  "summary": {
+    "total": 20,
+    "by_source": {"remember-intent": 20},
+    "by_type": {"constraint": 2, "lesson": 16, "preference": 2}
+  }
+}
+```
+
+Apply result:
+
+```json
+{
+  "action": "cleanup-reject",
+  "dry_run": false,
+  "summary": {
+    "total": 20,
+    "by_source": {"remember-intent": 20},
+    "by_type": {"constraint": 2, "lesson": 16, "preference": 2}
+  },
+  "processed": 20,
+  "failures": 0
+}
+```
+
+Post-apply snapshot:
+
+```json
+{
+  "accepted_count": 3,
+  "candidate_count": 1836,
+  "candidate_hygiene": {
+    "stale_count": 1745,
+    "duplicate_count": 4,
+    "fragment_like_count": 207,
+    "extracted_hidden_count": 198,
+    "likely_actionable_count": 71
+  }
+}
+```
+
+### Stale active sessions were garbage-collected
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  session gc --stale-after 24h --dry-run
+```
+
+Result: `stale sessions found (dry-run): 90`.
+
+```sh
+/private/tmp/traceary-dogfood --db-path /Users/duck8823/.config/traceary/traceary.db \
+  session gc --stale-after 24h
+```
+
+Result: `ended stale sessions: 90`.
+
+The follow-up `doctor --client codex --json` check reports `stale-active-sessions=pass`.
+
+## Release-gate conclusion
+
+#1178 can close for v0.21.0 with these explicit residuals:
+
+1. The installed PATH binary is still 0.20.1 until release installation, so `doctor --client codex` warns about the dev binary path mismatch. This should disappear after the v0.21 release is installed locally.
+2. Historical duplicate prompt rows and `ended_with_late_events` sessions remain in the DB by design. They are regression evidence and should not be deleted.
+3. The live Codex environment still has both manual hooks and plugin hooks registered. After v0.21 installation, remove the legacy manual fallback or keep only one registration path to avoid double-firing older binaries. This is a release-operator cleanup item, not a product-code change, because v0.21 hook idempotency already suppresses duplicate content when the released binary handles the writes.
+4. Claude coverage still has a warning, but #1174 made it visible and diagnostic rather than silent.
+5. The remaining memory inbox backlog is operator data. #1178 verified the bounded dry-run/apply cleanup path; no separate product issue is required unless the operator later wants an automated drain policy beyond manual `memory inbox cleanup`.
+6. Antigravity support is intentionally deferred to v0.22.0 (#1194-#1197).


### PR DESCRIPTION
## Motivation

Closes #1178.

This is the final v0.21.0 dogfood acceptance artifact for the #1166 release gate. It records real Traceary DB evidence after the v0.21 hook/runtime fixes and explicitly separates preserved historical failure rows from fresh dev-binary verification.

## Changes

- Adds `.ai/spec/1178.md` with the v0.21.0 dogfood evidence matrix.
- Records Codex stop-as-turn-boundary, prompt/transcript idempotency, doctor duplicate-audit behavior, session snapshot resume readiness, Claude diagnostic coverage, memory cleanup dry-run/apply, stale-session GC, and the Gemini→Antigravity v0.22 deferral.
- Documents residual release-operator cleanup for local duplicate Codex hook registration and PATH binary mismatch.

## Verification

- `git diff --check --cached` (Claude delegate) — pass
- `rtk git diff --check --cached` — pass
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk go test ./...` — pass, 2497 tests / 21 packages
- `GOCACHE=/private/tmp/traceary-go-build-cache go build ./...` — pass
- `GOCACHE=/private/tmp/traceary-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run` — pass, 0 issues
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk make docs/check` — pass
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk make integrations/check` — pass
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk make release/check` — pass
- `GOCACHE=/private/tmp/traceary-go-build-cache rtk make landing/check` — pass

## AI review

Claude reviewer: APPROVE

- Low residuals only: local dual Codex hook registration until post-release cleanup, visible Claude coverage warning, and remaining operator memory backlog.
- No blocking findings for closing #1178.

## Residual risks

- The locally installed PATH binary is still 0.20.1 until v0.21.0 is installed.
- Historical DB rows remain `ended_with_late_events` / duplicate prompt evidence by design.
- Antigravity support is deferred to v0.22.0 (#1194-#1197).
