### PR TITLE
v0.32.0-1b: model usage availability and idempotent accounting

### DIFF
--- a/.ai/spec/1456.md
+++ b/.ai/spec/1456.md
@@ -1,0 +1,83 @@
+# Issue #1456: usage availability and idempotent accounting
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Purpose: provide one provider-neutral write model for host adapters without turning missing counters into zero or counting a terminal call/run twice.
+- Current state: sessions and events have lifecycle identity, but there is no typed usage value, authoritative usage observation, cost provenance, or additive usage table.
+- Expected behavior: a pending call/run may be finalized once; an identical replay is a no-op; conflicting terminal data fails closed; immutable session snapshots form one supersession chain.
+- Non-goals: host JSON/JSONL parsing, lineage beyond `session_id`, aggregate CLI/MCP queries, provider billing reconciliation, inferred tokenization, and price-table contents belong to later v0.32 issues.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Usage value | `unknown`, `unavailable`, or `known(value)` | preserves known zero and known positive counters | only `known` carries a non-negative integer |
+| Usage counters | six independent values | carries input, cached input, cache-write input, output, reasoning output, and total | a finalized observation contains no `unknown` dimension |
+| Usage cost | unknown, unavailable, estimated, or provider-reported | carries integer micro-units and provenance | estimates require a non-empty price-table version; provider-reported cost cannot carry one |
+| Observation identity | opaque adapter-owned ID plus host/source/version | deduplicates one authoritative call, run, or snapshot revision | semantic metadata for an ID is immutable |
+| Observation lifecycle | pending or finalized | pending may become finalized; finalized is immutable | finalization requires a normalized terminal reason and no unknown usage/cost values |
+| Accounting mode | additive, latest snapshot, or excluded | declares aggregate semantics without a boolean flag | session snapshots are finalized and use latest-snapshot accounting only |
+| Snapshot chain | series key, increasing revision, optional predecessor | inserts an immutable successor | one predecessor has at most one successor; a new series has no predecessor; later revisions supersede the current head |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Availability/value and cost invariants | `domain/types` | provider-neutral meaning changes | SQL and adapters must not recreate the rules |
+| Lifecycle and semantic equivalence | `domain/model.UsageObservation` | accounting state-machine changes | usecase remains orchestration only |
+| Atomic insert/finalize/supersede | `infrastructure/sqlite.UsageObservationDatasource` | persistence/concurrency strategy changes | adapters must not issue SQL |
+| Write orchestration | `application/usecase.UsageObservationUsecase` | consumer workflow changes | it does not decide domain validity |
+| Host boundary/correlation | later adapter issues | each host contract differs | neutral model does not parse host payloads |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `UsageObservationRepository.Record` | usage usecase | SQLite schema, conditional writes, snapshot-head lookup | applied/already-applied or typed conflict/invariant error |
+| `UsageObservationUsecase.Record` | host adapters | repository implementation | wraps configuration/storage failures; preserves typed conflicts via `%w` |
+| SQLite migration 27 | all existing stores | nullable numeric representation and constraints | additive migration; a failed migration rolls back transactionally |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| missing never becomes zero | unknown or unavailable usage | construct/persist | numeric value/column is absent | domain + SQLite |
+| known zero remains known | known usage value `0` | round-trip | state is known and value is zero | domain + SQLite |
+| late terminal completion | matching pending observation | record finalized observation | one row becomes finalized | SQLite integration |
+| idempotent replay | finalized observation | record same semantics again | already-applied and no mutation | domain + SQLite |
+| conflicting replay | same ID, different counters/metadata | record | typed conflict and existing row is unchanged | domain + SQLite |
+| versioned estimate | estimated cost | construct | missing price version is rejected; valid version round-trips | domain + SQLite |
+| snapshot supersession | current snapshot head | record a higher revision referencing it | both rows remain immutable and only one head exists | SQLite integration |
+| no snapshot branching | already superseded predecessor | record another successor | conflict and no row is added | SQLite integration |
+| compatibility | store at migration 26 with events/sessions | initialize with migration 27 | prior rows are unchanged and new table is usable | migration integration |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| typed usage/cost states | constructor tests | value objects with private fields | centralize validation and equality |
+| lifecycle equivalence/conflict | aggregate transition tests | `Reconcile` on the aggregate | keep decisions out of datasource |
+| durable idempotency | concurrent/replay datasource tests | unique identity plus guarded conditional update | shared row encoder/decoder |
+| snapshot chain | successor/head tests | transactional predecessor validation plus unique predecessor | isolate snapshot checks from row persistence |
+| migration compatibility | pre-v27 fixture test | additive constrained table/indexes | keep old tables untouched |
+
+### Risks / rollback
+
+- Procedural-logic risk: datasource code could become the owner of lifecycle decisions. Mitigation: restore rows as domain aggregates and use one domain reconciliation method before writes.
+- Premature-abstraction risk: no provider strategy/factory or aggregate query API is introduced before adapters exist.
+- Migration / compatibility: migration 27 only creates a table and indexes. It does not alter, backfill, or reinterpret events/sessions. Unknown values are stored as `NULL`, never `0`.
+- Concurrency: identity uniqueness and guarded pending-to-finalized updates prevent double counting; snapshot predecessor uniqueness prevents branching.
+- Rollback: disable adapter writes first. The additive table can remain unread by older binaries. A migration failure rolls back; no down-migration or destructive rewrite is required.
+- Rollback trigger: any observed duplicate finalized identity, snapshot branch, constraint bypass, or changed pre-v27 event/session row blocks adapter rollout and v0.32 release.
+
+### PR sequence / design checkpoint
+
+- This PR implements only the neutral domain/application/persistence slice for #1456.
+- #1453 adds lineage columns/contracts additively.
+- Host adapters (#1451, #1447, #1455, #1450, #1452) consume this write boundary one issue at a time.
+- #1449 adds read aggregates after every adapter shares these accounting semantics.
+- #1457 must reconcile live/historical data and file/close follow-up issues before the release tag.
+
+Design checkpoint: proceed with an additive `usage_observations` table, per-dimension state/value columns, integer micro-cost with explicit origin/version, and a single `Record` transition boundary. No public CLI/MCP surface is added in this issue.

--- a/.ai/spec/1456.md
+++ b/.ai/spec/1456.md
@@ -19,7 +19,7 @@
 | Observation identity | opaque adapter-owned ID plus host/source/version | deduplicates one authoritative call, run, or snapshot revision | semantic metadata for an ID is immutable |
 | Observation lifecycle | pending or finalized | pending may become finalized; finalized is immutable | finalization requires a normalized terminal reason and no unknown usage/cost values |
 | Accounting mode | additive, latest snapshot, or excluded | declares aggregate semantics without a boolean flag | session snapshots are finalized and use latest-snapshot accounting only |
-| Snapshot chain | series key, increasing revision, optional predecessor | inserts an immutable successor | one predecessor has at most one successor; a new series has no predecessor; later revisions supersede the current head |
+| Snapshot chain | series key, increasing revision, optional predecessor | inserts an immutable successor | one series keeps the same session and source; one predecessor has at most one successor; a new series has no predecessor; later revisions supersede the current head |
 
 ### Responsibility assignment
 

--- a/.ai/spec/1456.md
+++ b/.ai/spec/1456.md
@@ -38,6 +38,7 @@
 | `UsageObservationRepository.Record` | usage usecase | SQLite schema, conditional writes, snapshot-head lookup | applied/already-applied or typed conflict/invariant error |
 | `UsageObservationUsecase.Record` | host adapters | repository implementation | wraps configuration/storage failures; preserves typed conflicts via `%w` |
 | SQLite migration 27 | all existing stores | nullable numeric representation and constraints | additive migration; a failed migration rolls back transactionally |
+| Encrypted portability bundle | operators moving stores between machines | NDJSON encoding and transactional restore | usage evidence round-trips without collapsing known zero; snapshot chains restore predecessors first |
 
 ### Behavior tests
 
@@ -52,6 +53,7 @@
 | snapshot supersession | current snapshot head | record a higher revision referencing it | both rows remain immutable and only one head exists | SQLite integration |
 | no snapshot branching | already superseded predecessor | record another successor | conflict and no row is added | SQLite integration |
 | compatibility | store at migration 26 with events/sessions | initialize with migration 27 | prior rows are unchanged and new table is usable | migration integration |
+| portability | finalized usage snapshot chain | encrypted export then import | counters, cost provenance, and predecessor identities are preserved; exact re-import is a no-op | usecase + SQLite integration |
 
 ### TDD plan
 
@@ -68,6 +70,7 @@
 - Procedural-logic risk: datasource code could become the owner of lifecycle decisions. Mitigation: restore rows as domain aggregates and use one domain reconciliation method before writes.
 - Premature-abstraction risk: no provider strategy/factory or aggregate query API is introduced before adapters exist.
 - Migration / compatibility: migration 27 only creates a table and indexes. It does not alter, backfill, or reinterpret events/sessions. Unknown values are stored as `NULL`, never `0`.
+- Portability: schema-27 bundles include `usage_observations.ndjson`; filtered exports include complete usage chains for selected sessions. Older manifest-v2 readers reject the unknown table rather than silently discarding it.
 - Concurrency: identity uniqueness and guarded pending-to-finalized updates prevent double counting; snapshot predecessor uniqueness prevents branching.
 - Rollback: disable adapter writes first. The additive table can remain unread by older binaries. A migration failure rolls back; no down-migration or destructive rewrite is required.
 - Rollback trigger: any observed duplicate finalized identity, snapshot branch, constraint bypass, or changed pre-v27 event/session row blocks adapter rollout and v0.32 release.

--- a/application/usecase/bundle_codec.go
+++ b/application/usecase/bundle_codec.go
@@ -4,8 +4,8 @@
 // machines through any file-transport they already have (AirDrop,
 // scp, Syncthing, etc.). Traceary never ships its own transport.
 //
-// Portability covers all five tables — events, sessions, command_audits,
-// memories, and memory_edges — see docs/operations/cross-machine-handoff
+// Portability covers events, sessions, command_audits, memories, memory_edges,
+// and usage_observations — see docs/operations/cross-machine-handoff
 // for the operator guide.
 package usecase
 
@@ -137,6 +137,34 @@ func encodeCommandAuditsNDJSON(audits []*model.CommandAudit) (*bytes.Buffer, err
 	return buf, nil
 }
 
+func encodeUsageObservationsNDJSON(observations []*model.UsageObservation) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	sorted := append([]*model.UsageObservation(nil), observations...)
+	for _, observation := range sorted {
+		if observation == nil {
+			return nil, xerrors.Errorf("encode usage observation: observation must not be nil")
+		}
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		left := sorted[i].Descriptor()
+		right := sorted[j].Descriptor()
+		if left.SnapshotSeries() != right.SnapshotSeries() {
+			return left.SnapshotSeries() < right.SnapshotSeries()
+		}
+		if left.SnapshotRevision() != right.SnapshotRevision() {
+			return left.SnapshotRevision() < right.SnapshotRevision()
+		}
+		return left.ObservationID().String() < right.ObservationID().String()
+	})
+	enc := json.NewEncoder(buf)
+	for _, observation := range sorted {
+		if err := enc.Encode(bundleUsageObservationRowFromModel(observation)); err != nil {
+			return nil, xerrors.Errorf("encode usage observation: %w", err)
+		}
+	}
+	return buf, nil
+}
+
 func filterSessionsForBundleExport(sessions []*model.Session, events []*model.Event, opts BundleExportOptions) []*model.Session {
 	referencedSessionIDs := make(map[string]struct{}, len(events))
 	for _, event := range events {
@@ -188,6 +216,30 @@ func filterCommandAuditsForEvents(audits []*model.CommandAudit, events []*model.
 	for _, audit := range audits {
 		if _, ok := eventIDs[audit.EventID().String()]; ok {
 			filtered = append(filtered, audit)
+		}
+	}
+	return filtered
+}
+
+func filterUsageObservationsForBundleExport(
+	observations []*model.UsageObservation,
+	sessions []*model.Session,
+	opts BundleExportOptions,
+) []*model.UsageObservation {
+	if opts.Since.IsZero() && opts.Until.IsZero() && opts.Workspace.String() == "" {
+		return observations
+	}
+	sessionIDs := make(map[string]struct{}, len(sessions))
+	for _, session := range sessions {
+		sessionIDs[session.SessionID().String()] = struct{}{}
+	}
+	filtered := make([]*model.UsageObservation, 0, len(observations))
+	for _, observation := range observations {
+		if observation == nil {
+			continue
+		}
+		if _, included := sessionIDs[observation.Descriptor().SessionID().String()]; included {
+			filtered = append(filtered, observation)
 		}
 	}
 	return filtered

--- a/application/usecase/bundle_rows.go
+++ b/application/usecase/bundle_rows.go
@@ -4,8 +4,8 @@
 // machines through any file-transport they already have (AirDrop,
 // scp, Syncthing, etc.). Traceary never ships its own transport.
 //
-// Portability covers all five tables — events, sessions, command_audits,
-// memories, and memory_edges — see docs/operations/cross-machine-handoff
+// Portability covers events, sessions, command_audits, memories, memory_edges,
+// and usage_observations — see docs/operations/cross-machine-handoff
 // for the operator guide.
 package usecase
 
@@ -162,6 +162,222 @@ type bundleCommandAuditRow struct {
 	ExitCode            *int   `json:"exit_code,omitempty"`
 	Failed              bool   `json:"failed,omitempty"`
 	FailureReason       string `json:"failure_reason"`
+}
+
+type bundleUsageObservationRow struct {
+	ObservationID         string `json:"observation_id"`
+	SessionID             string `json:"session_id"`
+	Host                  string `json:"host"`
+	SourceName            string `json:"source_name"`
+	SourceVersion         string `json:"source_version"`
+	Provider              string `json:"provider,omitempty"`
+	Model                 string `json:"model,omitempty"`
+	Scope                 string `json:"scope"`
+	Accounting            string `json:"accounting"`
+	Status                string `json:"status"`
+	ObservedAt            string `json:"observed_at"`
+	FinalizedAt           string `json:"finalized_at,omitempty"`
+	TerminalCode          string `json:"terminal_code,omitempty"`
+	InputState            string `json:"input_state"`
+	InputTokens           *int64 `json:"input_tokens,omitempty"`
+	CachedInputState      string `json:"cached_input_state"`
+	CachedInputTokens     *int64 `json:"cached_input_tokens,omitempty"`
+	CacheWriteInputState  string `json:"cache_write_input_state"`
+	CacheWriteInputTokens *int64 `json:"cache_write_input_tokens,omitempty"`
+	OutputState           string `json:"output_state"`
+	OutputTokens          *int64 `json:"output_tokens,omitempty"`
+	ReasoningOutputState  string `json:"reasoning_output_state"`
+	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens,omitempty"`
+	TotalState            string `json:"total_state"`
+	TotalTokens           *int64 `json:"total_tokens,omitempty"`
+	CostState             string `json:"cost_state"`
+	CostAmountMicros      *int64 `json:"cost_amount_micros,omitempty"`
+	CostCurrency          string `json:"cost_currency,omitempty"`
+	CostOrigin            string `json:"cost_origin,omitempty"`
+	PriceTableVersion     string `json:"price_table_version,omitempty"`
+	SnapshotSeries        string `json:"snapshot_series,omitempty"`
+	SnapshotRevision      *int64 `json:"snapshot_revision,omitempty"`
+	SupersedesID          string `json:"supersedes_id,omitempty"`
+}
+
+func bundleUsageObservationRowFromModel(observation *model.UsageObservation) bundleUsageObservationRow {
+	descriptor := observation.Descriptor()
+	source := descriptor.Source()
+	counters := observation.Counters()
+	cost := observation.Cost()
+	row := bundleUsageObservationRow{
+		ObservationID: descriptor.ObservationID().String(), SessionID: descriptor.SessionID().String(),
+		Host: source.Host(), SourceName: source.Name(), SourceVersion: source.Version(),
+		Provider: source.Provider(), Model: source.Model(), Scope: descriptor.Scope().String(),
+		Accounting: descriptor.Accounting().String(), Status: observation.Status().String(),
+		ObservedAt: descriptor.ObservedAt().UTC().Format(time.RFC3339Nano),
+		InputState: counters.Input().State().String(), InputTokens: bundleUsageValuePointer(counters.Input()),
+		CachedInputState: counters.CachedInput().State().String(), CachedInputTokens: bundleUsageValuePointer(counters.CachedInput()),
+		CacheWriteInputState: counters.CacheWriteInput().State().String(), CacheWriteInputTokens: bundleUsageValuePointer(counters.CacheWriteInput()),
+		OutputState: counters.Output().State().String(), OutputTokens: bundleUsageValuePointer(counters.Output()),
+		ReasoningOutputState: counters.ReasoningOutput().State().String(), ReasoningOutputTokens: bundleUsageValuePointer(counters.ReasoningOutput()),
+		TotalState: counters.Total().State().String(), TotalTokens: bundleUsageValuePointer(counters.Total()),
+		CostState: cost.State().String(), CostCurrency: cost.Currency(), CostOrigin: cost.Origin().String(),
+		PriceTableVersion: cost.PriceTableVersion(), SnapshotSeries: descriptor.SnapshotSeries(),
+	}
+	if value, present := cost.AmountMicros(); present {
+		row.CostAmountMicros = &value
+	}
+	if value, present := observation.FinalizedAt().Value(); present {
+		row.FinalizedAt = value.UTC().Format(time.RFC3339Nano)
+	}
+	if value, present := observation.TerminalCode().Value(); present {
+		row.TerminalCode = value.String()
+	}
+	if descriptor.SnapshotRevision() > 0 {
+		value := descriptor.SnapshotRevision()
+		row.SnapshotRevision = &value
+	}
+	if value, present := descriptor.SupersedesID().Value(); present {
+		row.SupersedesID = value.String()
+	}
+	return row
+}
+
+func bundleUsageValuePointer(value types.UsageValue) *int64 {
+	if numeric, present := value.Value(); present {
+		return &numeric
+	}
+	return nil
+}
+
+func (r bundleUsageObservationRow) toUsageObservation() (*model.UsageObservation, error) {
+	id, err := types.UsageObservationIDFrom(r.ObservationID)
+	if err != nil {
+		return nil, xerrors.Errorf("observation_id: %w", err)
+	}
+	sessionID, err := types.SessionIDFrom(r.SessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("session_id: %w", err)
+	}
+	source, err := types.UsageSourceOf(r.Host, r.SourceName, r.SourceVersion, r.Provider, r.Model)
+	if err != nil {
+		return nil, xerrors.Errorf("source: %w", err)
+	}
+	scope, err := types.UsageScopeFrom(r.Scope)
+	if err != nil {
+		return nil, xerrors.Errorf("scope: %w", err)
+	}
+	accounting, err := types.UsageAccountingFrom(r.Accounting)
+	if err != nil {
+		return nil, xerrors.Errorf("accounting: %w", err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, r.ObservedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("observed_at: %w", err)
+	}
+	var descriptor model.UsageObservationDescriptor
+	if scope == types.UsageScopeSessionSnapshot {
+		if r.SnapshotRevision == nil {
+			return nil, xerrors.Errorf("snapshot_revision is required for a session snapshot")
+		}
+		predecessor := types.None[types.UsageObservationID]()
+		if r.SupersedesID != "" {
+			value, err := types.UsageObservationIDFrom(r.SupersedesID)
+			if err != nil {
+				return nil, xerrors.Errorf("supersedes_id: %w", err)
+			}
+			predecessor = types.Some(value)
+		}
+		descriptor, err = model.NewUsageSnapshotDescriptor(id, sessionID, source, r.SnapshotSeries, *r.SnapshotRevision, predecessor, observedAt)
+	} else {
+		descriptor, err = model.NewUsageObservationDescriptor(id, sessionID, source, scope, accounting, observedAt)
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("descriptor: %w", err)
+	}
+	values := []struct {
+		name  string
+		state string
+		value *int64
+	}{
+		{"input", r.InputState, r.InputTokens}, {"cached_input", r.CachedInputState, r.CachedInputTokens},
+		{"cache_write_input", r.CacheWriteInputState, r.CacheWriteInputTokens}, {"output", r.OutputState, r.OutputTokens},
+		{"reasoning_output", r.ReasoningOutputState, r.ReasoningOutputTokens}, {"total", r.TotalState, r.TotalTokens},
+	}
+	restored := make([]types.UsageValue, 0, len(values))
+	for _, item := range values {
+		optional := types.None[int64]()
+		if item.value != nil {
+			optional = types.Some(*item.value)
+		}
+		value, err := types.UsageValueFrom(item.state, optional)
+		if err != nil {
+			return nil, xerrors.Errorf("%s usage: %w", item.name, err)
+		}
+		restored = append(restored, value)
+	}
+	counters, err := types.UsageCountersOf(restored[0], restored[1], restored[2], restored[3], restored[4], restored[5])
+	if err != nil {
+		return nil, xerrors.Errorf("counters: %w", err)
+	}
+	costAmount := types.None[int64]()
+	if r.CostAmountMicros != nil {
+		costAmount = types.Some(*r.CostAmountMicros)
+	}
+	cost, err := types.UsageCostFrom(r.CostState, costAmount, r.CostCurrency, r.CostOrigin, r.PriceTableVersion)
+	if err != nil {
+		return nil, xerrors.Errorf("cost: %w", err)
+	}
+	status, err := types.UsageObservationStatusFrom(r.Status)
+	if err != nil {
+		return nil, xerrors.Errorf("status: %w", err)
+	}
+	terminal := types.None[types.UsageTerminalCode]()
+	if r.TerminalCode != "" {
+		value, err := types.UsageTerminalCodeFrom(r.TerminalCode)
+		if err != nil {
+			return nil, xerrors.Errorf("terminal_code: %w", err)
+		}
+		terminal = types.Some(value)
+	}
+	finalizedAt := types.None[time.Time]()
+	if r.FinalizedAt != "" {
+		value, err := time.Parse(time.RFC3339Nano, r.FinalizedAt)
+		if err != nil {
+			return nil, xerrors.Errorf("finalized_at: %w", err)
+		}
+		finalizedAt = types.Some(value)
+	}
+	observation, err := model.UsageObservationOf(descriptor, status, counters, cost, terminal, finalizedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("aggregate: %w", err)
+	}
+	return observation, nil
+}
+
+func sortBundleUsageObservationRows(rows []bundleRow) ([]bundleUsageObservationRow, error) {
+	observations := make([]bundleUsageObservationRow, 0, len(rows))
+	for _, generic := range rows {
+		row, ok := generic.(bundleUsageObservationRow)
+		if !ok {
+			return nil, xerrors.Errorf("unexpected usage_observations row type %T", generic)
+		}
+		observations = append(observations, row)
+	}
+	sort.Slice(observations, func(i, j int) bool {
+		if observations[i].SnapshotSeries != observations[j].SnapshotSeries {
+			return observations[i].SnapshotSeries < observations[j].SnapshotSeries
+		}
+		leftRevision := int64(0)
+		rightRevision := int64(0)
+		if observations[i].SnapshotRevision != nil {
+			leftRevision = *observations[i].SnapshotRevision
+		}
+		if observations[j].SnapshotRevision != nil {
+			rightRevision = *observations[j].SnapshotRevision
+		}
+		if leftRevision != rightRevision {
+			return leftRevision < rightRevision
+		}
+		return observations[i].ObservationID < observations[j].ObservationID
+	})
+	return observations, nil
 }
 
 type bundleRefRow struct {

--- a/application/usecase/bundle_tables.go
+++ b/application/usecase/bundle_tables.go
@@ -4,8 +4,8 @@
 // machines through any file-transport they already have (AirDrop,
 // scp, Syncthing, etc.). Traceary never ships its own transport.
 //
-// Portability covers all five tables — events, sessions, command_audits,
-// memories, and memory_edges — see docs/operations/cross-machine-handoff
+// Portability covers events, sessions, command_audits, memories, memory_edges,
+// and usage_observations — see docs/operations/cross-machine-handoff
 // for the operator guide.
 package usecase
 
@@ -25,17 +25,72 @@ func (u *bundleUsecase) bundleTableRegistry() map[string]bundleTableImporter {
 	commandAudits := bundleCommandAuditsTable{}
 	memories := bundleMemoriesTable{}
 	memoryEdges := bundleMemoryEdgesTable{}
+	usageObservations := bundleUsageObservationsTable{}
 	return map[string]bundleTableImporter{
-		sessions.Name():      sessions,
-		events.Name():        events,
-		commandAudits.Name(): commandAudits,
-		memories.Name():      memories,
-		memoryEdges.Name():   memoryEdges,
+		sessions.Name():          sessions,
+		events.Name():            events,
+		commandAudits.Name():     commandAudits,
+		memories.Name():          memories,
+		memoryEdges.Name():       memoryEdges,
+		usageObservations.Name(): usageObservations,
 	}
 }
 
 func bundleTableImportOrder() []string {
-	return []string{"sessions", "events", "command_audits", "memories", "memory_edges"}
+	return []string{"sessions", "usage_observations", "events", "command_audits", "memories", "memory_edges"}
+}
+
+type bundleUsageObservationsTable struct{}
+
+func (bundleUsageObservationsTable) Name() string { return "usage_observations" }
+
+func (bundleUsageObservationsTable) FileName() string { return "usage_observations.ndjson" }
+
+func (bundleUsageObservationsTable) Export(_ context.Context, input bundleExportInputRows) (*bytes.Buffer, error) {
+	return encodeUsageObservationsNDJSON(input.UsageObservations)
+}
+
+func (bundleUsageObservationsTable) Decode(r io.Reader) ([]bundleRow, error) {
+	decoder := json.NewDecoder(r)
+	rows := []bundleRow{}
+	for decoder.More() {
+		var row bundleUsageObservationRow
+		if err := decoder.Decode(&row); err != nil {
+			return nil, xerrors.Errorf("usage observation row: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (bundleUsageObservationsTable) Apply(
+	ctx context.Context,
+	tx BundleImportTransaction,
+	rows []bundleRow,
+	policy bundleImportPolicy,
+) (int, int, error) {
+	sortedRows, err := sortBundleUsageObservationRows(rows)
+	if err != nil {
+		return 0, 0, err
+	}
+	imported := 0
+	skipped := 0
+	for _, row := range sortedRows {
+		observation, err := row.toUsageObservation()
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("restore usage observation: %w", err)
+		}
+		didImport, err := tx.ImportUsageObservation(ctx, observation, policy.OnConflict)
+		if err != nil {
+			return imported, skipped, xerrors.Errorf("usage observation %s: %w", observation.Descriptor().ObservationID(), err)
+		}
+		if didImport {
+			imported++
+		} else {
+			skipped++
+		}
+	}
+	return imported, skipped, nil
 }
 
 type bundleSessionsTable struct{}

--- a/application/usecase/bundle_usecase.go
+++ b/application/usecase/bundle_usecase.go
@@ -4,8 +4,8 @@
 // machines through any file-transport they already have (AirDrop,
 // scp, Syncthing, etc.). Traceary never ships its own transport.
 //
-// Portability covers all five tables — events, sessions, command_audits,
-// memories, and memory_edges — see docs/operations/cross-machine-handoff
+// Portability covers events, sessions, command_audits, memories, memory_edges,
+// and usage_observations — see docs/operations/cross-machine-handoff
 // for the operator guide.
 package usecase
 
@@ -160,6 +160,10 @@ type BundleImportResult struct {
 	// newly written vs skipped due to idempotency or orphan-edge tolerance.
 	MemoryEdgesImported int
 	MemoryEdgesSkipped  int
+	// UsageObservationsImported / UsageObservationsSkipped count durable usage
+	// observations restored vs retained as exact or policy-selected duplicates.
+	UsageObservationsImported int
+	UsageObservationsSkipped  int
 	// BundleSchemaVersion is the schema_migrations version the
 	// archive carried at Export time.
 	BundleSchemaVersion int
@@ -228,6 +232,8 @@ type BundleEventRepository interface {
 	ListBundleMemories(ctx context.Context) ([]apptypes.MemoryDetails, error)
 	// ListBundleMemoryEdges returns all memory graph edges for bundle export.
 	ListBundleMemoryEdges(ctx context.Context) ([]*model.MemoryEdge, error)
+	// ListBundleUsageObservations returns all provider-neutral usage evidence.
+	ListBundleUsageObservations(ctx context.Context) ([]*model.UsageObservation, error)
 	// BeginBundleImport starts the single transaction used by all table
 	// importers in registry order.
 	BeginBundleImport(ctx context.Context) (BundleImportTransaction, error)
@@ -243,6 +249,7 @@ type BundleImportTransaction interface {
 	MemoryExists(ctx context.Context, memoryID types.MemoryID) (bool, error)
 	MemoryEdgeExists(ctx context.Context, edgeID types.MemoryEdgeID) (bool, error)
 	ImportMemoryEdge(ctx context.Context, edge *model.MemoryEdge, policy BundleConflictPolicy) (bool, error)
+	ImportUsageObservation(ctx context.Context, observation *model.UsageObservation, policy BundleConflictPolicy) (bool, error)
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
 }
@@ -306,6 +313,11 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 	if err != nil {
 		return xerrors.Errorf("failed to list memory edges for bundle: %w", err)
 	}
+	usageObservations, err := u.repository.ListBundleUsageObservations(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to list usage observations for bundle: %w", err)
+	}
+	usageObservations = filterUsageObservationsForBundleExport(usageObservations, sessions, opts)
 
 	registry := u.bundleTableRegistry()
 	sessionsImporter := registry["sessions"]
@@ -334,6 +346,11 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 	memoryEdgesBuf, err := memoryEdgesImporter.Export(ctx, bundleExportInputRows{MemoryEdges: memoryEdges})
 	if err != nil {
 		return xerrors.Errorf("failed to encode memory edges: %w", err)
+	}
+	usageObservationsImporter := registry["usage_observations"]
+	usageObservationsBuf, err := usageObservationsImporter.Export(ctx, bundleExportInputRows{UsageObservations: usageObservations})
+	if err != nil {
+		return xerrors.Errorf("failed to encode usage observations: %w", err)
 	}
 
 	manifest := bundleManifest{
@@ -383,6 +400,12 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 				RowCount:  len(memoryEdges),
 				Checksum:  hashSHA256(memoryEdgesBuf.Bytes()),
 			},
+			"usage_observations": {
+				TableName: "usage_observations",
+				File:      usageObservationsImporter.FileName(),
+				RowCount:  len(usageObservations),
+				Checksum:  hashSHA256(usageObservationsBuf.Bytes()),
+			},
 		},
 	}
 	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
@@ -391,12 +414,13 @@ func (u *bundleUsecase) Export(ctx context.Context, opts BundleExportOptions) er
 	}
 
 	plaintext, err := encodeTarGz(map[string][]byte{
-		"manifest.json":         manifestBytes,
-		"sessions.ndjson":       sessionsBuf.Bytes(),
-		"events.ndjson":         eventsBuf.Bytes(),
-		"command_audits.ndjson": commandAuditsBuf.Bytes(),
-		"memories.ndjson":       memoriesBuf.Bytes(),
-		"memory_edges.ndjson":   memoryEdgesBuf.Bytes(),
+		"manifest.json":             manifestBytes,
+		"sessions.ndjson":           sessionsBuf.Bytes(),
+		"events.ndjson":             eventsBuf.Bytes(),
+		"command_audits.ndjson":     commandAuditsBuf.Bytes(),
+		"memories.ndjson":           memoriesBuf.Bytes(),
+		"memory_edges.ndjson":       memoryEdgesBuf.Bytes(),
+		"usage_observations.ndjson": usageObservationsBuf.Bytes(),
 	})
 	if err != nil {
 		return xerrors.Errorf("failed to build tar.gz: %w", err)
@@ -523,6 +547,9 @@ func (u *bundleUsecase) Import(ctx context.Context, opts BundleImportOptions) (B
 		case "memory_edges":
 			result.MemoryEdgesImported += imported
 			result.MemoryEdgesSkipped += skipped
+		case "usage_observations":
+			result.UsageObservationsImported += imported
+			result.UsageObservationsSkipped += skipped
 		}
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -537,11 +564,12 @@ func (u *bundleUsecase) Import(ctx context.Context, opts BundleImportOptions) (B
 type bundleRow any
 
 type bundleExportInputRows struct {
-	Sessions      []*model.Session
-	Events        []*model.Event
-	CommandAudits []*model.CommandAudit
-	Memories      []apptypes.MemoryDetails
-	MemoryEdges   []*model.MemoryEdge
+	Sessions          []*model.Session
+	Events            []*model.Event
+	CommandAudits     []*model.CommandAudit
+	Memories          []apptypes.MemoryDetails
+	MemoryEdges       []*model.MemoryEdge
+	UsageObservations []*model.UsageObservation
 }
 
 type bundleImportPolicy struct {

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -63,6 +63,8 @@ type fakeBundleRepo struct {
 	memoryEdges               map[string]*model.MemoryEdge
 	exportMemories            []apptypes.MemoryDetails
 	exportMemoryEdges         []*model.MemoryEdge
+	usageObservations         map[string]*model.UsageObservation
+	exportUsageObservations   []*model.UsageObservation
 	enforceMemorySupersedesFK bool
 	forceErr                  error
 }
@@ -80,12 +82,16 @@ func (r *fakeBundleRepo) ListBundleMemories(context.Context) ([]apptypes.MemoryD
 func (r *fakeBundleRepo) ListBundleMemoryEdges(context.Context) ([]*model.MemoryEdge, error) {
 	return r.exportMemoryEdges, nil
 }
+func (r *fakeBundleRepo) ListBundleUsageObservations(context.Context) ([]*model.UsageObservation, error) {
+	return r.exportUsageObservations, nil
+}
 func (r *fakeBundleRepo) BeginBundleImport(context.Context) (usecase.BundleImportTransaction, error) {
 	tx := &fakeBundleTx{
-		repo:        r,
-		events:      map[string]bool{},
-		memories:    map[string]*model.Memory{},
-		memoryEdges: map[string]*model.MemoryEdge{},
+		repo:              r,
+		events:            map[string]bool{},
+		memories:          map[string]*model.Memory{},
+		memoryEdges:       map[string]*model.MemoryEdge{},
+		usageObservations: map[string]*model.UsageObservation{},
 	}
 	for id, value := range r.events {
 		tx.events[id] = value
@@ -96,14 +102,37 @@ func (r *fakeBundleRepo) BeginBundleImport(context.Context) (usecase.BundleImpor
 	for id, value := range r.memoryEdges {
 		tx.memoryEdges[id] = value
 	}
+	for id, value := range r.usageObservations {
+		tx.usageObservations[id] = value
+	}
 	return tx, nil
 }
 
 type fakeBundleTx struct {
-	repo        *fakeBundleRepo
-	events      map[string]bool
-	memories    map[string]*model.Memory
-	memoryEdges map[string]*model.MemoryEdge
+	repo              *fakeBundleRepo
+	events            map[string]bool
+	memories          map[string]*model.Memory
+	memoryEdges       map[string]*model.MemoryEdge
+	usageObservations map[string]*model.UsageObservation
+}
+
+func (tx *fakeBundleTx) ImportUsageObservation(_ context.Context, observation *model.UsageObservation, policy usecase.BundleConflictPolicy) (bool, error) {
+	if observation == nil {
+		return false, model.ErrInvalidUsageObservation
+	}
+	id := observation.Descriptor().ObservationID().String()
+	if existing, ok := tx.usageObservations[id]; ok {
+		transition, err := existing.Reconcile(observation)
+		if err == nil {
+			return transition == model.UsageObservationTransitionApplied, nil
+		}
+		if policy == usecase.BundleConflictSkip {
+			return false, nil
+		}
+		return false, err
+	}
+	tx.usageObservations[id] = observation
+	return true, nil
 }
 
 func (tx *fakeBundleTx) ImportSession(_ context.Context, session *model.Session, policy usecase.BundleConflictPolicy, missingParent usecase.BundleMissingParentPolicy) (bool, error) {
@@ -242,6 +271,7 @@ func (tx *fakeBundleTx) Commit(context.Context) error {
 	tx.repo.events = tx.events
 	tx.repo.memories = tx.memories
 	tx.repo.memoryEdges = tx.memoryEdges
+	tx.repo.usageObservations = tx.usageObservations
 	return nil
 }
 func (tx *fakeBundleTx) Rollback(context.Context) error { return nil }
@@ -270,6 +300,58 @@ func mustEventInSessionWorkspace(t *testing.T, id string, ts time.Time, session 
 		sessionID, workspace,
 		"body-"+id, ts,
 	)
+}
+
+func mustBundleUsageSnapshot(
+	t *testing.T,
+	id string,
+	revision int64,
+	predecessor string,
+	ts time.Time,
+) *model.UsageObservation {
+	t.Helper()
+	source, err := types.UsageSourceOf("codex", "headless_stream", "0.31.0", "openai", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observationID, err := types.UsageObservationIDFrom(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	supersedes := types.None[types.UsageObservationID]()
+	if predecessor != "" {
+		value, err := types.UsageObservationIDFrom(predecessor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		supersedes = types.Some(value)
+	}
+	descriptor, err := model.NewUsageSnapshotDescriptor(
+		observationID, types.SessionID("usage-session"), source, "codex:usage-session", revision, supersedes, ts,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unavailable := types.UnavailableUsageValue()
+	counters, err := types.UsageCountersOf(zero, unavailable, unavailable, zero, unavailable, zero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cost, err := types.EstimatedUsageCost(0, "USD", "prices-2026-07")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, cost, types.UsageTerminalSuccess, ts.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
 }
 
 func mustBundleMemoryID(t *testing.T, id string) types.MemoryID {
@@ -792,6 +874,75 @@ func TestBundleUsecase_ExportWritesManifestV2Tables(t *testing.T) {
 		if got := hashForTest(files[file]); got != entry.Checksum {
 			t.Fatalf("%s checksum = %s, want %s", table, entry.Checksum, got)
 		}
+	}
+}
+
+func TestBundleUsecase_RoundTripsUsageSnapshotChainWithoutCollapsingKnownZero(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	root := mustBundleUsageSnapshot(t, "usage-root", 1, "", ts)
+	successor := mustBundleUsageSnapshot(t, "usage-successor", 2, "usage-root", ts.Add(2*time.Minute))
+	exportRepo := &fakeBundleRepo{
+		schema:                  27,
+		exportUsageObservations: []*model.UsageObservation{successor, root},
+	}
+	out := filepath.Join(t.TempDir(), "usage-bundle.tbun")
+	if err := usecase.NewBundleUsecase(fakeEventQuery{}, exportRepo, func() time.Time { return ts }).Export(
+		context.Background(),
+		usecase.BundleExportOptions{OutPath: out, Passphrase: []byte("pass1")},
+	); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	files := openTestBundle(t, out, []byte("pass1"))
+	if len(files["usage_observations.ndjson"]) == 0 {
+		t.Fatal("bundle missing usage_observations.ndjson rows")
+	}
+	var manifest struct {
+		Tables map[string]struct {
+			RowCount int `json:"row_count"`
+		} `json:"tables"`
+	}
+	if err := json.Unmarshal(files["manifest.json"], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if got := manifest.Tables["usage_observations"].RowCount; got != 2 {
+		t.Fatalf("usage row count = %d, want 2", got)
+	}
+
+	importRepo := &fakeBundleRepo{schema: 27}
+	importUC := usecase.NewBundleUsecase(fakeEventQuery{}, importRepo, nil)
+	result, err := importUC.Import(context.Background(), usecase.BundleImportOptions{
+		InPath: out, Passphrase: []byte("pass1"),
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.UsageObservationsImported != 2 || result.UsageObservationsSkipped != 0 {
+		t.Fatalf("Import result = %+v, want 2 usage observations imported", result)
+	}
+	restored := importRepo.usageObservations["usage-root"]
+	if restored == nil {
+		t.Fatal("usage root was not restored")
+	}
+	if value, present := restored.Counters().Input().Value(); !present || value != 0 {
+		t.Fatalf("restored known-zero input = %d/%t", value, present)
+	}
+	if restored.Cost().Origin() != types.UsageCostEstimated || restored.Cost().PriceTableVersion() != "prices-2026-07" {
+		t.Fatalf("restored cost provenance = %s/%q", restored.Cost().Origin(), restored.Cost().PriceTableVersion())
+	}
+	if predecessor, present := importRepo.usageObservations["usage-successor"].Descriptor().SupersedesID().Value(); !present || predecessor.String() != "usage-root" {
+		t.Fatalf("restored successor predecessor = %q/%t", predecessor, present)
+	}
+
+	result, err = importUC.Import(context.Background(), usecase.BundleImportOptions{
+		InPath: out, Passphrase: []byte("pass1"),
+	})
+	if err != nil {
+		t.Fatalf("idempotent Import: %v", err)
+	}
+	if result.UsageObservationsImported != 0 || result.UsageObservationsSkipped != 2 {
+		t.Fatalf("idempotent result = %+v, want 2 usage observations skipped", result)
 	}
 }
 

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -129,7 +129,7 @@ func (tx *fakeBundleTx) ImportUsageObservation(_ context.Context, observation *m
 		if policy == usecase.BundleConflictSkip {
 			return false, nil
 		}
-		return false, err
+		return false, xerrors.Errorf("usage observation conflict: %w", err)
 	}
 	tx.usageObservations[id] = observation
 	return true, nil

--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -305,6 +305,7 @@ func mustEventInSessionWorkspace(t *testing.T, id string, ts time.Time, session 
 func mustBundleUsageSnapshot(
 	t *testing.T,
 	id string,
+	sessionID string,
 	revision int64,
 	predecessor string,
 	ts time.Time,
@@ -327,7 +328,7 @@ func mustBundleUsageSnapshot(
 		supersedes = types.Some(value)
 	}
 	descriptor, err := model.NewUsageSnapshotDescriptor(
-		observationID, types.SessionID("usage-session"), source, "codex:usage-session", revision, supersedes, ts,
+		observationID, types.SessionID(sessionID), source, "codex:"+sessionID, revision, supersedes, ts,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -881,8 +882,8 @@ func TestBundleUsecase_RoundTripsUsageSnapshotChainWithoutCollapsingKnownZero(t 
 	t.Parallel()
 
 	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
-	root := mustBundleUsageSnapshot(t, "usage-root", 1, "", ts)
-	successor := mustBundleUsageSnapshot(t, "usage-successor", 2, "usage-root", ts.Add(2*time.Minute))
+	root := mustBundleUsageSnapshot(t, "usage-root", "usage-session", 1, "", ts)
+	successor := mustBundleUsageSnapshot(t, "usage-successor", "usage-session", 2, "usage-root", ts.Add(2*time.Minute))
 	exportRepo := &fakeBundleRepo{
 		schema:                  27,
 		exportUsageObservations: []*model.UsageObservation{successor, root},
@@ -943,6 +944,48 @@ func TestBundleUsecase_RoundTripsUsageSnapshotChainWithoutCollapsingKnownZero(t 
 	}
 	if result.UsageObservationsImported != 0 || result.UsageObservationsSkipped != 2 {
 		t.Fatalf("idempotent result = %+v, want 2 usage observations skipped", result)
+	}
+}
+
+func TestBundleUsecase_FilteredExportKeepsCompleteUsageSnapshotChainForSelectedSession(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	root := mustBundleUsageSnapshot(t, "selected-root", "selected-session", 1, "", ts)
+	successor := mustBundleUsageSnapshot(t, "selected-successor", "selected-session", 2, "selected-root", ts.Add(2*time.Minute))
+	excluded := mustBundleUsageSnapshot(t, "excluded-root", "excluded-session", 1, "", ts)
+	exportRepo := &fakeBundleRepo{
+		schema: 27,
+		exportSessions: []*model.Session{
+			mustSessionInWorkspace(t, "selected-session", "", ts, types.Workspace("selected")),
+			mustSessionInWorkspace(t, "excluded-session", "", ts, types.Workspace("excluded")),
+		},
+		exportUsageObservations: []*model.UsageObservation{successor, excluded, root},
+	}
+	out := filepath.Join(t.TempDir(), "filtered-usage-bundle.tbun")
+	if err := usecase.NewBundleUsecase(fakeEventQuery{}, exportRepo, func() time.Time { return ts }).Export(
+		context.Background(),
+		usecase.BundleExportOptions{OutPath: out, Passphrase: []byte("pass1"), Workspace: types.Workspace("selected")},
+	); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	importRepo := &fakeBundleRepo{schema: 27}
+	result, err := usecase.NewBundleUsecase(fakeEventQuery{}, importRepo, nil).Import(
+		context.Background(),
+		usecase.BundleImportOptions{InPath: out, Passphrase: []byte("pass1")},
+	)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.UsageObservationsImported != 2 || result.UsageObservationsSkipped != 0 {
+		t.Fatalf("filtered import result = %+v, want complete selected chain", result)
+	}
+	if importRepo.usageObservations["selected-root"] == nil || importRepo.usageObservations["selected-successor"] == nil {
+		t.Fatal("filtered bundle did not preserve both selected snapshot revisions")
+	}
+	if importRepo.usageObservations["excluded-root"] != nil {
+		t.Fatal("filtered bundle leaked an excluded session usage observation")
 	}
 }
 

--- a/application/usecase/usage_observation_usecase.go
+++ b/application/usecase/usage_observation_usecase.go
@@ -1,0 +1,38 @@
+package usecase
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+)
+
+// UsageObservationUsecase is the write boundary consumed by host usage
+// adapters. Domain and repository layers own validity and idempotency.
+type UsageObservationUsecase interface {
+	Record(ctx context.Context, observation *model.UsageObservation) (model.UsageObservationTransition, error)
+}
+
+type usageObservationUsecase struct {
+	repository model.UsageObservationRepository
+}
+
+// NewUsageObservationUsecase creates the provider-neutral usage write usecase.
+func NewUsageObservationUsecase(repository model.UsageObservationRepository) UsageObservationUsecase {
+	return &usageObservationUsecase{repository: repository}
+}
+
+func (u *usageObservationUsecase) Record(
+	ctx context.Context,
+	observation *model.UsageObservation,
+) (model.UsageObservationTransition, error) {
+	if u.repository == nil {
+		return "", xerrors.Errorf("usage observation repository is not configured")
+	}
+	transition, err := u.repository.Record(ctx, observation)
+	if err != nil {
+		return transition, xerrors.Errorf("failed to record usage observation: %w", err)
+	}
+	return transition, nil
+}

--- a/application/usecase/usage_observation_usecase_test.go
+++ b/application/usecase/usage_observation_usecase_test.go
@@ -1,0 +1,56 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestUsageObservationUsecase_RecordDelegatesTransitionAndPreservesConflict(t *testing.T) {
+	t.Parallel()
+
+	repo := &usageObservationRepositoryStub{
+		transition: model.UsageObservationTransitionAlreadyApplied,
+		err:        model.ErrConflictingUsageObservation,
+	}
+	sut := usecase.NewUsageObservationUsecase(repo)
+
+	transition, err := sut.Record(context.Background(), &model.UsageObservation{})
+	if transition != model.UsageObservationTransitionAlreadyApplied {
+		t.Fatalf("Record() transition = %q", transition)
+	}
+	if !errors.Is(err, model.ErrConflictingUsageObservation) {
+		t.Fatalf("Record() error = %v", err)
+	}
+	if !repo.called {
+		t.Fatal("repository was not called")
+	}
+}
+
+func TestUsageObservationUsecase_RecordRejectsMissingRepository(t *testing.T) {
+	t.Parallel()
+
+	sut := usecase.NewUsageObservationUsecase(nil)
+	if _, err := sut.Record(context.Background(), &model.UsageObservation{}); err == nil {
+		t.Fatal("Record() error = nil")
+	}
+}
+
+type usageObservationRepositoryStub struct {
+	called     bool
+	transition model.UsageObservationTransition
+	err        error
+}
+
+func (s *usageObservationRepositoryStub) Record(context.Context, *model.UsageObservation) (model.UsageObservationTransition, error) {
+	s.called = true
+	return s.transition, s.err
+}
+
+func (s *usageObservationRepositoryStub) FindByID(context.Context, types.UsageObservationID) (types.Optional[*model.UsageObservation], error) {
+	return types.None[*model.UsageObservation](), nil
+}

--- a/domain/model/usage_observation.go
+++ b/domain/model/usage_observation.go
@@ -372,6 +372,9 @@ func (o *UsageObservation) ValidateSnapshotSuccessor(head *UsageObservation) err
 		head.status != types.UsageObservationFinalized {
 		return newUsageObservationConflict(o.descriptor.observationID, "snapshot series")
 	}
+	if head.descriptor.sessionID != o.descriptor.sessionID || head.descriptor.source != o.descriptor.source {
+		return newUsageObservationConflict(o.descriptor.observationID, "snapshot lineage")
+	}
 	if !hasPredecessor || predecessor != head.descriptor.observationID {
 		return newUsageObservationConflict(o.descriptor.observationID, "snapshot predecessor")
 	}

--- a/domain/model/usage_observation.go
+++ b/domain/model/usage_observation.go
@@ -342,7 +342,10 @@ func (o *UsageObservation) Reconcile(proposed *UsageObservation) (UsageObservati
 		}
 		currentCode, _ := o.terminalCode.Value()
 		proposedCode, _ := proposed.terminalCode.Value()
-		if o.counters == proposed.counters && o.cost == proposed.cost && currentCode == proposedCode {
+		currentFinalizedAt, _ := o.finalizedAt.Value()
+		proposedFinalizedAt, _ := proposed.finalizedAt.Value()
+		if o.counters == proposed.counters && o.cost == proposed.cost && currentCode == proposedCode &&
+			currentFinalizedAt.Equal(proposedFinalizedAt) {
 			return UsageObservationTransitionAlreadyApplied, nil
 		}
 		return "", newUsageObservationConflict(o.descriptor.observationID, "terminal accounting")

--- a/domain/model/usage_observation.go
+++ b/domain/model/usage_observation.go
@@ -1,0 +1,421 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// UsageObservationDescriptor is immutable semantic identity shared by pending
+// and finalized representations of one authoritative observation.
+type UsageObservationDescriptor struct {
+	observationID    types.UsageObservationID
+	sessionID        types.SessionID
+	source           types.UsageSource
+	scope            types.UsageScope
+	accounting       types.UsageAccounting
+	observedAt       time.Time
+	snapshotSeries   string
+	snapshotRevision int64
+	supersedesID     types.Optional[types.UsageObservationID]
+}
+
+// NewUsageObservationDescriptor creates identity for a call or run. Session
+// snapshots use NewUsageSnapshotDescriptor so their chain cannot be omitted.
+func NewUsageObservationDescriptor(
+	observationID types.UsageObservationID,
+	sessionID types.SessionID,
+	source types.UsageSource,
+	scope types.UsageScope,
+	accounting types.UsageAccounting,
+	observedAt time.Time,
+) (UsageObservationDescriptor, error) {
+	if scope != types.UsageScopeCall && scope != types.UsageScopeRun {
+		return UsageObservationDescriptor{}, xerrors.Errorf("call/run descriptor has unsupported scope %q", scope)
+	}
+	if accounting != types.UsageAccountingAdditive && accounting != types.UsageAccountingExcluded {
+		return UsageObservationDescriptor{}, xerrors.Errorf("call/run descriptor has unsupported accounting %q", accounting)
+	}
+	descriptor := UsageObservationDescriptor{
+		observationID: observationID,
+		sessionID:     sessionID,
+		source:        source,
+		scope:         scope,
+		accounting:    accounting,
+		observedAt:    observedAt,
+		supersedesID:  types.None[types.UsageObservationID](),
+	}
+	if err := descriptor.validate(); err != nil {
+		return UsageObservationDescriptor{}, err
+	}
+	return descriptor, nil
+}
+
+// NewUsageSnapshotDescriptor creates identity for one immutable cumulative
+// session snapshot revision.
+func NewUsageSnapshotDescriptor(
+	observationID types.UsageObservationID,
+	sessionID types.SessionID,
+	source types.UsageSource,
+	series string,
+	revision int64,
+	supersedesID types.Optional[types.UsageObservationID],
+	observedAt time.Time,
+) (UsageObservationDescriptor, error) {
+	descriptor := UsageObservationDescriptor{
+		observationID:    observationID,
+		sessionID:        sessionID,
+		source:           source,
+		scope:            types.UsageScopeSessionSnapshot,
+		accounting:       types.UsageAccountingLatestSnapshot,
+		observedAt:       observedAt,
+		snapshotSeries:   strings.TrimSpace(series),
+		snapshotRevision: revision,
+		supersedesID:     supersedesID,
+	}
+	if err := descriptor.validate(); err != nil {
+		return UsageObservationDescriptor{}, err
+	}
+	return descriptor, nil
+}
+
+func (d UsageObservationDescriptor) validate() error {
+	if _, err := types.UsageObservationIDFrom(d.observationID.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation descriptor: %w", err)
+	}
+	if _, err := types.SessionIDFrom(d.sessionID.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation descriptor: %w", err)
+	}
+	if _, err := types.UsageSourceOf(d.source.Host(), d.source.Name(), d.source.Version(), d.source.Provider(), d.source.Model()); err != nil {
+		return xerrors.Errorf("invalid usage observation descriptor: %w", err)
+	}
+	if _, err := types.UsageScopeFrom(d.scope.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation descriptor: %w", err)
+	}
+	if _, err := types.UsageAccountingFrom(d.accounting.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation descriptor: %w", err)
+	}
+	if d.observedAt.IsZero() {
+		return xerrors.Errorf("usage observation timestamp must not be zero")
+	}
+	if d.scope == types.UsageScopeSessionSnapshot {
+		if d.accounting != types.UsageAccountingLatestSnapshot || d.snapshotSeries == "" || d.snapshotRevision < 1 {
+			return xerrors.Errorf("session snapshot requires latest-snapshot accounting, series, and positive revision")
+		}
+		if len(d.snapshotSeries) > 512 {
+			return xerrors.Errorf("usage snapshot series must not exceed 512 bytes")
+		}
+	} else if d.snapshotSeries != "" || d.snapshotRevision != 0 {
+		return xerrors.Errorf("call/run descriptor must not carry snapshot metadata")
+	} else if _, present := d.supersedesID.Value(); present {
+		return xerrors.Errorf("call/run descriptor must not supersede a snapshot")
+	}
+	if predecessor, present := d.supersedesID.Value(); present {
+		if _, err := types.UsageObservationIDFrom(predecessor.String()); err != nil {
+			return xerrors.Errorf("invalid superseded observation ID: %w", err)
+		}
+		if predecessor == d.observationID {
+			return xerrors.Errorf("usage snapshot cannot supersede itself")
+		}
+	}
+	return nil
+}
+
+func (d UsageObservationDescriptor) equivalent(other UsageObservationDescriptor) bool {
+	if d.observationID != other.observationID || d.sessionID != other.sessionID || d.source != other.source ||
+		d.scope != other.scope || d.accounting != other.accounting || d.snapshotSeries != other.snapshotSeries ||
+		d.snapshotRevision != other.snapshotRevision || !d.observedAt.Equal(other.observedAt) {
+		return false
+	}
+	currentPredecessor, currentPresent := d.supersedesID.Value()
+	otherPredecessor, otherPresent := other.supersedesID.Value()
+	return currentPresent == otherPresent && (!currentPresent || currentPredecessor == otherPredecessor)
+}
+
+// ObservationID returns the adapter-owned authoritative identity.
+func (d UsageObservationDescriptor) ObservationID() types.UsageObservationID {
+	return d.observationID
+}
+
+// SessionID returns the correlated Traceary or host session identity.
+func (d UsageObservationDescriptor) SessionID() types.SessionID { return d.sessionID }
+
+// Source returns the versioned local usage source.
+func (d UsageObservationDescriptor) Source() types.UsageSource { return d.source }
+
+// Scope returns call, run, or session-snapshot granularity.
+func (d UsageObservationDescriptor) Scope() types.UsageScope { return d.scope }
+
+// Accounting returns the explicit aggregate behavior.
+func (d UsageObservationDescriptor) Accounting() types.UsageAccounting { return d.accounting }
+
+// ObservedAt returns the authoritative source boundary timestamp.
+func (d UsageObservationDescriptor) ObservedAt() time.Time { return d.observedAt }
+
+// SnapshotSeries returns the immutable snapshot series key, when applicable.
+func (d UsageObservationDescriptor) SnapshotSeries() string { return d.snapshotSeries }
+
+// SnapshotRevision returns the positive ingest revision, when applicable.
+func (d UsageObservationDescriptor) SnapshotRevision() int64 { return d.snapshotRevision }
+
+// SupersedesID returns the predecessor snapshot identity, when applicable.
+func (d UsageObservationDescriptor) SupersedesID() types.Optional[types.UsageObservationID] {
+	return d.supersedesID
+}
+
+// UsageObservation is the aggregate root for idempotent usage accounting.
+type UsageObservation struct {
+	descriptor   UsageObservationDescriptor
+	status       types.UsageObservationStatus
+	counters     types.UsageCounters
+	cost         types.UsageCost
+	terminalCode types.Optional[types.UsageTerminalCode]
+	finalizedAt  types.Optional[time.Time]
+}
+
+// NewPendingUsageObservation creates an open call/run with no numeric usage.
+func NewPendingUsageObservation(descriptor UsageObservationDescriptor) (*UsageObservation, error) {
+	return UsageObservationOf(
+		descriptor,
+		types.UsageObservationPending,
+		types.UnknownUsageCounters(),
+		types.UnknownUsageCost(),
+		types.None[types.UsageTerminalCode](),
+		types.None[time.Time](),
+	)
+}
+
+// NewFinalizedUsageObservation creates a terminal observation. Every counter
+// dimension and the cost must be explicitly known or unavailable.
+func NewFinalizedUsageObservation(
+	descriptor UsageObservationDescriptor,
+	counters types.UsageCounters,
+	cost types.UsageCost,
+	terminalCode types.UsageTerminalCode,
+	finalizedAt time.Time,
+) (*UsageObservation, error) {
+	return UsageObservationOf(
+		descriptor,
+		types.UsageObservationFinalized,
+		counters,
+		cost,
+		types.Some(terminalCode),
+		types.Some(finalizedAt),
+	)
+}
+
+// UsageObservationOf restores a persisted aggregate while rechecking every
+// domain invariant.
+func UsageObservationOf(
+	descriptor UsageObservationDescriptor,
+	status types.UsageObservationStatus,
+	counters types.UsageCounters,
+	cost types.UsageCost,
+	terminalCode types.Optional[types.UsageTerminalCode],
+	finalizedAt types.Optional[time.Time],
+) (*UsageObservation, error) {
+	observation := &UsageObservation{
+		descriptor:   descriptor,
+		status:       status,
+		counters:     counters,
+		cost:         cost,
+		terminalCode: terminalCode,
+		finalizedAt:  finalizedAt,
+	}
+	if err := observation.validate(); err != nil {
+		return nil, err
+	}
+	return observation, nil
+}
+
+func (o *UsageObservation) validate() error {
+	if o == nil {
+		return ErrInvalidUsageObservation
+	}
+	if err := o.descriptor.validate(); err != nil {
+		return xerrors.Errorf("invalid usage observation: %w", err)
+	}
+	if _, err := types.UsageObservationStatusFrom(o.status.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation: %w", err)
+	}
+	if _, err := types.UsageCountersOf(
+		o.counters.Input(), o.counters.CachedInput(), o.counters.CacheWriteInput(),
+		o.counters.Output(), o.counters.ReasoningOutput(), o.counters.Total(),
+	); err != nil {
+		return xerrors.Errorf("invalid usage observation counters: %w", err)
+	}
+	amount := types.None[int64]()
+	if value, present := o.cost.AmountMicros(); present {
+		amount = types.Some(value)
+	}
+	if _, err := types.UsageCostFrom(
+		o.cost.State().String(), amount, o.cost.Currency(), o.cost.Origin().String(), o.cost.PriceTableVersion(),
+	); err != nil {
+		return xerrors.Errorf("invalid usage observation cost: %w", err)
+	}
+
+	if o.status == types.UsageObservationPending {
+		if o.descriptor.scope == types.UsageScopeSessionSnapshot {
+			return xerrors.Errorf("session snapshot cannot be pending: %w", ErrInvalidUsageObservation)
+		}
+		if !allUsageValuesHaveState(o.counters, types.UsageValueUnknown) || o.cost.State() != types.UsageCostUnknown {
+			return xerrors.Errorf("pending usage observation must contain only unknown values: %w", ErrInvalidUsageObservation)
+		}
+		if _, present := o.terminalCode.Value(); present {
+			return xerrors.Errorf("pending usage observation must not have a terminal code: %w", ErrInvalidUsageObservation)
+		}
+		if _, present := o.finalizedAt.Value(); present {
+			return xerrors.Errorf("pending usage observation must not have a final timestamp: %w", ErrInvalidUsageObservation)
+		}
+		return nil
+	}
+
+	if o.counters.Availability() == types.UsageAvailabilityUnknown || o.cost.State() == types.UsageCostUnknown {
+		return xerrors.Errorf("finalized usage observation must not contain unknown values: %w", ErrInvalidUsageObservation)
+	}
+	code, present := o.terminalCode.Value()
+	if !present {
+		return xerrors.Errorf("finalized usage observation requires a terminal code: %w", ErrInvalidUsageObservation)
+	}
+	if _, err := types.UsageTerminalCodeFrom(code.String()); err != nil {
+		return xerrors.Errorf("invalid usage observation terminal code: %w", err)
+	}
+	finalizedAt, present := o.finalizedAt.Value()
+	if !present || finalizedAt.IsZero() || finalizedAt.Before(o.descriptor.observedAt) {
+		return xerrors.Errorf("finalized usage observation has an invalid final timestamp: %w", ErrInvalidUsageObservation)
+	}
+	return nil
+}
+
+func allUsageValuesHaveState(counters types.UsageCounters, state types.UsageValueState) bool {
+	values := []types.UsageValue{
+		counters.Input(), counters.CachedInput(), counters.CacheWriteInput(),
+		counters.Output(), counters.ReasoningOutput(), counters.Total(),
+	}
+	for _, value := range values {
+		if value.State() != state {
+			return false
+		}
+	}
+	return true
+}
+
+// UsageObservationTransition is the observable result of Record/Reconcile.
+type UsageObservationTransition string
+
+const (
+	// UsageObservationTransitionApplied means a row or terminal state was written.
+	UsageObservationTransitionApplied UsageObservationTransition = "applied"
+	// UsageObservationTransitionAlreadyApplied means an exact replay changed nothing.
+	UsageObservationTransitionAlreadyApplied UsageObservationTransition = "already_applied"
+)
+
+// Reconcile applies one semantically matching pending-to-finalized transition.
+// Replays are no-ops and all other changes fail closed.
+func (o *UsageObservation) Reconcile(proposed *UsageObservation) (UsageObservationTransition, error) {
+	if o == nil || proposed == nil {
+		return "", ErrInvalidUsageObservation
+	}
+	if !o.descriptor.equivalent(proposed.descriptor) {
+		return "", newUsageObservationConflict(o.descriptor.observationID, "identity metadata")
+	}
+	if o.status == types.UsageObservationPending {
+		switch proposed.status {
+		case types.UsageObservationPending:
+			return UsageObservationTransitionAlreadyApplied, nil
+		case types.UsageObservationFinalized:
+			o.status = proposed.status
+			o.counters = proposed.counters
+			o.cost = proposed.cost
+			o.terminalCode = proposed.terminalCode
+			o.finalizedAt = proposed.finalizedAt
+			return UsageObservationTransitionApplied, nil
+		}
+	}
+	if o.status == types.UsageObservationFinalized {
+		if proposed.status == types.UsageObservationPending {
+			return UsageObservationTransitionAlreadyApplied, nil
+		}
+		currentCode, _ := o.terminalCode.Value()
+		proposedCode, _ := proposed.terminalCode.Value()
+		if o.counters == proposed.counters && o.cost == proposed.cost && currentCode == proposedCode {
+			return UsageObservationTransitionAlreadyApplied, nil
+		}
+		return "", newUsageObservationConflict(o.descriptor.observationID, "terminal accounting")
+	}
+	return "", ErrInvalidUsageObservation
+}
+
+// ValidateSnapshotSuccessor verifies that this observation can extend the
+// supplied current snapshot head. A nil head is valid only for the first
+// revision of a series and therefore requires no predecessor.
+func (o *UsageObservation) ValidateSnapshotSuccessor(head *UsageObservation) error {
+	if o == nil || o.descriptor.scope != types.UsageScopeSessionSnapshot || o.status != types.UsageObservationFinalized {
+		return ErrInvalidUsageObservation
+	}
+	predecessor, hasPredecessor := o.descriptor.supersedesID.Value()
+	if head == nil {
+		if hasPredecessor {
+			return newUsageObservationConflict(o.descriptor.observationID, "missing snapshot predecessor")
+		}
+		return nil
+	}
+	if head.descriptor.scope != types.UsageScopeSessionSnapshot ||
+		head.descriptor.snapshotSeries != o.descriptor.snapshotSeries ||
+		head.status != types.UsageObservationFinalized {
+		return newUsageObservationConflict(o.descriptor.observationID, "snapshot series")
+	}
+	if !hasPredecessor || predecessor != head.descriptor.observationID {
+		return newUsageObservationConflict(o.descriptor.observationID, "snapshot predecessor")
+	}
+	if o.descriptor.snapshotRevision <= head.descriptor.snapshotRevision {
+		return newUsageObservationConflict(o.descriptor.observationID, "snapshot revision")
+	}
+	return nil
+}
+
+// Descriptor returns immutable semantic identity.
+func (o *UsageObservation) Descriptor() UsageObservationDescriptor { return o.descriptor }
+
+// Status returns pending or finalized lifecycle state.
+func (o *UsageObservation) Status() types.UsageObservationStatus { return o.status }
+
+// Counters returns provider-neutral token dimensions.
+func (o *UsageObservation) Counters() types.UsageCounters { return o.counters }
+
+// Cost returns explicit availability and provenance for monetary cost.
+func (o *UsageObservation) Cost() types.UsageCost { return o.cost }
+
+// TerminalCode returns the normalized terminal code when finalized.
+func (o *UsageObservation) TerminalCode() types.Optional[types.UsageTerminalCode] {
+	return o.terminalCode
+}
+
+// FinalizedAt returns the first accepted terminal timestamp.
+func (o *UsageObservation) FinalizedAt() types.Optional[time.Time] { return o.finalizedAt }
+
+// UsageObservationConflictError reports a fail-closed semantic conflict
+// without including host body or free-form terminal data.
+type UsageObservationConflictError struct {
+	observationID types.UsageObservationID
+	field         string
+}
+
+func newUsageObservationConflict(id types.UsageObservationID, field string) *UsageObservationConflictError {
+	return &UsageObservationConflictError{observationID: id, field: field}
+}
+
+func (e *UsageObservationConflictError) Error() string {
+	return fmt.Sprintf("usage observation %q conflicts on %s", e.observationID, e.field)
+}
+
+func (e *UsageObservationConflictError) Unwrap() error { return ErrConflictingUsageObservation }
+
+// ObservationID returns the identity whose proposed semantics conflicted.
+func (e *UsageObservationConflictError) ObservationID() types.UsageObservationID {
+	return e.observationID
+}

--- a/domain/model/usage_observation_errors.go
+++ b/domain/model/usage_observation_errors.go
@@ -1,0 +1,9 @@
+package model
+
+import "golang.org/x/xerrors"
+
+// ErrInvalidUsageObservation identifies a violated observation invariant.
+var ErrInvalidUsageObservation = xerrors.New("invalid usage observation")
+
+// ErrConflictingUsageObservation identifies a fail-closed replay conflict.
+var ErrConflictingUsageObservation = xerrors.New("conflicting usage observation")

--- a/domain/model/usage_observation_repository.go
+++ b/domain/model/usage_observation_repository.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"context"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// UsageObservationRepository atomically records provider-neutral usage state.
+type UsageObservationRepository interface {
+	// Record inserts an observation or applies its single pending-to-finalized
+	// transition. Exact redelivery is reported as already applied.
+	Record(ctx context.Context, observation *UsageObservation) (UsageObservationTransition, error)
+	// FindByID restores an observation or returns None when it does not exist.
+	FindByID(ctx context.Context, observationID types.UsageObservationID) (types.Optional[*UsageObservation], error)
+}

--- a/domain/model/usage_observation_test.go
+++ b/domain/model/usage_observation_test.go
@@ -64,6 +64,31 @@ func TestUsageObservation_ReconcileRejectsConflictingTerminalData(t *testing.T) 
 	}
 }
 
+func TestUsageObservation_ReconcileRejectsDifferentTerminalTimestamp(t *testing.T) {
+	t.Parallel()
+
+	descriptor := usageDescriptor(t, "usage-time-conflict")
+	current := finalizedUsageObservation(t, descriptor, 1)
+	proposed, err := model.NewFinalizedUsageObservation(
+		descriptor,
+		current.Counters(),
+		current.Cost(),
+		types.UsageTerminalSuccess,
+		time.Date(2026, 7, 23, 12, 2, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := current.Reconcile(proposed); !errors.Is(err, model.ErrConflictingUsageObservation) {
+		t.Fatalf("Reconcile(different finalized_at) error = %v", err)
+	}
+	finalizedAt, _ := current.FinalizedAt().Value()
+	if !finalizedAt.Equal(time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC)) {
+		t.Fatalf("conflict mutated finalized_at = %v", finalizedAt)
+	}
+}
+
 func TestUsageObservation_finalizedRejectsUnknownUsage(t *testing.T) {
 	t.Parallel()
 

--- a/domain/model/usage_observation_test.go
+++ b/domain/model/usage_observation_test.go
@@ -2,6 +2,7 @@ package model_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,6 +131,65 @@ func TestUsageObservation_snapshotMustBeFinalized(t *testing.T) {
 	}
 	if _, err := model.NewPendingUsageObservation(descriptor); err == nil {
 		t.Fatal("NewPendingUsageObservation(snapshot) error = nil")
+	}
+}
+
+func TestUsageObservation_SnapshotSuccessorRequiresSameSessionAndSource(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	source, err := types.UsageSourceOf("antigravity", "statusline", "1.1.5", "google", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootID, _ := types.UsageObservationIDFrom("snapshot-lineage-root")
+	rootDescriptor, err := model.NewUsageSnapshotDescriptor(
+		rootID, types.SessionID("session-1"), source, "snapshot-series", 1,
+		types.None[types.UsageObservationID](), ts,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	makeFinalized := func(descriptor model.UsageObservationDescriptor) *model.UsageObservation {
+		unavailable := types.UnavailableUsageValue()
+		counters, err := types.UsageCountersOf(unavailable, unavailable, unavailable, unavailable, unavailable, unavailable)
+		if err != nil {
+			t.Fatal(err)
+		}
+		observation, err := model.NewFinalizedUsageObservation(
+			descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalSuccess, descriptor.ObservedAt().Add(time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return observation
+	}
+	root := makeFinalized(rootDescriptor)
+
+	otherSource, err := types.UsageSourceOf("antigravity", "statusline", "1.1.6", "google", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name      string
+		sessionID types.SessionID
+		source    types.UsageSource
+	}{
+		{name: "different session", sessionID: types.SessionID("session-2"), source: source},
+		{name: "different source", sessionID: types.SessionID("session-1"), source: otherSource},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			successorID, _ := types.UsageObservationIDFrom("snapshot-" + strings.ReplaceAll(tt.name, " ", "-"))
+			descriptor, err := model.NewUsageSnapshotDescriptor(
+				successorID, tt.sessionID, tt.source, "snapshot-series", 2, types.Some(rootID), ts.Add(time.Minute),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := makeFinalized(descriptor).ValidateSnapshotSuccessor(root); !errors.Is(err, model.ErrConflictingUsageObservation) {
+				t.Fatalf("ValidateSnapshotSuccessor() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/domain/model/usage_observation_test.go
+++ b/domain/model/usage_observation_test.go
@@ -1,0 +1,160 @@
+package model_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestUsageObservation_ReconcileFinalizesPendingOnce(t *testing.T) {
+	t.Parallel()
+
+	descriptor := usageDescriptor(t, "usage-1")
+	pending, err := model.NewPendingUsageObservation(descriptor)
+	if err != nil {
+		t.Fatalf("NewPendingUsageObservation() error = %v", err)
+	}
+	finalized := finalizedUsageObservation(t, descriptor, 0)
+
+	transition, err := pending.Reconcile(finalized)
+	if err != nil {
+		t.Fatalf("Reconcile(finalized) error = %v", err)
+	}
+	if transition != model.UsageObservationTransitionApplied || pending.Status() != types.UsageObservationFinalized {
+		t.Fatalf("transition/status = %q/%q", transition, pending.Status())
+	}
+	input, ok := pending.Counters().Input().Value()
+	if !ok || input != 0 {
+		t.Fatalf("final input = %d, present %v", input, ok)
+	}
+
+	transition, err = pending.Reconcile(finalized)
+	if err != nil {
+		t.Fatalf("Reconcile(replay) error = %v", err)
+	}
+	if transition != model.UsageObservationTransitionAlreadyApplied {
+		t.Fatalf("replay transition = %q", transition)
+	}
+}
+
+func TestUsageObservation_ReconcileRejectsConflictingTerminalData(t *testing.T) {
+	t.Parallel()
+
+	descriptor := usageDescriptor(t, "usage-conflict")
+	current := finalizedUsageObservation(t, descriptor, 1)
+	proposed := finalizedUsageObservation(t, descriptor, 2)
+
+	_, err := current.Reconcile(proposed)
+	if err == nil {
+		t.Fatal("Reconcile(conflict) error = nil")
+	}
+	if !errors.Is(err, model.ErrConflictingUsageObservation) {
+		t.Fatalf("Reconcile(conflict) error = %v", err)
+	}
+	var conflict *model.UsageObservationConflictError
+	if !errors.As(err, &conflict) || conflict.ObservationID() != descriptor.ObservationID() {
+		t.Fatalf("Reconcile(conflict) error type/id = %T/%q", err, conflict.ObservationID())
+	}
+	input, _ := current.Counters().Input().Value()
+	if input != 1 {
+		t.Fatalf("conflict mutated input = %d", input)
+	}
+}
+
+func TestUsageObservation_finalizedRejectsUnknownUsage(t *testing.T) {
+	t.Parallel()
+
+	descriptor := usageDescriptor(t, "usage-unknown")
+	_, err := model.NewFinalizedUsageObservation(
+		descriptor,
+		types.UnknownUsageCounters(),
+		types.UnavailableUsageCost(),
+		types.UsageTerminalSuccess,
+		time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC),
+	)
+	if err == nil {
+		t.Fatal("NewFinalizedUsageObservation(unknown) error = nil")
+	}
+}
+
+func TestUsageObservation_snapshotMustBeFinalized(t *testing.T) {
+	t.Parallel()
+
+	source, err := types.UsageSourceOf("antigravity", "statusline", "1.1.5", "google", "gemini-2.5-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := types.UsageObservationIDFrom("snapshot-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := model.NewUsageSnapshotDescriptor(
+		id,
+		types.SessionID("conversation-1"),
+		source,
+		"antigravity:conversation-1:gemini-2.5-pro",
+		1,
+		types.None[types.UsageObservationID](),
+		time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("NewUsageSnapshotDescriptor() error = %v", err)
+	}
+	if _, err := model.NewPendingUsageObservation(descriptor); err == nil {
+		t.Fatal("NewPendingUsageObservation(snapshot) error = nil")
+	}
+}
+
+func usageDescriptor(t *testing.T, value string) model.UsageObservationDescriptor {
+	t.Helper()
+	source, err := types.UsageSourceOf("codex", "headless_stream", "0.145.0", "openai", "gpt-5.6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := types.UsageObservationIDFrom(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id,
+		types.SessionID("session-1"),
+		source,
+		types.UsageScopeCall,
+		types.UsageAccountingAdditive,
+		time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return descriptor
+}
+
+func finalizedUsageObservation(t *testing.T, descriptor model.UsageObservationDescriptor, inputTokens int64) *model.UsageObservation {
+	t.Helper()
+	input, err := types.KnownUsageValue(inputTokens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counters, err := types.UsageCountersOf(input, zero, zero, zero, zero, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor,
+		counters,
+		types.UnavailableUsageCost(),
+		types.UsageTerminalSuccess,
+		time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}

--- a/domain/types/usage_cost.go
+++ b/domain/types/usage_cost.go
@@ -1,0 +1,157 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// UsageCostState separates absent cost evidence from a known amount.
+type UsageCostState string
+
+const (
+	// UsageCostUnknown means terminal cost evidence is not known yet.
+	UsageCostUnknown UsageCostState = "unknown"
+	// UsageCostUnavailable means the terminal source has no usable cost.
+	UsageCostUnavailable UsageCostState = "unavailable"
+	// UsageCostKnown means a non-negative amount and provenance are present.
+	UsageCostKnown UsageCostState = "known"
+)
+
+// UsageCostOrigin distinguishes a versioned Traceary estimate from an amount
+// explicitly reported by a provider surface.
+type UsageCostOrigin string
+
+const (
+	// UsageCostEstimated identifies a Traceary estimate from a versioned table.
+	UsageCostEstimated UsageCostOrigin = "estimated"
+	// UsageCostProviderReported identifies an amount reported by the source.
+	UsageCostProviderReported UsageCostOrigin = "provider_reported"
+)
+
+// UsageCost stores integer currency micro-units to avoid floating-point
+// accounting. Currency is an uppercase ISO-style three-letter code.
+type UsageCost struct {
+	state             UsageCostState
+	amountMicros      int64
+	currency          string
+	origin            UsageCostOrigin
+	priceTableVersion string
+}
+
+// UnknownUsageCost creates the cost state for a pending observation.
+func UnknownUsageCost() UsageCost { return UsageCost{state: UsageCostUnknown} }
+
+// UnavailableUsageCost creates a terminal cost without a numeric amount.
+func UnavailableUsageCost() UsageCost { return UsageCost{state: UsageCostUnavailable} }
+
+// EstimatedUsageCost creates a versioned Traceary estimate in micro-units.
+func EstimatedUsageCost(amountMicros int64, currency string, priceTableVersion string) (UsageCost, error) {
+	version := strings.TrimSpace(priceTableVersion)
+	if version == "" {
+		return UsageCost{}, xerrors.Errorf("estimated usage cost requires a price-table version")
+	}
+	return knownUsageCost(amountMicros, currency, UsageCostEstimated, version)
+}
+
+// ProviderReportedUsageCost creates source-reported cost in micro-units.
+func ProviderReportedUsageCost(amountMicros int64, currency string) (UsageCost, error) {
+	return knownUsageCost(amountMicros, currency, UsageCostProviderReported, "")
+}
+
+// UsageCostFrom restores a validated persisted cost tuple.
+func UsageCostFrom(
+	state string,
+	amountMicros Optional[int64],
+	currency string,
+	origin string,
+	priceTableVersion string,
+) (UsageCost, error) {
+	switch UsageCostState(state) {
+	case UsageCostUnknown:
+		if err := requireEmptyUsageCost(amountMicros, currency, origin, priceTableVersion); err != nil {
+			return UsageCost{}, xerrors.Errorf("invalid unknown usage cost: %w", err)
+		}
+		return UnknownUsageCost(), nil
+	case UsageCostUnavailable:
+		if err := requireEmptyUsageCost(amountMicros, currency, origin, priceTableVersion); err != nil {
+			return UsageCost{}, xerrors.Errorf("invalid unavailable usage cost: %w", err)
+		}
+		return UnavailableUsageCost(), nil
+	case UsageCostKnown:
+		amount, present := amountMicros.Value()
+		if !present {
+			return UsageCost{}, xerrors.Errorf("known usage cost requires an amount")
+		}
+		switch UsageCostOrigin(origin) {
+		case UsageCostEstimated:
+			return EstimatedUsageCost(amount, currency, priceTableVersion)
+		case UsageCostProviderReported:
+			if strings.TrimSpace(priceTableVersion) != "" {
+				return UsageCost{}, xerrors.Errorf("provider-reported usage cost must not carry a price-table version")
+			}
+			return ProviderReportedUsageCost(amount, currency)
+		default:
+			return UsageCost{}, xerrors.Errorf("unsupported usage cost origin: %q", origin)
+		}
+	default:
+		return UsageCost{}, xerrors.Errorf("unsupported usage cost state: %q", state)
+	}
+}
+
+func knownUsageCost(amountMicros int64, currency string, origin UsageCostOrigin, priceTableVersion string) (UsageCost, error) {
+	if amountMicros < 0 {
+		return UsageCost{}, xerrors.Errorf("usage cost amount must not be negative")
+	}
+	normalizedCurrency := strings.TrimSpace(currency)
+	if !isUpperCurrency(normalizedCurrency) {
+		return UsageCost{}, xerrors.Errorf("usage cost currency must be three uppercase ASCII letters")
+	}
+	return UsageCost{
+		state: UsageCostKnown, amountMicros: amountMicros, currency: normalizedCurrency,
+		origin: origin, priceTableVersion: priceTableVersion,
+	}, nil
+}
+
+func requireEmptyUsageCost(amount Optional[int64], currency, origin, version string) error {
+	if _, present := amount.Value(); present || currency != "" || origin != "" || version != "" {
+		return xerrors.Errorf("cost without a known value must not carry amount or provenance")
+	}
+	return nil
+}
+
+func isUpperCurrency(value string) bool {
+	if len(value) != 3 {
+		return false
+	}
+	for _, char := range value {
+		if char < 'A' || char > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+// State returns the explicit cost availability state.
+func (c UsageCost) State() UsageCostState { return c.state }
+
+// AmountMicros returns the integer micro-unit amount only when known.
+func (c UsageCost) AmountMicros() (int64, bool) {
+	if c.state != UsageCostKnown {
+		return 0, false
+	}
+	return c.amountMicros, true
+}
+
+// Currency returns the uppercase three-letter currency when known.
+func (c UsageCost) Currency() string { return c.currency }
+
+// Origin returns estimate or provider-reported provenance when known.
+func (c UsageCost) Origin() UsageCostOrigin { return c.origin }
+
+// PriceTableVersion returns the required version for an estimated cost.
+func (c UsageCost) PriceTableVersion() string { return c.priceTableVersion }
+
+func (s UsageCostState) String() string { return string(s) }
+
+func (o UsageCostOrigin) String() string { return string(o) }

--- a/domain/types/usage_cost_test.go
+++ b/domain/types/usage_cost_test.go
@@ -1,0 +1,46 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestUsageCost_estimateRequiresVersionAndDiffersFromProviderReported(t *testing.T) {
+	t.Parallel()
+
+	if _, err := types.EstimatedUsageCost(1250, "USD", ""); err == nil {
+		t.Fatal("EstimatedUsageCost without price-table version error = nil")
+	}
+
+	estimated, err := types.EstimatedUsageCost(1250, "USD", "openai-2026-07-01")
+	if err != nil {
+		t.Fatalf("EstimatedUsageCost() error = %v", err)
+	}
+	if estimated.Origin() != types.UsageCostEstimated || estimated.PriceTableVersion() != "openai-2026-07-01" {
+		t.Fatalf("estimated provenance = %q/%q", estimated.Origin(), estimated.PriceTableVersion())
+	}
+
+	provider, err := types.ProviderReportedUsageCost(1250, "USD")
+	if err != nil {
+		t.Fatalf("ProviderReportedUsageCost() error = %v", err)
+	}
+	if provider.Origin() != types.UsageCostProviderReported || provider.PriceTableVersion() != "" {
+		t.Fatalf("provider provenance = %q/%q", provider.Origin(), provider.PriceTableVersion())
+	}
+}
+
+func TestUsageCost_unknownAndUnavailableCarryNoAmount(t *testing.T) {
+	t.Parallel()
+
+	for name, cost := range map[string]types.UsageCost{
+		"unknown":     types.UnknownUsageCost(),
+		"unavailable": types.UnavailableUsageCost(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := cost.AmountMicros(); ok {
+				t.Fatal("AmountMicros() unexpectedly present")
+			}
+		})
+	}
+}

--- a/domain/types/usage_observation.go
+++ b/domain/types/usage_observation.go
@@ -1,0 +1,136 @@
+package types
+
+import (
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// UsageObservationID is the opaque, adapter-defined authoritative identity
+// for one call, run, or snapshot revision.
+type UsageObservationID string
+
+// UsageObservationIDFrom validates an opaque authoritative identity.
+func UsageObservationIDFrom(value string) (UsageObservationID, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", xerrors.Errorf("usage observation ID must not be empty")
+	}
+	if len(trimmed) > 512 {
+		return "", xerrors.Errorf("usage observation ID must not exceed 512 bytes")
+	}
+	return UsageObservationID(trimmed), nil
+}
+
+func (id UsageObservationID) String() string { return string(id) }
+
+// UsageScope is the accounting granularity selected by a host adapter.
+type UsageScope string
+
+const (
+	// UsageScopeCall identifies one provider call.
+	UsageScopeCall UsageScope = "call"
+	// UsageScopeRun identifies one host run summary.
+	UsageScopeRun UsageScope = "run"
+	// UsageScopeSessionSnapshot identifies a cumulative session snapshot.
+	UsageScopeSessionSnapshot UsageScope = "session_snapshot"
+)
+
+// UsageScopeFrom restores a validated usage scope.
+func UsageScopeFrom(value string) (UsageScope, error) {
+	scope := UsageScope(value)
+	switch scope {
+	case UsageScopeCall, UsageScopeRun, UsageScopeSessionSnapshot:
+		return scope, nil
+	default:
+		return "", xerrors.Errorf("unsupported usage scope: %q", value)
+	}
+}
+
+func (s UsageScope) String() string { return string(s) }
+
+// UsageAccounting declares how a finalized observation may participate in an
+// aggregate. Excluded is explicit rather than an overloaded boolean.
+type UsageAccounting string
+
+const (
+	// UsageAccountingAdditive contributes a finalized observation once.
+	UsageAccountingAdditive UsageAccounting = "additive"
+	// UsageAccountingLatestSnapshot selects only the unsuperseded series head.
+	UsageAccountingLatestSnapshot UsageAccounting = "latest_snapshot"
+	// UsageAccountingExcluded retains evidence without contributing to totals.
+	UsageAccountingExcluded UsageAccounting = "excluded"
+)
+
+// UsageAccountingFrom restores a validated accounting mode.
+func UsageAccountingFrom(value string) (UsageAccounting, error) {
+	accounting := UsageAccounting(value)
+	switch accounting {
+	case UsageAccountingAdditive, UsageAccountingLatestSnapshot, UsageAccountingExcluded:
+		return accounting, nil
+	default:
+		return "", xerrors.Errorf("unsupported usage accounting mode: %q", value)
+	}
+}
+
+func (a UsageAccounting) String() string { return string(a) }
+
+// UsageObservationStatus is the durable lifecycle state.
+type UsageObservationStatus string
+
+const (
+	// UsageObservationPending is open for one terminal completion.
+	UsageObservationPending UsageObservationStatus = "pending"
+	// UsageObservationFinalized is immutable terminal accounting.
+	UsageObservationFinalized UsageObservationStatus = "finalized"
+)
+
+// UsageObservationStatusFrom restores a validated lifecycle status.
+func UsageObservationStatusFrom(value string) (UsageObservationStatus, error) {
+	status := UsageObservationStatus(value)
+	switch status {
+	case UsageObservationPending, UsageObservationFinalized:
+		return status, nil
+	default:
+		return "", xerrors.Errorf("unsupported usage observation status: %q", value)
+	}
+}
+
+func (s UsageObservationStatus) String() string { return string(s) }
+
+// UsageSource identifies the versioned, body-free local surface selected by
+// an adapter. Provider and model remain empty when the host did not report them.
+type UsageSource struct {
+	host     string
+	name     string
+	version  string
+	provider string
+	model    string
+}
+
+// UsageSourceOf creates a validated local host-source descriptor.
+func UsageSourceOf(host, name, version, provider, model string) (UsageSource, error) {
+	source := UsageSource{
+		host: strings.TrimSpace(host), name: strings.TrimSpace(name), version: strings.TrimSpace(version),
+		provider: strings.TrimSpace(provider), model: strings.TrimSpace(model),
+	}
+	if source.host == "" || source.name == "" || source.version == "" {
+		return UsageSource{}, xerrors.Errorf("usage source host, name, and version must not be empty")
+	}
+	return source, nil
+}
+
+// Host returns the local AI host name.
+func (s UsageSource) Host() string { return s.host }
+
+// Name returns the selected host surface or capture mode.
+func (s UsageSource) Name() string { return s.name }
+
+// Version returns the verified host source version.
+func (s UsageSource) Version() string { return s.version }
+
+// Provider returns the reported provider, or empty when absent.
+func (s UsageSource) Provider() string { return s.provider }
+
+// Model returns the reported model, or empty when absent.
+func (s UsageSource) Model() string { return s.model }

--- a/domain/types/usage_terminal_code.go
+++ b/domain/types/usage_terminal_code.go
@@ -1,0 +1,41 @@
+package types
+
+import "golang.org/x/xerrors"
+
+// UsageTerminalCode is the privacy-safe closed terminal classification used
+// by usage adapters. Free-form host reasons never cross this boundary.
+type UsageTerminalCode string
+
+const (
+	// UsageTerminalSuccess records normal terminal completion.
+	UsageTerminalSuccess UsageTerminalCode = "success"
+	// UsageTerminalFailure records a terminal failure.
+	UsageTerminalFailure UsageTerminalCode = "failure"
+	// UsageTerminalTimeout records deadline expiration.
+	UsageTerminalTimeout UsageTerminalCode = "timeout"
+	// UsageTerminalSignal records operating-system signal termination.
+	UsageTerminalSignal UsageTerminalCode = "signal"
+	// UsageTerminalAbortedStream records a stream without normal completion.
+	UsageTerminalAbortedStream UsageTerminalCode = "aborted_stream"
+	// UsageTerminalUnknown records a terminal boundary without a safer class.
+	UsageTerminalUnknown UsageTerminalCode = "unknown"
+)
+
+// UsageTerminalCodeFrom restores a validated terminal code.
+func UsageTerminalCodeFrom(value string) (UsageTerminalCode, error) {
+	code := UsageTerminalCode(value)
+	switch code {
+	case UsageTerminalSuccess,
+		UsageTerminalFailure,
+		UsageTerminalTimeout,
+		UsageTerminalSignal,
+		UsageTerminalAbortedStream,
+		UsageTerminalUnknown:
+		return code, nil
+	default:
+		return "", xerrors.Errorf("unsupported usage terminal code: %q", value)
+	}
+}
+
+// String returns the persisted representation.
+func (c UsageTerminalCode) String() string { return string(c) }

--- a/domain/types/usage_value.go
+++ b/domain/types/usage_value.go
@@ -1,0 +1,198 @@
+package types
+
+import "golang.org/x/xerrors"
+
+// UsageValueState describes whether one provider-reported usage dimension has
+// a numeric value. Known zero is distinct from both missing states.
+type UsageValueState string
+
+const (
+	// UsageValueUnknown means the authoritative terminal value is not known yet.
+	UsageValueUnknown UsageValueState = "unknown"
+	// UsageValueUnavailable means the terminal source did not report a value.
+	UsageValueUnavailable UsageValueState = "unavailable"
+	// UsageValueKnown means a non-negative number, including zero, is present.
+	UsageValueKnown UsageValueState = "known"
+)
+
+// UsageAvailability is the derived completeness of a set of usage counters.
+type UsageAvailability string
+
+const (
+	// UsageAvailabilityUnknown means at least one dimension remains open.
+	UsageAvailabilityUnknown UsageAvailability = "unknown"
+	// UsageAvailabilityUnavailable means no dimension has a numeric value.
+	UsageAvailabilityUnavailable UsageAvailability = "unavailable"
+	// UsageAvailabilityPartial means some, but not all, dimensions are known.
+	UsageAvailabilityPartial UsageAvailability = "partial"
+	// UsageAvailabilityAvailable means every dimension is known.
+	UsageAvailabilityAvailable UsageAvailability = "available"
+)
+
+// UsageValue preserves the availability state independently from its value.
+type UsageValue struct {
+	state UsageValueState
+	value int64
+}
+
+// UnknownUsageValue creates a value whose authoritative terminal state is not
+// known yet. It is valid only on pending observations.
+func UnknownUsageValue() UsageValue { return UsageValue{state: UsageValueUnknown} }
+
+// UnavailableUsageValue creates a terminal value for a dimension the source
+// did not report.
+func UnavailableUsageValue() UsageValue { return UsageValue{state: UsageValueUnavailable} }
+
+// KnownUsageValue creates a provider-reported or derived non-negative count.
+// Zero remains an explicit known value.
+func KnownUsageValue(value int64) (UsageValue, error) {
+	if value < 0 {
+		return UsageValue{}, xerrors.Errorf("usage value must not be negative")
+	}
+	return UsageValue{state: UsageValueKnown, value: value}, nil
+}
+
+// UsageValueFrom restores and validates a persisted state/value pair.
+func UsageValueFrom(state string, value Optional[int64]) (UsageValue, error) {
+	switch UsageValueState(state) {
+	case UsageValueUnknown:
+		if _, present := value.Value(); present {
+			return UsageValue{}, xerrors.Errorf("unknown usage value must not carry a number")
+		}
+		return UnknownUsageValue(), nil
+	case UsageValueUnavailable:
+		if _, present := value.Value(); present {
+			return UsageValue{}, xerrors.Errorf("unavailable usage value must not carry a number")
+		}
+		return UnavailableUsageValue(), nil
+	case UsageValueKnown:
+		numeric, present := value.Value()
+		if !present {
+			return UsageValue{}, xerrors.Errorf("known usage value requires a number")
+		}
+		return KnownUsageValue(numeric)
+	default:
+		return UsageValue{}, xerrors.Errorf("unsupported usage value state: %q", state)
+	}
+}
+
+// State returns the explicit availability state.
+func (v UsageValue) State() UsageValueState { return v.state }
+
+// Value returns a numeric value only for the known state.
+func (v UsageValue) Value() (int64, bool) {
+	if v.state != UsageValueKnown {
+		return 0, false
+	}
+	return v.value, true
+}
+
+func (v UsageValue) validate() error {
+	_, err := UsageValueFrom(v.state.String(), optionalUsageValue(v))
+	return err
+}
+
+// String returns the persisted state representation.
+func (s UsageValueState) String() string { return string(s) }
+
+func optionalUsageValue(value UsageValue) Optional[int64] {
+	if numeric, present := value.Value(); present {
+		return Some(numeric)
+	}
+	return None[int64]()
+}
+
+// UsageCounters contains every provider-neutral token dimension. Each
+// dimension keeps its own availability because host contracts are partial.
+type UsageCounters struct {
+	input           UsageValue
+	cachedInput     UsageValue
+	cacheWriteInput UsageValue
+	output          UsageValue
+	reasoningOutput UsageValue
+	total           UsageValue
+}
+
+// UnknownUsageCounters creates the only counter state valid for a pending
+// observation.
+func UnknownUsageCounters() UsageCounters {
+	unknown := UnknownUsageValue()
+	return usageCountersOfUnchecked(unknown, unknown, unknown, unknown, unknown, unknown)
+}
+
+// UsageCountersOf creates a validated counter set.
+func UsageCountersOf(
+	input UsageValue,
+	cachedInput UsageValue,
+	cacheWriteInput UsageValue,
+	output UsageValue,
+	reasoningOutput UsageValue,
+	total UsageValue,
+) (UsageCounters, error) {
+	values := []UsageValue{input, cachedInput, cacheWriteInput, output, reasoningOutput, total}
+	for _, value := range values {
+		if err := value.validate(); err != nil {
+			return UsageCounters{}, xerrors.Errorf("invalid usage counters: %w", err)
+		}
+	}
+	return usageCountersOfUnchecked(input, cachedInput, cacheWriteInput, output, reasoningOutput, total), nil
+}
+
+func usageCountersOfUnchecked(
+	input UsageValue,
+	cachedInput UsageValue,
+	cacheWriteInput UsageValue,
+	output UsageValue,
+	reasoningOutput UsageValue,
+	total UsageValue,
+) UsageCounters {
+	return UsageCounters{
+		input: input, cachedInput: cachedInput, cacheWriteInput: cacheWriteInput,
+		output: output, reasoningOutput: reasoningOutput, total: total,
+	}
+}
+
+// Input returns input-token availability and value.
+func (c UsageCounters) Input() UsageValue { return c.input }
+
+// CachedInput returns cached-input-token availability and value.
+func (c UsageCounters) CachedInput() UsageValue { return c.cachedInput }
+
+// CacheWriteInput returns cache-write-input-token availability and value.
+func (c UsageCounters) CacheWriteInput() UsageValue { return c.cacheWriteInput }
+
+// Output returns output-token availability and value.
+func (c UsageCounters) Output() UsageValue { return c.output }
+
+// ReasoningOutput returns reasoning-output-token availability and value.
+func (c UsageCounters) ReasoningOutput() UsageValue { return c.reasoningOutput }
+
+// Total returns total-token availability and value.
+func (c UsageCounters) Total() UsageValue { return c.total }
+
+// Availability derives source completeness without collapsing unavailable
+// dimensions into numeric zero.
+func (c UsageCounters) Availability() UsageAvailability {
+	values := c.values()
+	known := 0
+	for _, value := range values {
+		if value.State() == UsageValueUnknown {
+			return UsageAvailabilityUnknown
+		}
+		if value.State() == UsageValueKnown {
+			known++
+		}
+	}
+	switch known {
+	case 0:
+		return UsageAvailabilityUnavailable
+	case len(values):
+		return UsageAvailabilityAvailable
+	default:
+		return UsageAvailabilityPartial
+	}
+}
+
+func (c UsageCounters) values() []UsageValue {
+	return []UsageValue{c.input, c.cachedInput, c.cacheWriteInput, c.output, c.reasoningOutput, c.total}
+}

--- a/domain/types/usage_value_test.go
+++ b/domain/types/usage_value_test.go
@@ -1,0 +1,94 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestUsageValue_distinguishesUnknownUnavailableAndKnownZero(t *testing.T) {
+	t.Parallel()
+
+	unknown := types.UnknownUsageValue()
+	if unknown.State() != types.UsageValueUnknown {
+		t.Fatalf("unknown state = %q", unknown.State())
+	}
+	if _, ok := unknown.Value(); ok {
+		t.Fatal("unknown Value() unexpectedly present")
+	}
+
+	unavailable := types.UnavailableUsageValue()
+	if unavailable.State() != types.UsageValueUnavailable {
+		t.Fatalf("unavailable state = %q", unavailable.State())
+	}
+	if _, ok := unavailable.Value(); ok {
+		t.Fatal("unavailable Value() unexpectedly present")
+	}
+
+	zero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatalf("KnownUsageValue(0) error = %v", err)
+	}
+	value, ok := zero.Value()
+	if !ok || value != 0 || zero.State() != types.UsageValueKnown {
+		t.Fatalf("known zero = state %q value %d present %v", zero.State(), value, ok)
+	}
+}
+
+func TestKnownUsageValue_rejectsNegativeValue(t *testing.T) {
+	t.Parallel()
+
+	if _, err := types.KnownUsageValue(-1); err == nil {
+		t.Fatal("KnownUsageValue(-1) error = nil")
+	}
+}
+
+func TestUsageCounters_derivesAvailability(t *testing.T) {
+	t.Parallel()
+
+	knownZero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	knownPositive, err := types.KnownUsageValue(12)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allUnknown := types.UnknownUsageCounters()
+	if got := allUnknown.Availability(); got != types.UsageAvailabilityUnknown {
+		t.Fatalf("unknown availability = %q", got)
+	}
+
+	allUnavailable, err := types.UsageCountersOf(
+		types.UnavailableUsageValue(), types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+		types.UnavailableUsageValue(), types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+	)
+	if err != nil {
+		t.Fatalf("UsageCountersOf(unavailable) error = %v", err)
+	}
+	if got := allUnavailable.Availability(); got != types.UsageAvailabilityUnavailable {
+		t.Fatalf("unavailable availability = %q", got)
+	}
+
+	partial, err := types.UsageCountersOf(
+		knownZero, types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+		knownPositive, types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+	)
+	if err != nil {
+		t.Fatalf("UsageCountersOf(partial) error = %v", err)
+	}
+	if got := partial.Availability(); got != types.UsageAvailabilityPartial {
+		t.Fatalf("partial availability = %q", got)
+	}
+
+	available, err := types.UsageCountersOf(
+		knownZero, knownZero, knownZero, knownZero, knownZero, knownPositive,
+	)
+	if err != nil {
+		t.Fatalf("UsageCountersOf(available) error = %v", err)
+	}
+	if got := available.Availability(); got != types.UsageAvailabilityAvailable {
+		t.Fatalf("available availability = %q", got)
+	}
+}

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -307,6 +307,21 @@ func (t *bundleImportTx) ImportUsageObservation(
 	if observation == nil {
 		return false, model.ErrInvalidUsageObservation
 	}
+	if observation.Descriptor().Scope() == types.UsageScopeSessionSnapshot {
+		if predecessorID, present := observation.Descriptor().SupersedesID().Value(); present {
+			predecessor, err := findUsageObservation(ctx, t.tx, predecessorID)
+			if err != nil {
+				return false, xerrors.Errorf("failed to inspect usage snapshot predecessor: %w", err)
+			}
+			value, found := predecessor.Value()
+			if !found {
+				return false, xerrors.Errorf("usage snapshot predecessor %s is missing: %w", predecessorID, model.ErrConflictingUsageObservation)
+			}
+			if err := observation.ValidateSnapshotSuccessor(value); err != nil {
+				return false, xerrors.Errorf("failed to validate referenced usage snapshot predecessor: %w", err)
+			}
+		}
+	}
 	current, err := findUsageObservation(ctx, t.tx, observation.Descriptor().ObservationID())
 	if err != nil {
 		return false, xerrors.Errorf("failed to inspect usage observation conflict: %w", err)
@@ -336,19 +351,6 @@ func (t *bundleImportTx) ImportUsageObservation(
 	}
 
 	if observation.Descriptor().Scope() == types.UsageScopeSessionSnapshot {
-		if predecessorID, present := observation.Descriptor().SupersedesID().Value(); present {
-			predecessor, err := findUsageObservation(ctx, t.tx, predecessorID)
-			if err != nil {
-				return false, xerrors.Errorf("failed to inspect usage snapshot predecessor: %w", err)
-			}
-			value, found := predecessor.Value()
-			if !found {
-				return false, xerrors.Errorf("usage snapshot predecessor %s is missing: %w", predecessorID, model.ErrConflictingUsageObservation)
-			}
-			if err := observation.ValidateSnapshotSuccessor(value); err != nil {
-				return false, xerrors.Errorf("failed to validate referenced usage snapshot predecessor: %w", err)
-			}
-		}
 		head, err := findUsageSnapshotHead(ctx, t.tx, observation.Descriptor().SnapshotSeries())
 		if err != nil {
 			return false, xerrors.Errorf("failed to inspect usage snapshot series: %w", err)

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -341,7 +341,10 @@ func (t *bundleImportTx) ImportUsageObservation(
 			return false, xerrors.Errorf("failed to inspect usage snapshot series: %w", err)
 		}
 		if err := observation.ValidateSnapshotSuccessor(head); err != nil {
-			if policy == usecase.BundleConflictSkip && errors.Is(err, model.ErrConflictingUsageObservation) {
+			// A missing predecessor means the bundle itself is incomplete; never
+			// turn that structural loss into a successful skip. Skip remains valid
+			// when a complete destination series simply conflicts with this one.
+			if policy == usecase.BundleConflictSkip && head != nil && errors.Is(err, model.ErrConflictingUsageObservation) {
 				return false, nil
 			}
 			return false, xerrors.Errorf("failed to validate usage snapshot successor: %w", err)

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -338,7 +338,7 @@ func (t *bundleImportTx) ImportUsageObservation(
 			return false, nil
 		}
 		if !errors.Is(reconcileErr, model.ErrConflictingUsageObservation) {
-			return false, reconcileErr
+			return false, xerrors.Errorf("failed to reconcile usage observation: %w", reconcileErr)
 		}
 		switch policy {
 		case usecase.BundleConflictSkip:
@@ -346,7 +346,7 @@ func (t *bundleImportTx) ImportUsageObservation(
 		case usecase.BundleConflictReplace:
 			return false, xerrors.Errorf("usage observation replacement is unsafe for immutable accounting evidence: %w", reconcileErr)
 		default:
-			return false, reconcileErr
+			return false, xerrors.Errorf("usage observation conflict: %w", reconcileErr)
 		}
 	}
 

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -228,9 +228,53 @@ SELECT id, from_memory_id, to_memory_id, relation_type, valid_from, valid_to, cr
 	return edges, nil
 }
 
+// ListBundleUsageObservations returns every durable usage observation in a
+// deterministic order that keeps snapshot predecessors before successors.
+func (d *BundleDatasource) ListBundleUsageObservations(ctx context.Context) ([]*model.UsageObservation, error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for bundle usage observation export: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	rows, err := db.QueryContext(ctx, `
+SELECT observation_id, session_id, host, source_name, source_version, provider, model,
+       scope, accounting, status, observed_at, finalized_at, terminal_code,
+       input_state, input_tokens, cached_input_state, cached_input_tokens,
+       cache_write_input_state, cache_write_input_tokens, output_state, output_tokens,
+       reasoning_output_state, reasoning_output_tokens, total_state, total_tokens,
+       cost_state, cost_amount_micros, cost_currency, cost_origin, price_table_version,
+       snapshot_series, snapshot_revision, supersedes_id
+  FROM usage_observations
+ ORDER BY COALESCE(snapshot_series, ''), COALESCE(snapshot_revision, 0), observation_id`)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query usage observations for bundle export: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	observations := []*model.UsageObservation{}
+	for rows.Next() {
+		observation, err := scanUsageObservation(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to scan bundle usage observation row: %w", err)
+		}
+		observations = append(observations, observation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate bundle usage observation rows: %w", err)
+	}
+	return observations, nil
+}
+
 // BeginBundleImport starts the transaction shared by every table
-// importer in a bundle (sessions, events, command_audits, memories,
-// and memory_edges).
+// importer in a bundle (sessions, usage_observations, events,
+// command_audits, memories, and memory_edges).
 func (d *BundleDatasource) BeginBundleImport(ctx context.Context) (usecase.BundleImportTransaction, error) {
 	db, err := d.db.open(ctx)
 	if err != nil {
@@ -249,6 +293,64 @@ func (d *BundleDatasource) BeginBundleImport(ctx context.Context) (usecase.Bundl
 type bundleImportTx struct {
 	db *sql.DB
 	tx *sql.Tx
+}
+
+// ImportUsageObservation converges exact replays and pending-to-finalized
+// transitions without allowing bundle conflict policy to rewrite immutable
+// accounting evidence. Conflicting snapshots may be skipped, but replace is
+// rejected because it could invalidate an existing snapshot chain.
+func (t *bundleImportTx) ImportUsageObservation(
+	ctx context.Context,
+	observation *model.UsageObservation,
+	policy usecase.BundleConflictPolicy,
+) (bool, error) {
+	if observation == nil {
+		return false, model.ErrInvalidUsageObservation
+	}
+	current, err := findUsageObservation(ctx, t.tx, observation.Descriptor().ObservationID())
+	if err != nil {
+		return false, xerrors.Errorf("failed to inspect usage observation conflict: %w", err)
+	}
+	if existing, present := current.Value(); present {
+		transition, reconcileErr := existing.Reconcile(observation)
+		if reconcileErr == nil {
+			if transition == model.UsageObservationTransitionApplied {
+				if err := updateFinalizedUsageObservation(ctx, t.tx, existing); err != nil {
+					return false, xerrors.Errorf("failed to import usage finalization: %w", err)
+				}
+				return true, nil
+			}
+			return false, nil
+		}
+		if !errors.Is(reconcileErr, model.ErrConflictingUsageObservation) {
+			return false, reconcileErr
+		}
+		switch policy {
+		case usecase.BundleConflictSkip:
+			return false, nil
+		case usecase.BundleConflictReplace:
+			return false, xerrors.Errorf("usage observation replacement is unsafe for immutable accounting evidence: %w", reconcileErr)
+		default:
+			return false, reconcileErr
+		}
+	}
+
+	if observation.Descriptor().Scope() == types.UsageScopeSessionSnapshot {
+		head, err := findUsageSnapshotHead(ctx, t.tx, observation.Descriptor().SnapshotSeries())
+		if err != nil {
+			return false, xerrors.Errorf("failed to inspect usage snapshot series: %w", err)
+		}
+		if err := observation.ValidateSnapshotSuccessor(head); err != nil {
+			if policy == usecase.BundleConflictSkip && errors.Is(err, model.ErrConflictingUsageObservation) {
+				return false, nil
+			}
+			return false, xerrors.Errorf("failed to validate usage snapshot successor: %w", err)
+		}
+	}
+	if err := insertUsageObservation(ctx, t.tx, observation); err != nil {
+		return false, xerrors.Errorf("failed to import usage observation: %w", err)
+	}
+	return true, nil
 }
 
 // ImportSession inserts or replaces the session according to policy. Missing

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -336,6 +336,19 @@ func (t *bundleImportTx) ImportUsageObservation(
 	}
 
 	if observation.Descriptor().Scope() == types.UsageScopeSessionSnapshot {
+		if predecessorID, present := observation.Descriptor().SupersedesID().Value(); present {
+			predecessor, err := findUsageObservation(ctx, t.tx, predecessorID)
+			if err != nil {
+				return false, xerrors.Errorf("failed to inspect usage snapshot predecessor: %w", err)
+			}
+			value, found := predecessor.Value()
+			if !found {
+				return false, xerrors.Errorf("usage snapshot predecessor %s is missing: %w", predecessorID, model.ErrConflictingUsageObservation)
+			}
+			if err := observation.ValidateSnapshotSuccessor(value); err != nil {
+				return false, xerrors.Errorf("failed to validate referenced usage snapshot predecessor: %w", err)
+			}
+		}
 		head, err := findUsageSnapshotHead(ctx, t.tx, observation.Descriptor().SnapshotSeries())
 		if err != nil {
 			return false, xerrors.Errorf("failed to inspect usage snapshot series: %w", err)

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -309,4 +309,74 @@ func TestBundleDatasource_UsageObservationsPreserveSnapshotChainAndRejectReplace
 	if err := conflictTx.Rollback(ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	missingTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingID, _ := types.UsageObservationIDFrom("usage-missing-predecessor")
+	missingPredecessorID, _ := types.UsageObservationIDFrom("not-in-bundle-or-store")
+	missingDescriptor, err := model.NewUsageSnapshotDescriptor(
+		missingID, types.SessionID("session-1"), source, "missing-series", 3,
+		types.Some(missingPredecessorID), ts.Add(3*time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing, err := model.NewFinalizedUsageObservation(
+		missingDescriptor, root.Counters(), types.UnavailableUsageCost(), types.UsageTerminalSuccess,
+		missingDescriptor.ObservedAt().Add(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := missingTx.ImportUsageObservation(ctx, missing, usecase.BundleConflictSkip); err == nil || imported {
+		_ = missingTx.Rollback(ctx)
+		t.Fatalf("missing predecessor import = %t/%v, want fail closed", imported, err)
+	}
+	if err := missingTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBundleDatasource_LaterTableFailureRollsBackImportedUsageObservation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := sqlite.NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	bundles := sqlite.NewBundleDatasource(db, sqlite.NewEventDatasource(db))
+	tx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := sqliteFinalizedUsage(t, sqliteUsageDescriptor(t, "usage-rolled-back"), 10)
+	if imported, err := tx.ImportUsageObservation(ctx, observation, usecase.BundleConflictSkip); err != nil || !imported {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("ImportUsageObservation() = %t/%v", imported, err)
+	}
+	eventID, err := types.EventIDFrom("missing-event")
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit, err := model.NewCommandAudit(eventID, "go test ./...", "", "", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := tx.ImportCommandAudit(ctx, audit, usecase.BundleConflictSkip); err == nil || imported {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("ImportCommandAudit() = %t/%v, want failure", imported, err)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := sqlite.NewUsageObservationDatasource(db).FindByID(ctx, observation.Descriptor().ObservationID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := stored.Value(); present {
+		t.Fatal("usage observation survived rolled-back bundle transaction")
+	}
 }

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -337,6 +337,19 @@ func TestBundleDatasource_UsageObservationsPreserveSnapshotChainAndRejectReplace
 	if err := missingTx.Rollback(ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	missingWithHeadTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingWithHead := makeSnapshot("usage-missing-predecessor-with-head", 3, "absent-from-existing-series", 30)
+	if imported, err := missingWithHeadTx.ImportUsageObservation(ctx, missingWithHead, usecase.BundleConflictSkip); err == nil || imported {
+		_ = missingWithHeadTx.Rollback(ctx)
+		t.Fatalf("missing predecessor with destination head import = %t/%v, want fail closed", imported, err)
+	}
+	if err := missingWithHeadTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBundleDatasource_LaterTableFailureRollsBackImportedUsageObservation(t *testing.T) {

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -350,6 +350,19 @@ func TestBundleDatasource_UsageObservationsPreserveSnapshotChainAndRejectReplace
 	if err := missingWithHeadTx.Rollback(ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	sameIDMissingTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sameIDMissing := makeSnapshot("usage-successor", 2, "absent-same-id-predecessor", 20)
+	if imported, err := sameIDMissingTx.ImportUsageObservation(ctx, sameIDMissing, usecase.BundleConflictSkip); err == nil || imported {
+		_ = sameIDMissingTx.Rollback(ctx)
+		t.Fatalf("same-ID missing predecessor import = %t/%v, want fail closed", imported, err)
+	}
+	if err := sameIDMissingTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBundleDatasource_LaterTableFailureRollsBackImportedUsageObservation(t *testing.T) {

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -208,3 +208,105 @@ func TestBundleDatasource_ImportSessionBackfillsMissingParent(t *testing.T) {
 		t.Fatalf("parent label = %q, want marker", got)
 	}
 }
+
+func TestBundleDatasource_UsageObservationsPreserveSnapshotChainAndRejectReplace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := sqlite.NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	bundles := sqlite.NewBundleDatasource(db, sqlite.NewEventDatasource(db))
+	source, err := types.UsageSourceOf("codex", "headless_stream", "0.31.0", "openai", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	makeSnapshot := func(id string, revision int64, predecessor string, inputTokens int64) *model.UsageObservation {
+		observationID, err := types.UsageObservationIDFrom(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		supersedes := types.None[types.UsageObservationID]()
+		if predecessor != "" {
+			value, err := types.UsageObservationIDFrom(predecessor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			supersedes = types.Some(value)
+		}
+		descriptor, err := model.NewUsageSnapshotDescriptor(
+			observationID, types.SessionID("session-1"), source, "codex:session-1", revision, supersedes, ts.Add(time.Duration(revision)*time.Minute),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		input, err := types.KnownUsageValue(inputTokens)
+		if err != nil {
+			t.Fatal(err)
+		}
+		unavailable := types.UnavailableUsageValue()
+		counters, err := types.UsageCountersOf(input, unavailable, unavailable, unavailable, unavailable, input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		observation, err := model.NewFinalizedUsageObservation(
+			descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalSuccess,
+			descriptor.ObservedAt().Add(time.Second),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return observation
+	}
+	root := makeSnapshot("usage-root", 1, "", 10)
+	successor := makeSnapshot("usage-successor", 2, "usage-root", 20)
+	tx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, observation := range []*model.UsageObservation{root, successor} {
+		imported, err := tx.ImportUsageObservation(ctx, observation, usecase.BundleConflictSkip)
+		if err != nil || !imported {
+			_ = tx.Rollback(ctx)
+			t.Fatalf("ImportUsageObservation(%s) = %t/%v", observation.Descriptor().ObservationID(), imported, err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := bundles.ListBundleUsageObservations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 2 || listed[0].Descriptor().ObservationID().String() != "usage-root" || listed[1].Descriptor().ObservationID().String() != "usage-successor" {
+		t.Fatalf("listed snapshot order = %#v", listed)
+	}
+
+	replayTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := replayTx.ImportUsageObservation(ctx, successor, usecase.BundleConflictSkip); err != nil || imported {
+		_ = replayTx.Rollback(ctx)
+		t.Fatalf("exact replay = %t/%v, want skipped", imported, err)
+	}
+	if err := replayTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	conflictTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = conflictTx.ImportUsageObservation(ctx, makeSnapshot("usage-successor", 2, "usage-root", 99), usecase.BundleConflictReplace)
+	if err == nil || !errors.Is(err, model.ErrConflictingUsageObservation) {
+		_ = conflictTx.Rollback(ctx)
+		t.Fatalf("conflicting replacement error = %v, want ErrConflictingUsageObservation", err)
+	}
+	if err := conflictTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -70,7 +70,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	tables := []string{"events", "command_audits", "sessions", "schema_migrations"}
+	tables := []string{"events", "command_audits", "sessions", "usage_observations", "schema_migrations"}
 	for _, table := range tables {
 		var count int
 		if err := db.QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&count); err != nil {
@@ -92,6 +92,53 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	}
 
 	assertSessionSpawnMetadataSchema(t, db)
+}
+
+func TestMigrations_usageObservationsAreAdditiveAndPreserveExistingRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	preV027 := onDiskSQLiteMigrationsBefore(t, 27)
+	store := newStoreManagementDatasource(t, dbPath, preV027)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-v027) error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions(session_id, started_at, client, agent, workspace, label, summary, model, runtime_mode)
+		VALUES ('existing-session', '2026-07-23T10:00:00Z', 'hook', 'codex', '/repo', 'keep-label', 'keep-summary', 'model-1', 'interactive')`); err != nil {
+		t.Fatalf("insert existing session: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO events(id, kind, agent, session_id, body, created_at, client, workspace, body_availability)
+		VALUES ('existing-event', 'note', 'codex', 'existing-session', 'keep-body', '2026-07-23T10:01:00Z', 'hook', '/repo', 'available')`); err != nil {
+		t.Fatalf("insert existing event: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store = newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(v027) error = %v", err)
+	}
+	db, err = sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var label, summary, body string
+	if err := db.QueryRow(`SELECT label, summary FROM sessions WHERE session_id = 'existing-session'`).Scan(&label, &summary); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT body FROM events WHERE id = 'existing-event'`).Scan(&body); err != nil {
+		t.Fatal(err)
+	}
+	if label != "keep-label" || summary != "keep-summary" || body != "keep-body" {
+		t.Fatalf("existing rows changed: label=%q summary=%q body=%q", label, summary, body)
+	}
 }
 
 func TestMigrations_hookDeliveryAttemptsBackfillBodyFreeDenominator(t *testing.T) {

--- a/infrastructure/sqlite/usage_observation_datasource.go
+++ b/infrastructure/sqlite/usage_observation_datasource.go
@@ -1,0 +1,447 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const selectUsageObservation = `
+SELECT observation_id, session_id, host, source_name, source_version, provider, model,
+       scope, accounting, status, observed_at, finalized_at, terminal_code,
+       input_state, input_tokens, cached_input_state, cached_input_tokens,
+       cache_write_input_state, cache_write_input_tokens, output_state, output_tokens,
+       reasoning_output_state, reasoning_output_tokens, total_state, total_tokens,
+       cost_state, cost_amount_micros, cost_currency, cost_origin, price_table_version,
+       snapshot_series, snapshot_revision, supersedes_id
+  FROM usage_observations
+ WHERE observation_id = ?`
+
+// UsageObservationDatasource persists usage observations with serialized
+// write transitions and immutable snapshot chains.
+type UsageObservationDatasource struct {
+	db *Database
+}
+
+// NewUsageObservationDatasource creates a usage observation datasource.
+func NewUsageObservationDatasource(db *Database) *UsageObservationDatasource {
+	return &UsageObservationDatasource{db: db}
+}
+
+var _ model.UsageObservationRepository = (*UsageObservationDatasource)(nil)
+
+// Record inserts or idempotently finalizes one authoritative observation.
+func (d *UsageObservationDatasource) Record(
+	ctx context.Context,
+	observation *model.UsageObservation,
+) (transition model.UsageObservationTransition, err error) {
+	if observation == nil {
+		return "", model.ErrInvalidUsageObservation
+	}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return "", xerrors.Errorf("failed to open DB for usage observation record: %w", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("failed to close DB after usage observation record: %w", closeErr)
+		}
+	}()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", xerrors.Errorf("failed to acquire usage observation connection: %w", err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil && err == nil {
+			err = xerrors.Errorf("failed to close usage observation connection: %w", closeErr)
+		}
+	}()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return "", xerrors.Errorf("failed to begin usage observation transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if _, rollbackErr := conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK"); rollbackErr != nil {
+			slog.Debug("failed to roll back usage observation transaction", "error", rollbackErr)
+		}
+	}()
+
+	current, err := findUsageObservation(ctx, conn, observation.Descriptor().ObservationID())
+	if err != nil {
+		return "", xerrors.Errorf("failed to inspect existing usage observation: %w", err)
+	}
+	if existing, present := current.Value(); present {
+		transition, err = existing.Reconcile(observation)
+		if err != nil {
+			return "", xerrors.Errorf("failed to reconcile usage observation: %w", err)
+		}
+		if transition == model.UsageObservationTransitionApplied {
+			if err := updateFinalizedUsageObservation(ctx, conn, existing); err != nil {
+				return "", xerrors.Errorf("failed to apply usage finalization: %w", err)
+			}
+		}
+	} else {
+		if observation.Descriptor().Scope() == types.UsageScopeSessionSnapshot {
+			head, err := findUsageSnapshotHead(ctx, conn, observation.Descriptor().SnapshotSeries())
+			if err != nil {
+				return "", xerrors.Errorf("failed to inspect usage snapshot series: %w", err)
+			}
+			if err := observation.ValidateSnapshotSuccessor(head); err != nil {
+				return "", xerrors.Errorf("failed to validate usage snapshot successor: %w", err)
+			}
+		}
+		if err := insertUsageObservation(ctx, conn, observation); err != nil {
+			return "", xerrors.Errorf("failed to record new usage observation: %w", err)
+		}
+		transition = model.UsageObservationTransitionApplied
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return "", xerrors.Errorf("failed to commit usage observation transaction: %w", err)
+	}
+	committed = true
+	return transition, nil
+}
+
+// FindByID restores an observation by authoritative identity.
+func (d *UsageObservationDatasource) FindByID(
+	ctx context.Context,
+	observationID types.UsageObservationID,
+) (types.Optional[*model.UsageObservation], error) {
+	if _, err := types.UsageObservationIDFrom(observationID.String()); err != nil {
+		return types.None[*model.UsageObservation](), xerrors.Errorf("invalid usage observation lookup identity: %w", err)
+	}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return types.None[*model.UsageObservation](), xerrors.Errorf("failed to open DB for usage observation lookup: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+	observation, err := findUsageObservation(ctx, db, observationID)
+	if err != nil {
+		return types.None[*model.UsageObservation](), xerrors.Errorf("failed to find usage observation: %w", err)
+	}
+	return observation, nil
+}
+
+type usageRowScanner interface {
+	Scan(dest ...any) error
+}
+
+type usageQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type usageExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func findUsageObservation(
+	ctx context.Context,
+	queryer usageQueryer,
+	observationID types.UsageObservationID,
+) (types.Optional[*model.UsageObservation], error) {
+	observation, err := scanUsageObservation(queryer.QueryRowContext(ctx, selectUsageObservation, observationID.String()))
+	if errors.Is(err, sql.ErrNoRows) {
+		return types.None[*model.UsageObservation](), nil
+	}
+	if err != nil {
+		return types.None[*model.UsageObservation](), xerrors.Errorf("failed to restore usage observation: %w", err)
+	}
+	return types.Some(observation), nil
+}
+
+func findUsageSnapshotHead(ctx context.Context, queryer usageQueryer, series string) (*model.UsageObservation, error) {
+	const query = `
+SELECT COUNT(*), COALESCE(MAX(candidate.observation_id), '')
+  FROM usage_observations AS candidate
+ WHERE candidate.snapshot_series = ?
+   AND NOT EXISTS (
+       SELECT 1 FROM usage_observations AS successor
+        WHERE successor.supersedes_id = candidate.observation_id
+   )`
+	var count int
+	var observationID string
+	if err := queryer.QueryRowContext(ctx, query, series).Scan(&count, &observationID); err != nil {
+		return nil, xerrors.Errorf("failed to inspect usage snapshot head: %w", err)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	if count != 1 {
+		return nil, xerrors.Errorf("usage snapshot series %q has %d heads: %w", series, count, model.ErrConflictingUsageObservation)
+	}
+	id, err := types.UsageObservationIDFrom(observationID)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid usage snapshot head identity: %w", err)
+	}
+	head, err := findUsageObservation(ctx, queryer, id)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load usage snapshot head: %w", err)
+	}
+	value, present := head.Value()
+	if !present {
+		return nil, xerrors.Errorf("usage snapshot head disappeared: %w", model.ErrConflictingUsageObservation)
+	}
+	return value, nil
+}
+
+func scanUsageObservation(row usageRowScanner) (*model.UsageObservation, error) {
+	var (
+		observationID, sessionID, host, sourceName, sourceVersion string
+		provider, modelName, finalizedAt, terminalCode            sql.NullString
+		scope, accounting, status, observedAt                     string
+		inputState, cachedInputState, cacheWriteInputState        string
+		outputState, reasoningOutputState, totalState             string
+		inputTokens, cachedInputTokens, cacheWriteInputTokens     sql.NullInt64
+		outputTokens, reasoningOutputTokens, totalTokens          sql.NullInt64
+		costState                                                 string
+		costAmount                                                sql.NullInt64
+		costCurrency, costOrigin, priceTableVersion               sql.NullString
+		snapshotSeries, supersedesID                              sql.NullString
+		snapshotRevision                                          sql.NullInt64
+	)
+	if err := row.Scan(
+		&observationID, &sessionID, &host, &sourceName, &sourceVersion, &provider, &modelName,
+		&scope, &accounting, &status, &observedAt, &finalizedAt, &terminalCode,
+		&inputState, &inputTokens, &cachedInputState, &cachedInputTokens,
+		&cacheWriteInputState, &cacheWriteInputTokens, &outputState, &outputTokens,
+		&reasoningOutputState, &reasoningOutputTokens, &totalState, &totalTokens,
+		&costState, &costAmount, &costCurrency, &costOrigin, &priceTableVersion,
+		&snapshotSeries, &snapshotRevision, &supersedesID,
+	); err != nil {
+		return nil, xerrors.Errorf("failed to scan usage observation row: %w", err)
+	}
+
+	id, err := types.UsageObservationIDFrom(observationID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage observation ID: %w", err)
+	}
+	sid, err := types.SessionIDFrom(sessionID)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage session ID: %w", err)
+	}
+	source, err := types.UsageSourceOf(host, sourceName, sourceVersion, provider.String, modelName.String)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage source: %w", err)
+	}
+	observedTime, err := time.Parse(time.RFC3339Nano, observedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid usage observed_at: %w", err)
+	}
+	resolvedScope, err := types.UsageScopeFrom(scope)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage scope: %w", err)
+	}
+	resolvedAccounting, err := types.UsageAccountingFrom(accounting)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage accounting: %w", err)
+	}
+
+	var descriptor model.UsageObservationDescriptor
+	if resolvedScope == types.UsageScopeSessionSnapshot {
+		predecessor := types.None[types.UsageObservationID]()
+		if supersedesID.Valid {
+			value, err := types.UsageObservationIDFrom(supersedesID.String)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to restore superseded usage observation ID: %w", err)
+			}
+			predecessor = types.Some(value)
+		}
+		if !snapshotRevision.Valid {
+			return nil, xerrors.Errorf("usage snapshot revision is missing")
+		}
+		descriptor, err = model.NewUsageSnapshotDescriptor(
+			id, sid, source, snapshotSeries.String, snapshotRevision.Int64, predecessor, observedTime,
+		)
+	} else {
+		descriptor, err = model.NewUsageObservationDescriptor(id, sid, source, resolvedScope, resolvedAccounting, observedTime)
+	}
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage observation descriptor: %w", err)
+	}
+
+	counters, err := restoreUsageCounters(
+		inputState, inputTokens, cachedInputState, cachedInputTokens,
+		cacheWriteInputState, cacheWriteInputTokens, outputState, outputTokens,
+		reasoningOutputState, reasoningOutputTokens, totalState, totalTokens,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage counters: %w", err)
+	}
+	cost, err := types.UsageCostFrom(
+		costState, optionalInt64(costAmount), costCurrency.String, costOrigin.String, priceTableVersion.String,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage cost: %w", err)
+	}
+	resolvedStatus, err := types.UsageObservationStatusFrom(status)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage observation status: %w", err)
+	}
+	resolvedTerminal := types.None[types.UsageTerminalCode]()
+	if terminalCode.Valid {
+		code, err := types.UsageTerminalCodeFrom(terminalCode.String)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore usage terminal code: %w", err)
+		}
+		resolvedTerminal = types.Some(code)
+	}
+	resolvedFinalizedAt := types.None[time.Time]()
+	if finalizedAt.Valid {
+		value, err := time.Parse(time.RFC3339Nano, finalizedAt.String)
+		if err != nil {
+			return nil, xerrors.Errorf("invalid usage finalized_at: %w", err)
+		}
+		resolvedFinalizedAt = types.Some(value)
+	}
+	observation, err := model.UsageObservationOf(descriptor, resolvedStatus, counters, cost, resolvedTerminal, resolvedFinalizedAt)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to restore usage observation aggregate: %w", err)
+	}
+	return observation, nil
+}
+
+func restoreUsageCounters(values ...any) (types.UsageCounters, error) {
+	if len(values) != 12 {
+		return types.UsageCounters{}, xerrors.Errorf("usage counter row requires 12 values")
+	}
+	restored := make([]types.UsageValue, 0, 6)
+	for index := 0; index < len(values); index += 2 {
+		state, stateOK := values[index].(string)
+		numeric, numericOK := values[index+1].(sql.NullInt64)
+		if !stateOK || !numericOK {
+			return types.UsageCounters{}, xerrors.Errorf("invalid usage counter row types")
+		}
+		value, err := types.UsageValueFrom(state, optionalInt64(numeric))
+		if err != nil {
+			return types.UsageCounters{}, xerrors.Errorf("failed to restore usage counter %d: %w", index/2, err)
+		}
+		restored = append(restored, value)
+	}
+	counters, err := types.UsageCountersOf(restored[0], restored[1], restored[2], restored[3], restored[4], restored[5])
+	if err != nil {
+		return types.UsageCounters{}, xerrors.Errorf("failed to validate restored usage counters: %w", err)
+	}
+	return counters, nil
+}
+
+func optionalInt64(value sql.NullInt64) types.Optional[int64] {
+	if value.Valid {
+		return types.Some(value.Int64)
+	}
+	return types.None[int64]()
+}
+
+func insertUsageObservation(ctx context.Context, exec usageExecer, observation *model.UsageObservation) error {
+	const query = `
+INSERT INTO usage_observations (
+    observation_id, session_id, host, source_name, source_version, provider, model,
+    scope, accounting, status, observed_at, finalized_at, terminal_code,
+    input_state, input_tokens, cached_input_state, cached_input_tokens,
+    cache_write_input_state, cache_write_input_tokens, output_state, output_tokens,
+    reasoning_output_state, reasoning_output_tokens, total_state, total_tokens,
+    cost_state, cost_amount_micros, cost_currency, cost_origin, price_table_version,
+    snapshot_series, snapshot_revision, supersedes_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	args := usageObservationArgs(observation)
+	if _, err := exec.ExecContext(ctx, query, args...); err != nil {
+		return xerrors.Errorf("failed to insert usage observation: %w", err)
+	}
+	return nil
+}
+
+func updateFinalizedUsageObservation(ctx context.Context, exec usageExecer, observation *model.UsageObservation) error {
+	const query = `
+UPDATE usage_observations
+   SET status = ?, finalized_at = ?, terminal_code = ?,
+       input_state = ?, input_tokens = ?, cached_input_state = ?, cached_input_tokens = ?,
+       cache_write_input_state = ?, cache_write_input_tokens = ?, output_state = ?, output_tokens = ?,
+       reasoning_output_state = ?, reasoning_output_tokens = ?, total_state = ?, total_tokens = ?,
+       cost_state = ?, cost_amount_micros = ?, cost_currency = ?, cost_origin = ?, price_table_version = ?
+ WHERE observation_id = ? AND status = 'pending'`
+	args := usageFinalizationArgs(observation)
+	args = append(args, observation.Descriptor().ObservationID().String())
+	result, err := exec.ExecContext(ctx, query, args...)
+	if err != nil {
+		return xerrors.Errorf("failed to finalize usage observation: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to inspect usage finalization: %w", err)
+	}
+	if updated != 1 {
+		return xerrors.Errorf("usage observation finalization updated %d rows: %w", updated, model.ErrConflictingUsageObservation)
+	}
+	return nil
+}
+
+func usageObservationArgs(observation *model.UsageObservation) []any {
+	descriptor := observation.Descriptor()
+	source := descriptor.Source()
+	args := []any{
+		descriptor.ObservationID().String(), descriptor.SessionID().String(), source.Host(), source.Name(), source.Version(),
+		nullableString(source.Provider()), nullableString(source.Model()), descriptor.Scope().String(), descriptor.Accounting().String(),
+		observation.Status().String(), formatTimestamp(descriptor.ObservedAt()),
+	}
+	args = append(args, usageFinalizationArgs(observation)[1:]...)
+	args = append(args, nullableString(descriptor.SnapshotSeries()))
+	if descriptor.SnapshotRevision() > 0 {
+		args = append(args, descriptor.SnapshotRevision())
+	} else {
+		args = append(args, nil)
+	}
+	if predecessor, present := descriptor.SupersedesID().Value(); present {
+		args = append(args, predecessor.String())
+	} else {
+		args = append(args, nil)
+	}
+	return args
+}
+
+func usageFinalizationArgs(observation *model.UsageObservation) []any {
+	args := []any{observation.Status().String()}
+	if finalizedAt, present := observation.FinalizedAt().Value(); present {
+		args = append(args, formatTimestamp(finalizedAt))
+	} else {
+		args = append(args, nil)
+	}
+	if terminalCode, present := observation.TerminalCode().Value(); present {
+		args = append(args, terminalCode.String())
+	} else {
+		args = append(args, nil)
+	}
+	for _, value := range []types.UsageValue{
+		observation.Counters().Input(), observation.Counters().CachedInput(), observation.Counters().CacheWriteInput(),
+		observation.Counters().Output(), observation.Counters().ReasoningOutput(), observation.Counters().Total(),
+	} {
+		args = append(args, value.State().String())
+		if numeric, present := value.Value(); present {
+			args = append(args, numeric)
+		} else {
+			args = append(args, nil)
+		}
+	}
+	cost := observation.Cost()
+	args = append(args, cost.State().String())
+	if amount, present := cost.AmountMicros(); present {
+		args = append(args, amount, cost.Currency(), cost.Origin().String(), nullableString(cost.PriceTableVersion()))
+	} else {
+		args = append(args, nil, nil, nil, nil)
+	}
+	return args
+}

--- a/infrastructure/sqlite/usage_observation_datasource_test.go
+++ b/infrastructure/sqlite/usage_observation_datasource_test.go
@@ -283,6 +283,14 @@ func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
 	}); err == nil {
 		t.Fatal("estimated cost with a blank price-table version was inserted")
 	}
+	for _, whitespace := range []string{"\t", "\n", " \t\r\n "} {
+		if err := insertRawFinalizedUsage(db, rawUsageRow{
+			id: "invalid-ascii-whitespace-estimate-version-" + fmt.Sprintf("%x", whitespace), scope: "call", accounting: "additive",
+			costState: "known", costAmount: 1, costCurrency: "USD", costOrigin: "estimated", priceVersion: whitespace,
+		}); err == nil {
+			t.Fatalf("estimated cost with ASCII-whitespace price-table version %q was inserted", whitespace)
+		}
+	}
 	if err := insertRawFinalizedUsage(db, rawUsageRow{
 		id: "invalid-null-snapshot", scope: "session_snapshot", accounting: "latest_snapshot",
 		costState: "unavailable",
@@ -294,6 +302,9 @@ func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
 		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 1,
 	}); err != nil {
 		t.Fatalf("valid snapshot root insert error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE usage_observations SET session_id = 'session-2' WHERE observation_id = 'series-a-1'`); err == nil {
+		t.Fatal("immutable snapshot descriptor was updated")
 	}
 	if err := insertRawFinalizedUsage(db, rawUsageRow{
 		id: "series-a-second-root", scope: "session_snapshot", accounting: "latest_snapshot",
@@ -308,6 +319,18 @@ func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
 		t.Fatal("cross-series snapshot predecessor was inserted")
 	}
 	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-a-cross-session", sessionID: "session-2", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 2, supersedesID: "series-a-1",
+	}); err == nil {
+		t.Fatal("cross-session snapshot predecessor was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-a-cross-source", sourceVersion: "2.0.0", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 2, supersedesID: "series-a-1",
+	}); err == nil {
+		t.Fatal("cross-source snapshot predecessor was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
 		id: "series-a-0", scope: "session_snapshot", accounting: "latest_snapshot",
 		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 0, supersedesID: "series-a-1",
 	}); err == nil {
@@ -317,6 +340,8 @@ func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
 
 type rawUsageRow struct {
 	id               string
+	sessionID        string
+	sourceVersion    string
 	scope            string
 	accounting       string
 	costState        string
@@ -330,6 +355,14 @@ type rawUsageRow struct {
 }
 
 func insertRawFinalizedUsage(db *sql.DB, row rawUsageRow) error {
+	sessionID := row.sessionID
+	if sessionID == "" {
+		sessionID = "session-1"
+	}
+	sourceVersion := row.sourceVersion
+	if sourceVersion == "" {
+		sourceVersion = "1.0.0"
+	}
 	_, err := db.Exec(`
 INSERT INTO usage_observations (
     observation_id, session_id, host, source_name, source_version,
@@ -338,11 +371,11 @@ INSERT INTO usage_observations (
     output_state, reasoning_output_state, total_state,
     cost_state, cost_amount_micros, cost_currency, cost_origin, price_table_version,
     snapshot_series, snapshot_revision, supersedes_id
-) VALUES (?, 'session-1', 'test-host', 'test-source', '1.0.0',
+) VALUES (?, ?, 'test-host', 'test-source', ?,
     ?, ?, 'finalized', '2026-07-23T12:00:00Z', '2026-07-23T12:01:00Z', 'success',
     'unavailable', 'unavailable', 'unavailable', 'unavailable', 'unavailable', 'unavailable',
     ?, ?, ?, ?, ?, ?, ?, ?)`,
-		row.id, row.scope, row.accounting,
+		row.id, sessionID, sourceVersion, row.scope, row.accounting,
 		row.costState, row.costAmount, row.costCurrency, row.costOrigin, row.priceVersion,
 		row.snapshotSeries, row.snapshotRevision, row.supersedesID,
 	)

--- a/infrastructure/sqlite/usage_observation_datasource_test.go
+++ b/infrastructure/sqlite/usage_observation_datasource_test.go
@@ -272,6 +272,18 @@ func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
 		t.Fatal("known cost without currency/origin was inserted")
 	}
 	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "invalid-null-estimate-version", scope: "call", accounting: "additive",
+		costState: "known", costAmount: 1, costCurrency: "USD", costOrigin: "estimated",
+	}); err == nil {
+		t.Fatal("estimated cost with a NULL price-table version was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "invalid-blank-estimate-version", scope: "call", accounting: "additive",
+		costState: "known", costAmount: 1, costCurrency: "USD", costOrigin: "estimated", priceVersion: "   ",
+	}); err == nil {
+		t.Fatal("estimated cost with a blank price-table version was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
 		id: "invalid-null-snapshot", scope: "session_snapshot", accounting: "latest_snapshot",
 		costState: "unavailable",
 	}); err == nil {

--- a/infrastructure/sqlite/usage_observation_datasource_test.go
+++ b/infrastructure/sqlite/usage_observation_datasource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -247,6 +248,96 @@ func TestUsageObservationDatasource_RecordRejectsConcurrentConflictingFinals(t *
 	if applied != 1 || conflicts != 1 {
 		t.Fatalf("applied/conflicts = %d/%d", applied, conflicts)
 	}
+}
+
+func TestUsageObservationMigration_RejectsMalformedDirectRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "invalid-known-cost", scope: "call", accounting: "additive",
+		costState: "known", costAmount: 1,
+	}); err == nil {
+		t.Fatal("known cost without currency/origin was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "invalid-null-snapshot", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable",
+	}); err == nil {
+		t.Fatal("snapshot without series/revision was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-a-1", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 1,
+	}); err != nil {
+		t.Fatalf("valid snapshot root insert error = %v", err)
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-a-second-root", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 2,
+	}); err == nil {
+		t.Fatal("second snapshot root was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-b-2", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-b", snapshotRevision: 2, supersedesID: "series-a-1",
+	}); err == nil {
+		t.Fatal("cross-series snapshot predecessor was inserted")
+	}
+	if err := insertRawFinalizedUsage(db, rawUsageRow{
+		id: "series-a-0", scope: "session_snapshot", accounting: "latest_snapshot",
+		costState: "unavailable", snapshotSeries: "series-a", snapshotRevision: 0, supersedesID: "series-a-1",
+	}); err == nil {
+		t.Fatal("non-increasing snapshot revision was inserted")
+	}
+}
+
+type rawUsageRow struct {
+	id               string
+	scope            string
+	accounting       string
+	costState        string
+	costAmount       any
+	costCurrency     any
+	costOrigin       any
+	priceVersion     any
+	snapshotSeries   any
+	snapshotRevision any
+	supersedesID     any
+}
+
+func insertRawFinalizedUsage(db *sql.DB, row rawUsageRow) error {
+	_, err := db.Exec(`
+INSERT INTO usage_observations (
+    observation_id, session_id, host, source_name, source_version,
+    scope, accounting, status, observed_at, finalized_at, terminal_code,
+    input_state, cached_input_state, cache_write_input_state,
+    output_state, reasoning_output_state, total_state,
+    cost_state, cost_amount_micros, cost_currency, cost_origin, price_table_version,
+    snapshot_series, snapshot_revision, supersedes_id
+) VALUES (?, 'session-1', 'test-host', 'test-source', '1.0.0',
+    ?, ?, 'finalized', '2026-07-23T12:00:00Z', '2026-07-23T12:01:00Z', 'success',
+    'unavailable', 'unavailable', 'unavailable', 'unavailable', 'unavailable', 'unavailable',
+    ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.id, row.scope, row.accounting,
+		row.costState, row.costAmount, row.costCurrency, row.costOrigin, row.priceVersion,
+		row.snapshotSeries, row.snapshotRevision, row.supersedesID,
+	)
+	if err != nil {
+		return fmt.Errorf("insert raw finalized usage: %w", err)
+	}
+	return nil
 }
 
 func sqliteUsageDescriptor(t *testing.T, value string) model.UsageObservationDescriptor {

--- a/infrastructure/sqlite/usage_observation_datasource_test.go
+++ b/infrastructure/sqlite/usage_observation_datasource_test.go
@@ -1,0 +1,357 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestUsageObservationDatasource_RecordFinalizesPendingIdempotently(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	store := sqlite.NewStoreManagementDatasource(db)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	sut := sqlite.NewUsageObservationDatasource(db)
+
+	descriptor := sqliteUsageDescriptor(t, "usage-late")
+	pending, err := model.NewPendingUsageObservation(descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transition, err := sut.Record(ctx, pending)
+	if err != nil || transition != model.UsageObservationTransitionApplied {
+		t.Fatalf("Record(pending) = %q, %v", transition, err)
+	}
+	assertUsageNumericNull(t, dbPath, "usage-late", "input_tokens")
+
+	finalized := sqliteFinalizedUsage(t, descriptor, 0)
+	transition, err = sut.Record(ctx, finalized)
+	if err != nil || transition != model.UsageObservationTransitionApplied {
+		t.Fatalf("Record(finalized) = %q, %v", transition, err)
+	}
+	transition, err = sut.Record(ctx, finalized)
+	if err != nil || transition != model.UsageObservationTransitionAlreadyApplied {
+		t.Fatalf("Record(replay) = %q, %v", transition, err)
+	}
+
+	stored, err := sut.FindByID(ctx, descriptor.ObservationID())
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	observation, present := stored.Value()
+	if !present || observation.Status() != types.UsageObservationFinalized {
+		t.Fatalf("stored observation present/status = %v/%v", present, observation)
+	}
+	input, known := observation.Counters().Input().Value()
+	if !known || input != 0 {
+		t.Fatalf("stored input = %d known=%v", input, known)
+	}
+
+	conflicting := sqliteFinalizedUsage(t, descriptor, 1)
+	if _, err := sut.Record(ctx, conflicting); !errors.Is(err, model.ErrConflictingUsageObservation) {
+		t.Fatalf("Record(conflict) error = %v", err)
+	}
+	stored, err = sut.FindByID(ctx, descriptor.ObservationID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, _ = stored.Value()
+	input, _ = observation.Counters().Input().Value()
+	if input != 0 {
+		t.Fatalf("conflict mutated input = %d", input)
+	}
+}
+
+func TestUsageObservationDatasource_RecordPersistsUnavailableWithoutZero(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sut := sqlite.NewUsageObservationDatasource(db)
+	descriptor := sqliteUsageDescriptor(t, "usage-unavailable")
+	counters, err := types.UsageCountersOf(
+		types.UnavailableUsageValue(), types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+		types.UnavailableUsageValue(), types.UnavailableUsageValue(), types.UnavailableUsageValue(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalFailure,
+		time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sut.Record(ctx, observation); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	assertUsageNumericNull(t, dbPath, "usage-unavailable", "input_tokens")
+}
+
+func TestUsageObservationDatasource_RecordPreservesCostProvenance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sut := sqlite.NewUsageObservationDatasource(db)
+	estimated, err := types.EstimatedUsageCost(2500, "USD", "openai-2026-07-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := types.ProviderReportedUsageCost(2400, "USD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		id          string
+		cost        types.UsageCost
+		wantOrigin  types.UsageCostOrigin
+		wantVersion string
+	}{
+		{id: "usage-estimated", cost: estimated, wantOrigin: types.UsageCostEstimated, wantVersion: "openai-2026-07-01"},
+		{id: "usage-provider", cost: provider, wantOrigin: types.UsageCostProviderReported},
+	} {
+		descriptor := sqliteUsageDescriptor(t, tt.id)
+		base := sqliteFinalizedUsage(t, descriptor, 3)
+		observation, err := model.NewFinalizedUsageObservation(
+			descriptor, base.Counters(), tt.cost, types.UsageTerminalSuccess,
+			time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sut.Record(ctx, observation); err != nil {
+			t.Fatalf("Record(%s) error = %v", tt.id, err)
+		}
+		stored, err := sut.FindByID(ctx, descriptor.ObservationID())
+		if err != nil {
+			t.Fatal(err)
+		}
+		value, present := stored.Value()
+		if !present || value.Cost().Origin() != tt.wantOrigin || value.Cost().PriceTableVersion() != tt.wantVersion {
+			t.Fatalf("stored cost %s = present %v origin %q version %q", tt.id, present, value.Cost().Origin(), value.Cost().PriceTableVersion())
+		}
+	}
+}
+
+func TestUsageObservationDatasource_RecordBuildsOneSnapshotChain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sut := sqlite.NewUsageObservationDatasource(db)
+
+	first := sqliteSnapshotObservation(t, "snapshot-1", 1, types.None[types.UsageObservationID](), 100)
+	if _, err := sut.Record(ctx, first); err != nil {
+		t.Fatalf("Record(first) error = %v", err)
+	}
+	firstID := first.Descriptor().ObservationID()
+	second := sqliteSnapshotObservation(t, "snapshot-2", 2, types.Some(firstID), 150)
+	if _, err := sut.Record(ctx, second); err != nil {
+		t.Fatalf("Record(second) error = %v", err)
+	}
+
+	branch := sqliteSnapshotObservation(t, "snapshot-branch", 3, types.Some(firstID), 175)
+	if _, err := sut.Record(ctx, branch); !errors.Is(err, model.ErrConflictingUsageObservation) {
+		t.Fatalf("Record(branch) error = %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var rows, heads int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM usage_observations WHERE snapshot_series = 'antigravity:conversation-1:model-1'`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM usage_observations AS candidate
+		WHERE candidate.snapshot_series = 'antigravity:conversation-1:model-1'
+		AND NOT EXISTS (SELECT 1 FROM usage_observations AS successor WHERE successor.supersedes_id = candidate.observation_id)`).Scan(&heads); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 2 || heads != 1 {
+		t.Fatalf("snapshot rows/heads = %d/%d", rows, heads)
+	}
+}
+
+func TestUsageObservationDatasource_RecordRejectsConcurrentConflictingFinals(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	sut := sqlite.NewUsageObservationDatasource(db)
+	descriptor := sqliteUsageDescriptor(t, "usage-race")
+	proposals := []*model.UsageObservation{
+		sqliteFinalizedUsage(t, descriptor, 10),
+		sqliteFinalizedUsage(t, descriptor, 20),
+	}
+
+	type result struct {
+		transition model.UsageObservationTransition
+		err        error
+	}
+	start := make(chan struct{})
+	results := make(chan result, len(proposals))
+	for _, proposal := range proposals {
+		go func(observation *model.UsageObservation) {
+			<-start
+			transition, err := sut.Record(ctx, observation)
+			results <- result{transition: transition, err: err}
+		}(proposal)
+	}
+	close(start)
+	applied, conflicts := 0, 0
+	for range proposals {
+		got := <-results
+		if got.err == nil && got.transition == model.UsageObservationTransitionApplied {
+			applied++
+		} else if errors.Is(got.err, model.ErrConflictingUsageObservation) {
+			conflicts++
+		} else {
+			t.Fatalf("unexpected concurrent result = %q, %v", got.transition, got.err)
+		}
+	}
+	if applied != 1 || conflicts != 1 {
+		t.Fatalf("applied/conflicts = %d/%d", applied, conflicts)
+	}
+}
+
+func sqliteUsageDescriptor(t *testing.T, value string) model.UsageObservationDescriptor {
+	t.Helper()
+	source, err := types.UsageSourceOf("codex", "headless_stream", "0.145.0", "openai", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := types.UsageObservationIDFrom(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id, types.SessionID("session-1"), source, types.UsageScopeCall,
+		types.UsageAccountingAdditive, time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return descriptor
+}
+
+func sqliteFinalizedUsage(t *testing.T, descriptor model.UsageObservationDescriptor, inputTokens int64) *model.UsageObservation {
+	t.Helper()
+	input, err := types.KnownUsageValue(inputTokens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero, err := types.KnownUsageValue(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counters, err := types.UsageCountersOf(input, zero, zero, zero, zero, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalSuccess,
+		time.Date(2026, 7, 23, 12, 1, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func sqliteSnapshotObservation(
+	t *testing.T,
+	value string,
+	revision int64,
+	supersedes types.Optional[types.UsageObservationID],
+	inputTokens int64,
+) *model.UsageObservation {
+	t.Helper()
+	source, err := types.UsageSourceOf("antigravity", "statusline", "1.1.5", "google", "model-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := types.UsageObservationIDFrom(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := model.NewUsageSnapshotDescriptor(
+		id, types.SessionID("conversation-1"), source, "antigravity:conversation-1:model-1",
+		revision, supersedes, time.Date(2026, 7, 23, 12, int(revision), 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := types.KnownUsageValue(inputTokens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := types.KnownUsageValue(inputTokens / 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := types.UnavailableUsageValue()
+	counters, err := types.UsageCountersOf(input, u, u, output, u, u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), types.UsageTerminalSuccess,
+		time.Date(2026, 7, 23, 12, int(revision), 1, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func assertUsageNumericNull(t *testing.T, dbPath, observationID, column string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var isNull int
+	query := `SELECT ` + column + ` IS NULL FROM usage_observations WHERE observation_id = ?`
+	if err := db.QueryRow(query, observationID).Scan(&isNull); err != nil {
+		t.Fatal(err)
+	}
+	if isNull != 1 {
+		t.Fatalf("%s.%s is not NULL", observationID, column)
+	}
+}

--- a/schema/sqlite/migrations/000027_create_usage_observations.sql
+++ b/schema/sqlite/migrations/000027_create_usage_observations.sql
@@ -63,7 +63,9 @@ CREATE TABLE usage_observations (
             AND cost_currency GLOB '[A-Z][A-Z][A-Z]'
             AND cost_origin IS NOT NULL
             AND (
-                (cost_origin = 'estimated' AND length(price_table_version) > 0)
+                (cost_origin = 'estimated'
+                    AND price_table_version IS NOT NULL
+                    AND length(trim(price_table_version)) > 0)
                 OR (cost_origin = 'provider_reported' AND price_table_version IS NULL)
             ))
     ),

--- a/schema/sqlite/migrations/000027_create_usage_observations.sql
+++ b/schema/sqlite/migrations/000027_create_usage_observations.sql
@@ -1,0 +1,127 @@
+CREATE TABLE usage_observations (
+    observation_id TEXT PRIMARY KEY NOT NULL CHECK (length(observation_id) BETWEEN 1 AND 512),
+    session_id TEXT NOT NULL CHECK (length(session_id) > 0),
+    host TEXT NOT NULL CHECK (length(host) > 0),
+    source_name TEXT NOT NULL CHECK (length(source_name) > 0),
+    source_version TEXT NOT NULL CHECK (length(source_version) > 0),
+    provider TEXT,
+    model TEXT,
+    scope TEXT NOT NULL CHECK (scope IN ('call', 'run', 'session_snapshot')),
+    accounting TEXT NOT NULL CHECK (accounting IN ('additive', 'latest_snapshot', 'excluded')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'finalized')),
+    observed_at TEXT NOT NULL,
+    finalized_at TEXT,
+    terminal_code TEXT CHECK (terminal_code IN ('success', 'failure', 'timeout', 'signal', 'aborted_stream', 'unknown')),
+
+    input_state TEXT NOT NULL CHECK (input_state IN ('unknown', 'unavailable', 'known')),
+    input_tokens INTEGER,
+    cached_input_state TEXT NOT NULL CHECK (cached_input_state IN ('unknown', 'unavailable', 'known')),
+    cached_input_tokens INTEGER,
+    cache_write_input_state TEXT NOT NULL CHECK (cache_write_input_state IN ('unknown', 'unavailable', 'known')),
+    cache_write_input_tokens INTEGER,
+    output_state TEXT NOT NULL CHECK (output_state IN ('unknown', 'unavailable', 'known')),
+    output_tokens INTEGER,
+    reasoning_output_state TEXT NOT NULL CHECK (reasoning_output_state IN ('unknown', 'unavailable', 'known')),
+    reasoning_output_tokens INTEGER,
+    total_state TEXT NOT NULL CHECK (total_state IN ('unknown', 'unavailable', 'known')),
+    total_tokens INTEGER,
+
+    cost_state TEXT NOT NULL CHECK (cost_state IN ('unknown', 'unavailable', 'known')),
+    cost_amount_micros INTEGER,
+    cost_currency TEXT,
+    cost_origin TEXT CHECK (cost_origin IN ('estimated', 'provider_reported')),
+    price_table_version TEXT,
+
+    snapshot_series TEXT,
+    snapshot_revision INTEGER,
+    supersedes_id TEXT REFERENCES usage_observations(observation_id) ON DELETE RESTRICT,
+
+    CHECK ((input_state = 'known' AND input_tokens IS NOT NULL AND input_tokens >= 0)
+        OR (input_state != 'known' AND input_tokens IS NULL)),
+    CHECK ((cached_input_state = 'known' AND cached_input_tokens IS NOT NULL AND cached_input_tokens >= 0)
+        OR (cached_input_state != 'known' AND cached_input_tokens IS NULL)),
+    CHECK ((cache_write_input_state = 'known' AND cache_write_input_tokens IS NOT NULL AND cache_write_input_tokens >= 0)
+        OR (cache_write_input_state != 'known' AND cache_write_input_tokens IS NULL)),
+    CHECK ((output_state = 'known' AND output_tokens IS NOT NULL AND output_tokens >= 0)
+        OR (output_state != 'known' AND output_tokens IS NULL)),
+    CHECK ((reasoning_output_state = 'known' AND reasoning_output_tokens IS NOT NULL AND reasoning_output_tokens >= 0)
+        OR (reasoning_output_state != 'known' AND reasoning_output_tokens IS NULL)),
+    CHECK ((total_state = 'known' AND total_tokens IS NOT NULL AND total_tokens >= 0)
+        OR (total_state != 'known' AND total_tokens IS NULL)),
+
+    CHECK (
+        (cost_state IN ('unknown', 'unavailable')
+            AND cost_amount_micros IS NULL
+            AND cost_currency IS NULL
+            AND cost_origin IS NULL
+            AND price_table_version IS NULL)
+        OR
+        (cost_state = 'known'
+            AND cost_amount_micros IS NOT NULL
+            AND cost_amount_micros >= 0
+            AND cost_currency GLOB '[A-Z][A-Z][A-Z]'
+            AND (
+                (cost_origin = 'estimated' AND length(price_table_version) > 0)
+                OR (cost_origin = 'provider_reported' AND price_table_version IS NULL)
+            ))
+    ),
+
+    CHECK (
+        (scope = 'session_snapshot'
+            AND accounting = 'latest_snapshot'
+            AND status = 'finalized'
+            AND length(snapshot_series) > 0
+            AND snapshot_revision >= 1)
+        OR
+        (scope IN ('call', 'run')
+            AND accounting IN ('additive', 'excluded')
+            AND snapshot_series IS NULL
+            AND snapshot_revision IS NULL
+            AND supersedes_id IS NULL)
+    ),
+
+    CHECK (
+        (status = 'pending'
+            AND finalized_at IS NULL
+            AND terminal_code IS NULL
+            AND input_state = 'unknown'
+            AND cached_input_state = 'unknown'
+            AND cache_write_input_state = 'unknown'
+            AND output_state = 'unknown'
+            AND reasoning_output_state = 'unknown'
+            AND total_state = 'unknown'
+            AND cost_state = 'unknown')
+        OR
+        (status = 'finalized'
+            AND finalized_at IS NOT NULL
+            AND terminal_code IS NOT NULL
+            AND input_state != 'unknown'
+            AND cached_input_state != 'unknown'
+            AND cache_write_input_state != 'unknown'
+            AND output_state != 'unknown'
+            AND reasoning_output_state != 'unknown'
+            AND total_state != 'unknown'
+            AND cost_state != 'unknown')
+    ),
+
+    CHECK (supersedes_id IS NULL OR supersedes_id != observation_id),
+    UNIQUE (snapshot_series, snapshot_revision)
+);
+
+CREATE UNIQUE INDEX idx_usage_observations_single_successor
+    ON usage_observations(supersedes_id)
+    WHERE supersedes_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_usage_observations_single_series_root
+    ON usage_observations(snapshot_series)
+    WHERE scope = 'session_snapshot' AND supersedes_id IS NULL;
+
+CREATE INDEX idx_usage_observations_session_observed
+    ON usage_observations(session_id, observed_at, observation_id);
+
+CREATE INDEX idx_usage_observations_snapshot_series_revision
+    ON usage_observations(snapshot_series, snapshot_revision DESC)
+    WHERE scope = 'session_snapshot';
+
+CREATE INDEX idx_usage_observations_aggregate
+    ON usage_observations(status, accounting, observed_at, observation_id);

--- a/schema/sqlite/migrations/000027_create_usage_observations.sql
+++ b/schema/sqlite/migrations/000027_create_usage_observations.sql
@@ -63,9 +63,9 @@ CREATE TABLE usage_observations (
             AND cost_currency GLOB '[A-Z][A-Z][A-Z]'
             AND cost_origin IS NOT NULL
             AND (
-                (cost_origin = 'estimated'
-                    AND price_table_version IS NOT NULL
-                    AND length(trim(price_table_version)) > 0)
+				(cost_origin = 'estimated'
+					AND price_table_version IS NOT NULL
+					AND length(trim(price_table_version, char(9, 10, 11, 12, 13, 32))) > 0)
                 OR (cost_origin = 'provider_reported' AND price_table_version IS NULL)
             ))
     ),
@@ -124,14 +124,30 @@ FOR EACH ROW
 WHEN NEW.supersedes_id IS NOT NULL
 BEGIN
     SELECT CASE WHEN NOT EXISTS (
-        SELECT 1
-          FROM usage_observations AS predecessor
-         WHERE predecessor.observation_id = NEW.supersedes_id
-           AND predecessor.snapshot_series = NEW.snapshot_series
-           AND predecessor.scope = 'session_snapshot'
+		 SELECT 1
+		  FROM usage_observations AS predecessor
+		 WHERE predecessor.observation_id = NEW.supersedes_id
+		   AND predecessor.snapshot_series = NEW.snapshot_series
+		   AND predecessor.session_id = NEW.session_id
+		   AND predecessor.host = NEW.host
+		   AND predecessor.source_name = NEW.source_name
+		   AND predecessor.source_version = NEW.source_version
+		   AND predecessor.provider IS NEW.provider
+		   AND predecessor.model IS NEW.model
+		   AND predecessor.scope = 'session_snapshot'
            AND predecessor.status = 'finalized'
            AND predecessor.snapshot_revision < NEW.snapshot_revision
     ) THEN RAISE(ABORT, 'invalid usage snapshot predecessor') END;
+END;
+
+CREATE TRIGGER usage_observations_reject_descriptor_update
+BEFORE UPDATE OF observation_id, session_id, host, source_name, source_version,
+    provider, model, scope, accounting, observed_at, snapshot_series,
+    snapshot_revision, supersedes_id
+ON usage_observations
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'usage observation descriptor is immutable');
 END;
 
 CREATE UNIQUE INDEX idx_usage_observations_single_successor

--- a/schema/sqlite/migrations/000027_create_usage_observations.sql
+++ b/schema/sqlite/migrations/000027_create_usage_observations.sql
@@ -34,7 +34,7 @@ CREATE TABLE usage_observations (
 
     snapshot_series TEXT,
     snapshot_revision INTEGER,
-    supersedes_id TEXT REFERENCES usage_observations(observation_id) ON DELETE RESTRICT,
+    supersedes_id TEXT,
 
     CHECK ((input_state = 'known' AND input_tokens IS NOT NULL AND input_tokens >= 0)
         OR (input_state != 'known' AND input_tokens IS NULL)),
@@ -59,7 +59,9 @@ CREATE TABLE usage_observations (
         (cost_state = 'known'
             AND cost_amount_micros IS NOT NULL
             AND cost_amount_micros >= 0
+            AND cost_currency IS NOT NULL
             AND cost_currency GLOB '[A-Z][A-Z][A-Z]'
+            AND cost_origin IS NOT NULL
             AND (
                 (cost_origin = 'estimated' AND length(price_table_version) > 0)
                 OR (cost_origin = 'provider_reported' AND price_table_version IS NULL)
@@ -70,7 +72,9 @@ CREATE TABLE usage_observations (
         (scope = 'session_snapshot'
             AND accounting = 'latest_snapshot'
             AND status = 'finalized'
+            AND snapshot_series IS NOT NULL
             AND length(snapshot_series) > 0
+            AND snapshot_revision IS NOT NULL
             AND snapshot_revision >= 1)
         OR
         (scope IN ('call', 'run')
@@ -105,8 +109,28 @@ CREATE TABLE usage_observations (
     ),
 
     CHECK (supersedes_id IS NULL OR supersedes_id != observation_id),
-    UNIQUE (snapshot_series, snapshot_revision)
+    UNIQUE (snapshot_series, snapshot_revision),
+    UNIQUE (observation_id, snapshot_series),
+    FOREIGN KEY (supersedes_id, snapshot_series)
+        REFERENCES usage_observations(observation_id, snapshot_series)
+        ON DELETE RESTRICT
 );
+
+CREATE TRIGGER usage_observations_validate_snapshot_predecessor
+BEFORE INSERT ON usage_observations
+FOR EACH ROW
+WHEN NEW.supersedes_id IS NOT NULL
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1
+          FROM usage_observations AS predecessor
+         WHERE predecessor.observation_id = NEW.supersedes_id
+           AND predecessor.snapshot_series = NEW.snapshot_series
+           AND predecessor.scope = 'session_snapshot'
+           AND predecessor.status = 'finalized'
+           AND predecessor.snapshot_revision < NEW.snapshot_revision
+    ) THEN RAISE(ABORT, 'invalid usage snapshot predecessor') END;
+END;
 
 CREATE UNIQUE INDEX idx_usage_observations_single_successor
     ON usage_observations(supersedes_id)


### PR DESCRIPTION
## Motivation

Host adapters need one provider-neutral accounting contract before v0.32 can ingest usage safely. Missing counters must remain distinct from numeric zero, terminal redelivery must not double count a call/run, and cumulative session snapshots must remain immutable rather than being added together.

Closes #1456

## Changes

- add explicit `unknown` / `unavailable` / `known` usage values and derive overall `available` / `partial` state without fabricating numbers
- add integer micro-cost values with separate `estimated` and `provider_reported` provenance; estimates require a price-table version
- add a usage observation aggregate with pending-to-finalized idempotency, closed terminal codes, additive/excluded/latest-snapshot accounting, and typed conflicts
- add migration 27 with nullable numeric columns, database constraints, snapshot-chain uniqueness, and no changes to existing event/session rows
- add a SQLite datasource that serializes writes with `BEGIN IMMEDIATE`, rejects conflicting replay, and permits one immutable snapshot successor
- expose a small application write boundary for the host adapter issues that follow

## Structure / behavior

- Domain types own missing-value, cost-provenance, lifecycle, and snapshot-successor rules.
- The application usecase only orchestrates the repository call.
- SQLite owns atomic persistence and restores rows through domain constructors.
- Host parsing, extended run lineage, and CLI/MCP aggregates remain in their dedicated v0.32 issues.

## Validation

- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- `git diff origin/main...HEAD --check`

All passed locally on the committed head.