### PR TITLE
v0.23.0-6: diagnose native Grok integration health

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -328,6 +328,16 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			})
 			continue
 		}
+		if targetClient == "grok" {
+			state, probeErr := probeGrokDoctorState(ctx, resolvedProjectDir)
+			if probeErr != nil {
+				report.Checks = append(report.Checks, doctorCheck{Name: "grok-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect Grok installation: %v", "Grok installation の検査に失敗しました: %v", probeErr), Hint: Localize("run `grok inspect --json` and retry doctor after resolving the host error", "`grok inspect --json` のエラーを解消してから doctor を再実行してください")})
+			} else {
+				report.Checks = append(report.Checks, buildGrokDoctorChecks(state, input.currentVersion)...)
+			}
+			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, outputPath, resolvedProjectDir, input.coverageThreshold))
+			continue
+		}
 
 		var check doctorCheck
 		if targetClient == "codex" {

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -130,7 +130,8 @@ func grokHookFileHasVerifiedCoverage(path string) bool {
 		Timeout int    `json:"timeout"`
 	}
 	type route struct {
-		Hooks []command `json:"hooks"`
+		Matcher string    `json:"matcher"`
+		Hooks   []command `json:"hooks"`
 	}
 	var file struct {
 		Hooks map[string][]route `json:"hooks"`
@@ -152,7 +153,7 @@ func grokHookFileHasVerifiedCoverage(path string) bool {
 	}
 	for event, contract := range contracts {
 		routes, ok := file.Hooks[event]
-		if !ok || len(routes) != 1 || len(routes[0].Hooks) != 1 {
+		if !ok || len(routes) != 1 || routes[0].Matcher != "" || len(routes[0].Hooks) != 1 {
 			return false
 		}
 		got := routes[0].Hooks[0]

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -52,9 +52,8 @@ type grokInspectDocument struct {
 		Name     string `json:"name"`
 		Enabled  bool   `json:"enabled"`
 		Provides struct {
-			Skills     int  `json:"skills"`
-			Hooks      bool `json:"hooks"`
-			MCPServers int  `json:"mcpServers"`
+			Skills     int `json:"skills"`
+			MCPServers int `json:"mcpServers"`
 		} `json:"provides"`
 	} `json:"plugins"`
 }
@@ -103,7 +102,6 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		state.PluginEnabled = plugin.Enabled
 		state.MCPServers = plugin.Provides.MCPServers
 		state.Skills = plugin.Provides.Skills
-		state.NativeHooks = plugin.Provides.Hooks
 	}
 	for _, hook := range document.Hooks {
 		if hook.Source.Type == "project" {

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	grokDoctorLookPath = exec.LookPath
+	grokDoctorOutput   = func(ctx context.Context, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, "grok", args...).Output()
+	}
+)
+
+var grokVersionPattern = regexp.MustCompile(`grok\s+([^\s]+)`)
+var grokTracearyVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+type grokDoctorState struct {
+	CLIAvailable    bool
+	HostVersion     string
+	PluginInstalled bool
+	PluginEnabled   bool
+	PluginVersion   string
+	ProjectTrusted  bool
+	ProjectHooks    bool
+	NativeHooks     bool
+	MCPServers      int
+	Skills          int
+}
+
+type grokPluginListEntry struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type grokInspectDocument struct {
+	ProjectTrusted bool `json:"projectTrusted"`
+	Hooks          []struct {
+		Target string `json:"target"`
+		Source struct {
+			Type       string `json:"type"`
+			PluginName string `json:"plugin_name"`
+		} `json:"source"`
+	} `json:"hooks"`
+	Plugins []struct {
+		Name     string `json:"name"`
+		Enabled  bool   `json:"enabled"`
+		Provides struct {
+			Skills     int  `json:"skills"`
+			Hooks      bool `json:"hooks"`
+			MCPServers int  `json:"mcpServers"`
+		} `json:"provides"`
+	} `json:"plugins"`
+}
+
+func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorState, error) {
+	state := grokDoctorState{}
+	if _, err := grokDoctorLookPath("grok"); err != nil {
+		return state, nil
+	}
+	state.CLIAvailable = true
+	versionOutput, err := grokDoctorOutput(ctx, "--version")
+	if err != nil {
+		return state, xerrors.Errorf("failed to read Grok version: %w", err)
+	}
+	if match := grokVersionPattern.FindStringSubmatch(string(versionOutput)); len(match) == 2 {
+		state.HostVersion = match[1]
+	}
+	listOutput, err := grokDoctorOutput(ctx, "plugin", "list", "--json")
+	if err != nil {
+		return state, xerrors.Errorf("failed to list Grok plugins: %w", err)
+	}
+	var plugins []grokPluginListEntry
+	if err := json.Unmarshal(listOutput, &plugins); err != nil {
+		return state, xerrors.Errorf("failed to decode Grok plugin list: %w", err)
+	}
+	for _, plugin := range plugins {
+		if plugin.Name == "traceary" {
+			state.PluginInstalled = true
+			state.PluginVersion = plugin.Version
+			break
+		}
+	}
+	inspectOutput, err := grokDoctorOutput(ctx, "--cwd", projectDir, "inspect", "--json")
+	if err != nil {
+		return state, xerrors.Errorf("failed to inspect Grok configuration: %w", err)
+	}
+	var document grokInspectDocument
+	if err := json.Unmarshal(inspectOutput, &document); err != nil {
+		return state, xerrors.Errorf("failed to decode Grok inspection: %w", err)
+	}
+	state.ProjectTrusted = document.ProjectTrusted
+	for _, plugin := range document.Plugins {
+		if plugin.Name != "traceary" {
+			continue
+		}
+		state.PluginEnabled = plugin.Enabled
+		state.MCPServers = plugin.Provides.MCPServers
+		state.Skills = plugin.Provides.Skills
+		state.NativeHooks = plugin.Provides.Hooks
+	}
+	for _, hook := range document.Hooks {
+		if hook.Source.Type == "project" {
+			state.ProjectHooks = true
+		}
+		if hook.Source.PluginName == "traceary" && grokHookFileHasVerifiedCoverage(hook.Target) {
+			state.NativeHooks = true
+		}
+	}
+	return state, nil
+}
+
+func grokHookFileHasVerifiedCoverage(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var file struct {
+		Hooks map[string]json.RawMessage `json:"hooks"`
+	}
+	if json.Unmarshal(data, &file) != nil || len(file.Hooks) != 7 {
+		return false
+	}
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "PreCompact", "PostCompact"} {
+		if _, ok := file.Hooks[event]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doctorCheck {
+	if !state.CLIAvailable {
+		return []doctorCheck{{Name: "grok-cli", Status: doctorStatusFail, Message: Localize("Grok CLI is not installed", "Grok CLI がインストールされていません"), Hint: Localize("install Grok Build, then rerun doctor", "Grok Build をインストールして doctor を再実行してください")}}
+	}
+	checks := []doctorCheck{{Name: "grok-cli", Status: doctorStatusPass, Message: localizef("detected Grok CLI %s", "Grok CLI %s を検出しました", state.HostVersion)}}
+	if !state.PluginInstalled {
+		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: Localize("native Traceary Grok plugin is not installed", "native Traceary Grok plugin がインストールされていません"), Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
+		return checks
+	}
+	pluginStatus := doctorStatusPass
+	pluginMessage := localizef("native Traceary Grok plugin %s is installed and enabled", "native Traceary Grok plugin %s はインストール済みで有効です", state.PluginVersion)
+	pluginHint := ""
+	if !state.PluginEnabled {
+		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin is installed but disabled", "native Traceary Grok plugin はインストール済みですが無効です")
+		pluginHint = "grok plugin enable traceary"
+	} else if grokTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
+		pluginStatus = doctorStatusWarn
+		pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
+		pluginHint = "grok plugin update traceary"
+	}
+	checks = append(checks, doctorCheck{Name: "grok-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
+	trustStatus := doctorStatusPass
+	trustMessage := Localize("Grok project hooks are trusted or no project hook route is configured", "Grok project hook は信頼済み、または project hook route は未設定です")
+	if state.ProjectHooks && !state.ProjectTrusted {
+		trustStatus = doctorStatusWarn
+		trustMessage = Localize("Grok project hooks are configured but the project is not trusted", "Grok project hook は設定されていますが project が信頼されていません")
+	}
+	checks = append(checks, doctorCheck{Name: "grok-hook-trust", Status: trustStatus, Message: trustMessage, Hint: Localize("use Grok /hooks-trust for this project when project hooks are intended", "project hook を使用する場合は Grok の /hooks-trust で信頼してください")})
+	hookStatus := doctorStatusPass
+	hookMessage := Localize("native Grok hooks cover all seven verified events", "native Grok hook は検証済み7 eventをすべてカバーしています")
+	if !state.NativeHooks {
+		hookStatus, hookMessage = doctorStatusWarn, Localize("native Grok hook coverage is missing or incomplete", "native Grok hook coverage が不足しています")
+	}
+	checks = append(checks, doctorCheck{Name: "grok-hooks", Status: hookStatus, Message: hookMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
+	mcpStatus := doctorStatusPass
+	mcpMessage := Localize("native Grok plugin exposes one Traceary MCP server", "native Grok plugin は Traceary MCP server を1件公開しています")
+	if state.MCPServers != 1 {
+		mcpStatus = doctorStatusWarn
+		mcpMessage = localizef("native Grok plugin exposes %d Traceary MCP server entries; expected 1", "native Grok plugin の Traceary MCP server は %d 件です。1件必要です", state.MCPServers)
+	}
+	checks = append(checks, doctorCheck{Name: "grok-mcp", Status: mcpStatus, Message: mcpMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
+	skillStatus := doctorStatusPass
+	skillMessage := Localize("native Grok plugin exposes all three Traceary skills", "native Grok plugin は Traceary skill を3件すべて公開しています")
+	if state.Skills != 3 {
+		skillStatus = doctorStatusWarn
+		skillMessage = localizef("native Grok plugin exposes %d Traceary skills; expected 3", "native Grok plugin の Traceary skill は %d 件です。3件必要です", state.Skills)
+	}
+	checks = append(checks, doctorCheck{Name: "grok-skills", Status: skillStatus, Message: skillMessage, Hint: Localize("update or reinstall the native Traceary Grok plugin", "native Traceary Grok plugin を更新または再インストールしてください")})
+	return checks
+}

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -95,6 +96,9 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		return state, xerrors.Errorf("failed to decode Grok inspection: %w", err)
 	}
 	state.ProjectTrusted = document.ProjectTrusted
+	if info, statErr := os.Stat(filepath.Join(projectDir, ".grok", "hooks", "traceary.json")); statErr == nil && info.Mode().IsRegular() {
+		state.ProjectHooks = true
+	}
 	for _, plugin := range document.Plugins {
 		if plugin.Name != "traceary" {
 			continue
@@ -119,14 +123,41 @@ func grokHookFileHasVerifiedCoverage(path string) bool {
 	if err != nil {
 		return false
 	}
+	type command struct {
+		Name    string `json:"name"`
+		Type    string `json:"type"`
+		Command string `json:"command"`
+		Timeout int    `json:"timeout"`
+	}
+	type route struct {
+		Hooks []command `json:"hooks"`
+	}
 	var file struct {
-		Hooks map[string]json.RawMessage `json:"hooks"`
+		Hooks map[string][]route `json:"hooks"`
 	}
 	if json.Unmarshal(data, &file) != nil || len(file.Hooks) != 7 {
 		return false
 	}
-	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "PreCompact", "PostCompact"} {
-		if _, ok := file.Hooks[event]; !ok {
+	contracts := map[string]struct {
+		name   string
+		action string
+	}{
+		"SessionStart":     {name: "traceary-session-start", action: "session-start"},
+		"UserPromptSubmit": {name: "traceary-prompt", action: "user-prompt-submit"},
+		"PreToolUse":       {name: "traceary-tool-pre", action: "pre-tool-use"},
+		"PostToolUse":      {name: "traceary-audit", action: "post-tool-use"},
+		"Stop":             {name: "traceary-stop", action: "stop"},
+		"PreCompact":       {name: "traceary-compact-pre", action: "pre-compact"},
+		"PostCompact":      {name: "traceary-compact-post", action: "post-compact"},
+	}
+	for event, contract := range contracts {
+		routes, ok := file.Hooks[event]
+		if !ok || len(routes) != 1 || len(routes[0].Hooks) != 1 {
+			return false
+		}
+		got := routes[0].Hooks[0]
+		wantCommand := `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + contract.action + `"`
+		if got.Name != contract.name || got.Type != "command" || got.Command != wantCommand || got.Timeout != 5 {
 			return false
 		}
 	}

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGrokDoctorChecks(t *testing.T) {
+	healthy := grokDoctorState{CLIAvailable: true, HostVersion: "0.2.99", PluginInstalled: true, PluginEnabled: true, PluginVersion: "0.23.0", ProjectTrusted: true, NativeHooks: true, MCPServers: 1, Skills: 3}
+	tests := []struct {
+		name       string
+		mutate     func(*grokDoctorState)
+		check      string
+		status     string
+		messageSub string
+	}{
+		{name: "absent CLI", mutate: func(s *grokDoctorState) { *s = grokDoctorState{} }, check: "grok-cli", status: doctorStatusFail, messageSub: "not installed"},
+		{name: "absent plugin", mutate: func(s *grokDoctorState) { s.PluginInstalled = false }, check: "grok-plugin", status: doctorStatusWarn, messageSub: "not installed"},
+		{name: "version mismatch", mutate: func(s *grokDoctorState) { s.PluginVersion = "0.22.0" }, check: "grok-plugin", status: doctorStatusWarn, messageSub: "does not match"},
+		{name: "untrusted project hooks", mutate: func(s *grokDoctorState) { s.ProjectHooks, s.ProjectTrusted = true, false }, check: "grok-hook-trust", status: doctorStatusWarn, messageSub: "not trusted"},
+		{name: "missing MCP", mutate: func(s *grokDoctorState) { s.MCPServers = 0 }, check: "grok-mcp", status: doctorStatusWarn, messageSub: "0"},
+		{name: "missing skills", mutate: func(s *grokDoctorState) { s.Skills = 2 }, check: "grok-skills", status: doctorStatusWarn, messageSub: "2"},
+		{name: "missing hooks", mutate: func(s *grokDoctorState) { s.NativeHooks = false }, check: "grok-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
+		{name: "healthy", mutate: func(*grokDoctorState) {}, check: "grok-plugin", status: doctorStatusPass, messageSub: "enabled"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := healthy
+			tc.mutate(&state)
+			checks := buildGrokDoctorChecks(state, "0.23.0")
+			var found *doctorCheck
+			for i := range checks {
+				if checks[i].Name == tc.check {
+					found = &checks[i]
+					break
+				}
+			}
+			if found == nil || found.Status != tc.status || !strings.Contains(found.Message, tc.messageSub) {
+				t.Fatalf("checks = %+v, want %s %s containing %q", checks, tc.check, tc.status, tc.messageSub)
+			}
+			for _, check := range checks {
+				if strings.Contains(check.Message+check.Hint, "/private/") {
+					t.Fatalf("check exposed private path: %+v", check)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildGrokDoctorChecksSkipsParityForDevelopmentVersion(t *testing.T) {
+	state := grokDoctorState{CLIAvailable: true, HostVersion: "0.2.99", PluginInstalled: true, PluginEnabled: true, PluginVersion: "0.22.0", ProjectTrusted: true, NativeHooks: true, MCPServers: 1, Skills: 3}
+	checks := buildGrokDoctorChecks(state, "dev (commit=none)")
+	for _, check := range checks {
+		if check.Name == "grok-plugin" && check.Status != doctorStatusPass {
+			t.Fatalf("development version parity check = %+v, want pass", check)
+		}
+	}
+}

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -122,8 +122,7 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 	}
 	hooks := file["hooks"].(map[string]any)
 	routes := hooks["PostCompact"].([]any)
-	commands := routes[0].(map[string]any)["hooks"].([]any)
-	commands[0].(map[string]any)["command"] = `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "stop"`
+	routes[0].(map[string]any)["matcher"] = "unexpected"
 	data, err = json.Marshal(file)
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -1,6 +1,11 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -54,5 +59,125 @@ func TestBuildGrokDoctorChecksSkipsParityForDevelopmentVersion(t *testing.T) {
 		if check.Name == "grok-plugin" && check.Status != doctorStatusPass {
 			t.Fatalf("development version parity check = %+v, want pass", check)
 		}
+	}
+}
+
+func TestProbeGrokDoctorStateUsesHostInventoryAndHookFile(t *testing.T) {
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	projectDir := t.TempDir()
+	pluginHook := filepath.Join(t.TempDir(), "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+	calls := []string{}
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.99 (build)\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary","version":"0.23.0"}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.CLIAvailable || state.HostVersion != "0.2.99" || !state.PluginInstalled || !state.PluginEnabled || state.PluginVersion != "0.23.0" || !state.NativeHooks || state.MCPServers != 1 || state.Skills != 3 {
+		t.Fatalf("state = %+v, want healthy host inventory", state)
+	}
+	if got, want := strings.Join(calls, "|"), "--version|plugin list --json|--cwd "+projectDir+" inspect --json"; got != want {
+		t.Fatalf("Grok calls = %q, want %q", got, want)
+	}
+}
+
+func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+	projectDir := t.TempDir()
+	projectHook := filepath.Join(projectDir, ".grok", "hooks", "traceary.json")
+	if err := os.MkdirAll(filepath.Dir(projectHook), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(projectHook, []byte(`{"hooks":{}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	pluginHook := filepath.Join(t.TempDir(), "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+	var file map[string]any
+	data, err := os.ReadFile(pluginHook)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	hooks := file["hooks"].(map[string]any)
+	routes := hooks["PostCompact"].([]any)
+	commands := routes[0].(map[string]any)["hooks"].([]any)
+	commands[0].(map[string]any)["command"] = `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "stop"`
+	data, err = json.Marshal(file)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(pluginHook, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.99\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary","version":"0.23.0"}]`), nil
+		default:
+			return []byte(`{"projectTrusted":false,"plugins":[{"name":"traceary","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary"}}]}`), nil
+		}
+	}
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if state.NativeHooks || !state.ProjectHooks || state.ProjectTrusted {
+		t.Fatalf("state = %+v, invalid hook contract must not pass and untrusted project hooks must be detected", state)
+	}
+}
+
+func writeGrokDoctorHookFixture(t *testing.T, path string, complete bool) {
+	t.Helper()
+	contracts := []struct{ event, name, action string }{
+		{"SessionStart", "traceary-session-start", "session-start"},
+		{"UserPromptSubmit", "traceary-prompt", "user-prompt-submit"},
+		{"PreToolUse", "traceary-tool-pre", "pre-tool-use"},
+		{"PostToolUse", "traceary-audit", "post-tool-use"},
+		{"Stop", "traceary-stop", "stop"},
+		{"PreCompact", "traceary-compact-pre", "pre-compact"},
+		{"PostCompact", "traceary-compact-post", "post-compact"},
+	}
+	if !complete {
+		contracts = contracts[:1]
+	}
+	hooks := map[string]any{}
+	for _, contract := range contracts {
+		hooks[contract.event] = []any{map[string]any{"hooks": []any{map[string]any{
+			"name":    contract.name,
+			"type":    "command",
+			"command": `"${GROK_PLUGIN_ROOT}/scripts/traceary-grok.sh" "` + contract.action + `"`,
+			"timeout": 5,
+		}}}}
+	}
+	data, err := json.Marshal(map[string]any{"hooks": hooks})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
 }


### PR DESCRIPTION
## Motivation

A native Grok plugin can be installed while disabled, stale, incomplete, or paired with untrusted project hooks. Generic config-file checks cannot distinguish those states or prove runtime event coverage.

## Changes

- probe `grok --version`, `grok plugin list --json`, and `grok inspect --json` read-only
- diagnose CLI availability, plugin enabled/version parity, project-hook trust, seven-event native hook coverage, one MCP server, and three skills
- reuse shared recent-event coverage for native `agent=grok` data
- keep diagnostic output free of plugin/project paths and payloads
- add table tests for absent CLI/plugin, version mismatch, untrusted hooks, missing MCP/skills/hooks, healthy setup, and development-version behavior

## Validation

- healthy isolated HOME dogfood: all `grok-*` checks pass; zero recent events reports the shared insufficient-evidence sample gate without false coverage claims
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- docs i18n and diff checks

Closes #1278
