### PR TITLE
feat: soft-deadline hook contexts and store-size doctor budget

### DIFF
--- a/docs/hooks/README.ja.md
+++ b/docs/hooks/README.ja.md
@@ -212,6 +212,8 @@ traceary hooks install --client codex --upgrade
 
 SQLite が writer 競合を待つのは最大1秒です。packaged host hook の budget は必ずこの待機時間を上回る必要があります。Gemini の生成・同梱 hook timeout は10秒で、DB attempt が失敗して spool record を保持したまま host deadline より前に制御を戻せます。この関係は意図的です: `SQLite busy_timeout < host hook timeout`。
 
+host 向け hook プロセスは、パッケージ済み 10s budget より少し短い内部 soft deadline（既定 **8s**、`TRACEARY_HOOK_SOFT_DEADLINE` で上書き、`0`/`off` で無効）も適用します。multi-GB ストアの cold open が数秒かかる場合でも、先に自分で cancel することで spool 保持を決定的にします。detached worker（`memory-extract-worker` / `grok-transcript-worker`）は soft deadline の対象外です。live SQLite がおおよそ 1 GiB を超えると `traceary doctor` は `store-size` を WARN します。
+
 ### メモリ抽出キュー
 
 session end、turn boundary、subagent stop の hook は、主要な event を先に commit してから、メモリ自動抽出を `~/.config/traceary/hooks/memory-extract/` に enqueue します。job に入るのは抽出条件と運用 metadata だけで、mode は `0600` です。同じ database・session・workspace への繰り返し要求は1件にまとめます。host hook が終了した後、分離した内部 worker が既存の extractor を呼び出します。成功時は job を削除し、失敗または中断された場合は再試行できる状態で残します。これにより、抽出処理は host hook timeout を消費せず、主要 event の commit を遅らせません。

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -212,6 +212,8 @@ Later hook invocations drain a bounded batch of pending spool records (oldest fi
 
 SQLite waits at most 1 second for a busy writer. Every packaged host hook budget must exceed that wait. Gemini's generated and packaged hook timeout is 10 seconds, leaving time for the DB attempt to fail and the spool record to remain durable before the host deadline. This relationship is intentional: `SQLite busy_timeout < host hook timeout`.
 
+Host-facing hook processes also apply an internal soft deadline (default **8s**, override with `TRACEARY_HOOK_SOFT_DEADLINE`, disable with `0`/`off`) slightly below the packaged 10s host budgets. Canceling ourselves first keeps spool retention deterministic on multi-GB stores whose cold open already costs several seconds. Detached workers (`memory-extract-worker`, `grok-transcript-worker`) are not soft-deadline bound. `traceary doctor` reports a `store-size` WARN when the live SQLite file exceeds ~1 GiB.
+
 ### Memory extraction queue
 
 Session-end, turn-boundary, and subagent-stop hooks commit their primary event first, then enqueue memory auto-extraction under `~/.config/traceary/hooks/memory-extract/`. Jobs contain extraction criteria and operational metadata only, use mode `0600`, and coalesce repeated requests for the same database, session, and workspace. A detached internal worker calls the existing extractor after the host hook returns; success removes the job, while a failed or interrupted worker leaves it available for retry. Extraction therefore no longer consumes the host hook timeout or delays the primary event commit.

--- a/main.go
+++ b/main.go
@@ -15,8 +15,10 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -236,16 +238,74 @@ func run() error {
 	return nil
 }
 
+// defaultHookSoftDeadline is slightly below the smallest packaged host hook
+// budget (10s for codex/claude/gemini). Canceling ourselves first keeps the
+// spool / fail-soft path deterministic instead of racing a mid-commit host kill.
+const defaultHookSoftDeadline = 8 * time.Second
+
+// hookSoftDeadlineEnvKey overrides the soft deadline (Go duration, e.g. "8s").
+// Empty / invalid / non-positive values disable the soft deadline (signal-only).
+const hookSoftDeadlineEnvKey = "TRACEARY_HOOK_SOFT_DEADLINE"
+
 func commandContext(args []string) (context.Context, context.CancelFunc) {
 	if isHookCommandArgs(args) {
-		return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		// Detached workers are not bound by host hook budgets; keep signal-only.
+		if isDetachedHookWorkerArgs(args) {
+			return ctx, stopSignals
+		}
+		if deadline := resolveHookSoftDeadline(); deadline > 0 {
+			timedCtx, cancelTimeout := context.WithTimeout(ctx, deadline)
+			return timedCtx, func() {
+				cancelTimeout()
+				stopSignals()
+			}
+		}
+		return ctx, stopSignals
 	}
 	return context.WithCancel(context.Background())
+}
+
+func resolveHookSoftDeadline() time.Duration {
+	raw, ok := os.LookupEnv(hookSoftDeadlineEnvKey)
+	if !ok {
+		return defaultHookSoftDeadline
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "0" || strings.EqualFold(raw, "off") || strings.EqualFold(raw, "none") {
+		return 0
+	}
+	// Accept Go durations ("8s") and plain seconds ("8") for operator convenience.
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d <= 0 {
+			return 0
+		}
+		return d
+	}
+	if secs, err := strconv.ParseFloat(raw, 64); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs * float64(time.Second))
+	}
+	return defaultHookSoftDeadline
 }
 
 func isHookCommandArgs(args []string) bool {
 	for _, arg := range args[1:] {
 		if arg == "hook" {
+			return true
+		}
+	}
+	return false
+}
+
+// isDetachedHookWorkerArgs reports hidden workers that run outside host
+// timeout budgets (memory-extract / grok-transcript).
+func isDetachedHookWorkerArgs(args []string) bool {
+	for _, arg := range args[1:] {
+		switch arg {
+		case "memory-extract-worker", "grok-transcript-worker":
 			return true
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime/debug"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/xerrors"
@@ -29,6 +30,69 @@ func TestIsHookCommandArgs(t *testing.T) {
 				t.Fatalf("isHookCommandArgs(%q) = %v, want %v", tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsDetachedHookWorkerArgs(t *testing.T) {
+	t.Parallel()
+	if !isDetachedHookWorkerArgs([]string{"traceary", "hook", "memory-extract-worker", "--job", "x"}) {
+		t.Fatal("memory-extract-worker should be detached")
+	}
+	if !isDetachedHookWorkerArgs([]string{"traceary", "hook", "grok-transcript-worker", "--job", "x"}) {
+		t.Fatal("grok-transcript-worker should be detached")
+	}
+	if isDetachedHookWorkerArgs([]string{"traceary", "hook", "prompt", "claude"}) {
+		t.Fatal("prompt must not be treated as detached worker")
+	}
+}
+
+func TestResolveHookSoftDeadline(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(hookSoftDeadlineEnvKey, "")
+		_ = os.Unsetenv(hookSoftDeadlineEnvKey)
+		if got := resolveHookSoftDeadline(); got != defaultHookSoftDeadline {
+			t.Fatalf("got %v, want %v", got, defaultHookSoftDeadline)
+		}
+	})
+	t.Run("off", func(t *testing.T) {
+		t.Setenv(hookSoftDeadlineEnvKey, "off")
+		if got := resolveHookSoftDeadline(); got != 0 {
+			t.Fatalf("got %v, want 0", got)
+		}
+	})
+	t.Run("duration", func(t *testing.T) {
+		t.Setenv(hookSoftDeadlineEnvKey, "4s")
+		if got := resolveHookSoftDeadline(); got != 4*time.Second {
+			t.Fatalf("got %v", got)
+		}
+	})
+	t.Run("seconds number", func(t *testing.T) {
+		t.Setenv(hookSoftDeadlineEnvKey, "6")
+		if got := resolveHookSoftDeadline(); got != 6*time.Second {
+			t.Fatalf("got %v", got)
+		}
+	})
+}
+
+func TestCommandContext_AppliesSoftDeadlineToHooks(t *testing.T) {
+	t.Setenv(hookSoftDeadlineEnvKey, "50ms")
+	ctx, cancel := commandContext([]string{"traceary", "hook", "prompt", "claude"})
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("hook context must have a soft deadline")
+	}
+	if remaining := time.Until(deadline); remaining > 200*time.Millisecond || remaining < 0 {
+		t.Fatalf("deadline remaining = %v", remaining)
+	}
+}
+
+func TestCommandContext_DetachedWorkerHasNoSoftDeadline(t *testing.T) {
+	t.Setenv(hookSoftDeadlineEnvKey, "50ms")
+	ctx, cancel := commandContext([]string{"traceary", "hook", "memory-extract-worker", "--job", "x"})
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("detached worker must not receive host soft deadline")
 	}
 }
 

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -248,6 +248,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved DB path: %s", "解決した DB パス: %s", resolvedDBPath),
 	})
+	report.Checks = append(report.Checks, inspectStoreSizeBudget(resolvedDBPath))
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
 
 	report.Checks = append(report.Checks, inspectDoctorConfig())

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+// storeSizeWarnBytes is the on-disk size above which multi-GB cold opens
+// routinely approach host hook budgets (10s packaged). Measured dogfood
+// stores around 2.4 GB already spend 2–4 s on cold open alone.
+const storeSizeWarnBytes int64 = 1 << 30 // 1 GiB
+
+func inspectStoreSizeBudget(dbPath string) doctorCheck {
+	const name = "store-size"
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return doctorCheck{
+				Name:    name,
+				Status:  doctorStatusPass,
+				Message: Localize("SQLite store file does not exist yet (no size budget concern)", "SQLite ストアファイルはまだありません（サイズ予算の懸念なし）"),
+			}
+		}
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusWarn,
+			Message: localizef("failed to inspect SQLite store size: %v", "SQLite ストアサイズの検査に失敗しました: %v", err),
+		}
+	}
+	size := info.Size()
+	if size < storeSizeWarnBytes {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorStatusPass,
+			Message: localizef(
+				"SQLite store size is within the hook cold-open budget: %s",
+				"SQLite ストアサイズは hook cold-open 予算内です: %s",
+				formatByteSize(size),
+			),
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"SQLite store is large (%s); cold opens can consume several seconds of the host hook budget and raise timeout-kill / spool backlog risk",
+			"SQLite ストアが大きいです (%s)。cold open が host hook budget の数秒を消費し、timeout-kill / spool backlog のリスクが上がります",
+			formatByteSize(size),
+		),
+		Hint: Localize(
+			"run `traceary store gc --dry-run` then apply when safe; archive-before-GC is tracked separately. Prefer keeping the live store under ~1 GiB for multi-host dogfood.",
+			"`traceary store gc --dry-run` で確認後、安全なら適用してください。archive-before-GC は別 issue です。multi-host dogfood では live store をおおよそ 1 GiB 未満に保つことを推奨します。",
+		),
+		FixCommand: "traceary store gc --dry-run",
+	}
+}
+
+func formatByteSize(size int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case size >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(size)/float64(gib))
+	case size >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(size)/float64(mib))
+	case size >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(size)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
+}

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectStoreSizeBudget_MissingFilePasses(t *testing.T) {
+	check := inspectStoreSizeBudget(filepath.Join(t.TempDir(), "missing.db"))
+	if check.Status != doctorStatusPass {
+		t.Fatalf("check = %#v", check)
+	}
+}
+
+func TestInspectStoreSizeBudget_SmallFilePasses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "small.db")
+	if err := os.WriteFile(path, []byte("tiny"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectStoreSizeBudget(path)
+	if check.Status != doctorStatusPass {
+		t.Fatalf("check = %#v", check)
+	}
+	if !strings.Contains(check.Message, "within") {
+		t.Fatalf("message = %q", check.Message)
+	}
+}
+
+func TestInspectStoreSizeBudget_LargeFileWarns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.db")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sparse-ish: Seek past the warn threshold then write one byte.
+	if _, err := f.Seek(storeSizeWarnBytes, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	check := inspectStoreSizeBudget(path)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check = %#v", check)
+	}
+	if !strings.Contains(check.Message, "large") {
+		t.Fatalf("message = %q", check.Message)
+	}
+	if !strings.Contains(check.Hint, "store gc") {
+		t.Fatalf("hint = %q", check.Hint)
+	}
+}
+
+func TestFormatByteSize(t *testing.T) {
+	if got := formatByteSize(512); got != "512 B" {
+		t.Fatalf("got %q", got)
+	}
+	if got := formatByteSize(storeSizeWarnBytes); !strings.Contains(got, "GiB") {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/presentation/cli/testdata/doctor/default.golden.json
+++ b/presentation/cli/testdata/doctor/default.golden.json
@@ -15,6 +15,16 @@
       "auto_fix_available": false
     },
     {
+      "name": "store-size",
+      "status": "pass",
+      "severity": "PASS",
+      "section": "Hooks",
+      "message": "SQLite store file does not exist yet (no size budget concern)",
+      "hint": "",
+      "fix_command": "",
+      "auto_fix_available": false
+    },
+    {
       "name": "path",
       "status": "pass",
       "severity": "PASS",
@@ -329,6 +339,16 @@
       "name": "Hooks",
       "checks": [
         {
+          "name": "store-size",
+          "status": "pass",
+          "severity": "PASS",
+          "section": "Hooks",
+          "message": "SQLite store file does not exist yet (no size budget concern)",
+          "hint": "",
+          "fix_command": "",
+          "auto_fix_available": false
+        },
+        {
           "name": "hook-spool",
           "status": "pass",
           "severity": "PASS",
@@ -372,7 +392,7 @@
     }
   ],
   "summary": {
-    "pass": 15,
+    "pass": 16,
     "warn": 2,
     "fail": 0
   },


### PR DESCRIPTION
## Summary
- Host-facing `traceary hook …` processes get an internal soft deadline (default 8s, `TRACEARY_HOOK_SOFT_DEADLINE` override) slightly below packaged 10s host budgets.
- Detached workers stay signal-only (not host-budget bound).
- Doctor adds `store-size` WARN above ~1 GiB with a store gc dry-run hint.
- Docs describe the soft-deadline / size-budget relationship.

## Out of scope (follow-ups)
- Automatic store GC / archive-before-GC (#1309)
- Deeper cold-open page-cache optimization (profile-driven)

## Test plan
- [x] `go test ./ -run 'Hook|SoftDeadline|CommandContext'`
- [x] `go test ./presentation/cli/ -run 'Doctor|StoreSize|Golden'`
- [ ] CI green
- [ ] Dogfood: hooks on the 2.4 GB store no longer die mid-commit under normal load after #1342/#1343 deploy

Closes #1344