### PR TITLE
fix: dotenv false positives and replay timeline truncation

### DIFF
--- a/application/sensitivepath/classify.go
+++ b/application/sensitivepath/classify.go
@@ -125,7 +125,9 @@ type rule struct {
 }
 
 var defaultRules = []rule{
-	{class: ClassDotenv, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `=])(\.?env(?:\.[A-Za-z0-9_.-]+)?|\.env)(?:$|[\s"'` + "`" + `])`)},
+	// Require the leading dot so bare "env" / "env vars" shell boilerplate
+	// never matches. Covers ".env", ".env.local", "path/to/.env.production".
+	{class: ClassDotenv, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `=/])\.env(?:\.[A-Za-z0-9_.-]+)?(?:$|[\s"'` + "`" + `])`)},
 	{class: ClassDotenv, pattern: regexp.MustCompile(`(?i)\.env(?:\.[A-Za-z0-9_.-]+)?`)},
 	{class: ClassSSHKey, pattern: regexp.MustCompile(`(?i)(?:^|[\s"'` + "`" + `])(?:~|/Users/[^/\s]+|/home/[^/\s]+)?/\.ssh(?:/|$)`)},
 	{class: ClassSSHKey, pattern: regexp.MustCompile(`(?i)\bid_(?:rsa|ed25519|ecdsa|dsa)\b`)},

--- a/application/sensitivepath/classify_test.go
+++ b/application/sensitivepath/classify_test.go
@@ -92,6 +92,43 @@ func TestClassify_NoMatch(t *testing.T) {
 	}
 }
 
+func TestClassify_DoesNotMatchBareEnvOrShellBoilerplate(t *testing.T) {
+	t.Parallel()
+
+	// Host shell boilerplate often says "cwd, env vars" without any dotenv path.
+	// Matching bare "env" flooded list --sensitive / command_audit.sensitive.
+	cases := []string{
+		"Shell state (cwd, env vars) persists for subsequent calls",
+		"export PATH=$PATH:/usr/local/bin",
+		"printenv HOME",
+		"env | sort",
+		"echo env",
+	}
+	for _, cmd := range cases {
+		got := sensitivepath.Classify(sensitivepath.Input{Command: cmd})
+		if got.Matched {
+			t.Fatalf("Command %q matched sensitive class %q path %q; want no match", cmd, got.Class, got.MatchedPath)
+		}
+	}
+}
+
+func TestClassify_StillMatchesDotenvPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"cat .env",
+		"cat .env.local",
+		"Read path/to/.env.production",
+		`{"file_path":"/Users/me/project/.env"}`,
+	}
+	for _, cmd := range cases {
+		got := sensitivepath.Classify(sensitivepath.Input{Command: cmd, ToolName: "Read"})
+		if !got.Matched || got.Class != sensitivepath.ClassDotenv {
+			t.Fatalf("Command %q got %#v, want dotenv match", cmd, got)
+		}
+	}
+}
+
 func TestClassifyCommandBody_ParsesAuditShape(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/replay.go
+++ b/presentation/cli/replay.go
@@ -283,10 +283,9 @@ func replayDataFromBundle(bundle apptypes.ReplayBundle, dbPathFlag string) repla
 		end := block.BlockEnd().UTC()
 		workspaces := make([]replayTimelineWorkspace, 0, len(block.WorkspaceBreakdown()))
 		for _, ws := range block.WorkspaceBreakdown() {
-			activity := strings.TrimSpace(ws.Summary())
-			if activity == "" {
-				activity = formatKindCounts(computeKindCounts(ws.Kinds()))
-			}
+			// Same bounded activity projection as `traceary timeline` so
+			// replay never embeds multi‑MB prompt/transcript raw bodies.
+			activity := workspaceActivityText(ws)
 			workspaces = append(workspaces, replayTimelineWorkspace{
 				Workspace:  ws.Workspace(),
 				EventCount: ws.EventCount(),

--- a/presentation/cli/replay_runner_test.go
+++ b/presentation/cli/replay_runner_test.go
@@ -147,3 +147,66 @@ func TestRootCLI_Replay_WritesMarkdownOnSuccess(t *testing.T) {
 		t.Errorf("stdout = %q, want markdown success line", stdout.String())
 	}
 }
+
+func TestRootCLI_Replay_MarkdownTruncatesTimelineActivity(t *testing.T) {
+	t.Parallel()
+
+	// Multi-kilobyte prompt-style summary must not be embedded raw in replay
+	// Markdown (same bound as timeline: timelineSummaryMaxRune = 72).
+	huge := strings.Repeat("PROMPT-BODY-", 5000) // ~60KB, well over 72 runes
+	marker := "UNIQUE_REPLAY_MARKER_SHOULD_NOT_APPEAR_IN_FULL"
+	huge = marker + huge
+	block := apptypes.TimelineBlockOf(
+		time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 21, 12, 30, 0, 0, time.UTC),
+		3,
+		[]string{"codex"},
+		[]apptypes.TimelineWorkspaceBreakdown{
+			apptypes.TimelineWorkspaceBreakdownOf(
+				"duck8823/traceary",
+				3,
+				[]string{"prompt"},
+				[]string{"codex"},
+				huge,
+				apptypes.TimelineSummarySourcePrompt,
+			),
+		},
+	)
+	bundle := apptypes.ReplayBundleOf(
+		time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC),
+		nil,
+		nil,
+		[]apptypes.TimelineBlock{block},
+		nil,
+	)
+	outPath := filepath.Join(t.TempDir(), "replay.md")
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithReplay(&replayUsecaseStub{bundle: bundle}),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"replay", "--format", "markdown", "--out", outPath})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	body, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "# Traceary replay") {
+		t.Fatalf("missing title")
+	}
+	if strings.Contains(text, huge) {
+		t.Fatalf("markdown embedded full timeline activity (%d bytes)", len(huge))
+	}
+	// Truncated activity may keep a short prefix of the marker, but not the full multi-KB body.
+	if len(text) > 200_000 {
+		t.Fatalf("markdown too large (%d bytes); expected bounded digest", len(text))
+	}
+	// The unbounded PROMPT-BODY repetition must not appear hundreds of times.
+	if strings.Count(text, "PROMPT-BODY-") > 5 {
+		t.Fatalf("timeline activity not truncated: PROMPT-BODY- count=%d", strings.Count(text, "PROMPT-BODY-"))
+	}
+}


### PR DESCRIPTION
## Summary
- Dotenv classification requires `.env` / `.env.*` (no bare `env` / `env vars` shell boilerplate).
- Replay timeline activity uses the same 72-rune bounded projection as `traceary timeline`.
- Tests: shell boilerplate non-match; markdown replay rejects multi-KB raw timeline activity.

## Test plan
- [x] `go test ./application/sensitivepath/ -v`
- [x] `go test ./presentation/cli/ -run Replay -v`
- [x] golangci-lint on touched packages

Post-v0.26.0 quality fix for release dogfood findings.