### PR TITLE
v0.21.1-1: ship Antigravity hook and plugin support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,8 +78,8 @@ codex   # Codex 内で /plugins を開き、Traceary Plugins から Traceary を
 `traceary integration codex install` ヘルパーは v0.14.0 で廃止され、cleanup 専用 `traceary integration codex uninstall` surface は v0.15.0 で削除されました。install / uninstall は上記の Codex CLI 公式 `/plugins` flow を使ってください。移行方法と旧 install を残した環境の手動 cleanup 手順は [Codex plugin ガイド](./docs/integrations/codex-plugin.ja.md) を参照してください。
 
 **Gemini CLI** — v0.21.0 時点でレガシー / アクティブな委譲パスではありません。
-Gemini CLI は Google の AI エージェントホストとして **Antigravity** に移行中です。Traceary の Gemini extension package（`integrations/gemini-extension/`）は既存インストール向けに引き続き提供されます。Antigravity の capability detection は #1195 で実装済みですが、サポートされた公開 CLI/hook contract が確認されていないため、v0.21.0 では Antigravity の hook / package / release asset を意図的に提供しません（#1196 で判断）。
-詳細は [Gemini extension ガイド（レガシー）](./docs/integrations/gemini-extension.ja.md) と [Antigravity 移行状況](./docs/integrations/antigravity.ja.md) を参照してください。
+Gemini CLI は Google の AI エージェントホストとして **Antigravity** に移行中です。Traceary の Gemini extension package（`integrations/gemini-extension/`）は既存インストール向けに引き続き提供されます。v0.21.1 以降、Antigravity は packaged plugin（`integrations/antigravity-plugin/`）を持つサポート対象の hook client です。`traceary hooks install --client antigravity` で導入できます。
+詳細は [Gemini extension ガイド（レガシー）](./docs/integrations/gemini-extension.ja.md) と [Antigravity hooks / plugin ガイド](./docs/integrations/antigravity.ja.md) を参照してください。
 
 全体像は [ネイティブ連携ガイド](./docs/integrations/README.ja.md) にまとめています。Anthropic API を直接使う場合は experimental な [native memory-tool backend](./docs/integrations/anthropic-memory-tool.ja.md) も試せます。
 
@@ -216,9 +216,9 @@ $ traceary timeline --limit 2
 | Claude Code | 完全対応 | Bash + MCP + failure hook | あり | あり | Full |
 | Codex | 完全対応（`SessionStart` + `Stop`） | tool hook | あり | なし | Partial |
 | Gemini CLI | 完全対応（`SessionStart` + `SessionEnd`） | tool hook | なし | なし | Basic（レガシー） |
-| Antigravity | — | — | — | — | Doctor: `tool_unavailable` (#1195); v0.21.0 では package/hook/asset 未提供 (#1196) |
+| Antigravity | 完全対応（`PreInvocation` 開始 / `Stop` turn 境界） | `run_command` hook（`PreToolUse` + `PostToolUse` を突き合わせ） | なし | なし | Partial |
 
-> **v0.21.0 メモ:** Gemini CLI は Google の旧 AI エージェントホストです。Antigravity（`/Applications/Antigravity.app`、bundle ID `com.google.antigravity`、バージョン 2.1.4）が現行の後継であり、capability detection は #1195 で実装済みです。この調査（#1196）の結果、サポートされた公開 CLI/hook contract が確認されていないため、v0.21.0 では Antigravity の hook / package / release asset を意図的に提供しません。Gemini CLI extension package は既存インストール向けに引き続き提供されます。現時点で判明している内容は [Antigravity 移行状況](./docs/integrations/antigravity.ja.md) を参照してください。
+> **v0.21.1 メモ:** Gemini CLI は Google の旧 AI エージェントホストです。Antigravity（`/Applications/Antigravity.app`、bundle ID `com.google.antigravity`）が現行の後継です。v0.21.1 以降、Traceary は Antigravity を実際の hook client としてサポートし、文書化された公開 hook surface に対する packaged plugin（`integrations/antigravity-plugin/`）を提供します。`traceary hooks install --client antigravity` で導入できます。Gemini CLI extension package は既存インストール向けに引き続き提供されます。詳細は [Antigravity hooks / plugin ガイド](./docs/integrations/antigravity.ja.md) を参照してください。
 >
 > 2026 Q2 メモ: Claude Code の `SubagentStop` / `PreCompact` hook は利用可能ですが、Traceary の managed hook 集合には wire していません。Codex の memory feature flag (`~/.codex/config.toml`) は Codex 側の capture 挙動にのみ影響し、Traceary の `memory admin import codex` は flag 状態に関わらず動作します。`traceary doctor` は同じ内容を `<client>-host-capabilities` として surface します。詳細は [hook contract](./docs/hooks/contract.ja.md#2026-q2-ホスト別機能メモ) を参照。
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ codex   # then, inside Codex: /plugins -> Traceary Plugins -> Traceary
 The `traceary integration codex install` helper was retired in v0.14.0 and the cleanup-only `traceary integration codex uninstall` surface was removed in v0.15.0. Use Codex CLI's official `/plugins` flow shown above for install / uninstall. See the [Codex plugin guide](./docs/integrations/codex-plugin.md) for migration details and manual cleanup steps for legacy installs.
 
 **Gemini CLI** — legacy / not the active delegation path as of v0.21.0.
-Gemini CLI is being superseded by **Antigravity** as Google's AI agent host. The Traceary Gemini extension package (`integrations/gemini-extension/`) remains available for existing installs. Antigravity capability detection is implemented in #1195, but v0.21.0 intentionally ships no Antigravity hook, package, or release asset (decided in #1196) because no supported public CLI/hook contract is confirmed.
-See the [Gemini extension guide (legacy)](./docs/integrations/gemini-extension.md) and the [Antigravity migration status](./docs/integrations/antigravity.md).
+Gemini CLI is being superseded by **Antigravity** as Google's AI agent host. The Traceary Gemini extension package (`integrations/gemini-extension/`) remains available for existing installs. As of v0.21.1, Antigravity is a supported hook client with a packaged plugin (`integrations/antigravity-plugin/`); install with `traceary hooks install --client antigravity`.
+See the [Gemini extension guide (legacy)](./docs/integrations/gemini-extension.md) and the [Antigravity hooks and plugin guide](./docs/integrations/antigravity.md).
 
 For the integration overview, use the [native integrations guide](./docs/integrations/README.md). Direct Anthropic API users can also try the experimental [native memory-tool backend](./docs/integrations/anthropic-memory-tool.md).
 
@@ -219,9 +219,9 @@ The query surface is shared: once Traceary is installed, every host can use the 
 | Claude Code | Full | Bash + MCP + failure hooks | Yes | Yes | Full |
 | Codex | Full (`SessionStart` + `Stop`) | Tool hooks | Yes | No | Partial |
 | Gemini CLI | Full (`SessionStart` + `SessionEnd`) | Tool hooks | No | No | Basic (legacy) |
-| Antigravity | — | — | — | — | Doctor: `tool_unavailable` (#1195); no package/hook/asset shipped in v0.21.0 (#1196) |
+| Antigravity | Full (`PreInvocation` start; `Stop` turn boundary) | `run_command` hooks (`PreToolUse` + `PostToolUse` paired) | No | No | Partial |
 
-> **v0.21.0 note:** Gemini CLI is the legacy Google AI agent host. Antigravity (`/Applications/Antigravity.app`, bundle ID `com.google.antigravity`, version 2.1.4) is the active successor, with capability detection implemented in #1195. After that investigation (#1196), v0.21.0 intentionally ships no Antigravity hook, package, or release asset because no supported public CLI/hook contract is confirmed. The Gemini CLI extension package remains available for existing installs. See the [Antigravity migration status](./docs/integrations/antigravity.md) for what is known locally.
+> **v0.21.1 note:** Gemini CLI is the legacy Google AI agent host. Antigravity (`/Applications/Antigravity.app`, bundle ID `com.google.antigravity`) is the active successor. As of v0.21.1, Traceary supports Antigravity as a real hook client with a packaged plugin (`integrations/antigravity-plugin/`) against the documented public hook surface. Install with `traceary hooks install --client antigravity`. The Gemini CLI extension package remains available for existing installs. See the [Antigravity hooks and plugin guide](./docs/integrations/antigravity.md).
 >
 > 2026 Q2 note: Claude Code's `SubagentStop` / `PreCompact` hooks are available but not wired into Traceary's managed hook set. The Codex memory feature flag in `~/.codex/config.toml` changes Codex's own capture behaviour, not Traceary's — `traceary memory admin import codex` works regardless. `traceary doctor` surfaces the same notes under `<client>-host-capabilities`, and the full list lives in the [hook contract](./docs/hooks/contract.md#2026-q2-host-capability-notes).
 

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -76,6 +76,9 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkGemini(root, version); err != nil {
 		return err
 	}
+	if err := checkAntigravity(root); err != nil {
+		return err
+	}
 	return checkDocs(root)
 }
 
@@ -419,12 +422,66 @@ func checkGemini(root, version string) error {
 		"Gemini traceary-memory-capture skill stub must be removed (replaced by traceary-memory-review and traceary-memory-remember)")
 }
 
+// checkAntigravity validates the packaged Antigravity plugin. Antigravity's
+// hooks.json uses a top-level hook-group map (Traceary owns the "traceary"
+// group) rather than the shared {"hooks": {...}} shape, so it is validated with
+// a dedicated parser. The plugin.json follows the official Antigravity schema
+// (name + description only), so no version field is tracked here.
+func checkAntigravity(root string) error {
+	var manifest struct {
+		Schema      string `json:"$schema"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := readJSON(root, "integrations/antigravity-plugin/plugin.json", &manifest); err != nil {
+		return err
+	}
+	if manifest.Name != "traceary" {
+		return xerrors.Errorf("unexpected Antigravity plugin name")
+	}
+	if manifest.Schema != "https://antigravity.google/schemas/v1/plugin.json" {
+		return xerrors.Errorf("antigravity plugin must declare the official plugin.json schema")
+	}
+
+	hooksPath := "integrations/antigravity-plugin/hooks.json"
+	data, err := os.ReadFile(filepath.Join(root, hooksPath))
+	if err != nil {
+		return xerrors.Errorf("missing file: %s", hooksPath)
+	}
+	var groups map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(data, &groups); err != nil {
+		return xerrors.Errorf("invalid json in %s: %w", hooksPath, err)
+	}
+	group, ok := groups["traceary"]
+	if !ok {
+		return xerrors.Errorf("antigravity hooks must define the traceary group")
+	}
+	for _, event := range []string{"PreInvocation", "PreToolUse", "PostToolUse", "Stop"} {
+		if _, ok := group[event]; !ok {
+			return xerrors.Errorf("antigravity traceary group must include %s", event)
+		}
+	}
+	raw := string(data)
+	for _, fragment := range []string{
+		"'hook' 'antigravity' 'pre-invocation'",
+		"'hook' 'antigravity' 'pre-tool-use'",
+		"'hook' 'antigravity' 'post-tool-use'",
+		"'hook' 'antigravity' 'stop'",
+	} {
+		if !strings.Contains(raw, fragment) {
+			return xerrors.Errorf("antigravity packaged hooks must invoke %s", fragment)
+		}
+	}
+	return nil
+}
+
 func checkDocs(root string) error {
 	pairs := []string{
 		"docs/integrations/README.md",
 		"docs/integrations/claude-plugin.md",
 		"docs/integrations/codex-plugin.md",
 		"docs/integrations/gemini-extension.md",
+		"docs/integrations/antigravity.md",
 	}
 	for _, english := range pairs {
 		japanese := strings.TrimSuffix(english, ".md") + ".ja.md"

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -20,7 +20,7 @@
 ## 連携まわり
 
 - [ネイティブ連携ガイド](./integrations/README.ja.md): Claude / Codex / Gemini（レガシー）向けパッケージ、導入手順、smoke test
-- [Antigravity 移行状況](./integrations/antigravity.ja.md): Antigravity のローカル調査、#1195 capability detection（実装済み）、v0.21.0 で Antigravity の package / hook / release asset を意図的に提供しないという #1196 の判断
+- [Antigravity hooks / plugin](./integrations/antigravity.ja.md): v0.21.1 の hook client サポート、packaged plugin、install パス、制限事項、公式 hook/plugin リファレンス
 - [Hooks ガイド](./hooks/README.ja.md): Claude Code / Codex / Gemini（レガシー）の hook 設定、導入手順、トラブルシュート
 - [MCP ガイド](./mcp/README.ja.md): `traceary mcp-server` の起動方法、ツール一覧、MCP クライアント連携
 - [インタラクティブ運用ガイド](./interactive/README.ja.md): `list`、`tail`、`search`、`show`、`handoff` の使い分け

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This page is the detailed docs index for Traceary. Start here when the top-level
 ## Integrations
 
 - [Native integrations](./integrations/README.md): packaged Claude / Codex / Gemini (legacy) integration bundles, install flows, and smoke tests
-- [Antigravity migration status](./integrations/antigravity.md): local discovery, #1195 capability detection (implemented), and the #1196 decision to intentionally ship no Antigravity package/hook/release asset in v0.21.0
+- [Antigravity hooks and plugin](./integrations/antigravity.md): v0.21.1 hook client support, packaged plugin, install paths, limitations, and the official hook/plugin references
 - [Hooks guide](./hooks/README.md): Claude Code / Codex / Gemini (legacy) hook setup, install flow, and troubleshooting
 - [MCP guide](./mcp/README.md): running `traceary mcp-server`, tool surface, and host-client integration notes
 - [Interactive workflows](./interactive/README.md): how to inspect live and recent activity with `list`, `tail`, `search`, `show`, and `handoff`

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -232,12 +232,21 @@ Codex の `Stop` は assistant 応答ごとに発火するため、Traceary は 
 
 ### Gemini CLI *（レガシー互換）*
 
-> Gemini CLI はレガシー hook パスです。Antigravity は v0.21.0 時点で Traceary の hook 設定を持っておらず、サポートされた公開 CLI/hook contract が確認されていないため、v0.21.0 では Antigravity の hook / package / release asset を意図的に提供しません（#1196 で判断）。現在の Antigravity 機能ステートを確認するには `traceary doctor --client antigravity --json` を実行してください。`/Applications/Antigravity.app` がインストールされている環境では、Google がサポートされた公開 CLI/hook contract を公開するまでステートは `tool_unavailable` になります。
+> Gemini CLI はレガシー hook パスです。後継の Antigravity は v0.21.1 からサポートされています（下記参照）。
 
 1. `examples/hooks/gemini.settings.json` を `.gemini/settings.json` または `~/.gemini/settings.json` にマージする
 2. `hooksConfig.enabled` が既に `true` になっていることを確認する。Traceary はここを自動変更しません
 3. Gemini CLI を起動して、少なくとも 1 回 shell command を実行する
 4. `traceary list --limit 10` または `traceary search "<command>"` で記録結果を確認する
+
+### Antigravity
+
+1. Traceary hook をインストールする: `traceary hooks install --client antigravity --project-dir .`（workspace は `.agents/hooks.json`）または `--global`（`~/.gemini/config/hooks.json`）。`agy` / `antigravity-cli` alias も使えます
+2. Antigravity の conversation を開始し、少なくとも 1 回 `run_command` tool を実行する
+3. `traceary list --limit 10` で記録結果を確認する
+4. `traceary doctor --client antigravity --json` で install を確認する（`antigravity-capability` と `antigravity-config` を報告）
+
+Antigravity に `SessionStart` はなく、Traceary は `PreInvocation` から session を冪等に開始します。Codex 同様 `Stop` は execution 単位の turn 境界なので session は開いたままで、MCP `manage_session` または stale GC で終了します。audit 対象は `run_command` tool のみです（`PreToolUse` の command args と `PostToolUse` の結果を突き合わせます）。詳細は [Antigravity hooks / plugin ガイド](../integrations/antigravity.ja.md) を参照してください。
 
 Traceary CLI が失敗したときの stderr は plain `Error: ...` です。wrapper 経由の hook 実行でも、exit code と stderr text をそのまま扱えます。
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -232,12 +232,21 @@ Codex `Stop` fires after every assistant response, so Traceary records it as a t
 
 ### Gemini CLI *(legacy compatibility)*
 
-> Gemini CLI is the legacy hook path. Antigravity does not have a Traceary hook config in v0.21.0, and v0.21.0 intentionally ships no Antigravity hook, package, or release asset (decided in #1196) because no supported public CLI/hook contract is confirmed. To check the current Antigravity capability state, run `traceary doctor --client antigravity --json` — on a machine with `/Applications/Antigravity.app` installed, the state will be `tool_unavailable` until Google exposes a supported public CLI/hook contract.
+> Gemini CLI is the legacy hook path; Antigravity is the active successor (supported from v0.21.1 — see below).
 
 1. Merge `examples/hooks/gemini.settings.json` into `.gemini/settings.json` or `~/.gemini/settings.json`.
 2. Ensure `hooksConfig.enabled` is already `true`. Traceary does not toggle this for you.
 3. Start Gemini CLI and run at least one shell command.
 4. Verify the resulting events with `traceary list --limit 10` or `traceary search "<command>"`.
+
+### Antigravity
+
+1. Install the Traceary hooks: `traceary hooks install --client antigravity --project-dir .` (workspace `.agents/hooks.json`) or `--global` (`~/.gemini/config/hooks.json`). The `agy` and `antigravity-cli` aliases also work.
+2. Start an Antigravity conversation and run at least one `run_command` tool call.
+3. Verify the resulting events with `traceary list --limit 10`.
+4. Check the install with `traceary doctor --client antigravity --json` (reports `antigravity-capability` and `antigravity-config`).
+
+Antigravity has no `SessionStart`: Traceary starts the session idempotently from `PreInvocation`. Like Codex, `Stop` is a per-execution turn boundary, so the session stays open and ends via MCP `manage_session` or stale GC. Only `run_command` tool calls are audited (the command args from `PreToolUse` are paired with the result from `PostToolUse`). See the [Antigravity hooks and plugin guide](../integrations/antigravity.md).
 
 When a Traceary CLI command fails, stderr is a plain `Error: ...` line. Hook wrappers can rely on the exit code and stderr text without stripping structured JSON logs.
 

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -10,20 +10,20 @@
 - `○` ホスト側に hook はあるが Traceary 未配線
 - `✕` ホスト自体が公開していない
 
-**最終確認日: 2026-04-27 (Gemini CLI は 2026-06-10 に 0.43.0 で再確認済).** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
+**最終確認日: 2026-04-27 (Gemini CLI は 2026-06-10 に 0.43.0 で再確認済。Antigravity は v0.21.1 向けに 2026-06-20 に追加).** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
 
-> **v0.21.0 注記:** このマトリクスに掲載されている Gemini CLI の hook カバレッジは**レガシー互換のみ**です。Gemini CLI はレガシーの Google AI エージェントホストであり、後継は Antigravity（`/Applications/Antigravity.app`）です。**Antigravity は v0.21.0 において確認・サポートされた hook カバレッジはありません。** Antigravity の capability detection は #1195 で実装済みです。この調査（#1196）の結果、サポートされた公開 CLI/hook contract が確認されていないため、v0.21.0 では Antigravity の hook / package / release asset を意図的に提供しません。Google がサポートされた公開 CLI/hook contract を公開するまで、Antigravity の列はこのマトリクスに追加しません。
+> **v0.21.1 注記:** このマトリクスに掲載されている Gemini CLI の hook カバレッジは**レガシー互換のみ**です。Gemini CLI はレガシーの Google AI エージェントホストであり、後継は Antigravity（`/Applications/Antigravity.app`）です。**v0.21.1 以降、Antigravity はサポート対象の hook client** であり、文書化された公開 hook surface に対する packaged plugin（`integrations/antigravity-plugin/`）を提供します。[Antigravity hooks / plugin ガイド](../integrations/antigravity.ja.md) を参照してください。
 
 ## ライフサイクルイベント → ホスト hook マトリクス
 
-| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | 確認方法 |
-|---|---|---|---|---|
-| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | `traceary list events --kind session_started --limit 5` |
-| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | `traceary list events --kind prompt --limit 5` |
-| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | `traceary list events --kind command_executed --limit 5` |
-| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | `traceary list events --kind transcript --limit 5` |
-| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ✕ Codex 0.125 に compact hook なし (upstream openai/codex#16098) | ● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない) | `traceary list events --kind compact_summary --limit 5` |
-| `session_ended` | ● `SessionEnd` | ✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ● `SessionEnd` | `traceary list events --kind session_ended --limit 5` |
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | 確認方法 |
+|---|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation`（`conversationId` を key にした冪等開始。Antigravity に `SessionStart` はない） | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ✕ 文書化された user-prompt hook なし | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse`（`run_command`。command args は `conversationId + stepIdx` で 2 event をまたいで突き合わせ） | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop`（`transcriptPath`、best-effort な寛容 JSONL 走査） | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ✕ Codex 0.125 に compact hook なし (upstream openai/codex#16098) | ● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない) | ✕ 文書化された compact hook なし | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ● `SessionEnd` | ✕ host のセッション終了信号なし — Antigravity `Stop` は execution 単位の境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | `traceary list events --kind session_ended --limit 5` |
 
 ### Traceary 未配線のホスト hook
 
@@ -36,12 +36,14 @@
 | Claude Code | `Notification`, `PreToolUse` (他 matcher), `StopFailure`, `UserPromptExpansion`, `PermissionRequest`, `PermissionDenied`, `PostToolBatch`, `TaskCreated`, `TaskCompleted`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `Elicitation`, `ElicitationResult` | ○ 利用可 | 現行パッケージでは未配線 |
 | Codex CLI | `PreToolUse`, `PermissionRequest`, `Notification` | ○ 利用可 | 未配線 |
 | Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ 利用可 | 未配線 |
+| Antigravity | `run_command` 以外の tool に対する `PreToolUse` | ○ 利用可 | audit 対象は `run_command` のみ |
 
 ## ホスト別参照
 
 - Claude Code: https://code.claude.com/docs/en/hooks · パッケージ config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
 - Codex CLI: upstream binary `codex-cli 0.125.0` — hook surface はローカルインストールのバイナリ文字列 (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionRequest`, `UserPromptSubmit`) から推定。compact hook tracking: openai/codex#16098. パッケージ config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
 - Gemini CLI: ローカルインストール同梱の hooks reference (`/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`。文書化された hook surface に post-compress event はなく、`PreCompress` は compression 前に非同期で発火する advisory-only hook). パッケージ config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+- Antigravity: 公開 hook surface は https://antigravity.google/assets/docs/antigravity-2-0/hooks.md および https://antigravity.google/assets/docs/editor/ide-hooks.md、plugin packaging は https://antigravity.google/assets/docs/cli/cli-plugins.md に文書化（2026-06-20 JST 確認）。パッケージ config: [`integrations/antigravity-plugin/hooks.json`](../../integrations/antigravity-plugin/hooks.json)
 
 ## 更新方法
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -10,20 +10,20 @@ Legend:
 - `○` available in the host but not wired by Traceary yet
 - `✕` not exposed by this host
 
-**Last verified: 2026-04-27 (Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
+**Last verified: 2026-04-27 (Gemini CLI re-verified 2026-06-10 against 0.43.0; Antigravity added 2026-06-20 for v0.21.1).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
 
-> **v0.21.0 note:** Gemini CLI hook coverage in this matrix is **legacy compatibility only**. Gemini CLI is the legacy Google AI agent host; Antigravity (`/Applications/Antigravity.app`) is the active successor. **Antigravity has no confirmed or supported hook coverage in v0.21.0.** Antigravity capability detection is implemented in #1195. After that investigation (#1196), v0.21.0 intentionally ships no Antigravity hook, package, or release asset because no supported public CLI/hook contract is confirmed. No Antigravity column appears in this matrix until Google exposes a supported public CLI/hook contract.
+> **v0.21.1 note:** Gemini CLI hook coverage in this matrix is **legacy compatibility only**. Gemini CLI is the legacy Google AI agent host; Antigravity (`/Applications/Antigravity.app`) is the active successor. As of **v0.21.1, Antigravity is a supported hook client** with a packaged plugin against the documented public hook surface (`integrations/antigravity-plugin/`). See the [Antigravity hooks and plugin guide](../integrations/antigravity.md).
 
 ## Lifecycle event → host hook matrix
 
-| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Verification |
-|---|---|---|---|---|
-| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | `traceary list events --kind session_started --limit 5` |
-| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | `traceary list events --kind prompt --limit 5` |
-| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | `traceary list events --kind command_executed --limit 5` |
-| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | `traceary list events --kind transcript --limit 5` |
-| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ✕ no compact hook in Codex 0.125 (upstream openai/codex#16098) | ● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary) | `traceary list events --kind compact_summary --limit 5` |
-| `session_ended` | ● `SessionEnd` | ✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ● `SessionEnd` | `traceary list events --kind session_ended --limit 5` |
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.125 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Verification |
+|---|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation` (idempotent, keyed by `conversationId`; Antigravity has no `SessionStart`) | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ✕ no documented user-prompt hook | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse` (`run_command`; command args paired across the two events by `conversationId + stepIdx`) | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop` (`transcriptPath`, best-effort lenient JSONL scan) | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ✕ no compact hook in Codex 0.125 (upstream openai/codex#16098) | ● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary) | ✕ no documented compact hook | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ● `SessionEnd` | ✕ no host session-end signal — Antigravity `Stop` is a per-execution boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | `traceary list events --kind session_ended --limit 5` |
 
 ### Other host hooks Traceary does not wire today
 
@@ -36,12 +36,14 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 | Claude Code | `Notification`, `PreToolUse` (other matchers), `StopFailure`, `UserPromptExpansion`, `PermissionRequest`, `PermissionDenied`, `PostToolBatch`, `TaskCreated`, `TaskCompleted`, `TeammateIdle`, `InstructionsLoaded`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `Elicitation`, `ElicitationResult` | ○ available | not in current packaged hooks |
 | Codex CLI | `PreToolUse`, `PermissionRequest`, `Notification` | ○ available | not wired |
 | Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ available | not wired |
+| Antigravity | `PreToolUse` for non-`run_command` tools | ○ available | only `run_command` is audited |
 
 ## Per-host references
 
 - Claude Code: https://code.claude.com/docs/en/hooks · packaged config: [`integrations/claude-plugin/hooks/hooks.json`](../../integrations/claude-plugin/hooks/hooks.json)
 - Codex CLI: upstream binary `codex-cli 0.125.0` — hook surface inferred from local install strings (`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, `Notification`, `PermissionRequest`, `UserPromptSubmit`). Compact hook tracking: openai/codex#16098. Packaged config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
 - Gemini CLI: hooks reference shipped with the local install at `/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md` (no post-compress event in the documented hook surface; `PreCompress` is advisory-only and fires asynchronously before compression). Packaged config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
+- Antigravity: public hook surface documented at https://antigravity.google/assets/docs/antigravity-2-0/hooks.md and https://antigravity.google/assets/docs/editor/ide-hooks.md; plugin packaging at https://antigravity.google/assets/docs/cli/cli-plugins.md (verified 2026-06-20 JST). Packaged config: [`integrations/antigravity-plugin/hooks.json`](../../integrations/antigravity-plugin/hooks.json)
 
 ## Maintenance
 

--- a/docs/integrations/README.ja.md
+++ b/docs/integrations/README.ja.md
@@ -2,9 +2,9 @@
 
 [English](./README.md)
 
-Traceary は、Claude Code / Codex / Gemini CLI（レガシー）向けにネイティブ連携パッケージを用意しています。
+Traceary は、Claude Code / Codex / Gemini CLI（レガシー）/ Antigravity 向けにネイティブ連携パッケージを用意しています。
 
-> **v0.21.0 注記:** Gemini CLI はレガシーの Google AI エージェントホストです。**Antigravity**（`/Applications/Antigravity.app`）が後継ホストとして位置づけられており、capability detection は #1195 で実装済みです。この調査（#1196）の結果、v0.21.0 では Antigravity の hook / package / release asset を**意図的に提供しません** — サポートされた公開 CLI/hook contract が確認されていないためです。ローカルで把握している情報は [Antigravity 移行状況](./antigravity.ja.md) を参照してください。
+> **v0.21.1 注記:** Gemini CLI はレガシーの Google AI エージェントホストです。**Antigravity**（`/Applications/Antigravity.app`）が後継ホストです。v0.21.1 以降、Traceary は Antigravity を実際の hook client としてサポートし、文書化された公開 hook surface に対する packaged plugin を提供します。詳細は [Antigravity hooks / plugin ガイド](./antigravity.ja.md) を参照してください。
 
 これらのパッケージは、次の共通ランタイム契約でそろえています。
 
@@ -30,14 +30,14 @@ Traceary は、Claude Code / Codex / Gemini CLI（レガシー）向けにネイ
 | Claude Code | `integrations/claude-plugin/` | `.claude-plugin/marketplace.json` を基点にした Claude marketplace |
 | Codex | `plugins/traceary/` | Codex CLI 公式の `/plugins` flow を使い、リポジトリ内の marketplace `.agents/plugins/marketplace.json` から install。plugin manifest で同梱 `hooks.json` を参照するため session / prompt / audit hook が自動配線される。`traceary integration codex install` helper は v0.14.0 で、cleanup 専用 `traceary integration codex uninstall` は v0.15.0 で廃止。いずれも非表示の stub になり、Codex 公式の `/plugins` flow と [docs/integrations/codex-plugin.ja.md](./codex-plugin.ja.md) の手動 cleanup 手順を案内するのみ。 |
 | Gemini CLI | `integrations/gemini-extension/` | `gemini-extension.json` を root にした Gemini extension archive — v0.21.0 以降は**レガシー互換のみ**。アクティブな委譲パスではない |
-| Antigravity | — | サポートされた公開 CLI/hook contract は未確認。v0.21.0 では package / hook / release asset を意図的に提供しません（#1196 で判断）。`traceary doctor --client antigravity --json` で現在の機能ステートを確認できます（#1195）。 |
+| Antigravity | `integrations/antigravity-plugin/` | v0.21.1 でサポート。`traceary hooks install --client antigravity` で `<project>/.agents/hooks.json`（workspace）または `~/.gemini/config/hooks.json`（`--global`）に hook を install。同梱 plugin は同じ `traceary` hook グループに加え、公式 Antigravity plugin スキーマに従う `plugin.json` を提供。`traceary doctor --client antigravity --json` で capability + config ステートを確認できます。 |
 
 ## host 別ガイド
 
 - [Claude Code plugin](./claude-plugin.ja.md)
 - [Codex plugin](./codex-plugin.ja.md)
 - [Gemini CLI extension（レガシー）](./gemini-extension.ja.md)
-- [Antigravity 移行状況](./antigravity.ja.md)
+- [Antigravity hooks / plugin](./antigravity.ja.md)
 - [Anthropic native memory tool (experimental)](./anthropic-memory-tool.ja.md)
 
 ## 検証と smoke test

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -2,9 +2,9 @@
 
 [日本語](./README.ja.md)
 
-Traceary ships native integration packages for Claude Code, Codex, and Gemini CLI (legacy).
+Traceary ships native integration packages for Claude Code, Codex, Gemini CLI (legacy), and Antigravity.
 
-> **v0.21.0 note:** Gemini CLI is the legacy Google AI agent host. **Antigravity** (`/Applications/Antigravity.app`) is the active successor, with capability detection implemented in #1195. After that investigation (#1196), v0.21.0 **intentionally ships no Antigravity hook, package, or release asset** — no supported public CLI/hook contract is confirmed. See the [Antigravity migration status](./antigravity.md) for what is known locally.
+> **v0.21.1 note:** Gemini CLI is the legacy Google AI agent host. **Antigravity** (`/Applications/Antigravity.app`) is the active successor. As of v0.21.1, Traceary supports Antigravity as a real hook client with a packaged plugin against the documented public hook surface. See the [Antigravity hooks and plugin guide](./antigravity.md).
 
 These packages all share the same runtime contract:
 
@@ -36,14 +36,14 @@ Current automatic fixes cover Traceary-managed hook config installation/upgrade 
 | Claude Code | `integrations/claude-plugin/` | Claude marketplace rooted at `.claude-plugin/marketplace.json` |
 | Codex | `plugins/traceary/` | Installed via Codex CLI's official `/plugins` flow against the repo-local marketplace at `.agents/plugins/marketplace.json`; the plugin manifest declares the bundled `hooks.json` so Codex wires session / prompt / audit hooks automatically. The `traceary integration codex install` helper was retired in v0.14.0 and the cleanup-only `traceary integration codex uninstall` was retired in v0.15.0; both are now hidden stubs that point at Codex's official `/plugins` flow plus the manual cleanup steps in [docs/integrations/codex-plugin.md](./codex-plugin.md). |
 | Gemini CLI | `integrations/gemini-extension/` | Gemini extension archive rooted at `gemini-extension.json` — **legacy compatibility only** as of v0.21.0; not the active delegation path |
-| Antigravity | — | No supported public CLI/hook contract confirmed; v0.21.0 intentionally ships no package, hook, or release asset (decided in #1196). `traceary doctor --client antigravity --json` reports the current capability state (#1195). |
+| Antigravity | `integrations/antigravity-plugin/` | Supported in v0.21.1. Hooks install to `<project>/.agents/hooks.json` (workspace) or `~/.gemini/config/hooks.json` (`--global`) via `traceary hooks install --client antigravity`; the packaged plugin ships the same `traceary` hook group plus a `plugin.json` following the official Antigravity plugin schema. `traceary doctor --client antigravity --json` reports capability + config state. |
 
 ## Per-host guides
 
 - [Claude Code plugin](./claude-plugin.md)
 - [Codex plugin](./codex-plugin.md)
 - [Gemini CLI extension (legacy)](./gemini-extension.md)
-- [Antigravity migration status](./antigravity.md)
+- [Antigravity hooks and plugin](./antigravity.md)
 - [Anthropic native memory tool (experimental)](./anthropic-memory-tool.md)
 
 ## Validation and smoke tests

--- a/docs/integrations/antigravity.ja.md
+++ b/docs/integrations/antigravity.ja.md
@@ -1,55 +1,107 @@
-# Antigravity 移行状況
+# Antigravity hooks / plugin
 
 [English](./antigravity.md)
 
-Antigravity は、Google の AI エージェントホストとして Gemini CLI の後継です。このページでは、v0.21.0 時点で Traceary がローカルで把握している Antigravity の情報と、その結果としての判断を説明します。
+Antigravity は、Google の AI エージェントホストとして Gemini CLI の後継です。**v0.21.1** 以降、Traceary は Antigravity を実際の hook client としてサポートし、packaged plugin を提供します。利用するのは公開されている hook/plugin サーフェスのみで、認証情報の読み取り・アプリ内部の非公開フォーマット・ブラウザ自動操作は一切行いません。
 
-> **まとめ:** v0.21.0 では Antigravity の公開 CLI / hook contract は確認されていません。Antigravity の capability detection は #1195 で実装済みです。この調査の結果、**v0.21.0 では Antigravity の hook / package / release asset を意図的に提供しません** — Google が公開していない hook contract を Traceary が捏造することはありません。将来のサポートにはサポートされた公開 CLI/hook contract が必要です。既存の Gemini CLI インストールでは、引き続き [Gemini CLI extension](./gemini-extension.ja.md) を使用できます。
+> **v0.21.0 からの変更点:** v0.21.0 では Antigravity の capability **診断のみ**（`doctor --client antigravity` → `tool_unavailable`）を提供し、当時は公開 contract が確認できなかったため hook / package を意図的に提供しませんでした。その後 Google が公開 Antigravity hook/plugin/CLI サーフェスを公開したため、v0.21.1 では Antigravity を診断専用ホストからサポート対象の hook client へと切り替えます。
 
-## ローカルでの調査結果（v0.21.0）
+## 自動配線される内容
 
-開発環境で確認された情報：
+Antigravity の `hooks.json` は *hook-group 名* から event config への top-level map（Traceary は `traceary` グループを所有）で、他ホストが共有する `{"hooks": {...}}` 形式とは異なります。Traceary はこのホスト向けに独自の document を render / merge します。
 
-| プロパティ | 値 |
+| Antigravity event | Traceary の効果 |
 | --- | --- |
-| アプリケーションパス | `/Applications/Antigravity.app` |
-| Bundle ID | `com.google.antigravity` |
-| バージョン | 2.1.4 |
-| URL スキーム | `antigravity://` |
-| PATH 上の CLI | 見つからず |
-| ユーザーデータディレクトリ | `~/Library/Application Support/Antigravity` |
-| 状態ヒント | `~/.gemini/antigravity`、`~/.gemini/config/config.json` |
+| `PreInvocation` | `conversationId` を key にした冪等な session 開始/更新（Antigravity に `SessionStart` はありません）。最初の workspace path を workspace とする |
+| `PreToolUse` (`run_command`) | 提案された `{CommandLine, Cwd}` を `conversationId + stepIdx` で永続化。ブロックしない（`{"decision":"allow"}`） |
+| `PostToolUse` (`run_command`) | 同一 step の `PreToolUse` が永続化した command を突き合わせ、`command_executed` audit を記録（step の `error` 付き）。pending が無ければ fail soft |
+| `Stop` | `transcriptPath` から turn の transcript（best effort）と turn 境界を記録。session は**閉じない** |
 
-## 機能検出（v0.21.0）
+Antigravity の payload は camelCase フィールド（`conversationId`, `workspacePaths`, `transcriptPath`, `toolCall.name`, `toolCall.args.CommandLine`, `toolCall.args.Cwd`, `stepIdx`, `terminationReason`）を使います。Traceary は共有 runtime（session / audit / transcript）を再利用する前に、これらを内部形式へ正規化します。
 
-`traceary doctor --client antigravity --json` は Antigravity のインストール状況を調査し、以下の 4 つの機能ステートのいずれかを報告します：
+## 制限事項
 
-| ステート | 意味 |
-| --- | --- |
-| `not_installed` | アプリバンドル（`/Applications/Antigravity.app`）も PATH 上の `antigravity` CLI も見つからない |
-| `tool_unavailable` | アプリまたは CLI は見つかったが、サポートされた公開 headless/hook/package サーフェスが未確認 |
-| `not_authenticated` | サポートされたサーフェスでインストールされているが、認証または設定が完了していない（将来/予約済み。v0.21.0 では未到達。認証情報を読み取るのではなく、サポートされた CLI/contract チェックで検出） |
-| `available` | サポートされた CLI/hook contract が確認・設定済み（v0.21.0 では未到達） |
+- **`SessionStart` が無い。** conversation 単位で最初に発火するのは `PreInvocation`（毎回のモデル呼び出し前に発火）なので、Traceary はこれを `conversationId` を key にした冪等な session 開始/更新として使います。
+- **`Stop` は execution 単位の境界であり session 終了ではない**（Codex と同じモデル — #1170）。session 行は開いたままで（memory auto-extract は発火）、MCP `manage_session` または stale GC（`traceary session gc`）でのみ終了します。
+- **audit 対象は `run_command` tool 呼び出しのみ。** `PostToolUse` は `stepIdx`/`error` のみを持ち command args を持たないため、args を持つ `PreToolUse` と step 単位で突き合わせます。`run_command` 以外の tool は何も記録しません。
+- **transcript 抽出は best effort。** 文書化された `transcriptPath` のファイルは `transcript.jsonl` ですが、その行ごとのスキーマは公開 hook contract の一部ではないため、抽出器は複数の妥当な JSONL 形状から assistant の text/thinking ブロックを寛容に走査し、それ以外は黙ってスキップします。
+- **認証情報・keychain・cookie・ブラウザストレージは一切読みません。** ディスクから読むのは文書化された `transcriptPath` hook フィールドのみです。
 
-ローカル開発環境での現在のステートは **`tool_unavailable`** です：`/Applications/Antigravity.app`（バージョン 2.1.4）はインストールされていますが、公開 CLI や hook contract は確認されていません。実行例：
+## インストール
+
+1. まず Traceary CLI をインストールします。
+
+```sh
+brew tap duck8823/traceary https://github.com/duck8823/traceary
+brew install traceary
+# または
+GO111MODULE=on go install github.com/duck8823/traceary@latest
+```
+
+2. Antigravity 向けの Traceary hook をインストールします。
+
+```sh
+# workspace レベル → <project>/.agents/hooks.json
+traceary hooks install --client antigravity --project-dir .
+
+# または user レベル → ~/.gemini/config/hooks.json
+traceary hooks install --client antigravity --global
+```
+
+alias `agy` と `antigravity-cli` は canonical な `antigravity` client に解決されます。インストールは非破壊で、置換されるのは `traceary` hook グループのみ、その他の top-level hook グループはそのまま保持されます。`--upgrade` で再実行すると、ユーザー追加グループを保持したまま managed グループを更新します。
+
+代わりに、同梱の plugin（[`integrations/antigravity-plugin/`](../../integrations/antigravity-plugin/)）を追加することもできます。これは同じ `traceary` hook グループを `hooks.json` として、公式 Antigravity plugin スキーマに従う `plugin.json` manifest とともに同梱しています。
+
+## セットアップガイド
+
+```sh
+traceary hooks guide --client antigravity --project-dir .
+```
+
+install command、doctor command、想定 config path、および Antigravity 固有の注記（PreInvocation の session モデル、Stop の turn 境界、run_command の突き合わせ）を表示します。
+
+## Doctor
 
 ```sh
 traceary doctor --client antigravity --json
 ```
 
-このチェックはアプリを起動したり、ブラウザ自動操作や認証情報の読み取りを行いません。アプリバンドルと PATH 上の CLI バイナリの存在のみを確認します。
+`doctor` は Antigravity 向けに 2 つの check を報告します。
 
-Antigravity はデフォルトの doctor クライアントリスト（`["claude","codex","gemini"]`）に含まれていません。`--client antigravity` を明示的に指定してください。
+- `antigravity-capability` — Antigravity のインストール（PATH 上の `agy`/`antigravity` CLI、またはアプリバンドル）を検出すると `pass`。Traceary は公開 hooks/plugin contract をサポートし、Traceary 側の認証は不要なためです。CLI もバンドルも無い場合は `not_installed`（warn）。この check はアプリを起動せず、ブラウザ自動操作も認証情報の読み取りも行いません。
+- `antigravity-config` — 解決された `hooks.json` に `traceary` hook グループが登録されているかを報告し、グループが無い場合は `--upgrade` での修復を案内します。
 
-## v0.21.0 で未確認の事項
+Antigravity はデフォルトの doctor client 一覧（`["claude","codex","gemini"]`）に含まれません。明示的に `--client antigravity` を指定してください。
 
-- 公開 CLI バイナリや hook contract は確認されていません。`antigravity` コマンドは PATH 上にありません。
-- `gemini extensions install` に相当する extension / plugin インストール機構は確認されていません。
-- Traceary 向けの hook イベントスキーマ（セッションライフサイクル、ツール監査、プロンプト/トランスクリプト取得）は未確立です。
+## ローカルでの調査結果
 
-## 判断とフォローアップ
+ローカル開発環境で観測した内容です。
 
-- **#1195** ✓ — Antigravity 機能検出（`traceary doctor --client antigravity --json`）— v0.21.0 で実装済み
-- **#1196** ✓ — 判断: v0.21.0 では Antigravity の hook / package / 生成メタデータ / release asset を**意図的に提供しません**。受け入れ条件では、サポートされた公開 hook/plugin/MCP/headless CLI サーフェスが確認できた**場合にのみ** package を追加することになっていました。#1195 で確認できなかったため、fake package を出荷せず、意図的に省略した package を文書化し、doctor の `tool_unavailable` ステートを維持します。
+| プロパティ | 値 |
+| --- | --- |
+| アプリパス | `/Applications/Antigravity.app` |
+| Bundle ID | `com.google.antigravity` |
+| URL スキーム | `antigravity://` |
+| workspace hooks パス | `<project>/.agents/hooks.json` |
+| global hooks パス | `~/.gemini/config/hooks.json` |
 
-実際の Antigravity package は、Google がサポートされた公開 CLI/hook contract を公開した時点で、将来の issue で**初めて**追加します。それまでは、Antigravity セッションは Traceary のイベントログに記録されません。Gemini CLI から Antigravity へ移行中の場合は、Gemini CLI セッションについては引き続き [Gemini CLI extension](./gemini-extension.ja.md) を使用してください。
+## パッケージ検証
+
+```sh
+agy plugin validate integrations/antigravity-plugin
+# リポジトリ内の構造検証:
+go run ./cmd/repo-tooling integrations verify
+```
+
+## 公式リファレンス
+
+2026-06-20 JST に確認:
+
+- Antigravity 2.0 hooks: https://antigravity.google/assets/docs/antigravity-2-0/hooks.md
+- Antigravity IDE hooks: https://antigravity.google/assets/docs/editor/ide-hooks.md
+- Antigravity CLI plugins: https://antigravity.google/assets/docs/cli/cli-plugins.md
+- Antigravity 2.0 plugins: https://antigravity.google/assets/docs/antigravity-2-0/plugins.md
+- Antigravity IDE plugins: https://antigravity.google/assets/docs/editor/ide-plugins.md
+- Antigravity CLI install: https://antigravity.google/assets/docs/cli/cli-install.md
+
+Gemini CLI から移行する場合、既存の Gemini CLI インストールでは引き続き [Gemini CLI extension](./gemini-extension.ja.md) を使用できます。

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -1,12 +1,79 @@
-# Antigravity migration status
+# Antigravity hooks and plugin
 
 [日本語](./antigravity.ja.md)
 
-Antigravity is Google's successor to Gemini CLI as an AI agent host. This page describes what Traceary has discovered locally about Antigravity in v0.21.0 and the resulting decision.
+Antigravity is Google's successor to Gemini CLI as an AI agent host. As of **v0.21.1**, Traceary supports Antigravity as a real hook client with a packaged plugin, using only the documented public hook/plugin surface — no credential reads, no private app-internal formats, no browser automation.
 
-> **Summary:** No supported public CLI/hook contract for Antigravity has been confirmed in v0.21.0. Antigravity capability detection is implemented in #1195. After that investigation, **v0.21.0 intentionally ships no Antigravity hook, package, or release asset** — Traceary will not fabricate a hook contract that Google has not published. Future support requires a supported public CLI/hook contract. The existing [Gemini CLI extension](./gemini-extension.md) remains available for existing Gemini CLI installs.
+> **What changed from v0.21.0:** v0.21.0 shipped Antigravity capability **diagnostics only** (`doctor --client antigravity` → `tool_unavailable`) and intentionally shipped no hook or package, because no public contract was confirmed at the time. Google has since published the public Antigravity hook/plugin/CLI surface, so v0.21.1 converts Antigravity from a diagnostic-only host into a supported hook client.
 
-## Local discovery (v0.21.0)
+## What it wires automatically
+
+Antigravity's `hooks.json` is a top-level map of *hook-group name* to event configs (Traceary owns the `traceary` group), which differs from the `{"hooks": {...}}` shape the other hosts share. Traceary renders and merges its own document for this host.
+
+| Antigravity event | Traceary effect |
+| --- | --- |
+| `PreInvocation` | Idempotent session start/refresh keyed by `conversationId` (Antigravity has no `SessionStart`); the first workspace path becomes the workspace |
+| `PreToolUse` (`run_command`) | Persists the proposed `{CommandLine, Cwd}` keyed by `conversationId + stepIdx`; never blocks (`{"decision":"allow"}`) |
+| `PostToolUse` (`run_command`) | Pairs the command persisted by `PreToolUse` for the same step and records a `command_executed` audit (with the step `error`); fails soft when no pending command exists |
+| `Stop` | Records the turn transcript from `transcriptPath` (best effort) and a turn boundary; **does not** close the session |
+
+Antigravity payloads use camelCase fields (`conversationId`, `workspacePaths`, `transcriptPath`, `toolCall.name`, `toolCall.args.CommandLine`, `toolCall.args.Cwd`, `stepIdx`, `terminationReason`). Traceary normalizes these into its internal shape before reusing the shared session / audit / transcript runtime.
+
+## Limitations
+
+- **No `SessionStart`.** The earliest per-conversation signal is `PreInvocation`, which fires before every model call, so Traceary uses it as an idempotent session start/refresh keyed by `conversationId`.
+- **`Stop` is a per-execution boundary, not a session end** (the same model as Codex — #1170). The session row stays open (memory auto-extract still fires) and ends only via MCP `manage_session` or stale GC (`traceary session gc`).
+- **Only `run_command` tool calls are audited.** `PostToolUse` carries only `stepIdx`/`error`, not the command args; the args arrive on `PreToolUse`, so Traceary pairs the two across the step. Non-`run_command` tools record nothing.
+- **Transcript extraction is best effort.** The documented `transcriptPath` file is `transcript.jsonl`, but its per-line schema is not part of the public hook contract, so the extractor leniently scans for assistant text/thinking blocks across several plausible JSONL shapes and silently skips otherwise.
+- **No credential, keychain, cookie, or browser-storage reads.** Only the documented `transcriptPath` hook field is read from disk.
+
+## Install
+
+1. Install the Traceary CLI first.
+
+```sh
+brew tap duck8823/traceary https://github.com/duck8823/traceary
+brew install traceary
+# or
+GO111MODULE=on go install github.com/duck8823/traceary@latest
+```
+
+2. Install the Traceary hooks for Antigravity.
+
+```sh
+# workspace-level install → <project>/.agents/hooks.json
+traceary hooks install --client antigravity --project-dir .
+
+# or user-level install → ~/.gemini/config/hooks.json
+traceary hooks install --client antigravity --global
+```
+
+Aliases `agy` and `antigravity-cli` resolve to the same canonical `antigravity` client. The install is non-destructive: only the `traceary` hook group is replaced, and every other top-level hook group is preserved verbatim. Re-run with `--upgrade` to refresh the managed group while preserving user-added groups.
+
+Alternatively, add the packaged plugin under [`integrations/antigravity-plugin/`](../../integrations/antigravity-plugin/), which ships the same `traceary` hook group as `hooks.json` plus a `plugin.json` manifest following the official Antigravity plugin schema.
+
+## Setup guide
+
+```sh
+traceary hooks guide --client antigravity --project-dir .
+```
+
+This prints the install command, the doctor command, the expected config path, and the Antigravity-specific notes (PreInvocation session model, Stop turn boundary, run_command pairing).
+
+## Doctor
+
+```sh
+traceary doctor --client antigravity --json
+```
+
+`doctor` reports two checks for Antigravity:
+
+- `antigravity-capability` — `pass` when an Antigravity install is detected (the `agy`/`antigravity` CLI on PATH or the app bundle), since Traceary supports the public hooks/plugin contract and needs no Traceary-side authentication. It reports `not_installed` (warn) when neither the CLI nor the bundle is present. This check does not launch the app, perform browser automation, or read credentials.
+- `antigravity-config` — reports whether the resolved `hooks.json` registers the `traceary` hook group, with the `--upgrade` remediation when the group is missing.
+
+Antigravity is not in the default doctor client list (`["claude","codex","gemini"]`); pass `--client antigravity` explicitly.
+
+## Local discovery
 
 The following was observed in the local development environment:
 
@@ -14,42 +81,27 @@ The following was observed in the local development environment:
 | --- | --- |
 | Application path | `/Applications/Antigravity.app` |
 | Bundle ID | `com.google.antigravity` |
-| Version | 2.1.4 |
 | URL scheme | `antigravity://` |
-| CLI on PATH | Not found |
-| User data directory | `~/Library/Application Support/Antigravity` |
-| State hints | `~/.gemini/antigravity`, `~/.gemini/config/config.json` |
+| Workspace hooks path | `<project>/.agents/hooks.json` |
+| Global hooks path | `~/.gemini/config/hooks.json` |
 
-## Capability detection (v0.21.0)
-
-`traceary doctor --client antigravity --json` probes for Antigravity installation and reports one of four capability states:
-
-| State | Meaning |
-| --- | --- |
-| `not_installed` | No app bundle (`/Applications/Antigravity.app`) and no `antigravity` CLI found on PATH |
-| `tool_unavailable` | App or CLI found but no supported public headless/hook/package surface is confirmed |
-| `not_authenticated` | Installed with a supported surface but not authenticated or configured (future/reserved; not reachable in v0.21.0 — detected via a supported CLI/contract check, not by reading credentials) |
-| `available` | Supported CLI/hook contract confirmed and configured (not yet reachable in v0.21.0) |
-
-In the local development environment, the current state is **`tool_unavailable`**: `/Applications/Antigravity.app` (version 2.1.4) is installed, but no public CLI or hook contract is confirmed. Run:
+## Package validation
 
 ```sh
-traceary doctor --client antigravity --json
+agy plugin validate integrations/antigravity-plugin
+# structural validation in-repo:
+go run ./cmd/repo-tooling integrations verify
 ```
 
-This check does not launch the app, perform browser automation, or read credentials — it only checks for the presence of the app bundle and a CLI binary on PATH.
+## Official references
 
-Antigravity is not included in the default doctor client list (`["claude","codex","gemini"]`). Pass `--client antigravity` explicitly.
+Verified 2026-06-20 JST:
 
-## What is not confirmed in v0.21.0
+- Antigravity 2.0 hooks: https://antigravity.google/assets/docs/antigravity-2-0/hooks.md
+- Antigravity IDE hooks: https://antigravity.google/assets/docs/editor/ide-hooks.md
+- Antigravity CLI plugins: https://antigravity.google/assets/docs/cli/cli-plugins.md
+- Antigravity 2.0 plugins: https://antigravity.google/assets/docs/antigravity-2-0/plugins.md
+- Antigravity IDE plugins: https://antigravity.google/assets/docs/editor/ide-plugins.md
+- Antigravity CLI install: https://antigravity.google/assets/docs/cli/cli-install.md
 
-- No public CLI binary or hook contract is confirmed. There is no `antigravity` command on PATH.
-- No extension/plugin install mechanism equivalent to `gemini extensions install` has been confirmed.
-- No hook event schema (session lifecycle, tool audit, prompt capture) has been established for Traceary.
-
-## Decision and follow-up
-
-- **#1195** ✓ — Antigravity capability detection (`traceary doctor --client antigravity --json`) — implemented in v0.21.0
-- **#1196** ✓ — Decision: v0.21.0 intentionally ships **no** Antigravity hook, package, generated metadata, or release asset. The acceptance criteria allowed a package **only if** a supported public hook/plugin/MCP/headless CLI surface was confirmed; #1195 confirmed none, so Traceary documents the intentionally omitted package and keeps the doctor `tool_unavailable` state instead of shipping a fake package.
-
-A real Antigravity package will be added under a future issue **only once** Google publishes a supported public CLI/hook contract. Until then, Antigravity sessions will not appear in Traceary's event log. If you are migrating from Gemini CLI to Antigravity, continue using the [Gemini CLI extension](./gemini-extension.md) for Gemini CLI sessions in the meantime.
+If you are migrating from Gemini CLI, the [Gemini CLI extension](./gemini-extension.md) remains available for existing Gemini CLI installs.

--- a/docs/integrations/gemini-extension.ja.md
+++ b/docs/integrations/gemini-extension.ja.md
@@ -2,7 +2,7 @@
 
 [English](./gemini-extension.md)
 
-> **v0.21.0 — レガシー注記:** Gemini CLI はレガシーの Google AI エージェントホストであり、Traceary のアクティブな委譲パスではなくなっています。後継ホストは **Antigravity** です。Antigravity の capability detection は #1195 で実装済みですが、サポートされた公開 CLI/hook contract が確認されていないため、v0.21.0 では Antigravity の hook / package / release asset を**意図的に提供しません**（#1196 で判断）。このページは既に Gemini CLI を使用している既存インストール向けに Gemini extension package を説明します。Antigravity サポートの現状は [Antigravity 移行状況](./antigravity.ja.md) を参照してください。
+> **レガシー注記:** Gemini CLI はレガシーの Google AI エージェントホストであり、Traceary のアクティブな委譲パスではなくなっています。後継ホストは **Antigravity** で、v0.21.1 以降は packaged plugin を持つサポート対象の hook client です。このページは既に Gemini CLI を使用している既存インストール向けに Gemini extension package を説明します。Antigravity については [Antigravity hooks / plugin ガイド](./antigravity.ja.md) を参照してください。
 
 Gemini 向け package は `integrations/gemini-extension/` にあります。Gemini CLI は install された extension の root に `gemini-extension.json` があることを前提にするため、Traceary では tagged release ごとにこの package を専用 archive として配布します。
 

--- a/docs/integrations/gemini-extension.md
+++ b/docs/integrations/gemini-extension.md
@@ -2,7 +2,7 @@
 
 [日本語](./gemini-extension.ja.md)
 
-> **v0.21.0 — Legacy notice:** Gemini CLI is the legacy Google AI agent host and is no longer the active delegation path for Traceary. **Antigravity** is the active successor. Antigravity capability detection is implemented in #1195, but v0.21.0 **intentionally ships no Antigravity hook, package, or release asset** (decided in #1196) because no supported public CLI/hook contract is confirmed. This page describes the existing Gemini extension package, which remains available for installs already using Gemini CLI. For the current state of Antigravity support, see the [Antigravity migration status](./antigravity.md).
+> **Legacy notice:** Gemini CLI is the legacy Google AI agent host and is no longer the active delegation path for Traceary. **Antigravity** is the active successor and, as of v0.21.1, is a supported hook client with a packaged plugin. This page describes the existing Gemini extension package, which remains available for installs already using Gemini CLI. For Antigravity, see the [Antigravity hooks and plugin guide](./antigravity.md).
 
 The Gemini package lives under `integrations/gemini-extension/`. Gemini CLI expects `gemini-extension.json` at the root of the installed extension, so Traceary ships this package as a dedicated extension archive on tagged releases.
 

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -42,7 +42,7 @@ GitHub Releases から自分の platform に合う archive を取得し、展開
 
 タグ付き release では、Claude Code / Codex 向け package を repository 内で version をそろえて同じ release tag で管理・公開します。Gemini CLI extension archive（`traceary.tar.gz`）も既存 Gemini CLI 導入環境向けのレガシー互換として release asset に含まれます。
 
-v0.21.0 では Antigravity 向けパッケージ・release asset は公開していません。この省略は意図的なものです（#1196 で判断）。Antigravity のサポートされた公開 CLI/hook contract が確認されていないため、Traceary は捏造した hook contract や package を出荷しません。doctor のステートは `tool_unavailable` のまま（#1195）であり、実際の package は Google がサポートされた公開 CLI/hook contract を公開した時点で、将来の issue で初めて追加します。
+v0.21.1 以降、Traceary は文書化された公開 Antigravity hook/plugin surface に対する Antigravity plugin package（`integrations/antigravity-plugin/`）を提供します。hook の導入は `traceary hooks install --client antigravity`（workspace は `.agents/hooks.json`）または `--global`（`~/.gemini/config/hooks.json`）で行います。詳細は [Antigravity hooks / plugin ガイド](../integrations/antigravity.ja.md) を参照してください。
 
 host ごとの install 手順は [ネイティブ連携ガイド](../integrations/README.ja.md) を参照してください。
 
@@ -124,7 +124,7 @@ GoReleaser workflow が artifact の公開を自動化しますが、maintainer 
    - Gemini レビューは**不要**です（Gemini CLI は retired / 利用不可）。
    - Codex の実装・レビューは、ローカルポリシーやユーザー指示で無効化されている場合は**不要**です。Codex が有効かつ利用可能な場合にのみ Codex app review を取得します。
    - 最新 head に対する Claude レビューを取得し、ローカル dogfood と `go test ./...` / `golangci-lint` / CI が green であることを確認してから merge commit でマージします。
-   - Antigravity は v0.21.0 で release asset を持たず、将来サポートされた公開 CLI/hook contract が現れない限り doctor ステートは `tool_unavailable` のままです（上記「ネイティブ連携パッケージ」を参照）。
+   - Antigravity は v0.21.1 以降サポート対象であり、`integrations/antigravity-plugin/` を同梱します。doctor は `antigravity-capability` と `antigravity-config` を報告します（上記「ネイティブ連携パッケージ」を参照）。
 8. **tag を打って push する。** release-prep PR が merge されたら、`git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z` を実行します。`v*` tag が `.github/workflows/release.yml` を起動します。
 9. **release workflow を監視する。** tag run に対して `gh run watch` を実行し、成功後に `gh release view vX.Y.Z` で公開を確認します。GitHub Release が publish されると `.github/workflows/pages.yml` も発火し、`docs/landing/` を GitHub Pages に再 deploy します。その run が成功し、`https://duck8823.github.io/traceary/`（CNAME 経由で `https://duck8823.net/traceary/`）が新バージョンを反映していることを確認してください。
 10. **Homebrew formula PR を確認する。** release workflow が `maintenance/homebrew-vX.Y.Z` PR を開いて auto-merge を有効化します。実際に merge されたか確認し、`brew update && brew upgrade traceary && traceary -v` で新バージョンを確かめます。

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -42,7 +42,7 @@ Download the archive that matches your platform from the GitHub Releases page an
 
 Tagged releases publish Claude Code and Codex packages versioned in-repo and tracked in the same release tag. The Gemini CLI extension archive (`traceary.tar.gz`) is also published as a release asset for legacy compatibility with existing Gemini CLI installs.
 
-No Antigravity package or release asset is published in v0.21.0. This omission is intentional (decided in #1196): no supported public CLI/hook contract for Antigravity is confirmed, so Traceary will not ship a fabricated hook contract or package. The doctor state stays `tool_unavailable` (#1195) and a real package will be added under a future issue only once Google publishes a supported public CLI/hook contract.
+As of v0.21.1, Traceary ships an Antigravity plugin package (`integrations/antigravity-plugin/`) against the documented public Antigravity hook/plugin surface. Install the hooks with `traceary hooks install --client antigravity` (workspace `.agents/hooks.json`) or `--global` (`~/.gemini/config/hooks.json`). See the [Antigravity hooks and plugin guide](../integrations/antigravity.md).
 
 See the [native integrations guide](../integrations/README.md) for the host-specific install flows.
 
@@ -124,7 +124,7 @@ The GoReleaser workflow automates artifact publishing, but a handful of steps st
    - Gemini review is **not** required — Gemini CLI is retired/unavailable.
    - Codex implementation/review is **not** required when local policy or a user instruction disables it; obtain a Codex app review only when Codex is enabled and available.
    - Obtain a fresh Claude review on the latest head, confirm local dogfood plus `go test ./...` / `golangci-lint` / CI are green, then merge with a merge commit.
-   - Antigravity has no release asset in v0.21.0 and its doctor state stays `tool_unavailable` (see "Native agent packages" above) unless a future supported public CLI/hook contract appears.
+   - Antigravity is supported from v0.21.1 and ships `integrations/antigravity-plugin/`; doctor reports `antigravity-capability` and `antigravity-config` (see "Native agent packages" above).
 8. **Tag and push.** After the release-prep PR merges, run `git checkout main && git pull --ff-only && git tag vX.Y.Z && git push origin vX.Y.Z`. The `v*` tag triggers `.github/workflows/release.yml`.
 9. **Watch the release workflow.** `gh run watch` against the tag run. On success, verify with `gh release view vX.Y.Z`. Publishing the GitHub Release also triggers `.github/workflows/pages.yml`, which re-deploys `docs/landing/` to GitHub Pages — confirm that run succeeds and that `https://duck8823.github.io/traceary/` (CNAME-redirected to `https://duck8823.net/traceary/`) reflects the new version.
 10. **Confirm the Homebrew formula PR.** The release workflow opens `maintenance/homebrew-vX.Y.Z` and enables auto-merge, but confirm it actually merged. `brew update && brew upgrade traceary && traceary -v` should report the new version.

--- a/infrastructure/filesystem/antigravity_hooks_handler.go
+++ b/infrastructure/filesystem/antigravity_hooks_handler.go
@@ -1,0 +1,280 @@
+package filesystem
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+)
+
+// antigravityHookTimeoutSeconds is the per-hook timeout written into the
+// packaged Antigravity hooks.json. The Antigravity default is 30s; Traceary's
+// runtime entrypoints are fail-soft and quick, so 10s keeps a slow disk from
+// stalling the host loop while leaving ample headroom.
+const antigravityHookTimeoutSeconds = 10
+
+// antigravityManagedGroup is the top-level hooks.json key Traceary owns. The
+// merge path replaces only this group and preserves every other group.
+const antigravityManagedGroup = "traceary"
+
+// AntigravityHooksHandler installs Traceary hooks for Antigravity (the
+// Antigravity 2.0 app, the Antigravity IDE, and the `agy` CLI). Antigravity's
+// hooks.json uses a top-level map of hook-group name to event configs that is
+// incompatible with the `{"hooks": {...}}` document the other clients share, so
+// this handler renders and merges its own document shape via the
+// rawHookDocumentHandler interface the orchestrator dispatches to.
+type AntigravityHooksHandler struct{}
+
+// NewAntigravityHooksHandler constructs an AntigravityHooksHandler.
+func NewAntigravityHooksHandler() *AntigravityHooksHandler {
+	return &AntigravityHooksHandler{}
+}
+
+// Name returns the canonical client identifier.
+func (h *AntigravityHooksHandler) Name() string { return "antigravity" }
+
+// Build satisfies application.HooksClientHandler. Antigravity's document is
+// rendered by renderDocument (the official shape is incompatible with the
+// shared model.Hooks marshaller), so this returns an empty aggregate and is
+// never used for Antigravity generation.
+func (h *AntigravityHooksHandler) Build(_ string) model.Hooks {
+	return model.HooksOf(nil, nil)
+}
+
+// DefaultInstallPath returns the workspace-level Antigravity hooks config path.
+// Global installs target ~/.gemini/config/hooks.json and are routed through the
+// CLI's --global resolver, not this method.
+func (h *AntigravityHooksHandler) DefaultInstallPath(projectDir string) (string, error) {
+	return filepath.Join(projectDir, ".agents", "hooks.json"), nil
+}
+
+// antigravityHookCommand mirrors a single Antigravity hook handler entry.
+type antigravityHookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+// antigravityMatcherEntry is the `{matcher, hooks:[…]}` wrapper used by the
+// PreToolUse / PostToolUse events.
+type antigravityMatcherEntry struct {
+	Matcher string                   `json:"matcher"`
+	Hooks   []antigravityHookCommand `json:"hooks"`
+}
+
+// buildAntigravityGroup renders the ordered Traceary hook group for the given
+// binary. PreInvocation / Stop list handlers directly (matcher ignored);
+// PreToolUse / PostToolUse wrap handlers in a run_command matcher entry. The
+// event keys are emitted in a deterministic order via orderedJSONObject.
+func buildAntigravityGroup(tracearyBin string) (json.RawMessage, error) {
+	preInvocation := newHookRuntimeCommand(tracearyBin, "hook", "antigravity", "pre-invocation")
+	preToolUse := newHookRuntimeCommand(tracearyBin, "hook", "antigravity", "pre-tool-use")
+	postToolUse := newHookRuntimeCommand(tracearyBin, "hook", "antigravity", "post-tool-use")
+	stop := newHookRuntimeCommand(tracearyBin, "hook", "antigravity", "stop")
+
+	directHandlers := func(command string) []antigravityHookCommand {
+		return []antigravityHookCommand{{Type: "command", Command: command, Timeout: antigravityHookTimeoutSeconds}}
+	}
+	matcherHandlers := func(command string) []antigravityMatcherEntry {
+		return []antigravityMatcherEntry{{
+			Matcher: "run_command",
+			Hooks:   directHandlers(command),
+		}}
+	}
+
+	return marshalOrderedJSONObject([]orderedJSONField{
+		{Key: "PreInvocation", Value: directHandlers(preInvocation)},
+		{Key: "PreToolUse", Value: matcherHandlers(preToolUse)},
+		{Key: "PostToolUse", Value: matcherHandlers(postToolUse)},
+		{Key: "Stop", Value: directHandlers(stop)},
+	})
+}
+
+// renderDocument renders a fresh Antigravity hooks.json containing only the
+// Traceary group. It satisfies the package-internal rawHookDocumentHandler
+// interface the orchestrator dispatches to.
+func (h *AntigravityHooksHandler) renderDocument(tracearyBin string) ([]byte, error) {
+	group, err := buildAntigravityGroup(tracearyBin)
+	if err != nil {
+		return nil, err
+	}
+	return marshalOrderedJSONObject([]orderedJSONField{
+		{Key: antigravityManagedGroup, Value: group},
+	})
+}
+
+// mergeDocument replaces the Traceary group in an existing Antigravity
+// hooks.json while preserving every other top-level hook group verbatim. A nil
+// or whitespace-only existing document renders a fresh file. The diff reports
+// per-event Added / Refreshed / Preserved / Removed for the Traceary group. It
+// satisfies the package-internal rawHookDocumentHandler interface.
+func (h *AntigravityHooksHandler) mergeDocument(existing []byte, tracearyBin string) ([]byte, hookMergeDiff, error) {
+	group, err := buildAntigravityGroup(tracearyBin)
+	if err != nil {
+		return nil, hookMergeDiff{}, err
+	}
+
+	if len(strings.TrimSpace(string(existing))) == 0 {
+		encoded, err := marshalOrderedJSONObject([]orderedJSONField{
+			{Key: antigravityManagedGroup, Value: group},
+		})
+		if err != nil {
+			return nil, hookMergeDiff{}, err
+		}
+		diff := hookMergeDiff{AddedEvents: antigravityGroupEventNames(group)}
+		return encoded, diff, nil
+	}
+
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(existing, &root); err != nil {
+		return nil, hookMergeDiff{}, xerrors.Errorf("existing Antigravity hooks file must contain a JSON object: %w", err)
+	}
+
+	diff := antigravityGroupDiff(root[antigravityManagedGroup], group)
+	root[antigravityManagedGroup] = group
+
+	keys := make([]string, 0, len(root))
+	for key := range root {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	fields := make([]orderedJSONField, 0, len(keys))
+	for _, key := range keys {
+		fields = append(fields, orderedJSONField{Key: key, Value: root[key]})
+	}
+	encoded, err := marshalOrderedJSONObject(fields)
+	if err != nil {
+		return nil, hookMergeDiff{}, err
+	}
+	return encoded, diff, nil
+}
+
+// antigravityGroupEventNames returns the sorted event keys present in a
+// rendered Traceary group.
+func antigravityGroupEventNames(group json.RawMessage) []string {
+	events := map[string]json.RawMessage{}
+	if err := json.Unmarshal(group, &events); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(events))
+	for name := range events {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// antigravityGroupDiff classifies each event in the desired Traceary group
+// against the existing group's events.
+func antigravityGroupDiff(existingGroup, desiredGroup json.RawMessage) hookMergeDiff {
+	desired := map[string]json.RawMessage{}
+	_ = json.Unmarshal(desiredGroup, &desired)
+	existing := map[string]json.RawMessage{}
+	if len(existingGroup) > 0 {
+		_ = json.Unmarshal(existingGroup, &existing)
+	}
+
+	var diff hookMergeDiff
+	for event, desiredValue := range desired {
+		existingValue, ok := existing[event]
+		switch {
+		case !ok:
+			diff.AddedEvents = append(diff.AddedEvents, event)
+		case jsonRawEqual(existingValue, desiredValue):
+			diff.PreservedEvents = append(diff.PreservedEvents, event)
+		default:
+			diff.RefreshedEvents = append(diff.RefreshedEvents, event)
+		}
+	}
+	for event := range existing {
+		if _, ok := desired[event]; !ok {
+			diff.RemovedEvents = append(diff.RemovedEvents, event)
+		}
+	}
+	sort.Strings(diff.AddedEvents)
+	sort.Strings(diff.RefreshedEvents)
+	sort.Strings(diff.PreservedEvents)
+	sort.Strings(diff.RemovedEvents)
+	return diff
+}
+
+// jsonRawEqual compares two raw JSON values for semantic equality by
+// re-marshalling through any so key order and whitespace do not matter.
+func jsonRawEqual(a, b json.RawMessage) bool {
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	encodedA, err := json.Marshal(av)
+	if err != nil {
+		return false
+	}
+	encodedB, err := json.Marshal(bv)
+	if err != nil {
+		return false
+	}
+	return string(encodedA) == string(encodedB)
+}
+
+// orderedJSONField is a single key/value pair rendered in declaration order.
+type orderedJSONField struct {
+	Key   string
+	Value any
+}
+
+// marshalOrderedJSONObject renders a JSON object whose keys appear in the given
+// order with two-space indentation, matching the formatting of the other
+// packaged hook configs. Field values may be json.RawMessage (re-indented) or
+// any json.Marshal-able value.
+func marshalOrderedJSONObject(fields []orderedJSONField) ([]byte, error) {
+	ordered := make(map[string]json.RawMessage, len(fields))
+	order := make([]string, 0, len(fields))
+	for _, field := range fields {
+		raw, ok := field.Value.(json.RawMessage)
+		if !ok {
+			encoded, err := json.Marshal(field.Value)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to marshal hook field %q: %w", field.Key, err)
+			}
+			raw = encoded
+		}
+		ordered[field.Key] = raw
+		order = append(order, field.Key)
+	}
+	return marshalIndentOrdered(ordered, order, "", "  ")
+}
+
+// marshalIndentOrdered marshals a raw-message object with the given key order
+// and indentation. It builds the compact object first (preserving order) then
+// runs json.Indent so nested values are pretty-printed consistently.
+func marshalIndentOrdered(values map[string]json.RawMessage, order []string, prefix, indent string) ([]byte, error) {
+	var builder strings.Builder
+	builder.WriteByte('{')
+	for i, key := range order {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to marshal hook key %q: %w", key, err)
+		}
+		builder.Write(encodedKey)
+		builder.WriteByte(':')
+		builder.Write(values[key])
+	}
+	builder.WriteByte('}')
+
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, []byte(builder.String()), prefix, indent); err != nil {
+		return nil, xerrors.Errorf("failed to indent hook document: %w", err)
+	}
+	return indented.Bytes(), nil
+}

--- a/infrastructure/filesystem/antigravity_hooks_handler.go
+++ b/infrastructure/filesystem/antigravity_hooks_handler.go
@@ -109,10 +109,12 @@ func (h *AntigravityHooksHandler) renderDocument(tracearyBin string) ([]byte, er
 }
 
 // mergeDocument replaces the Traceary group in an existing Antigravity
-// hooks.json while preserving every other top-level hook group verbatim. A nil
-// or whitespace-only existing document renders a fresh file. The diff reports
-// per-event Added / Refreshed / Preserved / Removed for the Traceary group. It
-// satisfies the package-internal rawHookDocumentHandler interface.
+// hooks.json while preserving every other top-level hook group verbatim and in
+// its original document order. A nil or whitespace-only existing document
+// renders a fresh file. A newly introduced Traceary group is appended after the
+// existing groups. The diff reports per-event Added / Refreshed / Preserved /
+// Removed for the Traceary group. It satisfies the package-internal
+// rawHookDocumentHandler interface.
 func (h *AntigravityHooksHandler) mergeDocument(existing []byte, tracearyBin string) ([]byte, hookMergeDiff, error) {
 	group, err := buildAntigravityGroup(tracearyBin)
 	if err != nil {
@@ -136,15 +138,20 @@ func (h *AntigravityHooksHandler) mergeDocument(existing []byte, tracearyBin str
 	}
 
 	diff := antigravityGroupDiff(root[antigravityManagedGroup], group)
+	_, hadManagedGroup := root[antigravityManagedGroup]
 	root[antigravityManagedGroup] = group
 
-	keys := make([]string, 0, len(root))
-	for key := range root {
-		keys = append(keys, key)
+	// Preserve the original top-level group order so foreign hook groups stay
+	// where the user put them. A newly introduced Traceary group is appended.
+	order, err := orderedTopLevelKeys(existing)
+	if err != nil {
+		return nil, hookMergeDiff{}, err
 	}
-	sort.Strings(keys)
-	fields := make([]orderedJSONField, 0, len(keys))
-	for _, key := range keys {
+	if !hadManagedGroup {
+		order = append(order, antigravityManagedGroup)
+	}
+	fields := make([]orderedJSONField, 0, len(order))
+	for _, key := range order {
 		fields = append(fields, orderedJSONField{Key: key, Value: root[key]})
 	}
 	encoded, err := marshalOrderedJSONObject(fields)
@@ -152,6 +159,73 @@ func (h *AntigravityHooksHandler) mergeDocument(existing []byte, tracearyBin str
 		return nil, hookMergeDiff{}, err
 	}
 	return encoded, diff, nil
+}
+
+// orderedTopLevelKeys returns the keys of a JSON object in document order. It
+// streams the top-level tokens rather than decoding into a map so the original
+// group ordering is preserved. An empty document yields no keys.
+func orderedTopLevelKeys(document []byte) ([]string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	openBrace, err := decoder.Token()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read Antigravity hooks document: %w", err)
+	}
+	if delim, ok := openBrace.(json.Delim); !ok || delim != '{' {
+		return nil, xerrors.Errorf("existing Antigravity hooks file must contain a JSON object")
+	}
+	var keys []string
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read Antigravity hooks key: %w", err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			return nil, xerrors.Errorf("Antigravity hooks document key must be a string")
+		}
+		keys = append(keys, key)
+		// Skip the value associated with this key (object/array/scalar).
+		if err := skipJSONValue(decoder); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
+
+// skipJSONValue consumes exactly one JSON value (scalar, object, or array) from
+// the decoder, descending through nested delimiters until balanced.
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return xerrors.Errorf("failed to read Antigravity hooks value: %w", err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		// Object: each entry is a key token followed by its value.
+		for decoder.More() {
+			if _, err := decoder.Token(); err != nil {
+				return xerrors.Errorf("failed to read Antigravity hooks key: %w", err)
+			}
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+	case '[':
+		// Array: each entry is a bare value.
+		for decoder.More() {
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return xerrors.Errorf("failed to read Antigravity hooks value: %w", err)
+	}
+	return nil
 }
 
 // antigravityGroupEventNames returns the sorted event keys present in a

--- a/infrastructure/filesystem/antigravity_hooks_handler_test.go
+++ b/infrastructure/filesystem/antigravity_hooks_handler_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"bytes"
 	"encoding/json"
 	"path/filepath"
 	"sort"
@@ -22,6 +23,29 @@ func parseAntigravityDoc(t *testing.T, data []byte) antigravityDoc {
 		t.Fatalf("failed to parse rendered Antigravity document: %v\n%s", err, data)
 	}
 	return doc
+}
+
+// topLevelKeyOrder returns the top-level object keys of a rendered document in
+// document order so order-sensitive assertions do not depend on map iteration.
+func topLevelKeyOrder(t *testing.T, data []byte) []string {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if _, err := decoder.Token(); err != nil { // opening '{'
+		t.Fatalf("failed to read document open token: %v\n%s", err, data)
+	}
+	var keys []string
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			t.Fatalf("failed to read document key: %v\n%s", err, data)
+		}
+		keys = append(keys, token.(string))
+		var skip json.RawMessage
+		if err := decoder.Decode(&skip); err != nil {
+			t.Fatalf("failed to skip document value: %v\n%s", err, data)
+		}
+	}
+	return keys
 }
 
 func TestAntigravityHooksHandler_DefaultInstallPath(t *testing.T) {
@@ -215,6 +239,65 @@ func TestAntigravityHooksHandler_MergeDocument(t *testing.T) {
 		}
 		if cmpDiff := cmp.Diff([]string{"PostToolUse", "PreInvocation", "PreToolUse"}, sortedStrings(diff.AddedEvents)); cmpDiff != "" {
 			t.Fatalf("AddedEvents mismatch (-want +got):\n%s", cmpDiff)
+		}
+	})
+
+	t.Run("preserves the original top-level group order", func(t *testing.T) {
+		t.Parallel()
+
+		// Groups are in non-alphabetical document order; the merge must keep
+		// this order rather than re-sorting alphabetically.
+		existing := []byte(`{
+  "zzz-vendor": {
+    "Stop": [
+      {"type": "command", "command": "zzz stop"}
+    ]
+  },
+  "traceary": {
+    "Stop": [
+      {"type": "command", "command": "old-traceary stop"}
+    ]
+  },
+  "aaa-vendor": {
+    "Stop": [
+      {"type": "command", "command": "aaa stop"}
+    ]
+  }
+}`)
+
+		encoded, _, err := handler.mergeDocument(existing, "traceary")
+		if err != nil {
+			t.Fatalf("MergeDocument returned error: %v", err)
+		}
+		want := []string{"zzz-vendor", "traceary", "aaa-vendor"}
+		if cmpDiff := cmp.Diff(want, topLevelKeyOrder(t, encoded)); cmpDiff != "" {
+			t.Fatalf("top-level group order mismatch (-want +got):\n%s", cmpDiff)
+		}
+	})
+
+	t.Run("appends a newly introduced traceary group after foreign groups", func(t *testing.T) {
+		t.Parallel()
+
+		existing := []byte(`{
+  "zzz-vendor": {
+    "Stop": [
+      {"type": "command", "command": "zzz stop"}
+    ]
+  },
+  "aaa-vendor": {
+    "Stop": [
+      {"type": "command", "command": "aaa stop"}
+    ]
+  }
+}`)
+
+		encoded, _, err := handler.mergeDocument(existing, "traceary")
+		if err != nil {
+			t.Fatalf("MergeDocument returned error: %v", err)
+		}
+		want := []string{"zzz-vendor", "aaa-vendor", "traceary"}
+		if cmpDiff := cmp.Diff(want, topLevelKeyOrder(t, encoded)); cmpDiff != "" {
+			t.Fatalf("top-level group order mismatch (-want +got):\n%s", cmpDiff)
 		}
 	})
 

--- a/infrastructure/filesystem/antigravity_hooks_handler_test.go
+++ b/infrastructure/filesystem/antigravity_hooks_handler_test.go
@@ -1,0 +1,256 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// antigravityDoc is a lenient view over a rendered Antigravity hooks.json used
+// by the handler tests. Each event is captured as a raw message so the test can
+// assert the matcher shape (direct handler list vs {matcher, hooks:[…]}).
+type antigravityDoc map[string]map[string]json.RawMessage
+
+func parseAntigravityDoc(t *testing.T, data []byte) antigravityDoc {
+	t.Helper()
+	var doc antigravityDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("failed to parse rendered Antigravity document: %v\n%s", err, data)
+	}
+	return doc
+}
+
+func TestAntigravityHooksHandler_DefaultInstallPath(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAntigravityHooksHandler()
+	got, err := handler.DefaultInstallPath("/tmp/project")
+	if err != nil {
+		t.Fatalf("DefaultInstallPath returned error: %v", err)
+	}
+	want := filepath.Join("/tmp/project", ".agents", "hooks.json")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("DefaultInstallPath mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAntigravityHooksHandler_RenderDocument(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAntigravityHooksHandler()
+	data, err := handler.renderDocument("traceary")
+	if err != nil {
+		t.Fatalf("RenderDocument returned error: %v", err)
+	}
+	doc := parseAntigravityDoc(t, data)
+
+	group, ok := doc["traceary"]
+	if !ok {
+		t.Fatalf("rendered document has no traceary group:\n%s", data)
+	}
+
+	wantEvents := []string{"PostToolUse", "PreInvocation", "PreToolUse", "Stop"}
+	gotEvents := make([]string, 0, len(group))
+	for event := range group {
+		gotEvents = append(gotEvents, event)
+	}
+	if diff := cmp.Diff(wantEvents, sortedStrings(gotEvents)); diff != "" {
+		t.Fatalf("traceary group events mismatch (-want +got):\n%s", diff)
+	}
+
+	t.Run("PreInvocation and Stop list handlers directly (matcher-less)", func(t *testing.T) {
+		t.Parallel()
+
+		for _, event := range []string{"PreInvocation", "Stop"} {
+			var handlers []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+				Timeout int    `json:"timeout"`
+				Matcher string `json:"matcher"`
+			}
+			if err := json.Unmarshal(group[event], &handlers); err != nil {
+				t.Fatalf("%s should be a direct handler list: %v\n%s", event, err, group[event])
+			}
+			if diff := cmp.Diff(1, len(handlers)); diff != "" {
+				t.Fatalf("%s handler count mismatch (-want +got):\n%s", event, diff)
+			}
+			if handlers[0].Type != "command" {
+				t.Fatalf("%s handler type = %q, want command", event, handlers[0].Type)
+			}
+			if handlers[0].Matcher != "" {
+				t.Fatalf("%s handler must be matcher-less, got matcher %q", event, handlers[0].Matcher)
+			}
+			if handlers[0].Timeout != antigravityHookTimeoutSeconds {
+				t.Fatalf("%s timeout = %d, want %d", event, handlers[0].Timeout, antigravityHookTimeoutSeconds)
+			}
+		}
+	})
+
+	t.Run("PreToolUse and PostToolUse wrap handlers in a run_command matcher", func(t *testing.T) {
+		t.Parallel()
+
+		for _, event := range []string{"PreToolUse", "PostToolUse"} {
+			var entries []struct {
+				Matcher string `json:"matcher"`
+				Hooks   []struct {
+					Type    string `json:"type"`
+					Command string `json:"command"`
+				} `json:"hooks"`
+			}
+			if err := json.Unmarshal(group[event], &entries); err != nil {
+				t.Fatalf("%s should be a {matcher, hooks} list: %v\n%s", event, err, group[event])
+			}
+			if diff := cmp.Diff(1, len(entries)); diff != "" {
+				t.Fatalf("%s entry count mismatch (-want +got):\n%s", event, diff)
+			}
+			if diff := cmp.Diff("run_command", entries[0].Matcher); diff != "" {
+				t.Fatalf("%s matcher mismatch (-want +got):\n%s", event, diff)
+			}
+			if diff := cmp.Diff(1, len(entries[0].Hooks)); diff != "" {
+				t.Fatalf("%s nested hook count mismatch (-want +got):\n%s", event, diff)
+			}
+			if entries[0].Hooks[0].Type != "command" {
+				t.Fatalf("%s nested hook type = %q, want command", event, entries[0].Hooks[0].Type)
+			}
+		}
+	})
+
+	t.Run("each event invokes the matching hidden runtime subcommand", func(t *testing.T) {
+		t.Parallel()
+
+		raw := string(data)
+		for _, fragment := range []string{
+			"'hook' 'antigravity' 'pre-invocation'",
+			"'hook' 'antigravity' 'pre-tool-use'",
+			"'hook' 'antigravity' 'post-tool-use'",
+			"'hook' 'antigravity' 'stop'",
+		} {
+			if !strings.Contains(raw, fragment) {
+				t.Fatalf("rendered document missing runtime command %q:\n%s", fragment, raw)
+			}
+		}
+	})
+}
+
+func TestAntigravityHooksHandler_MergeDocument(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAntigravityHooksHandler()
+
+	t.Run("empty existing renders a fresh document with all events added", func(t *testing.T) {
+		t.Parallel()
+
+		encoded, diff, err := handler.mergeDocument(nil, "traceary")
+		if err != nil {
+			t.Fatalf("MergeDocument returned error: %v", err)
+		}
+		doc := parseAntigravityDoc(t, encoded)
+		if _, ok := doc["traceary"]; !ok {
+			t.Fatalf("merged document has no traceary group:\n%s", encoded)
+		}
+		want := []string{"PostToolUse", "PreInvocation", "PreToolUse", "Stop"}
+		if cmpDiff := cmp.Diff(want, sortedStrings(diff.AddedEvents)); cmpDiff != "" {
+			t.Fatalf("AddedEvents mismatch (-want +got):\n%s", cmpDiff)
+		}
+	})
+
+	t.Run("preserves a foreign hook group and replaces the traceary group", func(t *testing.T) {
+		t.Parallel()
+
+		existing := []byte(`{
+  "vendor-x": {
+    "PreInvocation": [
+      {"type": "command", "command": "vendor-x audit"}
+    ]
+  },
+  "traceary": {
+    "Stop": [
+      {"type": "command", "command": "old-traceary stop"}
+    ]
+  }
+}`)
+
+		encoded, diff, err := handler.mergeDocument(existing, "traceary")
+		if err != nil {
+			t.Fatalf("MergeDocument returned error: %v", err)
+		}
+		doc := parseAntigravityDoc(t, encoded)
+
+		// Foreign group preserved verbatim.
+		vendor, ok := doc["vendor-x"]
+		if !ok {
+			t.Fatalf("vendor-x group was not preserved:\n%s", encoded)
+		}
+		if _, ok := vendor["PreInvocation"]; !ok {
+			t.Fatalf("vendor-x PreInvocation was not preserved:\n%s", encoded)
+		}
+		if !strings.Contains(string(encoded), "vendor-x audit") {
+			t.Fatalf("vendor-x command was not preserved verbatim:\n%s", encoded)
+		}
+
+		// Traceary group fully replaced with the four managed events.
+		group, ok := doc["traceary"]
+		if !ok {
+			t.Fatalf("traceary group missing after merge:\n%s", encoded)
+		}
+		wantEvents := []string{"PostToolUse", "PreInvocation", "PreToolUse", "Stop"}
+		gotEvents := make([]string, 0, len(group))
+		for event := range group {
+			gotEvents = append(gotEvents, event)
+		}
+		if cmpDiff := cmp.Diff(wantEvents, sortedStrings(gotEvents)); cmpDiff != "" {
+			t.Fatalf("merged traceary events mismatch (-want +got):\n%s", cmpDiff)
+		}
+		if strings.Contains(string(encoded), "old-traceary stop") {
+			t.Fatalf("stale traceary command survived the merge:\n%s", encoded)
+		}
+
+		// Stop existed before (refreshed); the other three are added.
+		if cmpDiff := cmp.Diff([]string{"Stop"}, sortedStrings(diff.RefreshedEvents)); cmpDiff != "" {
+			t.Fatalf("RefreshedEvents mismatch (-want +got):\n%s", cmpDiff)
+		}
+		if cmpDiff := cmp.Diff([]string{"PostToolUse", "PreInvocation", "PreToolUse"}, sortedStrings(diff.AddedEvents)); cmpDiff != "" {
+			t.Fatalf("AddedEvents mismatch (-want +got):\n%s", cmpDiff)
+		}
+	})
+
+	t.Run("re-merging an up-to-date document reports every event preserved", func(t *testing.T) {
+		t.Parallel()
+
+		first, _, err := handler.mergeDocument(nil, "traceary")
+		if err != nil {
+			t.Fatalf("initial MergeDocument returned error: %v", err)
+		}
+		_, diff, err := handler.mergeDocument(first, "traceary")
+		if err != nil {
+			t.Fatalf("re-merge returned error: %v", err)
+		}
+		want := []string{"PostToolUse", "PreInvocation", "PreToolUse", "Stop"}
+		if cmpDiff := cmp.Diff(want, sortedStrings(diff.PreservedEvents)); cmpDiff != "" {
+			t.Fatalf("PreservedEvents mismatch (-want +got):\n%s", cmpDiff)
+		}
+		if len(diff.AddedEvents)+len(diff.RefreshedEvents)+len(diff.RemovedEvents) != 0 {
+			t.Fatalf("expected no add/refresh/remove on up-to-date re-merge, got %+v", diff)
+		}
+	})
+
+	t.Run("non-object existing document is an error", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := handler.mergeDocument([]byte(`["not", "an", "object"]`), "traceary")
+		if err == nil {
+			t.Fatalf("expected error for non-object existing document")
+		}
+	})
+}
+
+// sortedStrings returns a sorted copy of the given slice for stable assertions.
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -16,12 +16,26 @@ import (
 )
 
 var hooksClientAliases = map[string]string{
-	"claude":      "claude",
-	"claude-code": "claude",
-	"codex":       "codex",
-	"codex-cli":   "codex",
-	"gemini":      "gemini",
-	"gemini-cli":  "gemini",
+	"claude":          "claude",
+	"claude-code":     "claude",
+	"codex":           "codex",
+	"codex-cli":       "codex",
+	"gemini":          "gemini",
+	"gemini-cli":      "gemini",
+	"antigravity":     "antigravity",
+	"agy":             "antigravity",
+	"antigravity-cli": "antigravity",
+}
+
+// rawHookDocumentHandler is the optional interface a client handler implements
+// when its hook configuration document does not fit the shared
+// `{"hooks": {...}}` shape and the model.Hooks marshaller. Antigravity uses a
+// top-level map of hook-group name to event configs, so its handler renders and
+// merges its own document. The orchestrator dispatches to this interface before
+// falling back to the model.Hooks path.
+type rawHookDocumentHandler interface {
+	renderDocument(tracearyBin string) ([]byte, error)
+	mergeDocument(existing []byte, tracearyBin string) ([]byte, hookMergeDiff, error)
 }
 
 // HooksOrchestrator implements application.HooksOrchestrator using filesystem
@@ -61,6 +75,14 @@ func (o *HooksOrchestrator) GenerateWithMatcher(
 	handler, err := o.resolveHandler(client)
 	if err != nil {
 		return nil, err
+	}
+
+	if rawHandler, ok := handler.(rawHookDocumentHandler); ok {
+		encoded, err := rawHandler.renderDocument(tracearyBin)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to render hook document: %w", err)
+		}
+		return encoded, nil
 	}
 
 	return marshalHooks(buildHooksForInstall(handler, tracearyBin, matcherPreset))
@@ -143,8 +165,7 @@ func (o *HooksOrchestrator) installWithDiff(
 		return "", hookMergeDiff{}, err
 	}
 
-	hooks := buildHooksForInstall(handler, tracearyBin, matcherPreset)
-	encoded, diff, err := renderInstallContent(resolvedOutputPath, hooks, force)
+	encoded, diff, err := o.renderInstallContentForHandler(handler, resolvedOutputPath, tracearyBin, matcherPreset, force)
 	if err != nil {
 		return "", hookMergeDiff{}, err
 	}
@@ -165,6 +186,48 @@ func (o *HooksOrchestrator) installWithDiff(
 // their audit hook so they fall back to the default Build(bin).
 type matcherPresetHandler interface {
 	BuildWithMatcher(tracearyBin string, preset ClaudeMatcherPreset) model.Hooks
+}
+
+// renderInstallContentForHandler renders the bytes to write for the given
+// handler, dispatching to the raw-document path for handlers whose document
+// shape is incompatible with the shared model.Hooks marshaller (Antigravity).
+func (o *HooksOrchestrator) renderInstallContentForHandler(
+	handler application.HooksClientHandler,
+	resolvedOutputPath string,
+	tracearyBin string,
+	matcherPreset string,
+	force bool,
+) ([]byte, hookMergeDiff, error) {
+	rawHandler, ok := handler.(rawHookDocumentHandler)
+	if !ok {
+		hooks := buildHooksForInstall(handler, tracearyBin, matcherPreset)
+		return renderInstallContent(resolvedOutputPath, hooks, force)
+	}
+
+	if force {
+		encoded, err := rawHandler.renderDocument(tracearyBin)
+		if err != nil {
+			return nil, hookMergeDiff{}, xerrors.Errorf("failed to render hook document: %w", err)
+		}
+		return encoded, hookMergeDiff{}, nil
+	}
+
+	existingContent, err := safeReadFile(resolvedOutputPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			encoded, diff, mergeErr := rawHandler.mergeDocument(nil, tracearyBin)
+			if mergeErr != nil {
+				return nil, hookMergeDiff{}, xerrors.Errorf("failed to render hook document: %w", mergeErr)
+			}
+			return encoded, diff, nil
+		}
+		return nil, hookMergeDiff{}, xerrors.Errorf("failed to read existing hooks file: %w", err)
+	}
+	encoded, diff, mergeErr := rawHandler.mergeDocument(existingContent, tracearyBin)
+	if mergeErr != nil {
+		return nil, hookMergeDiff{}, xerrors.Errorf("failed to merge hook document: %w", mergeErr)
+	}
+	return encoded, diff, nil
 }
 
 func buildHooksForInstall(handler application.HooksClientHandler, tracearyBin string, matcherPreset string) model.Hooks {
@@ -236,7 +299,7 @@ func normalizeHooksClient(handlers map[string]application.HooksClientHandler, cl
 	}
 
 	return "", xerrors.Errorf(
-		"unsupported client: %s (valid values: claude, codex, gemini; aliases: claude-code, codex-cli, gemini-cli)",
+		"unsupported client: %s (valid values: claude, codex, gemini, antigravity; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli)",
 		client,
 	)
 }

--- a/infrastructure/filesystem/hooks_orchestrator_test.go
+++ b/infrastructure/filesystem/hooks_orchestrator_test.go
@@ -25,6 +25,155 @@ func newTestOrchestrator(homeDir string) *filesystem.HooksOrchestrator {
 	})
 }
 
+func newAntigravityOrchestrator() *filesystem.HooksOrchestrator {
+	return filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+		"antigravity": filesystem.NewAntigravityHooksHandler(),
+	})
+}
+
+func TestHooksOrchestrator_AntigravityGenerateRendersGroupDocument(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := newAntigravityOrchestrator()
+
+	for _, client := range []string{"antigravity", "agy", "antigravity-cli"} {
+		t.Run(client, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := orchestrator.Generate(context.Background(), client, "traceary")
+			if err != nil {
+				t.Fatalf("Generate(%q) error = %v", client, err)
+			}
+			root := map[string]json.RawMessage{}
+			if err := json.Unmarshal(encoded, &root); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			// Antigravity uses a top-level hook-group map, not the shared
+			// {"hooks": {...}} envelope.
+			if _, ok := root["hooks"]; ok {
+				t.Fatalf("antigravity document must not use the shared hooks envelope: %s", encoded)
+			}
+			if _, ok := root["traceary"]; !ok {
+				t.Fatalf("antigravity document missing the traceary group: %s", encoded)
+			}
+			if !strings.Contains(string(encoded), "'hook' 'antigravity' 'pre-invocation'") {
+				t.Fatalf("antigravity document missing runtime command: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestHooksOrchestrator_AntigravityNormalizeClient(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := newAntigravityOrchestrator()
+
+	for _, alias := range []string{"antigravity", "agy", "antigravity-cli"} {
+		t.Run(alias, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := orchestrator.NormalizeClient(alias)
+			if err != nil {
+				t.Fatalf("NormalizeClient(%q) error = %v", alias, err)
+			}
+			if got != "antigravity" {
+				t.Fatalf("NormalizeClient(%q) = %q, want antigravity", alias, got)
+			}
+		})
+	}
+}
+
+func TestHooksOrchestrator_AntigravityInstallWritesAgentsPath(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	orchestrator := newAntigravityOrchestrator()
+
+	resolved, err := orchestrator.Install(
+		context.Background(),
+		"antigravity", "traceary",
+		projectDir,
+		types.None[string](),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if got, want := resolved, filepath.Join(projectDir, ".agents", "hooks.json"); got != want {
+		t.Fatalf("Install() = %q, want %q", got, want)
+	}
+
+	content, err := os.ReadFile(resolved)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", resolved, err)
+	}
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(content, &root); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if _, ok := root["traceary"]; !ok {
+		t.Fatalf("installed antigravity hooks missing the traceary group: %s", content)
+	}
+}
+
+func TestHooksOrchestrator_AntigravityInstallPreservesForeignGroup(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	orchestrator := newAntigravityOrchestrator()
+
+	hooksPath := filepath.Join(projectDir, ".agents", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := []byte(`{
+  "vendor-x": {
+    "PreInvocation": [
+      {"type": "command", "command": "vendor-x audit"}
+    ]
+  }
+}
+`)
+	if err := os.WriteFile(hooksPath, existing, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := orchestrator.Install(
+		context.Background(),
+		"antigravity", "traceary",
+		projectDir,
+		types.None[string](),
+		false,
+	); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	content, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(content), "vendor-x audit") {
+		t.Fatalf("install dropped the foreign hook group: %s", content)
+	}
+	if !strings.Contains(string(content), `"traceary"`) {
+		t.Fatalf("install did not add the traceary group: %s", content)
+	}
+}
+
+func TestHooksOrchestrator_AntigravityResolveInstallPath(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := newAntigravityOrchestrator()
+
+	resolved, err := orchestrator.ResolveInstallPath("agy", "/project", types.None[string]())
+	if err != nil {
+		t.Fatalf("ResolveInstallPath() error = %v", err)
+	}
+	if want := filepath.Join("/project", ".agents", "hooks.json"); resolved != want {
+		t.Fatalf("ResolveInstallPath() = %q, want %q", resolved, want)
+	}
+}
+
 func TestHooksOrchestrator_GenerateReturnsClientSpecificJSON(t *testing.T) {
 	t.Parallel()
 

--- a/integrations/antigravity-plugin/hooks.json
+++ b/integrations/antigravity-plugin/hooks.json
@@ -1,0 +1,42 @@
+{
+  "traceary": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "'traceary' 'hook' 'antigravity' 'pre-invocation'",
+        "timeout": 10
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'antigravity' 'pre-tool-use'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'antigravity' 'post-tool-use'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "'traceary' 'hook' 'antigravity' 'stop'",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/integrations/antigravity-plugin/plugin.json
+++ b/integrations/antigravity-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "traceary",
+  "description": "Local-first Traceary integration for Antigravity with automatic session/audit hooks."
+}

--- a/main.go
+++ b/main.go
@@ -187,9 +187,10 @@ func run() error {
 	}
 
 	hooksOrchestrator := filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
-		"claude": filesystem.NewClaudeHooksHandler(),
-		"codex":  filesystem.NewCodexHooksHandler(),
-		"gemini": filesystem.NewGeminiHooksHandler(),
+		"claude":      filesystem.NewClaudeHooksHandler(),
+		"codex":       filesystem.NewCodexHooksHandler(),
+		"gemini":      filesystem.NewGeminiHooksHandler(),
+		"antigravity": filesystem.NewAntigravityHooksHandler(),
 	})
 	hooksInspector := filesystem.NewHooksInspector()
 	pluginCacheInspector := filesystem.NewPluginCacheInspector()

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -298,9 +298,14 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 
 	for _, targetClient := range resolvedClients {
 		if targetClient == "antigravity" {
-			// Antigravity has no hook install path or config contract yet.
-			// Run only the capability detection check and skip all hook checks.
+			// Antigravity uses a top-level hook-group document
+			// (.agents/hooks.json workspace, ~/.gemini/config/hooks.json
+			// global) that does not fit the shared config inspector, so run
+			// the capability detection plus a dedicated config-file check.
 			report.Checks = append(report.Checks, inspectAntigravityCapability())
+			if outputPath, pathErr := c.hooksOrchestrator.ResolveInstallPath(targetClient, resolvedProjectDir, types.None[string]()); pathErr == nil {
+				report.Checks = append(report.Checks, inspectAntigravityConfigFile(outputPath))
+			}
 			continue
 		}
 

--- a/presentation/cli/doctor_antigravity.go
+++ b/presentation/cli/doctor_antigravity.go
@@ -1,9 +1,54 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"runtime"
 )
+
+// inspectAntigravityConfigFile reports whether the Antigravity hooks config at
+// outputPath registers the Traceary hook group. Antigravity's hooks.json is a
+// top-level map of hook-group name to event configs, so this checks for the
+// "traceary" group rather than the shared {"hooks": {...}} shape.
+func inspectAntigravityConfigFile(outputPath string) doctorCheck {
+	const checkName = "antigravity-config"
+	data, err := os.ReadFile(outputPath) // #nosec G304 -- resolved install path
+	if err != nil {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"no Antigravity hooks config at %s. Install with: traceary hooks install --client antigravity",
+				"%s に Antigravity hooks config がありません。導入: traceary hooks install --client antigravity",
+				outputPath,
+			),
+		}
+	}
+	var groups map[string]json.RawMessage
+	if err := json.Unmarshal(data, &groups); err != nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("invalid Antigravity hooks config at %s: %v", "%s の Antigravity hooks config が不正です: %v", outputPath, err),
+		}
+	}
+	if _, ok := groups["traceary"]; !ok {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusWarn,
+			Message: localizef(
+				"Antigravity hooks config at %s has no traceary group. Run: traceary hooks install --client antigravity --upgrade",
+				"%s の Antigravity hooks config に traceary グループがありません。実行: traceary hooks install --client antigravity --upgrade",
+				outputPath,
+			),
+		}
+	}
+	return doctorCheck{
+		Name:    checkName,
+		Status:  doctorStatusPass,
+		Message: localizef("Antigravity hooks config registers the traceary group: %s", "Antigravity hooks config に traceary グループが登録されています: %s", outputPath),
+	}
+}
 
 // antigravityCapabilityState represents the detected installation and
 // automation-surface state of the Antigravity application.
@@ -63,17 +108,23 @@ func antigravityProbeToState(p antigravityCapabilityProbe) antigravityCapability
 // lookPath is exec.LookPath-compatible; bundlePathExists reports whether a
 // given filesystem path exists, accepting os.Stat-compatible semantics.
 //
-// As of v0.21.0, no supported public CLI/hook contract for Antigravity is
-// confirmed, so SupportedSurfaceConfirmed is always false and even a
-// PATH-resolvable binary yields tool_unavailable.
+// As of v0.21.1, Traceary ships a documented Antigravity hooks/plugin contract
+// (workspace .agents/hooks.json, global ~/.gemini/config/hooks.json, and the
+// packaged integrations/antigravity-plugin). A present install — the `agy` CLI
+// on PATH or the app bundle — therefore confirms a supported surface. The hook
+// contract needs no Traceary-side authentication and Traceary does not read
+// credentials, so a present install is considered ready (available).
 func detectAntigravityCapabilityWithBundlePaths(
 	lookPath func(string) (string, error),
 	bundlePathExists func(string) bool,
 	bundlePaths []string,
 ) antigravityCapabilityState {
 	probe := antigravityCapabilityProbe{}
-	if _, err := lookPath("antigravity"); err == nil {
-		probe.CLIFound = true
+	for _, binary := range []string{"agy", "antigravity"} {
+		if _, err := lookPath(binary); err == nil {
+			probe.CLIFound = true
+			break
+		}
 	}
 	for _, bundlePath := range bundlePaths {
 		if bundlePathExists(bundlePath) {
@@ -81,8 +132,10 @@ func detectAntigravityCapabilityWithBundlePaths(
 			break
 		}
 	}
-	// No supported public hook/automation contract is confirmed for Antigravity
-	// in v0.21.0; SupportedSurfaceConfirmed stays false.
+	if probe.CLIFound || probe.BundleFound {
+		probe.SupportedSurfaceConfirmed = true
+		probe.AuthenticatedOrConfigured = true
+	}
 	return antigravityProbeToState(probe)
 }
 
@@ -105,8 +158,14 @@ func buildAntigravityCapabilityCheck(state antigravityCapabilityState) doctorChe
 			Name:   checkName,
 			Status: doctorStatusPass,
 			Message: Localize(
-				"Antigravity CLI/hook contract is available and configured.",
-				"Antigravity CLI/hook contract は利用可能で設定済みです。",
+				"Antigravity is installed and Traceary supports its public hooks/plugin contract. "+
+					"Install hooks with: traceary hooks install --client antigravity (workspace .agents/hooks.json) "+
+					"or --global (~/.gemini/config/hooks.json), or add the packaged integrations/antigravity-plugin. "+
+					"Traceary does not read Antigravity credentials.",
+				"Antigravity はインストールされており、Traceary は公開された hooks/plugin contract をサポートしています。"+
+					"hook の導入: traceary hooks install --client antigravity (workspace は .agents/hooks.json) "+
+					"または --global (~/.gemini/config/hooks.json)、もしくは同梱の integrations/antigravity-plugin を追加してください。"+
+					"Traceary は Antigravity の認証情報を読み取りません。",
 			),
 		}
 	case antigravityStateNotAuthenticated:
@@ -127,14 +186,10 @@ func buildAntigravityCapabilityCheck(state antigravityCapabilityState) doctorChe
 			Name:   checkName,
 			Status: doctorStatusWarn,
 			Message: Localize(
-				"Antigravity app is installed but no supported public headless/hook/package surface is confirmed (tool_unavailable). "+
-					"Traceary cannot capture Antigravity sessions until Google exposes a supported CLI/hook contract. "+
-					"v0.21.0 intentionally ships no Antigravity hook/package/release asset while the public automation surface is unavailable; "+
-					"future support requires a supported public CLI/hook contract.",
-				"Antigravity アプリはインストールされていますが、公開済みの headless/hook/package サーフェスは確認されていません (tool_unavailable)。"+
-					"Google が CLI/hook contract を公開するまで、Traceary は Antigravity セッションをキャプチャできません。"+
-					"v0.21.0 では、公開された automation サーフェスが利用できない間は Antigravity の hook / package / release asset を意図的に提供しません。"+
-					"将来のサポートにはサポートされた公開 CLI/hook contract が必要です。",
+				"Antigravity is installed but no supported public surface was detected (tool_unavailable). "+
+					"Traceary supports the public Antigravity hooks/plugin contract; reinstall the `agy` CLI or app bundle and re-run doctor.",
+				"Antigravity はインストールされていますが、サポートされた公開サーフェスを検出できませんでした (tool_unavailable)。"+
+					"Traceary は公開された Antigravity hooks/plugin contract をサポートしています。`agy` CLI またはアプリバンドルを再インストールし、doctor を再実行してください。",
 			),
 		}
 	default: // antigravityStateNotInstalled
@@ -151,14 +206,18 @@ func buildAntigravityCapabilityCheck(state antigravityCapabilityState) doctorChe
 	}
 }
 
+// antigravityBundleExistsFunc reports whether an Antigravity app bundle exists
+// at the given path. It is a package-level var so tests can force a
+// deterministic installed/not-installed state regardless of the host machine.
+var antigravityBundleExistsFunc = func(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // inspectAntigravityCapability is the doctor-facing entry point. It wires
 // the production path lookup (execLookPathFunc) and bundle existence check
-// (os.Stat) into detectAntigravityCapability.
+// (antigravityBundleExistsFunc) into detectAntigravityCapability.
 func inspectAntigravityCapability() doctorCheck {
-	bundleExists := func(path string) bool {
-		_, err := os.Stat(path)
-		return err == nil
-	}
-	state := detectAntigravityCapability(execLookPathFunc, bundleExists)
+	state := detectAntigravityCapability(execLookPathFunc, antigravityBundleExistsFunc)
 	return buildAntigravityCapabilityCheck(state)
 }

--- a/presentation/cli/doctor_antigravity_internal_test.go
+++ b/presentation/cli/doctor_antigravity_internal_test.go
@@ -76,29 +76,40 @@ func TestDetectAntigravityCapability(t *testing.T) {
 		}
 	})
 
-	t.Run("tool_unavailable when app bundle exists but no CLI", func(t *testing.T) {
+	t.Run("available when app bundle exists (Traceary supports the hooks/plugin contract)", func(t *testing.T) {
 		// Use detectAntigravityCapabilityWithBundlePaths with an explicit fake path so
 		// bundle detection is exercised on all platforms (antigravityBundlePaths returns
 		// nil on non-macOS, which would skip the hasBundle predicate).
 		state := detectAntigravityCapabilityWithBundlePaths(noPath, hasBundle, []string{"/fake/Antigravity.app"})
-		if state != antigravityStateToolUnavailable {
-			t.Fatalf("state = %v, want tool_unavailable", state)
+		if state != antigravityStateAvailable {
+			t.Fatalf("state = %v, want available", state)
 		}
 	})
 
-	t.Run("tool_unavailable when CLI on PATH (no confirmed hook contract)", func(t *testing.T) {
-		// Even with a CLI present, no supported public hook/automation
-		// contract is confirmed for Antigravity yet.
+	t.Run("available when antigravity CLI on PATH", func(t *testing.T) {
 		state := detectAntigravityCapability(hasPath, noBundle)
-		if state != antigravityStateToolUnavailable {
-			t.Fatalf("state = %v, want tool_unavailable", state)
+		if state != antigravityStateAvailable {
+			t.Fatalf("state = %v, want available", state)
 		}
 	})
 
-	t.Run("tool_unavailable when both CLI and bundle exist", func(t *testing.T) {
+	t.Run("available when agy CLI on PATH", func(t *testing.T) {
+		agyOnPath := func(cmd string) (string, error) {
+			if cmd == "agy" {
+				return "/usr/local/bin/agy", nil
+			}
+			return "", errors.New("not found")
+		}
+		state := detectAntigravityCapability(agyOnPath, noBundle)
+		if state != antigravityStateAvailable {
+			t.Fatalf("state = %v, want available", state)
+		}
+	})
+
+	t.Run("available when both CLI and bundle exist", func(t *testing.T) {
 		state := detectAntigravityCapabilityWithBundlePaths(hasPath, hasBundle, []string{"/fake/Antigravity.app"})
-		if state != antigravityStateToolUnavailable {
-			t.Fatalf("state = %v, want tool_unavailable", state)
+		if state != antigravityStateAvailable {
+			t.Fatalf("state = %v, want available", state)
 		}
 	})
 }
@@ -133,16 +144,13 @@ func TestBuildAntigravityCapabilityCheck(t *testing.T) {
 		if !strings.Contains(check.Message, "tool_unavailable") {
 			t.Fatalf("tool_unavailable message must contain 'tool_unavailable', got: %q", check.Message)
 		}
-		// v0.21.0 intentionally ships no Antigravity package; the message must state the
-		// decision rather than tracking it as outstanding implementation work.
-		if !strings.Contains(check.Message, "intentionally ships no Antigravity") {
-			t.Fatalf("tool_unavailable message must state the intentional no-package decision, got: %q", check.Message)
+		// v0.21.1 ships Antigravity hook/plugin support; the message must point
+		// at the supported contract rather than the retired no-package decision.
+		if !strings.Contains(check.Message, "hooks/plugin contract") {
+			t.Fatalf("tool_unavailable message must reference the supported hooks/plugin contract, got: %q", check.Message)
 		}
-		if !strings.Contains(check.Message, "supported public CLI/hook contract") {
-			t.Fatalf("tool_unavailable message must state future support requires a supported public CLI/hook contract, got: %q", check.Message)
-		}
-		if strings.Contains(check.Message, "#1196") {
-			t.Fatalf("tool_unavailable message must not track package work in #1196, got: %q", check.Message)
+		if strings.Contains(check.Message, "intentionally ships no Antigravity") {
+			t.Fatalf("tool_unavailable message must not keep the retired no-package decision, got: %q", check.Message)
 		}
 	})
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -1975,8 +1975,10 @@ func TestRootCLI_DoctorAntigravity(t *testing.T) {
 			t.Fatalf("antigravity-capability check not found in report; checks: %v", checkNames)
 		}
 
-		// Must NOT include hook-config or coverage checks for other clients.
-		forbidden := []string{"antigravity-config", "claude-config", "codex-config", "gemini-config"}
+		// Must NOT include hook-config or coverage checks for OTHER clients.
+		// antigravity-config IS expected now that Antigravity hooks are
+		// supported (v0.21.1).
+		forbidden := []string{"claude-config", "codex-config", "gemini-config"}
 		for _, name := range checkNames {
 			for _, f := range forbidden {
 				if name == f {
@@ -1985,11 +1987,13 @@ func TestRootCLI_DoctorAntigravity(t *testing.T) {
 			}
 		}
 
-		// The capability check must be warn (no supported surface in test env).
+		// The capability check is pass when an Antigravity install is detected
+		// (the supported hooks/plugin contract) and warn otherwise; both are
+		// valid depending on the test environment.
 		for _, check := range report.Checks {
 			if check.Name == "antigravity-capability" {
-				if check.Status != "warn" {
-					t.Fatalf("antigravity-capability status = %q, want warn", check.Status)
+				if check.Status != "warn" && check.Status != "pass" {
+					t.Fatalf("antigravity-capability status = %q, want warn or pass", check.Status)
 				}
 			}
 		}
@@ -2011,11 +2015,15 @@ func TestRootCLI_DoctorAntigravity(t *testing.T) {
 	})
 
 	t.Run("not_installed path warns with non-empty capability message", func(t *testing.T) {
-		// PATH is cleared and no bundle is created, so this exercises the
-		// not_installed path via the production inspectAntigravityCapability
-		// route (or tool_unavailable on platforms where bundles exist).
+		// PATH is cleared (so no agy/antigravity CLI resolves) and the bundle
+		// probe is forced to report "missing" so this subtest deterministically
+		// exercises the not_installed path regardless of whether the host
+		// machine actually has Antigravity installed.
 		// The pure detector state assertions live in the internal unit tests;
 		// this E2E subtest only validates the overall warn shape and message presence.
+		cli.SetAntigravityBundleExistsFunc(func(string) bool { return false })
+		t.Cleanup(cli.ResetAntigravityBundleExistsFunc)
+
 		rootCmd := newTestRootCLI(cli.WithStoreManagement(initStub)).Command()
 		stdout := &bytes.Buffer{}
 		rootCmd.SetOut(stdout)

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -63,6 +63,24 @@ func ResetTopNowFunc() {
 	topNowFunc = time.Now
 }
 
+// SetAntigravityPendingNowFunc replaces the current-time function used for
+// Antigravity pending-state TTL pruning for tests.
+func SetAntigravityPendingNowFunc(f func() time.Time) {
+	antigravityPendingNowFunc = f
+}
+
+// ResetAntigravityPendingNowFunc restores the default current-time function
+// used for Antigravity pending-state TTL pruning.
+func ResetAntigravityPendingNowFunc() {
+	antigravityPendingNowFunc = time.Now
+}
+
+// AntigravityPendingCommandPath exposes the resolved pending-state file path for
+// a conversation/step pair so tests can age or inspect it directly.
+func AntigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {
+	return antigravityPendingCommandPath(conversationID, stepIdx)
+}
+
 // SetDetectRepoContextFunc replaces the work-context resolver for tests.
 func SetDetectRepoContextFunc(f func(context.Context) (string, error)) {
 	detectRepoContextFunc = f

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -26,6 +26,22 @@ func ResetUserHomeDirFunc() {
 	userHomeDirFunc = os.UserHomeDir
 }
 
+// SetAntigravityBundleExistsFunc replaces the Antigravity bundle existence
+// probe for tests so the not_installed / installed capability path can be
+// exercised deterministically regardless of the host machine.
+func SetAntigravityBundleExistsFunc(f func(string) bool) {
+	antigravityBundleExistsFunc = f
+}
+
+// ResetAntigravityBundleExistsFunc restores the default Antigravity bundle
+// existence probe.
+func ResetAntigravityBundleExistsFunc() {
+	antigravityBundleExistsFunc = func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+}
+
 // SetGCNowFunc replaces the current-time function for tests.
 func SetGCNowFunc(f func() time.Time) {
 	gcNowFunc = f

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -1,0 +1,505 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// newHookAntigravityCommand wires the hidden Antigravity hook runtime
+// entrypoints. Antigravity's hook payloads use camelCase fields
+// (conversationId, workspacePaths, transcriptPath, toolCall.*, stepIdx) that
+// differ from the snake_case fields the shared runtime resolves, so each
+// subcommand normalizes the payload into the internal shape before reusing the
+// shared session / audit / transcript logic. Each subcommand also writes the
+// JSON output contract Antigravity expects on stdout.
+func (c *RootCLI) newHookAntigravityCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "antigravity <pre-invocation|pre-tool-use|post-tool-use|stop>",
+		Short:  "Runtime entrypoints for Antigravity hooks",
+		Hidden: true,
+	}
+	cmd.AddCommand(c.newHookAntigravityEventCommand("pre-invocation", c.runHookAntigravityPreInvocation))
+	cmd.AddCommand(c.newHookAntigravityEventCommand("pre-tool-use", c.runHookAntigravityPreToolUse))
+	cmd.AddCommand(c.newHookAntigravityEventCommand("post-tool-use", c.runHookAntigravityPostToolUse))
+	cmd.AddCommand(c.newHookAntigravityEventCommand("stop", c.runHookAntigravityStop))
+
+	return cmd
+}
+
+func (c *RootCLI) newHookAntigravityEventCommand(
+	event string,
+	run func(ctx context.Context, output io.Writer, input io.Reader, dbPath string) error,
+) *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:    event,
+		Short:  "Record Antigravity " + event + " hook events",
+		Hidden: true,
+		Args:   noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runHookBestEffort("antigravity "+event, func() error {
+				return run(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), dbPath)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
+
+	return cmd
+}
+
+// antigravityHookClient is the canonical client name used for Antigravity hook
+// state files and recorded events.
+const antigravityHookClient = "antigravity"
+
+// runHookAntigravityPreInvocation starts or refreshes a Traceary session keyed
+// by conversationId. PreInvocation fires before every model call, so this is
+// idempotent: an existing session is treated as already started. Output is an
+// empty object so Antigravity injects no steps.
+func (c *RootCLI) runHookAntigravityPreInvocation(ctx context.Context, output io.Writer, input io.Reader, dbPath string) error {
+	defer func() { _ = writeAntigravityJSON(output, map[string]any{}) }()
+
+	if c.storeManagement == nil || c.session == nil {
+		return nil
+	}
+	ctx = apptypes.WithSourceHook(ctx, "pre_invocation")
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	sessionID := types.SessionID(strings.TrimSpace(hookPayloadString(payload, "conversationId", "")))
+	if sessionID == "" {
+		return nil
+	}
+
+	// Idempotent: if the persisted hook state already points at this
+	// conversation, the session is started — just refresh workspace state.
+	existingState, err := readHookSessionState(antigravityHookClient)
+	if err != nil {
+		return err
+	}
+
+	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+		sessionID: sessionID.String(),
+		cwd:       antigravityWorkspaceCwd(payload),
+	})
+
+	resolvedDBPath, err := resolveDBPath(dbPath)
+	if err != nil {
+		return err
+	}
+	c.applyDatabasePath(resolvedDBPath)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("failed to initialize store: %w", err)
+	}
+
+	workspace, err := resolveHookWorkspace(ctx, normalized, antigravityHookClient, existingState == sessionID)
+	if err != nil {
+		return err
+	}
+	agent, err := types.AgentFrom(antigravityHookClient)
+	if err != nil {
+		return xerrors.Errorf("failed to resolve antigravity agent: %w", err)
+	}
+
+	if existingState != sessionID {
+		if _, err := c.session.Start(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
+			// PreInvocation re-fires for the same conversation after the
+			// session row already exists; treat that as a no-op refresh
+			// instead of an error so the session/workspace state still
+			// gets (re)written below.
+			if !errors.Is(err, model.ErrInvalidSessionState) {
+				return xerrors.Errorf("failed to record antigravity session start: %w", err)
+			}
+		}
+		if err := writeHookSessionState(antigravityHookClient, sessionID); err != nil {
+			return err
+		}
+		if err := clearHookSessionEndMarker(antigravityHookClient, sessionID); err != nil {
+			return err
+		}
+	}
+
+	if workspace != "" {
+		if err := writeHookWorkspaceState(antigravityHookClient, workspace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runHookAntigravityPreToolUse persists the proposed run_command details keyed
+// by conversationId + stepIdx so PostToolUse — which carries no command args —
+// can pair them when recording the audit. It never blocks: output is always
+// {"decision":"allow"}.
+func (c *RootCLI) runHookAntigravityPreToolUse(_ context.Context, output io.Writer, input io.Reader, _ string) error {
+	defer func() { _ = writeAntigravityJSON(output, map[string]any{"decision": "allow"}) }()
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	toolName := strings.TrimSpace(hookPayloadString(payload, "toolCall.name", ""))
+	if toolName != "run_command" {
+		return nil
+	}
+	conversationID := strings.TrimSpace(hookPayloadString(payload, "conversationId", ""))
+	stepIdx := strings.TrimSpace(hookPayloadString(payload, "stepIdx", ""))
+	command := hookPayloadString(payload, "toolCall.args.CommandLine", "")
+	if conversationID == "" || stepIdx == "" || strings.TrimSpace(command) == "" {
+		return nil
+	}
+	cwd := hookPayloadString(payload, "toolCall.args.Cwd", "")
+	return writeAntigravityPendingCommand(conversationID, stepIdx, antigravityPendingCommand{Command: command, Cwd: cwd})
+}
+
+// runHookAntigravityPostToolUse pairs the PostToolUse step with the command
+// persisted by PreToolUse and records a command audit. It fails soft and emits
+// {} when no pending command is available (e.g. a non-run_command tool, or a
+// PostToolUse without a matching PreToolUse).
+func (c *RootCLI) runHookAntigravityPostToolUse(ctx context.Context, output io.Writer, input io.Reader, dbPath string) error {
+	defer func() { _ = writeAntigravityJSON(output, map[string]any{}) }()
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	conversationID := strings.TrimSpace(hookPayloadString(payload, "conversationId", ""))
+	stepIdx := strings.TrimSpace(hookPayloadString(payload, "stepIdx", ""))
+	if conversationID == "" || stepIdx == "" {
+		return nil
+	}
+	pending, ok, err := readAntigravityPendingCommand(conversationID, stepIdx)
+	if err != nil {
+		return err
+	}
+	if !ok || strings.TrimSpace(pending.Command) == "" {
+		return nil
+	}
+	// Pair the persisted command with the PostToolUse error/cwd and reuse the
+	// shared audit path through a normalized snake_case payload.
+	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+		sessionID:   conversationID,
+		cwd:         firstNonEmpty(pending.Cwd, antigravityWorkspaceCwd(payload)),
+		toolName:    "run_command",
+		toolCommand: pending.Command,
+		errMessage:  hookPayloadString(payload, "error", ""),
+	})
+	if err := c.runHookAudit(ctx, bytes.NewReader(normalized), antigravityHookClient, dbPath); err != nil {
+		return err
+	}
+	return clearAntigravityPendingCommand(conversationID, stepIdx)
+}
+
+// runHookAntigravityStop records the final assistant turn (best effort, from
+// transcriptPath) and a turn boundary. Like Codex, Antigravity's Stop is a
+// per-execution boundary rather than a hard session end, so the session row is
+// kept open (memory auto-extract still fires). Output keeps the agent stopped
+// with {"decision":""}.
+func (c *RootCLI) runHookAntigravityStop(ctx context.Context, output io.Writer, input io.Reader, dbPath string) error {
+	defer func() { _ = writeAntigravityJSON(output, map[string]any{"decision": ""}) }()
+
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return err
+	}
+	sessionID := strings.TrimSpace(hookPayloadString(payload, "conversationId", ""))
+	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+		sessionID:      sessionID,
+		cwd:            antigravityWorkspaceCwd(payload),
+		transcriptPath: hookPayloadString(payload, "transcriptPath", ""),
+	})
+
+	// Transcript first so the turn's transcript event is recorded before any
+	// turn-boundary side effects, keeping the event order chronological.
+	if err := c.runHookTranscript(ctx, bytes.NewReader(normalized), antigravityHookClient, dbPath); err != nil {
+		slog.Debug("antigravity stop transcript failed", "session_id", sessionID, "error", err)
+	}
+	return c.runHookSession(ctx, nil, bytes.NewReader(normalized), antigravityHookClient, "stop", dbPath)
+}
+
+// antigravityNormalizeOptions carries the resolved values used to build a
+// normalized snake_case payload from an Antigravity hook payload.
+type antigravityNormalizeOptions struct {
+	sessionID      string
+	cwd            string
+	transcriptPath string
+	toolName       string
+	toolCommand    string
+	errMessage     string
+}
+
+// normalizeAntigravityPayload builds an internal snake_case payload from the
+// Antigravity camelCase payload so the shared runtime helpers
+// (resolveHookSessionID, resolveHookWorkspace, runHookAudit, runHookTranscript)
+// can consume it unchanged.
+func normalizeAntigravityPayload(_ []byte, opts antigravityNormalizeOptions) []byte {
+	normalized := map[string]any{}
+	if opts.sessionID != "" {
+		normalized["session_id"] = opts.sessionID
+	}
+	if opts.cwd != "" {
+		normalized["cwd"] = opts.cwd
+	}
+	if opts.transcriptPath != "" {
+		normalized["transcript_path"] = opts.transcriptPath
+	}
+	if opts.toolName != "" {
+		normalized["tool_name"] = opts.toolName
+	}
+	if opts.toolCommand != "" {
+		normalized["tool_input"] = map[string]any{"command": opts.toolCommand}
+	}
+	if strings.TrimSpace(opts.errMessage) != "" {
+		normalized["error"] = opts.errMessage
+	}
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return []byte("{}")
+	}
+	return encoded
+}
+
+// antigravityWorkspaceCwd returns the first workspace path from the payload, if
+// any, used as the cwd for workspace detection. Antigravity exposes
+// workspacePaths (an array of absolute mounted workspace roots) rather than a
+// single cwd on common-field payloads.
+func antigravityWorkspaceCwd(payload []byte) string {
+	value, ok := lookupHookPayloadValue(payload, "workspacePaths")
+	if !ok || value == nil {
+		return ""
+	}
+	paths, ok := value.([]any)
+	if !ok {
+		return ""
+	}
+	for _, entry := range paths {
+		if path, ok := entry.(string); ok && strings.TrimSpace(path) != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func writeAntigravityJSON(output io.Writer, value map[string]any) error {
+	if output == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal antigravity hook output: %w", err)
+	}
+	if _, err := output.Write(encoded); err != nil {
+		return xerrors.Errorf("failed to write antigravity hook output: %w", err)
+	}
+	return nil
+}
+
+// antigravityPendingCommand is the run_command detail persisted by PreToolUse
+// and paired by PostToolUse.
+type antigravityPendingCommand struct {
+	Command string `json:"command"`
+	Cwd     string `json:"cwd,omitempty"`
+}
+
+func antigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	key := sanitizeHookStateKey(conversationID) + "-" + sanitizeHookStateKey(stepIdx)
+	return filepath.Join(stateDir, "antigravity-pending", key), nil
+}
+
+func writeAntigravityPendingCommand(conversationID, stepIdx string, pending antigravityPendingCommand) error {
+	statePath, err := antigravityPendingCommandPath(conversationID, stepIdx)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		return xerrors.Errorf("failed to create antigravity pending state directory: %w", err)
+	}
+	data, err := json.Marshal(pending)
+	if err != nil {
+		return xerrors.Errorf("failed to encode antigravity pending command: %w", err)
+	}
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
+		return xerrors.Errorf("failed to write antigravity pending command: %w", err)
+	}
+	return nil
+}
+
+func readAntigravityPendingCommand(conversationID, stepIdx string) (antigravityPendingCommand, bool, error) {
+	statePath, err := antigravityPendingCommandPath(conversationID, stepIdx)
+	if err != nil {
+		return antigravityPendingCommand{}, false, err
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return antigravityPendingCommand{}, false, nil
+		}
+		return antigravityPendingCommand{}, false, xerrors.Errorf("failed to read antigravity pending command: %w", err)
+	}
+	var pending antigravityPendingCommand
+	if err := json.Unmarshal(data, &pending); err != nil {
+		return antigravityPendingCommand{}, false, nil
+	}
+	return pending, true, nil
+}
+
+func clearAntigravityPendingCommand(conversationID, stepIdx string) error {
+	statePath, err := antigravityPendingCommandPath(conversationID, stepIdx)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to clear antigravity pending command: %w", err)
+	}
+	return nil
+}
+
+// extractAntigravityTranscript resolves the Antigravity transcriptPath and
+// leniently reads the final assistant turn. Antigravity's transcript.jsonl
+// per-line schema is not part of the public hook contract, so the extractor
+// tries several plausible assistant-turn shapes and fails soft otherwise. Only
+// the documented transcriptPath hook field is read — no private app data.
+func extractAntigravityTranscript(payload []byte) ([]apptypes.EventBodyBlock, bool) {
+	transcriptPath := strings.TrimSpace(hookPayloadString(payload, "transcript_path", ""))
+	if transcriptPath == "" {
+		return nil, false
+	}
+	return readLastAssistantTranscriptBlocksLenient(transcriptPath)
+}
+
+// readLastAssistantTranscriptBlocksLenient scans a JSONL transcript for the
+// last assistant turn across several plausible shapes:
+//
+//   - Claude-style envelope: {"type":"assistant","message":{"role":"assistant","content":[{type,text|thinking}]}}
+//   - flat role + content array: {"role":"assistant","content":[{type,text}]}
+//   - flat role + content string: {"role":"assistant","content":"…"}
+//   - flat role + text string: {"role":"assistant","text":"…"}
+//
+// Returns ok=false on IO/parse failure so callers can silently skip.
+func readLastAssistantTranscriptBlocksLenient(path string) ([]apptypes.EventBodyBlock, bool) {
+	file, err := os.Open(path) // #nosec G304 -- path supplied by the host Stop hook
+	if err != nil {
+		slog.Debug("failed to open antigravity transcript file", "path", path, "error", err)
+		return nil, false
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var lastBlocks []apptypes.EventBodyBlock
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var entry antigravityTranscriptLine
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if !entry.isAssistant() {
+			continue
+		}
+		if blocks := entry.blocks(); len(blocks) > 0 {
+			lastBlocks = blocks
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Debug("failed while scanning antigravity transcript file", "path", path, "error", err)
+		return nil, false
+	}
+	return lastBlocks, len(lastBlocks) > 0
+}
+
+// antigravityTranscriptLine is a lenient view over a JSONL transcript row. It
+// accepts both the nested Claude-style envelope and a flat role/content shape.
+type antigravityTranscriptLine struct {
+	Type    string                        `json:"type"`
+	Role    string                        `json:"role"`
+	Text    string                        `json:"text"`
+	Content json.RawMessage               `json:"content"`
+	Message *antigravityTranscriptMessage `json:"message"`
+}
+
+type antigravityTranscriptMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+func (l antigravityTranscriptLine) isAssistant() bool {
+	if strings.EqualFold(l.Type, "assistant") || strings.EqualFold(l.Role, "assistant") {
+		return true
+	}
+	return l.Message != nil && strings.EqualFold(l.Message.Role, "assistant")
+}
+
+func (l antigravityTranscriptLine) blocks() []apptypes.EventBodyBlock {
+	if l.Message != nil && len(l.Message.Content) > 0 {
+		if blocks := antigravityContentBlocks(l.Message.Content); len(blocks) > 0 {
+			return blocks
+		}
+	}
+	if len(l.Content) > 0 {
+		if blocks := antigravityContentBlocks(l.Content); len(blocks) > 0 {
+			return blocks
+		}
+	}
+	if text := strings.TrimSpace(l.Text); text != "" {
+		return []apptypes.EventBodyBlock{{Type: apptypes.EventBodyBlockTypeText, Text: text}}
+	}
+	return nil
+}
+
+// antigravityContentBlocks parses a content value that may be a plain string or
+// an array of typed blocks. Unknown block types are skipped.
+func antigravityContentBlocks(raw json.RawMessage) []apptypes.EventBodyBlock {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(trimmed, &text); err != nil {
+			return nil
+		}
+		if strings.TrimSpace(text) == "" {
+			return nil
+		}
+		return []apptypes.EventBodyBlock{{Type: apptypes.EventBodyBlockTypeText, Text: strings.TrimSpace(text)}}
+	}
+	var items []transcriptContent
+	if err := json.Unmarshal(trimmed, &items); err != nil {
+		return nil
+	}
+	return extractAssistantBlocks(items)
+}

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
@@ -95,7 +96,7 @@ func (c *RootCLI) runHookAntigravityPreInvocation(ctx context.Context, output io
 		return err
 	}
 
-	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+	normalized := normalizeAntigravityPayload(antigravityNormalizeOptions{
 		sessionID: sessionID.String(),
 		cwd:       antigravityWorkspaceCwd(payload),
 	})
@@ -194,7 +195,7 @@ func (c *RootCLI) runHookAntigravityPostToolUse(ctx context.Context, output io.W
 	}
 	// Pair the persisted command with the PostToolUse error/cwd and reuse the
 	// shared audit path through a normalized snake_case payload.
-	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+	normalized := normalizeAntigravityPayload(antigravityNormalizeOptions{
 		sessionID:   conversationID,
 		cwd:         firstNonEmpty(pending.Cwd, antigravityWorkspaceCwd(payload)),
 		toolName:    "run_command",
@@ -220,7 +221,7 @@ func (c *RootCLI) runHookAntigravityStop(ctx context.Context, output io.Writer, 
 		return err
 	}
 	sessionID := strings.TrimSpace(hookPayloadString(payload, "conversationId", ""))
-	normalized := normalizeAntigravityPayload(payload, antigravityNormalizeOptions{
+	normalized := normalizeAntigravityPayload(antigravityNormalizeOptions{
 		sessionID:      sessionID,
 		cwd:            antigravityWorkspaceCwd(payload),
 		transcriptPath: hookPayloadString(payload, "transcriptPath", ""),
@@ -249,7 +250,7 @@ type antigravityNormalizeOptions struct {
 // Antigravity camelCase payload so the shared runtime helpers
 // (resolveHookSessionID, resolveHookWorkspace, runHookAudit, runHookTranscript)
 // can consume it unchanged.
-func normalizeAntigravityPayload(_ []byte, opts antigravityNormalizeOptions) []byte {
+func normalizeAntigravityPayload(opts antigravityNormalizeOptions) []byte {
 	normalized := map[string]any{}
 	if opts.sessionID != "" {
 		normalized["session_id"] = opts.sessionID
@@ -327,6 +328,17 @@ type antigravityPendingCommand struct {
 	Cwd     string `json:"cwd,omitempty"`
 }
 
+// antigravityPendingStaleAfter bounds how long an unpaired PreToolUse pending
+// command file is kept. PostToolUse normally consumes and clears it within
+// seconds, but a cancelled, interrupted, or never-delivered PostToolUse would
+// otherwise leak the file forever. Writes opportunistically prune siblings
+// older than this so the antigravity-pending directory does not grow unbounded.
+const antigravityPendingStaleAfter = 24 * time.Hour
+
+// antigravityPendingNowFunc returns the current time used for pending-state TTL
+// pruning. It is a package var so tests can pin a deterministic clock.
+var antigravityPendingNowFunc = time.Now
+
 func antigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {
 	stateDir, err := resolveHookStateDir()
 	if err != nil {
@@ -344,6 +356,9 @@ func writeAntigravityPendingCommand(conversationID, stepIdx string, pending anti
 	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
 		return xerrors.Errorf("failed to create antigravity pending state directory: %w", err)
 	}
+	// Opportunistically drop stale siblings left by PreToolUse steps whose
+	// PostToolUse never paired them (cancelled / interrupted / missing).
+	pruneStaleAntigravityPendingCommands(filepath.Dir(statePath))
 	data, err := json.Marshal(pending)
 	if err != nil {
 		return xerrors.Errorf("failed to encode antigravity pending command: %w", err)
@@ -382,6 +397,31 @@ func clearAntigravityPendingCommand(conversationID, stepIdx string) error {
 		return xerrors.Errorf("failed to clear antigravity pending command: %w", err)
 	}
 	return nil
+}
+
+// pruneStaleAntigravityPendingCommands removes pending command files in
+// pendingDir whose modification time is older than antigravityPendingStaleAfter.
+// It is best effort: directory and per-file errors are ignored so a cleanup
+// failure never blocks recording the current step.
+func pruneStaleAntigravityPendingCommands(pendingDir string) {
+	entries, err := os.ReadDir(pendingDir)
+	if err != nil {
+		return
+	}
+	now := antigravityPendingNowFunc()
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) <= antigravityPendingStaleAfter {
+			continue
+		}
+		_ = os.Remove(filepath.Join(pendingDir, entry.Name()))
+	}
 }
 
 // extractAntigravityTranscript resolves the Antigravity transcriptPath and

--- a/presentation/cli/hook_antigravity_test.go
+++ b/presentation/cli/hook_antigravity_test.go
@@ -1,0 +1,180 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+	cli "github.com/duck8823/traceary/presentation/cli"
+)
+
+// runAntigravityHook executes a hidden `hook antigravity <event>` subcommand
+// with the given payload and returns the JSON the runtime wrote to stdout. The
+// runtime entrypoints are fail-soft, so Execute() is expected to succeed and
+// the test asserts the output contract plus any recorded usecase calls.
+func runAntigravityHook(t *testing.T, event, payload string, opts ...cli.RootCLIOption) (string, *eventUsecaseStub, *sessionUsecaseStub) {
+	t.Helper()
+
+	eventStub := &eventUsecaseStub{}
+	sessionStub := &sessionUsecaseStub{}
+	base := []cli.RootCLIOption{
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	}
+	rootCmd := newTestRootCLI(append(base, opts...)...).Command()
+
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"hook", "antigravity", event})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(hook antigravity %s) error = %v", event, err)
+	}
+	return stdout.String(), eventStub, sessionStub
+}
+
+func TestRootCLI_HookAntigravityPreInvocation(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	out, _, sessionStub := runAntigravityHook(t, "pre-invocation",
+		`{"conversationId":"conv-1","workspacePaths":["/repo"]}`)
+
+	if out != "{}" {
+		t.Fatalf("PreInvocation output = %q, want {}", out)
+	}
+	if got, want := sessionStub.startCall.sessionID, types.SessionID("conv-1"); got != want {
+		t.Fatalf("session start sessionID = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startCall.agent, types.Agent("antigravity"); got != want {
+		t.Fatalf("session start agent = %q, want %q", got, want)
+	}
+	if got, want := sessionStub.startCall.workspace, types.Workspace("github.com/duck8823/traceary"); got != want {
+		t.Fatalf("session start workspace = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookAntigravityPreInvocationMissingConversationIsNoop(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	out, _, sessionStub := runAntigravityHook(t, "pre-invocation", `{"workspacePaths":["/repo"]}`)
+
+	if out != "{}" {
+		t.Fatalf("PreInvocation output = %q, want {}", out)
+	}
+	if sessionStub.startCall.sessionID != "" {
+		t.Fatalf("session should not start without conversationId, got %q", sessionStub.startCall.sessionID)
+	}
+}
+
+func TestRootCLI_HookAntigravityToolUsePairing(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// PreToolUse persists the run_command details keyed by conversationId+stepIdx.
+	preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"conv-1","stepIdx":"3","toolCall":{"name":"run_command","args":{"CommandLine":"go test ./...","Cwd":"/repo"}}}`)
+	if preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want {\"decision\":\"allow\"}", preOut)
+	}
+
+	// PostToolUse — carrying only stepIdx/error — pairs the persisted command
+	// and records a command audit.
+	postOut, eventStub, _ := runAntigravityHook(t, "post-tool-use",
+		`{"conversationId":"conv-1","stepIdx":"3","error":""}`)
+	if postOut != "{}" {
+		t.Fatalf("PostToolUse output = %q, want {}", postOut)
+	}
+	if got, want := eventStub.auditCall.command, "go test ./..."; got != want {
+		t.Fatalf("audit command = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.agent, types.Agent("antigravity"); got != want {
+		t.Fatalf("audit agent = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.sessionID, types.SessionID("conv-1"); got != want {
+		t.Fatalf("audit sessionID = %q, want %q", got, want)
+	}
+	if eventStub.auditCall.failed {
+		t.Fatalf("audit should not be flagged failed for an empty error field")
+	}
+}
+
+func TestRootCLI_HookAntigravityToolUsePairingFlagsError(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	if preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"conv-2","stepIdx":"7","toolCall":{"name":"run_command","args":{"CommandLine":"false","Cwd":"/repo"}}}`); preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want allow", preOut)
+	}
+
+	_, eventStub, _ := runAntigravityHook(t, "post-tool-use",
+		`{"conversationId":"conv-2","stepIdx":"7","error":"command exited with status 1"}`)
+	if !eventStub.auditCall.failed {
+		t.Fatalf("audit should be flagged failed when PostToolUse carries an error")
+	}
+}
+
+func TestRootCLI_HookAntigravityPostToolUseWithoutPendingIsNoop(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// No PreToolUse ran for this step, so there is no pending command to pair.
+	out, eventStub, _ := runAntigravityHook(t, "post-tool-use",
+		`{"conversationId":"conv-3","stepIdx":"1","error":""}`)
+	if out != "{}" {
+		t.Fatalf("PostToolUse output = %q, want {}", out)
+	}
+	if eventStub.auditCall.command != "" {
+		t.Fatalf("PostToolUse without pending state must not record an audit, got command %q", eventStub.auditCall.command)
+	}
+}
+
+func TestRootCLI_HookAntigravityPreToolUseNonRunCommandIsNoop(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// A non-run_command tool persists nothing; a following PostToolUse for the
+	// same step therefore records no audit.
+	preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"conv-4","stepIdx":"2","toolCall":{"name":"read_file","args":{"Path":"README.md"}}}`)
+	if preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want allow", preOut)
+	}
+
+	out, eventStub, _ := runAntigravityHook(t, "post-tool-use",
+		`{"conversationId":"conv-4","stepIdx":"2","error":""}`)
+	if out != "{}" {
+		t.Fatalf("PostToolUse output = %q, want {}", out)
+	}
+	if eventStub.auditCall.command != "" {
+		t.Fatalf("non-run_command tool must not record an audit, got command %q", eventStub.auditCall.command)
+	}
+}
+
+func TestRootCLI_HookAntigravityStopOutputContract(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	out, _, _ := runAntigravityHook(t, "stop",
+		`{"conversationId":"conv-1","workspacePaths":["/repo"],"terminationReason":"completed"}`)
+	if out != `{"decision":""}` {
+		t.Fatalf("Stop output = %q, want {\"decision\":\"\"}", out)
+	}
+}

--- a/presentation/cli/hook_antigravity_test.go
+++ b/presentation/cli/hook_antigravity_test.go
@@ -2,8 +2,10 @@ package cli_test
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/domain/types"
 	cli "github.com/duck8823/traceary/presentation/cli"
@@ -106,6 +108,75 @@ func TestRootCLI_HookAntigravityToolUsePairing(t *testing.T) {
 	}
 	if eventStub.auditCall.failed {
 		t.Fatalf("audit should not be flagged failed for an empty error field")
+	}
+}
+
+func TestRootCLI_HookAntigravityToolUsePairingNumericStepIdx(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	// Antigravity may emit stepIdx as a JSON number rather than a string. Both
+	// Pre/PostToolUse key pending state on the same rendered value, so the
+	// numeric form still pairs and records an audit.
+	if preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"conv-num","stepIdx":5,"toolCall":{"name":"run_command","args":{"CommandLine":"go vet ./...","Cwd":"/repo"}}}`); preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want allow", preOut)
+	}
+
+	_, eventStub, _ := runAntigravityHook(t, "post-tool-use",
+		`{"conversationId":"conv-num","stepIdx":5,"error":""}`)
+	if got, want := eventStub.auditCall.command, "go vet ./..."; got != want {
+		t.Fatalf("audit command = %q, want %q", got, want)
+	}
+	if got, want := eventStub.auditCall.sessionID, types.SessionID("conv-num"); got != want {
+		t.Fatalf("audit sessionID = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookAntigravityPrunesStalePendingCommands(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	cli.SetAntigravityPendingNowFunc(func() time.Time { return now })
+	t.Cleanup(cli.ResetAntigravityPendingNowFunc)
+
+	// A PreToolUse persists a pending command for a step that never receives a
+	// matching PostToolUse.
+	if preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"stale-conv","stepIdx":"1","toolCall":{"name":"run_command","args":{"CommandLine":"sleep 1","Cwd":"/repo"}}}`); preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want allow", preOut)
+	}
+
+	stalePath, err := cli.AntigravityPendingCommandPath("stale-conv", "1")
+	if err != nil {
+		t.Fatalf("AntigravityPendingCommandPath error = %v", err)
+	}
+	// Age the unpaired file beyond the TTL relative to the pinned clock.
+	old := now.Add(-48 * time.Hour)
+	if err := os.Chtimes(stalePath, old, old); err != nil {
+		t.Fatalf("Chtimes error = %v", err)
+	}
+
+	// A later PreToolUse for a different step opportunistically prunes the stale
+	// sibling while persisting its own fresh state.
+	if preOut, _, _ := runAntigravityHook(t, "pre-tool-use",
+		`{"conversationId":"fresh-conv","stepIdx":"1","toolCall":{"name":"run_command","args":{"CommandLine":"go build ./...","Cwd":"/repo"}}}`); preOut != `{"decision":"allow"}` {
+		t.Fatalf("PreToolUse output = %q, want allow", preOut)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale pending command should be pruned, stat err = %v", err)
+	}
+	freshPath, err := cli.AntigravityPendingCommandPath("fresh-conv", "1")
+	if err != nil {
+		t.Fatalf("AntigravityPendingCommandPath error = %v", err)
+	}
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Fatalf("fresh pending command should persist, stat err = %v", err)
 	}
 }
 

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -64,6 +64,7 @@ func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd.AddCommand(c.newHookSubagentStopCommand())
 	hookCmd.AddCommand(c.newHookPromptCommand())
 	hookCmd.AddCommand(c.newHookTranscriptCommand())
+	hookCmd.AddCommand(c.newHookAntigravityCommand())
 
 	return hookCmd
 }
@@ -1236,6 +1237,8 @@ func transcriptExtractorFor(client string) (transcriptExtractor, bool) {
 		return extractCodexTranscript, true
 	case "gemini":
 		return extractGeminiTranscript, true
+	case "antigravity":
+		return extractAntigravityTranscript, true
 	default:
 		return nil, false
 	}

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -16,8 +16,8 @@ import (
 )
 
 var hooksClientFlagUsage = Localize(
-	"target client (claude|codex|gemini; aliases: claude-code, codex-cli, gemini-cli)",
-	"対象クライアント (claude|codex|gemini; alias: claude-code, codex-cli, gemini-cli)",
+	"target client (claude|codex|gemini|antigravity; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli)",
+	"対象クライアント (claude|codex|gemini|antigravity; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli)",
 )
 
 func (c *RootCLI) newHooksCommand() *cobra.Command {
@@ -49,8 +49,8 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 		Use:   "install --client <claude|codex|gemini>",
 		Short: Localize("Write hook configuration examples to the standard config path", "標準の設定パスへ hook 設定例を書き出す"),
 		Long: Localize(
-			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini.\nAliases: claude-code, codex-cli, gemini-cli.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini). Codex hooks are already user-level, so --global is a no-op there.\nUse --upgrade for a non-destructive migration: only Traceary-managed entries are replaced, user-added entries are preserved, and a summary of added / refreshed / unchanged events is printed. Re-running --upgrade on an already up-to-date config is a no-op.",
-			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini。\nalias: claude-code, codex-cli, gemini-cli。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json)。Codex の hook は元から user-level なため --global は効果ありません。\n--upgrade を指定すると非破壊マイグレーションになります (Traceary 管理分のみ置換、ユーザー追加の hook は保持、追加 / 更新 / 変更なしの内訳を表示)。既に最新の設定に対して再実行しても no-op です。",
+			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini, antigravity.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini, ~/.gemini/config/hooks.json for Antigravity; Antigravity's workspace path is .agents/hooks.json). Codex hooks are already user-level, so --global is a no-op there.\nUse --upgrade for a non-destructive migration: only Traceary-managed entries are replaced, user-added entries are preserved, and a summary of added / refreshed / unchanged events is printed. Re-running --upgrade on an already up-to-date config is a no-op.",
+			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini, antigravity。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json、Antigravity は ~/.gemini/config/hooks.json; Antigravity の workspace パスは .agents/hooks.json)。Codex の hook は元から user-level なため --global は効果ありません。\n--upgrade を指定すると非破壊マイグレーションになります (Traceary 管理分のみ置換、ユーザー追加の hook は保持、追加 / 更新 / 変更なしの内訳を表示)。既に最新の設定に対して再実行しても no-op です。",
 		),
 		Example: strings.Join([]string{
 			"  traceary hooks install --client claude --project-dir .",
@@ -95,8 +95,8 @@ func (c *RootCLI) newHooksPrintCommand() *cobra.Command {
 		Use:   "print --client <claude|codex|gemini>",
 		Short: Localize("Print hook configuration examples for the current environment", "現在の環境向けの hook 設定例を出力する"),
 		Long: Localize(
-			"Print generated hook configuration for a supported client.\nSupported clients: claude, codex, gemini.\nAliases: claude-code, codex-cli, gemini-cli.\nWhen --traceary-bin is omitted, generated hooks call `traceary` from PATH.",
-			"対応 client 向けの生成済み hook 設定を出力します。\n対応 client: claude, codex, gemini。\nalias: claude-code, codex-cli, gemini-cli。\n--traceary-bin を省略した場合、生成される hook は PATH 上の `traceary` を呼びます。",
+			"Print generated hook configuration for a supported client.\nSupported clients: claude, codex, gemini, antigravity.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli.\nWhen --traceary-bin is omitted, generated hooks call `traceary` from PATH.",
+			"対応 client 向けの生成済み hook 設定を出力します。\n対応 client: claude, codex, gemini, antigravity。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli。\n--traceary-bin を省略した場合、生成される hook は PATH 上の `traceary` を呼びます。",
 		),
 		Example: strings.Join([]string{
 			"  traceary hooks print --client claude",
@@ -400,8 +400,8 @@ func requireHooksClient(client string) error {
 
 	return xerrors.Errorf(
 		Localize(
-			"--client is required (supported: claude, codex, gemini; aliases: claude-code, codex-cli, gemini-cli)",
-			"--client は必須です (対応 client: claude, codex, gemini; alias: claude-code, codex-cli, gemini-cli)",
+			"--client is required (supported: claude, codex, gemini, antigravity; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli)",
+			"--client は必須です (対応 client: claude, codex, gemini, antigravity; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli)",
 		),
 	)
 }
@@ -446,6 +446,8 @@ func resolveHooksGlobalPath(canonicalClient string) (string, bool, error) {
 		return filepath.Join(home, ".claude", "settings.json"), true, nil
 	case "gemini":
 		return filepath.Join(home, ".gemini", "settings.json"), true, nil
+	case "antigravity":
+		return filepath.Join(home, ".gemini", "config", "hooks.json"), true, nil
 	case "codex":
 		return "", false, nil
 	}

--- a/presentation/cli/hooks_guide.go
+++ b/presentation/cli/hooks_guide.go
@@ -112,6 +112,11 @@ func buildHooksGuide(c *RootCLI, client string, projectDir string, outputPath st
 		notes = append(notes,
 			Localize("Gemini requires hooksConfig.enabled=true before Traceary hooks can run.", "Gemini では Traceary hook が動く前に hooksConfig.enabled=true が必要です。"),
 		)
+	case "antigravity":
+		notes = append(notes,
+			Localize("Antigravity has no SessionStart hook: Traceary starts/refreshes the session idempotently from PreInvocation (keyed by conversationId). Like Codex, Stop is a per-execution boundary, so the session stays open and ends only via MCP manage_session or stale GC (traceary session gc).", "Antigravity には SessionStart hook がありません: Traceary は PreInvocation (conversationId 単位) から session を冪等に開始/更新します。Codex 同様 Stop は execution 単位の境界なので session は開いたままで、MCP manage_session または stale GC (traceary session gc) でのみ終了します。"),
+			Localize("Command audits are paired across PreToolUse (carries the command) and PostToolUse (carries the result), so only run_command tool calls are recorded. Use --global to install to ~/.gemini/config/hooks.json instead of the workspace .agents/hooks.json.", "command audit は PreToolUse (command を保持) と PostToolUse (結果を保持) を突き合わせて記録するため、run_command tool 呼び出しのみが対象です。workspace の .agents/hooks.json ではなく ~/.gemini/config/hooks.json に入れる場合は --global を使ってください。"),
+		)
 	}
 
 	return &hooksGuide{

--- a/presentation/cli/hooks_guide_test.go
+++ b/presentation/cli/hooks_guide_test.go
@@ -46,6 +46,43 @@ func TestRootCLI_HooksGuideCommand(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HooksGuideCommand_Antigravity(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) {
+		return homeDir, nil
+	})
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	rootCmd := newTestRootCLI().Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	// The agy alias must normalize to the canonical antigravity client.
+	rootCmd.SetArgs([]string{
+		"hooks",
+		"guide",
+		"--client", "agy",
+		"--project-dir", projectDir,
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "traceary hooks install --client antigravity") {
+		t.Fatalf("stdout = %q, want install step normalized to antigravity", output)
+	}
+	if !strings.Contains(output, ".agents/hooks.json") {
+		t.Fatalf("stdout = %q, want the workspace .agents/hooks.json path", output)
+	}
+	if !strings.Contains(output, "PreInvocation") {
+		t.Fatalf("stdout = %q, want the Antigravity PreInvocation note", output)
+	}
+}
+
 func TestRootCLI_HooksGuideCommand_MissingClientReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -124,6 +124,55 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("prints Antigravity group document", func(t *testing.T) {
+		// Antigravity uses a top-level hook-group map (Traceary owns the
+		// "traceary" group), not the shared {"hooks": {...}} envelope, so the
+		// printed document is parsed with a dedicated shape.
+		rootCmd := newTestRootCLI().Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"hooks", "print", "--client", "antigravity", "--traceary-bin", tracearyBin})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var doc map[string]map[string]json.RawMessage
+		if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.Bytes())
+		}
+		group, ok := doc["traceary"]
+		if !ok {
+			t.Fatalf("printed Antigravity document missing the traceary group:\n%s", stdout.Bytes())
+		}
+		for _, event := range []string{"PreInvocation", "PreToolUse", "PostToolUse", "Stop"} {
+			if _, ok := group[event]; !ok {
+				t.Fatalf("printed Antigravity group missing %s event:\n%s", event, stdout.Bytes())
+			}
+		}
+		if !strings.Contains(stdout.String(), `'/tmp/traceary bin/traceary' 'hook' 'antigravity' 'pre-invocation'`) {
+			t.Fatalf("printed Antigravity document missing the PreInvocation runtime command:\n%s", stdout.Bytes())
+		}
+	})
+
+	t.Run("prints Antigravity group document with agy alias", func(t *testing.T) {
+		rootCmd := newTestRootCLI().Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"hooks", "print", "--client", "agy", "--traceary-bin", tracearyBin})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		var doc map[string]json.RawMessage
+		if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.Bytes())
+		}
+		if _, ok := doc["traceary"]; !ok {
+			t.Fatalf("agy alias did not print the traceary group:\n%s", stdout.Bytes())
+		}
+	})
+
 	t.Run("uses stable command name when traceary-bin is not specified", func(t *testing.T) {
 		settings := executeHooksPrintWithoutTracearyBin(t, "claude")
 		if diff := cmp.Diff(`'traceary' 'hook' 'session' 'claude' 'start'`, settings.Hooks["SessionStart"][0].Hooks[0].Command); diff != "" {

--- a/presentation/cli/testhelpers_test.go
+++ b/presentation/cli/testhelpers_test.go
@@ -21,9 +21,10 @@ func newTestHooksOptions() []cli.RootCLIOption {
 
 	return []cli.RootCLIOption{
 		cli.WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
-			"claude": filesystem.NewClaudeHooksHandler(),
-			"codex":  filesystem.NewCodexHooksHandlerWithHomeDirFunc(homeDirFunc),
-			"gemini": filesystem.NewGeminiHooksHandler(),
+			"claude":      filesystem.NewClaudeHooksHandler(),
+			"codex":       filesystem.NewCodexHooksHandlerWithHomeDirFunc(homeDirFunc),
+			"gemini":      filesystem.NewGeminiHooksHandler(),
+			"antigravity": filesystem.NewAntigravityHooksHandler(),
 		})),
 		cli.WithHooksInspector(filesystem.NewHooksInspector()),
 		cli.WithPluginCacheInspector(filesystem.NewPluginCacheInspector()),


### PR DESCRIPTION
## Motivation

v0.21.0 treated Antigravity as diagnostic-only, but current official Antigravity docs expose hooks, plugin packaging, and the `agy` CLI. This PR corrects that stale state and ships first-class Traceary hook/plugin support for Antigravity.

Closes #1213

## Summary

- add Antigravity hook generation/install support (`antigravity`, `agy`, `antigravity-cli`) with the official hook-group `hooks.json` shape
- add hidden Antigravity hook runtime for PreInvocation, PreToolUse/PostToolUse run_command pairing, and Stop transcript/turn boundary capture
- add packaged `integrations/antigravity-plugin` validated by Antigravity CLI
- update doctor capability/config checks and EN/JA docs, including host coverage and setup guidance

## Validation

- `agy plugin validate integrations/antigravity-plugin`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-lint-cache go run ./cmd/repo-tooling integrations verify`
- `git diff --check HEAD~1..HEAD`
