### PR TITLE
fix: align remember skill to candidate-only inbox contract

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -82,7 +82,60 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkAntigravity(root); err != nil {
 		return err
 	}
+	if err := checkRememberSkillContract(root); err != nil {
+		return err
+	}
 	return checkDocs(root)
+}
+
+// rememberSkillPaths are the packaged copies of the shared
+// traceary-memory-remember skill. They must stay byte-identical and must not
+// reintroduce the accepted-status contradiction for explicit remember.
+var rememberSkillPaths = []string{
+	"integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md",
+	"plugins/traceary/skills/traceary-memory-remember/SKILL.md",
+	"integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md",
+	"integrations/antigravity-plugin/skills/traceary-memory-remember/SKILL.md",
+	"integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md",
+}
+
+// checkRememberSkillContract enforces the explicit-remember product contract:
+// agent skills write review-inbox candidates (status=candidate via
+// action=propose) and never auto-accept. Host package copies must stay
+// synchronized so a single package cannot reintroduce status=accepted wording.
+func checkRememberSkillContract(root string) error {
+	var reference []byte
+	for i, rel := range rememberSkillPaths {
+		path := filepath.Join(root, rel)
+		data, err := os.ReadFile(path) // #nosec G304 -- fixed package path under repo root
+		if err != nil {
+			return xerrors.Errorf("missing remember skill: %s: %w", rel, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, "status=candidate") && !strings.Contains(body, "`status=candidate`") {
+			return xerrors.Errorf("%s must state that explicit remember lands as status=candidate", rel)
+		}
+		if !strings.Contains(body, `action="propose"`) && !strings.Contains(body, `"action": "propose"`) {
+			return xerrors.Errorf("%s must instruct manage_memory action=propose for the agent skill path", rel)
+		}
+		// Reject the old contradiction: procedure claimed action=remember →
+		// accepted while the frontmatter promised candidate / never auto-accepted.
+		if strings.Contains(body, "status=accepted") {
+			return xerrors.Errorf("%s must not claim status=accepted for the agent remember skill path", rel)
+		}
+		// JSON example must not invoke action=remember (immediate accept).
+		if strings.Contains(body, `"action": "remember"`) {
+			return xerrors.Errorf("%s must not call manage_memory action=remember from the agent skill path", rel)
+		}
+		if i == 0 {
+			reference = data
+			continue
+		}
+		if string(data) != string(reference) {
+			return xerrors.Errorf("remember skill copies diverged: %s does not match %s", rel, rememberSkillPaths[0])
+		}
+	}
+	return nil
 }
 
 func checkGrok(root, version string) error {

--- a/integrations/antigravity-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-memory-remember/SKILL.md
@@ -8,6 +8,12 @@ version: 1.0.0
 
 Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
 
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
 ## Workflow
 
 1. **Confirm scope**. Pick exactly one of:
@@ -36,25 +42,23 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    | `file` | `docs/architecture/redaction.md` |
    | `issue` | `#462` |
    | `pr` | `#468` |
-4. **Call `manage_memory`**:
-   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
-   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
 
    ```
    manage_memory({
-     "action": "remember",
+     "action": "propose",
      "type": "constraint",
      "workspace": "<current workspace>",
      "fact": "<short, durable statement>",
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-remember/SKILL.md
@@ -8,6 +8,12 @@ version: 1.0.0
 
 Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
 
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
 ## Workflow
 
 1. **Confirm scope**. Pick exactly one of:
@@ -36,25 +42,23 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    | `file` | `docs/architecture/redaction.md` |
    | `issue` | `#462` |
    | `pr` | `#468` |
-4. **Call `manage_memory`**:
-   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
-   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
 
    ```
    manage_memory({
-     "action": "remember",
+     "action": "propose",
      "type": "constraint",
      "workspace": "<current workspace>",
      "fact": "<short, durable statement>",
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md
@@ -8,6 +8,12 @@ version: 1.0.0
 
 Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
 
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
 ## Workflow
 
 1. **Confirm scope**. Pick exactly one of:
@@ -36,25 +42,23 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    | `file` | `docs/architecture/redaction.md` |
    | `issue` | `#462` |
    | `pr` | `#468` |
-4. **Call `manage_memory`**:
-   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
-   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
 
    ```
    manage_memory({
-     "action": "remember",
+     "action": "propose",
      "type": "constraint",
      "workspace": "<current workspace>",
      "fact": "<short, durable statement>",
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md
@@ -8,6 +8,12 @@ version: 1.0.0
 
 Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
 
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
 ## Workflow
 
 1. **Confirm scope**. Pick exactly one of:
@@ -36,25 +42,23 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    | `file` | `docs/architecture/redaction.md` |
    | `issue` | `#462` |
    | `pr` | `#468` |
-4. **Call `manage_memory`**:
-   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
-   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
 
    ```
    manage_memory({
-     "action": "remember",
+     "action": "propose",
      "type": "constraint",
      "workspace": "<current workspace>",
      "fact": "<short, durable statement>",
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/plugins/traceary/skills/traceary-memory-remember/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-remember/SKILL.md
@@ -8,6 +8,12 @@ version: 1.0.0
 
 Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
 
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
 ## Workflow
 
 1. **Confirm scope**. Pick exactly one of:
@@ -36,25 +42,23 @@ Use this skill **only** when the operator explicitly asks Traceary to remember a
    | `file` | `docs/architecture/redaction.md` |
    | `issue` | `#462` |
    | `pr` | `#468` |
-4. **Call `manage_memory`**:
-   - For an explicit "remember this now" verb, use `action="remember"`. The memory lands at `status=accepted` because the user's direct ask **is** the acceptance signal.
-   - If you are unsure whether the user wants the fact made permanent right now, use `action="propose"` instead. That lands at `status=candidate` and the operator can review it later via `traceary-memory-review`.
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
 
    ```
    manage_memory({
-     "action": "remember",
+     "action": "propose",
      "type": "constraint",
      "workspace": "<current workspace>",
      "fact": "<short, durable statement>",
      "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
    })
    ```
-5. **Inform the operator** which path was used (`accepted` for `remember`, `candidate` for `propose`) and how to undo: `manage_memory({"action": "reject", "ids": ["<id>"]})`.
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
 
 ## Guardrails
 
 - **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
-- **Match the action to the certainty.** A direct "remember X" → `action="remember"` (status=accepted, the explicit verb is the consent). Anything weaker → `action="propose"` (status=candidate) and let `traceary-memory-review` handle acceptance.
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
 - **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
 - **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
 - **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.


### PR DESCRIPTION
## Summary
- Canonical explicit-remember contract for agent skills: `action=propose` → `status=candidate` (never auto-accepted).
- Synchronized Claude / Codex / Gemini / Antigravity / Grok skill copies.
- `go run ./cmd/repo-tooling integrations verify` fails if copies diverge or reintroduce `status=accepted` / `action: remember` examples.

## Test plan
- [x] `go run ./cmd/repo-tooling integrations verify`
- [x] `go test ./cmd/repo-tooling/`

Closes #1288