### PR TITLE
docs: archive-before-GC design note and manifest v1

### DIFF
--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -159,7 +159,7 @@ target ごとの policy:
 
 - `events`: `events.created_at < cutoff` の row を削除します。紐づく `command_audits` は foreign key により cascade されます。
 - `sessions`: `COALESCE(ended_at, started_at) < cutoff` かつ surviving event から参照されていない終了済み session を削除します。active session (`ended_at IS NULL`) は常に保護されます。
-- `memories`: `updated_at < cutoff` の `expired` / `superseded` memory だけを削除します。`accepted`、手動追加された `candidate`、その他の status は status が変わらない限り無期限に保持します。**例外:** auto-extracted candidate (`source IN (extracted, extracted-hidden)`) は 14 日以上経過したものを同じ pass で削除します — これらは best-effort signal で curated fact ではないため、短い retention で inbox を整理します。evidence/artifact ref は cascade され、削除対象を指す `supersedes_memory_id` は FK 整合性維持のため事前に NULL へ更新されます。
+- `memories`: `updated_at < cutoff` の `expired` / `superseded` / `rejected` memory を物理削除します。`accepted` と `candidate` は age 削除しません。**例外:** 未レビューの auto-extracted candidate (`source IN (extracted, extracted-hidden, compact-summary)`) は 14 日超で **hard delete ではなく `expired` へ decay** し、keep-days の物理 GC まで restore 可能です（#1368）。物理削除時は evidence/artifact ref が cascade され、削除または decay 直前の行を指す `supersedes_memory_id` は先に NULL へ更新されます。
 - `memory_edges`: `valid_to < cutoff` の終了済み edge を削除します。endpoint の memory が削除される場合も edge は自動 cascade されます。
 - `all`: events、sessions、memories、memory_edges の順に依存関係を保って適用します。
 
@@ -168,6 +168,7 @@ target ごとの policy:
 - `gc` は opt-in であり、Traceary が background で自動削除することはありません
 - 従来どおり event だけを掃除したい場合は `--target events` を使ってください
 - 長期の監査履歴を残したい場合は、強めの cleanup の前に backup を取ってください
+- cold 行の export と **verify-before-delete** は [Archive-before-GC](./archive-before-gc.ja.md)（#1309）を参照。フルファイル backup は [バックアップガイド](../backup/README.ja.md)
 
 ## 履歴 content の可逆的な dedupe
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -160,7 +160,7 @@ Target policies:
 
 - `events`: delete rows where `events.created_at < cutoff`; linked `command_audits` cascade via foreign keys.
 - `sessions`: delete ended sessions where `COALESCE(ended_at, started_at) < cutoff` and no surviving events reference the session. Active sessions (`ended_at IS NULL`) are always protected.
-- `memories`: delete only `expired` or `superseded` memories where `updated_at < cutoff`. `accepted`, manually-added `candidate`, and other statuses are kept indefinitely unless their status changes. **Exception:** auto-extracted candidates (`source IN (extracted, extracted-hidden)`) older than 14 days are also deleted in this pass — these rows are best-effort signal, not curated facts, and short retention keeps the inbox honest. Evidence/artifact refs cascade; `supersedes_memory_id` pointers to deleted rows are cleared first to preserve FK integrity.
+- `memories`: physically delete `expired`, `superseded`, or `rejected` memories where `updated_at < cutoff`. `accepted` and `candidate` rows are not age-deleted. **Exception:** unreviewed auto-extracted candidates (`source IN (extracted, extracted-hidden, compact-summary)`) older than 14 days are **decayed to `expired`** (not hard-deleted) so they remain restorable until keep-days GC (#1368). Evidence/artifact refs cascade on physical delete; `supersedes_memory_id` pointers to deleted or about-to-decay rows are cleared first.
 - `memory_edges`: delete closed edges where `valid_to < cutoff`; edges also cascade automatically when either endpoint memory is deleted.
 - `all`: apply the policies in dependency order: events, sessions, memories, then memory_edges.
 
@@ -169,6 +169,7 @@ Practical implications:
 - `gc` is opt-in; Traceary does not delete history automatically in the background
 - use `--target events` for legacy event-only cleanup
 - if you care about long-term audit history, take a backup before an aggressive cleanup
+- for cold-row export with **verify-before-delete**, see [Archive-before-GC](./archive-before-gc.md) (#1309); full-file backup remains [Backup guide](../backup/README.md)
 
 ## Reversible historical content dedupe
 

--- a/docs/storage/archive-before-gc.ja.md
+++ b/docs/storage/archive-before-gc.ja.md
@@ -1,0 +1,164 @@
+# Archive-before-GC 設計ノートとマニフェスト契約
+
+[English](./archive-before-gc.md)
+
+Epic #1309 · 設計スライス #1370 · 親カット #1360。
+
+本ドキュメントは **Structure-Behavior Design Note** と **版付き archive manifest 契約**です。スライス 2 (#1371) が手動オペレータ経路を実装し、スライス 3 (#1372) が同じ application core を opt-in 自動スケジューラに再利用します。設計 PR 自体では破壊的 GC を有効化しません。
+
+## 要求要約
+
+| 項目 | 内容 |
+|---|---|
+| **目的** | マルチ GB の live SQLite を、履歴を黙って捨てずに縮小する。対象行を版付き・完全性検証済み（任意で暗号化）archive に export し、**検証後に限り** archive 済み identity だけを live DB から削除する。 |
+| **現状** | `traceary store gc` は `--keep-days` に基づき hard delete。フルファイル backup と portable bundle はあるが、GC 対象 cold 行の stream archive + verify-before-delete ではない。 |
+| **期待する振る舞い** | dry-run 優先の plan → stream export → manifest / digest 検証（密封時は decrypt 往復）→ 厳密 ID 削除 → 任意 VACUUM。restore は idempotent。失敗時 live DB は不変。 |
+| **非対象** | Compressed VFS / ZIPVFS、ネットワーク退避、既定 retention の auto-archive 化、フル backup の置換、memory の auto-accept。 |
+
+### v0.28.0 リリース姿勢
+
+| スライス | Issue | 姿勢 |
+|---|---|---|
+| 1 設計 + manifest | #1370 | **リリースブロッキング**（本文書） |
+| 2 手動 archive + restore | #1371 | **リリースブロッキング** |
+| 3 opt-in 自動スケジューラ + doctor | #1372 | **v0.28.0 スコープ内**（スコープアウトしない）。**opt-in / fail-closed**、既定オンにしない |
+| 4 dogfood + 決定ログ | #1373 | **リリースブロッキング**証拠 |
+
+memory decay 系 GC (#1368/#1369) と削除経路の所有権を分離する: verify-after-archive 削除は #1371、candidate→expired は #1368。
+
+## 概念モデル
+
+| 概念 | 状態 | 振る舞い | 不変条件 |
+|---|---|---|---|
+| **Live store** | 通常 path の hot SQLite | hooks/CLI/MCP 書き込み | archive 途中の部分削除禁止。検証後のみ削除 |
+| **Archive plan** | 計算済み・未書き込み | テーブルごとの主キー集合 | 同一 cutoff/target/clock で dry-run と apply が一致 |
+| **Archive package** | 呼び出し側 path のファイル | envelope + payload + manifest | magic/version、digest 一致、ID 厳密 |
+| **Manifest** | package 内 JSON v1 | schema・cutoff・件数・digest | seal 後不変 |
+| **Cold record set** | 対象 target の GC 適格行 | export → delete | accepted memory を暗黙削除しない（既存 GC 規則に従う） |
+| **Restore run** | package の import | PK 単位 insert-or-skip | 内容が異なる live 行は黙って上書きしない |
+| **Retention mode** | config: 既定 `disabled` / `archive_then_gc` | 自動経路は opt-in のみ | パスフレーズは env **名**のみ。秘密は永続化しない |
+
+## 責務表
+
+| 責務 | 所有者 | 変更理由 | 非所有者 |
+|---|---|---|---|
+| 適格性（何が cold か） | 既存 GC target + keep-days | retention 方針 | Presentation |
+| 行集合の stream export/import | application archive use case | 形式・バッチ | CLI フラグ構文 |
+| Manifest 生成・検証 | application codec + 純粋 verifier | schema 版 | SQL 文字列のみ |
+| 密封 seal/open | bundle 系 crypto 再利用 | パラメータ | doctor 文言 |
+| 検証後の厳密 ID 削除 | StoreManagement / SQLite | ID リスト SQL | CLI |
+| 自動 worker + lease | #1372 | スケジュール | 手動 CLI |
+| オペレータ面 | presentation/cli | UX | domain 不変条件 |
+
+## 境界 / IF
+
+| 境界 | 消費者 | 隠蔽する詳細 | エラー契約 |
+|---|---|---|---|
+| `ArchivePlan` | CLI / worker | SQL 選択 | 不正 target → ユーザーエラー、空 plan → 成功 no-op |
+| `ExportArchive` | CLI / worker | stream・一時ファイル rename | IO 失敗時 live DB 不変。最終 path に不完全 package を残さない |
+| `VerifyArchive` | CLI、削除前、restore | decrypt + re-hash | fail-closed。検証失敗で削除しない |
+| `DeleteArchived` | apply のみ | トランザクション複数表削除 | v1: 欠落 ID は hard fail（安全側） |
+| `RestoreArchive` | CLI | idempotent insert | 内容衝突は skip+報告、1 件でも非ゼロ終了 (v1) |
+| config `retention` (#1372) | doctor / worker | ファイル + env | 密封モードで env 欠落 → WARN、削除なし |
+
+### 提案 CLI（#1371 規範。変更時は設計改訂）
+
+```text
+traceary store archive create --output PATH [--target …] [--keep-days N] [--dry-run] [--passphrase-env NAME]
+traceary store archive verify --input PATH [--passphrase-env NAME]
+traceary store archive restore --input PATH [--dry-run] [--passphrase-env NAME]
+```
+
+自動モード (#1372) は同じ use case を呼ぶ。SQL を再実装しない。
+
+## Archive package 形式 (v1)
+
+1. **任意の外枠 envelope**: magic `TRCARYAR` + version `1` +（密封時）salt/nonce/ciphertext。非密封時も magic+version+payload で manifest digest による完全性を持つ。
+2. **内包 payload**: zstd または gzip 圧縮 tar（依存が無ければ gzip。#1371 でベンチ結果を PR に記録）。
+3. **tar メンバ**: `manifest.json`、`tables/<table>.ndjson`、`tables/<table>.sha256`。
+
+詳細フィールドと JSON Schema は英語版および [`archive-manifest.v1.schema.json`](./archive-manifest.v1.schema.json) を正とする。
+
+**Identity 規則**
+
+- export 順序: 表固定順、表内は PK 昇順。
+- delete 順序: FK 安全な逆順。**export 時の ID 集合のみ**を使い、削除前に cutoff を取り直さない。
+- `row_ids_sha256` はソート済み ID の改行連結の SHA-256。
+
+## 削除前検証チェックリスト
+
+1. ファイル存在・magic/version
+2. 密封時: passphrase env で decrypt 成功
+3. manifest が schema v1 に適合
+4. 各 ndjson の digest 一致
+5. 各行 parse・PK 一意・件数一致
+6. `row_ids_sha256` 再計算一致
+7. 任意: live 残存行との内容サンプル照合
+8. 以上を通過後にのみ、厳密 ID 削除トランザクション
+
+失敗時: abort、live DB 不変。
+
+## クラッシュ窓
+
+| 窓 | リスク | 緩和 |
+|---|---|---|
+| export 途中 | 不完全ファイル | `PATH.partial` + fsync + atomic rename |
+| export 済・未 verify | 孤児 archive | 安全。verify 再実行可 |
+| verify 後・delete 途中 | 部分削除 | 単一トランザクション |
+| delete 後 VACUUM 失敗 | 領域未回収 | データ整合は維持、エラー報告 |
+| 自動 worker 競合 | 二重 archive | DB 単位 lease + interval (#1372) |
+| restore 衝突 | 黙上書き | v1: skip+報告 |
+
+## レコード単位圧縮ベンチ計画
+
+DB 全体の一括 zstd だけでは不十分。#1371 で次を記録する:
+
+- 短文 event 1 万件
+- 大きな command audit 1 千件
+- dogfood 実機 multi-GB（#1373）
+- 1 行 archive のフロアサイズ
+
+## 振る舞いテスト / TDD
+
+英語版の Behavior tests 表および TDD plan を正とする（#1371/#1372 実装時）。
+
+## 設定スケッチ (#1372、既定 fail-closed)
+
+```json
+{
+  "retention": {
+    "mode": "disabled",
+    "archive_then_gc": {
+      "interval": "168h",
+      "keep_days": 90,
+      "target": "all",
+      "output_dir": "~/.config/traceary/archives",
+      "passphrase_env": "TRACEARY_ARCHIVE_PASSPHRASE"
+    }
+  }
+}
+```
+
+## リスク / ロールバック
+
+- 手続き的巨大 usecase → plan/export/verify/delete/restore 分離
+- bundle との過剰共通化 → まず crypto helper のみ共有
+- decay GC との二重書き込み → 所有権分離を ops に明記
+- 自動削除の驚き → 既定 disabled、doctor 可視化
+
+**ロールバック:** 自動は opt-in。手動コマンドはドキュメント付きで出荷可能。破壊的既定は現状の archive なし `store gc` のまま。
+
+## PR 分割
+
+| PR | Issue | 成果物 |
+|---|---|---|
+| 設計 | #1370 | 本文書 + schema |
+| 手動 | #1371 | コマンド + usecase + テスト + ベンチ |
+| 自動 | #1372 | config + worker + doctor |
+| dogfood | #1373 | 証拠ログ |
+
+## 関連
+
+- Epic: #1309
+- Storage: [README.ja.md](./README.ja.md)
+- Backup: [../backup/README.ja.md](../backup/README.ja.md)

--- a/docs/storage/archive-before-gc.md
+++ b/docs/storage/archive-before-gc.md
@@ -1,0 +1,250 @@
+# Archive-before-GC design note and manifest contract
+
+[日本語](./archive-before-gc.ja.md)
+
+Part of epic #1309 · closes design slice #1370 · parent cut #1360.
+
+This document is the **Structure-Behavior Design Note** and **versioned archive manifest contract** for hot/cold store retention. Slice 2 (#1371) implements the manual operator path; slice 3 (#1372) reuses the same application core for opt-in automatic scheduling. No destructive GC enablement ships in the design PR itself.
+
+## Requirement summary
+
+| Item | Detail |
+|---|---|
+| **Purpose** | Let operators shrink multi-GB live SQLite stores without silently losing cold history: export eligible rows into a versioned, integrity-checked (and optionally encrypted) archive, **verify**, then delete only the exact archived identities from the live DB. |
+| **Status quo** | `traceary store gc` hard-deletes aged rows (events/sessions/memories/edges) under `--keep-days`. There is full-file backup (`store backup`) and portable encrypted bundle (`store bundle`), but neither is a stream archive of GC-eligible cold rows with verify-before-delete. |
+| **Expected behavior** | Dry-run-first archive plan → stream export → manifest + digest verification (+ decrypt round-trip when sealed) → delete exact IDs → optional VACUUM. Restore re-imports archived identities idempotently. Failures leave the live DB unchanged. |
+| **Non-goals (this design)** | Compressed VFS / ZIPVFS; network offload; changing default retention to auto-archive; rewriting full-file backup; auto-accept of memories. |
+
+### Release posture (v0.28.0)
+
+| Slice | Issue | Posture |
+|---|---|---|
+| 1 Design + manifest contract | #1370 | **Release-blocking** (this doc) |
+| 2 Manual archive + restore | #1371 | **Release-blocking** |
+| 3 Opt-in automatic scheduler + doctor | #1372 | **In scope for v0.28.0** (user: no scope-out); still **opt-in / fail-closed**, never default-on |
+| 4 Dogfood + decision log | #1373 | **Release-blocking** evidence |
+
+Serialize GC rewrites with memory-decay GC work (#1368/#1369): archive ownership of the delete-after-verify path is #1371; decay ownership of candidate → expired transitions remains #1368.
+
+## Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| **Live store** | hot SQLite under normal path | Accepts hooks/CLI/MCP writes | Never partially deleted mid-archive; all deletes after verified archive only |
+| **Archive plan** | computed, not yet written | Lists exact primary keys per table in stable order | Same plan on dry-run and apply for same cutoff/target/clock |
+| **Archive package** | file at caller path | Contains envelope + payload + manifest | Magic + version; payload digest matches manifest; row IDs exact |
+| **Archive manifest** | JSON v1 inside package | Records schema version, cutoff, table counts, per-row digests, package digest | Immutable after seal; verification reads this first |
+| **Cold record set** | rows matching GC eligibility for selected target(s) | Eligible for export then delete | Accepted memories never auto-included unless operator target explicitly includes them under GC rules |
+| **Restore run** | import of archive package | Insert-or-skip by primary key | Never overwrite differing live rows silently; report conflicts |
+| **Retention mode** | config: `disabled` (default) / `archive_then_gc` | Automatic path only when opt-in | Passphrase via env **name** only; secrets never persisted |
+
+## Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner |
+|---|---|---|---|
+| Eligibility rules (what is cold) | Align with existing GC targets + keep-days; domain/types for target enum | Retention policy change | Presentation |
+| Stream export / import of row sets | `application/usecase` archive use case | Export format / batching | CLI flag parsing |
+| Manifest build + verify | application codec + pure verifier | Manifest schema version | SQLite SQL strings alone |
+| Envelope seal/open (optional encryption) | Reuse bundle crypto primitives (Argon2id + XChaCha20-Poly1305) | Crypto parameters | Doctor message text |
+| Exact-ID delete after verify | `StoreManagement` / SQLite datasource | SQL identity lists | CLI |
+| Opportunistic auto worker + lease | infrastructure + hook/doctor piggyback (#1372) | Scheduling policy | Manual CLI path |
+| Operator surface | `presentation/cli` (`store archive …` / `store gc --archive` — final names in #1371) | UX | Domain invariants |
+
+## Boundaries / interfaces
+
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `ArchivePlan(ctx, cutoff, target) → Plan` | CLI, auto worker | SQL selection | Invalid target → user error; empty plan → success no-op |
+| `ExportArchive(ctx, plan, path, opts) → Manifest` | CLI, auto worker | Streaming write, temp file rename | IO / disk full → live DB unchanged; no partial package at final path |
+| `VerifyArchive(ctx, path, opts) → Report` | CLI, before delete, restore | Decrypt + re-hash | Fail closed; never delete on verify fail |
+| `DeleteArchived(ctx, manifest) → Counts` | CLI apply path only | Transactional multi-table delete by ID | Missing ID is warn+continue or hard fail (choose hard fail in v1 for safety) |
+| `RestoreArchive(ctx, path, opts) → Counts` | CLI | Idempotent insert | Conflict if live row differs → abort batch or skip with report (v1: skip+report, exit non-zero if any conflict) |
+| Config `retention` section (#1372) | doctor, worker | File + env | Missing passphrase env when sealed mode → WARN, no delete |
+
+### Proposed CLI shape (normative for #1371; bikeshed only with design amendment)
+
+```text
+traceary store archive create --output PATH [--target all|events|…] [--keep-days N] [--dry-run] [--passphrase-env NAME]
+traceary store archive verify --input PATH [--passphrase-env NAME]
+traceary store archive restore --input PATH [--dry-run] [--passphrase-env NAME]
+# Optional sugar later:
+traceary store gc --archive PATH …   # archive-then-gc one shot; still verify-before-delete
+```
+
+Automatic mode (#1372) calls the same use case methods; it does not reimplement SQL.
+
+## Archive package format (v1)
+
+Inspired by `store bundle` but specialized for cold-row GC:
+
+1. **Optional outer envelope** (same family as bundle): magic `TRCARYAR` (8 bytes) + version byte `1` + salt(16) + nonce(24) + ciphertext, when passphrase is provided. Without passphrase: magic + version + raw payload (still integrity-checked via manifest digests).
+2. **Inner payload**: gzip or zstd compressed tar (choose **zstd** if stdlib/module already available; otherwise gzip for zero new deps — decision recorded in #1371 PR with benchmark numbers).
+3. **Tar members** (stable names):
+   - `manifest.json` — schema below
+   - `tables/<table>.ndjson` — one JSON object per line, full row projection needed for restore
+   - `tables/<table>.sha256` — hex digest of the exact ndjson bytes
+
+### `manifest.json` schema (v1)
+
+Machine-readable JSON Schema: [`archive-manifest.v1.schema.json`](./archive-manifest.v1.schema.json).
+
+Logical fields:
+
+```json
+{
+  "schema_version": 1,
+  "format": "traceary.store.archive",
+  "created_at": "2026-07-17T12:00:00.000000000Z",
+  "tool_version": "0.28.0",
+  "source_db_fingerprint": {
+    "path": "~/.config/traceary/traceary.db",
+    "page_count": 12345,
+    "schema_user_version": 42
+  },
+  "plan": {
+    "target": "all",
+    "keep_days": 90,
+    "cutoff": "2026-04-18T00:00:00.000000000Z",
+    "dry_run": false
+  },
+  "tables": [
+    {
+      "name": "events",
+      "primary_key": ["id"],
+      "row_count": 1000,
+      "ndjson_sha256": "…",
+      "row_ids_sha256": "…",
+      "compressed_bytes": 123456,
+      "uncompressed_bytes": 987654
+    }
+  ],
+  "totals": {
+    "rows": 1000,
+    "compressed_bytes": 123456,
+    "uncompressed_bytes": 987654
+  },
+  "payload_sha256": "…",
+  "encryption": {
+    "mode": "none|xchacha20poly1305-argon2id",
+    "kdf": "argon2id",
+    "kdf_params": { "time": 3, "memory_kib": 65536, "threads": 4 }
+  }
+}
+```
+
+**Identity rules**
+
+- Export order: table order fixed (`events`, `command_audits`, `sessions`, `memories`, `memory_edges`, then child ref tables as needed). Within a table, primary key ascending.
+- Delete order: reverse FK-safe order (children before parents) using the **same ID sets** listed in the archive (never re-query with a new cutoff after export).
+- `row_ids_sha256` is the SHA-256 of `join("\n", sorted_ids)+"\n"` so verify can prove the ID set without re-reading full bodies when only identity checks are needed.
+
+## Verification checklist (must pass before delete)
+
+1. File exists; magic + version parse.
+2. If sealed: decrypt succeeds with configured passphrase env (wrong secret → fail, no delete).
+3. `manifest.json` validates against schema v1.
+4. Each `tables/<name>.ndjson` digest matches manifest.
+5. Each line parses; primary keys unique; `row_count` matches.
+6. `row_ids_sha256` matches reconstructed ID list.
+7. Optional deep check: re-hash full payload / sample N random rows against live DB (same content) when still present.
+8. Only then open a write transaction that deletes **exactly** those IDs for each table.
+
+Any failure → abort; live DB unchanged; leave archive file as-is for inspection.
+
+## Crash windows and recovery
+
+| Window | Risk | Mitigation |
+|---|---|---|
+| Mid-export write | Partial file | Write to `PATH.partial` + fsync + atomic rename |
+| Export done, verify not run | Orphan archive | Safe; operator re-runs verify |
+| Verify OK, delete mid-transaction | Partial delete | Single SQLite transaction for all deletes; rollback on error |
+| Delete committed, VACUUM fails | Space not reclaimed | Report VACUUM error; data already consistent |
+| Auto worker concurrent | Double archive / race | Per-DB exclusive lease file + interval marker (#1372) |
+| Restore into divergent live row | Silent clobber | v1 skip+report conflict; never overwrite different content |
+
+## Per-record compression benchmark plan
+
+Bulk zstd on a whole DB is **not** sufficient. #1371 must record:
+
+| Case | Method | Metrics |
+|---|---|---|
+| Synthetic 10k short events | ndjson+zstd vs gzip vs none | compressed size, export seconds, restore seconds |
+| Synthetic 1k large command audits (~100 KiB bodies) | same | ratio vs full-file `store backup` size for same rows |
+| Live dogfood multi-GB store sample (operator machine, #1373) | archive create dry-run + apply on copy | pre/post live size, `store-size` doctor, read latency of `sessions --snapshot` before/after |
+| Single-row overhead | 1-row archive package | floor size (manifest+envelope) |
+
+Acceptance for benchmarks in #1371 PR body (not a hard CI gate): document numbers so #1372/operators can judge cold storage cost.
+
+## Behavior tests (slice 2+)
+
+| # | Behavior | Given | When | Then | Level |
+|---|---|---|---|---|---|
+| 1 | Dry-run plan | Aged events exist | `archive create --dry-run` | Prints counts; no file; DB unchanged | CLI + usecase |
+| 2 | Export identities | Known IDs | create | Manifest row_ids match query | usecase |
+| 3 | Verify-before-delete | Valid archive | apply path | Delete only after verify OK | usecase |
+| 4 | Corrupt body | Bit-flip ndjson | verify / apply | Fail; zero deletes | usecase |
+| 5 | Wrong passphrase | Sealed archive | verify | Fail closed | usecase |
+| 6 | Idempotent restore | Empty target DB | restore twice | Second run skips all; exit 0 | usecase |
+| 7 | Conflict restore | Live row differs | restore | Skip conflict; non-zero exit | usecase |
+| 8 | Empty plan | Nothing eligible | create | No-op success | CLI |
+| 9 | Auto disabled default | Fresh config | worker tick | No archive, no delete | #1372 |
+| 10 | Lease conflict | Lease held | second worker | Skip; doctor shows reason | #1372 |
+
+## TDD plan (for #1371)
+
+| Behavior | Red | Green | Refactor |
+|---|---|---|---|
+| Plan counts | Test plan builder against fixture DB | Implement SQL selectors reusing GC eligibility | Share eligibility helpers with `CollectGarbage` carefully (don't couple delete SQL) |
+| Manifest digests | Test golden small fixture | Write ndjson + sha helpers | Extract pure `archivecodec` package if files grow |
+| Verify fail closed | Mutate bytes in test | Verifier checks | — |
+| Delete exact IDs | Archive then delete | ID-list DELETE in tx | — |
+| Restore skip | Double restore | Insert-or-skip | — |
+
+## Config sketch (#1372 only; defaults fail-closed)
+
+```json
+{
+  "retention": {
+    "mode": "disabled",
+    "archive_then_gc": {
+      "interval": "168h",
+      "keep_days": 90,
+      "target": "all",
+      "output_dir": "~/.config/traceary/archives",
+      "passphrase_env": "TRACEARY_ARCHIVE_PASSPHRASE"
+    }
+  }
+}
+```
+
+- `mode` default `disabled`.
+- Never store passphrase material in config or SQLite.
+- Doctor surfaces last success/failure, next eligibility, counts/bytes; never secrets.
+
+## Risks / rollback
+
+| Risk | Mitigation |
+|---|---|
+| Procedural mega-usecase | Separate plan / export / verify / delete / restore; pure codec tests |
+| Premature shared framework with bundle | Share **crypto helpers only** first; diverge formats freely |
+| GC dual-writer with decay (#1368) | Decay changes candidate→expired only; archive deletes aged terminal rows; document order: decay then archive-gc in ops notes |
+| Operator deletes archive after GC | Document: archive is the recovery path; full-file backup remains the disaster path |
+| Auto mode surprise deletes | Default disabled; dry-run markers; doctor WARN before first auto run |
+
+**Rollback:** feature flags are unnecessary if auto is opt-in. Manual commands can ship disabled behind docs until dogfood (#1373). Tag can ship commands; destructive default remains today's `store gc` without archive unless operator passes archive flags.
+
+## Implementation PR split
+
+| PR | Issue | Deliverable |
+|---|---|---|
+| Design | #1370 | This doc + schema fixture |
+| Manual path | #1371 | Commands + usecase + tests + benchmarks section in PR |
+| Auto path | #1372 | Config + worker + doctor + tests |
+| Dogfood | #1373 | Evidence log + any small ops doc fixes (no scope-out) |
+
+## Linkage
+
+- Epic: #1309
+- Storage overview: [README.md](./README.md)
+- Full-file backup (orthogonal): [../backup/README.md](../backup/README.md)
+- Bundle portability (crypto precedent): application `bundle_codec.go`

--- a/docs/storage/archive-manifest.v1.schema.json
+++ b/docs/storage/archive-manifest.v1.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/duck8823/traceary/docs/storage/archive-manifest.v1.schema.json",
+  "title": "Traceary store archive manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "format",
+    "created_at",
+    "tool_version",
+    "plan",
+    "tables",
+    "totals",
+    "payload_sha256",
+    "encryption"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "format": {
+      "type": "string",
+      "const": "traceary.store.archive"
+    },
+    "created_at": {
+      "type": "string",
+      "description": "RFC3339Nano UTC timestamp when the archive was sealed."
+    },
+    "tool_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Traceary version string that produced the archive."
+    },
+    "source_db_fingerprint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": {
+        "path": { "type": "string" },
+        "page_count": { "type": "integer", "minimum": 0 },
+        "schema_user_version": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "keep_days", "cutoff", "dry_run"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "enum": ["events", "sessions", "memories", "memory_edges", "all"]
+        },
+        "keep_days": { "type": "integer", "minimum": 1 },
+        "cutoff": {
+          "type": "string",
+          "description": "RFC3339Nano UTC lower bound used for eligibility (rows strictly older)."
+        },
+        "dry_run": { "type": "boolean" }
+      }
+    },
+    "tables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "primary_key",
+          "row_count",
+          "ndjson_sha256",
+          "row_ids_sha256",
+          "compressed_bytes",
+          "uncompressed_bytes"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "events",
+              "command_audits",
+              "sessions",
+              "memories",
+              "memory_evidence_refs",
+              "memory_artifact_refs",
+              "memory_edges"
+            ]
+          },
+          "primary_key": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1
+          },
+          "row_count": { "type": "integer", "minimum": 0 },
+          "ndjson_sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "row_ids_sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "compressed_bytes": { "type": "integer", "minimum": 0 },
+          "uncompressed_bytes": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "totals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rows", "compressed_bytes", "uncompressed_bytes"],
+      "properties": {
+        "rows": { "type": "integer", "minimum": 0 },
+        "compressed_bytes": { "type": "integer", "minimum": 0 },
+        "uncompressed_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "payload_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "encryption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["none", "xchacha20poly1305-argon2id"]
+        },
+        "kdf": { "type": "string", "const": "argon2id" },
+        "kdf_params": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "time": { "type": "integer", "minimum": 1 },
+            "memory_kib": { "type": "integer", "minimum": 1 },
+            "threads": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Structure-Behavior design note (EN+JA) for archive-before-GC (#1309)
- Versioned `archive-manifest.v1.schema.json` so #1371 can implement without reinterpretation
- Verification checklist, crash windows, CLI sketch, TDD/behavior tests, #1372 config sketch
- Link and align storage README memory GC notes with #1368/#1369 decay/rejected policy
- **#1372 stays in v0.28.0 scope** (opt-in only; no scope-out)

Closes #1370

## Test plan
- [ ] Docs CI / Docs job green
- [ ] Manual read-through: slice 2 implementer can derive package layout + verify-before-delete without new design questions