### PR TITLE
feat: classify sensitive path access on command audits

### DIFF
--- a/application/sensitivepath/classify.go
+++ b/application/sensitivepath/classify.go
@@ -1,0 +1,342 @@
+// Package sensitivepath classifies command audits for sensitive path/intent
+// access. Classification is a separate claim from secret redaction and from
+// host capture coverage: matching a path pattern does not prove the file was
+// opened unless structured tool evidence supports that.
+package sensitivepath
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Class is the sensitivity category that matched.
+type Class string
+
+// Known sensitivity classes.
+const (
+	// ClassNone means no pattern matched.
+	ClassNone Class = ""
+	// ClassDotenv covers .env style files.
+	ClassDotenv Class = "dotenv"
+	// ClassSSHKey covers SSH private key paths and basenames.
+	ClassSSHKey Class = "ssh_key"
+	// ClassCloudCreds covers cloud credential files and directories.
+	ClassCloudCreds Class = "cloud_creds"
+	// ClassBrowserProfile covers browser profile/cookie paths.
+	ClassBrowserProfile Class = "browser_profile"
+	// ClassKeyMaterial covers PEM/key files and OS keychains.
+	ClassKeyMaterial Class = "key_material"
+	// ClassCustom covers user-supplied exact substrings.
+	ClassCustom Class = "custom"
+)
+
+// Operation is the inferred access operation.
+type Operation string
+
+// Known access operations.
+const (
+	// OpUnknown means the operation could not be inferred.
+	OpUnknown Operation = "unknown"
+	// OpRead is a read-like operation.
+	OpRead Operation = "read"
+	// OpWrite is a write-like operation.
+	OpWrite Operation = "write"
+	// OpStat is a metadata/stat operation.
+	OpStat Operation = "stat"
+	// OpList is a directory listing operation.
+	OpList Operation = "list"
+)
+
+// Evidence describes how strong the path-access claim is.
+type Evidence string
+
+const (
+	// EvidenceCommandTextOnly means only shell/command text matched; file open
+	// is not proven.
+	EvidenceCommandTextOnly Evidence = "command_text_only"
+	// EvidenceStructuredFileTool means a host file tool reported a path.
+	EvidenceStructuredFileTool Evidence = "structured_file_tool"
+	// EvidenceUnresolvedPath means a pattern matched but the path could not be
+	// resolved against a workspace root.
+	EvidenceUnresolvedPath Evidence = "unresolved_path"
+)
+
+// Coverage is the audit-trail completeness claim for this event.
+type Coverage string
+
+// Known coverage levels for the audit payload quality claim.
+const (
+	// CoverageComplete means command plus I/O material is present and untruncated.
+	CoverageComplete Coverage = "complete"
+	// CoveragePartial means useful material exists but is incomplete (e.g. truncated).
+	CoveragePartial Coverage = "partial"
+	// CoverageUnobservable means there is not enough material to judge.
+	CoverageUnobservable Coverage = "unobservable"
+)
+
+// RedactionClaim is independent from sensitivity matching.
+type RedactionClaim string
+
+// Known redaction claim values (separate from sensitivity match).
+const (
+	// RedactionUnknown means redaction status was not determined.
+	RedactionUnknown RedactionClaim = "unknown"
+	// RedactionApplied means redaction markers were applied on capture.
+	RedactionApplied RedactionClaim = "applied"
+	// RedactionUnnecessary means no secret patterns required redaction.
+	RedactionUnnecessary RedactionClaim = "unnecessary"
+	// RedactionUnavailable means redaction could not run.
+	RedactionUnavailable RedactionClaim = "unavailable"
+	// RedactionFailed means redaction was attempted and failed.
+	RedactionFailed RedactionClaim = "failed"
+)
+
+// Classification is the separable sensitive-path claim for one audit event.
+type Classification struct {
+	Matched        bool           `json:"matched"`
+	Class          Class          `json:"class,omitempty"`
+	Operation      Operation      `json:"operation,omitempty"`
+	Evidence       Evidence       `json:"evidence,omitempty"`
+	Coverage       Coverage       `json:"coverage,omitempty"`
+	Redaction      RedactionClaim `json:"redaction,omitempty"`
+	MatchedPath    string         `json:"matched_path,omitempty"`
+	IntentOnly     bool           `json:"intent_only"`
+	Summary        string         `json:"summary,omitempty"`
+	CoverageGap    string         `json:"coverage_gap,omitempty"`
+}
+
+// Input is the raw material used to classify one audit.
+type Input struct {
+	Command        string
+	Input          string
+	Output         string
+	ToolName       string
+	InputTruncated bool
+	OutputTruncated bool
+	InputRedacted  bool
+	OutputRedacted bool
+	ExtraPatterns  []string
+}
+
+type rule struct {
+	class   Class
+	pattern *regexp.Regexp
+}
+
+var defaultRules = []rule{
+	{class: ClassDotenv, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `=])(\.?env(?:\.[A-Za-z0-9_.-]+)?|\.env)(?:$|[\s"'` + "`" + `])`)},
+	{class: ClassDotenv, pattern: regexp.MustCompile(`(?i)\.env(?:\.[A-Za-z0-9_.-]+)?`)},
+	{class: ClassSSHKey, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `])(?:~|/Users/[^/\s]+|/home/[^/\s]+)?/\.ssh(?:/|$)`)},
+	{class: ClassSSHKey, pattern: regexp.MustCompile(`(?i)\bid_(?:rsa|ed25519|ecdsa|dsa)\b`)},
+	{class: ClassCloudCreds, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `])(?:~|/Users/[^/\s]+|/home/[^/\s]+)?/\.aws(?:/|$)`)},
+	{class: ClassCloudCreds, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `=])(?:credentials|gcloud/application_default_credentials\.json|service[_-]?account\.json)`)},
+	{class: ClassBrowserProfile, pattern: regexp.MustCompile(`(?i)(?:Chrome|Chromium|Firefox|Brave)/.*(?:Default|Profile \d+|Cookies|Login Data)`)},
+	{class: ClassBrowserProfile, pattern: regexp.MustCompile(`(?i)Library/Application Support/(?:Google/Chrome|Firefox|BraveSoftware)`)},
+	{class: ClassKeyMaterial, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `])[^\s"'` + "`" + `]+\.(?:pem|p12|pfx|key)(?:$|[\s"'` + "`" + `])`)},
+	{class: ClassKeyMaterial, pattern: regexp.MustCompile(`(?i)(?:keychain|login\.keychain-db|Keychains/)`)},
+}
+
+// Classify returns the sensitive-path claim for the given audit material.
+// Empty or non-matching input yields Matched=false with coverage derived from
+// truncation / observability of the payload.
+func Classify(in Input) Classification {
+	text := strings.Join([]string{in.Command, in.Input, in.Output}, "\n")
+	coverage, gap := coverageFrom(in)
+	redaction := redactionFrom(in)
+
+	if strings.TrimSpace(text) == "" {
+		return Classification{
+			Matched:    false,
+			Coverage:   CoverageUnobservable,
+			Redaction:  redaction,
+			CoverageGap: "empty_payload",
+			Summary:    "no audit payload to classify",
+		}
+	}
+
+	matchedClass := ClassNone
+	matchedPath := ""
+	for _, r := range defaultRules {
+		if loc := r.pattern.FindStringIndex(text); loc != nil {
+			matchedClass = r.class
+			matchedPath = strings.TrimSpace(text[loc[0]:loc[1]])
+			break
+		}
+	}
+	if matchedClass == ClassNone {
+		for _, raw := range in.ExtraPatterns {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(raw))
+			if err != nil {
+				continue
+			}
+			if loc := re.FindStringIndex(text); loc != nil {
+				matchedClass = ClassCustom
+				matchedPath = strings.TrimSpace(text[loc[0]:loc[1]])
+				break
+			}
+		}
+	}
+
+	if matchedClass == ClassNone {
+		return Classification{
+			Matched:   false,
+			Coverage:  coverage,
+			Redaction: redaction,
+			CoverageGap: gap,
+			Summary:   "no sensitive path pattern matched",
+		}
+	}
+
+	evidence := EvidenceCommandTextOnly
+	intentOnly := true
+	if isStructuredFileTool(in.ToolName) && looksLikePath(matchedPath) {
+		evidence = EvidenceStructuredFileTool
+		intentOnly = false
+	} else if strings.Contains(matchedPath, "*") || strings.Contains(matchedPath, "?") {
+		evidence = EvidenceUnresolvedPath
+	}
+
+	op := inferOperation(in.Command, in.ToolName)
+	summary := "sensitive path observed via structured file tool"
+	if intentOnly {
+		summary = "sensitive intent observed; file access not proven"
+	}
+
+	return Classification{
+		Matched:     true,
+		Class:       matchedClass,
+		Operation:   op,
+		Evidence:    evidence,
+		Coverage:    coverage,
+		Redaction:   redaction,
+		MatchedPath: sanitizeMatchedPath(matchedPath),
+		IntentOnly:  intentOnly,
+		Summary:     summary,
+		CoverageGap: gap,
+	}
+}
+
+// ClassifyCommandBody classifies a command_executed event body that follows
+// Traceary's "command\n\nINPUT:\n...\n\nOUTPUT:\n..." shape.
+func ClassifyCommandBody(body string, extra []string) Classification {
+	command, input, output := splitCommandBody(body)
+	return Classify(Input{
+		Command:       command,
+		Input:         input,
+		Output:        output,
+		ExtraPatterns: extra,
+	})
+}
+
+func splitCommandBody(body string) (command, input, output string) {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	parts := strings.SplitN(body, "\n\nINPUT:\n", 2)
+	command = strings.TrimSpace(parts[0])
+	if len(parts) < 2 {
+		return command, "", ""
+	}
+	rest := parts[1]
+	outParts := strings.SplitN(rest, "\n\nOUTPUT:\n", 2)
+	input = outParts[0]
+	if len(outParts) == 2 {
+		output = outParts[1]
+	}
+	return command, input, output
+}
+
+func coverageFrom(in Input) (Coverage, string) {
+	switch {
+	case in.InputTruncated || in.OutputTruncated:
+		return CoveragePartial, "stdout_truncated"
+	case strings.TrimSpace(in.Command) == "" && strings.TrimSpace(in.Input) == "" && strings.TrimSpace(in.Output) == "":
+		return CoverageUnobservable, "empty_payload"
+	case strings.TrimSpace(in.Command) != "" && strings.TrimSpace(in.Input) == "" && strings.TrimSpace(in.Output) == "":
+		return CoveragePartial, "command_text_only"
+	default:
+		return CoverageComplete, ""
+	}
+}
+
+func redactionFrom(in Input) RedactionClaim {
+	switch {
+	case in.InputRedacted || in.OutputRedacted:
+		return RedactionApplied
+	default:
+		return RedactionUnknown
+	}
+}
+
+func inferOperation(command, toolName string) Operation {
+	lowerTool := strings.ToLower(strings.TrimSpace(toolName))
+	switch lowerTool {
+	case "read", "read_file", "cat":
+		return OpRead
+	case "write", "edit", "search_replace", "apply_patch":
+		return OpWrite
+	case "list_dir", "ls", "glob":
+		return OpList
+	case "stat":
+		return OpStat
+	}
+
+	lower := strings.ToLower(command)
+	switch {
+	case strings.Contains(lower, "cat ") || strings.HasPrefix(lower, "cat") || strings.Contains(lower, "head ") || strings.Contains(lower, "less ") || strings.Contains(lower, "type "):
+		return OpRead
+	case strings.Contains(lower, "tee ") || strings.Contains(lower, " >") || strings.Contains(lower, ">>") || strings.Contains(lower, "cp ") || strings.Contains(lower, "mv "):
+		return OpWrite
+	case strings.Contains(lower, "ls ") || strings.HasPrefix(lower, "ls") || strings.Contains(lower, "find "):
+		return OpList
+	case strings.Contains(lower, "stat ") || strings.Contains(lower, "test -"):
+		return OpStat
+	default:
+		return OpUnknown
+	}
+}
+
+func isStructuredFileTool(toolName string) bool {
+	switch strings.ToLower(strings.TrimSpace(toolName)) {
+	case "read", "write", "edit", "search_replace", "read_file", "write_file", "list_dir", "glob":
+		return true
+	default:
+		return false
+	}
+}
+
+func looksLikePath(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, "/") || strings.HasPrefix(s, ".") || strings.HasPrefix(s, "~") {
+		return true
+	}
+	return filepath.Ext(s) != ""
+}
+
+func sanitizeMatchedPath(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `"'`+"`")
+	if len(s) > 200 {
+		return s[:200]
+	}
+	return s
+}
+
+// DefaultPatternDescriptions returns bilingual documentation lines for the
+// built-in pattern set (for docs generation / help text).
+func DefaultPatternDescriptions() []string {
+	return []string{
+		"dotenv: .env and .env.* files",
+		"ssh_key: ~/.ssh and id_rsa / id_ed25519 style key basenames",
+		"cloud_creds: ~/.aws, credentials files, service account JSON",
+		"browser_profile: Chrome / Firefox / Brave profile and cookie paths",
+		"key_material: *.pem / *.key / *.p12 and macOS keychain paths",
+		"custom: user-supplied exact substrings via config extra patterns",
+	}
+}

--- a/application/sensitivepath/classify_test.go
+++ b/application/sensitivepath/classify_test.go
@@ -1,0 +1,126 @@
+package sensitivepath_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application/sensitivepath"
+)
+
+func TestClassify_ShellCommandTextOnlyDotenv(t *testing.T) {
+	t.Parallel()
+
+	got := sensitivepath.Classify(sensitivepath.Input{
+		Command: "cat .env",
+	})
+	if !got.Matched {
+		t.Fatalf("Matched = false, want true")
+	}
+	if got.Class != sensitivepath.ClassDotenv {
+		t.Fatalf("Class = %q, want dotenv", got.Class)
+	}
+	if got.Evidence != sensitivepath.EvidenceCommandTextOnly {
+		t.Fatalf("Evidence = %q, want command_text_only", got.Evidence)
+	}
+	if !got.IntentOnly {
+		t.Fatal("IntentOnly = false, want true for command-text-only")
+	}
+	if !strings.Contains(got.Summary, "not proven") {
+		t.Fatalf("Summary = %q, want not-proven wording", got.Summary)
+	}
+	if got.Operation != sensitivepath.OpRead {
+		t.Fatalf("Operation = %q, want read", got.Operation)
+	}
+}
+
+func TestClassify_StructuredFileToolRead(t *testing.T) {
+	t.Parallel()
+
+	got := sensitivepath.Classify(sensitivepath.Input{
+		Command:  "Read",
+		ToolName: "Read",
+		Input:    `{"file_path":"/Users/me/project/.env.local"}`,
+	})
+	if !got.Matched || got.Class != sensitivepath.ClassDotenv {
+		t.Fatalf("got %#v, want matched dotenv", got)
+	}
+	if got.Evidence != sensitivepath.EvidenceStructuredFileTool {
+		t.Fatalf("Evidence = %q, want structured_file_tool", got.Evidence)
+	}
+	if got.IntentOnly {
+		t.Fatal("IntentOnly = true, want false for structured file tool")
+	}
+}
+
+func TestClassify_TruncatedStdoutIsPartialCoverage(t *testing.T) {
+	t.Parallel()
+
+	got := sensitivepath.Classify(sensitivepath.Input{
+		Command:         "cat ~/.ssh/id_ed25519",
+		Output:          "-----BEGIN OPENSSH PRIVATE KEY-----\n...",
+		OutputTruncated: true,
+	})
+	if !got.Matched || got.Class != sensitivepath.ClassSSHKey {
+		t.Fatalf("got %#v, want ssh_key match", got)
+	}
+	if got.Coverage != sensitivepath.CoveragePartial {
+		t.Fatalf("Coverage = %q, want partial", got.Coverage)
+	}
+	if got.CoverageGap != "stdout_truncated" {
+		t.Fatalf("CoverageGap = %q, want stdout_truncated", got.CoverageGap)
+	}
+}
+
+func TestClassify_UnresolvedCustomPattern(t *testing.T) {
+	t.Parallel()
+
+	got := sensitivepath.Classify(sensitivepath.Input{
+		Command:       "vim secrets/prod-token",
+		ExtraPatterns: []string{"prod-token"},
+	})
+	if !got.Matched || got.Class != sensitivepath.ClassCustom {
+		t.Fatalf("got %#v, want custom match", got)
+	}
+}
+
+func TestClassify_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	got := sensitivepath.Classify(sensitivepath.Input{Command: "go test ./..."})
+	if got.Matched {
+		t.Fatalf("Matched = true for ordinary command: %#v", got)
+	}
+}
+
+func TestClassifyCommandBody_ParsesAuditShape(t *testing.T) {
+	t.Parallel()
+
+	body := "cat .env\n\nINPUT:\n\n\nOUTPUT:\nFOO=bar\n"
+	got := sensitivepath.ClassifyCommandBody(body, nil)
+	if !got.Matched || got.Class != sensitivepath.ClassDotenv {
+		t.Fatalf("got %#v, want dotenv from body", got)
+	}
+}
+
+func TestClassify_CloudAndBrowserPatterns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cmd  string
+		want sensitivepath.Class
+	}{
+		{name: "aws", cmd: "cat ~/.aws/credentials", want: sensitivepath.ClassCloudCreds},
+		{name: "browser", cmd: "cp ~/Library/Application Support/Google/Chrome/Default/Cookies /tmp/", want: sensitivepath.ClassBrowserProfile},
+		{name: "pem", cmd: "openssl x509 -in server.pem -text", want: sensitivepath.ClassKeyMaterial},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := sensitivepath.Classify(sensitivepath.Input{Command: tc.cmd})
+			if !got.Matched || got.Class != tc.want {
+				t.Fatalf("got %#v, want class %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/audit/sensitive-path.ja.md
+++ b/docs/audit/sensitive-path.ja.md
@@ -1,0 +1,56 @@
+# Sensitive path 検出
+
+[English](./sensitive-path.md)
+
+Sensitive-path 検出は、dotenv・SSH 鍵・cloud credentials・browser profile・
+鍵材料など高リスクな場所に触れたように見える command audit を flag します。
+次の claim とは**別**です:
+
+- **Secret redaction** — 保存 payload の値をマスクする（`application/redaction`）
+- **Host capture coverage** — hook 証跡が信頼できるほど完全か
+
+## 一致の意味
+
+一致は、audit 材料の中に **sensitive な intent または path 文字列** が観測
+されたことを意味します。それだけでは OS がファイルを開いたことの証明にはなり
+ません。
+
+| Evidence | 意味 |
+|---|---|
+| `command_text_only` | shell / command テキストが一致（例: `cat .env`）。intent は観測。file access は未証明 |
+| `structured_file_tool` | host の file tool payload に path が含まれる（例: Read/Write）。より強い path claim |
+| `unresolved_path` | パターンは一致したが path をきれいに解決できない |
+
+Coverage（`complete` / `partial` / `unobservable`）は payload 品質
+（truncate、空 body、command のみ）を表し、sensitivity そのものではありません。
+
+## 既定パターン class
+
+実装は `application/sensitivepath`:
+
+- `dotenv` — `.env`、`.env.*`
+- `ssh_key` — `~/.ssh`、`id_rsa` / `id_ed25519` basename
+- `cloud_creds` — `~/.aws`、credentials / service-account JSON 名
+- `browser_profile` — Chrome / Firefox / Brave の profile / cookie path
+- `key_material` — `*.pem` / `*.key` / `*.p12`、keychain path
+- `custom` — 追加パターン（`extra_redact_patterns` と同系統。設定配線は今後拡張可）
+
+## CLI
+
+```sh
+# 一致した command audit のみ（event body の compute-on-read）
+traceary list --sensitive --kind audit --limit 20
+
+# 詳細 JSON の command_audit に `sensitive` object が付く
+traceary show <event-id> --json
+```
+
+## doctor
+
+`traceary doctor` の `sensitive-access-audit` は直近の一致を要約し、intent-only
+や弱い coverage のとき WARN します。検出は受動的で、blocking / deny/ask はしません。
+
+## Non-goals
+
+- hook のリアルタイム allow/deny
+- host が command テキストしか出さない場合の OS レベルの open 証明

--- a/docs/audit/sensitive-path.md
+++ b/docs/audit/sensitive-path.md
@@ -1,0 +1,57 @@
+# Sensitive path detection
+
+[日本語](./sensitive-path.ja.md)
+
+Sensitive-path detection flags command audits that appear to touch high-risk
+locations such as dotenv files, SSH keys, cloud credentials, browser profiles,
+or key material. It is a **separate claim** from:
+
+- **Secret redaction** — masks values in stored payloads (`application/redaction`)
+- **Host capture coverage** — whether the hook trail is complete enough to trust
+
+## What a match means
+
+A match means Traceary observed **sensitive intent or path text** in the audit
+material. It does **not** by itself prove the OS opened the file.
+
+| Evidence | Meaning |
+|---|---|
+| `command_text_only` | Shell/command text matched (e.g. `cat .env`). Intent observed; file access not proven. |
+| `structured_file_tool` | Host file tool payload included a path (e.g. Read/Write). Stronger path claim. |
+| `unresolved_path` | Pattern matched but path could not be resolved cleanly. |
+
+Coverage (`complete` / `partial` / `unobservable`) describes payload quality
+(truncation, empty body, command-only rows), not sensitivity.
+
+## Default pattern classes
+
+Implemented in `application/sensitivepath`:
+
+- `dotenv` — `.env`, `.env.*`
+- `ssh_key` — `~/.ssh`, `id_rsa` / `id_ed25519` basenames
+- `cloud_creds` — `~/.aws`, credentials / service-account JSON names
+- `browser_profile` — Chrome / Firefox / Brave profile and cookie paths
+- `key_material` — `*.pem` / `*.key` / `*.p12`, keychain paths
+- `custom` — exact substrings supplied as extra patterns (same spirit as
+  `extra_redact_patterns`; configuration wiring may expand later)
+
+## CLI
+
+```sh
+# list only matching command audits (compute-on-read on event bodies)
+traceary list --sensitive --kind audit --limit 20
+
+# full audit detail includes a `sensitive` object on command_audit JSON
+traceary show <event-id> --json
+```
+
+## Doctor
+
+`traceary doctor` includes `sensitive-access-audit`, which summarizes recent
+matches and warns when matches are intent-only or have weak coverage. Passive is
+passive: no blocking, no deny/ask policy.
+
+## Non-goals
+
+- Real-time hook allow/deny
+- OS-level proof of open when the host only exposes command text

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -268,6 +268,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		report.Checks = append(report.Checks, c.inspectCommandAuditReliability(ctx, input.strict))
 		report.Checks = append(report.Checks, c.inspectContentEventReliability(ctx, input.strict))
 		report.Checks = append(report.Checks, c.inspectRetryLoops(ctx))
+		report.Checks = append(report.Checks, c.inspectSensitiveAccessAuditCoverage(ctx))
 	}
 
 	resolvedProjectDir, err := resolveHooksProjectDir(input.projectDir)

--- a/presentation/cli/doctor_report.go
+++ b/presentation/cli/doctor_report.go
@@ -138,7 +138,7 @@ func buildDoctorSections(checks []doctorCheck) []doctorSection {
 
 func doctorSectionNameForCheck(name string) string {
 	switch {
-	case name == "db-path" || name == "db-write" || name == "stale-active-sessions" || name == "audit-reliability" || name == "content-event-reliability":
+	case name == "db-path" || name == "db-write" || name == "stale-active-sessions" || name == "audit-reliability" || name == "content-event-reliability" || name == "sensitive-access-audit" || name == "retry-loops":
 		return "Database"
 	case name == "config" || name == "project-dir" || name == "version" || name == "path":
 		return "Environment"

--- a/presentation/cli/doctor_sensitive_access.go
+++ b/presentation/cli/doctor_sensitive_access.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/duck8823/traceary/application/sensitivepath"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const doctorSensitiveAccessScanLimit = 500
+
+// inspectSensitiveAccessAuditCoverage explains whether recent command audits
+// yield trustworthy sensitive-path claims. It never treats redaction or host
+// coverage as the same signal as a sensitive match.
+func (c *RootCLI) inspectSensitiveAccessAuditCoverage(ctx context.Context) doctorCheck {
+	const checkName = "sensitive-access-audit"
+	if c.event == nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusSkip,
+			Message: localizef("event usecase is not configured", "event usecase が設定されていません"),
+		}
+	}
+
+	events, err := c.event.List(ctx, apptypes.NewEventListCriteriaBuilder(doctorSensitiveAccessScanLimit).
+		Kind(types.EventKindCommandExecuted).
+		Build())
+	if err != nil {
+		return doctorCheck{
+			Name:    checkName,
+			Status:  doctorStatusFail,
+			Message: localizef("failed to list recent command audits: %v", "recent command audit の取得に失敗しました: %v", err),
+		}
+	}
+
+	var matched, intentOnly, partial, structured int
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		cls := sensitivepath.ClassifyCommandBody(event.Body(), nil)
+		if !cls.Matched {
+			continue
+		}
+		matched++
+		if cls.IntentOnly {
+			intentOnly++
+		}
+		if cls.Coverage == sensitivepath.CoveragePartial || cls.Coverage == sensitivepath.CoverageUnobservable {
+			partial++
+		}
+		if cls.Evidence == sensitivepath.EvidenceStructuredFileTool {
+			structured++
+		}
+	}
+
+	details := fmt.Sprintf("scanned=%d matched=%d intent_only=%d structured=%d weak_coverage=%d",
+		len(events), matched, intentOnly, structured, partial)
+	if matched == 0 {
+		return doctorCheck{
+			Name:   checkName,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"scanned %d recent command audit(s); no sensitive-path matches (sensitive, redaction, and host coverage remain separate claims) (%s)",
+				"%d 件の recent command audit を検査しました。sensitive-path 一致はありません（sensitive / redaction / host coverage は別 claim です）(%s)",
+				len(events), details,
+			),
+			Hint: Localize(
+				"use `traceary list --sensitive --kind audit` after sessions that touch .env / SSH / cloud credential paths",
+				".env / SSH / cloud credential に触れた session の後は `traceary list --sensitive --kind audit` で確認してください",
+			),
+		}
+	}
+
+	status := doctorStatusPass
+	if intentOnly > 0 || partial > 0 {
+		status = doctorStatusWarn
+	}
+	return doctorCheck{
+		Name:   checkName,
+		Status: status,
+		Message: localizef(
+			"scanned %d recent command audit(s); sensitive-path matches present (%s). Intent-only rows are not proof of file open",
+			"%d 件の recent command audit を検査しました。sensitive-path 一致があります (%s)。intent-only 行は file open の証明ではありません",
+			len(events), details,
+		),
+		Hint: Localize(
+			"sensitive-path detection is passive flagging only; redaction and capture coverage are separate claims. Prefer structured file-tool evidence when available.",
+			"sensitive-path 検出は受動的な flag のみです。redaction と capture coverage は別 claim です。可能な場合は structured file-tool 証拠を優先してください。",
+		),
+	}
+}

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/sensitivepath"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 )
@@ -96,7 +97,7 @@ func newCommandAuditOutput(audit *model.CommandAudit) *commandAudit {
 	if ec, ok := audit.ExitCode().Value(); ok {
 		exitCode = &ec
 	}
-	return &commandAudit{
+	out := &commandAudit{
 		Command:             audit.Command(),
 		Input:               audit.Input(),
 		Output:              audit.Output(),
@@ -107,6 +108,30 @@ func newCommandAuditOutput(audit *model.CommandAudit) *commandAudit {
 		ExitCode:            exitCode,
 		Failed:              audit.Failed(),
 	}
+	classification := sensitivepath.Classify(sensitivepath.Input{
+		Command:         audit.Command(),
+		Input:           audit.Input(),
+		Output:          audit.Output(),
+		InputTruncated:  audit.InputTruncated(),
+		OutputTruncated: audit.OutputTruncated(),
+		InputRedacted:   audit.InputRedacted(),
+		OutputRedacted:  audit.OutputRedacted(),
+	})
+	if classification.Matched || classification.Coverage != sensitivepath.CoverageComplete {
+		out.Sensitive = &sensitiveClassification{
+			Matched:     classification.Matched,
+			Class:       string(classification.Class),
+			Operation:   string(classification.Operation),
+			Evidence:    string(classification.Evidence),
+			Coverage:    string(classification.Coverage),
+			Redaction:   string(classification.Redaction),
+			MatchedPath: classification.MatchedPath,
+			IntentOnly:  classification.IntentOnly,
+			Summary:     classification.Summary,
+			CoverageGap: classification.CoverageGap,
+		}
+	}
+	return out
 }
 
 func writeJSON(output io.Writer, value any) error {

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -128,6 +128,10 @@ type listCommandInput struct {
 	to              string
 	until           string
 	failuresOnly    bool
+	// sensitiveOnly keeps command_executed events whose bodies match the
+	// sensitive-path classifier (compute-on-read; independent of redaction).
+	// When set, kind defaults to command_executed if unset.
+	sensitiveOnly   bool
 	sourceHook      string
 	asJSON          bool
 	wide            bool

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -8,32 +8,35 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/sensitivepath"
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 func (c *RootCLI) newListCommand() *cobra.Command {
 	var (
-		dbPath       string
-		limit        int
-		offset       int
-		kind         string
-		client       string
-		agent        string
-		sessionID    string
-		repo         string
-		from         string
-		since        string
-		to           string
-		until        string
-		failuresOnly bool
-		sourceHook   string
-		asJSON       bool
-		wide         bool
-		utc          bool
-		fields       []string
-		preset       string
-		color        string
+		dbPath        string
+		limit         int
+		offset        int
+		kind          string
+		client        string
+		agent         string
+		sessionID     string
+		repo          string
+		from          string
+		since         string
+		to            string
+		until         string
+		failuresOnly  bool
+		sensitiveOnly bool
+		sourceHook    string
+		asJSON        bool
+		wide          bool
+		utc           bool
+		fields        []string
+		preset        string
+		color         string
 	)
 
 	listCmd := &cobra.Command{
@@ -55,6 +58,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 				to:              to,
 				until:           until,
 				failuresOnly:    failuresOnly,
+				sensitiveOnly:   sensitiveOnly,
 				sourceHook:      sourceHook,
 				sourceHookSet:   cmd.Flags().Changed("source-hook"),
 				asJSON:          asJSON,
@@ -78,6 +82,7 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 	listCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	listCmd.Flags().IntVar(&limit, "limit", 20, Localize("number of events to display", "表示件数"))
 	listCmd.Flags().IntVar(&offset, "offset", 0, Localize("number of events to skip before listing", "一覧表示前にスキップする件数"))
+	listCmd.Flags().BoolVar(&sensitiveOnly, "sensitive", false, Localize("list only command audits that match sensitive-path patterns (compute-on-read; not redaction)", "sensitive-path パターンに一致した command audit のみ一覧する（compute-on-read。redaction とは別）"))
 	listCmd.Flags().StringVar(&kind, "kind", "", Localize("filter by event kind (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)", "イベント種別で絞り込む (note, command_executed, reviewed, session_started, session_ended, compact_summary, prompt, transcript; alias: audit)"))
 	listCmd.Flags().StringVar(&client, "client", "", Localize("filter by client", "記録経路で絞り込む"))
 	listCmd.Flags().StringVar(&agent, "agent", "", Localize("filter by agent", "作業主体で絞り込む"))
@@ -117,6 +122,10 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		return err
 	}
 	applyReadPresetToListInput(&input, preset)
+	if input.sensitiveOnly && strings.TrimSpace(input.kind) == "" {
+		input.kind = "command_executed"
+		input.kindSet = true
+	}
 	resolvedKind, err := resolveListKind(input.kind)
 	if err != nil {
 		return err
@@ -157,7 +166,19 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 
-	criteria := apptypes.NewEventListCriteriaBuilder(input.limit).
+	fetchLimit := input.limit
+	if input.sensitiveOnly {
+		// Over-fetch so compute-on-read filtering still returns up to --limit
+		// matches without requiring a SQL-side index for this claim.
+		fetchLimit = input.limit * 20
+		if fetchLimit < 100 {
+			fetchLimit = 100
+		}
+		if fetchLimit > 2000 {
+			fetchLimit = 2000
+		}
+	}
+	criteria := apptypes.NewEventListCriteriaBuilder(fetchLimit).
 		Offset(input.offset).
 		Kind(types.EventKind(resolvedKind)).
 		Client(types.Client(strings.TrimSpace(input.client))).
@@ -172,6 +193,9 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 	events, err := c.event.List(ctx, criteria)
 	if err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to list events", "イベント一覧の取得に失敗しました"), err)
+	}
+	if input.sensitiveOnly {
+		events = filterSensitiveCommandEvents(events, input.limit)
 	}
 	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON, preset.fields)
 	if err != nil {
@@ -208,4 +232,24 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 // search accept the same kind values and aliases (e.g. "audit").
 func resolveListKind(value string) (string, error) {
 	return validateSearchKind(value)
+}
+
+func filterSensitiveCommandEvents(events []*model.Event, limit int) []*model.Event {
+	if limit <= 0 {
+		limit = 20
+	}
+	out := make([]*model.Event, 0, limit)
+	for _, event := range events {
+		if event == nil || event.Kind() != types.EventKindCommandExecuted {
+			continue
+		}
+		if !sensitivepath.ClassifyCommandBody(event.Body(), nil).Matched {
+			continue
+		}
+		out = append(out, event)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
 }

--- a/presentation/cli/list_test.go
+++ b/presentation/cli/list_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,6 +206,58 @@ func TestRootCLI_ListCommand(t *testing.T) {
 
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	t.Run("--sensitive keeps only sensitive command audits", func(t *testing.T) {
+		t.Parallel()
+
+		agent, err := types.AgentFrom("codex")
+		if err != nil {
+			t.Fatalf("AgentFrom() error = %v", err)
+		}
+		sessionID, err := types.SessionIDFrom("session-1")
+		if err != nil {
+			t.Fatalf("SessionIDFrom() error = %v", err)
+		}
+		mk := func(id, body string) *model.Event {
+			t.Helper()
+			eventID, err := types.EventIDFrom(id)
+			if err != nil {
+				t.Fatalf("EventIDFrom(%s) error = %v", id, err)
+			}
+			return model.EventOf(
+				eventID,
+				types.EventKindCommandExecuted,
+				"cli",
+				agent,
+				sessionID,
+				"duck8823/traceary",
+				body,
+				time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC),
+			)
+		}
+		listStub := &eventUsecaseStub{listEvents: []*model.Event{
+			mk("event-sensitive", "cat .env\n\nINPUT:\n\n\nOUTPUT:\n"),
+			mk("event-normal", "go test ./...\n\nINPUT:\n\n\nOUTPUT:\nok"),
+		}}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(listStub),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"list", "--db-path", "/tmp/test-traceary.db", "--sensitive", "--json"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !strings.Contains(stdout.String(), "event-sensitive") {
+			t.Fatalf("stdout missing sensitive event: %s", stdout.String())
+		}
+		if strings.Contains(stdout.String(), "event-normal") {
+			t.Fatalf("stdout should filter ordinary audit: %s", stdout.String())
 		}
 	})
 }

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -27,15 +27,30 @@ type event struct {
 
 // commandAudit is the JSON shape of a command audit in CLI output.
 type commandAudit struct {
-	Command             string `json:"command"`
-	Input               string `json:"input"`
-	Output              string `json:"output"`
-	InputTruncated      bool   `json:"input_truncated"`
-	OutputTruncated     bool   `json:"output_truncated"`
-	InputOriginalBytes  int    `json:"input_original_bytes,omitempty"`
-	OutputOriginalBytes int    `json:"output_original_bytes,omitempty"`
-	ExitCode            *int   `json:"exit_code,omitempty"`
-	Failed              bool   `json:"failed,omitempty"`
+	Command             string                    `json:"command"`
+	Input               string                    `json:"input"`
+	Output              string                    `json:"output"`
+	InputTruncated      bool                      `json:"input_truncated"`
+	OutputTruncated     bool                      `json:"output_truncated"`
+	InputOriginalBytes  int                       `json:"input_original_bytes,omitempty"`
+	OutputOriginalBytes int                       `json:"output_original_bytes,omitempty"`
+	ExitCode            *int                      `json:"exit_code,omitempty"`
+	Failed              bool                      `json:"failed,omitempty"`
+	Sensitive           *sensitiveClassification  `json:"sensitive,omitempty"`
+}
+
+// sensitiveClassification is the separable sensitive-path claim (not redaction).
+type sensitiveClassification struct {
+	Matched     bool   `json:"matched"`
+	Class       string `json:"class,omitempty"`
+	Operation   string `json:"operation,omitempty"`
+	Evidence    string `json:"evidence,omitempty"`
+	Coverage    string `json:"coverage,omitempty"`
+	Redaction   string `json:"redaction,omitempty"`
+	MatchedPath string `json:"matched_path,omitempty"`
+	IntentOnly  bool   `json:"intent_only"`
+	Summary     string `json:"summary,omitempty"`
+	CoverageGap string `json:"coverage_gap,omitempty"`
 }
 
 // eventDetails is the JSON shape of an event-with-audit pair in CLI output.

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -188,7 +188,15 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 			"    \"input\": \"stdin\",\n" +
 			"    \"output\": \"stdout\",\n" +
 			"    \"input_truncated\": true,\n" +
-			"    \"output_truncated\": false\n" +
+			"    \"output_truncated\": false,\n" +
+			"    \"sensitive\": {\n" +
+			"      \"matched\": false,\n" +
+			"      \"coverage\": \"partial\",\n" +
+			"      \"redaction\": \"unknown\",\n" +
+			"      \"intent_only\": false,\n" +
+			"      \"summary\": \"no sensitive path pattern matched\",\n" +
+			"      \"coverage_gap\": \"stdout_truncated\"\n" +
+			"    }\n" +
 			"  }\n" +
 			"}\n"
 		if diff := cmp.Diff(want, stdout.String()); diff != "" {

--- a/presentation/cli/testdata/audit/redacted_with_audit.golden.json
+++ b/presentation/cli/testdata/audit/redacted_with_audit.golden.json
@@ -15,6 +15,14 @@
     "output": "Authorization: Bearer [REDACTED]",
     "input_truncated": false,
     "output_truncated": true,
-    "exit_code": 1
+    "exit_code": 1,
+    "sensitive": {
+      "matched": false,
+      "coverage": "partial",
+      "redaction": "applied",
+      "intent_only": false,
+      "summary": "no sensitive path pattern matched",
+      "coverage_gap": "stdout_truncated"
+    }
   }
 }

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -78,7 +78,17 @@
       "name": "retry-loops",
       "status": "skip",
       "severity": "PASS",
-      "section": "Hooks",
+      "section": "Database",
+      "message": "event usecase is not configured",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
+      "name": "sensitive-access-audit",
+      "status": "skip",
+      "severity": "PASS",
+      "section": "Database",
       "message": "event usecase is not configured",
       "hint": "",
       "fix_command": "",
@@ -263,6 +273,26 @@
           "hint": "",
           "fix_command": "",
           "auto_fix_available": false
+        },
+        {
+          "name": "retry-loops",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "event usecase is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
+          "name": "sensitive-access-audit",
+          "status": "skip",
+          "severity": "PASS",
+          "section": "Database",
+          "message": "event usecase is not configured",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
         }
       ]
     },
@@ -298,16 +328,6 @@
     {
       "name": "Hooks",
       "checks": [
-        {
-          "name": "retry-loops",
-          "status": "skip",
-          "severity": "PASS",
-          "section": "Hooks",
-          "message": "event usecase is not configured",
-          "hint": "",
-          "fix_command": "",
-          "auto_fix_available": false
-        },
         {
           "name": "hook-spool",
           "status": "pass",
@@ -352,7 +372,7 @@
     }
   ],
   "summary": {
-    "pass": 14,
+    "pass": 15,
     "warn": 2,
     "fail": 0
   },


### PR DESCRIPTION
## Summary
- Sensitive-path classification is a separate claim from redaction and capture coverage.
- Default pattern classes: dotenv, ssh_key, cloud_creds, browser_profile, key_material, custom.
- CLI: `traceary list --sensitive`; `traceary show --json` includes `command_audit.sensitive`.
- Doctor: `sensitive-access-audit` summarizes intent-only vs structured evidence.

## Test plan
- [x] `go test ./application/sensitivepath/ ./presentation/cli/`
- [x] `go tool golangci-lint run` on touched packages
- [x] docs i18n pair for `docs/audit/sensitive-path`

Closes #1257