### PR TITLE
feat: drive host coverage docs and doctor from one matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Verify Antigravity current-state wording
         run: go run ./cmd/repo-tooling docs verify-antigravity-status
 
+      - name: Verify host-coverage matrix tables
+        run: go run ./cmd/repo-tooling docs verify-host-coverage
+
       - name: Verify removed-alias examples
         run: python3 scripts/verify_docs_no_removed_aliases.py
 

--- a/application/hostcoverage/matrix.go
+++ b/application/hostcoverage/matrix.go
@@ -1,0 +1,234 @@
+// Package hostcoverage is the machine-readable source of truth for the per-host
+// lifecycle capture matrix used by doctor diagnostics and the bilingual
+// host-coverage docs table.
+package hostcoverage
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/xerrors"
+)
+
+// Status is the matrix cell classification for one host × lifecycle event.
+type Status string
+
+const (
+	// StatusWired means Traceary's packaged integration captures this event.
+	StatusWired Status = "wired"
+	// StatusAvailable means the host exposes a hook but Traceary does not wire it.
+	StatusAvailable Status = "available"
+	// StatusUnsupported means the host does not expose a usable signal.
+	StatusUnsupported Status = "unsupported"
+)
+
+// Localized is a bilingual text pair.
+type Localized struct {
+	EN string `json:"en"`
+	JA string `json:"ja"`
+}
+
+// LifecycleEvent is one row of the coverage matrix.
+type LifecycleEvent struct {
+	ID           string     `json:"id"`
+	Verification Localized  `json:"verification"`
+}
+
+// EventCell is one host cell for a lifecycle event.
+type EventCell struct {
+	Status  Status    `json:"status"`
+	Summary Localized `json:"summary"`
+}
+
+// Host is one column of the coverage matrix.
+type Host struct {
+	ID                        string               `json:"id"`
+	Package                   string               `json:"package"`
+	Label                     Localized            `json:"label"`
+	DoctorClient              string               `json:"doctor_client"`
+	ExpectsSessionEnrichment  bool                 `json:"expects_session_enrichment"`
+	Events                    map[string]EventCell `json:"events"`
+}
+
+// Matrix is the full host × lifecycle coverage document.
+type Matrix struct {
+	SchemaVersion   int              `json:"schema_version"`
+	LastVerified    string           `json:"last_verified"`
+	Notes           Localized        `json:"notes"`
+	LifecycleEvents []LifecycleEvent `json:"lifecycle_events"`
+	Hosts           []Host           `json:"hosts"`
+}
+
+//go:embed matrix.json
+var matrixJSON []byte
+
+var (
+	matrixOnce sync.Once
+	matrixVal  Matrix
+	matrixErr  error
+)
+
+// Load returns the embedded host coverage matrix.
+func Load() (Matrix, error) {
+	matrixOnce.Do(func() {
+		if err := json.Unmarshal(matrixJSON, &matrixVal); err != nil {
+			matrixErr = xerrors.Errorf("parse host coverage matrix: %w", err)
+			return
+		}
+		if err := matrixVal.validate(); err != nil {
+			matrixErr = err
+			return
+		}
+	})
+	return matrixVal, matrixErr
+}
+
+// MustLoad returns the matrix or panics. Reserved for init-time wiring where a
+// missing matrix is a programming error.
+func MustLoad() Matrix {
+	m, err := Load()
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// HostByDoctorClient returns the matrix host for a doctor --client value.
+func (m Matrix) HostByDoctorClient(client string) (Host, bool) {
+	for _, host := range m.Hosts {
+		if host.DoctorClient == client || host.ID == client {
+			return host, true
+		}
+	}
+	return Host{}, false
+}
+
+// WiredLifecycleEvents returns the lifecycle event IDs marked status=wired for
+// the given doctor client.
+func (m Matrix) WiredLifecycleEvents(client string) []string {
+	host, ok := m.HostByDoctorClient(client)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(host.Events))
+	for id, cell := range host.Events {
+		if cell.Status == StatusWired {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// ExpectsSessionEnrichment reports whether doctor should judge prompt/transcript
+// coverage for the host once a minimum sample of sessions is observed.
+func (m Matrix) ExpectsSessionEnrichment(client string) bool {
+	host, ok := m.HostByDoctorClient(client)
+	if !ok {
+		return false
+	}
+	return host.ExpectsSessionEnrichment
+}
+
+func (m Matrix) validate() error {
+	if m.SchemaVersion != 1 {
+		return xerrors.Errorf("unsupported host coverage schema_version %d", m.SchemaVersion)
+	}
+	if m.LastVerified == "" {
+		return xerrors.Errorf("host coverage matrix missing last_verified")
+	}
+	if len(m.LifecycleEvents) == 0 {
+		return xerrors.Errorf("host coverage matrix has no lifecycle_events")
+	}
+	if len(m.Hosts) == 0 {
+		return xerrors.Errorf("host coverage matrix has no hosts")
+	}
+	for _, event := range m.LifecycleEvents {
+		if event.ID == "" {
+			return xerrors.Errorf("lifecycle event missing id")
+		}
+	}
+	for _, host := range m.Hosts {
+		if host.ID == "" || host.DoctorClient == "" {
+			return xerrors.Errorf("host missing id or doctor_client")
+		}
+		for _, event := range m.LifecycleEvents {
+			cell, ok := host.Events[event.ID]
+			if !ok {
+				return xerrors.Errorf("host %s missing lifecycle event %s", host.ID, event.ID)
+			}
+			switch cell.Status {
+			case StatusWired, StatusAvailable, StatusUnsupported:
+			default:
+				return xerrors.Errorf("host %s event %s has invalid status %q", host.ID, event.ID, cell.Status)
+			}
+			if cell.Summary.EN == "" || cell.Summary.JA == "" {
+				return xerrors.Errorf("host %s event %s missing bilingual summary", host.ID, event.ID)
+			}
+		}
+	}
+	return nil
+}
+
+// RenderMatrixTable builds the Markdown table for language ("en" or "ja").
+func (m Matrix) RenderMatrixTable(lang string) string {
+	var b strings.Builder
+	b.WriteString("| Traceary lifecycle event |")
+	for _, host := range m.Hosts {
+		b.WriteString(" ")
+		b.WriteString(pick(lang, host.Label))
+		b.WriteString(" |")
+	}
+	b.WriteString(" ")
+	if lang == "ja" {
+		b.WriteString("確認方法")
+	} else {
+		b.WriteString("Verification")
+	}
+	b.WriteString(" |\n|---|")
+	for range m.Hosts {
+		b.WriteString("---|")
+	}
+	b.WriteString("---|\n")
+	for _, event := range m.LifecycleEvents {
+		b.WriteString("| `")
+		b.WriteString(event.ID)
+		b.WriteString("` |")
+		for _, host := range m.Hosts {
+			cell := host.Events[event.ID]
+			b.WriteString(" ")
+			b.WriteString(pick(lang, cell.Summary))
+			b.WriteString(" |")
+		}
+		b.WriteString(" ")
+		b.WriteString(pick(lang, event.Verification))
+		b.WriteString(" |\n")
+	}
+	return b.String()
+}
+
+func pick(lang string, loc Localized) string {
+	if lang == "ja" {
+		return loc.JA
+	}
+	return loc.EN
+}
+
+// StatusSymbol is a convenience for diagnostics (not used in docs cells, which
+// already embed the symbol in the summary).
+func StatusSymbol(status Status) string {
+	switch status {
+	case StatusWired:
+		return "●"
+	case StatusAvailable:
+		return "○"
+	case StatusUnsupported:
+		return "✕"
+	default:
+		return fmt.Sprintf("?(%s)", status)
+	}
+}

--- a/application/hostcoverage/matrix.json
+++ b/application/hostcoverage/matrix.json
@@ -1,0 +1,324 @@
+{
+  "schema_version": 1,
+  "last_verified": "2026-07-16",
+  "notes": {
+    "en": "Last verified: 2026-07-16 (Grok Build 0.2.101 re-probe for unobserved hooks + 0.2.99 fixtures; Antigravity CLI 1.1.1 and the current official hook contract; Gemini CLI re-verified 2026-06-10 against 0.43.0).",
+    "ja": "最終確認日: 2026-07-16（Grok Build 0.2.101 の未観測 hook 再 probe + 0.2.99 fixture、Antigravity CLI 1.1.1 と現行公式 hook contract。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。"
+  },
+  "lifecycle_events": [
+    {
+      "id": "session_started",
+      "verification": {
+        "en": "`traceary list events --kind session_started --limit 5`",
+        "ja": "`traceary list events --kind session_started --limit 5`"
+      }
+    },
+    {
+      "id": "prompt",
+      "verification": {
+        "en": "`traceary list events --kind prompt --limit 5`",
+        "ja": "`traceary list events --kind prompt --limit 5`"
+      }
+    },
+    {
+      "id": "command_executed",
+      "verification": {
+        "en": "`traceary list events --kind command_executed --limit 5`",
+        "ja": "`traceary list events --kind command_executed --limit 5`"
+      }
+    },
+    {
+      "id": "transcript",
+      "verification": {
+        "en": "`traceary list events --kind transcript --limit 5`",
+        "ja": "`traceary list events --kind transcript --limit 5`"
+      }
+    },
+    {
+      "id": "compact_summary",
+      "verification": {
+        "en": "`traceary list events --kind compact_summary --limit 5`",
+        "ja": "`traceary list events --kind compact_summary --limit 5`"
+      }
+    },
+    {
+      "id": "session_ended",
+      "verification": {
+        "en": "`traceary list events --kind session_ended --limit 5`",
+        "ja": "`traceary list events --kind session_ended --limit 5`"
+      }
+    }
+  ],
+  "hosts": [
+    {
+      "id": "claude",
+      "package": "claude-plugin",
+      "label": {
+        "en": "Claude Code (`claude-plugin`)",
+        "ja": "Claude Code (`claude-plugin`)"
+      },
+      "doctor_client": "claude",
+      "expects_session_enrichment": true,
+      "events": {
+        "session_started": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionStart`",
+            "ja": "● `SessionStart`"
+          }
+        },
+        "prompt": {
+          "status": "wired",
+          "summary": {
+            "en": "● `UserPromptSubmit`",
+            "ja": "● `UserPromptSubmit`"
+          }
+        },
+        "command_executed": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher)",
+            "ja": "● `PostToolUse` + `PostToolUseFailure` (Bash, `mcp__.*`, built-in tool matcher)"
+          }
+        },
+        "transcript": {
+          "status": "wired",
+          "summary": {
+            "en": "● `Stop`",
+            "ja": "● `Stop`"
+          }
+        },
+        "compact_summary": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume)",
+            "ja": "● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume)"
+          }
+        },
+        "session_ended": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionEnd`",
+            "ja": "● `SessionEnd`"
+          }
+        }
+      }
+    },
+    {
+      "id": "codex",
+      "package": "plugins/traceary",
+      "label": {
+        "en": "Codex CLI 0.144.1 (`plugins/traceary`)",
+        "ja": "Codex CLI 0.144.1 (`plugins/traceary`)"
+      },
+      "doctor_client": "codex",
+      "expects_session_enrichment": true,
+      "events": {
+        "session_started": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionStart`",
+            "ja": "● `SessionStart`"
+          }
+        },
+        "prompt": {
+          "status": "wired",
+          "summary": {
+            "en": "● `UserPromptSubmit`",
+            "ja": "● `UserPromptSubmit`"
+          }
+        },
+        "command_executed": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PostToolUse`",
+            "ja": "● `PostToolUse`"
+          }
+        },
+        "transcript": {
+          "status": "wired",
+          "summary": {
+            "en": "● `Stop` (`last_assistant_message`)",
+            "ja": "● `Stop` (`last_assistant_message`)"
+          }
+        },
+        "compact_summary": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreCompact` + `PostCompact` markers (`trigger` only; Codex exposes no compacted summary body)",
+            "ja": "● `PreCompact` + `PostCompact` marker（`trigger` のみ。Codex は圧縮後サマリー本文を公開しない）"
+          }
+        },
+        "session_ended": {
+          "status": "unsupported",
+          "summary": {
+            "en": "✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC",
+            "ja": "✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由"
+          }
+        }
+      }
+    },
+    {
+      "id": "gemini",
+      "package": "gemini-extension",
+      "label": {
+        "en": "Gemini CLI (`gemini-extension`)",
+        "ja": "Gemini CLI (`gemini-extension`)"
+      },
+      "doctor_client": "gemini",
+      "expects_session_enrichment": true,
+      "events": {
+        "session_started": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionStart`",
+            "ja": "● `SessionStart`"
+          }
+        },
+        "prompt": {
+          "status": "wired",
+          "summary": {
+            "en": "● `BeforeAgent`",
+            "ja": "● `BeforeAgent`"
+          }
+        },
+        "command_executed": {
+          "status": "wired",
+          "summary": {
+            "en": "● `AfterTool`",
+            "ja": "● `AfterTool`"
+          }
+        },
+        "transcript": {
+          "status": "wired",
+          "summary": {
+            "en": "● `AfterAgent`",
+            "ja": "● `AfterAgent`"
+          }
+        },
+        "compact_summary": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary)",
+            "ja": "● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない)"
+          }
+        },
+        "session_ended": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionEnd`",
+            "ja": "● `SessionEnd`"
+          }
+        }
+      }
+    },
+    {
+      "id": "antigravity",
+      "package": "antigravity-plugin",
+      "label": {
+        "en": "Antigravity (`antigravity-plugin`)",
+        "ja": "Antigravity (`antigravity-plugin`)"
+      },
+      "doctor_client": "antigravity",
+      "expects_session_enrichment": true,
+      "events": {
+        "session_started": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreInvocation` (idempotent, keyed by `conversationId`; Antigravity has no `SessionStart`)",
+            "ja": "● `PreInvocation`（`conversationId` を key にした冪等開始。Antigravity に `SessionStart` はない）"
+          }
+        },
+        "prompt": {
+          "status": "wired",
+          "summary": {
+            "en": "● `Stop` (no direct prompt field; recovered from the latest `USER_INPUT` / `USER_EXPLICIT` row at `transcriptPath`)",
+            "ja": "● `Stop`（直接の prompt field は無い。`transcriptPath` の最新 `USER_INPUT` / `USER_EXPLICIT` 行から復元）"
+          }
+        },
+        "command_executed": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreToolUse` + `PostToolUse` (`run_command`; command args paired across the two events by `conversationId + stepIdx`)",
+            "ja": "● `PreToolUse` + `PostToolUse`（`run_command`。command args は `conversationId + stepIdx` で 2 event をまたいで突き合わせ）"
+          }
+        },
+        "transcript": {
+          "status": "wired",
+          "summary": {
+            "en": "● `Stop` (`transcriptPath`, best-effort lenient JSONL scan)",
+            "ja": "● `Stop`（`transcriptPath`、best-effort な寛容 JSONL 走査）"
+          }
+        },
+        "compact_summary": {
+          "status": "unsupported",
+          "summary": {
+            "en": "✕ no documented compact hook",
+            "ja": "✕ 文書化された compact hook なし"
+          }
+        },
+        "session_ended": {
+          "status": "unsupported",
+          "summary": {
+            "en": "✕ no host session-end signal — Antigravity `Stop` is a per-execution boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC",
+            "ja": "✕ host のセッション終了信号なし — Antigravity `Stop` は execution 単位の境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由"
+          }
+        }
+      }
+    },
+    {
+      "id": "grok",
+      "package": "grok-plugin",
+      "label": {
+        "en": "Grok Build 0.2.99",
+        "ja": "Grok Build 0.2.99"
+      },
+      "doctor_client": "grok",
+      "expects_session_enrichment": true,
+      "events": {
+        "session_started": {
+          "status": "wired",
+          "summary": {
+            "en": "● `SessionStart` (native `agent=grok`)",
+            "ja": "● `SessionStart`（native の `agent=grok`）"
+          }
+        },
+        "prompt": {
+          "status": "wired",
+          "summary": {
+            "en": "● `UserPromptSubmit` (`prompt`; native `agent=grok`)",
+            "ja": "● `UserPromptSubmit`（`prompt`、native の `agent=grok`）"
+          }
+        },
+        "command_executed": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreToolUse` validation + `PostToolUse` completed audit (input/result are co-located; missing/denied reads are failed result variants)",
+            "ja": "● `PreToolUse` の検証 + `PostToolUse` の完了監査（input/result は同一 payload。missing/denied read は失敗 result variant）"
+          }
+        },
+        "transcript": {
+          "status": "wired",
+          "summary": {
+            "en": "● `Stop` (best-effort current-prompt message chunks from `updates.jsonl`; no model field)",
+            "ja": "● `Stop`（`updates.jsonl` から現在の prompt の message chunk を best-effort 取得。model field はない）"
+          }
+        },
+        "compact_summary": {
+          "status": "wired",
+          "summary": {
+            "en": "● `PreCompact` + `PostCompact` (native live-observed markers from `source`; no summary body)",
+            "ja": "● `PreCompact` + `PostCompact`（native で live 確認済みの `source` marker。summary 本文なし）"
+          }
+        },
+        "session_ended": {
+          "status": "available",
+          "summary": {
+            "en": "○ documented `SessionEnd`, but not emitted by headless completion, TUI `/quit`, or TUI `/new` probes",
+            "ja": "○ `SessionEnd` は文書化済みだが、headless 完了・TUI `/quit`・TUI `/new` の probe では未発火"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/application/hostcoverage/matrix_test.go
+++ b/application/hostcoverage/matrix_test.go
@@ -1,0 +1,55 @@
+package hostcoverage_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application/hostcoverage"
+)
+
+func TestLoad_ParsesEmbeddedMatrix(t *testing.T) {
+	t.Parallel()
+
+	m, err := hostcoverage.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if m.LastVerified == "" {
+		t.Fatal("LastVerified is empty")
+	}
+	if len(m.Hosts) < 5 {
+		t.Fatalf("Hosts = %d, want at least claude/codex/gemini/antigravity/grok", len(m.Hosts))
+	}
+	wired := m.WiredLifecycleEvents("claude")
+	if len(wired) == 0 {
+		t.Fatal("claude wired lifecycle events is empty")
+	}
+	if !m.ExpectsSessionEnrichment("antigravity") {
+		t.Fatal("antigravity should expect session enrichment")
+	}
+	table := m.RenderMatrixTable("en")
+	if !strings.Contains(table, "session_started") || !strings.Contains(table, "Claude Code") {
+		t.Fatalf("EN table missing expected content:\n%s", table)
+	}
+	ja := m.RenderMatrixTable("ja")
+	if !strings.Contains(ja, "確認方法") {
+		t.Fatalf("JA table missing 確認方法 column:\n%s", ja)
+	}
+}
+
+func TestLoad_GrokSessionEndedIsAvailableNotWired(t *testing.T) {
+	t.Parallel()
+
+	m, err := hostcoverage.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	host, ok := m.HostByDoctorClient("grok")
+	if !ok {
+		t.Fatal("missing grok host")
+	}
+	cell := host.Events["session_ended"]
+	if cell.Status != hostcoverage.StatusAvailable {
+		t.Fatalf("grok session_ended status = %q, want available", cell.Status)
+	}
+}

--- a/cmd/repo-tooling/docs.go
+++ b/cmd/repo-tooling/docs.go
@@ -96,9 +96,47 @@ func newDocsCommand() *cobra.Command {
 			return nil
 		},
 	}
+	generateHostCoverageCmd := &cobra.Command{
+		Use:   "generate-host-coverage",
+		Short: "Regenerate the host-coverage matrix tables from application/hostcoverage/matrix.json",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := findRepoRoot()
+			if err != nil {
+				return err
+			}
+			if err := generateHostCoverageDocs(root); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "ok: regenerated host-coverage matrix tables from application/hostcoverage/matrix.json"); err != nil {
+				return xerrors.Errorf("failed to write generate result: %w", err)
+			}
+			return nil
+		},
+	}
+	verifyHostCoverageCmd := &cobra.Command{
+		Use:   "verify-host-coverage",
+		Short: "Verify host-coverage.md tables match application/hostcoverage/matrix.json",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := findRepoRoot()
+			if err != nil {
+				return err
+			}
+			if err := verifyHostCoverageDocs(root); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), "ok: host-coverage matrix tables match application/hostcoverage/matrix.json"); err != nil {
+				return xerrors.Errorf("failed to write verify result: %w", err)
+			}
+			return nil
+		},
+	}
 	cmd.AddCommand(verifyI18n)
 	cmd.AddCommand(verifyLandingCmd)
 	cmd.AddCommand(verifyAntigravityCmd)
+	cmd.AddCommand(generateHostCoverageCmd)
+	cmd.AddCommand(verifyHostCoverageCmd)
 	return cmd
 }
 

--- a/cmd/repo-tooling/docs_host_coverage.go
+++ b/cmd/repo-tooling/docs_host_coverage.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/duck8823/traceary/application/hostcoverage"
+	"golang.org/x/xerrors"
+)
+
+const (
+	hostCoverageBeginMarker = "<!-- host-coverage-matrix:begin -->"
+	hostCoverageEndMarker   = "<!-- host-coverage-matrix:end -->"
+	hostCoverageGenComment  = "<!-- DO NOT EDIT: generated from application/hostcoverage/matrix.json via `go run ./cmd/repo-tooling docs generate-host-coverage`. -->"
+)
+
+var hostCoverageDocFiles = []struct {
+	rel  string
+	lang string
+}{
+	{rel: "docs/hooks/host-coverage.md", lang: "en"},
+	{rel: "docs/hooks/host-coverage.ja.md", lang: "ja"},
+}
+
+func generateHostCoverageDocs(root string) error {
+	matrix, err := hostcoverage.Load()
+	if err != nil {
+		return xerrors.Errorf("load host coverage matrix: %w", err)
+	}
+	for _, doc := range hostCoverageDocFiles {
+		if err := rewriteHostCoverageDoc(filepath.Join(root, doc.rel), matrix.RenderMatrixTable(doc.lang)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyHostCoverageDocs(root string) error {
+	matrix, err := hostcoverage.Load()
+	if err != nil {
+		return xerrors.Errorf("load host coverage matrix: %w", err)
+	}
+	for _, doc := range hostCoverageDocFiles {
+		path := filepath.Join(root, doc.rel)
+		data, err := os.ReadFile(path) // #nosec G304 -- fixed docs path under repo root
+		if err != nil {
+			return xerrors.Errorf("read %s: %w", doc.rel, err)
+		}
+		wantBody := hostCoverageGenComment + "\n" + strings.TrimSuffix(matrix.RenderMatrixTable(doc.lang), "\n")
+		gotBody, err := extractHostCoverageSection(string(data))
+		if err != nil {
+			return xerrors.Errorf("%s: %w", doc.rel, err)
+		}
+		if strings.TrimSpace(gotBody) != strings.TrimSpace(wantBody) {
+			return xerrors.Errorf("%s host-coverage matrix section drifted from application/hostcoverage/matrix.json; run `go run ./cmd/repo-tooling docs generate-host-coverage`", doc.rel)
+		}
+	}
+	return nil
+}
+
+func rewriteHostCoverageDoc(path, table string) error {
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed docs path under repo root
+	if err != nil {
+		return xerrors.Errorf("read %s: %w", path, err)
+	}
+	updated, err := replaceHostCoverageSection(string(data), hostCoverageGenComment+"\n"+strings.TrimSuffix(table, "\n"))
+	if err != nil {
+		return xerrors.Errorf("%s: %w", path, err)
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		return xerrors.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func extractHostCoverageSection(content string) (string, error) {
+	begin := strings.Index(content, hostCoverageBeginMarker)
+	end := strings.Index(content, hostCoverageEndMarker)
+	if begin < 0 || end < 0 || end <= begin {
+		return "", xerrors.Errorf("missing %s / %s markers", hostCoverageBeginMarker, hostCoverageEndMarker)
+	}
+	start := begin + len(hostCoverageBeginMarker)
+	return strings.TrimSpace(content[start:end]), nil
+}
+
+func replaceHostCoverageSection(content, body string) (string, error) {
+	begin := strings.Index(content, hostCoverageBeginMarker)
+	end := strings.Index(content, hostCoverageEndMarker)
+	if begin < 0 || end < 0 || end <= begin {
+		return "", xerrors.Errorf("missing %s / %s markers", hostCoverageBeginMarker, hostCoverageEndMarker)
+	}
+	var b strings.Builder
+	b.WriteString(content[:begin])
+	b.WriteString(hostCoverageBeginMarker)
+	b.WriteString("\n")
+	b.WriteString(strings.TrimSpace(body))
+	b.WriteString("\n")
+	b.WriteString(content[end:])
+	return b.String(), nil
+}

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -16,6 +16,8 @@
 
 ## ライフサイクルイベント → ホスト hook マトリクス
 
+<!-- host-coverage-matrix:begin -->
+<!-- DO NOT EDIT: generated from application/hostcoverage/matrix.json via `go run ./cmd/repo-tooling docs generate-host-coverage`. -->
 | Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Grok Build 0.2.99 | 確認方法 |
 |---|---|---|---|---|---|---|
 | `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation`（`conversationId` を key にした冪等開始。Antigravity に `SessionStart` はない） | ● `SessionStart`（native の `agent=grok`） | `traceary list events --kind session_started --limit 5` |
@@ -24,6 +26,7 @@
 | `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop`（`transcriptPath`、best-effort な寛容 JSONL 走査） | ● `Stop`（`updates.jsonl` から現在の prompt の message chunk を best-effort 取得。model field はない） | `traceary list events --kind transcript --limit 5` |
 | `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` で resume) | ● `PreCompact` + `PostCompact` marker（`trigger` のみ。Codex は圧縮後サマリー本文を公開しない） | ● `PreCompress` (marker のみ — Gemini に post-compress 側 hook はない) | ✕ 文書化された compact hook なし | ● `PreCompact` + `PostCompact`（native で live 確認済みの `source` marker。summary 本文なし） | `traceary list events --kind compact_summary --limit 5` |
 | `session_ended` | ● `SessionEnd` | ✕ host のセッション終了信号なし — Codex `Stop` は応答ごとの turn 境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ● `SessionEnd` | ✕ host のセッション終了信号なし — Antigravity `Stop` は execution 単位の境界でありセッション終了ではない (#1170)。終了は MCP `manage_session` または stale GC 経由 | ○ `SessionEnd` は文書化済みだが、headless 完了・TUI `/quit`・TUI `/new` の probe では未発火 | `traceary list events --kind session_ended --limit 5` |
+<!-- host-coverage-matrix:end -->
 
 > **Antigravity headless `agy --print`:** 現行 CLI は `PreInvocation`、必要に応じて `PreToolUse`/`PostToolUse`、および `transcriptPath` 付き `Stop` を発行します。Traceary は Stop で prompt と transcript を復元します。実行時の欠落は `antigravity-event-coverage` が DB 証拠から検出します。hook event は `client=hook`, `agent=antigravity` で記録されるため、`traceary list --agent antigravity` で確認してください。
 
@@ -58,11 +61,16 @@
 
 ## 更新方法
 
-このマトリクスは手書きのスナップショット。更新手順:
+上のライフサイクルマトリクス表は機械可読な正本
+[`application/hostcoverage/matrix.json`](../../application/hostcoverage/matrix.json)
+から生成されます。doctor の host-capability / event-coverage 期待値も同じ embedded matrix を読みます。
+
+更新手順:
 
 1. 確認したい host CLI をバンプ／再インストール。
-2. ホスト側 hook reference と上の表を diff。
-3. `●` セルごとに「確認方法」コマンドを実行し、`~/.config/traceary/traceary.db` に新しい行があることを確認。
-4. ページ冒頭の **最終確認日** を更新。
+2. `application/hostcoverage/matrix.json` を更新（status、日英 summary、`last_verified`）。
+3. `go run ./cmd/repo-tooling docs generate-host-coverage` で marker 付き表セクションを再生成。
+4. `●` セルごとに「確認方法」コマンドを実行し、`~/.config/traceary/traceary.db` に新しい行があることを確認。
+5. `go run ./cmd/repo-tooling docs verify-host-coverage` を実行（CI でも強制）。
 
 `/schedule` 経由の日次 drift check は #814 で配線する。

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -16,6 +16,8 @@ Legend:
 
 ## Lifecycle event → host hook matrix
 
+<!-- host-coverage-matrix:begin -->
+<!-- DO NOT EDIT: generated from application/hostcoverage/matrix.json via `go run ./cmd/repo-tooling docs generate-host-coverage`. -->
 | Traceary lifecycle event | Claude Code (`claude-plugin`) | Codex CLI 0.144.1 (`plugins/traceary`) | Gemini CLI (`gemini-extension`) | Antigravity (`antigravity-plugin`) | Grok Build 0.2.99 | Verification |
 |---|---|---|---|---|---|---|
 | `session_started` | ● `SessionStart` | ● `SessionStart` | ● `SessionStart` | ● `PreInvocation` (idempotent, keyed by `conversationId`; Antigravity has no `SessionStart`) | ● `SessionStart` (native `agent=grok`) | `traceary list events --kind session_started --limit 5` |
@@ -24,6 +26,7 @@ Legend:
 | `transcript` | ● `Stop` | ● `Stop` (`last_assistant_message`) | ● `AfterAgent` | ● `Stop` (`transcriptPath`, best-effort lenient JSONL scan) | ● `Stop` (best-effort current-prompt message chunks from `updates.jsonl`; no model field) | `traceary list events --kind transcript --limit 5` |
 | `compact_summary` | ● `PostCompact` (+ `PreCompact` marker, `SessionStart matcher=compact` resume) | ● `PreCompact` + `PostCompact` markers (`trigger` only; Codex exposes no compacted summary body) | ● `PreCompress` (marker only — Gemini exposes no post-compress hook with the resulting summary) | ✕ no documented compact hook | ● `PreCompact` + `PostCompact` (native live-observed markers from `source`; no summary body) | `traceary list events --kind compact_summary --limit 5` |
 | `session_ended` | ● `SessionEnd` | ✕ no host session-end signal — Codex `Stop` is a per-response turn boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ● `SessionEnd` | ✕ no host session-end signal — Antigravity `Stop` is a per-execution boundary, not a session end (#1170); ends via MCP `manage_session` or stale GC | ○ documented `SessionEnd`, but not emitted by headless completion, TUI `/quit`, or TUI `/new` probes | `traceary list events --kind session_ended --limit 5` |
+<!-- host-coverage-matrix:end -->
 
 > **Antigravity headless `agy --print`:** the current CLI emits `PreInvocation`, `PreToolUse`/`PostToolUse` when needed, and `Stop` with `transcriptPath`. Traceary recovers prompt and transcript at Stop. `antigravity-event-coverage` detects runtime gaps from database evidence. Hook events are stored with `client=hook`, `agent=antigravity`, so verify them with `traceary list --agent antigravity`.
 
@@ -58,11 +61,16 @@ This list excludes hooks that already appear in the lifecycle matrix above.
 
 ## Maintenance
 
-This matrix is a manually curated snapshot. To refresh:
+The lifecycle matrix table above is generated from the machine-readable source
+[`application/hostcoverage/matrix.json`](../../application/hostcoverage/matrix.json).
+Doctor host-capability and event-coverage expectations load the same embedded matrix.
+
+To refresh:
 
 1. Bump or re-install the host CLI you want to re-check.
-2. Diff the host's hook reference against the table above.
-3. For each `●` cell, run the verification command and confirm a recent row exists in `~/.config/traceary/traceary.db`.
-4. Update the **Last verified** date at the top of this page.
+2. Update `application/hostcoverage/matrix.json` (status, bilingual summaries, `last_verified`).
+3. Run `go run ./cmd/repo-tooling docs generate-host-coverage` to rewrite the marked table sections.
+4. For each `●` cell, run the verification command and confirm a recent row exists in `~/.config/traceary/traceary.db`.
+5. Run `go run ./cmd/repo-tooling docs verify-host-coverage` (also enforced in CI).
 
 A daily drift check is wired through `/schedule` (see #814).

--- a/docs/operations/repo-tooling.ja.md
+++ b/docs/operations/repo-tooling.ja.md
@@ -54,6 +54,8 @@ maintainer-only の repository automation は性質が異なります。
 
 - `go run ./cmd/repo-tooling integrations verify`
 - `go run ./cmd/repo-tooling docs verify-i18n`
+- `go run ./cmd/repo-tooling docs verify-host-coverage`
+- `go run ./cmd/repo-tooling docs generate-host-coverage`
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`
 - `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`

--- a/docs/operations/repo-tooling.md
+++ b/docs/operations/repo-tooling.md
@@ -54,6 +54,8 @@ The repository should converge on subcommands shaped like these:
 
 - `go run ./cmd/repo-tooling integrations verify`
 - `go run ./cmd/repo-tooling docs verify-i18n`
+- `go run ./cmd/repo-tooling docs verify-host-coverage`
+- `go run ./cmd/repo-tooling docs generate-host-coverage`
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`
 - `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`

--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/hostcoverage"
 )
 
 func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
@@ -79,56 +80,73 @@ func (c *RootCLI) inspectClaudePluginCacheStatus() *doctorCheck {
 }
 
 // inspectHostCapabilityGaps surfaces informational notes about host
-// capabilities that Traceary does not yet wire into its managed hook set.
-// The checks intentionally return pass status with descriptive messages so
-// the operator sees the gap without treating it as a regression — the
-// content was verified against each host's bundled hook reference docs
-// (gemini-cli 0.43.0 as of v0.21.0).
+// capabilities driven by application/hostcoverage (the same matrix that
+// generates docs/hooks/host-coverage.md). Checks return pass with descriptive
+// messages so operators see the expected wired lifecycle set without treating
+// a complete install as a regression.
 func inspectHostCapabilityGaps(client, configPath string) []doctorCheck {
-	switch client {
-	case "claude":
+	matrix, err := hostcoverage.Load()
+	if err != nil {
 		return []doctorCheck{{
-			Name:   "claude-host-capabilities",
-			Status: doctorStatusPass,
-			Message: localizef(
-				"claude host: SubagentStop and PreCompact hooks are wired into the Traceary-managed config alongside the existing SessionStart / SessionEnd / Stop / PostCompact coverage (hooks config: %s)",
-				"claude ホスト: SubagentStop と PreCompact は既存の SessionStart / SessionEnd / Stop / PostCompact と並んで Traceary 管理の hook config に組み込み済みです (hooks config: %s)",
-				configPath,
-			),
+			Name:    client + "-host-capabilities",
+			Status:  doctorStatusFail,
+			Message: localizef("failed to load host coverage matrix: %v", "host coverage matrix の読み込みに失敗しました: %v", err),
 		}}
+	}
+	host, ok := matrix.HostByDoctorClient(client)
+	if !ok {
+		return nil
+	}
+
+	wired := matrix.WiredLifecycleEvents(client)
+	wiredList := strings.Join(wired, ", ")
+	if wiredList == "" {
+		wiredList = "(none)"
+	}
+
+	checks := []doctorCheck{{
+		Name:   client + "-host-capabilities",
+		Status: doctorStatusPass,
+		Message: localizef(
+			"%s host: Traceary matrix promises wired lifecycle coverage for %s (source application/hostcoverage; hooks config: %s)",
+			"%s ホスト: Traceary の matrix は %s の lifecycle coverage を wired として約束しています (正本 application/hostcoverage; hooks config: %s)",
+			client,
+			wiredList,
+			configPath,
+		),
+	}}
+
+	// Keep the codex memory-flag and gemini compact-boundary footnotes that are
+	// not expressible as simple lifecycle cells.
+	switch client {
 	case "codex":
 		codexConfigPath := describeCodexConfigPath()
-		return []doctorCheck{{
-			Name:   "codex-host-capabilities",
-			Status: doctorStatusPass,
-			Message: localizef(
-				"codex host: Codex CLI 0.144.1 compact and subagent hooks are wired (PreCompact / PostCompact markers and SubagentStart / SubagentStop child sessions). Memory features still depend on the per-install feature flag in %s; Traceary's `memory import codex` works regardless of that flag",
-				"codex ホスト: Codex CLI 0.144.1 の compact / subagent hook を配線済みです (PreCompact / PostCompact marker、SubagentStart / SubagentStop child session)。memory 機能は引き続き per-install feature flag (%s) に依存しますが、Traceary の `memory import codex` は flag 状態に関わらず動作します",
-				codexConfigPath,
-			),
-		}}
+		checks[0].Message = localizef(
+			"codex host: matrix-wired lifecycle coverage is %s. Compact and subagent hooks are part of the managed set; memory features still depend on the per-install feature flag in %s (Traceary's `memory import codex` works regardless). hooks config context: %s",
+			"codex ホスト: matrix 上の wired lifecycle は %s です。compact / subagent hook は managed set に含まれます。memory 機能は per-install feature flag (%s) に依存しますが、Traceary の `memory import codex` は flag 状態に関わらず動作します。hooks config 文脈: %s",
+			wiredList,
+			codexConfigPath,
+			configPath,
+		)
 	case "gemini":
-		return []doctorCheck{
-			{
-				Name:   "gemini-host-capabilities",
-				Status: doctorStatusPass,
-				Message: localizef(
-					"gemini host: memory manager agent and auto-memory remain experimental features on Gemini CLI (verified against 0.43.0); Traceary's Tier 3 hook coverage (SessionStart / SessionEnd / BeforeAgent / AfterAgent / AfterTool / PreCompress) does not yet surface those experimental signals (hooks config: %s)",
-					"gemini ホスト: memory manager agent / auto-memory は Gemini CLI の experimental 機能です (0.43.0 で確認済)。Traceary の Tier 3 hook (SessionStart / SessionEnd / BeforeAgent / AfterAgent / AfterTool / PreCompress) は現時点でそれらの experimental 信号を surface しません (hooks config: %s)",
-					configPath,
-				),
-			},
-			{
+		checks[0].Message = localizef(
+			"gemini host: matrix-wired lifecycle coverage is %s. Memory manager agent and auto-memory remain experimental on Gemini CLI and are not Traceary lifecycle events (hooks config: %s)",
+			"gemini ホスト: matrix 上の wired lifecycle は %s です。memory manager agent / auto-memory は Gemini CLI の experimental 機能であり Traceary lifecycle event ではありません (hooks config: %s)",
+			wiredList,
+			configPath,
+		)
+		if cell, ok := host.Events["compact_summary"]; ok && cell.Status == hostcoverage.StatusWired {
+			checks = append(checks, doctorCheck{
 				Name:   "gemini-compact-coverage",
 				Status: doctorStatusPass,
 				Message: Localize(
-					"gemini host: compact summaries are captured at the pre-compact boundary only (PreCompress marker). Gemini CLI exposes no post-compress hook — PreCompress is advisory-only and fires asynchronously before compression (verified against the gemini-cli 0.43.0 hook reference) — so a missing post-compact digest is expected upstream behavior, not a broken install",
-					"gemini ホスト: compact summary は pre-compact 境界のみで捕捉します (PreCompress marker)。Gemini CLI に post-compress hook は存在せず、PreCompress は compression 前に非同期で発火する advisory-only hook です (gemini-cli 0.43.0 の hook reference で確認済)。post-compact digest が無いのは upstream の想定挙動であり、インストール不良ではありません",
+					"gemini host: compact summaries are captured at the pre-compact boundary only (PreCompress marker). Gemini CLI exposes no post-compress hook — PreCompress is advisory-only and fires asynchronously before compression — so a missing post-compact digest is expected upstream behavior, not a broken install",
+					"gemini ホスト: compact summary は pre-compact 境界のみで捕捉します (PreCompress marker)。Gemini CLI に post-compress hook は存在せず、PreCompress は compression 前に非同期で発火する advisory-only hook です。post-compact digest が無いのは upstream の想定挙動であり、インストール不良ではありません",
 				),
-			},
+			})
 		}
 	}
-	return nil
+	return checks
 }
 
 // describeCodexConfigPath returns the canonical ~/.codex/config.toml path

--- a/presentation/cli/doctor_event_coverage.go
+++ b/presentation/cli/doctor_event_coverage.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/hostcoverage"
 	apptypes "github.com/duck8823/traceary/application/types"
 	appusecase "github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/types"
@@ -21,6 +22,20 @@ func (c *RootCLI) inspectClientEventCoverage(ctx context.Context, client, output
 			Name:    checkName,
 			Status:  doctorStatusSkip,
 			Message: localizef("event usecase is not configured", "event usecase が設定されていません"),
+		}
+	}
+
+	// Skip ratio judgment for hosts that the matrix does not promise prompt /
+	// transcript enrichment for (keeps doctor aligned with hostcoverage).
+	if matrix, err := hostcoverage.Load(); err == nil && !matrix.ExpectsSessionEnrichment(client) {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"host coverage matrix does not require prompt/transcript enrichment for %s; event-coverage ratio is not judged",
+				"host coverage matrix は %s に prompt/transcript enrichment を要求しないため、event-coverage ratio は判定しません",
+				client,
+			),
 		}
 	}
 

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -128,8 +128,8 @@ func TestRootCLI_DoctorCommand(t *testing.T) {
 		if msg := gotMessages["gemini-compact-coverage"]; !strings.Contains(msg, "no post-compress hook") || !strings.Contains(msg, "PreCompress") {
 			t.Fatalf("gemini-compact-coverage message should explain the missing post-compress hook, got: %q", msg)
 		}
-		if msg := gotMessages["gemini-host-capabilities"]; !strings.Contains(msg, "BeforeAgent") || !strings.Contains(msg, "PreCompress") {
-			t.Fatalf("gemini-host-capabilities message should list the wired BeforeAgent / PreCompress hooks, got: %q", msg)
+		if msg := gotMessages["gemini-host-capabilities"]; !strings.Contains(msg, "prompt") || !strings.Contains(msg, "compact_summary") {
+			t.Fatalf("gemini-host-capabilities message should list matrix-wired lifecycle events including prompt and compact_summary, got: %q", msg)
 		}
 	})
 

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -149,7 +149,7 @@
       "status": "pass",
       "severity": "PASS",
       "section": "MCP",
-      "message": "codex host: Codex CLI 0.144.1 compact and subagent hooks are wired (PreCompact / PostCompact markers and SubagentStart / SubagentStop child sessions). Memory features still depend on the per-install feature flag in /tmp/traceary-json-golden-home/.codex/config.toml; Traceary's `memory import codex` works regardless of that flag",
+      "message": "codex host: matrix-wired lifecycle coverage is command_executed, compact_summary, prompt, session_started, transcript. Compact and subagent hooks are part of the managed set; memory features still depend on the per-install feature flag in /tmp/traceary-json-golden-home/.codex/config.toml (Traceary's `memory import codex` works regardless). hooks config context: /tmp/traceary-json-golden-home/.codex/hooks.json",
       "hint": "",
       "fix_command": "",
       "auto_fix_available": false
@@ -288,7 +288,7 @@
           "status": "pass",
           "severity": "PASS",
           "section": "MCP",
-          "message": "codex host: Codex CLI 0.144.1 compact and subagent hooks are wired (PreCompact / PostCompact markers and SubagentStart / SubagentStop child sessions). Memory features still depend on the per-install feature flag in /tmp/traceary-json-golden-home/.codex/config.toml; Traceary's `memory import codex` works regardless of that flag",
+          "message": "codex host: matrix-wired lifecycle coverage is command_executed, compact_summary, prompt, session_started, transcript. Compact and subagent hooks are part of the managed set; memory features still depend on the per-install feature flag in /tmp/traceary-json-golden-home/.codex/config.toml (Traceary's `memory import codex` works regardless). hooks config context: /tmp/traceary-json-golden-home/.codex/hooks.json",
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false


### PR DESCRIPTION
## Summary
- Introduce `application/hostcoverage/matrix.json` as the single source for the host × lifecycle capture matrix.
- Generate/verify bilingual `docs/hooks/host-coverage*.md` table sections via `docs generate-host-coverage` / `verify-host-coverage` (CI-enforced).
- Wire doctor host-capability messages and event-coverage enrichment expectations to the same embedded matrix.

## Test plan
- [x] `go test ./application/hostcoverage/ ./cmd/repo-tooling/ ./presentation/cli/`
- [x] `go run ./cmd/repo-tooling docs verify-host-coverage`
- [x] `go tool golangci-lint run` on touched packages

Closes #1261