### PR TITLE
chore: dogfood v0.21.3 workspace hook configs

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,0 +1,42 @@
+{
+  "traceary": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "'traceary' 'hook' 'antigravity' 'pre-invocation'",
+        "timeout": 10
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'antigravity' 'pre-tool-use'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'traceary' 'hook' 'antigravity' 'post-tool-use'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "'traceary' 'hook' 'antigravity' 'stop'",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,5 +1,19 @@
 {
   "hooks": {
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-transcript",
+            "type": "command",
+            "command": "'traceary' 'hook' 'transcript' 'gemini'",
+            "timeout": 5000,
+            "description": "Record agent response as a transcript event"
+          }
+        ]
+      }
+    ],
     "AfterTool": [
       {
         "matcher": "run_shell_command",
@@ -7,9 +21,37 @@
           {
             "name": "traceary-audit",
             "type": "command",
-            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-audit.sh' 'gemini'",
+            "command": "'traceary' 'hook' 'audit' 'gemini'",
             "timeout": 5000,
             "description": "Record shell command audits in Traceary"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-prompt",
+            "type": "command",
+            "command": "'traceary' 'hook' 'prompt' 'gemini'",
+            "timeout": 5000,
+            "description": "Record user prompt as a prompt event"
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "traceary-pre-compress",
+            "type": "command",
+            "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'",
+            "timeout": 5000,
+            "description": "Record a pre-compact marker (Gemini exposes no post-compress hook)"
           }
         ]
       }
@@ -21,7 +63,7 @@
           {
             "name": "traceary-session-end",
             "type": "command",
-            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-session.sh' 'gemini' 'end'",
+            "command": "'traceary' 'hook' 'session' 'gemini' 'end'",
             "timeout": 5000,
             "description": "Finish a Traceary session"
           }
@@ -35,7 +77,7 @@
           {
             "name": "traceary-session-start",
             "type": "command",
-            "command": "TRACEARY_BIN='traceary' bash '/Users/duck8823/.config/traceary/hook-scripts/traceary-session.sh' 'gemini' 'start'",
+            "command": "'traceary' 'hook' 'session' 'gemini' 'start'",
             "timeout": 5000,
             "description": "Start a Traceary session"
           }


### PR DESCRIPTION
Closes #1233

## Motivation

After v0.21.3 was released and the local Traceary runtime/plugins were upgraded, the repository dogfood workspace should keep the generated hook configs that match the current supported host surfaces.

## Changes

- Add `.agents/hooks.json` with the generated Antigravity `traceary` hook group.
- Refresh `.gemini/settings.json` to the current Gemini legacy hook config:
  - direct `traceary hook ... gemini` runtime commands;
  - prompt capture via `BeforeAgent`;
  - transcript capture via `AfterAgent`;
  - pre-compact marker via `PreCompress`.

## Validation

- `python3 -m json.tool .gemini/settings.json`
- `python3 -m json.tool .agents/hooks.json`
- `traceary doctor --client gemini --project-dir . --warnings-ok`
- `traceary doctor --client antigravity --project-dir . --warnings-ok`
- `git diff --check`

## Notes

Doctor still reports historical content duplicate / event-coverage warnings from existing local data, but the config/plugin-version checks pass after this update.
