### PR TITLE
feat: drain and cap the hook memory-extract job queue

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -218,7 +218,7 @@ host 向け hook プロセスは、パッケージ済み 10s budget より少し
 
 session end、turn boundary、subagent stop の hook は、主要な event を先に commit してから、メモリ自動抽出を `~/.config/traceary/hooks/memory-extract/` に enqueue します。job に入るのは抽出条件と運用 metadata だけで、mode は `0600` です。同じ database・session・workspace への繰り返し要求は1件にまとめます。host hook が終了した後、分離した内部 worker が既存の extractor を呼び出します。成功時は job を削除し、失敗または中断された場合は再試行できる状態で残します。これにより、抽出処理は host hook timeout を消費せず、主要 event の commit を遅らせません。
 
-`traceary doctor` は `hook-memory-extract` check で、未処理件数、以前失敗した件数、読めない件数、最古の経過時間を報告します。抽出内容や保存された条件は表示しません。次に同じ対象の hook 要求が来ると worker が再起動します。警告が残り続ける場合は debug log を確認してください。
+`traceary doctor` は `hook-memory-extract` check で、未処理件数、以前失敗した件数、terminal（試行上限到達）件数、読めない件数、最古の経過時間を報告します。抽出内容や保存された条件は表示しません。後続 hook は同一 session に限らず oldest-first の bounded batch で queue 全体を drain し、`traceary doctor --fix` で大きめに drain できます。試行上限に達した job は terminal になり、retention 後に GC されます。terminal 以外の失敗が残る場合は debug log を確認してください。
 
 ## トラブルシュート
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -218,7 +218,7 @@ Host-facing hook processes also apply an internal soft deadline (default **8s**,
 
 Session-end, turn-boundary, and subagent-stop hooks commit their primary event first, then enqueue memory auto-extraction under `~/.config/traceary/hooks/memory-extract/`. Jobs contain extraction criteria and operational metadata only, use mode `0600`, and coalesce repeated requests for the same database, session, and workspace. A detached internal worker calls the existing extractor after the host hook returns; success removes the job, while a failed or interrupted worker leaves it available for retry. Extraction therefore no longer consumes the host hook timeout or delays the primary event commit.
 
-`traceary doctor` reports the pending count, previously failed count, unreadable count, and oldest age through `hook-memory-extract`. It never prints extracted content or the stored criteria. A later matching hook request launches the worker again; persistent warnings should be investigated through debug logs.
+`traceary doctor` reports the pending count, previously failed count, terminal (attempt-cap exhausted) count, unreadable count, and oldest age through `hook-memory-extract`. It never prints extracted content or the stored criteria. Later hooks drain a bounded oldest-first batch across sessions (not only the same session key), and `traceary doctor --fix` forces a larger drain. Jobs that exhaust the total attempt ceiling become terminal and are garbage-collected after a retention window; persistent non-terminal failures should be investigated through debug logs.
 
 ## Troubleshooting
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -287,7 +287,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Message: localizef("resolved project directory: %s", "解決した project directory: %s", resolvedProjectDir),
 	})
 	report.Checks = append(report.Checks, c.inspectHookSpoolDiagnostics(resolvedClients))
-	report.Checks = append(report.Checks, inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
+	report.Checks = append(report.Checks, c.inspectHookMemoryExtractDiagnostics(time.Now().UTC()))
 	report.Checks = append(report.Checks, inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
 
 	for _, targetClient := range resolvedClients {

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -27,6 +27,17 @@ const (
 	hookMemoryExtractJobSchemaVersion = 1
 	hookMemoryExtractMaxRunsPerWorker = 2
 	hookMemoryExtractErrorLimit       = 1024
+	// hookMemoryExtractMaxAttempts is the total attempt ceiling across workers.
+	// Jobs that hit the ceiling become terminal and stop being relaunched.
+	hookMemoryExtractMaxAttempts = 5
+	// hookMemoryExtractTerminalRetention is how long a terminally failed job
+	// remains visible to doctor before opportunistic GC removes it.
+	hookMemoryExtractTerminalRetention = 24 * time.Hour
+	// hookMemoryExtractDrainBatchLimit caps how many other-session jobs a
+	// later hook may launch or GC so drain cannot thrash the host.
+	hookMemoryExtractDrainBatchLimit = 3
+	// hookMemoryExtractDoctorFixLimit is the larger batch used by doctor --fix.
+	hookMemoryExtractDoctorFixLimit = 50
 )
 
 type hookMemoryExtractRequest struct {
@@ -69,15 +80,22 @@ func (c *RootCLI) scheduleHookMemoryExtract(request hookMemoryExtractRequest) {
 	if c.memory == nil {
 		return
 	}
-	jobPath, err := enqueueHookMemoryExtract(request, time.Now().UTC())
+	now := time.Now().UTC()
+	jobPath, err := enqueueHookMemoryExtract(request, now)
 	if err != nil {
 		slog.Debug("hook memory extraction enqueue failed", "session_id", request.SessionID, "source_boundary", request.SourceBoundary, "error", err)
 		return
 	}
 	if err := c.launchHookMemoryExtractWorker(jobPath); err != nil {
-		// The durable job remains pending. A later hook invocation can launch
-		// another worker, and doctor surfaces the backlog in the meantime.
+		// The durable job remains pending. Opportunistic queue drain (below)
+		// and doctor --fix can relaunch it; doctor surfaces the backlog.
 		slog.Debug("hook memory extraction worker launch failed", "job", jobPath, "error", err)
+	}
+	// Queue-wide drain: retry/GC jobs for *other* sessions. Ended sessions
+	// never re-hit scheduleHookMemoryExtract, so this is the recovery path.
+	// Skip the job we just launched to avoid a double worker start.
+	if launched, removed := c.drainHookMemoryExtractQueue(now, hookMemoryExtractDrainBatchLimit, jobPath); launched > 0 || removed > 0 {
+		slog.Debug("hook memory extraction queue drain", "launched", launched, "removed", removed)
 	}
 }
 
@@ -184,12 +202,6 @@ func enqueueHookMemoryExtract(request hookMemoryExtractRequest, requestedAt time
 }
 
 func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string) error {
-	if c.storeManagement == nil {
-		return xerrors.Errorf("initialize store usecase is not configured")
-	}
-	if c.memory == nil {
-		return xerrors.Errorf("memory usecase is not configured")
-	}
 	resolvedJobPath, err := filepath.Abs(strings.TrimSpace(jobPath))
 	if err != nil {
 		return xerrors.Errorf("failed to resolve memory extraction job path: %w", err)
@@ -239,6 +251,16 @@ func (c *RootCLI) runHookMemoryExtractWorker(ctx context.Context, jobPath string
 		}
 		if readErr != nil {
 			return readErr
+		}
+		if hookMemoryExtractJobIsTerminal(job) {
+			// Already exhausted the attempt ceiling; leave for retention GC.
+			return nil
+		}
+		if c.storeManagement == nil {
+			return xerrors.Errorf("initialize store usecase is not configured")
+		}
+		if c.memory == nil {
+			return xerrors.Errorf("memory usecase is not configured")
 		}
 		attemptedAt := time.Now().UTC()
 		job.Attempts++
@@ -499,7 +521,75 @@ func scanHookMemoryExtractJobs() ([]hookMemoryExtractJob, []string, error) {
 	return jobs, unreadable, nil
 }
 
-func inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
+func hookMemoryExtractJobIsTerminal(job hookMemoryExtractJob) bool {
+	return job.Attempts >= hookMemoryExtractMaxAttempts
+}
+
+func hookMemoryExtractJobReadyForGC(job hookMemoryExtractJob, now time.Time) bool {
+	if !hookMemoryExtractJobIsTerminal(job) {
+		return false
+	}
+	if job.LastAttemptAt == nil {
+		return true
+	}
+	return !job.LastAttemptAt.Add(hookMemoryExtractTerminalRetention).After(now)
+}
+
+// drainHookMemoryExtractQueue relaunches pending jobs (oldest first) and
+// garbage-collects terminally failed jobs past the retention window. It never
+// re-extracts inline: each relaunch goes through the detached worker so host
+// hook budgets stay small. skipPaths are ignored (e.g. a job just launched by
+// scheduleHookMemoryExtract). Returns launch and remove counts.
+func (c *RootCLI) drainHookMemoryExtractQueue(now time.Time, limit int, skipPaths ...string) (launched, removed int) {
+	if limit <= 0 {
+		return 0, 0
+	}
+	skip := make(map[string]struct{}, len(skipPaths))
+	for _, p := range skipPaths {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			skip[trimmed] = struct{}{}
+		}
+	}
+	jobs, _, err := scanHookMemoryExtractJobs()
+	if err != nil || len(jobs) == 0 {
+		return 0, 0
+	}
+	// scan already returns oldest first.
+	for _, job := range jobs {
+		if launched+removed >= limit {
+			break
+		}
+		if strings.TrimSpace(job.Path) == "" {
+			continue
+		}
+		if _, ok := skip[job.Path]; ok {
+			continue
+		}
+		if hookMemoryExtractJobReadyForGC(job, now) {
+			if err := os.Remove(job.Path); err != nil && !os.IsNotExist(err) {
+				slog.Debug("hook memory extraction terminal GC failed", "job", job.Path, "error", err)
+				continue
+			}
+			// Best-effort cleanup of sidecar files.
+			_ = os.Remove(job.Path + ".lock")
+			_ = os.Remove(job.Path + ".rerun")
+			removed++
+			continue
+		}
+		if hookMemoryExtractJobIsTerminal(job) {
+			// Still within retention; leave visible for doctor.
+			continue
+		}
+		if err := c.launchHookMemoryExtractWorker(job.Path); err != nil {
+			slog.Debug("hook memory extraction drain launch failed", "job", job.Path, "error", err)
+			continue
+		}
+		launched++
+	}
+	return launched, removed
+}
+
+func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
 	const name = "hook-memory-extract"
 	jobs, unreadable, err := scanHookMemoryExtractJobs()
 	if err != nil {
@@ -509,6 +599,7 @@ func inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook memory extraction jobs found", "未処理の hook memory extraction job はありません")}
 	}
 	failed := 0
+	terminal := 0
 	oldestAge := time.Duration(0)
 	if len(jobs) > 0 {
 		oldestAge = now.Sub(jobs[0].RequestedAt)
@@ -520,16 +611,35 @@ func inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck {
 		if job.Attempts > 0 {
 			failed++
 		}
+		if hookMemoryExtractJobIsTerminal(job) {
+			terminal++
+		}
 	}
 	return doctorCheck{
 		Name:   name,
 		Status: doctorStatusWarn,
 		Message: localizef(
-			"found %d pending memory extraction job(s), %d previously failed job(s), and %d unreadable job(s); oldest age %s",
-			"未処理の memory extraction job が %d 件、以前失敗した job が %d 件、読めない job が %d 件あります。最古 age %s",
-			len(jobs), failed, len(unreadable), oldestAge.Round(time.Second),
+			"found %d pending memory extraction job(s), %d previously failed job(s), %d terminal job(s), and %d unreadable job(s); oldest age %s",
+			"未処理の memory extraction job が %d 件、以前失敗した job が %d 件、terminal job が %d 件、読めない job が %d 件あります。最古 age %s",
+			len(jobs), failed, terminal, len(unreadable), oldestAge.Round(time.Second),
 		),
-		Hint: Localize("a later hook retries pending jobs automatically; run doctor again after the next hook and inspect debug logs if failures remain", "次の hook が未処理 job を自動再試行します。次の hook 後に doctor を再実行し、失敗が残る場合は debug log を確認してください"),
+		Hint: Localize(
+			"later hooks drain a bounded oldest-first batch across sessions (not only the same session key). Terminal jobs (attempts exhausted) are GC'd after retention. Run `traceary doctor --fix` to force a larger drain, or inspect debug logs if failures remain.",
+			"後続 hook は同一 session に限らず oldest-first の bounded batch で queue 全体を drain します。terminal job（試行上限到達）は retention 後に GC されます。大きめに drain するには `traceary doctor --fix` を使い、失敗が残る場合は debug log を確認してください。",
+		),
+		FixCommand:       "traceary doctor --fix",
+		AutoFixAvailable: true,
+		FixFunc: func(ctx context.Context, dryRun bool) (string, error) {
+			pending, _, err := scanHookMemoryExtractJobs()
+			if err != nil {
+				return "", err
+			}
+			if dryRun {
+				return localizef("would drain/GC up to %d pending memory extraction job(s)", "未処理 memory extraction job 最大 %d 件を drain/GC します", min(len(pending), hookMemoryExtractDoctorFixLimit)), nil
+			}
+			launched, removed := c.drainHookMemoryExtractQueue(time.Now().UTC(), hookMemoryExtractDoctorFixLimit)
+			return localizef("drained memory extraction queue: launched=%d removed=%d", "memory extraction queue を drain しました: launched=%d removed=%d", launched, removed), nil
+		},
 	}
 }
 

--- a/presentation/cli/hook_memory_extract_queue.go
+++ b/presentation/cli/hook_memory_extract_queue.go
@@ -629,7 +629,7 @@ func (c *RootCLI) inspectHookMemoryExtractDiagnostics(now time.Time) doctorCheck
 		),
 		FixCommand:       "traceary doctor --fix",
 		AutoFixAvailable: true,
-		FixFunc: func(ctx context.Context, dryRun bool) (string, error) {
+		FixFunc: func(_ context.Context, dryRun bool) (string, error) {
 			pending, _, err := scanHookMemoryExtractJobs()
 			if err != nil {
 				return "", err

--- a/presentation/cli/hook_memory_extract_queue_internal_test.go
+++ b/presentation/cli/hook_memory_extract_queue_internal_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,22 +41,219 @@ func TestInspectHookMemoryExtractDiagnosticsReportsPendingFailureMetadata(t *tes
 		t.Fatalf("WriteFile(broken job) error = %v", err)
 	}
 
-	check := inspectHookMemoryExtractDiagnostics(now)
+	check := (&RootCLI{}).inspectHookMemoryExtractDiagnostics(now)
 	if check.Name != "hook-memory-extract" || check.Status != doctorStatusWarn {
 		t.Fatalf("check = %+v, want warning", check)
 	}
-	for _, want := range []string{"1 pending", "1 previously failed", "1 unreadable", "3m0s"} {
+	for _, want := range []string{"1 pending", "1 previously failed", "0 terminal", "1 unreadable", "3m0s"} {
 		if !strings.Contains(check.Message, want) {
 			t.Fatalf("check message = %q, want %q", check.Message, want)
 		}
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("doctor check must expose auto-fix drain, got %#v", check)
+	}
+	if !strings.Contains(check.Hint, "doctor --fix") {
+		t.Fatalf("hint = %q", check.Hint)
 	}
 }
 
 func TestInspectHookMemoryExtractDiagnosticsPassesWithoutJobs(t *testing.T) {
 	t.Setenv(hookStateDirEnvKey, t.TempDir())
-	check := inspectHookMemoryExtractDiagnostics(time.Now().UTC())
+	check := (&RootCLI{}).inspectHookMemoryExtractDiagnostics(time.Now().UTC())
 	if check.Status != doctorStatusPass {
 		t.Fatalf("check = %+v, want pass", check)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_LaunchesOtherSessionJobs(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	// Ended session that will never re-hit scheduleHookMemoryExtract.
+	ended := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("ended-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	endedPath, err := enqueueHookMemoryExtract(ended, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("enqueue ended: %v", err)
+	}
+
+	var mu sync.Mutex
+	launched := []string{}
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(jobPath string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		launched = append(launched, jobPath)
+		return nil
+	}))
+
+	gotLaunched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if gotLaunched != 1 || removed != 0 {
+		t.Fatalf("launched=%d removed=%d want 1/0", gotLaunched, removed)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(launched) != 1 || launched[0] != endedPath {
+		t.Fatalf("launcher paths = %#v, want %q", launched, endedPath)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_GCsTerminalJobsPastRetention(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("terminal-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, now.Add(-48*time.Hour))
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	job, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	job.Attempts = hookMemoryExtractMaxAttempts
+	last := now.Add(-hookMemoryExtractTerminalRetention - time.Hour)
+	job.LastAttemptAt = &last
+	job.LastError = "context canceled"
+	if err := writeHookMemoryExtractJob(path, job); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(string) error {
+		t.Fatal("terminal jobs must not be relaunched")
+		return nil
+	}))
+	launched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if launched != 0 || removed != 1 {
+		t.Fatalf("launched=%d removed=%d want 0/1", launched, removed)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("terminal job must be GC'd, stat err=%v", err)
+	}
+}
+
+func TestDrainHookMemoryExtractQueue_RetainsTerminalWithinRetention(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("recent-terminal"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	job, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	job.Attempts = hookMemoryExtractMaxAttempts
+	last := now.Add(-time.Minute)
+	job.LastAttemptAt = &last
+	if err := writeHookMemoryExtractJob(path, job); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(string) error {
+		t.Fatal("terminal jobs within retention must not be relaunched")
+		return nil
+	}))
+	launched, removed := root.drainHookMemoryExtractQueue(now, 5)
+	if launched != 0 || removed != 0 {
+		t.Fatalf("launched=%d removed=%d want 0/0", launched, removed)
+	}
+	check := root.inspectHookMemoryExtractDiagnostics(now)
+	if !strings.Contains(check.Message, "1 terminal") {
+		t.Fatalf("message = %q", check.Message)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("must retain for doctor visibility: %v", err)
+	}
+}
+
+func TestInspectHookMemoryExtractDiagnostics_FixFuncDrains(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	now := time.Now().UTC()
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("fix-session"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var launched int
+	root := NewRootCLI(WithHookMemoryExtractLauncher(func(jobPath string) error {
+		if jobPath == path {
+			launched++
+		}
+		return nil
+	}))
+	check := root.inspectHookMemoryExtractDiagnostics(now)
+	if check.FixFunc == nil {
+		t.Fatal("FixFunc is nil")
+	}
+	if _, err := check.FixFunc(context.Background(), true); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	msg, err := check.FixFunc(context.Background(), false)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !strings.Contains(msg, "launched=1") {
+		t.Fatalf("apply msg = %q", msg)
+	}
+	if launched != 1 {
+		t.Fatalf("launched = %d", launched)
+	}
+}
+
+func TestRunHookMemoryExtractWorker_SkipsTerminalJobs(t *testing.T) {
+	t.Setenv(hookStateDirEnvKey, t.TempDir())
+	request := hookMemoryExtractRequest{
+		SessionID:      types.SessionID("skip-terminal"),
+		Workspace:      types.Workspace("traceary"),
+		DBPath:         filepath.Join(t.TempDir(), "traceary.db"),
+		SourceBoundary: "session_end",
+	}
+	path, err := enqueueHookMemoryExtract(request, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	job, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	job.Attempts = hookMemoryExtractMaxAttempts
+	job.LastError = "already terminal"
+	if err := writeHookMemoryExtractJob(path, job); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// No store/memory wired: would fail if extract ran.
+	root := &RootCLI{}
+	if err := root.runHookMemoryExtractWorker(context.Background(), path); err != nil {
+		t.Fatalf("terminal worker must no-op, got %v", err)
+	}
+	got, err := readHookMemoryExtractJob(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if got.Attempts != hookMemoryExtractMaxAttempts || got.LastError != "already terminal" {
+		t.Fatalf("terminal job mutated: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Queue-wide opportunistic drain relaunches pending memory-extract jobs across sessions (oldest first), not only the same session key.
- Total attempt ceiling marks jobs terminal; terminally failed jobs stay visible for retention then are GC'd.
- `traceary doctor --fix` forces a larger drain; doctor hint and EN/JA docs match the real retry semantics.

## Test plan
- [x] `go test ./presentation/cli/ -run 'HookMemoryExtract|DrainHookMemory|InspectHookMemory'`
- [x] `go test ./presentation/cli/ -run 'Doctor|Hook'`
- [ ] CI green
- [ ] Dogfood: drain the 354-job backlog to PASS (or terminal+GC)

Closes #1343