### PR TITLE
feat: project large host-tool audits into compact summaries

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -69,6 +69,8 @@ session 解決ルール:
 
 command audit の input/output payload は、解決後の上限を超えると保存前に切り詰められます。上限の優先順位は `--max-*-bytes` flag、`TRACEARY_MAX_AUDIT_*_BYTES`、`~/.config/traceary/config.json` の `audit.max_*_bytes`、組み込み既定値です。切り詰め後も head / tail の文脈、構造化された `input_truncated` / `output_truncated` metadata、`original_bytes` marker は残ります。省略された byte は `traceary show` や MCP `full_body=true` でも復元できません。
 
+**read 面**（`sessions --snapshot --json`、list 系の recent-command ペイン）では、大きい host-tool payload（`Edit` / `Write` / `Read` / shell）を tool-aware な compact summary（tool 名、path、rune 数、content hash、head/tail、`traceary show <event_id>` の retrieval hint）に投影します。これは presentation 時の投影のみで、永続化された raw 本体と `traceary show` はフル fidelity のままです。
+
 command string も、保存前に組み込みの best-effort secret redactor を通ります。`input_redacted` / `output_redacted` は input/output payload の redaction だけを表し、command redaction 専用 flag はまだ出しません。
 
 session 解決ルールは `traceary log` と同じです。

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -69,6 +69,8 @@ Useful flags:
 
 Command-audit input/output payloads are truncated before persistence when they exceed the resolved limit. The resolved limit is `--max-*-bytes` flag, then `TRACEARY_MAX_AUDIT_*_BYTES`, then `audit.max_*_bytes` in `~/.config/traceary/config.json`, then the built-in default. Truncated payloads preserve head and tail context and include structured `input_truncated` / `output_truncated` metadata plus an `original_bytes` marker; omitted bytes are not recoverable through `traceary show` or MCP `full_body=true`.
 
+On **read surfaces** (`sessions --snapshot --json`, list-style recent-command panes), large host-tool payloads (`Edit` / `Write` / `Read` / shell) are projected into a tool-aware compact summary (tool name, path when present, rune counts, content hash, head/tail, and a `traceary show <event_id>` retrieval hint). This is a presentation-time projection only: raw persistence and `traceary show` remain full-fidelity.
+
 Command strings also pass through the built-in best-effort secret redactors before storage. `input_redacted` / `output_redacted` only report input/output payload redaction; they do not expose a separate command-redaction flag.
 
 Session resolution follows the same rules as `traceary log`.

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"io"
+	"unicode/utf8"
 
 	"golang.org/x/xerrors"
 
@@ -65,6 +66,17 @@ func newEventOutput(e *model.Event) event {
 // through newEventOutput so the full body remains retrievable.
 func newTruncatedEventOutput(e *model.Event, limit int) event {
 	base := newEventOutput(e)
+	// Prefer tool-aware compact projection for large host-tool payloads so
+	// list/snapshot surfaces keep auditability (path, hashes, sizes) without
+	// re-emitting full Edit/Write/Read bodies. Full body remains available via
+	// `traceary show` (newEventOutput).
+	if summary, ok := summarizeToolAwareCommandBody(base.Message, base.EventID); ok {
+		base.Message = summary
+		base.Truncated = true
+		base.MessageLength = utf8.RuneCountInString(apptypes.ExtractPlainBody(e.Body()))
+		base.MessageBytes = len(e.Body())
+		return base
+	}
 	result := apptypes.TruncateCommandPayload(base.Message, limit)
 	base.Message = result.Body
 	if result.Truncated {

--- a/presentation/cli/tool_aware_summary.go
+++ b/presentation/cli/tool_aware_summary.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// toolAwareSummaryMinRunes is the body size at which tool-aware compact
+// projection replaces the truncated raw payload on list/snapshot surfaces.
+// Smaller bodies keep the existing truncation-only path.
+const toolAwareSummaryMinRunes = 200
+
+var (
+	toolAwareEditWritePattern = regexp.MustCompile(`(?is)^\s*(Edit|Write|MultiEdit|NotebookEdit)\b`)
+	toolAwareReadPattern      = regexp.MustCompile(`(?is)^\s*(Read|NotebookRead)\b`)
+	toolAwarePathPattern      = regexp.MustCompile(`(?i)(?:file_path|path|target_file|AbsolutePath|TargetFile)\s*[:=]\s*["']?([^\s"',}]+)`)
+	toolAwareShellPattern     = regexp.MustCompile(`(?is)^\s*(Bash|run_command|Shell)\b`)
+)
+
+// toolAwareSummary is the compact projection for a large host-tool audit body.
+type toolAwareSummary struct {
+	Tool           string
+	Path           string
+	InputRunes     int
+	OutputRunes    int
+	ContentSHA256  string
+	Head           string
+	Tail           string
+	Truncated      bool
+	RetrievalNote  string
+}
+
+// summarizeToolAwareCommandBody projects large Edit/Write/Read/shell audit
+// bodies into structured metadata for AI-facing list/snapshot surfaces.
+// Returns ok=false when the body is small or not a recognized tool shape so
+// callers keep the existing truncation path. Full fidelity remains available
+// via `traceary show <event_id>`.
+func summarizeToolAwareCommandBody(body string, eventID string) (string, bool) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return "", false
+	}
+	if utf8.RuneCountInString(trimmed) < toolAwareSummaryMinRunes {
+		return "", false
+	}
+
+	tool := detectToolAwareTool(trimmed)
+	if tool == "" {
+		return "", false
+	}
+
+	path := firstSubmatch(toolAwarePathPattern, trimmed)
+	inputPart, outputPart := splitToolAwareIO(trimmed)
+	sum := toolAwareSummary{
+		Tool:          tool,
+		Path:          path,
+		InputRunes:    utf8.RuneCountInString(inputPart),
+		OutputRunes:   utf8.RuneCountInString(outputPart),
+		ContentSHA256: shortSHA256(trimmed),
+		Head:          headRunes(trimmed, 80),
+		Tail:          tailRunes(trimmed, 40),
+		Truncated:     true,
+		RetrievalNote: largePayloadRetrievalHint(eventID),
+	}
+	return formatToolAwareSummary(sum), true
+}
+
+func detectToolAwareTool(body string) string {
+	if m := toolAwareEditWritePattern.FindStringSubmatch(body); len(m) > 1 {
+		return m[1]
+	}
+	if m := toolAwareReadPattern.FindStringSubmatch(body); len(m) > 1 {
+		return m[1]
+	}
+	if m := toolAwareShellPattern.FindStringSubmatch(body); len(m) > 1 {
+		return m[1]
+	}
+	// Bare shell command line (no host tool name): first token.
+	fields := strings.Fields(body)
+	if len(fields) == 0 {
+		return ""
+	}
+	first := fields[0]
+	switch first {
+	case "cat", "head", "tail", "sed", "awk", "rg", "grep", "git", "go", "make":
+		return "shell"
+	default:
+		return ""
+	}
+}
+
+func splitToolAwareIO(body string) (input, output string) {
+	// Common Traceary audit formatting embeds INPUT:/OUTPUT: sections.
+	upper := body
+	inIdx := strings.Index(upper, "INPUT:")
+	outIdx := strings.Index(upper, "OUTPUT:")
+	switch {
+	case inIdx >= 0 && outIdx > inIdx:
+		return body[inIdx:], body[outIdx:]
+	case outIdx >= 0:
+		return body[:outIdx], body[outIdx:]
+	case inIdx >= 0:
+		return body[inIdx:], ""
+	default:
+		return body, ""
+	}
+}
+
+func formatToolAwareSummary(sum toolAwareSummary) string {
+	parts := []string{
+		fmt.Sprintf("tool=%s", sum.Tool),
+	}
+	if sum.Path != "" {
+		parts = append(parts, "path="+sum.Path)
+	}
+	parts = append(parts,
+		fmt.Sprintf("input_runes=%d", sum.InputRunes),
+		fmt.Sprintf("output_runes=%d", sum.OutputRunes),
+		"sha256="+sum.ContentSHA256,
+		"truncated=true",
+	)
+	if sum.Head != "" {
+		parts = append(parts, "head="+quoteSummaryFragment(sum.Head))
+	}
+	if sum.Tail != "" {
+		parts = append(parts, "tail="+quoteSummaryFragment(sum.Tail))
+	}
+	if sum.RetrievalNote != "" {
+		parts = append(parts, "detail="+sum.RetrievalNote)
+	}
+	return strings.Join(parts, " ")
+}
+
+func quoteSummaryFragment(value string) string {
+	value = strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\"", "'")
+	return `"` + value + `"`
+}
+
+func firstSubmatch(re *regexp.Regexp, value string) string {
+	m := re.FindStringSubmatch(value)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+func shortSHA256(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:8])
+}
+
+func headRunes(value string, n int) string {
+	runes := []rune(value)
+	if n <= 0 || len(runes) <= n {
+		return string(runes)
+	}
+	return string(runes[:n]) + "…"
+}
+
+func tailRunes(value string, n int) string {
+	runes := []rune(value)
+	if n <= 0 || len(runes) <= n {
+		return ""
+	}
+	return "…" + string(runes[len(runes)-n:])
+}

--- a/presentation/cli/tool_aware_summary_test.go
+++ b/presentation/cli/tool_aware_summary_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestSummarizeToolAwareCommandBody_Edit(t *testing.T) {
+	t.Parallel()
+	body := "Edit path=/Users/me/repo/main.go\nINPUT:\n" + strings.Repeat("old line\n", 40) + "OUTPUT:\n" + strings.Repeat("new line\n", 40)
+	got, ok := summarizeToolAwareCommandBody(body, "evt-edit-1")
+	if !ok {
+		t.Fatal("expected tool-aware summary")
+	}
+	for _, want := range []string{"tool=Edit", "path=", "input_runes=", "sha256=", "truncated=true", "traceary show evt-edit-1"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, strings.Repeat("old line", 5)) {
+		t.Fatalf("summary leaked full edit body: %q", got)
+	}
+}
+
+func TestSummarizeToolAwareCommandBody_Read(t *testing.T) {
+	t.Parallel()
+	body := "Read path=docs/cli/README.md\n" + strings.Repeat("# heading\ncontent line\n", 50)
+	got, ok := summarizeToolAwareCommandBody(body, "evt-read-1")
+	if !ok {
+		t.Fatal("expected tool-aware summary")
+	}
+	if !strings.Contains(got, "tool=Read") || !strings.Contains(got, "docs/cli/README.md") {
+		t.Fatalf("summary = %q", got)
+	}
+}
+
+func TestSummarizeToolAwareCommandBody_SkipsSmallBodies(t *testing.T) {
+	t.Parallel()
+	if _, ok := summarizeToolAwareCommandBody("Edit path=x\nshort", "evt"); ok {
+		t.Fatal("small body should not use tool-aware summary")
+	}
+}
+
+func TestNewTruncatedEventOutput_UsesToolAwareSummary(t *testing.T) {
+	t.Parallel()
+	createdAt := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	body := "Write path=/tmp/out.txt\nINPUT:\n" + strings.Repeat("payload-line\n", 60)
+	ev := model.EventOf(
+		domtypes.EventID("evt-write-1"),
+		domtypes.EventKindCommandExecuted,
+		domtypes.Client("hook"),
+		domtypes.Agent("claude"),
+		domtypes.SessionID("sess-1"),
+		domtypes.Workspace("github.com/duck8823/traceary"),
+		body,
+		createdAt,
+	)
+	out := newTruncatedEventOutput(ev, 500)
+	if !out.Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+	if !strings.Contains(out.Message, "tool=Write") {
+		t.Fatalf("message = %q, want tool-aware Write summary", out.Message)
+	}
+	if strings.Contains(out.Message, "payload-line\npayload-line") {
+		t.Fatalf("message leaked write body: %q", out.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- Read-time tool-aware compact projection for large `Edit`/`Write`/`Read`/shell audit bodies on list/snapshot surfaces.
- Summary keeps path, rune counts, content hash, head/tail, and `traceary show` retrieval hint.
- Raw persistence and `traceary show` are unchanged (full fidelity).

## Test plan
- [x] Unit tests for Edit/Read/Write summarization and small-body skip
- [x] `go test ./presentation/cli/ -run ToolAware`
- [x] golangci-lint

Closes #1243