### PR TITLE
docs: record OTel GenAI and next-host research decisions

### DIFF
--- a/docs/research/next-host-evaluation.ja.md
+++ b/docs/research/next-host-evaluation.ja.md
@@ -1,0 +1,45 @@
+# 決定: 次ホスト評価 — Copilot CLI vs opencode (#1256)
+
+[English](./next-host-evaluation.md)
+
+**Status:** v0.26.0 向け評価完了 — **この issue では host 実装なし**  
+**Date:** 2026-07-16  
+**Issue:** #1256
+
+## 決定
+
+- **次ホスト候補の第一候補:** GitHub Copilot CLI（hook surface が文書化され CLI でサポート）。
+- #1256 / v0.26.0 内では Copilot CLI も opencode も**実装しない**。実装は後続マイルストーンで package / doctor / contract 計画後に専用 child issue へ分割する。
+- **opencode:** 二次ウォッチ。plugin/event モデルはあるが Traceary の shell-hook 包装とは異なり、`application/hostcoverage` に対する sanitized live probe が先。
+
+## 一次情報
+
+### GitHub Copilot CLI
+
+- Hooks reference: https://docs.github.com/en/copilot/reference/hooks-reference
+- Using hooks: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks
+- Tutorial: https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks
+
+### opencode
+
+- Plugins / events: https://opencode.ai/docs/plugins/
+
+## v0.25 host 枠組みとの対照
+
+| 観点 | Copilot CLI | opencode |
+|---|---|---|
+| 文書化された hook / lifecycle | あり | plugin event（別モデル） |
+| marketplace 秘密なしの local install | repo/user hooks JSON で可能と見込まれる | TypeScript plugin 経路 |
+| `scripts/hooks` + hostcoverage 適合 | 高い | 中（adapter 必要） |
+| 評価 PR での実装リスク | 同梱すると高い | 同梱すると高い |
+
+## Follow-ups（v0.26.0 外）
+
+1. Copilot CLI hook の sanitized live probe → fixture と hostcoverage 行。
+2. packaging + doctor の設計メモ。
+3. probe 通過後の専用実装 issue（1 issue = 1 PR）。
+
+## 確認した Non-goals
+
+- 評価 PR での新規 host package 出荷。
+- live fixture なしの lifecycle 完全互換主張。

--- a/docs/research/next-host-evaluation.md
+++ b/docs/research/next-host-evaluation.md
@@ -1,0 +1,47 @@
+# Decision: next host evaluation — Copilot CLI vs opencode (#1256)
+
+[日本語](./next-host-evaluation.ja.md)
+
+**Status:** evaluation complete for v0.26.0 — **no host implementation in this issue**  
+**Date:** 2026-07-16  
+**Issue:** #1256
+
+## Decision
+
+- **Preferred next host candidate:** GitHub Copilot CLI (hook surface is documented and CLI-supported).
+- **Do not implement** Copilot CLI or opencode inside #1256 / v0.26.0. Split any implementation into dedicated child issues under a later milestone after package + doctor + contract work is planned.
+- **opencode:** keep as secondary watch item; plugin/event model exists but differs from Traceary’s shell-hook packaging and still needs a sanitized live probe against `application/hostcoverage` before commit.
+
+## Primary sources
+
+### GitHub Copilot CLI
+
+- Hooks reference: https://docs.github.com/en/copilot/reference/hooks-reference  
+  Documents hook events, configuration formats, and payloads for Copilot CLI (local shell hooks).
+- Using hooks with Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks
+- Hooks tutorial (repo-scoped `.github/hooks/`): https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks
+
+### opencode
+
+- Plugins / events: https://opencode.ai/docs/plugins/  
+  Event subscription model (`command.executed`, message events, etc.) rather than Traceary’s existing shell hook install path.
+
+## Evaluation against v0.25 host framework
+
+| Criterion | Copilot CLI | opencode |
+|---|---|---|
+| Documented hook/lifecycle surface | Yes (official hooks reference) | Plugin events (different model) |
+| Local install without marketplace secrets | Likely via repo/user hooks JSON | Plugin TypeScript path |
+| Fit to `scripts/hooks` + `hostcoverage` matrix | High (command hooks map to session/prompt/audit/stop patterns) | Medium (needs adapter layer) |
+| Implementation risk in evaluation PR | High if bundled | High if bundled |
+
+## Follow-ups (not in v0.26.0)
+
+1. Sanitized live probe of Copilot CLI hooks → fixtures under `presentation/cli/testdata/` and rows in `application/hostcoverage/matrix.json`.
+2. Design note for packaging (`integrations/…`) + doctor checks.
+3. Separate implementation issues (1 issue = 1 PR) after probe passes.
+
+## Non-goals confirmed
+
+- Shipping a new host package in the evaluation PR.
+- Claiming full lifecycle parity without versioned live fixtures.

--- a/docs/research/otel-genai-export.ja.md
+++ b/docs/research/otel-genai-export.ja.md
@@ -1,0 +1,34 @@
+# 決定: OTel GenAI export (#1258)
+
+[English](./otel-genai-export.md)
+
+**Status:** v0.26.0 では no-go（文書化された決定）  
+**Date:** 2026-07-16  
+**Issue:** #1258
+
+## 決定
+
+v0.26.0 ではネットワーク経由の OTel GenAI export を**出荷しない**。Traceary は local-first を維持し、GenAI semantic conventions が安定し、具体的な consumer 要件が現れるまで export を既定 product surface に載せない。
+
+## 一次情報
+
+- OpenTelemetry GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+- GenAI conventions リポジトリ: https://github.com/open-telemetry/semantic-conventions-genai
+- OTel blog (2026-05): https://opentelemetry.io/blog/2026/genai-observability/
+
+## 調査結果
+
+- 2026 年中盤時点でも GenAI semantic conventions は **development / experimental**。属性名・形状は dual-emission / opt-in が必要な状況が続く。
+- Traceary が session / audit / transcript を固定マッピングできる「凍結済み」属性集合はまだない。
+- sensitive-path / redaction / coverage / host-reported model はローカル監査 claim であり、既定でネットワーク送信すると local-first 方針と衝突する。
+
+## 再検討条件
+
+- GenAI conventions が stable になる（または pin 可能な凍結 subset）。
+- 明示的な consumer があり experimental 属性の変化を許容する。
+- export が **opt-in**（既定オフ）で、private payload を span に載せない設計。
+
+## 確認した Non-goals
+
+- 既定のネットワーク telemetry。
+- 評価 PR 内での export 実装。

--- a/docs/research/otel-genai-export.md
+++ b/docs/research/otel-genai-export.md
@@ -1,0 +1,34 @@
+# Decision: OTel GenAI export (#1258)
+
+[日本語](./otel-genai-export.ja.md)
+
+**Status:** no-go for v0.26.0 (documented decision)  
+**Date:** 2026-07-16  
+**Issue:** #1258
+
+## Decision
+
+Do **not** ship network OTel GenAI export in v0.26.0. Traceary remains local-first; export stays out of the default product surface until GenAI semantic conventions stabilize and a concrete consumer requirement exists.
+
+## Primary sources
+
+- OpenTelemetry GenAI semantic conventions home (moved / active development): https://opentelemetry.io/docs/specs/semconv/gen-ai/
+- GenAI conventions repository: https://github.com/open-telemetry/semantic-conventions-genai
+- OTel blog on GenAI observability (2026-05): https://opentelemetry.io/blog/2026/genai-observability/
+
+## Findings
+
+- GenAI semantic conventions remain in **development / experimental** status as of mid-2026. Attribute names and shapes still require stability opt-in dual-emission in several ecosystems.
+- There is no single stable, frozen attribute set that Traceary can map sessions / audits / transcripts to without risking breakages on semconv bumps.
+- Traceary’s stored claims (sensitive-path, redaction, coverage, host-reported model) are local audit semantics; pushing them over the network by default conflicts with the local-first product stance.
+
+## Conditions to revisit
+
+- GenAI conventions marked stable (or a frozen subset Traceary can pin).
+- An explicit consumer (user or integration) that needs OTLP export and accepts experimental attribute churn.
+- A design that keeps export **opt-in**, off by default, with no private payloads in spans unless explicitly enabled.
+
+## Non-goals confirmed
+
+- Default network telemetry.
+- Shipping export code in the evaluation PR.


### PR DESCRIPTION
## Summary
- #1258: OTel GenAI export is a documented **no-go** for v0.26.0 (conventions experimental; local-first).
- #1256: Copilot CLI preferred next host candidate; **no implementation** in this PR; opencode secondary watch.

## Sources
Primary URLs are cited in `docs/research/*.md`.

Closes #1258
Closes #1256