### PR TITLE
Codex prompt/transcript hook writes should be idempotent

### DIFF
--- a/.ai/spec/1205.md
+++ b/.ai/spec/1205.md
@@ -1,0 +1,40 @@
+## Structure-Behavior Design Note (#1205)
+
+### Requirement summary
+- Purpose: Codex (and other host) prompt/transcript hook writes must be idempotent, and existing DB duplicates must be detectable.
+- Current: write-side dedup already exists (`saveDedupedHookContentEvent` / `hookContentEventDuplicateExists`, #1167), but there is no diagnostic for prompt/transcript duplicate rows already in the DB. `doctor` only reports command-audit reliability.
+- Expected: `doctor` gains a `content-event-reliability` check that scans recent hook-originated prompt/transcript events and reports duplicate groups by identity, without dumping full bodies. `command_executed` is out of scope (handled by `audit-reliability` and its re-run semantics).
+- Non-target: DB schema migration, historical cleanup, destructive remediation, command-audit dedup changes.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Content event sample | hook-originated prompt/transcript event | feeds reliability scan | bounded recent window only; `client="hook"` only |
+| Duplicate content group | same {kind, client, agent, session_id, workspace, source_hook, normalized body} | count > 1 is suspicious | body never appears in message; only IDs/counts/kind/source_hook |
+| Proximity window | createdAt clustering | default groups only near-simultaneous writes; strict reports every exact group | mirrors write-side `duplicateHookContentEventWindow`, widened for clock skew |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason | Not owner / reason |
+|---|---|---|---|
+| Collect bounded recent prompt/transcript events | doctor CLI | existing maintainer diagnostic surface | domain must not know scan windows |
+| Classify duplicate groups | pure helpers in `doctor_content_reliability.go` | presentation owns severity/message | datasource not required (events carry body/source_hook) |
+
+### Boundaries / interfaces
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `inspectContentEventReliability` | doctor report | per-kind List + bounded limit | fail only on List error |
+| `contentEventReliabilityFindingsFromEvents` | tests/doctor | grouping + time clustering | returns counts/samples, never full bodies |
+
+### Behavior tests
+| Behavior | Given | When | Then |
+|---|---|---|---|
+| Duplicate detected | two near-simultaneous identical prompt/transcript events | findings built | one group count=2 with kind/source_hook |
+| Far-apart not warned | identical body minutes apart (default) | findings built | no group |
+| command_executed excluded | command_executed events present | findings built | scanned/groups unaffected |
+| Strict reports exact groups | far-apart identical events, strict=true | findings built | one exact group |
+| Message body-free | duplicate with large body | check rendered | body absent, IDs present, hint references `traceary show <event_id>` |
+
+### Risks / rollback
+- False positives: bounded by proximity window + label "candidate"; strict is opt-in.
+- Performance: bounded `List` per kind only (no per-row Show; events already carry body/source_hook).
+- Rollback trigger: diagnostic too slow or noisy → revert the check wiring.

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -80,6 +80,12 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 
 これは自動 cleanup ではなく dogfood review の信号として扱ってください。check は count と sample event ID だけを表示し、command input/output body は出しません。process-review の指標に使う前に、sample row を `traceary show <event_id>` で確認し、本当に duplicate / drift なのか、正当な繰り返し作業なのかを切り分けてください。
 
+### Content event reliability の dogfood signal
+
+`traceary doctor` は bounded な recent prompt/transcript hook window に対して `content-event-reliability` check も出します。ここでは、同じ prompt / transcript の content がその window 内で複数回記録されている duplicate content candidate group を報告します。
+
+これも自動 cleanup ではなく dogfood review の信号として扱ってください。check は count と sample event ID だけを表示し、captured content body は出しません。指標に使う前に、sample row を `traceary show <event_id>` で確認し、本当に duplicate なのか、正当な繰り返し content なのかを切り分けてください。
+
 ### active ingestion 中に cleanup を強く走らせる
 
 `traceary store gc` は古い row を削除したあとに `VACUUM` を実行します。

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -80,6 +80,12 @@ Set `TRACEARY_HOOK_STATE_KEY` explicitly in the hook environment when you need a
 
 Treat this as a dogfood review signal, not as automatic cleanup. The check intentionally prints counts and sampled event IDs only; it does not dump command input/output bodies. Before using process-review metrics, inspect the sampled rows with `traceary show <event_id>` and confirm whether they are real duplicates/drift or legitimate repeated work.
 
+### Content event reliability dogfood signal
+
+`traceary doctor` also includes a `content-event-reliability` check over a bounded recent prompt/transcript hook window. It reports duplicate content candidate groups when the same captured prompt or transcript content is recorded more than once within that window.
+
+Treat this as a dogfood review signal, not as automatic cleanup. The check intentionally prints counts and sampled event IDs only; it does not dump captured content bodies. Before acting on the metric, inspect the sampled rows with `traceary show <event_id>` and confirm whether they are real duplicates or legitimate repeated content.
+
 ### Concurrent cleanup versus active ingestion
 
 `traceary store gc` deletes old rows and then runs `VACUUM`.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -129,7 +129,7 @@ func (c *RootCLI) newDoctorCommand() *cobra.Command {
 	doctorCmd.Flags().BoolVar(&asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	doctorCmd.Flags().BoolVar(&fix, "fix", false, Localize("apply known safe remediations for warning and failing checks", "警告・失敗チェックに対して既知の安全な修復を適用する"))
 	doctorCmd.Flags().BoolVar(&dryRun, "dry-run", false, Localize("preview --fix actions without writing files", "ファイルを書き込まずに --fix の処理をプレビューする"))
-	doctorCmd.Flags().BoolVar(&strict, "strict", false, Localize("audit-reliability: report every exact duplicate group regardless of time, not only near-simultaneous writes", "audit-reliability: 時間に関係なく完全一致する duplicate group をすべて報告する（near-simultaneous な書き込みだけに限定しない）"))
+	doctorCmd.Flags().BoolVar(&strict, "strict", false, Localize("audit-reliability / content-event-reliability: report every exact duplicate group regardless of time, not only near-simultaneous writes", "audit-reliability / content-event-reliability: 時間に関係なく完全一致する duplicate group をすべて報告する（near-simultaneous な書き込みだけに限定しない）"))
 	doctorCmd.Flags().BoolVar(&warningsOK, "warnings-ok", false, Localize("exit 0 when doctor finds warnings but no failures (for CI/smoke automation)", "doctor が警告のみを見つけた場合は exit 0 にする（CI / smoke automation 向け）"))
 	doctorCmd.Flags().Float64Var(&coverageThreshold, "coverage-threshold", defaultDoctorCoverageThreshold, Localize("client event coverage: warn when the recent prompt/transcript-missing session ratio is above this value (0.0 to 1.0)", "client event coverage: recent session の prompt/transcript 欠落比率がこの値を超えたら警告する (0.0 から 1.0)"))
 
@@ -278,6 +278,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		})
 		report.Checks = append(report.Checks, c.inspectStaleActiveSessions(ctx))
 		report.Checks = append(report.Checks, c.inspectCommandAuditReliability(ctx, input.strict))
+		report.Checks = append(report.Checks, c.inspectContentEventReliability(ctx, input.strict))
 	}
 
 	resolvedProjectDir, err := resolveHooksProjectDir(input.projectDir)
@@ -1964,7 +1965,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "stale-active-sessions" || name == "audit-reliability":
+	case name == "db-path" || name == "db-write" || name == "stale-active-sessions" || name == "audit-reliability" || name == "content-event-reliability":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/doctor_content_reliability.go
+++ b/presentation/cli/doctor_content_reliability.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const contentEventReliabilityScanLimit = 200
+
+// contentEventDuplicateProximityWindow bounds how close in time two
+// identity-matching prompt/transcript events must be to count as a likely hook
+// double-write rather than a genuine repeat. Real hook duplicates land
+// near-simultaneously (the write-side guard, duplicateHookContentEventWindow,
+// suppresses exact repeats within 2s); a user legitimately re-sending the same
+// prompt does so seconds-to-minutes apart. This window sits an order of
+// magnitude above the 2s write guard (to absorb clock skew and slow writes) yet
+// far below the spacing of deliberate repeats, so the default diagnostic stays
+// actionable. `traceary doctor --strict` ignores this window and reports every
+// exact duplicate group for forensic analysis. It mirrors
+// commandAuditDuplicateProximityWindow but is a separate constant: command
+// audits and content events keep independent dedup semantics.
+const contentEventDuplicateProximityWindow = 10 * time.Second
+
+type contentEventReliabilityFindings struct {
+	ScannedContentCount int
+	DuplicateGroups     []contentEventDuplicateGroup
+}
+
+type contentEventDuplicateGroup struct {
+	EventIDs   []string
+	Count      int
+	Kind       string
+	SourceHook string
+}
+
+type contentEventDuplicateGroupKey struct {
+	Kind           string
+	Client         string
+	Agent          string
+	SessionID      string
+	Workspace      string
+	SourceHook     string
+	NormalizedBody string
+}
+
+// contentEventDuplicateRecord is one identity-matching content event considered
+// for duplicate grouping, carrying the timestamp used for time clustering.
+type contentEventDuplicateRecord struct {
+	eventID   string
+	createdAt time.Time
+}
+
+// inspectContentEventReliability scans recent hook-originated prompt/transcript
+// events and reports duplicate groups. command_executed is intentionally out of
+// scope (it is covered by inspectCommandAuditReliability, whose re-run semantics
+// differ): this diagnostic lists only the prompt and transcript kinds filtered
+// to client="hook", matching the write-side dedup eligibility in
+// isDedupEligibleHookContentEvent.
+func (c *RootCLI) inspectContentEventReliability(ctx context.Context, strict bool) doctorCheck {
+	const checkName = "content-event-reliability"
+	if c.event == nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusSkip,
+			Message: localizef("event usecase is not configured", "event usecase が設定されていません"),
+		}
+	}
+
+	events := make([]*model.Event, 0, contentEventReliabilityScanLimit*2)
+	for _, kind := range []types.EventKind{types.EventKindPrompt, types.EventKindTranscript} {
+		listed, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(contentEventReliabilityScanLimit).
+			Kind(kind).
+			Client(types.Client("hook")).
+			Build())
+		if err != nil {
+			return doctorCheck{
+				Name:    checkName,
+				Status:  doctorStatusFail,
+				Message: localizef("failed to list recent %s events: %v", "recent %s event の取得に失敗しました: %v", kind.String(), err),
+			}
+		}
+		for _, event := range listed {
+			if event == nil {
+				continue
+			}
+			events = append(events, event)
+		}
+	}
+
+	return contentEventReliabilityCheckFromFindings(contentEventReliabilityFindingsFromEvents(events, strict), strict)
+}
+
+func contentEventReliabilityFindingsFromEvents(events []*model.Event, strict bool) contentEventReliabilityFindings {
+	findings := contentEventReliabilityFindings{}
+	groups := map[contentEventDuplicateGroupKey][]contentEventDuplicateRecord{}
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		// Defensive: only hook-originated prompt/transcript content participates,
+		// mirroring isDedupEligibleHookContentEvent. command_executed never reaches
+		// here because the caller lists only the prompt/transcript kinds.
+		if event.Client().String() != "hook" {
+			continue
+		}
+		if event.Kind() != types.EventKindPrompt && event.Kind() != types.EventKindTranscript {
+			continue
+		}
+		findings.ScannedContentCount++
+		key := newContentEventDuplicateGroupKey(event)
+		groups[key] = append(groups[key], contentEventDuplicateRecord{
+			eventID:   event.EventID().String(),
+			createdAt: event.CreatedAt(),
+		})
+	}
+	for key, records := range groups {
+		findings.DuplicateGroups = append(findings.DuplicateGroups, contentEventDuplicateGroupsFromRecords(key, records, strict)...)
+	}
+	sort.Slice(findings.DuplicateGroups, func(i, j int) bool {
+		return findings.DuplicateGroups[i].EventIDs[0] < findings.DuplicateGroups[j].EventIDs[0]
+	})
+	return findings
+}
+
+func newContentEventDuplicateGroupKey(event *model.Event) contentEventDuplicateGroupKey {
+	return contentEventDuplicateGroupKey{
+		Kind:           event.Kind().String(),
+		Client:         event.Client().String(),
+		Agent:          event.Agent().String(),
+		SessionID:      event.SessionID().String(),
+		Workspace:      event.Workspace().String(),
+		SourceHook:     event.SourceHook(),
+		NormalizedBody: normalizeContentEventBody(event.Body()),
+	}
+}
+
+// normalizeContentEventBody trims surrounding whitespace so trivially different
+// trailing newlines do not split an otherwise identical pair. It intentionally
+// does not collapse interior whitespace: genuinely different prompts must remain
+// distinct.
+func normalizeContentEventBody(body string) string {
+	return strings.TrimSpace(body)
+}
+
+// contentEventDuplicateGroupsFromRecords turns the identity-matching records of
+// a single group key into reportable duplicate groups. In strict mode any group
+// of 2+ exact matches is reported regardless of time. By default the records are
+// clustered by time proximity (consecutive records within
+// contentEventDuplicateProximityWindow) so that only near-simultaneous writes —
+// the likely hook duplicates — are reported. This mirrors
+// commandAuditDuplicateGroupsFromRecords.
+func contentEventDuplicateGroupsFromRecords(key contentEventDuplicateGroupKey, records []contentEventDuplicateRecord, strict bool) []contentEventDuplicateGroup {
+	if len(records) <= 1 {
+		return nil
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if !records[i].createdAt.Equal(records[j].createdAt) {
+			return records[i].createdAt.Before(records[j].createdAt)
+		}
+		return records[i].eventID < records[j].eventID
+	})
+
+	groupFromRun := func(run []contentEventDuplicateRecord) (contentEventDuplicateGroup, bool) {
+		if len(run) < 2 {
+			return contentEventDuplicateGroup{}, false
+		}
+		ids := make([]string, len(run))
+		for i, record := range run {
+			ids[i] = record.eventID
+		}
+		sort.Strings(ids)
+		return contentEventDuplicateGroup{
+			EventIDs:   ids,
+			Count:      len(ids),
+			Kind:       key.Kind,
+			SourceHook: key.SourceHook,
+		}, true
+	}
+
+	if strict {
+		if group, ok := groupFromRun(records); ok {
+			return []contentEventDuplicateGroup{group}
+		}
+		return nil
+	}
+
+	var groups []contentEventDuplicateGroup
+	run := []contentEventDuplicateRecord{records[0]}
+	for _, record := range records[1:] {
+		if record.createdAt.Sub(run[len(run)-1].createdAt) <= contentEventDuplicateProximityWindow {
+			run = append(run, record)
+			continue
+		}
+		if group, ok := groupFromRun(run); ok {
+			groups = append(groups, group)
+		}
+		run = []contentEventDuplicateRecord{record}
+	}
+	if group, ok := groupFromRun(run); ok {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func contentEventReliabilityCheckFromFindings(findings contentEventReliabilityFindings, strict bool) doctorCheck {
+	const checkName = "content-event-reliability"
+	duplicateRecordCount := 0
+	for _, group := range findings.DuplicateGroups {
+		duplicateRecordCount += group.Count
+	}
+	if len(findings.DuplicateGroups) == 0 {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"scanned %d recent prompt/transcript hook event(s); no duplicate content groups found",
+				"%d 件の recent prompt/transcript hook event を検査しました。duplicate content group はありません",
+				findings.ScannedContentCount,
+			),
+		}
+	}
+
+	hint := Localize(
+		"likely hook duplicates (identity-matching prompt/transcript content within "+contentEventDuplicateProximityWindow.String()+"); deliberate repeats farther apart are excluded. Re-run with --strict to surface every exact duplicate group, then inspect with `traceary show <event_id>`. No automatic cleanup is performed",
+		"hook 由来とみられる duplicate（"+contentEventDuplicateProximityWindow.String()+" 以内の identity 一致 prompt/transcript content）です。離れた意図的な再送は除外されます。完全一致する duplicate group をすべて見るには --strict を付け、`traceary show <event_id>` で確認してください。自動的な削除は行いません",
+	)
+	if strict {
+		hint = Localize(
+			"--strict: every exact duplicate content group is reported regardless of time gap, so deliberate repeats appear too; inspect the sampled event IDs with `traceary show <event_id>` before drawing conclusions. No automatic cleanup is performed",
+			"--strict: 時間差に関係なく完全一致する duplicate content group をすべて報告します（意図的な再送も含みます）。結論を出す前に sample event ID を `traceary show <event_id>` で確認してください。自動的な削除は行いません",
+		)
+	}
+
+	return doctorCheck{
+		Name:   checkName,
+		Status: doctorStatusWarn,
+		Hint:   hint,
+		Message: localizef(
+			"scanned %d recent prompt/transcript hook event(s); duplicate_groups=%d duplicate_records=%d samples: %s",
+			"%d 件の recent prompt/transcript hook event を検査しました。duplicate_groups=%d duplicate_records=%d samples: %s",
+			findings.ScannedContentCount,
+			len(findings.DuplicateGroups),
+			duplicateRecordCount,
+			formatContentEventDuplicateSamples(findings.DuplicateGroups),
+		),
+	}
+}
+
+func formatContentEventDuplicateSamples(groups []contentEventDuplicateGroup) string {
+	if len(groups) == 0 {
+		return "-"
+	}
+	limit := len(groups)
+	if limit > 3 {
+		limit = 3
+	}
+	parts := make([]string, 0, limit)
+	for _, group := range groups[:limit] {
+		eventIDs := group.EventIDs
+		if len(eventIDs) > 4 {
+			eventIDs = eventIDs[:4]
+		}
+		sourceHook := group.SourceHook
+		if sourceHook == "" {
+			sourceHook = "-"
+		}
+		parts = append(parts, fmt.Sprintf(
+			"kind=%s source_hook=%s count=%d event_ids=%s",
+			group.Kind,
+			sourceHook,
+			group.Count,
+			strings.Join(eventIDs, ","),
+		))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/presentation/cli/doctor_content_reliability_internal_test.go
+++ b/presentation/cli/doctor_content_reliability_internal_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// TestContentEventReliabilityFindingsDetectDuplicateGroups confirms that
+// near-simultaneous identical prompt/transcript hook events (the #1205 Codex
+// double-write) are reported as one duplicate group, and that the rendered check
+// surfaces the event IDs without leaking the body.
+func TestContentEventReliabilityFindingsDetectDuplicateGroups(t *testing.T) {
+	largeBody := strings.Repeat("p", 2048)
+	base := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		mustContentEvent(t, "evt-a", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", largeBody, base),
+		mustContentEvent(t, "evt-b", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", largeBody, base.Add(time.Second)),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if findings.ScannedContentCount != 2 {
+		t.Fatalf("ScannedContentCount = %d, want 2", findings.ScannedContentCount)
+	}
+	if len(findings.DuplicateGroups) != 1 || findings.DuplicateGroups[0].Count != 2 {
+		t.Fatalf("DuplicateGroups = %+v, want one group of 2", findings.DuplicateGroups)
+	}
+	if findings.DuplicateGroups[0].Kind != "prompt" || findings.DuplicateGroups[0].SourceHook != "user_prompt_submit" {
+		t.Fatalf("group metadata = %+v, want kind=prompt source_hook=user_prompt_submit", findings.DuplicateGroups[0])
+	}
+
+	check := contentEventReliabilityCheckFromFindings(findings, false)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check status = %q, want warn", check.Status)
+	}
+	if !strings.Contains(check.Message, "evt-a") || !strings.Contains(check.Message, "evt-b") {
+		t.Fatalf("check message = %q, want sampled event IDs", check.Message)
+	}
+	if strings.Contains(check.Message, largeBody) {
+		t.Fatalf("check message leaked full content body")
+	}
+	if !strings.Contains(check.Hint, "traceary show <event_id>") {
+		t.Fatalf("check hint = %q, want `traceary show <event_id>` guidance", check.Hint)
+	}
+}
+
+// TestContentEventReliabilityFindingsDetectTranscriptDuplicates ensures the
+// transcript kind is also covered and kept distinct from prompt.
+func TestContentEventReliabilityFindingsDetectTranscriptDuplicates(t *testing.T) {
+	base := time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		mustContentEvent(t, "evt-t1", types.EventKindTranscript, "session-1", "workspace-1", "stop", "assistant turn", base),
+		mustContentEvent(t, "evt-t2", types.EventKindTranscript, "session-1", "workspace-1", "stop", "assistant turn", base.Add(time.Second)),
+		// Same body but prompt kind must not merge with the transcript group.
+		mustContentEvent(t, "evt-p1", types.EventKindPrompt, "session-1", "workspace-1", "stop", "assistant turn", base),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if len(findings.DuplicateGroups) != 1 || findings.DuplicateGroups[0].Count != 2 {
+		t.Fatalf("DuplicateGroups = %+v, want one transcript group of 2", findings.DuplicateGroups)
+	}
+	if findings.DuplicateGroups[0].Kind != "transcript" {
+		t.Fatalf("group kind = %q, want transcript", findings.DuplicateGroups[0].Kind)
+	}
+}
+
+// TestContentEventReliabilityFindingsIgnoreFarApartByDefault covers the
+// false-positive guard: identical content re-sent minutes apart is a deliberate
+// repeat, not a hook double-write, so it must NOT warn by default.
+func TestContentEventReliabilityFindingsIgnoreFarApartByDefault(t *testing.T) {
+	base := time.Date(2026, 6, 20, 2, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		mustContentEvent(t, "evt-1", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "run the tests", base),
+		mustContentEvent(t, "evt-2", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "run the tests", base.Add(9*time.Minute)),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if len(findings.DuplicateGroups) != 0 {
+		t.Fatalf("DuplicateGroups = %+v, want none for far-apart repeats", findings.DuplicateGroups)
+	}
+	check := contentEventReliabilityCheckFromFindings(findings, false)
+	if check.Status != doctorStatusPass {
+		t.Fatalf("check status = %q, want pass", check.Status)
+	}
+}
+
+// TestContentEventReliabilityFindingsDistinctBodiesNotGrouped verifies that
+// different bodies (even near-simultaneous) are never grouped.
+func TestContentEventReliabilityFindingsDistinctBodiesNotGrouped(t *testing.T) {
+	base := time.Date(2026, 6, 20, 3, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		mustContentEvent(t, "evt-1", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "first prompt", base),
+		mustContentEvent(t, "evt-2", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "second prompt", base.Add(time.Second)),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if len(findings.DuplicateGroups) != 0 {
+		t.Fatalf("DuplicateGroups = %+v, want none for distinct bodies", findings.DuplicateGroups)
+	}
+}
+
+// TestContentEventReliabilityFindingsStrictReportsFarApart confirms strict mode
+// reports the whole exact group regardless of time gap.
+func TestContentEventReliabilityFindingsStrictReportsFarApart(t *testing.T) {
+	base := time.Date(2026, 6, 20, 4, 0, 0, 0, time.UTC)
+	newEvents := func() []*model.Event {
+		return []*model.Event{
+			mustContentEvent(t, "evt-near-1", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "hello", base),
+			mustContentEvent(t, "evt-near-2", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "hello", base.Add(time.Second)),
+			mustContentEvent(t, "evt-far", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "hello", base.Add(20*time.Minute)),
+		}
+	}
+
+	defaultFindings := contentEventReliabilityFindingsFromEvents(newEvents(), false)
+	if len(defaultFindings.DuplicateGroups) != 1 || defaultFindings.DuplicateGroups[0].Count != 2 {
+		t.Fatalf("default DuplicateGroups = %+v, want only the near-simultaneous pair", defaultFindings.DuplicateGroups)
+	}
+
+	strictFindings := contentEventReliabilityFindingsFromEvents(newEvents(), true)
+	if len(strictFindings.DuplicateGroups) != 1 || strictFindings.DuplicateGroups[0].Count != 3 {
+		t.Fatalf("strict DuplicateGroups = %+v, want one exact group of 3", strictFindings.DuplicateGroups)
+	}
+}
+
+// TestContentEventReliabilityFindingsExcludeNonHookAndCommand pins acceptance
+// criterion #3: command_executed events and non-hook content writes never affect
+// this diagnostic.
+func TestContentEventReliabilityFindingsExcludeNonHookAndCommand(t *testing.T) {
+	base := time.Date(2026, 6, 20, 5, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		// command_executed (even client="hook") must be ignored.
+		mustEventWithClient(t, "evt-cmd-1", "hook", types.EventKindCommandExecuted, "session-1", "workspace-1", "audit", "go test ./...", base),
+		mustEventWithClient(t, "evt-cmd-2", "hook", types.EventKindCommandExecuted, "session-1", "workspace-1", "audit", "go test ./...", base.Add(time.Second)),
+		// non-hook content writes (direct CLI/MCP) must be ignored.
+		mustEventWithClient(t, "evt-cli-1", "cli", types.EventKindPrompt, "session-1", "workspace-1", "", "note body", base),
+		mustEventWithClient(t, "evt-cli-2", "cli", types.EventKindPrompt, "session-1", "workspace-1", "", "note body", base.Add(time.Second)),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if findings.ScannedContentCount != 0 {
+		t.Fatalf("ScannedContentCount = %d, want 0 (command/non-hook excluded)", findings.ScannedContentCount)
+	}
+	if len(findings.DuplicateGroups) != 0 {
+		t.Fatalf("DuplicateGroups = %+v, want none", findings.DuplicateGroups)
+	}
+}
+
+// TestContentEventReliabilityFindingsNormalizeTrailingWhitespace verifies bodies
+// differing only by trailing whitespace are treated as identical.
+func TestContentEventReliabilityFindingsNormalizeTrailingWhitespace(t *testing.T) {
+	base := time.Date(2026, 6, 20, 6, 0, 0, 0, time.UTC)
+	events := []*model.Event{
+		mustContentEvent(t, "evt-1", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "same body", base),
+		mustContentEvent(t, "evt-2", types.EventKindPrompt, "session-1", "workspace-1", "user_prompt_submit", "same body\n", base.Add(time.Second)),
+	}
+
+	findings := contentEventReliabilityFindingsFromEvents(events, false)
+	if len(findings.DuplicateGroups) != 1 || findings.DuplicateGroups[0].Count != 2 {
+		t.Fatalf("DuplicateGroups = %+v, want one group of 2 after normalization", findings.DuplicateGroups)
+	}
+}
+
+func mustContentEvent(t *testing.T, eventID string, kind types.EventKind, sessionID, workspace, sourceHook, body string, createdAt time.Time) *model.Event {
+	t.Helper()
+	return mustEventWithClient(t, eventID, "hook", kind, sessionID, workspace, sourceHook, body, createdAt)
+}
+
+func mustEventWithClient(t *testing.T, eventID, client string, kind types.EventKind, sessionID, workspace, sourceHook, body string, createdAt time.Time) *model.Event {
+	t.Helper()
+	return model.EventOfWithSourceHook(
+		types.EventID(eventID),
+		kind,
+		types.Client(client),
+		types.Agent("codex"),
+		types.SessionID(sessionID),
+		types.Workspace(workspace),
+		body,
+		createdAt,
+		sourceHook,
+	)
+}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -65,6 +65,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "content-event-reliability",
+      "status": "skip",
+      "severity": "PASS",
+      "section": "Database",
+      "message": "event usecase is not configured",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "project-dir",
       "status": "pass",
       "severity": "PASS",
@@ -203,6 +213,16 @@
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false
+        },
+        {
+          "name": "content-event-reliability",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "event usecase is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
         }
       ]
     },
@@ -252,7 +272,7 @@
     }
   ],
   "summary": {
-    "pass": 9,
+    "pass": 10,
     "warn": 2,
     "fail": 0
   },


### PR DESCRIPTION
Closes #1205

## Motivation

Dogfood logs showed Codex prompt/transcript hooks could leave duplicate content rows in existing databases. The write-side suppression already exists, but operators also need a safe diagnostic for rows that were recorded before suppression or by older installs.

## Changes

- Add `content-event-reliability` to `traceary doctor` for bounded prompt/transcript hook duplicate detection.
- Keep `command_executed` semantics separate from content-event diagnostics.
- Add Structure-Behavior design note and behavior tests for duplicate grouping, strict mode, exclusions, and body-safe output.
- Document the new dogfood signal in operations docs.

## Validation

- Claude implementation lead completed the code/docs changes.
- Claude independent review: APPROVE.
- `git diff --check`
- `GOCACHE=/private/tmp/traceary-gocache go test ./presentation/cli ./infrastructure/sqlite`
- `GOCACHE=/private/tmp/traceary-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- Dogfood temp DB: repeated `hook prompt codex` / `hook transcript codex` produced one prompt and one transcript in `traceary list`, and `sessions --snapshot` reported `total_events=3`.
- Existing-duplicate diagnostic smoke: manually duplicated a prompt row in a temp DB; `doctor --client codex --warnings-ok --json` reported `content-event-reliability` as WARN with sampled event IDs only.
