### PR TITLE
v0.22.0-9: move hook memory auto-extract to a durable queue

### DIFF
--- a/.ai/spec/1270.md
+++ b/.ai/spec/1270.md
@@ -16,7 +16,7 @@
 | Extraction request | database, session, workspace, source boundary, request time | coalesces repeated boundaries | one pending job per database/session/workspace key |
 | Extraction job | pending, processing, failed, complete | survives worker failure; records bounded error metadata | mode `0600`; success is the only path that removes it |
 | Worker claim | unlocked or OS-file-locked | prevents concurrent extraction of one job | process death releases the claim without deleting the job |
-| Rerun marker | absent or present | preserves a boundary arriving during extraction | content-free and coalesced |
+| Rerun marker | absent or present | preserves a boundary arriving during extraction or completion | first writer preserves the oldest request time; worker checks before and after job removal |
 
 ### Responsibility assignment
 
@@ -45,6 +45,7 @@
 | Criteria parity | a queued session/workspace | the worker runs | the existing extractor receives the same criteria | CLI |
 | Retry after failure | extractor returns an error | worker runs, then succeeds | job retains failure metadata, then is removed on retry | CLI |
 | Coalescing | repeated boundaries for one key | hooks enqueue twice | one JSON job path remains | CLI |
+| Completion race | a request arrives after the worker's first rerun check | the worker removes the completed job | either enqueue or the worker recreates the job and hands it off | CLI |
 | Boundary parity | session end, turn boundary, subagent stop | each hook commits | each enqueues its current session/workspace with the source boundary | CLI |
 | Diagnostics | pending, failed, unreadable jobs | doctor inspects the queue | counts and oldest age are reported without content | unit/golden |
 

--- a/.ai/spec/1270.md
+++ b/.ai/spec/1270.md
@@ -1,0 +1,65 @@
+# Issue #1270: durable hook memory-extraction queue
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Purpose: keep memory auto-extraction outside every host hook deadline while preserving the existing extraction criteria.
+- Current behavior: session end, turn boundary, and subagent stop call `MemoryUsecase.Extract` synchronously after recording their primary boundary.
+- Expected behavior: commit the primary hook work, coalesce a durable extraction request, return immediately, and let a detached retryable worker call the existing extractor.
+- Non-goals: change candidate selection, auto-accept memories, introduce a SQLite migration, or reuse the raw payload spool as the extraction contract.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Extraction request | database, session, workspace, source boundary, request time | coalesces repeated boundaries | one pending job per database/session/workspace key |
+| Extraction job | pending, processing, failed, complete | survives worker failure; records bounded error metadata | mode `0600`; success is the only path that removes it |
+| Worker claim | unlocked or OS-file-locked | prevents concurrent extraction of one job | process death releases the claim without deleting the job |
+| Rerun marker | absent or present | preserves a boundary arriving during extraction | content-free and coalesced |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Decide when extraction is requested | hook runtime orchestration | host boundary mapping changes | queue must not know host payloads |
+| Durable coalescing and retry metadata | hook memory-extraction queue | queue state transition changes | hook handlers must not implement file-state rules |
+| Candidate selection | existing `MemoryUsecase.Extract` | memory policy changes | worker must not duplicate extraction rules |
+| Operational visibility | doctor queue check | diagnostic contract changes | worker logs alone are not discoverable |
+| Process detachment | platform-specific launcher helper | OS process semantics change | queue state remains platform-neutral |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `scheduleHookMemoryExtract` | hook handlers | file naming, locking, process launch | enqueue/launch failure is logged; primary committed hook work remains successful |
+| hidden `hook memory-extract-worker --job` command | detached process | queue encoding and claim lifecycle | failure exits non-zero after persisting attempt/error metadata |
+| `MemoryUsecase.Extract` | worker | candidate rules and persistence | unchanged criteria: session ID plus workspace |
+| `hook-memory-extract` doctor check | operator/automation | job content and DB path | reports counts and age only; never prints criteria or extracted content |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Hook latency is extraction-independent | an injected extractor | a stop hook runs | no synchronous extract call occurs; a job is launched | CLI |
+| Criteria parity | a queued session/workspace | the worker runs | the existing extractor receives the same criteria | CLI |
+| Retry after failure | extractor returns an error | worker runs, then succeeds | job retains failure metadata, then is removed on retry | CLI |
+| Coalescing | repeated boundaries for one key | hooks enqueue twice | one JSON job path remains | CLI |
+| Boundary parity | session end, turn boundary, subagent stop | each hook commits | each enqueues its current session/workspace with the source boundary | CLI |
+| Diagnostics | pending, failed, unreadable jobs | doctor inspects the queue | counts and oldest age are reported without content | unit/golden |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| asynchronous hook path | existing tests expect immediate extraction | assert queued job and no synchronous call | central scheduling helper |
+| durable worker | failure currently disappears | persist attempts/error and retain job | queue transition methods |
+| coalescing | repeated stops create repeated work | stable digest key and file lock | request/job value objects |
+| observability | doctor has no queue signal | add check and JSON golden entry | diagnostic scanner |
+
+### Risks / rollback
+
+- Procedural-design risk: keep file transitions in the queue module; hook handlers only construct requests.
+- Premature-abstraction risk: one filesystem queue and one worker command; no generic background-job framework.
+- Migration / compatibility: additive state directory only, no database or public CLI migration. Existing synchronous CLI `session end` behavior outside hidden hooks remains unchanged.
+- Rollback trigger: extraction requests remain pending after healthy subsequent boundaries, workers duplicate candidates, or hook latency regresses. Reverting restores synchronous extraction; pending mode-`0600` metadata files can be removed after inspection.

--- a/.ai/spec/1270.md
+++ b/.ai/spec/1270.md
@@ -16,7 +16,7 @@
 | Extraction request | database, session, workspace, source boundary, request time | coalesces repeated boundaries | one pending job per database/session/workspace key |
 | Extraction job | pending, processing, failed, complete | survives worker failure; records bounded error metadata | mode `0600`; success is the only path that removes it |
 | Worker claim | unlocked or OS-file-locked | prevents concurrent extraction of one job | process death releases the claim without deleting the job |
-| Rerun marker | absent or present | preserves a boundary arriving during extraction or completion | first writer preserves the oldest request time; worker checks before and after job removal |
+| Rerun marker | absent or present | preserves a boundary arriving during extraction or completion | synced temporary file is atomically linked once; worker checks before and after job removal and again after unlock |
 
 ### Responsibility assignment
 
@@ -45,7 +45,7 @@
 | Criteria parity | a queued session/workspace | the worker runs | the existing extractor receives the same criteria | CLI |
 | Retry after failure | extractor returns an error | worker runs, then succeeds | job retains failure metadata, then is removed on retry | CLI |
 | Coalescing | repeated boundaries for one key | hooks enqueue twice | one JSON job path remains | CLI |
-| Completion race | a request arrives after the worker's first rerun check | the worker removes the completed job | either enqueue or the worker recreates the job and hands it off | CLI |
+| Completion race | a request arrives after the worker's first or final rerun check | the worker removes the completed job | enqueue recreates the job, and the worker relaunches it after unlock when needed | CLI |
 | Boundary parity | session end, turn boundary, subagent stop | each hook commits | each enqueues its current session/workspace with the source boundary | CLI |
 | Diagnostics | pending, failed, unreadable jobs | doctor inspects the queue | counts and oldest age are reported without content | unit/golden |
 

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -204,6 +204,12 @@ traceary hooks install --client codex --upgrade
 
 SQLite が writer 競合を待つのは最大1秒です。packaged host hook の budget は必ずこの待機時間を上回る必要があります。Gemini の生成・同梱 hook timeout は10秒で、DB attempt が失敗して spool record を保持したまま host deadline より前に制御を戻せます。この関係は意図的です: `SQLite busy_timeout < host hook timeout`。
 
+### メモリ抽出キュー
+
+session end、turn boundary、subagent stop の hook は、主要な event を先に commit してから、メモリ自動抽出を `~/.config/traceary/hooks/memory-extract/` に enqueue します。job に入るのは抽出条件と運用 metadata だけで、mode は `0600` です。同じ database・session・workspace への繰り返し要求は1件にまとめます。host hook が終了した後、分離した内部 worker が既存の extractor を呼び出します。成功時は job を削除し、失敗または中断された場合は再試行できる状態で残します。これにより、抽出処理は host hook timeout を消費せず、主要 event の commit を遅らせません。
+
+`traceary doctor` は `hook-memory-extract` check で、未処理件数、以前失敗した件数、読めない件数、最古の経過時間を報告します。抽出内容や保存された条件は表示しません。次に同じ対象の hook 要求が来ると worker が再起動します。警告が残り続ける場合は debug log を確認してください。
+
 ## トラブルシュート
 
 hooks やローカル SQLite ストアの挙動がおかしいときは `traceary doctor --client <claude|codex|gemini>` を実行してください。

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -204,6 +204,12 @@ Every hidden `traceary hook ...` entrypoint writes the exact host payload to a m
 
 SQLite waits at most 1 second for a busy writer. Every packaged host hook budget must exceed that wait. Gemini's generated and packaged hook timeout is 10 seconds, leaving time for the DB attempt to fail and the spool record to remain durable before the host deadline. This relationship is intentional: `SQLite busy_timeout < host hook timeout`.
 
+### Memory extraction queue
+
+Session-end, turn-boundary, and subagent-stop hooks commit their primary event first, then enqueue memory auto-extraction under `~/.config/traceary/hooks/memory-extract/`. Jobs contain extraction criteria and operational metadata only, use mode `0600`, and coalesce repeated requests for the same database, session, and workspace. A detached internal worker calls the existing extractor after the host hook returns; success removes the job, while a failed or interrupted worker leaves it available for retry. Extraction therefore no longer consumes the host hook timeout or delays the primary event commit.
+
+`traceary doctor` reports the pending count, previously failed count, unreadable count, and oldest age through `hook-memory-extract`. It never prints extracted content or the stored criteria. A later matching hook request launches the worker again; persistent warnings should be investigated through debug logs.
+
 ## Troubleshooting
 
 Run `traceary doctor --client <claude|codex|gemini>` when hooks or the local SQLite store do not behave as expected.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/go-cmp v0.7.0
+	github.com/gofrs/flock v0.13.0
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pelletier/go-toml/v2 v2.4.2
@@ -99,7 +100,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -296,6 +296,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Message: localizef("resolved project directory: %s", "解決した project directory: %s", resolvedProjectDir),
 	})
 	report.Checks = append(report.Checks, inspectHookSpoolDiagnostics(resolvedClients))
+	report.Checks = append(report.Checks, inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
 
 	for _, targetClient := range resolvedClients {
 		if targetClient == "antigravity" {

--- a/presentation/cli/hook_detached_process_unix.go
+++ b/presentation/cli/hook_detached_process_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedHookProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/presentation/cli/hook_detached_process_windows.go
+++ b/presentation/cli/hook_detached_process_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cli
+
+import "os/exec"
+
+func configureDetachedHookProcess(_ *exec.Cmd) {}

--- a/presentation/cli/hook_detached_process_windows.go
+++ b/presentation/cli/hook_detached_process_windows.go
@@ -2,6 +2,15 @@
 
 package cli
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
 
-func configureDetachedHookProcess(_ *exec.Cmd) {}
+	"golang.org/x/sys/windows"
+)
+
+func configureDetachedHookProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS | windows.CREATE_BREAKAWAY_FROM_JOB,
+	}
+}

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -74,15 +74,19 @@ func (c *RootCLI) scheduleHookMemoryExtract(request hookMemoryExtractRequest) {
 		slog.Debug("hook memory extraction enqueue failed", "session_id", request.SessionID, "source_boundary", request.SourceBoundary, "error", err)
 		return
 	}
-	launcher := c.hookMemoryExtractLauncher
-	if launcher == nil {
-		launcher = launchDetachedHookMemoryExtractWorker
-	}
-	if err := launcher(jobPath); err != nil {
+	if err := c.launchHookMemoryExtractWorker(jobPath); err != nil {
 		// The durable job remains pending. A later hook invocation can launch
 		// another worker, and doctor surfaces the backlog in the meantime.
 		slog.Debug("hook memory extraction worker launch failed", "job", jobPath, "error", err)
 	}
+}
+
+func (c *RootCLI) launchHookMemoryExtractWorker(jobPath string) error {
+	launcher := c.hookMemoryExtractLauncher
+	if launcher == nil {
+		launcher = launchDetachedHookMemoryExtractWorker
+	}
+	return launcher(jobPath)
 }
 
 func hookMemoryExtractQueueDir() (string, error) {
@@ -142,11 +146,17 @@ func enqueueHookMemoryExtract(request hookMemoryExtractRequest, requestedAt time
 		RequestedAt:    requestedAt,
 	}
 	if existing, readErr := readHookMemoryExtractJob(jobPath); readErr == nil {
+		if existing.RequestedAt.Before(job.RequestedAt) {
+			job.RequestedAt = existing.RequestedAt
+		}
 		job.Attempts = existing.Attempts
 		job.LastAttemptAt = existing.LastAttemptAt
 		job.LastError = existing.LastError
 	} else if !errors.Is(readErr, os.ErrNotExist) {
-		return "", readErr
+		corruptPath := fmt.Sprintf("%s.%s.corrupt.json", jobPath, requestedAt.Format("20060102T150405.000000000Z"))
+		if renameErr := os.Rename(jobPath, corruptPath); renameErr != nil {
+			return "", xerrors.Errorf("failed to quarantine unreadable memory extraction job: %w", renameErr)
+		}
 	}
 	if err := writeHookMemoryExtractJob(jobPath, job); err != nil {
 		return "", err
@@ -170,8 +180,22 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		return err
 	}
 	insideQueue, err := filepath.Rel(queueDir, resolvedJobPath)
-	if err != nil || insideQueue == "." || strings.HasPrefix(insideQueue, ".."+string(filepath.Separator)) || filepath.IsAbs(insideQueue) {
+	if err != nil || insideQueue == "." || filepath.Dir(insideQueue) != "." || filepath.IsAbs(insideQueue) {
 		return xerrors.Errorf("memory extraction job is outside the queue directory")
+	}
+	name := filepath.Base(insideQueue)
+	if len(name) != 69 || !strings.HasSuffix(name, ".json") {
+		return xerrors.Errorf("memory extraction job name is invalid")
+	}
+	if _, decodeErr := hex.DecodeString(strings.TrimSuffix(name, ".json")); decodeErr != nil {
+		return xerrors.Errorf("memory extraction job name is invalid: %w", decodeErr)
+	}
+	info, statErr := os.Lstat(resolvedJobPath)
+	if statErr == nil && !info.Mode().IsRegular() {
+		return xerrors.Errorf("memory extraction job is not a regular file")
+	}
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return xerrors.Errorf("failed to inspect memory extraction job: %w", statErr)
 	}
 
 	jobLock := flock.New(resolvedJobPath + ".lock")
@@ -182,7 +206,12 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 	if !locked {
 		return nil
 	}
-	defer func() { _ = jobLock.Unlock() }()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			_ = jobLock.Unlock()
+		}
+	}()
 
 	for run := 0; run < hookMemoryExtractMaxRunsPerWorker; run++ {
 		job, readErr := readHookMemoryExtractJob(resolvedJobPath)
@@ -191,6 +220,13 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		}
 		if readErr != nil {
 			return readErr
+		}
+		attemptedAt := time.Now().UTC()
+		job.Attempts++
+		job.LastAttemptAt = &attemptedAt
+		job.LastError = ""
+		if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
+			return writeErr
 		}
 		resolvedDBPath, resolveErr := resolveDBPath(job.DBPath)
 		if resolveErr != nil {
@@ -214,6 +250,16 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 			if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
 				return writeErr
 			}
+			if run+1 >= hookMemoryExtractMaxRunsPerWorker {
+				if unlockErr := jobLock.Unlock(); unlockErr != nil {
+					return xerrors.Errorf("failed to release memory extraction job before handoff: %w", unlockErr)
+				}
+				lockHeld = false
+				if launchErr := c.launchHookMemoryExtractWorker(resolvedJobPath); launchErr != nil {
+					return xerrors.Errorf("failed to hand off pending memory extraction job: %w", launchErr)
+				}
+				return nil
+			}
 			continue
 		} else if !os.IsNotExist(rerunErr) {
 			return xerrors.Errorf("failed to inspect memory extraction rerun marker: %w", rerunErr)
@@ -227,9 +273,6 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 }
 
 func (c *RootCLI) failHookMemoryExtractJob(path string, job hookMemoryExtractJob, cause error) error {
-	now := time.Now().UTC()
-	job.Attempts++
-	job.LastAttemptAt = &now
 	job.LastError = truncateHookMemoryExtractError(cause.Error())
 	if err := writeHookMemoryExtractJob(path, job); err != nil {
 		return xerrors.Errorf("memory extraction failed (%v) and job metadata update failed: %w", cause, err)
@@ -272,6 +315,10 @@ func writeHookMemoryExtractJob(path string, job hookMemoryExtractJob) error {
 	if _, err := tmp.Write(encoded); err != nil {
 		_ = tmp.Close()
 		return xerrors.Errorf("failed to write memory extraction job: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to sync memory extraction job: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		return xerrors.Errorf("failed to close memory extraction job: %w", err)

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -309,6 +309,23 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		} else if !os.IsNotExist(rerunErr) {
 			return xerrors.Errorf("failed to inspect post-completion memory extraction rerun marker: %w", rerunErr)
 		}
+		if c.hookMemoryAfterFinalCheck != nil {
+			c.hookMemoryAfterFinalCheck()
+		}
+		if unlockErr := jobLock.Unlock(); unlockErr != nil {
+			return xerrors.Errorf("failed to release completed memory extraction job: %w", unlockErr)
+		}
+		lockHeld = false
+		// Close the final lost-wakeup window: an enqueue that observed the
+		// old lock after our post-remove check may have recreated the job and
+		// launched a worker that exited before this unlock. Relaunch it here.
+		if _, statErr := os.Stat(resolvedJobPath); statErr == nil {
+			if launchErr := c.launchHookMemoryExtractWorker(resolvedJobPath); launchErr != nil {
+				return xerrors.Errorf("failed to hand off post-completion memory extraction job: %w", launchErr)
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return xerrors.Errorf("failed to inspect post-unlock memory extraction job: %w", statErr)
+		}
 		return nil
 	}
 	return nil
@@ -372,23 +389,41 @@ func writeHookMemoryExtractJob(path string, job hookMemoryExtractJob) error {
 }
 
 func publishHookMemoryExtractRerun(path string, requestedAt time.Time) error {
-	marker, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if errors.Is(err, os.ErrExist) {
-		return nil
-	}
+	return publishHookMemoryExtractRerunWithHook(path, requestedAt, nil)
+}
+
+func publishHookMemoryExtractRerunWithHook(path string, requestedAt time.Time, beforePublish func()) error {
+	marker, err := os.CreateTemp(filepath.Dir(path), ".memory-extract-rerun-*.tmp")
 	if err != nil {
 		return xerrors.Errorf("failed to create memory extraction rerun marker: %w", err)
 	}
+	tmpPath := marker.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := marker.Chmod(0o600); err != nil {
+		_ = marker.Close()
+		return xerrors.Errorf("failed to protect memory extraction rerun marker: %w", err)
+	}
 	if _, err := marker.WriteString(requestedAt.Format(time.RFC3339Nano) + "\n"); err != nil {
 		_ = marker.Close()
+		_ = os.Remove(tmpPath)
 		return xerrors.Errorf("failed to write memory extraction rerun marker: %w", err)
 	}
 	if err := marker.Sync(); err != nil {
 		_ = marker.Close()
+		_ = os.Remove(tmpPath)
 		return xerrors.Errorf("failed to sync memory extraction rerun marker: %w", err)
 	}
 	if err := marker.Close(); err != nil {
+		_ = os.Remove(tmpPath)
 		return xerrors.Errorf("failed to close memory extraction rerun marker: %w", err)
+	}
+	if beforePublish != nil {
+		beforePublish()
+	}
+	if err := os.Link(tmpPath, path); errors.Is(err, os.ErrExist) {
+		return nil
+	} else if err != nil {
+		return xerrors.Errorf("failed to publish memory extraction rerun marker: %w", err)
 	}
 	return nil
 }

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -130,8 +130,27 @@ func enqueueHookMemoryExtract(request hookMemoryExtractRequest, requestedAt time
 	if !locked {
 		// The worker may already have read the current job. A separate rerun
 		// marker preserves a boundary that arrives while extraction is active.
-		if err := os.WriteFile(jobPath+".rerun", []byte(requestedAt.Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+		if err := publishHookMemoryExtractRerun(jobPath+".rerun", requestedAt); err != nil {
 			return "", xerrors.Errorf("failed to mark memory extraction rerun: %w", err)
+		}
+		// Cover the completion race where the worker removed the job between
+		// our failed lock attempt and rerun publication. The worker also checks
+		// the marker after removal; either side may recreate the same job, and
+		// the atomic rename keeps the result readable.
+		if _, statErr := os.Stat(jobPath); errors.Is(statErr, os.ErrNotExist) {
+			job := hookMemoryExtractJob{
+				SchemaVersion:  hookMemoryExtractJobSchemaVersion,
+				SessionID:      request.SessionID,
+				Workspace:      request.Workspace,
+				DBPath:         strings.TrimSpace(request.DBPath),
+				SourceBoundary: strings.TrimSpace(request.SourceBoundary),
+				RequestedAt:    readHookMemoryExtractRerunTime(jobPath+".rerun", requestedAt),
+			}
+			if err := writeHookMemoryExtractJob(jobPath, job); err != nil {
+				return "", err
+			}
+		} else if statErr != nil {
+			return "", xerrors.Errorf("failed to inspect contended memory extraction job: %w", statErr)
 		}
 		return jobPath, nil
 	}
@@ -177,7 +196,7 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 	}
 	queueDir, err := hookMemoryExtractQueueDir()
 	if err != nil {
-		return err
+		return xerrors.Errorf("failed to create memory extraction rerun marker: %w", err)
 	}
 	insideQueue, err := filepath.Rel(queueDir, resolvedJobPath)
 	if err != nil || insideQueue == "." || filepath.Dir(insideQueue) != "." || filepath.IsAbs(insideQueue) {
@@ -244,8 +263,11 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 			return c.failHookMemoryExtractJob(resolvedJobPath, job, extractErr)
 		}
 		if _, rerunErr := os.Stat(resolvedJobPath + ".rerun"); rerunErr == nil {
+			rerunRequestedAt := readHookMemoryExtractRerunTime(resolvedJobPath+".rerun", job.RequestedAt)
 			_ = os.Remove(resolvedJobPath + ".rerun")
-			job.RequestedAt = time.Now().UTC()
+			if rerunRequestedAt.Before(job.RequestedAt) {
+				job.RequestedAt = rerunRequestedAt
+			}
 			job.LastError = ""
 			if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
 				return writeErr
@@ -264,8 +286,28 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		} else if !os.IsNotExist(rerunErr) {
 			return xerrors.Errorf("failed to inspect memory extraction rerun marker: %w", rerunErr)
 		}
+		if c.hookMemoryBeforeJobRemoval != nil {
+			c.hookMemoryBeforeJobRemoval()
+		}
 		if removeErr := os.Remove(resolvedJobPath); removeErr != nil && !os.IsNotExist(removeErr) {
 			return xerrors.Errorf("failed to clear memory extraction job: %w", removeErr)
+		}
+		if _, rerunErr := os.Stat(resolvedJobPath + ".rerun"); rerunErr == nil {
+			job.RequestedAt = readHookMemoryExtractRerunTime(resolvedJobPath+".rerun", job.RequestedAt)
+			_ = os.Remove(resolvedJobPath + ".rerun")
+			if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
+				return writeErr
+			}
+			if unlockErr := jobLock.Unlock(); unlockErr != nil {
+				return xerrors.Errorf("failed to release memory extraction job after completion race: %w", unlockErr)
+			}
+			lockHeld = false
+			if launchErr := c.launchHookMemoryExtractWorker(resolvedJobPath); launchErr != nil {
+				return xerrors.Errorf("failed to hand off raced memory extraction job: %w", launchErr)
+			}
+			return nil
+		} else if !os.IsNotExist(rerunErr) {
+			return xerrors.Errorf("failed to inspect post-completion memory extraction rerun marker: %w", rerunErr)
 		}
 		return nil
 	}
@@ -327,6 +369,43 @@ func writeHookMemoryExtractJob(path string, job hookMemoryExtractJob) error {
 		return xerrors.Errorf("failed to publish memory extraction job: %w", err)
 	}
 	return nil
+}
+
+func publishHookMemoryExtractRerun(path string, requestedAt time.Time) error {
+	marker, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		return nil
+	}
+	if err != nil {
+		return xerrors.Errorf("failed to create memory extraction rerun marker: %w", err)
+	}
+	if _, err := marker.WriteString(requestedAt.Format(time.RFC3339Nano) + "\n"); err != nil {
+		_ = marker.Close()
+		return xerrors.Errorf("failed to write memory extraction rerun marker: %w", err)
+	}
+	if err := marker.Sync(); err != nil {
+		_ = marker.Close()
+		return xerrors.Errorf("failed to sync memory extraction rerun marker: %w", err)
+	}
+	if err := marker.Close(); err != nil {
+		return xerrors.Errorf("failed to close memory extraction rerun marker: %w", err)
+	}
+	return nil
+}
+
+func readHookMemoryExtractRerunTime(path string, fallback time.Time) time.Time {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fallback
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(data)))
+	if err != nil {
+		return fallback
+	}
+	if parsed.Before(fallback) {
+		return parsed
+	}
+	return fallback
 }
 
 func launchDetachedHookMemoryExtractWorker(jobPath string) error {

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -1,0 +1,381 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	hookMemoryExtractJobSchemaVersion = 1
+	hookMemoryExtractMaxRunsPerWorker = 2
+	hookMemoryExtractErrorLimit       = 1024
+)
+
+type hookMemoryExtractRequest struct {
+	SessionID      types.SessionID
+	Workspace      types.Workspace
+	DBPath         string
+	SourceBoundary string
+}
+
+type hookMemoryExtractJob struct {
+	SchemaVersion  int             `json:"schema_version"`
+	SessionID      types.SessionID `json:"session_id"`
+	Workspace      types.Workspace `json:"workspace"`
+	DBPath         string          `json:"db_path"`
+	SourceBoundary string          `json:"source_boundary"`
+	RequestedAt    time.Time       `json:"requested_at"`
+	Attempts       int             `json:"attempts,omitempty"`
+	LastAttemptAt  *time.Time      `json:"last_attempt_at,omitempty"`
+	LastError      string          `json:"last_error,omitempty"`
+	Path           string          `json:"-"`
+}
+
+func (c *RootCLI) newHookMemoryExtractWorkerCommand() *cobra.Command {
+	var jobPath string
+	cmd := &cobra.Command{
+		Use:    "memory-extract-worker",
+		Short:  "Process one durable hook memory-extraction job",
+		Hidden: true,
+		Args:   noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runHookMemoryExtractWorker(cmd.Context(), jobPath)
+		},
+	}
+	cmd.Flags().StringVar(&jobPath, "job", "", "durable extraction job path")
+	_ = cmd.MarkFlagRequired("job")
+	return cmd
+}
+
+func (c *RootCLI) scheduleHookMemoryExtract(request hookMemoryExtractRequest) {
+	if c.memory == nil {
+		return
+	}
+	jobPath, err := enqueueHookMemoryExtract(request, time.Now().UTC())
+	if err != nil {
+		slog.Debug("hook memory extraction enqueue failed", "session_id", request.SessionID, "source_boundary", request.SourceBoundary, "error", err)
+		return
+	}
+	launcher := c.hookMemoryExtractLauncher
+	if launcher == nil {
+		launcher = launchDetachedHookMemoryExtractWorker
+	}
+	if err := launcher(jobPath); err != nil {
+		// The durable job remains pending. A later hook invocation can launch
+		// another worker, and doctor surfaces the backlog in the meantime.
+		slog.Debug("hook memory extraction worker launch failed", "job", jobPath, "error", err)
+	}
+}
+
+func hookMemoryExtractQueueDir() (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, "memory-extract"), nil
+}
+
+func hookMemoryExtractJobPath(request hookMemoryExtractRequest) (string, error) {
+	dir, err := hookMemoryExtractQueueDir()
+	if err != nil {
+		return "", err
+	}
+	key := strings.Join([]string{
+		strings.TrimSpace(request.DBPath),
+		strings.TrimSpace(request.SessionID.String()),
+		strings.TrimSpace(request.Workspace.String()),
+	}, "\x00")
+	digest := sha256.Sum256([]byte(key))
+	return filepath.Join(dir, hex.EncodeToString(digest[:])+".json"), nil
+}
+
+func enqueueHookMemoryExtract(request hookMemoryExtractRequest, requestedAt time.Time) (string, error) {
+	if request.SessionID == "" {
+		return "", xerrors.Errorf("memory extraction session ID is empty")
+	}
+	jobPath, err := hookMemoryExtractJobPath(request)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(jobPath), 0o700); err != nil {
+		return "", xerrors.Errorf("failed to create memory extraction queue: %w", err)
+	}
+	jobLock := flock.New(jobPath + ".lock")
+	locked, err := jobLock.TryLock()
+	if err != nil {
+		return "", xerrors.Errorf("failed to lock memory extraction job: %w", err)
+	}
+	if !locked {
+		// The worker may already have read the current job. A separate rerun
+		// marker preserves a boundary that arrives while extraction is active.
+		if err := os.WriteFile(jobPath+".rerun", []byte(requestedAt.Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+			return "", xerrors.Errorf("failed to mark memory extraction rerun: %w", err)
+		}
+		return jobPath, nil
+	}
+	defer func() { _ = jobLock.Unlock() }()
+
+	job := hookMemoryExtractJob{
+		SchemaVersion:  hookMemoryExtractJobSchemaVersion,
+		SessionID:      request.SessionID,
+		Workspace:      request.Workspace,
+		DBPath:         strings.TrimSpace(request.DBPath),
+		SourceBoundary: strings.TrimSpace(request.SourceBoundary),
+		RequestedAt:    requestedAt,
+	}
+	if existing, readErr := readHookMemoryExtractJob(jobPath); readErr == nil {
+		job.Attempts = existing.Attempts
+		job.LastAttemptAt = existing.LastAttemptAt
+		job.LastError = existing.LastError
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		return "", readErr
+	}
+	if err := writeHookMemoryExtractJob(jobPath, job); err != nil {
+		return "", err
+	}
+	return jobPath, nil
+}
+
+func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string) error {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("initialize store usecase is not configured")
+	}
+	if c.memory == nil {
+		return xerrors.Errorf("memory usecase is not configured")
+	}
+	resolvedJobPath, err := filepath.Abs(strings.TrimSpace(jobPath))
+	if err != nil {
+		return xerrors.Errorf("failed to resolve memory extraction job path: %w", err)
+	}
+	queueDir, err := hookMemoryExtractQueueDir()
+	if err != nil {
+		return err
+	}
+	insideQueue, err := filepath.Rel(queueDir, resolvedJobPath)
+	if err != nil || insideQueue == "." || strings.HasPrefix(insideQueue, ".."+string(filepath.Separator)) || filepath.IsAbs(insideQueue) {
+		return xerrors.Errorf("memory extraction job is outside the queue directory")
+	}
+
+	jobLock := flock.New(resolvedJobPath + ".lock")
+	locked, err := jobLock.TryLock()
+	if err != nil {
+		return xerrors.Errorf("failed to lock memory extraction job: %w", err)
+	}
+	if !locked {
+		return nil
+	}
+	defer func() { _ = jobLock.Unlock() }()
+
+	for run := 0; run < hookMemoryExtractMaxRunsPerWorker; run++ {
+		job, readErr := readHookMemoryExtractJob(resolvedJobPath)
+		if errors.Is(readErr, os.ErrNotExist) {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+		resolvedDBPath, resolveErr := resolveDBPath(job.DBPath)
+		if resolveErr != nil {
+			return c.failHookMemoryExtractJob(resolvedJobPath, job, resolveErr)
+		}
+		c.applyDatabasePath(resolvedDBPath)
+		if initErr := c.storeManagement.Initialize(ctx); initErr != nil {
+			return c.failHookMemoryExtractJob(resolvedJobPath, job, xerrors.Errorf("failed to initialize store: %w", initErr))
+		}
+		_, extractErr := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
+			SessionID(job.SessionID).
+			Workspace(job.Workspace).
+			Build())
+		if extractErr != nil {
+			return c.failHookMemoryExtractJob(resolvedJobPath, job, extractErr)
+		}
+		if _, rerunErr := os.Stat(resolvedJobPath + ".rerun"); rerunErr == nil {
+			_ = os.Remove(resolvedJobPath + ".rerun")
+			job.RequestedAt = time.Now().UTC()
+			job.LastError = ""
+			if writeErr := writeHookMemoryExtractJob(resolvedJobPath, job); writeErr != nil {
+				return writeErr
+			}
+			continue
+		} else if !os.IsNotExist(rerunErr) {
+			return xerrors.Errorf("failed to inspect memory extraction rerun marker: %w", rerunErr)
+		}
+		if removeErr := os.Remove(resolvedJobPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return xerrors.Errorf("failed to clear memory extraction job: %w", removeErr)
+		}
+		return nil
+	}
+	return nil
+}
+
+func (c *RootCLI) failHookMemoryExtractJob(path string, job hookMemoryExtractJob, cause error) error {
+	now := time.Now().UTC()
+	job.Attempts++
+	job.LastAttemptAt = &now
+	job.LastError = truncateHookMemoryExtractError(cause.Error())
+	if err := writeHookMemoryExtractJob(path, job); err != nil {
+		return xerrors.Errorf("memory extraction failed (%v) and job metadata update failed: %w", cause, err)
+	}
+	return xerrors.Errorf("memory extraction failed: %w", cause)
+}
+
+func readHookMemoryExtractJob(path string) (hookMemoryExtractJob, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return hookMemoryExtractJob{}, xerrors.Errorf("failed to read memory extraction job: %w", err)
+	}
+	var job hookMemoryExtractJob
+	if err := json.Unmarshal(data, &job); err != nil {
+		return hookMemoryExtractJob{}, xerrors.Errorf("failed to decode memory extraction job: %w", err)
+	}
+	if job.SchemaVersion != hookMemoryExtractJobSchemaVersion || job.SessionID == "" {
+		return hookMemoryExtractJob{}, xerrors.Errorf("unsupported or incomplete memory extraction job")
+	}
+	job.Path = path
+	return job, nil
+}
+
+func writeHookMemoryExtractJob(path string, job hookMemoryExtractJob) error {
+	encoded, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode memory extraction job: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".memory-extract-*.tmp")
+	if err != nil {
+		return xerrors.Errorf("failed to create memory extraction job: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to protect memory extraction job: %w", err)
+	}
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		return xerrors.Errorf("failed to write memory extraction job: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return xerrors.Errorf("failed to close memory extraction job: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return xerrors.Errorf("failed to publish memory extraction job: %w", err)
+	}
+	return nil
+}
+
+func launchDetachedHookMemoryExtractWorker(jobPath string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return xerrors.Errorf("failed to resolve traceary executable: %w", err)
+	}
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return xerrors.Errorf("failed to open null device: %w", err)
+	}
+	defer func() { _ = devNull.Close() }()
+	cmd := exec.Command(executable, "hook", "memory-extract-worker", "--job", jobPath)
+	cmd.Stdin = devNull
+	cmd.Stdout = devNull
+	cmd.Stderr = devNull
+	cmd.Env = append(os.Environ(), hookAuditSuppressionEnvKey+"=1")
+	configureDetachedHookProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return xerrors.Errorf("failed to start memory extraction worker: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return xerrors.Errorf("failed to release memory extraction worker: %w", err)
+	}
+	return nil
+}
+
+func scanHookMemoryExtractJobs() ([]hookMemoryExtractJob, []string, error) {
+	dir, err := hookMemoryExtractQueueDir()
+	if err != nil {
+		return nil, nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to read memory extraction queue: %w", err)
+	}
+	jobs := []hookMemoryExtractJob{}
+	unreadable := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		job, readErr := readHookMemoryExtractJob(path)
+		if readErr != nil {
+			unreadable = append(unreadable, path)
+			continue
+		}
+		jobs = append(jobs, job)
+	}
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].RequestedAt.Before(jobs[j].RequestedAt) })
+	sort.Strings(unreadable)
+	return jobs, unreadable, nil
+}
+
+func inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
+	const name = "hook-memory-extract"
+	jobs, unreadable, err := scanHookMemoryExtractJobs()
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect memory extraction queue: %v", "memory extraction queue の検査に失敗しました: %v", err)}
+	}
+	if len(jobs) == 0 && len(unreadable) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook memory extraction jobs found", "未処理の hook memory extraction job はありません")}
+	}
+	failed := 0
+	oldestAge := time.Duration(0)
+	if len(jobs) > 0 {
+		oldestAge = now.Sub(jobs[0].RequestedAt)
+		if oldestAge < 0 {
+			oldestAge = 0
+		}
+	}
+	for _, job := range jobs {
+		if job.Attempts > 0 {
+			failed++
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"found %d pending memory extraction job(s), %d previously failed job(s), and %d unreadable job(s); oldest age %s",
+			"未処理の memory extraction job が %d 件、以前失敗した job が %d 件、読めない job が %d 件あります。最古 age %s",
+			len(jobs), failed, len(unreadable), oldestAge.Round(time.Second),
+		),
+		Hint: Localize("a later hook retries pending jobs automatically; run doctor again after the next hook and inspect debug logs if failures remain", "次の hook が未処理 job を自動再試行します。次の hook 後に doctor を再実行し、失敗が残る場合は debug log を確認してください"),
+	}
+}
+
+func truncateHookMemoryExtractError(message string) string {
+	message = strings.TrimSpace(message)
+	if len(message) <= hookMemoryExtractErrorLimit {
+		return message
+	}
+	return fmt.Sprintf("%s...", message[:hookMemoryExtractErrorLimit-3])
+}

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -143,3 +143,22 @@ func TestEnqueueHookMemoryExtractPreservesOldestContendedRerunTime(t *testing.T)
 		t.Fatalf("rerun requested_at = %s, want oldest %s", got, oldestRerun)
 	}
 }
+
+func TestPublishHookMemoryExtractRerunIsCompleteBeforeVisibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "job.rerun")
+	requestedAt := time.Date(2026, 7, 13, 11, 0, 0, 123, time.UTC)
+	if err := publishHookMemoryExtractRerunWithHook(path, requestedAt, func() {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("marker became visible before atomic publish: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("publishHookMemoryExtractRerunWithHook() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(marker) error = %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != requestedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("marker = %q, want %q", got, requestedAt.Format(time.RFC3339Nano))
+	}
+}

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
+
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -108,5 +110,36 @@ func TestEnqueueHookMemoryExtractPreservesOldestRequestTime(t *testing.T) {
 	}
 	if !job.RequestedAt.Equal(first) {
 		t.Fatalf("requested_at = %s, want oldest %s", job.RequestedAt, first)
+	}
+}
+
+func TestEnqueueHookMemoryExtractPreservesOldestContendedRerunTime(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("contended-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "turn_boundary",
+	}
+	first := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	path, err := enqueueHookMemoryExtract(request, first)
+	if err != nil {
+		t.Fatalf("first enqueueHookMemoryExtract() error = %v", err)
+	}
+	jobLock := flock.New(path + ".lock")
+	if err := jobLock.Lock(); err != nil {
+		t.Fatalf("Lock() error = %v", err)
+	}
+	t.Cleanup(func() { _ = jobLock.Unlock() })
+	oldestRerun := first.Add(time.Minute)
+	if _, err := enqueueHookMemoryExtract(request, oldestRerun); err != nil {
+		t.Fatalf("contended enqueueHookMemoryExtract() error = %v", err)
+	}
+	if _, err := enqueueHookMemoryExtract(request, oldestRerun.Add(time.Minute)); err != nil {
+		t.Fatalf("second contended enqueueHookMemoryExtract() error = %v", err)
+	}
+	got := readHookMemoryExtractRerunTime(path+".rerun", oldestRerun.Add(time.Hour))
+	if !got.Equal(oldestRerun) {
+		t.Fatalf("rerun requested_at = %s, want oldest %s", got, oldestRerun)
 	}
 }

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -55,3 +55,58 @@ func TestInspectHookMemoryExtractDiagnosticsPassesWithoutJobs(t *testing.T) {
 		t.Fatalf("check = %+v, want pass", check)
 	}
 }
+
+func TestEnqueueHookMemoryExtractQuarantinesUnreadableJob(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("corrupt-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("first enqueueHookMemoryExtract() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(corrupt job) error = %v", err)
+	}
+	if _, err := enqueueHookMemoryExtract(request, time.Now().UTC().Add(time.Second)); err != nil {
+		t.Fatalf("second enqueueHookMemoryExtract() error = %v", err)
+	}
+	if _, err := readHookMemoryExtractJob(path); err != nil {
+		t.Fatalf("replacement job error = %v", err)
+	}
+	jobs, unreadable, err := scanHookMemoryExtractJobs()
+	if err != nil {
+		t.Fatalf("scanHookMemoryExtractJobs() error = %v", err)
+	}
+	if len(jobs) != 1 || len(unreadable) != 1 {
+		t.Fatalf("jobs=%d unreadable=%d, want one replacement and one quarantined file", len(jobs), len(unreadable))
+	}
+}
+
+func TestEnqueueHookMemoryExtractPreservesOldestRequestTime(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("oldest-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "turn_boundary",
+	}
+	first := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	path, err := enqueueHookMemoryExtract(request, first)
+	if err != nil {
+		t.Fatalf("first enqueueHookMemoryExtract() error = %v", err)
+	}
+	if _, err := enqueueHookMemoryExtract(request, first.Add(time.Hour)); err != nil {
+		t.Fatalf("second enqueueHookMemoryExtract() error = %v", err)
+	}
+	job, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("readHookMemoryExtractJob() error = %v", err)
+	}
+	if !job.RequestedAt.Equal(first) {
+		t.Fatalf("requested_at = %s, want oldest %s", job.RequestedAt, first)
+	}
+}

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestInspectHookMemoryExtractDiagnosticsReportsPendingFailureMetadata(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("session-1"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "turn_boundary",
+	}
+	path, err := enqueueHookMemoryExtract(request, now.Add(-3*time.Minute))
+	if err != nil {
+		t.Fatalf("enqueueHookMemoryExtract() error = %v", err)
+	}
+	job, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("readHookMemoryExtractJob() error = %v", err)
+	}
+	job.Attempts = 2
+	job.LastError = "simulated failure"
+	if err := writeHookMemoryExtractJob(path, job); err != nil {
+		t.Fatalf("writeHookMemoryExtractJob() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "memory-extract", "broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(broken job) error = %v", err)
+	}
+
+	check := inspectHookMemoryExtractDiagnostics(now)
+	if check.Name != "hook-memory-extract" || check.Status != doctorStatusWarn {
+		t.Fatalf("check = %+v, want warning", check)
+	}
+	for _, want := range []string{"1 pending", "1 previously failed", "1 unreadable", "3m0s"} {
+		if !strings.Contains(check.Message, want) {
+			t.Fatalf("check message = %q, want %q", check.Message, want)
+		}
+	}
+}
+
+func TestInspectHookMemoryExtractDiagnosticsPassesWithoutJobs(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	check := inspectHookMemoryExtractDiagnostics(time.Now().UTC())
+	if check.Status != doctorStatusPass {
+		t.Fatalf("check = %+v, want pass", check)
+	}
+}

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -364,11 +364,6 @@ func (c *RootCLI) runHookSession(
 		if _, err := c.session.End(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to record hook session end: %w", err)
 		}
-		// Extraction runs after the durable boundary commit in a detached,
-		// retryable worker so host hook timeouts cannot discard its result.
-		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
-			SessionID: sessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "session_end",
-		})
 		if shouldTrackClaudeCancellation {
 			if err := clearHookCancellationDiagnosticsForSession(client, "SessionEnd", sessionID); err != nil {
 				slog.Debug("hook session-end cancellation diagnostic cleanup failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
@@ -390,6 +385,11 @@ func (c *RootCLI) runHookSession(
 		if err := markHookSessionEnded(client, sessionID); err != nil {
 			return err
 		}
+		// Schedule only after every primary event and hook-state transition is
+		// complete, so worker startup cannot consume the cleanup budget.
+		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
+			SessionID: sessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "session_end",
+		})
 		return nil
 	case "stop":
 		// Codex fires Stop after every assistant response, not when the
@@ -960,6 +960,7 @@ func (c *RootCLI) runHookSubagentStop(
 	activeParentSessionID := types.SessionID("")
 	childWasActive := false
 	lazySynthesizedChild := false
+	var memoryExtractRequest *hookMemoryExtractRequest
 	if toolUseID != "" {
 		active, findErr := findHookActiveSubagentStateForTool(client, parentSessionID, toolUseID)
 		if findErr != nil {
@@ -997,11 +998,10 @@ func (c *RootCLI) runHookSubagentStop(
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
 		}
-		// Preserve main-session extraction parity without sharing the host
-		// SubagentStop time budget.
-		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
+		request := hookMemoryExtractRequest{
 			SessionID: childSessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "subagent_stop",
-		})
+		}
+		memoryExtractRequest = &request
 		if activeParentSessionID != "" {
 			parentSessionID = activeParentSessionID
 		}
@@ -1015,12 +1015,18 @@ func (c *RootCLI) runHookSubagentStop(
 	// events; the legacy `[phase:subagent]` body prefix is retired on
 	// write but readers still match it for pre-#672 rows.
 	if lazySynthesizedChild {
+		if memoryExtractRequest != nil {
+			c.scheduleHookMemoryExtract(*memoryExtractRequest)
+		}
 		return nil
 	}
 	subagentType := hookPayloadString(payload, "subagent_type", "")
 	_, err = c.event.Log(ctx, subagentType, types.EventKindSessionEnded, types.Client("hook"), agent, parentSessionID, workspace, apptypes.LogRedaction{})
 	if err != nil {
 		return xerrors.Errorf("failed to record subagent-stop event: %w", err)
+	}
+	if memoryExtractRequest != nil {
+		c.scheduleHookMemoryExtract(*memoryExtractRequest)
 	}
 	return nil
 }

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -65,6 +65,7 @@ func (c *RootCLI) newHookCommand() *cobra.Command {
 	hookCmd.AddCommand(c.newHookPromptCommand())
 	hookCmd.AddCommand(c.newHookTranscriptCommand())
 	hookCmd.AddCommand(c.newHookAntigravityCommand())
+	hookCmd.AddCommand(c.newHookMemoryExtractWorkerCommand())
 
 	return hookCmd
 }
@@ -363,20 +364,11 @@ func (c *RootCLI) runHookSession(
 		if _, err := c.session.End(ctx, types.Client("hook"), agent, sessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to record hook session end: %w", err)
 		}
-		// Auto-extract memory candidates at session end so the
-		// next session sees fresh inbox candidates without requiring
-		// the agent to ask. Best-effort: any error here must not block
-		// the session-end record from committing. The extractor is
-		// candidate-only (no auto-accept) and dedupes against existing
-		// candidate keys, so re-firing is safe. See #810.
-		if c.memory != nil {
-			if _, err := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
-				SessionID(sessionID).
-				Workspace(workspace).
-				Build()); err != nil {
-				slog.Debug("hook session-end auto-extract failed", "client", client, "session_id", sessionID, "error", err)
-			}
-		}
+		// Extraction runs after the durable boundary commit in a detached,
+		// retryable worker so host hook timeouts cannot discard its result.
+		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
+			SessionID: sessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "session_end",
+		})
 		if shouldTrackClaudeCancellation {
 			if err := clearHookCancellationDiagnosticsForSession(client, "SessionEnd", sessionID); err != nil {
 				slog.Debug("hook session-end cancellation diagnostic cleanup failed", "client", client, "session_id", sessionID, "path", hookCancellationDiagnosticPath, "error", err)
@@ -431,11 +423,9 @@ func (c *RootCLI) runHookSession(
 		} else if err != nil {
 			return err
 		}
-		// Memory auto-extract stays on the turn boundary because Codex
-		// exposes no true session-end hook — end-only extraction would
-		// never fire for Codex. The extractor is candidate-only and
-		// dedupes against existing candidate keys, so per-turn re-firing
-		// is safe. See #810.
+		// Codex exposes no true session-end hook, so keep requesting
+		// extraction at each turn boundary. The durable queue coalesces
+		// repeated requests and moves extraction outside the host budget.
 		if c.memory == nil {
 			return nil
 		}
@@ -443,20 +433,13 @@ func (c *RootCLI) runHookSession(
 		if err != nil {
 			return err
 		}
-		c.applyDatabasePath(resolvedDBPath)
-		if err := c.storeManagement.Initialize(ctx); err != nil {
-			return xerrors.Errorf("failed to initialize store: %w", err)
-		}
 		workspace, err := resolveHookWorkspace(ctx, payload, client, true)
 		if err != nil {
 			return err
 		}
-		if _, err := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
-			SessionID(sessionID).
-			Workspace(workspace).
-			Build()); err != nil {
-			slog.Debug("hook turn-boundary auto-extract failed", "client", client, "session_id", sessionID, "error", err)
-		}
+		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
+			SessionID: sessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "turn_boundary",
+		})
 		return nil
 	default:
 		return xerrors.Errorf("unsupported hook session action: %s", action)
@@ -1014,17 +997,11 @@ func (c *RootCLI) runHookSubagentStop(
 		if _, err := c.session.End(ctx, types.Client("hook"), types.Agent(""), childSessionID, workspace, ""); err != nil {
 			return xerrors.Errorf("failed to end subagent session: %w", err)
 		}
-		// Subagent-end auto-extract parity with main session-end
-		// (#810, #832). Best-effort: errors must not block the
-		// boundary record.
-		if c.memory != nil {
-			if _, extractErr := c.memory.Extract(ctx, apptypes.NewMemoryExtractionCriteriaBuilder().
-				SessionID(childSessionID).
-				Workspace(workspace).
-				Build()); extractErr != nil {
-				slog.Debug("hook subagent-stop auto-extract failed", "client", client, "child_session_id", childSessionID, "error", extractErr)
-			}
-		}
+		// Preserve main-session extraction parity without sharing the host
+		// SubagentStop time budget.
+		c.scheduleHookMemoryExtract(hookMemoryExtractRequest{
+			SessionID: childSessionID, Workspace: workspace, DBPath: resolvedDBPath, SourceBoundary: "subagent_stop",
+		})
 		if activeParentSessionID != "" {
 			parentSessionID = activeParentSessionID
 		}

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -935,6 +935,68 @@ func TestRootCLI_HookMemoryExtractWorkerHandsOffRerunAtRunLimit(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HookMemoryExtractWorkerHandsOffRerunPublishedBeforeRemoval(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "completion-race-key")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-completion-race-key"), []byte("completion-race-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-completion-race-key-repo"), []byte("traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	var jobPath string
+	queueCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			jobPath = path
+			return nil
+		}),
+	).Command()
+	queueCmd.SetOut(&bytes.Buffer{})
+	queueCmd.SetErr(&bytes.Buffer{})
+	queueCmd.SetIn(strings.NewReader(`{"session_id":"completion-race-session"}`))
+	queueCmd.SetArgs([]string{"hook", "session", "codex", "stop"})
+	if err := queueCmd.Execute(); err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+
+	var handedOffPath string
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+		cli.WithHookMemoryBeforeJobRemoval(func() {
+			if err := os.WriteFile(jobPath+".rerun", []byte(time.Now().UTC().Format(time.RFC3339Nano)+"\n"), 0o600); err != nil {
+				t.Fatalf("WriteFile(rerun marker) error = %v", err)
+			}
+		}),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			handedOffPath = path
+			return nil
+		}),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", jobPath})
+	if err := workerCmd.Execute(); err != nil {
+		t.Fatalf("worker Execute() error = %v", err)
+	}
+	if handedOffPath != jobPath {
+		t.Fatalf("handoff path = %q, want %q", handedOffPath, jobPath)
+	}
+	if _, err := os.Stat(jobPath); err != nil {
+		t.Fatalf("completion-race job must be recreated: %v", err)
+	}
+}
+
 func TestRootCLI_HookMemoryExtractWorkerRejectsJobOutsideQueue(t *testing.T) {
 	homeDir := t.TempDir()
 	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -656,6 +656,7 @@ func TestRootCLI_HookSessionCommand_EndQueuesMemoryAutoExtractWithoutBlocking(t 
 		extractErr: errors.New("simulated extract failure"),
 	}
 	var launchedJobPath string
+	primaryCleanupCompleteAtLaunch := false
 	sessionStub := &sessionUsecaseStub{
 		endEvent: model.EventOf(
 			types.EventID("evt-end-extract-fail"),
@@ -675,6 +676,10 @@ func TestRootCLI_HookSessionCommand_EndQueuesMemoryAutoExtractWithoutBlocking(t 
 		cli.WithMemory(memoryStub),
 		cli.WithHookMemoryExtractLauncher(func(path string) error {
 			launchedJobPath = path
+			_, sessionErr := os.Stat(filepath.Join(stateDir, "claude-test-key-extract-fail"))
+			_, workspaceErr := os.Stat(filepath.Join(stateDir, "claude-test-key-extract-fail-repo"))
+			_, markerErr := os.Stat(filepath.Join(stateDir, "ended", "claude-auto-extract-fail-session"))
+			primaryCleanupCompleteAtLaunch = os.IsNotExist(sessionErr) && os.IsNotExist(workspaceErr) && markerErr == nil
 			return nil
 		}),
 	).Command()
@@ -691,6 +696,9 @@ func TestRootCLI_HookSessionCommand_EndQueuesMemoryAutoExtractWithoutBlocking(t 
 	}
 	if got, want := sessionStub.endCall.sessionID, types.SessionID("auto-extract-fail-session"); got != want {
 		t.Fatalf("session.End sessionID = %q, want %q (must be invoked even when extract fails)", got, want)
+	}
+	if !primaryCleanupCompleteAtLaunch {
+		t.Fatal("worker launched before session-end hook state cleanup completed")
 	}
 	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
 	if got, want := job.SourceBoundary, "session_end"; got != want {
@@ -715,13 +723,14 @@ func TestRootCLI_HookSessionCommand_EndQueuesMemoryAutoExtractWithoutBlocking(t 
 		t.Fatalf("ReadFile(failed job) error = %v", err)
 	}
 	var failedJob struct {
-		Attempts  int    `json:"attempts"`
-		LastError string `json:"last_error"`
+		Attempts      int    `json:"attempts"`
+		LastAttemptAt string `json:"last_attempt_at"`
+		LastError     string `json:"last_error"`
 	}
 	if err := json.Unmarshal(data, &failedJob); err != nil {
 		t.Fatalf("json.Unmarshal(failed job) error = %v", err)
 	}
-	if failedJob.Attempts != 1 || !strings.Contains(failedJob.LastError, "simulated extract failure") {
+	if failedJob.Attempts != 1 || failedJob.LastAttemptAt == "" || !strings.Contains(failedJob.LastError, "simulated extract failure") {
 		t.Fatalf("failed job metadata = %+v, want retryable attempt", failedJob)
 	}
 	memoryStub.extractErr = nil
@@ -856,6 +865,94 @@ func TestRootCLI_HookSessionCommand_RepeatedStopsCoalesceMemoryExtractionJob(t *
 	}
 	if jsonCount != 1 {
 		t.Fatalf("memory extraction JSON jobs = %d, want 1", jsonCount)
+	}
+}
+
+func TestRootCLI_HookMemoryExtractWorkerHandsOffRerunAtRunLimit(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "rerun-limit-key")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-rerun-limit-key"), []byte("rerun-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-rerun-limit-key-repo"), []byte("traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	var jobPath string
+	queueCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			jobPath = path
+			return nil
+		}),
+	).Command()
+	queueCmd.SetOut(&bytes.Buffer{})
+	queueCmd.SetErr(&bytes.Buffer{})
+	queueCmd.SetIn(strings.NewReader(`{"session_id":"rerun-session"}`))
+	queueCmd.SetArgs([]string{"hook", "session", "codex", "stop"})
+	if err := queueCmd.Execute(); err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+
+	memoryStub := &memoryUsecaseStub{}
+	memoryStub.extractFunc = func(context.Context, apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
+		if err := os.WriteFile(jobPath+".rerun", []byte("rerun\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile(rerun marker) error = %v", err)
+		}
+		return nil, nil
+	}
+	var handedOffPath string
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			handedOffPath = path
+			return nil
+		}),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", jobPath})
+	if err := workerCmd.Execute(); err != nil {
+		t.Fatalf("worker Execute() error = %v", err)
+	}
+	if memoryStub.extractCallCount != 2 {
+		t.Fatalf("extract calls = %d, want bounded 2", memoryStub.extractCallCount)
+	}
+	if handedOffPath != jobPath {
+		t.Fatalf("handoff path = %q, want %q", handedOffPath, jobPath)
+	}
+	if _, err := os.Stat(jobPath); err != nil {
+		t.Fatalf("handed-off job must remain pending: %v", err)
+	}
+}
+
+func TestRootCLI_HookMemoryExtractWorkerRejectsJobOutsideQueue(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	outsidePath := filepath.Join(t.TempDir(), strings.Repeat("a", 64)+".json")
+	if err := os.WriteFile(outsidePath, []byte(`{"schema_version":1,"session_id":"outside"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(outside job) error = %v", err)
+	}
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", outsidePath})
+	err := workerCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "outside the queue directory") {
+		t.Fatalf("worker error = %v, want outside-queue rejection", err)
 	}
 }
 
@@ -2162,6 +2259,7 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 	eventStub := &eventUsecaseStub{}
 	memoryStub := &memoryUsecaseStub{}
 	var launchedJobPath string
+	primaryEventCompleteAtLaunch := false
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithSession(sessionStub),
@@ -2169,6 +2267,7 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 		cli.WithMemory(memoryStub),
 		cli.WithHookMemoryExtractLauncher(func(path string) error {
 			launchedJobPath = path
+			primaryEventCompleteAtLaunch = eventStub.logCall.sessionID == types.SessionID("parent-session")
 			return nil
 		}),
 	).Command()
@@ -2185,6 +2284,9 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 	}
 	if got, want := eventStub.logCall.sessionID, types.SessionID("parent-session"); got != want {
 		t.Fatalf("back-compat log sessionID = %q, want %q", got, want)
+	}
+	if !primaryEventCompleteAtLaunch {
+		t.Fatal("worker launched before subagent-stop primary event completed")
 	}
 	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
 	if got, want := job.SessionID, "parent-session:sub:toolu_1"; got != want {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -997,6 +997,85 @@ func TestRootCLI_HookMemoryExtractWorkerHandsOffRerunPublishedBeforeRemoval(t *t
 	}
 }
 
+func TestRootCLI_HookMemoryExtractWorkerHandsOffEnqueueAfterFinalCheck(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "post-check-race-key")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-post-check-race-key"), []byte("post-check-race-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-post-check-race-key-repo"), []byte("traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	var jobPath string
+	queueCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(&sessionUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			jobPath = path
+			return nil
+		}),
+	).Command()
+	queueCmd.SetOut(&bytes.Buffer{})
+	queueCmd.SetErr(&bytes.Buffer{})
+	queueCmd.SetIn(strings.NewReader(`{"session_id":"post-check-race-session"}`))
+	queueCmd.SetArgs([]string{"hook", "session", "codex", "stop"})
+	if err := queueCmd.Execute(); err != nil {
+		t.Fatalf("queue Execute() error = %v", err)
+	}
+
+	contendingLaunches := 0
+	handoffLaunches := 0
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(&memoryUsecaseStub{}),
+		cli.WithHookMemoryAfterFinalCheck(func() {
+			contendingCmd := newTestRootCLI(
+				cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+				cli.WithSession(&sessionUsecaseStub{}),
+				cli.WithMemory(&memoryUsecaseStub{}),
+				cli.WithHookMemoryExtractLauncher(func(string) error {
+					contendingLaunches++
+					return nil
+				}),
+			).Command()
+			contendingCmd.SetOut(&bytes.Buffer{})
+			contendingCmd.SetErr(&bytes.Buffer{})
+			contendingCmd.SetIn(strings.NewReader(`{"session_id":"post-check-race-session"}`))
+			contendingCmd.SetArgs([]string{"hook", "session", "codex", "stop"})
+			if err := contendingCmd.Execute(); err != nil {
+				t.Fatalf("contending Execute() error = %v", err)
+			}
+		}),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			if path != jobPath {
+				t.Fatalf("handoff path = %q, want %q", path, jobPath)
+			}
+			handoffLaunches++
+			return nil
+		}),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", jobPath})
+	if err := workerCmd.Execute(); err != nil {
+		t.Fatalf("worker Execute() error = %v", err)
+	}
+	if contendingLaunches != 1 || handoffLaunches != 1 {
+		t.Fatalf("launches = contending:%d handoff:%d, want 1 each", contendingLaunches, handoffLaunches)
+	}
+	if _, err := os.Stat(jobPath); err != nil {
+		t.Fatalf("post-check race job must remain pending: %v", err)
+	}
+}
+
 func TestRootCLI_HookMemoryExtractWorkerRejectsJobOutsideQueue(t *testing.T) {
 	homeDir := t.TempDir()
 	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -26,6 +26,28 @@ import (
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
+type hookMemoryExtractJobFixture struct {
+	SessionID      string `json:"session_id"`
+	Workspace      string `json:"workspace"`
+	SourceBoundary string `json:"source_boundary"`
+}
+
+func readHookMemoryExtractJobForTest(t *testing.T, path string) hookMemoryExtractJobFixture {
+	t.Helper()
+	if path == "" {
+		t.Fatal("memory extraction worker was not launched")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(memory extraction job) error = %v", err)
+	}
+	var job hookMemoryExtractJobFixture
+	if err := json.Unmarshal(data, &job); err != nil {
+		t.Fatalf("json.Unmarshal(memory extraction job) error = %v", err)
+	}
+	return job
+}
+
 func TestRootCLI_HookSessionCommand_StartRecordsSessionAndState(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
@@ -511,7 +533,7 @@ func TestRootCLI_HookSessionCommand_EndWritesCancellationDiagnosticBeforeWorkspa
 	}
 }
 
-func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {
+func TestRootCLI_HookSessionCommand_StopQueuesMemoryAutoExtract(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-extract")
 
 	homeDir := t.TempDir()
@@ -530,6 +552,7 @@ func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {
 	}
 
 	memoryStub := &memoryUsecaseStub{}
+	var launchedJobPath string
 	sessionStub := &sessionUsecaseStub{
 		endEvent: model.EventOf(
 			types.EventID("evt-end-extract"),
@@ -547,6 +570,10 @@ func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithSession(sessionStub),
 		cli.WithMemory(memoryStub),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			launchedJobPath = path
+			return nil
+		}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -557,11 +584,18 @@ func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	if got, want := memoryStub.extractCriteria.SessionID(), types.SessionID("auto-extract-session"); got != want {
-		t.Fatalf("auto-extract session ID = %q, want %q", got, want)
+	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
+	if got, want := job.SessionID, "auto-extract-session"; got != want {
+		t.Fatalf("queued session ID = %q, want %q", got, want)
 	}
-	if got, want := memoryStub.extractCriteria.Workspace(), types.Workspace("github.com/duck8823/traceary"); got != want {
-		t.Fatalf("auto-extract workspace = %q, want %q", got, want)
+	if got, want := job.Workspace, "github.com/duck8823/traceary"; got != want {
+		t.Fatalf("queued workspace = %q, want %q", got, want)
+	}
+	if got, want := job.SourceBoundary, "turn_boundary"; got != want {
+		t.Fatalf("queued source boundary = %q, want %q", got, want)
+	}
+	if got := memoryStub.extractCriteria.SessionID(); got != "" {
+		t.Fatalf("synchronous extraction session ID = %q, want empty", got)
 	}
 	// stop is a turn boundary (#1170): the session must stay open and
 	// the hook state must survive so later prompts/audits resolve to
@@ -578,9 +612,29 @@ func TestRootCLI_HookSessionCommand_StopFiresMemoryAutoExtract(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(stateDir, "ended", "claude-auto-extract-session")); !os.IsNotExist(err) {
 		t.Fatalf("stop must not create an end marker: %v", err)
 	}
+
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", launchedJobPath})
+	if err := workerCmd.Execute(); err != nil {
+		t.Fatalf("worker Execute() error = %v", err)
+	}
+	if got, want := memoryStub.extractCriteria.SessionID(), types.SessionID("auto-extract-session"); got != want {
+		t.Fatalf("worker extraction session ID = %q, want %q", got, want)
+	}
+	if got, want := memoryStub.extractCriteria.Workspace(), types.Workspace("github.com/duck8823/traceary"); got != want {
+		t.Fatalf("worker extraction workspace = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(launchedJobPath); !os.IsNotExist(err) {
+		t.Fatalf("successful worker must remove job: %v", err)
+	}
 }
 
-func TestRootCLI_HookSessionCommand_EndAutoExtractFailureDoesNotPropagate(t *testing.T) {
+func TestRootCLI_HookSessionCommand_EndQueuesMemoryAutoExtractWithoutBlocking(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key-extract-fail")
 
 	homeDir := t.TempDir()
@@ -601,6 +655,7 @@ func TestRootCLI_HookSessionCommand_EndAutoExtractFailureDoesNotPropagate(t *tes
 	memoryStub := &memoryUsecaseStub{
 		extractErr: errors.New("simulated extract failure"),
 	}
+	var launchedJobPath string
 	sessionStub := &sessionUsecaseStub{
 		endEvent: model.EventOf(
 			types.EventID("evt-end-extract-fail"),
@@ -618,6 +673,10 @@ func TestRootCLI_HookSessionCommand_EndAutoExtractFailureDoesNotPropagate(t *tes
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithSession(sessionStub),
 		cli.WithMemory(memoryStub),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			launchedJobPath = path
+			return nil
+		}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -632,6 +691,52 @@ func TestRootCLI_HookSessionCommand_EndAutoExtractFailureDoesNotPropagate(t *tes
 	}
 	if got, want := sessionStub.endCall.sessionID, types.SessionID("auto-extract-fail-session"); got != want {
 		t.Fatalf("session.End sessionID = %q, want %q (must be invoked even when extract fails)", got, want)
+	}
+	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
+	if got, want := job.SourceBoundary, "session_end"; got != want {
+		t.Fatalf("queued source boundary = %q, want %q", got, want)
+	}
+	if got := memoryStub.extractCriteria.SessionID(); got != "" {
+		t.Fatalf("synchronous extraction session ID = %q, want empty", got)
+	}
+
+	workerCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	workerCmd.SetOut(&bytes.Buffer{})
+	workerCmd.SetErr(&bytes.Buffer{})
+	workerCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", launchedJobPath})
+	if err := workerCmd.Execute(); err == nil {
+		t.Fatal("worker Execute() error = nil, want extraction failure")
+	}
+	data, err := os.ReadFile(launchedJobPath)
+	if err != nil {
+		t.Fatalf("ReadFile(failed job) error = %v", err)
+	}
+	var failedJob struct {
+		Attempts  int    `json:"attempts"`
+		LastError string `json:"last_error"`
+	}
+	if err := json.Unmarshal(data, &failedJob); err != nil {
+		t.Fatalf("json.Unmarshal(failed job) error = %v", err)
+	}
+	if failedJob.Attempts != 1 || !strings.Contains(failedJob.LastError, "simulated extract failure") {
+		t.Fatalf("failed job metadata = %+v, want retryable attempt", failedJob)
+	}
+	memoryStub.extractErr = nil
+	retryCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	).Command()
+	retryCmd.SetOut(&bytes.Buffer{})
+	retryCmd.SetErr(&bytes.Buffer{})
+	retryCmd.SetArgs([]string{"hook", "memory-extract-worker", "--job", launchedJobPath})
+	if err := retryCmd.Execute(); err != nil {
+		t.Fatalf("retry worker Execute() error = %v", err)
+	}
+	if _, err := os.Stat(launchedJobPath); !os.IsNotExist(err) {
+		t.Fatalf("successful retry must remove job: %v", err)
 	}
 }
 
@@ -658,11 +763,16 @@ func TestRootCLI_HookSessionCommand_CodexStopKeepsSessionOpen(t *testing.T) {
 	memoryStub := &memoryUsecaseStub{
 		extractErr: errors.New("simulated extract failure"),
 	}
+	var launchedJobPath string
 
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(storeStub),
 		cli.WithSession(sessionStub),
 		cli.WithMemory(memoryStub),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			launchedJobPath = path
+			return nil
+		}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -678,8 +788,12 @@ func TestRootCLI_HookSessionCommand_CodexStopKeepsSessionOpen(t *testing.T) {
 	if got := sessionStub.endCall.sessionID; got != "" {
 		t.Fatalf("session.End called with %q, want no End on codex stop", got)
 	}
-	if got, want := memoryStub.extractCriteria.SessionID(), types.SessionID("codex-session"); got != want {
-		t.Fatalf("auto-extract session ID = %q, want %q", got, want)
+	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
+	if got, want := job.SessionID, "codex-session"; got != want {
+		t.Fatalf("queued session ID = %q, want %q", got, want)
+	}
+	if got := memoryStub.extractCriteria.SessionID(); got != "" {
+		t.Fatalf("synchronous extraction session ID = %q, want empty", got)
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "codex-codex-stop-key")); err != nil {
 		t.Fatalf("session state should survive codex stop: %v", err)
@@ -689,6 +803,59 @@ func TestRootCLI_HookSessionCommand_CodexStopKeepsSessionOpen(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "ended", "codex-codex-session")); !os.IsNotExist(err) {
 		t.Fatalf("codex stop must not create an end marker: %v", err)
+	}
+}
+
+func TestRootCLI_HookSessionCommand_RepeatedStopsCoalesceMemoryExtractionJob(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "coalesce-key")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-coalesce-key"), []byte("coalesce-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-coalesce-key-repo"), []byte("traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	launched := []string{}
+	for range 2 {
+		rootCmd := newTestRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithSession(&sessionUsecaseStub{}),
+			cli.WithMemory(&memoryUsecaseStub{}),
+			cli.WithHookMemoryExtractLauncher(func(path string) error {
+				launched = append(launched, path)
+				return nil
+			}),
+		).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetIn(strings.NewReader(`{"session_id":"coalesce-session"}`))
+		rootCmd.SetArgs([]string{"hook", "session", "codex", "stop"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	}
+	if len(launched) != 2 || launched[0] != launched[1] {
+		t.Fatalf("launched jobs = %v, want same coalesced path twice", launched)
+	}
+	entries, err := os.ReadDir(filepath.Join(stateDir, "memory-extract"))
+	if err != nil {
+		t.Fatalf("ReadDir(memory-extract) error = %v", err)
+	}
+	jsonCount := 0
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") {
+			jsonCount++
+		}
+	}
+	if jsonCount != 1 {
+		t.Fatalf("memory extraction JSON jobs = %d, want 1", jsonCount)
 	}
 }
 
@@ -1984,16 +2151,26 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-child-key"), []byte("parent-session"), 0o600); err != nil {
 		t.Fatalf("WriteFile(session state) error = %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-stop-child-key-repo"), []byte("traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
 	startedAt := time.Now().UTC().Format(time.RFC3339)
 	if err := os.WriteFile(filepath.Join(activeDir, "claude-parent-session"), []byte(`{"children":{"toolu_1":{"child_session_id":"parent-session:sub:toolu_1","started_at":"`+startedAt+`"}}}`), 0o600); err != nil {
 		t.Fatalf("WriteFile(active state) error = %v", err)
 	}
 	sessionStub := &sessionUsecaseStub{}
 	eventStub := &eventUsecaseStub{}
+	memoryStub := &memoryUsecaseStub{}
+	var launchedJobPath string
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithSession(sessionStub),
 		cli.WithEvent(eventStub),
+		cli.WithMemory(memoryStub),
+		cli.WithHookMemoryExtractLauncher(func(path string) error {
+			launchedJobPath = path
+			return nil
+		}),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
@@ -2008,6 +2185,16 @@ func TestRootCLI_HookSubagentStopCommand_EndsChildAndClearsActiveState(t *testin
 	}
 	if got, want := eventStub.logCall.sessionID, types.SessionID("parent-session"); got != want {
 		t.Fatalf("back-compat log sessionID = %q, want %q", got, want)
+	}
+	job := readHookMemoryExtractJobForTest(t, launchedJobPath)
+	if got, want := job.SessionID, "parent-session:sub:toolu_1"; got != want {
+		t.Fatalf("queued subagent session ID = %q, want %q", got, want)
+	}
+	if got, want := job.Workspace, "traceary"; got != want {
+		t.Fatalf("queued subagent workspace = %q, want %q", got, want)
+	}
+	if got, want := job.SourceBoundary, "subagent_stop"; got != want {
+		t.Fatalf("queued source boundary = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(activeDir, "claude-parent-session")); !os.IsNotExist(err) {
 		t.Fatalf("active state should be cleared after final child stops; stat err=%v", err)

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -38,6 +38,7 @@ type RootCLI struct {
 	defaultReadFields          []string
 	readPresets                map[string]presentation.ReadPreset
 	defaultReadColor           string
+	hookMemoryExtractLauncher  func(string) error
 	// databasePathSetter is invoked by each subcommand's RunE after it
 	// resolves --db-path / TRACEARY_DB_PATH, so the shared Database
 	// instance opens the user-specified path instead of the composition-
@@ -176,6 +177,13 @@ func WithReadPresets(presets map[string]presentation.ReadPreset) RootCLIOption {
 // falls back to the built-in auto behavior.
 func WithDefaultReadColor(value string) RootCLIOption {
 	return func(c *RootCLI) { c.defaultReadColor = value }
+}
+
+// WithHookMemoryExtractLauncher overrides the detached worker launcher used by
+// hook-driven memory extraction. It is primarily intended for deterministic
+// tests; production callers use the default process launcher.
+func WithHookMemoryExtractLauncher(launcher func(string) error) RootCLIOption {
+	return func(c *RootCLI) { c.hookMemoryExtractLauncher = launcher }
 }
 
 // WithDatabasePathSetter injects a callback invoked by every subcommand

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -39,6 +39,7 @@ type RootCLI struct {
 	readPresets                map[string]presentation.ReadPreset
 	defaultReadColor           string
 	hookMemoryExtractLauncher  func(string) error
+	hookMemoryBeforeJobRemoval func()
 	// databasePathSetter is invoked by each subcommand's RunE after it
 	// resolves --db-path / TRACEARY_DB_PATH, so the shared Database
 	// instance opens the user-specified path instead of the composition-
@@ -184,6 +185,12 @@ func WithDefaultReadColor(value string) RootCLIOption {
 // tests; production callers use the default process launcher.
 func WithHookMemoryExtractLauncher(launcher func(string) error) RootCLIOption {
 	return func(c *RootCLI) { c.hookMemoryExtractLauncher = launcher }
+}
+
+// WithHookMemoryBeforeJobRemoval installs a deterministic synchronization
+// point for queue race tests. Production callers must leave it unset.
+func WithHookMemoryBeforeJobRemoval(hook func()) RootCLIOption {
+	return func(c *RootCLI) { c.hookMemoryBeforeJobRemoval = hook }
 }
 
 // WithDatabasePathSetter injects a callback invoked by every subcommand

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -40,6 +40,7 @@ type RootCLI struct {
 	defaultReadColor           string
 	hookMemoryExtractLauncher  func(string) error
 	hookMemoryBeforeJobRemoval func()
+	hookMemoryAfterFinalCheck  func()
 	// databasePathSetter is invoked by each subcommand's RunE after it
 	// resolves --db-path / TRACEARY_DB_PATH, so the shared Database
 	// instance opens the user-specified path instead of the composition-
@@ -191,6 +192,12 @@ func WithHookMemoryExtractLauncher(launcher func(string) error) RootCLIOption {
 // point for queue race tests. Production callers must leave it unset.
 func WithHookMemoryBeforeJobRemoval(hook func()) RootCLIOption {
 	return func(c *RootCLI) { c.hookMemoryBeforeJobRemoval = hook }
+}
+
+// WithHookMemoryAfterFinalCheck installs a deterministic synchronization
+// point after the worker's final marker check but before unlock.
+func WithHookMemoryAfterFinalCheck(hook func()) RootCLIOption {
+	return func(c *RootCLI) { c.hookMemoryAfterFinalCheck = hook }
 }
 
 // WithDatabasePathSetter injects a callback invoked by every subcommand

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -95,6 +95,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "hook-memory-extract",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "no pending hook memory extraction jobs found",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "codex-config",
       "status": "warn",
       "severity": "WARN",
@@ -279,6 +289,16 @@
           "auto_fix_available": false
         },
         {
+          "name": "hook-memory-extract",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "no pending hook memory extraction jobs found",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "codex-config",
           "status": "warn",
           "severity": "WARN",
@@ -292,7 +312,7 @@
     }
   ],
   "summary": {
-    "pass": 11,
+    "pass": 12,
     "warn": 2,
     "fail": 0
   },

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -331,6 +331,8 @@ type memoryUsecaseStub struct {
 	setValidityErr      error
 	extractDetails      []apptypes.MemoryDetails
 	extractErr          error
+	extractFunc         func(context.Context, apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error)
+	extractCallCount    int
 	importResult        apptypes.MemoryImportResult
 	importErr           error
 	bridgeImportResult  apptypes.MemoryBridgeImportResult
@@ -491,8 +493,12 @@ func (s *memoryUsecaseStub) Show(_ context.Context, memoryID types.MemoryID) (ap
 	return s.showDetails, s.showErr
 }
 
-func (s *memoryUsecaseStub) Extract(_ context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
+func (s *memoryUsecaseStub) Extract(ctx context.Context, criteria apptypes.MemoryExtractionCriteria) ([]apptypes.MemoryDetails, error) {
 	s.extractCriteria = criteria
+	s.extractCallCount++
+	if s.extractFunc != nil {
+		return s.extractFunc(ctx, criteria)
+	}
 	return s.extractDetails, s.extractErr
 }
 


### PR DESCRIPTION
## Motivation

Memory auto-extraction currently runs synchronously inside session-end, turn-boundary, and subagent-stop hooks. On a large store it consumes the same short host timeout as primary event recording, so a slow or killed extraction can delay the hook and silently discard extraction progress.

## Changes

- enqueue mode-0600 extraction jobs after primary hook commits and coalesce by database/session/workspace
- launch a detached hidden worker that reuses the existing `MemoryUsecase.Extract` criteria
- retain failed/interrupted jobs with bounded attempt/error metadata and preserve requests that arrive during extraction
- add `hook-memory-extract` doctor diagnostics without exposing criteria or content
- cover session end, turn boundary, subagent stop, coalescing, failure/retry, doctor JSON, and Windows compilation
- document queue behavior in the bilingual hook guide and record the structure/behavior design note

## Validation

- `go test ./...`
- `go tool golangci-lint run --timeout=5m`
- `GOOS=windows GOARCH=amd64 go test -c -o /private/tmp/traceary-cli-windows.test.exe ./presentation/cli`
- `git diff --check`
- dogfood: built a temporary binary, ran Codex session start/stop against a temporary DB/state root, waited for the detached worker, and confirmed `hook-memory-extract: pass`

Closes #1270
