### PR TITLE
docs: document host coverage matrix status semantics

### DIFF
--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -10,7 +10,17 @@
 - `○` ホスト側に hook はあるが Traceary 未配線
 - `✕` ホスト自体が公開していない
 
-**最終確認日: 2026-07-16（Grok Build 0.2.101 の未観測 hook 再 probe + 0.2.99 fixture、Antigravity CLI 1.1.1 と現行公式 hook contract。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
+### ステータスの意味
+
+ステータスはホストの能力ではなく、**Traceary 側の配線状態**を表します。
+
+- **wired** — Traceary のパッケージ統合がこの lifecycle event を今日記録できる。live host contract（payload probe 済み、fixture コミット済み）で検証されたものだけが記録の保証対象です。Verification 列の `traceary list events --kind <event>` で確認できます。
+- **available** — ホストはこのイベントの hook や signal を公開していますが、Traceary は（まだ）配線していません。これは記録の保証では**ありません**。その host では該当イベントが Traceary DB に現れません。例: Grok の `SessionEnd`（文書化済みだが probe では未発火）、v0.29.0 以前の Kimi `PreCompact`/`PostCompact`。
+- **unsupported** — ホストがこのイベントの利用可能な signal を公開していません（例: Codex/Antigravity の session end。代わりに MCP `manage_session` または stale GC で終了します）。
+
+機械可読な [host contract](./host-contract.json) との対応: contract で `supported` / `best_effort`（live fixture あり）に分類されるイベントが **wired** セルの根拠になり、ホストが文書化・発火するが Traceary 未配線のイベントが **available** セルの、`unavailable` のイベントが **unsupported** セルの根拠になります。matrix 本体は `application/hostcoverage/matrix.json` にあり、この表はそこから生成されます — 下の生成ブロックは編集しないでください。
+
+**最終確認日: 2026-07-19（Kimi Code 0.27.0 の live hook probe と統合 (#1393)。Grok Build 0.2.101 の未観測 hook 再 probe + 0.2.99 fixture、Antigravity CLI 1.1.1 と現行公式 hook contract。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
 
 > **v0.21.1 注記:** このマトリクスに掲載されている Gemini CLI の hook カバレッジは**レガシー互換のみ**です。Gemini CLI はレガシーの Google AI エージェントホストであり、後継は Antigravity（`/Applications/Antigravity.app`）です。**v0.21.1 以降、Antigravity はサポート対象の hook client** であり、文書化された公開 hook surface に対する packaged plugin（`integrations/antigravity-plugin/`）を提供します。[Antigravity hooks / plugin ガイド](../integrations/antigravity.ja.md) を参照してください。
 

--- a/docs/hooks/host-coverage.ja.md
+++ b/docs/hooks/host-coverage.ja.md
@@ -14,11 +14,11 @@
 
 ステータスはホストの能力ではなく、**Traceary 側の配線状態**を表します。
 
-- **wired** — Traceary のパッケージ統合がこの lifecycle event を今日記録できる。live host contract（payload probe 済み、fixture コミット済み）で検証されたものだけが記録の保証対象です。Verification 列の `traceary list events --kind <event>` で確認できます。
+- **wired** — Traceary のパッケージ統合がこの lifecycle event を今日記録できます。慣例として wired セルは live 検証済みの host contract（payload probe 済み、fixture コミット済み）に裏付けられますが、matrix 自体が表明するのは配線の有無のみです。その host で Traceary DB に現れることが期待できるのは wired のイベントです。Verification 列の `traceary list events --kind <event>` で確認できます。
 - **available** — ホストはこのイベントの hook や signal を公開していますが、Traceary は（まだ）配線していません。これは記録の保証では**ありません**。その host では該当イベントが Traceary DB に現れません。例: Grok の `SessionEnd`（文書化済みだが probe では未発火）、v0.29.0 以前の Kimi `PreCompact`/`PostCompact`。
 - **unsupported** — ホストがこのイベントの利用可能な signal を公開していません（例: Codex/Antigravity の session end。代わりに MCP `manage_session` または stale GC で終了します）。
 
-機械可読な [host contract](./host-contract.json) との対応: contract で `supported` / `best_effort`（live fixture あり）に分類されるイベントが **wired** セルの根拠になり、ホストが文書化・発火するが Traceary 未配線のイベントが **available** セルの、`unavailable` のイベントが **unsupported** セルの根拠になります。matrix 本体は `application/hostcoverage/matrix.json` にあり、この表はそこから生成されます — 下の生成ブロックは編集しないでください。
+機械可読な [host contract](./host-contract.json) との関係: contract で `supported` / `best_effort`（live fixture あり）に分類されるイベントが **wired** セルの根拠になり、ホスト側に signal はあるが Traceary 未配線のイベント（contract では `unavailable` でもホスト側 signal が存在するもの。例: Grok `SessionEnd`）が **available** セルの、ホスト側に利用可能な signal がないイベントが **unsupported** セルの根拠になります。matrix 本体は `application/hostcoverage/matrix.json` にあり、この表はそこから生成されます — 下の生成ブロックは編集しないでください。
 
 **最終確認日: 2026-07-19（Kimi Code 0.27.0 の live hook probe と統合 (#1393)。Grok Build 0.2.101 の未観測 hook 再 probe + 0.2.99 fixture、Antigravity CLI 1.1.1 と現行公式 hook contract。Gemini CLI は 2026-06-10 に 0.43.0 で再確認済み）。** Traceary 統合パッケージのバンプ、もしくは host CLI のリリースで hook surface が変化したときに更新する。
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -14,11 +14,11 @@ Legend:
 
 The statuses describe **Traceary's wiring state**, not the host's capability:
 
-- **wired** — the packaged Traceary integration captures this lifecycle event today, verified against the live host contract (payload probed and fixtures committed). Wired events are the only capture guarantee; see `traceary list events --kind <event>` in the Verification column.
+- **wired** — the packaged Traceary integration captures this lifecycle event today. By convention, wired cells are backed by a live-verified host contract (payload probed, fixtures committed), though the matrix itself only asserts the wiring. Wired events are the ones you can expect in the Traceary DB for that host; see `traceary list events --kind <event>` in the Verification column.
 - **available** — the host exposes a hook or signal for this event, but Traceary does not wire it (yet). This is **not** a capture claim: the event will not appear in the Traceary DB for that host. Examples: Grok `SessionEnd` (documented but not emitted in probes), Kimi `PreCompact`/`PostCompact` before v0.29.0.
 - **unsupported** — the host does not expose a usable signal for this event (e.g. Codex/Antigravity session end; they end via MCP `manage_session` or stale GC instead).
 
-Mapping to the machine-readable [host contract](./host-contract.json): contract events classified `supported` / `best_effort` with live fixtures back the **wired** cells; events the host documents or emits without Traceary wiring back the **available** cells; `unavailable` events back the **unsupported** cells. The matrix itself lives in `application/hostcoverage/matrix.json` and this table is generated from it — do not edit the generated block below.
+Relationship to the machine-readable [host contract](./host-contract.json): contract events classified `supported` / `best_effort` with live fixtures back the **wired** cells; events the host documents or emits but Traceary does not wire (contract `unavailable` with a host-side signal, e.g. Grok `SessionEnd`) back the **available** cells; events with no usable host signal back the **unsupported** cells. The matrix itself lives in `application/hostcoverage/matrix.json` and this table is generated from it — do not edit the generated block below.
 
 **Last verified: 2026-07-19 (Kimi Code 0.27.0 live hook probe and integration (#1393); Grok Build 0.2.101 re-probe for unobserved hooks + 0.2.99 fixtures; Antigravity CLI 1.1.1 and the current official hook contract; Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
 

--- a/docs/hooks/host-coverage.md
+++ b/docs/hooks/host-coverage.md
@@ -10,7 +10,17 @@ Legend:
 - `○` available in the host but not wired by Traceary yet
 - `✕` not exposed by this host
 
-**Last verified: 2026-07-16 (Grok Build 0.2.101 re-probe for unobserved hooks + 0.2.99 fixtures; Antigravity CLI 1.1.1 and the current official hook contract; Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
+### Status semantics
+
+The statuses describe **Traceary's wiring state**, not the host's capability:
+
+- **wired** — the packaged Traceary integration captures this lifecycle event today, verified against the live host contract (payload probed and fixtures committed). Wired events are the only capture guarantee; see `traceary list events --kind <event>` in the Verification column.
+- **available** — the host exposes a hook or signal for this event, but Traceary does not wire it (yet). This is **not** a capture claim: the event will not appear in the Traceary DB for that host. Examples: Grok `SessionEnd` (documented but not emitted in probes), Kimi `PreCompact`/`PostCompact` before v0.29.0.
+- **unsupported** — the host does not expose a usable signal for this event (e.g. Codex/Antigravity session end; they end via MCP `manage_session` or stale GC instead).
+
+Mapping to the machine-readable [host contract](./host-contract.json): contract events classified `supported` / `best_effort` with live fixtures back the **wired** cells; events the host documents or emits without Traceary wiring back the **available** cells; `unavailable` events back the **unsupported** cells. The matrix itself lives in `application/hostcoverage/matrix.json` and this table is generated from it — do not edit the generated block below.
+
+**Last verified: 2026-07-19 (Kimi Code 0.27.0 live hook probe and integration (#1393); Grok Build 0.2.101 re-probe for unobserved hooks + 0.2.99 fixtures; Antigravity CLI 1.1.1 and the current official hook contract; Gemini CLI re-verified 2026-06-10 against 0.43.0).** Refresh this page when bumping Traceary integration packages or when a host CLI release changes its hook surface.
 
 > **v0.21.1 note:** Gemini CLI hook coverage in this matrix is **legacy compatibility only**. Gemini CLI is the legacy Google AI agent host; Antigravity (`/Applications/Antigravity.app`) is the active successor. As of **v0.21.1, Antigravity is a supported hook client** with a packaged plugin against the documented public hook surface (`integrations/antigravity-plugin/`). See the [Antigravity hooks and plugin guide](../integrations/antigravity.md).
 


### PR DESCRIPTION
## Summary

Closes #1410 (v0.29.0-10 follow-up).

Raised by a reviewer on #1402: readers (and future tooling) could misread `available` as "Traceary can capture this". The matrix statuses now have explicit semantics documented in both host-coverage variants:

- **wired** — captured today, verified against the live host contract (the only capture guarantee)
- **available** — the host exposes the hook, Traceary does not wire it (explicitly **not** a capture claim; examples: Grok `SessionEnd`, pre-v0.29.0 Kimi compact)
- **unsupported** — no usable host signal (Codex/Antigravity session end)

Also maps the statuses to the host-contract vocabulary (supported/best_effort ↔ wired; unwired-but-exposed ↔ available; unavailable ↔ unsupported) and refreshes the stale `Last verified` header (2026-07-16 → 2026-07-19, now including the Kimi integration).

## Verification

- `docs verify-i18n` ✅ / `docs verify-host-coverage` ✅
