### PR TITLE
fix: unify the Claude session-history skill with the shared text

### DIFF
--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -207,10 +207,6 @@ func checkRememberSkillContract(root string) error {
 // sharedSkillPaths groups the packaged copies of each shared skill across
 // hosts. Copies of a skill must stay byte-identical so a single host cannot
 // drift; the first path in each group is the reference document.
-//
-// The Claude copy of traceary-session-history intentionally uses older,
-// Claude-specific wording and is excluded from that skill's parity group;
-// all other hosts share one text.
 var sharedSkillPaths = map[string][]string{
 	"traceary-memory-review": {
 		"integrations/claude-plugin/skills/traceary-memory-review/SKILL.md",
@@ -221,10 +217,11 @@ var sharedSkillPaths = map[string][]string{
 		"integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md",
 	},
 	"traceary-session-history": {
-		"integrations/grok-plugin/skills/traceary-session-history/SKILL.md",
+		"integrations/claude-plugin/skills/traceary-session-history/SKILL.md",
 		"plugins/traceary/skills/traceary-session-history/SKILL.md",
 		"integrations/gemini-extension/skills/traceary-session-history/SKILL.md",
 		"integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md",
+		"integrations/grok-plugin/skills/traceary-session-history/SKILL.md",
 		"integrations/kimi-plugin/skills/traceary-session-history/SKILL.md",
 	},
 }

--- a/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
@@ -11,13 +11,13 @@ Use the packaged `traceary` MCP server as the default read path when the user as
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
-- `session_status(action="active")`: only when the user is asking about the still-open session
-- `list_events`: recent history without a keyword filter
+- `session_status(action="active")`: only when the question is specifically about an open session
+- `list_events`: quick recent history without a keyword query
 - `search`: keyword-driven lookups
 - `get_context`: summarize the lead-up around an event
 
 ## Guardrails
 
-- Prefer the read tools above before suggesting direct SQLite inspection.
-- Do not call `record_event(type="log")` or `record_event(type="audit")` unless the user explicitly wants to record a new event.
-- Hooks already capture session boundaries and shell command audits, so avoid duplicating those writes manually.
+- Prefer MCP reads before direct SQLite inspection.
+- Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
+- Automatic hooks already cover session boundaries and shell command audits.


### PR DESCRIPTION
## Summary

Closes #1412 (v0.29.0-12 follow-up).

The new shared-skill parity check (#1406) found `integrations/claude-plugin/skills/traceary-session-history/SKILL.md` using older wording while codex/gemini/antigravity/grok/kimi share one text. The differences are phrasing-only — the guidance (prefer read tools, don't manually record hook-covered events) is identical:

```diff
- `session_status(action="active")`: only when the user is asking about the still-open session
+ `session_status(action="active")`: only when the question is specifically about an open session
```

This is drift, not intentional host customization, so the Claude copy is aligned with the shared text and re-included in the parity group — all six host packages are now byte-identical for both `traceary-session-history` and `traceary-memory-review` under `checkSharedSkillParity`.

## Verification

- `integrations verify` ✅ (parity group now includes the Claude copy)
- `go test ./...` ✅ / `go tool golangci-lint run` ✅
