### PR TITLE
fix: treat already-started hook sessions as spool-replay success

### DIFF
--- a/presentation/cli/hook_session.go
+++ b/presentation/cli/hook_session.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -81,6 +83,21 @@ func (c *RootCLI) runHookSession(
 		}
 		event, err := c.session.Start(ctx, types.Client("hook"), agent, sessionID, workspace, parentSessionID)
 		if err != nil {
+			// Spool replay (and hosts that re-fire SessionStart) often hit a
+			// session that already committed before the kill. Treat "already
+			// exists" as an idempotent success so the spool record can drain.
+			if sessionID != "" && errors.Is(err, model.ErrInvalidSessionState) {
+				slog.Debug("hook session start already recorded; treating as success", "client", client, "session_id", sessionID)
+				if err := writeHookSessionState(client, sessionID); err != nil {
+					return err
+				}
+				if output != nil {
+					if _, err := fmt.Fprintln(output, sessionID); err != nil {
+						return xerrors.Errorf("failed to print session ID: %w", err)
+					}
+				}
+				return nil
+			}
 			return xerrors.Errorf("failed to record hook session start: %w", err)
 		}
 		// Host-reported model is optional. Claude may omit it; Gemini/Antigravity

--- a/presentation/cli/hook_session_idempotent_test.go
+++ b/presentation/cli/hook_session_idempotent_test.go
@@ -1,0 +1,38 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestHookSessionStart_AlreadyExistsIsIdempotentForSpoolReplay(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+
+	sessionStub := &sessionUsecaseStub{
+		startErr: model.ErrInvalidSessionState,
+	}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"session-already","cwd":"/tmp","hook_event_name":"SessionStart"}`))
+	rootCmd.SetArgs([]string{"hook", "session", "codex", "start"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "session-already") {
+		t.Fatalf("stdout = %q, want session id printed for idempotent start", stdout.String())
+	}
+	if sessionStub.startCall.sessionID.String() != "session-already" {
+		t.Fatalf("Start sessionID = %q", sessionStub.startCall.sessionID)
+	}
+}


### PR DESCRIPTION
## Summary
- Hook SessionStart is idempotent when the session already exists (`ErrInvalidSessionState`).
- Enables #1342 spool drain to clear residual timeout-killed session starts that partially committed.

## Test plan
- [x] `go test ./presentation/cli/ -run HookSessionStart_AlreadyExists`
- [ ] CI green
- [ ] Dogfood: `doctor --fix` clears remaining session spool records

Closes #1353