### PR TITLE
feat: package a native Traceary plugin for Kimi Code

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -138,6 +138,9 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkGrok(root, version); err != nil {
 		return err
 	}
+	if err := checkKimi(root, version); err != nil {
+		return err
+	}
 	if err := checkAntigravity(root); err != nil {
 		return err
 	}
@@ -156,6 +159,7 @@ var rememberSkillPaths = []string{
 	"integrations/gemini-extension/skills/traceary-memory-remember/SKILL.md",
 	"integrations/antigravity-plugin/skills/traceary-memory-remember/SKILL.md",
 	"integrations/grok-plugin/skills/traceary-memory-remember/SKILL.md",
+	"integrations/kimi-plugin/skills/traceary-memory-remember/SKILL.md",
 }
 
 // checkRememberSkillContract enforces the explicit-remember product contract:
@@ -254,6 +258,85 @@ func checkGrok(root, version string) error {
 	}
 	for _, skill := range expectedSkills {
 		if err := requireExists(root, "integrations/grok-plugin/skills/"+skill+"/SKILL.md", "missing Grok "+skill+" skill"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkKimi(root, version string) error {
+	var manifest struct {
+		Name       string   `json:"name"`
+		Version    string   `json:"version"`
+		Skills     []string `json:"skills"`
+		MCPServers map[string]struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		} `json:"mcpServers"`
+		Hooks []struct {
+			Event   string `json:"event"`
+			Matcher string `json:"matcher"`
+			Command string `json:"command"`
+			Timeout int    `json:"timeout"`
+		} `json:"hooks"`
+	}
+	if err := readJSON(root, "integrations/kimi-plugin/kimi.plugin.json", &manifest); err != nil {
+		return err
+	}
+	if manifest.Name != "traceary" {
+		return xerrors.Errorf("unexpected Kimi plugin name")
+	}
+	if manifest.Version != version {
+		return xerrors.Errorf("kimi plugin version must track v%s", version)
+	}
+	server, ok := manifest.MCPServers["traceary"]
+	if len(manifest.MCPServers) != 1 || !ok || server.Command != "traceary" || !equalStrings(server.Args, []string{"mcp-server"}) {
+		return xerrors.Errorf("kimi plugin must expose the traceary mcp-server")
+	}
+
+	// The manifest hook rules must stay in lockstep with the verified
+	// TOML plan (infrastructure/filesystem/kimi_hooks_handler.go).
+	expectedHooks := []struct {
+		event, matcher, action string
+	}{
+		{"SessionStart", "", "session-start"},
+		{"SessionEnd", "", "session-end"},
+		{"UserPromptSubmit", "", "user-prompt-submit"},
+		{"PreToolUse", "Agent", "pre-tool-use"},
+		{"PostToolUse", "", "post-tool-use"},
+		{"PostToolUseFailure", "", "post-tool-use-failure"},
+		{"Stop", "", "stop"},
+		{"SubagentStop", "", "subagent-stop"},
+		{"PreCompact", "", "pre-compact"},
+		{"PostCompact", "", "post-compact"},
+	}
+	if len(manifest.Hooks) != len(expectedHooks) {
+		return xerrors.Errorf("kimi plugin must declare exactly %d verified hook rules, got %d", len(expectedHooks), len(manifest.Hooks))
+	}
+	for i, want := range expectedHooks {
+		hook := manifest.Hooks[i]
+		expectedCommand := "traceary hook kimi " + want.action
+		if hook.Event != want.event || hook.Matcher != want.matcher || hook.Command != expectedCommand || hook.Timeout != 5 {
+			return xerrors.Errorf("kimi plugin hook rule %d (%s) drifted from the verified Kimi contract", i, want.event)
+		}
+	}
+
+	expectedSkills := []string{"traceary-memory-remember", "traceary-memory-review", "traceary-session-history"}
+	entries, err := os.ReadDir(filepath.Join(root, "integrations/kimi-plugin/skills"))
+	if err != nil {
+		return xerrors.Errorf("failed to read Kimi skills: %w", err)
+	}
+	actualSkills := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			actualSkills = append(actualSkills, entry.Name())
+		}
+	}
+	if !equalStrings(actualSkills, expectedSkills) {
+		return xerrors.Errorf("kimi plugin skills must be exactly %v, got %v", expectedSkills, actualSkills)
+	}
+	for _, skill := range expectedSkills {
+		if err := requireExists(root, "integrations/kimi-plugin/skills/"+skill+"/SKILL.md", "missing Kimi "+skill+" skill"); err != nil {
 			return err
 		}
 	}

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -147,6 +147,9 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkRememberSkillContract(root); err != nil {
 		return err
 	}
+	if err := checkSharedSkillParity(root); err != nil {
+		return err
+	}
 	return checkDocs(root)
 }
 
@@ -196,6 +199,53 @@ func checkRememberSkillContract(root string) error {
 		}
 		if string(data) != string(reference) {
 			return xerrors.Errorf("remember skill copies diverged: %s does not match %s", rel, rememberSkillPaths[0])
+		}
+	}
+	return nil
+}
+
+// sharedSkillPaths groups the packaged copies of each shared skill across
+// hosts. Copies of a skill must stay byte-identical so a single host cannot
+// drift; the first path in each group is the reference document.
+//
+// The Claude copy of traceary-session-history intentionally uses older,
+// Claude-specific wording and is excluded from that skill's parity group;
+// all other hosts share one text.
+var sharedSkillPaths = map[string][]string{
+	"traceary-memory-review": {
+		"integrations/claude-plugin/skills/traceary-memory-review/SKILL.md",
+		"plugins/traceary/skills/traceary-memory-review/SKILL.md",
+		"integrations/gemini-extension/skills/traceary-memory-review/SKILL.md",
+		"integrations/antigravity-plugin/skills/traceary-memory-review/SKILL.md",
+		"integrations/grok-plugin/skills/traceary-memory-review/SKILL.md",
+		"integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md",
+	},
+	"traceary-session-history": {
+		"integrations/grok-plugin/skills/traceary-session-history/SKILL.md",
+		"plugins/traceary/skills/traceary-session-history/SKILL.md",
+		"integrations/gemini-extension/skills/traceary-session-history/SKILL.md",
+		"integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md",
+		"integrations/kimi-plugin/skills/traceary-session-history/SKILL.md",
+	},
+}
+
+// checkSharedSkillParity enforces byte-identity of the shared skill copies
+// across every host package.
+func checkSharedSkillParity(root string) error {
+	for skill, paths := range sharedSkillPaths {
+		var reference []byte
+		for i, rel := range paths {
+			data, err := os.ReadFile(filepath.Join(root, rel)) // #nosec G304 -- fixed package path under repo root
+			if err != nil {
+				return xerrors.Errorf("missing shared %s skill: %s: %w", skill, rel, err)
+			}
+			if i == 0 {
+				reference = data
+				continue
+			}
+			if string(data) != string(reference) {
+				return xerrors.Errorf("shared %s skill copies diverged: %s does not match %s", skill, rel, paths[0])
+			}
 		}
 	}
 	return nil
@@ -266,8 +316,13 @@ func checkGrok(root, version string) error {
 
 func checkKimi(root, version string) error {
 	var manifest struct {
-		Name       string   `json:"name"`
-		Version    string   `json:"version"`
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Description string `json:"description"`
+		Homepage    string `json:"homepage"`
+		Interface   struct {
+			DisplayName string `json:"displayName"`
+		} `json:"interface"`
 		Skills     []string `json:"skills"`
 		MCPServers map[string]struct {
 			Command string   `json:"command"`
@@ -288,6 +343,12 @@ func checkKimi(root, version string) error {
 	}
 	if manifest.Version != version {
 		return xerrors.Errorf("kimi plugin version must track v%s", version)
+	}
+	if strings.TrimSpace(manifest.Description) == "" || strings.TrimSpace(manifest.Homepage) == "" || strings.TrimSpace(manifest.Interface.DisplayName) == "" {
+		return xerrors.Errorf("kimi plugin must declare description, homepage, and interface.displayName")
+	}
+	if !equalStrings(manifest.Skills, []string{"./skills/"}) {
+		return xerrors.Errorf("kimi plugin skills field must be exactly [\"./skills/\"], got %v", manifest.Skills)
 	}
 	server, ok := manifest.MCPServers["traceary"]
 	if len(manifest.MCPServers) != 1 || !ok || server.Command != "traceary" || !equalStrings(server.Args, []string{"mcp-server"}) {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -479,4 +479,20 @@ func TestInstallKimiPluginScript(t *testing.T) {
 			t.Fatalf("record = %v, want traceary entry", entry)
 		}
 	})
+
+	t.Run("installed.json with non-object entries is rebuilt", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(kimiHome, "plugins"), 0o755); err != nil {
+			t.Fatalf("mkdir plugins: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), []byte(`{"plugins":[null,"bogus"]}`), 0o600); err != nil {
+			t.Fatalf("seed installed.json with non-object entries: %v", err)
+		}
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("install with non-object entries failed: %v\n%s", err, output)
+		}
+		if entry := readRecord(t, kimiHome); entry["id"] != "traceary" {
+			t.Fatalf("record = %v, want traceary entry", entry)
+		}
+	})
 }

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -398,8 +398,16 @@ func TestInstallKimiPluginScript(t *testing.T) {
 		if output, err := runScript(t, kimiHome); err != nil {
 			t.Fatalf("install script failed: %v\n%s", err, output)
 		}
-		if _, err := os.Stat(filepath.Join(kimiHome, "plugins", "managed", "traceary", "kimi.plugin.json")); err != nil {
+		managedPath := filepath.Join(kimiHome, "plugins", "managed", "traceary")
+		if _, err := os.Stat(filepath.Join(managedPath, "kimi.plugin.json")); err != nil {
 			t.Fatalf("managed manifest missing: %v", err)
+		}
+		linkTarget, err := os.Readlink(managedPath)
+		if err != nil {
+			t.Fatalf("managed path is not a generation symlink: %v", err)
+		}
+		if !strings.Contains(linkTarget, ".traceary-gen-") {
+			t.Fatalf("managed symlink target = %q, want a .traceary-gen-* generation dir", linkTarget)
 		}
 		entry := readRecord(t, kimiHome)
 		if entry["id"] != "traceary" || entry["enabled"] != true || entry["state"] != "ok" {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -333,4 +335,148 @@ func writeHookTree(t *testing.T, root string) {
 	if n == 0 {
 		t.Fatal("seed syncHookCopies wrote 0 files")
 	}
+}
+
+// TestInstallKimiPluginScript exercises scripts/install-kimi-plugin.sh in a
+// sandboxed KIMI_CODE_HOME with stub kimi/traceary binaries on PATH.
+func TestInstallKimiPluginScript(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot() error = %v", err)
+	}
+	scriptPath := filepath.Join(repoRoot, "scripts", "install-kimi-plugin.sh")
+
+	newStubBin := func(t *testing.T) string {
+		t.Helper()
+		binDir := t.TempDir()
+		for _, name := range []string{"kimi", "traceary"} {
+			stub := filepath.Join(binDir, name)
+			if err := os.WriteFile(stub, []byte("#!/bin/bash\nexit 0\n"), 0o755); err != nil {
+				t.Fatalf("write stub %s: %v", name, err)
+			}
+		}
+		return binDir
+	}
+
+	runScript := func(t *testing.T, kimiHome string, extraEnv ...string) (string, error) {
+		t.Helper()
+		cmd := exec.Command("bash", scriptPath) // #nosec G204 -- test invokes the repository install script
+		cmd.Env = append(os.Environ(),
+			"KIMI_CODE_HOME="+kimiHome,
+			"PATH="+newStubBin(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		)
+		cmd.Env = append(cmd.Env, extraEnv...)
+		output, err := cmd.CombinedOutput()
+		return string(output), err
+	}
+
+	readRecord := func(t *testing.T, kimiHome string) map[string]any {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(kimiHome, "plugins", "installed.json"))
+		if err != nil {
+			t.Fatalf("read installed.json: %v", err)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("decode installed.json: %v", err)
+		}
+		plugins, ok := parsed["plugins"].([]any)
+		if !ok || len(plugins) != 1 {
+			t.Fatalf("installed.json plugins = %v, want exactly one entry", parsed["plugins"])
+		}
+		entry, ok := plugins[0].(map[string]any)
+		if !ok {
+			t.Fatalf("installed.json entry is not an object: %v", plugins[0])
+		}
+		return entry
+	}
+
+	t.Run("fresh install writes the managed copy and record", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("install script failed: %v\n%s", err, output)
+		}
+		if _, err := os.Stat(filepath.Join(kimiHome, "plugins", "managed", "traceary", "kimi.plugin.json")); err != nil {
+			t.Fatalf("managed manifest missing: %v", err)
+		}
+		entry := readRecord(t, kimiHome)
+		if entry["id"] != "traceary" || entry["enabled"] != true || entry["state"] != "ok" {
+			t.Fatalf("record = %v, want enabled traceary entry", entry)
+		}
+	})
+
+	t.Run("reinstall preserves user-controlled fields", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("first install failed: %v\n%s", err, output)
+		}
+		// Simulate the user disabling the plugin via /plugins.
+		recordPath := filepath.Join(kimiHome, "plugins", "installed.json")
+		data, err := os.ReadFile(recordPath)
+		if err != nil {
+			t.Fatalf("read record: %v", err)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("decode record: %v", err)
+		}
+		entry := parsed["plugins"].([]any)[0].(map[string]any)
+		entry["enabled"] = false
+		entry["custom_note"] = "keep me"
+		updated, err := json.Marshal(parsed)
+		if err != nil {
+			t.Fatalf("encode record: %v", err)
+		}
+		if err := os.WriteFile(recordPath, updated, 0o600); err != nil {
+			t.Fatalf("write record: %v", err)
+		}
+
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("reinstall failed: %v\n%s", err, output)
+		}
+		entry = readRecord(t, kimiHome)
+		if entry["enabled"] != false {
+			t.Fatalf("reinstall reset enabled to %v, want preserved false", entry["enabled"])
+		}
+		if entry["custom_note"] != "keep me" {
+			t.Fatalf("reinstall dropped unknown field: %v", entry)
+		}
+	})
+
+	t.Run("empty installed.json starts fresh", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(kimiHome, "plugins"), 0o755); err != nil {
+			t.Fatalf("mkdir plugins: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), nil, 0o600); err != nil {
+			t.Fatalf("seed empty installed.json: %v", err)
+		}
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("install with empty installed.json failed: %v\n%s", err, output)
+		}
+		if entry := readRecord(t, kimiHome); entry["id"] != "traceary" {
+			t.Fatalf("record = %v, want traceary entry", entry)
+		}
+	})
+
+	t.Run("corrupt installed.json is backed up and replaced", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(kimiHome, "plugins"), 0o755); err != nil {
+			t.Fatalf("mkdir plugins: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("seed corrupt installed.json: %v", err)
+		}
+		if output, err := runScript(t, kimiHome); err != nil {
+			t.Fatalf("install with corrupt installed.json failed: %v\n%s", err, output)
+		}
+		if _, err := os.Stat(filepath.Join(kimiHome, "plugins", "installed.json.traceary-backup")); err != nil {
+			t.Fatalf("corrupt record was not backed up: %v", err)
+		}
+		if entry := readRecord(t, kimiHome); entry["id"] != "traceary" {
+			t.Fatalf("record = %v, want traceary entry", entry)
+		}
+	})
 }

--- a/cmd/repo-tooling/release.go
+++ b/cmd/repo-tooling/release.go
@@ -29,6 +29,7 @@ var bumpManifests = []string{
 	"integrations/antigravity-plugin/plugin.json",
 	"integrations/gemini-extension/gemini-extension.json",
 	"integrations/grok-plugin/plugin.json",
+	"integrations/kimi-plugin/kimi.plugin.json",
 	"plugins/traceary/.codex-plugin/plugin.json",
 }
 

--- a/infrastructure/filesystem/kimi_hooks_handler_test.go
+++ b/infrastructure/filesystem/kimi_hooks_handler_test.go
@@ -1,6 +1,9 @@
 package filesystem
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -67,6 +70,45 @@ func TestKimiHooksHandler_RendersTOMLHookRules(t *testing.T) {
 	}
 	if !strings.Contains(text, "timeout = 5") {
 		t.Error("rendered document missing per-hook timeout")
+	}
+}
+
+func TestKimiHooksHandler_PlanMatchesPackagedManifest(t *testing.T) {
+	t.Parallel()
+
+	// The packaged kimi.plugin.json hooks must stay in lockstep with the
+	// handler plan so the TOML print path and the plugin distribution path
+	// can never drift apart.
+	manifestBytes, err := os.ReadFile(filepath.Join("..", "..", "integrations", "kimi-plugin", "kimi.plugin.json"))
+	if err != nil {
+		t.Fatalf("read packaged Kimi manifest: %v", err)
+	}
+	var manifest struct {
+		Hooks []struct {
+			Event   string `json:"event"`
+			Matcher string `json:"matcher"`
+			Command string `json:"command"`
+			Timeout int    `json:"timeout"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatalf("decode packaged Kimi manifest: %v", err)
+	}
+	if len(manifest.Hooks) != len(kimiHookPlan) {
+		t.Fatalf("packaged manifest declares %d hook rules, want %d from the handler plan", len(manifest.Hooks), len(kimiHookPlan))
+	}
+	for i, rule := range kimiHookPlan {
+		hook := manifest.Hooks[i]
+		if hook.Event != rule.event || hook.Matcher != rule.matcher {
+			t.Errorf("rule %d: manifest = (%q, %q), want plan (%q, %q)", i, hook.Event, hook.Matcher, rule.event, rule.matcher)
+		}
+		wantCommand := "traceary hook kimi " + rule.action
+		if hook.Command != wantCommand {
+			t.Errorf("rule %d (%s): manifest command = %q, want %q", i, rule.event, hook.Command, wantCommand)
+		}
+		if hook.Timeout != kimiHookTimeoutSeconds {
+			t.Errorf("rule %d (%s): manifest timeout = %d, want %d", i, rule.event, hook.Timeout, kimiHookTimeoutSeconds)
+		}
 	}
 }
 

--- a/integrations/kimi-plugin/kimi.plugin.json
+++ b/integrations/kimi-plugin/kimi.plugin.json
@@ -1,0 +1,82 @@
+{
+  "name": "traceary",
+  "version": "0.28.0",
+  "description": "Local-first Traceary integration for Kimi Code with MCP tools and native session, audit, transcript, compact, and subagent hooks.",
+  "homepage": "https://github.com/duck8823/traceary",
+  "keywords": [
+    "traceary",
+    "session",
+    "audit",
+    "memory",
+    "mcp",
+    "local-first"
+  ],
+  "interface": {
+    "displayName": "Traceary",
+    "shortDescription": "Local-first work logs, shell audits, and durable memory for Kimi Code sessions."
+  },
+  "skills": [
+    "./skills/"
+  ],
+  "mcpServers": {
+    "traceary": {
+      "command": "traceary",
+      "args": [
+        "mcp-server"
+      ]
+    }
+  },
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "command": "traceary hook kimi session-start",
+      "timeout": 5
+    },
+    {
+      "event": "SessionEnd",
+      "command": "traceary hook kimi session-end",
+      "timeout": 5
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "traceary hook kimi user-prompt-submit",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "Agent",
+      "command": "traceary hook kimi pre-tool-use",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUse",
+      "command": "traceary hook kimi post-tool-use",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUseFailure",
+      "command": "traceary hook kimi post-tool-use-failure",
+      "timeout": 5
+    },
+    {
+      "event": "Stop",
+      "command": "traceary hook kimi stop",
+      "timeout": 5
+    },
+    {
+      "event": "SubagentStop",
+      "command": "traceary hook kimi subagent-stop",
+      "timeout": 5
+    },
+    {
+      "event": "PreCompact",
+      "command": "traceary hook kimi pre-compact",
+      "timeout": 5
+    },
+    {
+      "event": "PostCompact",
+      "command": "traceary hook kimi post-compact",
+      "timeout": 5
+    }
+  ]
+}

--- a/integrations/kimi-plugin/skills/traceary-memory-remember/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-memory-remember/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: traceary-memory-remember
+description: Use ONLY when the user explicitly asks to remember a specific durable fact, decision, constraint, or preference. Trigger phrases — "覚えておいて", "remember that", "for the record", "save this as", "記憶しておいて", "メモして". Do NOT use for generic notes, status updates, or session summaries. The candidate lands in the review inbox; never auto-accepted.
+version: 1.0.0
+---
+
+# Traceary memory remember
+
+Use this skill **only** when the operator explicitly asks Traceary to remember a specific durable fact. Generic note-taking, status updates, or session summaries do not belong here — those go to `traceary-memory-review`.
+
+## Canonical contract
+
+Explicit remember requests land as **`status=candidate`** in the review inbox. They are **never auto-accepted**. Durable L3 memory grows only through a later accept step (`traceary-memory-review` or an explicit operator accept).
+
+Use MCP `manage_memory` with **`action="propose"`** for this skill. Do not call `action="remember"` from the agent skill path — that CLI/MCP path accepts immediately and bypasses inbox review.
+
+## Workflow
+
+1. **Confirm scope**. Pick exactly one of:
+   - `workspace` — applies to the current repo / workspace identifier (default for repo-scoped facts).
+   - `agent` — applies to a specific agent identity across workspaces.
+   - `session_family` — applies to a session family (rare; use only when the operator says so).
+2. **Pick a memory type** that matches the fact: `decision`, `constraint`, `lesson`, `preference`, `artifact`.
+3. **Build evidence_refs**. Each ref has `kind` and `value`. The `kind` is constrained to this enum:
+
+   | `kind` | Typical `value` |
+   | --- | --- |
+   | `event` | `events.id` (e.g. `evt-abc123…`) |
+   | `session` | `sessions.session_id` (e.g. `session-…`) |
+   | `url` | `https://…` |
+   | `file` | `docs/memory/README.md` |
+   | `issue` | `#462` |
+   | `pr` | `#468` |
+
+   Unknown values fail with `unknown evidence ref kind: <value>`. At minimum include the current `session` id.
+
+   For optional `artifact_refs[].kind` (used to point at follow-up reading material), the enum is **smaller** — `event` and `session` are NOT allowed:
+
+   | `kind` | Typical `value` |
+   | --- | --- |
+   | `url` | `https://grafana.internal/...` |
+   | `file` | `docs/architecture/redaction.md` |
+   | `issue` | `#462` |
+   | `pr` | `#468` |
+4. **Call `manage_memory` with `action="propose"`** so the row lands at `status=candidate`:
+
+   ```
+   manage_memory({
+     "action": "propose",
+     "type": "constraint",
+     "workspace": "<current workspace>",
+     "fact": "<short, durable statement>",
+     "evidence_refs": [{"kind": "session", "value": "<current session id>"}]
+   })
+   ```
+5. **Inform the operator** that a **candidate** was written for review (`status=candidate`), and how to review or undo: `traceary-memory-review`, or `manage_memory({"action": "accept"|"reject", "ids": ["<id>"]})`.
+
+## Guardrails
+
+- **Explicit ask only.** Do not use this skill on hints, hedges, or generic chat. The trigger requires a direct verb ("remember", "save", "覚えておいて", "メモして").
+- **Candidate only.** Every write from this skill is `action="propose"` → `status=candidate`. Never auto-accept; never call `action="remember"` from this skill.
+- **One scope only.** Send exactly one of `workspace`, `agent`, `session_family`. Sending more than one is a contract violation.
+- **No secrets.** Traceary redacts on write, but do not pass secret-shaped values into `fact` or `evidence_refs.value` — keep secrets in tool I/O where redaction is exhaustive.
+- **Do not duplicate.** If `query_memory(action="retrieve", workspace=..., query=...)` already returns the same fact, ask the operator before proposing again.

--- a/integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: traceary-memory-review
+description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
+version: 1.1.0
+---
+
+# Traceary memory review
+
+Use this skill when the operator explicitly asks to look at Traceary's pending memory inbox, accept/reject candidates, or to recap the current session. This is a **read + curate** skill — it does not write durable memory on its own. For explicit "remember X" requests use `traceary-memory-remember`.
+
+## Workflow
+
+1. **List candidates**. Call `query_memory` with `action="retrieve"` and `status=["candidate"]`. Default scope is the current workspace; broaden to agent / session_family only if the user says so.
+   ```
+   query_memory({
+     "action": "retrieve",
+     "status": ["candidate"],
+     "workspace": "<current workspace>",
+     "limit": 20
+   })
+   ```
+2. **Present the inbox to the user**. For each candidate include the memory id, type, fact, and the conversation evidence the candidate carries. Do not narrate the JSON verbatim — summarize so a busy operator can decide quickly.
+3. **Wait for the operator's decision per memory**. The operator may accept, reject, or ask to re-scope a candidate. Do not assume silence implies accept.
+4. **Apply decisions** via `manage_memory`:
+   - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
+   - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
+   - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+
+## Human fallback: `traceary memory inbox review`
+
+When the operator would rather drive the review themselves at the terminal — for example because they want to clear the inbox without an agent narrating each candidate, or the agent does not have enough scope to curate confidently — point them at the **interactive CLI**. This is the **preferred human fallback** for inbox review (added in v0.14, see #925).
+
+```sh
+traceary memory inbox review
+traceary memory inbox review --workspace <workspace> --type preference --limit 10
+```
+
+Properties to relay so the operator can decide whether the interactive flow fits:
+
+- TTY-only. Refuses to start without a TTY and exits with code `2`, printing batch-fallback guidance.
+- Same filter set as `memory inbox list` (`--workspace`, `--agent`, `--session-family`, `--type`, `--source`, `--include-hidden`, `--limit`).
+- Action keys: `a` accept, `x` reject, `s` skip, `e` edit/distill, `v` view evidence, `?` help, `q` quit.
+- Accept / reject reuse the same application use cases as `memory inbox accept|reject` — same dedupe, same status transitions.
+- Edit/distill **requires the operator to type a new fact** and routes through `traceary memory store distill --replace=supersede`; the candidate's LLM-authored text is never auto-accepted.
+
+## Script / batch fallback: `memory inbox list` + `memory inbox accept|reject`
+
+For non-interactive shells (CI, automation, headless agents, long pipelines) the agent or operator should fall back to the snapshot path. This is **distinct** from the interactive review above — pick this path when there is no TTY, when the ids to act on are already known, or when a script needs deterministic exit codes.
+
+```sh
+traceary memory inbox list --workspace <workspace> --json
+traceary memory inbox accept <memory-id>           # single id (positional)
+traceary memory inbox accept --ids id1,id2,id3     # batch
+traceary memory inbox reject <memory-id>
+traceary memory inbox reject --ids id1,id2,id3
+```
+
+`--id-only` is available on `accept` / `reject` for scripted callers that want only the resulting memory id on stdout.
+
+## Guardrails
+
+- **Read first, write last.** The skill leads with `query_memory(retrieve)` and never accepts memory before the operator has seen the list.
+- **Never auto-accept candidate memories unless the user explicitly instructs it.** No silent batch accept, no "looks fine, let me approve them all" without a per-id operator decision. `manage_memory(action="accept")` is one-tap-irreversible from a UX standpoint, and the same rule applies to the CLI fallbacks: do not run `memory inbox accept --ids ...` on the operator's behalf without a direct instruction.
+- **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
+- **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
+- **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: traceary-session-history
+description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
+version: 1.0.0
+---
+
+# Traceary session history
+
+Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
+
+## Preferred tools
+
+- `session_status(action="latest")`: most recent session metadata for the current workspace
+- `session_status(action="active")`: only when the question is specifically about an open session
+- `list_events`: quick recent history without a keyword query
+- `search`: keyword-driven lookups
+- `get_context`: summarize the lead-up around an event
+
+## Guardrails
+
+- Prefer MCP reads before direct SQLite inspection.
+- Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
+- Automatic hooks already cover session boundaries and shell command audits.

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -4,10 +4,11 @@
 # Kimi Code loads managed plugins from $KIMI_CODE_HOME/plugins/managed/<id>/
 # (default ~/.kimi-code) and tracks them in $KIMI_CODE_HOME/plugins/
 # installed.json. This script mirrors the official local-install behavior
-# (schema verified against Kimi Code 0.27.0): the package is staged and
-# swapped into the managed copy, and the install record is upserted while
-# preserving user-controlled fields (enabled/state and unknown keys) from a
-# previous install. Re-running is idempotent.
+# (schema verified against Kimi Code 0.27.0): the package is staged as a
+# generation directory and the managed symlink is flipped with a single
+# atomic rename, then the install record is upserted while preserving
+# user-controlled fields (enabled/state and unknown keys) from a previous
+# install. Re-running is idempotent.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -53,25 +54,42 @@ if installed_path.exists() and installed_path.stat().st_size > 0:
         print(f"warning: installed.json is invalid ({exc}); backed up to {backup} and starting fresh", file=sys.stderr)
 PY
 
-# Stage the new package and swap it in with rollback on failure, keeping
-# the previous install intact until the new copy is fully in place.
-STAGING_DIR="${KIMI_HOME}/plugins/managed/.traceary-staging"
-BACKUP_DIR="${KIMI_HOME}/plugins/managed/.traceary-previous"
-rm -rf "${STAGING_DIR}" "${BACKUP_DIR}"
-mkdir -p "${KIMI_HOME}/plugins/managed"
-cp -R "${PLUGIN_DIR}" "${STAGING_DIR}"
-if [ -d "${MANAGED_DIR}" ]; then
-  mv "${MANAGED_DIR}" "${BACKUP_DIR}"
-fi
-if ! mv "${STAGING_DIR}" "${MANAGED_DIR}"; then
-  rm -rf "${MANAGED_DIR}"
-  if [ -d "${BACKUP_DIR}" ]; then
-    mv "${BACKUP_DIR}" "${MANAGED_DIR}"
-  fi
-  echo "error: failed to swap in the new package; previous install restored" >&2
-  exit 1
-fi
-rm -rf "${BACKUP_DIR}"
+# Stage the new package as a generation directory and flip the managed
+# symlink with a single rename, so the managed path never points at a
+# missing or half-copied package. Kimi Code resolves the symlink (verified
+# against 0.27.0).
+MANAGED_ROOT="${KIMI_HOME}/plugins/managed"
+GEN_DIR="${MANAGED_ROOT}/.traceary-gen-$(date +%Y%m%d%H%M%S)"
+rm -rf "${GEN_DIR}"
+mkdir -p "${MANAGED_ROOT}"
+cp -R "${PLUGIN_DIR}" "${GEN_DIR}"
+python3 - "${MANAGED_DIR}" "${GEN_DIR}" <<'PY'
+import os
+import shutil
+import sys
+
+managed_dir, gen_dir = sys.argv[1], sys.argv[2]
+tmp_link = managed_dir + ".traceary-tmp"
+if os.path.lexists(tmp_link):
+    os.unlink(tmp_link)
+os.symlink(gen_dir, tmp_link)
+if os.path.islink(managed_dir) or not os.path.exists(managed_dir):
+    # Single rename: the managed path flips to the new generation atomically.
+    os.replace(tmp_link, managed_dir)
+else:
+    # One-time migration from a direct-copy install: remove the real
+    # directory first, then flip.
+    os.unlink(tmp_link)
+    shutil.rmtree(managed_dir)
+    os.symlink(gen_dir, managed_dir)
+PY
+
+# Prune superseded generations (the current one stays linked).
+for old in "${MANAGED_ROOT}"/.traceary-gen-*; do
+  [ -e "${old}" ] || continue
+  [ "${old}" = "${GEN_DIR}" ] && continue
+  rm -rf "${old}"
+done
 
 python3 - "${INSTALLED_JSON}" "${MANAGED_DIR}" <<'PY'
 import json

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -57,7 +57,10 @@ PY
 # Stage the new package as a unique generation directory and flip the
 # managed symlink with a single rename, so the managed path never points at
 # a missing or half-copied package. Kimi Code resolves the symlink
-# (verified against 0.27.0).
+# (verified against 0.27.0). A pre-0.29 direct-copy managed directory is
+# migrated by moving it aside first — that one-time path cannot be a single
+# rename (a symlink cannot atomically replace a non-empty directory), so
+# run the first install after upgrading while Kimi Code is not running.
 MANAGED_ROOT="${KIMI_HOME}/plugins/managed"
 mkdir -p "${MANAGED_ROOT}"
 GEN_DIR="$(mktemp -d "${MANAGED_ROOT}/.traceary-gen-XXXXXXXX")"
@@ -68,7 +71,7 @@ import shutil
 import sys
 
 managed_dir, gen_dir = sys.argv[1], sys.argv[2]
-tmp_link = managed_dir + ".traceary-tmp"
+tmp_link = "{}.traceary-tmp-{}".format(managed_dir, os.getpid())
 if os.path.lexists(tmp_link):
     os.unlink(tmp_link)
 os.symlink(gen_dir, tmp_link)
@@ -82,6 +85,7 @@ try:
     else:
         # One-time migration from a direct-copy install: move the real
         # directory aside (single rename), flip the symlink, then clean up.
+        # Not a single atomic swap by construction — see the header comment.
         os.replace(managed_dir, backup_dir)
         try:
             os.replace(tmp_link, managed_dir)

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -54,15 +54,14 @@ if installed_path.exists() and installed_path.stat().st_size > 0:
         print(f"warning: installed.json is invalid ({exc}); backed up to {backup} and starting fresh", file=sys.stderr)
 PY
 
-# Stage the new package as a generation directory and flip the managed
-# symlink with a single rename, so the managed path never points at a
-# missing or half-copied package. Kimi Code resolves the symlink (verified
-# against 0.27.0).
+# Stage the new package as a unique generation directory and flip the
+# managed symlink with a single rename, so the managed path never points at
+# a missing or half-copied package. Kimi Code resolves the symlink
+# (verified against 0.27.0).
 MANAGED_ROOT="${KIMI_HOME}/plugins/managed"
-GEN_DIR="${MANAGED_ROOT}/.traceary-gen-$(date +%Y%m%d%H%M%S)"
-rm -rf "${GEN_DIR}"
 mkdir -p "${MANAGED_ROOT}"
-cp -R "${PLUGIN_DIR}" "${GEN_DIR}"
+GEN_DIR="$(mktemp -d "${MANAGED_ROOT}/.traceary-gen-XXXXXXXX")"
+cp -R "${PLUGIN_DIR}/." "${GEN_DIR}/"
 python3 - "${MANAGED_DIR}" "${GEN_DIR}" <<'PY'
 import os
 import shutil
@@ -73,15 +72,27 @@ tmp_link = managed_dir + ".traceary-tmp"
 if os.path.lexists(tmp_link):
     os.unlink(tmp_link)
 os.symlink(gen_dir, tmp_link)
-if os.path.islink(managed_dir) or not os.path.exists(managed_dir):
-    # Single rename: the managed path flips to the new generation atomically.
-    os.replace(tmp_link, managed_dir)
-else:
-    # One-time migration from a direct-copy install: remove the real
-    # directory first, then flip.
-    os.unlink(tmp_link)
-    shutil.rmtree(managed_dir)
-    os.symlink(gen_dir, managed_dir)
+backup_dir = managed_dir + ".traceary-backup"
+try:
+    if os.path.lexists(backup_dir):
+        shutil.rmtree(backup_dir)
+    if os.path.islink(managed_dir) or not os.path.lexists(managed_dir):
+        # Single rename: the managed path flips to the new generation atomically.
+        os.replace(tmp_link, managed_dir)
+    else:
+        # One-time migration from a direct-copy install: move the real
+        # directory aside (single rename), flip the symlink, then clean up.
+        os.replace(managed_dir, backup_dir)
+        try:
+            os.replace(tmp_link, managed_dir)
+        except BaseException:
+            os.replace(backup_dir, managed_dir)
+            raise
+        shutil.rmtree(backup_dir)
+except BaseException:
+    if os.path.lexists(tmp_link):
+        os.unlink(tmp_link)
+    raise
 PY
 
 # Prune superseded generations (the current one stays linked).

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Install the Traceary Kimi plugin into the local Kimi Code plugin directory.
+#
+# Kimi Code loads managed plugins from $KIMI_CODE_HOME/plugins/managed/<id>/
+# (default ~/.kimi-code) and tracks them in $KIMI_CODE_HOME/plugins/
+# installed.json. This script mirrors the official local-install behavior:
+# the packaged directory is copied and the install record is upserted, so
+# edits here only take effect after a reinstall.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="${ROOT_DIR}/integrations/kimi-plugin"
+KIMI_HOME="${KIMI_CODE_HOME:-${HOME}/.kimi-code}"
+MANAGED_DIR="${KIMI_HOME}/plugins/managed/traceary"
+INSTALLED_JSON="${KIMI_HOME}/plugins/installed.json"
+
+command -v kimi >/dev/null 2>&1 || {
+  echo 'error: kimi CLI is not installed' >&2
+  exit 69
+}
+command -v traceary >/dev/null 2>&1 || {
+  echo 'error: traceary is not on PATH (plugin hooks and the MCP server invoke it)' >&2
+  exit 69
+}
+command -v python3 >/dev/null 2>&1 || {
+  echo 'error: python3 is required to update the plugin install record' >&2
+  exit 69
+}
+
+mkdir -p "${KIMI_HOME}/plugins/managed"
+rm -rf "${MANAGED_DIR}"
+cp -R "${PLUGIN_DIR}" "${MANAGED_DIR}"
+
+python3 - "${INSTALLED_JSON}" "${MANAGED_DIR}" <<'PY'
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+installed_path = pathlib.Path(sys.argv[1])
+managed_dir = sys.argv[2]
+
+if installed_path.exists():
+    data = json.loads(installed_path.read_text())
+else:
+    data = {"plugins": []}
+
+plugins = [entry for entry in data.get("plugins", []) if entry.get("id") != "traceary"]
+plugins.append({
+    "id": "traceary",
+    "root": managed_dir,
+    "source": "local-path",
+    "enabled": True,
+    "state": "ok",
+    "installedAt": datetime.now(timezone.utc).isoformat(),
+})
+data["plugins"] = plugins
+
+tmp_path = installed_path.with_suffix(".json.tmp")
+tmp_path.write_text(json.dumps(data, indent=2) + "\n")
+tmp_path.replace(installed_path)
+PY
+
+echo "installed Traceary Kimi plugin to ${MANAGED_DIR}"
+echo "next: run '/plugins reload' (or start a new session) to activate hooks, skills, and the traceary MCP server"

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -3,9 +3,11 @@
 #
 # Kimi Code loads managed plugins from $KIMI_CODE_HOME/plugins/managed/<id>/
 # (default ~/.kimi-code) and tracks them in $KIMI_CODE_HOME/plugins/
-# installed.json. This script mirrors the official local-install behavior:
-# the packaged directory is copied and the install record is upserted, so
-# edits here only take effect after a reinstall.
+# installed.json. This script mirrors the official local-install behavior
+# (schema verified against Kimi Code 0.27.0): the package is staged and
+# swapped into the managed copy, and the install record is upserted while
+# preserving user-controlled fields (enabled/state and unknown keys) from a
+# previous install. Re-running is idempotent.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -27,9 +29,34 @@ command -v python3 >/dev/null 2>&1 || {
   exit 69
 }
 
+# Validate or initialize the install record BEFORE touching the managed
+# copy, so a corrupt file cannot leave a half-updated install behind.
+python3 - "${INSTALLED_JSON}" <<'PY'
+import json
+import pathlib
+import shutil
+import sys
+
+installed_path = pathlib.Path(sys.argv[1])
+if installed_path.exists() and installed_path.stat().st_size > 0:
+    try:
+        data = json.loads(installed_path.read_text())
+        if not isinstance(data, dict) or not isinstance(data.get("plugins"), list):
+            raise ValueError("installed.json is not a valid InstalledFile object")
+    except (ValueError, json.JSONDecodeError) as exc:
+        backup = installed_path.with_suffix(".json.traceary-backup")
+        shutil.copy2(installed_path, backup)
+        print(f"warning: installed.json is invalid ({exc}); backed up to {backup} and starting fresh", file=sys.stderr)
+PY
+
+# Stage the new package and swap it in atomically, keeping the previous
+# install intact until the copy succeeds.
+STAGING_DIR="${KIMI_HOME}/plugins/managed/.traceary-staging"
+rm -rf "${STAGING_DIR}"
 mkdir -p "${KIMI_HOME}/plugins/managed"
+cp -R "${PLUGIN_DIR}" "${STAGING_DIR}"
 rm -rf "${MANAGED_DIR}"
-cp -R "${PLUGIN_DIR}" "${MANAGED_DIR}"
+mv "${STAGING_DIR}" "${MANAGED_DIR}"
 
 python3 - "${INSTALLED_JSON}" "${MANAGED_DIR}" <<'PY'
 import json
@@ -40,20 +67,34 @@ from datetime import datetime, timezone
 installed_path = pathlib.Path(sys.argv[1])
 managed_dir = sys.argv[2]
 
-if installed_path.exists():
-    data = json.loads(installed_path.read_text())
-else:
-    data = {"plugins": []}
+data = {"plugins": []}
+if installed_path.exists() and installed_path.stat().st_size > 0:
+    try:
+        candidate = json.loads(installed_path.read_text())
+        if isinstance(candidate, dict) and isinstance(candidate.get("plugins"), list):
+            data = candidate
+    except (ValueError, json.JSONDecodeError):
+        # Validated (and backed up) earlier; fall back to a fresh record.
+        data = {"plugins": []}
 
-plugins = [entry for entry in data.get("plugins", []) if entry.get("id") != "traceary"]
-plugins.append({
+plugins = []
+preserved = {}
+for entry in data.get("plugins", []):
+    if entry.get("id") == "traceary":
+        preserved = entry
+    else:
+        plugins.append(entry)
+
+record = dict(preserved)
+record.update({
     "id": "traceary",
     "root": managed_dir,
-    "source": "local-path",
-    "enabled": True,
-    "state": "ok",
+    "source": preserved.get("source", "local-path"),
+    "enabled": preserved.get("enabled", True),
+    "state": preserved.get("state", "ok"),
     "installedAt": datetime.now(timezone.utc).isoformat(),
 })
+plugins.append(record)
 data["plugins"] = plugins
 
 tmp_path = installed_path.with_suffix(".json.tmp")

--- a/scripts/install-kimi-plugin.sh
+++ b/scripts/install-kimi-plugin.sh
@@ -30,7 +30,9 @@ command -v python3 >/dev/null 2>&1 || {
 }
 
 # Validate or initialize the install record BEFORE touching the managed
-# copy, so a corrupt file cannot leave a half-updated install behind.
+# copy, so a corrupt file cannot leave a half-updated install behind. Every
+# entry must be an object with an id, or the merge below would fail after
+# the swap.
 python3 - "${INSTALLED_JSON}" <<'PY'
 import json
 import pathlib
@@ -43,20 +45,33 @@ if installed_path.exists() and installed_path.stat().st_size > 0:
         data = json.loads(installed_path.read_text())
         if not isinstance(data, dict) or not isinstance(data.get("plugins"), list):
             raise ValueError("installed.json is not a valid InstalledFile object")
+        if any(not isinstance(entry, dict) or "id" not in entry for entry in data["plugins"]):
+            raise ValueError("installed.json contains a plugin entry without an id")
     except (ValueError, json.JSONDecodeError) as exc:
         backup = installed_path.with_suffix(".json.traceary-backup")
         shutil.copy2(installed_path, backup)
         print(f"warning: installed.json is invalid ({exc}); backed up to {backup} and starting fresh", file=sys.stderr)
 PY
 
-# Stage the new package and swap it in atomically, keeping the previous
-# install intact until the copy succeeds.
+# Stage the new package and swap it in with rollback on failure, keeping
+# the previous install intact until the new copy is fully in place.
 STAGING_DIR="${KIMI_HOME}/plugins/managed/.traceary-staging"
-rm -rf "${STAGING_DIR}"
+BACKUP_DIR="${KIMI_HOME}/plugins/managed/.traceary-previous"
+rm -rf "${STAGING_DIR}" "${BACKUP_DIR}"
 mkdir -p "${KIMI_HOME}/plugins/managed"
 cp -R "${PLUGIN_DIR}" "${STAGING_DIR}"
-rm -rf "${MANAGED_DIR}"
-mv "${STAGING_DIR}" "${MANAGED_DIR}"
+if [ -d "${MANAGED_DIR}" ]; then
+  mv "${MANAGED_DIR}" "${BACKUP_DIR}"
+fi
+if ! mv "${STAGING_DIR}" "${MANAGED_DIR}"; then
+  rm -rf "${MANAGED_DIR}"
+  if [ -d "${BACKUP_DIR}" ]; then
+    mv "${BACKUP_DIR}" "${MANAGED_DIR}"
+  fi
+  echo "error: failed to swap in the new package; previous install restored" >&2
+  exit 1
+fi
+rm -rf "${BACKUP_DIR}"
 
 python3 - "${INSTALLED_JSON}" "${MANAGED_DIR}" <<'PY'
 import json
@@ -80,6 +95,8 @@ if installed_path.exists() and installed_path.stat().st_size > 0:
 plugins = []
 preserved = {}
 for entry in data.get("plugins", []):
+    if not isinstance(entry, dict):
+        continue
     if entry.get("id") == "traceary":
         preserved = entry
     else:

--- a/scripts/verify_release_manifests.py
+++ b/scripts/verify_release_manifests.py
@@ -19,6 +19,7 @@ PLUGIN_MANIFESTS = [
     ROOT / 'integrations' / 'antigravity-plugin' / 'plugin.json',
     ROOT / 'integrations' / 'gemini-extension' / 'gemini-extension.json',
     ROOT / 'integrations' / 'grok-plugin' / 'plugin.json',
+    ROOT / 'integrations' / 'kimi-plugin' / 'kimi.plugin.json',
     ROOT / 'plugins' / 'traceary' / '.codex-plugin' / 'plugin.json',
 ]
 


### PR DESCRIPTION
## Summary

Closes #1398 (v0.29.0-5), part of #1393.

Kimi Code declares hooks, MCP servers, and skills in a single plugin manifest (`kimi.plugin.json`), so the plugin is the distribution path — no TOML merge into the user's `config.toml` (v0.29.0 non-goal).

### Package: `integrations/kimi-plugin/`

- `kimi.plugin.json` — declares the 10 verified hook rules (same plan as `traceary hooks print --client kimi`: session/prompt/audit/failure/stop/subagent/compact), the `traceary` MCP server (`traceary mcp-server`), and the three shared skills (byte-identical to the other hosts' copies)
- `scripts/install-kimi-plugin.sh` — mirrors the official local install: copies the package to `~/.kimi-code/plugins/managed/traceary` **and upserts `plugins/installed.json`** (schema verified against the installed CLI's record reader: `{id, root, source, enabled, state, installedAt}`). A plain file copy alone does not activate the plugin — the record is required; verified live
- repo-tooling: `checkKimi` (version lockstep, MCP server, hook rule parity with the handler plan, skill set), kimi remember-skill path, release manifest lists (`verify_release_manifests.py`, `bumpManifests`)

### Live dogfood (kimi 0.27.0)

After `install-kimi-plugin.sh`, a real kimi session with the built traceary on PATH recorded via the **plugin-declared hooks** (not manual TOML):

`session_started → prompt → command_executed → transcript (wire log side channel) → session_ended`

Note: the plugin invokes `traceary` from PATH; end users need the kimi-aware traceary binary (this PR series) on PATH.

## Verification

- `go test ./...` ✅ / `go tool golangci-lint run` ✅
- `repo-tooling integrations verify` ✅ / `verify_release_manifests.py` ✅
- Install script idempotent (re-install replaces the managed copy and record)

## Out of scope

- Official marketplace submission (per parent issue)
- MCP runtime verification in a live session (#1400 dogfood)
