### PR TITLE
fix: chunk archive SELECT IN lists under SQLite variable limit

### DIFF
--- a/infrastructure/sqlite/store_archive.go
+++ b/infrastructure/sqlite/store_archive.go
@@ -336,14 +336,30 @@ func queryArchiveMapsIn(ctx context.Context, db *sql.DB, queryFmt string, ids []
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := make([]string, len(ids))
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		placeholders[i] = "?"
-		args[i] = id
+	// Stay under SQLite's bind-variable limit (dogfood #1386: large event
+	// sets for command_audits blew up unchunked IN lists).
+	const chunk = 400
+	var out []map[string]any
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		part := ids[start:end]
+		placeholders := make([]string, len(part))
+		args := make([]any, len(part))
+		for i, id := range part {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		query := fmt.Sprintf(queryFmt, strings.Join(placeholders, ","))
+		rows, err := queryArchiveMaps(ctx, db, query, args...)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rows...)
 	}
-	query := fmt.Sprintf(queryFmt, strings.Join(placeholders, ","))
-	return queryArchiveMaps(ctx, db, query, args...)
+	return out, nil
 }
 
 func scanArchiveMaps(rows *sql.Rows) ([]map[string]any, error) {

--- a/infrastructure/sqlite/store_archive_test.go
+++ b/infrastructure/sqlite/store_archive_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -97,3 +98,57 @@ VALUES ('new-e1', 'note', 'cli', 'manual', 's1', '', 'body', '2099-01-01T00:00:0
 	}
 }
 
+
+func TestStoreArchive_listsLargeCommandAuditSetsWithoutVariableLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "traceary.db")
+	storeManager := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	conn, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// >400 events with audits forces chunked IN lists (#1386).
+	const n = 450
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("old-e-%04d", i)
+		_, err = conn.Exec(`INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook)
+VALUES (?, 'note', 'cli', 'manual', 's1', '', 'body', '2020-01-01T00:00:00Z', '')`, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = conn.Exec(`INSERT INTO command_audits(event_id, command_text, input_text, output_text, input_truncated, output_truncated, exit_code, failed)
+VALUES (?, 'echo', '', '', 0, 0, 0, 0)`, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sut := usecase.NewStoreManagementUsecase(storeManager)
+	result, err := sut.CreateStoreArchive(context.Background(), apptypes.StoreArchiveCreateParams{
+		Before: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Target: apptypes.GarbageCollectionTargetEvents,
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalRows < n {
+		t.Fatalf("TotalRows = %d, want >= %d", result.TotalRows, n)
+	}
+	var audits int
+	for _, table := range result.Tables {
+		if table.Name == "command_audits" {
+			audits = table.RowCount
+		}
+	}
+	if audits != n {
+		t.Fatalf("command_audits = %d, want %d", audits, n)
+	}
+}


### PR DESCRIPTION
## Summary
- Chunk `queryArchiveMapsIn` at 400 IDs (same as delete path)
- Test with 450 events + audits (forces multi-chunk)
- Found during archive dogfood on multi-GB store (#1373)

Closes #1386

## Test plan
- [x] `go test ./infrastructure/sqlite/ -run StoreArchive`
- [ ] CI green