### PR TITLE
feat: single-source packaged hook scripts with drift checks

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -12,20 +12,59 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// canonical hook sources that must be copied verbatim into every packaged
-// integration's scripts directory.
-var integrationHookSources = []string{
-	"scripts/hooks/common.sh",
-	"scripts/hooks/traceary-session.sh",
-	"scripts/hooks/traceary-audit.sh",
+// integrationHookCopy describes one canonical scripts/hooks/*.sh source and the
+// packaged destinations that must stay byte-identical to it. Host packages only
+// receive the wrappers they still ship; Antigravity calls the Go runtime
+// directly and is intentionally absent here.
+type integrationHookCopy struct {
+	source   string
+	packages []string
 }
 
-// packaged integration scripts directories that must hold copies of the
-// canonical hook sources.
-var integrationHookPackages = []string{
+// sharedCompatibilityPackages are the host packages that still ship the common
+// compatibility shell wrappers (session/audit + common helpers).
+var sharedCompatibilityPackages = []string{
 	"integrations/claude-plugin/scripts",
 	"plugins/traceary/scripts",
 	"integrations/gemini-extension/scripts",
+}
+
+// integrationHookCopies is the single-source membership matrix for packaged
+// hook shell wrappers. Edit scripts/hooks/, then run
+// `go run ./cmd/repo-tooling integrations sync-hooks` (or hand-copy) so each
+// destination stays byte-identical; integrations verify fails on drift.
+var integrationHookCopies = []integrationHookCopy{
+	{
+		source:   "scripts/hooks/common.sh",
+		packages: sharedCompatibilityPackages,
+	},
+	{
+		source:   "scripts/hooks/traceary-session.sh",
+		packages: sharedCompatibilityPackages,
+	},
+	{
+		source:   "scripts/hooks/traceary-audit.sh",
+		packages: sharedCompatibilityPackages,
+	},
+	{
+		source: "scripts/hooks/traceary-prompt.sh",
+		packages: []string{
+			"integrations/claude-plugin/scripts",
+			"integrations/gemini-extension/scripts",
+		},
+	},
+	{
+		source: "scripts/hooks/traceary-compact.sh",
+		packages: []string{
+			"integrations/claude-plugin/scripts",
+		},
+	},
+	{
+		source: "scripts/hooks/traceary-grok.sh",
+		packages: []string{
+			"integrations/grok-plugin/scripts",
+		},
+	},
 }
 
 func newIntegrationsCommand() *cobra.Command {
@@ -51,7 +90,27 @@ func newIntegrationsCommand() *cobra.Command {
 			return nil
 		},
 	}
+	syncHooks := &cobra.Command{
+		Use:   "sync-hooks",
+		Short: "Copy canonical scripts/hooks/*.sh into packaged integration scripts directories",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := findRepoRoot()
+			if err != nil {
+				return err
+			}
+			n, err := syncHookCopies(root)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "ok: synchronized %d packaged hook script copies from scripts/hooks/\n", n); err != nil {
+				return xerrors.Errorf("failed to write sync result: %w", err)
+			}
+			return nil
+		},
+	}
 	cmd.AddCommand(verify)
+	cmd.AddCommand(syncHooks)
 	return cmd
 }
 
@@ -237,24 +296,59 @@ func readVersion(root string) (string, error) {
 }
 
 func checkHooksAreCopied(root string) error {
-	for _, source := range integrationHookSources {
-		sourceText, err := os.ReadFile(filepath.Join(root, source))
+	for _, copy := range integrationHookCopies {
+		sourceText, err := os.ReadFile(filepath.Join(root, copy.source)) // #nosec G304 -- fixed package path under repo root
 		if err != nil {
-			return xerrors.Errorf("missing canonical hook source: %s", source)
+			return xerrors.Errorf("missing canonical hook source: %s", copy.source)
 		}
-		name := filepath.Base(source)
-		for _, pkg := range integrationHookPackages {
+		name := filepath.Base(copy.source)
+		for _, pkg := range copy.packages {
 			target := filepath.Join(pkg, name)
-			targetText, err := os.ReadFile(filepath.Join(root, target))
+			targetText, err := os.ReadFile(filepath.Join(root, target)) // #nosec G304 -- fixed package path under repo root
 			if err != nil {
 				return xerrors.Errorf("missing packaged hook script: %s", target)
 			}
 			if string(targetText) != string(sourceText) {
-				return xerrors.Errorf("packaged hook script drifted from canonical source: %s", target)
+				return xerrors.Errorf("packaged hook script drifted from canonical source: %s (expected byte-identical to %s)", target, copy.source)
 			}
 		}
 	}
 	return nil
+}
+
+// syncHookCopies overwrites each packaged destination with the canonical
+// scripts/hooks source. Returns the number of files written.
+func syncHookCopies(root string) (int, error) {
+	written := 0
+	for _, copy := range integrationHookCopies {
+		sourcePath := filepath.Join(root, copy.source)
+		sourceText, err := os.ReadFile(sourcePath) // #nosec G304 -- fixed package path under repo root
+		if err != nil {
+			return written, xerrors.Errorf("missing canonical hook source: %s: %w", copy.source, err)
+		}
+		name := filepath.Base(copy.source)
+		info, err := os.Stat(sourcePath)
+		if err != nil {
+			return written, xerrors.Errorf("stat canonical hook source: %s: %w", copy.source, err)
+		}
+		mode := info.Mode()
+		if mode&0o111 == 0 {
+			// Canonical sources should stay executable; force +x on copies.
+			mode |= 0o111
+		}
+		for _, pkg := range copy.packages {
+			targetDir := filepath.Join(root, pkg)
+			if err := os.MkdirAll(targetDir, 0o755); err != nil {
+				return written, xerrors.Errorf("create package scripts dir %s: %w", pkg, err)
+			}
+			target := filepath.Join(targetDir, name)
+			if err := os.WriteFile(target, sourceText, mode.Perm()); err != nil {
+				return written, xerrors.Errorf("write packaged hook script %s: %w", filepath.Join(pkg, name), err)
+			}
+			written++
+		}
+	}
+	return written, nil
 }
 
 func checkClaude(root, version string) error {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -162,4 +164,173 @@ func grokHookFixture() hookFile {
 		}}}}
 	}
 	return hookFile{Hooks: hooks}
+}
+
+func TestIntegrationHookCopies_MembershipMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Pin the single-source matrix so a host package cannot silently drop out of
+	// drift checking (or gain an unexpected shared script requirement).
+	wantByBase := map[string][]string{
+		"common.sh": {
+			"integrations/claude-plugin/scripts",
+			"plugins/traceary/scripts",
+			"integrations/gemini-extension/scripts",
+		},
+		"traceary-session.sh": {
+			"integrations/claude-plugin/scripts",
+			"plugins/traceary/scripts",
+			"integrations/gemini-extension/scripts",
+		},
+		"traceary-audit.sh": {
+			"integrations/claude-plugin/scripts",
+			"plugins/traceary/scripts",
+			"integrations/gemini-extension/scripts",
+		},
+		"traceary-prompt.sh": {
+			"integrations/claude-plugin/scripts",
+			"integrations/gemini-extension/scripts",
+		},
+		"traceary-compact.sh": {
+			"integrations/claude-plugin/scripts",
+		},
+		"traceary-grok.sh": {
+			"integrations/grok-plugin/scripts",
+		},
+	}
+
+	gotByBase := make(map[string][]string, len(integrationHookCopies))
+	for _, copy := range integrationHookCopies {
+		base := filepath.Base(copy.source)
+		if !strings.HasPrefix(copy.source, "scripts/hooks/") {
+			t.Fatalf("source %q must live under scripts/hooks/", copy.source)
+		}
+		gotByBase[base] = append([]string(nil), copy.packages...)
+	}
+
+	if len(gotByBase) != len(wantByBase) {
+		t.Fatalf("integrationHookCopies covers %d scripts, want %d", len(gotByBase), len(wantByBase))
+	}
+	for base, wantPkgs := range wantByBase {
+		gotPkgs, ok := gotByBase[base]
+		if !ok {
+			t.Fatalf("missing membership for %s", base)
+		}
+		if len(gotPkgs) != len(wantPkgs) {
+			t.Fatalf("%s packages = %v, want %v", base, gotPkgs, wantPkgs)
+		}
+		for i := range wantPkgs {
+			if gotPkgs[i] != wantPkgs[i] {
+				t.Fatalf("%s packages = %v, want %v", base, gotPkgs, wantPkgs)
+			}
+		}
+	}
+}
+
+func TestCheckHooksAreCopied_DetectsDriftAndMissing(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeHookTree(t, root)
+
+	if err := checkHooksAreCopied(root); err != nil {
+		t.Fatalf("checkHooksAreCopied(synced tree) error = %v", err)
+	}
+
+	// Drift a shared copy.
+	driftPath := filepath.Join(root, "integrations/claude-plugin/scripts/common.sh")
+	if err := os.WriteFile(driftPath, []byte("#!/bin/bash\necho drifted\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile drift: %v", err)
+	}
+	err := checkHooksAreCopied(root)
+	if err == nil {
+		t.Fatal("checkHooksAreCopied(drifted) error = nil, want drift error")
+	}
+	if !strings.Contains(err.Error(), "drifted") {
+		t.Fatalf("error = %v, want drifted message", err)
+	}
+
+	// Restore, then remove a package-specific copy.
+	if err := os.WriteFile(driftPath, []byte("#!/bin/bash\n# common\n"), 0o755); err != nil {
+		t.Fatalf("restore common.sh: %v", err)
+	}
+	missing := filepath.Join(root, "integrations/grok-plugin/scripts/traceary-grok.sh")
+	if err := os.Remove(missing); err != nil {
+		t.Fatalf("Remove grok script: %v", err)
+	}
+	err = checkHooksAreCopied(root)
+	if err == nil {
+		t.Fatal("checkHooksAreCopied(missing) error = nil, want missing error")
+	}
+	if !strings.Contains(err.Error(), "missing packaged hook script") {
+		t.Fatalf("error = %v, want missing packaged hook script", err)
+	}
+}
+
+func TestSyncHookCopies_RewritesPackagedScripts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeHookTree(t, root)
+
+	// Corrupt a destination, then sync from canonical.
+	target := filepath.Join(root, "plugins/traceary/scripts/traceary-audit.sh")
+	if err := os.WriteFile(target, []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile stale audit: %v", err)
+	}
+
+	n, err := syncHookCopies(root)
+	if err != nil {
+		t.Fatalf("syncHookCopies() error = %v", err)
+	}
+	wantN := 0
+	for _, copy := range integrationHookCopies {
+		wantN += len(copy.packages)
+	}
+	if n != wantN {
+		t.Fatalf("syncHookCopies() wrote %d files, want %d", n, wantN)
+	}
+	if err := checkHooksAreCopied(root); err != nil {
+		t.Fatalf("checkHooksAreCopied after sync error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile after sync: %v", err)
+	}
+	if string(got) != "#!/bin/bash\n# audit\n" {
+		t.Fatalf("audit copy = %q, want canonical content", got)
+	}
+}
+
+// writeHookTree creates a minimal scripts/hooks + package-copy tree that
+// satisfies checkHooksAreCopied for the membership matrix.
+func writeHookTree(t *testing.T, root string) {
+	t.Helper()
+
+	canonical := map[string]string{
+		"common.sh":           "#!/bin/bash\n# common\n",
+		"traceary-session.sh": "#!/bin/bash\n# session\n",
+		"traceary-audit.sh":   "#!/bin/bash\n# audit\n",
+		"traceary-prompt.sh":  "#!/bin/bash\n# prompt\n",
+		"traceary-compact.sh": "#!/bin/bash\n# compact\n",
+		"traceary-grok.sh":    "#!/bin/sh\n# grok\n",
+	}
+	hooksDir := filepath.Join(root, "scripts/hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll hooks: %v", err)
+	}
+	for name, body := range canonical {
+		path := filepath.Join(hooksDir, name)
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+
+	n, err := syncHookCopies(root)
+	if err != nil {
+		t.Fatalf("seed syncHookCopies: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("seed syncHookCopies wrote 0 files")
+	}
 }

--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -14,11 +14,13 @@ host ごとのネイティブ連携パッケージを使いたい場合は、ま
 
 ## 含まれるファイル
 
-- `scripts/hooks/*.sh`: `traceary hook ...` へ委譲する互換ラッパー
+- `scripts/hooks/*.sh`: **canonical** な互換ラッパー（`traceary hook ...` へ委譲）
 - `examples/hooks/claude.settings.json`: Claude Code の設定例
 - `examples/hooks/codex.hooks.json`: Codex CLI の設定例
 - `examples/hooks/gemini.settings.json`: Gemini CLI の設定例
 - `integrations/` と `plugins/` の配布パッケージには、bundle 形式の都合で必要な wrapper copy も含まれます
+
+編集は `scripts/hooks/` のみ行い、続けて `go run ./cmd/repo-tooling integrations sync-hooks` を実行して Claude / Codex / Gemini / Grok パッケージのコピーをバイト一致に保ちます。コピーがドリフトすると `integrations verify`（CI）が失敗します。
 
 新しく生成する hook 設定では、`~/.config/traceary/hook-scripts` へ portable script をインストールしません。新しい runtime 経路を使うには、hook 設定を再生成するか、配布済み integration package を使ってください。
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -14,11 +14,13 @@ If you want host-native packages instead of manual hook wiring, start with the [
 
 ## Files
 
-- `scripts/hooks/*.sh`: compatibility wrappers that delegate to `traceary hook ...`
+- `scripts/hooks/*.sh`: **canonical** compatibility wrappers that delegate to `traceary hook ...`
 - `examples/hooks/claude.settings.json`: Claude Code example
 - `examples/hooks/codex.hooks.json`: Codex CLI example
 - `examples/hooks/gemini.settings.json`: Gemini CLI example
 - packaged host integrations under `integrations/` and `plugins/` ship matching wrapper copies when the bundle format still expects script assets
+
+Edit only `scripts/hooks/`, then run `go run ./cmd/repo-tooling integrations sync-hooks` so Claude / Codex / Gemini / Grok package copies stay byte-identical. `integrations verify` (CI) fails when a packaged copy drifts.
 
 Traceary no longer installs portable hook-script copies under `~/.config/traceary/hook-scripts` for generated configs. Regenerate the hook config, or use a packaged integration, when you want the runtime entrypoint to stay `traceary hook ...`.
 

--- a/docs/operations/repo-tooling.ja.md
+++ b/docs/operations/repo-tooling.ja.md
@@ -53,6 +53,7 @@ maintainer-only の repository automation は性質が異なります。
 最終的には、次のような subcommand に寄せます。
 
 - `go run ./cmd/repo-tooling integrations verify`
+- `go run ./cmd/repo-tooling integrations sync-hooks`
 - `go run ./cmd/repo-tooling docs verify-i18n`
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`

--- a/docs/operations/repo-tooling.md
+++ b/docs/operations/repo-tooling.md
@@ -53,6 +53,7 @@ Examples that do **not** belong there:
 The repository should converge on subcommands shaped like these:
 
 - `go run ./cmd/repo-tooling integrations verify`
+- `go run ./cmd/repo-tooling integrations sync-hooks`
 - `go run ./cmd/repo-tooling docs verify-i18n`
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`

--- a/scripts/hooks/assets_external_test.go
+++ b/scripts/hooks/assets_external_test.go
@@ -25,6 +25,7 @@ func TestAssets_returnsAllCanonicalScripts(t *testing.T) {
 		"traceary-audit.sh":   false,
 		"traceary-compact.sh": false,
 		"traceary-prompt.sh":  false,
+		"traceary-grok.sh":    false,
 	}
 
 	for _, asset := range assets {
@@ -40,8 +41,9 @@ func TestAssets_returnsAllCanonicalScripts(t *testing.T) {
 			t.Errorf("asset %q contains CRLF line endings", asset.Name())
 		}
 
-		if !strings.HasPrefix(asset.Content(), "#!/bin/bash") {
-			t.Errorf("asset %q does not start with shebang", asset.Name())
+		// Shared wrappers use bash; the Grok host entrypoint is POSIX sh.
+		if !strings.HasPrefix(asset.Content(), "#!/bin/bash") && !strings.HasPrefix(asset.Content(), "#!/bin/sh") {
+			t.Errorf("asset %q does not start with a shell shebang", asset.Name())
 		}
 	}
 

--- a/scripts/hooks/traceary-grok.sh
+++ b/scripts/hooks/traceary-grok.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+action="${1:?missing Grok hook action}"
+case "${action}" in
+  session-start|user-prompt-submit|pre-tool-use|post-tool-use|stop|pre-compact|post-compact) ;;
+  *)
+    printf 'unsupported Grok hook action: %s\n' "${action}" >&2
+    exit 64
+    ;;
+esac
+
+exec traceary hook grok "${action}"


### PR DESCRIPTION
## Summary
- Expand `integrationHookCopies` so every packaged shell wrapper (including prompt, compact, and Grok) has an explicit package membership and must stay byte-identical to `scripts/hooks/`.
- Add `go run ./cmd/repo-tooling integrations sync-hooks` to regenerate package copies from the canonical source.
- Table-driven tests cover membership, drift, and missing-copy failure modes; document the edit/sync workflow.

## Test plan
- [x] `go test ./cmd/repo-tooling/ ./scripts/hooks/`
- [x] `go run ./cmd/repo-tooling integrations verify`
- [x] `go run ./cmd/repo-tooling docs verify-i18n`

Closes #1260