### PR TITLE
v0.22.0-8: preserve hook events across host timeout kills

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -198,6 +198,12 @@ traceary hooks install --client codex --upgrade
 
 その場合はファイルを自分で確認し、本当に置き換えてよいときだけ `--force` を使ってください。
 
+### timeout kill 時の保全
+
+すべての非公開 `traceary hook ...` entrypoint は、SQLite に触れる前に host payload を `~/.config/traceary/hooks/spool/` 配下の mode `0600` record へ保存します。record は atomic に公開され、hook operation が成功した後だけ削除されます。SIGTERM は command context を cancel します。host が競合中または低速な hook を kill しても、先に公開した record が残るため event は黙って消えません。`traceary doctor` は残存 record と読めない record を `hook-spool` check で報告します。残存 record は payload を確認し、対応する command を再実行してから削除してください。経過時間だけでは自動削除しません。
+
+SQLite が writer 競合を待つのは最大1秒です。packaged host hook の budget は必ずこの待機時間を上回る必要があります。Gemini の生成・同梱 hook timeout は10秒で、DB attempt が失敗して spool record を保持したまま host deadline より前に制御を戻せます。この関係は意図的です: `SQLite busy_timeout < host hook timeout`。
+
 ## トラブルシュート
 
 hooks やローカル SQLite ストアの挙動がおかしいときは `traceary doctor --client <claude|codex|gemini>` を実行してください。

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -198,6 +198,12 @@ After `hooks install`, Traceary prints the matching `doctor` command so you can 
 
 In those cases, inspect the file yourself and only rerun with `--force` when replacing the file is truly acceptable.
 
+### Timeout-kill preservation
+
+Every hidden `traceary hook ...` entrypoint writes the exact host payload to a mode-`0600` record under `~/.config/traceary/hooks/spool/` before it touches SQLite. The record is atomically published and removed only after the hook operation returns successfully. SIGTERM cancels the command context; if the host kills a contended or slow hook, the already-published record remains available instead of the event disappearing silently. `traceary doctor` reports retained or unreadable records through the `hook-spool` check. Inspect the payload and retry the matching command before removing a retained record; Traceary does not delete it based on age alone.
+
+SQLite waits at most 1 second for a busy writer. Every packaged host hook budget must exceed that wait. Gemini's generated and packaged hook timeout is 10 seconds, leaving time for the DB attempt to fail and the spool record to remain durable before the host deadline. This relationship is intentional: `SQLite busy_timeout < host hook timeout`.
+
 ## Troubleshooting
 
 Run `traceary doctor --client <claude|codex|gemini>` when hooks or the local SQLite store do not behave as expected.

--- a/examples/hooks/gemini.settings.json
+++ b/examples/hooks/gemini.settings.json
@@ -8,7 +8,7 @@
             "name": "traceary-session-start",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'gemini' 'start'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Start a Traceary session"
           }
         ]
@@ -22,7 +22,7 @@
             "name": "traceary-session-end",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'gemini' 'end'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Finish a Traceary session"
           }
         ]
@@ -36,7 +36,7 @@
             "name": "traceary-prompt",
             "type": "command",
             "command": "'traceary' 'hook' 'prompt' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record user prompt as a prompt event"
           }
         ]
@@ -50,7 +50,7 @@
             "name": "traceary-transcript",
             "type": "command",
             "command": "'traceary' 'hook' 'transcript' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record agent response as a transcript event"
           }
         ]
@@ -64,7 +64,7 @@
             "name": "traceary-audit",
             "type": "command",
             "command": "'traceary' 'hook' 'audit' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record shell command audits in Traceary"
           }
         ]
@@ -78,7 +78,7 @@
             "name": "traceary-pre-compress",
             "type": "command",
             "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record a pre-compact marker (Gemini exposes no post-compress hook)"
           }
         ]

--- a/infrastructure/filesystem/gemini_hooks_handler.go
+++ b/infrastructure/filesystem/gemini_hooks_handler.go
@@ -7,7 +7,9 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-const geminiHooksDefaultTimeoutMillis = 5000
+// Keep host timeout comfortably above SQLite's one-second busy timeout so a
+// contended write can fail soft while its durable spool record remains.
+const geminiHooksDefaultTimeoutMillis = 10000
 
 // GeminiHooksHandler installs Traceary hooks for the Gemini CLI.
 type GeminiHooksHandler struct{}

--- a/infrastructure/filesystem/gemini_hooks_handler_test.go
+++ b/infrastructure/filesystem/gemini_hooks_handler_test.go
@@ -34,7 +34,7 @@ func TestGeminiHooksHandler_Build(t *testing.T) {
 		if diff := cmp.Diff(true, ok); diff != "" {
 			t.Fatalf("SessionStart timeout presence mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(5000, timeout); diff != "" {
+		if diff := cmp.Diff(10000, timeout); diff != "" {
 			t.Fatalf("SessionStart timeout mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff("Start a Traceary session", command.Description()); diff != "" {
@@ -76,7 +76,7 @@ func TestGeminiHooksHandler_Build(t *testing.T) {
 		if diff := cmp.Diff(true, hasTimeout); diff != "" {
 			t.Fatalf("BeforeAgent timeout presence mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(5000, timeout); diff != "" {
+		if diff := cmp.Diff(10000, timeout); diff != "" {
 			t.Fatalf("BeforeAgent timeout mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -109,7 +109,7 @@ func TestGeminiHooksHandler_Build(t *testing.T) {
 		if diff := cmp.Diff(true, hasTimeout); diff != "" {
 			t.Fatalf("AfterAgent timeout presence mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(5000, timeout); diff != "" {
+		if diff := cmp.Diff(10000, timeout); diff != "" {
 			t.Fatalf("AfterAgent timeout mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -182,11 +182,11 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string) (err error
 	return nil
 }
 
-// sqliteBusyTimeout is the SQLite busy-wait window in milliseconds
-// applied via the busy_timeout pragma. Five seconds is long enough to
-// absorb routine hook/MCP write contention while still surfacing real
-// deadlocks to the caller.
-const sqliteBusyTimeout = 5000
+// sqliteBusyTimeout is deliberately shorter than every packaged host hook
+// budget. Contention therefore returns control while the hook process still
+// has time to retain its write-ahead spool record instead of being killed at
+// the same instant SQLite's wait expires.
+const sqliteBusyTimeout = 1000
 
 func sqliteDSN(dbPath string) string {
 	values := url.Values{}

--- a/infrastructure/sqlite/database_concurrency_test.go
+++ b/infrastructure/sqlite/database_concurrency_test.go
@@ -2,11 +2,14 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
@@ -76,6 +79,43 @@ func TestDatabase_ConcurrentWritersAndReaders_NoSQLITE_BUSY(t *testing.T) {
 
 	for err := range errCh {
 		t.Error(err)
+	}
+}
+
+func TestDatabase_ContendedHookWriteFailsBeforeHostBudget(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	eventDS, _, storeManager := newFullDatasources(t, dbPath, listSessionsTestMigrations())
+	ctx := context.Background()
+	if err := storeManager.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	locker, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := locker.Close(); err != nil {
+			t.Errorf("locker.Close() error = %v", err)
+		}
+	})
+	if _, err := locker.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE error = %v", err)
+	}
+	defer func() { _, _ = locker.ExecContext(ctx, "ROLLBACK") }()
+
+	started := time.Now()
+	err = eventDS.Save(ctx, newConcurrencyTestEvent(t, "contended-event", "contended-session", time.Now().UTC()))
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("Save() error = nil, want SQLITE_BUSY")
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("contended Save() elapsed = %s, must return before 5s host budget", elapsed)
+	}
+	if elapsed < 800*time.Millisecond {
+		t.Fatalf("contended Save() elapsed = %s, busy timeout did not apply", elapsed)
 	}
 }
 

--- a/infrastructure/sqlite/database_dsn_test.go
+++ b/infrastructure/sqlite/database_dsn_test.go
@@ -23,7 +23,7 @@ func TestSQLiteDSN_IncludesConcurrencyPragmas(t *testing.T) {
 	wants := []string{
 		"journal_mode%28WAL%29",
 		"synchronous%28NORMAL%29",
-		"busy_timeout%285000%29",
+		"busy_timeout%281000%29",
 		"foreign_keys%281%29",
 	}
 	for _, want := range wants {
@@ -60,7 +60,7 @@ func TestSQLiteDSN_AppliesPragmasOnOpen(t *testing.T) {
 	}{
 		{"journal_mode", "wal"},
 		{"synchronous", "1"}, // NORMAL
-		{"busy_timeout", "5000"},
+		{"busy_timeout", "1000"},
 		{"foreign_keys", "1"},
 	}
 	for _, tt := range tests {

--- a/integrations/gemini-extension/hooks/hooks.json
+++ b/integrations/gemini-extension/hooks/hooks.json
@@ -8,7 +8,7 @@
             "name": "traceary-session-start",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'gemini' 'start'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Start a Traceary session"
           }
         ]
@@ -22,7 +22,7 @@
             "name": "traceary-session-end",
             "type": "command",
             "command": "'traceary' 'hook' 'session' 'gemini' 'end'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Finish a Traceary session"
           }
         ]
@@ -36,7 +36,7 @@
             "name": "traceary-prompt",
             "type": "command",
             "command": "'traceary' 'hook' 'prompt' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record user prompt as a prompt event"
           }
         ]
@@ -50,7 +50,7 @@
             "name": "traceary-transcript",
             "type": "command",
             "command": "'traceary' 'hook' 'transcript' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record agent response as a transcript event"
           }
         ]
@@ -64,7 +64,7 @@
             "name": "traceary-audit",
             "type": "command",
             "command": "'traceary' 'hook' 'audit' 'gemini'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record shell command audits in Traceary"
           }
         ]
@@ -78,7 +78,7 @@
             "name": "traceary-pre-compress",
             "type": "command",
             "command": "'traceary' 'hook' 'compact' 'gemini' 'pre-compact'",
-            "timeout": 5000,
+            "timeout": 10000,
             "description": "Record a pre-compact marker (Gemini exposes no post-compress hook)"
           }
         ]

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"fmt"
@@ -11,9 +12,11 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"os/signal"
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"syscall"
 
 	"golang.org/x/xerrors"
 
@@ -221,12 +224,31 @@ func run() error {
 	).Command()
 	rootCmd.Version = versionString()
 	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
+	commandCtx, stopSignals := commandContext(os.Args)
+	defer stopSignals()
+	rootCmd.SetContext(commandCtx)
 
 	if err := rootCmd.Execute(); err != nil {
 		return xerrors.Errorf("failed to execute CLI command: %w", err)
 	}
 
 	return nil
+}
+
+func commandContext(args []string) (context.Context, context.CancelFunc) {
+	if isHookCommandArgs(args) {
+		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	}
+	return context.WithCancel(context.Background())
+}
+
+func isHookCommandArgs(args []string) bool {
+	for _, arg := range args[1:] {
+		if arg == "hook" {
+			return true
+		}
+	}
+	return false
 }
 
 type cliExitCoder interface {

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,27 @@ import (
 	"golang.org/x/xerrors"
 )
 
+func TestIsHookCommandArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "direct hook command", args: []string{"traceary", "hook", "prompt", "claude"}, want: true},
+		{name: "global flag before hook", args: []string{"traceary", "--config", "config.json", "hook", "prompt", "claude"}, want: true},
+		{name: "ordinary command", args: []string{"traceary", "doctor", "--client", "claude"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isHookCommandArgs(tt.args); got != tt.want {
+				t.Fatalf("isHookCommandArgs(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteCLIError(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -295,6 +295,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved project directory: %s", "解決した project directory: %s", resolvedProjectDir),
 	})
+	report.Checks = append(report.Checks, inspectHookSpoolDiagnostics(resolvedClients))
 
 	for _, targetClient := range resolvedClients {
 		if targetClient == "antigravity" {

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -54,8 +54,8 @@ func (c *RootCLI) newHookAntigravityEventCommand(
 		Hidden: true,
 		Args:   noArgsLocalized(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runHookBestEffort("antigravity "+event, func() error {
-				return run(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), dbPath)
+			return c.runHookDurably(cmd.Context(), "antigravity "+event, hookInvocationSpec{Command: "antigravity", Client: antigravityHookClient, Action: event, DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return run(cmd.Context(), cmd.OutOrStdout(), input, dbPath)
 			})
 		},
 	}
@@ -229,10 +229,14 @@ func (c *RootCLI) runHookAntigravityStop(ctx context.Context, output io.Writer, 
 
 	// Transcript first so the turn's transcript event is recorded before any
 	// turn-boundary side effects, keeping the event order chronological.
-	if err := c.runHookTranscript(ctx, bytes.NewReader(normalized), antigravityHookClient, dbPath); err != nil {
-		slog.Debug("antigravity stop transcript failed", "session_id", sessionID, "error", err)
+	transcriptErr := c.runHookTranscript(ctx, bytes.NewReader(normalized), antigravityHookClient, dbPath)
+	if transcriptErr != nil {
+		slog.Debug("antigravity stop transcript failed", "session_id", sessionID, "error", transcriptErr)
 	}
-	return c.runHookSession(ctx, nil, bytes.NewReader(normalized), antigravityHookClient, "stop", dbPath)
+	if err := c.runHookSession(ctx, nil, bytes.NewReader(normalized), antigravityHookClient, "stop", dbPath); err != nil {
+		return err
+	}
+	return transcriptErr
 }
 
 // antigravityNormalizeOptions carries the resolved values used to build a

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -78,8 +78,8 @@ func (c *RootCLI) newHookSessionCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("session", func() error {
-				return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			return c.runHookDurably(cmd.Context(), "session", hookInvocationSpec{Command: "session", Client: args[0], Action: args[1], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookSession(cmd.Context(), cmd.OutOrStdout(), input, args[0], args[1], dbPath)
 			})
 		},
 	}
@@ -97,8 +97,8 @@ func (c *RootCLI) newHookAuditCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("audit", func() error {
-				return c.runHookAudit(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return c.runHookDurably(cmd.Context(), "audit", hookInvocationSpec{Command: "audit", Client: args[0], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookAudit(cmd.Context(), input, args[0], dbPath)
 			})
 		},
 	}
@@ -116,8 +116,8 @@ func (c *RootCLI) newHookCompactCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("compact", func() error {
-				return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), cmd.InOrStdin(), args[0], args[1], dbPath)
+			return c.runHookDurably(cmd.Context(), "compact", hookInvocationSpec{Command: "compact", Client: args[0], Action: args[1], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookCompact(cmd.Context(), cmd.OutOrStdout(), input, args[0], args[1], dbPath)
 			})
 		},
 	}
@@ -135,8 +135,8 @@ func (c *RootCLI) newHookSubagentStartCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("subagent-start", func() error {
-				return c.runHookSubagentStart(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return c.runHookDurably(cmd.Context(), "subagent-start", hookInvocationSpec{Command: "subagent-start", Client: args[0], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookSubagentStart(cmd.Context(), input, args[0], dbPath)
 			})
 		},
 	}
@@ -154,8 +154,8 @@ func (c *RootCLI) newHookSubagentStopCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("subagent-stop", func() error {
-				return c.runHookSubagentStop(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return c.runHookDurably(cmd.Context(), "subagent-stop", hookInvocationSpec{Command: "subagent-stop", Client: args[0], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookSubagentStop(cmd.Context(), input, args[0], dbPath)
 			})
 		},
 	}
@@ -173,8 +173,8 @@ func (c *RootCLI) newHookPromptCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("prompt", func() error {
-				return c.runHookPrompt(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return c.runHookDurably(cmd.Context(), "prompt", hookInvocationSpec{Command: "prompt", Client: args[0], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookPrompt(cmd.Context(), input, args[0], dbPath)
 			})
 		},
 	}
@@ -192,8 +192,8 @@ func (c *RootCLI) newHookTranscriptCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runHookBestEffort("transcript", func() error {
-				return c.runHookTranscript(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			return c.runHookDurably(cmd.Context(), "transcript", hookInvocationSpec{Command: "transcript", Client: args[0], DBPath: dbPath}, cmd.InOrStdin(), func(input io.Reader) error {
+				return c.runHookTranscript(cmd.Context(), input, args[0], dbPath)
 			})
 		},
 	}

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+const hookSpoolSchemaVersion = 1
+
+type hookInvocationSpec struct {
+	Command string
+	Client  string
+	Action  string
+	DBPath  string
+}
+
+type hookSpoolRecord struct {
+	SchemaVersion int       `json:"schema_version"`
+	Command       string    `json:"command"`
+	Client        string    `json:"client"`
+	Action        string    `json:"action,omitempty"`
+	DBPath        string    `json:"db_path,omitempty"`
+	Payload       string    `json:"payload"`
+	CreatedAt     time.Time `json:"created_at"`
+	Path          string    `json:"-"`
+}
+
+// explicitHookPayloadReader tells readHookPayload that the bytes came from a
+// durable spool wrapper and must take precedence over TRACEARY_HOOK_INPUT.
+type explicitHookPayloadReader struct{ *bytes.Reader }
+
+func newExplicitHookPayloadReader(payload []byte) io.Reader {
+	return &explicitHookPayloadReader{Reader: bytes.NewReader(payload)}
+}
+
+func (c *RootCLI) runHookDurably(
+	ctx context.Context,
+	name string,
+	spec hookInvocationSpec,
+	input io.Reader,
+	run func(io.Reader) error,
+) error {
+	return runHookBestEffort(name, func() error {
+		payload, err := readHookPayload(input)
+		if err != nil {
+			return err
+		}
+		record := hookSpoolRecord{
+			SchemaVersion: hookSpoolSchemaVersion,
+			Command:       strings.TrimSpace(spec.Command),
+			Client:        strings.TrimSpace(spec.Client),
+			Action:        strings.TrimSpace(spec.Action),
+			DBPath:        strings.TrimSpace(spec.DBPath),
+			Payload:       string(payload),
+			CreatedAt:     time.Now().UTC(),
+		}
+		path, err := persistHookSpoolRecord(record)
+		if err != nil {
+			// Preserve existing fail-soft behavior when the state directory is
+			// unavailable. The operational error remains visible in debug logs;
+			// successful persistence is the timeout-kill guarantee.
+			slog.Debug("hook spool persistence failed", "command", spec.Command, "client", spec.Client, "error", err)
+			return run(newExplicitHookPayloadReader(payload))
+		}
+		if err := ctx.Err(); err != nil {
+			return xerrors.Errorf("hook context cancelled after spool persistence: %w", err)
+		}
+		if err := run(newExplicitHookPayloadReader(payload)); err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return xerrors.Errorf("failed to clear committed hook spool record: %w", err)
+		}
+		return nil
+	})
+}
+
+func persistHookSpoolRecord(record hookSpoolRecord) (string, error) {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", xerrors.Errorf("failed to create hook spool directory: %w", err)
+	}
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return "", xerrors.Errorf("failed to generate hook spool ID: %w", err)
+	}
+	base := fmt.Sprintf("%s-%s-%s.json", record.CreatedAt.Format("20060102T150405.000000000Z"), sanitizeHookStateKey(record.Client), hex.EncodeToString(random))
+	path := filepath.Join(dir, base)
+	tmpPath := path + ".tmp"
+	encoded, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode hook spool record: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(tmpPath, encoded, 0o600); err != nil {
+		return "", xerrors.Errorf("failed to write hook spool record: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", xerrors.Errorf("failed to publish hook spool record: %w", err)
+	}
+	return path, nil
+}
+
+func hookSpoolDir() (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, "spool"), nil
+}
+
+func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error) {
+	dir, err := hookSpoolDir()
+	if err != nil {
+		return nil, nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to read hook spool directory: %w", err)
+	}
+	allowed := make(map[string]struct{}, len(clients))
+	for _, client := range clients {
+		allowed[strings.TrimSpace(client)] = struct{}{}
+	}
+	records := []hookSpoolRecord{}
+	unreadable := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			unreadable = append(unreadable, path)
+			continue
+		}
+		var record hookSpoolRecord
+		if err := json.Unmarshal(data, &record); err != nil || record.SchemaVersion != hookSpoolSchemaVersion {
+			unreadable = append(unreadable, path)
+			continue
+		}
+		if len(allowed) > 0 {
+			if _, ok := allowed[record.Client]; !ok {
+				continue
+			}
+		}
+		record.Path = path
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].CreatedAt.After(records[j].CreatedAt) })
+	sort.Strings(unreadable)
+	return records, unreadable, nil
+}
+
+func inspectHookSpoolDiagnostics(clients []string) doctorCheck {
+	const name = "hook-spool"
+	records, unreadable, err := scanHookSpoolRecords(clients)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect hook spool: %v", "hook spool の検査に失敗しました: %v", err)}
+	}
+	if len(records) == 0 && len(unreadable) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook spool records found", "未処理の hook spool record はありません")}
+	}
+	latest := "-"
+	if len(records) > 0 {
+		latest = fmt.Sprintf("client=%s command=%s action=%s created_at=%s path=%s", emptyAsDash(records[0].Client), emptyAsDash(records[0].Command), emptyAsDash(records[0].Action), records[0].CreatedAt.Format(time.RFC3339Nano), records[0].Path)
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"found %d pending hook spool record(s) and %d unreadable record(s); latest %s",
+			"未処理の hook spool record が %d 件、読めない record が %d 件あります。latest %s",
+			len(records), len(unreadable), latest,
+		),
+		Hint: Localize("the host interrupted or Traceary failed before commit; inspect the preserved payload and retry the matching hook command before removing the record", "host が中断したか commit 前に Traceary が失敗しました。保存された payload を確認し、対応する hook command を再実行してから record を削除してください"),
+	}
+}

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunHookDurably_RemovesSpoolAfterSuccess(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	c := &RootCLI{}
+	var got string
+
+	err := c.runHookDurably(context.Background(), "prompt", hookInvocationSpec{Command: "prompt", Client: "claude"}, strings.NewReader(`{"prompt":"hello"}`), func(input io.Reader) error {
+		payload, err := readHookPayload(input)
+		got = string(payload)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("runHookDurably() error = %v", err)
+	}
+	if got != `{"prompt":"hello"}` {
+		t.Fatalf("payload = %q", got)
+	}
+	entries, err := os.ReadDir(filepath.Join(stateDir, "spool"))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("spool entries = %d, want 0", len(entries))
+	}
+}
+
+func TestRunHookDurably_RetainsSpoolAfterFailure(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	t.Setenv("TRACEARY_HOOK_INPUT", `{"prompt":"current-env"}`)
+	c := &RootCLI{}
+
+	if err := c.runHookDurably(context.Background(), "prompt", hookInvocationSpec{Command: "prompt", Client: "claude"}, strings.NewReader(`{"prompt":"stdin"}`), func(input io.Reader) error {
+		payload, err := readHookPayload(input)
+		if err != nil {
+			return err
+		}
+		if string(payload) != `{"prompt":"current-env"}` {
+			t.Fatalf("payload = %q", payload)
+		}
+		return errors.New("database busy")
+	}); err != nil {
+		t.Fatalf("runHookDurably() must remain fail-soft, error = %v", err)
+	}
+
+	records, unreadable, err := scanHookSpoolRecords([]string{"claude"})
+	if err != nil {
+		t.Fatalf("scanHookSpoolRecords() error = %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 {
+		t.Fatalf("records=%d unreadable=%d, want 1/0", len(records), len(unreadable))
+	}
+	if records[0].Payload != `{"prompt":"current-env"}` || records[0].Command != "prompt" {
+		t.Fatalf("record = %#v", records[0])
+	}
+	info, err := os.Stat(records[0].Path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("spool mode = %o, want 600", got)
+	}
+
+	check := inspectHookSpoolDiagnostics([]string{"claude"})
+	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "1 pending") {
+		t.Fatalf("doctor check = %#v", check)
+	}
+}
+
+func TestReadHookPayload_ExplicitReaderOverridesEnvironment(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_INPUT", `{"source":"env"}`)
+	payload, err := readHookPayload(newExplicitHookPayloadReader([]byte(`{"source":"spool"}`)))
+	if err != nil {
+		t.Fatalf("readHookPayload() error = %v", err)
+	}
+	if got := string(payload); got != `{"source":"spool"}` {
+		t.Fatalf("payload = %q", got)
+	}
+}
+
+func TestHookSpoolSurvivesSIGTERM(t *testing.T) {
+	if os.Getenv("TRACEARY_HOOK_SPOOL_SIGNAL_HELPER") == "1" {
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+		defer stop()
+		_ = (&RootCLI{}).runHookDurably(ctx, "prompt", hookInvocationSpec{Command: "prompt", Client: "claude"}, strings.NewReader(`{"prompt":"preserve me"}`), func(io.Reader) error {
+			<-ctx.Done()
+			return ctx.Err()
+		})
+		return
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM process test is not supported on Windows")
+	}
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHookSpoolSurvivesSIGTERM$")
+	cmd.Env = append(os.Environ(), "TRACEARY_HOOK_SPOOL_SIGNAL_HELPER=1", hookStateDirEnvKey+"="+stateDir)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	spoolDir := filepath.Join(stateDir, "spool")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		entries, _ := os.ReadDir(spoolDir)
+		if len(entries) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			t.Fatal("spool record was not published before timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("Signal(SIGTERM) error = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper exit error = %v", err)
+	}
+	records, unreadable, err := scanHookSpoolRecords([]string{"claude"})
+	if err != nil {
+		t.Fatalf("scanHookSpoolRecords() error = %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 || records[0].Payload != `{"prompt":"preserve me"}` {
+		t.Fatalf("records=%#v unreadable=%#v", records, unreadable)
+	}
+}

--- a/presentation/cli/hooks_helper.go
+++ b/presentation/cli/hooks_helper.go
@@ -140,8 +140,10 @@ func runHooksHelperBuildFailureOutput(input io.Reader, output io.Writer) error {
 }
 
 func readHookPayload(input io.Reader) ([]byte, error) {
-	if envValue, ok := lookupHookEnv("TRACEARY_HOOK_INPUT"); ok {
-		return []byte(envValue), nil
+	if _, explicit := input.(*explicitHookPayloadReader); !explicit {
+		if envValue, ok := lookupHookEnv("TRACEARY_HOOK_INPUT"); ok {
+			return []byte(envValue), nil
+		}
 	}
 	if input == nil {
 		return nil, nil

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -113,7 +113,7 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 		if diff := cmp.Diff("traceary-session-start", gotHook.Name); diff != "" {
 			t.Fatalf("SessionStart hook name mismatch (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(5000, gotHook.Timeout); diff != "" {
+		if diff := cmp.Diff(10000, gotHook.Timeout); diff != "" {
 			t.Fatalf("SessionStart hook timeout mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff("*", *settings.Hooks["AfterAgent"][0].Matcher); diff != "" {

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -85,6 +85,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "hook-spool",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "no pending hook spool records found",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "codex-config",
       "status": "warn",
       "severity": "WARN",
@@ -259,6 +269,16 @@
       "name": "Hooks",
       "checks": [
         {
+          "name": "hook-spool",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "no pending hook spool records found",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "codex-config",
           "status": "warn",
           "severity": "WARN",
@@ -272,7 +292,7 @@
     }
   ],
   "summary": {
-    "pass": 10,
+    "pass": 11,
     "warn": 2,
     "fail": 0
   },


### PR DESCRIPTION
## Motivation

A host timeout can terminate a hook while SQLite is still waiting on a writer lock. Because the previous SQLite busy timeout equaled Gemini's host hook timeout and hook errors were fail-soft, the event could disappear without durable evidence.

## Changes

- atomically spool every hook payload before executing its runtime handler
- remove the mode-0600 spool record only after the handler succeeds
- cancel hook command contexts on SIGTERM while leaving the already-published record intact
- report retained and unreadable records through the new `hook-spool` doctor check
- reduce SQLite `busy_timeout` from 5 seconds to 1 second
- raise generated and packaged Gemini hook timeouts from 5 seconds to 10 seconds
- document the required `SQLite busy_timeout < host hook timeout` relationship

## Safety

- retained records are never deleted based on age
- doctor does not print payload bodies
- spool persistence uses temp-file + atomic rename under the existing local hook state root
- if the spool directory itself is unavailable, existing fail-soft hook execution remains unchanged

## Validation

- `go test ./...` (2,652 tests passed across 21 packages)
- `go tool golangci-lint run --timeout=5m`
- `git diff --check`
- contention test holds a concurrent SQLite writer and confirms the hook-like write returns before the 5-second host budget
- child-process test sends SIGTERM after the spool barrier and confirms the payload record survives
- dogfood failure injection retained one prompt record and `doctor` reported `hook-spool=warn`
- bilingual docs, changelog coverage, release manifests, and packaged integration verification passed

Closes #1269