### PR TITLE
feat: add Kimi installation, version, and coverage checks to doctor

### DIFF
--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -293,6 +293,19 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	report.Checks = append(report.Checks, inspectHookGrokTranscriptDiagnostics(time.Now().UTC()))
 
 	for _, targetClient := range resolvedClients {
+		if targetClient == "kimi" {
+			// Kimi has no hook install path (the plugin is the distribution
+			// path), so the shared ResolveInstallPath would fail closed; the
+			// plugin state is probed directly from the Kimi home instead.
+			state, probeErr := probeKimiDoctorState(ctx, resolvedProjectDir)
+			if probeErr != nil {
+				report.Checks = append(report.Checks, doctorCheck{Name: "kimi-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect Kimi installation: %v", "Kimi installation の検査に失敗しました: %v", probeErr)})
+			} else {
+				report.Checks = append(report.Checks, buildKimiDoctorChecks(state, input.currentVersion)...)
+			}
+			report.Checks = append(report.Checks, c.inspectClientEventCoverage(ctx, targetClient, "", resolvedProjectDir, input.coverageThreshold))
+			continue
+		}
 		if targetClient == "antigravity" {
 			// Antigravity supports three independent hook install routes
 			// (workspace .agents/hooks.json, user-level

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -299,7 +299,9 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 			// plugin state is probed directly from the Kimi home instead.
 			state, probeErr := probeKimiDoctorState(ctx, resolvedProjectDir)
 			if probeErr != nil {
-				report.Checks = append(report.Checks, doctorCheck{Name: "kimi-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect Kimi installation: %v", "Kimi installation の検査に失敗しました: %v", probeErr)})
+				// probeKimiDoctorState renders path-free errors only; keep the
+				// remediation generic rather than echoing host internals.
+				report.Checks = append(report.Checks, doctorCheck{Name: "kimi-inspect", Status: doctorStatusWarn, Message: localizef("failed to inspect the Kimi plugin installation: %v", "Kimi plugin の導入状態を検査できませんでした: %v", probeErr), Hint: Localize("reinstall the native Traceary Kimi plugin with scripts/install-kimi-plugin.sh, then rerun doctor", "scripts/install-kimi-plugin.sh で native Traceary Kimi plugin を再インストールしてから doctor を再実行してください")})
 			} else {
 				report.Checks = append(report.Checks, buildKimiDoctorChecks(state, input.currentVersion)...)
 			}

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -20,7 +20,11 @@ var (
 )
 
 var grokVersionPattern = regexp.MustCompile(`grok\s+([^\s]+)`)
-var grokTracearyVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// releaseTracearyVersionPattern matches released Traceary versions so
+// plugin/binary parity checks can skip development builds. Shared by the
+// host plugin checks (grok, kimi).
+var releaseTracearyVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 type grokDoctorState struct {
 	CLIAvailable    bool
@@ -180,7 +184,7 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	if !state.PluginEnabled {
 		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin is installed but disabled", "native Traceary Grok plugin はインストール済みですが無効です")
 		pluginHint = "grok plugin enable traceary"
-	} else if grokTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
+	} else if releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
 		pluginStatus = doctorStatusWarn
 		pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
 		pluginHint = "grok plugin update traceary"

--- a/presentation/cli/doctor_kimi.go
+++ b/presentation/cli/doctor_kimi.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+var (
+	kimiDoctorLookPath = exec.LookPath
+	kimiDoctorOutput   = func(ctx context.Context, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, "kimi", args...).Output()
+	}
+)
+
+// kimiExpectedHooks mirrors the verified hook plan (10 rules) the packaged
+// plugin and the TOML print path declare. The doctor check validates the
+// installed managed copy against it.
+var kimiExpectedHooks = []struct {
+	event   string
+	matcher string
+	action  string
+}{
+	{"SessionStart", "", "session-start"},
+	{"SessionEnd", "", "session-end"},
+	{"UserPromptSubmit", "", "user-prompt-submit"},
+	{"PreToolUse", "Agent", "pre-tool-use"},
+	{"PostToolUse", "", "post-tool-use"},
+	{"PostToolUseFailure", "", "post-tool-use-failure"},
+	{"Stop", "", "stop"},
+	{"SubagentStop", "", "subagent-stop"},
+	{"PreCompact", "", "pre-compact"},
+	{"PostCompact", "", "post-compact"},
+}
+
+type kimiDoctorState struct {
+	CLIAvailable    bool
+	HostVersion     string
+	PluginInstalled bool
+	PluginEnabled   bool
+	PluginVersion   string
+	NativeHooks     bool
+	PluginMCP       bool
+	UserMCP         bool
+	Skills          int
+}
+
+type kimiPluginManifest struct {
+	Version    string `json:"version"`
+	MCPServers map[string]struct {
+		Command string   `json:"command"`
+		Args    []string `json:"args"`
+	} `json:"mcpServers"`
+	Hooks []struct {
+		Event   string `json:"event"`
+		Matcher string `json:"matcher"`
+		Command string `json:"command"`
+		Timeout int    `json:"timeout"`
+	} `json:"hooks"`
+}
+
+// probeKimiDoctorState inspects the local Kimi Code installation. Kimi Code
+// has no CLI inspect command, so state is probed from the filesystem: the
+// managed plugin copy under $KIMI_CODE_HOME/plugins/managed/traceary (a
+// symlink into a generation dir) and the install record.
+func probeKimiDoctorState(ctx context.Context, projectDir string) (kimiDoctorState, error) {
+	state := kimiDoctorState{}
+	if _, err := kimiDoctorLookPath("kimi"); err != nil {
+		return state, nil
+	}
+	state.CLIAvailable = true
+	versionOutput, err := kimiDoctorOutput(ctx, "--version")
+	if err != nil {
+		return state, xerrors.Errorf("failed to read Kimi Code version: %w", err)
+	}
+	state.HostVersion = strings.TrimSpace(string(versionOutput))
+
+	kimiHome := kimiDoctorCodeHome()
+	manifestPath := filepath.Join(kimiHome, "plugins", "managed", "traceary", "kimi.plugin.json")
+	manifestBytes, err := os.ReadFile(manifestPath) // #nosec G304 -- fixed path under the Kimi home
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return state, xerrors.Errorf("failed to read Kimi plugin manifest: %w", err)
+		}
+	} else {
+		state.PluginInstalled = true
+		var manifest kimiPluginManifest
+		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+			return state, xerrors.Errorf("failed to decode Kimi plugin manifest: %w", err)
+		}
+		state.PluginVersion = manifest.Version
+		state.NativeHooks = kimiManifestHasVerifiedHooks(manifest)
+		if server, ok := manifest.MCPServers["traceary"]; ok && server.Command == "traceary" {
+			state.PluginMCP = true
+		}
+		state.Skills = countKimiPluginSkills(kimiHome)
+		state.PluginEnabled = kimiPluginRecordEnabled(kimiHome)
+	}
+	state.UserMCP = kimiMCPJSONRegisters(kimiHome, projectDir)
+	return state, nil
+}
+
+func kimiDoctorCodeHome() string {
+	if home := strings.TrimSpace(os.Getenv("KIMI_CODE_HOME")); home != "" {
+		return home
+	}
+	home, err := userHomeDirFunc()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".kimi-code")
+}
+
+func kimiManifestHasVerifiedHooks(manifest kimiPluginManifest) bool {
+	if len(manifest.Hooks) != len(kimiExpectedHooks) {
+		return false
+	}
+	for i, want := range kimiExpectedHooks {
+		hook := manifest.Hooks[i]
+		if hook.Event != want.event || hook.Matcher != want.matcher ||
+			hook.Command != "traceary hook kimi "+want.action || hook.Timeout != 5 {
+			return false
+		}
+	}
+	return true
+}
+
+func countKimiPluginSkills(kimiHome string) int {
+	entries, err := os.ReadDir(filepath.Join(kimiHome, "plugins", "managed", "traceary", "skills"))
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if info, err := os.Stat(filepath.Join(kimiHome, "plugins", "managed", "traceary", "skills", entry.Name(), "SKILL.md")); err == nil && info.Mode().IsRegular() {
+			count++
+		}
+	}
+	return count
+}
+
+// kimiPluginRecordEnabled reads the install record: enabled=true and
+// state=ok. A missing record means the plugin is not activated (mirroring the
+// official installer behavior).
+func kimiPluginRecordEnabled(kimiHome string) bool {
+	data, err := os.ReadFile(filepath.Join(kimiHome, "plugins", "installed.json")) // #nosec G304 -- fixed path under the Kimi home
+	if err != nil {
+		return false
+	}
+	var record struct {
+		Plugins []struct {
+			ID      string `json:"id"`
+			Enabled bool   `json:"enabled"`
+			State   string `json:"state"`
+		} `json:"plugins"`
+	}
+	if json.Unmarshal(data, &record) != nil {
+		return false
+	}
+	for _, entry := range record.Plugins {
+		if entry.ID == "traceary" {
+			return entry.Enabled && entry.State == "ok"
+		}
+	}
+	return false
+}
+
+// kimiMCPJSONRegisters checks the user-level and project-level mcp.json
+// files for a traceary server entry (the plugin-declared server is checked
+// separately from the manifest).
+func kimiMCPJSONRegisters(kimiHome, projectDir string) bool {
+	candidates := []string{filepath.Join(kimiHome, "mcp.json")}
+	if projectDir != "" {
+		candidates = append(candidates, filepath.Join(projectDir, ".kimi-code", "mcp.json"))
+	}
+	for _, path := range candidates {
+		data, err := os.ReadFile(path) // #nosec G304 -- fixed name under the Kimi home / project dir
+		if err != nil {
+			continue
+		}
+		var doc struct {
+			MCPServers map[string]json.RawMessage `json:"mcpServers"`
+		}
+		if json.Unmarshal(data, &doc) != nil {
+			continue
+		}
+		if _, ok := doc.MCPServers["traceary"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func buildKimiDoctorChecks(state kimiDoctorState, tracearyVersion string) []doctorCheck {
+	if !state.CLIAvailable {
+		return []doctorCheck{{Name: "kimi-cli", Status: doctorStatusFail, Message: Localize("Kimi Code CLI is not installed", "Kimi Code CLI がインストールされていません"), Hint: Localize("install Kimi Code, then rerun doctor", "Kimi Code をインストールして doctor を再実行してください")}}
+	}
+	checks := []doctorCheck{{Name: "kimi-cli", Status: doctorStatusPass, Message: localizef("detected Kimi Code CLI %s", "Kimi Code CLI %s を検出しました", state.HostVersion)}}
+	if !state.PluginInstalled {
+		checks = append(checks, doctorCheck{Name: "kimi-plugin", Status: doctorStatusWarn, Message: Localize("native Traceary Kimi plugin is not installed", "native Traceary Kimi plugin がインストールされていません"), Hint: Localize("install the native plugin with scripts/install-kimi-plugin.sh", "scripts/install-kimi-plugin.sh で native plugin をインストールしてください")})
+		return checks
+	}
+	pluginStatus := doctorStatusPass
+	pluginMessage := localizef("native Traceary Kimi plugin %s is installed and enabled", "native Traceary Kimi plugin %s はインストール済みで有効です", state.PluginVersion)
+	pluginHint := ""
+	if !state.PluginEnabled {
+		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Kimi plugin is installed but not enabled", "native Traceary Kimi plugin はインストール済みですが有効ではありません")
+		pluginHint = "enable the plugin with /plugins, or reinstall with scripts/install-kimi-plugin.sh"
+	} else if grokTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
+		pluginStatus = doctorStatusWarn
+		pluginMessage = localizef("native Traceary Kimi plugin version %s does not match Traceary %s", "native Traceary Kimi plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
+		pluginHint = "./scripts/install-kimi-plugin.sh  # from a matching release tag checkout"
+	}
+	checks = append(checks, doctorCheck{Name: "kimi-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
+
+	hookStatus := doctorStatusPass
+	hookMessage := Localize("native Kimi plugin hooks cover all ten verified events", "native Kimi plugin hook は検証済み 10 event をすべてカバーしています")
+	if !state.NativeHooks {
+		hookStatus, hookMessage = doctorStatusWarn, Localize("native Kimi plugin hook coverage is missing or incomplete", "native Kimi plugin hook coverage が不足しています")
+	}
+	checks = append(checks, doctorCheck{Name: "kimi-hooks", Status: hookStatus, Message: hookMessage, Hint: Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")})
+
+	mcpStatus := doctorStatusPass
+	mcpMessage := Localize("native Kimi plugin declares the traceary MCP server", "native Kimi plugin は traceary MCP server を宣言しています")
+	mcpHint := ""
+	if !state.PluginMCP {
+		if state.UserMCP {
+			mcpMessage = Localize("traceary MCP server is registered in mcp.json (plugin does not declare one)", "traceary MCP server は mcp.json に登録されています (plugin 側の宣言はありません)")
+		} else {
+			mcpStatus = doctorStatusWarn
+			mcpMessage = Localize("no traceary MCP server registration found in the Kimi plugin or mcp.json", "Kimi plugin と mcp.json のどちらにも traceary MCP server の登録がありません")
+			mcpHint = "reinstall the native Traceary Kimi plugin"
+		}
+	}
+	checks = append(checks, doctorCheck{Name: "kimi-mcp", Status: mcpStatus, Message: mcpMessage, Hint: mcpHint})
+
+	skillStatus := doctorStatusPass
+	skillMessage := Localize("native Kimi plugin exposes all three Traceary skills", "native Kimi plugin は Traceary skill を3件すべて公開しています")
+	if state.Skills != 3 {
+		skillStatus = doctorStatusWarn
+		skillMessage = localizef("native Kimi plugin exposes %d Traceary skills; expected 3", "native Kimi plugin の Traceary skill は %d 件です。3件必要です", state.Skills)
+	}
+	checks = append(checks, doctorCheck{Name: "kimi-skills", Status: skillStatus, Message: skillMessage, Hint: Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")})
+	return checks
+}

--- a/presentation/cli/doctor_kimi.go
+++ b/presentation/cli/doctor_kimi.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +21,7 @@ var (
 
 // kimiExpectedHooks mirrors the verified hook plan (10 rules) the packaged
 // plugin and the TOML print path declare. The doctor check validates the
-// installed managed copy against it.
+// installed managed copy against it, order-independently.
 var kimiExpectedHooks = []struct {
 	event   string
 	matcher string
@@ -38,16 +39,22 @@ var kimiExpectedHooks = []struct {
 	{"PostCompact", "", "post-compact"},
 }
 
+// kimiExpectedSkills are the three shared skills every host package ships.
+var kimiExpectedSkills = []string{"traceary-memory-remember", "traceary-memory-review", "traceary-session-history"}
+
 type kimiDoctorState struct {
 	CLIAvailable    bool
 	HostVersion     string
 	PluginInstalled bool
 	PluginEnabled   bool
-	PluginVersion   string
-	NativeHooks     bool
-	PluginMCP       bool
-	UserMCP         bool
-	Skills          int
+	// PluginRecordKnown is false when the install record cannot be read or
+	// parsed, so the enabled state is undetermined rather than "disabled".
+	PluginRecordKnown bool
+	PluginVersion     string
+	NativeHooks       bool
+	PluginMCP         bool
+	UserMCP           bool
+	Skills            int
 }
 
 type kimiPluginManifest struct {
@@ -62,6 +69,17 @@ type kimiPluginManifest struct {
 		Command string `json:"command"`
 		Timeout int    `json:"timeout"`
 	} `json:"hooks"`
+}
+
+// kimiProbeError renders a path-free probe error. Filesystem errors carry
+// the failing path inside *os.PathError, and doctor messages must never
+// expose home-directory layouts.
+func kimiProbeError(operation string, err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return xerrors.Errorf("%s: %s", operation, pathErr.Err)
+	}
+	return xerrors.Errorf("%s: %v", operation, err)
 }
 
 // probeKimiDoctorState inspects the local Kimi Code installation. Kimi Code
@@ -85,21 +103,19 @@ func probeKimiDoctorState(ctx context.Context, projectDir string) (kimiDoctorSta
 	manifestBytes, err := os.ReadFile(manifestPath) // #nosec G304 -- fixed path under the Kimi home
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return state, xerrors.Errorf("failed to read Kimi plugin manifest: %w", err)
+			return state, kimiProbeError("failed to read the Kimi plugin manifest", err)
 		}
 	} else {
 		state.PluginInstalled = true
 		var manifest kimiPluginManifest
 		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-			return state, xerrors.Errorf("failed to decode Kimi plugin manifest: %w", err)
+			return state, kimiProbeError("failed to parse the Kimi plugin manifest", err)
 		}
 		state.PluginVersion = manifest.Version
 		state.NativeHooks = kimiManifestHasVerifiedHooks(manifest)
-		if server, ok := manifest.MCPServers["traceary"]; ok && server.Command == "traceary" {
-			state.PluginMCP = true
-		}
+		state.PluginMCP = kimiServerDeclaresTraceary(manifest.MCPServers)
 		state.Skills = countKimiPluginSkills(kimiHome)
-		state.PluginEnabled = kimiPluginRecordEnabled(kimiHome)
+		state.PluginEnabled, state.PluginRecordKnown = kimiPluginRecordEnabled(kimiHome)
 	}
 	state.UserMCP = kimiMCPJSONRegisters(kimiHome, projectDir)
 	return state, nil
@@ -117,13 +133,24 @@ func kimiDoctorCodeHome() string {
 }
 
 func kimiManifestHasVerifiedHooks(manifest kimiPluginManifest) bool {
-	if len(manifest.Hooks) != len(kimiExpectedHooks) {
-		return false
+	type rule struct {
+		event   string
+		matcher string
+		command string
 	}
-	for i, want := range kimiExpectedHooks {
-		hook := manifest.Hooks[i]
-		if hook.Event != want.event || hook.Matcher != want.matcher ||
-			hook.Command != "traceary hook kimi "+want.action || hook.Timeout != 5 {
+	counts := map[rule]int{}
+	for _, want := range kimiExpectedHooks {
+		counts[rule{want.event, want.matcher, "traceary hook kimi " + want.action}]++
+	}
+	for _, hook := range manifest.Hooks {
+		key := rule{hook.Event, hook.Matcher, hook.Command}
+		if _, ok := counts[key]; !ok || hook.Timeout != 5 {
+			return false
+		}
+		counts[key]--
+	}
+	for _, remaining := range counts {
+		if remaining != 0 {
 			return false
 		}
 	}
@@ -131,16 +158,9 @@ func kimiManifestHasVerifiedHooks(manifest kimiPluginManifest) bool {
 }
 
 func countKimiPluginSkills(kimiHome string) int {
-	entries, err := os.ReadDir(filepath.Join(kimiHome, "plugins", "managed", "traceary", "skills"))
-	if err != nil {
-		return 0
-	}
 	count := 0
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		if info, err := os.Stat(filepath.Join(kimiHome, "plugins", "managed", "traceary", "skills", entry.Name(), "SKILL.md")); err == nil && info.Mode().IsRegular() {
+	for _, skill := range kimiExpectedSkills {
+		if info, err := os.Stat(filepath.Join(kimiHome, "plugins", "managed", "traceary", "skills", skill, "SKILL.md")); err == nil && info.Mode().IsRegular() {
 			count++
 		}
 	}
@@ -148,12 +168,12 @@ func countKimiPluginSkills(kimiHome string) int {
 }
 
 // kimiPluginRecordEnabled reads the install record: enabled=true and
-// state=ok. A missing record means the plugin is not activated (mirroring the
-// official installer behavior).
-func kimiPluginRecordEnabled(kimiHome string) bool {
+// state=ok. known=false means the record is missing or unreadable, so the
+// enabled state cannot be determined.
+func kimiPluginRecordEnabled(kimiHome string) (enabled, known bool) {
 	data, err := os.ReadFile(filepath.Join(kimiHome, "plugins", "installed.json")) // #nosec G304 -- fixed path under the Kimi home
 	if err != nil {
-		return false
+		return false, false
 	}
 	var record struct {
 		Plugins []struct {
@@ -163,19 +183,32 @@ func kimiPluginRecordEnabled(kimiHome string) bool {
 		} `json:"plugins"`
 	}
 	if json.Unmarshal(data, &record) != nil {
-		return false
+		return false, false
 	}
 	for _, entry := range record.Plugins {
 		if entry.ID == "traceary" {
-			return entry.Enabled && entry.State == "ok"
+			return entry.Enabled && entry.State == "ok", true
 		}
 	}
-	return false
+	return false, true
+}
+
+// kimiServerDeclaresTraceary validates a traceary MCP server declaration:
+// the command must be traceary launching mcp-server.
+func kimiServerDeclaresTraceary(servers map[string]struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}) bool {
+	server, ok := servers["traceary"]
+	if !ok {
+		return false
+	}
+	return server.Command == "traceary" && len(server.Args) == 1 && server.Args[0] == "mcp-server"
 }
 
 // kimiMCPJSONRegisters checks the user-level and project-level mcp.json
-// files for a traceary server entry (the plugin-declared server is checked
-// separately from the manifest).
+// files for a valid traceary server declaration (the plugin-declared server
+// is checked separately from the manifest).
 func kimiMCPJSONRegisters(kimiHome, projectDir string) bool {
 	candidates := []string{filepath.Join(kimiHome, "mcp.json")}
 	if projectDir != "" {
@@ -187,12 +220,15 @@ func kimiMCPJSONRegisters(kimiHome, projectDir string) bool {
 			continue
 		}
 		var doc struct {
-			MCPServers map[string]json.RawMessage `json:"mcpServers"`
+			MCPServers map[string]struct {
+				Command string   `json:"command"`
+				Args    []string `json:"args"`
+			} `json:"mcpServers"`
 		}
 		if json.Unmarshal(data, &doc) != nil {
 			continue
 		}
-		if _, ok := doc.MCPServers["traceary"]; ok {
+		if kimiServerDeclaresTraceary(doc.MCPServers) {
 			return true
 		}
 	}
@@ -211,10 +247,16 @@ func buildKimiDoctorChecks(state kimiDoctorState, tracearyVersion string) []doct
 	pluginStatus := doctorStatusPass
 	pluginMessage := localizef("native Traceary Kimi plugin %s is installed and enabled", "native Traceary Kimi plugin %s はインストール済みで有効です", state.PluginVersion)
 	pluginHint := ""
-	if !state.PluginEnabled {
-		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Kimi plugin is installed but not enabled", "native Traceary Kimi plugin はインストール済みですが有効ではありません")
-		pluginHint = "enable the plugin with /plugins, or reinstall with scripts/install-kimi-plugin.sh"
-	} else if grokTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
+	switch {
+	case !state.PluginRecordKnown:
+		pluginStatus = doctorStatusWarn
+		pluginMessage = Localize("native Traceary Kimi plugin is installed, but its activation record cannot be confirmed", "native Traceary Kimi plugin はインストール済みですが、有効化の記録を確認できません")
+		pluginHint = Localize("reinstall the native Traceary Kimi plugin with scripts/install-kimi-plugin.sh", "scripts/install-kimi-plugin.sh で native Traceary Kimi plugin を再インストールしてください")
+	case !state.PluginEnabled:
+		pluginStatus = doctorStatusWarn
+		pluginMessage = Localize("native Traceary Kimi plugin is installed but not enabled", "native Traceary Kimi plugin はインストール済みですが有効ではありません")
+		pluginHint = Localize("enable the plugin with /plugins, or reinstall with scripts/install-kimi-plugin.sh", "/plugins で有効化するか、scripts/install-kimi-plugin.sh で再インストールしてください")
+	case releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v"):
 		pluginStatus = doctorStatusWarn
 		pluginMessage = localizef("native Traceary Kimi plugin version %s does not match Traceary %s", "native Traceary Kimi plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
 		pluginHint = "./scripts/install-kimi-plugin.sh  # from a matching release tag checkout"
@@ -237,16 +279,16 @@ func buildKimiDoctorChecks(state kimiDoctorState, tracearyVersion string) []doct
 		} else {
 			mcpStatus = doctorStatusWarn
 			mcpMessage = Localize("no traceary MCP server registration found in the Kimi plugin or mcp.json", "Kimi plugin と mcp.json のどちらにも traceary MCP server の登録がありません")
-			mcpHint = "reinstall the native Traceary Kimi plugin"
+			mcpHint = Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")
 		}
 	}
 	checks = append(checks, doctorCheck{Name: "kimi-mcp", Status: mcpStatus, Message: mcpMessage, Hint: mcpHint})
 
 	skillStatus := doctorStatusPass
 	skillMessage := Localize("native Kimi plugin exposes all three Traceary skills", "native Kimi plugin は Traceary skill を3件すべて公開しています")
-	if state.Skills != 3 {
+	if state.Skills != len(kimiExpectedSkills) {
 		skillStatus = doctorStatusWarn
-		skillMessage = localizef("native Kimi plugin exposes %d Traceary skills; expected 3", "native Kimi plugin の Traceary skill は %d 件です。3件必要です", state.Skills)
+		skillMessage = localizef("native Kimi plugin exposes %d Traceary skills; expected %d", "native Kimi plugin の Traceary skill は %d 件です。%d 件必要です", state.Skills, len(kimiExpectedSkills))
 	}
 	checks = append(checks, doctorCheck{Name: "kimi-skills", Status: skillStatus, Message: skillMessage, Hint: Localize("reinstall the native Traceary Kimi plugin", "native Traceary Kimi plugin を再インストールしてください")})
 	return checks

--- a/presentation/cli/doctor_kimi_internal_test.go
+++ b/presentation/cli/doctor_kimi_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestBuildKimiDoctorChecks(t *testing.T) {
-	healthy := kimiDoctorState{CLIAvailable: true, HostVersion: "0.27.0", PluginInstalled: true, PluginEnabled: true, PluginVersion: "0.28.0", NativeHooks: true, PluginMCP: true, Skills: 3}
+	healthy := kimiDoctorState{CLIAvailable: true, HostVersion: "0.27.0", PluginInstalled: true, PluginEnabled: true, PluginRecordKnown: true, PluginVersion: "0.28.0", NativeHooks: true, PluginMCP: true, Skills: 3}
 	tests := []struct {
 		name       string
 		mutate     func(*kimiDoctorState)
@@ -19,6 +20,7 @@ func TestBuildKimiDoctorChecks(t *testing.T) {
 	}{
 		{name: "absent CLI", mutate: func(s *kimiDoctorState) { *s = kimiDoctorState{} }, check: "kimi-cli", status: doctorStatusFail, messageSub: "not installed"},
 		{name: "absent plugin", mutate: func(s *kimiDoctorState) { s.PluginInstalled = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "not installed"},
+		{name: "unknown activation record", mutate: func(s *kimiDoctorState) { s.PluginRecordKnown = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "activation record"},
 		{name: "disabled plugin", mutate: func(s *kimiDoctorState) { s.PluginEnabled = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "not enabled"},
 		{name: "version mismatch", mutate: func(s *kimiDoctorState) { s.PluginVersion = "0.27.0" }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "does not match"},
 		{name: "incomplete hooks", mutate: func(s *kimiDoctorState) { s.NativeHooks = false }, check: "kimi-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
@@ -48,6 +50,15 @@ func TestBuildKimiDoctorChecks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildKimiDoctorChecksHealthyStatePassesEveryCheck(t *testing.T) {
+	state := kimiDoctorState{CLIAvailable: true, HostVersion: "0.27.0", PluginInstalled: true, PluginEnabled: true, PluginRecordKnown: true, PluginVersion: "0.28.0", NativeHooks: true, PluginMCP: true, Skills: 3}
+	for _, check := range buildKimiDoctorChecks(state, "0.28.0") {
+		if check.Status != doctorStatusPass {
+			t.Fatalf("healthy state produced %s %s: %s", check.Name, check.Status, check.Message)
+		}
 	}
 }
 
@@ -122,7 +133,7 @@ func TestProbeKimiDoctorStateReadsManagedPluginAndRecord(t *testing.T) {
 	}
 }
 
-func TestProbeKimiDoctorStateDetectsUserMCPToml(t *testing.T) {
+func TestProbeKimiDoctorStateDetectsUserMCPJSON(t *testing.T) {
 	originalLookPath, originalOutput := kimiDoctorLookPath, kimiDoctorOutput
 	t.Cleanup(func() { kimiDoctorLookPath, kimiDoctorOutput = originalLookPath, originalOutput })
 	kimiDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/kimi", nil }
@@ -144,4 +155,137 @@ func TestProbeKimiDoctorStateDetectsUserMCPToml(t *testing.T) {
 	if state.PluginInstalled {
 		t.Fatal("no managed copy must mean PluginInstalled=false")
 	}
+}
+
+func TestKimiMCPJSONRegistersRejectsInvalidDeclarations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "null server", body: `{"mcpServers": {"traceary": null}}`},
+		{name: "wrong command", body: `{"mcpServers": {"traceary": {"command": "other", "args": ["mcp-server"]}}}`},
+		{name: "missing mcp-server arg", body: `{"mcpServers": {"traceary": {"command": "traceary"}}}`},
+		{name: "invalid JSON", body: `{not json`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kimiHome := t.TempDir()
+			if err := os.WriteFile(filepath.Join(kimiHome, "mcp.json"), []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write mcp.json: %v", err)
+			}
+			if kimiMCPJSONRegisters(kimiHome, "") {
+				t.Fatalf("kimiMCPJSONRegisters() = true for %s, want false", tc.name)
+			}
+		})
+	}
+}
+
+func TestKimiManifestHasVerifiedHooksIsOrderIndependent(t *testing.T) {
+	base := `[
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5}
+  ]`
+
+	t.Run("shuffled order still satisfies the contract", func(t *testing.T) {
+		shuffled := `[
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5}
+  ]`
+		var manifest kimiPluginManifest
+		if err := json.Unmarshal([]byte(`{"hooks":`+shuffled+`}`), &manifest); err != nil {
+			t.Fatalf("decode shuffled manifest: %v", err)
+		}
+		if !kimiManifestHasVerifiedHooks(manifest) {
+			t.Fatal("shuffled manifest must satisfy the verified hook contract")
+		}
+	})
+
+	t.Run("extra hook rule is rejected", func(t *testing.T) {
+		var manifest kimiPluginManifest
+		extra := base[:len(base)-2] + `,
+    {"event": "Notification", "command": "traceary hook kimi notification", "timeout": 5}
+  ]`
+		if err := json.Unmarshal([]byte(`{"hooks":`+extra+`}`), &manifest); err != nil {
+			t.Fatalf("decode manifest with extra rule: %v", err)
+		}
+		if kimiManifestHasVerifiedHooks(manifest) {
+			t.Fatal("manifest with an unverified extra rule must be rejected")
+		}
+	})
+}
+
+func TestProbeKimiDoctorStateSanitizesManifestErrors(t *testing.T) {
+	originalLookPath, originalOutput := kimiDoctorLookPath, kimiDoctorOutput
+	t.Cleanup(func() { kimiDoctorLookPath, kimiDoctorOutput = originalLookPath, originalOutput })
+	kimiDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/kimi", nil }
+	kimiDoctorOutput = func(_ context.Context, _ ...string) ([]byte, error) { return []byte("0.27.0\n"), nil }
+
+	kimiHome := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", kimiHome)
+	manifestDir := filepath.Join(kimiHome, "plugins", "managed", "traceary")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("mkdir manifest dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "kimi.plugin.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt manifest: %v", err)
+	}
+
+	_, err := probeKimiDoctorState(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("corrupt manifest must surface a probe error")
+	}
+	if strings.Contains(err.Error(), kimiHome) || strings.Contains(err.Error(), "/private/") || strings.Contains(err.Error(), "/var/") {
+		t.Fatalf("probe error leaked a path: %v", err)
+	}
+}
+
+func TestKimiPluginRecordEnabledTriState(t *testing.T) {
+	t.Run("missing record is unknown", func(t *testing.T) {
+		enabled, known := kimiPluginRecordEnabled(t.TempDir())
+		if enabled || known {
+			t.Fatalf("missing record = (%v, %v), want (false, false)", enabled, known)
+		}
+	})
+	t.Run("corrupt record is unknown", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(kimiHome, "plugins"), 0o755); err != nil {
+			t.Fatalf("mkdir plugins: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("write corrupt record: %v", err)
+		}
+		enabled, known := kimiPluginRecordEnabled(kimiHome)
+		if enabled || known {
+			t.Fatalf("corrupt record = (%v, %v), want (false, false)", enabled, known)
+		}
+	})
+	t.Run("disabled record is known but not enabled", func(t *testing.T) {
+		kimiHome := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(kimiHome, "plugins"), 0o755); err != nil {
+			t.Fatalf("mkdir plugins: %v", err)
+		}
+		record := `{"plugins": [{"id": "traceary", "enabled": false, "state": "ok"}]}`
+		if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), []byte(record), 0o600); err != nil {
+			t.Fatalf("write record: %v", err)
+		}
+		enabled, known := kimiPluginRecordEnabled(kimiHome)
+		if enabled || !known {
+			t.Fatalf("disabled record = (%v, %v), want (false, true)", enabled, known)
+		}
+	})
 }

--- a/presentation/cli/doctor_kimi_internal_test.go
+++ b/presentation/cli/doctor_kimi_internal_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildKimiDoctorChecks(t *testing.T) {
+	healthy := kimiDoctorState{CLIAvailable: true, HostVersion: "0.27.0", PluginInstalled: true, PluginEnabled: true, PluginVersion: "0.28.0", NativeHooks: true, PluginMCP: true, Skills: 3}
+	tests := []struct {
+		name       string
+		mutate     func(*kimiDoctorState)
+		check      string
+		status     string
+		messageSub string
+	}{
+		{name: "absent CLI", mutate: func(s *kimiDoctorState) { *s = kimiDoctorState{} }, check: "kimi-cli", status: doctorStatusFail, messageSub: "not installed"},
+		{name: "absent plugin", mutate: func(s *kimiDoctorState) { s.PluginInstalled = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "not installed"},
+		{name: "disabled plugin", mutate: func(s *kimiDoctorState) { s.PluginEnabled = false }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "not enabled"},
+		{name: "version mismatch", mutate: func(s *kimiDoctorState) { s.PluginVersion = "0.27.0" }, check: "kimi-plugin", status: doctorStatusWarn, messageSub: "does not match"},
+		{name: "incomplete hooks", mutate: func(s *kimiDoctorState) { s.NativeHooks = false }, check: "kimi-hooks", status: doctorStatusWarn, messageSub: "incomplete"},
+		{name: "missing MCP", mutate: func(s *kimiDoctorState) { s.PluginMCP = false }, check: "kimi-mcp", status: doctorStatusWarn, messageSub: "no traceary MCP server"},
+		{name: "user mcp.json fallback", mutate: func(s *kimiDoctorState) { s.PluginMCP, s.UserMCP = false, true }, check: "kimi-mcp", status: doctorStatusPass, messageSub: "mcp.json"},
+		{name: "missing skills", mutate: func(s *kimiDoctorState) { s.Skills = 2 }, check: "kimi-skills", status: doctorStatusWarn, messageSub: "2"},
+		{name: "healthy", mutate: func(*kimiDoctorState) {}, check: "kimi-plugin", status: doctorStatusPass, messageSub: "enabled"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := healthy
+			tc.mutate(&state)
+			checks := buildKimiDoctorChecks(state, "0.28.0")
+			var found *doctorCheck
+			for i := range checks {
+				if checks[i].Name == tc.check {
+					found = &checks[i]
+					break
+				}
+			}
+			if found == nil || found.Status != tc.status || !strings.Contains(found.Message, tc.messageSub) {
+				t.Fatalf("checks = %+v, want %s %s containing %q", checks, tc.check, tc.status, tc.messageSub)
+			}
+			for _, check := range checks {
+				if strings.Contains(check.Message+check.Hint, "/private/") {
+					t.Fatalf("check exposed private path: %+v", check)
+				}
+			}
+		})
+	}
+}
+
+func TestProbeKimiDoctorStateReadsManagedPluginAndRecord(t *testing.T) {
+	originalLookPath, originalOutput := kimiDoctorLookPath, kimiDoctorOutput
+	t.Cleanup(func() { kimiDoctorLookPath, kimiDoctorOutput = originalLookPath, originalOutput })
+	kimiDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/kimi", nil }
+	kimiDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 1 && args[0] == "--version" {
+			return []byte("0.27.0\n"), nil
+		}
+		return nil, nil
+	}
+
+	kimiHome := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", kimiHome)
+	manifestDir := filepath.Join(kimiHome, "plugins", "managed", "traceary")
+	if err := os.MkdirAll(filepath.Join(manifestDir, "skills", "traceary-memory-remember"), 0o755); err != nil {
+		t.Fatalf("mkdir skills: %v", err)
+	}
+	for _, skill := range []string{"traceary-memory-remember", "traceary-memory-review", "traceary-session-history"} {
+		if err := os.MkdirAll(filepath.Join(manifestDir, "skills", skill), 0o755); err != nil {
+			t.Fatalf("mkdir skill %s: %v", skill, err)
+		}
+		if err := os.WriteFile(filepath.Join(manifestDir, "skills", skill, "SKILL.md"), []byte("# skill\n"), 0o600); err != nil {
+			t.Fatalf("write skill: %v", err)
+		}
+	}
+	manifest := `{
+  "name": "traceary",
+  "version": "0.28.0",
+  "mcpServers": {"traceary": {"command": "traceary", "args": ["mcp-server"]}},
+  "hooks": [
+    {"event": "SessionStart", "command": "traceary hook kimi session-start", "timeout": 5},
+    {"event": "SessionEnd", "command": "traceary hook kimi session-end", "timeout": 5},
+    {"event": "UserPromptSubmit", "command": "traceary hook kimi user-prompt-submit", "timeout": 5},
+    {"event": "PreToolUse", "matcher": "Agent", "command": "traceary hook kimi pre-tool-use", "timeout": 5},
+    {"event": "PostToolUse", "command": "traceary hook kimi post-tool-use", "timeout": 5},
+    {"event": "PostToolUseFailure", "command": "traceary hook kimi post-tool-use-failure", "timeout": 5},
+    {"event": "Stop", "command": "traceary hook kimi stop", "timeout": 5},
+    {"event": "SubagentStop", "command": "traceary hook kimi subagent-stop", "timeout": 5},
+    {"event": "PreCompact", "command": "traceary hook kimi pre-compact", "timeout": 5},
+    {"event": "PostCompact", "command": "traceary hook kimi post-compact", "timeout": 5}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(manifestDir, "kimi.plugin.json"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	record := `{"plugins": [{"id": "traceary", "root": "` + manifestDir + `", "source": "local-path", "enabled": true, "state": "ok", "installedAt": "2026-07-19T00:00:00Z"}]}`
+	if err := os.WriteFile(filepath.Join(kimiHome, "plugins", "installed.json"), []byte(record), 0o600); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	state, err := probeKimiDoctorState(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("probeKimiDoctorState() error = %v", err)
+	}
+	if !state.CLIAvailable || state.HostVersion != "0.27.0" {
+		t.Fatalf("CLI state = %+v", state)
+	}
+	if !state.PluginInstalled || !state.PluginEnabled || state.PluginVersion != "0.28.0" {
+		t.Fatalf("plugin state = %+v", state)
+	}
+	if !state.NativeHooks {
+		t.Fatal("managed manifest must satisfy the verified hook contract")
+	}
+	if !state.PluginMCP {
+		t.Fatal("managed manifest must declare the traceary MCP server")
+	}
+	if state.Skills != 3 {
+		t.Fatalf("skills = %d, want 3", state.Skills)
+	}
+}
+
+func TestProbeKimiDoctorStateDetectsUserMCPToml(t *testing.T) {
+	originalLookPath, originalOutput := kimiDoctorLookPath, kimiDoctorOutput
+	t.Cleanup(func() { kimiDoctorLookPath, kimiDoctorOutput = originalLookPath, originalOutput })
+	kimiDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/kimi", nil }
+	kimiDoctorOutput = func(_ context.Context, _ ...string) ([]byte, error) { return []byte("0.27.0\n"), nil }
+
+	kimiHome := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", kimiHome)
+	if err := os.WriteFile(filepath.Join(kimiHome, "mcp.json"), []byte(`{"mcpServers": {"traceary": {"command": "traceary", "args": ["mcp-server"]}}}`), 0o600); err != nil {
+		t.Fatalf("write mcp.json: %v", err)
+	}
+
+	state, err := probeKimiDoctorState(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("probeKimiDoctorState() error = %v", err)
+	}
+	if !state.UserMCP {
+		t.Fatal("user-level mcp.json registration must be detected")
+	}
+	if state.PluginInstalled {
+		t.Fatal("no managed copy must mean PluginInstalled=false")
+	}
+}

--- a/presentation/cli/doctor_plugin_version.go
+++ b/presentation/cli/doctor_plugin_version.go
@@ -64,6 +64,11 @@ func (c *RootCLI) detectPluginInstalls() []doctorPluginInstall {
 		"grok",
 		"./scripts/install-grok-plugin.sh  # from a matching release tag checkout",
 	)...)
+	installs = append(installs, detectManifestInstalls(
+		filepath.Join(home, ".kimi-code", "plugins", "managed", "traceary", "kimi.plugin.json"),
+		"kimi",
+		"./scripts/install-kimi-plugin.sh  # from a matching release tag checkout",
+	)...)
 	return installs
 }
 


### PR DESCRIPTION
## Summary

Closes #1399 (v0.29.0-6), part of #1393.

Adds doctor diagnostics for the Kimi Code integration. Kimi Code has no CLI inspect command, so state is probed from the filesystem under `$KIMI_CODE_HOME`.

### Checks

| Check | Healthy | Degraded |
|---|---|---|
| `kimi-cli` | `kimi --version` detected | FAIL when CLI absent |
| `kimi-plugin` | managed copy + `installed.json` enabled/ok | WARN absent / disabled / version mismatch with the running binary |
| `kimi-hooks` | managed manifest satisfies the verified 10-rule contract | WARN when coverage drifts |
| `kimi-mcp` | plugin declares `traceary mcp-server` | passes via `~/.kimi-code/mcp.json` / project `.kimi-code/mcp.json` fallback; WARN when neither |
| `kimi-skills` | 3 shared skills present | WARN otherwise |
| `kimi-plugin-version` | managed manifest tracked by release manifests | version drift hint (soft-pass on dev builds) |
| `kimi-event-coverage` | matrix-driven recent-event ratio | same shared semantics as other hosts |

### Notes

- Kimi stays **opt-in**: `--client kimi` (aliases work via the orchestrator); default doctor clients (claude/codex/gemini) are unchanged.
- The kimi branch bypasses `ResolveInstallPath` (fail-closed by design — the plugin is the install path).
- Messages never expose private paths (asserted in tests).

## Verification

- `go test ./...` ✅ / `go tool golangci-lint run` ✅
- Live: `doctor --client kimi` against the real install reports all kimi checks passing (CLI 0.27.0, plugin 0.28.0 enabled, 10 hooks, MCP declared, 3 skills)
