### PR TITLE
feat: doctor detects and refreshes stale managed hook generations

### DIFF
--- a/presentation/cli/doctor_config_inspect.go
+++ b/presentation/cli/doctor_config_inspect.go
@@ -473,7 +473,7 @@ func (c *RootCLI) configHasTracearyHooks(outputPath string) bool {
 	return hasTracearyHook
 }
 
-func (c *RootCLI) inspectDoctorConfigFile(_ context.Context, client string, outputPath string, projectDir string) doctorCheck {
+func (c *RootCLI) inspectDoctorConfigFile(ctx context.Context, client string, outputPath string, projectDir string) doctorCheck {
 	content, err := os.ReadFile(outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -566,11 +566,15 @@ func (c *RootCLI) inspectDoctorConfigFile(_ context.Context, client string, outp
 				return missingClientHookCoverageCheck(client, client+"-config", outputPath, projectDir, missing, true)
 			}
 		}
-		return doctorCheck{
+		pass := doctorCheck{
 			Name:    client + "-config",
 			Status:  doctorStatusPass,
 			Message: localizef("%s config contains Traceary-managed hooks: %s", "%s の設定には Traceary 管理下の hook があります: %s", client, outputPath),
 		}
+		// Catch generation drift (e.g. timeout 5000 vs packaged 10000) that
+		// still has complete event coverage — the class of silent failure
+		// behind gemini-event-coverage drops on stale managed configs.
+		return c.attachManagedGenerationCheck(ctx, pass, client, content, outputPath, projectDir)
 	}
 
 	return doctorCheck{

--- a/presentation/cli/doctor_managed_generation.go
+++ b/presentation/cli/doctor_managed_generation.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/xerrors"
+
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -24,7 +26,7 @@ func managedHookTimeouts(content []byte, extractKey func(name, command string) s
 		} `json:"hooks"`
 	}
 	if err := json.Unmarshal(content, &root); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("failed to decode hooks document for generation drift: %w", err)
 	}
 	out := map[string]int{}
 	for _, matchers := range root.Hooks {
@@ -122,11 +124,11 @@ func (c *RootCLI) attachManagedGenerationCheck(ctx context.Context, check doctor
 			return localizef("would refresh stale Traceary-managed hooks in %s", "%s の古い Traceary 管理 hook を更新します", outputPath), nil
 		}
 		if c.hooksOrchestrator == nil {
-			return "", fmt.Errorf("hooks orchestrator is not configured")
+			return "", xerrors.New("hooks orchestrator is not configured")
 		}
 		_, _, err := c.hooksOrchestrator.UpgradeWithMatcher(ctx, client, "traceary", projectDir, types.Some(outputPath), "")
 		if err != nil {
-			return "", err
+			return "", xerrors.Errorf("failed to refresh stale managed hooks: %w", err)
 		}
 		return localizef("refreshed Traceary-managed hooks in %s", "%s の Traceary 管理 hook を更新しました", outputPath), nil
 	}

--- a/presentation/cli/doctor_managed_generation.go
+++ b/presentation/cli/doctor_managed_generation.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// managedHookTimeouts maps managedKey -> timeout millis for Traceary-managed
+// commands found in a hooks-shaped JSON document. Entries without a timeout
+// field are recorded as -1 so "missing vs present" also counts as drift.
+func managedHookTimeouts(content []byte, extractKey func(name, command string) string) (map[string]int, error) {
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher *string `json:"matcher"`
+			Hooks   []struct {
+				Name    string `json:"name"`
+				Command string `json:"command"`
+				Timeout *int   `json:"timeout"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(content, &root); err != nil {
+		return nil, err
+	}
+	out := map[string]int{}
+	for _, matchers := range root.Hooks {
+		for _, matcher := range matchers {
+			for _, command := range matcher.Hooks {
+				key := extractKey(command.Name, command.Command)
+				if key == "" {
+					continue
+				}
+				timeout := -1
+				if command.Timeout != nil {
+					timeout = *command.Timeout
+				}
+				// First occurrence wins; duplicates are handled by other checks.
+				if _, exists := out[key]; !exists {
+					out[key] = timeout
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// managedHookTimeoutDrift returns human-readable reasons when installed
+// Traceary-managed hook timeouts diverge from what the current generation
+// would write. Empty when generation is current (or no managed hooks).
+func managedHookTimeoutDrift(installed, desired []byte, extractKey func(name, command string) string) []string {
+	installedTimeouts, err := managedHookTimeouts(installed, extractKey)
+	if err != nil || len(installedTimeouts) == 0 {
+		return nil
+	}
+	desiredTimeouts, err := managedHookTimeouts(desired, extractKey)
+	if err != nil || len(desiredTimeouts) == 0 {
+		return nil
+	}
+	reasons := []string{}
+	for key, want := range desiredTimeouts {
+		got, ok := installedTimeouts[key]
+		if !ok {
+			continue // missing keys are coverage/upgrade gaps, not generation drift
+		}
+		if got != want {
+			reasons = append(reasons, fmt.Sprintf("%s timeout installed=%s desired=%s", key, formatHookTimeout(got), formatHookTimeout(want)))
+		}
+	}
+	return reasons
+}
+
+func formatHookTimeout(ms int) string {
+	if ms < 0 {
+		return "unset"
+	}
+	return fmt.Sprintf("%dms", ms)
+}
+
+// attachManagedGenerationCheck upgrades a would-be PASS client-config check
+// into WARN when installed managed hook timeouts lag the current generation.
+func (c *RootCLI) attachManagedGenerationCheck(ctx context.Context, check doctorCheck, client string, content []byte, outputPath, projectDir string) doctorCheck {
+	if check.Status != doctorStatusPass {
+		return check
+	}
+	if c.hooksOrchestrator == nil || c.hooksInspector == nil {
+		return check
+	}
+	// Plugin-managed Claude must not rewrite project settings from doctor.
+	if client == "claude" && c.detectClaudeTracearyPluginForCLI().Active {
+		return check
+	}
+	desired, err := c.hooksOrchestrator.Generate(ctx, client, "traceary")
+	if err != nil {
+		return check
+	}
+	reasons := managedHookTimeoutDrift(content, desired, c.hooksInspector.ExtractManagedKeyFromEntry)
+	if len(reasons) == 0 {
+		return check
+	}
+	dryRunCommand := fmt.Sprintf("traceary doctor --fix --dry-run --client %s --project-dir %s", client, shellQuote(projectDir))
+	check.Status = doctorStatusWarn
+	check.Message = localizef(
+		"%s config has Traceary-managed hooks but their generation is stale (%s). Host budgets or command payloads lag the installed Traceary version; prompt/transcript coverage can silently drop: %s",
+		"%s config に Traceary 管理 hook はありますが generation が古いです (%s)。host budget や command payload がインストール済み Traceary より遅れ、prompt/transcript coverage が黙って欠けることがあります: %s",
+		client,
+		strings.Join(reasons, "; "),
+		outputPath,
+	)
+	check.Hint = localizef(
+		"preview the non-destructive refresh with `%s`; it rewrites only Traceary-managed entries (timeouts, commands) and preserves non-Traceary hooks",
+		"`%s` で非破壊 refresh をプレビューしてください。Traceary 管理エントリ（timeout / command）だけを更新し、Traceary 以外の hook は保持します",
+		dryRunCommand,
+	)
+	check.FixCommand = dryRunCommand
+	check.AutoFixAvailable = true
+	check.FixFunc = func(ctx context.Context, dryRun bool) (string, error) {
+		if dryRun {
+			return localizef("would refresh stale Traceary-managed hooks in %s", "%s の古い Traceary 管理 hook を更新します", outputPath), nil
+		}
+		if c.hooksOrchestrator == nil {
+			return "", fmt.Errorf("hooks orchestrator is not configured")
+		}
+		_, _, err := c.hooksOrchestrator.UpgradeWithMatcher(ctx, client, "traceary", projectDir, types.Some(outputPath), "")
+		if err != nil {
+			return "", err
+		}
+		return localizef("refreshed Traceary-managed hooks in %s", "%s の Traceary 管理 hook を更新しました", outputPath), nil
+	}
+	return check
+}

--- a/presentation/cli/doctor_managed_generation_test.go
+++ b/presentation/cli/doctor_managed_generation_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+func TestManagedHookTimeoutDrift_DetectsStaleTimeout(t *testing.T) {
+	extract := filesystem.NewHooksInspector().ExtractManagedKeyFromEntry
+	installed := []byte(`{
+  "hooks": {
+    "BeforeAgent": [{
+      "hooks": [{
+        "name": "traceary-before-agent",
+        "type": "command",
+        "command": "'traceary' 'hook' 'prompt' 'gemini'",
+        "timeout": 5000
+      }]
+    }]
+  }
+}`)
+	desired := []byte(`{
+  "hooks": {
+    "BeforeAgent": [{
+      "hooks": [{
+        "name": "traceary-before-agent",
+        "type": "command",
+        "command": "'traceary' 'hook' 'prompt' 'gemini'",
+        "timeout": 10000
+      }]
+    }]
+  }
+}`)
+	reasons := managedHookTimeoutDrift(installed, desired, extract)
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "5000ms") || !strings.Contains(reasons[0], "10000ms") {
+		t.Fatalf("reasons = %#v", reasons)
+	}
+	if reasons := managedHookTimeoutDrift(desired, desired, extract); len(reasons) != 0 {
+		t.Fatalf("current generation must not drift: %#v", reasons)
+	}
+}
+
+func TestAttachManagedGenerationCheck_EndToEnd(t *testing.T) {
+	homeDir := t.TempDir()
+	projectDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(ResetUserHomeDirFunc)
+
+	root := NewRootCLI(
+		WithHooksOrchestrator(filesystem.NewHooksOrchestrator(map[string]application.HooksClientHandler{
+			"gemini": filesystem.NewGeminiHooksHandler(),
+		})),
+		WithHooksInspector(filesystem.NewHooksInspector()),
+	)
+	if root.hooksOrchestrator == nil {
+		t.Fatal("hooks orchestrator not wired")
+	}
+	path, err := root.hooksOrchestrator.Install(context.Background(), "gemini", "traceary", projectDir, types.None[string](), true)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// Downgrade timeouts to the 2026-06 dogfood generation.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := strings.ReplaceAll(string(content), "10000", "5000")
+	if stale == string(content) {
+		t.Fatal("fixture expected timeout 10000 in generated gemini hooks")
+	}
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := root.inspectDoctorConfigFile(context.Background(), "gemini", path, projectDir)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check = %#v, want warn for stale generation", check)
+	}
+	if !strings.Contains(check.Message, "stale") && !strings.Contains(check.Message, "generation") {
+		t.Fatalf("message = %q", check.Message)
+	}
+	if !check.AutoFixAvailable || check.FixFunc == nil {
+		t.Fatalf("AutoFix missing: %#v", check)
+	}
+	if _, err := check.FixFunc(context.Background(), false); err != nil {
+		t.Fatalf("fix: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), "10000") {
+		t.Fatalf("after fix should restore 10000, got:\n%s", after)
+	}
+	// Re-inspect must pass.
+	pass := root.inspectDoctorConfigFile(context.Background(), "gemini", path, projectDir)
+	if pass.Status != doctorStatusPass {
+		t.Fatalf("after fix status = %#v", pass)
+	}
+
+	// Sanity: path lives under the project.
+	if !strings.HasPrefix(path, projectDir) && !strings.Contains(path, filepath.Base(projectDir)) {
+		t.Logf("install path = %s (projectDir = %s)", path, projectDir)
+	}
+}


### PR DESCRIPTION
## Summary
- After enrichment coverage passes, doctor compares installed Traceary-managed hook timeouts to the current generation for that client.
- Stale generations (classic dogfood case: Gemini `timeout: 5000` while packaged hooks use `10000`) WARN on `<client>-config` with `doctor --fix` upgrade remediation.
- Plugin-managed Claude still does not rewrite project settings from doctor.

## Test plan
- [x] Unit: timeout drift detection
- [x] End-to-end: install gemini hooks → age timeouts → doctor warns → fix restores 10000
- [x] `go test ./presentation/cli/ -run 'Doctor|ManagedGeneration|ManagedHook'`
- [ ] CI green
- [ ] Dogfood: resync workspace Gemini settings and confirm `gemini-event-coverage` recovers

Closes #1345