### PR TITLE
v0.23.0-1: verify Grok Build hook contract

### DIFF
--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -4,6 +4,8 @@
 
 このページでは、AI エージェントごとに hook でどこまで自動記録できるかを整理しています。
 
+Grok Build 0.2.99 の versioned かつ機械可読な live contract は [`host-contract.json`](./host-contract.json) にあります。upstream で文書化された hook と live で観測した payload を分離し、sanitized fixture がある event だけを `supported` または `best_effort` と分類します。Grok runtime の配線はこの contract 検証には含めず、#1275 と #1276 で扱います。
+
 ## 対応レベル
 
 ### Tier 1: フル対応 (Claude Code)

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -4,6 +4,8 @@
 
 This document defines the hook capability tiers across AI agent clients.
 
+The versioned, machine-readable live contract for Grok Build 0.2.99 is [`host-contract.json`](./host-contract.json). It separates upstream-documented hooks from live-observed payloads and requires a sanitized fixture before Traceary classifies an event as `supported` or `best_effort`. Grok runtime wiring remains outside this contract-verification change and is tracked in #1275 and #1276.
+
 ## Capability Tiers
 
 ### Tier 1: Full (Claude Code)

--- a/docs/hooks/host-contract.json
+++ b/docs/hooks/host-contract.json
@@ -114,6 +114,15 @@
           "fixture": null,
           "note": "External Grok subagents remained disabled; no parent/child field contract is claimed."
         },
+        "Notification": {
+          "documented": true,
+          "observed": false,
+          "verification": "not_probed_no_traceary_mapping",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "Notification has no Traceary lifecycle mapping and was not included in the live contract probe."
+        },
         "PreCompact": {
           "documented": true,
           "observed": true,

--- a/docs/hooks/host-contract.json
+++ b/docs/hooks/host-contract.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "last_verified": "2026-07-14",
+  "hosts": {
+    "grok": {
+      "host_version": "0.2.99",
+      "host_build": "b1b49ccb71a7",
+      "official_contract": "https://docs.x.ai/build/features/hooks",
+      "verification_method": "Live hooks captured from sanitized empty workspaces; raw payloads remained outside the repository.",
+      "field_availability": {
+        "session_id": "present on every observed event",
+        "cwd": "present on every observed event",
+        "workspace_root": "present on every observed event",
+        "transcript_path": "present on prompt, tool, stop, and compact events; absent on SessionStart",
+        "model": "unavailable on every observed hook payload",
+        "tool_input": "present on PreToolUse and PostToolUse",
+        "tool_result": "present on PostToolUse; failed and denied reads are nested result variants",
+        "failure_details": "no top-level failure field observed; FileNotFound and PermissionDenied are nested PostToolUse result variants",
+        "compact_summary": "unavailable; compact hooks expose source and transcriptPath only",
+        "subagent_parent_id": "unavailable because subagent hooks were not live-probed under the external-agent policy gate"
+      },
+      "events": {
+        "SessionStart": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "supported",
+          "traceary_event": "session_started",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/session_start.json",
+          "note": "source=new; no transcriptPath or model field"
+        },
+        "UserPromptSubmit": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "supported",
+          "traceary_event": "prompt",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/user_prompt_submit.json",
+          "note": "prompt, promptId, and transcriptPath are present"
+        },
+        "PreToolUse": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "supported",
+          "traceary_event": "command_executed",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/pre_tool_use.json",
+          "note": "toolUseId correlates with PostToolUse"
+        },
+        "PostToolUse": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "supported",
+          "traceary_event": "command_executed",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use.json",
+          "variant_fixtures": [
+            "presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_missing.json",
+            "presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_denied.json"
+          ],
+          "note": "Missing and sandbox-denied reads still emit PostToolUse with FileNotFound or PermissionDenied result variants."
+        },
+        "PostToolUseFailure": {
+          "documented": true,
+          "observed": false,
+          "verification": "live_not_emitted",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "Not emitted by missing-file or sandbox-denied read probes in 0.2.99; those failures arrived through PostToolUse."
+        },
+        "PermissionDenied": {
+          "documented": true,
+          "observed": false,
+          "verification": "live_not_emitted",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "A kernel-sandbox denied read emitted PostToolUse with a PermissionDenied result variant instead."
+        },
+        "Stop": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "best_effort",
+          "traceary_event": "transcript",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/stop.json",
+          "note": "Turn boundary with promptId, reason, and transcriptPath; no assistant body or model field."
+        },
+        "StopFailure": {
+          "documented": true,
+          "observed": false,
+          "verification": "not_safely_triggered",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "No API failure was intentionally induced in the live probe."
+        },
+        "SubagentStart": {
+          "documented": true,
+          "observed": false,
+          "verification": "not_probed_policy_gate",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "External Grok subagents remained disabled; no parent/child field contract is claimed."
+        },
+        "SubagentStop": {
+          "documented": true,
+          "observed": false,
+          "verification": "not_probed_policy_gate",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "External Grok subagents remained disabled; no parent/child field contract is claimed."
+        },
+        "PreCompact": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "best_effort",
+          "traceary_event": "compact_summary",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/pre_compact.json",
+          "note": "Manual compact marker; no summary body is exposed."
+        },
+        "PostCompact": {
+          "documented": true,
+          "observed": true,
+          "verification": "live_observed",
+          "traceary_support": "best_effort",
+          "traceary_event": "compact_summary",
+          "fixture": "presentation/cli/testdata/grok_hooks/v0.2.99/post_compact.json",
+          "note": "Manual compact completion marker; no summary body is exposed."
+        },
+        "SessionEnd": {
+          "documented": true,
+          "observed": false,
+          "verification": "live_not_emitted",
+          "traceary_support": "unavailable",
+          "traceary_event": null,
+          "fixture": null,
+          "note": "Not emitted on headless completion, TUI /quit, or TUI /new in 0.2.99."
+        }
+      }
+    }
+  }
+}

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -10,22 +10,24 @@
 - `○` ホスト側に hook はあるが Traceary 未配線
 - `✕` ホスト自体が公開していない
 
-**最終確認日: 2026-07-13（Antigravity CLI 1.1.1 と現行公式 hook contract を再確認。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
+**最終確認日: 2026-07-14（Grok Build 0.2.99 の live payload、Antigravity CLI 1.1.1 と現行公式 hook contract を確認。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
 
 > **v0.21.1 注記:** このマトリクスに掲載されている Gemini CLI の hook カバレッジは**レガシー互換のみ**です。Gemini CLI はレガシーの Google AI エージェントホストであり、後継は Antigravity（`/Applications/Antigravity.app`）です。**v0.21.1 以降、Antigravity はサポート対象の hook client** であり、文書化された公開 hook surface に対する packaged plugin（`integrations/antigravity-plugin/`）を提供します。[Antigravity hooks / plugin ガイド](../integrations/antigravity.ja.md) を参照してください。
 
 ## ライフサイクルイベント → ホスト hook マトリクス
 
-| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | 確認方法 |
-|---|---|---|---|---|---|
-| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation`（`conversationId` を key にした冪等開始。Antigravity に `SessionStart` はない） | `traceary list events --kind session_started --limit 5` |
-| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ● `Stop`（直接の prompt field は無い。`transcriptPath` の最新 `USER_INPUT` / `USER_EXPLICIT` 行から復元） | `traceary list events --kind prompt --limit 5` |
-| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse`（`run_command`。command args は `conversationId + stepIdx` で 2 event をまたいで突き合わせ） | `traceary list events --kind command_executed --limit 5` |
-| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop`（`transcriptPath`、best-effort な寛容 JSONL 走査） | `traceary list events --kind transcript --limit 5` |
-| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ● `PreCompact` + `PostCompact` marker（`trigger` のみ。Codex は圧縮後サマリー本文を公開しない） | ● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない) | ✕ 文書化された compact hook なし | `traceary list events --kind compact_summary --limit 5` |
-| `session_ended` | ● `SessionEnd` | ✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ● `SessionEnd` | ✕ host のセッション終了信号なし — Antigravity `Stop` は execution 単位の境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | `traceary list events --kind session_ended --limit 5` |
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Grok Build 0.2.99 | 確認方法 |
+|---|---|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation`（`conversationId` を key にした冪等開始。Antigravity に `SessionStart` はない） | ○ `SessionStart`（live で確認済み。native runtime 配線は #1275） | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ● `Stop`（直接の prompt field は無い。`transcriptPath` の最新 `USER_INPUT` / `USER_EXPLICIT` 行から復元） | ○ `UserPromptSubmit`（`prompt`、`promptId`、`transcriptPath` を live で確認） | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse`（`run_command`。command args は `conversationId + stepIdx` で 2 event をまたいで突き合わせ） | ○ `PreToolUse` + `PostToolUse`（`toolUseId` で対応付け。missing/denied read は `PostToolUse` の result variant） | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop`（`transcriptPath`、best-effort な寛容 JSONL 走査） | ○ `Stop`（`transcriptPath` のみ。hook payload に assistant 本文と model はない） | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ● `PreCompact` + `PostCompact` marker（`trigger` のみ。Codex は圧縮後サマリー本文を公開しない） | ● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない) | ✕ 文書化された compact hook なし | ○ `PreCompact` + `PostCompact`（live で確認した marker。summary 本文なし） | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ● `SessionEnd` | ✕ host のセッション終了信号なし — Antigravity `Stop` は execution 単位の境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ○ `SessionEnd` は文書化済みだが、headless 完了・TUI `/quit`・TUI `/new` の probe では未発火 | `traceary list events --kind session_ended --limit 5` |
 
 > **Antigravity headless `agy --print`:** 現行 CLI は `PreInvocation`、必要に応じて `PreToolUse`/`PostToolUse`、および `transcriptPath` 付き `Stop` を発行します。Traceary は Stop で prompt と transcript を復元します。実行時の欠落は `antigravity-event-coverage` が DB 証拠から検出します。hook event は `client=hook`, `agent=antigravity` で記録されるため、`traceary list --agent antigravity` で確認してください。
+
+> **Grok Build 0.2.99 contract:** sanitized な空 workspace で `SessionStart`、`UserPromptSubmit`、`PreToolUse`、`PostToolUse`、`Stop`、`PreCompact`、`PostCompact` を live capture しました。`PostToolUseFailure`、`PermissionDenied`、`SessionEnd` は文書化されていますが、対応する failure / denial / end probe では発火せず、`FileNotFound` と `PermissionDenied` は `PostToolUse.toolResult` の variant として返りました。`StopFailure` は意図的に API error を起こしておらず、Grok subagent は外部 agent policy gate に従って無効のままです。そのため Traceary は未観測 event を v0.23 の対応対象として主張しません。field 単位の証拠は [`host-contract.json`](./host-contract.json) にあります。
 
 ### Traceary 未配線のホスト hook
 
@@ -40,6 +42,8 @@
 | Codex CLI | `PreToolUse`, `PermissionRequest` | ○ 利用可 | 未配線 |
 | Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ 利用可 | 未配線 |
 | Antigravity | `run_command` 以外の tool に対する `PreToolUse` | ○ 利用可 | audit 対象は `run_command` のみ |
+| Grok Build | `PostToolUseFailure`, `PermissionDenied`, `SessionEnd`, `StopFailure` | ○ 文書化済み、0.2.99 live 未確認 | live payload を確認するまで Traceary では利用不可。tool denial は現状 `PostToolUse` で到達 |
+| Grok Build | `SubagentStart`, `SubagentStop` | ○ 文書化済み、policy gate により probe 保留 | parent/child field contract は未確定 |
 
 ## ホスト別参照
 
@@ -47,6 +51,7 @@
 - Codex CLI: Codex CLI 0.144.1 の公式 hook reference（`SessionStart`, `SubagentStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `UserPromptSubmit`, `SubagentStop`, `Stop`）。 パッケージ config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
 - Gemini CLI: ローカルインストール同梱の hooks reference (`/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`。文書化された hook surface に post-compress event はなく、`PreCompress` は compression 前に非同期で発火する advisory-only hook). パッケージ config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
 - Antigravity: 公開 hook surface は https://www.antigravity.google/docs/hooks および https://antigravity.google/assets/docs/editor/ide-hooks.md、plugin packaging は https://antigravity.google/assets/docs/cli/cli-plugins.md に文書化（2026-06-20 JST 確認）。パッケージ config: [`integrations/antigravity-plugin/hooks.json`](../../integrations/antigravity-plugin/hooks.json)
+- Grok Build: 公式 hook surface は https://docs.x.ai/build/features/hooks（最終更新 2026-07-02）。0.2.99 の live payload contract は [`host-contract.json`](./host-contract.json)、sanitized fixture は [`presentation/cli/testdata/grok_hooks/v0.2.99`](../../presentation/cli/testdata/grok_hooks/v0.2.99/) を参照
 
 ## 更新方法
 

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -44,6 +44,7 @@
 | Antigravity | `run_command` 以外の tool に対する `PreToolUse` | ○ 利用可 | audit 対象は `run_command` のみ |
 | Grok Build | `PostToolUseFailure`, `PermissionDenied`, `SessionEnd`, `StopFailure` | ○ 文書化済み、0.2.99 live 未確認 | live payload を確認するまで Traceary では利用不可。tool denial は現状 `PostToolUse` で到達 |
 | Grok Build | `SubagentStart`, `SubagentStop` | ○ 文書化済み、policy gate により probe 保留 | parent/child field contract は未確定 |
+| Grok Build | `Notification` | ○ 文書化済み、未検証 | Traceary lifecycle event への対応付けがなく、利用不可 |
 
 ## ホスト別参照
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -10,22 +10,24 @@ Legend:
 - `○` available in the host but not wired by Traceary yet
 - `✕` not exposed by this host
 
-**Last verified: 2026-07-13 (Antigravity CLI 1.1.1 and the current official hook contract re-verified; Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
+**Last verified: 2026-07-14 (Grok Build 0.2.99 live payloads; Antigravity CLI 1.1.1 and the current official hook contract; Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
 
 > **v0.21.1 note:** Gemini CLI hook coverage in this matrix is **legacy compatibility only**. Gemini CLI is the legacy Google AI agent host; Antigravity (`/Applications/Antigravity.app`) is the active successor. As of **v0.21.1, Antigravity is a supported hook client** with a packaged plugin against the documented public hook surface (`integrations/antigravity-plugin/`). See the [Antigravity hooks and plugin guide](../integrations/antigravity.md).
 
 ## Lifecycle event → host hook matrix
 
-| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Verification |
-|---|---|---|---|---|---|
-| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation` (idempotent, keyed by `conversationId`; Antigravity has no `SessionStart`) | `traceary list events --kind session_started --limit 5` |
-| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ● `Stop` (no direct prompt field; recovered from the latest `USER_INPUT` / `USER_EXPLICIT` row at `transcriptPath`) | `traceary list events --kind prompt --limit 5` |
-| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse` (`run_command`; command args paired across the two events by `conversationId + stepIdx`) | `traceary list events --kind command_executed --limit 5` |
-| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop` (`transcriptPath`, best-effort lenient JSONL scan) | `traceary list events --kind transcript --limit 5` |
-| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ● `PreCompact` + `PostCompact` markers (`trigger` only; Codex exposes no compacted summary body) | ● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary) | ✕ no documented compact hook | `traceary list events --kind compact_summary --limit 5` |
-| `session_ended` | ● `SessionEnd` | ✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ● `SessionEnd` | ✕ no host session-end signal — Antigravity `Stop` is a per-execution boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | `traceary list events --kind session_ended --limit 5` |
+| Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Grok Build 0.2.99 | Verification |
+|---|---|---|---|---|---|---|
+| `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation` (idempotent, keyed by `conversationId`; Antigravity has no `SessionStart`) | ○ `SessionStart` (live-observed; native runtime wiring is tracked in #1275) | `traceary list events --kind session_started --limit 5` |
+| `prompt` | ● `UserPromptSubmit` | ● `UserPromptSubmit` | ● `BeforeAgent` | ● `Stop` (no direct prompt field; recovered from the latest `USER_INPUT` / `USER_EXPLICIT` row at `transcriptPath`) | ○ `UserPromptSubmit` (`prompt`, `promptId`, `transcriptPath` live-observed) | `traceary list events --kind prompt --limit 5` |
+| `command_executed` | ● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher) | ● `PostToolUse` | ● `AfterTool` | ● `PreToolUse` + `PostToolUse` (`run_command`; command args paired across the two events by `conversationId + stepIdx`) | ○ `PreToolUse` + `PostToolUse` (`toolUseId` correlation; missing/denied reads are `PostToolUse` result variants) | `traceary list events --kind command_executed --limit 5` |
+| `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop` (`transcriptPath`, best-effort lenient JSONL scan) | ○ `Stop` (`transcriptPath` only; no assistant body or model in the hook payload) | `traceary list events --kind transcript --limit 5` |
+| `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ● `PreCompact` + `PostCompact` markers (`trigger` only; Codex exposes no compacted summary body) | ● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary) | ✕ no documented compact hook | ○ `PreCompact` + `PostCompact` (live-observed markers; no summary body) | `traceary list events --kind compact_summary --limit 5` |
+| `session_ended` | ● `SessionEnd` | ✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ● `SessionEnd` | ✕ no host session-end signal — Antigravity `Stop` is a per-execution boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ○ documented `SessionEnd`, but not emitted by headless completion, TUI `/quit`, or TUI `/new` probes | `traceary list events --kind session_ended --limit 5` |
 
 > **Antigravity headless `agy --print`:** the current CLI emits `PreInvocation`, `PreToolUse`/`PostToolUse` when needed, and `Stop` with `transcriptPath`. Traceary recovers prompt and transcript at Stop. `antigravity-event-coverage` detects runtime gaps from database evidence. Hook events are stored with `client=hook`, `agent=antigravity`, so verify them with `traceary list --agent antigravity`.
+
+> **Grok Build 0.2.99 contract:** `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact`, and `PostCompact` were captured live in sanitized empty workspaces. `PostToolUseFailure`, `PermissionDenied`, and `SessionEnd` were documented but did not fire in the corresponding failure/denial/end probes; Grok returned `FileNotFound` and `PermissionDenied` as nested `PostToolUse.toolResult` variants. `StopFailure` was not intentionally induced, and Grok subagents remained disabled by the external-agent policy gate. Traceary therefore makes no v0.23 support claim for those unobserved events. The field-level evidence is in [`host-contract.json`](./host-contract.json).
 
 ### Other host hooks Traceary does not wire today
 
@@ -40,6 +42,8 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 | Codex CLI | `PreToolUse`, `PermissionRequest` | ○ available | not wired |
 | Gemini CLI | `BeforeTool`, `BeforeToolSelection`, `BeforeModel`, `AfterModel`, `Notification` | ○ available | not wired |
 | Antigravity | `PreToolUse` for non-`run_command` tools | ○ available | only `run_command` is audited |
+| Grok Build | `PostToolUseFailure`, `PermissionDenied`, `SessionEnd`, `StopFailure` | ○ documented, not live-confirmed on 0.2.99 | unavailable to Traceary until a live payload is observed; tool denial currently arrives through `PostToolUse` |
+| Grok Build | `SubagentStart`, `SubagentStop` | ○ documented, policy-gated probe pending | no parent/child field contract is claimed |
 
 ## Per-host references
 
@@ -47,6 +51,7 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 - Codex CLI: official Codex CLI 0.144.1 hook reference (`SessionStart`, `SubagentStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `UserPromptSubmit`, `SubagentStop`, `Stop`). Packaged config: [`plugins/traceary/hooks.json`](../../plugins/traceary/hooks.json)
 - Gemini CLI: hooks reference shipped with the local install at `/opt/homebrew/Cellar/gemini-cli/0.43.0/libexec/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md` (no post-compress event in the documented hook surface; `PreCompress` is advisory-only and fires asynchronously before compression). Packaged config: [`integrations/gemini-extension/hooks/hooks.json`](../../integrations/gemini-extension/hooks/hooks.json)
 - Antigravity: public hook surface documented at https://www.antigravity.google/docs/hooks and https://antigravity.google/assets/docs/editor/ide-hooks.md; plugin packaging at https://antigravity.google/assets/docs/cli/cli-plugins.md (verified 2026-06-20 JST). Packaged config: [`integrations/antigravity-plugin/hooks.json`](../../integrations/antigravity-plugin/hooks.json)
+- Grok Build: official hook surface at https://docs.x.ai/build/features/hooks (last updated 2026-07-02); live 0.2.99 payload contract: [`host-contract.json`](./host-contract.json); sanitized fixtures: [`presentation/cli/testdata/grok_hooks/v0.2.99`](../../presentation/cli/testdata/grok_hooks/v0.2.99/)
 
 ## Maintenance
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -44,6 +44,7 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 | Antigravity | `PreToolUse` for non-`run_command` tools | ○ available | only `run_command` is audited |
 | Grok Build | `PostToolUseFailure`, `PermissionDenied`, `SessionEnd`, `StopFailure` | ○ documented, not live-confirmed on 0.2.99 | unavailable to Traceary until a live payload is observed; tool denial currently arrives through `PostToolUse` |
 | Grok Build | `SubagentStart`, `SubagentStop` | ○ documented, policy-gated probe pending | no parent/child field contract is claimed |
+| Grok Build | `Notification` | ○ documented, not probed | no Traceary lifecycle mapping; unavailable |
 
 ## Per-host references
 

--- a/presentation/cli/hook_grok_contract_test.go
+++ b/presentation/cli/hook_grok_contract_test.go
@@ -1,0 +1,213 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type grokHostContract struct {
+	Hosts struct {
+		Grok struct {
+			Events map[string]grokContractEvent `json:"events"`
+		} `json:"grok"`
+	} `json:"hosts"`
+}
+
+type grokContractEvent struct {
+	Observed        bool     `json:"observed"`
+	TracearySupport string   `json:"traceary_support"`
+	Fixture         *string  `json:"fixture"`
+	VariantFixtures []string `json:"variant_fixtures"`
+	Note            string   `json:"note"`
+}
+
+func TestGrokHostContract(t *testing.T) {
+	t.Parallel()
+
+	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
+	contractPath := filepath.Join(repositoryRoot, "docs", "hooks", "host-contract.json")
+	contractBytes, err := os.ReadFile(contractPath)
+	if err != nil {
+		t.Fatalf("read Grok host contract: %v", err)
+	}
+
+	var contract grokHostContract
+	if err := json.Unmarshal(contractBytes, &contract); err != nil {
+		t.Fatalf("decode Grok host contract: %v", err)
+	}
+
+	expectedHookNames := map[string]string{
+		"SessionStart":     "session_start",
+		"UserPromptSubmit": "user_prompt_submit",
+		"PreToolUse":       "pre_tool_use",
+		"PostToolUse":      "post_tool_use",
+		"Stop":             "stop",
+		"PreCompact":       "pre_compact",
+		"PostCompact":      "post_compact",
+	}
+	referencedFixtures := make(map[string]struct{})
+
+	for eventName, event := range contract.Hosts.Grok.Events {
+		t.Run(eventName, func(t *testing.T) {
+			switch event.TracearySupport {
+			case "supported", "best_effort":
+				if !event.Observed {
+					t.Fatal("supported Grok event must be live-observed")
+				}
+				if event.Fixture == nil {
+					t.Fatal("supported Grok event must reference a fixture")
+				}
+				expectedHookName, ok := expectedHookNames[eventName]
+				if !ok {
+					t.Fatal("supported Grok event has no expected hook name")
+				}
+				referencedFixtures[*event.Fixture] = struct{}{}
+				validateGrokFixture(t, repositoryRoot, *event.Fixture, expectedHookName)
+				for _, fixture := range event.VariantFixtures {
+					referencedFixtures[fixture] = struct{}{}
+					validateGrokFixture(t, repositoryRoot, fixture, expectedHookName)
+				}
+			case "unavailable":
+				if event.Observed {
+					t.Fatal("unavailable Grok event must not be marked live-observed")
+				}
+				if event.Fixture != nil {
+					t.Fatal("unavailable Grok event must not reference a fixture")
+				}
+				if strings.TrimSpace(event.Note) == "" {
+					t.Fatal("unavailable Grok event must explain the limitation")
+				}
+			default:
+				t.Fatalf("unknown Traceary support level %q", event.TracearySupport)
+			}
+		})
+	}
+
+	fixtureDirectory := filepath.Join(repositoryRoot, "presentation", "cli", "testdata", "grok_hooks", "v0.2.99")
+	fixtures, err := filepath.Glob(filepath.Join(fixtureDirectory, "*.json"))
+	if err != nil {
+		t.Fatalf("list Grok fixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no Grok fixtures found")
+	}
+	for _, fixture := range fixtures {
+		repositoryRelativeFixture, err := filepath.Rel(repositoryRoot, fixture)
+		if err != nil {
+			t.Fatalf("resolve repository-relative Grok fixture path: %v", err)
+		}
+		repositoryRelativeFixture = filepath.ToSlash(repositoryRelativeFixture)
+		if _, ok := referencedFixtures[repositoryRelativeFixture]; !ok {
+			t.Errorf("Grok fixture %s is not referenced by the host contract", repositoryRelativeFixture)
+		}
+		fixtureBytes, err := os.ReadFile(fixture)
+		if err != nil {
+			t.Fatalf("read Grok fixture %s: %v", fixture, err)
+		}
+		for _, privateValue := range []string{"/Users/", "/private/tmp/", "duck8823"} {
+			if strings.Contains(string(fixtureBytes), privateValue) {
+				t.Errorf("Grok fixture %s contains private value %q", fixture, privateValue)
+			}
+		}
+	}
+}
+
+func validateGrokFixture(t *testing.T, repositoryRoot, fixturePath, expectedHookName string) {
+	t.Helper()
+
+	expectedDirectory := filepath.Join("presentation", "cli", "testdata", "grok_hooks", "v0.2.99")
+	cleanFixturePath := filepath.Clean(filepath.FromSlash(fixturePath))
+	if filepath.Dir(cleanFixturePath) != expectedDirectory {
+		t.Fatalf("Grok fixture %s must be directly under %s", fixturePath, filepath.ToSlash(expectedDirectory))
+	}
+
+	fixtureBytes, err := os.ReadFile(filepath.Join(repositoryRoot, cleanFixturePath))
+	if err != nil {
+		t.Fatalf("read Grok fixture %s: %v", fixturePath, err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(fixtureBytes, &payload); err != nil {
+		t.Fatalf("decode Grok fixture %s: %v", fixturePath, err)
+	}
+
+	requireStringField(t, payload, "hookEventName")
+	if payload["hookEventName"] != expectedHookName {
+		t.Fatalf("hookEventName = %v, want %q", payload["hookEventName"], expectedHookName)
+	}
+	for _, field := range []string{"sessionId", "cwd", "workspaceRoot", "timestamp"} {
+		requireStringField(t, payload, field)
+	}
+
+	switch expectedHookName {
+	case "session_start":
+		requireStringField(t, payload, "source")
+		if _, exists := payload["transcriptPath"]; exists {
+			t.Error("SessionStart fixture must preserve observed absence of transcriptPath")
+		}
+	case "user_prompt_submit":
+		for _, field := range []string{"prompt", "promptId", "transcriptPath"} {
+			requireStringField(t, payload, field)
+		}
+	case "pre_tool_use":
+		validateGrokToolFields(t, payload)
+		requireStringField(t, payload, "permissionMode")
+	case "post_tool_use":
+		validateGrokToolFields(t, payload)
+		requireObjectField(t, payload, "toolResult")
+		requireBoolField(t, payload, "toolResultTruncated")
+		requireBoolField(t, payload, "isBackgrounded")
+	case "stop":
+		for _, field := range []string{"promptId", "reason", "transcriptPath"} {
+			requireStringField(t, payload, field)
+		}
+	case "pre_compact", "post_compact":
+		for _, field := range []string{"source", "transcriptPath"} {
+			requireStringField(t, payload, field)
+		}
+		if _, exists := payload["summary"]; exists {
+			t.Error("compact fixture must preserve observed absence of summary body")
+		}
+	default:
+		t.Fatalf("unsupported fixture hookEventName %q", expectedHookName)
+	}
+}
+
+func validateGrokToolFields(t *testing.T, payload map[string]any) {
+	t.Helper()
+	for _, field := range []string{"toolName", "toolUseId", "transcriptPath"} {
+		requireStringField(t, payload, field)
+	}
+	requireObjectField(t, payload, "toolInput")
+	requireBoolField(t, payload, "toolInputTruncated")
+}
+
+func requireStringField(t *testing.T, payload map[string]any, field string) {
+	t.Helper()
+	value, ok := payload[field].(string)
+	if !ok || value == "" {
+		t.Errorf("%s must be a non-empty string, got %s", field, describeValue(payload[field]))
+	}
+}
+
+func requireBoolField(t *testing.T, payload map[string]any, field string) {
+	t.Helper()
+	if _, ok := payload[field].(bool); !ok {
+		t.Errorf("%s must be a boolean, got %s", field, describeValue(payload[field]))
+	}
+}
+
+func requireObjectField(t *testing.T, payload map[string]any, field string) {
+	t.Helper()
+	if _, ok := payload[field].(map[string]any); !ok {
+		t.Errorf("%s must be an object, got %s", field, describeValue(payload[field]))
+	}
+}
+
+func describeValue(value any) string {
+	return fmt.Sprintf("%T(%v)", value, value)
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/post_compact.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/post_compact.json
@@ -1,0 +1,9 @@
+{
+  "hookEventName": "post_compact",
+  "sessionId": "019f0000-0000-7000-8000-000000000004",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:03:03Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "source": "manual"
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use.json
@@ -1,0 +1,25 @@
+{
+  "hookEventName": "post_tool_use",
+  "sessionId": "019f0000-0000-7000-8000-000000000001",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:00:03Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "toolName": "read_file",
+  "toolUseId": "tool-contract-probe-1",
+  "toolInput": {"target_file": "VERSION"},
+  "toolInputTruncated": false,
+  "toolResult": {
+    "type": "ReadFile",
+    "FileContent": {
+      "content": "1→0.0.0-contract-probe\n",
+      "content_concise": "1→0.0.0-contract-probe\n",
+      "absolute_path": "/workspace/traceary-contract-probe/VERSION",
+      "offset": null,
+      "raw_output": "0.0.0-contract-probe\n",
+      "total_lines": 2
+    }
+  },
+  "toolResultTruncated": false,
+  "isBackgrounded": false
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_denied.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_denied.json
@@ -1,0 +1,18 @@
+{
+  "hookEventName": "post_tool_use",
+  "sessionId": "019f0000-0000-7000-8000-000000000003",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:02:03Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "toolName": "read_file",
+  "toolUseId": "tool-contract-probe-3",
+  "toolInput": {"target_file": "DENIED.txt"},
+  "toolInputTruncated": false,
+  "toolResult": {
+    "type": "ReadFile",
+    "PermissionDenied": "Permission denied: /workspace/traceary-contract-probe/DENIED.txt"
+  },
+  "toolResultTruncated": false,
+  "isBackgrounded": false
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_missing.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/post_tool_use_missing.json
@@ -1,0 +1,18 @@
+{
+  "hookEventName": "post_tool_use",
+  "sessionId": "019f0000-0000-7000-8000-000000000002",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:01:03Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "toolName": "read_file",
+  "toolUseId": "tool-contract-probe-2",
+  "toolInput": {"target_file": "MISSING_CONTRACT_PROBE.txt"},
+  "toolInputTruncated": false,
+  "toolResult": {
+    "type": "ReadFile",
+    "FileNotFound": "Error: /workspace/traceary-contract-probe/MISSING_CONTRACT_PROBE.txt does not exist.\nNote: your current working directory is /workspace/traceary-contract-probe"
+  },
+  "toolResultTruncated": false,
+  "isBackgrounded": false
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/pre_compact.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/pre_compact.json
@@ -1,0 +1,9 @@
+{
+  "hookEventName": "pre_compact",
+  "sessionId": "019f0000-0000-7000-8000-000000000004",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:03:00Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "source": "manual"
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/pre_tool_use.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/pre_tool_use.json
@@ -1,0 +1,13 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "019f0000-0000-7000-8000-000000000001",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:00:02Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "toolName": "read_file",
+  "toolUseId": "tool-contract-probe-1",
+  "toolInput": {"target_file": "VERSION"},
+  "toolInputTruncated": false,
+  "permissionMode": "auto"
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/session_start.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hookEventName": "session_start",
+  "sessionId": "019f0000-0000-7000-8000-000000000001",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:00:00Z",
+  "source": "new"
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/stop.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/stop.json
@@ -1,0 +1,10 @@
+{
+  "hookEventName": "stop",
+  "sessionId": "019f0000-0000-7000-8000-000000000001",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:00:04Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "promptId": "prompt-contract-probe-1",
+  "reason": "end_turn"
+}

--- a/presentation/cli/testdata/grok_hooks/v0.2.99/user_prompt_submit.json
+++ b/presentation/cli/testdata/grok_hooks/v0.2.99/user_prompt_submit.json
@@ -1,0 +1,10 @@
+{
+  "hookEventName": "user_prompt_submit",
+  "sessionId": "019f0000-0000-7000-8000-000000000001",
+  "cwd": "/workspace/traceary-contract-probe",
+  "workspaceRoot": "/workspace/traceary-contract-probe",
+  "timestamp": "2026-07-14T00:00:01Z",
+  "transcriptPath": "/workspace/.grok/sessions/contract-probe/events.jsonl",
+  "promptId": "prompt-contract-probe-1",
+  "prompt": "contract probe"
+}


### PR DESCRIPTION
## Motivation

Traceary must freeze Grok Build parser behavior from payloads observed on the installed host rather than infer it from the broader upstream hook documentation. The contract also needs to make limitations explicit before runtime integration work starts.

## Changes

- add a versioned, machine-readable Grok Build 0.2.99 host contract
- add sanitized fixtures for every live-observed supported or best-effort event
- distinguish documented-but-unobserved events as unavailable
- document the Grok lifecycle coverage in English and Japanese
- validate fixture shape, contract references, result variants, and private-data exclusions

## Validation

- `go test ./presentation/cli -run '^TestGrokHostContract$' -count=1`
- `go run ./cmd/repo-tooling docs verify-i18n`
- `go test ./...`
- `go tool golangci-lint run --timeout=5m`
- `go vet ./...`
- `git diff --check`
- `jq -e . docs/hooks/host-contract.json`
- private-path/value scan over committed contract fixtures

All checks passed. The Grok subagent payload probe remains policy-gated, so the contract explicitly marks subagent lifecycle events unavailable.

Closes #1273
