### PR TITLE
feat: add Kimi Code as a native Traceary client

### DIFF
--- a/domain/types/client_test.go
+++ b/domain/types/client_test.go
@@ -19,6 +19,7 @@ func TestClientFrom(t *testing.T) {
 		{name: "hook client", input: "hook", want: "hook"},
 		{name: "mcp client", input: "mcp", want: "mcp"},
 		{name: "grok client", input: "grok", want: "grok"},
+		{name: "kimi client", input: "kimi", want: "kimi"},
 		{name: "trims whitespace", input: "  cli  ", want: "cli"},
 		{name: "accepts arbitrary channel name", input: "custom-plugin", want: "custom-plugin"},
 		{name: "empty string returns error", input: "", wantErr: true},

--- a/infrastructure/filesystem/hooks_orchestrator.go
+++ b/infrastructure/filesystem/hooks_orchestrator.go
@@ -28,6 +28,9 @@ var hooksClientAliases = map[string]string{
 	"grok":            "grok",
 	"grok-build":      "grok",
 	"grok-cli":        "grok",
+	"kimi":            "kimi",
+	"kimi-code":       "kimi",
+	"kimi-cli":        "kimi",
 }
 
 // rawHookDocumentHandler is the optional interface a client handler implements
@@ -343,7 +346,7 @@ func normalizeHooksClient(handlers map[string]application.HooksClientHandler, cl
 	}
 
 	return "", xerrors.Errorf(
-		"unsupported client: %s (valid values: claude, codex, gemini, antigravity, grok; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli)",
+		"unsupported client: %s (valid values: claude, codex, gemini, antigravity, grok, kimi; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli)",
 		client,
 	)
 }

--- a/infrastructure/filesystem/hooks_orchestrator_test.go
+++ b/infrastructure/filesystem/hooks_orchestrator_test.go
@@ -23,6 +23,7 @@ func newTestOrchestrator(homeDir string) *filesystem.HooksOrchestrator {
 		}),
 		"gemini": filesystem.NewGeminiHooksHandler(),
 		"grok":   filesystem.NewGrokHooksHandler(),
+		"kimi":   filesystem.NewKimiHooksHandler(),
 	})
 }
 
@@ -199,7 +200,7 @@ func TestHooksOrchestrator_GenerateHandlesAliases(t *testing.T) {
 
 	orchestrator := newTestOrchestrator(t.TempDir())
 
-	aliases := []string{"claude-code", "codex-cli", "gemini-cli", "grok-build", "grok-cli"}
+	aliases := []string{"claude-code", "codex-cli", "gemini-cli", "grok-build", "grok-cli", "kimi-code", "kimi-cli"}
 	for _, alias := range aliases {
 		t.Run(alias, func(t *testing.T) {
 			t.Parallel()
@@ -381,7 +382,7 @@ func TestHooksOrchestrator_SupportedClients(t *testing.T) {
 
 	orchestrator := newTestOrchestrator(t.TempDir())
 
-	if diff := cmp.Diff([]string{"claude", "codex", "gemini", "grok"}, orchestrator.SupportedClients()); diff != "" {
+	if diff := cmp.Diff([]string{"claude", "codex", "gemini", "grok", "kimi"}, orchestrator.SupportedClients()); diff != "" {
 		t.Fatalf("SupportedClients() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -402,6 +403,9 @@ func TestHooksOrchestrator_NormalizeClient(t *testing.T) {
 		{"grok", "grok"},
 		{"grok-build", "grok"},
 		{"grok-cli", "grok"},
+		{"kimi", "kimi"},
+		{"kimi-code", "kimi"},
+		{"kimi-cli", "kimi"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/infrastructure/filesystem/kimi_hooks_handler.go
+++ b/infrastructure/filesystem/kimi_hooks_handler.go
@@ -1,0 +1,39 @@
+package filesystem
+
+import (
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+)
+
+// KimiHooksHandler is the client-specific boundary for Kimi Code hooks.
+// Native event mapping and installation remain disabled until capture wiring
+// is implemented by the dependent runtime issue.
+type KimiHooksHandler struct{}
+
+// NewKimiHooksHandler constructs the Kimi hook boundary.
+func NewKimiHooksHandler() *KimiHooksHandler { return &KimiHooksHandler{} }
+
+// Name returns the canonical client identifier.
+func (h *KimiHooksHandler) Name() string { return "kimi" }
+
+// Build returns an empty, deterministic hook document. This deliberately
+// reaches a registered Kimi boundary without claiming that capture is wired;
+// the actual capture wiring lands in the dependent runtime issue.
+func (h *KimiHooksHandler) Build(_ string) model.Hooks {
+	return model.HooksOf([]string{}, map[string][]model.HookEntry{})
+}
+
+// DefaultInstallPath fails closed until native runtime support is
+// implemented; the Traceary Kimi plugin will be the distribution path.
+func (h *KimiHooksHandler) DefaultInstallPath(_ string) (string, error) {
+	return "", kimiInstallUnavailableError()
+}
+
+func (h *KimiHooksHandler) validateInstall() error {
+	return kimiInstallUnavailableError()
+}
+
+func kimiInstallUnavailableError() error {
+	return xerrors.Errorf("kimi hook installation is not available until native runtime support is implemented; the Traceary Kimi plugin (kimi.plugin.json) will be the distribution path")
+}

--- a/infrastructure/filesystem/kimi_hooks_handler_test.go
+++ b/infrastructure/filesystem/kimi_hooks_handler_test.go
@@ -1,0 +1,24 @@
+package filesystem
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKimiHooksHandler_ExposesFailClosedBoundary(t *testing.T) {
+	t.Parallel()
+
+	handler := NewKimiHooksHandler()
+	if got := handler.Name(); got != "kimi" {
+		t.Fatalf("Name() = %q, want kimi", got)
+	}
+	if got := handler.Build("traceary").Events(); len(got) != 0 {
+		t.Fatalf("Build().Events() = %v, want empty until runtime support lands", got)
+	}
+	if _, err := handler.DefaultInstallPath(t.TempDir()); err == nil || !strings.Contains(err.Error(), "native runtime support") {
+		t.Fatalf("DefaultInstallPath() error = %v, want fail-closed runtime support error", err)
+	}
+	if err := handler.validateInstall(); err == nil || !strings.Contains(err.Error(), "native runtime support") {
+		t.Fatalf("validateInstall() error = %v, want fail-closed runtime support error", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func run() error {
 		"gemini":      filesystem.NewGeminiHooksHandler(),
 		"antigravity": filesystem.NewAntigravityHooksHandler(),
 		"grok":        filesystem.NewGrokHooksHandler(),
+		"kimi":        filesystem.NewKimiHooksHandler(),
 	})
 	hooksInspector := filesystem.NewHooksInspector()
 	pluginCacheInspector := filesystem.NewPluginCacheInspector()

--- a/presentation/cli/hooks.go
+++ b/presentation/cli/hooks.go
@@ -16,8 +16,8 @@ import (
 )
 
 var hooksClientFlagUsage = Localize(
-	"target client (claude|codex|gemini|antigravity|grok; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli)",
-	"対象クライアント (claude|codex|gemini|antigravity|grok; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli)",
+	"target client (claude|codex|gemini|antigravity|grok|kimi; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli)",
+	"対象クライアント (claude|codex|gemini|antigravity|grok|kimi; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli)",
 )
 
 func (c *RootCLI) newHooksCommand() *cobra.Command {
@@ -46,11 +46,11 @@ func (c *RootCLI) newHooksInstallCommand() *cobra.Command {
 	)
 
 	installCmd := &cobra.Command{
-		Use:   "install --client <claude|codex|gemini|antigravity|grok>",
+		Use:   "install --client <claude|codex|gemini|antigravity|grok|kimi>",
 		Short: Localize("Write hook configuration examples to the standard config path", "標準の設定パスへ hook 設定例を書き出す"),
 		Long: Localize(
-			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini, antigravity, grok.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli.\nGrok writes project hooks to .grok/hooks/traceary.json; use --global for ~/.grok/hooks/traceary.json.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini, ~/.gemini/config/hooks.json for Antigravity; Antigravity's workspace path is .agents/hooks.json). Codex hooks are already user-level, so --global is a no-op there.\nUse --upgrade for a non-destructive migration: only Traceary-managed entries are replaced, user-added entries are preserved, and a summary of added / refreshed / unchanged events is printed. Re-running --upgrade on an already up-to-date config is a no-op.",
-			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini, antigravity, grok。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli。\nGrok の project hook は .grok/hooks/traceary.json に書き込み、--global では ~/.grok/hooks/traceary.json に書き込みます。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json、Antigravity は ~/.gemini/config/hooks.json; Antigravity の workspace パスは .agents/hooks.json)。Codex の hook は元から user-level なため --global は効果ありません。\n--upgrade を指定すると非破壊マイグレーションになります (Traceary 管理分のみ置換、ユーザー追加の hook は保持、追加 / 更新 / 変更なしの内訳を表示)。既に最新の設定に対して再実行しても no-op です。",
+			"Generate hook configuration for a supported client and write it to the standard config path.\nSupported clients: claude, codex, gemini, antigravity, grok, kimi.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli.\nGrok writes project hooks to .grok/hooks/traceary.json; use --global for ~/.grok/hooks/traceary.json.\nKimi is recognized as a native client identity, but `hooks install` is not available: the Traceary Kimi plugin (kimi.plugin.json) will be the distribution path. `hooks print --client kimi` exposes the currently empty boundary.\nUse --global to write to the user-level config (~/.claude/settings.json for Claude, ~/.gemini/settings.json for Gemini, ~/.gemini/config/hooks.json for Antigravity; Antigravity's workspace path is .agents/hooks.json). Codex hooks are already user-level, so --global is a no-op there.\nUse --upgrade for a non-destructive migration: only Traceary-managed entries are replaced, user-added entries are preserved, and a summary of added / refreshed / unchanged events is printed. Re-running --upgrade on an already up-to-date config is a no-op.",
+			"対応 client 向けの hook 設定を生成し、標準の設定パスへ書き出します。\n対応 client: claude, codex, gemini, antigravity, grok, kimi。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli。\nGrok の project hook は .grok/hooks/traceary.json に書き込み、--global では ~/.grok/hooks/traceary.json に書き込みます。\nKimi は native client 識別子として認識されますが、Traceary Kimi plugin (kimi.plugin.json) が配布経路となるため `hooks install` は利用できません。`hooks print --client kimi` は現時点の空の境界を表示します。\n--global を指定すると user-level 設定に書き込みます (Claude は ~/.claude/settings.json、Gemini は ~/.gemini/settings.json、Antigravity は ~/.gemini/config/hooks.json; Antigravity の workspace パスは .agents/hooks.json)。Codex の hook は元から user-level なため --global は効果ありません。\n--upgrade を指定すると非破壊マイグレーションになります (Traceary 管理分のみ置換、ユーザー追加の hook は保持、追加 / 更新 / 変更なしの内訳を表示)。既に最新の設定に対して再実行しても no-op です。",
 		),
 		Example: strings.Join([]string{
 			"  traceary hooks install --client claude --project-dir .",
@@ -92,11 +92,11 @@ func (c *RootCLI) newHooksPrintCommand() *cobra.Command {
 	)
 
 	printCmd := &cobra.Command{
-		Use:   "print --client <claude|codex|gemini|antigravity|grok>",
+		Use:   "print --client <claude|codex|gemini|antigravity|grok|kimi>",
 		Short: Localize("Print hook configuration examples for the current environment", "現在の環境向けの hook 設定例を出力する"),
 		Long: Localize(
-			"Print generated hook configuration for a supported client.\nSupported clients: claude, codex, gemini, antigravity, grok.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli.\nWhen --traceary-bin is omitted, generated hooks call `traceary` from PATH.",
-			"対応 client 向けの生成済み hook 設定を出力します。\n対応 client: claude, codex, gemini, antigravity, grok。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli。\n--traceary-bin を省略した場合、生成される hook は PATH 上の `traceary` を呼びます。",
+			"Print generated hook configuration for a supported client.\nSupported clients: claude, codex, gemini, antigravity, grok, kimi.\nAliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli.\nWhen --traceary-bin is omitted, generated hooks call `traceary` from PATH.",
+			"対応 client 向けの生成済み hook 設定を出力します。\n対応 client: claude, codex, gemini, antigravity, grok, kimi。\nalias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli。\n--traceary-bin を省略した場合、生成される hook は PATH 上の `traceary` を呼びます。",
 		),
 		Example: strings.Join([]string{
 			"  traceary hooks print --client claude",
@@ -400,8 +400,8 @@ func requireHooksClient(client string) error {
 
 	return xerrors.Errorf(
 		Localize(
-			"--client is required (supported: claude, codex, gemini, antigravity, grok; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli)",
-			"--client は必須です (対応 client: claude, codex, gemini, antigravity, grok; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli)",
+			"--client is required (supported: claude, codex, gemini, antigravity, grok, kimi; aliases: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli)",
+			"--client は必須です (対応 client: claude, codex, gemini, antigravity, grok, kimi; alias: claude-code, codex-cli, gemini-cli, agy, antigravity-cli, grok-build, grok-cli, kimi-code, kimi-cli)",
 		),
 	)
 }

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -322,14 +322,17 @@ func TestRootCLI_HooksInstallCommand(t *testing.T) {
 	t.Run("fails closed for Kimi until native runtime support lands", func(t *testing.T) {
 		for _, client := range []string{"kimi", "kimi-code", "kimi-cli"} {
 			for _, tc := range []struct {
-				name       string
-				extraArgs  []string
-				seedOutput bool
+				name           string
+				extraArgs      []string
+				seedOutput     bool
+				wantErrContent string
 			}{
-				{name: "default path"},
-				{name: "explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json")}},
-				{name: "force with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--force"}, seedOutput: true},
-				{name: "upgrade with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--upgrade"}, seedOutput: true},
+				{name: "default path", wantErrContent: "native runtime support"},
+				{name: "explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json")}, wantErrContent: "native runtime support"},
+				{name: "force with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--force"}, seedOutput: true, wantErrContent: "native runtime support"},
+				{name: "upgrade with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--upgrade"}, seedOutput: true, wantErrContent: "native runtime support"},
+				{name: "global", extraArgs: []string{"--global"}, wantErrContent: "--global is not supported"},
+				{name: "global with force", extraArgs: []string{"--global", "--force"}, wantErrContent: "--global is not supported"},
 			} {
 				t.Run(client+"/"+tc.name, func(t *testing.T) {
 					args := []string{
@@ -357,8 +360,8 @@ func TestRootCLI_HooksInstallCommand(t *testing.T) {
 					rootCmd.SetErr(&bytes.Buffer{})
 					rootCmd.SetArgs(args)
 					err := rootCmd.Execute()
-					if err == nil || !strings.Contains(err.Error(), "native runtime support") {
-						t.Fatalf("Execute() error = %v, want fail-closed native runtime support error", err)
+					if err == nil || !strings.Contains(err.Error(), tc.wantErrContent) {
+						t.Fatalf("Execute() error = %v, want fail-closed error containing %q", err, tc.wantErrContent)
 					}
 					if outputPath == "" {
 						return

--- a/presentation/cli/hooks_test.go
+++ b/presentation/cli/hooks_test.go
@@ -216,6 +216,26 @@ func TestRootCLI_HooksPrintCommand(t *testing.T) {
 		})
 	}
 
+	for _, client := range []string{"kimi", "kimi-code", "kimi-cli"} {
+		t.Run("reaches empty Kimi boundary with "+client, func(t *testing.T) {
+			rootCmd := newTestRootCLI().Command()
+			stdout := &bytes.Buffer{}
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs([]string{"hooks", "print", "--client", client, "--traceary-bin", tracearyBin})
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			var settings printedHooksSettings
+			if err := json.Unmarshal(stdout.Bytes(), &settings); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.Bytes())
+			}
+			if len(settings.Hooks) != 0 {
+				t.Fatalf("Kimi hooks = %v, want empty boundary before runtime support", settings.Hooks)
+			}
+		})
+	}
+
 	t.Run("uses stable command name when traceary-bin is not specified", func(t *testing.T) {
 		settings := executeHooksPrintWithoutTracearyBin(t, "claude")
 		if diff := cmp.Diff(`'traceary' 'hook' 'session' 'claude' 'start'`, settings.Hooks["SessionStart"][0].Hooks[0].Command); diff != "" {
@@ -296,6 +316,63 @@ func TestRootCLI_HooksInstallCommand(t *testing.T) {
 					t.Fatal("installed Grok hooks missing SessionStart")
 				}
 			})
+		}
+	})
+
+	t.Run("fails closed for Kimi until native runtime support lands", func(t *testing.T) {
+		for _, client := range []string{"kimi", "kimi-code", "kimi-cli"} {
+			for _, tc := range []struct {
+				name       string
+				extraArgs  []string
+				seedOutput bool
+			}{
+				{name: "default path"},
+				{name: "explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json")}},
+				{name: "force with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--force"}, seedOutput: true},
+				{name: "upgrade with explicit output", extraArgs: []string{"--output", filepath.Join(t.TempDir(), "hooks.json"), "--upgrade"}, seedOutput: true},
+			} {
+				t.Run(client+"/"+tc.name, func(t *testing.T) {
+					args := []string{
+						"hooks", "install",
+						"--client", client,
+						"--project-dir", projectDir,
+						"--traceary-bin", "traceary",
+					}
+					args = append(args, tc.extraArgs...)
+					var outputPath string
+					for i, arg := range args {
+						if arg == "--output" {
+							outputPath = args[i+1]
+						}
+					}
+					const original = `{"user":"content"}`
+					if tc.seedOutput {
+						if err := os.WriteFile(outputPath, []byte(original), 0o600); err != nil {
+							t.Fatalf("seed output: %v", err)
+						}
+					}
+
+					rootCmd := newTestRootCLI().Command()
+					rootCmd.SetOut(&bytes.Buffer{})
+					rootCmd.SetErr(&bytes.Buffer{})
+					rootCmd.SetArgs(args)
+					err := rootCmd.Execute()
+					if err == nil || !strings.Contains(err.Error(), "native runtime support") {
+						t.Fatalf("Execute() error = %v, want fail-closed native runtime support error", err)
+					}
+					if outputPath == "" {
+						return
+					}
+					content, readErr := os.ReadFile(outputPath)
+					if tc.seedOutput {
+						if readErr != nil || string(content) != original {
+							t.Fatalf("output after failed install = %q, %v; want unchanged", content, readErr)
+						}
+					} else if !os.IsNotExist(readErr) {
+						t.Fatalf("output created after failed install: content=%q, error=%v", content, readErr)
+					}
+				})
+			}
 		}
 	})
 

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -112,6 +112,50 @@ func TestRootCLI_SessionStartCommand_AcceptsAndSerializesGrokClient(t *testing.T
 	}
 }
 
+func TestRootCLI_SessionStartCommand_AcceptsAndSerializesKimiClient(t *testing.T) {
+	t.Parallel()
+
+	sessionStub := &sessionUsecaseStub{startEvent: model.EventOf(
+		types.EventID("event-kimi"),
+		types.EventKindSessionStarted,
+		types.Client("kimi"),
+		types.Agent("kimi"),
+		types.SessionID("session-kimi"),
+		types.Workspace("duck8823/traceary"),
+		"session started",
+		time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC),
+	)}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "start", "--json",
+		"--db-path", "/tmp/test-traceary.db",
+		"--client", "kimi",
+		"--agent", "kimi",
+		"--workspace", "duck8823/traceary",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := sessionStub.startCall.client; got != "kimi" {
+		t.Fatalf("Start client = %q, want kimi", got)
+	}
+	var output struct {
+		Client string `json:"client"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.Bytes())
+	}
+	if output.Client != "kimi" {
+		t.Fatalf("JSON client = %q, want kimi", output.Client)
+	}
+}
+
 func TestRootCLI_SessionStartCommand_NoParentStaysParentless(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/testhelpers_test.go
+++ b/presentation/cli/testhelpers_test.go
@@ -26,6 +26,7 @@ func newTestHooksOptions() []cli.RootCLIOption {
 			"gemini":      filesystem.NewGeminiHooksHandler(),
 			"antigravity": filesystem.NewAntigravityHooksHandler(),
 			"grok":        filesystem.NewGrokHooksHandler(),
+			"kimi":        filesystem.NewKimiHooksHandler(),
 		})),
 		cli.WithHooksInspector(filesystem.NewHooksInspector()),
 		cli.WithPluginCacheInspector(filesystem.NewPluginCacheInspector()),


### PR DESCRIPTION
## Summary

Closes #1395 (v0.29.0-2), part of #1393.

Adds `kimi` as a native Traceary client identity, following the same pattern as Grok's v0.23.0-2. No hook event parsing yet — that lands in v0.29.0-3 (#1396).

### Changes

- Canonical client `kimi` with aliases `kimi-code` / `kimi-cli` (`hooksClientAliases`, error messages, CLI usage strings EN/JA)
- `KimiHooksHandler` boundary registered in the orchestrator: `Build` returns an empty deterministic document, `DefaultInstallPath` / `validateInstall` fail closed with a message pointing to the Kimi plugin (`kimi.plugin.json`) as the future distribution path
- Tests: handler boundary, alias canonicalization, `hooks print --client kimi` reaching the empty boundary, install failing closed on all paths (default/explicit output/force/upgrade), session client serialization

### Out of scope (per issue)

- Hook event parsing / capture (#1396)
- doctor checks (#1399)
- `resolveHooksGlobalPath` kimi case — `--global` is rejected before any write, matching Grok's -2 behavior

## Verification

- `go test ./...` ✅
- `go tool golangci-lint run` ✅ (0 issues)
- `traceary hooks print --client kimi` reaches the Kimi handler boundary (empty document) instead of failing client validation
