### PR TITLE
v0.30.0-1b: add metadata-only SQLite event queries

### DIFF
--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -27,3 +27,20 @@ type EventQueryService interface {
 	// ListTimelineBlocks returns work blocks separated by idle gaps.
 	ListTimelineBlocks(ctx context.Context, workspace types.Workspace, from, to time.Time, gapSeconds, limit int) ([]apptypes.TimelineBlock, error)
 }
+
+// EventMetadataQueryService provides body-free event inspection operations.
+// It is separate from EventQueryService so consumers cannot accidentally
+// request a partial domain Event through an include-body flag.
+type EventMetadataQueryService interface {
+	// ListRecentMetadata returns body-free events in descending time order.
+	ListRecentMetadata(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error)
+	// ListWindowMetadata returns every matching body-free event under one
+	// read snapshot. criteria.Limit() controls the internal page size.
+	ListWindowMetadata(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error)
+	// SearchMetadata searches event and command content in SQLite but returns
+	// only body-free event metadata to the caller.
+	SearchMetadata(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]apptypes.EventMetadata, error)
+	// GetContextMetadata returns body-free context membership in descending
+	// time order.
+	GetContextMetadata(ctx context.Context, criteria apptypes.EventContextCriteria) ([]apptypes.EventMetadata, error)
+}

--- a/application/types/event_metadata.go
+++ b/application/types/event_metadata.go
@@ -1,0 +1,155 @@
+package types
+
+import (
+	"time"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// EventBodyExtent describes persisted event-body size and truncation facts.
+// Unknown facts remain absent instead of being represented as zero or false.
+type EventBodyExtent struct {
+	originalBytes       domtypes.Optional[int]
+	storedBytes         int
+	ingestTruncated     domtypes.Optional[bool]
+	storageTruncated    domtypes.Optional[bool]
+	bodyMetadataVersion domtypes.Optional[int]
+}
+
+// EventBodyExtentOf creates persisted event-body extent metadata.
+func EventBodyExtentOf(
+	originalBytes domtypes.Optional[int],
+	storedBytes int,
+	ingestTruncated domtypes.Optional[bool],
+	storageTruncated domtypes.Optional[bool],
+	bodyMetadataVersion domtypes.Optional[int],
+) (EventBodyExtent, error) {
+	if storedBytes < 0 {
+		return EventBodyExtent{}, xerrors.Errorf("stored body bytes must be greater than or equal to 0")
+	}
+	if value, ok := originalBytes.Value(); ok && value < 0 {
+		return EventBodyExtent{}, xerrors.Errorf("original body bytes must be greater than or equal to 0")
+	}
+	if value, ok := bodyMetadataVersion.Value(); ok && value < 0 {
+		return EventBodyExtent{}, xerrors.Errorf("body metadata version must be greater than or equal to 0")
+	}
+	return EventBodyExtent{
+		originalBytes:       originalBytes,
+		storedBytes:         storedBytes,
+		ingestTruncated:     ingestTruncated,
+		storageTruncated:    storageTruncated,
+		bodyMetadataVersion: bodyMetadataVersion,
+	}, nil
+}
+
+// OriginalBytes returns the original payload size when the ingest path knew it.
+func (e EventBodyExtent) OriginalBytes() domtypes.Optional[int] { return e.originalBytes }
+
+// StoredBytes returns the persisted UTF-8 byte count.
+func (e EventBodyExtent) StoredBytes() int { return e.storedBytes }
+
+// IngestTruncated reports known ingestion truncation.
+func (e EventBodyExtent) IngestTruncated() domtypes.Optional[bool] { return e.ingestTruncated }
+
+// StorageTruncated reports known storage-policy truncation.
+func (e EventBodyExtent) StorageTruncated() domtypes.Optional[bool] { return e.storageTruncated }
+
+// BodyMetadataVersion returns the internal extraction version when known.
+func (e EventBodyExtent) BodyMetadataVersion() domtypes.Optional[int] {
+	return e.bodyMetadataVersion
+}
+
+// CommandAuditMetadata contains body-free command outcome facts.
+type CommandAuditMetadata struct {
+	exitCode domtypes.Optional[int]
+	failed   bool
+}
+
+// CommandAuditMetadataOf creates command outcome metadata.
+func CommandAuditMetadataOf(exitCode domtypes.Optional[int], failed bool) CommandAuditMetadata {
+	return CommandAuditMetadata{exitCode: exitCode, failed: failed}
+}
+
+// ExitCode returns the recorded command exit code when present.
+func (m CommandAuditMetadata) ExitCode() domtypes.Optional[int] { return m.exitCode }
+
+// Failed reports a structural or recorded command failure.
+func (m CommandAuditMetadata) Failed() bool { return m.failed }
+
+// EventMetadata is a body-free read model for event inspection surfaces.
+type EventMetadata struct {
+	eventID      domtypes.EventID
+	kind         domtypes.EventKind
+	client       domtypes.Client
+	agent        domtypes.Agent
+	sessionID    domtypes.SessionID
+	workspace    domtypes.Workspace
+	sourceHook   string
+	createdAt    time.Time
+	bodyExtent   EventBodyExtent
+	commandAudit domtypes.Optional[CommandAuditMetadata]
+}
+
+// EventMetadataOf creates a body-free event read model.
+func EventMetadataOf(
+	eventID domtypes.EventID,
+	kind domtypes.EventKind,
+	client domtypes.Client,
+	agent domtypes.Agent,
+	sessionID domtypes.SessionID,
+	workspace domtypes.Workspace,
+	sourceHook string,
+	createdAt time.Time,
+	bodyExtent EventBodyExtent,
+	commandAudit domtypes.Optional[CommandAuditMetadata],
+) (EventMetadata, error) {
+	if createdAt.IsZero() {
+		return EventMetadata{}, xerrors.Errorf("created at must not be zero")
+	}
+	return EventMetadata{
+		eventID:      eventID,
+		kind:         kind,
+		client:       client,
+		agent:        agent,
+		sessionID:    sessionID,
+		workspace:    workspace,
+		sourceHook:   sourceHook,
+		createdAt:    createdAt,
+		bodyExtent:   bodyExtent,
+		commandAudit: commandAudit,
+	}, nil
+}
+
+// EventID returns the event identity.
+func (m EventMetadata) EventID() domtypes.EventID { return m.eventID }
+
+// Kind returns the event kind.
+func (m EventMetadata) Kind() domtypes.EventKind { return m.kind }
+
+// Client returns the event client.
+func (m EventMetadata) Client() domtypes.Client { return m.client }
+
+// Agent returns the event agent.
+func (m EventMetadata) Agent() domtypes.Agent { return m.agent }
+
+// SessionID returns the session identity.
+func (m EventMetadata) SessionID() domtypes.SessionID { return m.sessionID }
+
+// Workspace returns the event workspace.
+func (m EventMetadata) Workspace() domtypes.Workspace { return m.workspace }
+
+// SourceHook returns the source hook attribution.
+func (m EventMetadata) SourceHook() string { return m.sourceHook }
+
+// CreatedAt returns the event timestamp.
+func (m EventMetadata) CreatedAt() time.Time { return m.createdAt }
+
+// BodyExtent returns persisted body size and truncation facts.
+func (m EventMetadata) BodyExtent() EventBodyExtent { return m.bodyExtent }
+
+// CommandAudit returns body-free command outcome metadata when linked.
+func (m EventMetadata) CommandAudit() domtypes.Optional[CommandAuditMetadata] {
+	return m.commandAudit
+}

--- a/application/types/event_metadata_test.go
+++ b/application/types/event_metadata_test.go
@@ -1,0 +1,80 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestEventBodyExtentOf_RejectsInvalidStoredBytes(t *testing.T) {
+	t.Parallel()
+
+	if _, err := apptypes.EventBodyExtentOf(
+		domtypes.None[int](),
+		-1,
+		domtypes.None[bool](),
+		domtypes.None[bool](),
+		domtypes.None[int](),
+	); err == nil {
+		t.Fatal("EventBodyExtentOf() error = nil, want invalid stored byte count")
+	}
+}
+
+func TestEventMetadataOf_PreservesUnknownBodyFacts(t *testing.T) {
+	t.Parallel()
+
+	eventID, err := domtypes.EventIDFrom("event-1")
+	if err != nil {
+		t.Fatalf("EventIDFrom() error = %v", err)
+	}
+	agent, err := domtypes.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	sessionID, err := domtypes.SessionIDFrom("session-1")
+	if err != nil {
+		t.Fatalf("SessionIDFrom() error = %v", err)
+	}
+	extent, err := apptypes.EventBodyExtentOf(
+		domtypes.None[int](),
+		42,
+		domtypes.None[bool](),
+		domtypes.None[bool](),
+		domtypes.None[int](),
+	)
+	if err != nil {
+		t.Fatalf("EventBodyExtentOf() error = %v", err)
+	}
+
+	createdAt := time.Date(2026, 7, 22, 1, 2, 3, 0, time.UTC)
+	metadata, err := apptypes.EventMetadataOf(
+		eventID,
+		domtypes.EventKindNote,
+		domtypes.Client("cli"),
+		agent,
+		sessionID,
+		domtypes.Workspace("duck8823/traceary"),
+		"manual",
+		createdAt,
+		extent,
+		domtypes.None[apptypes.CommandAuditMetadata](),
+	)
+	if err != nil {
+		t.Fatalf("EventMetadataOf() error = %v", err)
+	}
+
+	if metadata.EventID() != eventID || metadata.CreatedAt() != createdAt {
+		t.Fatalf("metadata identity = %s/%s, want %s/%s", metadata.EventID(), metadata.CreatedAt(), eventID, createdAt)
+	}
+	if _, ok := metadata.BodyExtent().OriginalBytes().Value(); ok {
+		t.Fatal("OriginalBytes() unexpectedly present")
+	}
+	if got := metadata.BodyExtent().StoredBytes(); got != 42 {
+		t.Fatalf("StoredBytes() = %d, want 42", got)
+	}
+	if _, ok := metadata.CommandAudit().Value(); ok {
+		t.Fatal("CommandAudit() unexpectedly present")
+	}
+}

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -193,8 +193,6 @@ func (d *EventDatasource) GetContextMetadata(
 
 	workspace := strings.TrimSpace(criteria.Workspace().String())
 	sessionID := strings.TrimSpace(criteria.SessionID().String())
-	client := strings.TrimSpace(criteria.Client().String())
-	agent := strings.TrimSpace(criteria.Agent().String())
 	rows, err := db.QueryContext(
 		ctx,
 		getContextEventMetadataQuery,
@@ -202,10 +200,6 @@ func (d *EventDatasource) GetContextMetadata(
 		workspace,
 		sessionID,
 		sessionID,
-		client,
-		client,
-		agent,
-		agent,
 		criteria.Limit(),
 	)
 	if err != nil {

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -1,0 +1,525 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+//go:embed sql/select_recent_event_metadata.sql
+var selectRecentEventMetadataQuery string
+
+//go:embed sql/select_recent_event_metadata_by_source_hook.sql
+var selectRecentEventMetadataBySourceHookQuery string
+
+//go:embed sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
+var selectRecentEventMetadataBySourceHookWithLegacyQuery string
+
+//go:embed sql/search_event_metadata.sql
+var searchEventMetadataQuery string
+
+//go:embed sql/get_context_event_metadata.sql
+var getContextEventMetadataQuery string
+
+var _ queryservice.EventMetadataQueryService = (*EventDatasource)(nil)
+
+// ListRecentMetadata returns body-free event metadata in descending time order.
+func (d *EventDatasource) ListRecentMetadata(
+	ctx context.Context,
+	criteria apptypes.EventListCriteria,
+) ([]apptypes.EventMetadata, error) {
+	if err := validateMetadataListCriteria(criteria, false); err != nil {
+		return nil, err
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event metadata listing: %w", err)
+	}
+	defer closeMetadataResource(db)
+
+	rows, err := queryRecentEventMetadata(
+		ctx,
+		db,
+		criteria,
+		formatOptionalTimestamp(criteria.From()),
+		formatOptionalTimestamp(criteria.To()),
+		criteria.Limit(),
+		criteria.Offset(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query recent event metadata: %w", err)
+	}
+	return collectEventMetadata(rows, criteria.Limit(), "recent event metadata")
+}
+
+// ListWindowMetadata returns all matching body-free events under one read snapshot.
+func (d *EventDatasource) ListWindowMetadata(
+	ctx context.Context,
+	criteria apptypes.EventListCriteria,
+) ([]apptypes.EventMetadata, error) {
+	if err := validateMetadataListCriteria(criteria, true); err != nil {
+		return nil, err
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event metadata window: %w", err)
+	}
+	defer closeMetadataResource(db)
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to begin event metadata window transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback event metadata transaction", "error", err)
+		}
+	}()
+
+	batch := criteria.Limit()
+	metadata := make([]apptypes.EventMetadata, 0, batch)
+	offset := 0
+	for {
+		rows, err := queryRecentEventMetadataTx(
+			ctx,
+			tx,
+			criteria,
+			formatOptionalTimestamp(criteria.From()),
+			formatOptionalTimestamp(criteria.To()),
+			batch,
+			offset,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to query event metadata window page: %w", err)
+		}
+
+		page, err := collectEventMetadata(rows, batch, "event metadata window")
+		if err != nil {
+			return nil, err
+		}
+		metadata = append(metadata, page...)
+		if d.onListWindowBatch != nil {
+			d.onListWindowBatch(offset/batch, len(page))
+		}
+		if len(page) < batch {
+			break
+		}
+		offset += len(page)
+	}
+	return metadata, nil
+}
+
+// SearchMetadata searches content in SQLite while returning only body-free rows.
+func (d *EventDatasource) SearchMetadata(
+	ctx context.Context,
+	criteria apptypes.EventSearchCriteria,
+) ([]apptypes.EventMetadata, error) {
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event metadata search: %w", err)
+	}
+	defer closeMetadataResource(db)
+
+	queryValue := strings.TrimSpace(criteria.Query())
+	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
+	rows, err := db.QueryContext(
+		ctx,
+		searchEventMetadataQuery,
+		queryValue,
+		likeQuery,
+		likeQuery,
+		likeQuery,
+		likeQuery,
+		criteria.Workspace().String(),
+		criteria.Workspace().String(),
+		criteria.SessionID().String(),
+		criteria.SessionID().String(),
+		criteria.Client().String(),
+		criteria.Client().String(),
+		criteria.Agent().String(),
+		criteria.Agent().String(),
+		criteria.Kind().String(),
+		criteria.Kind().String(),
+		formatOptionalTimestamp(criteria.From()),
+		formatOptionalTimestamp(criteria.From()),
+		formatOptionalTimestamp(criteria.To()),
+		formatOptionalTimestamp(criteria.To()),
+		boolToInt(criteria.FailuresOnly()),
+		criteria.Limit(),
+		criteria.Offset(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query event metadata search: %w", err)
+	}
+	return collectEventMetadata(rows, criteria.Limit(), "event metadata search")
+}
+
+// GetContextMetadata returns body-free context membership in descending time order.
+func (d *EventDatasource) GetContextMetadata(
+	ctx context.Context,
+	criteria apptypes.EventContextCriteria,
+) ([]apptypes.EventMetadata, error) {
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event metadata context: %w", err)
+	}
+	defer closeMetadataResource(db)
+
+	workspace := strings.TrimSpace(criteria.Workspace().String())
+	sessionID := strings.TrimSpace(criteria.SessionID().String())
+	client := strings.TrimSpace(criteria.Client().String())
+	agent := strings.TrimSpace(criteria.Agent().String())
+	rows, err := db.QueryContext(
+		ctx,
+		getContextEventMetadataQuery,
+		workspace,
+		workspace,
+		sessionID,
+		sessionID,
+		client,
+		client,
+		agent,
+		agent,
+		criteria.Limit(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query event metadata context: %w", err)
+	}
+	return collectEventMetadata(rows, criteria.Limit(), "event metadata context")
+}
+
+func validateMetadataListCriteria(criteria apptypes.EventListCriteria, requireZeroOffset bool) error {
+	if criteria.Limit() <= 0 {
+		return xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if requireZeroOffset && criteria.Offset() != 0 {
+		return xerrors.Errorf("offset must be zero for ListWindowMetadata (paging is handled internally)")
+	}
+	if !requireZeroOffset && criteria.Offset() < 0 {
+		return xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return xerrors.Errorf("from must be earlier than to")
+	}
+	return nil
+}
+
+func formatOptionalTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return formatTimestamp(value)
+}
+
+func closeMetadataResource(db *sql.DB) {
+	if err := db.Close(); err != nil {
+		slog.Debug("failed to close event metadata resource", "error", err)
+	}
+}
+
+func collectEventMetadata(
+	rows *sql.Rows,
+	capacity int,
+	operation string,
+) ([]apptypes.EventMetadata, error) {
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close event metadata rows", "error", err)
+		}
+	}()
+
+	metadata := make([]apptypes.EventMetadata, 0, capacity)
+	for rows.Next() {
+		row, err := scanEventMetadata(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore %s row: %w", operation, err)
+		}
+		metadata = append(metadata, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate %s rows: %w", operation, err)
+	}
+	return metadata, nil
+}
+
+func scanEventMetadata(rowScanner interface{ Scan(dest ...any) error }) (apptypes.EventMetadata, error) {
+	var (
+		eventIDValue          string
+		eventKindValue        string
+		clientValue           string
+		agentValue            string
+		sessionIDValue        string
+		workspaceValue        string
+		sourceHookValue       sql.NullString
+		createdAtValue        string
+		originalBytesValue    sql.NullInt64
+		storedBytesValue      sql.NullInt64
+		ingestTruncatedValue  sql.NullBool
+		storageTruncatedValue sql.NullBool
+		metadataVersionValue  sql.NullInt64
+		auditEventIDValue     sql.NullString
+		exitCodeValue         sql.NullInt64
+		failedValue           sql.NullBool
+	)
+	if err := rowScanner.Scan(
+		&eventIDValue,
+		&eventKindValue,
+		&clientValue,
+		&agentValue,
+		&sessionIDValue,
+		&workspaceValue,
+		&sourceHookValue,
+		&createdAtValue,
+		&originalBytesValue,
+		&storedBytesValue,
+		&ingestTruncatedValue,
+		&storageTruncatedValue,
+		&metadataVersionValue,
+		&auditEventIDValue,
+		&exitCodeValue,
+		&failedValue,
+	); err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to scan event metadata row: %w", err)
+	}
+
+	eventID, err := types.EventIDFrom(eventIDValue)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore metadata event ID: %w", err)
+	}
+	eventKind, err := types.EventKindFrom(eventKindValue)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore metadata event kind: %w", err)
+	}
+	agent, err := types.AgentFrom(agentValue)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore metadata agent: %w", err)
+	}
+	sessionID, err := types.SessionIDFrom(sessionIDValue)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore metadata session ID: %w", err)
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore metadata created_at: %w", err)
+	}
+	if !storedBytesValue.Valid {
+		return apptypes.EventMetadata{}, xerrors.Errorf("stored body bytes are missing for event %s", eventID)
+	}
+	storedBytes, err := checkedInt(storedBytesValue.Int64, "stored body bytes")
+	if err != nil {
+		return apptypes.EventMetadata{}, err
+	}
+
+	originalBytes, err := optionalInt(originalBytesValue, "original body bytes")
+	if err != nil {
+		return apptypes.EventMetadata{}, err
+	}
+	metadataVersion, err := optionalInt(metadataVersionValue, "body metadata version")
+	if err != nil {
+		return apptypes.EventMetadata{}, err
+	}
+	bodyExtent, err := apptypes.EventBodyExtentOf(
+		originalBytes,
+		storedBytes,
+		optionalBool(ingestTruncatedValue),
+		optionalBool(storageTruncatedValue),
+		metadataVersion,
+	)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to restore event body extent: %w", err)
+	}
+
+	commandAudit := types.None[apptypes.CommandAuditMetadata]()
+	if auditEventIDValue.Valid {
+		if !failedValue.Valid {
+			return apptypes.EventMetadata{}, xerrors.Errorf("failed flag is missing for command audit %s", auditEventIDValue.String)
+		}
+		exitCode, err := optionalInt(exitCodeValue, "command exit code")
+		if err != nil {
+			return apptypes.EventMetadata{}, err
+		}
+		commandAudit = types.Some(apptypes.CommandAuditMetadataOf(exitCode, failedValue.Bool))
+	}
+
+	metadata, err := apptypes.EventMetadataOf(
+		eventID,
+		eventKind,
+		types.Client(clientValue),
+		agent,
+		sessionID,
+		types.Workspace(workspaceValue),
+		sourceHookValue.String,
+		createdAt,
+		bodyExtent,
+		commandAudit,
+	)
+	if err != nil {
+		return apptypes.EventMetadata{}, xerrors.Errorf("failed to build event metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+func optionalInt(value sql.NullInt64, field string) (types.Optional[int], error) {
+	if !value.Valid {
+		return types.None[int](), nil
+	}
+	converted, err := checkedInt(value.Int64, field)
+	if err != nil {
+		return types.None[int](), err
+	}
+	return types.Some(converted), nil
+}
+
+func optionalBool(value sql.NullBool) types.Optional[bool] {
+	if !value.Valid {
+		return types.None[bool]()
+	}
+	return types.Some(value.Bool)
+}
+
+func checkedInt(value int64, field string) (int, error) {
+	converted := int(value)
+	if int64(converted) != value {
+		return 0, xerrors.Errorf("%s exceeds platform integer range", field)
+	}
+	return converted, nil
+}
+
+func queryRecentEventMetadata(
+	ctx context.Context,
+	db *sql.DB,
+	criteria apptypes.EventListCriteria,
+	fromValue, toValue string,
+	limit, offset int,
+) (*sql.Rows, error) {
+	return queryRecentEventMetadataWith(
+		ctx,
+		db.QueryContext,
+		criteria,
+		fromValue,
+		toValue,
+		limit,
+		offset,
+	)
+}
+
+func queryRecentEventMetadataTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	criteria apptypes.EventListCriteria,
+	fromValue, toValue string,
+	limit, offset int,
+) (*sql.Rows, error) {
+	return queryRecentEventMetadataWith(
+		ctx,
+		tx.QueryContext,
+		criteria,
+		fromValue,
+		toValue,
+		limit,
+		offset,
+	)
+}
+
+type metadataQueryContext func(context.Context, string, ...any) (*sql.Rows, error)
+
+func queryRecentEventMetadataWith(
+	ctx context.Context,
+	query metadataQueryContext,
+	criteria apptypes.EventListCriteria,
+	fromValue, toValue string,
+	limit, offset int,
+) (*sql.Rows, error) {
+	sourceHook := criteria.SourceHook()
+	failuresFlag := boolToInt(criteria.FailuresOnly())
+	if sourceHook == "" {
+		rows, err := query(
+			ctx,
+			selectRecentEventMetadataQuery,
+			criteria.Kind().String(), criteria.Kind().String(),
+			criteria.Client().String(), criteria.Client().String(),
+			criteria.Agent().String(), criteria.Agent().String(),
+			criteria.SessionID().String(), criteria.SessionID().String(),
+			criteria.Workspace().String(), criteria.Workspace().String(),
+			failuresFlag,
+			fromValue, fromValue,
+			toValue, toValue,
+			limit,
+			offset,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("query recent event metadata: %w", err)
+		}
+		return rows, nil
+	}
+	if sourceHookHasLegacyPrefix(sourceHook) {
+		rows, err := query(
+			ctx,
+			selectRecentEventMetadataBySourceHookWithLegacyQuery,
+			sourceHookLegacyQueryArgs(
+				sourceHook,
+				criteria.Kind(),
+				criteria.Client(),
+				criteria.Agent(),
+				criteria.SessionID(),
+				criteria.Workspace(),
+				failuresFlag,
+				fromValue,
+				toValue,
+				limit,
+				offset,
+			)...,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("query recent event metadata by source hook with legacy: %w", err)
+		}
+		return rows, nil
+	}
+	rows, err := query(
+		ctx,
+		selectRecentEventMetadataBySourceHookQuery,
+		sourceHookPrimaryQueryArgs(
+			sourceHook,
+			criteria.Kind(),
+			criteria.Client(),
+			criteria.Agent(),
+			criteria.SessionID(),
+			criteria.Workspace(),
+			failuresFlag,
+			fromValue,
+			toValue,
+			limit,
+			offset,
+		)...,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("query recent event metadata by source hook: %w", err)
+	}
+	return rows, nil
+}

--- a/infrastructure/sqlite/event_metadata_query_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_query_internal_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var metadataSelectListPattern = regexp.MustCompile(`(?is)\bselect\b(.*?)\bfrom\b`)
+
+func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
+	t.Parallel()
+
+	queries := map[string]string{
+		"recent":             selectRecentEventMetadataQuery,
+		"recent source hook": selectRecentEventMetadataBySourceHookQuery,
+		"recent legacy hook": selectRecentEventMetadataBySourceHookWithLegacyQuery,
+		"search":             searchEventMetadataQuery,
+		"context":            getContextEventMetadataQuery,
+	}
+	for name, query := range queries {
+		name, query := name, query
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			selectLists := metadataSelectListPattern.FindAllStringSubmatch(strings.ToLower(query), -1)
+			if len(selectLists) == 0 {
+				t.Fatalf("query has no FROM clause: %s", query)
+			}
+			for _, match := range selectLists {
+				selectList := match[1]
+				for _, forbidden := range []string{"e.body,", "e.body ", "body_blocks", "command_text", "input_text", "output_text"} {
+					if strings.Contains(selectList, forbidden) {
+						t.Fatalf("SELECT list contains body-bearing column %q: %s", forbidden, selectList)
+					}
+				}
+			}
+		})
+	}
+}

--- a/infrastructure/sqlite/event_metadata_query_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_query_internal_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 var metadataSelectListPattern = regexp.MustCompile(`(?is)\bselect\b(.*?)\bfrom\b`)
+var bodyBearingColumnPattern = regexp.MustCompile(`(?i)\b(?:e\.)?body\b|\bbody_blocks\b|\bcommand_text\b|\binput_text\b|\boutput_text\b`)
 
 func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
 	t.Parallel()
@@ -28,10 +29,8 @@ func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
 			}
 			for _, match := range selectLists {
 				selectList := match[1]
-				for _, forbidden := range []string{"e.body,", "e.body ", "body_blocks", "command_text", "input_text", "output_text"} {
-					if strings.Contains(selectList, forbidden) {
-						t.Fatalf("SELECT list contains body-bearing column %q: %s", forbidden, selectList)
-					}
+				if forbidden := bodyBearingColumnPattern.FindString(selectList); forbidden != "" {
+					t.Fatalf("SELECT list contains body-bearing column %q: %s", forbidden, selectList)
 				}
 			}
 		})

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -1,0 +1,380 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestEventMetadataQuery_ListRecentDoesNotHydrateBody(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	small := newEventForSQLiteTest(t, "event-small", "cli", "codex", "session-1", "duck8823/traceary", "x", base)
+	largeBody := strings.Repeat("large-payload-", 256*1024)
+	large := newEventForSQLiteTest(t, "event-large", "cli", "codex", "session-1", "duck8823/traceary", largeBody, base.Add(time.Second))
+	for _, event := range []*model.Event{small, large} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(10).Build()
+	got, err := sut.ListRecentMetadata(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListRecentMetadata() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(metadata) = %d, want 2", len(got))
+	}
+	if diff := cmp.Diff([]string{"event-large", "event-small"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("event order mismatch (-want +got):\n%s", diff)
+	}
+	if got[0].BodyExtent().StoredBytes() != len(largeBody) {
+		t.Fatalf("large StoredBytes() = %d, want %d", got[0].BodyExtent().StoredBytes(), len(largeBody))
+	}
+	if got[1].BodyExtent().StoredBytes() != 1 {
+		t.Fatalf("small StoredBytes() = %d, want 1", got[1].BodyExtent().StoredBytes())
+	}
+
+	full, err := sut.ListRecent(context.Background(), 10, 0, types.EventKind(""), types.Client(""), types.Agent(""), types.SessionID(""), types.Workspace(""), false, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	fullIDs := make([]string, 0, len(full))
+	for _, event := range full {
+		fullIDs = append(fullIDs, event.EventID().String())
+	}
+	if diff := cmp.Diff(fullIDs, metadataIDs(got)); diff != "" {
+		t.Fatalf("metadata/full membership mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEventMetadataQuery_AllocationDoesNotScaleWithStoredBody(t *testing.T) {
+	const iterations = 8
+	measure := func(name, body string) uint64 {
+		t.Helper()
+		dbPath := filepath.Join(t.TempDir(), name, "traceary.db")
+		sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+		if err := storeManager.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize(%s) error = %v", name, err)
+		}
+		event := newEventForSQLiteTest(t, "event-1", "cli", "codex", "session-1", "ws", body, time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC))
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", name, err)
+		}
+
+		criteria := apptypes.NewEventListCriteriaBuilder(1).Build()
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+		for range iterations {
+			got, err := sut.ListRecentMetadata(context.Background(), criteria)
+			if err != nil {
+				t.Fatalf("ListRecentMetadata(%s) error = %v", name, err)
+			}
+			if len(got) != 1 || got[0].BodyExtent().StoredBytes() != len(body) {
+				t.Fatalf("ListRecentMetadata(%s) returned invalid extent", name)
+			}
+		}
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+
+	smallAlloc := measure("small", "x")
+	largeBody := strings.Repeat("0123456789abcdef", 512*1024) // 8 MiB.
+	largeAlloc := measure("large", largeBody)
+	const allowedDelta = 512 * 1024
+	if largeAlloc > smallAlloc+allowedDelta {
+		t.Fatalf("metadata allocation scaled with body: small=%d large=%d delta=%d (allowed %d)", smallAlloc, largeAlloc, largeAlloc-smallAlloc, allowedDelta)
+	}
+}
+
+func TestEventMetadataQuery_ReturnsBodyFreeCommandAuditMetadata(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	event, audit := newSearchAuditFixture(t, "event-audit", "duck8823/traceary", time.Date(2026, 7, 22, 2, 0, 0, 0, time.UTC))
+	audit.SetExitCode(types.Some(23))
+	audit.SetFailed(true)
+	if err := sut.SaveWithAudit(context.Background(), event, audit); err != nil {
+		t.Fatalf("SaveWithAudit() error = %v", err)
+	}
+
+	got, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).FailuresOnly(true).Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(metadata) = %d, want 1", len(got))
+	}
+	auditMetadata, ok := got[0].CommandAudit().Value()
+	if !ok {
+		t.Fatal("CommandAudit() absent, want metadata")
+	}
+	exitCode, ok := auditMetadata.ExitCode().Value()
+	if !ok || exitCode != 23 || !auditMetadata.Failed() {
+		t.Fatalf("command metadata = exit %d (present=%v), failed=%v", exitCode, ok, auditMetadata.Failed())
+	}
+}
+
+func TestEventMetadataQuery_SourceHookFiltersPreserveLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	primary := newEventForSQLiteTest(t, "event-primary", "hook", "codex", "session-1", "ws", "done", time.Date(2026, 7, 22, 2, 0, 0, 0, time.UTC))
+	primary.SetSourceHook("stop")
+	if err := sut.Save(context.Background(), primary); err != nil {
+		t.Fatalf("Save(primary) error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO events(id, kind, client, agent, session_id, workspace, body, source_hook, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)`, "event-legacy", "session_ended", "hook", "codex", "session-1", "ws", "[phase:subagent] done", time.Date(2026, 7, 22, 2, 1, 0, 0, time.UTC).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert legacy event: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close DB: %v", err)
+	}
+
+	primaryMetadata, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(10).SourceHook("stop").Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata(primary) error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"event-primary"}, metadataIDs(primaryMetadata)); diff != "" {
+		t.Fatalf("primary source-hook mismatch (-want +got):\n%s", diff)
+	}
+
+	legacyMetadata, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(10).SourceHook("subagent_stop").Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata(legacy) error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"event-legacy"}, metadataIDs(legacyMetadata)); diff != "" {
+		t.Fatalf("legacy source-hook mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEventMetadataQuery_SearchAndContextPreserveOrdering(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 22, 3, 0, 0, 0, time.UTC)
+	for i, body := range []string{"needle one", "needle two"} {
+		event := newEventForSQLiteTest(t, "event-"+string(rune('1'+i)), "cli", "codex", "session-1", "duck8823/traceary", body, base.Add(time.Duration(i)*time.Second))
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+
+	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(10).
+		Query("needle").
+		Workspace(types.Workspace("duck8823/traceary")).
+		Build()
+	search, err := sut.SearchMetadata(context.Background(), searchCriteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"event-2", "event-1"}, metadataIDs(search)); diff != "" {
+		t.Fatalf("search order mismatch (-want +got):\n%s", diff)
+	}
+
+	contextCriteria := apptypes.NewEventContextCriteriaBuilder(10).
+		Workspace(types.Workspace("duck8823/traceary")).
+		SessionID(types.SessionID("session-1")).
+		Build()
+	contextEvents, err := sut.GetContextMetadata(context.Background(), contextCriteria)
+	if err != nil {
+		t.Fatalf("GetContextMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"event-2", "event-1"}, metadataIDs(contextEvents)); diff != "" {
+		t.Fatalf("context order mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEventMetadataQuery_ListWindowPreservesSnapshotPagingSemantics(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 22, 4, 0, 0, 0, time.UTC)
+	const total = 205
+	for i := range total {
+		event := newEventForSQLiteTest(
+			t,
+			fmt.Sprintf("event-%03d", i),
+			"cli",
+			"codex",
+			"session-1",
+			"duck8823/traceary",
+			strings.Repeat("body", i%11+1),
+			base.Add(time.Duration(i)*time.Second),
+		)
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(event-%03d) error = %v", i, err)
+		}
+	}
+
+	var pageSizes []int
+	sut.SetListWindowBatchHookForTest(func(_ int, batchSize int) {
+		pageSizes = append(pageSizes, batchSize)
+	})
+	criteria := apptypes.NewEventListCriteriaBuilder(100).
+		From(base).
+		To(base.Add(total * time.Second)).
+		Build()
+	got, err := sut.ListWindowMetadata(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("ListWindowMetadata() error = %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("len(metadata) = %d, want %d", len(got), total)
+	}
+	if diff := cmp.Diff([]int{100, 100, 5}, pageSizes); diff != "" {
+		t.Fatalf("page sizes mismatch (-want +got):\n%s", diff)
+	}
+	if got[0].EventID().String() != "event-204" || got[len(got)-1].EventID().String() != "event-000" {
+		t.Fatalf("metadata order = %s ... %s, want event-204 ... event-000", got[0].EventID(), got[len(got)-1].EventID())
+	}
+}
+
+func TestEventBodyMetadataMigration_BackfillsAndTracksStoredBytes(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	initialMigrations := fstest.MapFS{
+		"000001_init.sql": {Data: []byte(`
+CREATE TABLE events (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    client TEXT NOT NULL DEFAULT '',
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    workspace TEXT NOT NULL DEFAULT '',
+    body TEXT NOT NULL,
+    source_hook TEXT,
+    created_at TEXT NOT NULL
+);`)},
+	}
+	_, initialStoreManager := newEventDatasource(t, dbPath, initialMigrations)
+	if err := initialStoreManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(initial) error = %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(initial) error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "event-historical", "note", "cli", "codex", "session-1", "ws", "日本語", time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert historical event: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close initial DB: %v", err)
+	}
+
+	migrationPath := filepath.Join(onDiskSQLiteMigrationDir(t), "000021_add_event_body_metadata.sql")
+	migrationSQL, err := os.ReadFile(migrationPath)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	updatedMigrations := fstest.MapFS{
+		"000001_init.sql":                    initialMigrations["000001_init.sql"],
+		"000021_add_event_body_metadata.sql": {Data: migrationSQL},
+	}
+	sut, storeManager := newEventDatasource(t, dbPath, updatedMigrations)
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(updated) error = %v", err)
+	}
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(updated) error = %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close updated DB: %v", err)
+		}
+	}()
+
+	var historicalBytes int
+	var historicalOriginal, historicalIngest, historicalStorage sql.NullInt64
+	if err := db.QueryRow(`SELECT body_stored_bytes, body_original_bytes, body_ingest_truncated, body_storage_truncated FROM events WHERE id = ?`, "event-historical").Scan(&historicalBytes, &historicalOriginal, &historicalIngest, &historicalStorage); err != nil {
+		t.Fatalf("query historical stored bytes: %v", err)
+	}
+	if historicalBytes != len("日本語") {
+		t.Fatalf("historical body_stored_bytes = %d, want %d", historicalBytes, len("日本語"))
+	}
+	if historicalOriginal.Valid || historicalIngest.Valid || historicalStorage.Valid {
+		t.Fatalf("historical unknown facts became known: original=%v ingest=%v storage=%v", historicalOriginal, historicalIngest, historicalStorage)
+	}
+
+	event := newEventForSQLiteTest(t, "event-utf8", "cli", "codex", "session-1", "ws", "日本語", time.Now().UTC().Add(time.Second))
+	if err := sut.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	var storedBytes int
+	if err := db.QueryRow(`SELECT body_stored_bytes FROM events WHERE id = ?`, "event-utf8").Scan(&storedBytes); err != nil {
+		t.Fatalf("query stored bytes: %v", err)
+	}
+	if storedBytes != len("日本語") {
+		t.Fatalf("body_stored_bytes = %d, want %d", storedBytes, len("日本語"))
+	}
+	if _, err := db.Exec(`UPDATE events SET body = ? WHERE id = ?`, "updated", "event-utf8"); err != nil {
+		t.Fatalf("update body: %v", err)
+	}
+	if err := db.QueryRow(`SELECT body_stored_bytes FROM events WHERE id = ?`, "event-utf8").Scan(&storedBytes); err != nil {
+		t.Fatalf("query updated stored bytes: %v", err)
+	}
+	if storedBytes != len("updated") {
+		t.Fatalf("updated body_stored_bytes = %d, want %d", storedBytes, len("updated"))
+	}
+}
+
+func metadataIDs(metadata []apptypes.EventMetadata) []string {
+	ids := make([]string, 0, len(metadata))
+	for _, event := range metadata {
+		ids = append(ids, event.EventID().String())
+	}
+	return ids
+}

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -71,6 +71,9 @@ func TestEventMetadataQuery_ListRecentDoesNotHydrateBody(t *testing.T) {
 }
 
 func TestEventMetadataQuery_AllocationDoesNotScaleWithStoredBody(t *testing.T) {
+	// Repeating the query reduces one-off allocator noise. The 512 KiB margin is
+	// deliberately far below the 8 MiB body, so accidentally hydrating the body
+	// still fails while normal SQLite/Go bookkeeping variance is tolerated.
 	const iterations = 8
 	measure := func(name, body string) uint64 {
 		t.Helper()
@@ -108,6 +111,99 @@ func TestEventMetadataQuery_AllocationDoesNotScaleWithStoredBody(t *testing.T) {
 	const allowedDelta = 512 * 1024
 	if largeAlloc > smallAlloc+allowedDelta {
 		t.Fatalf("metadata allocation scaled with body: small=%d large=%d delta=%d (allowed %d)", smallAlloc, largeAlloc, largeAlloc-smallAlloc, allowedDelta)
+	}
+}
+
+func TestEventMetadataQuery_ListRecentPreservesFullQueryMembership(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 22, 1, 30, 0, 0, time.UTC)
+	newEvent := func(id string, kind types.EventKind, client, agent, session, workspace string, createdAt time.Time) *model.Event {
+		t.Helper()
+		return model.EventOf(
+			mustEventIDForSQLite(t, id),
+			kind,
+			types.Client(client),
+			mustAgentForSQLite(t, agent),
+			mustSessionIDForSQLite(t, session),
+			types.Workspace(workspace),
+			"body for "+id,
+			createdAt,
+		)
+	}
+
+	event1 := newEvent("event-1", types.EventKindNote, "cli", "codex", "session-1", "ws-1", base)
+	event2 := newEvent("event-2", types.EventKindPrompt, "hook", "claude", "session-2", "ws-2", base.Add(time.Second))
+	event2.SetSourceHook("stop")
+	event3 := newEvent("event-3", types.EventKindNote, "hook", "codex", "session-1", "ws-2", base.Add(2*time.Second))
+	event3.SetSourceHook("stop")
+	for _, event := range []*model.Event{event1, event2, event3} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+	event4, audit := newSearchAuditFixture(t, "event-4", "ws-1", base.Add(3*time.Second))
+	audit.SetExitCode(types.Some(1))
+	audit.SetFailed(true)
+	if err := sut.SaveWithAudit(context.Background(), event4, audit); err != nil {
+		t.Fatalf("SaveWithAudit() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		criteria apptypes.EventListCriteria
+	}{
+		{name: "all", criteria: apptypes.NewEventListCriteriaBuilder(10).Build()},
+		{name: "kind", criteria: apptypes.NewEventListCriteriaBuilder(10).Kind(types.EventKindPrompt).Build()},
+		{name: "client", criteria: apptypes.NewEventListCriteriaBuilder(10).Client(types.Client("hook")).Build()},
+		{name: "agent", criteria: apptypes.NewEventListCriteriaBuilder(10).Agent(types.Agent("claude")).Build()},
+		{name: "session", criteria: apptypes.NewEventListCriteriaBuilder(10).SessionID(types.SessionID("session-2")).Build()},
+		{name: "workspace", criteria: apptypes.NewEventListCriteriaBuilder(10).Workspace(types.Workspace("ws-1")).Build()},
+		{name: "time range", criteria: apptypes.NewEventListCriteriaBuilder(10).From(base.Add(time.Second)).To(base.Add(3 * time.Second)).Build()},
+		{name: "source hook", criteria: apptypes.NewEventListCriteriaBuilder(10).SourceHook("stop").Build()},
+		{name: "failures only", criteria: apptypes.NewEventListCriteriaBuilder(10).FailuresOnly(true).Build()},
+		{name: "offset", criteria: apptypes.NewEventListCriteriaBuilder(2).Offset(1).Build()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := sut.ListRecentMetadata(context.Background(), tt.criteria)
+			if err != nil {
+				t.Fatalf("ListRecentMetadata() error = %v", err)
+			}
+			full, err := sut.ListRecent(
+				context.Background(),
+				tt.criteria.Limit(),
+				tt.criteria.Offset(),
+				tt.criteria.Kind(),
+				tt.criteria.Client(),
+				tt.criteria.Agent(),
+				tt.criteria.SessionID(),
+				tt.criteria.Workspace(),
+				tt.criteria.FailuresOnly(),
+				tt.criteria.From(),
+				tt.criteria.To(),
+				tt.criteria.SourceHook(),
+			)
+			if err != nil {
+				t.Fatalf("ListRecent() error = %v", err)
+			}
+			fullIDs := make([]string, 0, len(full))
+			for _, event := range full {
+				fullIDs = append(fullIDs, event.EventID().String())
+			}
+			if len(fullIDs) == 0 {
+				t.Fatal("test filter returned no fixtures")
+			}
+			if diff := cmp.Diff(fullIDs, metadataIDs(metadata)); diff != "" {
+				t.Fatalf("metadata/full membership mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -219,6 +315,10 @@ func TestEventMetadataQuery_SearchAndContextPreserveOrdering(t *testing.T) {
 	contextCriteria := apptypes.NewEventContextCriteriaBuilder(10).
 		Workspace(types.Workspace("duck8823/traceary")).
 		SessionID(types.SessionID("session-1")).
+		// Full GetContext historically ignores these fields. Metadata retrieval
+		// must preserve that membership contract until both APIs change together.
+		Client(types.Client("nonexistent")).
+		Agent(types.Agent("nonexistent")).
 		Build()
 	contextEvents, err := sut.GetContextMetadata(context.Background(), contextCriteria)
 	if err != nil {
@@ -368,6 +468,25 @@ CREATE TABLE events (
 	}
 	if storedBytes != len("updated") {
 		t.Fatalf("updated body_stored_bytes = %d, want %d", storedBytes, len("updated"))
+	}
+
+	if _, err := db.Exec(`INSERT INTO events(id, kind, client, agent, session_id, workspace, body, body_stored_bytes, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, "event-explicit-bytes", "note", "cli", "codex", "session-1", "ws", "exact", 999, time.Now().UTC().Add(2*time.Second).Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("insert with caller-supplied stored bytes: %v", err)
+	}
+	if err := db.QueryRow(`SELECT body_stored_bytes FROM events WHERE id = ?`, "event-explicit-bytes").Scan(&storedBytes); err != nil {
+		t.Fatalf("query recomputed stored bytes: %v", err)
+	}
+	if storedBytes != len("exact") {
+		t.Fatalf("recomputed body_stored_bytes = %d, want %d", storedBytes, len("exact"))
+	}
+
+	for name, statement := range map[string]string{
+		"negative stored bytes": `UPDATE events SET body_stored_bytes = -1 WHERE id = 'event-utf8'`,
+		"invalid truncation":    `UPDATE events SET body_ingest_truncated = 2 WHERE id = 'event-utf8'`,
+	} {
+		if _, err := db.Exec(statement); err == nil {
+			t.Fatalf("%s unexpectedly satisfied metadata constraints", name)
+		}
 	}
 }
 

--- a/infrastructure/sqlite/sql/get_context_event_metadata.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata.sql
@@ -8,7 +8,5 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE (? = '' OR e.workspace = ?)
    AND (? = '' OR e.session_id = ?)
-   AND (? = '' OR e.client = ?)
-   AND (? = '' OR e.agent = ?)
  ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata.sql
@@ -1,0 +1,14 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE (? = '' OR e.workspace = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/search_event_metadata.sql
+++ b/infrastructure/sqlite/sql/search_event_metadata.sql
@@ -1,0 +1,37 @@
+SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       a.event_id, a.exit_code, a.failed
+  FROM events e
+  LEFT JOIN command_audits a ON a.event_id = e.id
+ WHERE (? = '' OR
+        (CASE WHEN json_valid(e.body)
+                   AND json_type(e.body, '$.blocks') = 'array'
+                   AND NOT EXISTS (
+                     SELECT 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
+                   )
+              THEN COALESCE(
+                     (SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
+                        FROM json_each(json_extract(e.body, '$.blocks'))
+                       WHERE json_extract(value, '$.type') = 'text'),
+                     '')
+              ELSE e.body
+         END) LIKE ? ESCAPE '\' OR
+        COALESCE(a.command_text, '') LIKE ? ESCAPE '\' OR
+        COALESCE(a.input_text, '') LIKE ? ESCAPE '\' OR
+        COALESCE(a.output_text, '') LIKE ? ESCAPE '\')
+   AND (? = '' OR e.workspace = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+   AND (? = 0 OR a.failed = 1 OR (a.exit_code IS NOT NULL AND a.exit_code != 0))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata.sql
@@ -1,0 +1,18 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.workspace = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
@@ -1,0 +1,19 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.source_hook = ?
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.workspace = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
@@ -1,0 +1,51 @@
+SELECT id, kind, client, agent, session_id, workspace,
+       source_hook, created_at,
+       body_original_bytes, body_stored_bytes,
+       body_ingest_truncated, body_storage_truncated,
+       body_metadata_version,
+       audit_event_id, exit_code, failed
+  FROM (
+        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+               e.source_hook, e.created_at,
+               e.body_original_bytes, e.body_stored_bytes,
+               e.body_ingest_truncated, e.body_storage_truncated,
+               e.body_metadata_version,
+               ca.event_id AS audit_event_id, ca.exit_code, ca.failed
+          FROM events e
+          LEFT JOIN command_audits ca ON ca.event_id = e.id
+         WHERE e.source_hook = ?
+           AND (? = '' OR e.kind = ?)
+           AND (? = '' OR e.client = ?)
+           AND (? = '' OR e.agent = ?)
+           AND (? = '' OR e.session_id = ?)
+           AND (? = '' OR e.workspace = ?)
+           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+        UNION ALL
+        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+               e.source_hook, e.created_at,
+               e.body_original_bytes, e.body_stored_bytes,
+               e.body_ingest_truncated, e.body_storage_truncated,
+               e.body_metadata_version,
+               ca.event_id AS audit_event_id, ca.exit_code, ca.failed
+          FROM events e
+          LEFT JOIN command_audits ca ON ca.event_id = e.id
+         WHERE e.source_hook IS NULL
+           AND (
+                 (? = 'subagent_stop' AND e.kind = 'session_ended'
+                      AND e.body LIKE '[phase:subagent]%')
+              OR (? = 'pre_compact' AND e.kind = 'compact_summary'
+                      AND e.body LIKE '[phase:pre-compact]%')
+               )
+           AND (? = '' OR e.kind = ?)
+           AND (? = '' OR e.client = ?)
+           AND (? = '' OR e.agent = ?)
+           AND (? = '' OR e.session_id = ?)
+           AND (? = '' OR e.workspace = ?)
+           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+       ) events_union
+ ORDER BY ts_norm(created_at) DESC, id DESC
+ LIMIT ? OFFSET ?

--- a/schema/sqlite/migrations/000021_add_event_body_metadata.sql
+++ b/schema/sqlite/migrations/000021_add_event_body_metadata.sql
@@ -1,8 +1,13 @@
-ALTER TABLE events ADD COLUMN body_original_bytes INTEGER;
-ALTER TABLE events ADD COLUMN body_stored_bytes INTEGER;
-ALTER TABLE events ADD COLUMN body_ingest_truncated INTEGER;
-ALTER TABLE events ADD COLUMN body_storage_truncated INTEGER;
-ALTER TABLE events ADD COLUMN body_metadata_version INTEGER;
+ALTER TABLE events ADD COLUMN body_original_bytes INTEGER
+    CHECK (body_original_bytes IS NULL OR body_original_bytes >= 0);
+ALTER TABLE events ADD COLUMN body_stored_bytes INTEGER
+    CHECK (body_stored_bytes IS NULL OR body_stored_bytes >= 0);
+ALTER TABLE events ADD COLUMN body_ingest_truncated INTEGER
+    CHECK (body_ingest_truncated IS NULL OR body_ingest_truncated IN (0, 1));
+ALTER TABLE events ADD COLUMN body_storage_truncated INTEGER
+    CHECK (body_storage_truncated IS NULL OR body_storage_truncated IN (0, 1));
+ALTER TABLE events ADD COLUMN body_metadata_version INTEGER
+    CHECK (body_metadata_version IS NULL OR body_metadata_version >= 0);
 
 -- Historical rows can prove only their stored byte count. Original size and
 -- truncation provenance remain NULL rather than being invented as zero/false.
@@ -17,7 +22,6 @@ UPDATE events
 CREATE TRIGGER events_body_metadata_after_insert
 AFTER INSERT ON events
 FOR EACH ROW
-WHEN NEW.body_stored_bytes IS NULL
 BEGIN
     UPDATE events
        SET body_stored_bytes = length(CAST(NEW.body AS BLOB))

--- a/schema/sqlite/migrations/000021_add_event_body_metadata.sql
+++ b/schema/sqlite/migrations/000021_add_event_body_metadata.sql
@@ -1,0 +1,34 @@
+ALTER TABLE events ADD COLUMN body_original_bytes INTEGER;
+ALTER TABLE events ADD COLUMN body_stored_bytes INTEGER;
+ALTER TABLE events ADD COLUMN body_ingest_truncated INTEGER;
+ALTER TABLE events ADD COLUMN body_storage_truncated INTEGER;
+ALTER TABLE events ADD COLUMN body_metadata_version INTEGER;
+
+-- Historical rows can prove only their stored byte count. Original size and
+-- truncation provenance remain NULL rather than being invented as zero/false.
+UPDATE events
+   SET body_stored_bytes = length(CAST(body AS BLOB))
+ WHERE body_stored_bytes IS NULL;
+
+-- Existing insert paths intentionally remain compatible. The trigger records
+-- stored UTF-8 bytes without requiring callers to materialize body content a
+-- second time or to claim knowledge of original/truncation facts they do not
+-- possess.
+CREATE TRIGGER events_body_metadata_after_insert
+AFTER INSERT ON events
+FOR EACH ROW
+WHEN NEW.body_stored_bytes IS NULL
+BEGIN
+    UPDATE events
+       SET body_stored_bytes = length(CAST(NEW.body AS BLOB))
+     WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER events_body_metadata_after_body_update
+AFTER UPDATE OF body ON events
+FOR EACH ROW
+BEGIN
+    UPDATE events
+       SET body_stored_bytes = length(CAST(NEW.body AS BLOB))
+     WHERE id = NEW.id;
+END;


### PR DESCRIPTION
## Motivation

Metadata inspection currently restores complete event bodies before presentation code can omit or truncate them. This makes otherwise small list, search, and context reads scale with stored prompts, transcripts, and command payloads.

## What changed

- added a body-free `EventMetadata` read model and consumer-oriented query service
- added dedicated SQLite metadata queries for recent lists, snapshot windows, search, context, source-hook compatibility, and command outcome metadata
- added additive body extent columns with conservative historical backfill and insert/update triggers
- kept full event queries and detail behavior unchanged
- added query-shape, migration, pagination, source-hook, large-body, and allocation regressions

## Design

Implements the accepted projection contract from #1439. Metadata SQL may inspect body content in search or legacy predicates, but no body-bearing column is selected or scanned into Go.

## Validation

- `GOCACHE=/private/tmp/traceary-1428-gocache go vet ./...`
- `GOCACHE=/private/tmp/traceary-1428-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-1428-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-1428-lint-cache go tool golangci-lint run`
- `git diff --check`

Closes #1428
