### PR TITLE
feat: drain and replay timeout-killed hook spool records

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -206,7 +206,9 @@ traceary hooks install --client codex --upgrade
 
 ### timeout kill 時の保全
 
-すべての非公開 `traceary hook ...` entrypoint は、SQLite に触れる前に host payload を `~/.config/traceary/hooks/spool/` 配下の mode `0600` record へ保存します。record は atomic に公開され、hook operation が成功した後だけ削除されます。SIGTERM は command context を cancel します。host が競合中または低速な hook を kill しても、先に公開した record が残るため event は黙って消えません。`traceary doctor` は残存 record と読めない record を `hook-spool` check で報告します。残存 record は payload を確認し、対応する command を再実行してから削除してください。経過時間だけでは自動削除しません。
+すべての非公開 `traceary hook ...` entrypoint は、SQLite に触れる前に host payload を `~/.config/traceary/hooks/spool/` 配下の mode `0600` record へ保存します。record は atomic に公開され、hook operation が成功した後だけ削除されます。SIGTERM は command context を cancel します。host が競合中または低速な hook を kill しても、先に公開した record が残るため event は黙って消えません。
+
+後続の hook 呼び出しは、自身の処理の前に未処理 spool record を oldest-first の bounded batch で drain します。Traceary が解釈できる command だけを replay し、replay が成功した record のみ削除します。`traceary doctor` は残存 record と読めない record を `hook-spool` check で報告し、`traceary doctor --fix` は host timeout 外で大きめに drain します。手動削除前に spool ディレクトリの payload を確認してください。経過時間だけでは自動削除しません。
 
 SQLite が writer 競合を待つのは最大1秒です。packaged host hook の budget は必ずこの待機時間を上回る必要があります。Gemini の生成・同梱 hook timeout は10秒で、DB attempt が失敗して spool record を保持したまま host deadline より前に制御を戻せます。この関係は意図的です: `SQLite busy_timeout < host hook timeout`。
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -206,7 +206,9 @@ In those cases, inspect the file yourself and only rerun with `--force` when rep
 
 ### Timeout-kill preservation
 
-Every hidden `traceary hook ...` entrypoint writes the exact host payload to a mode-`0600` record under `~/.config/traceary/hooks/spool/` before it touches SQLite. The record is atomically published and removed only after the hook operation returns successfully. SIGTERM cancels the command context; if the host kills a contended or slow hook, the already-published record remains available instead of the event disappearing silently. `traceary doctor` reports retained or unreadable records through the `hook-spool` check. Inspect the payload and retry the matching command before removing a retained record; Traceary does not delete it based on age alone.
+Every hidden `traceary hook ...` entrypoint writes the exact host payload to a mode-`0600` record under `~/.config/traceary/hooks/spool/` before it touches SQLite. The record is atomically published and removed only after the hook operation returns successfully. SIGTERM cancels the command context; if the host kills a contended or slow hook, the already-published record remains available instead of the event disappearing silently.
+
+Later hook invocations drain a bounded batch of pending spool records (oldest first) before their own work, replaying only commands Traceary still understands and deleting a record only after replay returns successfully. `traceary doctor` reports retained or unreadable records through the `hook-spool` check; `traceary doctor --fix` forces a larger drain when you want to clear a backlog outside a live host timeout. Inspect payloads under the spool directory before manual removal; Traceary does not delete records based on age alone.
 
 SQLite waits at most 1 second for a busy writer. Every packaged host hook budget must exceed that wait. Gemini's generated and packaged hook timeout is 10 seconds, leaving time for the DB attempt to fail and the spool record to remain durable before the host deadline. This relationship is intentional: `SQLite busy_timeout < host hook timeout`.
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -285,7 +285,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved project directory: %s", "解決した project directory: %s", resolvedProjectDir),
 	})
-	report.Checks = append(report.Checks, inspectHookSpoolDiagnostics(resolvedClients))
+	report.Checks = append(report.Checks, c.inspectHookSpoolDiagnostics(resolvedClients))
 	report.Checks = append(report.Checks, inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
 	report.Checks = append(report.Checks, inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
 

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -18,7 +18,12 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const hookSpoolSchemaVersion = 1
+const (
+	hookSpoolSchemaVersion = 1
+	// hookSpoolReplayBatchLimit caps opportunistic drain work per hook
+	// invocation so replay cannot exhaust the host timeout budget.
+	hookSpoolReplayBatchLimit = 5
+)
 
 type hookInvocationSpec struct {
 	Command string
@@ -54,6 +59,13 @@ func (c *RootCLI) runHookDurably(
 	run func(io.Reader) error,
 ) error {
 	return runHookBestEffort(name, func() error {
+		// Drain a bounded batch of older timeout-killed records before this
+		// invocation's own work. Failures stay on disk for later retries.
+		if ctx.Err() == nil {
+			if replayed, failed := c.drainHookSpoolRecords(ctx, hookSpoolReplayBatchLimit); replayed > 0 || failed > 0 {
+				slog.Debug("hook spool drain", "replayed", replayed, "failed", failed)
+			}
+		}
 		payload, err := readHookPayload(input)
 		if err != nil {
 			return err
@@ -86,6 +98,112 @@ func (c *RootCLI) runHookDurably(
 		}
 		return nil
 	})
+}
+
+// drainHookSpoolRecords replays up to limit pending spool records (oldest
+// first). A record is removed only after replay returns nil. Returns counts
+// of successful replays and retained failures.
+func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replayed, failed int) {
+	if limit <= 0 {
+		return 0, 0
+	}
+	records, _, err := scanHookSpoolRecords(nil)
+	if err != nil || len(records) == 0 {
+		return 0, 0
+	}
+	// scanHookSpoolRecords returns newest first; drain oldest first.
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].CreatedAt.Before(records[j].CreatedAt)
+	})
+	for i, record := range records {
+		if i >= limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		if strings.TrimSpace(record.Path) == "" {
+			failed++
+			continue
+		}
+		if err := c.replayHookSpoolRecord(ctx, record); err != nil {
+			failed++
+			slog.Debug("hook spool replay failed", "path", record.Path, "command", record.Command, "client", record.Client, "error", err)
+			continue
+		}
+		if err := os.Remove(record.Path); err != nil && !os.IsNotExist(err) {
+			failed++
+			slog.Debug("hook spool clear failed after replay", "path", record.Path, "error", err)
+			continue
+		}
+		replayed++
+	}
+	return replayed, failed
+}
+
+func (c *RootCLI) replayHookSpoolRecord(ctx context.Context, record hookSpoolRecord) error {
+	input := newExplicitHookPayloadReader([]byte(record.Payload))
+	dbPath := record.DBPath
+	client := record.Client
+	action := record.Action
+	switch strings.TrimSpace(record.Command) {
+	case "session":
+		return c.runHookSession(ctx, io.Discard, input, client, action, dbPath)
+	case "audit":
+		return c.runHookAudit(ctx, input, client, dbPath)
+	case "compact":
+		return c.runHookCompact(ctx, io.Discard, input, client, action, dbPath)
+	case "subagent-start":
+		return c.runHookSubagentStart(ctx, input, client, dbPath)
+	case "subagent-stop":
+		return c.runHookSubagentStop(ctx, input, client, dbPath)
+	case "prompt":
+		return c.runHookPrompt(ctx, input, client, dbPath)
+	case "transcript":
+		return c.runHookTranscript(ctx, input, client, dbPath)
+	case "antigravity":
+		return c.replayAntigravitySpoolRecord(ctx, input, action, dbPath)
+	case "grok":
+		return c.replayGrokSpoolRecord(ctx, input, action, dbPath)
+	default:
+		return xerrors.Errorf("unsupported hook spool command: %s", record.Command)
+	}
+}
+
+func (c *RootCLI) replayAntigravitySpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
+	switch strings.TrimSpace(action) {
+	case "pre-invocation":
+		return c.runHookAntigravityPreInvocation(ctx, io.Discard, input, dbPath)
+	case "pre-tool-use":
+		return c.runHookAntigravityPreToolUse(ctx, io.Discard, input, dbPath)
+	case "post-tool-use":
+		return c.runHookAntigravityPostToolUse(ctx, io.Discard, input, dbPath)
+	case "stop":
+		return c.runHookAntigravityStop(ctx, io.Discard, input, dbPath)
+	default:
+		return xerrors.Errorf("unsupported antigravity spool action: %s", action)
+	}
+}
+
+func (c *RootCLI) replayGrokSpoolRecord(ctx context.Context, input io.Reader, action, dbPath string) error {
+	switch strings.TrimSpace(action) {
+	case "session-start":
+		return c.runHookGrokSessionStart(ctx, input, dbPath)
+	case "user-prompt-submit":
+		return c.runHookGrokUserPromptSubmit(ctx, input, dbPath)
+	case "pre-tool-use":
+		return c.runHookGrokPreToolUse(ctx, input, dbPath)
+	case "post-tool-use":
+		return c.runHookGrokPostToolUse(ctx, input, dbPath)
+	case "stop":
+		return c.runHookGrokStop(ctx, input, dbPath)
+	case "pre-compact":
+		return c.runHookGrokPreCompact(ctx, input, dbPath)
+	case "post-compact":
+		return c.runHookGrokPostCompact(ctx, input, dbPath)
+	default:
+		return xerrors.Errorf("unsupported grok spool action: %s", action)
+	}
 }
 
 func persistHookSpoolRecord(record hookSpoolRecord) (string, error) {
@@ -172,7 +290,7 @@ func scanHookSpoolRecords(clients []string) ([]hookSpoolRecord, []string, error)
 	return records, unreadable, nil
 }
 
-func inspectHookSpoolDiagnostics(clients []string) doctorCheck {
+func (c *RootCLI) inspectHookSpoolDiagnostics(clients []string) doctorCheck {
 	const name = "hook-spool"
 	records, unreadable, err := scanHookSpoolRecords(clients)
 	if err != nil {
@@ -193,6 +311,31 @@ func inspectHookSpoolDiagnostics(clients []string) doctorCheck {
 			"未処理の hook spool record が %d 件、読めない record が %d 件あります。latest %s",
 			len(records), len(unreadable), latest,
 		),
-		Hint: Localize("the host interrupted or Traceary failed before commit; inspect the preserved payload and retry the matching hook command before removing the record", "host が中断したか commit 前に Traceary が失敗しました。保存された payload を確認し、対応する hook command を再実行してから record を削除してください"),
+		Hint: Localize(
+			"records are drained automatically on later hook invocations (bounded batch). Run `traceary doctor --fix` to force a larger drain, or inspect payloads under the hook spool directory before manual removal.",
+			"record は後続 hook 呼び出し時に bounded batch で自動 drain されます。`traceary doctor --fix` で大きめに drain するか、手動削除前に spool ディレクトリの payload を確認してください。",
+		),
+		FixCommand:       "traceary doctor --fix",
+		AutoFixAvailable: true,
+		FixFunc: func(ctx context.Context, dryRun bool) (string, error) {
+			pending, _, err := scanHookSpoolRecords(nil)
+			if err != nil {
+				return "", err
+			}
+			if dryRun {
+				return localizef("would drain up to %d pending hook spool record(s)", "未処理 hook spool record 最大 %d 件を drain します", min(len(pending), 200)), nil
+			}
+			// Force path: allow a larger batch than the per-hook opportunistic drain.
+			limit := len(pending)
+			if limit > 200 {
+				limit = 200
+			}
+			replayed, failed := c.drainHookSpoolRecords(ctx, limit)
+			remaining := len(pending) - replayed
+			if remaining < 0 {
+				remaining = 0
+			}
+			return localizef("drained hook spool: replayed=%d failed=%d remaining_estimate=%d", "hook spool を drain しました: replayed=%d failed=%d remaining_estimate=%d", replayed, failed, remaining), nil
+		},
 	}
 }

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -13,6 +13,10 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
 )
 
 func TestRunHookDurably_RemovesSpoolAfterSuccess(t *testing.T) {
@@ -78,9 +82,203 @@ func TestRunHookDurably_RetainsSpoolAfterFailure(t *testing.T) {
 		t.Fatalf("spool mode = %o, want 600", got)
 	}
 
-	check := inspectHookSpoolDiagnostics([]string{"claude"})
+	check := c.inspectHookSpoolDiagnostics([]string{"claude"})
 	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "1 pending") {
 		t.Fatalf("doctor check = %#v", check)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("doctor check must expose auto-fix drain, got %#v", check)
+	}
+	if !strings.Contains(check.Hint, "doctor --fix") {
+		t.Fatalf("hint should mention doctor --fix, got %q", check.Hint)
+	}
+}
+
+func TestDrainHookSpoolRecords_ReplaysAndRemoves(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	// Seed a timeout-killed prompt record.
+	record := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"recover me","session_id":"session-spool-1","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	path, err := persistHookSpoolRecord(record)
+	if err != nil {
+		t.Fatalf("persistHookSpoolRecord() error = %v", err)
+	}
+
+	if n, f := root.drainHookSpoolRecords(context.Background(), 0); n != 0 || f != 0 {
+		t.Fatalf("limit 0: replayed=%d failed=%d", n, f)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("limit 0 must not touch spool: %v", err)
+	}
+
+	replayed, failed := root.drainHookSpoolRecords(context.Background(), 5)
+	if replayed != 1 || failed != 0 {
+		t.Fatalf("successful replay: replayed=%d failed=%d want 1/0", replayed, failed)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("successful replay must remove spool, stat err=%v", err)
+	}
+	if eventStub.logCalls != 1 || eventStub.lastMessage != "recover me" {
+		t.Fatalf("event log calls=%d message=%q", eventStub.logCalls, eventStub.lastMessage)
+	}
+
+	// Unsupported command is fail-closed: retain the record.
+	bad := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "not-a-real-hook",
+		Client:        "claude",
+		Payload:       `{}`,
+		CreatedAt:     time.Now().UTC().Add(-2 * time.Minute),
+	}
+	badPath, err := persistHookSpoolRecord(bad)
+	if err != nil {
+		t.Fatalf("persist bad: %v", err)
+	}
+	replayed, failed = root.drainHookSpoolRecords(context.Background(), 5)
+	if replayed != 0 || failed != 1 {
+		t.Fatalf("unsupported: replayed=%d failed=%d want 0/1", replayed, failed)
+	}
+	if _, err := os.Stat(badPath); err != nil {
+		t.Fatalf("unsupported command must not delete spool: %v", err)
+	}
+}
+
+func TestDrainHookSpoolRecords_BatchLimitAndOldestFirst(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+
+	older := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"older","session_id":"s-old","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-2 * time.Minute),
+	}
+	newer := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"newer","session_id":"s-new","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	if _, err := persistHookSpoolRecord(older); err != nil {
+		t.Fatalf("persist older: %v", err)
+	}
+	if _, err := persistHookSpoolRecord(newer); err != nil {
+		t.Fatalf("persist newer: %v", err)
+	}
+
+	replayed, failed := root.drainHookSpoolRecords(context.Background(), 1)
+	if replayed != 1 || failed != 0 {
+		t.Fatalf("batch 1: replayed=%d failed=%d", replayed, failed)
+	}
+	if eventStub.logCalls != 1 || eventStub.lastMessage != "older" {
+		t.Fatalf("expected oldest-first drain, got calls=%d message=%q", eventStub.logCalls, eventStub.lastMessage)
+	}
+
+	remaining, unreadable, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(unreadable) != 0 || len(remaining) != 1 || remaining[0].Payload != newer.Payload {
+		t.Fatalf("remaining=%#v unreadable=%#v", remaining, unreadable)
+	}
+}
+
+func TestDrainHookSpoolRecords_StopsOnCancelledContext(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(&spoolEventUsecaseStub{}),
+	)
+	record := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"cancelled","session_id":"s-cancel","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	path, err := persistHookSpoolRecord(record)
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	replayed, failed := root.drainHookSpoolRecords(ctx, 5)
+	if replayed != 0 || failed != 0 {
+		t.Fatalf("cancelled context: replayed=%d failed=%d want 0/0", replayed, failed)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cancelled drain must retain spool: %v", err)
+	}
+}
+
+func TestInspectHookSpoolDiagnostics_FixFuncDrains(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+
+	eventStub := &spoolEventUsecaseStub{}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithEvent(eventStub),
+	)
+	record := hookSpoolRecord{
+		SchemaVersion: hookSpoolSchemaVersion,
+		Command:       "prompt",
+		Client:        "claude",
+		Payload:       `{"prompt":"doctor-fix","session_id":"s-fix","cwd":"/tmp"}`,
+		CreatedAt:     time.Now().UTC().Add(-time.Minute),
+	}
+	if _, err := persistHookSpoolRecord(record); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	check := root.inspectHookSpoolDiagnostics([]string{"claude"})
+	if check.Status != doctorStatusWarn || check.FixFunc == nil {
+		t.Fatalf("check = %#v", check)
+	}
+	dryMsg, err := check.FixFunc(context.Background(), true)
+	if err != nil {
+		t.Fatalf("dry-run fix: %v", err)
+	}
+	if !strings.Contains(dryMsg, "1") {
+		t.Fatalf("dry-run message = %q", dryMsg)
+	}
+	applyMsg, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply fix: %v", err)
+	}
+	if !strings.Contains(applyMsg, "replayed=1") {
+		t.Fatalf("apply message = %q", applyMsg)
+	}
+	records, _, err := scanHookSpoolRecords(nil)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("after doctor --fix, remaining=%d", len(records))
 	}
 }
 
@@ -141,4 +339,61 @@ func TestHookSpoolSurvivesSIGTERM(t *testing.T) {
 	if len(unreadable) != 0 || len(records) != 1 || records[0].Payload != `{"prompt":"preserve me"}` {
 		t.Fatalf("records=%#v unreadable=%#v", records, unreadable)
 	}
+}
+
+// Minimal stubs for spool drain tests (package cli internal).
+
+type spoolStoreManagementStub struct{}
+
+func (s *spoolStoreManagementStub) Initialize(context.Context) error { return nil }
+func (s *spoolStoreManagementStub) CreateBackup(context.Context, string, bool) error {
+	return nil
+}
+func (s *spoolStoreManagementStub) RestoreBackup(context.Context, string, bool) error {
+	return nil
+}
+func (s *spoolStoreManagementStub) CollectGarbage(context.Context, time.Time, apptypes.GarbageCollectionTarget, bool) (apptypes.CollectGarbageResult, error) {
+	return apptypes.CollectGarbageResult{}, nil
+}
+func (s *spoolStoreManagementStub) CloseStaleSessions(context.Context, time.Duration, bool, []types.SessionID) (apptypes.CloseStaleSessionsResult, error) {
+	return apptypes.CloseStaleSessionsResult{}, nil
+}
+func (s *spoolStoreManagementStub) DedupeContentEvents(context.Context, apptypes.ContentEventDedupeParams) (apptypes.ContentEventDedupeResult, error) {
+	return apptypes.ContentEventDedupeResult{}, nil
+}
+func (s *spoolStoreManagementStub) RestoreContentEventDedupeRun(context.Context, string) (apptypes.ContentEventDedupeRestoreResult, error) {
+	return apptypes.ContentEventDedupeRestoreResult{}, nil
+}
+
+type spoolEventUsecaseStub struct {
+	logCalls    int
+	lastMessage string
+	logErr      error
+}
+
+func (s *spoolEventUsecaseStub) Log(_ context.Context, message string, _ types.EventKind, _ types.Client, _ types.Agent, _ types.SessionID, _ types.Workspace, _ apptypes.LogRedaction) (*model.Event, error) {
+	s.logCalls++
+	s.lastMessage = message
+	return nil, s.logErr
+}
+func (s *spoolEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, apptypes.AuditRedaction) (*model.Event, *model.CommandAudit, error) {
+	return nil, nil, nil
+}
+func (s *spoolEventUsecaseStub) Search(context.Context, apptypes.EventSearchCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+func (s *spoolEventUsecaseStub) List(context.Context, apptypes.EventListCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+func (s *spoolEventUsecaseStub) ListWindow(context.Context, apptypes.EventListCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+func (s *spoolEventUsecaseStub) Show(context.Context, types.EventID) (apptypes.EventDetails, error) {
+	return apptypes.EventDetails{}, nil
+}
+func (s *spoolEventUsecaseStub) Context(context.Context, apptypes.EventContextCriteria) ([]*model.Event, error) {
+	return nil, nil
+}
+func (s *spoolEventUsecaseStub) Timeline(context.Context, apptypes.TimelineCriteria) ([]apptypes.TimelineBlock, error) {
+	return nil, nil
 }


### PR DESCRIPTION
## Summary
- Drain a bounded oldest-first batch of pending hook spool records at the start of later hook invocations so host-timeout kills are no longer silent event loss.
- Wire `traceary doctor --fix` for a larger force drain of the `hook-spool` backlog; delete a record only after successful replay.
- Document automatic drain + doctor remediation in EN/JA hooks docs.

## Test plan
- [x] `go test ./presentation/cli/ -run 'HookSpool|DrainHookSpool|InspectHookSpool|ReadHookPayload_Explicit'`
- [x] `go test ./presentation/cli/ -run 'Doctor|Hook'`
- [ ] CI green
- [ ] After merge: live `traceary doctor --fix` against the multi-day spool backlog drains without duplicate session/event loss (dogfood)

Closes #1342