### PR TITLE
v0.30.0-2d: verify Antigravity Stop replay and rollout duplicate rate

### DIFF
--- a/.ai/spec/1465.md
+++ b/.ai/spec/1465.md
@@ -1,0 +1,55 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Purpose: prove that replaying an Antigravity Stop delivery with a stable completed-turn step ID does not amplify persisted prompt, transcript, or session-boundary state.
+- Current state: the Stop adapter derives `prompt_id` from the completed response `step_index`, and the delivery ledger can distinguish accepted writes from exact redelivery, but the behavior is not covered through the real CLI and SQLite store.
+- Expected behavior: one original Stop and one identical replay persist one prompt and one transcript, record two accepted attempts and two exact-redelivery attempts, and create no session-ended event.
+- Out of scope: deleting or rewriting historical candidate rows, changing heuristic dedupe rules, or treating Stop as a session end.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Completed turn | prompt, response blocks, response step ID | Normalizes a Stop payload | The response step ID is stable across replay |
+| Logical delivery | host, source hook, session, native step ID, semantic fingerprint | Accepts the first event and suppresses exact replay | Workspace is not part of logical delivery identity |
+| Delivery attempt | accepted or exact redelivery | Measures every stable-ID write attempt | Runtime attempts remain body-free and append-only |
+| Stop boundary | open conversation | Schedules optional extraction only | It never writes a session-ended event |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Parse completed Antigravity turn | Antigravity presentation adapter | Host transcript schema changes | Store; it must not know host payloads |
+| Enforce stable delivery identity | Event use case plus SQLite event store | Delivery invariants or persistence rules change | CLI adapter; it only supplies proven native identity |
+| Summarize exact attempts | Workspace identity read side | Diagnostic projection changes | Hook runtime; reporting must stay read-only |
+| Exercise rollout behavior | E2E test and dogfood script | Release QA contract changes | Production handler; no QA-only branches |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `hook antigravity stop` | Antigravity host and QA fixture | Transcript parsing and three internal hook paths | Fail-soft host output, durable store effects are verified separately |
+| Event repository `Save` | Event use case | Delivery transaction and attempt ledger | Exact replay returns the canonical event without a second body row |
+| `report workspace-identity --json` | Operator and dogfood script | Aggregate SQL and rate calculation | Existing/migrated store is required; report is read-only |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Exact Stop replay | Stable completed-turn fixture | Same Stop payload is executed twice | One prompt, one transcript, two accepted attempts, two exact attempts | CLI plus SQLite E2E |
+| Boundary remains open | No explicit session-end hook | Stop is replayed | No session-ended event is persisted | CLI plus SQLite E2E |
+| Report classification | Exact replay exists in the ledger | Workspace identity report runs | Exact delivery shows the replay; heuristic candidates remain zero | CLI plus SQLite E2E |
+| Rollout target | 101 distinct stable turns plus one replay | Fresh-store dogfood runs | 204 runtime attempts, 2 exact redeliveries, rate below 1% | Repeatable release QA script |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Stable fixture replay | Add failing real CLI/store assertions | Reuse current stable-ID path; fix only if observed behavior fails | Shared E2E fixture runner if duplication becomes material |
+| Fresh rollout sample | Add aggregate QA validation | Generate unique current-schema transcript rows and one replay | Keep QA generation outside production code |
+
+### Risks / rollback
+- Procedural-logic risk: keep measurement and fixtures in test/QA code; do not add production-only switches.
+- Premature-abstraction risk: use the existing RootCLI composition rather than a new replay service.
+- Migration / compatibility: no schema or historical-row mutation is introduced.
+- Rollback trigger: revert the test/QA commit if it proves flaky; any production correction must be isolated in a separate behavior commit.
+
+### Design checkpoint
+- Risk is Medium: this work verifies an existing cross-layer behavior but does not change a public API or schema.
+- The test observes database rows and report output rather than private helper call order.
+- A deterministic fixture and temporary fresh store avoid reading or modifying the operator's live data.

--- a/docs/release/v0.30.0-antigravity-stop-replay-dogfood.ja.md
+++ b/docs/release/v0.30.0-antigravity-stop-replay-dogfood.ja.md
@@ -1,0 +1,47 @@
+# v0.30.0 Antigravity Stop リプレイ dogfood
+
+[English](./v0.30.0-antigravity-stop-replay-dogfood.md)
+
+日付: 2026-07-22
+
+Issue: #1465
+
+## 検証する所見
+
+コピーした v0.29 ストアでは、Antigravity の `stop` と `stop_transcript` に対する履歴上の本文・時間窓候補率が 23.99% でした。このストアは安定した配信識別子の試行台帳より前のものなので、v0.30 の識別経路がホストによる再配信を抑止できるかは証明できませんでした。
+
+## 方法
+
+`scripts/verify-antigravity-stop-replay.sh` で現在のソースをビルドし、隔離した一時ストアを作成しました。現行スキーマの Antigravity 完了ターン 101 件を、実際の `traceary hook antigravity stop` コマンドに渡した後、最後の Stop ペイロードを 1 回再送しました。続けて実際のワークスペース識別レポートを実行し、読み取り専用レポートの前後で SQLite の集計件数が変わらないことも検証しました。
+
+コミットする E2E フィクスチャでは、安定した完了ターン応答ステップ (`step:41`) を RootCLI と SQLite を通して 2 回再送します。prompt と transcript の本文行が各 1 件であること、accepted と exact の試行分類、session-end 境界がないこと、ヒューリスティック候補が 0 件であることを検証します。
+
+この QA で使用した prompt と response は合成テキストだけです。運用者のストアは読み取らず、外部レビュアーへデータを送らず、履歴行も変更していません。
+
+## 結果
+
+- 異なる完了ターン: 101
+- Stop 呼び出し: 102
+- 保存された prompt event: 101
+- 保存された transcript event: 101
+- 保存された session-ended event: 0
+- 実行時の配信試行: 204
+- accepted 試行: 202
+- exact redelivery: 2
+- exact redelivery 率: 0.9804%
+- リリース目標: 1% 未満
+- 目標達成: はい
+- ヒューリスティック候補: 0
+- レポート前後で event 件数が不変: はい
+
+prompt と transcript の各 source hook は、accepted 101 件と exact redelivery 1 件を記録しました。全体では 2 / 204 となり、v0.30 のリリース目標を下回りました。
+
+## 診断
+
+v0.30 の安定 ID 経路に残る不具合は再現しませんでした。Antigravity Stop アダプターは、完了した response の `step_index` から `prompt_id` を導出します。prompt (`stop_transcript`) と transcript (`stop`) は別々の source-hook 名前空間を使い、同一再送は 2 件目の本文行を書き込む前に exact redelivery として分類されます。
+
+履歴上の 23.99% は、試行台帳導入前のデータに対するヒューリスティックな所見のままです。この QA では書き換え、削除、再分類を行いません。再実行可能な一時ストアの結果をリリース判断に使います。
+
+## リリース判断
+
+#1465 のブロッカー条件を満たしました。リプレイを E2E でカバーし、レポートがヒューリスティック候補ではなく exact redelivery として示し、目標判定に十分な新規ストアのサンプルを取得し、exact 率が 1% 未満であることを確認しました。

--- a/docs/release/v0.30.0-antigravity-stop-replay-dogfood.md
+++ b/docs/release/v0.30.0-antigravity-stop-replay-dogfood.md
@@ -1,0 +1,47 @@
+# v0.30.0 Antigravity Stop replay dogfood
+
+[日本語](./v0.30.0-antigravity-stop-replay-dogfood.ja.md)
+
+Date: 2026-07-22
+
+Issue: #1465
+
+## Finding being verified
+
+The copied v0.29 store measured a 23.99% historical content/time-window candidate rate for Antigravity `stop` and `stop_transcript`. That store predates the stable-delivery attempt ledger, so the result could not prove whether the v0.30 identity path suppresses host redelivery.
+
+## Method
+
+`scripts/verify-antigravity-stop-replay.sh` built the current source and created an isolated temporary store. It sent 101 distinct current-schema Antigravity completed turns through the real `traceary hook antigravity stop` command, then replayed the last Stop payload once. The script ran the real workspace-identity report and verified aggregate SQLite counts before and after the read-only report.
+
+The committed E2E fixture separately replays one stable completed-turn response step (`step:41`) twice through RootCLI and SQLite. It verifies one prompt and one transcript body row, accepted/exact attempt classification, the absence of a session-end boundary, and zero heuristic candidates.
+
+This QA used synthetic prompt and response text only. It did not read the operator store, transmit data to an external reviewer, or modify historical rows.
+
+## Results
+
+- distinct completed turns: 101
+- Stop invocations: 102
+- persisted prompt events: 101
+- persisted transcript events: 101
+- persisted session-ended events: 0
+- runtime delivery attempts: 204
+- accepted attempts: 202
+- exact redeliveries: 2
+- exact redelivery rate: 0.9804%
+- release target: less than 1%
+- target met: yes
+- heuristic candidates: 0
+- event counts unchanged by the report: yes
+
+The prompt and transcript source hooks each recorded 101 accepted attempts and one exact redelivery. The aggregate is therefore 2 / 204, below the v0.30 release target.
+
+## Diagnosis
+
+No remaining v0.30 stable-ID defect was reproduced. The Antigravity Stop adapter derives `prompt_id` from the completed response `step_index`; prompt (`stop_transcript`) and transcript (`stop`) use separate source-hook namespaces, and an identical replay is classified as an exact redelivery before a second body row is written.
+
+The historical 23.99% value remains a heuristic finding from pre-ledger data. It is not rewritten, deleted, or relabeled by this QA. The repeatable fresh-store result is the release decision input.
+
+## Release decision
+
+The #1465 blocker is satisfied: replay is covered end to end, the report exposes exact rather than heuristic redelivery, the fresh-store sample is large enough to evaluate the target, and the measured exact rate is below 1%.

--- a/presentation/cli/hook_delivery_e2e_test.go
+++ b/presentation/cli/hook_delivery_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,136 @@ import (
 	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 	cli "github.com/duck8823/traceary/presentation/cli"
 )
+
+func TestRootCLI_HookAntigravityStopReplayUsesStableDeliveryLedger(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/dogfood/antigravity-stop")
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	sessionDS := sqliteinfra.NewSessionDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	sessionUC := usecase.NewSessionUsecase(eventDS, sessionDS, sessionDS, eventDS)
+	identityDS := sqliteinfra.NewWorkspaceIdentityDatasource(db)
+	identityUC := usecase.NewWorkspaceIdentityUsecase(identityDS, identityDS, nil)
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	transcriptPath := filepath.Join("testdata", "antigravity_hooks", "current", "stop_transcript.jsonl")
+	payload := fmt.Sprintf(
+		`{"conversationId":"antigravity-stop-replay","workspacePaths":["/dogfood/antigravity-stop"],"transcriptPath":%q,"terminationReason":"completed"}`,
+		transcriptPath,
+	)
+	fire := func() {
+		t.Helper()
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(storeUC),
+			cli.WithEvent(eventUC),
+			cli.WithSession(sessionUC),
+			cli.WithWorkspaceIdentity(identityUC),
+			cli.WithDatabasePathSetter(db.SetPath),
+		).Command()
+		stdout := &bytes.Buffer{}
+		rootCmd.SetIn(strings.NewReader(payload))
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"hook", "antigravity", "stop", "--db-path", dbPath})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute(hook antigravity stop) error = %v", err)
+		}
+		if got := stdout.String(); got != `{"decision":""}` {
+			t.Fatalf("Stop output = %q, want decision contract", got)
+		}
+	}
+	fire()
+	fire()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = sqldb.Close() }()
+
+	for _, tc := range []struct {
+		kind       string
+		sourceHook string
+	}{
+		{kind: "prompt", sourceHook: "stop_transcript"},
+		{kind: "transcript", sourceHook: "stop"},
+	} {
+		var count int
+		if err := sqldb.QueryRow(
+			`SELECT COUNT(*) FROM events WHERE session_id = ? AND kind = ? AND source_hook = ?`,
+			"antigravity-stop-replay", tc.kind, tc.sourceHook,
+		).Scan(&count); err != nil {
+			t.Fatalf("count %s events: %v", tc.kind, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s events = %d, want one logical event after replay", tc.kind, count)
+		}
+	}
+	var boundaryCount int
+	if err := sqldb.QueryRow(
+		`SELECT COUNT(*) FROM events WHERE session_id = ? AND kind IN ('session_started', 'session_ended')`,
+		"antigravity-stop-replay",
+	).Scan(&boundaryCount); err != nil {
+		t.Fatalf("count session boundaries: %v", err)
+	}
+	if boundaryCount != 0 {
+		t.Fatalf("Stop session boundary events = %d, want zero", boundaryCount)
+	}
+
+	var accepted, exact, conflicts int
+	if err := sqldb.QueryRow(`
+		SELECT
+			SUM(outcome = 'accepted'),
+			SUM(outcome = 'exact_redelivery'),
+			SUM(outcome = 'conflict')
+		FROM hook_delivery_attempts
+		WHERE attempt_origin = 'runtime'
+	`).Scan(&accepted, &exact, &conflicts); err != nil {
+		t.Fatalf("read delivery attempts: %v", err)
+	}
+	if accepted != 2 || exact != 2 || conflicts != 0 {
+		t.Fatalf("delivery attempts accepted/exact/conflict = %d/%d/%d, want 2/2/0", accepted, exact, conflicts)
+	}
+
+	reportCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(storeUC),
+		cli.WithWorkspaceIdentity(identityUC),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	reportOut := &bytes.Buffer{}
+	reportCmd.SetOut(reportOut)
+	reportCmd.SetErr(&bytes.Buffer{})
+	reportCmd.SetArgs([]string{"report", "workspace-identity", "--db-path", dbPath, "--json"})
+	if err := reportCmd.Execute(); err != nil {
+		t.Fatalf("Execute(report workspace-identity) error = %v", err)
+	}
+	var report struct {
+		ExactDelivery struct {
+			AttemptCount         int     `json:"attempt_count"`
+			ExactRedeliveryCount int     `json:"exact_redelivery_count"`
+			ExactRedeliveryRate  float64 `json:"exact_redelivery_rate"`
+		} `json:"exact_delivery"`
+		Heuristic struct {
+			CandidateCount int `json:"candidate_count"`
+		} `json:"heuristic_candidates"`
+	}
+	if err := json.Unmarshal(reportOut.Bytes(), &report); err != nil {
+		t.Fatalf("Unmarshal(report) error = %v\n%s", err, reportOut.String())
+	}
+	if report.ExactDelivery.AttemptCount != 4 || report.ExactDelivery.ExactRedeliveryCount != 2 || report.ExactDelivery.ExactRedeliveryRate != 0.5 {
+		t.Fatalf("exact delivery report = %+v, want attempts=4 exact=2 rate=0.5", report.ExactDelivery)
+	}
+	if report.Heuristic.CandidateCount != 0 {
+		t.Fatalf("heuristic candidates = %d, want zero for suppressed stable-ID replay", report.Heuristic.CandidateCount)
+	}
+}
 
 func TestRootCLI_HookSessionRedeliveryKeepsCanonicalWorkspace(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())

--- a/presentation/cli/testdata/antigravity_hooks/current/stop_transcript.jsonl
+++ b/presentation/cli/testdata/antigravity_hooks/current/stop_transcript.jsonl
@@ -1,0 +1,2 @@
+{"step_index":40,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","content":"verify stable Stop replay"}
+{"step_index":41,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","thinking":"check the delivery ledger","content":"the replay is safe"}

--- a/scripts/verify-antigravity-stop-replay.sh
+++ b/scripts/verify-antigravity-stop-replay.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/traceary-antigravity-stop.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+binary=${TRACEARY_DOGFOOD_BINARY:-"$work_dir/traceary"}
+if [ -z "${TRACEARY_DOGFOOD_BINARY:-}" ]; then
+  (
+    cd "$repo_root"
+    go build -o "$binary" .
+  )
+fi
+
+db_path="$work_dir/traceary.db"
+state_dir="$work_dir/state"
+transcript_path="$work_dir/transcript.jsonl"
+export TRACEARY_HOOK_STATE_DIR="$state_dir"
+export TRACEARY_WORKSPACE="github.com/dogfood/antigravity-stop"
+
+fire_stop() {
+  payload=$(printf '{"conversationId":"antigravity-stop-rollout","workspacePaths":["/dogfood/antigravity-stop"],"transcriptPath":"%s","terminationReason":"completed"}' "$transcript_path")
+  output=$(printf '%s' "$payload" | "$binary" hook antigravity stop --db-path "$db_path")
+  if [ "$output" != '{"decision":""}' ]; then
+    printf 'unexpected Stop output: %s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+# 101 distinct stable turns provide 202 accepted body-event attempts. Replaying
+# the last turn adds two exact redeliveries, producing 2/204 = 0.9804%.
+turn=0
+while [ "$turn" -lt 101 ]; do
+  prompt_step=$((turn * 2))
+  response_step=$((prompt_step + 1))
+  {
+    printf '{"step_index":%d,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","content":"dogfood prompt %d"}\n' "$prompt_step" "$turn"
+    printf '{"step_index":%d,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","content":"dogfood response %d"}\n' "$response_step" "$turn"
+  } >"$transcript_path"
+  fire_stop
+  turn=$((turn + 1))
+done
+fire_stop
+
+before_report=$(python3 - "$db_path" <<'PY'
+import json
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as db:
+    result = {
+        "events": db.execute("SELECT COUNT(*) FROM events").fetchone()[0],
+        "prompts": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'prompt'").fetchone()[0],
+        "transcripts": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'transcript'").fetchone()[0],
+        "session_ended": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'session_ended'").fetchone()[0],
+    }
+print(json.dumps(result, sort_keys=True))
+PY
+)
+
+report_path="$work_dir/report.json"
+"$binary" report workspace-identity --db-path "$db_path" --json >"$report_path"
+
+python3 - "$db_path" "$report_path" "$before_report" <<'PY'
+import json
+import math
+import sqlite3
+import sys
+
+db_path, report_path, before_json = sys.argv[1:]
+before = json.loads(before_json)
+with open(report_path, encoding="utf-8") as stream:
+    report = json.load(stream)
+
+with sqlite3.connect(db_path) as db:
+    after = {
+        "events": db.execute("SELECT COUNT(*) FROM events").fetchone()[0],
+        "prompts": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'prompt'").fetchone()[0],
+        "transcripts": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'transcript'").fetchone()[0],
+        "session_ended": db.execute("SELECT COUNT(*) FROM events WHERE kind = 'session_ended'").fetchone()[0],
+    }
+
+exact = report["exact_delivery"]
+heuristic = report["heuristic_candidates"]
+expected_rate = 2 / 204
+checks = [
+    (before == after, f"report mutated event counts: {before} -> {after}"),
+    (after == {"events": 202, "prompts": 101, "transcripts": 101, "session_ended": 0}, f"unexpected event counts: {after}"),
+    (exact["attempt_count"] == 204, f"attempt_count={exact['attempt_count']}"),
+    (exact["exact_redelivery_count"] == 2, f"exact_redelivery_count={exact['exact_redelivery_count']}"),
+    (math.isclose(exact["exact_redelivery_rate"], expected_rate), f"exact_redelivery_rate={exact['exact_redelivery_rate']}"),
+    (exact["sample_available"] is True, "sample_available is false"),
+    (exact["target_met"] is True, "target_met is false"),
+    (heuristic["candidate_count"] == 0, f"heuristic candidate_count={heuristic['candidate_count']}"),
+]
+failures = [message for passed, message in checks if not passed]
+if failures:
+    raise SystemExit("; ".join(failures))
+
+print(json.dumps({
+    "event_counts": after,
+    "runtime_attempts": exact["attempt_count"],
+    "accepted_attempts": exact["attempt_count"] - exact["exact_redelivery_count"],
+    "exact_redeliveries": exact["exact_redelivery_count"],
+    "exact_redelivery_rate": exact["exact_redelivery_rate"],
+    "target_rate": exact["target_rate"],
+    "target_met": exact["target_met"],
+    "heuristic_candidates": heuristic["candidate_count"],
+    "report_preserved_events": before == after,
+}, indent=2, sort_keys=True))
+PY


### PR DESCRIPTION
## Motivation

The v0.30 workspace-identity dogfood found a 23.99% historical heuristic candidate rate for Antigravity Stop rows, while the copied pre-ledger store could not prove the post-rollout stable-ID behavior. The release needs a real CLI/store replay regression and a fresh exact-delivery sample before the tagged release.

## Changes

- add a current-schema Antigravity completed-turn fixture with a stable response step ID
- replay the same Stop payload through RootCLI and SQLite and verify prompt/transcript suppression, attempt classification, no session-end amplification, and zero heuristic candidates
- add a repeatable fresh-store dogfood script using 101 distinct turns plus one replay
- record bilingual QA evidence and the below-1% rollout result
- include the Medium-risk structure/behavior design note

## Validation

- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- `git diff --check origin/main...HEAD`
- `scripts/verify-antigravity-stop-replay.sh`
- `python3 scripts/verify_docs_no_removed_aliases.py`
- `sh -n scripts/verify-antigravity-stop-replay.sh`

## Dogfood result

- runtime attempts: 204
- accepted attempts: 202
- exact redeliveries: 2
- exact redelivery rate: 0.9804% (target: less than 1%)
- prompt/transcript events: 101 / 101
- session-ended events: 0
- heuristic candidates: 0
- read-only report preserved event counts

Closes #1465
