### PR TITLE
docs: add the missing Grok row to the README host table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -226,6 +226,7 @@ $ traceary timeline --limit 2
 | Claude Code | 完全対応 | Bash + MCP + failure hook | あり | あり | Full |
 | Codex | 完全対応（`SessionStart` + `Stop`） | tool hook | あり | なし | Partial |
 | Kimi Code | 完全対応（`SessionStart` + `SessionEnd`） | tool hook + failure hook | あり | marker（summary 本文なし） | Full |
+| Grok Build | 一部対応（`SessionStart`。`SessionEnd` は文書化済みだが未発火） | tool hook（失敗を含む result variant） | あり | marker（summary 本文なし） | Partial |
 | Gemini CLI | 完全対応（`SessionStart` + `SessionEnd`） | tool hook | なし | なし | Basic（レガシー） |
 | Antigravity | 完全対応（`PreInvocation` 開始 / `Stop` turn 境界） | `run_command` hook（`PreToolUse` + `PostToolUse` を突き合わせ） | なし | なし | Partial |
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The query surface is shared: once Traceary is installed, every host can use the 
 | Claude Code | Full | Bash + MCP + failure hooks | Yes | Yes | Full |
 | Codex | Full (`SessionStart` + `Stop`) | Tool hooks | Yes | No | Partial |
 | Kimi Code | Full (`SessionStart` + `SessionEnd`) | Tool hooks + failure hooks | Yes | Markers (no summary body) | Full |
+| Grok Build | Partial (`SessionStart`; `SessionEnd` documented but not emitted) | Tool hooks (result variants incl. failures) | Yes | Markers (no summary body) | Partial |
 | Gemini CLI | Full (`SessionStart` + `SessionEnd`) | Tool hooks | No | No | Basic (legacy) |
 | Antigravity | Full (`PreInvocation` start; `Stop` turn boundary) | `run_command` hooks (`PreToolUse` + `PostToolUse` paired) | No | No | Partial |
 


### PR DESCRIPTION
## Summary

Closes #1409 (v0.29.0-9 follow-up).

The README host comparison table never gained the Grok Build row when the integration shipped in v0.23.0 — found during the Kimi docs work (#1400). Adds the row to both README variants, aligned with the published host-coverage matrix:

- Session lifecycle: Partial (`SessionStart` wired; `SessionEnd` documented but not emitted per the Grok contract)
- Tool audit: hooks with failure result variants
- Prompt: Yes
- Compact: markers (no summary body)
- Tier: Partial

## Verification

- `docs verify-i18n` ✅
- Content matches `application/hostcoverage/matrix.json` (grok row)
