### PR TITLE
feat: add AI-safe sessions snapshot profile

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -739,6 +739,24 @@ session end 境界を記録し、生成された event ID を出力します。
 
 snapshot 出力は dashboard の各ペインに合わせて拡張されており、パイプ / CI / スクリプト経由の利用者も live view と同じデータを取得できます。テキスト snapshot は先頭の `RELIABILITY` セクションに続いて `ACTIVE SESSIONS` / `RECENT FAILURES` / `RECENT COMMANDS` / `CANDIDATE MEMORIES (count=N remember_intent=M)` / `STALE MEMORIES (count=N)` の各セクションに分かれ、空のペインも安定した empty-state 行を 1 行出すためヘッダーは常に出力されます。JSON snapshot は `sessions` / `failures` / `recent_commands` / `candidates` (`{ count, remember_intent_count, items }`) / `stale_memories` (`{ count, items }`) / `reliability` を持つ envelope オブジェクトでラップされています。`reliability.memory` には scan した candidate window の hygiene 構成をまとめた `candidate_hygiene` オブジェクト (`stale_count` / `duplicate_count` / `fragment_like_count` / `extracted_hidden_count` / `likely_actionable_count`) も含まれます。4 つの flag count は独立した診断軸で重複し得ます。`likely_actionable_count` はそのいずれにも該当しない候補の補集合です。`accepted_count` / `candidate_count` と同様に `scan_limit_reached` が true のときは scan したサンプルを反映します。`duplicate_count` は完全一致 (同一 scope・memory type・fact。extraction の dedupe key に一致) のみで、類似 duplicate は `traceary memory admin hygiene scan` が担当します。各ペインの行上限は dashboard と揃えており (failures 50 / recent commands 50 / candidates 25 / stale memories 25)、session ペインは引き続き `--limit` を使用します。
 
+### operator と AI-safe な JSON profile
+
+`--snapshot --json` の既定はフルの **operator** envelope（dashboard 各ペイン + body の truncate）です。agent の resume / handoff では次を使ってください:
+
+```sh
+traceary sessions --snapshot --json --profile ai
+```
+
+`ai` profile は bound された envelope を返します:
+
+- JSON に `profile: "ai"`
+- session の identity と `latest_event_id`、および retrieval hint（`traceary show <event_id>`）。大きい latest-event body は載せない
+- failure / recent-command は ID + kind + retrieval hint の小さなサンプル（raw body なし）
+- memory candidate / stale の件数と reliability hygiene のみ（candidate fact 配列なし）
+- session / 各ペインの上限をより厳しくする（既定の operator profile は変更しない）
+
+人間・dashboard・完全な script には operator snapshot を、agent が次の一手を決めるときは `--profile ai` を使います。
+
 snapshot 例:
 
 ```sh

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -747,6 +747,24 @@ Launch a live multi-pane dashboard that splits the workspace view into five pane
 
 Snapshot output mirrors the dashboard panes so non-interactive consumers (pipes, CI, scripts) see the same data the live view shows. The text snapshot starts with a `RELIABILITY` section, then prints `ACTIVE SESSIONS`, `RECENT FAILURES`, `RECENT COMMANDS`, `CANDIDATE MEMORIES (count=N remember_intent=M)`, and `STALE MEMORIES (count=N)` sections; empty panes print a stable empty-state line so headers always render. The JSON snapshot is wrapped in an envelope with `sessions`, `failures`, `recent_commands`, `candidates` (`{ count, remember_intent_count, items }`), `stale_memories` (`{ count, items }`), and `reliability` keys; each session node keeps the same fields earlier releases emitted. `reliability.memory` additionally carries a `candidate_hygiene` object (`stale_count`, `duplicate_count`, `fragment_like_count`, `extracted_hidden_count`, `likely_actionable_count`) summarising the hygiene composition of the scanned candidate window: the four flag counts are independent diagnostic dimensions and may overlap, `likely_actionable_count` is the complement (candidates flagged by none), and — like `accepted_count` / `candidate_count` — they reflect the scanned sample when `scan_limit_reached` is true. `duplicate_count` counts exact duplicates only (same scope, memory type, and fact, matching the extraction dedupe key); similarity duplicates stay in `traceary memory admin hygiene scan`. Per-pane row caps follow the dashboard defaults (50 failures, 50 recent commands, 25 candidates, 25 stale memories); the session pane keeps using `--limit`.
 
+### Operator vs AI-safe JSON profiles
+
+`--snapshot --json` defaults to the full **operator** envelope (dashboard panes with truncated bodies). For agent resume / handoff, prefer:
+
+```sh
+traceary sessions --snapshot --json --profile ai
+```
+
+The `ai` profile keeps a bounded envelope:
+
+- `profile: "ai"` in the JSON payload
+- session identity + `latest_event_id` with retrieval hints (`traceary show <event_id>`) instead of large latest-event bodies
+- small failure / recent-command samples as ID + kind + retrieval hints (no raw bodies)
+- memory candidate / stale counts and reliability hygiene without candidate fact arrays
+- tighter session / pane caps (does not change the default operator profile)
+
+Use the operator snapshot for humans, dashboards, and full-fidelity scripts. Use `--profile ai` when an agent should decide next steps without re-amplifying large command bodies or inbox facts.
+
 Example snapshot:
 
 ```sh

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -83,6 +83,10 @@ type sessionTreeNode struct {
 // that already destructure `sessions[*]` keep working — only the
 // outer wrapping is new.
 type topSnapshotPayload struct {
+	// Profile names the JSON projection. Omitted for the default operator
+	// envelope so existing consumers keep an unchanged shape; set to "ai"
+	// for the bounded agent-resume projection.
+	Profile        string                 `json:"profile,omitempty"`
 	Sessions       []*topSnapshotNode     `json:"sessions"`
 	Failures       []event                `json:"failures"`
 	RecentCommands []event                `json:"recent_commands"`

--- a/presentation/cli/top.go
+++ b/presentation/cli/top.go
@@ -35,6 +35,23 @@ const shortTopSessionIDLength = 12
 
 var topNowFunc = time.Now
 
+// topSnapshotProfile values control the JSON projection for
+// `sessions --snapshot --json` / `top --snapshot --json`.
+const (
+	topSnapshotProfileOperator = "operator"
+	topSnapshotProfileAI       = "ai"
+)
+
+// AI-safe pane caps keep the agent-resume envelope small. The operator
+// snapshot keeps the larger dashboard pane limits.
+const (
+	topAIPaneFailureLimit       = 5
+	topAIPaneRecentCommandLimit = 5
+	topAIPaneCandidateLimit     = 0 // counts only; no candidate facts
+	topAIPaneStaleMemoryLimit   = 0
+	topAISessionSampleLimit     = 20
+)
+
 type topCommandOptions struct {
 	dbPath     string
 	workspace  string
@@ -43,6 +60,7 @@ type topCommandOptions struct {
 	idle       time.Duration
 	snapshot   bool
 	asJSON     bool
+	profile    string
 	limit      int
 	staleAfter time.Duration
 	allowStale bool
@@ -98,6 +116,15 @@ func bindTopFlags(cmd *cobra.Command, opts *topCommandOptions) {
 	cmd.Flags().DurationVar(&opts.idle, "idle", 10*time.Minute, Localize("dim sessions whose latest activity is older than this duration", "最新 activity がこの duration より古い session を dim 表示する"))
 	cmd.Flags().BoolVar(&opts.snapshot, "snapshot", false, Localize("print one snapshot and exit", "一回限りの snapshot を出力して終了する"))
 	cmd.Flags().BoolVar(&opts.asJSON, "json", false, Localize("print JSON output with --snapshot", "--snapshot と併用して JSON 形式で出力する"))
+	cmd.Flags().StringVar(
+		&opts.profile,
+		"profile",
+		topSnapshotProfileOperator,
+		Localize(
+			"snapshot JSON profile: operator (default full dashboard envelope) or ai (bounded agent-resume envelope)",
+			"snapshot JSON の profile: operator（既定のフル dashboard envelope）または ai（AI resume 向けに bound した envelope）",
+		),
+	)
 	cmd.Flags().IntVar(&opts.limit, "limit", defaultTopLimit, Localize("maximum number of sessions to load", "読み込む最大セッション数"))
 	cmd.Flags().DurationVar(
 		&opts.staleAfter,
@@ -117,6 +144,25 @@ func bindTopFlags(cmd *cobra.Command, opts *topCommandOptions) {
 			"stale な active session も含めて表示し、JSON snapshot に is_stale メタデータを出力する",
 		),
 	)
+}
+
+// normalizeTopSnapshotProfile returns the canonical profile name or an error
+// when the value is not supported.
+func normalizeTopSnapshotProfile(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", topSnapshotProfileOperator:
+		return topSnapshotProfileOperator, nil
+	case topSnapshotProfileAI:
+		return topSnapshotProfileAI, nil
+	default:
+		return "", xerrors.Errorf(
+			"%s",
+			Localize(
+				"--profile must be operator or ai",
+				"--profile は operator または ai でなければなりません",
+			),
+		)
+	}
 }
 
 func (c *RootCLI) runTop(ctx context.Context, output io.Writer, opts topCommandOptions) error {
@@ -143,18 +189,42 @@ func (c *RootCLI) runTopNamed(ctx context.Context, output io.Writer, opts topCom
 		return xerrors.Errorf("%s", Localize("idle must be >= 0", "idle は 0 以上でなければなりません"))
 	}
 
+	profile, err := normalizeTopSnapshotProfile(opts.profile)
+	if err != nil {
+		return err
+	}
+	opts.profile = profile
+
 	if opts.snapshot {
 		snap, err := c.loadTopSnapshot(ctx, opts)
 		if err != nil {
 			return err
 		}
 		if opts.asJSON {
-			return writeTopSnapshotJSON(output, snap)
+			return writeTopSnapshotJSON(output, snap, opts.profile)
+		}
+		if opts.profile == topSnapshotProfileAI {
+			return xerrors.Errorf(
+				"%s",
+				Localize(
+					"--profile ai requires --snapshot --json",
+					"--profile ai には --snapshot --json が必要です",
+				),
+			)
 		}
 		return writeTopSnapshotText(output, snap, opts.idle, snap.Now)
 	}
 	if opts.asJSON {
 		return xerrors.Errorf("%s", Localize("--json requires --snapshot", "--json には --snapshot が必要です"))
+	}
+	if opts.profile == topSnapshotProfileAI {
+		return xerrors.Errorf(
+			"%s",
+			Localize(
+				"--profile ai requires --snapshot --json",
+				"--profile ai には --snapshot --json が必要です",
+			),
+		)
 	}
 	return c.runTopTUI(ctx, output, opts, commandName)
 }
@@ -163,17 +233,32 @@ func (c *RootCLI) runTopNamed(ctx context.Context, output io.Writer, opts topCom
 // using the same per-pane caps the live dashboard applies. The session pane
 // reuses the operator-controlled --limit flag; the secondary panes
 // intentionally use the small dashboard caps so the script-friendly snapshot
-// does not balloon under a noisy workspace.
+// does not balloon under a noisy workspace. The ai profile uses tighter
+// pane caps so agent-resume payloads stay bounded.
 func (c *RootCLI) loadTopSnapshot(ctx context.Context, opts topCommandOptions) (topDataSnapshot, error) {
+	sessionLimit := opts.limit
+	failureLimit := topPaneFailureLimit
+	commandLimit := topPaneRecentCommandLimit
+	candidateLimit := topPaneCandidateLimit
+	staleLimit := topPaneStaleMemoryLimit
+	if opts.profile == topSnapshotProfileAI {
+		if sessionLimit > topAISessionSampleLimit {
+			sessionLimit = topAISessionSampleLimit
+		}
+		failureLimit = topAIPaneFailureLimit
+		commandLimit = topAIPaneRecentCommandLimit
+		candidateLimit = topAIPaneCandidateLimit
+		staleLimit = topAIPaneStaleMemoryLimit
+	}
 	criteria := topDataCriteria{
 		Workspace:          opts.workspace,
 		Client:             opts.client,
 		Agent:              opts.agent,
-		SessionLimit:       opts.limit,
-		FailureLimit:       topPaneFailureLimit,
-		RecentCommandLimit: topPaneRecentCommandLimit,
-		CandidateLimit:     topPaneCandidateLimit,
-		StaleMemoryLimit:   topPaneStaleMemoryLimit,
+		SessionLimit:       sessionLimit,
+		FailureLimit:       failureLimit,
+		RecentCommandLimit: commandLimit,
+		CandidateLimit:     candidateLimit,
+		StaleMemoryLimit:   staleLimit,
 		StaleAfter:         opts.staleAfter,
 		AllowStale:         opts.allowStale,
 		Now:                topNowFunc(),

--- a/presentation/cli/top_data_internal_test.go
+++ b/presentation/cli/top_data_internal_test.go
@@ -522,8 +522,8 @@ func TestWriteTopSnapshotJSON_EmitsStaleActiveMetadata(t *testing.T) {
 		StaleAfter: 24 * time.Hour,
 		AllowStale: true,
 		Now:        now,
-	}); err != nil {
-		t.Fatalf("writeTopSnapshotJSON() error = %v", err)
+	}, topSnapshotProfileOperator); err != nil {
+		t.Fatalf("writeTopSnapshotJSON(, topSnapshotProfileOperator) error = %v", err)
 	}
 
 	var payload struct {
@@ -1233,8 +1233,8 @@ func TestWriteTopSnapshotJSON_EmitsReliabilityShape(t *testing.T) {
 				BodyLimitRunes:     apptypes.DefaultTopSnapshotBodyLimit,
 			},
 		},
-	}); err != nil {
-		t.Fatalf("writeTopSnapshotJSON() error = %v", err)
+	}, topSnapshotProfileOperator); err != nil {
+		t.Fatalf("writeTopSnapshotJSON(, topSnapshotProfileOperator) error = %v", err)
 	}
 
 	var payload struct {

--- a/presentation/cli/top_json.go
+++ b/presentation/cli/top_json.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"io"
+	"strings"
 	"time"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 )
 
 // writeTopSnapshotJSON renders the top dashboard snapshot as the
@@ -13,7 +15,19 @@ import (
 // shape; `failures`, `recent_commands`, `candidates`, and `stale_memories`
 // mirror the new dashboard panes so a script that consumes the snapshot has
 // the same data the live dashboard renders.
-func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
+//
+// profile selects the projection:
+//   - operator (default): full dashboard envelope (unchanged shape)
+//   - ai: bounded agent-resume envelope — counts/health + event IDs and
+//     retrieval hints instead of large bodies and memory candidate facts
+func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot, profile string) error {
+	if profile == topSnapshotProfileAI {
+		return writeTopSnapshotJSONAI(output, snap)
+	}
+	return writeTopSnapshotJSONOperator(output, snap)
+}
+
+func writeTopSnapshotJSONOperator(output io.Writer, snap topDataSnapshot) error {
 	staleCtx := snapshotStaleContext{
 		staleAfter: snap.StaleAfter,
 		now:        snap.Now,
@@ -68,6 +82,93 @@ func writeTopSnapshotJSON(output io.Writer, snap topDataSnapshot) error {
 		Reliability: topSnapshotReliabilityFromMetrics(snap.Reliability),
 	}
 	return writeJSON(output, payload)
+}
+
+// writeTopSnapshotJSONAI projects a bounded agent-resume envelope. It keeps
+// session identity + retrieval hints, small failure/command samples without
+// bodies, and memory counts/hygiene without candidate facts. Full detail stays
+// available via `traceary show <event_id>` and operator snapshot mode.
+func writeTopSnapshotJSONAI(output io.Writer, snap topDataSnapshot) error {
+	staleCtx := snapshotStaleContext{
+		staleAfter: snap.StaleAfter,
+		now:        snap.Now,
+	}
+	if staleCtx.now.IsZero() {
+		staleCtx.now = time.Now()
+	}
+	sessions := make([]*topSnapshotNode, 0, len(snap.Sessions))
+	for _, root := range snap.Sessions {
+		node := topSnapshotNodeFromSessionNode(root, 0, staleCtx)
+		stripTopSnapshotBodiesForAI(node)
+		sessions = append(sessions, node)
+	}
+
+	failures := make([]event, 0, len(snap.Failures))
+	for _, ev := range snap.Failures {
+		failures = append(failures, newAISafeEventHint(ev))
+	}
+	commands := make([]event, 0, len(snap.RecentCommands))
+	for _, ev := range snap.RecentCommands {
+		commands = append(commands, newAISafeEventHint(ev))
+	}
+
+	reliability := topSnapshotReliabilityFromMetrics(snap.Reliability)
+	// Reliability already carries candidate hygiene and counts; omit item arrays.
+	payload := topSnapshotPayload{
+		Profile:        topSnapshotProfileAI,
+		Sessions:       sessions,
+		Failures:       failures,
+		RecentCommands: commands,
+		Candidates: topSnapshotCandidates{
+			Count:               reliability.Memory.CandidateCount,
+			RememberIntentCount: snap.RememberIntentCandidateCount,
+			Items:               []memorySummaryOutput{},
+		},
+		StaleMemories: topSnapshotStale{
+			Count: snap.StaleMemories.Count(),
+			Items: []staleMemoryOutput{},
+		},
+		Reliability: reliability,
+	}
+	return writeJSON(output, payload)
+}
+
+// stripTopSnapshotBodiesForAI removes latest-event message bodies from the
+// session tree while preserving IDs so agents can `traceary show` on demand.
+func stripTopSnapshotBodiesForAI(node *topSnapshotNode) {
+	if node == nil {
+		return
+	}
+	if node.LatestEventID != "" {
+		node.LatestEventMessage = largePayloadRetrievalHint(node.LatestEventID)
+	} else {
+		node.LatestEventMessage = ""
+	}
+	node.LatestEventMessageTruncated = false
+	node.LatestEventMessageLength = 0
+	node.LatestEventMessageBytes = 0
+	for _, child := range node.Children {
+		stripTopSnapshotBodiesForAI(child)
+	}
+}
+
+// newAISafeEventHint keeps identity + kind metadata and replaces the body with
+// an explicit detail-read retrieval hint.
+func newAISafeEventHint(ev *model.Event) event {
+	if ev == nil {
+		return event{}
+	}
+	out := newEventOutput(ev)
+	id := strings.TrimSpace(out.EventID)
+	if id != "" {
+		out.Message = largePayloadRetrievalHint(id)
+	} else {
+		out.Message = ""
+	}
+	out.Truncated = false
+	out.MessageLength = 0
+	out.MessageBytes = 0
+	return out
 }
 
 func topSnapshotReliabilityFromMetrics(metrics topReliabilityMetrics) topSnapshotReliability {

--- a/presentation/cli/top_json_truncation_test.go
+++ b/presentation/cli/top_json_truncation_test.go
@@ -45,7 +45,7 @@ func TestWriteTopSnapshotJSON_TruncatesLargeRecentCommandBody(t *testing.T) {
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		RecentCommands: []*model.Event{ev},
 		Now:            createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -86,9 +86,9 @@ func TestWriteTopSnapshotJSON_RecognizesBrokenPipeWriter(t *testing.T) {
 
 	err := writeTopSnapshotJSON(brokenPipeWriter{}, topDataSnapshot{
 		Now: time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
-	})
+	}, topSnapshotProfileOperator)
 	if err == nil {
-		t.Fatal("writeTopSnapshotJSON() error = nil, want broken pipe")
+		t.Fatal("writeTopSnapshotJSON(, topSnapshotProfileOperator) error = nil, want broken pipe")
 	}
 	if !IsBrokenPipeError(err) {
 		t.Fatalf("IsBrokenPipeError(%v) = false, want true", err)
@@ -111,7 +111,7 @@ func TestWriteTopSnapshotJSON_LeavesSmallBodiesUntouched(t *testing.T) {
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		RecentCommands: []*model.Event{ev},
 		Now:            createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -143,7 +143,7 @@ func TestWriteTopSnapshotJSON_BoundaryLengthIsNotTruncated(t *testing.T) {
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		RecentCommands: []*model.Event{ev},
 		Now:            createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func TestWriteTopSnapshotJSON_TruncatesRecentFailures(t *testing.T) {
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		Failures: []*model.Event{ev},
 		Now:      createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestWriteTopSnapshotJSON_TruncatesLatestEventMessage(t *testing.T) {
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		Sessions: []*sessionNode{node},
 		Now:      createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -277,7 +277,7 @@ func TestWriteTopSnapshotJSON_LeavesSmallLatestEventMessageUntouched(t *testing.
 	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
 		Sessions: []*sessionNode{node},
 		Now:      createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 	out := buf.String()
@@ -314,7 +314,7 @@ func TestWriteTopSnapshotJSON_LargePayloadSamplesAreMetadataOnly(t *testing.T) {
 			),
 		},
 		Now: createdAt,
-	}); err != nil {
+	}, topSnapshotProfileOperator); err != nil {
 		t.Fatalf("writeTopSnapshotJSON: %v", err)
 	}
 
@@ -380,5 +380,101 @@ func TestWriteTopSnapshotTextEvents_TruncatesLongBody(t *testing.T) {
 	}
 	if strings.Contains(out, huge) {
 		t.Fatalf("text snapshot row leaked the full body: %q", out)
+	}
+}
+
+func TestWriteTopSnapshotJSON_AIProfileOmitsBodiesAndCandidateFacts(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	huge := strings.Repeat("x", apptypes.DefaultTopSnapshotBodyLimit+80)
+	cmd := newTopSnapshotEvent("evt-ai-cmd", huge, createdAt)
+	fail := newTopSnapshotEvent("evt-ai-fail", huge, createdAt)
+	node := newTopSnapshotSessionNode("sess-ai", "evt-latest", huge, createdAt)
+
+	var buf bytes.Buffer
+	if err := writeTopSnapshotJSON(&buf, topDataSnapshot{
+		Sessions:       []*sessionNode{node},
+		Failures:       []*model.Event{fail},
+		RecentCommands: []*model.Event{cmd},
+		Now:            createdAt,
+		Reliability: topReliabilityMetrics{
+			CandidateMemoryCount: 12,
+		},
+	}, topSnapshotProfileAI); err != nil {
+		t.Fatalf("writeTopSnapshotJSON(ai): %v", err)
+	}
+
+	var payload struct {
+		Profile        string `json:"profile"`
+		Sessions       []struct {
+			LatestEventMessage string `json:"latest_event_message"`
+			LatestEventID      string `json:"latest_event_id"`
+		} `json:"sessions"`
+		Failures []struct {
+			Message   string `json:"message"`
+			EventID   string `json:"event_id"`
+			Truncated bool   `json:"truncated"`
+		} `json:"failures"`
+		RecentCommands []struct {
+			Message string `json:"message"`
+			EventID string `json:"event_id"`
+		} `json:"recent_commands"`
+		Candidates struct {
+			Count int                      `json:"count"`
+			Items []map[string]interface{} `json:"items"`
+		} `json:"candidates"`
+		StaleMemories struct {
+			Items []map[string]interface{} `json:"items"`
+		} `json:"stale_memories"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, buf.String())
+	}
+	if payload.Profile != topSnapshotProfileAI {
+		t.Fatalf("profile = %q, want %q", payload.Profile, topSnapshotProfileAI)
+	}
+	if len(payload.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(payload.Sessions))
+	}
+	if !strings.Contains(payload.Sessions[0].LatestEventMessage, "traceary show ") {
+		t.Fatalf("latest_event_message = %q, want retrieval hint", payload.Sessions[0].LatestEventMessage)
+	}
+	if strings.Contains(payload.Sessions[0].LatestEventMessage, "xxx") {
+		t.Fatalf("latest_event_message still contains body: %q", payload.Sessions[0].LatestEventMessage)
+	}
+	if len(payload.Failures) != 1 || !strings.HasPrefix(payload.Failures[0].Message, "traceary show ") {
+		t.Fatalf("failures = %+v, want retrieval hint", payload.Failures)
+	}
+	if len(payload.RecentCommands) != 1 || !strings.HasPrefix(payload.RecentCommands[0].Message, "traceary show ") {
+		t.Fatalf("recent_commands = %+v, want retrieval hint", payload.RecentCommands)
+	}
+	if payload.Candidates.Count != 12 {
+		t.Fatalf("candidates.count = %d, want 12 from reliability metrics", payload.Candidates.Count)
+	}
+	if len(payload.Candidates.Items) != 0 {
+		t.Fatalf("candidates.items length = %d, want 0", len(payload.Candidates.Items))
+	}
+	if len(payload.StaleMemories.Items) != 0 {
+		t.Fatalf("stale_memories.items length = %d, want 0", len(payload.StaleMemories.Items))
+	}
+	// AI payload must stay well under the huge body size.
+	if len(buf.Bytes()) > 4000 {
+		t.Fatalf("AI snapshot size = %d bytes, want bounded envelope", len(buf.Bytes()))
+	}
+}
+
+func TestNormalizeTopSnapshotProfile(t *testing.T) {
+	t.Parallel()
+	got, err := normalizeTopSnapshotProfile("AI")
+	if err != nil || got != topSnapshotProfileAI {
+		t.Fatalf("normalize AI = %q, %v", got, err)
+	}
+	got, err = normalizeTopSnapshotProfile("")
+	if err != nil || got != topSnapshotProfileOperator {
+		t.Fatalf("normalize empty = %q, %v", got, err)
+	}
+	if _, err := normalizeTopSnapshotProfile("debug"); err == nil {
+		t.Fatal("normalize debug error = nil, want error")
 	}
 }


### PR DESCRIPTION
## Summary
- `traceary sessions --snapshot --json --profile ai` (also `top`) emits a bounded agent-resume envelope.
- Default operator snapshot JSON shape is unchanged.
- AI profile: `profile: "ai"`, retrieval hints for latest/failure/command events, candidate/stale counts without fact arrays, tighter pane caps.

## Test plan
- [x] Unit tests for AI projection and profile normalization
- [x] Live smoke: `sessions --snapshot --json --profile ai` returns `profile=ai`, empty candidate items, retrieval-hint messages
- [x] golangci-lint on presentation/cli

Closes #1245