### PR TITLE
feat: domain memory decay policy and restore transitions

### DIFF
--- a/domain/model/memory.go
+++ b/domain/model/memory.go
@@ -363,6 +363,44 @@ func (m *Memory) Expire(expiresAt time.Time) error {
 	return nil
 }
 
+// EligibleForDecay reports whether this memory may be auto-expired under the
+// given policy at now. Only candidates with an allowed auto-source whose
+// updated_at is strictly older than the policy threshold are eligible.
+// Accepted, rejected, superseded, and expired memories never decay.
+func (m *Memory) EligibleForDecay(policy types.MemoryDecayPolicy, now time.Time) bool {
+	if m.status != types.MemoryStatusCandidate {
+		return false
+	}
+	if !policy.AllowsSource(m.source) {
+		return false
+	}
+	cutoff := now.UTC().Add(-policy.OlderThan())
+	return m.updatedAt.UTC().Before(cutoff)
+}
+
+// MarkCandidateSupersededByDuplicate transitions a candidate to superseded
+// after an exact-duplicate collapse kept a newer representative row.
+func (m *Memory) MarkCandidateSupersededByDuplicate() error {
+	if m.status != types.MemoryStatusCandidate {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusSuperseded
+	m.updatedAt = m.now()
+	return nil
+}
+
+// RestoreToCandidate transitions an expired memory back to candidate and
+// clears the lifecycle expiresAt stamp so it re-enters the review inbox.
+func (m *Memory) RestoreToCandidate() error {
+	if m.status != types.MemoryStatusExpired {
+		return ErrInvalidMemoryState
+	}
+	m.status = types.MemoryStatusCandidate
+	m.expiresAt = types.None[time.Time]()
+	m.updatedAt = m.now()
+	return nil
+}
+
 func (m *Memory) now() time.Time {
 	return clockOrSystem(m.clock).Now()
 }

--- a/domain/model/memory_test.go
+++ b/domain/model/memory_test.go
@@ -334,3 +334,101 @@ func TestMemory_AttachRefsCandidateOnly(t *testing.T) {
 		t.Fatalf("AttachRefs() on accepted memory error = %v, want ErrInvalidMemoryState", err)
 	}
 }
+
+func TestMemory_EligibleForDecay(t *testing.T) {
+	t.Parallel()
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	policy, err := types.MemoryDecayPolicyOf(30*24*time.Hour, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("returns true for extracted candidate older than threshold", func(t *testing.T) {
+		t.Parallel()
+		m := mustCandidate(t, types.MemorySourceExtracted, old)
+		if !m.EligibleForDecay(policy, now) {
+			t.Fatal("want eligible")
+		}
+	})
+	t.Run("returns false for remember-intent and manual sources regardless of age", func(t *testing.T) {
+		t.Parallel()
+		for _, src := range []types.MemorySource{types.MemorySourceRememberIntent, types.MemorySourceManual} {
+			m := mustCandidate(t, src, old)
+			if m.EligibleForDecay(policy, now) {
+				t.Fatalf("source %s must not be eligible", src)
+			}
+		}
+	})
+	t.Run("returns false for accepted memory", func(t *testing.T) {
+		t.Parallel()
+		m := mustCandidate(t, types.MemorySourceExtracted, old)
+		if err := m.Accept(types.ConfidenceHigh); err != nil {
+			t.Fatal(err)
+		}
+		if m.EligibleForDecay(policy, now) {
+			t.Fatal("accepted must not decay")
+		}
+	})
+}
+
+func TestMemory_MarkCandidateSupersededByDuplicate(t *testing.T) {
+	t.Parallel()
+	m := mustCandidate(t, types.MemorySourceExtracted, time.Now().UTC())
+	if err := m.MarkCandidateSupersededByDuplicate(); err != nil {
+		t.Fatal(err)
+	}
+	if m.Status() != types.MemoryStatusSuperseded {
+		t.Fatalf("status = %s", m.Status())
+	}
+	accepted := mustCandidate(t, types.MemorySourceExtracted, time.Now().UTC())
+	_ = accepted.Accept(types.ConfidenceHigh)
+	if err := accepted.MarkCandidateSupersededByDuplicate(); !errors.Is(err, model.ErrInvalidMemoryState) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestMemory_RestoreToCandidate(t *testing.T) {
+	t.Parallel()
+	m := mustCandidate(t, types.MemorySourceExtracted, time.Now().UTC())
+	if err := m.Expire(time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.RestoreToCandidate(); err != nil {
+		t.Fatal(err)
+	}
+	if m.Status() != types.MemoryStatusCandidate {
+		t.Fatalf("status = %s", m.Status())
+	}
+	if _, ok := m.ExpiresAt().Value(); ok {
+		t.Fatal("expiresAt must be cleared")
+	}
+	if err := m.RestoreToCandidate(); !errors.Is(err, model.ErrInvalidMemoryState) {
+		t.Fatalf("restore non-expired err = %v", err)
+	}
+	rejected := mustCandidate(t, types.MemorySourceExtracted, time.Now().UTC())
+	_ = rejected.Reject()
+	if err := rejected.RestoreToCandidate(); !errors.Is(err, model.ErrInvalidMemoryState) {
+		t.Fatalf("restore rejected err = %v", err)
+	}
+}
+
+func mustCandidate(t *testing.T, source types.MemorySource, at time.Time) *model.Memory {
+	t.Helper()
+	id, _ := types.MemoryIDFrom("mem-decay-" + string(source) + at.Format("150405.000"))
+	m, err := model.NewMemoryCandidateWithClock(
+		id,
+		types.MemoryTypeDecision,
+		types.WorkspaceScopeOf(types.Workspace("github.com/duck8823/traceary")),
+		"fact for decay tests",
+		source,
+		nil,
+		nil,
+		types.None[types.MemoryID](),
+		fakeClock{now: at},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}

--- a/domain/types/memory_decay_policy.go
+++ b/domain/types/memory_decay_policy.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"slices"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// MemoryDecayPolicy is the value object that decides whether a candidate
+// memory is eligible for automatic expiry (non-destructive status transition).
+type MemoryDecayPolicy struct {
+	olderThan time.Duration
+	sources   []MemorySource
+}
+
+// DefaultDecaySources are the auto-extraction sources that may decay.
+// Explicit user intent (manual / remember-intent) and imports never decay.
+func DefaultDecaySources() []MemorySource {
+	return []MemorySource{
+		MemorySourceExtracted,
+		MemorySourceExtractedHidden,
+		MemorySourceCompactSummary,
+	}
+}
+
+// DefaultMemoryDecayOlderThan is 30 days — more conservative than the legacy
+// 14-day hard DELETE of stale extracted candidates.
+const DefaultMemoryDecayOlderThan = 720 * time.Hour
+
+// MemoryDecayPolicyOf builds a policy. olderThan must be positive; sources
+// default to DefaultDecaySources when empty.
+func MemoryDecayPolicyOf(olderThan time.Duration, sources []MemorySource) (MemoryDecayPolicy, error) {
+	if olderThan <= 0 {
+		return MemoryDecayPolicy{}, xerrors.Errorf("memory decay older-than must be positive")
+	}
+	if len(sources) == 0 {
+		sources = DefaultDecaySources()
+	}
+	// Defensive copy.
+	copied := append([]MemorySource(nil), sources...)
+	return MemoryDecayPolicy{olderThan: olderThan, sources: copied}, nil
+}
+
+// OlderThan returns the age threshold.
+func (p MemoryDecayPolicy) OlderThan() time.Duration { return p.olderThan }
+
+// Sources returns the allowed auto sources.
+func (p MemoryDecayPolicy) Sources() []MemorySource {
+	return append([]MemorySource(nil), p.sources...)
+}
+
+// AllowsSource reports whether source is in the decay allow-list.
+func (p MemoryDecayPolicy) AllowsSource(source MemorySource) bool {
+	return slices.Contains(p.sources, source)
+}

--- a/domain/types/memory_decay_policy_test.go
+++ b/domain/types/memory_decay_policy_test.go
@@ -1,0 +1,28 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryDecayPolicyOf_RejectsNonPositive(t *testing.T) {
+	t.Parallel()
+	if _, err := types.MemoryDecayPolicyOf(0, nil); err == nil {
+		t.Fatal("expected error for zero olderThan")
+	}
+}
+
+func TestMemoryDecayPolicyOf_DefaultsSources(t *testing.T) {
+	t.Parallel()
+	p, err := types.MemoryDecayPolicyOf(types.DefaultMemoryDecayOlderThan, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.AllowsSource(types.MemorySourceExtracted) || !p.AllowsSource(types.MemorySourceCompactSummary) {
+		t.Fatalf("default sources missing auto-extract sources: %#v", p.Sources())
+	}
+	if p.AllowsSource(types.MemorySourceManual) || p.AllowsSource(types.MemorySourceRememberIntent) {
+		t.Fatal("manual/remember-intent must not be in default decay sources")
+	}
+}


### PR DESCRIPTION
## Summary
Domain-only decay primitives for v0.28.0-2a: policy VO, eligibility, duplicate supersede, restore-to-candidate.

## Test plan
- [x] `go test ./domain/...`

Closes #1364