### PR TITLE
v0.30.0-3d: verify one-shot repair under concurrent writers

### DIFF
--- a/docs/operations/one-shot-repair.ja.md
+++ b/docs/operations/one-shot-repair.ja.md
@@ -84,3 +84,5 @@ traceary store backup restore \
 ```
 
 復元はストア全体の snapshot を置き換えるため、backup 後に記録された event も削除される。maintenance window で実施し、適用時の JSON は監査記録として保持する。
+
+activity と終了 writer の並行動作に関する release QA は、[v0.30.0 完結型セッション修復の並行書き込み dogfood](../release/v0.30.0-one-shot-repair-concurrency-dogfood.ja.md) に記録している。

--- a/docs/operations/one-shot-repair.md
+++ b/docs/operations/one-shot-repair.md
@@ -84,3 +84,5 @@ traceary store backup restore \
 ```
 
 Restoring replaces the complete store snapshot, so events written after the backup are also removed. Prefer a maintenance window and retain the apply JSON as an audit record.
+
+Release QA for concurrent activity and terminal writers is recorded in [v0.30.0 one-shot repair concurrency dogfood](../release/v0.30.0-one-shot-repair-concurrency-dogfood.md).

--- a/docs/release/v0.30.0-one-shot-repair-concurrency-dogfood.ja.md
+++ b/docs/release/v0.30.0-one-shot-repair-concurrency-dogfood.ja.md
@@ -1,0 +1,35 @@
+# v0.30.0 完結型セッション修復の並行書き込み dogfood
+
+[English](./v0.30.0-one-shot-repair-concurrency-dogfood.md)
+
+## 対象
+
+- Issue: #1473
+- 対象: #1434 で追加した SQLite の履歴 one-shot 修復アダプター
+- ストア: テストケースと繰り返しごとに作成する使い捨て SQLite データベース
+- 実運用ストアは読み取りも変更もしていない。
+
+## 決定的な割り込み
+
+修復トランザクションが全証拠候補を検査した後、最初の書き込みを行う前に、非公開 observer seam を実行する。実運用の preview と apply 経路は常に nil observer を渡す。統合テストはこの seam から実際の別接続による書き込みを commit し、次の 2 ケースを検証した。
+
+1. 証拠の完了時刻より後の新しい activity event
+2. 競合する `failure` 終了境界と `session_ended` event
+
+各修復実行には、変更されない先頭候補と、並行変更される 2 番目の候補を含めた。読み取り snapshot から書き込みへの移行が fail-closed になり、先頭候補を部分的に修復せず、`one_shot_repair` event を追加せず、競合側の activity または終了境界を 1 件だけ保持することを確認した。
+
+## 繰り返し
+
+```sh
+go test ./infrastructure/sqlite \
+  -run 'TestOneShotRepairFailsClosedWhenWriterCommitsAfterInspection' \
+  -count=100
+```
+
+結果は成功だった。activity の割り込み 100 回と終了境界の割り込み 100 回を実行し、部分修復や重複終了 event は発生しなかった。
+
+既存の決定的な event ID 衝突テストでは、先頭候補の更新後に失敗する経路を別途検証しており、複数候補を含むトランザクション全体が rollback されることを確認している。
+
+## 判定
+
+one-shot 修復の並行書き込み境界を v0.30.0 に含めてよい。候補検査後に commit した writer の状態を保持し、修復は fail-closed になり、同じ実行の他候補も部分的に変更しない。

--- a/docs/release/v0.30.0-one-shot-repair-concurrency-dogfood.md
+++ b/docs/release/v0.30.0-one-shot-repair-concurrency-dogfood.md
@@ -1,0 +1,47 @@
+# v0.30.0 one-shot repair concurrency dogfood
+
+[日本語](./v0.30.0-one-shot-repair-concurrency-dogfood.ja.md)
+
+## Scope
+
+- Issue: #1473
+- Target: the SQLite historical one-shot repair adapter added by #1434
+- Store: a fresh disposable SQLite database per test case and repetition
+- No production store was read or modified.
+
+## Deterministic interleaving
+
+A private observer seam runs after the repair transaction has inspected every
+evidence candidate and before its first write. Production preview and apply
+entry points always pass a nil observer. The integration test uses the seam to
+commit a real second-connection write in each of two cases:
+
+1. a new activity event later than the attested completion time;
+2. a competing `failure` terminal boundary and `session_ended` event.
+
+Each repair run contains a stable first candidate and the concurrently changed
+second candidate. The test verifies that the attempted snapshot-to-write
+upgrade fails closed, the stable candidate is not partially repaired, no
+`one_shot_repair` event is appended, and the competing activity or terminal
+boundary remains stored exactly once.
+
+## Repetition
+
+```sh
+go test ./infrastructure/sqlite \
+  -run 'TestOneShotRepairFailsClosedWhenWriterCommitsAfterInspection' \
+  -count=100
+```
+
+Result: pass. The command exercised 100 activity interleavings and 100 terminal
+interleavings without a partial repair or duplicate terminal event.
+
+The existing deterministic event-ID collision test separately covers failure
+after an earlier candidate update and proves that the complete multi-candidate
+transaction rolls back.
+
+## Decision
+
+The one-shot repair concurrency boundary is acceptable for v0.30.0. A writer
+that commits after inspection is preserved, repair fails closed, and no other
+candidate in the same run is partially changed.

--- a/infrastructure/sqlite/one_shot_repair_concurrency_test.go
+++ b/infrastructure/sqlite/one_shot_repair_concurrency_test.go
@@ -1,0 +1,160 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestOneShotRepairFailsClosedWhenWriterCommitsAfterInspection(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		intervene         func(context.Context, *Database, types.SessionID, time.Time) error
+		wantTerminal      bool
+		wantTerminalEvent int
+		wantActivityEvent int
+	}{
+		{
+			name: "new activity",
+			intervene: func(ctx context.Context, db *Database, sessionID types.SessionID, at time.Time) error {
+				event := model.EventOf("event-competing-activity", types.EventKindNote, "cli", "codex", sessionID, "workspace", "competing activity", at)
+				return NewEventDatasource(db).Save(ctx, event)
+			},
+			wantActivityEvent: 1,
+		},
+		{
+			name: "terminal boundary",
+			intervene: func(ctx context.Context, db *Database, sessionID types.SessionID, at time.Time) error {
+				sessions := NewSessionDatasource(db)
+				stored, err := sessions.FindByID(ctx, sessionID)
+				if err != nil {
+					return err
+				}
+				session, ok := stored.Value()
+				if !ok {
+					return model.ErrInvalidSessionState
+				}
+				if _, err := session.FinalizeOneShot(at, types.TerminalReasonFailure, "competing terminal boundary"); err != nil {
+					return fmt.Errorf("finalize competing one-shot session: %w", err)
+				}
+				event := model.EventOf("event-competing-terminal", types.EventKindSessionEnded, "cli", "codex", sessionID, "workspace", "session ended", at)
+				return sessions.SaveBoundary(ctx, session, event)
+			},
+			wantTerminal:      true,
+			wantTerminalEvent: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "traceary.db")
+			db := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+			store := NewStoreManagementDatasource(db)
+			if err := store.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+			startedAt := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+			suffix := strings.ReplaceAll(tc.name, " ", "-")
+			stableSessionID := types.SessionID("stable-" + suffix)
+			conflictSessionID := types.SessionID("concurrent-" + suffix)
+			for _, sessionID := range []types.SessionID{stableSessionID, conflictSessionID} {
+				session, err := model.NewSessionWithRuntimeMode(sessionID, startedAt, "cli", "codex", "workspace", types.RuntimeModeOneShot)
+				if err != nil {
+					t.Fatalf("NewSessionWithRuntimeMode() error = %v", err)
+				}
+				started := model.EventOf(types.EventID("event-started-"+sessionID.String()), types.EventKindSessionStarted, "cli", "codex", sessionID, "workspace", "session started", startedAt)
+				if err := NewSessionDatasource(db).SaveBoundary(ctx, session, started); err != nil {
+					t.Fatalf("SaveBoundary(start) error = %v", err)
+				}
+			}
+
+			completedAt := startedAt.Add(24 * time.Hour)
+			params := apptypes.OneShotRepairParams{
+				EvidenceHash: strings.Repeat("f", 64),
+				StaleAfter:   24 * time.Hour,
+				Now:          startedAt.Add(48 * time.Hour),
+				Entries: []apptypes.OneShotRepairEvidenceEntry{
+					concurrencyRepairEvidence(stableSessionID, completedAt),
+					concurrencyRepairEvidence(conflictSessionID, completedAt),
+				},
+			}
+			intervenedAt := completedAt.Add(time.Hour)
+			_, err := store.repairOneShotSessions(ctx, params, true, func(ctx context.Context) error {
+				return tc.intervene(ctx, db, conflictSessionID, intervenedAt)
+			})
+			if err == nil {
+				t.Fatal("repairOneShotSessions() error = nil, want concurrent snapshot conflict")
+			}
+
+			stableStored, findErr := NewSessionDatasource(db).FindByID(ctx, stableSessionID)
+			if findErr != nil {
+				t.Fatalf("FindByID(stable) error = %v", findErr)
+			}
+			stable, ok := stableStored.Value()
+			if !ok {
+				t.Fatal("stable session missing after conflict")
+			}
+			if _, terminal := stable.TerminalReason().Value(); terminal {
+				t.Fatal("stable candidate was partially repaired")
+			}
+
+			stored, findErr := NewSessionDatasource(db).FindByID(ctx, conflictSessionID)
+			if findErr != nil {
+				t.Fatalf("FindByID() error = %v", findErr)
+			}
+			got, ok := stored.Value()
+			if !ok {
+				t.Fatal("session missing after conflict")
+			}
+			_, terminal := got.TerminalReason().Value()
+			if terminal != tc.wantTerminal {
+				t.Fatalf("terminal = %v, want %v", terminal, tc.wantTerminal)
+			}
+			if tc.wantTerminal {
+				reason, _ := got.TerminalReason().Value()
+				if reason != types.TerminalReasonFailure {
+					t.Fatalf("terminal reason = %q, want failure", reason)
+				}
+			}
+			repairEvents, listErr := NewEventDatasource(db).ListRecent(ctx, 10, 0, "", "", "", "", "", false, time.Time{}, time.Time{}, "one_shot_repair")
+			if listErr != nil {
+				t.Fatalf("ListRecent(repair) error = %v", listErr)
+			}
+			if len(repairEvents) != 0 {
+				t.Fatalf("repair events = %d, want 0", len(repairEvents))
+			}
+			terminalEvents, listErr := NewEventDatasource(db).ListRecent(ctx, 10, 0, types.EventKindSessionEnded, "", "", "", "", false, time.Time{}, time.Time{}, "")
+			if listErr != nil {
+				t.Fatalf("ListRecent(terminal) error = %v", listErr)
+			}
+			if len(terminalEvents) != tc.wantTerminalEvent {
+				t.Fatalf("terminal events = %d, want %d", len(terminalEvents), tc.wantTerminalEvent)
+			}
+			activityEvents, listErr := NewEventDatasource(db).ListRecent(ctx, 10, 0, types.EventKindNote, "", "", conflictSessionID, "", false, time.Time{}, time.Time{}, "")
+			if listErr != nil {
+				t.Fatalf("ListRecent(activity) error = %v", listErr)
+			}
+			if len(activityEvents) != tc.wantActivityEvent {
+				t.Fatalf("activity events = %d, want %d", len(activityEvents), tc.wantActivityEvent)
+			}
+		})
+	}
+}
+
+func concurrencyRepairEvidence(sessionID types.SessionID, completedAt time.Time) apptypes.OneShotRepairEvidenceEntry {
+	return apptypes.OneShotRepairEvidenceEntry{
+		SessionID: sessionID, RuntimeMode: types.RuntimeModeOneShot,
+		TerminalReason: types.TerminalReasonSuccess, CompletedAt: completedAt,
+		EvidenceSource: apptypes.OneShotRepairEvidenceOperatorAttested, EvidenceRef: "test:concurrent-writer",
+	}
+}

--- a/infrastructure/sqlite/one_shot_repair_datasource.go
+++ b/infrastructure/sqlite/one_shot_repair_datasource.go
@@ -81,15 +81,25 @@ type oneShotRepairRecord struct {
 
 // PreviewOneShotSessions evaluates every evidence entry in a read-only transaction.
 func (d *StoreManagementDatasource) PreviewOneShotSessions(ctx context.Context, params apptypes.OneShotRepairParams) (apptypes.OneShotRepairResult, error) {
-	return d.repairOneShotSessions(ctx, params, false)
+	return d.repairOneShotSessions(ctx, params, false, nil)
 }
 
 // ApplyOneShotSessions evaluates and commits all eligible transitions in one transaction.
 func (d *StoreManagementDatasource) ApplyOneShotSessions(ctx context.Context, params apptypes.OneShotRepairParams) (apptypes.OneShotRepairResult, error) {
-	return d.repairOneShotSessions(ctx, params, true)
+	return d.repairOneShotSessions(ctx, params, true, nil)
 }
 
-func (d *StoreManagementDatasource) repairOneShotSessions(ctx context.Context, params apptypes.OneShotRepairParams, apply bool) (apptypes.OneShotRepairResult, error) {
+// oneShotRepairBeforeApply is a private deterministic observer seam used to
+// prove behavior when another connection commits after inspection. Production
+// preview and apply entry points always pass nil.
+type oneShotRepairBeforeApply func(context.Context) error
+
+func (d *StoreManagementDatasource) repairOneShotSessions(
+	ctx context.Context,
+	params apptypes.OneShotRepairParams,
+	apply bool,
+	beforeApply oneShotRepairBeforeApply,
+) (apptypes.OneShotRepairResult, error) {
 	var db *sql.DB
 	var err error
 	if apply {
@@ -124,6 +134,11 @@ func (d *StoreManagementDatasource) repairOneShotSessions(ctx context.Context, p
 			return apptypes.OneShotRepairResult{}, err
 		}
 		records = append(records, record)
+	}
+	if apply && beforeApply != nil {
+		if err := beforeApply(ctx); err != nil {
+			return apptypes.OneShotRepairResult{}, xerrors.Errorf("one-shot repair before-apply observer failed: %w", err)
+		}
 	}
 
 	if apply {


### PR DESCRIPTION
## Motivation

Historical one-shot repair must fail closed when a live writer commits after candidate inspection. This PR adds deterministic SQLite integration coverage for both activity and terminal-boundary writers before v0.30.0 release.

## Changes

- add a private, production-disabled observer seam after candidate inspection and before the first repair write
- verify a real second SQLite connection can commit competing activity or a terminal boundary
- verify repair fails without partial changes, duplicate terminal events, or repair audit events
- record the 100-repetition concurrency dogfood in paired release documentation

## Validation

- `go test ./infrastructure/sqlite -run 'TestOneShotRepairFailsClosedWhenWriterCommitsAfterInspection|TestStoreManagementDatasource_ApplyOneShotSessions_RollsBackWholeRun' -count=100`
- `go vet ./...`
- `go test ./...`
- `go tool golangci-lint run`
- `git diff --check`

Closes #1473
