### PR TITLE
v0.31.0-1b: prune raw bodies while preserving metadata

### DIFF
--- a/.ai/spec/1444.md
+++ b/.ai/spec/1444.md
@@ -72,6 +72,7 @@
 - Migration/compatibility: additive columns/tables, default `available`, existing readers remain valid; full readers gain additive availability fields. Older binaries see the explicit compatibility marker for pruned rows and do not silently fabricate an empty body or corrupt metadata.
 - Scope boundary: `command_audits` columns are independently captured audit metadata, not event raw-body derivatives. Raw-body retention does not delete or hide audit fields, and search may still match them.
 - Canonicalization: `retention-plan/v1` deliberately accepts only unsigned integer JSON numbers and ASCII schema keys. It uses deterministic UTF-8 string and lexicographic object-key encoding inspired by RFC 8785, but does not claim general RFC 8785 support.
+- Execution correspondence: raw-body plans declare one durable batch per candidate. Their canonical step order is `verify-plan`, `confirm-plan`, `verify-recovery`, `verify-source`, `prune-body`, `record-ledger`, matching the no-early-DB-open runtime order.
 - Rollback: retention remains opt-in; restore exact bodies from the pinned recovery package. Disable apply on any projection drift, integrity failure, recovery mismatch, or unexpected write.
 - Physical rollback is row restoration, not live DB file replacement. This intentionally avoids implementing the design document's future strengthened swap journal until a command actually needs database replacement.
 

--- a/.ai/spec/1444.md
+++ b/.ai/spec/1444.md
@@ -1,0 +1,82 @@
+# Issue #1444: raw-body retention with preserved metadata
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Purpose: reclaim event raw-body storage without deleting event/session metadata or changing metadata-only query results.
+- Current state: `events.body` is always selected by full projections; body extent metadata exists, but retained/unavailable state and reviewed plan execution do not.
+- Expected behavior: an immutable dry-run plan identifies exact body versions; apply requires a verified recovery package, rejects drift, records resumable progress, and changes only body availability/content. SQLite compaction is a separate explicit phase.
+- Non-goals: archive/backup rotation policy (#1443), automatic/default-on retention (#1445), and live-database file replacement. #1444 restores raw bodies transactionally from a verified recovery package rather than swapping the live database.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| BodyAvailability | `available`, `unavailable_retention` | describes whether the raw event body can be returned | unavailability is explicit and never inferred from an empty string |
+| RawBodyCandidate | event ID, created-at, stored bytes, SHA-256 | identifies one reviewed body version | all identity fields must match at apply time |
+| RawBodyRetentionPlan | schema version, plan ID, source snapshot, ordered candidates, cutoff | immutable reviewed intent | plan ID is SHA-256 of RFC 8785 canonical payload; unknown fields fail closed |
+| RawBodyRecoveryPackage | manifest, exact event/body rows, digests | verifies and restores candidate bodies | package coverage and candidate identities must exactly cover the plan |
+| RawBodyExecution | plan ID, status, per-candidate ledger | resumes apply and reports conflict | a candidate transitions once from pending to pruned; committed rows are idempotent |
+| Compaction | separate operator action | reclaims allocated SQLite pages | pruning never runs `VACUUM` implicitly |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Body availability invariant and plan/candidate value semantics | `domain/types` | retention vocabulary and invariants | CLI and SQL must not invent states |
+| Plan/recovery DTOs and observable results | `application/types` | use-case boundary | infrastructure rows must not leak outward |
+| Plan, recovery verification, apply orchestration | dedicated raw-body retention use case | workflow and transaction boundary | presentation must not choose eligible rows |
+| Snapshot queries, compare-and-set prune, execution ledger | `infrastructure/sqlite` adapter | SQL, paging, locking, writer order | application must not know table/column names |
+| Plan/apply/restore protocol and confirmation | `presentation/cli` | operator contract and input validation | CLI must not perform SQL or plan decisions |
+| Body-availability rendering | CLI/MCP presenters | protocol-specific additive output | domain must not know JSON/text shape |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `RawBodyRetentionPlanner.CreatePlan` | CLI plan command | read transaction, SQLite identity, paging | invalid cutoff/limit or indeterminate source fails without writes |
+| `RawBodyRecoveryManager.Create/Verify/Restore` | CLI recovery/apply/restore | package encoding, file fsync, row restoration | corrupt/incomplete/mismatched package fails closed |
+| `RawBodyRetentionExecutor.Apply` | CLI apply command | write transaction, CAS, ledger batching | stale/mismatched plan returns conflict with zero unreviewed deletions |
+| event query adapters | CLI/MCP event use cases | retained body columns | unavailable body is returned as an explicit typed state, not fabricated content |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| metadata preservation | mixed eligible rows | plan, recover, apply | metadata projection bytes are unchanged | CLI/MCP integration |
+| explicit unavailable detail | a pruned event | full-body show/read | body is absent and reason is `retention` | CLI/MCP integration |
+| dry-run purity | an eligible copied store | create plan | DB bytes/mtime and tables remain unchanged | SQLite integration |
+| stale-plan rejection | body or source snapshot changed | apply reviewed plan | apply fails before pruning any pending row | use-case/SQLite integration |
+| exact idempotency | apply interrupted after a committed batch | retry same plan | only pending exact identities transition; committed rows are no-ops | SQLite integration |
+| recovery prerequisite | no/corrupt/incomplete package | apply | apply fails with no body changes | use-case integration |
+| restore | pruned bodies with matching package | restore plan | exact bodies and availability return; second restore is a no-op | SQLite integration |
+| active-session exclusion | old body in active session | plan | candidate is excluded with `active_session` | SQLite integration |
+| no implicit compaction | successful apply | inspect page count/files | no `VACUUM` or database replacement occurred | SQLite integration |
+| canonical fixture | checked-in golden vector | encode/hash | exact canonical bytes and plan ID match | application unit |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| availability restoration | query pruned row fails to express reason | additive migration + domain state + scan/output | keep presenter mapping outside domain |
+| immutable plan | golden/hash and unknown-field tests fail | strict codec and canonicalizer | isolate canonical encoding from orchestration |
+| recovery-before-prune | apply accepts missing/mismatched recovery | package verifier and exact coverage check | separate verifier port from executor |
+| resumable CAS | crash/retry test double-prunes or skips | durable ledger + candidate CAS in bounded transactions | keep SQL/write order inside adapter |
+| restore | round-trip/idempotency tests fail | verified package restore path | share identity validation, not side-effect code |
+
+### Risks / rollback
+
+- Procedural-risk control: eligibility and state transitions live in value objects/ports; the use case only orchestrates planner, verifier, and executor.
+- Premature-abstraction control: support one raw-body policy and one package format in v0.31; do not introduce policy plugins.
+- Migration/compatibility: additive columns/tables, default `available`, existing readers remain valid; full readers gain additive availability fields. Older binaries see empty bodies for pruned rows but do not corrupt metadata.
+- Rollback: retention remains opt-in; restore exact bodies from the pinned recovery package. Disable apply on any projection drift, integrity failure, recovery mismatch, or unexpected write.
+- Physical rollback is row restoration, not live DB file replacement. This intentionally avoids implementing the design document's future strengthened swap journal until a command actually needs database replacement.
+
+### Delivery checkpoints inside the single #1444 PR
+
+1. Additive schema, availability read model, strict plan codec/golden verifier, read-only planner, and dry-run purity tests.
+2. Recovery package create/verify/restore, execution ledger, CAS apply, interruption/retry tests.
+3. CLI/MCP availability output, copied-store end-to-end QA, integrity checks, and explicit compaction separation.
+
+This remains one issue/branch/PR as required. Each checkpoint is a separate concern-focused commit and must pass `go test ./...` and `go tool golangci-lint run` before the next destructive capability is added.

--- a/.ai/spec/1444.md
+++ b/.ai/spec/1444.md
@@ -15,8 +15,8 @@
 |---|---|---|---|
 | BodyAvailability | `available`, `unavailable_retention` | describes whether the raw event body can be returned | unavailability is explicit and never inferred from an empty string |
 | RawBodyCandidate | event ID, created-at, stored bytes, SHA-256 | identifies one reviewed body version | all identity fields must match at apply time |
-| RawBodyRetentionPlan | schema version, plan ID, source snapshot, ordered candidates, cutoff | immutable reviewed intent | plan ID is SHA-256 of RFC 8785 canonical payload; unknown fields fail closed |
-| RawBodyRecoveryPackage | manifest, exact event/body rows, digests | verifies and restores candidate bodies | package coverage and candidate identities must exactly cover the plan |
+| RawBodyRetentionPlan | schema version, plan ID, source snapshot, ordered candidates, cutoff | immutable reviewed intent | plan ID is SHA-256 of the schema-restricted canonical JSON payload; unknown fields fail closed |
+| RawBodyRecoveryPackage | manifest, exact event/body rows, digests | verifies and restores candidate bodies | every planned candidate appears exactly once and matches; unrelated archive rows are allowed |
 | RawBodyExecution | plan ID, status, per-candidate ledger | resumes apply and reports conflict | a candidate transitions once from pending to pruned; committed rows are idempotent |
 | Compaction | separate operator action | reclaims allocated SQLite pages | pruning never runs `VACUUM` implicitly |
 
@@ -69,7 +69,9 @@
 
 - Procedural-risk control: eligibility and state transitions live in value objects/ports; the use case only orchestrates planner, verifier, and executor.
 - Premature-abstraction control: support one raw-body policy and one package format in v0.31; do not introduce policy plugins.
-- Migration/compatibility: additive columns/tables, default `available`, existing readers remain valid; full readers gain additive availability fields. Older binaries see empty bodies for pruned rows but do not corrupt metadata.
+- Migration/compatibility: additive columns/tables, default `available`, existing readers remain valid; full readers gain additive availability fields. Older binaries see the explicit compatibility marker for pruned rows and do not silently fabricate an empty body or corrupt metadata.
+- Scope boundary: `command_audits` columns are independently captured audit metadata, not event raw-body derivatives. Raw-body retention does not delete or hide audit fields, and search may still match them.
+- Canonicalization: `retention-plan/v1` deliberately accepts only unsigned integer JSON numbers and ASCII schema keys. It uses deterministic UTF-8 string and lexicographic object-key encoding inspired by RFC 8785, but does not claim general RFC 8785 support.
 - Rollback: retention remains opt-in; restore exact bodies from the pinned recovery package. Disable apply on any projection drift, integrity failure, recovery mismatch, or unexpected write.
 - Physical rollback is row restoration, not live DB file replacement. This intentionally avoids implementing the design document's future strengthened swap journal until a command actually needs database replacement.
 

--- a/application/raw_body_retention.go
+++ b/application/raw_body_retention.go
@@ -1,0 +1,19 @@
+package application
+
+import (
+	"context"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// RawBodyRetentionPlanner provides a body-free snapshot for immutable plan creation.
+type RawBodyRetentionPlanner interface {
+	ListRawBodyCandidates(ctx context.Context, before time.Time) (apptypes.RawBodyRetentionSnapshot, error)
+}
+
+// RawBodyRetentionExecutor applies and restores exact reviewed body identities.
+type RawBodyRetentionExecutor interface {
+	ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error)
+	RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error)
+}

--- a/application/raw_body_retention.go
+++ b/application/raw_body_retention.go
@@ -14,6 +14,6 @@ type RawBodyRetentionPlanner interface {
 
 // RawBodyRetentionExecutor applies and restores exact reviewed body identities.
 type RawBodyRetentionExecutor interface {
-	ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error)
-	RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error)
+	ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error)
+	RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error)
 }

--- a/application/types/raw_body_retention.go
+++ b/application/types/raw_body_retention.go
@@ -14,6 +14,7 @@ type RawBodyCandidate struct {
 type RawBodyRetentionSnapshot struct {
 	DatabaseIdentity  string
 	SQLiteUserVersion int
+	MigrationDigest   string
 	SnapshotAt        time.Time
 	Candidates        []RawBodyCandidate
 	ExcludedActive    []string

--- a/application/types/raw_body_retention.go
+++ b/application/types/raw_body_retention.go
@@ -1,0 +1,42 @@
+package types
+
+import "time"
+
+// RawBodyCandidate identifies one exact persisted event-body version.
+type RawBodyCandidate struct {
+	EventID     string
+	CreatedAt   time.Time
+	StoredBytes int
+	BodySHA256  string
+}
+
+// RawBodyRetentionSnapshot is the body-safe result of a read-only planner scan.
+type RawBodyRetentionSnapshot struct {
+	DatabaseIdentity  string
+	SQLiteUserVersion int
+	SnapshotAt        time.Time
+	Candidates        []RawBodyCandidate
+	ExcludedActive    []string
+}
+
+// RawBodyRecoveryBody contains one verified body used only at the executor boundary.
+type RawBodyRecoveryBody struct {
+	Candidate RawBodyCandidate
+	Body      string
+}
+
+// RawBodyApplyResult reports an idempotent plan application.
+type RawBodyApplyResult struct {
+	PlanID         string
+	CandidateCount int
+	PrunedCount    int
+	AlreadyPruned  int
+}
+
+// RawBodyRestoreResult reports an idempotent recovery operation.
+type RawBodyRestoreResult struct {
+	PlanID          string
+	CandidateCount  int
+	RestoredCount   int
+	AlreadyRestored int
+}

--- a/application/types/retention_plan.go
+++ b/application/types/retention_plan.go
@@ -1,0 +1,117 @@
+package types
+
+// RetentionPlan is the reviewed JSON envelope consumed by apply/restore.
+type RetentionPlan struct {
+	PlanID           string                    `json:"plan_id"`
+	CanonicalPayload RetentionCanonicalPayload `json:"canonical_payload"`
+	Display          RetentionPlanDisplay      `json:"display,omitempty"`
+}
+
+// RetentionCanonicalPayload is the hashed portion of retention-plan/v1.
+type RetentionCanonicalPayload struct {
+	SchemaVersion        string                   `json:"schema_version"`
+	CreatedAt            string                   `json:"created_at"`
+	SnapshotAt           string                   `json:"snapshot_at"`
+	Source               RetentionPlanSource      `json:"source"`
+	Policy               RetentionPlanPolicy      `json:"policy"`
+	ClassResults         []RetentionClassResult   `json:"class_results"`
+	Candidates           []RetentionPlanCandidate `json:"candidates"`
+	Exclusions           []RetentionPlanExclusion `json:"exclusions"`
+	RecoveryRequirements []RetentionRecoveryPoint `json:"recovery_requirements"`
+	Phases               []RetentionPlanPhase     `json:"phases"`
+}
+
+// RetentionPlanDisplay contains non-authoritative operator-facing fields.
+type RetentionPlanDisplay struct {
+	Summary string `json:"summary,omitempty"`
+}
+
+// RetentionPlanSource identifies the exact source store and reviewed roots.
+type RetentionPlanSource struct {
+	DatabaseIdentity  string              `json:"database_identity"`
+	SQLiteUserVersion int                 `json:"sqlite_user_version"`
+	MigrationDigest   string              `json:"migration_digest"`
+	Roots             []RetentionPlanRoot `json:"roots"`
+}
+
+// RetentionPlanRoot identifies one reviewed filesystem root without exposing it.
+type RetentionPlanRoot struct {
+	RootID      string `json:"root_id"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+// RetentionPlanPolicy records the configured ceilings used by the planner.
+type RetentionPlanPolicy struct {
+	Ceilings []RetentionPolicyCeiling `json:"ceilings"`
+}
+
+// RetentionPolicyCeiling records one class-specific policy ceiling.
+type RetentionPolicyCeiling struct {
+	Class   string `json:"class"`
+	Ceiling string `json:"ceiling"`
+	Value   string `json:"value"`
+}
+
+// RetentionExtent distinguishes known byte values from unknown extents.
+type RetentionExtent struct {
+	Availability string `json:"availability"`
+	Bytes        string `json:"bytes,omitempty"`
+}
+
+// RetentionCeilingResult reports current and projected status for one ceiling.
+type RetentionCeilingResult struct {
+	Ceiling   string          `json:"ceiling"`
+	Status    string          `json:"status"`
+	Current   RetentionExtent `json:"current"`
+	Projected RetentionExtent `json:"projected"`
+}
+
+// RetentionClassResult reports the AND-reduced status of one retention class.
+type RetentionClassResult struct {
+	Class    string                   `json:"class"`
+	Status   string                   `json:"status"`
+	Ceilings []RetentionCeilingResult `json:"ceilings"`
+}
+
+// RetentionPlanCandidate is one exact reviewed database or file identity.
+type RetentionPlanCandidate struct {
+	Class             string          `json:"class"`
+	IdentityKind      string          `json:"identity_kind"`
+	DatabaseIdentity  string          `json:"database_identity"`
+	RootID            string          `json:"root_id"`
+	RelativePath      string          `json:"relative_path"`
+	Timestamp         string          `json:"timestamp"`
+	CandidateIdentity string          `json:"candidate_identity"`
+	LogicalExtent     RetentionExtent `json:"logical_extent"`
+	AllocatedExtent   RetentionExtent `json:"allocated_extent"`
+	Reasons           []string        `json:"reasons"`
+}
+
+// RetentionPlanExclusion records one stable identity excluded from apply.
+type RetentionPlanExclusion struct {
+	Reason         string `json:"reason"`
+	StableIdentity string `json:"stable_identity"`
+}
+
+// RetentionRecoveryPoint pins the verified recovery artifact required by apply.
+type RetentionRecoveryPoint struct {
+	Generation     string `json:"generation"`
+	Digest         string `json:"digest"`
+	RootID         string `json:"root_id"`
+	RelativePath   string `json:"relative_path"`
+	CoverageDigest string `json:"coverage_digest"`
+	State          string `json:"state"`
+}
+
+// RetentionPlanBatch groups ordered candidate identities for one transaction.
+type RetentionPlanBatch struct {
+	Ordinal             string   `json:"ordinal"`
+	CandidateIdentities []string `json:"candidate_identities"`
+}
+
+// RetentionPlanPhase records ordered execution steps for one retention phase.
+type RetentionPlanPhase struct {
+	Phase        string               `json:"phase"`
+	Batches      []RetentionPlanBatch `json:"batches"`
+	OrderedSteps []string             `json:"ordered_steps"`
+}

--- a/application/usecase/raw_body_retention_usecase.go
+++ b/application/usecase/raw_body_retention_usecase.go
@@ -1,0 +1,225 @@
+package usecase
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// RawBodyRetentionUsecase creates and executes reviewed raw-body plans.
+type RawBodyRetentionUsecase interface {
+	CreatePlan(ctx context.Context, before time.Time, recoveryPath string, now time.Time) ([]byte, error)
+	Apply(ctx context.Context, planData []byte, recoveryPath, confirmedPlanID string, now time.Time) (apptypes.RawBodyApplyResult, error)
+	Restore(ctx context.Context, planData []byte, recoveryPath, confirmedPlanID string, now time.Time) (apptypes.RawBodyRestoreResult, error)
+}
+
+type rawBodyRetentionUsecase struct {
+	planner  application.RawBodyRetentionPlanner
+	executor application.RawBodyRetentionExecutor
+}
+
+// NewRawBodyRetentionUsecase creates the explicit plan/apply/restore workflow.
+func NewRawBodyRetentionUsecase(planner application.RawBodyRetentionPlanner, executor application.RawBodyRetentionExecutor) RawBodyRetentionUsecase {
+	return &rawBodyRetentionUsecase{planner: planner, executor: executor}
+}
+
+func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Time, recoveryPath string, now time.Time) ([]byte, error) {
+	if u.planner == nil {
+		return nil, xerrors.Errorf("raw-body retention planner is not configured")
+	}
+	if before.IsZero() || !before.Before(now) {
+		return nil, xerrors.Errorf("retention cutoff must be before the plan time")
+	}
+	snapshot, err := u.planner.ListRawBodyCandidates(ctx, before)
+	if err != nil {
+		return nil, xerrors.Errorf("list raw-body candidates: %w", err)
+	}
+	recovery, recoveryDigest, err := loadRawBodyRecovery(recoveryPath, snapshot.Candidates)
+	if err != nil {
+		return nil, err
+	}
+	_ = recovery
+
+	candidates := make([]apptypes.RetentionPlanCandidate, 0, len(snapshot.Candidates))
+	identities := make([]string, 0, len(snapshot.Candidates))
+	totalBytes := 0
+	for _, candidate := range snapshot.Candidates {
+		identity := rawBodyCandidateIdentity(candidate.EventID, candidate.BodySHA256)
+		identities = append(identities, identity)
+		totalBytes += candidate.StoredBytes
+		candidates = append(candidates, apptypes.RetentionPlanCandidate{
+			Class: "raw_body", IdentityKind: "database", DatabaseIdentity: candidate.EventID,
+			RootID: "", RelativePath: "", Timestamp: candidate.CreatedAt.UTC().Format(time.RFC3339Nano), CandidateIdentity: identity,
+			LogicalExtent:   apptypes.RetentionExtent{Availability: "known", Bytes: strconv.Itoa(candidate.StoredBytes)},
+			AllocatedExtent: apptypes.RetentionExtent{Availability: "unknown"}, Reasons: []string{"age"},
+		})
+	}
+	exclusions := make([]apptypes.RetentionPlanExclusion, 0, len(snapshot.ExcludedActive))
+	for _, eventID := range snapshot.ExcludedActive {
+		exclusions = append(exclusions, apptypes.RetentionPlanExclusion{Reason: "active_session", StableIdentity: "event:" + base64.RawURLEncoding.EncodeToString([]byte(eventID))})
+	}
+	coverage := sha256.Sum256([]byte(joinIdentities(identities)))
+	rootPath, err := filepath.Abs(filepath.Dir(recoveryPath))
+	if err != nil {
+		return nil, xerrors.Errorf("resolve recovery root: %w", err)
+	}
+	rootDigest := sha256.Sum256([]byte(rootPath))
+	migrationDigest := sha256.Sum256([]byte("traceary-sqlite-user-version:" + strconv.Itoa(snapshot.SQLiteUserVersion)))
+	status := "satisfied"
+	if len(candidates) > 0 {
+		status = "unsatisfied"
+	}
+	plan := apptypes.RetentionPlan{
+		CanonicalPayload: apptypes.RetentionCanonicalPayload{
+			SchemaVersion: retentionPlanSchemaVersion,
+			CreatedAt:     now.UTC().Format(time.RFC3339Nano), SnapshotAt: snapshot.SnapshotAt.UTC().Format(time.RFC3339Nano),
+			Source: apptypes.RetentionPlanSource{
+				DatabaseIdentity: snapshot.DatabaseIdentity, SQLiteUserVersion: snapshot.SQLiteUserVersion,
+				MigrationDigest: hex.EncodeToString(migrationDigest[:]),
+				Roots:           []apptypes.RetentionPlanRoot{{RootID: "recovery", Fingerprint: hex.EncodeToString(rootDigest[:])}},
+			},
+			Policy: apptypes.RetentionPlanPolicy{Ceilings: []apptypes.RetentionPolicyCeiling{{Class: "raw_body", Ceiling: "age", Value: strconv.FormatInt(now.Sub(before).Nanoseconds(), 10)}}},
+			ClassResults: []apptypes.RetentionClassResult{{
+				Class: "raw_body", Status: status,
+				Ceilings: []apptypes.RetentionCeilingResult{{Ceiling: "age", Status: status, Current: apptypes.RetentionExtent{Availability: "known", Bytes: strconv.Itoa(totalBytes)}, Projected: apptypes.RetentionExtent{Availability: "known", Bytes: "0"}}},
+			}},
+			Candidates: candidates, Exclusions: exclusions,
+			RecoveryRequirements: []apptypes.RetentionRecoveryPoint{{
+				Generation: "archive-" + recoveryDigest[:12], Digest: recoveryDigest, RootID: "recovery", RelativePath: filepath.Base(recoveryPath),
+				CoverageDigest: hex.EncodeToString(coverage[:]), State: "active",
+			}},
+			Phases: []apptypes.RetentionPlanPhase{{Phase: "body_prune", Batches: []apptypes.RetentionPlanBatch{{Ordinal: "0", CandidateIdentities: identities}}, OrderedSteps: []string{"verify-source", "verify-recovery", "prune-body", "record-ledger"}}},
+		},
+		Display: apptypes.RetentionPlanDisplay{Summary: strconv.Itoa(len(candidates)) + " raw-body candidates, " + strconv.Itoa(len(exclusions)) + " active-session exclusions"},
+	}
+	return encodeRetentionPlan(plan)
+}
+
+func (u *rawBodyRetentionUsecase) Apply(ctx context.Context, planData []byte, recoveryPath, confirmedPlanID string, now time.Time) (apptypes.RawBodyApplyResult, error) {
+	if u.executor == nil {
+		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("raw-body retention executor is not configured")
+	}
+	plan, candidates, bodies, err := u.prepareExecution(planData, recoveryPath)
+	if err != nil {
+		return apptypes.RawBodyApplyResult{}, err
+	}
+	if plan.PlanID != confirmedPlanID {
+		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
+	}
+	_ = bodies
+	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.PlanID, candidates, now.UTC())
+	if err != nil {
+		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("apply reviewed raw-body plan: %w", err)
+	}
+	return result, nil
+}
+
+func (u *rawBodyRetentionUsecase) Restore(ctx context.Context, planData []byte, recoveryPath, confirmedPlanID string, now time.Time) (apptypes.RawBodyRestoreResult, error) {
+	if u.executor == nil {
+		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("raw-body retention executor is not configured")
+	}
+	plan, _, bodies, err := u.prepareExecution(planData, recoveryPath)
+	if err != nil {
+		return apptypes.RawBodyRestoreResult{}, err
+	}
+	if plan.PlanID != confirmedPlanID {
+		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
+	}
+	result, err := u.executor.RestoreRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.PlanID, bodies, now.UTC())
+	if err != nil {
+		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("restore reviewed raw-body plan: %w", err)
+	}
+	return result, nil
+}
+
+func (u *rawBodyRetentionUsecase) prepareExecution(planData []byte, recoveryPath string) (apptypes.RetentionPlan, []apptypes.RawBodyCandidate, []apptypes.RawBodyRecoveryBody, error) {
+	plan, err := decodeRetentionPlan(planData)
+	if err != nil {
+		return apptypes.RetentionPlan{}, nil, nil, err
+	}
+	candidates := make([]apptypes.RawBodyCandidate, 0, len(plan.CanonicalPayload.Candidates))
+	for _, planned := range plan.CanonicalPayload.Candidates {
+		eventID, digest, err := parseRawBodyCandidateIdentity(planned.CandidateIdentity)
+		if err != nil || eventID != planned.DatabaseIdentity {
+			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("retention candidate identity does not match database identity")
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, planned.Timestamp)
+		if err != nil {
+			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("parse retention candidate timestamp: %w", err)
+		}
+		storedBytes, err := strconv.Atoi(planned.LogicalExtent.Bytes)
+		if err != nil || storedBytes < 0 {
+			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("invalid retention candidate stored bytes")
+		}
+		candidates = append(candidates, apptypes.RawBodyCandidate{EventID: eventID, CreatedAt: createdAt, StoredBytes: storedBytes, BodySHA256: digest})
+	}
+	bodies, recoveryDigest, err := loadRawBodyRecovery(recoveryPath, candidates)
+	if err != nil {
+		return apptypes.RetentionPlan{}, nil, nil, err
+	}
+	if recoveryDigest != plan.CanonicalPayload.RecoveryRequirements[0].Digest {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery package digest does not match reviewed plan")
+	}
+	return plan, candidates, bodies, nil
+}
+
+func loadRawBodyRecovery(path string, candidates []apptypes.RawBodyCandidate) ([]apptypes.RawBodyRecoveryBody, string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", xerrors.Errorf("read recovery package: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	manifest, files, err := openStoreArchivePackage(data, nil)
+	if err != nil {
+		return nil, "", xerrors.Errorf("open recovery package: %w", err)
+	}
+	if err := verifyStoreArchiveContents(manifest, files); err != nil {
+		return nil, "", xerrors.Errorf("verify recovery package: %w", err)
+	}
+	tables, err := parseStoreArchiveTables(manifest, files)
+	if err != nil {
+		return nil, "", xerrors.Errorf("parse recovery package: %w", err)
+	}
+	byID := make(map[string]string)
+	for _, row := range tables["events"] {
+		id, idOK := row["id"].(string)
+		body, bodyOK := row["body"].(string)
+		if idOK && bodyOK {
+			byID[id] = body
+		}
+	}
+	bodies := make([]apptypes.RawBodyRecoveryBody, 0, len(candidates))
+	for _, candidate := range candidates {
+		body, ok := byID[candidate.EventID]
+		if !ok {
+			return nil, "", xerrors.Errorf("recovery package does not cover event %s", candidate.EventID)
+		}
+		bodyDigest := sha256.Sum256([]byte(body))
+		if len(body) != candidate.StoredBytes || hex.EncodeToString(bodyDigest[:]) != candidate.BodySHA256 {
+			return nil, "", xerrors.Errorf("recovery package body does not match event %s", candidate.EventID)
+		}
+		bodies = append(bodies, apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: body})
+	}
+	return bodies, hex.EncodeToString(digest[:]), nil
+}
+
+func joinIdentities(identities []string) string {
+	result := ""
+	for index, identity := range identities {
+		if index > 0 {
+			result += "\n"
+		}
+		result += identity
+	}
+	return result
+}

--- a/application/usecase/raw_body_retention_usecase.go
+++ b/application/usecase/raw_body_retention_usecase.go
@@ -68,13 +68,11 @@ func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Ti
 	for _, eventID := range snapshot.ExcludedActive {
 		exclusions = append(exclusions, apptypes.RetentionPlanExclusion{Reason: "active_session", StableIdentity: "event:" + base64.RawURLEncoding.EncodeToString([]byte(eventID))})
 	}
-	coverage := sha256.Sum256([]byte(joinIdentities(identities)))
 	rootPath, err := filepath.Abs(filepath.Dir(recoveryPath))
 	if err != nil {
 		return nil, xerrors.Errorf("resolve recovery root: %w", err)
 	}
 	rootDigest := sha256.Sum256([]byte(rootPath))
-	migrationDigest := sha256.Sum256([]byte("traceary-sqlite-user-version:" + strconv.Itoa(snapshot.SQLiteUserVersion)))
 	status := "satisfied"
 	if len(candidates) > 0 {
 		status = "unsatisfied"
@@ -85,7 +83,7 @@ func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Ti
 			CreatedAt:     now.UTC().Format(time.RFC3339Nano), SnapshotAt: snapshot.SnapshotAt.UTC().Format(time.RFC3339Nano),
 			Source: apptypes.RetentionPlanSource{
 				DatabaseIdentity: snapshot.DatabaseIdentity, SQLiteUserVersion: snapshot.SQLiteUserVersion,
-				MigrationDigest: hex.EncodeToString(migrationDigest[:]),
+				MigrationDigest: snapshot.MigrationDigest,
 				Roots:           []apptypes.RetentionPlanRoot{{RootID: "recovery", Fingerprint: hex.EncodeToString(rootDigest[:])}},
 			},
 			Policy: apptypes.RetentionPlanPolicy{Ceilings: []apptypes.RetentionPolicyCeiling{{Class: "raw_body", Ceiling: "age", Value: strconv.FormatInt(now.Sub(before).Nanoseconds(), 10)}}},
@@ -96,12 +94,19 @@ func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Ti
 			Candidates: candidates, Exclusions: exclusions,
 			RecoveryRequirements: []apptypes.RetentionRecoveryPoint{{
 				Generation: "archive-" + recoveryDigest[:12], Digest: recoveryDigest, RootID: "recovery", RelativePath: filepath.Base(recoveryPath),
-				CoverageDigest: hex.EncodeToString(coverage[:]), State: "active",
+				CoverageDigest: hex.EncodeToString(make([]byte, sha256.Size)), State: "active",
 			}},
 			Phases: []apptypes.RetentionPlanPhase{{Phase: "body_prune", Batches: []apptypes.RetentionPlanBatch{{Ordinal: "0", CandidateIdentities: identities}}, OrderedSteps: []string{"verify-source", "verify-recovery", "prune-body", "record-ledger"}}},
 		},
 		Display: apptypes.RetentionPlanDisplay{Summary: strconv.Itoa(len(candidates)) + " raw-body candidates, " + strconv.Itoa(len(exclusions)) + " active-session exclusions"},
 	}
+	normalizeRetentionPlan(&plan)
+	identities = identities[:0]
+	for _, candidate := range plan.CanonicalPayload.Candidates {
+		identities = append(identities, candidate.CandidateIdentity)
+	}
+	coverage := sha256.Sum256([]byte(joinIdentities(identities)))
+	plan.CanonicalPayload.RecoveryRequirements[0].CoverageDigest = hex.EncodeToString(coverage[:])
 	return encodeRetentionPlan(plan)
 }
 
@@ -117,7 +122,7 @@ func (u *rawBodyRetentionUsecase) Apply(ctx context.Context, planData []byte, re
 		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
 	}
 	_ = bodies
-	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.PlanID, candidates, now.UTC())
+	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, candidates, now.UTC())
 	if err != nil {
 		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("apply reviewed raw-body plan: %w", err)
 	}
@@ -135,7 +140,7 @@ func (u *rawBodyRetentionUsecase) Restore(ctx context.Context, planData []byte, 
 	if plan.PlanID != confirmedPlanID {
 		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
 	}
-	result, err := u.executor.RestoreRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.PlanID, bodies, now.UTC())
+	result, err := u.executor.RestoreRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, bodies, now.UTC())
 	if err != nil {
 		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("restore reviewed raw-body plan: %w", err)
 	}
@@ -170,6 +175,36 @@ func (u *rawBodyRetentionUsecase) prepareExecution(planData []byte, recoveryPath
 	if recoveryDigest != plan.CanonicalPayload.RecoveryRequirements[0].Digest {
 		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery package digest does not match reviewed plan")
 	}
+	recovery := plan.CanonicalPayload.RecoveryRequirements[0]
+	if recovery.Generation != "archive-"+recoveryDigest[:12] {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery generation does not match reviewed package")
+	}
+	rootPath, err := filepath.Abs(filepath.Dir(recoveryPath))
+	if err != nil {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("resolve recovery root: %w", err)
+	}
+	rootDigest := sha256.Sum256([]byte(rootPath))
+	if len(plan.CanonicalPayload.Source.Roots) != 1 || plan.CanonicalPayload.Source.Roots[0].RootID != recovery.RootID || plan.CanonicalPayload.Source.Roots[0].Fingerprint != hex.EncodeToString(rootDigest[:]) || recovery.RelativePath != filepath.Base(recoveryPath) {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery location does not match reviewed plan")
+	}
+	identities := make([]string, len(plan.CanonicalPayload.Candidates))
+	totalBytes := 0
+	for index, candidate := range plan.CanonicalPayload.Candidates {
+		identities[index] = candidate.CandidateIdentity
+		totalBytes += candidates[index].StoredBytes
+	}
+	coverage := sha256.Sum256([]byte(joinIdentities(identities)))
+	if recovery.CoverageDigest != hex.EncodeToString(coverage[:]) {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery coverage does not match reviewed candidates")
+	}
+	wantStatus := "satisfied"
+	if len(candidates) > 0 {
+		wantStatus = "unsatisfied"
+	}
+	classResult := plan.CanonicalPayload.ClassResults[0]
+	if classResult.Status != wantStatus || classResult.Ceilings[0].Current.Bytes != strconv.Itoa(totalBytes) || classResult.Ceilings[0].Projected.Bytes != "0" {
+		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("retention class result does not match reviewed candidates")
+	}
 	return plan, candidates, bodies, nil
 }
 
@@ -195,6 +230,9 @@ func loadRawBodyRecovery(path string, candidates []apptypes.RawBodyCandidate) ([
 		id, idOK := row["id"].(string)
 		body, bodyOK := row["body"].(string)
 		if idOK && bodyOK {
+			if _, exists := byID[id]; exists {
+				return nil, "", xerrors.Errorf("recovery package contains duplicate event %s", id)
+			}
 			byID[id] = body
 		}
 	}

--- a/application/usecase/raw_body_retention_usecase.go
+++ b/application/usecase/raw_body_retention_usecase.go
@@ -96,7 +96,7 @@ func (u *rawBodyRetentionUsecase) CreatePlan(ctx context.Context, before time.Ti
 				Generation: "archive-" + recoveryDigest[:12], Digest: recoveryDigest, RootID: "recovery", RelativePath: filepath.Base(recoveryPath),
 				CoverageDigest: hex.EncodeToString(make([]byte, sha256.Size)), State: "active",
 			}},
-			Phases: []apptypes.RetentionPlanPhase{{Phase: "body_prune", Batches: []apptypes.RetentionPlanBatch{{Ordinal: "0", CandidateIdentities: identities}}, OrderedSteps: []string{"verify-source", "verify-recovery", "prune-body", "record-ledger"}}},
+			Phases: []apptypes.RetentionPlanPhase{{Phase: "body_prune", Batches: nil, OrderedSteps: []string{"verify-plan", "confirm-plan", "verify-recovery", "verify-source", "prune-body", "record-ledger"}}},
 		},
 		Display: apptypes.RetentionPlanDisplay{Summary: strconv.Itoa(len(candidates)) + " raw-body candidates, " + strconv.Itoa(len(exclusions)) + " active-session exclusions"},
 	}
@@ -114,12 +114,13 @@ func (u *rawBodyRetentionUsecase) Apply(ctx context.Context, planData []byte, re
 	if u.executor == nil {
 		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("raw-body retention executor is not configured")
 	}
-	plan, candidates, bodies, err := u.prepareExecution(planData, recoveryPath)
+	plan, err := decodeConfirmedRetentionPlan(planData, confirmedPlanID)
 	if err != nil {
 		return apptypes.RawBodyApplyResult{}, err
 	}
-	if plan.PlanID != confirmedPlanID {
-		return apptypes.RawBodyApplyResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
+	candidates, bodies, err := u.prepareExecution(plan, recoveryPath)
+	if err != nil {
+		return apptypes.RawBodyApplyResult{}, err
 	}
 	_ = bodies
 	result, err := u.executor.ApplyRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, candidates, now.UTC())
@@ -133,12 +134,13 @@ func (u *rawBodyRetentionUsecase) Restore(ctx context.Context, planData []byte, 
 	if u.executor == nil {
 		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("raw-body retention executor is not configured")
 	}
-	plan, _, bodies, err := u.prepareExecution(planData, recoveryPath)
+	plan, err := decodeConfirmedRetentionPlan(planData, confirmedPlanID)
 	if err != nil {
 		return apptypes.RawBodyRestoreResult{}, err
 	}
-	if plan.PlanID != confirmedPlanID {
-		return apptypes.RawBodyRestoreResult{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
+	_, bodies, err := u.prepareExecution(plan, recoveryPath)
+	if err != nil {
+		return apptypes.RawBodyRestoreResult{}, err
 	}
 	result, err := u.executor.RestoreRawBodyPlan(ctx, plan.CanonicalPayload.Source.DatabaseIdentity, plan.CanonicalPayload.Source.SQLiteUserVersion, plan.CanonicalPayload.Source.MigrationDigest, plan.PlanID, bodies, now.UTC())
 	if err != nil {
@@ -147,45 +149,52 @@ func (u *rawBodyRetentionUsecase) Restore(ctx context.Context, planData []byte, 
 	return result, nil
 }
 
-func (u *rawBodyRetentionUsecase) prepareExecution(planData []byte, recoveryPath string) (apptypes.RetentionPlan, []apptypes.RawBodyCandidate, []apptypes.RawBodyRecoveryBody, error) {
+func decodeConfirmedRetentionPlan(planData []byte, confirmedPlanID string) (apptypes.RetentionPlan, error) {
 	plan, err := decodeRetentionPlan(planData)
 	if err != nil {
-		return apptypes.RetentionPlan{}, nil, nil, err
+		return apptypes.RetentionPlan{}, err
 	}
+	if plan.PlanID != confirmedPlanID {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("confirmed plan ID does not match reviewed plan")
+	}
+	return plan, nil
+}
+
+func (u *rawBodyRetentionUsecase) prepareExecution(plan apptypes.RetentionPlan, recoveryPath string) ([]apptypes.RawBodyCandidate, []apptypes.RawBodyRecoveryBody, error) {
 	candidates := make([]apptypes.RawBodyCandidate, 0, len(plan.CanonicalPayload.Candidates))
 	for _, planned := range plan.CanonicalPayload.Candidates {
 		eventID, digest, err := parseRawBodyCandidateIdentity(planned.CandidateIdentity)
 		if err != nil || eventID != planned.DatabaseIdentity {
-			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("retention candidate identity does not match database identity")
+			return nil, nil, xerrors.Errorf("retention candidate identity does not match database identity")
 		}
 		createdAt, err := time.Parse(time.RFC3339Nano, planned.Timestamp)
 		if err != nil {
-			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("parse retention candidate timestamp: %w", err)
+			return nil, nil, xerrors.Errorf("parse retention candidate timestamp: %w", err)
 		}
 		storedBytes, err := strconv.Atoi(planned.LogicalExtent.Bytes)
 		if err != nil || storedBytes < 0 {
-			return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("invalid retention candidate stored bytes")
+			return nil, nil, xerrors.Errorf("invalid retention candidate stored bytes")
 		}
 		candidates = append(candidates, apptypes.RawBodyCandidate{EventID: eventID, CreatedAt: createdAt, StoredBytes: storedBytes, BodySHA256: digest})
 	}
 	bodies, recoveryDigest, err := loadRawBodyRecovery(recoveryPath, candidates)
 	if err != nil {
-		return apptypes.RetentionPlan{}, nil, nil, err
+		return nil, nil, err
 	}
 	if recoveryDigest != plan.CanonicalPayload.RecoveryRequirements[0].Digest {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery package digest does not match reviewed plan")
+		return nil, nil, xerrors.Errorf("recovery package digest does not match reviewed plan")
 	}
 	recovery := plan.CanonicalPayload.RecoveryRequirements[0]
 	if recovery.Generation != "archive-"+recoveryDigest[:12] {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery generation does not match reviewed package")
+		return nil, nil, xerrors.Errorf("recovery generation does not match reviewed package")
 	}
 	rootPath, err := filepath.Abs(filepath.Dir(recoveryPath))
 	if err != nil {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("resolve recovery root: %w", err)
+		return nil, nil, xerrors.Errorf("resolve recovery root: %w", err)
 	}
 	rootDigest := sha256.Sum256([]byte(rootPath))
 	if len(plan.CanonicalPayload.Source.Roots) != 1 || plan.CanonicalPayload.Source.Roots[0].RootID != recovery.RootID || plan.CanonicalPayload.Source.Roots[0].Fingerprint != hex.EncodeToString(rootDigest[:]) || recovery.RelativePath != filepath.Base(recoveryPath) {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery location does not match reviewed plan")
+		return nil, nil, xerrors.Errorf("recovery location does not match reviewed plan")
 	}
 	identities := make([]string, len(plan.CanonicalPayload.Candidates))
 	totalBytes := 0
@@ -195,7 +204,7 @@ func (u *rawBodyRetentionUsecase) prepareExecution(planData []byte, recoveryPath
 	}
 	coverage := sha256.Sum256([]byte(joinIdentities(identities)))
 	if recovery.CoverageDigest != hex.EncodeToString(coverage[:]) {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("recovery coverage does not match reviewed candidates")
+		return nil, nil, xerrors.Errorf("recovery coverage does not match reviewed candidates")
 	}
 	wantStatus := "satisfied"
 	if len(candidates) > 0 {
@@ -203,9 +212,9 @@ func (u *rawBodyRetentionUsecase) prepareExecution(planData []byte, recoveryPath
 	}
 	classResult := plan.CanonicalPayload.ClassResults[0]
 	if classResult.Status != wantStatus || classResult.Ceilings[0].Current.Bytes != strconv.Itoa(totalBytes) || classResult.Ceilings[0].Projected.Bytes != "0" {
-		return apptypes.RetentionPlan{}, nil, nil, xerrors.Errorf("retention class result does not match reviewed candidates")
+		return nil, nil, xerrors.Errorf("retention class result does not match reviewed candidates")
 	}
-	return plan, candidates, bodies, nil
+	return candidates, bodies, nil
 }
 
 func loadRawBodyRecovery(path string, candidates []apptypes.RawBodyCandidate) ([]apptypes.RawBodyRecoveryBody, string, error) {
@@ -225,28 +234,39 @@ func loadRawBodyRecovery(path string, candidates []apptypes.RawBodyCandidate) ([
 	if err != nil {
 		return nil, "", xerrors.Errorf("parse recovery package: %w", err)
 	}
-	byID := make(map[string]string)
+	type recoveryEvent struct {
+		body      string
+		createdAt string
+	}
+	byID := make(map[string]recoveryEvent)
 	for _, row := range tables["events"] {
 		id, idOK := row["id"].(string)
 		body, bodyOK := row["body"].(string)
-		if idOK && bodyOK {
+		createdAt, createdAtOK := row["created_at"].(string)
+		if idOK {
 			if _, exists := byID[id]; exists {
 				return nil, "", xerrors.Errorf("recovery package contains duplicate event %s", id)
 			}
-			byID[id] = body
+			if bodyOK && createdAtOK {
+				byID[id] = recoveryEvent{body: body, createdAt: createdAt}
+			}
 		}
 	}
 	bodies := make([]apptypes.RawBodyRecoveryBody, 0, len(candidates))
 	for _, candidate := range candidates {
-		body, ok := byID[candidate.EventID]
+		archived, ok := byID[candidate.EventID]
 		if !ok {
 			return nil, "", xerrors.Errorf("recovery package does not cover event %s", candidate.EventID)
 		}
-		bodyDigest := sha256.Sum256([]byte(body))
-		if len(body) != candidate.StoredBytes || hex.EncodeToString(bodyDigest[:]) != candidate.BodySHA256 {
+		archivedCreatedAt, err := time.Parse(time.RFC3339Nano, archived.createdAt)
+		if err != nil || !archivedCreatedAt.Equal(candidate.CreatedAt) {
+			return nil, "", xerrors.Errorf("recovery package timestamp does not match event %s", candidate.EventID)
+		}
+		bodyDigest := sha256.Sum256([]byte(archived.body))
+		if len(archived.body) != candidate.StoredBytes || hex.EncodeToString(bodyDigest[:]) != candidate.BodySHA256 {
 			return nil, "", xerrors.Errorf("recovery package body does not match event %s", candidate.EventID)
 		}
-		bodies = append(bodies, apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: body})
+		bodies = append(bodies, apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: archived.body})
 	}
 	return bodies, hex.EncodeToString(digest[:]), nil
 }

--- a/application/usecase/retention_plan_codec.go
+++ b/application/usecase/retention_plan_codec.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -263,10 +264,10 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 		}
 		seen[candidate.CandidateIdentity] = struct{}{}
 	}
-	if len(payload.Phases) != 1 || payload.Phases[0].Phase != "body_prune" || len(payload.Phases[0].Batches) != 1 {
-		return xerrors.Errorf("raw-body retention plan must contain one body_prune batch")
+	if len(payload.Phases) != 1 || payload.Phases[0].Phase != "body_prune" || len(payload.Phases[0].Batches) != len(payload.Candidates) {
+		return xerrors.Errorf("raw-body retention plan must contain one durable batch per candidate")
 	}
-	wantSteps := []string{"verify-source", "verify-recovery", "prune-body", "record-ledger"}
+	wantSteps := []string{"verify-plan", "confirm-plan", "verify-recovery", "verify-source", "prune-body", "record-ledger"}
 	if len(payload.Phases[0].OrderedSteps) != len(wantSteps) {
 		return xerrors.Errorf("retention body_prune steps are invalid")
 	}
@@ -275,12 +276,9 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 			return xerrors.Errorf("retention body_prune steps are invalid")
 		}
 	}
-	batch := payload.Phases[0].Batches[0]
-	if batch.Ordinal != "0" || len(batch.CandidateIdentities) != len(payload.Candidates) {
-		return xerrors.Errorf("retention plan batch does not cover every candidate")
-	}
 	for index, candidate := range payload.Candidates {
-		if batch.CandidateIdentities[index] != candidate.CandidateIdentity {
+		batch := payload.Phases[0].Batches[index]
+		if batch.Ordinal != strconv.Itoa(index) || len(batch.CandidateIdentities) != 1 || batch.CandidateIdentities[0] != candidate.CandidateIdentity {
 			return xerrors.Errorf("retention plan batch order does not match candidates")
 		}
 	}
@@ -297,6 +295,9 @@ func validateUTCInstant(value string) error {
 	}
 	if parsed.IsZero() {
 		return xerrors.Errorf("timestamp must not be zero")
+	}
+	if value != parsed.UTC().Format(time.RFC3339Nano) {
+		return xerrors.Errorf("timestamp must use canonical RFC3339Nano form")
 	}
 	return nil
 }
@@ -351,12 +352,12 @@ func normalizeRetentionPlan(plan *apptypes.RetentionPlan) {
 		}
 		return left.StableIdentity < right.StableIdentity
 	})
-	if len(plan.CanonicalPayload.Phases) == 1 && len(plan.CanonicalPayload.Phases[0].Batches) == 1 {
-		identities := make([]string, len(plan.CanonicalPayload.Candidates))
+	if len(plan.CanonicalPayload.Phases) == 1 {
+		batches := make([]apptypes.RetentionPlanBatch, len(plan.CanonicalPayload.Candidates))
 		for index, candidate := range plan.CanonicalPayload.Candidates {
-			identities[index] = candidate.CandidateIdentity
+			batches[index] = apptypes.RetentionPlanBatch{Ordinal: strconv.Itoa(index), CandidateIdentities: []string{candidate.CandidateIdentity}}
 		}
-		plan.CanonicalPayload.Phases[0].Batches[0].CandidateIdentities = identities
+		plan.CanonicalPayload.Phases[0].Batches = batches
 	}
 }
 

--- a/application/usecase/retention_plan_codec.go
+++ b/application/usecase/retention_plan_codec.go
@@ -1,0 +1,305 @@
+package usecase
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const retentionPlanSchemaVersion = "retention-plan/v1"
+
+var (
+	canonicalUnsignedInteger = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+	lowerHexDigest           = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+func encodeRetentionPlan(plan apptypes.RetentionPlan) ([]byte, error) {
+	normalizeRetentionPlan(&plan)
+	canonical, err := canonicalRetentionPayload(plan.CanonicalPayload)
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(canonical)
+	plan.PlanID = hex.EncodeToString(digest[:])
+	if err := validateRetentionPlan(plan); err != nil {
+		return nil, err
+	}
+	encoded, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return nil, xerrors.Errorf("marshal retention plan: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+func decodeRetentionPlan(data []byte) (apptypes.RetentionPlan, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var plan apptypes.RetentionPlan
+	if err := decoder.Decode(&plan); err != nil {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("parse retention plan: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return apptypes.RetentionPlan{}, err
+	}
+	if err := validateRetentionPlan(plan); err != nil {
+		return apptypes.RetentionPlan{}, err
+	}
+	normalized := plan
+	normalizeRetentionPlan(&normalized)
+	canonical, err := canonicalRetentionPayload(normalized.CanonicalPayload)
+	if err != nil {
+		return apptypes.RetentionPlan{}, err
+	}
+	digest := sha256.Sum256(canonical)
+	if hex.EncodeToString(digest[:]) != plan.PlanID {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("retention plan ID does not match canonical payload")
+	}
+	if !retentionPlanOrderEqual(plan, normalized) {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("retention plan arrays are not in canonical order")
+	}
+	return plan, nil
+}
+
+func canonicalRetentionPayload(payload apptypes.RetentionCanonicalPayload) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, xerrors.Errorf("marshal canonical payload: %w", err)
+	}
+	return canonicalizeJSON(raw)
+}
+
+func canonicalizeJSON(raw []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, xerrors.Errorf("decode canonical JSON input: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return nil, err
+	}
+	var output bytes.Buffer
+	if err := appendCanonicalJSON(&output, value); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func appendCanonicalJSON(output *bytes.Buffer, value any) error {
+	switch typed := value.(type) {
+	case nil:
+		output.WriteString("null")
+	case bool:
+		if typed {
+			output.WriteString("true")
+		} else {
+			output.WriteString("false")
+		}
+	case string:
+		encoded, err := canonicalJSONString(typed)
+		if err != nil {
+			return err
+		}
+		output.Write(encoded)
+	case json.Number:
+		if !canonicalUnsignedInteger.MatchString(typed.String()) {
+			return xerrors.Errorf("canonical retention JSON supports unsigned integer numbers only: %s", typed)
+		}
+		output.WriteString(typed.String())
+	case []any:
+		output.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				output.WriteByte(',')
+			}
+			if err := appendCanonicalJSON(output, item); err != nil {
+				return err
+			}
+		}
+		output.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			if !isASCII(key) {
+				return xerrors.Errorf("canonical retention object key must be ASCII: %q", key)
+			}
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		output.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				output.WriteByte(',')
+			}
+			encoded, err := canonicalJSONString(key)
+			if err != nil {
+				return err
+			}
+			output.Write(encoded)
+			output.WriteByte(':')
+			if err := appendCanonicalJSON(output, typed[key]); err != nil {
+				return err
+			}
+		}
+		output.WriteByte('}')
+	default:
+		return xerrors.Errorf("unsupported canonical JSON value %T", value)
+	}
+	return nil
+}
+
+func canonicalJSONString(value string) ([]byte, error) {
+	if !utf8.ValidString(value) {
+		return nil, xerrors.Errorf("canonical JSON string is not valid UTF-8")
+	}
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, xerrors.Errorf("encode canonical JSON string: %w", err)
+	}
+	encoded := bytes.TrimSuffix(output.Bytes(), []byte{'\n'})
+	encoded = bytes.ReplaceAll(encoded, []byte(`\u2028`), []byte("\xe2\x80\xa8"))
+	encoded = bytes.ReplaceAll(encoded, []byte(`\u2029`), []byte("\xe2\x80\xa9"))
+	return encoded, nil
+}
+
+func validateRetentionPlan(plan apptypes.RetentionPlan) error {
+	if !lowerHexDigest.MatchString(plan.PlanID) {
+		return xerrors.Errorf("retention plan ID must be a lowercase SHA-256 digest")
+	}
+	payload := plan.CanonicalPayload
+	if payload.SchemaVersion != retentionPlanSchemaVersion {
+		return xerrors.Errorf("unsupported retention plan schema %q", payload.SchemaVersion)
+	}
+	if payload.Source.DatabaseIdentity == "" || payload.CreatedAt == "" || payload.SnapshotAt == "" {
+		return xerrors.Errorf("retention plan source and timestamps are required")
+	}
+	if len(payload.RecoveryRequirements) != 1 || !lowerHexDigest.MatchString(payload.RecoveryRequirements[0].Digest) || payload.RecoveryRequirements[0].State != "active" {
+		return xerrors.Errorf("retention plan requires one active verified recovery point")
+	}
+	seen := make(map[string]struct{}, len(payload.Candidates))
+	for _, candidate := range payload.Candidates {
+		if candidate.Class != "raw_body" || candidate.IdentityKind != "database" || candidate.DatabaseIdentity == "" || candidate.RootID != "" || candidate.RelativePath != "" {
+			return xerrors.Errorf("retention plan contains a non-raw-body candidate")
+		}
+		if candidate.LogicalExtent.Availability != "known" || !canonicalUnsignedInteger.MatchString(candidate.LogicalExtent.Bytes) || candidate.AllocatedExtent.Availability != "unknown" {
+			return xerrors.Errorf("retention candidate extent is invalid")
+		}
+		if _, _, err := parseRawBodyCandidateIdentity(candidate.CandidateIdentity); err != nil {
+			return err
+		}
+		if _, exists := seen[candidate.CandidateIdentity]; exists {
+			return xerrors.Errorf("duplicate retention candidate %s", candidate.CandidateIdentity)
+		}
+		seen[candidate.CandidateIdentity] = struct{}{}
+	}
+	if len(payload.Phases) != 1 || payload.Phases[0].Phase != "body_prune" || len(payload.Phases[0].Batches) != 1 {
+		return xerrors.Errorf("raw-body retention plan must contain one body_prune batch")
+	}
+	batch := payload.Phases[0].Batches[0]
+	if batch.Ordinal != "0" || len(batch.CandidateIdentities) != len(payload.Candidates) {
+		return xerrors.Errorf("retention plan batch does not cover every candidate")
+	}
+	for index, candidate := range payload.Candidates {
+		if batch.CandidateIdentities[index] != candidate.CandidateIdentity {
+			return xerrors.Errorf("retention plan batch order does not match candidates")
+		}
+	}
+	return nil
+}
+
+func normalizeRetentionPlan(plan *apptypes.RetentionPlan) {
+	sort.Slice(plan.CanonicalPayload.Candidates, func(i, j int) bool {
+		left, right := plan.CanonicalPayload.Candidates[i], plan.CanonicalPayload.Candidates[j]
+		if left.Class != right.Class {
+			return left.Class < right.Class
+		}
+		if left.DatabaseIdentity != right.DatabaseIdentity {
+			return left.DatabaseIdentity < right.DatabaseIdentity
+		}
+		if left.RootID != right.RootID {
+			return left.RootID < right.RootID
+		}
+		if left.RelativePath != right.RelativePath {
+			return left.RelativePath < right.RelativePath
+		}
+		if left.Timestamp != right.Timestamp {
+			return left.Timestamp < right.Timestamp
+		}
+		return left.CandidateIdentity < right.CandidateIdentity
+	})
+	for index := range plan.CanonicalPayload.Candidates {
+		sort.Strings(plan.CanonicalPayload.Candidates[index].Reasons)
+	}
+	sort.Slice(plan.CanonicalPayload.Exclusions, func(i, j int) bool {
+		left, right := plan.CanonicalPayload.Exclusions[i], plan.CanonicalPayload.Exclusions[j]
+		if left.Reason != right.Reason {
+			return left.Reason < right.Reason
+		}
+		return left.StableIdentity < right.StableIdentity
+	})
+	if len(plan.CanonicalPayload.Phases) == 1 && len(plan.CanonicalPayload.Phases[0].Batches) == 1 {
+		identities := make([]string, len(plan.CanonicalPayload.Candidates))
+		for index, candidate := range plan.CanonicalPayload.Candidates {
+			identities[index] = candidate.CandidateIdentity
+		}
+		plan.CanonicalPayload.Phases[0].Batches[0].CandidateIdentities = identities
+	}
+}
+
+func retentionPlanOrderEqual(left, right apptypes.RetentionPlan) bool {
+	leftJSON, _ := json.Marshal(left.CanonicalPayload)
+	rightJSON, _ := json.Marshal(right.CanonicalPayload)
+	return bytes.Equal(leftJSON, rightJSON)
+}
+
+func rawBodyCandidateIdentity(eventID, digest string) string {
+	return "event:" + base64.RawURLEncoding.EncodeToString([]byte(eventID)) + ":sha256:" + digest
+}
+
+func parseRawBodyCandidateIdentity(value string) (string, string, error) {
+	parts := strings.Split(value, ":")
+	if len(parts) != 4 || parts[0] != "event" || parts[2] != "sha256" || !lowerHexDigest.MatchString(parts[3]) {
+		return "", "", xerrors.Errorf("invalid raw-body candidate identity")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || len(decoded) == 0 || !utf8.Valid(decoded) {
+		return "", "", xerrors.Errorf("invalid event ID in raw-body candidate identity")
+	}
+	return string(decoded), parts[3], nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if errorsIsEOF(err) {
+		return nil
+	}
+	if err == nil {
+		return xerrors.Errorf("JSON input contains multiple values")
+	}
+	return xerrors.Errorf("parse JSON trailer: %w", err)
+}
+
+func errorsIsEOF(err error) bool { return err == io.EOF }
+
+func isASCII(value string) bool {
+	for _, character := range value {
+		if character > 0x7f {
+			return false
+		}
+	}
+	return true
+}

--- a/application/usecase/retention_plan_codec.go
+++ b/application/usecase/retention_plan_codec.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"golang.org/x/xerrors"
@@ -55,9 +56,7 @@ func decodeRetentionPlan(data []byte) (apptypes.RetentionPlan, error) {
 	if err := validateRetentionPlan(plan); err != nil {
 		return apptypes.RetentionPlan{}, err
 	}
-	normalized := plan
-	normalizeRetentionPlan(&normalized)
-	canonical, err := canonicalRetentionPayload(normalized.CanonicalPayload)
+	canonical, err := canonicalRetentionPayload(plan.CanonicalPayload)
 	if err != nil {
 		return apptypes.RetentionPlan{}, err
 	}
@@ -65,10 +64,27 @@ func decodeRetentionPlan(data []byte) (apptypes.RetentionPlan, error) {
 	if hex.EncodeToString(digest[:]) != plan.PlanID {
 		return apptypes.RetentionPlan{}, xerrors.Errorf("retention plan ID does not match canonical payload")
 	}
+	normalized, err := cloneRetentionPlan(plan)
+	if err != nil {
+		return apptypes.RetentionPlan{}, err
+	}
+	normalizeRetentionPlan(&normalized)
 	if !retentionPlanOrderEqual(plan, normalized) {
 		return apptypes.RetentionPlan{}, xerrors.Errorf("retention plan arrays are not in canonical order")
 	}
 	return plan, nil
+}
+
+func cloneRetentionPlan(plan apptypes.RetentionPlan) (apptypes.RetentionPlan, error) {
+	data, err := json.Marshal(plan)
+	if err != nil {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("clone retention plan: %w", err)
+	}
+	var cloned apptypes.RetentionPlan
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return apptypes.RetentionPlan{}, xerrors.Errorf("restore cloned retention plan: %w", err)
+	}
+	return cloned, nil
 }
 
 func canonicalRetentionPayload(payload apptypes.RetentionCanonicalPayload) ([]byte, error) {
@@ -183,11 +199,47 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 	if payload.SchemaVersion != retentionPlanSchemaVersion {
 		return xerrors.Errorf("unsupported retention plan schema %q", payload.SchemaVersion)
 	}
-	if payload.Source.DatabaseIdentity == "" || payload.CreatedAt == "" || payload.SnapshotAt == "" {
+	if payload.Source.DatabaseIdentity == "" || !lowerHexDigest.MatchString(payload.Source.DatabaseIdentity) {
+		return xerrors.Errorf("retention plan database identity must be a lowercase SHA-256 digest")
+	}
+	if err := validateUTCInstant(payload.CreatedAt); err != nil {
+		return xerrors.Errorf("invalid retention plan created_at: %w", err)
+	}
+	if err := validateUTCInstant(payload.SnapshotAt); err != nil {
+		return xerrors.Errorf("invalid retention plan snapshot_at: %w", err)
+	}
+	if payload.Source.SQLiteUserVersion < 0 || !lowerHexDigest.MatchString(payload.Source.MigrationDigest) {
 		return xerrors.Errorf("retention plan source and timestamps are required")
+	}
+	rootIDs := make(map[string]struct{}, len(payload.Source.Roots))
+	for _, root := range payload.Source.Roots {
+		if root.RootID == "" || !lowerHexDigest.MatchString(root.Fingerprint) {
+			return xerrors.Errorf("retention plan root is invalid")
+		}
+		if _, exists := rootIDs[root.RootID]; exists {
+			return xerrors.Errorf("duplicate retention plan root %s", root.RootID)
+		}
+		rootIDs[root.RootID] = struct{}{}
 	}
 	if len(payload.RecoveryRequirements) != 1 || !lowerHexDigest.MatchString(payload.RecoveryRequirements[0].Digest) || payload.RecoveryRequirements[0].State != "active" {
 		return xerrors.Errorf("retention plan requires one active verified recovery point")
+	}
+	recovery := payload.RecoveryRequirements[0]
+	if recovery.Generation == "" || recovery.RootID == "" || recovery.RelativePath == "" || !safeRelativePath(recovery.RelativePath) || !lowerHexDigest.MatchString(recovery.CoverageDigest) {
+		return xerrors.Errorf("retention recovery point is invalid")
+	}
+	if _, exists := rootIDs[recovery.RootID]; !exists {
+		return xerrors.Errorf("retention recovery point references an unknown root")
+	}
+	if len(payload.Policy.Ceilings) != 1 || payload.Policy.Ceilings[0].Class != "raw_body" || payload.Policy.Ceilings[0].Ceiling != "age" || !canonicalUnsignedInteger.MatchString(payload.Policy.Ceilings[0].Value) {
+		return xerrors.Errorf("raw-body retention plan requires one age ceiling")
+	}
+	if len(payload.ClassResults) != 1 || payload.ClassResults[0].Class != "raw_body" || !validRetentionStatus(payload.ClassResults[0].Status) || len(payload.ClassResults[0].Ceilings) != 1 {
+		return xerrors.Errorf("raw-body retention class result is invalid")
+	}
+	ceilingResult := payload.ClassResults[0].Ceilings[0]
+	if ceilingResult.Ceiling != "age" || ceilingResult.Status != payload.ClassResults[0].Status || !validKnownExtent(ceilingResult.Current) || !validKnownExtent(ceilingResult.Projected) {
+		return xerrors.Errorf("raw-body retention ceiling result is invalid")
 	}
 	seen := make(map[string]struct{}, len(payload.Candidates))
 	for _, candidate := range payload.Candidates {
@@ -196,6 +248,12 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 		}
 		if candidate.LogicalExtent.Availability != "known" || !canonicalUnsignedInteger.MatchString(candidate.LogicalExtent.Bytes) || candidate.AllocatedExtent.Availability != "unknown" {
 			return xerrors.Errorf("retention candidate extent is invalid")
+		}
+		if candidate.AllocatedExtent.Bytes != "" || len(candidate.Reasons) != 1 || candidate.Reasons[0] != "age" {
+			return xerrors.Errorf("retention candidate reasons or unknown extent are invalid")
+		}
+		if err := validateUTCInstant(candidate.Timestamp); err != nil {
+			return xerrors.Errorf("invalid retention candidate timestamp: %w", err)
 		}
 		if _, _, err := parseRawBodyCandidateIdentity(candidate.CandidateIdentity); err != nil {
 			return err
@@ -208,6 +266,15 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 	if len(payload.Phases) != 1 || payload.Phases[0].Phase != "body_prune" || len(payload.Phases[0].Batches) != 1 {
 		return xerrors.Errorf("raw-body retention plan must contain one body_prune batch")
 	}
+	wantSteps := []string{"verify-source", "verify-recovery", "prune-body", "record-ledger"}
+	if len(payload.Phases[0].OrderedSteps) != len(wantSteps) {
+		return xerrors.Errorf("retention body_prune steps are invalid")
+	}
+	for index, step := range wantSteps {
+		if payload.Phases[0].OrderedSteps[index] != step {
+			return xerrors.Errorf("retention body_prune steps are invalid")
+		}
+	}
 	batch := payload.Phases[0].Batches[0]
 	if batch.Ordinal != "0" || len(batch.CandidateIdentities) != len(payload.Candidates) {
 		return xerrors.Errorf("retention plan batch does not cover every candidate")
@@ -218,6 +285,40 @@ func validateRetentionPlan(plan apptypes.RetentionPlan) error {
 		}
 	}
 	return nil
+}
+
+func validateUTCInstant(value string) error {
+	if !strings.HasSuffix(value, "Z") {
+		return xerrors.Errorf("timestamp must use UTC Z")
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return xerrors.Errorf("parse timestamp: %w", err)
+	}
+	if parsed.IsZero() {
+		return xerrors.Errorf("timestamp must not be zero")
+	}
+	return nil
+}
+
+func safeRelativePath(value string) bool {
+	if strings.HasPrefix(value, "/") || strings.Contains(value, "\\") {
+		return false
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func validRetentionStatus(value string) bool {
+	return value == "satisfied" || value == "unsatisfied" || value == "indeterminate"
+}
+
+func validKnownExtent(value apptypes.RetentionExtent) bool {
+	return value.Availability == "known" && canonicalUnsignedInteger.MatchString(value.Bytes)
 }
 
 func normalizeRetentionPlan(plan *apptypes.RetentionPlan) {

--- a/application/usecase/retention_plan_codec_internal_test.go
+++ b/application/usecase/retention_plan_codec_internal_test.go
@@ -1,0 +1,77 @@
+package usecase
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+func TestCanonicalizeJSON_matchesCheckedInGoldenVector(t *testing.T) {
+	t.Parallel()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() failed")
+	}
+	root := filepath.Join(filepath.Dir(file), "..", "..")
+	canonical, err := os.ReadFile(filepath.Join(root, "docs", "operations", "testdata", "retention-plan-canonical.golden.json"))
+	if err != nil {
+		t.Fatalf("read canonical fixture: %v", err)
+	}
+	plan, err := os.ReadFile(filepath.Join(root, "docs", "operations", "testdata", "retention-plan.golden.json"))
+	if err != nil {
+		t.Fatalf("read plan fixture: %v", err)
+	}
+	decoded, err := decodeGoldenPayload(plan)
+	if err != nil {
+		t.Fatalf("decode golden payload: %v", err)
+	}
+	got, err := canonicalizeJSON(decoded)
+	if err != nil {
+		t.Fatalf("canonicalizeJSON() error = %v", err)
+	}
+	if string(got) != string(canonical) {
+		t.Fatal("canonical bytes do not match checked-in golden vector")
+	}
+	digest := sha256.Sum256(got)
+	if hex.EncodeToString(digest[:]) != "3b101f3dcfeb284816dd34fc8de8c1f28df96181f505a385bbdbd0ff9cfdbba8" {
+		t.Fatalf("canonical digest = %s", hex.EncodeToString(digest[:]))
+	}
+}
+
+func TestRawBodyCandidateIdentity_roundTripsOpaqueEventID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		eventID = "event:with/slash:日本語"
+		digest  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	encoded := rawBodyCandidateIdentity(eventID, digest)
+	gotID, gotDigest, err := parseRawBodyCandidateIdentity(encoded)
+	if err != nil {
+		t.Fatalf("parseRawBodyCandidateIdentity() error = %v", err)
+	}
+	if gotID != eventID || gotDigest != digest {
+		t.Fatalf("round trip = (%q, %q)", gotID, gotDigest)
+	}
+}
+
+func decodeGoldenPayload(plan []byte) ([]byte, error) {
+	var envelope struct {
+		CanonicalPayload any `json:"canonical_payload"`
+	}
+	if err := json.Unmarshal(plan, &envelope); err != nil {
+		return nil, xerrors.Errorf("unmarshal golden plan: %w", err)
+	}
+	encoded, err := json.Marshal(envelope.CanonicalPayload)
+	if err != nil {
+		return nil, xerrors.Errorf("marshal golden payload: %w", err)
+	}
+	return encoded, nil
+}

--- a/domain/model/event.go
+++ b/domain/model/event.go
@@ -18,6 +18,7 @@ type Event struct {
 	sessionID        types.SessionID
 	workspace        types.Workspace
 	body             string
+	bodyAvailability types.BodyAvailability
 	createdAt        time.Time
 	sourceHook       string
 	rawWorkspace     string
@@ -53,14 +54,15 @@ func NewEventWithClock(
 		return nil, xerrors.Errorf("event body must not be empty")
 	}
 	return &Event{
-		eventID:   eventID,
-		kind:      kind,
-		client:    client,
-		agent:     agent,
-		sessionID: sessionID,
-		workspace: workspace,
-		body:      trimmedBody,
-		createdAt: clockOrSystem(clock).Now(),
+		eventID:          eventID,
+		kind:             kind,
+		client:           client,
+		agent:            agent,
+		sessionID:        sessionID,
+		workspace:        workspace,
+		body:             trimmedBody,
+		bodyAvailability: types.BodyAvailabilityAvailable,
+		createdAt:        clockOrSystem(clock).Now(),
 	}, nil
 }
 
@@ -76,14 +78,15 @@ func EventOf(
 	createdAt time.Time,
 ) *Event {
 	return &Event{
-		eventID:   eventID,
-		kind:      kind,
-		client:    client,
-		agent:     agent,
-		sessionID: sessionID,
-		workspace: workspace,
-		body:      body,
-		createdAt: createdAt,
+		eventID:          eventID,
+		kind:             kind,
+		client:           client,
+		agent:            agent,
+		sessionID:        sessionID,
+		workspace:        workspace,
+		body:             body,
+		bodyAvailability: types.BodyAvailabilityAvailable,
+		createdAt:        createdAt,
 	}
 }
 
@@ -104,6 +107,28 @@ func EventOfWithSourceHook(
 ) *Event {
 	event := EventOf(eventID, kind, client, agent, sessionID, workspace, body, createdAt)
 	event.sourceHook = sourceHook
+	return event
+}
+
+// EventOfWithBodyAvailabilityAndSourceHook restores an Event including its
+// explicit raw-body availability and source hook.
+func EventOfWithBodyAvailabilityAndSourceHook(
+	eventID types.EventID,
+	kind types.EventKind,
+	client types.Client,
+	agent types.Agent,
+	sessionID types.SessionID,
+	workspace types.Workspace,
+	body string,
+	bodyAvailability types.BodyAvailability,
+	createdAt time.Time,
+	sourceHook string,
+) *Event {
+	event := EventOfWithSourceHook(eventID, kind, client, agent, sessionID, workspace, body, createdAt, sourceHook)
+	event.bodyAvailability = bodyAvailability
+	if !bodyAvailability.IsAvailable() {
+		event.body = ""
+	}
 	return event
 }
 
@@ -153,6 +178,9 @@ func (e *Event) Workspace() types.Workspace { return e.workspace }
 
 // Body returns the event body.
 func (e *Event) Body() string { return e.body }
+
+// BodyAvailability returns whether the raw body can be returned.
+func (e *Event) BodyAvailability() types.BodyAvailability { return e.bodyAvailability }
 
 // CreatedAt returns the event creation time.
 func (e *Event) CreatedAt() time.Time { return e.createdAt }

--- a/domain/types/body_availability.go
+++ b/domain/types/body_availability.go
@@ -1,0 +1,35 @@
+package types
+
+import "golang.org/x/xerrors"
+
+// BodyAvailability describes whether an event raw body can be returned.
+type BodyAvailability string
+
+const (
+	// BodyAvailabilityAvailable means the persisted raw body is readable.
+	BodyAvailabilityAvailable BodyAvailability = "available"
+	// BodyAvailabilityUnavailableRetention means an explicit retention apply removed the raw body.
+	BodyAvailabilityUnavailableRetention BodyAvailability = "unavailable_retention"
+
+	// EventBodyUnavailableRetentionMarker is the compatibility-safe persisted
+	// placeholder for readers that predate body_availability. Current readers
+	// convert it to an absent body plus an explicit availability reason.
+	EventBodyUnavailableRetentionMarker = "[traceary:body-unavailable:retention]"
+)
+
+// BodyAvailabilityFrom validates a persisted body-availability value.
+func BodyAvailabilityFrom(value string) (BodyAvailability, error) {
+	availability := BodyAvailability(value)
+	switch availability {
+	case BodyAvailabilityAvailable, BodyAvailabilityUnavailableRetention:
+		return availability, nil
+	default:
+		return "", xerrors.Errorf("unsupported body availability: %q", value)
+	}
+}
+
+// String returns the persisted representation.
+func (a BodyAvailability) String() string { return string(a) }
+
+// IsAvailable reports whether the raw body can be returned.
+func (a BodyAvailability) IsAvailable() bool { return a == BodyAvailabilityAvailable }

--- a/domain/types/body_availability_test.go
+++ b/domain/types/body_availability_test.go
@@ -1,0 +1,35 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestBodyAvailabilityFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     string
+		available bool
+		wantErr   bool
+	}{
+		{name: "available", value: "available", available: true},
+		{name: "unavailable by retention", value: "unavailable_retention"},
+		{name: "unknown", value: "missing", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := types.BodyAvailabilityFrom(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("BodyAvailabilityFrom() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if err == nil && got.IsAvailable() != tt.available {
+				t.Fatalf("IsAvailable() = %t, want %t", got.IsAvailable(), tt.available)
+			}
+		})
+	}
+}

--- a/infrastructure/sqlite/backup_store_test.go
+++ b/infrastructure/sqlite/backup_store_test.go
@@ -232,6 +232,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/command_audit_store_test.go
+++ b/infrastructure/sqlite/command_audit_store_test.go
@@ -30,6 +30,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -439,6 +440,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/datasource_test.go
+++ b/infrastructure/sqlite/datasource_test.go
@@ -23,6 +23,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -804,8 +804,13 @@ func restoreEvent(
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore created_at: %w", err)
 	}
+	bodyAvailability := types.BodyAvailabilityAvailable
+	if bodyValue == types.EventBodyUnavailableRetentionMarker {
+		bodyAvailability = types.BodyAvailabilityUnavailableRetention
+		bodyValue = ""
+	}
 
-	return model.EventOfWithSourceHook(
+	return model.EventOfWithBodyAvailabilityAndSourceHook(
 		eventID,
 		eventKind,
 		types.Client(clientValue),
@@ -813,6 +818,7 @@ func restoreEvent(
 		sessionID,
 		types.Workspace(repoValue),
 		bodyValue,
+		bodyAvailability,
 		createdAt,
 		sourceHookValue,
 	), nil

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -665,15 +665,16 @@ func scanEvent(rowScanner interface {
 	Scan(dest ...any) error
 }) (*model.Event, error) {
 	var (
-		eventIDValue    string
-		eventKindValue  string
-		clientValue     string
-		agentValue      string
-		sessionIDValue  string
-		repoValue       string
-		bodyValue       string
-		sourceHookValue sql.NullString
-		createdAtValue  string
+		eventIDValue          string
+		eventKindValue        string
+		clientValue           string
+		agentValue            string
+		sessionIDValue        string
+		repoValue             string
+		bodyValue             string
+		bodyAvailabilityValue string
+		sourceHookValue       sql.NullString
+		createdAtValue        string
 	)
 
 	if err := rowScanner.Scan(
@@ -684,6 +685,7 @@ func scanEvent(rowScanner interface {
 		&sessionIDValue,
 		&repoValue,
 		&bodyValue,
+		&bodyAvailabilityValue,
 		&sourceHookValue,
 		&createdAtValue,
 	); err != nil {
@@ -698,6 +700,7 @@ func scanEvent(rowScanner interface {
 		sessionIDValue,
 		repoValue,
 		bodyValue,
+		bodyAvailabilityValue,
 		sourceHookValue.String,
 		createdAtValue,
 	)
@@ -723,15 +726,16 @@ func scanEventWithAudit(
 	failureReasonValue *sql.NullString,
 ) (*model.Event, error) {
 	var (
-		eventIDValue    string
-		eventKindValue  string
-		clientValue     string
-		agentValue      string
-		sessionIDValue  string
-		repoValue       string
-		bodyValue       string
-		sourceHookValue sql.NullString
-		createdAtValue  string
+		eventIDValue          string
+		eventKindValue        string
+		clientValue           string
+		agentValue            string
+		sessionIDValue        string
+		repoValue             string
+		bodyValue             string
+		bodyAvailabilityValue string
+		sourceHookValue       sql.NullString
+		createdAtValue        string
 	)
 
 	if err := rowScanner.Scan(
@@ -742,6 +746,7 @@ func scanEventWithAudit(
 		&sessionIDValue,
 		&repoValue,
 		&bodyValue,
+		&bodyAvailabilityValue,
 		&sourceHookValue,
 		&createdAtValue,
 		commandTextValue,
@@ -768,6 +773,7 @@ func scanEventWithAudit(
 		sessionIDValue,
 		repoValue,
 		bodyValue,
+		bodyAvailabilityValue,
 		sourceHookValue.String,
 		createdAtValue,
 	)
@@ -781,6 +787,7 @@ func restoreEvent(
 	sessionIDValue string,
 	repoValue string,
 	bodyValue string,
+	bodyAvailabilityValue string,
 	sourceHookValue string,
 	createdAtValue string,
 ) (*model.Event, error) {
@@ -804,9 +811,11 @@ func restoreEvent(
 	if err != nil {
 		return nil, xerrors.Errorf("failed to restore created_at: %w", err)
 	}
-	bodyAvailability := types.BodyAvailabilityAvailable
-	if bodyValue == types.EventBodyUnavailableRetentionMarker {
-		bodyAvailability = types.BodyAvailabilityUnavailableRetention
+	bodyAvailability, err := types.BodyAvailabilityFrom(bodyAvailabilityValue)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore body availability: %w", err)
+	}
+	if bodyAvailability == types.BodyAvailabilityUnavailableRetention {
 		bodyValue = ""
 	}
 

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -393,6 +393,7 @@ CREATE TABLE events (
     session_id TEXT NOT NULL,
     workspace TEXT NOT NULL DEFAULT '',
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     source_hook TEXT,
     created_at TEXT NOT NULL
 );`)},

--- a/infrastructure/sqlite/event_store_test.go
+++ b/infrastructure/sqlite/event_store_test.go
@@ -28,6 +28,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -123,6 +124,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -200,6 +202,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -275,6 +278,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -353,6 +357,7 @@ CREATE TABLE events (
     client TEXT NOT NULL DEFAULT '',
     workspace TEXT NOT NULL DEFAULT '',
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     source_hook TEXT,
     created_at TEXT NOT NULL
 );
@@ -530,6 +535,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -639,6 +645,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -691,6 +698,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -766,6 +774,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -831,5 +840,49 @@ CREATE TABLE command_audits (
 	// DESC order: got[0] = after, got[1] = at
 	if got[0].EventID().String() != "event-after" || got[1].EventID().String() != "event-at-boundary" {
 		t.Fatalf("got = %q/%q, want event-after/event-at-boundary", got[0].EventID(), got[1].EventID())
+	}
+}
+
+func TestDatasource_ListRecent_DoesNotInferRetentionFromBodyMarker(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := newEventForSQLiteTest(
+		t,
+		"event-marker-literal",
+		"cli",
+		"codex",
+		"session-marker",
+		"ws",
+		types.EventBodyUnavailableRetentionMarker,
+		time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	events, err := sut.ListRecent(context.Background(), 10, 0, "", "", "", "", "", false, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if got := events[0].Body(); got != types.EventBodyUnavailableRetentionMarker {
+		t.Fatalf("Body() = %q, want literal compatibility marker", got)
+	}
+	if got := events[0].BodyAvailability(); got != types.BodyAvailabilityAvailable {
+		t.Fatalf("BodyAvailability() = %s, want available", got)
+	}
+	matches, err := sut.Search(context.Background(), types.EventBodyUnavailableRetentionMarker, "", "", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil {
+		t.Fatalf("Search(marker literal) error = %v", err)
+	}
+	if len(matches) != 1 || matches[0].EventID().String() != "event-marker-literal" {
+		t.Fatalf("Search(marker literal) = %+v, want the available literal-body event", matches)
 	}
 }

--- a/infrastructure/sqlite/export_test.go
+++ b/infrastructure/sqlite/export_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 )
 
+// SetRawBodyPrunedHookForTest injects an interruption after a candidate write.
+func (d *StoreManagementDatasource) SetRawBodyPrunedHookForTest(hook func(index int) error) {
+	d.onRawBodyPruned = hook
+}
+
 // SetListWindowBatchHookForTest installs a hook that fires once per internal
 // paged read performed by ListWindow. Tests use it to assert the scan loop
 // actually issues multiple batches rather than returning all rows in a single

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -83,6 +83,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -468,6 +469,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT,
     client TEXT NOT NULL DEFAULT '',

--- a/infrastructure/sqlite/get_context_events_test.go
+++ b/infrastructure/sqlite/get_context_events_test.go
@@ -24,6 +24,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/get_event_details_test.go
+++ b/infrastructure/sqlite/get_event_details_test.go
@@ -24,6 +24,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -43,6 +43,7 @@ func listSessionsTestMigrations() fstest.MapFS {
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/raw_body_retention_datasource.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -26,7 +28,8 @@ func (d *StoreManagementDatasource) ListRawBodyCandidates(ctx context.Context, b
 	if before.IsZero() {
 		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("retention cutoff must not be zero")
 	}
-	db, err := d.db.open(ctx)
+	sourcePath := d.db.Path()
+	db, err := d.db.openAt(ctx, sourcePath)
 	if err != nil {
 		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to open DB for raw-body plan: %w", err)
 	}
@@ -38,7 +41,11 @@ func (d *StoreManagementDatasource) ListRawBodyCandidates(ctx context.Context, b
 	}
 	defer rollbackRawBodyTx(tx)
 
-	identity, version, err := rawBodySourceIdentity(ctx, tx)
+	identity, version, err := rawBodySourceIdentity(ctx, tx, sourcePath)
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, err
+	}
+	migrationDigest, err := rawBodySchemaDigest(ctx, tx)
 	if err != nil {
 		return apptypes.RawBodyRetentionSnapshot{}, err
 	}
@@ -109,114 +116,209 @@ SELECT e.id
 	}
 
 	return apptypes.RawBodyRetentionSnapshot{
-		DatabaseIdentity: identity, SQLiteUserVersion: version, SnapshotAt: time.Now().UTC(),
+		DatabaseIdentity: identity, SQLiteUserVersion: version, MigrationDigest: migrationDigest, SnapshotAt: time.Now().UTC(),
 		Candidates: candidates, ExcludedActive: excluded,
 	}, nil
 }
 
-// ApplyRawBodyPlan prunes only exact candidate versions in one transaction.
-func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error) {
+// ApplyRawBodyPlan prunes exact candidate versions in durable, resumable batches.
+func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error) {
 	result := apptypes.RawBodyApplyResult{PlanID: planID, CandidateCount: len(candidates)}
-	db, err := d.db.open(ctx)
+	sourcePath := d.db.Path()
+	db, err := d.db.openAt(ctx, sourcePath)
 	if err != nil {
 		return result, xerrors.Errorf("failed to open DB for raw-body apply: %w", err)
 	}
 	defer closeRawBodyResource(db)
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return result, xerrors.Errorf("failed to begin raw-body apply: %w", err)
-	}
-	defer rollbackRawBodyTx(tx)
-	if err := requireRawBodySource(ctx, tx, databaseIdentity, sqliteUserVersion); err != nil {
+	stamp := formatTimestamp(appliedAt)
+	if err := preflightRawBodyCandidates(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidates); err != nil {
 		return result, err
 	}
-	var executionStatus string
-	var executionCandidates int
-	executionErr := tx.QueryRowContext(ctx, `SELECT status, candidate_count FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus, &executionCandidates)
-	if executionErr != nil && !errors.Is(executionErr, sql.ErrNoRows) {
-		return result, xerrors.Errorf("failed to inspect raw-body execution: %w", executionErr)
+	if err := startRawBodyExecution(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, len(candidates), stamp); err != nil {
+		return result, err
 	}
-	if executionErr == nil {
-		if executionCandidates != len(candidates) {
-			return result, xerrors.Errorf("raw-body execution candidate count conflicts with plan")
-		}
-		if executionStatus == "restored" {
-			return result, xerrors.Errorf("restored raw-body plan is terminal; create a new plan to prune again")
-		}
-	}
-
-	type pendingCandidate struct {
-		candidate apptypes.RawBodyCandidate
-		body      string
-	}
-	pending := make([]pendingCandidate, 0, len(candidates))
-	for _, candidate := range candidates {
-		var body, createdAt, availability string
-		var stored int
-		var prunedPlan sql.NullString
-		err := tx.QueryRowContext(ctx, `SELECT body, created_at, body_availability, body_stored_bytes, body_pruned_plan_id FROM events WHERE id = ?`, candidate.EventID).
-			Scan(&body, &createdAt, &availability, &stored, &prunedPlan)
+	for index, candidate := range candidates {
+		pruned, err := applyRawBodyCandidate(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, candidate, stamp)
 		if err != nil {
-			return result, xerrors.Errorf("failed to verify raw-body candidate %s: %w", candidate.EventID, err)
+			return result, err
 		}
-		if availability == domtypes.BodyAvailabilityUnavailableRetention.String() && prunedPlan.String == planID {
-			var entryCount int
-			if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ? AND event_id = ? AND body_sha256 = ? AND stored_bytes = ?`, planID, candidate.EventID, candidate.BodySHA256, candidate.StoredBytes).Scan(&entryCount); err != nil || entryCount != 1 {
-				return result, xerrors.Errorf("raw-body execution ledger does not match pruned event %s", candidate.EventID)
-			}
+		if pruned {
+			result.PrunedCount++
+		} else {
 			result.AlreadyPruned++
-			continue
 		}
-		digest := sha256.Sum256([]byte(body))
-		if availability != domtypes.BodyAvailabilityAvailable.String() || createdAt != formatTimestamp(candidate.CreatedAt) || stored != candidate.StoredBytes || hex.EncodeToString(digest[:]) != candidate.BodySHA256 {
-			return result, xerrors.Errorf("raw-body plan is stale or mismatched at event %s", candidate.EventID)
-		}
-		pending = append(pending, pendingCandidate{candidate: candidate, body: body})
-	}
-
-	stamp := formatTimestamp(appliedAt)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_executions(plan_id, status, candidate_count, pruned_count, started_at)
-VALUES (?, 'running', ?, 0, ?)
-ON CONFLICT(plan_id) DO NOTHING`, planID, len(candidates), stamp); err != nil {
-		return result, xerrors.Errorf("failed to start raw-body execution: %w", err)
-	}
-	for index, item := range pending {
-		res, err := tx.ExecContext(ctx, `UPDATE events
-SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
-WHERE id = ? AND body_availability = 'available' AND body = ?`, domtypes.EventBodyUnavailableRetentionMarker, stamp, planID, item.candidate.EventID, item.body)
-		if err != nil {
-			return result, xerrors.Errorf("failed to prune raw body %s: %w", item.candidate.EventID, err)
-		}
-		changed, _ := res.RowsAffected()
-		if changed != 1 {
-			return result, xerrors.Errorf("raw-body candidate changed during apply: %s", item.candidate.EventID)
-		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_entries(plan_id, event_id, body_sha256, stored_bytes, pruned_at)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(plan_id, event_id) DO NOTHING`, planID, item.candidate.EventID, item.candidate.BodySHA256, item.candidate.StoredBytes, stamp); err != nil {
-			return result, xerrors.Errorf("failed to record raw-body entry: %w", err)
-		}
-		result.PrunedCount++
 		if d.onRawBodyPruned != nil {
 			if err := d.onRawBodyPruned(index); err != nil {
-				return result, xerrors.Errorf("raw-body apply interrupted: %w", err)
+				return result, xerrors.Errorf("raw-body apply interrupted after durable batch: %w", err)
 			}
 		}
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
-SET status = 'completed', pruned_count = ?, completed_at = ? WHERE plan_id = ?`, len(candidates), stamp, planID); err != nil {
-		return result, xerrors.Errorf("failed to complete raw-body execution: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return result, xerrors.Errorf("failed to commit raw-body apply: %w", err)
+	if err := completeRawBodyExecution(ctx, db, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest, planID, len(candidates), stamp); err != nil {
+		return result, err
 	}
 	return result, nil
 }
 
+func startRawBodyExecution(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidateCount int, stamp string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return xerrors.Errorf("failed to begin raw-body execution: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
+		return err
+	}
+	var status string
+	var recordedCount int
+	err = tx.QueryRowContext(ctx, `SELECT status, candidate_count FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&status, &recordedCount)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return xerrors.Errorf("failed to inspect raw-body execution: %w", err)
+	}
+	if err == nil {
+		if recordedCount != candidateCount {
+			return xerrors.Errorf("raw-body execution candidate count conflicts with plan")
+		}
+		if status == "restored" {
+			return xerrors.Errorf("restored raw-body plan is terminal; create a new plan to prune again")
+		}
+	} else if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_executions(plan_id, status, candidate_count, pruned_count, started_at)
+VALUES (?, 'running', ?, 0, ?)
+`, planID, candidateCount, stamp); err != nil {
+		return xerrors.Errorf("failed to start raw-body execution: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit raw-body execution start: %w", err)
+	}
+	return nil
+}
+
+func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidate apptypes.RawBodyCandidate, stamp string) (bool, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, xerrors.Errorf("failed to begin raw-body batch: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
+		return false, err
+	}
+	body, alreadyPruned, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate)
+	if err != nil {
+		return false, err
+	}
+	if alreadyPruned {
+		if err := tx.Commit(); err != nil {
+			return false, xerrors.Errorf("failed to commit raw-body idempotency check: %w", err)
+		}
+		return false, nil
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE events
+SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
+WHERE id = ? AND body_availability = 'available' AND body = ?`, domtypes.EventBodyUnavailableRetentionMarker, stamp, planID, candidate.EventID, body)
+	if err != nil {
+		return false, xerrors.Errorf("failed to prune raw body %s: %w", candidate.EventID, err)
+	}
+	changed, _ := res.RowsAffected()
+	if changed != 1 {
+		return false, xerrors.Errorf("raw-body candidate changed during apply: %s", candidate.EventID)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_entries(plan_id, event_id, body_sha256, stored_bytes, pruned_at)
+VALUES (?, ?, ?, ?, ?)
+`, planID, candidate.EventID, candidate.BodySHA256, candidate.StoredBytes, stamp); err != nil {
+		return false, xerrors.Errorf("failed to record raw-body entry: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
+SET pruned_count = (SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ?) WHERE plan_id = ?`, planID, planID); err != nil {
+		return false, xerrors.Errorf("failed to update raw-body execution progress: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, xerrors.Errorf("failed to commit raw-body batch: %w", err)
+	}
+	return true, nil
+}
+
+func preflightRawBodyCandidates(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidates []apptypes.RawBodyCandidate) error {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return xerrors.Errorf("failed to begin raw-body preflight: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		if _, _, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit raw-body preflight: %w", err)
+	}
+	return nil
+}
+
+func verifyRawBodyCandidateState(ctx context.Context, tx *sql.Tx, planID string, candidate apptypes.RawBodyCandidate) (string, bool, error) {
+	var body, createdAt, availability string
+	var stored int
+	var prunedPlan sql.NullString
+	var activeSession bool
+	err := tx.QueryRowContext(ctx, `SELECT e.body, e.created_at, e.body_availability, e.body_stored_bytes, e.body_pruned_plan_id,
+EXISTS(SELECT 1 FROM sessions AS s WHERE s.session_id = e.session_id AND s.ended_at IS NULL)
+FROM events AS e WHERE e.id = ?`, candidate.EventID).Scan(&body, &createdAt, &availability, &stored, &prunedPlan, &activeSession)
+	if err != nil {
+		return "", false, xerrors.Errorf("failed to verify raw-body candidate %s: %w", candidate.EventID, err)
+	}
+	if availability == domtypes.BodyAvailabilityUnavailableRetention.String() && prunedPlan.String == planID {
+		var entryCount int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ? AND event_id = ? AND body_sha256 = ? AND stored_bytes = ?`, planID, candidate.EventID, candidate.BodySHA256, candidate.StoredBytes).Scan(&entryCount); err != nil || entryCount != 1 {
+			return "", false, xerrors.Errorf("raw-body execution ledger does not match pruned event %s", candidate.EventID)
+		}
+		return body, true, nil
+	}
+	if activeSession {
+		return "", false, xerrors.Errorf("raw-body plan is stale because event %s belongs to an active session", candidate.EventID)
+	}
+	persistedCreatedAt, parseErr := time.Parse(time.RFC3339Nano, createdAt)
+	if parseErr != nil {
+		return "", false, xerrors.Errorf("failed to parse raw-body candidate timestamp %s: %w", candidate.EventID, parseErr)
+	}
+	digest := sha256.Sum256([]byte(body))
+	if availability != domtypes.BodyAvailabilityAvailable.String() || !persistedCreatedAt.Equal(candidate.CreatedAt) || stored != candidate.StoredBytes || hex.EncodeToString(digest[:]) != candidate.BodySHA256 {
+		return "", false, xerrors.Errorf("raw-body plan is stale or mismatched at event %s", candidate.EventID)
+	}
+	return body, false, nil
+}
+
+func completeRawBodyExecution(ctx context.Context, db *sql.DB, sourcePath, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, candidateCount int, stamp string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return xerrors.Errorf("failed to begin raw-body completion: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
+		return err
+	}
+	var ledgerCount int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ?`, planID).Scan(&ledgerCount); err != nil {
+		return xerrors.Errorf("failed to count raw-body execution ledger: %w", err)
+	}
+	if ledgerCount != candidateCount {
+		return xerrors.Errorf("raw-body execution is incomplete: ledger has %d of %d candidates", ledgerCount, candidateCount)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
+SET status = 'completed', pruned_count = ?, completed_at = ? WHERE plan_id = ?`, candidateCount, stamp, planID); err != nil {
+		return xerrors.Errorf("failed to complete raw-body execution: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return xerrors.Errorf("failed to commit raw-body completion: %w", err)
+	}
+	return nil
+}
+
 // RestoreRawBodyPlan restores exact bodies only for the execution that pruned them.
-func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error) {
+func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, migrationDigest, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error) {
 	result := apptypes.RawBodyRestoreResult{PlanID: planID, CandidateCount: len(bodies)}
-	db, err := d.db.open(ctx)
+	sourcePath := d.db.Path()
+	db, err := d.db.openAt(ctx, sourcePath)
 	if err != nil {
 		return result, xerrors.Errorf("failed to open DB for raw-body restore: %w", err)
 	}
@@ -226,7 +328,7 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 		return result, xerrors.Errorf("failed to begin raw-body restore: %w", err)
 	}
 	defer rollbackRawBodyTx(tx)
-	if err := requireRawBodySource(ctx, tx, databaseIdentity, sqliteUserVersion); err != nil {
+	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
 		return result, err
 	}
 	var executionStatus string
@@ -234,7 +336,7 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 	if err := tx.QueryRowContext(ctx, `SELECT status, candidate_count FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus, &executionCandidates); err != nil {
 		return result, xerrors.Errorf("raw-body execution is not available for restore: %w", err)
 	}
-	if executionCandidates != len(bodies) || (executionStatus != "completed" && executionStatus != "restored") {
+	if executionCandidates != len(bodies) || (executionStatus != "running" && executionStatus != "completed" && executionStatus != "restored") {
 		return result, xerrors.Errorf("raw-body execution state does not match restore plan")
 	}
 
@@ -279,24 +381,66 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 
 func rawBodySourceIdentity(ctx context.Context, q interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
-}) (string, int, error) {
-	var identity string
-	if err := q.QueryRowContext(ctx, `SELECT id FROM raw_body_retention_store_identity`).Scan(&identity); err != nil {
+}, databasePath string) (string, int, error) {
+	var lineageIdentity string
+	if err := q.QueryRowContext(ctx, `SELECT id FROM raw_body_retention_store_identity`).Scan(&lineageIdentity); err != nil {
 		return "", 0, xerrors.Errorf("failed to read raw-body store identity: %w", err)
 	}
+	canonicalPath, err := filepath.Abs(databasePath)
+	if err != nil {
+		return "", 0, xerrors.Errorf("resolve raw-body store path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(canonicalPath); err == nil {
+		canonicalPath = resolved
+	} else if !os.IsNotExist(err) {
+		return "", 0, xerrors.Errorf("resolve raw-body store symlinks: %w", err)
+	}
+	identityDigest := sha256.Sum256([]byte(lineageIdentity + "\x00" + filepath.Clean(canonicalPath)))
 	var version int
 	if err := q.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
 		return "", 0, xerrors.Errorf("failed to read SQLite user_version: %w", err)
 	}
-	return identity, version, nil
+	return hex.EncodeToString(identityDigest[:]), version, nil
 }
 
-func requireRawBodySource(ctx context.Context, tx *sql.Tx, expectedIdentity string, expectedVersion int) error {
-	identity, version, err := rawBodySourceIdentity(ctx, tx)
+func rawBodySchemaDigest(ctx context.Context, tx *sql.Tx) (string, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT type, name, tbl_name, sql
+  FROM sqlite_schema
+ WHERE sql IS NOT NULL
+   AND name NOT LIKE 'sqlite_%'
+ ORDER BY type, name, tbl_name, sql`)
+	if err != nil {
+		return "", xerrors.Errorf("failed to read SQLite schema for retention: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	hash := sha256.New()
+	for rows.Next() {
+		var objectType, name, tableName, statement string
+		if err := rows.Scan(&objectType, &name, &tableName, &statement); err != nil {
+			return "", xerrors.Errorf("failed to scan SQLite schema for retention: %w", err)
+		}
+		for _, value := range []string{objectType, name, tableName, statement} {
+			_, _ = hash.Write([]byte(value))
+			_, _ = hash.Write([]byte{0})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", xerrors.Errorf("failed to iterate SQLite schema for retention: %w", err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func requireRawBodySource(ctx context.Context, tx *sql.Tx, databasePath, expectedIdentity string, expectedVersion int, expectedMigrationDigest string) error {
+	identity, version, err := rawBodySourceIdentity(ctx, tx, databasePath)
 	if err != nil {
 		return err
 	}
-	if identity != expectedIdentity || version != expectedVersion {
+	migrationDigest, err := rawBodySchemaDigest(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if identity != expectedIdentity || version != expectedVersion || migrationDigest != expectedMigrationDigest {
 		return xerrors.Errorf("raw-body plan belongs to a different store")
 	}
 	return nil

--- a/infrastructure/sqlite/raw_body_retention_datasource.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource.go
@@ -181,6 +181,9 @@ func startRawBodyExecution(ctx context.Context, db *sql.DB, sourcePath, database
 		if status == "restored" {
 			return xerrors.Errorf("restored raw-body plan is terminal; create a new plan to prune again")
 		}
+		if status != "running" && status != "completed" {
+			return xerrors.Errorf("raw-body execution cannot resume from status %s", status)
+		}
 	} else if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_executions(plan_id, status, candidate_count, pruned_count, started_at)
 VALUES (?, 'running', ?, 0, ?)
 `, planID, candidateCount, stamp); err != nil {
@@ -201,6 +204,22 @@ func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, database
 	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
 		return false, err
 	}
+	var executionStatus string
+	if err := tx.QueryRowContext(ctx, `SELECT status FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus); err != nil {
+		return false, xerrors.Errorf("failed to inspect raw-body execution status: %w", err)
+	}
+	if executionStatus == "running" {
+		res, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions SET status = 'running' WHERE plan_id = ? AND status = 'running'`, planID)
+		if err != nil {
+			return false, xerrors.Errorf("failed to claim raw-body execution batch: %w", err)
+		}
+		changed, _ := res.RowsAffected()
+		if changed != 1 {
+			return false, xerrors.Errorf("raw-body execution is no longer running")
+		}
+	} else if executionStatus != "completed" {
+		return false, xerrors.Errorf("raw-body execution cannot apply from status %s", executionStatus)
+	}
 	body, alreadyPruned, err := verifyRawBodyCandidateState(ctx, tx, planID, candidate)
 	if err != nil {
 		return false, err
@@ -210,6 +229,9 @@ func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, database
 			return false, xerrors.Errorf("failed to commit raw-body idempotency check: %w", err)
 		}
 		return false, nil
+	}
+	if executionStatus != "running" {
+		return false, xerrors.Errorf("completed raw-body execution contains an unpruned candidate %s", candidate.EventID)
 	}
 	res, err := tx.ExecContext(ctx, `UPDATE events
 SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
@@ -272,6 +294,10 @@ FROM events AS e WHERE e.id = ?`, candidate.EventID).Scan(&body, &createdAt, &av
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ? AND event_id = ? AND body_sha256 = ? AND stored_bytes = ?`, planID, candidate.EventID, candidate.BodySHA256, candidate.StoredBytes).Scan(&entryCount); err != nil || entryCount != 1 {
 			return "", false, xerrors.Errorf("raw-body execution ledger does not match pruned event %s", candidate.EventID)
 		}
+		persistedCreatedAt, parseErr := time.Parse(time.RFC3339Nano, createdAt)
+		if parseErr != nil || !persistedCreatedAt.Equal(candidate.CreatedAt) || stored != candidate.StoredBytes || body != domtypes.EventBodyUnavailableRetentionMarker || activeSession {
+			return "", false, xerrors.Errorf("durable raw-body candidate state changed for event %s", candidate.EventID)
+		}
 		return body, true, nil
 	}
 	if activeSession {
@@ -297,6 +323,13 @@ func completeRawBodyExecution(ctx context.Context, db *sql.DB, sourcePath, datab
 	if err := requireRawBodySource(ctx, tx, sourcePath, databaseIdentity, sqliteUserVersion, migrationDigest); err != nil {
 		return err
 	}
+	var executionStatus string
+	if err := tx.QueryRowContext(ctx, `SELECT status FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus); err != nil {
+		return xerrors.Errorf("failed to inspect raw-body completion status: %w", err)
+	}
+	if executionStatus != "running" && executionStatus != "completed" {
+		return xerrors.Errorf("raw-body execution cannot complete from status %s", executionStatus)
+	}
 	var ledgerCount int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ?`, planID).Scan(&ledgerCount); err != nil {
 		return xerrors.Errorf("failed to count raw-body execution ledger: %w", err)
@@ -304,9 +337,20 @@ func completeRawBodyExecution(ctx context.Context, db *sql.DB, sourcePath, datab
 	if ledgerCount != candidateCount {
 		return xerrors.Errorf("raw-body execution is incomplete: ledger has %d of %d candidates", ledgerCount, candidateCount)
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
-SET status = 'completed', pruned_count = ?, completed_at = ? WHERE plan_id = ?`, candidateCount, stamp, planID); err != nil {
+	if executionStatus == "completed" {
+		if err := tx.Commit(); err != nil {
+			return xerrors.Errorf("failed to commit raw-body completion check: %w", err)
+		}
+		return nil
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
+	SET status = 'completed', pruned_count = ?, completed_at = ? WHERE plan_id = ? AND status = 'running'`, candidateCount, stamp, planID)
+	if err != nil {
 		return xerrors.Errorf("failed to complete raw-body execution: %w", err)
+	}
+	changed, _ := res.RowsAffected()
+	if changed != 1 {
+		return xerrors.Errorf("raw-body execution changed state before completion")
 	}
 	if err := tx.Commit(); err != nil {
 		return xerrors.Errorf("failed to commit raw-body completion: %w", err)
@@ -339,6 +383,16 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 	if executionCandidates != len(bodies) || (executionStatus != "running" && executionStatus != "completed" && executionStatus != "restored") {
 		return result, xerrors.Errorf("raw-body execution state does not match restore plan")
 	}
+	if executionStatus != "restored" {
+		res, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions SET status = 'restoring' WHERE plan_id = ? AND status = ?`, planID, executionStatus)
+		if err != nil {
+			return result, xerrors.Errorf("failed to claim raw-body restore: %w", err)
+		}
+		changed, _ := res.RowsAffected()
+		if changed != 1 {
+			return result, xerrors.Errorf("raw-body execution changed state before restore")
+		}
+	}
 
 	stamp := formatTimestamp(restoredAt)
 	for _, recovery := range bodies {
@@ -351,7 +405,26 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 		if err := tx.QueryRowContext(ctx, `SELECT body, body_availability, body_pruned_plan_id FROM events WHERE id = ?`, recovery.Candidate.EventID).Scan(&body, &availability, &prunedPlan); err != nil {
 			return result, xerrors.Errorf("failed to verify restore event %s: %w", recovery.Candidate.EventID, err)
 		}
+		var ledgerDigest string
+		var ledgerStored int
+		var ledgerRestoredAt sql.NullString
+		ledgerErr := tx.QueryRowContext(ctx, `SELECT body_sha256, stored_bytes, restored_at FROM raw_body_retention_entries WHERE plan_id = ? AND event_id = ?`, planID, recovery.Candidate.EventID).Scan(&ledgerDigest, &ledgerStored, &ledgerRestoredAt)
+		if errors.Is(ledgerErr, sql.ErrNoRows) {
+			if executionStatus != "running" || availability != domtypes.BodyAvailabilityAvailable.String() {
+				return result, xerrors.Errorf("raw-body restore ledger is missing event %s", recovery.Candidate.EventID)
+			}
+			// A running execution may have stopped before this candidate. Preserve
+			// the currently available body, including legitimate post-plan changes.
+			result.AlreadyRestored++
+			continue
+		}
+		if ledgerErr != nil || ledgerDigest != recovery.Candidate.BodySHA256 || ledgerStored != recovery.Candidate.StoredBytes {
+			return result, xerrors.Errorf("raw-body restore ledger does not match event %s", recovery.Candidate.EventID)
+		}
 		if availability == domtypes.BodyAvailabilityAvailable.String() {
+			if !ledgerRestoredAt.Valid {
+				return result, xerrors.Errorf("event %s is available before its restore was recorded", recovery.Candidate.EventID)
+			}
 			current := sha256.Sum256([]byte(body))
 			if hex.EncodeToString(current[:]) != recovery.Candidate.BodySHA256 {
 				return result, xerrors.Errorf("available body conflicts with recovery for event %s", recovery.Candidate.EventID)

--- a/infrastructure/sqlite/raw_body_retention_datasource.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource.go
@@ -1,0 +1,315 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+var (
+	_ application.RawBodyRetentionPlanner  = (*StoreManagementDatasource)(nil)
+	_ application.RawBodyRetentionExecutor = (*StoreManagementDatasource)(nil)
+)
+
+// ListRawBodyCandidates returns exact eligible identities under one read snapshot.
+func (d *StoreManagementDatasource) ListRawBodyCandidates(ctx context.Context, before time.Time) (apptypes.RawBodyRetentionSnapshot, error) {
+	if before.IsZero() {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("retention cutoff must not be zero")
+	}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to open DB for raw-body plan: %w", err)
+	}
+	defer closeRawBodyResource(db)
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to begin raw-body plan snapshot: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+
+	identity, version, err := rawBodySourceIdentity(ctx, tx)
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, err
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT e.id, e.created_at, e.body_stored_bytes, e.body
+  FROM events AS e
+ WHERE e.body_availability = 'available'
+   AND ts_norm(e.created_at) < ts_norm(?)
+   AND NOT EXISTS (
+       SELECT 1 FROM sessions AS s
+        WHERE s.session_id = e.session_id AND s.ended_at IS NULL
+   )
+ ORDER BY ts_norm(e.created_at), e.id`, formatTimestamp(before))
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to query raw-body candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	candidates := make([]apptypes.RawBodyCandidate, 0)
+	for rows.Next() {
+		var id, createdAtValue, body string
+		var stored sql.NullInt64
+		if err := rows.Scan(&id, &createdAtValue, &stored, &body); err != nil {
+			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to scan raw-body candidate: %w", err)
+		}
+		if !stored.Valid || stored.Int64 < 0 {
+			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("event %s has indeterminate stored body bytes", id)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
+		if err != nil {
+			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to parse candidate created_at: %w", err)
+		}
+		digest := sha256.Sum256([]byte(body))
+		storedBytes, err := checkedInt(stored.Int64, "stored body bytes")
+		if err != nil {
+			return apptypes.RawBodyRetentionSnapshot{}, err
+		}
+		candidates = append(candidates, apptypes.RawBodyCandidate{
+			EventID: id, CreatedAt: createdAt, StoredBytes: storedBytes, BodySHA256: hex.EncodeToString(digest[:]),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to iterate raw-body candidates: %w", err)
+	}
+
+	excludedRows, err := tx.QueryContext(ctx, `
+SELECT e.id
+  FROM events AS e
+  JOIN sessions AS s ON s.session_id = e.session_id
+ WHERE e.body_availability = 'available'
+   AND ts_norm(e.created_at) < ts_norm(?)
+   AND s.ended_at IS NULL
+ ORDER BY e.id`, formatTimestamp(before))
+	if err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to query active-session exclusions: %w", err)
+	}
+	defer func() { _ = excludedRows.Close() }()
+	excluded := make([]string, 0)
+	for excludedRows.Next() {
+		var id string
+		if err := excludedRows.Scan(&id); err != nil {
+			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to scan active-session exclusion: %w", err)
+		}
+		excluded = append(excluded, id)
+	}
+	if err := excludedRows.Err(); err != nil {
+		return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to iterate active-session exclusions: %w", err)
+	}
+
+	return apptypes.RawBodyRetentionSnapshot{
+		DatabaseIdentity: identity, SQLiteUserVersion: version, SnapshotAt: time.Now().UTC(),
+		Candidates: candidates, ExcludedActive: excluded,
+	}, nil
+}
+
+// ApplyRawBodyPlan prunes only exact candidate versions in one transaction.
+func (d *StoreManagementDatasource) ApplyRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, candidates []apptypes.RawBodyCandidate, appliedAt time.Time) (apptypes.RawBodyApplyResult, error) {
+	result := apptypes.RawBodyApplyResult{PlanID: planID, CandidateCount: len(candidates)}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return result, xerrors.Errorf("failed to open DB for raw-body apply: %w", err)
+	}
+	defer closeRawBodyResource(db)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, xerrors.Errorf("failed to begin raw-body apply: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, databaseIdentity, sqliteUserVersion); err != nil {
+		return result, err
+	}
+	var executionStatus string
+	var executionCandidates int
+	executionErr := tx.QueryRowContext(ctx, `SELECT status, candidate_count FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus, &executionCandidates)
+	if executionErr != nil && !errors.Is(executionErr, sql.ErrNoRows) {
+		return result, xerrors.Errorf("failed to inspect raw-body execution: %w", executionErr)
+	}
+	if executionErr == nil {
+		if executionCandidates != len(candidates) {
+			return result, xerrors.Errorf("raw-body execution candidate count conflicts with plan")
+		}
+		if executionStatus == "restored" {
+			return result, xerrors.Errorf("restored raw-body plan is terminal; create a new plan to prune again")
+		}
+	}
+
+	type pendingCandidate struct {
+		candidate apptypes.RawBodyCandidate
+		body      string
+	}
+	pending := make([]pendingCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		var body, createdAt, availability string
+		var stored int
+		var prunedPlan sql.NullString
+		err := tx.QueryRowContext(ctx, `SELECT body, created_at, body_availability, body_stored_bytes, body_pruned_plan_id FROM events WHERE id = ?`, candidate.EventID).
+			Scan(&body, &createdAt, &availability, &stored, &prunedPlan)
+		if err != nil {
+			return result, xerrors.Errorf("failed to verify raw-body candidate %s: %w", candidate.EventID, err)
+		}
+		if availability == domtypes.BodyAvailabilityUnavailableRetention.String() && prunedPlan.String == planID {
+			var entryCount int
+			if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM raw_body_retention_entries WHERE plan_id = ? AND event_id = ? AND body_sha256 = ? AND stored_bytes = ?`, planID, candidate.EventID, candidate.BodySHA256, candidate.StoredBytes).Scan(&entryCount); err != nil || entryCount != 1 {
+				return result, xerrors.Errorf("raw-body execution ledger does not match pruned event %s", candidate.EventID)
+			}
+			result.AlreadyPruned++
+			continue
+		}
+		digest := sha256.Sum256([]byte(body))
+		if availability != domtypes.BodyAvailabilityAvailable.String() || createdAt != formatTimestamp(candidate.CreatedAt) || stored != candidate.StoredBytes || hex.EncodeToString(digest[:]) != candidate.BodySHA256 {
+			return result, xerrors.Errorf("raw-body plan is stale or mismatched at event %s", candidate.EventID)
+		}
+		pending = append(pending, pendingCandidate{candidate: candidate, body: body})
+	}
+
+	stamp := formatTimestamp(appliedAt)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_executions(plan_id, status, candidate_count, pruned_count, started_at)
+VALUES (?, 'running', ?, 0, ?)
+ON CONFLICT(plan_id) DO NOTHING`, planID, len(candidates), stamp); err != nil {
+		return result, xerrors.Errorf("failed to start raw-body execution: %w", err)
+	}
+	for index, item := range pending {
+		res, err := tx.ExecContext(ctx, `UPDATE events
+SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
+WHERE id = ? AND body_availability = 'available' AND body = ?`, domtypes.EventBodyUnavailableRetentionMarker, stamp, planID, item.candidate.EventID, item.body)
+		if err != nil {
+			return result, xerrors.Errorf("failed to prune raw body %s: %w", item.candidate.EventID, err)
+		}
+		changed, _ := res.RowsAffected()
+		if changed != 1 {
+			return result, xerrors.Errorf("raw-body candidate changed during apply: %s", item.candidate.EventID)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO raw_body_retention_entries(plan_id, event_id, body_sha256, stored_bytes, pruned_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(plan_id, event_id) DO NOTHING`, planID, item.candidate.EventID, item.candidate.BodySHA256, item.candidate.StoredBytes, stamp); err != nil {
+			return result, xerrors.Errorf("failed to record raw-body entry: %w", err)
+		}
+		result.PrunedCount++
+		if d.onRawBodyPruned != nil {
+			if err := d.onRawBodyPruned(index); err != nil {
+				return result, xerrors.Errorf("raw-body apply interrupted: %w", err)
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions
+SET status = 'completed', pruned_count = ?, completed_at = ? WHERE plan_id = ?`, len(candidates), stamp, planID); err != nil {
+		return result, xerrors.Errorf("failed to complete raw-body execution: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return result, xerrors.Errorf("failed to commit raw-body apply: %w", err)
+	}
+	return result, nil
+}
+
+// RestoreRawBodyPlan restores exact bodies only for the execution that pruned them.
+func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, databaseIdentity string, sqliteUserVersion int, planID string, bodies []apptypes.RawBodyRecoveryBody, restoredAt time.Time) (apptypes.RawBodyRestoreResult, error) {
+	result := apptypes.RawBodyRestoreResult{PlanID: planID, CandidateCount: len(bodies)}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return result, xerrors.Errorf("failed to open DB for raw-body restore: %w", err)
+	}
+	defer closeRawBodyResource(db)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, xerrors.Errorf("failed to begin raw-body restore: %w", err)
+	}
+	defer rollbackRawBodyTx(tx)
+	if err := requireRawBodySource(ctx, tx, databaseIdentity, sqliteUserVersion); err != nil {
+		return result, err
+	}
+	var executionStatus string
+	var executionCandidates int
+	if err := tx.QueryRowContext(ctx, `SELECT status, candidate_count FROM raw_body_retention_executions WHERE plan_id = ?`, planID).Scan(&executionStatus, &executionCandidates); err != nil {
+		return result, xerrors.Errorf("raw-body execution is not available for restore: %w", err)
+	}
+	if executionCandidates != len(bodies) || (executionStatus != "completed" && executionStatus != "restored") {
+		return result, xerrors.Errorf("raw-body execution state does not match restore plan")
+	}
+
+	stamp := formatTimestamp(restoredAt)
+	for _, recovery := range bodies {
+		digest := sha256.Sum256([]byte(recovery.Body))
+		if len(recovery.Body) != recovery.Candidate.StoredBytes || hex.EncodeToString(digest[:]) != recovery.Candidate.BodySHA256 {
+			return result, xerrors.Errorf("recovery body does not match plan for event %s", recovery.Candidate.EventID)
+		}
+		var body, availability string
+		var prunedPlan sql.NullString
+		if err := tx.QueryRowContext(ctx, `SELECT body, body_availability, body_pruned_plan_id FROM events WHERE id = ?`, recovery.Candidate.EventID).Scan(&body, &availability, &prunedPlan); err != nil {
+			return result, xerrors.Errorf("failed to verify restore event %s: %w", recovery.Candidate.EventID, err)
+		}
+		if availability == domtypes.BodyAvailabilityAvailable.String() {
+			current := sha256.Sum256([]byte(body))
+			if hex.EncodeToString(current[:]) != recovery.Candidate.BodySHA256 {
+				return result, xerrors.Errorf("available body conflicts with recovery for event %s", recovery.Candidate.EventID)
+			}
+			result.AlreadyRestored++
+			continue
+		}
+		if availability != domtypes.BodyAvailabilityUnavailableRetention.String() || prunedPlan.String != planID {
+			return result, xerrors.Errorf("event %s was not pruned by plan %s", recovery.Candidate.EventID, planID)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE events SET body = ?, body_availability = 'available', body_pruned_at = NULL, body_pruned_plan_id = NULL WHERE id = ?`, recovery.Body, recovery.Candidate.EventID); err != nil {
+			return result, xerrors.Errorf("failed to restore raw body %s: %w", recovery.Candidate.EventID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_entries SET restored_at = ? WHERE plan_id = ? AND event_id = ?`, stamp, planID, recovery.Candidate.EventID); err != nil {
+			return result, xerrors.Errorf("failed to record raw-body restore: %w", err)
+		}
+		result.RestoredCount++
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_executions SET status = 'restored', completed_at = ? WHERE plan_id = ?`, stamp, planID); err != nil {
+		return result, xerrors.Errorf("failed to complete raw-body restore: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return result, xerrors.Errorf("failed to commit raw-body restore: %w", err)
+	}
+	return result, nil
+}
+
+func rawBodySourceIdentity(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (string, int, error) {
+	var identity string
+	if err := q.QueryRowContext(ctx, `SELECT id FROM raw_body_retention_store_identity`).Scan(&identity); err != nil {
+		return "", 0, xerrors.Errorf("failed to read raw-body store identity: %w", err)
+	}
+	var version int
+	if err := q.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
+		return "", 0, xerrors.Errorf("failed to read SQLite user_version: %w", err)
+	}
+	return identity, version, nil
+}
+
+func requireRawBodySource(ctx context.Context, tx *sql.Tx, expectedIdentity string, expectedVersion int) error {
+	identity, version, err := rawBodySourceIdentity(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if identity != expectedIdentity || version != expectedVersion {
+		return xerrors.Errorf("raw-body plan belongs to a different store")
+	}
+	return nil
+}
+
+func closeRawBodyResource(db *sql.DB) {
+	if err := db.Close(); err != nil {
+		slog.Debug("failed to close raw-body retention resource", "error", err)
+	}
+}
+
+func rollbackRawBodyTx(tx *sql.Tx) {
+	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		slog.Debug("failed to rollback raw-body retention transaction", "error", err)
+	}
+}

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -72,6 +72,25 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 	if retry.PrunedCount != 0 || retry.AlreadyPruned != 1 {
 		t.Fatalf("retry result = %+v", retry)
 	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions(session_id, started_at, ended_at, client, agent, workspace) VALUES ('retention-session', '2026-05-01T00:00:00Z', NULL, 'cli', 'codex', 'repo')`); err != nil {
+		t.Fatalf("activate session before retry: %v", err)
+	}
+	_ = db.Close()
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 2, 0, 0, 0, time.UTC)); err == nil {
+		t.Fatal("retry ApplyRawBodyPlan(active session) error = nil, want durable-state rejection")
+	}
+	db, err = sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(cleanup) error = %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM sessions WHERE session_id = 'retention-session'`); err != nil {
+		t.Fatalf("remove active session: %v", err)
+	}
+	_ = db.Close()
 
 	recovery := []apptypes.RawBodyRecoveryBody{{Candidate: snapshot.Candidates[0], Body: event.Body()}}
 	restored, err := store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, recovery, time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC))
@@ -341,6 +360,14 @@ func TestRawBodyRetention_partialExecutionCanBeRestored(t *testing.T) {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
 	}
 	store.SetRawBodyPrunedHookForTest(nil)
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET body = 'post-plan-change' WHERE id = 'partial-b'`); err != nil {
+		t.Fatalf("update unprocessed candidate: %v", err)
+	}
+	_ = db.Close()
 	recovery := make([]apptypes.RawBodyRecoveryBody, len(snapshot.Candidates))
 	for index, candidate := range snapshot.Candidates {
 		recovery[index] = apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: bodiesByID[candidate.EventID]}
@@ -357,8 +384,58 @@ func TestRawBodyRetention_partialExecutionCanBeRestored(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
 		}
-		if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != bodiesByID[candidate.EventID] {
+		wantBody := bodiesByID[candidate.EventID]
+		if candidate.EventID == "partial-b" {
+			wantBody = "post-plan-change"
+		}
+		if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != wantBody {
 			t.Fatalf("event %s not recovered from partial execution", candidate.EventID)
+		}
+	}
+}
+
+func TestRawBodyRetention_restoreBetweenBatchesStopsFurtherApply(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	bodiesByID := map[string]string{"race-a": "payload-a", "race-b": "payload-b"}
+	for index, id := range []string{"race-a", "race-b"} {
+		if err := events.Save(context.Background(), rawBodyRetentionEvent(t, id, bodiesByID[id], time.Date(2026, 5, 3, index, 0, 0, 0, time.UTC))); err != nil {
+			t.Fatalf("Save(%s) error = %v", id, err)
+		}
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	planID := "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+	recovery := make([]apptypes.RawBodyRecoveryBody, len(snapshot.Candidates))
+	for index, candidate := range snapshot.Candidates {
+		recovery[index] = apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: bodiesByID[candidate.EventID]}
+	}
+	var restoreErr error
+	store.SetRawBodyPrunedHookForTest(func(int) error {
+		store.SetRawBodyPrunedHookForTest(nil)
+		_, restoreErr = store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, recovery, time.Now().UTC())
+		return nil
+	})
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want restored-state stop")
+	}
+	if restoreErr != nil {
+		t.Fatalf("RestoreRawBodyPlan() error = %v", restoreErr)
+	}
+	for _, candidate := range snapshot.Candidates {
+		details, err := events.GetDetails(context.Background(), types.EventID(candidate.EventID))
+		if err != nil {
+			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
+		}
+		if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != bodiesByID[candidate.EventID] {
+			t.Fatalf("event %s changed after restore won the batch boundary", candidate.EventID)
 		}
 	}
 }

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -1,9 +1,11 @@
 package sqlite_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -38,7 +40,7 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 		t.Fatalf("candidate count = %d, want 1", len(snapshot.Candidates))
 	}
 	planID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("ApplyRawBodyPlan() error = %v", err)
 	}
@@ -55,8 +57,15 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 	if details.Event().BodyAvailability() != types.BodyAvailabilityUnavailableRetention || details.Event().Body() != "" {
 		t.Fatalf("pruned event availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
 	}
+	matches, err := events.Search(context.Background(), types.EventBodyUnavailableRetentionMarker, "", "", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil {
+		t.Fatalf("Search(retention marker) error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("Search(retention marker) returned %d pruned events, want 0", len(matches))
+	}
 
-	retry, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 2, 1, 0, 0, 0, time.UTC))
+	retry, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 2, 1, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
 	}
@@ -65,7 +74,7 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 	}
 
 	recovery := []apptypes.RawBodyRecoveryBody{{Candidate: snapshot.Candidates[0], Body: event.Body()}}
-	restored, err := store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, recovery, time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC))
+	restored, err := store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, recovery, time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("RestoreRawBodyPlan() error = %v", err)
 	}
@@ -79,8 +88,46 @@ func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
 	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != event.Body() {
 		t.Fatalf("restored event availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
 	}
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)); err == nil {
 		t.Fatal("ApplyRawBodyPlan() after restore error = nil, want terminal-plan rejection")
+	}
+}
+
+func TestRawBodyRetention_planSnapshotDoesNotChangeDatabaseBytes(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if err := events.Save(context.Background(), rawBodyRetentionEvent(t, "read-only-plan", "body", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	before, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("ReadFile(before) error = %v", err)
+	}
+	beforeInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat(before) error = %v", err)
+	}
+	if _, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	after, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after) error = %v", err)
+	}
+	afterInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat(after) error = %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("retention plan snapshot changed database bytes")
+	}
+	if !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
+		t.Fatalf("database mtime changed: before=%s after=%s", beforeInfo.ModTime(), afterInfo.ModTime())
 	}
 }
 
@@ -109,7 +156,7 @@ func TestRawBodyRetention_rejectsStaleCandidateWithoutPruning(t *testing.T) {
 	}
 	_ = db.Close()
 
-	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", snapshot.Candidates, time.Now().UTC())
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", snapshot.Candidates, time.Now().UTC())
 	if err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want stale-plan rejection")
 	}
@@ -119,6 +166,44 @@ func TestRawBodyRetention_rejectsStaleCandidateWithoutPruning(t *testing.T) {
 	}
 	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != "changed" {
 		t.Fatalf("stale apply changed event: availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
+	}
+}
+
+func TestRawBodyRetention_rejectsSchemaDriftWithoutPruning(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "schema-drift-event", "protected", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE retention_schema_drift(id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("create schema drift: %v", err)
+	}
+	_ = db.Close()
+
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", snapshot.Candidates, time.Now().UTC())
+	if err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want schema-drift rejection")
+	}
+	details, err := events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != "protected" {
+		t.Fatalf("schema-drift apply changed event: availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
 	}
 }
 
@@ -151,7 +236,45 @@ func TestRawBodyRetention_excludesActiveSessionBodies(t *testing.T) {
 	}
 }
 
-func TestRawBodyRetention_interruptionRollsBackAndRetryPrunesExactCandidates(t *testing.T) {
+func TestRawBodyRetention_rejectsSessionActivatedAfterPlan(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "activated-after-plan", "protected", time.Date(2026, 5, 1, 1, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions(session_id, started_at, ended_at, client, agent, workspace) VALUES ('retention-session', '2026-05-01T00:00:00Z', NULL, 'cli', 'codex', 'repo')`); err != nil {
+		t.Fatalf("activate session after plan: %v", err)
+	}
+	_ = db.Close()
+
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", snapshot.Candidates, time.Now().UTC())
+	if err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want active-session stale-plan rejection")
+	}
+	details, err := events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != "protected" {
+		t.Fatalf("active-session rejection changed event: availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
+	}
+}
+
+func TestRawBodyRetention_interruptionResumesFromDurableBatch(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
@@ -171,25 +294,60 @@ func TestRawBodyRetention_interruptionRollsBackAndRetryPrunesExactCandidates(t *
 	}
 	planID := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
-	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
 		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
 	}
-	for _, candidate := range snapshot.Candidates {
+	for index, candidate := range snapshot.Candidates {
 		details, err := events.GetDetails(context.Background(), types.EventID(candidate.EventID))
 		if err != nil {
 			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
 		}
-		if !details.Event().BodyAvailability().IsAvailable() {
-			t.Fatalf("event %s was pruned by rolled-back transaction", candidate.EventID)
+		wantAvailable := index != 0
+		if details.Event().BodyAvailability().IsAvailable() != wantAvailable {
+			t.Fatalf("event %s availability = %q, want available=%t after interruption", candidate.EventID, details.Event().BodyAvailability(), wantAvailable)
 		}
 	}
 	store.SetRawBodyPrunedHookForTest(nil)
-	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Now().UTC())
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
 	}
-	if result.PrunedCount != len(snapshot.Candidates) {
-		t.Fatalf("retry pruned = %d, want %d", result.PrunedCount, len(snapshot.Candidates))
+	if result.PrunedCount != len(snapshot.Candidates)-1 || result.AlreadyPruned != 1 {
+		t.Fatalf("retry result = %+v, want one resumed and one already durable", result)
+	}
+}
+
+func TestRawBodyRetention_planIsBoundToCopiedStorePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "original.db")
+	events, store := newEventDatasource(t, originalPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "path-bound", "payload", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	data, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read original DB: %v", err)
+	}
+	copyPath := filepath.Join(dir, "copy.db")
+	if err := os.WriteFile(copyPath, data, 0o600); err != nil {
+		t.Fatalf("write copied DB: %v", err)
+	}
+	_, copiedStore := newEventDatasource(t, copyPath, onDiskSQLiteMigrations(t))
+	if err := copiedStore.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize(copy) error = %v", err)
+	}
+	if _, err := copiedStore.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", snapshot.Candidates, time.Now().UTC()); err == nil {
+		t.Fatal("ApplyRawBodyPlan(copy) error = nil, want source-path mismatch")
 	}
 }
 

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -1,0 +1,235 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestRawBodyRetention_applyRetryAndRestore(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "retention-event", "body to recover", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	beforeMetadata := rawBodyMetadataRow(t, dbPath, event.EventID().String())
+
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	if len(snapshot.Candidates) != 1 {
+		t.Fatalf("candidate count = %d, want 1", len(snapshot.Candidates))
+	}
+	planID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ApplyRawBodyPlan() error = %v", err)
+	}
+	if result.PrunedCount != 1 || result.AlreadyPruned != 0 {
+		t.Fatalf("apply result = %+v", result)
+	}
+	if after := rawBodyMetadataRow(t, dbPath, event.EventID().String()); after != beforeMetadata {
+		t.Fatalf("metadata changed after prune:\nbefore=%q\nafter=%q", beforeMetadata, after)
+	}
+	details, err := events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if details.Event().BodyAvailability() != types.BodyAvailabilityUnavailableRetention || details.Event().Body() != "" {
+		t.Fatalf("pruned event availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
+	}
+
+	retry, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 2, 1, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
+	}
+	if retry.PrunedCount != 0 || retry.AlreadyPruned != 1 {
+		t.Fatalf("retry result = %+v", retry)
+	}
+
+	recovery := []apptypes.RawBodyRecoveryBody{{Candidate: snapshot.Candidates[0], Body: event.Body()}}
+	restored, err := store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, recovery, time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("RestoreRawBodyPlan() error = %v", err)
+	}
+	if restored.RestoredCount != 1 {
+		t.Fatalf("restore result = %+v", restored)
+	}
+	details, err = events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails(restored) error = %v", err)
+	}
+	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != event.Body() {
+		t.Fatalf("restored event availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
+	}
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)); err == nil {
+		t.Fatal("ApplyRawBodyPlan() after restore error = nil, want terminal-plan rejection")
+	}
+}
+
+func TestRawBodyRetention_rejectsStaleCandidateWithoutPruning(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := rawBodyRetentionEvent(t, "stale-event", "original", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET body = 'changed' WHERE id = 'stale-event'`); err != nil {
+		t.Fatalf("mutate body: %v", err)
+	}
+	_ = db.Close()
+
+	_, err = store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", snapshot.Candidates, time.Now().UTC())
+	if err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want stale-plan rejection")
+	}
+	details, err := events.GetDetails(context.Background(), event.EventID())
+	if err != nil {
+		t.Fatalf("GetDetails() error = %v", err)
+	}
+	if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != "changed" {
+		t.Fatalf("stale apply changed event: availability=%q body=%q", details.Event().BodyAvailability(), details.Event().Body())
+	}
+}
+
+func TestRawBodyRetention_excludesActiveSessionBodies(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions(session_id, started_at, ended_at, client, agent, workspace) VALUES ('retention-session', '2026-05-01T00:00:00Z', NULL, 'cli', 'codex', 'repo')`); err != nil {
+		t.Fatalf("insert active session: %v", err)
+	}
+	_ = db.Close()
+	event := rawBodyRetentionEvent(t, "active-event", "protected", time.Date(2026, 5, 1, 1, 0, 0, 0, time.UTC))
+	if err := events.Save(context.Background(), event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	if len(snapshot.Candidates) != 0 || len(snapshot.ExcludedActive) != 1 || snapshot.ExcludedActive[0] != "active-event" {
+		t.Fatalf("snapshot candidates=%+v exclusions=%+v", snapshot.Candidates, snapshot.ExcludedActive)
+	}
+}
+
+func TestRawBodyRetention_interruptionRollsBackAndRetryPrunesExactCandidates(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	for index, id := range []string{"interrupt-a", "interrupt-b"} {
+		event := rawBodyRetentionEvent(t, id, "payload-"+id, time.Date(2026, 5, 1, index, 0, 0, 0, time.UTC))
+		if err := events.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", id, err)
+		}
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	planID := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
+	}
+	for _, candidate := range snapshot.Candidates {
+		details, err := events.GetDetails(context.Background(), types.EventID(candidate.EventID))
+		if err != nil {
+			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
+		}
+		if !details.Event().BodyAvailability().IsAvailable() {
+			t.Fatalf("event %s was pruned by rolled-back transaction", candidate.EventID)
+		}
+	}
+	store.SetRawBodyPrunedHookForTest(nil)
+	result, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, planID, snapshot.Candidates, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("retry ApplyRawBodyPlan() error = %v", err)
+	}
+	if result.PrunedCount != len(snapshot.Candidates) {
+		t.Fatalf("retry pruned = %d, want %d", result.PrunedCount, len(snapshot.Candidates))
+	}
+}
+
+func rawBodyRetentionEvent(t *testing.T, id, body string, createdAt time.Time) *model.Event {
+	t.Helper()
+	eventID, err := types.EventIDFrom(id)
+	if err != nil {
+		t.Fatalf("EventIDFrom() error = %v", err)
+	}
+	agent, err := types.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	sessionID, err := types.SessionIDFrom("retention-session")
+	if err != nil {
+		t.Fatalf("SessionIDFrom() error = %v", err)
+	}
+	return model.EventOf(eventID, types.EventKindNote, "cli", agent, sessionID, "repo", body, createdAt)
+}
+
+func rawBodyMetadataRow(t *testing.T, dbPath, eventID string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var kind, client, agent, sessionID, workspace, createdAt string
+	var original, stored, ingest, storage, version sql.NullInt64
+	if err := db.QueryRow(`SELECT kind, client, agent, session_id, workspace, created_at,
+body_original_bytes, body_stored_bytes, body_ingest_truncated, body_storage_truncated, body_metadata_version
+FROM events WHERE id = ?`, eventID).Scan(&kind, &client, &agent, &sessionID, &workspace, &createdAt, &original, &stored, &ingest, &storage, &version); err != nil {
+		t.Fatalf("metadata query: %v", err)
+	}
+	return kind + "|" + client + "|" + agent + "|" + sessionID + "|" + workspace + "|" + createdAt + "|" + nullableInt(original) + "|" + nullableInt(stored) + "|" + nullableInt(ingest) + "|" + nullableInt(storage) + "|" + nullableInt(version)
+}
+
+func nullableInt(value sql.NullInt64) string {
+	if !value.Valid {
+		return "null"
+	}
+	return strconv.FormatInt(value.Int64, 10)
+}

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -317,6 +317,52 @@ func TestRawBodyRetention_interruptionResumesFromDurableBatch(t *testing.T) {
 	}
 }
 
+func TestRawBodyRetention_partialExecutionCanBeRestored(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	events, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	bodiesByID := map[string]string{"partial-a": "payload-a", "partial-b": "payload-b"}
+	for index, id := range []string{"partial-a", "partial-b"} {
+		if err := events.Save(context.Background(), rawBodyRetentionEvent(t, id, bodiesByID[id], time.Date(2026, 5, 2, index, 0, 0, 0, time.UTC))); err != nil {
+			t.Fatalf("Save(%s) error = %v", id, err)
+		}
+	}
+	snapshot, err := store.ListRawBodyCandidates(context.Background(), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("ListRawBodyCandidates() error = %v", err)
+	}
+	planID := "abababababababababababababababababababababababababababababababab"
+	store.SetRawBodyPrunedHookForTest(func(int) error { return errors.New("injected interruption") })
+	if _, err := store.ApplyRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, snapshot.Candidates, time.Now().UTC()); err == nil {
+		t.Fatal("ApplyRawBodyPlan() error = nil, want interruption")
+	}
+	store.SetRawBodyPrunedHookForTest(nil)
+	recovery := make([]apptypes.RawBodyRecoveryBody, len(snapshot.Candidates))
+	for index, candidate := range snapshot.Candidates {
+		recovery[index] = apptypes.RawBodyRecoveryBody{Candidate: candidate, Body: bodiesByID[candidate.EventID]}
+	}
+	result, err := store.RestoreRawBodyPlan(context.Background(), snapshot.DatabaseIdentity, snapshot.SQLiteUserVersion, snapshot.MigrationDigest, planID, recovery, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("RestoreRawBodyPlan(partial) error = %v", err)
+	}
+	if result.RestoredCount != 1 || result.AlreadyRestored != 1 {
+		t.Fatalf("partial restore result = %+v, want one restored and one unchanged", result)
+	}
+	for _, candidate := range snapshot.Candidates {
+		details, err := events.GetDetails(context.Background(), types.EventID(candidate.EventID))
+		if err != nil {
+			t.Fatalf("GetDetails(%s) error = %v", candidate.EventID, err)
+		}
+		if !details.Event().BodyAvailability().IsAvailable() || details.Event().Body() != bodiesByID[candidate.EventID] {
+			t.Fatalf("event %s not recovered from partial execution", candidate.EventID)
+		}
+	}
+}
+
 func TestRawBodyRetention_planIsBoundToCopiedStorePath(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/search_events_test.go
+++ b/infrastructure/sqlite/search_events_test.go
@@ -25,6 +25,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),
@@ -314,6 +315,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/infrastructure/sqlite/sql/find_latest_session.sql
+++ b/infrastructure/sqlite/sql/find_latest_session.sql
@@ -6,6 +6,7 @@ WITH candidate_sessions AS (
             started.session_id,
             started.workspace,
             started.body,
+            started.body_availability,
             started.source_hook,
             started.created_at,
             (
@@ -111,6 +112,7 @@ SELECT id,
        session_id,
        workspace,
        body,
+       body_availability,
        source_hook,
        created_at
   FROM candidate_sessions

--- a/infrastructure/sqlite/sql/get_context_events.sql
+++ b/infrastructure/sqlite/sql/get_context_events.sql
@@ -1,4 +1,4 @@
-SELECT id, kind, client, agent, session_id, workspace, body, source_hook, created_at
+SELECT id, kind, client, agent, session_id, workspace, body, body_availability, source_hook, created_at
   FROM events
  WHERE (? = '' OR workspace = ?)
    AND (? = '' OR session_id = ?)

--- a/infrastructure/sqlite/sql/get_event_details.sql
+++ b/infrastructure/sqlite/sql/get_event_details.sql
@@ -1,4 +1,4 @@
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at,
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at,
        ca.command_text, ca.command_wrapper, ca.command_name,
        ca.input_text, ca.output_text, ca.input_truncated, ca.output_truncated,
        ca.input_original_bytes, ca.output_original_bytes, ca.exit_code, ca.failed, ca.failure_reason

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -6,7 +6,7 @@
 -- search surface). Strip thinking before matching: when body parses as
 -- a canonical envelope, match only the joined text-block content;
 -- otherwise keep the raw body (legacy plain text, non-envelope JSON).
-SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
+SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits a ON a.event_id = e.id
  WHERE (? = '' OR
@@ -24,7 +24,7 @@ SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.bo
                        WHERE json_extract(value, '$.type') = 'text'),
                      '')
               ELSE CASE
-                     WHEN e.body = '[traceary:body-unavailable:retention]' THEN ''
+                     WHEN e.body_availability = 'unavailable_retention' THEN ''
                      ELSE e.body
                    END
          END) LIKE ? ESCAPE '\' OR

--- a/infrastructure/sqlite/sql/search_events.sql
+++ b/infrastructure/sqlite/sql/search_events.sql
@@ -23,7 +23,10 @@ SELECT DISTINCT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.bo
                         FROM json_each(json_extract(e.body, '$.blocks'))
                        WHERE json_extract(value, '$.type') = 'text'),
                      '')
-              ELSE e.body
+              ELSE CASE
+                     WHEN e.body = '[traceary:body-unavailable:retention]' THEN ''
+                     ELSE e.body
+                   END
          END) LIKE ? ESCAPE '\' OR
         COALESCE(a.command_text, '') LIKE ? ESCAPE '\' OR
         COALESCE(a.input_text, '') LIKE ? ESCAPE '\' OR

--- a/infrastructure/sqlite/sql/select_recent_events.sql
+++ b/infrastructure/sqlite/sql/select_recent_events.sql
@@ -1,7 +1,7 @@
 -- No source_hook filter. When a source_hook filter is set, the Go datasource
 -- dispatches to select_recent_events_by_source_hook.sql so hook-specific
 -- predicates stay isolated from the general recent-events path. See #683.
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE (? = '' OR e.kind = ?)

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook.sql
@@ -8,7 +8,7 @@
 -- `select_recent_events_by_source_hook_with_legacy.sql` instead so
 -- pre-#672 rows that lack source_hook but carry the `[phase:*]` body
 -- prefix stay reachable. See #683.
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE e.source_hook = ?

--- a/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_events_by_source_hook_with_legacy.sql
@@ -6,9 +6,9 @@
 --
 -- Result limit is applied to the combined set so pagination is stable
 -- even when all hits come from the legacy branch.
-SELECT id, kind, client, agent, session_id, workspace, body, source_hook, created_at
+SELECT id, kind, client, agent, session_id, workspace, body, body_availability, source_hook, created_at
   FROM (
-        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
+        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
           FROM events e
           LEFT JOIN command_audits ca ON ca.event_id = e.id
          WHERE e.source_hook = ?
@@ -21,7 +21,7 @@ SELECT id, kind, client, agent, session_id, workspace, body, source_hook, create
            AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
            AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
         UNION ALL
-        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.source_hook, e.created_at
+        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
           FROM events e
           LEFT JOIN command_audits ca ON ca.event_id = e.id
          WHERE e.source_hook IS NULL

--- a/infrastructure/sqlite/store_management_datasource.go
+++ b/infrastructure/sqlite/store_management_datasource.go
@@ -61,7 +61,8 @@ var updateStaleSessionsQuery string
 // StoreManagementDatasource provides store lifecycle and maintenance
 // operations backed by SQLite.
 type StoreManagementDatasource struct {
-	db *Database
+	db              *Database
+	onRawBodyPruned func(index int) error
 }
 
 // NewStoreManagementDatasource creates a new StoreManagementDatasource

--- a/infrastructure/sqlite/timeline_store_test.go
+++ b/infrastructure/sqlite/timeline_store_test.go
@@ -26,6 +26,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/main.go
+++ b/main.go
@@ -179,6 +179,7 @@ func run() error {
 	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	replayUsecase := usecase.NewReplayUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
+	rawBodyRetentionUsecase := usecase.NewRawBodyRetentionUsecase(storeManagementDatasource, storeManagementDatasource)
 	oneShotRepairUsecase := usecase.NewOneShotRepairUsecase(storeManagementDatasource, storeManagementDatasource)
 	workspaceIdentityUsecase := usecase.NewWorkspaceIdentityUsecase(workspaceIdentityDatasource, workspaceIdentityDatasource, types.SystemClock{})
 
@@ -223,6 +224,7 @@ func run() error {
 		cli.WithContext(contextUsecase),
 		cli.WithReplay(replayUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),
+		cli.WithRawBodyRetention(rawBodyRetentionUsecase),
 		cli.WithOneShotRepair(oneShotRepairUsecase),
 		cli.WithWorkspaceIdentity(workspaceIdentityUsecase),
 		cli.WithMCPServerRunner(mcpServer),

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -127,7 +127,7 @@ func writeEventJSON(output io.Writer, e *model.Event) error {
 }
 
 func newEventOutput(e *model.Event) event {
-	return event{
+	output := event{
 		EventID:    e.EventID().String(),
 		Kind:       e.Kind().String(),
 		Client:     e.Client().String(),
@@ -138,6 +138,11 @@ func newEventOutput(e *model.Event) event {
 		SourceHook: e.SourceHook(),
 		CreatedAt:  formatJSONTime(e.CreatedAt()),
 	}
+	if !e.BodyAvailability().IsAvailable() {
+		output.Message = ""
+		output.BodyUnavailableReason = "retention"
+	}
+	return output
 }
 
 // newTruncatedEventOutput is the snapshot-friendly variant of

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/mattn/go-runewidth"
 
-	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -91,7 +90,7 @@ func formatEventWideRow(event *model.Event, opts eventTextFormatOptions) string 
 		event.SessionID().String(),
 		formatOptionalColumn(event.Workspace().String()),
 		formatOptionalColumn(event.SourceHook()),
-		truncateMessage(apptypes.ExtractPlainBody(event.Body())),
+		truncateMessage(eventBodyForDisplay(event)),
 	}, "\t")
 }
 
@@ -131,7 +130,7 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 
 	messageIsLast := messageIndex == len(fields)-1
 	if !messageIsLast {
-		tokens[messageIndex] = truncateNormalized(apptypes.ExtractPlainBody(event.Body()), messageColumnMaxWidth)
+		tokens[messageIndex] = truncateNormalized(eventBodyForDisplay(event), messageColumnMaxWidth)
 		return strings.Join(tokens, sep)
 	}
 
@@ -164,7 +163,7 @@ func formatEventCompactRow(event *model.Event, opts eventTextFormatOptions, extr
 			remaining = messageMinWidth
 		}
 	}
-	plain := prefix + truncateNormalized(apptypes.ExtractPlainBody(event.Body()), remaining)
+	plain := prefix + truncateNormalized(eventBodyForDisplay(event), remaining)
 	if opts.hardTargetWidth && targetWidth > 0 && runeLen(plain) > targetWidth {
 		plain = truncateNormalized(plain, targetWidth)
 	}

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -11,18 +11,19 @@ import "time"
 // detail lookups (`traceary show`) that bypass truncation never emit
 // these keys.
 type event struct {
-	EventID       string `json:"event_id"`
-	Kind          string `json:"kind"`
-	Client        string `json:"client"`
-	Agent         string `json:"agent"`
-	SessionID     string `json:"session_id"`
-	Workspace     string `json:"workspace"`
-	Message       string `json:"message"`
-	SourceHook    string `json:"source_hook,omitempty"`
-	CreatedAt     string `json:"created_at"`
-	Truncated     bool   `json:"truncated,omitempty"`
-	MessageLength int    `json:"message_length,omitempty"`
-	MessageBytes  int    `json:"message_bytes,omitempty"`
+	EventID               string `json:"event_id"`
+	Kind                  string `json:"kind"`
+	Client                string `json:"client"`
+	Agent                 string `json:"agent"`
+	SessionID             string `json:"session_id"`
+	Workspace             string `json:"workspace"`
+	Message               string `json:"message"`
+	BodyUnavailableReason string `json:"body_unavailable_reason,omitempty"`
+	SourceHook            string `json:"source_hook,omitempty"`
+	CreatedAt             string `json:"created_at"`
+	Truncated             bool   `json:"truncated,omitempty"`
+	MessageLength         int    `json:"message_length,omitempty"`
+	MessageBytes          int    `json:"message_bytes,omitempty"`
 }
 
 // commandAudit is the JSON shape of a command audit in CLI output.

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -27,6 +27,7 @@ type RootCLI struct {
 	context                    usecase.ContextUsecase
 	replay                     usecase.ReplayUsecase
 	storeManagement            usecase.StoreManagementUsecase
+	rawBodyRetention           usecase.RawBodyRetentionUsecase
 	workspaceIdentity          usecase.WorkspaceIdentityUsecase
 	mcpServerRunner            MCPServerRunner
 	hooksOrchestrator          application.HooksOrchestrator
@@ -121,6 +122,11 @@ func WithReplay(replay usecase.ReplayUsecase) RootCLIOption {
 // backup, gc, and doctor commands.
 func WithStoreManagement(storeManagement usecase.StoreManagementUsecase) RootCLIOption {
 	return func(c *RootCLI) { c.storeManagement = storeManagement }
+}
+
+// WithRawBodyRetention injects the opt-in reviewed raw-body retention workflow.
+func WithRawBodyRetention(retention usecase.RawBodyRetentionUsecase) RootCLIOption {
+	return func(c *RootCLI) { c.rawBodyRetention = retention }
 }
 
 // WithWorkspaceIdentity injects body-free identity reporting and reviewed aliases.

--- a/presentation/cli/show.go
+++ b/presentation/cli/show.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
@@ -74,7 +75,7 @@ func writeEventDetails(output io.Writer, eventDetails apptypes.EventDetails) err
 		formatOptionalColumn(event.Workspace().String()),
 		formatOptionalColumn(event.SourceHook()),
 		event.CreatedAt().UTC().Format("2006-01-02T15:04:05Z07:00"),
-		apptypes.ExtractPlainBody(event.Body()),
+		eventBodyForDisplay(event),
 	); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print event fields", "イベント共通項目の出力に失敗しました"), err)
 	}
@@ -104,4 +105,11 @@ func writeEventDetails(output io.Writer, eventDetails apptypes.EventDetails) err
 	}
 
 	return nil
+}
+
+func eventBodyForDisplay(event *model.Event) string {
+	if event.BodyAvailability().IsAvailable() {
+		return apptypes.ExtractPlainBody(event.Body())
+	}
+	return Localize("[body unavailable: retention]", "[本文は保持ポリシーにより利用できません]")
 }

--- a/presentation/cli/show_test.go
+++ b/presentation/cli/show_test.go
@@ -130,6 +130,44 @@ func TestRootCLI_ShowCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("reports body unavailable by retention", func(t *testing.T) {
+		t.Parallel()
+
+		eventDetails, err := apptypes.EventDetailsOf(
+			model.EventOfWithBodyAvailabilityAndSourceHook(
+				eventID,
+				types.EventKindNote,
+				"cli",
+				agent,
+				sessionID,
+				"duck8823/traceary",
+				"",
+				types.BodyAvailabilityUnavailableRetention,
+				time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+				"",
+			),
+			types.None[*model.CommandAudit](),
+		)
+		if err != nil {
+			t.Fatalf("EventDetailsOf() error = %v", err)
+		}
+		stdout := &bytes.Buffer{}
+		rootCmd := cli.NewRootCLI(
+			cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+			cli.WithEvent(&eventUsecaseStub{showDetails: eventDetails}),
+		).Command()
+		rootCmd.SetOut(stdout)
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"show", "--db-path", "/tmp/test-traceary.db", "--json", "event-1"})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !bytes.Contains(stdout.Bytes(), []byte(`"body_unavailable_reason": "retention"`)) || !bytes.Contains(stdout.Bytes(), []byte(`"message": ""`)) {
+			t.Fatalf("stdout does not report retention unavailability: %s", stdout)
+		}
+	})
+
 	t.Run("displays event details in JSON format", func(t *testing.T) {
 		t.Parallel()
 

--- a/presentation/cli/store.go
+++ b/presentation/cli/store.go
@@ -17,6 +17,7 @@ func (c *RootCLI) newStoreCommand() *cobra.Command {
 	storeCmd.AddCommand(c.newStoreArchiveCommand())
 	storeCmd.AddCommand(c.newStoreGCCommand())
 	storeCmd.AddCommand(c.newStoreDedupeCommand())
+	storeCmd.AddCommand(c.newStoreRetentionCommand())
 	storeCmd.AddCommand(c.newStoreWorkspaceAliasCommand())
 	return storeCmd
 }

--- a/presentation/cli/store_retention.go
+++ b/presentation/cli/store_retention.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+type storeRetentionPlanInput struct {
+	dbPath       string
+	keepDays     int
+	recoveryPath string
+	outputPath   string
+}
+
+type storeRetentionExecutionInput struct {
+	dbPath          string
+	planPath        string
+	recoveryPath    string
+	confirmedPlanID string
+}
+
+func (c *RootCLI) newStoreRetentionCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:    "retention",
+		Short:  Localize("Plan and apply opt-in raw-body retention", "opt-in の本文保持ポリシーを計画・適用する"),
+		Hidden: true,
+	}
+	command.AddCommand(c.newStoreRetentionPlanCommand())
+	command.AddCommand(c.newStoreRetentionApplyCommand())
+	command.AddCommand(c.newStoreRetentionRestoreCommand())
+	return command
+}
+
+func (c *RootCLI) newStoreRetentionPlanCommand() *cobra.Command {
+	input := storeRetentionPlanInput{keepDays: defaultRetentionDays}
+	command := &cobra.Command{
+		Use:   "plan",
+		Short: Localize("Write an immutable raw-body retention plan", "変更不能な本文保持計画を書き出す"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runStoreRetentionPlan(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	command.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	command.Flags().IntVar(&input.keepDays, "keep-days", defaultRetentionDays, Localize("number of days of raw bodies to retain", "本文を保持する日数"))
+	command.Flags().StringVar(&input.recoveryPath, "recovery", "", Localize("verified unencrypted store archive covering every candidate", "全候補を含む検証済み・非暗号化 store archive"))
+	command.Flags().StringVar(&input.outputPath, "output", "", Localize("new plan output path", "新しい plan の出力先"))
+	_ = command.MarkFlagRequired("recovery")
+	_ = command.MarkFlagRequired("output")
+	return command
+}
+
+func (c *RootCLI) newStoreRetentionApplyCommand() *cobra.Command {
+	input := storeRetentionExecutionInput{}
+	command := &cobra.Command{
+		Use:   "apply",
+		Short: Localize("Apply an exact reviewed raw-body retention plan", "review 済み本文保持計画を厳密に適用する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runStoreRetentionApply(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	addStoreRetentionExecutionFlags(command, &input)
+	return command
+}
+
+func (c *RootCLI) newStoreRetentionRestoreCommand() *cobra.Command {
+	input := storeRetentionExecutionInput{}
+	command := &cobra.Command{
+		Use:   "restore",
+		Short: Localize("Restore raw bodies from the reviewed recovery package", "review 済み recovery package から本文を復元する"),
+		Args:  noArgsLocalized(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.runStoreRetentionRestore(cmd.Context(), cmd.OutOrStdout(), input)
+		},
+	}
+	addStoreRetentionExecutionFlags(command, &input)
+	return command
+}
+
+func addStoreRetentionExecutionFlags(command *cobra.Command, input *storeRetentionExecutionInput) {
+	command.Flags().StringVar(&input.dbPath, "db-path", "", dbPathFlagUsage())
+	command.Flags().StringVar(&input.planPath, "plan", "", Localize("reviewed plan path", "review 済み plan path"))
+	command.Flags().StringVar(&input.recoveryPath, "recovery", "", Localize("recovery package pinned by the plan", "plan が固定した recovery package"))
+	command.Flags().StringVar(&input.confirmedPlanID, "confirm-plan-id", "", Localize("exact reviewed plan ID", "review 済み plan ID の完全値"))
+	_ = command.MarkFlagRequired("plan")
+	_ = command.MarkFlagRequired("recovery")
+	_ = command.MarkFlagRequired("confirm-plan-id")
+}
+
+func (c *RootCLI) runStoreRetentionPlan(ctx context.Context, output io.Writer, input storeRetentionPlanInput) error {
+	if c.rawBodyRetention == nil || c.storeManagement == nil {
+		return xerrors.Errorf("%s", Localize("raw-body retention is not configured", "本文保持ポリシーが設定されていません"))
+	}
+	if input.keepDays <= 0 || input.keepDays > 36500 {
+		return xerrors.Errorf("%s", Localize("--keep-days must be between 1 and 36500", "--keep-days は 1 から 36500 の範囲が必要です"))
+	}
+	if strings.TrimSpace(input.outputPath) == "" {
+		return xerrors.Errorf("%s", Localize("--output is required", "--output が必要です"))
+	}
+	if _, err := os.Stat(input.outputPath); err == nil {
+		return xerrors.Errorf("%s", Localize("plan output already exists", "plan 出力先はすでに存在します"))
+	} else if !os.IsNotExist(err) {
+		return xerrors.Errorf("stat plan output: %w", err)
+	}
+	if err := c.prepareRetentionStore(ctx, input.dbPath); err != nil {
+		return err
+	}
+	now := gcNowFunc().UTC()
+	plan, err := c.rawBodyRetention.CreatePlan(ctx, now.AddDate(0, 0, -input.keepDays), input.recoveryPath, now)
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to create retention plan", "保持計画を作成できませんでした"), err)
+	}
+	file, err := os.OpenFile(input.outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return xerrors.Errorf("create plan output: %w", err)
+	}
+	if _, err := file.Write(plan); err != nil {
+		_ = file.Close()
+		return xerrors.Errorf("write plan output: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return xerrors.Errorf("sync plan output: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return xerrors.Errorf("close plan output: %w", err)
+	}
+	var header struct {
+		PlanID string `json:"plan_id"`
+	}
+	if err := json.Unmarshal(plan, &header); err != nil {
+		return xerrors.Errorf("read generated plan ID: %w", err)
+	}
+	if _, err := fmt.Fprintf(output, "Plan: %s\nPlan ID: %s\n", input.outputPath, header.PlanID); err != nil {
+		return xerrors.Errorf("print retention plan result: %w", err)
+	}
+	return nil
+}
+
+func (c *RootCLI) runStoreRetentionApply(ctx context.Context, output io.Writer, input storeRetentionExecutionInput) error {
+	plan, err := c.readRetentionExecutionInput(ctx, input)
+	if err != nil {
+		return err
+	}
+	result, err := c.rawBodyRetention.Apply(ctx, plan, input.recoveryPath, input.confirmedPlanID, gcNowFunc().UTC())
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("retention apply failed", "保持計画の適用に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintf(output, "Plan ID: %s\nCandidates: %d\nPruned: %d\nAlready pruned: %d\nCompaction: not run\n", result.PlanID, result.CandidateCount, result.PrunedCount, result.AlreadyPruned); err != nil {
+		return xerrors.Errorf("print retention apply result: %w", err)
+	}
+	return nil
+}
+
+func (c *RootCLI) runStoreRetentionRestore(ctx context.Context, output io.Writer, input storeRetentionExecutionInput) error {
+	plan, err := c.readRetentionExecutionInput(ctx, input)
+	if err != nil {
+		return err
+	}
+	result, err := c.rawBodyRetention.Restore(ctx, plan, input.recoveryPath, input.confirmedPlanID, gcNowFunc().UTC())
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("retention restore failed", "保持データの復元に失敗しました"), err)
+	}
+	if _, err := fmt.Fprintf(output, "Plan ID: %s\nCandidates: %d\nRestored: %d\nAlready restored: %d\n", result.PlanID, result.CandidateCount, result.RestoredCount, result.AlreadyRestored); err != nil {
+		return xerrors.Errorf("print retention restore result: %w", err)
+	}
+	return nil
+}
+
+func (c *RootCLI) readRetentionExecutionInput(ctx context.Context, input storeRetentionExecutionInput) ([]byte, error) {
+	if c.rawBodyRetention == nil || c.storeManagement == nil {
+		return nil, xerrors.Errorf("%s", Localize("raw-body retention is not configured", "本文保持ポリシーが設定されていません"))
+	}
+	if err := c.prepareRetentionStore(ctx, input.dbPath); err != nil {
+		return nil, err
+	}
+	plan, err := os.ReadFile(input.planPath)
+	if err != nil {
+		return nil, xerrors.Errorf("read retention plan: %w", err)
+	}
+	return plan, nil
+}
+
+func (c *RootCLI) prepareRetentionStore(ctx context.Context, dbPath string) error {
+	resolved, err := resolveDBPath(dbPath)
+	if err != nil {
+		return xerrors.Errorf("resolve retention DB path: %w", err)
+	}
+	c.applyDatabasePath(resolved)
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("initialize retention store: %w", err)
+	}
+	return nil
+}

--- a/presentation/cli/store_retention.go
+++ b/presentation/cli/store_retention.go
@@ -110,7 +110,7 @@ func (c *RootCLI) runStoreRetentionPlan(ctx context.Context, output io.Writer, i
 	} else if !os.IsNotExist(err) {
 		return xerrors.Errorf("stat plan output: %w", err)
 	}
-	if err := c.prepareRetentionStore(ctx, input.dbPath); err != nil {
+	if err := c.bindRetentionStore(input.dbPath); err != nil {
 		return err
 	}
 	now := gcNowFunc().UTC()
@@ -146,7 +146,7 @@ func (c *RootCLI) runStoreRetentionPlan(ctx context.Context, output io.Writer, i
 }
 
 func (c *RootCLI) runStoreRetentionApply(ctx context.Context, output io.Writer, input storeRetentionExecutionInput) error {
-	plan, err := c.readRetentionExecutionInput(ctx, input)
+	plan, err := c.readRetentionExecutionInput(input)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (c *RootCLI) runStoreRetentionApply(ctx context.Context, output io.Writer, 
 }
 
 func (c *RootCLI) runStoreRetentionRestore(ctx context.Context, output io.Writer, input storeRetentionExecutionInput) error {
-	plan, err := c.readRetentionExecutionInput(ctx, input)
+	plan, err := c.readRetentionExecutionInput(input)
 	if err != nil {
 		return err
 	}
@@ -175,11 +175,11 @@ func (c *RootCLI) runStoreRetentionRestore(ctx context.Context, output io.Writer
 	return nil
 }
 
-func (c *RootCLI) readRetentionExecutionInput(ctx context.Context, input storeRetentionExecutionInput) ([]byte, error) {
+func (c *RootCLI) readRetentionExecutionInput(input storeRetentionExecutionInput) ([]byte, error) {
 	if c.rawBodyRetention == nil || c.storeManagement == nil {
 		return nil, xerrors.Errorf("%s", Localize("raw-body retention is not configured", "本文保持ポリシーが設定されていません"))
 	}
-	if err := c.prepareRetentionStore(ctx, input.dbPath); err != nil {
+	if err := c.bindRetentionStore(input.dbPath); err != nil {
 		return nil, err
 	}
 	plan, err := os.ReadFile(input.planPath)
@@ -189,14 +189,11 @@ func (c *RootCLI) readRetentionExecutionInput(ctx context.Context, input storeRe
 	return plan, nil
 }
 
-func (c *RootCLI) prepareRetentionStore(ctx context.Context, dbPath string) error {
+func (c *RootCLI) bindRetentionStore(dbPath string) error {
 	resolved, err := resolveDBPath(dbPath)
 	if err != nil {
 		return xerrors.Errorf("resolve retention DB path: %w", err)
 	}
 	c.applyDatabasePath(resolved)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return xerrors.Errorf("initialize retention store: %w", err)
-	}
 	return nil
 }

--- a/presentation/cli/store_retention_internal_test.go
+++ b/presentation/cli/store_retention_internal_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+type rawBodyRetentionStub struct {
+	plan []byte
+}
+
+type retentionStoreStub struct {
+	minimalStoreStub
+	initCalled bool
+}
+
+func (s *retentionStoreStub) Initialize(context.Context) error {
+	s.initCalled = true
+	return nil
+}
+
+func (s *rawBodyRetentionStub) CreatePlan(context.Context, time.Time, string, time.Time) ([]byte, error) {
+	return s.plan, nil
+}
+
+func (*rawBodyRetentionStub) Apply(context.Context, []byte, string, string, time.Time) (apptypes.RawBodyApplyResult, error) {
+	return apptypes.RawBodyApplyResult{}, nil
+}
+
+func (*rawBodyRetentionStub) Restore(context.Context, []byte, string, string, time.Time) (apptypes.RawBodyRestoreResult, error) {
+	return apptypes.RawBodyRestoreResult{}, nil
+}
+
+func TestStoreRetentionPlanDoesNotInitializeOrMigrateStore(t *testing.T) {
+	t.Parallel()
+
+	store := &retentionStoreStub{}
+	root := NewRootCLI(
+		WithStoreManagement(store),
+		WithRawBodyRetention(&rawBodyRetentionStub{plan: []byte(`{"plan_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`)}),
+	)
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "plan.json")
+	if err := root.runStoreRetentionPlan(context.Background(), &bytes.Buffer{}, storeRetentionPlanInput{
+		dbPath: filepath.Join(dir, "old.db"), keepDays: 30,
+		recoveryPath: filepath.Join(dir, "recovery.tar"), outputPath: outputPath,
+	}); err != nil {
+		t.Fatalf("runStoreRetentionPlan() error = %v", err)
+	}
+	if store.initCalled {
+		t.Fatal("Initialize() called during retention plan")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "old.db")); !os.IsNotExist(err) {
+		t.Fatalf("old DB stat error = %v, want not exist", err)
+	}
+}
+
+func TestStoreRetentionApplyReadsAndValidatesBeforeStoreOpen(t *testing.T) {
+	t.Parallel()
+
+	store := &retentionStoreStub{}
+	root := NewRootCLI(
+		WithStoreManagement(store),
+		WithRawBodyRetention(&rawBodyRetentionStub{}),
+	)
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(planPath, []byte(`{"plan_id":"invalid-on-purpose"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(plan) error = %v", err)
+	}
+	if _, err := root.readRetentionExecutionInput(storeRetentionExecutionInput{
+		dbPath: filepath.Join(dir, "old.db"), planPath: planPath,
+	}); err != nil {
+		t.Fatalf("readRetentionExecutionInput() error = %v", err)
+	}
+	if store.initCalled {
+		t.Fatal("Initialize() called before retention plan validation")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "old.db")); !os.IsNotExist(err) {
+		t.Fatalf("old DB stat error = %v, want not exist", err)
+	}
+}

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -55,6 +55,31 @@ func TestResolveEventProjection(t *testing.T) {
 	}
 }
 
+func TestConvertEvents_reportsRetentionUnavailableBody(t *testing.T) {
+	t.Parallel()
+
+	eventID, err := types.EventIDFrom("retained-event")
+	if err != nil {
+		t.Fatalf("EventIDFrom() error = %v", err)
+	}
+	agent, err := types.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	sessionID, err := types.SessionIDFrom("session-1")
+	if err != nil {
+		t.Fatalf("SessionIDFrom() error = %v", err)
+	}
+	event := model.EventOfWithBodyAvailabilityAndSourceHook(
+		eventID, types.EventKindNote, "cli", agent, sessionID, "repo", "",
+		types.BodyAvailabilityUnavailableRetention, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), "",
+	)
+	output := convertEventsWithBodyLimit([]*model.Event{event}, 100)
+	if len(output) != 1 || output[0].Body != nil || output[0].BodyUnavailableReason != "retention" {
+		t.Fatalf("retention output = %+v", output)
+	}
+}
+
 func TestListEvents_MetadataProjectionOmitsBodyAndFullQuery(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -58,24 +58,25 @@ type intervalOutput struct {
 
 // eventOutput is an individual event in an eventsOutput list.
 type eventOutput struct {
-	EventID              string                    `json:"event_id" jsonschema:"event ID"`
-	Kind                 string                    `json:"kind" jsonschema:"event kind"`
-	Client               string                    `json:"client" jsonschema:"recording channel"`
-	Agent                string                    `json:"agent" jsonschema:"actor"`
-	SessionID            string                    `json:"session_id" jsonschema:"session identifier"`
-	Workspace            string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
-	Body                 *string                   `json:"body,omitempty" jsonschema:"event body as a plain-text projection; absent for projection=metadata. For transcript JSON envelopes this joins text blocks and excludes thinking blocks — use body_blocks for the canonical structured form. May be truncated to body_limit characters; check body_truncated and body_length"`
-	BodyBlocks           []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; populated for list_events only — search and get_context omit it so thinking-block text does not leak through those surfaces; also absent for legacy plain-text bodies, non-envelope JSON bodies, empty envelopes, and rows whose body is truncated"`
-	BodyTruncated        bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to disable response truncation; audit payloads truncated at ingestion stay visibly truncated and are not recoverable"`
-	BodyLength           int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
-	BodyOriginalBytes    *int                      `json:"body_original_bytes,omitempty" jsonschema:"original event body byte count when known"`
-	BodyStoredBytes      *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata"`
-	BodyIngestTruncated  *bool                     `json:"body_ingest_truncated,omitempty" jsonschema:"whether ingestion truncated the event body when known"`
-	BodyStorageTruncated *bool                     `json:"body_storage_truncated,omitempty" jsonschema:"whether storage policy truncated the event body when known"`
-	ExitCode             *int                      `json:"exit_code,omitempty" jsonschema:"command exit code when available in metadata projection"`
-	Failed               bool                      `json:"failed,omitempty" jsonschema:"whether the linked command audit failed"`
-	SourceHook           string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
-	CreatedAt            string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
+	EventID               string                    `json:"event_id" jsonschema:"event ID"`
+	Kind                  string                    `json:"kind" jsonschema:"event kind"`
+	Client                string                    `json:"client" jsonschema:"recording channel"`
+	Agent                 string                    `json:"agent" jsonschema:"actor"`
+	SessionID             string                    `json:"session_id" jsonschema:"session identifier"`
+	Workspace             string                    `json:"workspace,omitempty" jsonschema:"auxiliary work context identifier"`
+	Body                  *string                   `json:"body,omitempty" jsonschema:"event body as a plain-text projection; absent for projection=metadata. For transcript JSON envelopes this joins text blocks and excludes thinking blocks — use body_blocks for the canonical structured form. May be truncated to body_limit characters; check body_truncated and body_length"`
+	BodyUnavailableReason string                    `json:"body_unavailable_reason,omitempty" jsonschema:"reason the raw body is unavailable; currently retention"`
+	BodyBlocks            []apptypes.EventBodyBlock `json:"body_blocks,omitempty" jsonschema:"structured block form of the body when it is a canonical transcript envelope; populated for list_events only — search and get_context omit it so thinking-block text does not leak through those surfaces; also absent for legacy plain-text bodies, non-envelope JSON bodies, empty envelopes, and rows whose body is truncated"`
+	BodyTruncated         bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to disable response truncation; audit payloads truncated at ingestion stay visibly truncated and are not recoverable"`
+	BodyLength            int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
+	BodyOriginalBytes     *int                      `json:"body_original_bytes,omitempty" jsonschema:"original event body byte count when known"`
+	BodyStoredBytes       *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata"`
+	BodyIngestTruncated   *bool                     `json:"body_ingest_truncated,omitempty" jsonschema:"whether ingestion truncated the event body when known"`
+	BodyStorageTruncated  *bool                     `json:"body_storage_truncated,omitempty" jsonschema:"whether storage policy truncated the event body when known"`
+	ExitCode              *int                      `json:"exit_code,omitempty" jsonschema:"command exit code when available in metadata projection"`
+	Failed                bool                      `json:"failed,omitempty" jsonschema:"whether the linked command audit failed"`
+	SourceHook            string                    `json:"source_hook,omitempty" jsonschema:"hook identifier that produced this event (omitted for non-hook writes)"`
+	CreatedAt             string                    `json:"created_at" jsonschema:"event timestamp (RFC3339Nano)"`
 }
 
 // sessionHandoffOutput is the MCP output for the session_handoff tool.

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1994,7 +1994,7 @@ func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit 
 		if includeBlocks && !result.Truncated {
 			blocks, _ = apptypes.DecodeCanonicalEnvelope(event.Body())
 		}
-		outputs = append(outputs, eventOutput{
+		output := eventOutput{
 			EventID:       event.EventID().String(),
 			Kind:          event.Kind().String(),
 			Client:        event.Client().String(),
@@ -2007,7 +2007,13 @@ func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit 
 			BodyLength:    fullLen,
 			SourceHook:    event.SourceHook(),
 			CreatedAt:     event.CreatedAt().UTC().Format(time.RFC3339Nano),
-		})
+		}
+		if !event.BodyAvailability().IsAvailable() {
+			output.Body = nil
+			output.BodyBlocks = nil
+			output.BodyUnavailableReason = "retention"
+		}
+		outputs = append(outputs, output)
 	}
 
 	return outputs

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -1663,6 +1663,7 @@ CREATE TABLE events (
     agent TEXT NOT NULL,
     session_id TEXT NOT NULL,
     body TEXT NOT NULL,
+    body_availability TEXT NOT NULL DEFAULT 'available',
     created_at TEXT NOT NULL,
     source_hook TEXT
 );`),

--- a/schema/sqlite/migrations/000026_add_raw_body_retention.sql
+++ b/schema/sqlite/migrations/000026_add_raw_body_retention.sql
@@ -1,0 +1,45 @@
+ALTER TABLE events ADD COLUMN body_availability TEXT NOT NULL DEFAULT 'available'
+    CHECK (body_availability IN ('available', 'unavailable_retention'));
+ALTER TABLE events ADD COLUMN body_pruned_at TEXT;
+ALTER TABLE events ADD COLUMN body_pruned_plan_id TEXT;
+
+DROP TRIGGER IF EXISTS events_body_metadata_after_body_update;
+CREATE TRIGGER events_body_metadata_after_body_update
+AFTER UPDATE OF body ON events
+FOR EACH ROW
+WHEN NEW.body_availability = 'available'
+BEGIN
+    UPDATE events
+       SET body_stored_bytes = length(CAST(NEW.body AS BLOB))
+     WHERE id = NEW.id;
+END;
+
+CREATE TABLE raw_body_retention_store_identity (
+    id TEXT PRIMARY KEY NOT NULL,
+    CHECK (length(id) = 32)
+);
+
+INSERT INTO raw_body_retention_store_identity (id)
+VALUES (lower(hex(randomblob(16))));
+
+CREATE TABLE raw_body_retention_executions (
+    plan_id TEXT PRIMARY KEY NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'restored', 'conflicted')),
+    candidate_count INTEGER NOT NULL CHECK (candidate_count >= 0),
+    pruned_count INTEGER NOT NULL DEFAULT 0 CHECK (pruned_count >= 0),
+    started_at TEXT NOT NULL,
+    completed_at TEXT
+);
+
+CREATE TABLE raw_body_retention_entries (
+    plan_id TEXT NOT NULL REFERENCES raw_body_retention_executions(plan_id) ON DELETE CASCADE,
+    event_id TEXT NOT NULL REFERENCES events(id) ON DELETE RESTRICT,
+    body_sha256 TEXT NOT NULL,
+    stored_bytes INTEGER NOT NULL CHECK (stored_bytes >= 0),
+    pruned_at TEXT NOT NULL,
+    restored_at TEXT,
+    PRIMARY KEY (plan_id, event_id)
+);
+
+CREATE INDEX idx_events_raw_body_retention_candidates
+    ON events(body_availability, created_at, id);

--- a/schema/sqlite/migrations/000026_add_raw_body_retention.sql
+++ b/schema/sqlite/migrations/000026_add_raw_body_retention.sql
@@ -24,7 +24,7 @@ VALUES (lower(hex(randomblob(16))));
 
 CREATE TABLE raw_body_retention_executions (
     plan_id TEXT PRIMARY KEY NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'restored', 'conflicted')),
+    status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'restoring', 'restored', 'conflicted')),
     candidate_count INTEGER NOT NULL CHECK (candidate_count >= 0),
     pruned_count INTEGER NOT NULL DEFAULT 0 CHECK (pruned_count >= 0),
     started_at TEXT NOT NULL,


### PR DESCRIPTION
## Motivation

Traceary can preserve metadata-only event history, but it cannot reclaim raw event-body storage without deleting the event row. v0.31 needs an opt-in, reviewed, recoverable workflow that makes body unavailability explicit and never folds SQLite compaction into logical pruning.

## What changed

- add an additive body-availability schema, immutable canonical plan codec, source/candidate drift checks, and durable execution ledger
- require a digest-pinned verified recovery archive before apply
- make apply transactional, idempotent, interruption-safe, and terminal after restore
- preserve v0.30 metadata bytes and report `body_unavailable_reason=retention` in CLI/MCP full reads
- keep the retention command hidden until copied-store dogfooding in #1445; apply never runs `VACUUM`
- add High-risk Structure-Behavior design evidence and copied-store behavior tests

## Validation

- `go test ./...`
- `go tool golangci-lint run`
- `git diff --check`
- synthetic copied-store drill: archive → plan → apply → metadata byte comparison → retry → restore → `PRAGMA integrity_check`

Closes #1444
