### PR TITLE
feat: attach host-reported model to sessions

### DIFF
--- a/application/types/session_summary.go
+++ b/application/types/session_summary.go
@@ -7,6 +7,10 @@ import (
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
+// SessionModel is a host-reported model identifier attached to a SessionSummary.
+// Empty means the host did not report a model.
+type SessionModel string
+
 // SessionSummary holds aggregated information about a single session.
 type SessionSummary struct {
 	sessionID          domtypes.SessionID
@@ -20,6 +24,7 @@ type SessionSummary struct {
 	agents             []string
 	label              string
 	summary            string
+	model              string
 	parentSessionID    domtypes.SessionID
 	spawnEventID       domtypes.EventID
 	subagentKind       string
@@ -66,6 +71,7 @@ func SessionSummaryOf(
 		latestEventKind    domtypes.EventKind
 		latestEventMessage string
 		client             domtypes.Client
+		modelName          string
 	)
 	for _, metadata := range spawnMetadata {
 		switch value := metadata.(type) {
@@ -73,6 +79,8 @@ func SessionSummaryOf(
 			client = value
 		case domtypes.EventID:
 			spawnEventID = value
+		case SessionModel:
+			modelName = string(value)
 		case string:
 			subagentKind = value
 		case domtypes.Optional[int]:
@@ -97,6 +105,7 @@ func SessionSummaryOf(
 		agents:             slices.Clone(agents),
 		label:              label,
 		summary:            summary,
+		model:              modelName,
 		parentSessionID:    parentSessionID,
 		spawnEventID:       spawnEventID,
 		subagentKind:       subagentKind,
@@ -140,6 +149,9 @@ func (s SessionSummary) Label() string { return s.label }
 
 // Summary returns the session summary text.
 func (s SessionSummary) Summary() string { return s.summary }
+
+// Model returns the host-reported model identifier, or empty when unavailable.
+func (s SessionSummary) Model() string { return s.model }
 
 // ParentSessionID returns the parent session ID.
 func (s SessionSummary) ParentSessionID() domtypes.SessionID { return s.parentSessionID }

--- a/application/usecase/record_session_boundary_test.go
+++ b/application/usecase/record_session_boundary_test.go
@@ -452,6 +452,19 @@ func (s *sessionRepositoryStub) UpdateSummaryIfEmpty(_ context.Context, sessionI
 	return true, nil
 }
 
+func (s *sessionRepositoryStub) UpdateModelIfEmpty(_ context.Context, _ types.SessionID, modelName string) (bool, error) {
+	if strings.TrimSpace(modelName) == "" {
+		return false, nil
+	}
+	if s.session != nil && s.session.Model() != "" {
+		return false, nil
+	}
+	if s.session != nil {
+		s.session.SetModel(modelName)
+	}
+	return true, nil
+}
+
 func mustTime(t *testing.T) time.Time {
 	t.Helper()
 

--- a/application/usecase/session_model_test.go
+++ b/application/usecase/session_model_test.go
@@ -1,0 +1,63 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestSessionUsecase_SetModelIfEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stores host-reported model when empty", func(t *testing.T) {
+		t.Parallel()
+		session := model.NewSession(types.SessionID("session-1"), mustTime(t), types.Client("hook"), types.Agent("codex"), types.Workspace("ws"))
+		stub := &sessionRepositoryStub{session: session}
+		sut := usecase.NewSessionUsecase(nil, stub, nil, nil)
+		updated, err := sut.SetModelIfEmpty(context.Background(), types.SessionID("session-1"), "gpt-5.6")
+		if err != nil {
+			t.Fatalf("SetModelIfEmpty error = %v", err)
+		}
+		if !updated {
+			t.Fatal("expected update")
+		}
+		if session.Model() != "gpt-5.6" {
+			t.Fatalf("model = %q, want gpt-5.6", session.Model())
+		}
+	})
+
+	t.Run("empty model is no-op", func(t *testing.T) {
+		t.Parallel()
+		session := model.NewSession(types.SessionID("session-1"), mustTime(t), types.Client("hook"), types.Agent("codex"), types.Workspace("ws"))
+		stub := &sessionRepositoryStub{session: session}
+		sut := usecase.NewSessionUsecase(nil, stub, nil, nil)
+		updated, err := sut.SetModelIfEmpty(context.Background(), types.SessionID("session-1"), "  ")
+		if err != nil {
+			t.Fatalf("SetModelIfEmpty error = %v", err)
+		}
+		if updated {
+			t.Fatal("empty model should not update")
+		}
+	})
+
+	t.Run("does not overwrite existing model", func(t *testing.T) {
+		t.Parallel()
+		session := model.NewSession(types.SessionID("session-1"), mustTime(t), types.Client("hook"), types.Agent("codex"), types.Workspace("ws"))
+		session.SetModel("claude-sonnet-5")
+		stub := &sessionRepositoryStub{session: session}
+		sut := usecase.NewSessionUsecase(nil, stub, nil, nil)
+		updated, err := sut.SetModelIfEmpty(context.Background(), types.SessionID("session-1"), "gpt-5.6")
+		if err != nil {
+			t.Fatalf("SetModelIfEmpty error = %v", err)
+		}
+		if updated {
+			t.Fatal("should not overwrite existing model")
+		}
+		if session.Model() != "claude-sonnet-5" {
+			t.Fatalf("model = %q, want claude-sonnet-5", session.Model())
+		}
+	})
+}

--- a/application/usecase/session_usecase.go
+++ b/application/usecase/session_usecase.go
@@ -53,6 +53,11 @@ type SessionUsecase interface {
 	// Returns true when a row was actually updated.
 	SetSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error)
 
+	// SetModelIfEmpty stores a host-reported model identifier when the session
+	// row still has an empty model. Empty input is a no-op. Never fabricates
+	// a model value.
+	SetModelIfEmpty(ctx context.Context, sessionID types.SessionID, model string) (bool, error)
+
 	// Handoff returns the legacy session handoff summary shape used by older CLI
 	// and MCP callers.
 	//

--- a/application/usecase/session_usecase_impl.go
+++ b/application/usecase/session_usecase_impl.go
@@ -239,6 +239,28 @@ func (u *sessionUsecase) SetSummaryIfEmpty(ctx context.Context, sessionID types.
 	return updated, nil
 }
 
+func (u *sessionUsecase) SetModelIfEmpty(ctx context.Context, sessionID types.SessionID, modelName string) (bool, error) {
+	trimmedSessionID := strings.TrimSpace(sessionID.String())
+	if trimmedSessionID == "" {
+		return false, xerrors.Errorf("session ID must not be empty")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return false, nil
+	}
+	if u.sessionRepo == nil {
+		return false, xerrors.Errorf("session repository is not configured")
+	}
+	resolvedSessionID, err := types.SessionIDFrom(trimmedSessionID)
+	if err != nil {
+		return false, xerrors.Errorf("failed to resolve session ID: %w", err)
+	}
+	updated, err := u.sessionRepo.UpdateModelIfEmpty(ctx, resolvedSessionID, modelName)
+	if err != nil {
+		return false, xerrors.Errorf("failed to update session model: %w", err)
+	}
+	return updated, nil
+}
+
 func (u *sessionUsecase) List(ctx context.Context, criteria apptypes.SessionListCriteria) ([]apptypes.SessionSummary, error) {
 	if criteria.Limit() <= 0 {
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")

--- a/domain/model/session.go
+++ b/domain/model/session.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strings"
 	"time"
 
 	"github.com/duck8823/traceary/domain/types"
@@ -16,6 +17,9 @@ type Session struct {
 	workspace       types.Workspace
 	label           string
 	summary         string
+	// model is the host-reported model identifier when present. Empty means
+	// the host did not report a model; Traceary never fabricates one.
+	model           string
 	parentSessionID types.SessionID
 	spawnEventID    types.EventID
 	subagentKind    string
@@ -59,6 +63,9 @@ func NewChildSession(
 }
 
 // SessionOf restores a Session from persisted data.
+// spawnMetadata may include: EventID spawnEventID, string subagentKind,
+// Optional[int] spawnOrder, and optionally a trailing string model when the
+// caller places model as the 4th optional value.
 func SessionOf(
 	sessionID types.SessionID,
 	startedAt time.Time,
@@ -75,6 +82,7 @@ func SessionOf(
 		spawnEventID types.EventID
 		subagentKind string
 		spawnOrder   types.Optional[int]
+		modelName    string
 	)
 	if len(spawnMetadata) >= 1 {
 		if value, ok := spawnMetadata[0].(types.EventID); ok {
@@ -91,6 +99,11 @@ func SessionOf(
 			spawnOrder = value
 		}
 	}
+	if len(spawnMetadata) >= 4 {
+		if value, ok := spawnMetadata[3].(string); ok {
+			modelName = value
+		}
+	}
 	return &Session{
 		sessionID:       sessionID,
 		startedAt:       startedAt,
@@ -100,6 +113,7 @@ func SessionOf(
 		workspace:       workspace,
 		label:           label,
 		summary:         summary,
+		model:           modelName,
 		parentSessionID: parentSessionID,
 		spawnEventID:    spawnEventID,
 		subagentKind:    subagentKind,
@@ -144,6 +158,26 @@ func (s *Session) SetLabel(label string) { s.label = label }
 
 // Summary returns the session summary text.
 func (s *Session) Summary() string { return s.summary }
+
+// Model returns the host-reported model identifier, or empty when unavailable.
+func (s *Session) Model() string {
+	if s == nil {
+		return ""
+	}
+	return s.model
+}
+
+// SetModel stores a host-reported model identifier. Empty input is ignored so
+// callers can pass through missing host fields without clearing an existing
+// value; use SetModelOnlyIfEmpty on the repository for persistence guards.
+func (s *Session) SetModel(model string) {
+	if s == nil {
+		return
+	}
+	if trimmed := strings.TrimSpace(model); trimmed != "" {
+		s.model = trimmed
+	}
+}
 
 // ParentSessionID returns the parent session ID, or empty if top-level.
 func (s *Session) ParentSessionID() types.SessionID { return s.parentSessionID }

--- a/domain/model/session_repository.go
+++ b/domain/model/session_repository.go
@@ -26,4 +26,8 @@ type SessionRepository interface {
 	// existing value is NULL or empty, leaving manually authored summaries
 	// untouched. Returns true when a row was updated.
 	UpdateSummaryIfEmpty(ctx context.Context, sessionID types.SessionID, summary string) (bool, error)
+	// UpdateModelIfEmpty writes model into sessions.model when the existing
+	// value is empty. Host-reported values are never overwritten. Returns true
+	// when a row was updated.
+	UpdateModelIfEmpty(ctx context.Context, sessionID types.SessionID, model string) (bool, error)
 }

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -99,6 +99,9 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
 			Data: []byte(`CREATE INDEX IF NOT EXISTS idx_events_session_created_at_id_desc
 ON events(session_id, created_at DESC, id DESC);`),
 		},
+		"000020_add_session_model.sql": {
+			Data: []byte(`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT '';`),
+		},
 	}
 }
 

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -29,6 +29,9 @@ var updateSessionEndQuery string
 //go:embed sql/update_session_summary_if_empty.sql
 var updateSessionSummaryIfEmptyQuery string
 
+//go:embed sql/update_session_model_if_empty.sql
+var updateSessionModelIfEmptyQuery string
+
 //go:embed sql/select_session_by_id.sql
 var selectSessionByIDQuery string
 
@@ -183,6 +186,7 @@ func insertSessionRowIfMissing(ctx context.Context, exec sqlExecer, session *mod
 		spawnEventID,
 		session.SubagentKind(),
 		spawnOrder,
+		session.Model(),
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") && session.ParentSessionID().String() != "" {
@@ -291,6 +295,7 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		spawnEventIDValue    string
 		subagentKindValue    string
 		spawnOrderValue      sql.NullInt64
+		modelValue           string
 	)
 
 	if err := row.Scan(
@@ -306,6 +311,7 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		&spawnEventIDValue,
 		&subagentKindValue,
 		&spawnOrderValue,
+		&modelValue,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.None[*model.Session](), nil
@@ -348,6 +354,7 @@ func (d *SessionDatasource) FindByID(ctx context.Context, sessionID types.Sessio
 		types.EventID(spawnEventIDValue),
 		subagentKindValue,
 		optionalIntFromNullInt64(spawnOrderValue),
+		modelValue,
 	)), nil
 }
 
@@ -453,6 +460,37 @@ func (d *SessionDatasource) UpdateSummaryIfEmpty(ctx context.Context, sessionID 
 	res, err := db.ExecContext(ctx, updateSessionSummaryIfEmptyQuery, summary, sessionID.String())
 	if err != nil {
 		return false, xerrors.Errorf("failed to update session summary: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, xerrors.Errorf("failed to read rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
+// UpdateModelIfEmpty writes model into sessions.model when empty.
+func (d *SessionDatasource) UpdateModelIfEmpty(ctx context.Context, sessionID types.SessionID, modelName string) (bool, error) {
+	if strings.TrimSpace(sessionID.String()) == "" {
+		return false, xerrors.Errorf("session ID must not be empty")
+	}
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return false, nil
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("failed to open DB for session model update: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	res, err := db.ExecContext(ctx, updateSessionModelIfEmptyQuery, modelName, sessionID.String(), modelName)
+	if err != nil {
+		return false, xerrors.Errorf("failed to update session model: %w", err)
 	}
 	rows, err := res.RowsAffected()
 	if err != nil {
@@ -683,6 +721,7 @@ func scanSessionSummary(row interface {
 		spawnEventID       string
 		subagentKind       string
 		spawnOrder         sql.NullInt64
+		modelName          string
 		latestEventKindStr string
 		latestEventID      string
 		latestEventRawBody string
@@ -704,6 +743,7 @@ func scanSessionSummary(row interface {
 		&spawnEventID,
 		&subagentKind,
 		&spawnOrder,
+		&modelName,
 		&latestEventKindStr,
 		&latestEventID,
 		&latestEventRawBody,
@@ -763,6 +803,7 @@ func scanSessionSummary(row interface {
 		types.EventID(spawnEventID),
 		subagentKind,
 		optionalIntFromNullInt64(spawnOrder),
+		apptypes.SessionModel(modelName),
 		latestEventAt,
 		apptypes.SessionSummaryLatestEventOf(types.EventID(latestEventID), types.EventKind(latestEventKindStr), apptypes.ExtractPlainBody(latestEventRawBody)),
 	), nil

--- a/infrastructure/sqlite/sql/insert_session.sql
+++ b/infrastructure/sqlite/sql/insert_session.sql
@@ -1,1 +1,1 @@
-INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, workspace, parent_session_id, spawn_event_id, subagent_kind, spawn_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT OR IGNORE INTO sessions (session_id, started_at, client, agent, workspace, parent_session_id, spawn_event_id, subagent_kind, spawn_order, model) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/infrastructure/sqlite/sql/list_session_tree.sql
+++ b/infrastructure/sqlite/sql/list_session_tree.sql
@@ -59,6 +59,7 @@ SELECT
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
   s.spawn_order,
+  COALESCE(s.model, '') AS model,
   COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
   COALESCE(latest.latest_event_id, '') AS latest_event_id,
   COALESCE(latest.latest_event_body, '') AS latest_event_body

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -62,6 +62,7 @@ SELECT
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
   s.spawn_order,
+  COALESCE(s.model, '') AS model,
   COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
   COALESCE(latest.latest_event_id, '') AS latest_event_id,
   COALESCE(latest.latest_event_body, '') AS latest_event_body

--- a/infrastructure/sqlite/sql/select_session_by_id.sql
+++ b/infrastructure/sqlite/sql/select_session_by_id.sql
@@ -1,1 +1,1 @@
-SELECT session_id, started_at, ended_at, client, agent, workspace, label, summary, COALESCE(parent_session_id, ''), COALESCE(spawn_event_id, ''), subagent_kind, spawn_order FROM sessions WHERE session_id = ?
+SELECT session_id, started_at, ended_at, client, agent, workspace, label, summary, COALESCE(parent_session_id, ''), COALESCE(spawn_event_id, ''), subagent_kind, spawn_order, COALESCE(model, '') FROM sessions WHERE session_id = ?

--- a/infrastructure/sqlite/sql/session_lineage.sql
+++ b/infrastructure/sqlite/sql/session_lineage.sql
@@ -70,6 +70,7 @@ SELECT
   COALESCE(s.spawn_event_id, '') AS spawn_event_id,
   s.subagent_kind,
   s.spawn_order,
+  COALESCE(s.model, '') AS model,
   COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
   COALESCE(latest.latest_event_id, '') AS latest_event_id,
   COALESCE(latest.latest_event_body, '') AS latest_event_body

--- a/infrastructure/sqlite/sql/update_session_model_if_empty.sql
+++ b/infrastructure/sqlite/sql/update_session_model_if_empty.sql
@@ -1,0 +1,5 @@
+UPDATE sessions
+   SET model = ?
+ WHERE session_id = ?
+   AND (model IS NULL OR model = '')
+   AND ? <> ''

--- a/presentation/cli/hook_session.go
+++ b/presentation/cli/hook_session.go
@@ -83,6 +83,13 @@ func (c *RootCLI) runHookSession(
 		if err != nil {
 			return xerrors.Errorf("failed to record hook session start: %w", err)
 		}
+		// Host-reported model is optional. Claude may omit it; Gemini/Antigravity
+		// never send it. Empty degrades to no model (never fabricated).
+		if modelName := strings.TrimSpace(hookPayloadString(payload, "model", "")); modelName != "" {
+			if _, err := c.session.SetModelIfEmpty(ctx, event.SessionID(), modelName); err != nil {
+				slog.Debug("failed to attach host-reported session model", "error", err, "session_id", event.SessionID().String())
+			}
+		}
 		if err := writeHookSessionState(client, event.SessionID()); err != nil {
 			return err
 		}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -283,6 +283,7 @@ type sessionSummaryOutput struct {
 	Workspace       string   `json:"workspace,omitempty"`
 	Label           string   `json:"label,omitempty"`
 	Summary         string   `json:"summary,omitempty"`
+	Model           string   `json:"model,omitempty"`
 	ParentSessionID string   `json:"parent_session_id,omitempty"`
 	SpawnEventID    string   `json:"spawn_event_id,omitempty"`
 	SubagentKind    string   `json:"subagent_kind,omitempty"`

--- a/presentation/cli/session_list.go
+++ b/presentation/cli/session_list.go
@@ -166,6 +166,7 @@ func writeSessionSummariesJSON(output io.Writer, summaries []apptypes.SessionSum
 			Workspace:       string(s.Workspace()),
 			Label:           s.Label(),
 			Summary:         s.Summary(),
+			Model:           s.Model(),
 			ParentSessionID: string(s.ParentSessionID()),
 			SpawnEventID:    s.SpawnEventID().String(),
 			SubagentKind:    s.SubagentKind(),

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -128,6 +129,7 @@ type sessionUsecaseStub struct {
 	handoffErr      error
 	setSummaryErr   error
 	setSummaryCalls map[types.SessionID]string
+	setModelCalls   map[types.SessionID]string
 
 	startCall struct {
 		client          types.Client
@@ -252,6 +254,17 @@ func (s *sessionUsecaseStub) SetSummaryIfEmpty(_ context.Context, sessionID type
 		s.setSummaryCalls = make(map[types.SessionID]string)
 	}
 	s.setSummaryCalls[sessionID] = summary
+	return true, nil
+}
+
+func (s *sessionUsecaseStub) SetModelIfEmpty(_ context.Context, sessionID types.SessionID, modelName string) (bool, error) {
+	if s.setModelCalls == nil {
+		s.setModelCalls = make(map[types.SessionID]string)
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return false, nil
+	}
+	s.setModelCalls[sessionID] = modelName
 	return true, nil
 }
 

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -1569,6 +1569,9 @@ ALTER TABLE sessions ADD COLUMN spawn_order INTEGER;
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_spawn_order
     ON sessions(parent_session_id, spawn_order);`),
 		},
+		"000020_add_session_model.sql": {
+			Data: []byte(`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT '';`),
+		},
 		"000008_create_memories.sql": {
 			Data: []byte(`
 CREATE TABLE memories (

--- a/schema/sqlite/migrations/000020_add_session_model.sql
+++ b/schema/sqlite/migrations/000020_add_session_model.sql
@@ -1,0 +1,3 @@
+-- Host-reported model identifier for a session (opaque host string).
+-- Empty means the host did not report a model (Gemini/Antigravity/CLI/MCP).
+ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary
- Additive `sessions.model` column for host-reported model identifiers only.
- Hook session start extracts `model` when present; never fabricates.
- `sessions --json` includes `model,omitempty`.
- Gemini/Antigravity/CLI/MCP starts remain empty (documented degrade).

## Test plan
- [x] usecase SetModelIfEmpty tests
- [x] sqlite list/tree/lineage migration fixture update
- [x] `go test` domain/application/infrastructure/presentation packages

Closes #1265