### PR TITLE
v0.32.0-1e: capture verified Claude usage metadata

### DIFF
--- a/.ai/spec/1447.md
+++ b/.ai/spec/1447.md
@@ -1,0 +1,74 @@
+# Issue #1447: capture verified Claude usage metadata
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Purpose: persist authoritative Claude Code token/model metadata from local, host-owned JSON/JSONL while discarding prompt, response, thinking, tool, account, and path data before the application boundary.
+- Current state: the provider-neutral usage ledger and Codex reference adapter exist, while Claude Stop hooks only retain transcript/session events.
+- Expected behavior: native interactive transcripts record each unique assistant request (`requestId` + message id) once; a Traceary-owned `claude -p --output-format json|stream-json` run records only its terminal `result.usage`; a fixed capture mode prevents both representations from becoming additive.
+- Non-goals: text-derived token estimates, provider billing/API access, network interception, arbitrary transcript persistence, unsupported interactive hook payload inspection, aggregate CLI/MCP reporting, or other host adapters.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Claude capture mode | `transcript_calls` or `one_shot_stream` | selects the authoritative representation before execution | one run never records both call and run summaries as additive |
+| Interactive call identity | Claude session, request id, message id | deduplicates replayed transcript rows | row UUID is never identity; distinct request ids remain distinct retry calls |
+| Terminal run summary | Claude session and one terminal `result` row | records provider-reported final usage once | assistant usage rows are ignored in one-shot mode |
+| Usage counters | input, cache creation, cache read, output | preserve known zero and missing dimensions separately | cache creation maps to cache-write input; absent fields remain unavailable |
+| Missing usage boundary | stable Stop event or terminal one-shot completion | becomes one finalized excluded observation | no body-derived identity or inferred zero/model/cost |
+| Local source | bounded regular JSONL below Claude projects root | decodes a minimal envelope, then only assistant/result metadata | symlinks, oversized input, ambiguous files, and malformed authoritative metadata fail closed |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Locate and parse Claude transcript JSONL | `infrastructure/filesystem` Claude source | Claude file layout/schema or IO guards change | CLI/usecase must not know raw JSON or filesystem traversal |
+| Forward and inspect a supervised one-shot stream | `infrastructure/filesystem` stream adapter | Claude output contract changes | session runner must not parse provider envelopes |
+| Select accounting/scope and construct observations | Claude usage application usecase | representation precedence or terminal availability changes | filesystem must not persist; presentation must not own accounting rules |
+| Enforce replay/idempotency and persist observations | existing usage aggregate/repository | provider-neutral invariant/schema changes | Claude adapter must not duplicate reconciliation |
+| Resolve hook delivery and compose dependencies | presentation CLI | hook protocol/composition changes | usecase must not depend on Cobra or raw hook JSON |
+| Register usage before transcript capture | Claude hook handler/plugin manifest | packaged host contract changes | source reader must not mutate host configuration |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `ClaudeUsageSource.Load` | Claude capture usecase | Claude config root, project path, JSONL envelope, deduplication, bounds | missing transcript is a supported empty result; unsafe/ambiguous source or malformed authoritative usage fails with body/path-free errors |
+| `ClaudeUsageCaptureUsecase.Capture` | Stop hook CLI | call identity, availability, scope, observation construction | stable missing delivery becomes excluded/unavailable; repository/source errors are wrapped without payloads |
+| `ClaudeHeadlessUsageStream` | one-shot runner | chunking, terminal result selection, assistant-row suppression | output is forwarded byte-for-byte; malformed or missing authoritative terminal metadata fails closed |
+| `traceary hook usage claude` | packaged Stop hook | DB wiring, body-free durable replay, transcript lookup by session | one-shot mode is a safe no-op; unsupported clients are rejected |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| transcript calls | private-free assistant fixtures with duplicate row UUIDs | source loads and usecase captures | one observation per unique request/message pair, with exact cache fields/model | filesystem + usecase |
+| retries | two rows share a message id but have distinct request ids | capture | both calls are retained once | filesystem |
+| one-shot stream | assistant chunks plus one terminal result | supervised run completes | stdout is unchanged and only one run-scope summary is additive | filesystem + CLI |
+| known zero vs missing | a usage object reports zero for one field and omits another | capture | zero is known and omitted is unavailable | usecase |
+| duplicate delivery | identical transcript/Stop payload is delivered twice | capture twice | second write is already-applied | usecase/repository |
+| aborted/error without usage | stable terminal boundary has no selected usage object | capture twice | one excluded finalized unavailable observation is retained | usecase |
+| legacy mixed source | a complete legacy source contains assistant usage and terminal result | capture | terminal run summary wins and call rows are excluded/non-additive | filesystem + usecase |
+| privacy | adjacent prompt/response/tool/account/path fields contain sentinels | capture and durable retry | no sentinel crosses the source result or usage spool boundary | filesystem + CLI |
+| unsafe source | file is oversized, symlinked, or outside the Claude projects root | load | reject without reading arbitrary files or returning a path | filesystem |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| parse and deduplicate transcript calls | source tests fail because no Claude adapter exists | bounded minimal-envelope parser emits typed samples | keep provider schema private to filesystem |
+| preserve availability and scope | usecase tests fail | mapper creates call/run observations and stable unavailable fallbacks | share only small counter/state helpers, not a speculative universal adapter |
+| supervised one-shot precedence | stream/session-run tests fail | terminal result adapter and fixed mode suppress Stop capture | session runner remains orchestration only |
+| package contract | hook handler/plugin tests fail | usage command is registered before transcript | managed keys remain versioned and upgrade-safe |
+
+### Risks / rollback
+
+- Procedural risk: avoid transcript parsing, counter mapping, or precedence decisions inside `runHookUsage`; the CLI only sanitizes the delivery, initializes storage, and delegates.
+- Premature abstraction risk: keep Claude DTOs and capture port separate from Codex. Reuse only the provider-neutral usage repository/domain contract.
+- Compatibility: no schema migration is required. Existing Stop hooks continue working; upgraded hooks add a body-free usage command before transcript capture.
+- Performance/privacy guard: use one fixed-depth filename match under the configured Claude projects root, require regular non-symlink components, cap file/line size, and decode only allowlisted metadata.
+- Rollback: remove Claude usage hook registration and DI wiring. Provider-neutral observations already persisted remain valid; no downgrade is necessary.
+
+Design checkpoint: adopt two fixed modes. Native interactive execution uses transcript calls and deduplicates by `(requestId, message.id)`. Traceary-owned one-shot execution uses only the terminal `result.usage` run summary and suppresses Stop usage capture through a child-only environment marker. A complete legacy mixed source selects the terminal summary and retains call evidence as excluded. No missing field, model, total, retry, or failure usage is inferred.

--- a/application/claude_usage_source.go
+++ b/application/claude_usage_source.go
@@ -1,0 +1,79 @@
+package application
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// ClaudeUsageCaptureMode fixes the authoritative representation for a Claude run.
+type ClaudeUsageCaptureMode string
+
+const (
+	// ClaudeUsageModeTranscriptCalls records unique interactive assistant requests.
+	ClaudeUsageModeTranscriptCalls ClaudeUsageCaptureMode = "transcript_calls"
+	// ClaudeUsageModeOneShotStream records only the terminal one-shot result.
+	ClaudeUsageModeOneShotStream ClaudeUsageCaptureMode = "one_shot_stream"
+)
+
+// ClaudeUsageLoadCriteria selects one host-owned Claude transcript.
+type ClaudeUsageLoadCriteria struct {
+	SessionID types.SessionID
+}
+
+// ClaudeUsageCounters preserves provider field presence. Nil is unavailable;
+// a pointer to zero is a provider-reported known zero.
+type ClaudeUsageCounters struct {
+	InputTokens           *int64
+	CachedInputTokens     *int64
+	CacheWriteInputTokens *int64
+	OutputTokens          *int64
+	ReasoningOutputTokens *int64
+	TotalTokens           *int64
+}
+
+// ClaudeUsageSample is one body-free authoritative call or run record.
+type ClaudeUsageSample struct {
+	RecordID      string
+	SourceName    string
+	SourceVersion string
+	Model         string
+	Scope         types.UsageScope
+	ObservedAt    time.Time
+	TerminalCode  types.UsageTerminalCode
+	Available     bool
+	Counters      ClaudeUsageCounters
+}
+
+// ClaudeUsageLoadResult contains the selected representation and any retained
+// legacy evidence. Empty is a supported explicit outcome.
+type ClaudeUsageLoadResult struct {
+	Mode             ClaudeUsageCaptureMode
+	Samples          []ClaudeUsageSample
+	BoundaryObserved bool
+}
+
+// ClaudeUsageRepository persists provider-neutral observations idempotently.
+type ClaudeUsageRepository interface {
+	model.UsageObservationRepository
+}
+
+// ClaudeUsageSource reads only body-free usage metadata from local Claude files.
+type ClaudeUsageSource interface {
+	Load(context.Context, ClaudeUsageLoadCriteria) (ClaudeUsageLoadResult, error)
+}
+
+// ClaudeHeadlessUsageStream forwards a Traceary-owned Claude JSON stream while
+// retaining only terminal body-free usage metadata.
+type ClaudeHeadlessUsageStream interface {
+	io.Writer
+	Complete() (ClaudeUsageLoadResult, error)
+}
+
+// ClaudeHeadlessUsageStreamFactory creates one bounded stream adapter per run.
+type ClaudeHeadlessUsageStreamFactory interface {
+	New(io.Writer) ClaudeHeadlessUsageStream
+}

--- a/application/usecase/claude_usage_capture.go
+++ b/application/usecase/claude_usage_capture.go
@@ -1,0 +1,273 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// ClaudeUsageCaptureInput is one body-free Claude terminal boundary.
+type ClaudeUsageCaptureInput struct {
+	SessionID          types.SessionID
+	DeliveryID         string
+	FallbackSourceName string
+	FallbackTerminal   types.UsageTerminalCode
+}
+
+// ClaudeUsageCaptureResult exposes idempotent write outcomes for diagnostics.
+type ClaudeUsageCaptureResult struct {
+	Applied        int
+	AlreadyApplied int
+	Unavailable    int
+}
+
+// ClaudeUsageCaptureUsecase records transcript calls or a mutually exclusive
+// one-shot terminal summary in the provider-neutral usage ledger.
+type ClaudeUsageCaptureUsecase interface {
+	Capture(context.Context, ClaudeUsageCaptureInput) (ClaudeUsageCaptureResult, error)
+	CaptureHeadless(context.Context, ClaudeUsageCaptureInput, application.ClaudeUsageLoadResult) (ClaudeUsageCaptureResult, error)
+}
+
+type claudeUsageCaptureUsecase struct {
+	source     application.ClaudeUsageSource
+	repository application.ClaudeUsageRepository
+}
+
+// NewClaudeUsageCaptureUsecase creates the Claude adapter boundary.
+func NewClaudeUsageCaptureUsecase(
+	source application.ClaudeUsageSource,
+	repository application.ClaudeUsageRepository,
+) ClaudeUsageCaptureUsecase {
+	return &claudeUsageCaptureUsecase{source: source, repository: repository}
+}
+
+func (u *claudeUsageCaptureUsecase) Capture(
+	ctx context.Context,
+	input ClaudeUsageCaptureInput,
+) (ClaudeUsageCaptureResult, error) {
+	if u.source == nil {
+		return ClaudeUsageCaptureResult{}, xerrors.Errorf("Claude usage source must be configured")
+	}
+	loaded, err := u.source.Load(ctx, application.ClaudeUsageLoadCriteria{SessionID: input.SessionID})
+	if err != nil {
+		return ClaudeUsageCaptureResult{}, xerrors.Errorf("failed to load Claude usage source: %w", err)
+	}
+	return u.captureLoaded(ctx, input, loaded)
+}
+
+func (u *claudeUsageCaptureUsecase) CaptureHeadless(
+	ctx context.Context,
+	input ClaudeUsageCaptureInput,
+	loaded application.ClaudeUsageLoadResult,
+) (ClaudeUsageCaptureResult, error) {
+	return u.captureLoaded(ctx, input, loaded)
+}
+
+func (u *claudeUsageCaptureUsecase) captureLoaded(
+	ctx context.Context,
+	input ClaudeUsageCaptureInput,
+	loaded application.ClaudeUsageLoadResult,
+) (ClaudeUsageCaptureResult, error) {
+	if u.repository == nil {
+		return ClaudeUsageCaptureResult{}, xerrors.Errorf("Claude usage repository must be configured")
+	}
+	if _, err := types.SessionIDFrom(input.SessionID.String()); err != nil {
+		return ClaudeUsageCaptureResult{}, xerrors.Errorf("invalid Claude usage session: %w", err)
+	}
+	if loaded.Mode != application.ClaudeUsageModeTranscriptCalls &&
+		loaded.Mode != application.ClaudeUsageModeOneShotStream {
+		return ClaudeUsageCaptureResult{}, xerrors.Errorf("invalid Claude usage capture mode")
+	}
+
+	result := ClaudeUsageCaptureResult{}
+	for _, sample := range loaded.Samples {
+		accounting, err := claudeUsageAccounting(loaded.Mode, sample)
+		if err != nil {
+			return result, err
+		}
+		observation, err := claudeUsageObservation(input.SessionID, sample, accounting)
+		if err != nil {
+			return result, xerrors.Errorf("failed to map Claude usage sample %q: %w", sample.RecordID, err)
+		}
+		transition, err := u.repository.Record(ctx, observation)
+		if err != nil {
+			return result, xerrors.Errorf("failed to reconcile Claude usage sample %q: %w", sample.RecordID, err)
+		}
+		countClaudeUsageTransition(&result, transition)
+		if !sample.Available && transition == model.UsageObservationTransitionApplied {
+			result.Unavailable++
+		}
+	}
+	if loaded.BoundaryObserved || strings.TrimSpace(input.DeliveryID) == "" {
+		return result, nil
+	}
+	if err := u.recordUnavailableBoundary(ctx, input, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func claudeUsageAccounting(
+	mode application.ClaudeUsageCaptureMode,
+	sample application.ClaudeUsageSample,
+) (types.UsageAccounting, error) {
+	if !sample.Available {
+		return types.UsageAccountingExcluded, nil
+	}
+	switch mode {
+	case application.ClaudeUsageModeTranscriptCalls:
+		if sample.Scope != types.UsageScopeCall {
+			return "", xerrors.Errorf("Claude transcript mode requires call-scoped samples")
+		}
+		return types.UsageAccountingAdditive, nil
+	case application.ClaudeUsageModeOneShotStream:
+		switch sample.Scope {
+		case types.UsageScopeRun:
+			return types.UsageAccountingAdditive, nil
+		case types.UsageScopeCall:
+			// Complete legacy JSONL can contain both assistant usage and the
+			// terminal summary. Retain calls as evidence without double counting.
+			return types.UsageAccountingExcluded, nil
+		default:
+			return "", xerrors.Errorf("Claude one-shot mode has unsupported usage scope")
+		}
+	default:
+		return "", xerrors.Errorf("invalid Claude usage capture mode")
+	}
+}
+
+func (u *claudeUsageCaptureUsecase) recordUnavailableBoundary(
+	ctx context.Context,
+	input ClaudeUsageCaptureInput,
+	result *ClaudeUsageCaptureResult,
+) error {
+	sourceName := strings.TrimSpace(input.FallbackSourceName)
+	if sourceName == "" {
+		sourceName = "stop_hook"
+	}
+	terminal := input.FallbackTerminal
+	if terminal == "" {
+		terminal = types.UsageTerminalUnknown
+	}
+	id, err := types.UsageObservationIDFrom(
+		"claude:" + sourceName + ":" + input.SessionID.String() + ":" + strings.TrimSpace(input.DeliveryID),
+	)
+	if err != nil {
+		return xerrors.Errorf("invalid Claude unavailable observation identity: %w", err)
+	}
+	source, err := types.UsageSourceOf("claude", sourceName, "schema-v1", "anthropic", "")
+	if err != nil {
+		return xerrors.Errorf("invalid Claude unavailable source: %w", err)
+	}
+	now := time.Unix(0, 0).UTC()
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id, input.SessionID, source, types.UsageScopeCall, types.UsageAccountingExcluded, now,
+	)
+	if err != nil {
+		return xerrors.Errorf("invalid Claude unavailable descriptor: %w", err)
+	}
+	unavailable := types.UnavailableUsageValue()
+	counters, err := types.UsageCountersOf(unavailable, unavailable, unavailable, unavailable, unavailable, unavailable)
+	if err != nil {
+		return xerrors.Errorf("invalid Claude unavailable counters: %w", err)
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), terminal, now,
+	)
+	if err != nil {
+		return xerrors.Errorf("invalid Claude unavailable observation: %w", err)
+	}
+	transition, err := u.repository.Record(ctx, observation)
+	if err != nil {
+		return xerrors.Errorf("failed to record Claude unavailable observation: %w", err)
+	}
+	countClaudeUsageTransition(result, transition)
+	if transition == model.UsageObservationTransitionApplied {
+		result.Unavailable++
+	}
+	return nil
+}
+
+func claudeUsageObservation(
+	sessionID types.SessionID,
+	sample application.ClaudeUsageSample,
+	accounting types.UsageAccounting,
+) (*model.UsageObservation, error) {
+	id, err := types.UsageObservationIDFrom("claude:" + strings.TrimSpace(sample.RecordID))
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Claude usage identity: %w", err)
+	}
+	source, err := types.UsageSourceOf(
+		"claude", sample.SourceName, sample.SourceVersion, "anthropic", sample.Model,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Claude usage source: %w", err)
+	}
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id, sessionID, source, sample.Scope, accounting, sample.ObservedAt.UTC(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Claude usage descriptor: %w", err)
+	}
+	counters, err := claudeUsageCounters(sample.Counters, sample.Available)
+	if err != nil {
+		return nil, err
+	}
+	terminal := sample.TerminalCode
+	if terminal == "" {
+		terminal = types.UsageTerminalUnknown
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), terminal, sample.ObservedAt.UTC(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Claude usage observation: %w", err)
+	}
+	return observation, nil
+}
+
+func claudeUsageCounters(raw application.ClaudeUsageCounters, available bool) (types.UsageCounters, error) {
+	if !available {
+		unavailable := types.UnavailableUsageValue()
+		counters, err := types.UsageCountersOf(unavailable, unavailable, unavailable, unavailable, unavailable, unavailable)
+		if err != nil {
+			return types.UsageCounters{}, xerrors.Errorf("invalid unavailable Claude usage counters: %w", err)
+		}
+		return counters, nil
+	}
+	values := make([]types.UsageValue, 0, 6)
+	for _, value := range []*int64{
+		raw.InputTokens, raw.CachedInputTokens, raw.CacheWriteInputTokens,
+		raw.OutputTokens, raw.ReasoningOutputTokens, raw.TotalTokens,
+	} {
+		if value == nil {
+			values = append(values, types.UnavailableUsageValue())
+			continue
+		}
+		known, err := types.KnownUsageValue(*value)
+		if err != nil {
+			return types.UsageCounters{}, xerrors.Errorf("invalid Claude usage counter: %w", err)
+		}
+		values = append(values, known)
+	}
+	counters, err := types.UsageCountersOf(values[0], values[1], values[2], values[3], values[4], values[5])
+	if err != nil {
+		return types.UsageCounters{}, xerrors.Errorf("invalid Claude usage counters: %w", err)
+	}
+	return counters, nil
+}
+
+func countClaudeUsageTransition(result *ClaudeUsageCaptureResult, transition model.UsageObservationTransition) {
+	switch transition {
+	case model.UsageObservationTransitionApplied:
+		result.Applied++
+	case model.UsageObservationTransitionAlreadyApplied:
+		result.AlreadyApplied++
+	}
+}

--- a/application/usecase/claude_usage_capture.go
+++ b/application/usecase/claude_usage_capture.go
@@ -107,7 +107,7 @@ func (u *claudeUsageCaptureUsecase) captureLoaded(
 	if loaded.BoundaryObserved || strings.TrimSpace(input.DeliveryID) == "" {
 		return result, nil
 	}
-	if err := u.recordUnavailableBoundary(ctx, input, &result); err != nil {
+	if err := u.recordUnavailableBoundary(ctx, input, loaded.Mode, &result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -145,6 +145,7 @@ func claudeUsageAccounting(
 func (u *claudeUsageCaptureUsecase) recordUnavailableBoundary(
 	ctx context.Context,
 	input ClaudeUsageCaptureInput,
+	mode application.ClaudeUsageCaptureMode,
 	result *ClaudeUsageCaptureResult,
 ) error {
 	sourceName := strings.TrimSpace(input.FallbackSourceName)
@@ -165,9 +166,13 @@ func (u *claudeUsageCaptureUsecase) recordUnavailableBoundary(
 	if err != nil {
 		return xerrors.Errorf("invalid Claude unavailable source: %w", err)
 	}
+	scope := types.UsageScopeCall
+	if mode == application.ClaudeUsageModeOneShotStream {
+		scope = types.UsageScopeRun
+	}
 	now := time.Unix(0, 0).UTC()
 	descriptor, err := model.NewUsageObservationDescriptor(
-		id, input.SessionID, source, types.UsageScopeCall, types.UsageAccountingExcluded, now,
+		id, input.SessionID, source, scope, types.UsageAccountingExcluded, now,
 	)
 	if err != nil {
 		return xerrors.Errorf("invalid Claude unavailable descriptor: %w", err)

--- a/application/usecase/claude_usage_capture_test.go
+++ b/application/usecase/claude_usage_capture_test.go
@@ -1,0 +1,149 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+type claudeUsageSourceStub struct {
+	result application.ClaudeUsageLoadResult
+	err    error
+}
+
+func (s claudeUsageSourceStub) Load(
+	context.Context,
+	application.ClaudeUsageLoadCriteria,
+) (application.ClaudeUsageLoadResult, error) {
+	return s.result, s.err
+}
+
+func TestClaudeUsageCaptureUsecase_RecordsKnownZeroAndMissingFieldsOnce(t *testing.T) {
+	t.Parallel()
+	zero, input, cached, output := int64(0), int64(120), int64(80), int64(7)
+	observedAt := time.Date(2026, 7, 23, 2, 3, 4, 0, time.UTC)
+	source := claudeUsageSourceStub{result: application.ClaudeUsageLoadResult{
+		Mode:             application.ClaudeUsageModeTranscriptCalls,
+		BoundaryObserved: true,
+		Samples: []application.ClaudeUsageSample{{
+			RecordID: "transcript_calls:call-1", SourceName: "transcript_calls", SourceVersion: "schema-v1",
+			Model: "claude-opus-4-1", Scope: types.UsageScopeCall, ObservedAt: observedAt,
+			TerminalCode: types.UsageTerminalSuccess, Available: true,
+			Counters: application.ClaudeUsageCounters{
+				InputTokens: &input, CachedInputTokens: &cached, CacheWriteInputTokens: &zero,
+				OutputTokens: &output,
+			},
+		}},
+	}}
+	repository := &codexUsageRepositoryFake{}
+	sut := usecase.NewClaudeUsageCaptureUsecase(source, repository)
+	captureInput := usecase.ClaudeUsageCaptureInput{SessionID: "session-1", DeliveryID: "event_id:stop-1"}
+
+	first, err := sut.Capture(context.Background(), captureInput)
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	second, err := sut.Capture(context.Background(), captureInput)
+	if err != nil {
+		t.Fatalf("Capture() replay error = %v", err)
+	}
+	if first.Applied != 1 || second.AlreadyApplied != 1 || len(repository.observations) != 1 {
+		t.Fatalf("first=%+v second=%+v observations=%d", first, second, len(repository.observations))
+	}
+	for _, observation := range repository.observations {
+		descriptor := observation.Descriptor()
+		if descriptor.Scope() != types.UsageScopeCall ||
+			descriptor.Accounting() != types.UsageAccountingAdditive ||
+			descriptor.Source().Provider() != "anthropic" ||
+			descriptor.Source().Model() != "claude-opus-4-1" {
+			t.Fatalf("descriptor = %+v", descriptor)
+		}
+		counters := observation.Counters()
+		if value, known := counters.CacheWriteInput().Value(); !known || value != 0 {
+			t.Fatalf("cache creation = (%d, %t), want known zero", value, known)
+		}
+		if counters.ReasoningOutput().State() != types.UsageValueUnavailable ||
+			counters.Total().State() != types.UsageValueUnavailable {
+			t.Fatalf("unreported counters were not unavailable: %+v", counters)
+		}
+	}
+}
+
+func TestClaudeUsageCaptureUsecase_LegacyTerminalSummaryExcludesCallEvidence(t *testing.T) {
+	t.Parallel()
+	input, output := int64(25), int64(5)
+	observedAt := time.Date(2026, 7, 23, 2, 3, 4, 0, time.UTC)
+	source := claudeUsageSourceStub{result: application.ClaudeUsageLoadResult{
+		Mode:             application.ClaudeUsageModeOneShotStream,
+		BoundaryObserved: true,
+		Samples: []application.ClaudeUsageSample{
+			{
+				RecordID: "one_shot_stream:run-1", SourceName: "one_shot_stream", SourceVersion: "schema-v1",
+				Scope: types.UsageScopeRun, ObservedAt: observedAt, TerminalCode: types.UsageTerminalSuccess,
+				Available: true, Counters: application.ClaudeUsageCounters{InputTokens: &input, OutputTokens: &output},
+			},
+			{
+				RecordID: "transcript_calls:call-1", SourceName: "transcript_calls", SourceVersion: "schema-v1",
+				Scope: types.UsageScopeCall, ObservedAt: observedAt, TerminalCode: types.UsageTerminalSuccess,
+				Available: true, Counters: application.ClaudeUsageCounters{InputTokens: &input, OutputTokens: &output},
+			},
+		},
+	}}
+	repository := &codexUsageRepositoryFake{}
+	_, err := usecase.NewClaudeUsageCaptureUsecase(source, repository).Capture(
+		context.Background(), usecase.ClaudeUsageCaptureInput{SessionID: "session-1"},
+	)
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	additive, excluded := 0, 0
+	for _, observation := range repository.observations {
+		switch observation.Descriptor().Accounting() {
+		case types.UsageAccountingAdditive:
+			additive++
+			if observation.Descriptor().Scope() != types.UsageScopeRun {
+				t.Fatalf("additive scope = %q, want run", observation.Descriptor().Scope())
+			}
+		case types.UsageAccountingExcluded:
+			excluded++
+		}
+	}
+	if additive != 1 || excluded != 1 {
+		t.Fatalf("additive=%d excluded=%d", additive, excluded)
+	}
+}
+
+func TestClaudeUsageCaptureUsecase_RecordsStableUnavailableBoundary(t *testing.T) {
+	t.Parallel()
+	repository := &codexUsageRepositoryFake{}
+	sut := usecase.NewClaudeUsageCaptureUsecase(
+		claudeUsageSourceStub{result: application.ClaudeUsageLoadResult{
+			Mode: application.ClaudeUsageModeTranscriptCalls,
+		}},
+		repository,
+	)
+	input := usecase.ClaudeUsageCaptureInput{
+		SessionID: "session-1", DeliveryID: "event_id:stop-missing",
+	}
+	first, err := sut.Capture(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	second, err := sut.Capture(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Capture() replay error = %v", err)
+	}
+	if first.Applied != 1 || first.Unavailable != 1 || second.AlreadyApplied != 1 {
+		t.Fatalf("first=%+v second=%+v", first, second)
+	}
+	for _, observation := range repository.observations {
+		if observation.Descriptor().Accounting() != types.UsageAccountingExcluded ||
+			observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
+			t.Fatalf("unavailable observation = %+v", observation)
+		}
+	}
+}

--- a/application/usecase/claude_usage_capture_test.go
+++ b/application/usecase/claude_usage_capture_test.go
@@ -142,8 +142,35 @@ func TestClaudeUsageCaptureUsecase_RecordsStableUnavailableBoundary(t *testing.T
 	}
 	for _, observation := range repository.observations {
 		if observation.Descriptor().Accounting() != types.UsageAccountingExcluded ||
+			observation.Descriptor().Scope() != types.UsageScopeCall ||
 			observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
 			t.Fatalf("unavailable observation = %+v", observation)
+		}
+	}
+}
+
+func TestClaudeUsageCaptureUsecase_RecordsOneShotUnavailableBoundaryAtRunScope(t *testing.T) {
+	t.Parallel()
+	repository := &codexUsageRepositoryFake{}
+	sut := usecase.NewClaudeUsageCaptureUsecase(claudeUsageSourceStub{}, repository)
+	result, err := sut.CaptureHeadless(
+		context.Background(),
+		usecase.ClaudeUsageCaptureInput{
+			SessionID: "session-1", DeliveryID: "session_run",
+			FallbackSourceName: "one_shot_stream", FallbackTerminal: types.UsageTerminalAbortedStream,
+		},
+		application.ClaudeUsageLoadResult{Mode: application.ClaudeUsageModeOneShotStream},
+	)
+	if err != nil {
+		t.Fatalf("CaptureHeadless() error = %v", err)
+	}
+	if result.Applied != 1 || result.Unavailable != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	for _, observation := range repository.observations {
+		if observation.Descriptor().Scope() != types.UsageScopeRun ||
+			observation.Descriptor().Accounting() != types.UsageAccountingExcluded {
+			t.Fatalf("one-shot fallback = %+v", observation)
 		}
 	}
 }

--- a/docs/integrations/claude-plugin.ja.md
+++ b/docs/integrations/claude-plugin.ja.md
@@ -8,8 +8,24 @@ Claude 向け package は `integrations/claude-plugin/` にあり、repository r
 
 - `traceary mcp-server` を使う `traceary` MCP server
 - `SessionStart` / `SessionEnd` hook
+- transcript event の記録前に、ローカル transcript から Claude が報告した token 数を記録する `Stop` usage hook
 - `Bash` / `mcp__.*` / 組み込み tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`) 向けの `PostToolUse` / `PostToolUseFailure` audit hook
 - slash command として使える `/traceary-help` と、文脈で自動適用される `traceary-session-history` / `traceary-memory-review` / `traceary-memory-remember` skill。`traceary-memory-review` は review 意図の発話 (「Traceary inbox」「review memory candidates」「session recap」など) で発火し inbox の curate を案内、`traceary-memory-remember` は明示 write 発話 (「覚えておいて」「remember that」など) のみで発火します。
+
+## 利用量の記録
+
+Traceary は Claude の利用量を、同時には使わない二つの方式で記録します。
+
+- 通常の対話セッションでは、`Stop` 時にローカルの Claude transcript を読み、provider から返った一意な assistant response を 1 回ずつ記録します。識別には `requestId` と message id の組を使うため、同じ応答が transcript に重複していても二重計上しません。
+- Traceary が管理する完結型の print 実行では、最後の `result.usage` だけを記録します。
+
+```sh
+traceary session run -- claude -p --output-format stream-json "your prompt"
+```
+
+wrapper は Claude の起動前に完結型モードを選び、JSON 出力を変更せず転送し、その実行に対する transcript 単位の利用量記録を抑止します。入力、cache 作成、cache 読み取り、出力の各 token 数は、既知の 0 を含めて Claude のフィールドの意味を維持します。存在しないフィールドや、対応していない経路・中断された経路は「取得不可」のまま保持し、合計値、model 名、cost は推測しません。
+
+利用量 reader が読み取るのは session/call/model/counter/終了状態の metadata だけです。prompt、response、thinking、tool、account、transcript path、任意の error 内容は、利用量 ledger や hook の永続 retry spool にコピーしません。
 
 ## Memory activation strategy
 

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -8,8 +8,34 @@ The Claude package lives under `integrations/claude-plugin/` and is published th
 
 - `traceary` MCP server via `traceary mcp-server`
 - `SessionStart` / `SessionEnd` hooks
+- a `Stop` usage hook that records provider-reported Claude token counters from the local transcript before transcript-event capture
 - `PostToolUse` / `PostToolUseFailure` audit hooks for `Bash`, `mcp__.*`, and the built-in tool matcher (`Read`, `NotebookRead`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `Grep`, `Glob`, `Agent`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `ExitPlanMode`)
 - slash-style skills: `/traceary-help` plus the contextual `traceary-session-history`, `traceary-memory-review`, and `traceary-memory-remember` skills. `traceary-memory-review` triggers on review-intent phrases ("Traceary inbox", "review memory candidates", "session recap") and curates the inbox; `traceary-memory-remember` triggers only on explicit-write phrases ("remember that", "覚えておいて") and writes durable memory directly.
+
+## Usage accounting
+
+Traceary uses two mutually exclusive Claude capture modes:
+
+- Native interactive sessions read the local Claude transcript at `Stop` and
+  record each unique assistant provider response once. Identity is derived
+  from `requestId` plus the message id; duplicate transcript rows do not add
+  usage twice.
+- A Traceary-owned print run records only the terminal `result.usage` summary:
+
+```sh
+traceary session run -- claude -p --output-format stream-json "your prompt"
+```
+
+The wrapper selects one-shot mode before starting Claude, forwards JSON output
+unchanged, and suppresses transcript-call accounting for that run. Input,
+cache-creation, cache-read, and output counters retain provider field
+semantics, including known zero. Missing fields and unsupported/aborted paths
+remain explicitly unavailable; Traceary does not infer totals, model names, or
+cost.
+
+The usage reader decodes only session/call/model/counter/terminal metadata.
+Prompt, response, thinking, tool, account, transcript-path, and arbitrary error
+content are not copied into the usage ledger or durable hook retry spool.
 
 ## Memory activation strategy
 

--- a/infrastructure/filesystem/claude_headless_usage_stream.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream.go
@@ -101,7 +101,9 @@ func (s *claudeHeadlessUsageStream) Complete() (application.ClaudeUsageLoadResul
 	}
 	s.buffer = nil
 	if s.parseErr != nil {
-		return s.result, s.parseErr
+		return application.ClaudeUsageLoadResult{
+			Mode: application.ClaudeUsageModeOneShotStream,
+		}, s.parseErr
 	}
 	return s.result, nil
 }

--- a/infrastructure/filesystem/claude_headless_usage_stream.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream.go
@@ -1,0 +1,138 @@
+package filesystem
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+)
+
+type claudeHeadlessUsageStreamFactory struct {
+	now          func() time.Time
+	maxLineBytes int
+}
+
+// NewClaudeHeadlessUsageStreamFactory creates body-free streaming adapters for
+// Traceary-owned Claude print/one-shot invocations.
+func NewClaudeHeadlessUsageStreamFactory() application.ClaudeHeadlessUsageStreamFactory {
+	return &claudeHeadlessUsageStreamFactory{now: time.Now, maxLineBytes: defaultClaudeUsageMaxLineBytes}
+}
+
+func (f *claudeHeadlessUsageStreamFactory) New(destination io.Writer) application.ClaudeHeadlessUsageStream {
+	if destination == nil {
+		destination = io.Discard
+	}
+	return &claudeHeadlessUsageStream{
+		destination: destination,
+		now:         f.now,
+		maxLine:     f.maxLineBytes,
+		result: application.ClaudeUsageLoadResult{
+			Mode: application.ClaudeUsageModeOneShotStream,
+		},
+	}
+}
+
+type claudeHeadlessUsageStream struct {
+	destination io.Writer
+	now         func() time.Time
+	maxLine     int
+	buffer      []byte
+	result      application.ClaudeUsageLoadResult
+	parseErr    error
+	discardLine bool
+}
+
+func (s *claudeHeadlessUsageStream) Write(data []byte) (int, error) {
+	written, err := s.destination.Write(data)
+	if err != nil {
+		return written, xerrors.Errorf("failed to forward Claude headless output: %w", err)
+	}
+	if written != len(data) {
+		return written, io.ErrShortWrite
+	}
+	if s.parseErr != nil {
+		return written, nil
+	}
+	s.consume(data)
+	return written, nil
+}
+
+func (s *claudeHeadlessUsageStream) consume(data []byte) {
+	for len(data) > 0 {
+		newline := bytes.IndexByte(data, '\n')
+		chunk := data
+		complete := false
+		if newline >= 0 {
+			chunk = data[:newline]
+			data = data[newline+1:]
+			complete = true
+		} else {
+			data = nil
+		}
+		if !s.discardLine {
+			if len(s.buffer)+len(chunk) > s.maxLine {
+				s.parseErr = xerrors.Errorf("Claude headless usage line exceeds %d-byte limit", s.maxLine)
+				s.buffer = nil
+				s.discardLine = true
+			} else {
+				s.buffer = append(s.buffer, chunk...)
+			}
+		}
+		if complete {
+			if !s.discardLine && len(bytes.TrimSpace(s.buffer)) > 0 {
+				if err := s.parseLine(s.buffer); err != nil {
+					s.parseErr = err
+				}
+			}
+			s.buffer = nil
+			s.discardLine = false
+		}
+	}
+}
+
+func (s *claudeHeadlessUsageStream) Complete() (application.ClaudeUsageLoadResult, error) {
+	if s.parseErr == nil && !s.discardLine && len(bytes.TrimSpace(s.buffer)) > 0 {
+		s.parseErr = s.parseLine(s.buffer)
+	}
+	s.buffer = nil
+	if s.parseErr != nil {
+		return application.ClaudeUsageLoadResult{}, s.parseErr
+	}
+	return s.result, nil
+}
+
+func (s *claudeHeadlessUsageStream) parseLine(line []byte) error {
+	var envelope claudeUsageEnvelope
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return xerrors.Errorf("invalid Claude headless JSON event")
+	}
+	if envelope.Type != "result" {
+		return nil
+	}
+	sessionID := strings.TrimSpace(envelope.SessionID)
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(envelope.SessionID2)
+	}
+	if sessionID == "" || strings.ContainsAny(sessionID, "\r\n\x00") {
+		return xerrors.Errorf("invalid Claude headless session identity")
+	}
+	sample, err := claudeResultUsageSample(envelope, sessionID)
+	if err != nil {
+		return err
+	}
+	sample.ObservedAt = s.now().UTC()
+	if len(s.result.Samples) > 0 {
+		if !sameClaudeUsageSample(s.result.Samples[0], sample) {
+			return xerrors.Errorf("conflicting Claude headless terminal usage summaries")
+		}
+		return nil
+	}
+	s.result.Samples = append(s.result.Samples, sample)
+	s.result.BoundaryObserved = true
+	return nil
+}

--- a/infrastructure/filesystem/claude_headless_usage_stream.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream.go
@@ -101,7 +101,7 @@ func (s *claudeHeadlessUsageStream) Complete() (application.ClaudeUsageLoadResul
 	}
 	s.buffer = nil
 	if s.parseErr != nil {
-		return application.ClaudeUsageLoadResult{}, s.parseErr
+		return s.result, s.parseErr
 	}
 	return s.result, nil
 }
@@ -127,6 +127,7 @@ func (s *claudeHeadlessUsageStream) parseLine(line []byte) error {
 	}
 	sample.ObservedAt = s.now().UTC()
 	if len(s.result.Samples) > 0 {
+		sample.ObservedAt = s.result.Samples[0].ObservedAt
 		if !sameClaudeUsageSample(s.result.Samples[0], sample) {
 			return xerrors.Errorf("conflicting Claude headless terminal usage summaries")
 		}

--- a/infrastructure/filesystem/claude_headless_usage_stream_test.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream_test.go
@@ -59,14 +59,48 @@ func TestClaudeHeadlessUsageStream_MissingTerminalUsageRemainsUnavailable(t *tes
 	}
 }
 
+func TestClaudeHeadlessUsageStream_DeduplicatesIdenticalTerminalRows(t *testing.T) {
+	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	row := `{"type":"result","subtype":"success","session_id":"claude-session-1","usage":{"input_tokens":2,"output_tokens":1}}` + "\n"
+	if _, err := stream.Write([]byte(row + row)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if len(result.Samples) != 1 {
+		t.Fatalf("samples = %+v", result.Samples)
+	}
+}
+
+func TestClaudeHeadlessUsageStream_MissingSubtypeDoesNotInferSuccess(t *testing.T) {
+	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	row := `{"type":"result","session_id":"claude-session-1","usage":{"input_tokens":2,"output_tokens":1}}` + "\n"
+	if _, err := stream.Write([]byte(row)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if len(result.Samples) != 1 ||
+		result.Samples[0].TerminalCode != types.UsageTerminalUnknown {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
 func TestClaudeHeadlessUsageStream_RejectsMalformedUsageWithoutEchoingBody(t *testing.T) {
 	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
 	fixture := `{"type":"result","session_id":"claude-session-1","usage":{"input_tokens":"PRIVATE-INVALID"}}` + "\n"
 	if _, err := stream.Write([]byte(fixture)); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
-	_, err := stream.Complete()
+	result, err := stream.Complete()
 	if err == nil || strings.Contains(err.Error(), "PRIVATE-INVALID") {
 		t.Fatalf("Complete() error = %v", err)
+	}
+	if result.Mode != application.ClaudeUsageModeOneShotStream || result.BoundaryObserved {
+		t.Fatalf("parse failure result = %+v", result)
 	}
 }

--- a/infrastructure/filesystem/claude_headless_usage_stream_test.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream_test.go
@@ -1,0 +1,72 @@
+package filesystem_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+func TestClaudeHeadlessUsageStream_ForwardsBodiesButRetainsOnlyTerminalResult(t *testing.T) {
+	output := &bytes.Buffer{}
+	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(output)
+	fixture := "" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"PRIVATE-BODY"}],"usage":{"input_tokens":999,"output_tokens":999}}}` + "\n" +
+		`{"type":"result","subtype":"success","session_id":"claude-session-1","result":"PRIVATE-RESULT","usage":{"input_tokens":21,"cache_creation_input_tokens":0,"cache_read_input_tokens":10,"output_tokens":5},"modelUsage":{"claude-opus-4-1":{"costUSD":0.1}}}` + "\n"
+	for _, chunk := range [][]byte{[]byte(fixture[:17]), []byte(fixture[17:83]), []byte(fixture[83:])} {
+		if _, err := stream.Write(chunk); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if output.String() != fixture {
+		t.Fatal("forwarded output changed")
+	}
+	if result.Mode != application.ClaudeUsageModeOneShotStream ||
+		!result.BoundaryObserved || len(result.Samples) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	sample := result.Samples[0]
+	if sample.Scope != types.UsageScopeRun || !sample.Available ||
+		sample.Model != "claude-opus-4-1" ||
+		sample.Counters.InputTokens == nil || *sample.Counters.InputTokens != 21 {
+		t.Fatalf("sample = %+v", sample)
+	}
+	if strings.Contains(sample.RecordID, "PRIVATE") {
+		t.Fatalf("private body entered identity: %q", sample.RecordID)
+	}
+}
+
+func TestClaudeHeadlessUsageStream_MissingTerminalUsageRemainsUnavailable(t *testing.T) {
+	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	fixture := `{"type":"result","subtype":"error","is_error":true,"session_id":"claude-session-1","error":"PRIVATE-FAILURE"}` + "\n"
+	if _, err := stream.Write([]byte(fixture)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if len(result.Samples) != 1 || result.Samples[0].Available ||
+		result.Samples[0].TerminalCode != types.UsageTerminalFailure {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestClaudeHeadlessUsageStream_RejectsMalformedUsageWithoutEchoingBody(t *testing.T) {
+	stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	fixture := `{"type":"result","session_id":"claude-session-1","usage":{"input_tokens":"PRIVATE-INVALID"}}` + "\n"
+	if _, err := stream.Write([]byte(fixture)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	_, err := stream.Complete()
+	if err == nil || strings.Contains(err.Error(), "PRIVATE-INVALID") {
+		t.Fatalf("Complete() error = %v", err)
+	}
+}

--- a/infrastructure/filesystem/claude_headless_usage_stream_test.go
+++ b/infrastructure/filesystem/claude_headless_usage_stream_test.go
@@ -104,3 +104,28 @@ func TestClaudeHeadlessUsageStream_RejectsMalformedUsageWithoutEchoingBody(t *te
 		t.Fatalf("parse failure result = %+v", result)
 	}
 }
+
+func TestClaudeHeadlessUsageStream_DiscardsTerminalResultAfterLaterParseFailure(t *testing.T) {
+	valid := `{"type":"result","subtype":"success","session_id":"claude-session-1","usage":{"input_tokens":2,"output_tokens":1}}` + "\n"
+	tests := map[string]string{
+		"malformed JSON":  `{"type":"result"` + "\n",
+		"malformed usage": `{"type":"result","session_id":"claude-session-1","usage":{"input_tokens":"invalid"}}` + "\n",
+		"oversized line":  strings.Repeat("x", 8*1024*1024+1) + "\n",
+	}
+	for name, invalid := range tests {
+		t.Run(name, func(t *testing.T) {
+			stream := filesystem.NewClaudeHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+			if _, err := stream.Write([]byte(valid + invalid)); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			result, err := stream.Complete()
+			if err == nil {
+				t.Fatal("Complete() error = nil")
+			}
+			if result.Mode != application.ClaudeUsageModeOneShotStream ||
+				result.BoundaryObserved || len(result.Samples) != 0 {
+				t.Fatalf("parse failure result = %+v", result)
+			}
+		})
+	}
+}

--- a/infrastructure/filesystem/claude_hooks_handler.go
+++ b/infrastructure/filesystem/claude_hooks_handler.go
@@ -92,6 +92,7 @@ func (h *ClaudeHooksHandler) BuildWithMatcher(tracearyBin string, preset ClaudeM
 	compactPreSnapshotCommand := newHookRuntimeCommand(tracearyBin, "hook", "compact", "claude", "pre-compact")
 	compactResumeCommand := newHookRuntimeCommand(tracearyBin, "hook", "compact", "claude", "session-start-compact")
 	promptCommand := newHookRuntimeCommand(tracearyBin, "hook", "prompt", "claude")
+	usageCommand := newHookRuntimeCommand(tracearyBin, "hook", "usage", "claude")
 	transcriptCommand := newHookRuntimeCommand(tracearyBin, "hook", "transcript", "claude")
 	subagentStartCommand := newHookRuntimeCommand(tracearyBin, "hook", "subagent-start", "claude")
 	subagentStopCommand := newHookRuntimeCommand(tracearyBin, "hook", "subagent-stop", "claude")
@@ -153,6 +154,7 @@ func (h *ClaudeHooksHandler) BuildWithMatcher(tracearyBin string, preset ClaudeM
 		},
 		"Stop": {
 			model.HookEntryOf(types.Some("*"), []model.HookCommand{
+				model.HookCommandOf("traceary-usage", "command", usageCommand, types.None[int](), "", managedKeyOf("traceary-usage.sh", "claude")),
 				model.HookCommandOf("traceary-transcript", "command", transcriptCommand, types.None[int](), "", managedKeyOf("traceary-transcript.sh", "claude")),
 			}),
 		},

--- a/infrastructure/filesystem/claude_hooks_handler_test.go
+++ b/infrastructure/filesystem/claude_hooks_handler_test.go
@@ -88,6 +88,26 @@ func TestClaudeHooksHandler_Build(t *testing.T) {
 		}
 	})
 
+	t.Run("Stop captures usage before transcript", func(t *testing.T) {
+		t.Parallel()
+		entries := hooks.Entries("Stop")
+		if diff := cmp.Diff(1, len(entries)); diff != "" {
+			t.Fatalf("len(Stop entries) mismatch (-want +got):\n%s", diff)
+		}
+		commands := entries[0].Commands()
+		if diff := cmp.Diff(2, len(commands)); diff != "" {
+			t.Fatalf("len(Stop commands) mismatch (-want +got):\n%s", diff)
+		}
+		if commands[0].Name() != "traceary-usage" ||
+			commands[0].Command() != `'traceary' 'hook' 'usage' 'claude'` ||
+			commands[0].ManagedKey() != "traceary-usage.sh:claude" {
+			t.Fatalf("Stop usage command = %+v", commands[0])
+		}
+		if commands[1].Name() != "traceary-transcript" {
+			t.Fatalf("Stop transcript command = %+v", commands[1])
+		}
+	})
+
 	t.Run("PostToolUse covers Bash, mcp, and built-in tools", func(t *testing.T) {
 		t.Parallel()
 

--- a/infrastructure/filesystem/claude_usage_source.go
+++ b/infrastructure/filesystem/claude_usage_source.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -62,9 +63,38 @@ func (s *claudeUsageSource) Load(
 	if err != nil {
 		return application.ClaudeUsageLoadResult{}, err
 	}
-	paths, err := filepath.Glob(filepath.Join(root, "*", sessionID+".jsonl"))
+	rootHandle, err := os.OpenRoot(root)
 	if err != nil {
-		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to match Claude usage source")
+		if os.IsNotExist(err) {
+			return application.ClaudeUsageLoadResult{Mode: application.ClaudeUsageModeTranscriptCalls}, nil
+		}
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to open Claude projects root")
+	}
+	defer func() { _ = rootHandle.Close() }()
+	entries, err := fs.ReadDir(rootHandle.FS(), ".")
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to list Claude projects root")
+	}
+	paths := make([]string, 0, 1)
+	for _, entry := range entries {
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+				"Claude projects root must not contain symlinked project directories",
+			)
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(entry.Name(), sessionID+".jsonl")
+		if _, err := rootHandle.Lstat(candidate); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+				"failed to inspect Claude usage source",
+			)
+		}
+		paths = append(paths, candidate)
 	}
 	sort.Strings(paths)
 	if len(paths) == 0 {
@@ -73,7 +103,7 @@ func (s *claudeUsageSource) Load(
 	if len(paths) != 1 {
 		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("ambiguous Claude usage source")
 	}
-	return s.loadFile(ctx, root, paths[0], sessionID)
+	return s.loadFile(ctx, rootHandle, paths[0], sessionID)
 }
 
 func (s *claudeUsageSource) resolveProjectsRoot() (string, error) {
@@ -98,12 +128,12 @@ func (s *claudeUsageSource) resolveProjectsRoot() (string, error) {
 
 func (s *claudeUsageSource) loadFile(
 	ctx context.Context,
-	root string,
-	path string,
+	root *os.Root,
+	relative string,
 	sessionID string,
 ) (application.ClaudeUsageLoadResult, error) {
-	relative, err := filepath.Rel(root, path)
-	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(relative) {
 		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("Claude usage source escapes projects root")
 	}
 	info, err := validateClaudeUsagePath(root, relative)
@@ -115,7 +145,7 @@ func (s *claudeUsageSource) loadFile(
 			"Claude usage source exceeds %d-byte limit", s.maxFileBytes,
 		)
 	}
-	file, err := os.Open(path) // #nosec G304 -- all components were checked below the resolved projects root
+	file, err := root.Open(relative)
 	if err != nil {
 		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to open Claude usage source")
 	}
@@ -137,15 +167,15 @@ func (s *claudeUsageSource) loadFile(
 	return result, nil
 }
 
-func validateClaudeUsagePath(root, relative string) (os.FileInfo, error) {
-	current := root
+func validateClaudeUsagePath(root *os.Root, relative string) (os.FileInfo, error) {
+	current := ""
 	parts := strings.Split(filepath.Clean(relative), string(filepath.Separator))
 	for index, part := range parts {
 		if part == "" || part == "." || part == ".." {
 			return nil, xerrors.Errorf("invalid Claude usage source path")
 		}
 		current = filepath.Join(current, part)
-		info, err := os.Lstat(current)
+		info, err := root.Lstat(current)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to inspect Claude usage source")
 		}
@@ -317,9 +347,11 @@ func claudeResultUsageSample(
 	if err != nil {
 		return application.ClaudeUsageSample{}, err
 	}
-	terminal := types.UsageTerminalSuccess
+	terminal := types.UsageTerminalUnknown
 	if envelope.IsError || (envelope.Subtype != "" && envelope.Subtype != "success") {
 		terminal = types.UsageTerminalFailure
+	} else if envelope.Subtype == "success" {
+		terminal = types.UsageTerminalSuccess
 	}
 	return application.ClaudeUsageSample{
 		RecordID:      "one_shot_stream:" + opaqueClaudeIdentity(sessionID, "terminal-result"),

--- a/infrastructure/filesystem/claude_usage_source.go
+++ b/infrastructure/filesystem/claude_usage_source.go
@@ -1,0 +1,416 @@
+package filesystem
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	defaultClaudeUsageMaxFileBytes int64 = 256 * 1024 * 1024
+	defaultClaudeUsageMaxLineBytes       = 8 * 1024 * 1024
+)
+
+type claudeUsageSource struct {
+	userHomeDir  func() (string, error)
+	maxFileBytes int64
+	maxLineBytes int
+}
+
+// NewClaudeUsageSource creates the bounded local Claude transcript reader.
+func NewClaudeUsageSource() application.ClaudeUsageSource {
+	return &claudeUsageSource{
+		userHomeDir:  osUserHomeDir,
+		maxFileBytes: defaultClaudeUsageMaxFileBytes,
+		maxLineBytes: defaultClaudeUsageMaxLineBytes,
+	}
+}
+
+func newClaudeUsageSourceWithHomeDir(userHomeDir func() (string, error)) *claudeUsageSource {
+	return &claudeUsageSource{
+		userHomeDir:  userHomeDir,
+		maxFileBytes: defaultClaudeUsageMaxFileBytes,
+		maxLineBytes: defaultClaudeUsageMaxLineBytes,
+	}
+}
+
+func (s *claudeUsageSource) Load(
+	ctx context.Context,
+	criteria application.ClaudeUsageLoadCriteria,
+) (application.ClaudeUsageLoadResult, error) {
+	if ctx == nil {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("context must not be nil")
+	}
+	sessionID := strings.TrimSpace(criteria.SessionID.String())
+	if sessionID == "" || filepath.Base(sessionID) != sessionID || strings.ContainsAny(sessionID, `/\\`) {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("invalid Claude usage session ID")
+	}
+	root, err := s.resolveProjectsRoot()
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, err
+	}
+	paths, err := filepath.Glob(filepath.Join(root, "*", sessionID+".jsonl"))
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to match Claude usage source")
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return application.ClaudeUsageLoadResult{Mode: application.ClaudeUsageModeTranscriptCalls}, nil
+	}
+	if len(paths) != 1 {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("ambiguous Claude usage source")
+	}
+	return s.loadFile(ctx, root, paths[0], sessionID)
+}
+
+func (s *claudeUsageSource) resolveProjectsRoot() (string, error) {
+	claudeHome := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+	if claudeHome == "" {
+		home, err := s.userHomeDir()
+		if err != nil {
+			return "", xerrors.Errorf("failed to resolve Claude usage home")
+		}
+		claudeHome = filepath.Join(home, ".claude")
+	}
+	root := filepath.Join(claudeHome, "projects")
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return root, nil
+		}
+		return "", xerrors.Errorf("failed to resolve Claude projects root")
+	}
+	return resolved, nil
+}
+
+func (s *claudeUsageSource) loadFile(
+	ctx context.Context,
+	root string,
+	path string,
+	sessionID string,
+) (application.ClaudeUsageLoadResult, error) {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("Claude usage source escapes projects root")
+	}
+	info, err := validateClaudeUsagePath(root, relative)
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, err
+	}
+	if info.Size() > s.maxFileBytes {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+			"Claude usage source exceeds %d-byte limit", s.maxFileBytes,
+		)
+	}
+	file, err := os.Open(path) // #nosec G304 -- all components were checked below the resolved projects root
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to open Claude usage source")
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("Claude usage source changed during open")
+	}
+	limited := &io.LimitedReader{R: file, N: s.maxFileBytes + 1}
+	result, err := parseClaudeUsageJSONL(ctx, limited, sessionID, s.maxLineBytes)
+	if err != nil {
+		return application.ClaudeUsageLoadResult{}, err
+	}
+	if limited.N == 0 {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+			"Claude usage source exceeds %d-byte limit", s.maxFileBytes,
+		)
+	}
+	return result, nil
+}
+
+func validateClaudeUsagePath(root, relative string) (os.FileInfo, error) {
+	current := root
+	parts := strings.Split(filepath.Clean(relative), string(filepath.Separator))
+	for index, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return nil, xerrors.Errorf("invalid Claude usage source path")
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to inspect Claude usage source")
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, xerrors.Errorf("Claude usage source path must not contain symlinks")
+		}
+		if index < len(parts)-1 && !info.IsDir() {
+			return nil, xerrors.Errorf("Claude usage source parent must be a directory")
+		}
+		if index == len(parts)-1 {
+			if !info.Mode().IsRegular() {
+				return nil, xerrors.Errorf("Claude usage source must be a regular file")
+			}
+			return info, nil
+		}
+	}
+	return nil, xerrors.Errorf("invalid Claude usage source path")
+}
+
+type claudeUsageEnvelope struct {
+	Type       string          `json:"type"`
+	Timestamp  string          `json:"timestamp"`
+	SessionID  string          `json:"session_id"`
+	SessionID2 string          `json:"sessionId"`
+	RequestID  string          `json:"requestId"`
+	Message    json.RawMessage `json:"message"`
+	Usage      json.RawMessage `json:"usage"`
+	ModelUsage json.RawMessage `json:"modelUsage"`
+	Subtype    string          `json:"subtype"`
+	IsError    bool            `json:"is_error"`
+}
+
+type claudeAssistantMessage struct {
+	ID    string          `json:"id"`
+	Model string          `json:"model"`
+	Usage json.RawMessage `json:"usage"`
+}
+
+type claudeRawUsageCounters struct {
+	InputTokens         *int64 `json:"input_tokens"`
+	CacheReadTokens     *int64 `json:"cache_read_input_tokens"`
+	CacheCreationTokens *int64 `json:"cache_creation_input_tokens"`
+	OutputTokens        *int64 `json:"output_tokens"`
+}
+
+func parseClaudeUsageJSONL(
+	ctx context.Context,
+	reader io.Reader,
+	sessionID string,
+	maxLineBytes int,
+) (application.ClaudeUsageLoadResult, error) {
+	result := application.ClaudeUsageLoadResult{Mode: application.ClaudeUsageModeTranscriptCalls}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), maxLineBytes)
+	calls := make([]application.ClaudeUsageSample, 0)
+	seenCalls := make(map[string]application.ClaudeUsageSample)
+	var terminal *application.ClaudeUsageSample
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return application.ClaudeUsageLoadResult{}, xerrors.Errorf("Claude usage read canceled: %w", err)
+		}
+		line := scanner.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var envelope claudeUsageEnvelope
+		if err := json.Unmarshal(line, &envelope); err != nil {
+			return application.ClaudeUsageLoadResult{}, xerrors.Errorf("invalid Claude usage JSON event")
+		}
+		rowSessionID := strings.TrimSpace(envelope.SessionID)
+		if rowSessionID == "" {
+			rowSessionID = strings.TrimSpace(envelope.SessionID2)
+		}
+		if rowSessionID != "" && rowSessionID != sessionID {
+			continue
+		}
+		switch envelope.Type {
+		case "assistant":
+			sample, identity, relevant, err := claudeAssistantUsageSample(envelope, sessionID)
+			if err != nil {
+				return application.ClaudeUsageLoadResult{}, err
+			}
+			if !relevant {
+				continue
+			}
+			if existing, found := seenCalls[identity]; found {
+				if !sameClaudeUsageSample(existing, sample) {
+					return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+						"conflicting duplicate Claude assistant usage",
+					)
+				}
+				continue
+			}
+			seenCalls[identity] = sample
+			calls = append(calls, sample)
+			result.BoundaryObserved = true
+		case "result":
+			sample, err := claudeResultUsageSample(envelope, sessionID)
+			if err != nil {
+				return application.ClaudeUsageLoadResult{}, err
+			}
+			if terminal != nil && !sameClaudeUsageSample(*terminal, sample) {
+				return application.ClaudeUsageLoadResult{}, xerrors.Errorf(
+					"conflicting Claude terminal usage summaries",
+				)
+			}
+			terminal = &sample
+			result.Mode = application.ClaudeUsageModeOneShotStream
+			result.BoundaryObserved = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return application.ClaudeUsageLoadResult{}, xerrors.Errorf("failed to scan Claude usage source")
+	}
+	if terminal != nil {
+		result.Samples = append(result.Samples, *terminal)
+	}
+	result.Samples = append(result.Samples, calls...)
+	return result, nil
+}
+
+func claudeAssistantUsageSample(
+	envelope claudeUsageEnvelope,
+	sessionID string,
+) (application.ClaudeUsageSample, string, bool, error) {
+	if len(envelope.Message) == 0 || string(envelope.Message) == "null" {
+		return application.ClaudeUsageSample{}, "", false, nil
+	}
+	var message claudeAssistantMessage
+	if err := json.Unmarshal(envelope.Message, &message); err != nil {
+		return application.ClaudeUsageSample{}, "", false, xerrors.Errorf("invalid Claude assistant metadata")
+	}
+	requestID := strings.TrimSpace(envelope.RequestID)
+	messageID := strings.TrimSpace(message.ID)
+	if requestID == "" || messageID == "" || strings.ContainsAny(requestID+messageID, "\r\n\x00") {
+		return application.ClaudeUsageSample{}, "", false, nil
+	}
+	identity := requestID + "\x00" + messageID
+	observedAt, err := claudeObservedAt(envelope.Timestamp)
+	if err != nil {
+		return application.ClaudeUsageSample{}, "", false, err
+	}
+	counters, available, err := decodeClaudeUsage(message.Usage)
+	if err != nil {
+		return application.ClaudeUsageSample{}, "", false, err
+	}
+	return application.ClaudeUsageSample{
+		RecordID:      "transcript_calls:" + opaqueClaudeIdentity(sessionID, identity),
+		SourceName:    "transcript_calls",
+		SourceVersion: "schema-v1",
+		Model:         strings.TrimSpace(message.Model),
+		Scope:         types.UsageScopeCall,
+		ObservedAt:    observedAt,
+		TerminalCode:  types.UsageTerminalSuccess,
+		Available:     available,
+		Counters:      counters,
+	}, identity, true, nil
+}
+
+func claudeResultUsageSample(
+	envelope claudeUsageEnvelope,
+	sessionID string,
+) (application.ClaudeUsageSample, error) {
+	observedAt, err := claudeObservedAt(envelope.Timestamp)
+	if err != nil {
+		return application.ClaudeUsageSample{}, err
+	}
+	counters, available, err := decodeClaudeUsage(envelope.Usage)
+	if err != nil {
+		return application.ClaudeUsageSample{}, err
+	}
+	terminal := types.UsageTerminalSuccess
+	if envelope.IsError || (envelope.Subtype != "" && envelope.Subtype != "success") {
+		terminal = types.UsageTerminalFailure
+	}
+	return application.ClaudeUsageSample{
+		RecordID:      "one_shot_stream:" + opaqueClaudeIdentity(sessionID, "terminal-result"),
+		SourceName:    "one_shot_stream",
+		SourceVersion: "schema-v1",
+		Model:         singleClaudeModel(envelope.ModelUsage),
+		Scope:         types.UsageScopeRun,
+		ObservedAt:    observedAt,
+		TerminalCode:  terminal,
+		Available:     available,
+		Counters:      counters,
+	}, nil
+}
+
+func decodeClaudeUsage(raw json.RawMessage) (application.ClaudeUsageCounters, bool, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return application.ClaudeUsageCounters{}, false, nil
+	}
+	var counters claudeRawUsageCounters
+	if err := json.Unmarshal(raw, &counters); err != nil {
+		return application.ClaudeUsageCounters{}, false, xerrors.Errorf("invalid Claude usage counters")
+	}
+	for _, counter := range []*int64{
+		counters.InputTokens, counters.CacheReadTokens, counters.CacheCreationTokens, counters.OutputTokens,
+	} {
+		if counter != nil && *counter < 0 {
+			return application.ClaudeUsageCounters{}, false, xerrors.Errorf("invalid negative Claude usage counter")
+		}
+	}
+	if counters.InputTokens == nil || counters.OutputTokens == nil {
+		return application.ClaudeUsageCounters{}, false, xerrors.Errorf("incomplete Claude usage counters")
+	}
+	return application.ClaudeUsageCounters{
+		InputTokens:           counters.InputTokens,
+		CachedInputTokens:     counters.CacheReadTokens,
+		CacheWriteInputTokens: counters.CacheCreationTokens,
+		OutputTokens:          counters.OutputTokens,
+	}, true, nil
+}
+
+func claudeObservedAt(raw string) (time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Unix(0, 0).UTC(), nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, xerrors.Errorf("invalid Claude usage timestamp")
+	}
+	return parsed.UTC(), nil
+}
+
+func opaqueClaudeIdentity(sessionID, sourceIdentity string) string {
+	sum := sha256.Sum256([]byte(sessionID + "\x00" + sourceIdentity))
+	return hex.EncodeToString(sum[:])
+}
+
+func singleClaudeModel(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var models map[string]json.RawMessage
+	if json.Unmarshal(raw, &models) != nil || len(models) != 1 {
+		return ""
+	}
+	for model := range models {
+		return strings.TrimSpace(model)
+	}
+	return ""
+}
+
+func sameClaudeUsageSample(left, right application.ClaudeUsageSample) bool {
+	if left.RecordID != right.RecordID || left.SourceName != right.SourceName ||
+		left.SourceVersion != right.SourceVersion || left.Model != right.Model ||
+		left.Scope != right.Scope || !left.ObservedAt.Equal(right.ObservedAt) ||
+		left.TerminalCode != right.TerminalCode || left.Available != right.Available {
+		return false
+	}
+	leftCounters := left.Counters
+	rightCounters := right.Counters
+	return sameOptionalInt64(leftCounters.InputTokens, rightCounters.InputTokens) &&
+		sameOptionalInt64(leftCounters.CachedInputTokens, rightCounters.CachedInputTokens) &&
+		sameOptionalInt64(leftCounters.CacheWriteInputTokens, rightCounters.CacheWriteInputTokens) &&
+		sameOptionalInt64(leftCounters.OutputTokens, rightCounters.OutputTokens) &&
+		sameOptionalInt64(leftCounters.ReasoningOutputTokens, rightCounters.ReasoningOutputTokens) &&
+		sameOptionalInt64(leftCounters.TotalTokens, rightCounters.TotalTokens)
+}
+
+func sameOptionalInt64(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}

--- a/infrastructure/filesystem/claude_usage_source_export_test.go
+++ b/infrastructure/filesystem/claude_usage_source_export_test.go
@@ -1,0 +1,14 @@
+package filesystem
+
+import "github.com/duck8823/traceary/application"
+
+func NewClaudeUsageSourceForTest(
+	userHomeDir func() (string, error),
+	maxFileBytes int64,
+	maxLineBytes int,
+) application.ClaudeUsageSource {
+	source := newClaudeUsageSourceWithHomeDir(userHomeDir)
+	source.maxFileBytes = maxFileBytes
+	source.maxLineBytes = maxLineBytes
+	return source
+}

--- a/infrastructure/filesystem/claude_usage_source_test.go
+++ b/infrastructure/filesystem/claude_usage_source_test.go
@@ -95,6 +95,93 @@ func TestClaudeUsageSource_MissingSelectedUsageIsExplicitlyUnavailable(t *testin
 	}
 }
 
+func TestClaudeUsageSource_ErrorResultRetainsReportedUsageWithoutInferringSuccess(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-claude-error-usage"
+	writeClaudeUsageFixture(t, home, sessionID,
+		`{"type":"result","session_id":"session-claude-error-usage","subtype":"error","is_error":true,"timestamp":"2026-07-23T01:00:01Z","usage":{"input_tokens":3,"output_tokens":1},"error":"PRIVATE-ERROR"}`+"\n",
+	)
+	result, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Samples) != 1 || !result.Samples[0].Available ||
+		result.Samples[0].TerminalCode != types.UsageTerminalFailure {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestClaudeUsageSource_RejectsConflictingDuplicateAssistantUsage(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-conflict"
+	writeClaudeUsageFixture(t, home, sessionID, strings.Join([]string{
+		`{"type":"assistant","sessionId":"session-conflict","requestId":"req-1","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","usage":{"input_tokens":1,"output_tokens":1}}}`,
+		`{"type":"assistant","sessionId":"session-conflict","requestId":"req-1","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","usage":{"input_tokens":2,"output_tokens":1},"content":"PRIVATE-CONFLICT"}}`,
+	}, "\n")+"\n")
+	_, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err == nil || strings.Contains(err.Error(), "PRIVATE-CONFLICT") {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
+func TestClaudeUsageSource_RejectsAmbiguousExactSessionFiles(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-ambiguous"
+	for _, project := range []string{"project-a", "project-b"} {
+		path := filepath.Join(home, ".claude", "projects", project, sessionID+".jsonl")
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"type":"result"}`+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
+func TestClaudeUsageSource_UsesExactSessionNameInsteadOfGlobPattern(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session[1]"
+	writeClaudeUsageFixture(t, home, sessionID,
+		`{"type":"result","session_id":"session[1]","subtype":"success","usage":{"input_tokens":1,"output_tokens":1}}`+"\n",
+	)
+	result, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Samples) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestClaudeUsageSource_RejectsMalformedJSONWithoutLeakingBody(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-malformed"
+	writeClaudeUsageFixture(t, home, sessionID, `{"type":"assistant","private":"PRIVATE-MALFORMED"`+"\n")
+	_, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err == nil || strings.Contains(err.Error(), "PRIVATE-MALFORMED") {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
 func TestClaudeUsageSource_RejectsUnsafeOrOversizedSourceWithoutLeakingBody(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	t.Run("oversized", func(t *testing.T) {
@@ -127,6 +214,32 @@ func TestClaudeUsageSource_RejectsUnsafeOrOversizedSourceWithoutLeakingBody(t *t
 		).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
 		if err == nil {
 			t.Fatal("Load() error = nil, want symlink rejection")
+		}
+	})
+	t.Run("symlinked project directory", func(t *testing.T) {
+		home := t.TempDir()
+		projects := filepath.Join(home, ".claude", "projects")
+		if err := os.MkdirAll(projects, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		outside := filepath.Join(t.TempDir(), "project")
+		if err := os.MkdirAll(outside, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		sessionID := "session-parent-symlink"
+		if err := os.WriteFile(
+			filepath.Join(outside, sessionID+".jsonl"), []byte(`{"type":"result"}`), 0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(projects, "linked-project")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := filesystem.NewClaudeUsageSourceForTest(
+			func() (string, error) { return home, nil }, 1024, 1024,
+		).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+		if err == nil {
+			t.Fatal("Load() error = nil, want symlinked parent rejection")
 		}
 	})
 }

--- a/infrastructure/filesystem/claude_usage_source_test.go
+++ b/infrastructure/filesystem/claude_usage_source_test.go
@@ -1,0 +1,144 @@
+package filesystem_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+func TestClaudeUsageSource_DeduplicatesRequestAndMessageIdentityWithoutPrivateBodies(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-claude-1"
+	path := writeClaudeUsageFixture(t, home, sessionID, strings.Join([]string{
+		`{"type":"user","sessionId":"session-claude-1","message":{"content":"PRIVATE-PROMPT"}}`,
+		`{"type":"assistant","sessionId":"session-claude-1","requestId":"req-1","uuid":"row-a","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","model":"claude-opus-4-1","content":[{"type":"text","text":"PRIVATE-RESPONSE"}],"usage":{"input_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":8,"output_tokens":3}}}`,
+		`{"type":"assistant","sessionId":"session-claude-1","requestId":"req-1","uuid":"row-b","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","model":"claude-opus-4-1","content":[{"type":"text","text":"PRIVATE-DUPLICATE"}],"usage":{"input_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":8,"output_tokens":3}}}`,
+		`{"type":"assistant","sessionId":"session-claude-1","requestId":"req-2","timestamp":"2026-07-23T01:00:01Z","message":{"id":"msg-1","model":"claude-opus-4-1","usage":{"input_tokens":4,"cache_read_input_tokens":0,"output_tokens":1}}}`,
+	}, "\n")+"\n")
+	source := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	)
+	result, err := source.Load(
+		context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)},
+	)
+	if err != nil {
+		t.Fatalf("Load(%s) error = %v", filepath.Base(path), err)
+	}
+	if result.Mode != application.ClaudeUsageModeTranscriptCalls ||
+		!result.BoundaryObserved || len(result.Samples) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	first := result.Samples[0]
+	if first.Scope != types.UsageScopeCall || !first.Available ||
+		first.Model != "claude-opus-4-1" || first.Counters.CacheWriteInputTokens == nil ||
+		*first.Counters.CacheWriteInputTokens != 0 {
+		t.Fatalf("first sample = %+v", first)
+	}
+	if first.RecordID == result.Samples[1].RecordID {
+		t.Fatal("distinct request IDs collapsed into one call identity")
+	}
+	for _, sample := range result.Samples {
+		if strings.Contains(sample.RecordID, "req-") || strings.Contains(sample.RecordID, "msg-") {
+			t.Fatalf("source identity was not opaque: %q", sample.RecordID)
+		}
+	}
+}
+
+func TestClaudeUsageSource_LegacyResultWinsWhileRetainingCallEvidence(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-claude-legacy"
+	writeClaudeUsageFixture(t, home, sessionID, strings.Join([]string{
+		`{"type":"assistant","session_id":"session-claude-legacy","requestId":"req-1","timestamp":"2026-07-23T01:00:00Z","message":{"id":"msg-1","model":"claude-sonnet-4","usage":{"input_tokens":10,"output_tokens":2}}}`,
+		`{"type":"result","session_id":"session-claude-legacy","subtype":"success","timestamp":"2026-07-23T01:00:01Z","usage":{"input_tokens":20,"cache_creation_input_tokens":3,"cache_read_input_tokens":4,"output_tokens":5},"modelUsage":{"claude-sonnet-4":{"costUSD":0.01}},"result":"PRIVATE-RESULT"}`,
+	}, "\n")+"\n")
+	result, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if result.Mode != application.ClaudeUsageModeOneShotStream ||
+		!result.BoundaryObserved || len(result.Samples) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.Samples[0].Scope != types.UsageScopeRun ||
+		result.Samples[0].Model != "claude-sonnet-4" ||
+		result.Samples[1].Scope != types.UsageScopeCall {
+		t.Fatalf("samples = %+v", result.Samples)
+	}
+}
+
+func TestClaudeUsageSource_MissingSelectedUsageIsExplicitlyUnavailable(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	sessionID := "session-claude-aborted"
+	writeClaudeUsageFixture(t, home, sessionID,
+		`{"type":"result","session_id":"session-claude-aborted","subtype":"error","is_error":true,"timestamp":"2026-07-23T01:00:01Z","error":"PRIVATE-ERROR"}`+"\n",
+	)
+	result, err := filesystem.NewClaudeUsageSourceForTest(
+		func() (string, error) { return home, nil }, 1024*1024, 1024*1024,
+	).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Samples) != 1 || result.Samples[0].Available ||
+		result.Samples[0].TerminalCode != types.UsageTerminalFailure {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestClaudeUsageSource_RejectsUnsafeOrOversizedSourceWithoutLeakingBody(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Run("oversized", func(t *testing.T) {
+		home := t.TempDir()
+		sessionID := "session-oversized"
+		writeClaudeUsageFixture(t, home, sessionID, strings.Repeat("PRIVATE-SENTINEL", 8))
+		_, err := filesystem.NewClaudeUsageSourceForTest(
+			func() (string, error) { return home, nil }, 16, 1024,
+		).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+		if err == nil || strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
+			t.Fatalf("Load() error = %v", err)
+		}
+	})
+	t.Run("symlink", func(t *testing.T) {
+		home := t.TempDir()
+		project := filepath.Join(home, ".claude", "projects", "project")
+		if err := os.MkdirAll(project, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(t.TempDir(), "outside.jsonl")
+		if err := os.WriteFile(target, []byte(`{"type":"result"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sessionID := "session-symlink"
+		if err := os.Symlink(target, filepath.Join(project, sessionID+".jsonl")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := filesystem.NewClaudeUsageSourceForTest(
+			func() (string, error) { return home, nil }, 1024, 1024,
+		).Load(context.Background(), application.ClaudeUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+		if err == nil {
+			t.Fatal("Load() error = nil, want symlink rejection")
+		}
+	})
+}
+
+func writeClaudeUsageFixture(t *testing.T, home, sessionID, body string) string {
+	t.Helper()
+	path := filepath.Join(home, ".claude", "projects", "project", sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/integrations/claude-plugin/hooks/hooks.json
+++ b/integrations/claude-plugin/hooks/hooks.json
@@ -38,6 +38,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "'traceary' 'hook' 'usage' 'claude'"
+          },
+          {
+            "type": "command",
             "command": "'traceary' 'hook' 'transcript' 'claude'"
           }
         ]

--- a/main.go
+++ b/main.go
@@ -180,6 +180,9 @@ func run() error {
 	codexUsageUsecase := usecase.NewCodexUsageCaptureUsecase(
 		filesystem.NewCodexUsageSource(), usageObservationDatasource,
 	)
+	claudeUsageUsecase := usecase.NewClaudeUsageCaptureUsecase(
+		filesystem.NewClaudeUsageSource(), usageObservationDatasource,
+	)
 	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	replayUsecase := usecase.NewReplayUsecase(sessionDatasource, eventDatasource, memoryDatasource)
 	storeManagementUsecase := usecase.NewStoreManagementUsecase(storeManagementDatasource)
@@ -229,6 +232,8 @@ func run() error {
 		cli.WithBundle(bundleUsecase),
 		cli.WithCodexUsage(codexUsageUsecase),
 		cli.WithCodexHeadlessUsage(filesystem.NewCodexHeadlessUsageStreamFactory()),
+		cli.WithClaudeUsage(claudeUsageUsecase),
+		cli.WithClaudeHeadlessUsage(filesystem.NewClaudeHeadlessUsageStreamFactory()),
 		cli.WithContext(contextUsecase),
 		cli.WithReplay(replayUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -23,6 +23,8 @@ const (
 	runtimeSessionIDEnvKey     = "TRACEARY_RUNTIME_SESSION_ID"
 	codexUsageModeEnvKey       = "TRACEARY_CODEX_USAGE_MODE"
 	codexUsageModeHeadless     = "headless_stream"
+	claudeUsageModeEnvKey      = "TRACEARY_CLAUDE_USAGE_MODE"
+	claudeUsageModeOneShot     = "one_shot_stream"
 )
 
 const hookActiveSubagentStateTTL = 24 * time.Hour
@@ -213,10 +215,21 @@ func (c *RootCLI) newHookUsageCommand() *cobra.Command {
 		Hidden: true,
 		Args:   exactArgsLocalized(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(args[0]) == "codex" && strings.TrimSpace(os.Getenv(codexUsageModeEnvKey)) == codexUsageModeHeadless {
+			client := strings.TrimSpace(args[0])
+			if client == "codex" && strings.TrimSpace(os.Getenv(codexUsageModeEnvKey)) == codexUsageModeHeadless {
 				return nil
 			}
-			return c.runCodexUsageHookDurably(cmd.Context(), cmd.InOrStdin(), args[0], dbPath)
+			if client == "claude" && strings.TrimSpace(os.Getenv(claudeUsageModeEnvKey)) == claudeUsageModeOneShot {
+				return nil
+			}
+			switch client {
+			case "codex":
+				return c.runCodexUsageHookDurably(cmd.Context(), cmd.InOrStdin(), client, dbPath)
+			case "claude":
+				return c.runClaudeUsageHookDurably(cmd.Context(), cmd.InOrStdin(), client, dbPath)
+			default:
+				return c.runHookUsage(cmd.Context(), cmd.InOrStdin(), client, dbPath)
+			}
 		},
 	}
 	cmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
@@ -251,17 +264,61 @@ func (c *RootCLI) runCodexUsageHookDurably(ctx context.Context, input io.Reader,
 	})
 }
 
+func (c *RootCLI) runClaudeUsageHookDurably(ctx context.Context, input io.Reader, client, dbPath string) error {
+	payload, err := readHookPayload(input)
+	if err != nil {
+		return runHookBestEffort("usage", func() error { return err })
+	}
+	sessionID, err := resolveHookSessionID(payload, client)
+	if err != nil {
+		return runHookBestEffort("usage", func() error { return err })
+	}
+	if sessionID == "" {
+		return nil
+	}
+	minimal := struct {
+		SessionID string `json:"session_id"`
+		EventID   string `json:"event_id,omitempty"`
+		ToolUseID string `json:"tool_use_id,omitempty"`
+	}{
+		SessionID: sessionID.String(),
+		EventID:   strings.TrimSpace(hookPayloadString(payload, "event_id", "")),
+		ToolUseID: strings.TrimSpace(hookPayloadString(payload, "tool_use_id", "")),
+	}
+	sanitized, err := json.Marshal(minimal)
+	if err != nil {
+		return runHookBestEffort("usage", func() error {
+			return xerrors.Errorf("failed to encode body-free Claude usage payload: %w", err)
+		})
+	}
+	return c.runHookDurably(
+		ctx,
+		"usage",
+		hookInvocationSpec{Command: "usage", Client: client, DBPath: dbPath},
+		newExplicitHookPayloadReader(sanitized),
+		func(replay io.Reader) error {
+			return c.runHookUsage(ctx, replay, client, dbPath)
+		},
+	)
+}
+
 func (c *RootCLI) runHookUsage(
 	ctx context.Context,
 	input io.Reader,
 	client string,
 	dbPath string,
 ) error {
-	if client != "codex" {
+	if client != "codex" && client != "claude" {
 		return xerrors.Errorf("unsupported hook usage client: %s", client)
 	}
-	if c.storeManagement == nil || c.codexUsage == nil {
+	if c.storeManagement == nil {
+		return xerrors.Errorf("usage capture store dependency is not configured")
+	}
+	if client == "codex" && c.codexUsage == nil {
 		return xerrors.Errorf("Codex usage capture dependencies are not configured")
+	}
+	if client == "claude" && c.claudeUsage == nil {
+		return xerrors.Errorf("Claude usage capture dependencies are not configured")
 	}
 	payload, err := readHookPayload(input)
 	if err != nil {
@@ -284,11 +341,21 @@ func (c *RootCLI) runHookUsage(
 	if err := c.storeManagement.Initialize(ctx); err != nil {
 		return xerrors.Errorf("failed to initialize store: %w", err)
 	}
-	_, err = c.codexUsage.Capture(ctx, usecase.CodexUsageCaptureInput{
-		SessionID: sessionID, DeliveryID: deliveryID,
-	})
-	if err != nil {
-		return xerrors.Errorf("failed to capture Codex usage: %w", err)
+	switch client {
+	case "codex":
+		_, err = c.codexUsage.Capture(ctx, usecase.CodexUsageCaptureInput{
+			SessionID: sessionID, DeliveryID: deliveryID,
+		})
+		if err != nil {
+			return xerrors.Errorf("failed to capture Codex usage: %w", err)
+		}
+	case "claude":
+		_, err = c.claudeUsage.Capture(ctx, usecase.ClaudeUsageCaptureInput{
+			SessionID: sessionID, DeliveryID: deliveryID,
+		})
+		if err != nil {
+			return xerrors.Errorf("failed to capture Claude usage: %w", err)
+		}
 	}
 	return nil
 }

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -43,6 +43,30 @@ type codexUsageCaptureStub struct {
 	err      error
 }
 
+type claudeUsageCaptureStub struct {
+	inputs   []usecase.ClaudeUsageCaptureInput
+	headless []application.ClaudeUsageLoadResult
+	err      error
+}
+
+func (s *claudeUsageCaptureStub) Capture(
+	_ context.Context,
+	input usecase.ClaudeUsageCaptureInput,
+) (usecase.ClaudeUsageCaptureResult, error) {
+	s.inputs = append(s.inputs, input)
+	return usecase.ClaudeUsageCaptureResult{Applied: 1}, s.err
+}
+
+func (s *claudeUsageCaptureStub) CaptureHeadless(
+	_ context.Context,
+	input usecase.ClaudeUsageCaptureInput,
+	loaded application.ClaudeUsageLoadResult,
+) (usecase.ClaudeUsageCaptureResult, error) {
+	s.inputs = append(s.inputs, input)
+	s.headless = append(s.headless, loaded)
+	return usecase.ClaudeUsageCaptureResult{Applied: 1}, s.err
+}
+
 func (s *codexUsageCaptureStub) Capture(_ context.Context, input usecase.CodexUsageCaptureInput) (usecase.CodexUsageCaptureResult, error) {
 	s.inputs = append(s.inputs, input)
 	return usecase.CodexUsageCaptureResult{Applied: 1}, s.err
@@ -75,6 +99,55 @@ func TestRootCLI_HookUsageCommand_DelegatesBodyFreeCodexIdentity(t *testing.T) {
 	}
 	if usage.inputs[0].SessionID != types.SessionID("codex-session") || usage.inputs[0].DeliveryID != "event_id:stop-1" || strings.Contains(usage.inputs[0].DeliveryID, "private") {
 		t.Fatalf("capture input = %+v", usage.inputs[0])
+	}
+}
+
+func TestRootCLI_HookUsageCommand_DelegatesBodyFreeClaudeIdentity(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "claude-usage-key")
+	store := &storeManagementUsecaseStub{}
+	usage := &claudeUsageCaptureStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithClaudeUsage(usage),
+		cli.WithDatabasePathSetter(func(string) {}),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(
+		`{"session_id":"claude-session","tool_use_id":"stop-1","transcript_path":"/private/path","last_assistant_message":"private body"}`,
+	))
+	rootCmd.SetArgs([]string{
+		"hook", "usage", "claude", "--db-path", filepath.Join(t.TempDir(), "traceary.db"),
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !store.initCalled || len(usage.inputs) != 1 {
+		t.Fatalf("initialized=%t inputs=%+v", store.initCalled, usage.inputs)
+	}
+	if usage.inputs[0].SessionID != types.SessionID("claude-session") ||
+		usage.inputs[0].DeliveryID != "tool_use_id:stop-1" ||
+		strings.Contains(usage.inputs[0].DeliveryID, "private") {
+		t.Fatalf("capture input = %+v", usage.inputs[0])
+	}
+}
+
+func TestRootCLI_HookUsageCommand_SkipsClaudeStopDuringOwnedOneShot(t *testing.T) {
+	t.Setenv("TRACEARY_CLAUDE_USAGE_MODE", "one_shot_stream")
+	usage := &claudeUsageCaptureStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithClaudeUsage(usage),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"host-session","event_id":"stop-1"}`))
+	rootCmd.SetArgs([]string{"hook", "usage", "claude"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(usage.inputs) != 0 {
+		t.Fatalf("one-shot Stop must not capture transcript usage: %+v", usage.inputs)
 	}
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -187,6 +187,40 @@ func TestCodexUsageHookSpool_IsBodyFreeAndReplayable(t *testing.T) {
 	}
 }
 
+func TestClaudeUsageHookSpool_IsBodyAndPathFreeAndReplayable(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	usage := &spoolClaudeUsageStub{err: errors.New("database busy")}
+	root := NewRootCLI(
+		WithStoreManagement(&spoolStoreManagementStub{}),
+		WithClaudeUsage(usage),
+	)
+	payload := `{"session_id":"claude-session","event_id":"stop-1","transcript_path":"/private/transcript","last_assistant_message":"private body"}`
+	if err := root.runClaudeUsageHookDurably(
+		context.Background(), strings.NewReader(payload), "claude", "/tmp/traceary.db",
+	); err != nil {
+		t.Fatalf("runClaudeUsageHookDurably() must remain fail-soft: %v", err)
+	}
+	records, unreadable, err := scanHookSpoolRecords([]string{"claude"})
+	if err != nil {
+		t.Fatalf("scanHookSpoolRecords() error = %v", err)
+	}
+	if len(unreadable) != 0 || len(records) != 1 {
+		t.Fatalf("records=%d unreadable=%d", len(records), len(unreadable))
+	}
+	if records[0].Command != "usage" ||
+		records[0].Payload != `{"session_id":"claude-session","event_id":"stop-1"}` ||
+		strings.Contains(records[0].Payload, "private") ||
+		strings.Contains(records[0].Payload, "transcript") {
+		t.Fatalf("usage spool record = %#v", records[0])
+	}
+	usage.err = nil
+	replayed, failed := root.drainHookSpoolRecords(context.Background(), 5)
+	if replayed != 1 || failed != 0 || len(usage.inputs) != 2 {
+		t.Fatalf("replay = %d/%d calls=%d", replayed, failed, len(usage.inputs))
+	}
+}
+
 func TestDrainHookSpoolRecords_BatchLimitAndOldestFirst(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
@@ -450,6 +484,28 @@ type spoolEventUsecaseStub struct {
 type spoolCodexUsageStub struct {
 	inputs []usecase.CodexUsageCaptureInput
 	err    error
+}
+
+type spoolClaudeUsageStub struct {
+	inputs []usecase.ClaudeUsageCaptureInput
+	err    error
+}
+
+func (s *spoolClaudeUsageStub) Capture(
+	_ context.Context,
+	input usecase.ClaudeUsageCaptureInput,
+) (usecase.ClaudeUsageCaptureResult, error) {
+	s.inputs = append(s.inputs, input)
+	return usecase.ClaudeUsageCaptureResult{}, s.err
+}
+
+func (s *spoolClaudeUsageStub) CaptureHeadless(
+	_ context.Context,
+	input usecase.ClaudeUsageCaptureInput,
+	_ application.ClaudeUsageLoadResult,
+) (usecase.ClaudeUsageCaptureResult, error) {
+	s.inputs = append(s.inputs, input)
+	return usecase.ClaudeUsageCaptureResult{}, s.err
 }
 
 func (s *spoolCodexUsageStub) Capture(_ context.Context, input usecase.CodexUsageCaptureInput) (usecase.CodexUsageCaptureResult, error) {

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -26,6 +26,8 @@ type RootCLI struct {
 	bundle                     usecase.BundleUsecase
 	codexUsage                 usecase.CodexUsageCaptureUsecase
 	codexHeadlessUsage         application.CodexHeadlessUsageStreamFactory
+	claudeUsage                usecase.ClaudeUsageCaptureUsecase
+	claudeHeadlessUsage        application.ClaudeHeadlessUsageStreamFactory
 	context                    usecase.ContextUsecase
 	replay                     usecase.ReplayUsecase
 	storeManagement            usecase.StoreManagementUsecase
@@ -112,6 +114,16 @@ func WithCodexUsage(usage usecase.CodexUsageCaptureUsecase) RootCLIOption {
 // WithCodexHeadlessUsage injects the body-free `codex exec --json` stream adapter.
 func WithCodexHeadlessUsage(factory application.CodexHeadlessUsageStreamFactory) RootCLIOption {
 	return func(c *RootCLI) { c.codexHeadlessUsage = factory }
+}
+
+// WithClaudeUsage injects the body-free Claude usage capture adapter.
+func WithClaudeUsage(usage usecase.ClaudeUsageCaptureUsecase) RootCLIOption {
+	return func(c *RootCLI) { c.claudeUsage = usage }
+}
+
+// WithClaudeHeadlessUsage injects the body-free Claude one-shot stream adapter.
+func WithClaudeHeadlessUsage(factory application.ClaudeHeadlessUsageStreamFactory) RootCLIOption {
+	return func(c *RootCLI) { c.claudeHeadlessUsage = factory }
 }
 
 // WithMemoryEdge injects the MemoryEdgeUsecase used by

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -99,14 +99,26 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 	}
 
 	processStdout := stdout
-	usageMode := ""
+	codexUsageMode := ""
+	claudeUsageMode := ""
 	var headlessUsage application.CodexHeadlessUsageStream
+	var claudeHeadlessUsage application.ClaudeHeadlessUsageStream
 	if isCodexHeadlessUsageCommand(command) && c.codexHeadlessUsage != nil && c.codexUsage != nil {
-		usageMode = codexUsageModeHeadless
+		codexUsageMode = codexUsageModeHeadless
 		headlessUsage = c.codexHeadlessUsage.New(stdout)
 		processStdout = headlessUsage
+	} else if isClaudeHeadlessUsageCommand(command) && c.claudeHeadlessUsage != nil && c.claudeUsage != nil {
+		claudeUsageMode = claudeUsageModeOneShot
+		claudeHeadlessUsage = c.claudeHeadlessUsage.New(stdout)
+		processStdout = claudeHeadlessUsage
 	}
-	reason, exitCode, runErr := runOneShotProcess(ctx, stdin, processStdout, stderr, command, input.timeout, oneShotProcessEnvironment(resolvedDBPath, startEvent.SessionID(), types.SessionID(strings.TrimSpace(input.parentSessionID)), usageMode))
+	reason, exitCode, runErr := runOneShotProcess(
+		ctx, stdin, processStdout, stderr, command, input.timeout,
+		oneShotProcessEnvironment(
+			resolvedDBPath, startEvent.SessionID(), types.SessionID(strings.TrimSpace(input.parentSessionID)),
+			codexUsageMode, claudeUsageMode,
+		),
+	)
 	summary := "one-shot process finished: " + reason.String()
 	finalizeCtx, cancelFinalize := context.WithTimeout(context.WithoutCancel(ctx), oneShotFinalizeTimeout)
 	defer cancelFinalize()
@@ -122,6 +134,19 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 		}
 		if captureErr != nil {
 			usageErr = xerrors.Errorf("failed to record Codex headless usage: %w", captureErr)
+		}
+	}
+	if claudeHeadlessUsage != nil {
+		loaded, collectErr := claudeHeadlessUsage.Complete()
+		_, captureErr := c.claudeUsage.CaptureHeadless(finalizeCtx, usecase.ClaudeUsageCaptureInput{
+			SessionID: startEvent.SessionID(), DeliveryID: "session_run",
+			FallbackSourceName: "one_shot_stream", FallbackTerminal: codexUsageTerminal(reason),
+		}, loaded)
+		if collectErr != nil {
+			usageErr = xerrors.Errorf("failed to decode body-free Claude headless usage: %w", collectErr)
+		}
+		if captureErr != nil {
+			usageErr = xerrors.Errorf("failed to record Claude headless usage: %w", captureErr)
 		}
 	}
 	if _, _, finalizeErr := c.session.FinalizeOneShot(finalizeCtx, client, agent, startEvent.SessionID(), workspace, reason, summary); finalizeErr != nil {
@@ -177,13 +202,18 @@ func runOneShotProcess(ctx context.Context, stdin io.Reader, stdout, stderr io.W
 	return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process stream aborted: %w", err)
 }
 
-func oneShotProcessEnvironment(dbPath string, sessionID, parentSessionID types.SessionID, usageMode string) []string {
+func oneShotProcessEnvironment(
+	dbPath string,
+	sessionID, parentSessionID types.SessionID,
+	codexUsageMode, claudeUsageMode string,
+) []string {
 	overrides := map[string]string{
 		"TRACEARY_DB_PATH":           dbPath,
 		runtimeModeEnvKey:            types.RuntimeModeOneShot.String(),
 		runtimeSessionIDEnvKey:       sessionID.String(),
 		"TRACEARY_PARENT_SESSION_ID": parentSessionID.String(),
-		codexUsageModeEnvKey:         usageMode,
+		codexUsageModeEnvKey:         codexUsageMode,
+		claudeUsageModeEnvKey:        claudeUsageMode,
 	}
 	env := make([]string, 0, len(os.Environ())+len(overrides))
 	for _, entry := range os.Environ() {
@@ -209,6 +239,28 @@ func isCodexHeadlessUsageCommand(command []string) bool {
 		}
 	}
 	return false
+}
+
+func isClaudeHeadlessUsageCommand(command []string) bool {
+	if len(command) < 2 || filepath.Base(strings.TrimSpace(command[0])) != "claude" {
+		return false
+	}
+	printMode := false
+	jsonMode := false
+	for index := 1; index < len(command); index++ {
+		switch command[index] {
+		case "-p", "--print":
+			printMode = true
+		case "--output-format":
+			if index+1 < len(command) &&
+				(command[index+1] == "json" || command[index+1] == "stream-json") {
+				jsonMode = true
+			}
+		case "--output-format=json", "--output-format=stream-json":
+			jsonMode = true
+		}
+	}
+	return printMode && jsonMode
 }
 
 func codexUsageTerminal(reason types.TerminalReason) types.UsageTerminalCode {

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -127,26 +127,38 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 		loaded, collectErr := headlessUsage.Complete()
 		_, captureErr := c.codexUsage.CaptureHeadless(finalizeCtx, usecase.CodexUsageCaptureInput{
 			SessionID: startEvent.SessionID(), DeliveryID: "session_run",
-			FallbackSourceName: "headless_stream", FallbackTerminal: codexUsageTerminal(reason),
+			FallbackSourceName: "headless_stream", FallbackTerminal: usageTerminalFromReason(reason),
 		}, loaded)
 		if collectErr != nil {
-			usageErr = xerrors.Errorf("failed to decode body-free Codex headless usage: %w", collectErr)
+			usageErr = errors.Join(
+				usageErr,
+				xerrors.Errorf("failed to decode body-free Codex headless usage: %w", collectErr),
+			)
 		}
 		if captureErr != nil {
-			usageErr = xerrors.Errorf("failed to record Codex headless usage: %w", captureErr)
+			usageErr = errors.Join(
+				usageErr,
+				xerrors.Errorf("failed to record Codex headless usage: %w", captureErr),
+			)
 		}
 	}
 	if claudeHeadlessUsage != nil {
 		loaded, collectErr := claudeHeadlessUsage.Complete()
 		_, captureErr := c.claudeUsage.CaptureHeadless(finalizeCtx, usecase.ClaudeUsageCaptureInput{
 			SessionID: startEvent.SessionID(), DeliveryID: "session_run",
-			FallbackSourceName: "one_shot_stream", FallbackTerminal: codexUsageTerminal(reason),
+			FallbackSourceName: "one_shot_stream", FallbackTerminal: usageTerminalFromReason(reason),
 		}, loaded)
 		if collectErr != nil {
-			usageErr = xerrors.Errorf("failed to decode body-free Claude headless usage: %w", collectErr)
+			usageErr = errors.Join(
+				usageErr,
+				xerrors.Errorf("failed to decode body-free Claude headless usage: %w", collectErr),
+			)
 		}
 		if captureErr != nil {
-			usageErr = xerrors.Errorf("failed to record Claude headless usage: %w", captureErr)
+			usageErr = errors.Join(
+				usageErr,
+				xerrors.Errorf("failed to record Claude headless usage: %w", captureErr),
+			)
 		}
 	}
 	if _, _, finalizeErr := c.session.FinalizeOneShot(finalizeCtx, client, agent, startEvent.SessionID(), workspace, reason, summary); finalizeErr != nil {
@@ -247,8 +259,11 @@ func isClaudeHeadlessUsageCommand(command []string) bool {
 	}
 	printMode := false
 	jsonMode := false
+optionLoop:
 	for index := 1; index < len(command); index++ {
 		switch command[index] {
+		case "--":
+			break optionLoop
 		case "-p", "--print":
 			printMode = true
 		case "--output-format":
@@ -256,6 +271,7 @@ func isClaudeHeadlessUsageCommand(command []string) bool {
 				(command[index+1] == "json" || command[index+1] == "stream-json") {
 				jsonMode = true
 			}
+			index++
 		case "--output-format=json", "--output-format=stream-json":
 			jsonMode = true
 		}
@@ -263,7 +279,7 @@ func isClaudeHeadlessUsageCommand(command []string) bool {
 	return printMode && jsonMode
 }
 
-func codexUsageTerminal(reason types.TerminalReason) types.UsageTerminalCode {
+func usageTerminalFromReason(reason types.TerminalReason) types.UsageTerminalCode {
 	switch reason {
 	case types.TerminalReasonSuccess:
 		return types.UsageTerminalSuccess

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -74,6 +74,8 @@ func TestIsClaudeHeadlessUsageCommand_RequiresPrintAndJSONOutput(t *testing.T) {
 		{name: "single JSON", command: []string{"/usr/local/bin/claude", "--print", "--output-format=json"}, want: true},
 		{name: "plain print", command: []string{"claude", "-p"}, want: false},
 		{name: "interactive JSON option", command: []string{"claude", "--output-format", "json"}, want: false},
+		{name: "prompt option after separator", command: []string{"claude", "-p", "--", "--output-format=json"}, want: false},
+		{name: "JSON option before separator", command: []string{"claude", "-p", "--output-format=json", "--", "prompt"}, want: true},
 		{name: "other host", command: []string{"codex", "-p", "--output-format", "stream-json"}, want: false},
 	}
 	for _, test := range tests {

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -21,7 +21,7 @@ func TestRunOneShotProcess_TimeoutKillsProcessGroupPromptly(t *testing.T) {
 	reason, exitCode, err := runOneShotProcess(
 		context.Background(), bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{},
 		[]string{"sh", "-c", "(sleep 10) & wait"}, 20*time.Millisecond,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", ""),
 	)
 	if err == nil || reason != types.TerminalReasonTimeout || exitCode != oneShotTimeoutExitCode {
 		t.Fatalf("runOneShotProcess() = (%q, %d, %v), want timeout/%d/error", reason, exitCode, err, oneShotTimeoutExitCode)
@@ -39,7 +39,7 @@ func TestRunOneShotProcess_ClassifiesAbortedStream(t *testing.T) {
 		&bytes.Buffer{},
 		[]string{"sh", "-c", "printf output"},
 		0,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", ""),
 	)
 	if err == nil {
 		t.Fatal("runOneShotProcess() error = nil, want stream error")
@@ -53,12 +53,35 @@ func TestRunOneShotProcess_ClassifiesStartFailure(t *testing.T) {
 	reason, exitCode, err := runOneShotProcess(
 		context.Background(), bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{},
 		[]string{"/path/that/does/not/exist"}, 0,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", ""),
 	)
 	if err == nil {
 		t.Fatal("runOneShotProcess() error = nil, want start error")
 	}
 	if reason != types.TerminalReasonFailure || exitCode != oneShotStartExitCode {
 		t.Fatalf("runOneShotProcess() = (%q, %d), want (failure, %d)", reason, exitCode, oneShotStartExitCode)
+	}
+}
+
+func TestIsClaudeHeadlessUsageCommand_RequiresPrintAndJSONOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		command []string
+		want    bool
+	}{
+		{name: "stream JSON", command: []string{"claude", "-p", "--output-format", "stream-json"}, want: true},
+		{name: "single JSON", command: []string{"/usr/local/bin/claude", "--print", "--output-format=json"}, want: true},
+		{name: "plain print", command: []string{"claude", "-p"}, want: false},
+		{name: "interactive JSON option", command: []string{"claude", "--output-format", "json"}, want: false},
+		{name: "other host", command: []string{"codex", "-p", "--output-format", "stream-json"}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isClaudeHeadlessUsageCommand(test.command); got != test.want {
+				t.Fatalf("isClaudeHeadlessUsageCommand(%q) = %t, want %t", test.command, got, test.want)
+			}
+		})
 	}
 }

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/duck8823/traceary/application"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/filesystem"
@@ -184,6 +185,49 @@ func TestRootCLI_SessionRunCommand_CapturesBodyFreeClaudeHeadlessUsage(t *testin
 	if sample.Scope != types.UsageScopeRun || sample.Model != "claude-opus-4-1" ||
 		sample.Counters.InputTokens == nil || *sample.Counters.InputTokens != 21 {
 		t.Fatalf("headless sample = %+v", sample)
+	}
+	if sessionStub.finalizeReason != types.TerminalReasonSuccess {
+		t.Fatalf("finalize reason = %q", sessionStub.finalizeReason)
+	}
+}
+
+func TestRootCLI_SessionRunCommand_CapturesUnavailableClaudeBoundaryAfterParseFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	claude := filepath.Join(dir, "claude")
+	fixture := `{"type":"result","session_id":"claude-host-session","usage":{"input_tokens":"PRIVATE-INVALID"}}` + "\n"
+	script := "#!/bin/sh\nprintf '%s' '" + fixture + "'\n"
+	if err := os.WriteFile(claude, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := types.SessionID("one-shot-claude-invalid")
+	sessionStub := &sessionUsecaseStub{startEvent: model.EventOf(
+		"event-claude-invalid", types.EventKindSessionStarted, "cli", "claude", sessionID,
+		"duck8823/traceary", "session started", time.Now(),
+	)}
+	usage := &claudeUsageCaptureStub{err: errors.New("simulated capture failure")}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithClaudeUsage(usage),
+		cli.WithClaudeHeadlessUsage(filesystem.NewClaudeHeadlessUsageStreamFactory()),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "run", "--db-path", filepath.Join(dir, "traceary.db"),
+		"--session-id", sessionID.String(), "--", claude, "-p", "--output-format", "stream-json",
+	})
+	err := rootCmd.Execute()
+	if err == nil ||
+		!strings.Contains(err.Error(), "failed to decode body-free Claude headless usage") ||
+		!strings.Contains(err.Error(), "failed to record Claude headless usage") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(usage.headless) != 1 ||
+		usage.headless[0].Mode != application.ClaudeUsageModeOneShotStream ||
+		usage.headless[0].BoundaryObserved {
+		t.Fatalf("headless fallback = %+v", usage.headless)
 	}
 	if sessionStub.finalizeReason != types.TerminalReasonSuccess {
 		t.Fatalf("finalize reason = %q", sessionStub.finalizeReason)

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -142,6 +142,54 @@ func TestRootCLI_SessionRunCommand_CapturesBodyFreeCodexHeadlessUsage(t *testing
 	}
 }
 
+func TestRootCLI_SessionRunCommand_CapturesBodyFreeClaudeHeadlessUsage(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	claude := filepath.Join(dir, "claude")
+	fixture := `{"type":"assistant","message":{"content":[{"type":"text","text":"private body stays on stdout"}],"usage":{"input_tokens":999,"output_tokens":999}}}` + "\n" +
+		`{"type":"result","subtype":"success","session_id":"claude-host-session","result":"private result stays on stdout","usage":{"input_tokens":21,"cache_creation_input_tokens":0,"cache_read_input_tokens":10,"output_tokens":5},"modelUsage":{"claude-opus-4-1":{"costUSD":0.1}}}` + "\n"
+	script := "#!/bin/sh\nprintf '%s' '" + fixture + "'\n"
+	if err := os.WriteFile(claude, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := types.SessionID("one-shot-claude-headless")
+	sessionStub := &sessionUsecaseStub{startEvent: model.EventOf(
+		"event-claude-headless", types.EventKindSessionStarted, "cli", "claude", sessionID,
+		"duck8823/traceary", "session started", time.Now(),
+	)}
+	usage := &claudeUsageCaptureStub{}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithClaudeUsage(usage),
+		cli.WithClaudeHeadlessUsage(filesystem.NewClaudeHeadlessUsageStreamFactory()),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "run", "--db-path", filepath.Join(dir, "traceary.db"),
+		"--session-id", sessionID.String(), "--", claude, "-p", "--output-format", "stream-json",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stdout.String() != fixture {
+		t.Fatalf("stdout changed = %q", stdout.String())
+	}
+	if len(usage.headless) != 1 || len(usage.headless[0].Samples) != 1 {
+		t.Fatalf("headless capture = %+v", usage.headless)
+	}
+	sample := usage.headless[0].Samples[0]
+	if sample.Scope != types.UsageScopeRun || sample.Model != "claude-opus-4-1" ||
+		sample.Counters.InputTokens == nil || *sample.Counters.InputTokens != 21 {
+		t.Fatalf("headless sample = %+v", sample)
+	}
+	if sessionStub.finalizeReason != types.TerminalReasonSuccess {
+		t.Fatalf("finalize reason = %q", sessionStub.finalizeReason)
+	}
+}
+
 func TestRootCLI_SessionStartCommand(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -195,7 +195,8 @@ func TestRootCLI_SessionRunCommand_CapturesUnavailableClaudeBoundaryAfterParseFa
 	t.Parallel()
 	dir := t.TempDir()
 	claude := filepath.Join(dir, "claude")
-	fixture := `{"type":"result","session_id":"claude-host-session","usage":{"input_tokens":"PRIVATE-INVALID"}}` + "\n"
+	fixture := `{"type":"result","subtype":"success","session_id":"claude-host-session","usage":{"input_tokens":21,"output_tokens":5}}` + "\n" +
+		`{"type":"result","session_id":"claude-host-session","usage":{"input_tokens":"PRIVATE-INVALID"}}` + "\n"
 	script := "#!/bin/sh\nprintf '%s' '" + fixture + "'\n"
 	if err := os.WriteFile(claude, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
@@ -226,7 +227,8 @@ func TestRootCLI_SessionRunCommand_CapturesUnavailableClaudeBoundaryAfterParseFa
 	}
 	if len(usage.headless) != 1 ||
 		usage.headless[0].Mode != application.ClaudeUsageModeOneShotStream ||
-		usage.headless[0].BoundaryObserved {
+		usage.headless[0].BoundaryObserved ||
+		len(usage.headless[0].Samples) != 0 {
 		t.Fatalf("headless fallback = %+v", usage.headless)
 	}
 	if sessionStub.finalizeReason != types.TerminalReasonSuccess {


### PR DESCRIPTION
## Motivation

Claude Code reports authoritative usage in two different local surfaces: unique assistant request rows for native interactive transcripts and a terminal `result.usage` summary for print/one-shot runs. Traceary needs to retain those provider counters without double counting the same run or copying private transcript bodies.

## Changes

- add a bounded, body-free Claude transcript usage reader with `requestId` + message-id deduplication
- add a one-shot JSON stream adapter that forwards output unchanged and records only terminal result usage
- preserve known zero vs unavailable cache/input/output dimensions and explicit failure availability
- select capture mode before a Traceary-owned run and suppress its Stop transcript accounting
- add the Claude Stop usage hook before transcript capture, with body/path-free durable replay
- document the capture modes and privacy boundary in English and Japanese

## Validation

- `GOCACHE=/private/tmp/traceary-go-cache go vet ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-go-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `git diff --check`
- `./scripts/smoke_test_integrations.sh claude`

Closes #1447
