### PR TITLE
feat: decay stale extracted candidates in store gc

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,11 @@
 このファイルは、Traceary の各リリースで何が入ったかを時系列で追いやすくするための changelog です。  
 release note と同じ粒度で、版ごとの要点だけをまとめています。
 
+## [Unreleased]
+
+### Changed
+- **store gc の古い extracted candidate を hard DELETE ではなく decay に変更 (#1368)** — `store gc --target memories`（および `all`）は、14 日窓を超えた未レビューの `extracted` / `extracted-hidden` / `compact-summary` candidate を即削除しません。`status=expired` へ遷移し、keep-days の物理 GC まで restore 可能です。
+
 ## [v0.27.0] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 This file summarizes what changed in each Traceary release in chronological order.
 It mirrors the same level of detail as the GitHub release notes, but keeps the history in the repository.
 
+## [Unreleased]
+
+### Changed
+- **Stale extracted candidates decay instead of hard DELETE in store gc (#1368)** — `store gc --target memories` (and `all`) no longer hard-deletes unreviewed `extracted` / `extracted-hidden` / `compact-summary` candidates after the 14-day window. Those rows transition to `status=expired` so they remain restorable until keep-days physical GC.
+
 ## [v0.27.0] - 2026-07-17
 
 ### Fixed

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -329,13 +329,13 @@ func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *te
 	stale := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
 	fresh := now.Add(-3 * 24 * time.Hour).Format(time.RFC3339Nano)
 
-	// Stale candidates from extraction: should be auto-deleted.
+	// Stale candidates from extraction: decay to expired (rows remain).
 	insertRetentionMemoryWithSource(t, db, "extracted-stale", "candidate", "extracted", "", stale)
 	insertRetentionMemoryWithSource(t, db, "hidden-stale", "candidate", "extracted-hidden", "", stale)
 	insertRetentionMemoryWithSource(t, db, "compact-summary-stale", "candidate", "compact-summary", "", stale)
-	// Fresh extracted candidate: keep.
+	// Fresh extracted candidate: keep as candidate.
 	insertRetentionMemoryWithSource(t, db, "extracted-fresh", "candidate", "extracted", "", fresh)
-	// Manual / imported candidates do not auto-expire on this short window.
+	// Manual / imported candidates do not auto-decay on this short window.
 	insertRetentionMemoryWithSource(t, db, "manual-old", "candidate", "manual", "", stale)
 	insertRetentionMemoryWithSource(t, db, "imported-old", "candidate", "imported", "", stale)
 	// Accepted extraction is curated and survives gc unless it is
@@ -344,7 +344,7 @@ func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *te
 
 	// Use a `before` cutoff far in the past so the operator-controlled
 	// retention does not delete anything; only the 14-day extracted
-	// auto-expire should fire.
+	// auto-decay should fire (status update, not hard delete).
 	deletedCount, err := storeManager.CollectGarbage(
 		context.Background(),
 		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -358,11 +358,24 @@ func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *te
 		t.Fatalf("deletedCount mismatch (-want +got):\n%s", diff)
 	}
 	assertRetentionIDs(t, db, "memories", "id", []string{
+		"compact-summary-stale",
 		"extracted-accepted",
 		"extracted-fresh",
+		"extracted-stale",
+		"hidden-stale",
 		"imported-old",
 		"manual-old",
 	})
+	// Decayed rows must be expired, not deleted.
+	for _, id := range []string{"extracted-stale", "hidden-stale", "compact-summary-stale"} {
+		var status string
+		if err := db.QueryRow(`SELECT status FROM memories WHERE id = ?`, id).Scan(&status); err != nil {
+			t.Fatalf("status %s: %v", id, err)
+		}
+		if status != "expired" {
+			t.Fatalf("%s status = %q, want expired", id, status)
+		}
+	}
 	assertNoForeignKeyViolations(t, db)
 }
 
@@ -394,14 +407,22 @@ func TestDatasource_CollectGarbage_clearsSupersedesRefBeforeDeletingStaleExtract
 	); err != nil {
 		t.Fatalf("CollectGarbage() error = %v", err)
 	}
-	assertRetentionIDs(t, db, "memories", "id", []string{"manual-pointer"})
+	// Candidate is decayed to expired (still present); supersedes ref cleared.
+	assertRetentionIDs(t, db, "memories", "id", []string{"manual-pointer", "stale-compact"})
 	assertNoForeignKeyViolations(t, db)
 	var supersedes sql.NullString
 	if err := db.QueryRow(`SELECT supersedes_memory_id FROM memories WHERE id = 'manual-pointer'`).Scan(&supersedes); err != nil {
 		t.Fatalf("query supersedes_memory_id: %v", err)
 	}
 	if supersedes.Valid {
-		t.Fatalf("supersedes_memory_id = %q, want NULL after deleting referenced extracted candidate", supersedes.String)
+		t.Fatalf("supersedes_memory_id = %q, want NULL after decaying referenced extracted candidate", supersedes.String)
+	}
+	var status string
+	if err := db.QueryRow(`SELECT status FROM memories WHERE id = 'stale-compact'`).Scan(&status); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status != "expired" {
+		t.Fatalf("stale-compact status = %q, want expired", status)
 	}
 }
 

--- a/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
+++ b/infrastructure/sqlite/sql/delete_stale_extracted_candidates.sql
@@ -1,4 +1,9 @@
-DELETE FROM memories
+-- Non-destructive decay: transition unreviewed auto-extracted candidates to
+-- expired so they remain restorable until keep-days physical GC.
+UPDATE memories
+SET status = 'expired',
+    expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE status = 'candidate'
   AND source IN ('extracted', 'extracted-hidden', 'compact-summary')
   AND updated_at < ?

--- a/infrastructure/sqlite/store_management_datasource.go
+++ b/infrastructure/sqlite/store_management_datasource.go
@@ -43,9 +43,10 @@ var clearStaleExtractedCandidateSupersedesRefsQuery string
 // extracted-hidden, compact-summary)`. The default operator-controlled cutoff
 // (`--keep-days`) protects long-lived facts; this shorter window
 // applies only to auto-extracted candidates that were never reviewed.
-// Untouched extracted candidates older than this are deleted on the
-// next gc pass that targets `memories` or `all`. Tracked under
-// v0.11.0 sub-issue #832.
+// Untouched extracted candidates older than this are decayed to
+// status=expired (not hard-deleted) on the next gc pass that targets
+// `memories` or `all`, so operators can restore until keep-days GC.
+// Tracked under #1368 / v0.11.0 sub-issue #832.
 const staleExtractedCandidateRetention = 14 * 24 * time.Hour
 
 //go:embed sql/delete_old_memory_edges.sql
@@ -198,7 +199,9 @@ func (d *StoreManagementDatasource) RestoreBackup(ctx context.Context, inputPath
 	return nil
 }
 
-// CollectGarbage deletes store records older than the given time for the selected target.
+// CollectGarbage removes or decays store records older than the given time for
+// the selected target. Stale auto-extracted memory candidates are transitioned
+// to expired (counted in the return value) rather than hard-deleted.
 func (d *StoreManagementDatasource) CollectGarbage(
 	ctx context.Context,
 	before time.Time,
@@ -289,21 +292,19 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 			return 0, xerrors.Errorf("failed to delete old memories: %w", err)
 		}
 		total += count
-		// Auto-expire stale auto-extracted candidates that the operator
-		// never reviewed. The retention window is shorter than the
-		// operator-controlled cutoff because these rows are best-effort
-		// signal, not curated facts. See #810/#832.
+		// Decay (not hard-delete) stale auto-extracted candidates the
+		// operator never reviewed. Rows stay restorable as expired until
+		// keep-days physical GC. See #1368 / #810/#832.
 		extractedCutoff := formatTimestamp(time.Now().Add(-staleExtractedCandidateRetention))
-		// Clear supersedes_memory_id references that point at stale
-		// extracted candidates first so the subsequent delete cannot
-		// trip a foreign-key constraint when an unusual operator
-		// graph references one of these candidates.
+		// Clear supersedes_memory_id references that point at candidates
+		// about to leave the candidate status first so unusual operator
+		// graphs cannot trip a foreign-key constraint.
 		if _, err := tx.ExecContext(ctx, clearStaleExtractedCandidateSupersedesRefsQuery, extractedCutoff); err != nil {
 			return 0, xerrors.Errorf("failed to clear stale extracted candidate supersedes references: %w", err)
 		}
 		extractedCount, err := execRowsAffected(ctx, tx, deleteStaleExtractedCandidatesQuery, extractedCutoff)
 		if err != nil {
-			return 0, xerrors.Errorf("failed to delete stale extracted candidates: %w", err)
+			return 0, xerrors.Errorf("failed to decay stale extracted candidates: %w", err)
 		}
 		total += extractedCount
 	}


### PR DESCRIPTION
## Summary
- Replace `delete_stale_extracted_candidates.sql` hard DELETE with UPDATE to `status=expired`
- Keep rows restorable until keep-days physical GC; supersedes refs still cleared before transition
- Document behavior in bilingual CHANGELOG Unreleased
- Tests assert rows remain with `expired` status

Closes #1368

## Test plan
- [x] `go test ./infrastructure/sqlite/ -run CollectGarbage`
- [x] `go tool golangci-lint run ./infrastructure/sqlite/`
- [ ] CI green