### PR TITLE
v0.23.0-5: package a native Traceary plugin for Grok Build

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -100,45 +100,76 @@ func checkGrok(root, version string) error {
 		return xerrors.Errorf("grok plugin version must track v%s", version)
 	}
 
-	var mcp struct {
-		Traceary struct {
-			Command string   `json:"command"`
-			Args    []string `json:"args"`
-		} `json:"traceary"`
+	var mcp map[string]struct {
+		Command string   `json:"command"`
+		Args    []string `json:"args"`
 	}
 	if err := readJSON(root, "integrations/grok-plugin/.mcp.json", &mcp); err != nil {
 		return err
 	}
-	if mcp.Traceary.Command != "traceary" || !equalStrings(mcp.Traceary.Args, []string{"mcp-server"}) {
+	server, ok := mcp["traceary"]
+	if len(mcp) != 1 || !ok || server.Command != "traceary" || !equalStrings(server.Args, []string{"mcp-server"}) {
 		return xerrors.Errorf("grok plugin must expose traceary mcp-server")
 	}
 
 	hooksPath := "integrations/grok-plugin/hooks/hooks.json"
-	hooks, raw, err := readHookFile(root, hooksPath)
+	hooks, _, err := readHookFile(root, hooksPath)
 	if err != nil {
 		return err
 	}
 	if err := checkNoDuplicateTracearyHookEntries(hooksPath, hooks); err != nil {
 		return err
 	}
-	for event, action := range map[string]string{
-		"SessionStart": "session-start", "UserPromptSubmit": "user-prompt-submit",
-		"PreToolUse": "pre-tool-use", "PostToolUse": "post-tool-use", "Stop": "stop",
-		"PreCompact": "pre-compact", "PostCompact": "post-compact",
-	} {
-		if _, ok := hooks.Hooks[event]; !ok {
-			return xerrors.Errorf("grok hooks must include %s", event)
-		}
-		if !strings.Contains(raw, "${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh") || !strings.Contains(raw, `\"`+action+`\"`) {
-			return xerrors.Errorf("grok %s hook must use the plugin-root wrapper action %s", event, action)
-		}
+	if err := checkGrokHooks(hooksPath, hooks); err != nil {
+		return err
 	}
 	if err := requireExists(root, "integrations/grok-plugin/scripts/traceary-grok.sh", "missing Grok hook wrapper"); err != nil {
 		return err
 	}
-	for _, skill := range []string{"traceary-session-history", "traceary-memory-review", "traceary-memory-remember"} {
+	expectedSkills := []string{"traceary-memory-remember", "traceary-memory-review", "traceary-session-history"}
+	entries, err := os.ReadDir(filepath.Join(root, "integrations/grok-plugin/skills"))
+	if err != nil {
+		return xerrors.Errorf("failed to read Grok skills: %w", err)
+	}
+	actualSkills := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			actualSkills = append(actualSkills, entry.Name())
+		}
+	}
+	if !equalStrings(actualSkills, expectedSkills) {
+		return xerrors.Errorf("grok plugin skills must be exactly %v, got %v", expectedSkills, actualSkills)
+	}
+	for _, skill := range expectedSkills {
 		if err := requireExists(root, "integrations/grok-plugin/skills/"+skill+"/SKILL.md", "missing Grok "+skill+" skill"); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func checkGrokHooks(path string, hooks hookFile) error {
+	required := []struct{ event, name, action string }{
+		{"SessionStart", "traceary-session-start", "session-start"},
+		{"UserPromptSubmit", "traceary-prompt", "user-prompt-submit"},
+		{"PreToolUse", "traceary-tool-pre", "pre-tool-use"},
+		{"PostToolUse", "traceary-audit", "post-tool-use"},
+		{"Stop", "traceary-stop", "stop"},
+		{"PreCompact", "traceary-compact-pre", "pre-compact"},
+		{"PostCompact", "traceary-compact-post", "post-compact"},
+	}
+	if len(hooks.Hooks) != len(required) {
+		return xerrors.Errorf("%s must expose exactly %d verified events", path, len(required))
+	}
+	for _, want := range required {
+		entries := hooks.Hooks[want.event]
+		if len(entries) != 1 || entries[0].Matcher != "" || len(entries[0].Hooks) != 1 {
+			return xerrors.Errorf("%s %s must contain exactly one unfiltered command", path, want.event)
+		}
+		command := entries[0].Hooks[0]
+		expectedCommand := `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + want.action + `"`
+		if command.Name != want.name || command.Type != "command" || command.Command != expectedCommand || command.Timeout != 5 {
+			return xerrors.Errorf("%s %s command drifted from the verified Grok contract", path, want.event)
 		}
 	}
 	return nil
@@ -598,6 +629,7 @@ type hookCommand struct {
 	Name    string `json:"name"`
 	Type    string `json:"type"`
 	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
 }
 
 func hookMatchers(entries []hookEntry) []string {

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -76,10 +76,72 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkGemini(root, version); err != nil {
 		return err
 	}
+	if err := checkGrok(root, version); err != nil {
+		return err
+	}
 	if err := checkAntigravity(root); err != nil {
 		return err
 	}
 	return checkDocs(root)
+}
+
+func checkGrok(root, version string) error {
+	var manifest struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := readJSON(root, "integrations/grok-plugin/plugin.json", &manifest); err != nil {
+		return err
+	}
+	if manifest.Name != "traceary" {
+		return xerrors.Errorf("unexpected Grok plugin name")
+	}
+	if manifest.Version != version {
+		return xerrors.Errorf("grok plugin version must track v%s", version)
+	}
+
+	var mcp struct {
+		Traceary struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		} `json:"traceary"`
+	}
+	if err := readJSON(root, "integrations/grok-plugin/.mcp.json", &mcp); err != nil {
+		return err
+	}
+	if mcp.Traceary.Command != "traceary" || !equalStrings(mcp.Traceary.Args, []string{"mcp-server"}) {
+		return xerrors.Errorf("grok plugin must expose traceary mcp-server")
+	}
+
+	hooksPath := "integrations/grok-plugin/hooks/hooks.json"
+	hooks, raw, err := readHookFile(root, hooksPath)
+	if err != nil {
+		return err
+	}
+	if err := checkNoDuplicateTracearyHookEntries(hooksPath, hooks); err != nil {
+		return err
+	}
+	for event, action := range map[string]string{
+		"SessionStart": "session-start", "UserPromptSubmit": "user-prompt-submit",
+		"PreToolUse": "pre-tool-use", "PostToolUse": "post-tool-use", "Stop": "stop",
+		"PreCompact": "pre-compact", "PostCompact": "post-compact",
+	} {
+		if _, ok := hooks.Hooks[event]; !ok {
+			return xerrors.Errorf("grok hooks must include %s", event)
+		}
+		if !strings.Contains(raw, "${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh") || !strings.Contains(raw, `\"`+action+`\"`) {
+			return xerrors.Errorf("grok %s hook must use the plugin-root wrapper action %s", event, action)
+		}
+	}
+	if err := requireExists(root, "integrations/grok-plugin/scripts/traceary-grok.sh", "missing Grok hook wrapper"); err != nil {
+		return err
+	}
+	for _, skill := range []string{"traceary-session-history", "traceary-memory-review", "traceary-memory-remember"} {
+		if err := requireExists(root, "integrations/grok-plugin/skills/"+skill+"/SKILL.md", "missing Grok "+skill+" skill"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func readVersion(root string) (string, error) {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -121,3 +121,45 @@ func TestRequirePackagedHookCommand_PassesOnExpectedCommand(t *testing.T) {
 		t.Fatalf("requirePackagedHookCommand() error = %v, want nil", err)
 	}
 }
+
+func TestCheckGrokHooksRejectsContractDrift(t *testing.T) {
+	t.Parallel()
+	valid := grokHookFixture()
+	if err := checkGrokHooks("hooks.json", valid); err != nil {
+		t.Fatalf("checkGrokHooks(valid) error = %v", err)
+	}
+
+	valid.Hooks["Stop"][0].Hooks[0].Command = `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "pre-compact"`
+	if err := checkGrokHooks("hooks.json", valid); err == nil {
+		t.Fatal("checkGrokHooks(action swap) error = nil")
+	}
+	valid = grokHookFixture()
+	valid.Hooks["Stop"][0].Hooks[0].Timeout = 4
+	if err := checkGrokHooks("hooks.json", valid); err == nil {
+		t.Fatal("checkGrokHooks(timeout drift) error = nil")
+	}
+	valid = grokHookFixture()
+	valid.Hooks["SubagentStart"] = valid.Hooks["SessionStart"]
+	if err := checkGrokHooks("hooks.json", valid); err == nil {
+		t.Fatal("checkGrokHooks(extra event) error = nil")
+	}
+}
+
+func grokHookFixture() hookFile {
+	hooks := map[string][]hookEntry{}
+	for _, spec := range []struct{ event, name, action string }{
+		{"SessionStart", "traceary-session-start", "session-start"},
+		{"UserPromptSubmit", "traceary-prompt", "user-prompt-submit"},
+		{"PreToolUse", "traceary-tool-pre", "pre-tool-use"},
+		{"PostToolUse", "traceary-audit", "post-tool-use"},
+		{"Stop", "traceary-stop", "stop"},
+		{"PreCompact", "traceary-compact-pre", "pre-compact"},
+		{"PostCompact", "traceary-compact-post", "post-compact"},
+	} {
+		hooks[spec.event] = []hookEntry{{Hooks: []hookCommand{{
+			Name: spec.name, Type: "command", Timeout: 5,
+			Command: `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + spec.action + `"`,
+		}}}}
+	}
+	return hookFile{Hooks: hooks}
+}

--- a/cmd/repo-tooling/release.go
+++ b/cmd/repo-tooling/release.go
@@ -28,6 +28,7 @@ var bumpManifests = []string{
 	"integrations/claude-plugin/.claude-plugin/plugin.json",
 	"integrations/antigravity-plugin/plugin.json",
 	"integrations/gemini-extension/gemini-extension.json",
+	"integrations/grok-plugin/plugin.json",
 	"plugins/traceary/.codex-plugin/plugin.json",
 }
 

--- a/integrations/grok-plugin/.mcp.json
+++ b/integrations/grok-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "traceary": {
+    "command": "traceary",
+    "args": [
+      "mcp-server"
+    ]
+  }
+}

--- a/integrations/grok-plugin/hooks/hooks.json
+++ b/integrations/grok-plugin/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "description": "Native Traceary lifecycle hooks for Grok Build.",
+  "hooks": {
+    "SessionStart": [{"hooks": [{"name": "traceary-session-start", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"session-start\"", "timeout": 5}]}],
+    "UserPromptSubmit": [{"hooks": [{"name": "traceary-prompt", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"user-prompt-submit\"", "timeout": 5}]}],
+    "PreToolUse": [{"hooks": [{"name": "traceary-tool-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-tool-use\"", "timeout": 5}]}],
+    "PostToolUse": [{"hooks": [{"name": "traceary-audit", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-tool-use\"", "timeout": 5}]}],
+    "Stop": [{"hooks": [{"name": "traceary-stop", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"stop\"", "timeout": 5}]}],
+    "PreCompact": [{"hooks": [{"name": "traceary-compact-pre", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"pre-compact\"", "timeout": 5}]}],
+    "PostCompact": [{"hooks": [{"name": "traceary-compact-post", "type": "command", "command": "\"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh\" \"post-compact\"", "timeout": 5}]}]
+  }
+}

--- a/integrations/grok-plugin/plugin.json
+++ b/integrations/grok-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "traceary",
+  "version": "0.22.0",
+  "description": "Local-first Traceary integration for Grok Build with MCP tools and native session, audit, transcript, and compact hooks.",
+  "author": {
+    "name": "Shunsuke Maeda",
+    "email": "duck8823@gmail.com"
+  }
+}

--- a/integrations/grok-plugin/scripts/traceary-grok.sh
+++ b/integrations/grok-plugin/scripts/traceary-grok.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+action="${1:?missing Grok hook action}"
+case "${action}" in
+  session-start|user-prompt-submit|pre-tool-use|post-tool-use|stop|pre-compact|post-compact) ;;
+  *)
+    printf 'unsupported Grok hook action: %s\n' "${action}" >&2
+    exit 64
+    ;;
+esac
+
+exec traceary hook grok "${action}"

--- a/integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: traceary-memory-remember
+description: Use ONLY when the user explicitly asks to remember a specific durable fact, decision, constraint, or preference. Trigger phrases — "覚えておいて", "remember that", "for the record", "save this as", "記憶しておいて", "メモして". Do NOT use for generic notes, status updates, or session summaries. The candidate lands in the review inbox; never auto-accepted.
+version: 1.0.0
+---
+
+# Traceary memory remember
+
+Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
+
+## Workflow
+
+1. **Confirm scope**. Pick exactly one of:
+   - `workspace` — applies to the current repo / workspace identifier (default for repo-scoped facts).
+   - `agent` — applies to a specific agent identity across workspaces.
+   - `session_family` — applies to a session family (rare; use only when the operator says so).
+2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
+3. **Build evidence_refs**. Each ref has `kind` and `value`. The `kind` is constrained to this enum:
+
+   | `kind` | Typical `value` |
+   | --- | --- |
+   | `event` | `events.id` (e.g. `evt-abc123…`) |
+   | `session` | `sessions.session_id` (e.g. `session-…`) |
+   | `url` | `https://…` |
+   | `file` | `docs/memory/README.md` |
+   | `issue` | `#462` |
+   | `pr` | `#468` |
+
+   Unknown values fail with `unknown evidence ref kind: <value>`. At minimum include the current `session` id.
+
+   For optional `artifact_refs[].kind` (used to point at follow-up reading material), the enum is **smaller** — `event` and `session` are NOT allowed:
+
+   | `kind` | Typical `value` |
+   | --- | --- |
+   | `url` | `https://grafana.internal/...` |
+   | `file` | `docs/architecture/redaction.md` |
+   | `issue` | `#462` |
+   | `pr` | `#468` |
+4. **Call `manage_memory`**:
+   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
+   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+
+   ```
+   manage_memory({
+     "action": "remember",
+     "type": "constraint",
+     "workspace": "<current workspace>",
+     "fact": "<short, durable statement>",
+     "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+   })
+   ```
+5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+
+## Guardrails
+
+- **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
+- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
+- **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
+- **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/grok-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: traceary-memory-review
+description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
+version: 1.1.0
+---
+
+# Traceary memory review
+
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to recap the current session. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+
+## Workflow
+
+1. **List candidates**. Call `query_memory` with `action="retrieve"` and `status=["candidate"]`. Default scope is the current workspace; broaden to agent / session_family only if the user says so.
+   ```
+   query_memory({
+     "action": "retrieve",
+     "status": ["candidate"],
+     "workspace": "<current workspace>",
+     "limit": 20
+   })
+   ```
+2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
+4. **Apply decisions** via `manage_memory`:
+   - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
+   - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+
+## Human fallback: `traceary memory inbox review`
+
+When the operator would rather drive the review themselves at the terminal — for example because they want to clear the inbox without an agent narrating each candidate, or the agent does not have enough scope to curate confidently — point them at the **interactive CLI**. This is the **preferred human fallback** for inbox review (added in v0.14, see #925).
+
+```sh
+traceary memory inbox review
+traceary memory inbox review --workspace <workspace> --type preference --limit 10
+```
+
+Properties to relay so the operator can decide whether the interactive flow fits:
+
+- TTY-only. Refuses to start without a TTY and exits with code `2`, printing batch-fallback guidance.
+- Same filter set as `memory inbox list` (`--workspace`, `--agent`, `--session-family`, `--type`, `--source`, `--include-hidden`, `--limit`).
+- Action keys: `a` accept, `x` reject, `s` skip, `e` edit/distill, `v` view evidence, `?` help, `q` quit.
+- Accept / reject reuse the same application use cases as `memory inbox accept|reject` — same dedupe, same status transitions.
+- Edit/distill **requires the operator to type a new fact** and routes through `traceary memory store distill --replace=supersede`; the candidate's LLM-authored text is never auto-accepted.
+
+## Script / batch fallback: `memory inbox list` + `memory inbox accept|reject`
+
+For non-interactive shells (CI, automation, headless agents, long pipelines) the agent or operator should fall back to the snapshot path. This is **distinct** from the interactive review above — pick this path when there is no TTY, when the ids to act on are already known, or when a script needs deterministic exit codes.
+
+```sh
+traceary memory inbox list --workspace <workspace> --json
+traceary memory inbox accept <memory-id>           # single id (positional)
+traceary memory inbox accept --ids id1,id2,id3     # batch
+traceary memory inbox reject <memory-id>
+traceary memory inbox reject --ids id1,id2,id3
+```
+
+`--id-only` is available on `accept` / `reject` for scripted callers that want only the resulting memory id on stdout.
+
+## Guardrails
+
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never accepts memory before the operator has seen the list.
+- **Never auto-accept candidate memories unless the user explicitly instructs it.** No silent batch accept, no "looks fine, let me approve them all" without a per-id operator decision. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint, and the same rule applies to the CLI fallbacks: do not run `memory inbox accept --ids ...` on the operator's behalf without a direct instruction.
+- **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
+- **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
+- **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: traceary-session-history
+description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
+version: 1.0.0
+---
+
+# Traceary session history
+
+Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
+
+## Preferred tools
+
+- `session_status(action="latest")`: most recent session metadata for the current workspace
+- `session_status(action="active")`: only when the question is specifically about an open session
+- `list_events`: quick recent history without a keyword query
+- `search`: keyword-driven lookups
+- `get_context`: summarize the lead-up around an event
+
+## Guardrails
+
+- Prefer MCP reads before direct SQLite inspection.
+- Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
+- Automatic hooks already cover session boundaries and shell command audits.

--- a/scripts/install-grok-plugin.sh
+++ b/scripts/install-grok-plugin.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="${ROOT_DIR}/integrations/grok-plugin"
+
+command -v grok >/dev/null 2>&1 || {
+  echo 'error: grok CLI is not installed' >&2
+  exit 69
+}
+
+grok plugin validate "${PLUGIN_DIR}"
+if grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary"'; then
+  grok plugin uninstall traceary
+fi
+grok plugin install --trust "${PLUGIN_DIR}"
+grok plugin details traceary

--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -92,11 +92,37 @@ run_codex() {
   echo 'ok: codex runtime probe completed'
 }
 
+run_grok() {
+  command -v grok >/dev/null 2>&1 || {
+    echo "skip: grok not found" >&2
+    return 0
+  }
+
+  local tmp_home
+  tmp_home="$(mktemp -d)"
+  HOME="${tmp_home}" grok plugin validate "${ROOT_DIR}/integrations/grok-plugin"
+  HOME="${tmp_home}" grok plugin install --trust "${ROOT_DIR}/integrations/grok-plugin"
+  local list_output details_output inspect_output tmp_cwd
+  list_output="$(HOME="${tmp_home}" grok plugin list --json)"
+  details_output="$(HOME="${tmp_home}" grok plugin details traceary)"
+  tmp_cwd="$(mktemp -d)"
+  inspect_output="$(HOME="${tmp_home}" grok --cwd "${tmp_cwd}" inspect --json)"
+  [[ "${list_output}" == *'"name":"traceary"'* || "${list_output}" == *'"name": "traceary"'* ]]
+  [[ "${details_output}" == *traceary* ]]
+  [[ "${details_output}" == *traceary-session-history* ]]
+  [[ "${inspect_output}" == *'"plugin_name": "traceary"'* ]]
+  [[ "${inspect_output}" == *'"mcpServers": 1'* ]]
+  HOME="${tmp_home}" grok plugin uninstall traceary
+  rm -rf "${tmp_home}" "${tmp_cwd}"
+  echo 'ok: grok plugin validation, install, inventory, and uninstall passed'
+}
+
 case "${TARGET}" in
   all)
     run_claude
     run_codex
     run_gemini
+    run_grok
     ;;
   claude)
     run_claude
@@ -107,8 +133,11 @@ case "${TARGET}" in
   gemini)
     run_gemini
     ;;
+  grok)
+    run_grok
+    ;;
   *)
-    echo "usage: $0 [all|claude|codex|gemini]" >&2
+    echo "usage: $0 [all|claude|codex|gemini|grok]" >&2
     exit 64
     ;;
 esac

--- a/scripts/verify_release_manifests.py
+++ b/scripts/verify_release_manifests.py
@@ -18,6 +18,7 @@ PLUGIN_MANIFESTS = [
     ROOT / 'integrations' / 'claude-plugin' / '.claude-plugin' / 'plugin.json',
     ROOT / 'integrations' / 'antigravity-plugin' / 'plugin.json',
     ROOT / 'integrations' / 'gemini-extension' / 'gemini-extension.json',
+    ROOT / 'integrations' / 'grok-plugin' / 'plugin.json',
     ROOT / 'plugins' / 'traceary' / '.codex-plugin' / 'plugin.json',
 ]
 


### PR DESCRIPTION
## Motivation

Grok Build can discover Traceary's Claude package through compatibility mode, but that gives the integration a foreign package identity and Claude-specific hook protocol. A native package is required for Grok-owned hooks, skills, and MCP inventory.

## Changes

- add `integrations/grok-plugin/` with a native manifest
- expose one `traceary mcp-server`, seven verified Grok hook events, and three shared session/memory skills
- invoke hooks through a `GROK_PLUGIN_ROOT`-relative validated wrapper
- add local validate/install/update helper
- extend repository, release-manifest, and integration smoke verification
- verify isolated `grok inspect --json` attributes hooks, skills, and MCP inventory to plugin `traceary`

## Validation

- `grok plugin validate integrations/grok-plugin`
- isolated `grok plugin install --trust`, list, details, inspect, and uninstall smoke
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- `go run ./cmd/repo-tooling integrations verify`
- release manifest verification, docs i18n, shell syntax, and diff checks

Closes #1277
