### PR TITLE
fix: recover Antigravity workspace when workspacePaths is empty

### DIFF
--- a/docs/integrations/antigravity.ja.md
+++ b/docs/integrations/antigravity.ja.md
@@ -42,6 +42,8 @@ packaged plugin は `mcp_config.json` を通じてローカルの `traceary mcp-
 
 2026-07-13 に `agy` 1.1.1 と現行の公式 hook contract で再確認しました。公開 payload は prompt 本文を直接持ちませんが、すべての hook が `transcriptPath` を受け取ります。Traceary は Stop 時にそのファイルから最新の明示 user input と model response を読み取ります。hook 設定が健全でも file の読み取りや event 永続化までは証明できないため、`antigravity-event-coverage` が recent DB 証拠を検査し、transcript coverage が設定 threshold を下回ると警告します。
 
+`workspacePaths` が空のとき（`agy` 1.1.x の untrusted や一部 headless 実行で観測）は、hook プロセスの cwd（`hooks.json` があるディレクトリ）ではなく、Antigravity host プロセスの cwd 連鎖から project workspace を復元します。この fallback がないと、hook 自体は成功していても empty workspace で保存され、既定の `traceary list` workspace filter では見えません。
+
 > 記録された event の確認方法: hook 由来の Antigravity event は `client=hook`,
 > `agent=antigravity` で保存されます。`traceary list --agent antigravity` で読み取って
 > ください。`traceary list --client antigravity` ではこれらの event は 0 件になります。

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -42,6 +42,8 @@ Current Antigravity hooks expose the same lifecycle signals in headless and inte
 
 This was re-verified on 2026-07-13 against `agy` 1.1.1 and the current official hook contract. The public payload does not carry prompt text directly, but every hook receives `transcriptPath`; Traceary reads the latest explicit user input and model response from that file at Stop. A healthy hook configuration still does not prove that files were readable or events persisted, so `antigravity-event-coverage` checks recent database evidence and warns when transcript coverage falls below the configured threshold.
 
+When `workspacePaths` is empty (observed on `agy` 1.1.x for some untrusted or headless runs), Traceary recovers the project workspace from the Antigravity host process cwd chain instead of the hook process cwd (which is the `hooks.json` directory). Without that fallback, events would be stored with an empty workspace and would not appear under the default `traceary list` workspace filter even though hooks delivered successfully.
+
 > Inspecting recorded events: hook-originated Antigravity events are stored with
 > `client=hook` and `agent=antigravity`. Use `traceary list --agent antigravity`
 > to read them. `traceary list --client antigravity` returns no rows for these

--- a/presentation/cli/doctor_mcp.go
+++ b/presentation/cli/doctor_mcp.go
@@ -58,25 +58,40 @@ func (c *RootCLI) inspectAntigravityMCPRegistration() doctorCheck {
 	if err != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to resolve home directory for Antigravity MCP registration: %v", "Antigravity MCP registration 用のホームディレクトリを解決できませんでした: %v", err)}
 	}
-	pluginDir := antigravityCLIPluginDir(home)
-	info, err := os.Stat(pluginDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return doctorCheck{Name: name, Status: doctorStatusSkip, Message: localizef("Antigravity CLI plugin is not installed at %s; direct hook installations do not provide MCP tools", "%s に Antigravity CLI plugin がありません。hook の直接設定では MCP tool は提供されません", pluginDir)}
+	// Prefer the shared config plugin root (current packaged install) and fall
+	// back to the antigravity-cli import directory used by older installs.
+	pluginDirs := []string{
+		filepath.Join(home, ".gemini", "config", "plugins", "traceary"),
+		antigravityCLIPluginDir(home),
+	}
+	var presentDirs []string
+	var mcpPaths []string
+	for _, pluginDir := range pluginDirs {
+		info, err := os.Stat(pluginDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Antigravity CLI plugin directory: %v", "Antigravity CLI plugin directory の確認に失敗しました: %v", err)}
 		}
-		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Antigravity CLI plugin directory: %v", "Antigravity CLI plugin directory の確認に失敗しました: %v", err)}
-	}
-	if !info.IsDir() {
-		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("Antigravity CLI plugin path is not a directory: %s", "Antigravity CLI plugin path が directory ではありません: %s", pluginDir)}
-	}
-	mcpPath := filepath.Join(pluginDir, "mcp_config.json")
-	if _, err := os.Stat(mcpPath); err != nil {
-		if os.IsNotExist(err) {
-			return doctorCheck{Name: name, Status: doctorStatusWarn, Message: localizef("Antigravity CLI plugin is installed but does not include the Traceary MCP configuration: %s", "Antigravity CLI plugin は導入済みですが Traceary MCP configuration がありません: %s", mcpPath), Hint: "reinstall the Antigravity CLI plugin with MCP support", FixCommand: fix}
+		if !info.IsDir() {
+			return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("Antigravity CLI plugin path is not a directory: %s", "Antigravity CLI plugin path が directory ではありません: %s", pluginDir)}
 		}
-		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Antigravity MCP configuration: %v", "Antigravity MCP configuration の確認に失敗しました: %v", err)}
+		presentDirs = append(presentDirs, pluginDir)
+		mcpPath := filepath.Join(pluginDir, "mcp_config.json")
+		if _, err := os.Stat(mcpPath); err == nil {
+			mcpPaths = append(mcpPaths, mcpPath)
+		} else if err != nil && !os.IsNotExist(err) {
+			return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Antigravity MCP configuration: %v", "Antigravity MCP configuration の確認に失敗しました: %v", err)}
+		}
 	}
-	return c.inspectJSONMCPRegistration(name, "antigravity", []string{mcpPath}, fix)
+	if len(presentDirs) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusSkip, Message: localizef("Antigravity CLI plugin is not installed under ~/.gemini/config/plugins/traceary or ~/.gemini/antigravity-cli/plugins/traceary; direct hook installations do not provide MCP tools", "Antigravity CLI plugin が ~/.gemini/config/plugins/traceary または ~/.gemini/antigravity-cli/plugins/traceary にありません。hook の直接設定では MCP tool は提供されません")}
+	}
+	if len(mcpPaths) == 0 {
+		return doctorCheck{Name: name, Status: doctorStatusWarn, Message: localizef("Antigravity CLI plugin is installed but does not include the Traceary MCP configuration under: %s", "Antigravity CLI plugin は導入済みですが Traceary MCP configuration がありません: %s", strings.Join(presentDirs, ", ")), Hint: "reinstall the Antigravity CLI plugin with MCP support", FixCommand: fix}
+	}
+	return c.inspectJSONMCPRegistration(name, "antigravity", mcpPaths, fix)
 }
 
 func inspectJSONMCPRegistration(name, client string, paths []string, fix string) doctorCheck {

--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -45,6 +45,11 @@ func (c *RootCLI) detectPluginInstalls() []doctorPluginInstall {
 		}
 	}
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".codex", "plugins", "cache", "*", "traceary", "*", ".codex-plugin", "plugin.json"), "codex", "reinstall plugin to align")...)
+	// Antigravity can materialize the packaged plugin under either the CLI
+	// import root or the shared Gemini config plugins root. Prefer whichever
+	// copy is present; when both exist, doctor reports each install so a
+	// stale partial copy under antigravity-cli is still visible.
+	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "config", "plugins", "traceary", "plugin.json"), "antigravity", "cd <traceary-repository> && agy plugin install integrations/antigravity-plugin")...)
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "antigravity-cli", "plugins", "traceary", "plugin.json"), "antigravity", "cd <traceary-repository> && agy plugin install integrations/antigravity-plugin")...)
 	installs = append(installs, detectManifestInstalls(filepath.Join(home, ".gemini", "extensions", "traceary", "gemini-extension.json"), "gemini", "gemini extensions update traceary")...)
 	return installs

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -79,6 +79,33 @@ func ResetAntigravityPendingNowFunc() {
 	antigravityPendingNowFunc = time.Now
 }
 
+// SetAntigravityProcessCwdFunc replaces the process-cwd lookup used when
+// Antigravity payloads omit workspacePaths.
+func SetAntigravityProcessCwdFunc(f func(int) (string, error)) {
+	antigravityProcessCwdFunc = f
+}
+
+// ResetAntigravityProcessCwdFunc restores the default process-cwd lookup.
+func ResetAntigravityProcessCwdFunc() {
+	antigravityProcessCwdFunc = defaultAntigravityProcessCwd
+}
+
+// SetAntigravityParentPIDFunc replaces the parent-PID seed used for workspace
+// fallback discovery.
+func SetAntigravityParentPIDFunc(f func() int) {
+	antigravityParentPIDFunc = f
+}
+
+// ResetAntigravityParentPIDFunc restores the default parent-PID seed.
+func ResetAntigravityParentPIDFunc() {
+	antigravityParentPIDFunc = os.Getppid
+}
+
+// AntigravityWorkspaceCwd exposes antigravityWorkspaceCwd for tests.
+func AntigravityWorkspaceCwd(payload []byte) string {
+	return antigravityWorkspaceCwd(payload)
+}
+
 // AntigravityPendingCommandPath exposes the resolved pending-state file path for
 // a conversation/step pair so tests can age or inspect it directly.
 func AntigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {

--- a/presentation/cli/hook_antigravity.go
+++ b/presentation/cli/hook_antigravity.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -308,11 +311,34 @@ func normalizeAntigravityPayload(opts antigravityNormalizeOptions) []byte {
 	return encoded
 }
 
-// antigravityWorkspaceCwd returns the first workspace path from the payload, if
-// any, used as the cwd for workspace detection. Antigravity exposes
-// workspacePaths (an array of absolute mounted workspace roots) rather than a
-// single cwd on common-field payloads.
+// antigravityWorkspaceCwd returns a filesystem path used as the cwd for
+// workspace detection.
+//
+// Antigravity exposes workspacePaths (an array of absolute mounted workspace
+// roots) rather than a single cwd on common-field payloads. Current CLI
+// versions (agy 1.1.x) still fire hooks when workspacePaths is empty — for
+// example in untrusted workspaces or some headless print-mode paths — while
+// setting the hook process working directory to the hooks.json directory
+// (~/.gemini/config or a plugin package dir). Relying only on the hook process
+// cwd therefore loses the real project and records events with an empty
+// workspace, which then disappear from default `traceary list` / doctor
+// workspace filters.
+//
+// Resolution order:
+//  1. First non-empty entry in payload workspacePaths
+//  2. Parent-process cwd chain (skip Antigravity/Gemini config dirs; prefer a
+//     path that looks like a git work tree)
+//  3. Empty string (caller treats this as "no workspace")
 func antigravityWorkspaceCwd(payload []byte) string {
+	if path := firstAntigravityWorkspacePath(payload); path != "" {
+		return path
+	}
+	return resolveAntigravityFallbackWorkspaceCwd()
+}
+
+// firstAntigravityWorkspacePath returns the first non-empty workspacePaths
+// entry from an Antigravity hook payload.
+func firstAntigravityWorkspacePath(payload []byte) string {
 	value, ok := lookupHookPayloadValue(payload, "workspacePaths")
 	if !ok || value == nil {
 		return ""
@@ -323,10 +349,122 @@ func antigravityWorkspaceCwd(payload []byte) string {
 	}
 	for _, entry := range paths {
 		if path, ok := entry.(string); ok && strings.TrimSpace(path) != "" {
-			return path
+			return strings.TrimSpace(path)
 		}
 	}
 	return ""
+}
+
+// antigravityProcessCwdFunc resolves the current working directory of a process
+// by PID. Tests replace it so host process lookups stay deterministic.
+var antigravityProcessCwdFunc = defaultAntigravityProcessCwd
+
+// antigravityParentPIDFunc returns the parent PID of the current process. Tests
+// can override it without depending on real process topology.
+var antigravityParentPIDFunc = os.Getppid
+
+// resolveAntigravityFallbackWorkspaceCwd walks the parent process chain and
+// returns the first cwd that looks like a user workspace rather than an
+// Antigravity/Gemini configuration directory.
+func resolveAntigravityFallbackWorkspaceCwd() string {
+	const maxParents = 8
+	pid := antigravityParentPIDFunc()
+	var candidates []string
+	seen := map[int]struct{}{}
+	for i := 0; i < maxParents && pid > 1; i++ {
+		if _, ok := seen[pid]; ok {
+			break
+		}
+		seen[pid] = struct{}{}
+		cwd, err := antigravityProcessCwdFunc(pid)
+		if err == nil {
+			cwd = strings.TrimSpace(cwd)
+			if cwd != "" && !isAntigravityNonWorkspaceCwd(cwd) {
+				candidates = append(candidates, cwd)
+			}
+		}
+		parent, err := antigravityLookupParentPID(pid)
+		if err != nil || parent <= 1 || parent == pid {
+			break
+		}
+		pid = parent
+	}
+	for _, candidate := range candidates {
+		if looksLikeGitWorkTree(candidate) {
+			return candidate
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return ""
+}
+
+// isAntigravityNonWorkspaceCwd reports directories that Antigravity uses as
+// hook process cwd (config roots / plugin package dirs) rather than the user's
+// project workspace.
+func isAntigravityNonWorkspaceCwd(path string) bool {
+	cleaned := filepath.Clean(path)
+	base := filepath.Base(cleaned)
+	if base == "hooks" || base == "plugins" || base == "traceary" || base == "config" {
+		// Only reject when the path is clearly under a Gemini/Antigravity tree.
+		lower := strings.ToLower(cleaned)
+		if strings.Contains(lower, string(filepath.Separator)+".gemini"+string(filepath.Separator)) ||
+			strings.Contains(lower, string(filepath.Separator)+"antigravity-cli"+string(filepath.Separator)) ||
+			strings.HasSuffix(lower, string(filepath.Separator)+".gemini") {
+			return true
+		}
+	}
+	lower := strings.ToLower(cleaned)
+	markers := []string{
+		string(filepath.Separator) + ".gemini" + string(filepath.Separator) + "config",
+		string(filepath.Separator) + ".gemini" + string(filepath.Separator) + "antigravity-cli" + string(filepath.Separator) + "plugins",
+		string(filepath.Separator) + ".gemini" + string(filepath.Separator) + "config" + string(filepath.Separator) + "plugins",
+	}
+	for _, marker := range markers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeGitWorkTree(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil && (info.IsDir() || info.Mode().IsRegular())
+}
+
+// defaultAntigravityProcessCwd resolves a process cwd on the current OS.
+func defaultAntigravityProcessCwd(pid int) (string, error) {
+	if pid <= 0 {
+		return "", xerrors.Errorf("invalid pid %d", pid)
+	}
+	if runtime.GOOS == "linux" {
+		target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "cwd"))
+		if err != nil {
+			return "", xerrors.Errorf("read process cwd for pid %d: %w", pid, err)
+		}
+		return target, nil
+	}
+	// macOS and other BSDs: lsof reports the cwd as an "n<path>" field.
+	output, err := exec.Command("lsof", "-a", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn").Output()
+	if err != nil {
+		return "", xerrors.Errorf("lsof process cwd for pid %d: %w", pid, err)
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "n") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "n")), nil
+		}
+	}
+	return "", xerrors.Errorf("cwd not found for pid %d", pid)
+}
+
+func antigravityLookupParentPID(pid int) (int, error) {
+	info, err := hookParentProcessLookup(pid)
+	if err != nil {
+		return 0, err
+	}
+	return info.parentPID, nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/presentation/cli/hook_antigravity_test.go
+++ b/presentation/cli/hook_antigravity_test.go
@@ -443,3 +443,84 @@ func TestRootCLI_HookAntigravityStopOutputContract(t *testing.T) {
 		t.Fatalf("Stop output = %q, want {\"decision\":\"\"}", out)
 	}
 }
+
+func TestRootCLI_HookAntigravityPreInvocationEmptyWorkspacePathsUsesParentCwd(t *testing.T) {
+	// Live agy 1.1.x payloads can emit workspacePaths:[] while still firing
+	// PreInvocation. Recover the project from the host process cwd chain.
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	projectDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(projectDir, ".git"), 0o755); err != nil {
+		t.Fatalf("Mkdir(.git) error = %v", err)
+	}
+	// Seed git metadata so detectRepoContextFromDir can produce a stable local
+	// workspace identity from the recovered cwd.
+	if err := os.WriteFile(filepath.Join(projectDir, ".git", "config"), []byte("[core]\n\trepositoryformatversion = 0\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(git config) error = %v", err)
+	}
+
+	cli.SetAntigravityParentPIDFunc(func() int { return 4242 })
+	t.Cleanup(cli.ResetAntigravityParentPIDFunc)
+	cli.SetAntigravityProcessCwdFunc(func(pid int) (string, error) {
+		if pid == 4242 {
+			return projectDir, nil
+		}
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(cli.ResetAntigravityProcessCwdFunc)
+
+	out, _, sessionStub := runAntigravityHook(t, "pre-invocation",
+		`{"conversationId":"conv-empty-ws","workspacePaths":[]}`)
+	if out != "{}" {
+		t.Fatalf("PreInvocation output = %q, want {}", out)
+	}
+	if got, want := sessionStub.startCall.sessionID, types.SessionID("conv-empty-ws"); got != want {
+		t.Fatalf("session start sessionID = %q, want %q", got, want)
+	}
+	if sessionStub.startCall.workspace == "" {
+		t.Fatalf("session start workspace is empty; parent cwd fallback did not bind a workspace")
+	}
+}
+
+func TestAntigravityWorkspaceCwdPrefersPayloadThenParent(t *testing.T) {
+	if got := cli.AntigravityWorkspaceCwd([]byte(`{"workspacePaths":["/from-payload"]}`)); got != "/from-payload" {
+		t.Fatalf("payload path = %q, want /from-payload", got)
+	}
+
+	cli.SetAntigravityParentPIDFunc(func() int { return 99 })
+	t.Cleanup(cli.ResetAntigravityParentPIDFunc)
+	cli.SetAntigravityProcessCwdFunc(func(pid int) (string, error) {
+		if pid == 99 {
+			return "/recovered/project", nil
+		}
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(cli.ResetAntigravityProcessCwdFunc)
+
+	if got := cli.AntigravityWorkspaceCwd([]byte(`{"workspacePaths":[]}`)); got != "/recovered/project" {
+		t.Fatalf("empty workspacePaths fallback = %q, want /recovered/project", got)
+	}
+	if got := cli.AntigravityWorkspaceCwd([]byte(`{}`)); got != "/recovered/project" {
+		t.Fatalf("missing workspacePaths fallback = %q, want /recovered/project", got)
+	}
+}
+
+func TestIsAntigravityNonWorkspaceCwd(t *testing.T) {
+	// Exercise through AntigravityWorkspaceCwd by feeding a config-dir parent
+	// cwd and ensuring it is rejected when no payload path is present.
+	cli.SetAntigravityParentPIDFunc(func() int { return 77 })
+	t.Cleanup(cli.ResetAntigravityParentPIDFunc)
+	cli.SetAntigravityProcessCwdFunc(func(pid int) (string, error) {
+		if pid == 77 {
+			return filepath.Join("/Users/me", ".gemini", "config", "plugins", "traceary"), nil
+		}
+		return "", os.ErrNotExist
+	})
+	t.Cleanup(cli.ResetAntigravityProcessCwdFunc)
+	if got := cli.AntigravityWorkspaceCwd([]byte(`{"workspacePaths":[]}`)); got != "" {
+		t.Fatalf("config plugin cwd should be rejected, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- When Antigravity (`agy` 1.1.x) fires hooks with empty `workspacePaths`, recover the project workspace from the host process cwd chain instead of the hook process cwd (`hooks.json` dir).
- Events were previously persisted with empty workspace and invisible under the default `traceary list` / doctor workspace filter, which looked like "hooks configured but no delivery".
- Doctor now inspects both `~/.gemini/config/plugins/traceary` and `~/.gemini/antigravity-cli/plugins/traceary` for plugin version and MCP registration.

## Live evidence
- `agy --print` with the fixed binary recorded `session_started` + `prompt` + `transcript` for session `65d6f04f` with `workspace=github.com/duck8823/traceary`.

## Test plan
- [x] `go test ./presentation/cli/ -run 'Antigravity|HookAntigravity'`
- [x] `go tool golangci-lint run ./presentation/cli/`
- [x] Live `agy --print` probe shows workspace-bound events

Closes #1308