### PR TITLE
feat: MemoryDecayUsecase expire and restore paths

### DIFF
--- a/application/types/memory_decay.go
+++ b/application/types/memory_decay.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"time"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// MemoryDecayCriteria configures a decay run.
+type MemoryDecayCriteria struct {
+	OlderThan     time.Duration
+	Limit         int
+	Apply         bool
+	Dedupe        bool
+	IncludeHidden bool
+	Workspace     domtypes.Optional[domtypes.Workspace]
+	Now           time.Time
+}
+
+// MemoryDecayResult is the outcome of a decay dry-run or apply.
+type MemoryDecayResult struct {
+	ExpiredIDs     []string
+	SupersededIDs  []string
+	Skipped        map[string]int
+	RemainingAfter int
+	Applied        bool
+	OlderThan      time.Duration
+	Scanned        int
+}

--- a/application/usecase/memory_decay.go
+++ b/application/usecase/memory_decay.go
@@ -31,7 +31,7 @@ func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecay
 	}
 	policy, err := domtypes.MemoryDecayPolicyOf(olderThan, nil)
 	if err != nil {
-		return apptypes.MemoryDecayResult{}, err
+		return apptypes.MemoryDecayResult{}, xerrors.Errorf("invalid memory decay policy: %w", err)
 	}
 	limit := criteria.Limit
 	if limit <= 0 {
@@ -171,7 +171,7 @@ func (u *memoryUsecase) supersedeCandidateDuplicate(ctx context.Context, memoryI
 		return err
 	}
 	if err := memory.MarkCandidateSupersededByDuplicate(); err != nil {
-		return err
+		return xerrors.Errorf("failed to mark candidate superseded by duplicate: %w", err)
 	}
 	if err := u.memoryRepo.Save(ctx, memory); err != nil {
 		return xerrors.Errorf("failed to save superseded duplicate: %w", err)

--- a/application/usecase/memory_decay.go
+++ b/application/usecase/memory_decay.go
@@ -1,0 +1,229 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+const defaultMemoryDecayLimit = 500
+
+// Decay expires eligible auto-extracted candidates and optionally supersedes
+// exact duplicates. Dry-run is the default (criteria.Apply == false).
+func (u *memoryUsecase) Decay(ctx context.Context, criteria apptypes.MemoryDecayCriteria) (apptypes.MemoryDecayResult, error) {
+	if u.memoryQuery == nil {
+		return apptypes.MemoryDecayResult{}, xerrors.Errorf("memory query service is not configured")
+	}
+	if criteria.Apply && u.memoryRepo == nil {
+		return apptypes.MemoryDecayResult{}, xerrors.Errorf("memory repository is not configured")
+	}
+
+	olderThan := criteria.OlderThan
+	if olderThan <= 0 {
+		olderThan = domtypes.DefaultMemoryDecayOlderThan
+	}
+	policy, err := domtypes.MemoryDecayPolicyOf(olderThan, nil)
+	if err != nil {
+		return apptypes.MemoryDecayResult{}, err
+	}
+	limit := criteria.Limit
+	if limit <= 0 {
+		limit = defaultMemoryDecayLimit
+	}
+	now := criteria.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	sources := policy.Sources()
+	summaries, err := u.listCandidateSummariesForDecay(ctx, sources)
+	if err != nil {
+		return apptypes.MemoryDecayResult{}, err
+	}
+	if ws, ok := criteria.Workspace.Value(); ok && strings.TrimSpace(ws.String()) != "" {
+		filtered := make([]apptypes.MemorySummary, 0, len(summaries))
+		for _, s := range summaries {
+			if s.Scope().Kind() == domtypes.MemoryScopeKindWorkspace && s.Scope().Key() == ws.String() {
+				filtered = append(filtered, s)
+			}
+		}
+		summaries = filtered
+	}
+
+	result := apptypes.MemoryDecayResult{
+		ExpiredIDs:    make([]string, 0),
+		SupersededIDs: make([]string, 0),
+		Skipped:       map[string]int{},
+		Applied:       criteria.Apply,
+		OlderThan:     olderThan,
+		Scanned:       len(summaries),
+	}
+
+	// Expire pass (oldest first).
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].UpdatedAt().Equal(summaries[j].UpdatedAt()) {
+			return summaries[i].MemoryID().String() < summaries[j].MemoryID().String()
+		}
+		return summaries[i].UpdatedAt().Before(summaries[j].UpdatedAt())
+	})
+
+	eligible := make([]apptypes.MemorySummary, 0)
+	for _, s := range summaries {
+		// Reconstruct eligibility without full aggregate: mirror domain rules.
+		if s.Status() != domtypes.MemoryStatusCandidate {
+			result.Skipped["not_candidate"]++
+			continue
+		}
+		if !policy.AllowsSource(s.Source()) {
+			result.Skipped["source"]++
+			continue
+		}
+		cutoff := now.Add(-olderThan)
+		if !s.UpdatedAt().UTC().Before(cutoff) {
+			result.Skipped["too_new"]++
+			continue
+		}
+		eligible = append(eligible, s)
+	}
+
+	remaining := 0
+	if len(eligible) > limit {
+		remaining = len(eligible) - limit
+		eligible = eligible[:limit]
+	}
+	result.RemainingAfter = remaining
+
+	for _, s := range eligible {
+		result.ExpiredIDs = append(result.ExpiredIDs, s.MemoryID().String())
+		if !criteria.Apply {
+			continue
+		}
+		if _, err := u.Expire(ctx, s.MemoryID(), domtypes.Some(now)); err != nil {
+			result.Skipped["expire_error"]++
+			// Drop from expired list on failure.
+			result.ExpiredIDs = result.ExpiredIDs[:len(result.ExpiredIDs)-1]
+			continue
+		}
+	}
+
+	if criteria.Dedupe {
+		if err := u.decayDedupePass(ctx, criteria.Apply, &result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (u *memoryUsecase) decayDedupePass(ctx context.Context, apply bool, result *apptypes.MemoryDecayResult) error {
+	// Reload candidates for exact-key collapse.
+	summaries, err := u.listCandidateSummariesForDecay(ctx, domtypes.DefaultDecaySources())
+	if err != nil {
+		return err
+	}
+	type group struct {
+		items []apptypes.MemorySummary
+	}
+	groups := map[string]*group{}
+	for _, s := range summaries {
+		key := fmt.Sprintf("%s\x00%s\x00%s\x00%s", s.Scope().Kind().String(), s.Scope().Key(), s.MemoryType().String(), strings.TrimSpace(s.Fact()))
+		g := groups[key]
+		if g == nil {
+			g = &group{}
+			groups[key] = g
+		}
+		g.items = append(g.items, s)
+	}
+	for _, g := range groups {
+		if len(g.items) < 2 {
+			continue
+		}
+		sort.SliceStable(g.items, func(i, j int) bool {
+			if g.items[i].UpdatedAt().Equal(g.items[j].UpdatedAt()) {
+				return g.items[i].MemoryID().String() > g.items[j].MemoryID().String()
+			}
+			return g.items[i].UpdatedAt().After(g.items[j].UpdatedAt())
+		})
+		// Keep newest; supersede older.
+		for _, s := range g.items[1:] {
+			result.SupersededIDs = append(result.SupersededIDs, s.MemoryID().String())
+			if !apply {
+				continue
+			}
+			if err := u.supersedeCandidateDuplicate(ctx, s.MemoryID()); err != nil {
+				result.Skipped["dedupe_error"]++
+				result.SupersededIDs = result.SupersededIDs[:len(result.SupersededIDs)-1]
+			}
+		}
+	}
+	return nil
+}
+
+func (u *memoryUsecase) supersedeCandidateDuplicate(ctx context.Context, memoryID domtypes.MemoryID) error {
+	memory, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return err
+	}
+	if err := memory.MarkCandidateSupersededByDuplicate(); err != nil {
+		return err
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return xerrors.Errorf("failed to save superseded duplicate: %w", err)
+	}
+	return nil
+}
+
+func (u *memoryUsecase) listCandidateSummariesForDecay(ctx context.Context, sources []domtypes.MemorySource) ([]apptypes.MemorySummary, error) {
+	const pageSize = 2000
+	var all []apptypes.MemorySummary
+	offset := 0
+	for {
+		builder := apptypes.NewMemoryListCriteriaBuilder(pageSize).
+			Offset(offset).
+			Statuses([]domtypes.MemoryStatus{domtypes.MemoryStatusCandidate})
+		if len(sources) > 0 {
+			builder = builder.Sources(sources)
+		}
+		page, err := u.memoryQuery.List(ctx, builder.Build())
+		if err != nil {
+			return nil, xerrors.Errorf("failed to list candidates for decay: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		all = append(all, page...)
+		if len(page) < pageSize {
+			break
+		}
+		offset += pageSize
+	}
+	return all, nil
+}
+
+// Restore returns an expired memory to candidate status.
+func (u *memoryUsecase) Restore(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	if u.memoryRepo == nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("memory repository is not configured")
+	}
+	memory, err := u.findMemoryByID(ctx, memoryID)
+	if err != nil {
+		return apptypes.MemoryDetails{}, err
+	}
+	if err := memory.RestoreToCandidate(); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to restore memory: %w", err)
+	}
+	if err := u.memoryRepo.Save(ctx, memory); err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to save restored memory: %w", err)
+	}
+	details, err := apptypes.MemoryDetailsFrom(memory)
+	if err != nil {
+		return apptypes.MemoryDetails{}, xerrors.Errorf("failed to build memory details: %w", err)
+	}
+	return details, nil
+}

--- a/application/usecase/memory_decay_test.go
+++ b/application/usecase/memory_decay_test.go
@@ -1,0 +1,136 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+type decayQueryFake struct {
+	summaries []apptypes.MemorySummary
+}
+
+func (f *decayQueryFake) List(context.Context, apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
+	return f.summaries, nil
+}
+func (f *decayQueryFake) Search(context.Context, apptypes.MemorySearchCriteria) ([]apptypes.MemorySummary, error) {
+	return nil, nil
+}
+func (f *decayQueryFake) GetDetails(context.Context, domtypes.MemoryID) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
+
+var _ queryservice.MemoryQueryService = (*decayQueryFake)(nil)
+
+type decayRepoFake struct {
+	find  *model.Memory
+	saves int
+}
+
+func (r *decayRepoFake) Save(context.Context, *model.Memory) error {
+	r.saves++
+	return nil
+}
+func (r *decayRepoFake) FindByID(context.Context, domtypes.MemoryID) (domtypes.Optional[*model.Memory], error) {
+	if r.find == nil {
+		return domtypes.None[*model.Memory](), nil
+	}
+	return domtypes.Some(r.find), nil
+}
+func (r *decayRepoFake) SaveDistillation(context.Context, *model.Memory, []*model.Memory) error {
+	return nil
+}
+func (r *decayRepoFake) SaveSupersession(context.Context, *model.Memory, *model.Memory) error {
+	return nil
+}
+
+type decayClock struct{ t time.Time }
+
+func (c decayClock) Now() time.Time { return c.t }
+
+func TestMemoryUsecase_Decay_DryRunReportsEligibleWithoutWriting(t *testing.T) {
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	id, err := domtypes.MemoryIDFrom("mem-decay-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem, err := model.NewMemoryCandidateWithClock(
+		id,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("ws")),
+		"old extracted fact",
+		domtypes.MemorySourceExtracted,
+		nil, nil,
+		domtypes.None[domtypes.MemoryID](),
+		decayClock{t: old},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	details, err := apptypes.MemoryDetailsFrom(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := &decayQueryFake{summaries: []apptypes.MemorySummary{details.Summary()}}
+	repo := &decayRepoFake{}
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	result, err := sut.Decay(context.Background(), apptypes.MemoryDecayCriteria{
+		OlderThan: 24 * time.Hour,
+		Limit:     10,
+		Apply:     false,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("Decay() error = %v", err)
+	}
+	if result.Applied {
+		t.Fatal("dry-run must not set Applied")
+	}
+	if len(result.ExpiredIDs) != 1 || result.ExpiredIDs[0] != "mem-decay-1" {
+		t.Fatalf("ExpiredIDs = %#v", result.ExpiredIDs)
+	}
+	if repo.saves != 0 {
+		t.Fatalf("dry-run must not Save, saves=%d", repo.saves)
+	}
+}
+
+func TestMemoryUsecase_Restore_ExpiredToCandidate(t *testing.T) {
+	id, _ := domtypes.MemoryIDFrom("mem-restore-1")
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	mem, err := model.NewMemoryCandidateWithClock(
+		id,
+		domtypes.MemoryTypeDecision,
+		domtypes.WorkspaceScopeOf(domtypes.Workspace("ws")),
+		"restorable fact",
+		domtypes.MemorySourceExtracted,
+		nil, nil,
+		domtypes.None[domtypes.MemoryID](),
+		decayClock{t: now},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mem.Expire(now); err != nil {
+		t.Fatal(err)
+	}
+	repo := &decayRepoFake{find: mem}
+	sut := usecase.NewMemoryUsecase(repo, &decayQueryFake{}, nil)
+	details, err := sut.Restore(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if details.Summary().Status() != domtypes.MemoryStatusCandidate {
+		t.Fatalf("status = %s", details.Summary().Status())
+	}
+	if repo.saves != 1 {
+		t.Fatalf("saves = %d", repo.saves)
+	}
+}

--- a/application/usecase/memory_usecase.go
+++ b/application/usecase/memory_usecase.go
@@ -126,6 +126,13 @@ type MemoryUsecase interface {
 	// ImportInstructions proposes candidate memories from host instruction files.
 	ImportInstructions(ctx context.Context, criteria apptypes.MemoryBridgeImportCriteria) (apptypes.MemoryBridgeImportResult, error)
 
+	// Decay expires eligible auto-extracted candidates (dry-run by default)
+	// and optionally collapses exact duplicate candidates. Never auto-accepts.
+	Decay(ctx context.Context, criteria apptypes.MemoryDecayCriteria) (apptypes.MemoryDecayResult, error)
+
+	// Restore returns an expired memory to candidate status for re-review.
+	Restore(ctx context.Context, memoryID domtypes.MemoryID) (apptypes.MemoryDetails, error)
+
 	// Hygiene
 
 	// Scan surfaces suggestions for accepted durable memories that need attention.

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -477,6 +477,12 @@ func (s *memoryUsecaseStub) Expire(_ context.Context, memoryID types.MemoryID, e
 	s.expireCallCount++
 	return s.expireDetails, s.expireErr
 }
+func (s *memoryUsecaseStub) Decay(_ context.Context, _ apptypes.MemoryDecayCriteria) (apptypes.MemoryDecayResult, error) {
+	return apptypes.MemoryDecayResult{}, nil
+}
+func (s *memoryUsecaseStub) Restore(_ context.Context, _ types.MemoryID) (apptypes.MemoryDetails, error) {
+	return apptypes.MemoryDetails{}, nil
+}
 
 func (s *memoryUsecaseStub) SetValidity(_ context.Context, memoryID types.MemoryID, validFrom types.Optional[time.Time], validTo types.Optional[time.Time], clearTo bool) (apptypes.MemoryDetails, error) {
 	s.setValidityCall.memoryID = memoryID


### PR DESCRIPTION
## Summary
Application decay usecase + Restore. Depends on #1364 domain primitives (stacked on that branch).

## Test plan
- [x] `go test ./application/usecase/ -run 'Decay_DryRun|Restore_Expired'`

Closes #1365