### PR TITLE
v0.22.0-10: detect and remediate duplicate Codex hook registration

### DIFF
--- a/.ai/spec/1271.md
+++ b/.ai/spec/1271.md
@@ -1,0 +1,51 @@
+# Issue #1271: detect duplicate Codex hook registration
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Detect the unsafe state where the Traceary Codex plugin has confirmed active `plugin_hooks` while manual Traceary entries remain in `~/.codex/hooks.json`.
+- Report a dedicated warning that names the manual entries to remove.
+- Make `doctor --fix` remove only Traceary-managed manual entries and preserve unrelated hooks and top-level configuration.
+- Do not remove fallback hooks when plugin hooks are disabled or their state cannot be confirmed.
+- Document the manual-to-plugin migration in English and Japanese.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Codex plugin hook activation | plugin enabled plus explicit `features.plugin_hooks = true` | selects plugin-managed registration | absence of an explicit true value is not confirmation |
+| Manual Traceary registration | managed entries in `~/.codex/hooks.json` | invokes Traceary hook commands | non-Traceary entries are never owned by this remediation |
+| Duplicate registration | confirmed plugin activation plus manual registration | warns and offers cleanup | both conditions must hold |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Parse Codex plugin activation | `doctor_codex_plugin.go` | Codex TOML contract changes | hook JSON inspector does not know Codex TOML |
+| Identify and remove managed JSON entries | `HooksInspector` filesystem adapter | hook document shape or managed-key recognition changes | doctor must not duplicate JSON parsing rules |
+| Decide warning/fix availability | doctor presentation | operator-facing diagnostic policy changes | filesystem adapter does not decide severity |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `HooksInspector.ManagedEntries` | doctor | JSON traversal and canonical managed-key extraction | existing hook-config sentinel errors |
+| `HooksInspector.RemoveManagedHooks` | doctor fix | lossless ownership filtering and JSON rewrite | refuses invalid hook documents; never partially writes |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| detect duplicate paths | plugin enabled, `plugin_hooks=true`, manual entries present | doctor runs | WARN includes exact managed entries | CLI integration |
+| safe fix | duplicate paths and unrelated user hook | `doctor --fix` runs | managed entries removed; user hook retained | CLI integration |
+| dry run | duplicate paths | `doctor --fix --dry-run` runs | action previewed; file unchanged | CLI integration |
+| fallback safety | plugin hooks false or unspecified | doctor/fix runs | manual entries retained | CLI integration |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| managed entry filtering | adapter tests fail for mixed document | add inspector methods | share canonical key extraction |
+| diagnosis and remediation | doctor tests fail for duplicate path | add dedicated check/fix | keep activation decision separate from IO |
+| migration docs | grep misses upgrade sequence | update paired docs | keep commands aligned |
+
+### Risks / rollback
+- Procedural risk: embedding JSON ownership rules in doctor would drift from install/duplicate detection; the filesystem adapter remains the single owner.
+- Premature abstraction: only two focused inspector operations are added; no generic configuration editor is introduced.
+- Compatibility: explicit `plugin_hooks=true` is required before cleanup, so older/unknown Codex builds retain fallback hooks.
+- Rollback trigger: any loss of non-Traceary hooks or cleanup under an unconfirmed feature state; revert the remediation and retain warning-only behavior.

--- a/application/hooks_orchestrator.go
+++ b/application/hooks_orchestrator.go
@@ -10,24 +10,41 @@ import (
 // hook install (merge-only mode). The four slices are disjoint.
 //
 // AddedEvents     : events that had no Traceary-managed commands before
-//                   but now do (new hook coverage).
+//
+//	but now do (new hook coverage).
+//
 // RefreshedEvents : events whose Traceary-managed commands were replaced
-//                   with the current release's set (upgrade, binary
-//                   rename, or command drift).
+//
+//	with the current release's set (upgrade, binary
+//	rename, or command drift).
+//
 // PreservedEvents : events whose normalized command set matched; the
-//                   merged output is byte-identical for these events,
-//                   which is what makes --upgrade idempotent.
+//
+//	merged output is byte-identical for these events,
+//	which is what makes --upgrade idempotent.
+//
 // RemovedEvents   : events present only in the existing config that held
-//                   Traceary-managed commands for an event the current
-//                   release no longer emits (e.g. a hook retired between
-//                   releases). Those stale commands are stripped during
-//                   the merge so the upgrade leaves the Traceary footprint
-//                   consistent with the running binary.
+//
+//	Traceary-managed commands for an event the current
+//	release no longer emits (e.g. a hook retired between
+//	releases). Those stale commands are stripped during
+//	the merge so the upgrade leaves the Traceary footprint
+//	consistent with the running binary.
 type HookUpgradeDiff struct {
 	AddedEvents     []string
 	RefreshedEvents []string
 	PreservedEvents []string
 	RemovedEvents   []string
+}
+
+// HookManagedEntry identifies one Traceary-owned command in a host hook
+// configuration. Doctor uses this operator-facing identity when it needs to
+// explain which manual entries are safe to remove.
+type HookManagedEntry struct {
+	Event      string
+	Matcher    string
+	Name       string
+	ManagedKey string
 }
 
 // HooksOrchestrator is the application-level entrypoint for hook generation
@@ -88,6 +105,15 @@ type HooksOrchestrator interface {
 		outputPath types.Optional[string],
 		matcherPreset string,
 	) (string, HookUpgradeDiff, error)
+
+	// RemoveManaged removes only Traceary-owned commands from an existing hook
+	// configuration. When dryRun is true it returns the entries that would be
+	// removed without writing. Unrelated hooks and top-level fields are kept.
+	RemoveManaged(
+		ctx context.Context,
+		outputPath string,
+		dryRun bool,
+	) ([]HookManagedEntry, error)
 
 	// SupportedClients returns the canonical list of supported client
 	// identifiers (e.g. "claude", "codex", "gemini").

--- a/docs/integrations/codex-plugin.ja.md
+++ b/docs/integrations/codex-plugin.ja.md
@@ -67,13 +67,15 @@ fallback は `~/.codex/hooks.json` に Traceary 管理のエントリ (`traceary
 
 ### 二重記録の注意点
 
-将来 Codex 側で `plugin_hooks` が有効化されると、plugin manifest 経由の hook が自動で発火するようになります。このとき `~/.codex/hooks.json` に fallback で書き込まれた手動エントリがそのまま残っていると、**session / prompt / transcript / audit の各 event が二重に記録されます**。fallback を経由した install で plugin-managed hook を改めて有効化する前に、手動エントリを削除してください:
+将来 Codex 側で `plugin_hooks` が有効化されると、plugin manifest 経由の hook が自動で発火するようになります。このとき `~/.codex/hooks.json` に fallback で書き込まれた手動エントリがそのまま残っていると、**session / prompt / transcript / audit の各 event が二重に記録されます**。`[features].plugin_hooks = true` を設定した後、doctor で古い手動経路を検出・削除してください:
 
 ```sh
-# ~/.codex/hooks.json を開き、fallback が追加した次の名前付きエントリを削除:
-#   traceary-session-start / traceary-prompt / traceary-transcript /
-#   traceary-session-stop / traceary-audit
+traceary doctor --client codex --json
+traceary doctor --fix --dry-run --client codex
+traceary doctor --fix --client codex
 ```
+
+doctor が cleanup を提示するのは、Traceary plugin が enabled で、かつ `plugin_hooks = true` により plugin-managed hook の有効化を明示確認できた場合だけです。名前付きの Traceary 管理エントリ (`traceary-session-start` / `traceary-prompt` / `traceary-transcript` / `traceary-session-stop` / `traceary-audit`) だけを削除し、Traceary 以外の hook と top-level field は保持します。feature が false または未指定の場合は手動 fallback を残します。
 
 cleanup 後に `traceary doctor --client codex --json` を再実行し、登録経路が一つだけになっていることを確認してください。
 

--- a/docs/integrations/codex-plugin.md
+++ b/docs/integrations/codex-plugin.md
@@ -67,13 +67,15 @@ The fallback writes Traceary-managed entries directly into `~/.codex/hooks.json`
 
 ### Duplicate-capture warning
 
-If a future Codex build enables `plugin_hooks` for your install (the plugin manifest's hooks start firing automatically) while these manual entries remain in `~/.codex/hooks.json`, **every session/prompt/transcript/audit event will be recorded twice**. Before enabling plugin-managed hooks on an install that previously used the fallback, remove the manual entries:
+If a future Codex build enables `plugin_hooks` for your install (the plugin manifest's hooks start firing automatically) while these manual entries remain in `~/.codex/hooks.json`, **every session/prompt/transcript/audit event will be recorded twice**. After setting `[features].plugin_hooks = true`, let doctor detect and remove the obsolete manual path:
 
 ```sh
-# Inspect ~/.codex/hooks.json and delete the named entries the fallback created:
-#   traceary-session-start, traceary-prompt, traceary-transcript,
-#   traceary-session-stop, traceary-audit
+traceary doctor --client codex --json
+traceary doctor --fix --dry-run --client codex
+traceary doctor --fix --client codex
 ```
+
+Doctor only offers this cleanup when the Traceary plugin is enabled and `plugin_hooks = true` explicitly confirms plugin-managed hooks. It removes the named Traceary-managed entries (`traceary-session-start`, `traceary-prompt`, `traceary-transcript`, `traceary-session-stop`, and `traceary-audit`) while preserving unrelated hooks and top-level fields. When the feature is false or unspecified, doctor keeps the manual fallback intact.
 
 After cleanup, re-run `traceary doctor --client codex --json` to confirm only one registration path is active.
 

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -158,33 +158,68 @@ func removeTracearyManagedHooks(existingContent []byte) ([]byte, []application.H
 	if !ok {
 		return existingContent, nil, nil
 	}
-	hooks := map[string][]hookMatcherDocument{}
+	hooks := map[string][]json.RawMessage{}
 	if err := json.Unmarshal(hooksValue, &hooks); err != nil {
 		return nil, nil, xerrors.Errorf("existing hooks field must be a JSON object whose values are hook arrays: %w", err)
 	}
 
 	removed := make([]application.HookManagedEntry, 0)
 	for event, matchers := range hooks {
-		keptMatchers := make([]hookMatcherDocument, 0, len(matchers))
-		for _, matcher := range matchers {
-			matcherValue := ""
-			if matcher.Matcher != nil {
-				matcherValue = *matcher.Matcher
+		keptMatchers := make([]json.RawMessage, 0, len(matchers))
+		for _, matcherRaw := range matchers {
+			matcher := map[string]json.RawMessage{}
+			if err := json.Unmarshal(matcherRaw, &matcher); err != nil {
+				return nil, nil, xerrors.Errorf("hook matcher for event %s must be a JSON object: %w", event, err)
 			}
-			keptCommands := make([]hookCommandDocument, 0, len(matcher.Hooks))
-			for _, command := range matcher.Hooks {
+			matcherValue := ""
+			if rawMatcher, ok := matcher["matcher"]; ok {
+				if err := json.Unmarshal(rawMatcher, &matcherValue); err != nil {
+					return nil, nil, xerrors.Errorf("hook matcher value for event %s must be a string: %w", event, err)
+				}
+			}
+			commandsRaw, ok := matcher["hooks"]
+			if !ok {
+				return nil, nil, xerrors.Errorf("hook matcher for event %s must contain a hooks array", event)
+			}
+			commands := []json.RawMessage{}
+			if err := json.Unmarshal(commandsRaw, &commands); err != nil {
+				return nil, nil, xerrors.Errorf("hook commands for event %s must be an array: %w", event, err)
+			}
+			keptCommands := make([]json.RawMessage, 0, len(commands))
+			matcherChanged := false
+			for _, commandRaw := range commands {
+				var command struct {
+					Name    string `json:"name"`
+					Command string `json:"command"`
+				}
+				if err := json.Unmarshal(commandRaw, &command); err != nil {
+					return nil, nil, xerrors.Errorf("hook command for event %s must be a JSON object: %w", event, err)
+				}
 				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
 				if managedKey == "" {
-					keptCommands = append(keptCommands, command)
+					keptCommands = append(keptCommands, commandRaw)
 					continue
 				}
+				matcherChanged = true
 				removed = append(removed, application.HookManagedEntry{
 					Event: event, Matcher: matcherValue, Name: command.Name, ManagedKey: managedKey,
 				})
 			}
 			if len(keptCommands) > 0 {
-				matcher.Hooks = keptCommands
-				keptMatchers = append(keptMatchers, matcher)
+				if !matcherChanged {
+					keptMatchers = append(keptMatchers, matcherRaw)
+					continue
+				}
+				encodedCommands, err := json.Marshal(keptCommands)
+				if err != nil {
+					return nil, nil, xerrors.Errorf("failed to marshal retained hook commands: %w", err)
+				}
+				matcher["hooks"] = encodedCommands
+				encodedMatcher, err := json.Marshal(matcher)
+				if err != nil {
+					return nil, nil, xerrors.Errorf("failed to marshal retained hook matcher: %w", err)
+				}
+				keptMatchers = append(keptMatchers, encodedMatcher)
 			}
 		}
 		if len(keptMatchers) == 0 {
@@ -206,7 +241,7 @@ func removeTracearyManagedHooks(existingContent []byte) ([]byte, []application.H
 		return removed[i].ManagedKey < removed[j].ManagedKey
 	})
 
-	encodedHooks, err := json.MarshalIndent(hooks, "", "  ")
+	encodedHooks, err := json.Marshal(hooks)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to marshal filtered hooks JSON: %w", err)
 	}

--- a/infrastructure/filesystem/hooks_merge.go
+++ b/infrastructure/filesystem/hooks_merge.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain/model"
 )
 
@@ -145,6 +146,76 @@ func mergeHooksDocumentWithDiff(existingContent []byte, hooks model.Hooks) ([]by
 	}
 
 	return encodedRoot, diff, nil
+}
+
+func removeTracearyManagedHooks(existingContent []byte) ([]byte, []application.HookManagedEntry, error) {
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(existingContent, &root); err != nil {
+		return nil, nil, xerrors.Errorf("existing settings file must contain a JSON object: %w", err)
+	}
+
+	hooksValue, ok := root["hooks"]
+	if !ok {
+		return existingContent, nil, nil
+	}
+	hooks := map[string][]hookMatcherDocument{}
+	if err := json.Unmarshal(hooksValue, &hooks); err != nil {
+		return nil, nil, xerrors.Errorf("existing hooks field must be a JSON object whose values are hook arrays: %w", err)
+	}
+
+	removed := make([]application.HookManagedEntry, 0)
+	for event, matchers := range hooks {
+		keptMatchers := make([]hookMatcherDocument, 0, len(matchers))
+		for _, matcher := range matchers {
+			matcherValue := ""
+			if matcher.Matcher != nil {
+				matcherValue = *matcher.Matcher
+			}
+			keptCommands := make([]hookCommandDocument, 0, len(matcher.Hooks))
+			for _, command := range matcher.Hooks {
+				managedKey := extractTracearyManagedKeyFromEntry(command.Name, command.Command)
+				if managedKey == "" {
+					keptCommands = append(keptCommands, command)
+					continue
+				}
+				removed = append(removed, application.HookManagedEntry{
+					Event: event, Matcher: matcherValue, Name: command.Name, ManagedKey: managedKey,
+				})
+			}
+			if len(keptCommands) > 0 {
+				matcher.Hooks = keptCommands
+				keptMatchers = append(keptMatchers, matcher)
+			}
+		}
+		if len(keptMatchers) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = keptMatchers
+		}
+	}
+	sort.Slice(removed, func(i, j int) bool {
+		if removed[i].Event != removed[j].Event {
+			return removed[i].Event < removed[j].Event
+		}
+		if removed[i].Matcher != removed[j].Matcher {
+			return removed[i].Matcher < removed[j].Matcher
+		}
+		if removed[i].Name != removed[j].Name {
+			return removed[i].Name < removed[j].Name
+		}
+		return removed[i].ManagedKey < removed[j].ManagedKey
+	})
+
+	encodedHooks, err := json.MarshalIndent(hooks, "", "  ")
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to marshal filtered hooks JSON: %w", err)
+	}
+	root["hooks"] = encodedHooks
+	encodedRoot, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to marshal filtered settings JSON: %w", err)
+	}
+	return encodedRoot, removed, nil
 }
 
 // hasTracearyManagedCommands reports whether the matcher list contains at

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -165,7 +165,7 @@ func (o *HooksOrchestrator) RemoveManaged(
 	if dryRun || len(removed) == 0 {
 		return removed, nil
 	}
-	if err := safeWriteFile(outputPath, append(filtered, '\n'), 0o644); err != nil {
+	if err := safeWriteFileAtomic(outputPath, append(filtered, '\n'), 0o644); err != nil {
 		return nil, xerrors.Errorf("failed to write hook configuration: %w", err)
 	}
 	return removed, nil

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -143,6 +143,34 @@ func (o *HooksOrchestrator) UpgradeWithMatcher(
 	}, nil
 }
 
+// RemoveManaged removes the Traceary-owned subset of an existing hook file.
+// The safe filesystem helpers reject symlink traversal on Unix, matching hook
+// installation's write guarantees.
+func (o *HooksOrchestrator) RemoveManaged(
+	_ context.Context,
+	outputPath string,
+	dryRun bool,
+) ([]application.HookManagedEntry, error) {
+	if !filepath.IsAbs(outputPath) {
+		return nil, xerrors.Errorf("hook configuration path must be absolute: %s", outputPath)
+	}
+	content, err := safeReadFile(outputPath)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read hook configuration: %w", err)
+	}
+	filtered, removed, err := removeTracearyManagedHooks(content)
+	if err != nil {
+		return nil, err
+	}
+	if dryRun || len(removed) == 0 {
+		return removed, nil
+	}
+	if err := safeWriteFile(outputPath, append(filtered, '\n'), 0o644); err != nil {
+		return nil, xerrors.Errorf("failed to write hook configuration: %w", err)
+	}
+	return removed, nil
+}
+
 // installWithDiff is the shared implementation for InstallWithMatcher and
 // UpgradeWithMatcher. The diff is empty when force overwrites the file
 // (no merge performed) or when no existing file was present.

--- a/infrastructure/filesystem/hooks_orchestrator_unix_test.go
+++ b/infrastructure/filesystem/hooks_orchestrator_unix_test.go
@@ -135,3 +135,31 @@ func TestHooksOrchestrator_InstallForceRefusesSymlink(t *testing.T) {
 		t.Fatalf("victim content = %q, want untouched", got)
 	}
 }
+
+func TestHooksOrchestrator_RemoveManagedWriteFailurePreservesOriginal(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	orchestrator := newTestOrchestrator(homeDir)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	original := []byte(`{"hooks":{"Stop":[{"hooks":[{"name":"traceary-transcript","type":"command","command":"'traceary' 'hook' 'transcript' 'codex'"}]}]}}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod(read-only) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if _, err := orchestrator.RemoveManaged(context.Background(), path, false); err == nil {
+		t.Fatalf("RemoveManaged() error = nil, want temporary-file creation failure")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("hooks.json changed after failed atomic write\ngot:  %s\nwant: %s", got, original)
+	}
+}

--- a/infrastructure/filesystem/safe_fs_other.go
+++ b/infrastructure/filesystem/safe_fs_other.go
@@ -4,9 +4,47 @@ package filesystem
 
 import (
 	"os"
+	"path/filepath"
 
 	"golang.org/x/xerrors"
 )
+
+func safeWriteFileAtomic(absPath string, data []byte, fallbackPerm os.FileMode) (retErr error) {
+	if !filepath.IsAbs(absPath) {
+		return xerrors.Errorf("path must be absolute: %s", absPath)
+	}
+	perm := fallbackPerm.Perm()
+	if info, err := os.Stat(absPath); err == nil {
+		perm = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return xerrors.Errorf("failed to inspect %s: %w", absPath, err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(absPath), "."+filepath.Base(absPath)+".tmp-*")
+	if err != nil {
+		return xerrors.Errorf("failed to create temporary file for %s: %w", absPath, err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}()
+	if err := temp.Chmod(perm); err != nil {
+		return xerrors.Errorf("failed to preserve permissions for %s: %w", absPath, err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		return xerrors.Errorf("failed to write temporary file for %s: %w", absPath, err)
+	}
+	if err := temp.Sync(); err != nil {
+		return xerrors.Errorf("failed to sync temporary file for %s: %w", absPath, err)
+	}
+	if err := temp.Close(); err != nil {
+		return xerrors.Errorf("failed to close temporary file for %s: %w", absPath, err)
+	}
+	if err := os.Rename(tempPath, absPath); err != nil {
+		return xerrors.Errorf("failed to atomically replace %s: %w", absPath, err)
+	}
+	return nil
+}
 
 // safeMkdirAll creates the directory tree at absPath. The Unix
 // implementation pins every component with O_NOFOLLOW; on non-Unix

--- a/infrastructure/filesystem/safe_fs_unix.go
+++ b/infrastructure/filesystem/safe_fs_unix.go
@@ -3,6 +3,8 @@
 package filesystem
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"io"
 	"os"
@@ -13,6 +15,72 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 )
+
+func safeWriteFileAtomic(absPath string, data []byte, fallbackPerm os.FileMode) (retErr error) {
+	cleaned := filepath.Clean(absPath)
+	dir := filepath.Dir(cleaned)
+	base := filepath.Base(cleaned)
+	parentFD, err := descendToDir(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+
+	perm := fallbackPerm.Perm()
+	existingFD, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err == nil {
+		var stat unix.Stat_t
+		if statErr := unix.Fstat(existingFD, &stat); statErr != nil {
+			_ = unix.Close(existingFD)
+			return xerrors.Errorf("failed to stat %s: %w", absPath, statErr)
+		}
+		perm = os.FileMode(stat.Mode).Perm()
+		_ = unix.Close(existingFD)
+	} else if !errors.Is(err, unix.ENOENT) {
+		if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.EMLINK) {
+			return xerrors.Errorf("refusing to replace symbolic link: %s", absPath)
+		}
+		return xerrors.Errorf("failed to inspect %s: %w", absPath, err)
+	}
+
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return xerrors.Errorf("failed to generate temporary filename: %w", err)
+	}
+	tempName := "." + base + ".tmp-" + hex.EncodeToString(random)
+	tempFD, err := unix.Openat(parentFD, tempName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(perm))
+	if err != nil {
+		return xerrors.Errorf("failed to create temporary file for %s: %w", absPath, err)
+	}
+	temp := os.NewFile(uintptr(tempFD), filepath.Join(dir, tempName))
+	tempPresent := true
+	defer func() {
+		_ = temp.Close()
+		if tempPresent {
+			_ = unix.Unlinkat(parentFD, tempName, 0)
+		}
+	}()
+	if err := temp.Chmod(perm); err != nil {
+		return xerrors.Errorf("failed to preserve permissions for %s: %w", absPath, err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		return xerrors.Errorf("failed to write temporary file for %s: %w", absPath, err)
+	}
+	if err := temp.Sync(); err != nil {
+		return xerrors.Errorf("failed to sync temporary file for %s: %w", absPath, err)
+	}
+	if err := temp.Close(); err != nil {
+		return xerrors.Errorf("failed to close temporary file for %s: %w", absPath, err)
+	}
+	if err := unix.Renameat(parentFD, tempName, parentFD, base); err != nil {
+		return xerrors.Errorf("failed to atomically replace %s: %w", absPath, err)
+	}
+	tempPresent = false
+	if err := unix.Fsync(parentFD); err != nil {
+		return xerrors.Errorf("failed to sync parent directory for %s: %w", absPath, err)
+	}
+	return nil
+}
 
 // descendToDir opens the directory at absPath using an fd-pinned walk.
 // Each intermediate component is opened with O_NOFOLLOW so an attacker

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -327,7 +327,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			continue
 		}
 
-		check := c.inspectClaudeOrConfigFile(targetClient, outputPath, resolvedProjectDir)
+		check := c.inspectClaudeOrConfigFile(ctx, targetClient, outputPath, resolvedProjectDir)
 		c.attachDoctorConfigFix(&check, targetClient, outputPath, resolvedProjectDir)
 		report.Checks = append(report.Checks, check)
 		if targetClient == "gemini" || targetClient == "claude" {
@@ -1271,13 +1271,13 @@ func inspectDoctorConfig() doctorCheck {
 // run the file-level inspection first and only short-circuit to the
 // plugin-managed pass branch when the file is either missing or
 // structurally valid.
-func (c *RootCLI) inspectClaudeOrConfigFile(client, outputPath, projectDir string) doctorCheck {
+func (c *RootCLI) inspectClaudeOrConfigFile(ctx context.Context, client, outputPath, projectDir string) doctorCheck {
 	if client != "claude" {
-		return c.inspectDoctorConfigFile(client, outputPath, projectDir)
+		return c.inspectDoctorConfigFile(ctx, client, outputPath, projectDir)
 	}
 
 	detection := c.detectClaudeTracearyPluginForCLI()
-	configCheck := c.inspectDoctorConfigFile(client, outputPath, projectDir)
+	configCheck := c.inspectDoctorConfigFile(ctx, client, outputPath, projectDir)
 
 	if detection.Active {
 		// Structural failures (invalid JSON, malformed hooks field) are
@@ -1506,7 +1506,7 @@ func (c *RootCLI) claudeConfigHasTracearyHooks(outputPath string) bool {
 	return hasTracearyHook
 }
 
-func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, projectDir string) doctorCheck {
+func (c *RootCLI) inspectDoctorConfigFile(ctx context.Context, client string, outputPath string, projectDir string) doctorCheck {
 	content, err := os.ReadFile(outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1577,7 +1577,7 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 	if hasTracearyManagedHook {
 		if client == "codex" {
 			if state := c.detectCodexPluginHookFallback(); state.pluginHooksConfirmedActive() {
-				return c.codexDuplicateRegistrationCheck(state, outputPath)
+				return c.codexDuplicateRegistrationCheck(ctx, state, outputPath)
 			}
 		}
 		duplicates, duplicateErr := c.hooksInspector.DuplicateManagedHooks(content)

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -1042,6 +1042,9 @@ func (c *RootCLI) attachDoctorConfigFix(check *doctorCheck, client, outputPath, 
 	if check == nil || check.Name != client+"-config" || check.Status != doctorStatusWarn {
 		return
 	}
+	if check.AutoFixAvailable || check.FixFunc != nil {
+		return
+	}
 	if client == "claude" {
 		detection := c.detectClaudeTracearyPluginForCLI()
 		if detection.Active {
@@ -1508,7 +1511,9 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 	if err != nil {
 		if os.IsNotExist(err) {
 			if client == "codex" {
-				if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+				if state := c.detectCodexPluginHookFallback(); state.pluginHooksConfirmedActive() {
+					return codexPluginManagedHooksCheck(state, outputPath)
+				} else if state.PluginEnabled {
 					return codexPluginHookFallbackCheck(state, outputPath, localizef("does not exist", "が存在しません"))
 				}
 			}
@@ -1550,7 +1555,9 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 
 	if !hasHooksField {
 		if client == "codex" {
-			if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+			if state := c.detectCodexPluginHookFallback(); state.pluginHooksConfirmedActive() {
+				return codexPluginManagedHooksCheck(state, outputPath)
+			} else if state.PluginEnabled {
 				return codexPluginHookFallbackCheck(state, outputPath, localizef("has no hooks field", "には hooks フィールドがありません"))
 			}
 		}
@@ -1568,6 +1575,11 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 	}
 
 	if hasTracearyManagedHook {
+		if client == "codex" {
+			if state := c.detectCodexPluginHookFallback(); state.pluginHooksConfirmedActive() {
+				return c.codexDuplicateRegistrationCheck(state, outputPath)
+			}
+		}
 		duplicates, duplicateErr := c.hooksInspector.DuplicateManagedHooks(content)
 		if duplicateErr != nil {
 			return doctorCheck{
@@ -1614,7 +1626,9 @@ func (c *RootCLI) inspectDoctorConfigFile(client string, outputPath string, proj
 	}
 
 	if client == "codex" {
-		if state := c.detectCodexPluginHookFallback(); state.PluginEnabled {
+		if state := c.detectCodexPluginHookFallback(); state.pluginHooksConfirmedActive() {
+			return codexPluginManagedHooksCheck(state, outputPath)
+		} else if state.PluginEnabled {
 			return codexPluginHookFallbackCheck(state, outputPath, localizef("has hook entries but none are Traceary-managed", "には hook エントリはありますが Traceary 管理のものがありません"))
 		}
 	}

--- a/presentation/cli/doctor_codex_plugin.go
+++ b/presentation/cli/doctor_codex_plugin.go
@@ -1,12 +1,89 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
+	"golang.org/x/xerrors"
 )
+
+func (s codexPluginHookFallbackState) pluginHooksConfirmedActive() bool {
+	return s.PluginEnabled && s.PluginHooksFeature != nil && *s.PluginHooksFeature
+}
+
+func codexPluginManagedHooksCheck(state codexPluginHookFallbackState, hooksPath string) doctorCheck {
+	pluginKey := state.PluginKey
+	if pluginKey == "" {
+		pluginKey = "traceary@<marketplace>"
+	}
+	return doctorCheck{
+		Name:   "codex-config",
+		Status: doctorStatusPass,
+		Message: localizef(
+			"codex plugin %q has confirmed plugin-managed hooks (`[features].plugin_hooks = true`); no manual Traceary entries are required in %s",
+			"codex plugin %q では plugin-managed hook が有効です (`[features].plugin_hooks = true`)。%s に手動 Traceary エントリは不要です",
+			pluginKey,
+			hooksPath,
+		),
+	}
+}
+
+func (c *RootCLI) codexDuplicateRegistrationCheck(state codexPluginHookFallbackState, hooksPath string) doctorCheck {
+	const checkName = "codex-config"
+	entries, err := c.hooksOrchestrator.RemoveManaged(context.Background(), hooksPath, true)
+	if err != nil {
+		return doctorCheck{
+			Name: checkName, Status: doctorStatusFail,
+			Message: localizef("failed to inspect manual Codex hook entries: %v", "Codex の手動 hook エントリを検査できませんでした: %v", err),
+		}
+	}
+	if len(entries) == 0 {
+		return codexPluginManagedHooksCheck(state, hooksPath)
+	}
+	entryNames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			name = entry.ManagedKey
+		}
+		entryNames = append(entryNames, fmt.Sprintf("%s:%s", entry.Event, name))
+	}
+	sort.Strings(entryNames)
+	joined := strings.Join(entryNames, ", ")
+	check := doctorCheck{
+		Name: checkName, Status: doctorStatusWarn, AutoFixAvailable: true,
+		FixCommand: "traceary doctor --fix --dry-run --client codex",
+		Hint: Localize(
+			"preview the cleanup with `traceary doctor --fix --dry-run --client codex`; only Traceary-managed manual entries are removed",
+			"`traceary doctor --fix --dry-run --client codex` で cleanup を確認してください。Traceary 管理の手動エントリだけを削除します",
+		),
+		Message: localizef(
+			"Codex plugin hooks are confirmed active, but manual Traceary hooks are also registered in %s; matching events will be captured twice. Remove these manual entries: %s",
+			"Codex plugin hook は有効ですが、%s に手動 Traceary hook も登録されています。該当 event が二重記録されます。次の手動エントリを削除してください: %s",
+			hooksPath, joined,
+		),
+	}
+	check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
+		action := fmt.Sprintf("remove manual Traceary hooks from %s: %s", hooksPath, joined)
+		if dryRun {
+			return "would: " + action, nil
+		}
+		removed, err := c.hooksOrchestrator.RemoveManaged(ctx, hooksPath, false)
+		if err != nil {
+			return action, xerrors.Errorf("remove manual Traceary hooks: %w", err)
+		}
+		if len(removed) == 0 {
+			return "skip: manual Traceary hooks already absent", nil
+		}
+		return action, nil
+	}
+	return check
+}
 
 // codexPluginHookFallbackState captures the subset of ~/.codex/config.toml
 // that doctor needs to surface the v0.15.1 plugin_hooks fallback warning.

--- a/presentation/cli/doctor_codex_plugin.go
+++ b/presentation/cli/doctor_codex_plugin.go
@@ -33,9 +33,9 @@ func codexPluginManagedHooksCheck(state codexPluginHookFallbackState, hooksPath 
 	}
 }
 
-func (c *RootCLI) codexDuplicateRegistrationCheck(state codexPluginHookFallbackState, hooksPath string) doctorCheck {
+func (c *RootCLI) codexDuplicateRegistrationCheck(ctx context.Context, state codexPluginHookFallbackState, hooksPath string) doctorCheck {
 	const checkName = "codex-config"
-	entries, err := c.hooksOrchestrator.RemoveManaged(context.Background(), hooksPath, true)
+	entries, err := c.hooksOrchestrator.RemoveManaged(ctx, hooksPath, true)
 	if err != nil {
 		return doctorCheck{
 			Name: checkName, Status: doctorStatusFail,

--- a/presentation/cli/doctor_fix_test.go
+++ b/presentation/cli/doctor_fix_test.go
@@ -232,6 +232,9 @@ func TestRootCLI_DoctorFix(t *testing.T) {
 		if !strings.Contains(string(content), `"custom"`) || !strings.Contains(string(content), `"keep": true`) {
 			t.Fatalf("top-level user configuration disappeared after fix:\n%s", content)
 		}
+		if !strings.Contains(string(content), `"matcherExtension"`) || !strings.Contains(string(content), `"futureCommandField"`) {
+			t.Fatalf("unknown user hook fields disappeared after fix:\n%s", content)
+		}
 	})
 
 	t.Run("disabled codex plugin hooks retain manual fallback entries", func(t *testing.T) {
@@ -254,6 +257,33 @@ func TestRootCLI_DoctorFix(t *testing.T) {
 		}
 		if !strings.Contains(string(content), "traceary-session-start") || !strings.Contains(string(content), "traceary-audit") {
 			t.Fatalf("manual fallback hooks were removed while plugin_hooks=false:\n%s", content)
+		}
+	})
+
+	t.Run("unspecified codex plugin hooks retain manual fallback entries", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		setDoctorFixHome(t, homeDir)
+		setTracearyPathToCurrentExecutableAt(t, filepath.Join(t.TempDir(), "bin"))
+		writeCodexDuplicateAuditHook(t, homeDir)
+		codexDir := filepath.Join(homeDir, ".codex")
+		config := "[plugins.\"traceary@local-traceary-plugins\"]\nenabled = true\n"
+		if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(config), 0o644); err != nil {
+			t.Fatalf("WriteFile(config.toml) error = %v", err)
+		}
+
+		stdout := &bytes.Buffer{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--fix", "--client", "codex", "--project-dir", projectDir, "--json"})
+		executeDoctorAllowWarnings(t, rootCmd)
+		content, err := os.ReadFile(filepath.Join(codexDir, "hooks.json"))
+		if err != nil {
+			t.Fatalf("ReadFile() error = %v", err)
+		}
+		if !strings.Contains(string(content), "traceary-session-start") || !strings.Contains(string(content), "traceary-audit") {
+			t.Fatalf("manual fallback hooks were removed while plugin_hooks was unspecified:\n%s", content)
 		}
 	})
 }

--- a/presentation/cli/doctor_fix_test.go
+++ b/presentation/cli/doctor_fix_test.go
@@ -189,6 +189,85 @@ func TestRootCLI_DoctorFix(t *testing.T) {
 			t.Fatalf("user hook disappeared from codex hooks:\n%s", after)
 		}
 	})
+
+	t.Run("confirmed codex plugin hooks remove only manual Traceary entries", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		setDoctorFixHome(t, homeDir)
+		setTracearyPathToCurrentExecutableAt(t, filepath.Join(t.TempDir(), "bin"))
+		writeCodexDuplicateAuditHook(t, homeDir)
+		writeCodexPluginHookFeature(t, homeDir, "true")
+
+		stdout := &bytes.Buffer{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--fix", "--client", "codex", "--project-dir", projectDir, "--json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v\n%s", err, stdout.String())
+		}
+		report := decodeDoctorReport(t, stdout.Bytes())
+		if got := doctorStatuses(report)["codex-config"]; got != "pass" {
+			t.Fatalf("codex-config status = %q, want pass; report=%s", got, stdout.String())
+		}
+		foundRemoval := false
+		for _, fix := range report.Fixes {
+			if fix.Name == "codex-config" && strings.Contains(fix.Action, "remove manual Traceary hooks") {
+				foundRemoval = true
+			}
+		}
+		if !foundRemoval {
+			t.Fatalf("fixes = %#v, want manual hook removal", report.Fixes)
+		}
+		content, err := os.ReadFile(filepath.Join(homeDir, ".codex", "hooks.json"))
+		if err != nil {
+			t.Fatalf("ReadFile() error = %v", err)
+		}
+		if strings.Contains(string(content), "traceary-") || strings.Contains(string(content), "'traceary'") {
+			t.Fatalf("manual Traceary hooks remain after fix:\n%s", content)
+		}
+		if !strings.Contains(string(content), "echo user-hook") {
+			t.Fatalf("user hook disappeared after fix:\n%s", content)
+		}
+		if !strings.Contains(string(content), `"custom"`) || !strings.Contains(string(content), `"keep": true`) {
+			t.Fatalf("top-level user configuration disappeared after fix:\n%s", content)
+		}
+	})
+
+	t.Run("disabled codex plugin hooks retain manual fallback entries", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectDir := t.TempDir()
+		setDoctorFixHome(t, homeDir)
+		setTracearyPathToCurrentExecutableAt(t, filepath.Join(t.TempDir(), "bin"))
+		writeCodexDuplicateAuditHook(t, homeDir)
+		writeCodexPluginHookFeature(t, homeDir, "false")
+
+		stdout := &bytes.Buffer{}
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{})).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"doctor", "--fix", "--client", "codex", "--project-dir", projectDir, "--json"})
+		executeDoctorAllowWarnings(t, rootCmd)
+		content, err := os.ReadFile(filepath.Join(homeDir, ".codex", "hooks.json"))
+		if err != nil {
+			t.Fatalf("ReadFile() error = %v", err)
+		}
+		if !strings.Contains(string(content), "traceary-session-start") || !strings.Contains(string(content), "traceary-audit") {
+			t.Fatalf("manual fallback hooks were removed while plugin_hooks=false:\n%s", content)
+		}
+	})
+}
+
+func writeCodexPluginHookFeature(t *testing.T, homeDir, value string) {
+	t.Helper()
+	codexDir := filepath.Join(homeDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := "[features]\nplugin_hooks = " + value + "\n\n[plugins.\"traceary@local-traceary-plugins\"]\nenabled = true\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(config.toml) error = %v", err)
+	}
 }
 
 func setDoctorFixHome(t *testing.T, homeDir string) {

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -390,6 +390,7 @@ func writeCodexDuplicateAuditHook(t *testing.T, home string) {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 	content := `{
+	"custom": {"keep": true},
   "hooks": {
     "SessionStart": [
       {"hooks": [{"name": "traceary-session-start", "type": "command", "command": "'traceary' 'hook' 'session' 'codex' 'start'"}]}

--- a/presentation/cli/doctor_plugin_test.go
+++ b/presentation/cli/doctor_plugin_test.go
@@ -405,10 +405,10 @@ func writeCodexDuplicateAuditHook(t *testing.T, home string) {
       ]}
     ],
     "PostToolUse": [
-      {"matcher": "", "hooks": [
+      {"matcher": "", "matcherExtension": {"keep": true}, "hooks": [
         {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
         {"name": "traceary-audit", "type": "command", "command": "'traceary' 'hook' 'audit' 'codex'"},
-        {"name": "user-audit", "type": "command", "command": "echo user-hook"}
+        {"name": "user-audit", "type": "command", "command": "echo user-hook", "futureCommandField": {"keep": true}}
       ]}
     ]
   }


### PR DESCRIPTION
## Motivation

Codex installations can retain Traceary manual fallback hooks after plugin-managed hooks become active, causing every matching host event to be recorded twice.

## Changes
- detect the confirmed dual-registration state when the Traceary plugin is enabled and `features.plugin_hooks = true`
- report the exact manual entries that must be removed
- make `doctor --fix` remove only Traceary-managed entries while preserving user hooks and top-level configuration
- retain manual fallback hooks when plugin hooks are false or unconfirmed
- document the manual-to-plugin migration in English and Japanese

## Validation
- `git diff --check`
- `go vet ./...`
- `go test ./...`
- `go tool golangci-lint run --timeout=5m` (0 issues)
- Windows compile-only: `GOOS=windows GOARCH=amd64 go test -exec=/usr/bin/true ./...`

Closes #1271
