### PR TITLE
v0.32.0-1g: capture verified Grok usage metadata

### DIFF
--- a/.ai/spec/1450.md
+++ b/.ai/spec/1450.md
@@ -1,0 +1,56 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Purpose: persist provider-reported Grok Build usage from the verified headless terminal stream, and make native-hook unavailability explicit without estimating counters.
+- Current state: Grok lifecycle hooks are supported, but they expose no usage. Grok Build 0.2.106 headless `streaming-json` exposes one terminal `end.usage`.
+- Expected behavior: a Traceary-owned headless run forwards stdout unchanged, retains only allowlisted terminal metadata, records one additive run observation, and records unavailable evidence when the terminal usage is absent. A native Stop with a stable `promptId` records one excluded unavailable call observation.
+- Non-goals: TUI storage, provider API interception, prompt/response retention, pricing, and inferred model/token data.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Grok terminal boundary | request ID, session ID, stop code, turn count | closes one headless request | only `end` is authoritative; the two provider IDs are normalized to one bounded portable digest |
+| Grok usage sample | model (when unambiguous), five counters | maps to one run observation | all counters are provider-reported, non-negative, and presence-preserving |
+| Native Stop availability | session ID, stable prompt ID | records excluded unavailable evidence | no stable boundary means no invented observation |
+| Stream adapter | bounded pending line, terminal signature | forwards bytes and extracts metadata | ignores thought/text bodies and fails closed on conflicts |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| JSONL schema decoding and bounds | filesystem adapter | host stream changes | CLI/use case must not depend on host DTOs |
+| Usage observation mapping/idempotency | Grok usage use case | accounting policy changes | adapter must not know domain persistence |
+| Process selection and hook suppression | session CLI | command lifecycle changes | use case does not launch processes |
+| Native Stop availability trigger | Grok hook CLI | hook contract changes | stream adapter does not consume hooks |
+| Durable storage/conflict detection | usage repository | persistence changes | hook/stream code must not issue SQL |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `GrokHeadlessUsageStream` | one-shot CLI | JSONL bodies and buffering | output forwarding errors immediately; malformed/conflicting terminal metadata on `Complete` |
+| `GrokUsageCaptureUsecase` | one-shot and Grok Stop CLI | domain descriptor construction | invalid identity/counter or repository conflict is returned |
+| Grok Stop input | hook CLI | full hook payload | only normalized session/prompt identity crosses into usage use case |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Exact terminal capture | sanitized mixed stream | complete | stdout is byte-identical and one sample contains verified counters | adapter |
+| Cross-session redelivery | one provider terminal under two Traceary wrapper sessions | capture | one observation remains; identical content is idempotent and changed content conflicts | use case / repository |
+| Idempotent terminal | duplicate canonical `end` | complete | one sample is returned | adapter |
+| Conflict rejection | same request identity with changed usage | complete | result is discarded with an error | adapter |
+| Missing usage | terminal without `usage` or no terminal | capture | one excluded unavailable run is recorded | use case |
+| Native hook unavailable | Stop with stable prompt ID and explicit DB path | handle/replay | one excluded unavailable call is recorded in that DB; durable replay is idempotent | CLI/use case |
+| Private-body exclusion | thought/text payload contains sentinels | complete/persist | sentinels are neither retained nor persisted | adapter/integration |
+| Owned-run suppression | Grok headless child invokes Stop hook | handle | hook-side unavailable record is skipped; terminal stream remains authoritative | CLI |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Stream allowlist/bounds | fixture and malformed-table tests | bounded envelope parser | canonical terminal signature helper |
+| Observation mapping | repository transition tests | provider-neutral mapping | shared counter conversion patterns only if duplication becomes material |
+| CLI selection/suppression | command and Stop tests | Grok mode wiring | keep launch orchestration separate from parsing |
+
+### Risks / rollback
+- Procedural-risk: keep JSON decoding, domain mapping, and process orchestration in separate owners.
+- Premature abstraction: add Grok-specific ports; do not generalize incompatible host terminal schemas.
+- Migration / compatibility: no schema migration; old hooks continue lifecycle capture and only add excluded availability evidence when stable.
+- Rollback trigger: stdout drift, private-body persistence, double counting, or ambiguous terminal identity. Revert adapter wiring while retaining the source-verification decision.

--- a/application/grok_usage_source.go
+++ b/application/grok_usage_source.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"io"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// GrokUsageCounters preserves presence from the verified terminal end.usage
+// contract. Nil is unavailable; a pointer to zero is known zero.
+type GrokUsageCounters struct {
+	InputTokens       *int64
+	CachedInputTokens *int64
+	OutputTokens      *int64
+	ReasoningTokens   *int64
+	TotalTokens       *int64
+}
+
+// GrokUsageSample is one body-free terminal request total.
+type GrokUsageSample struct {
+	RecordID      string
+	SourceName    string
+	SourceVersion string
+	Model         string
+	ObservedAt    time.Time
+	TerminalCode  types.UsageTerminalCode
+	Available     bool
+	Counters      GrokUsageCounters
+}
+
+// GrokUsageLoadResult contains one authoritative terminal result. A terminal
+// may be observed without a usage object; its provider identity remains
+// available so unavailable evidence is portable across Traceary sessions.
+type GrokUsageLoadResult struct {
+	Samples          []GrokUsageSample
+	BoundaryObserved bool
+	TerminalRecordID string
+	TerminalCode     types.UsageTerminalCode
+}
+
+// GrokUsageRepository persists provider-neutral observations idempotently.
+type GrokUsageRepository interface {
+	model.UsageObservationRepository
+}
+
+// GrokHeadlessUsageStream forwards a Traceary-owned Grok streaming-json
+// response while retaining only terminal body-free usage metadata.
+type GrokHeadlessUsageStream interface {
+	io.Writer
+	Complete() (GrokUsageLoadResult, error)
+}
+
+// GrokHeadlessUsageStreamFactory creates one bounded adapter per run.
+type GrokHeadlessUsageStreamFactory interface {
+	New(io.Writer) GrokHeadlessUsageStream
+}

--- a/application/usecase/grok_usage_capture.go
+++ b/application/usecase/grok_usage_capture.go
@@ -1,0 +1,337 @@
+package usecase
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// GrokUsageCaptureInput identifies one body-free Grok boundary.
+type GrokUsageCaptureInput struct {
+	SessionID        types.SessionID
+	DeliveryID       string
+	FallbackTerminal types.UsageTerminalCode
+}
+
+// GrokUsageCaptureResult exposes idempotent write outcomes.
+type GrokUsageCaptureResult struct {
+	Applied        int
+	AlreadyApplied int
+	Unavailable    int
+}
+
+// GrokUsageCaptureUsecase records terminal headless results and explicit
+// unavailable native Stop boundaries.
+type GrokUsageCaptureUsecase interface {
+	CaptureHeadless(context.Context, GrokUsageCaptureInput, application.GrokUsageLoadResult) (GrokUsageCaptureResult, error)
+	CaptureHookUnavailable(context.Context, GrokUsageCaptureInput) (GrokUsageCaptureResult, error)
+}
+
+type grokUsageCaptureUsecase struct {
+	repository application.GrokUsageRepository
+}
+
+// NewGrokUsageCaptureUsecase creates the Grok adapter boundary.
+func NewGrokUsageCaptureUsecase(repository application.GrokUsageRepository) GrokUsageCaptureUsecase {
+	return &grokUsageCaptureUsecase{repository: repository}
+}
+
+func (u *grokUsageCaptureUsecase) CaptureHeadless(
+	ctx context.Context,
+	input GrokUsageCaptureInput,
+	loaded application.GrokUsageLoadResult,
+) (GrokUsageCaptureResult, error) {
+	if err := u.validateInput(input); err != nil {
+		return GrokUsageCaptureResult{}, err
+	}
+	if len(loaded.Samples) > 1 ||
+		(len(loaded.Samples) == 1 && !loaded.BoundaryObserved) ||
+		(loaded.BoundaryObserved && len(loaded.Samples) == 0 &&
+			!validGrokUsageIdentity(strings.TrimSpace(loaded.TerminalRecordID))) {
+		return GrokUsageCaptureResult{}, xerrors.Errorf("inconsistent Grok terminal boundary and samples")
+	}
+	result := GrokUsageCaptureResult{}
+	if len(loaded.Samples) == 1 {
+		observation, err := grokUsageObservation(input.SessionID, loaded.Samples[0])
+		if err != nil {
+			return result, xerrors.Errorf("failed to map Grok usage sample: %w", err)
+		}
+		transition, err := u.recordPortableHeadless(ctx, observation)
+		if err != nil {
+			return result, xerrors.Errorf("failed to reconcile Grok usage sample: %w", err)
+		}
+		countGrokUsageTransition(&result, transition)
+		return result, nil
+	}
+	if loaded.BoundaryObserved {
+		return u.recordUnavailable(
+			ctx,
+			input,
+			types.UsageScopeRun,
+			"headless_stream",
+			"0.2.106",
+			loaded.TerminalRecordID,
+			loaded.TerminalCode,
+			result,
+		)
+	}
+	return u.recordUnavailable(
+		ctx,
+		input,
+		types.UsageScopeRun,
+		"headless_stream",
+		"schema-v1",
+		"",
+		input.FallbackTerminal,
+		result,
+	)
+}
+
+func (u *grokUsageCaptureUsecase) recordPortableHeadless(
+	ctx context.Context,
+	proposed *model.UsageObservation,
+) (model.UsageObservationTransition, error) {
+	id := proposed.Descriptor().ObservationID()
+	existing, err := u.repository.FindByID(ctx, id)
+	if err != nil {
+		return "", xerrors.Errorf("failed to inspect Grok provider identity: %w", err)
+	}
+	if current, present := existing.Value(); present {
+		return reconcilePortableGrokObservation(current, proposed)
+	}
+	transition, err := u.repository.Record(ctx, proposed)
+	if err == nil {
+		return transition, nil
+	}
+	if !errors.Is(err, model.ErrConflictingUsageObservation) {
+		return "", xerrors.Errorf("failed to record Grok provider identity: %w", err)
+	}
+	// Another process may have committed the same provider terminal after the
+	// lookup. Re-read it so cross-session redelivery remains idempotent while a
+	// payload change for that provider identity still fails closed.
+	existing, lookupErr := u.repository.FindByID(ctx, id)
+	if lookupErr != nil {
+		return "", errors.Join(err, lookupErr)
+	}
+	if current, present := existing.Value(); present {
+		return reconcilePortableGrokObservation(current, proposed)
+	}
+	return "", xerrors.Errorf("Grok provider identity conflict disappeared: %w", err)
+}
+
+func reconcilePortableGrokObservation(
+	current, proposed *model.UsageObservation,
+) (model.UsageObservationTransition, error) {
+	currentDescriptor := current.Descriptor()
+	proposedDescriptor := proposed.Descriptor()
+	currentTerminal, currentTerminalPresent := current.TerminalCode().Value()
+	proposedTerminal, proposedTerminalPresent := proposed.TerminalCode().Value()
+	currentFinalizedAt, currentFinalizedPresent := current.FinalizedAt().Value()
+	proposedFinalizedAt, proposedFinalizedPresent := proposed.FinalizedAt().Value()
+	equivalent := currentDescriptor.ObservationID() == proposedDescriptor.ObservationID() &&
+		currentDescriptor.Source() == proposedDescriptor.Source() &&
+		currentDescriptor.Scope() == proposedDescriptor.Scope() &&
+		currentDescriptor.Accounting() == proposedDescriptor.Accounting() &&
+		currentDescriptor.ObservedAt().Equal(proposedDescriptor.ObservedAt()) &&
+		current.Status() == proposed.Status() &&
+		current.Counters() == proposed.Counters() &&
+		current.Cost() == proposed.Cost() &&
+		currentTerminalPresent == proposedTerminalPresent &&
+		(!currentTerminalPresent || currentTerminal == proposedTerminal) &&
+		currentFinalizedPresent == proposedFinalizedPresent &&
+		(!currentFinalizedPresent || currentFinalizedAt.Equal(proposedFinalizedAt))
+	if equivalent {
+		return model.UsageObservationTransitionAlreadyApplied, nil
+	}
+	return "", xerrors.Errorf(
+		"provider terminal %s changed across Traceary sessions: %w",
+		currentDescriptor.ObservationID(),
+		model.ErrConflictingUsageObservation,
+	)
+}
+
+func (u *grokUsageCaptureUsecase) CaptureHookUnavailable(
+	ctx context.Context,
+	input GrokUsageCaptureInput,
+) (GrokUsageCaptureResult, error) {
+	if err := u.validateInput(input); err != nil {
+		return GrokUsageCaptureResult{}, err
+	}
+	if strings.TrimSpace(input.DeliveryID) == "" {
+		return GrokUsageCaptureResult{}, nil
+	}
+	return u.recordUnavailable(
+		ctx,
+		input,
+		types.UsageScopeCall,
+		"stop_hook",
+		"schema-v1",
+		"",
+		input.FallbackTerminal,
+		GrokUsageCaptureResult{},
+	)
+}
+
+func (u *grokUsageCaptureUsecase) validateInput(input GrokUsageCaptureInput) error {
+	if u.repository == nil {
+		return xerrors.Errorf("Grok usage repository must be configured")
+	}
+	if _, err := types.SessionIDFrom(input.SessionID.String()); err != nil {
+		return xerrors.Errorf("invalid Grok usage session: %w", err)
+	}
+	return nil
+}
+
+func (u *grokUsageCaptureUsecase) recordUnavailable(
+	ctx context.Context,
+	input GrokUsageCaptureInput,
+	scope types.UsageScope,
+	sourceName string,
+	sourceVersion string,
+	providerRecordID string,
+	terminal types.UsageTerminalCode,
+	result GrokUsageCaptureResult,
+) (GrokUsageCaptureResult, error) {
+	identity := input.SessionID.String() + "\x00" + strings.TrimSpace(input.DeliveryID)
+	if strings.TrimSpace(providerRecordID) != "" {
+		identity = strings.TrimSpace(providerRecordID)
+	}
+	digest := sha256.Sum256([]byte(identity))
+	id, err := types.UsageObservationIDFrom("grok:" + sourceName + ":" + hex.EncodeToString(digest[:]))
+	if err != nil {
+		return result, xerrors.Errorf("invalid Grok unavailable observation identity: %w", err)
+	}
+	source, err := types.UsageSourceOf("grok", sourceName, sourceVersion, "xai", "")
+	if err != nil {
+		return result, xerrors.Errorf("invalid Grok unavailable source: %w", err)
+	}
+	observedAt := time.Unix(0, 0).UTC()
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id, input.SessionID, source, scope, types.UsageAccountingExcluded, observedAt,
+	)
+	if err != nil {
+		return result, xerrors.Errorf("invalid Grok unavailable descriptor: %w", err)
+	}
+	unavailable := types.UnavailableUsageValue()
+	counters, err := types.UsageCountersOf(
+		unavailable, unavailable, unavailable, unavailable, unavailable, unavailable,
+	)
+	if err != nil {
+		return result, xerrors.Errorf("invalid Grok unavailable counters: %w", err)
+	}
+	if terminal == "" {
+		terminal = types.UsageTerminalUnknown
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), terminal, observedAt,
+	)
+	if err != nil {
+		return result, xerrors.Errorf("invalid Grok unavailable observation: %w", err)
+	}
+	var transition model.UsageObservationTransition
+	if strings.TrimSpace(providerRecordID) != "" {
+		transition, err = u.recordPortableHeadless(ctx, observation)
+	} else {
+		transition, err = u.repository.Record(ctx, observation)
+	}
+	if err != nil {
+		return result, xerrors.Errorf("failed to record Grok unavailable observation: %w", err)
+	}
+	countGrokUsageTransition(&result, transition)
+	if transition == model.UsageObservationTransitionApplied {
+		result.Unavailable++
+	}
+	return result, nil
+}
+
+func grokUsageObservation(
+	sessionID types.SessionID,
+	sample application.GrokUsageSample,
+) (*model.UsageObservation, error) {
+	if !sample.Available {
+		return nil, xerrors.Errorf("Grok terminal sample must be available")
+	}
+	recordID := strings.TrimSpace(sample.RecordID)
+	if !validGrokUsageIdentity(recordID) {
+		return nil, xerrors.Errorf("invalid Grok usage record identity")
+	}
+	digest := sha256.Sum256([]byte(recordID))
+	id, err := types.UsageObservationIDFrom("grok:headless_stream:" + hex.EncodeToString(digest[:]))
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Grok usage identity: %w", err)
+	}
+	source, err := types.UsageSourceOf(
+		"grok", sample.SourceName, sample.SourceVersion, "xai", sample.Model,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Grok usage source: %w", err)
+	}
+	descriptor, err := model.NewUsageObservationDescriptor(
+		id, sessionID, source, types.UsageScopeRun, types.UsageAccountingAdditive, sample.ObservedAt.UTC(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Grok usage descriptor: %w", err)
+	}
+	counters, err := grokUsageCounters(sample.Counters)
+	if err != nil {
+		return nil, err
+	}
+	terminal := sample.TerminalCode
+	if terminal == "" {
+		terminal = types.UsageTerminalUnknown
+	}
+	observation, err := model.NewFinalizedUsageObservation(
+		descriptor, counters, types.UnavailableUsageCost(), terminal, sample.ObservedAt.UTC(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("invalid Grok usage observation: %w", err)
+	}
+	return observation, nil
+}
+
+func grokUsageCounters(raw application.GrokUsageCounters) (types.UsageCounters, error) {
+	values := make([]types.UsageValue, 0, 5)
+	for _, value := range []*int64{
+		raw.InputTokens, raw.CachedInputTokens, raw.OutputTokens, raw.ReasoningTokens, raw.TotalTokens,
+	} {
+		if value == nil {
+			values = append(values, types.UnavailableUsageValue())
+			continue
+		}
+		known, err := types.KnownUsageValue(*value)
+		if err != nil {
+			return types.UsageCounters{}, xerrors.Errorf("invalid Grok usage counter: %w", err)
+		}
+		values = append(values, known)
+	}
+	unavailable := types.UnavailableUsageValue()
+	counters, err := types.UsageCountersOf(
+		values[0], values[1], unavailable, values[2], values[3], values[4],
+	)
+	if err != nil {
+		return types.UsageCounters{}, xerrors.Errorf("invalid Grok usage counters: %w", err)
+	}
+	return counters, nil
+}
+
+func validGrokUsageIdentity(value string) bool {
+	return value != "" && len(value) <= 512 && !strings.ContainsAny(value, "\r\n\x00")
+}
+
+func countGrokUsageTransition(result *GrokUsageCaptureResult, transition model.UsageObservationTransition) {
+	switch transition {
+	case model.UsageObservationTransitionApplied:
+		result.Applied++
+	case model.UsageObservationTransitionAlreadyApplied:
+		result.AlreadyApplied++
+	}
+}

--- a/application/usecase/grok_usage_capture_test.go
+++ b/application/usecase/grok_usage_capture_test.go
@@ -1,0 +1,206 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestGrokUsageCapture_RecordsVerifiedRunExactlyOnce(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	input := usecase.GrokUsageCaptureInput{SessionID: "session-1", DeliveryID: "session_run"}
+	loaded := application.GrokUsageLoadResult{
+		BoundaryObserved: true,
+		Samples:          []application.GrokUsageSample{grokUsageSampleFixture()},
+	}
+	result, err := capture.CaptureHeadless(context.Background(), input, loaded)
+	if err != nil || result.Applied != 1 || len(repository.observations) != 1 {
+		t.Fatalf("CaptureHeadless() = (%+v, %v), observations = %d", result, err, len(repository.observations))
+	}
+	result, err = capture.CaptureHeadless(context.Background(), input, loaded)
+	if err != nil || result.AlreadyApplied != 1 || len(repository.observations) != 1 {
+		t.Fatalf("redelivery = (%+v, %v), observations = %d", result, err, len(repository.observations))
+	}
+	for _, observation := range repository.observations {
+		if observation.Descriptor().Scope() != types.UsageScopeRun ||
+			observation.Descriptor().Accounting() != types.UsageAccountingAdditive ||
+			observation.Counters().Availability() != types.UsageAvailabilityPartial {
+			t.Fatalf("observation = %+v", observation)
+		}
+		if value, known := observation.Counters().ReasoningOutput().Value(); !known || value != 20 {
+			t.Fatalf("reasoning = (%d, %t)", value, known)
+		}
+		if value, known := observation.Counters().CachedInput().Value(); !known || value != 0 {
+			t.Fatalf("cached input = (%d, %t)", value, known)
+		}
+	}
+}
+
+func TestGrokUsageCapture_DeduplicatesProviderTerminalAcrossTracearySessions(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	loaded := application.GrokUsageLoadResult{
+		BoundaryObserved: true,
+		Samples:          []application.GrokUsageSample{grokUsageSampleFixture()},
+	}
+	first, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-1", DeliveryID: "session_run"},
+		loaded,
+	)
+	if err != nil || first.Applied != 1 {
+		t.Fatalf("first capture = (%+v, %v)", first, err)
+	}
+	replayed, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-2", DeliveryID: "session_run"},
+		loaded,
+	)
+	if err != nil || replayed.AlreadyApplied != 1 || len(repository.observations) != 1 {
+		t.Fatalf("cross-session replay = (%+v, %v), observations = %d", replayed, err, len(repository.observations))
+	}
+
+	changed := grokUsageSampleFixture()
+	changedTotal := *changed.Counters.TotalTokens + 1
+	changed.Counters.TotalTokens = &changedTotal
+	_, err = capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-3", DeliveryID: "session_run"},
+		application.GrokUsageLoadResult{
+			BoundaryObserved: true,
+			Samples:          []application.GrokUsageSample{changed},
+		},
+	)
+	if err == nil || len(repository.observations) != 1 {
+		t.Fatalf("conflicting cross-session replay error = %v, observations = %d", err, len(repository.observations))
+	}
+}
+
+func TestGrokUsageCapture_RecordsUnavailableRunAndStableHookCall(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	headless, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{
+			SessionID: "session-1", DeliveryID: "session_run",
+			FallbackTerminal: types.UsageTerminalFailure,
+		},
+		application.GrokUsageLoadResult{},
+	)
+	if err != nil || headless.Unavailable != 1 {
+		t.Fatalf("CaptureHeadless() = (%+v, %v)", headless, err)
+	}
+	hook, err := capture.CaptureHookUnavailable(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "session-1", DeliveryID: "prompt_id:prompt-1"},
+	)
+	if err != nil || hook.Unavailable != 1 {
+		t.Fatalf("CaptureHookUnavailable() = (%+v, %v)", hook, err)
+	}
+	replayed, err := capture.CaptureHookUnavailable(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "session-1", DeliveryID: "prompt_id:prompt-1"},
+	)
+	if err != nil || replayed.AlreadyApplied != 1 || replayed.Unavailable != 0 {
+		t.Fatalf("hook redelivery = (%+v, %v)", replayed, err)
+	}
+	var runCount, callCount int
+	for _, observation := range repository.observations {
+		switch observation.Descriptor().Scope() {
+		case types.UsageScopeRun:
+			runCount++
+		case types.UsageScopeCall:
+			callCount++
+		}
+		if observation.Descriptor().Accounting() != types.UsageAccountingExcluded ||
+			observation.Counters().Availability() != types.UsageAvailabilityUnavailable {
+			t.Fatalf("unavailable observation = %+v", observation)
+		}
+	}
+	if runCount != 1 || callCount != 1 {
+		t.Fatalf("run = %d call = %d", runCount, callCount)
+	}
+}
+
+func TestGrokUsageCapture_DeduplicatesUnavailableProviderTerminalAcrossTracearySessions(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	loaded := application.GrokUsageLoadResult{
+		BoundaryObserved: true,
+		TerminalRecordID: "headless_stream:provider-request-without-usage",
+		TerminalCode:     types.UsageTerminalFailure,
+	}
+	first, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-1", DeliveryID: "session_run"},
+		loaded,
+	)
+	if err != nil || first.Applied != 1 || first.Unavailable != 1 {
+		t.Fatalf("first capture = (%+v, %v)", first, err)
+	}
+	replayed, err := capture.CaptureHeadless(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-2", DeliveryID: "session_run"},
+		loaded,
+	)
+	if err != nil || replayed.AlreadyApplied != 1 || replayed.Unavailable != 0 ||
+		len(repository.observations) != 1 {
+		t.Fatalf("cross-session replay = (%+v, %v), observations = %d", replayed, err, len(repository.observations))
+	}
+	for _, observation := range repository.observations {
+		if observation.Descriptor().Source().Version() != "0.2.106" ||
+			observation.TerminalCode().OrElse(types.UsageTerminalUnknown) != types.UsageTerminalFailure {
+			t.Fatalf("unavailable provider terminal = %+v", observation)
+		}
+	}
+}
+
+func TestGrokUsageCapture_DoesNotInventHookIdentity(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	result, err := capture.CaptureHookUnavailable(
+		context.Background(),
+		usecase.GrokUsageCaptureInput{SessionID: "session-1"},
+	)
+	if err != nil || result != (usecase.GrokUsageCaptureResult{}) || len(repository.observations) != 0 {
+		t.Fatalf("CaptureHookUnavailable() = (%+v, %v), observations = %d", result, err, len(repository.observations))
+	}
+}
+
+func TestGrokUsageCapture_RejectsInconsistentTerminalBoundary(t *testing.T) {
+	repository := newGoogleUsageRepositoryStub()
+	capture := usecase.NewGrokUsageCaptureUsecase(repository)
+	input := usecase.GrokUsageCaptureInput{SessionID: "session-1", DeliveryID: "session_run"}
+	for name, loaded := range map[string]application.GrokUsageLoadResult{
+		"sample without boundary": {Samples: []application.GrokUsageSample{grokUsageSampleFixture()}},
+		"boundary without sample": {BoundaryObserved: true},
+		"multiple samples": {
+			BoundaryObserved: true,
+			Samples:          []application.GrokUsageSample{grokUsageSampleFixture(), grokUsageSampleFixture()},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := capture.CaptureHeadless(context.Background(), input, loaded); err == nil {
+				t.Fatal("CaptureHeadless() error = nil")
+			}
+		})
+	}
+}
+
+func grokUsageSampleFixture() application.GrokUsageSample {
+	input, cached, output, reasoning, total := int64(21440), int64(0), int64(25), int64(20), int64(21465)
+	return application.GrokUsageSample{
+		RecordID: "headless_stream:request-1:session-1", SourceName: "headless_stream",
+		SourceVersion: "0.2.106", Model: "grok-4.5-build",
+		ObservedAt: time.Unix(0, 0).UTC(), TerminalCode: types.UsageTerminalSuccess, Available: true,
+		Counters: application.GrokUsageCounters{
+			InputTokens: &input, CachedInputTokens: &cached, OutputTokens: &output,
+			ReasoningTokens: &reasoning, TotalTokens: &total,
+		},
+	}
+}

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -10,7 +10,8 @@ Traceary v0.23.0 は Grok Build をネイティブにサポートします。
 
 ## 対応範囲
 
-このパッケージは、Grok Build 0.2.99 で実際に確認した契約を対象にします。
+ライフサイクル用パッケージは、Grok Build 0.2.99 で実際に確認した hook 契約を
+対象にします。usage 取得は、Grok Build 0.2.106 の headless 終端契約にも固定します。
 
 | Grok event | Traceary の処理 |
 | --- | --- |
@@ -20,6 +21,40 @@ Traceary v0.23.0 は Grok Build をネイティブにサポートします。
 | `PostToolUse` | 完了したコマンド監査を1件記録する。確認済みのファイル不在・拒否結果も失敗として扱う |
 | `Stop` | `updates.jsonl` から可能な範囲で transcript を記録し、turn 境界を作る。セッションは終了しない |
 | `PreCompact` / `PostCompact` | compact 前後の marker を別々に記録する。Grok は summary 本文を公開しない |
+
+## usage の利用可否
+
+Grok の native hook は provider usage を公開しません。そのため Traceary は、
+検証済みの `promptId` で安定した境界を識別できる `Stop` に限り、集計対象外の
+`unavailable` call observation を記録します。transcript、compact marker、retry、
+subagent、response 本文から token 数を推定しません。安定した識別子がない Stop では、
+usage 行を合成しません。
+
+終了範囲が明確な headless 実行では、Grok の検証済み終端 stream を Traceary 管理の
+完結型ライフサイクルから利用します。
+
+```sh
+traceary session run -- \
+  grok --no-auto-update -p "your prompt" --output-format streaming-json
+```
+
+Traceary は stdout を変更せず転送し、終端 `end` の metadata だけを読み取ります。
+`requestId`/`sessionId` ごとに `end.usage` を1件保存し、input、cache-read input、
+output、reasoning、total token を記録します。途中の thought/text event、cost field、
+error 本文、transcript 本文は破棄します。終端 usage object がない場合はゼロではなく、
+同じ portable provider identity を維持したまま、集計対象外の `unavailable` run
+observation を1件記録します。不正・競合・上限超過の終端 metadata は fail closed し、
+代替 observation を生成しません。`modelUsage` がモデルを1件だけ示す場合はそのモデル名を
+残します。複数モデルにまたがる合計はモデル未特定の
+まま保存し、分割や二重集計をしません。
+provider の `requestId` / `sessionId` の組は、長さ固定の portable identity に正規化します。
+そのため、同じ終端結果が別の Traceary wrapper session から再送されても冪等です。
+同じ identity で counter が変化した場合は、安全側に倒して競合として拒否します。
+
+retry と subagent の利用量は、Grok の終端合計に含まれる範囲だけを採用します。
+Traceary は途中 event を加算せず、回数も推定しません。compact hook の count は
+provider usage ではなく context 圧縮の測定値なので、ライフサイクル記録だけに使います。
+TUI の usage 経路は対応済みと表明しません。
 
 `SessionEnd`、独立した失敗 hook、subagent の親子関係は payload を実環境で
 確認できていないため、v0.23.0 の対応対象に含めません。Traceary は利用できない

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -9,7 +9,9 @@ memory/session skills. Recorded hook events use `client=hook` and `agent=grok`.
 
 ## Supported coverage
 
-The package targets the live-verified Grok Build 0.2.99 contract.
+The lifecycle package targets the live-verified Grok Build 0.2.99 hook
+contract. Usage capture additionally pins the Grok Build 0.2.106 headless
+terminal contract.
 
 | Grok event | Traceary behavior |
 | --- | --- |
@@ -19,6 +21,42 @@ The package targets the live-verified Grok Build 0.2.99 contract.
 | `PostToolUse` | Records one completed command audit, including observed missing-file and denial result variants |
 | `Stop` | Records a best-effort transcript from `updates.jsonl` and a turn boundary; it does not end the session |
 | `PreCompact` / `PostCompact` | Records phase-specific compact markers; Grok exposes no summary body |
+
+## Usage availability
+
+Grok's native hooks do not expose provider usage. Traceary therefore records
+an excluded `unavailable` call observation at a `Stop` boundary only when the
+verified `promptId` supplies a stable identity. It does not estimate tokens
+from the transcript, compact markers, retries, subagents, or response text.
+A Stop without a stable identity creates no synthetic usage row.
+
+For a bounded headless run, use Grok's verified terminal stream through the
+Traceary-owned one-shot lifecycle:
+
+```sh
+traceary session run -- \
+  grok --no-auto-update -p "your prompt" --output-format streaming-json
+```
+
+Traceary forwards stdout byte-for-byte and reads only the terminal `end`
+metadata. One `end.usage` is stored per `requestId`/`sessionId`, including
+input, cache-read input, output, reasoning, and total tokens. Incremental
+thought/text events, cost fields, error bodies, and transcript content are
+discarded. A missing terminal usage object becomes one excluded
+`unavailable` run observation rather than zero while retaining the same
+portable provider identity. Malformed, conflicting, or oversized terminal
+metadata fails closed and creates no substitute observation. If `modelUsage`
+names exactly one model, that model is retained; multi-model aggregate usage remains
+model-unattributed and is never split or counted twice.
+The provider `requestId`/`sessionId` pair is normalized to a bounded portable
+identity, so replaying the same terminal result under another Traceary wrapper
+session remains idempotent; changed counters for that identity fail closed.
+
+Retry and subagent activity is included only to the extent that Grok's
+terminal aggregate includes it. Traceary does not add incremental events or
+infer cardinality. Compact hooks remain lifecycle-only because their counts,
+when present, are context-compression measurements rather than provider usage.
+No TUI usage path is claimed.
 
 `SessionEnd`, standalone failure hooks, and subagent parent/child correlation
 are not claimed in v0.23.0 because their payloads were not live-verified.

--- a/infrastructure/filesystem/grok_headless_usage_stream.go
+++ b/infrastructure/filesystem/grok_headless_usage_stream.go
@@ -1,0 +1,273 @@
+package filesystem
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+const defaultGrokUsageMaxLineBytes = 8 * 1024 * 1024
+
+type grokHeadlessUsageStreamFactory struct {
+	maxLineBytes int
+}
+
+// NewGrokHeadlessUsageStreamFactory creates body-free adapters for
+// Traceary-owned Grok `streaming-json` invocations.
+func NewGrokHeadlessUsageStreamFactory() application.GrokHeadlessUsageStreamFactory {
+	return &grokHeadlessUsageStreamFactory{maxLineBytes: defaultGrokUsageMaxLineBytes}
+}
+
+func (f *grokHeadlessUsageStreamFactory) New(destination io.Writer) application.GrokHeadlessUsageStream {
+	if destination == nil {
+		destination = io.Discard
+	}
+	return &grokHeadlessUsageStream{
+		destination: destination,
+		maxLine:     f.maxLineBytes,
+	}
+}
+
+type grokHeadlessUsageStream struct {
+	destination       io.Writer
+	maxLine           int
+	buffer            []byte
+	result            application.GrokUsageLoadResult
+	parseErr          error
+	discardLine       bool
+	terminalSeen      bool
+	terminalSignature [sha256.Size]byte
+	terminalRequestID string
+}
+
+func (s *grokHeadlessUsageStream) Write(data []byte) (int, error) {
+	written, err := s.destination.Write(data)
+	if err != nil {
+		return written, xerrors.Errorf("failed to forward Grok headless output: %w", err)
+	}
+	if written != len(data) {
+		return written, io.ErrShortWrite
+	}
+	if s.parseErr == nil {
+		s.consume(data)
+	}
+	return written, nil
+}
+
+func (s *grokHeadlessUsageStream) consume(data []byte) {
+	for len(data) > 0 {
+		newline := bytes.IndexByte(data, '\n')
+		chunk := data
+		complete := false
+		if newline >= 0 {
+			chunk = data[:newline]
+			data = data[newline+1:]
+			complete = true
+		} else {
+			data = nil
+		}
+		if !s.discardLine {
+			if len(s.buffer)+len(chunk) > s.maxLine {
+				s.parseErr = xerrors.Errorf("Grok headless usage line exceeds %d-byte limit", s.maxLine)
+				s.buffer = nil
+				s.discardLine = true
+			} else {
+				s.buffer = append(s.buffer, chunk...)
+			}
+		}
+		if complete {
+			if !s.discardLine && len(bytes.TrimSpace(s.buffer)) > 0 {
+				if err := s.parseLine(s.buffer); err != nil {
+					s.parseErr = err
+				}
+			}
+			s.buffer = nil
+			s.discardLine = false
+		}
+	}
+}
+
+func (s *grokHeadlessUsageStream) Complete() (application.GrokUsageLoadResult, error) {
+	if s.parseErr == nil && !s.discardLine && len(bytes.TrimSpace(s.buffer)) > 0 {
+		s.parseErr = s.parseLine(s.buffer)
+	}
+	s.buffer = nil
+	if s.parseErr != nil {
+		return application.GrokUsageLoadResult{}, s.parseErr
+	}
+	return s.result, nil
+}
+
+type grokStreamEnvelope struct {
+	Type string `json:"type"`
+}
+
+type grokStreamEnd struct {
+	Type       string                     `json:"type"`
+	RequestID  string                     `json:"requestId"`
+	SessionID  string                     `json:"sessionId"`
+	StopReason string                     `json:"stopReason"`
+	NumTurns   *int64                     `json:"num_turns"`
+	Usage      *grokStreamUsage           `json:"usage"`
+	ModelUsage map[string]json.RawMessage `json:"modelUsage"`
+}
+
+type grokStreamUsage struct {
+	InputTokens       *int64 `json:"input_tokens"`
+	CachedInputTokens *int64 `json:"cache_read_input_tokens"`
+	OutputTokens      *int64 `json:"output_tokens"`
+	ReasoningTokens   *int64 `json:"reasoning_tokens"`
+	TotalTokens       *int64 `json:"total_tokens"`
+}
+
+func (s *grokHeadlessUsageStream) parseLine(line []byte) error {
+	var envelope grokStreamEnvelope
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return xerrors.Errorf("invalid Grok headless JSON event")
+	}
+	if envelope.Type != "end" {
+		return nil
+	}
+	var end grokStreamEnd
+	if err := json.Unmarshal(line, &end); err != nil {
+		return xerrors.Errorf("invalid Grok headless terminal event")
+	}
+	return s.parseEnd(end)
+}
+
+func (s *grokHeadlessUsageStream) parseEnd(end grokStreamEnd) error {
+	requestID := strings.TrimSpace(end.RequestID)
+	sessionID := strings.TrimSpace(end.SessionID)
+	if !validGrokStreamIdentity(requestID) || !validGrokStreamIdentity(sessionID) {
+		return xerrors.Errorf("invalid Grok headless terminal identity")
+	}
+	if end.NumTurns == nil || *end.NumTurns < 0 {
+		return xerrors.Errorf("invalid Grok headless terminal turn count")
+	}
+	if len(end.StopReason) > 128 || strings.ContainsAny(end.StopReason, "\r\n\x00") {
+		return xerrors.Errorf("invalid Grok headless terminal reason")
+	}
+	terminal := types.UsageTerminalUnknown
+	if strings.TrimSpace(end.StopReason) == "EndTurn" {
+		terminal = types.UsageTerminalSuccess
+	}
+	modelNames := make([]string, 0, len(end.ModelUsage))
+	for modelName := range end.ModelUsage {
+		modelName = strings.TrimSpace(modelName)
+		if !validGrokStreamIdentity(modelName) {
+			return xerrors.Errorf("invalid Grok headless model identity")
+		}
+		modelNames = append(modelNames, modelName)
+	}
+	sort.Strings(modelNames)
+	model := ""
+	if len(modelNames) == 1 {
+		model = modelNames[0]
+	}
+
+	next := application.GrokUsageLoadResult{
+		BoundaryObserved: true,
+		TerminalRecordID: grokHeadlessRecordID(requestID, sessionID),
+		TerminalCode:     terminal,
+	}
+	if end.Usage != nil {
+		if err := validateGrokStreamUsage(*end.Usage); err != nil {
+			return err
+		}
+		next.Samples = []application.GrokUsageSample{{
+			RecordID:      next.TerminalRecordID,
+			SourceName:    "headless_stream",
+			SourceVersion: "0.2.106",
+			Model:         model,
+			ObservedAt:    time.Unix(0, 0).UTC(),
+			TerminalCode:  terminal,
+			Available:     true,
+			Counters: application.GrokUsageCounters{
+				InputTokens:       end.Usage.InputTokens,
+				CachedInputTokens: end.Usage.CachedInputTokens,
+				OutputTokens:      end.Usage.OutputTokens,
+				ReasoningTokens:   end.Usage.ReasoningTokens,
+				TotalTokens:       end.Usage.TotalTokens,
+			},
+		}}
+	}
+	signature, err := grokTerminalMetadataSignature(end, modelNames)
+	if err != nil {
+		return err
+	}
+	if s.terminalSeen {
+		if s.terminalRequestID != requestID || s.terminalSignature != signature {
+			return xerrors.Errorf("conflicting Grok headless terminal results")
+		}
+		return nil
+	}
+	s.terminalSeen = true
+	s.terminalRequestID = requestID
+	s.terminalSignature = signature
+	s.result = next
+	return nil
+}
+
+func grokHeadlessRecordID(requestID, sessionID string) string {
+	digest := sha256.Sum256([]byte(requestID + "\x00" + sessionID))
+	return "headless_stream:" + hex.EncodeToString(digest[:])
+}
+
+func validateGrokStreamUsage(usage grokStreamUsage) error {
+	for _, value := range []*int64{
+		usage.InputTokens,
+		usage.CachedInputTokens,
+		usage.OutputTokens,
+		usage.ReasoningTokens,
+		usage.TotalTokens,
+	} {
+		if value == nil {
+			return xerrors.Errorf("incomplete Grok headless terminal usage")
+		}
+		if *value < 0 {
+			return xerrors.Errorf("invalid negative Grok headless terminal usage")
+		}
+	}
+	return nil
+}
+
+func grokTerminalMetadataSignature(
+	end grokStreamEnd,
+	modelNames []string,
+) ([sha256.Size]byte, error) {
+	type terminalSignature struct {
+		RequestID  string           `json:"request_id"`
+		SessionID  string           `json:"session_id"`
+		StopReason string           `json:"stop_reason"`
+		NumTurns   int64            `json:"num_turns"`
+		Usage      *grokStreamUsage `json:"usage"`
+		Models     []string         `json:"models"`
+	}
+	normalized := terminalSignature{
+		RequestID:  strings.TrimSpace(end.RequestID),
+		SessionID:  strings.TrimSpace(end.SessionID),
+		StopReason: strings.TrimSpace(end.StopReason),
+		NumTurns:   *end.NumTurns,
+		Usage:      end.Usage,
+		Models:     modelNames,
+	}
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return [sha256.Size]byte{}, xerrors.Errorf("failed to normalize Grok terminal metadata: %w", err)
+	}
+	return sha256.Sum256(encoded), nil
+}
+
+func validGrokStreamIdentity(value string) bool {
+	return value != "" && len(value) <= 512 && !strings.ContainsAny(value, "\r\n\x00")
+}

--- a/infrastructure/filesystem/grok_headless_usage_stream_test.go
+++ b/infrastructure/filesystem/grok_headless_usage_stream_test.go
@@ -1,0 +1,150 @@
+package filesystem_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+	"github.com/duck8823/traceary/infrastructure/filesystem"
+)
+
+func TestGrokHeadlessUsageStream_UsesVersionedTerminalFixture(t *testing.T) {
+	fixture, err := os.ReadFile("../../presentation/cli/testdata/grok_usage/v0.2.106/headless_stream.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := &bytes.Buffer{}
+	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(output)
+	for _, chunk := range [][]byte{fixture[:13], fixture[13:87], fixture[87:]} {
+		if _, err := stream.Write(chunk); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if !bytes.Equal(output.Bytes(), fixture) {
+		t.Fatal("forwarded output changed")
+	}
+	if !result.BoundaryObserved || len(result.Samples) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	sample := result.Samples[0]
+	if !sample.Available ||
+		sample.RecordID != "headless_stream:ae531a76b3e09738546f60434a97e5090e00833f09aeb76ff382b98bc7d5911a" ||
+		sample.Model != "grok-4.5-build" || sample.TerminalCode != types.UsageTerminalSuccess {
+		t.Fatalf("sample = %+v", sample)
+	}
+	for name, got := range map[string]*int64{
+		"input": sample.Counters.InputTokens, "cached": sample.Counters.CachedInputTokens,
+		"output": sample.Counters.OutputTokens, "reasoning": sample.Counters.ReasoningTokens,
+		"total": sample.Counters.TotalTokens,
+	} {
+		if got == nil {
+			t.Fatalf("%s counter is unavailable", name)
+		}
+	}
+	if *sample.Counters.InputTokens != 21440 || *sample.Counters.CachedInputTokens != 0 ||
+		*sample.Counters.OutputTokens != 25 || *sample.Counters.ReasoningTokens != 20 ||
+		*sample.Counters.TotalTokens != 21465 {
+		t.Fatalf("counters = %+v", sample.Counters)
+	}
+	if strings.Contains(sample.RecordID, "synthetic body") {
+		t.Fatalf("body entered identity: %q", sample.RecordID)
+	}
+}
+
+func TestGrokHeadlessUsageStream_NormalizesMaximumProviderIdentityToBoundedRecordID(t *testing.T) {
+	requestID := strings.Repeat("r", 512)
+	sessionID := strings.Repeat("s", 512)
+	fixture := `{"type":"end","requestId":"` + requestID + `","sessionId":"` + sessionID +
+		`","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":3}}` + "\n"
+	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	if _, err := stream.Write([]byte(fixture)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil || len(result.Samples) != 1 {
+		t.Fatalf("Complete() = (%+v, %v)", result, err)
+	}
+	recordID := result.Samples[0].RecordID
+	if !strings.HasPrefix(recordID, "headless_stream:") || len(recordID) != len("headless_stream:")+64 {
+		t.Fatalf("bounded record ID = %q (length %d)", recordID, len(recordID))
+	}
+}
+
+func TestGrokHeadlessUsageStream_TerminalWithoutUsagePreservesProviderIdentity(t *testing.T) {
+	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	fixture := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"Error","num_turns":1,"error":{"message":"PRIVATE"}}` + "\n"
+	if _, err := stream.Write([]byte(fixture)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if !result.BoundaryObserved || len(result.Samples) != 0 ||
+		result.TerminalRecordID != "headless_stream:6141b7faf78062b03ca6768a5551d1c80812d8a669d5713fe22a6310ef6cc64c" ||
+		result.TerminalCode != types.UsageTerminalUnknown {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestGrokHeadlessUsageStream_DeduplicatesNormalizedTerminalAndRejectsConflict(t *testing.T) {
+	first := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":3},"modelUsage":{"model-1":{"private":"FIRST"}},"text":"PRIVATE FIRST"}` + "\n"
+	equivalent := `{"text":"PRIVATE SECOND","modelUsage":{"model-1":{"private":"SECOND"}},"usage":{"reasoning_tokens":0,"total_tokens":3,"output_tokens":1,"input_tokens":2,"cache_read_input_tokens":0},"num_turns":1,"stopReason":"EndTurn","sessionId":"session-1","requestId":"request-1","type":"end"}` + "\n"
+	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	if _, err := stream.Write([]byte(first + equivalent)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil || !result.BoundaryObserved || len(result.Samples) != 1 {
+		t.Fatalf("Complete() = (%+v, %v)", result, err)
+	}
+
+	conflict := strings.Replace(first, `"total_tokens":3`, `"total_tokens":4`, 1)
+	stream = filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	if _, err := stream.Write([]byte(first + conflict)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err = stream.Complete()
+	if err == nil || result.BoundaryObserved || len(result.Samples) != 0 {
+		t.Fatalf("Complete() = (%+v, %v)", result, err)
+	}
+}
+
+func TestGrokHeadlessUsageStream_RejectsMalformedTerminalAndDiscardsPartialResult(t *testing.T) {
+	valid := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":3},"modelUsage":{}}` + "\n"
+	for name, invalid := range map[string]string{
+		"negative":       `{"type":"end","requestId":"request-2","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":-1,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":0}}` + "\n",
+		"incomplete":     `{"type":"end","requestId":"request-2","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":1}}` + "\n",
+		"malformed JSON": `{"type":"end"` + "\n",
+		"oversized line": strings.Repeat("x", 8*1024*1024+1) + "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+			if _, err := stream.Write([]byte(valid + invalid)); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			result, err := stream.Complete()
+			if err == nil || result.BoundaryObserved || len(result.Samples) != 0 {
+				t.Fatalf("Complete() = (%+v, %v)", result, err)
+			}
+		})
+	}
+}
+
+func TestGrokHeadlessUsageStream_LeavesModelUnknownWhenAggregateSpansModels(t *testing.T) {
+	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(&bytes.Buffer{})
+	fixture := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"EndTurn","num_turns":2,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":3},"modelUsage":{"model-a":{},"model-b":{}}}` + "\n"
+	if _, err := stream.Write([]byte(fixture)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	result, err := stream.Complete()
+	if err != nil || len(result.Samples) != 1 || result.Samples[0].Model != "" {
+		t.Fatalf("Complete() = (%+v, %v)", result, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -184,6 +184,7 @@ func run() error {
 		filesystem.NewClaudeUsageSource(), usageObservationDatasource,
 	)
 	geminiUsageUsecase := usecase.NewGeminiUsageCaptureUsecase(usageObservationDatasource)
+	grokUsageUsecase := usecase.NewGrokUsageCaptureUsecase(usageObservationDatasource)
 	antigravityUsageUsecase := usecase.NewAntigravityUsageCaptureUsecase(
 		filesystem.NewAntigravityUsageSource(), usageObservationDatasource,
 	)
@@ -241,6 +242,8 @@ func run() error {
 		cli.WithGeminiUsage(geminiUsageUsecase),
 		cli.WithGeminiHeadlessUsage(filesystem.NewGeminiHeadlessUsageStreamFactory()),
 		cli.WithAntigravityUsage(antigravityUsageUsecase),
+		cli.WithGrokUsage(grokUsageUsecase),
+		cli.WithGrokHeadlessUsage(filesystem.NewGrokHeadlessUsageStreamFactory()),
 		cli.WithContext(contextUsecase),
 		cli.WithReplay(replayUsecase),
 		cli.WithStoreManagement(storeManagementUsecase),

--- a/presentation/cli/hook_grok.go
+++ b/presentation/cli/hook_grok.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 )
 
 const grokHookClient = "grok"
@@ -154,7 +155,43 @@ func (c *RootCLI) runHookGrokStop(ctx context.Context, input io.Reader, dbPath s
 		}
 	}
 	boundaryErr := c.runHookSession(ctx, nil, bytes.NewReader(normalized), grokHookClient, "stop", dbPath)
-	return errors.Join(transcriptErr, boundaryErr)
+	var usageErr error
+	if !isTracearyOwnedGrokOneShot() && c.grokUsage != nil {
+		sessionID, resolveErr := resolveHookSessionID(normalized, grokHookClient)
+		if resolveErr != nil {
+			usageErr = resolveErr
+		} else if sessionID != "" {
+			promptID := strings.TrimSpace(hookPayloadString(normalized, "prompt_id", ""))
+			deliveryID := ""
+			if promptID != "" {
+				deliveryID = "prompt_id:" + promptID
+			}
+			if deliveryID != "" {
+				resolvedDBPath, pathErr := resolveDBPath(dbPath)
+				if pathErr != nil {
+					usageErr = pathErr
+				} else if c.storeManagement == nil {
+					usageErr = xerrors.Errorf("usage capture store dependency is not configured")
+				} else {
+					c.applyDatabasePath(resolvedDBPath)
+					if initializeErr := c.storeManagement.Initialize(ctx); initializeErr != nil {
+						usageErr = xerrors.Errorf("failed to initialize store: %w", initializeErr)
+					} else {
+						_, usageErr = c.grokUsage.CaptureHookUnavailable(ctx, usecase.GrokUsageCaptureInput{
+							SessionID:  sessionID,
+							DeliveryID: deliveryID,
+						})
+					}
+				}
+			}
+		}
+	}
+	return errors.Join(transcriptErr, boundaryErr, usageErr)
+}
+
+func isTracearyOwnedGrokOneShot() bool {
+	return strings.TrimSpace(os.Getenv(grokUsageModeEnvKey)) == grokUsageModeOneShot &&
+		explicitOneShotRuntimeSessionID() != ""
 }
 
 // normalizeGrokHookPayload maps only fields proven by the versioned live

--- a/presentation/cli/hook_grok_test.go
+++ b/presentation/cli/hook_grok_test.go
@@ -169,6 +169,101 @@ func TestRootCLI_HookGrokStopRecordsBestEffortTranscript(t *testing.T) {
 	}
 }
 
+func TestRootCLI_HookGrokStopRecordsStableUsageUnavailability(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-stop-usage")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	usage := &grokUsageCaptureStub{}
+
+	runGrokHook(
+		t, "stop", grokFixtureWithoutField(t, "stop.json", "transcriptPath"),
+		nil, nil, cli.WithGrokUsage(usage),
+	)
+
+	if len(usage.hooks) != 1 ||
+		usage.hooks[0].SessionID != "019f0000-0000-7000-8000-000000000001" ||
+		usage.hooks[0].DeliveryID != "prompt_id:prompt-contract-probe-1" {
+		t.Fatalf("usage hooks = %+v", usage.hooks)
+	}
+}
+
+func TestRootCLI_HookGrokStopUsesOnlyVerifiedPromptIdentityForUsage(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-stop-usage-identity")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+
+	for _, test := range []struct {
+		name         string
+		promptID     any
+		toolUseID    any
+		wantDelivery string
+	}{
+		{name: "tool identity alone is unverified", promptID: nil, toolUseID: "tool-stop-1"},
+		{name: "prompt wins when both are present", promptID: "prompt-stop-1", toolUseID: "tool-stop-1", wantDelivery: "prompt_id:prompt-stop-1"},
+		{name: "blank prompt does not fall back to tool", promptID: "   ", toolUseID: "tool-stop-1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload := grokFixtureWithoutField(t, "stop.json", "transcriptPath")
+			if test.promptID == nil {
+				payload = grokJSONWithoutField(t, payload, "promptId")
+			} else {
+				payload = grokJSONWithField(t, payload, "promptId", test.promptID)
+			}
+			payload = grokJSONWithField(t, payload, "toolUseId", test.toolUseID)
+			usage := &grokUsageCaptureStub{}
+			runGrokHook(t, "stop", payload, nil, nil, cli.WithGrokUsage(usage))
+			if test.wantDelivery == "" {
+				if len(usage.hooks) != 0 {
+					t.Fatalf("usage hooks = %+v, want none", usage.hooks)
+				}
+				return
+			}
+			if len(usage.hooks) != 1 || usage.hooks[0].DeliveryID != test.wantDelivery {
+				t.Fatalf("usage hooks = %+v, want delivery %q", usage.hooks, test.wantDelivery)
+			}
+		})
+	}
+}
+
+func TestRootCLI_HookGrokStopSuppressesUnavailableDuringOwnedHeadlessRun(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-stop-owned")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	t.Setenv("TRACEARY_GROK_USAGE_MODE", "one_shot_stream")
+	t.Setenv("TRACEARY_RUNTIME_MODE", "one_shot")
+	t.Setenv("TRACEARY_RUNTIME_SESSION_ID", "one-shot-grok-owned")
+	usage := &grokUsageCaptureStub{}
+
+	runGrokHook(
+		t, "stop", grokFixtureWithoutField(t, "stop.json", "transcriptPath"),
+		nil, nil, cli.WithGrokUsage(usage),
+	)
+
+	if len(usage.hooks) != 0 {
+		t.Fatalf("usage hooks = %+v, want suppressed", usage.hooks)
+	}
+}
+
+func TestRootCLI_HookGrokStopDoesNotTrustUsageModeAlone(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-stop-mode-only")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	t.Setenv("TRACEARY_GROK_USAGE_MODE", "one_shot_stream")
+	usage := &grokUsageCaptureStub{}
+	payload := grokJSONWithField(
+		t,
+		grokFixtureWithoutField(t, "stop.json", "transcriptPath"),
+		"promptId",
+		"prompt-mode-only",
+	)
+
+	runGrokHook(t, "stop", payload, nil, nil, cli.WithGrokUsage(usage))
+
+	if len(usage.hooks) != 1 || usage.hooks[0].DeliveryID != "prompt_id:prompt-mode-only" {
+		t.Fatalf("usage hooks = %+v, want native availability capture", usage.hooks)
+	}
+}
+
 func TestRootCLI_HookGrokCompactRecordsObservedMarkers(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-compact")
@@ -443,14 +538,19 @@ func grokJSONWithField(t *testing.T, input, field string, value any) string {
 
 func grokFixtureWithoutField(t *testing.T, name, field string) string {
 	t.Helper()
+	return grokJSONWithoutField(t, readGrokFixture(t, name), field)
+}
+
+func grokJSONWithoutField(t *testing.T, input, field string) string {
+	t.Helper()
 	var payload map[string]any
-	if err := json.Unmarshal([]byte(readGrokFixture(t, name)), &payload); err != nil {
-		t.Fatalf("decode Grok fixture %s: %v", name, err)
+	if err := json.Unmarshal([]byte(input), &payload); err != nil {
+		t.Fatalf("decode Grok JSON: %v", err)
 	}
 	delete(payload, field)
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		t.Fatalf("encode Grok fixture %s without %s: %v", name, field, err)
+		t.Fatalf("encode Grok JSON without %s: %v", field, err)
 	}
 	return string(encoded)
 }

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -27,6 +27,8 @@ const (
 	claudeUsageModeOneShot     = "one_shot_stream"
 	geminiUsageModeEnvKey      = "TRACEARY_GEMINI_USAGE_MODE"
 	geminiUsageModeOneShot     = "one_shot_stream"
+	grokUsageModeEnvKey        = "TRACEARY_GROK_USAGE_MODE"
+	grokUsageModeOneShot       = "one_shot_stream"
 )
 
 const hookActiveSubagentStateTTL = 24 * time.Hour

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -57,6 +57,31 @@ type geminiUsageCaptureStub struct {
 	err         error
 }
 
+type grokUsageCaptureStub struct {
+	inputs   []usecase.GrokUsageCaptureInput
+	headless []application.GrokUsageLoadResult
+	hooks    []usecase.GrokUsageCaptureInput
+	err      error
+}
+
+func (s *grokUsageCaptureStub) CaptureHeadless(
+	_ context.Context,
+	input usecase.GrokUsageCaptureInput,
+	loaded application.GrokUsageLoadResult,
+) (usecase.GrokUsageCaptureResult, error) {
+	s.inputs = append(s.inputs, input)
+	s.headless = append(s.headless, loaded)
+	return usecase.GrokUsageCaptureResult{Applied: len(loaded.Samples)}, s.err
+}
+
+func (s *grokUsageCaptureStub) CaptureHookUnavailable(
+	_ context.Context,
+	input usecase.GrokUsageCaptureInput,
+) (usecase.GrokUsageCaptureResult, error) {
+	s.hooks = append(s.hooks, input)
+	return usecase.GrokUsageCaptureResult{Applied: 1, Unavailable: 1}, s.err
+}
+
 func (s *geminiUsageCaptureStub) CaptureHeadless(
 	_ context.Context,
 	input usecase.GeminiUsageCaptureInput,
@@ -300,6 +325,84 @@ func TestRootCLI_HookUsageCommand_PersistsVerifiedCodexUsageIdempotently(t *test
 	}
 	if count != 1 || input != 100 || cached != 80 || cacheWrite != 0 || output != 6 || reasoning != 2 || total != 106 || modelName != "gpt-5.6-sol" || costState != "unavailable" {
 		t.Fatalf("stored usage = count=%d input=%d cached=%d cache_write=%d output=%d reasoning=%d total=%d model=%q cost=%q", count, input, cached, cacheWrite, output, reasoning, total, modelName, costState)
+	}
+}
+
+func TestRootCLI_HookGrokStopRoutesUsageToExplicitDatabaseIdempotently(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-usage-db-routing")
+	t.Setenv("TRACEARY_WORKSPACE", "duck8823/traceary")
+	dir := t.TempDir()
+	defaultDBPath := filepath.Join(dir, "default.db")
+	targetDBPath := filepath.Join(dir, "target.db")
+	t.Setenv("TRACEARY_DB_PATH", defaultDBPath)
+
+	db := sqliteinfra.NewDatabase(
+		defaultDBPath,
+		os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")),
+	)
+	store := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	usage := usecase.NewGrokUsageCaptureUsecase(sqliteinfra.NewUsageObservationDatasource(db))
+	payload := `{
+		"hookEventName":"stop",
+		"sessionId":"019f0000-0000-7000-8000-000000000088",
+		"cwd":"/workspace/traceary",
+		"promptId":"prompt-db-route-1",
+		"reason":"end_turn"
+	}`
+
+	// The first attempt fails after durable spooling. The next invocation must
+	// replay that record to the original explicit DB and then treat its own
+	// identical delivery as an idempotent no-op.
+	failedRoot := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{initErr: errors.New("simulated initialization failure")}),
+		cli.WithSession(&sessionUsecaseStub{}),
+		cli.WithGrokUsage(&grokUsageCaptureStub{}),
+	).Command()
+	failedRoot.SetOut(&bytes.Buffer{})
+	failedRoot.SetErr(&bytes.Buffer{})
+	failedRoot.SetIn(strings.NewReader(payload))
+	failedRoot.SetArgs([]string{"hook", "grok", "stop", "--db-path", targetDBPath})
+	if err := failedRoot.Execute(); err != nil {
+		t.Fatalf("fail-open first Execute() error = %v", err)
+	}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithSession(&sessionUsecaseStub{}),
+		cli.WithGrokUsage(usage),
+		cli.WithDatabasePathSetter(db.SetPath),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"hook", "grok", "stop", "--db-path", targetDBPath})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("replay Execute() error = %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite", targetDBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+	var count int
+	var sourceName, scope, accounting, sessionID string
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*), source_name, scope, accounting, session_id
+		  FROM usage_observations
+	`).Scan(&count, &sourceName, &scope, &accounting, &sessionID); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || sourceName != "stop_hook" || scope != "call" ||
+		accounting != "excluded" || sessionID != "019f0000-0000-7000-8000-000000000088" {
+		t.Fatalf(
+			"stored usage = count=%d source=%q scope=%q accounting=%q session=%q",
+			count, sourceName, scope, accounting, sessionID,
+		)
+	}
+	if _, err := os.Stat(defaultDBPath); !os.IsNotExist(err) {
+		t.Fatalf("default DB must remain untouched, Stat() error = %v", err)
 	}
 }
 

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -31,6 +31,8 @@ type RootCLI struct {
 	geminiUsage                usecase.GeminiUsageCaptureUsecase
 	geminiHeadlessUsage        application.GeminiHeadlessUsageStreamFactory
 	antigravityUsage           usecase.AntigravityUsageCaptureUsecase
+	grokUsage                  usecase.GrokUsageCaptureUsecase
+	grokHeadlessUsage          application.GrokHeadlessUsageStreamFactory
 	context                    usecase.ContextUsecase
 	replay                     usecase.ReplayUsecase
 	storeManagement            usecase.StoreManagementUsecase
@@ -142,6 +144,16 @@ func WithGeminiHeadlessUsage(factory application.GeminiHeadlessUsageStreamFactor
 // WithAntigravityUsage injects cumulative status and unavailable Stop capture.
 func WithAntigravityUsage(usage usecase.AntigravityUsageCaptureUsecase) RootCLIOption {
 	return func(c *RootCLI) { c.antigravityUsage = usage }
+}
+
+// WithGrokUsage injects headless usage and unavailable Stop capture.
+func WithGrokUsage(usage usecase.GrokUsageCaptureUsecase) RootCLIOption {
+	return func(c *RootCLI) { c.grokUsage = usage }
+}
+
+// WithGrokHeadlessUsage injects the body-free Grok streaming-json adapter.
+func WithGrokHeadlessUsage(factory application.GrokHeadlessUsageStreamFactory) RootCLIOption {
+	return func(c *RootCLI) { c.grokHeadlessUsage = factory }
 }
 
 // WithMemoryEdge injects the MemoryEdgeUsecase used by

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -102,9 +102,11 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 	codexUsageMode := ""
 	claudeUsageMode := ""
 	geminiUsageMode := ""
+	grokUsageMode := ""
 	var headlessUsage application.CodexHeadlessUsageStream
 	var claudeHeadlessUsage application.ClaudeHeadlessUsageStream
 	var geminiHeadlessUsage application.GeminiHeadlessUsageStream
+	var grokHeadlessUsage application.GrokHeadlessUsageStream
 	if isCodexHeadlessUsageCommand(command) && c.codexHeadlessUsage != nil && c.codexUsage != nil {
 		codexUsageMode = codexUsageModeHeadless
 		headlessUsage = c.codexHeadlessUsage.New(stdout)
@@ -117,12 +119,16 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 		geminiUsageMode = geminiUsageModeOneShot
 		geminiHeadlessUsage = c.geminiHeadlessUsage.New(stdout)
 		processStdout = geminiHeadlessUsage
+	} else if isGrokHeadlessUsageCommand(command) && c.grokHeadlessUsage != nil && c.grokUsage != nil {
+		grokUsageMode = grokUsageModeOneShot
+		grokHeadlessUsage = c.grokHeadlessUsage.New(stdout)
+		processStdout = grokHeadlessUsage
 	}
 	reason, exitCode, runErr := runOneShotProcess(
 		ctx, stdin, processStdout, stderr, command, input.timeout,
 		oneShotProcessEnvironment(
 			resolvedDBPath, startEvent.SessionID(), types.SessionID(strings.TrimSpace(input.parentSessionID)),
-			codexUsageMode, claudeUsageMode, geminiUsageMode,
+			codexUsageMode, claudeUsageMode, geminiUsageMode, grokUsageMode,
 		),
 	)
 	summary := "one-shot process finished: " + reason.String()
@@ -186,6 +192,26 @@ func (c *RootCLI) runSessionOneShot(ctx context.Context, stdin io.Reader, stdout
 			)
 		}
 	}
+	if grokHeadlessUsage != nil {
+		loaded, collectErr := grokHeadlessUsage.Complete()
+		if collectErr != nil {
+			usageErr = errors.Join(
+				usageErr,
+				xerrors.Errorf("failed to decode body-free Grok headless usage: %w", collectErr),
+			)
+		} else {
+			_, captureErr := c.grokUsage.CaptureHeadless(finalizeCtx, usecase.GrokUsageCaptureInput{
+				SessionID: startEvent.SessionID(), DeliveryID: "session_run",
+				FallbackTerminal: usageTerminalFromReason(reason),
+			}, loaded)
+			if captureErr != nil {
+				usageErr = errors.Join(
+					usageErr,
+					xerrors.Errorf("failed to record Grok headless usage: %w", captureErr),
+				)
+			}
+		}
+	}
 	if _, _, finalizeErr := c.session.FinalizeOneShot(finalizeCtx, client, agent, startEvent.SessionID(), workspace, reason, summary); finalizeErr != nil {
 		if exitCode == 0 {
 			exitCode = 1
@@ -242,7 +268,7 @@ func runOneShotProcess(ctx context.Context, stdin io.Reader, stdout, stderr io.W
 func oneShotProcessEnvironment(
 	dbPath string,
 	sessionID, parentSessionID types.SessionID,
-	codexUsageMode, claudeUsageMode, geminiUsageMode string,
+	codexUsageMode, claudeUsageMode, geminiUsageMode, grokUsageMode string,
 ) []string {
 	overrides := map[string]string{
 		"TRACEARY_DB_PATH":           dbPath,
@@ -252,6 +278,7 @@ func oneShotProcessEnvironment(
 		codexUsageModeEnvKey:         codexUsageMode,
 		claudeUsageModeEnvKey:        claudeUsageMode,
 		geminiUsageModeEnvKey:        geminiUsageMode,
+		grokUsageModeEnvKey:          grokUsageMode,
 	}
 	env := make([]string, 0, len(os.Environ())+len(overrides))
 	for _, entry := range os.Environ() {
@@ -331,6 +358,46 @@ optionLoop:
 		default:
 			if value, found := strings.CutPrefix(command[index], "--prompt="); found && value != "" {
 				promptMode = true
+			}
+		}
+	}
+	return promptMode && streamMode
+}
+
+func isGrokHeadlessUsageCommand(command []string) bool {
+	if len(command) < 2 || filepath.Base(strings.TrimSpace(command[0])) != "grok" {
+		return false
+	}
+	promptMode := false
+	streamMode := false
+optionLoop:
+	for index := 1; index < len(command); index++ {
+		switch command[index] {
+		case "--":
+			break optionLoop
+		case "-p", "--single", "--prompt-file", "--prompt-json":
+			promptMode = true
+			if index+1 < len(command) {
+				index++
+			}
+		case "--output-format":
+			if index+1 < len(command) && command[index+1] == "streaming-json" {
+				streamMode = true
+			}
+			index++
+		case "--output-format=streaming-json":
+			streamMode = true
+		default:
+			if strings.HasPrefix(command[index], "-p") &&
+				!strings.HasPrefix(command[index], "--") &&
+				len(command[index]) > len("-p") {
+				promptMode = true
+			}
+			for _, prefix := range []string{"--single=", "--prompt-file=", "--prompt-json="} {
+				if value, found := strings.CutPrefix(command[index], prefix); found && value != "" {
+					promptMode = true
+					break
+				}
 			}
 		}
 	}

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -21,7 +21,7 @@ func TestRunOneShotProcess_TimeoutKillsProcessGroupPromptly(t *testing.T) {
 	reason, exitCode, err := runOneShotProcess(
 		context.Background(), bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{},
 		[]string{"sh", "-c", "(sleep 10) & wait"}, 20*time.Millisecond,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", "", ""),
 	)
 	if err == nil || reason != types.TerminalReasonTimeout || exitCode != oneShotTimeoutExitCode {
 		t.Fatalf("runOneShotProcess() = (%q, %d, %v), want timeout/%d/error", reason, exitCode, err, oneShotTimeoutExitCode)
@@ -39,7 +39,7 @@ func TestRunOneShotProcess_ClassifiesAbortedStream(t *testing.T) {
 		&bytes.Buffer{},
 		[]string{"sh", "-c", "printf output"},
 		0,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", "", ""),
 	)
 	if err == nil {
 		t.Fatal("runOneShotProcess() error = nil, want stream error")
@@ -53,7 +53,7 @@ func TestRunOneShotProcess_ClassifiesStartFailure(t *testing.T) {
 	reason, exitCode, err := runOneShotProcess(
 		context.Background(), bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{},
 		[]string{"/path/that/does/not/exist"}, 0,
-		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", ""),
+		oneShotProcessEnvironment("/tmp/test.db", "session", "", "", "", "", ""),
 	)
 	if err == nil {
 		t.Fatal("runOneShotProcess() error = nil, want start error")
@@ -83,6 +83,35 @@ func TestIsClaudeHeadlessUsageCommand_RequiresPrintAndJSONOutput(t *testing.T) {
 			t.Parallel()
 			if got := isClaudeHeadlessUsageCommand(test.command); got != test.want {
 				t.Fatalf("isClaudeHeadlessUsageCommand(%q) = %t, want %t", test.command, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsGrokHeadlessUsageCommand_RequiresSingleAndStreamingJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		command []string
+		want    bool
+	}{
+		{name: "short single", command: []string{"grok", "-p", "prompt", "--output-format", "streaming-json"}, want: true},
+		{name: "attached short single", command: []string{"grok", "-pprompt", "--output-format", "streaming-json"}, want: true},
+		{name: "long single", command: []string{"/usr/local/bin/grok", "--single=prompt", "--output-format=streaming-json"}, want: true},
+		{name: "prompt file", command: []string{"grok", "--prompt-file", "prompt.md", "--output-format=streaming-json"}, want: true},
+		{name: "prompt JSON", command: []string{"grok", "--prompt-json={\"type\":\"text\",\"text\":\"prompt\"}", "--output-format=streaming-json"}, want: true},
+		{name: "plain single", command: []string{"grok", "-p", "prompt"}, want: false},
+		{name: "interactive stream", command: []string{"grok", "--output-format", "streaming-json"}, want: false},
+		{name: "unrelated attached short option", command: []string{"grok", "-xprompt", "--output-format", "streaming-json"}, want: false},
+		{name: "option after separator", command: []string{"grok", "-p", "prompt", "--", "--output-format=streaming-json"}, want: false},
+		{name: "attached prompt after separator", command: []string{"grok", "--output-format=streaming-json", "--", "-pprompt"}, want: false},
+		{name: "other host", command: []string{"gemini", "-p", "prompt", "--output-format", "streaming-json"}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isGrokHeadlessUsageCommand(test.command); got != test.want {
+				t.Fatalf("isGrokHeadlessUsageCommand(%q) = %t, want %t", test.command, got, test.want)
 			}
 		})
 	}

--- a/presentation/cli/session_test.go
+++ b/presentation/cli/session_test.go
@@ -143,6 +143,105 @@ func TestRootCLI_SessionRunCommand_CapturesBodyFreeCodexHeadlessUsage(t *testing
 	}
 }
 
+func TestRootCLI_SessionRunCommand_CapturesBodyFreeGrokHeadlessUsage(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	grok := filepath.Join(dir, "grok")
+	modeFile := filepath.Join(dir, "usage-mode")
+	fixturePath, err := filepath.Abs("testdata/grok_usage/v0.2.106/headless_stream.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\nprintf '%s' \"$TRACEARY_GROK_USAGE_MODE\" > " + modeFile + "\ncat " + fixturePath + "\n"
+	if err := os.WriteFile(grok, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := types.SessionID("one-shot-grok-headless")
+	sessionStub := &sessionUsecaseStub{startEvent: model.EventOf(
+		"event-grok-headless", types.EventKindSessionStarted, "cli", "grok", sessionID,
+		"duck8823/traceary", "session started", time.Now(),
+	)}
+	usage := &grokUsageCaptureStub{}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithGrokUsage(usage),
+		cli.WithGrokHeadlessUsage(filesystem.NewGrokHeadlessUsageStreamFactory()),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "run", "--db-path", filepath.Join(dir, "traceary.db"), "--agent", "grok", "--",
+		grok, "--no-auto-update", "-p", "prompt", "--output-format", "streaming-json",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stdout.Bytes(), fixture) {
+		t.Fatal("stdout changed")
+	}
+	if len(usage.headless) != 1 || len(usage.headless[0].Samples) != 1 {
+		t.Fatalf("headless capture = %+v", usage.headless)
+	}
+	mode, err := os.ReadFile(modeFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(mode) != "one_shot_stream" {
+		t.Fatalf("TRACEARY_GROK_USAGE_MODE = %q", mode)
+	}
+}
+
+func TestRootCLI_SessionRunCommand_DoesNotPersistGrokUsageAfterParseFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	grok := filepath.Join(dir, "grok")
+	streamPath := filepath.Join(dir, "conflicting.jsonl")
+	first := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":3}}`
+	conflict := `{"type":"end","requestId":"request-1","sessionId":"session-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":2,"cache_read_input_tokens":0,"output_tokens":1,"reasoning_tokens":0,"total_tokens":4}}`
+	if err := os.WriteFile(streamPath, []byte(first+"\n"+conflict+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ncat " + shellQuoteForTest(streamPath) + "\n"
+	if err := os.WriteFile(grok, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := types.SessionID("one-shot-grok-invalid")
+	sessionStub := &sessionUsecaseStub{startEvent: model.EventOf(
+		"event-grok-invalid", types.EventKindSessionStarted, "cli", "grok", sessionID,
+		"duck8823/traceary", "session started", time.Now(),
+	)}
+	usage := &grokUsageCaptureStub{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+		cli.WithGrokUsage(usage),
+		cli.WithGrokHeadlessUsage(filesystem.NewGrokHeadlessUsageStreamFactory()),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{
+		"session", "run", "--db-path", filepath.Join(dir, "traceary.db"),
+		"--session-id", sessionID.String(), "--agent", "grok", "--",
+		grok, "-p", "prompt", "--output-format", "streaming-json",
+	})
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed to decode body-free Grok headless usage") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(usage.headless) != 0 {
+		t.Fatalf("parse failure reached persistence: %+v", usage.headless)
+	}
+	if sessionStub.finalizeReason != types.TerminalReasonSuccess {
+		t.Fatalf("finalize reason = %q", sessionStub.finalizeReason)
+	}
+}
+
 func TestRootCLI_SessionRunCommand_CapturesBodyFreeClaudeHeadlessUsage(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/presentation/cli/testdata/grok_usage/v0.2.106/headless_stream.jsonl
+++ b/presentation/cli/testdata/grok_usage/v0.2.106/headless_stream.jsonl
@@ -1,0 +1,3 @@
+{"type":"thought","data":"synthetic body ignored by usage adapter"}
+{"type":"text","data":"OK"}
+{"type":"end","requestId":"request-synthetic-1","sessionId":"session-synthetic-1","stopReason":"EndTurn","num_turns":1,"usage":{"input_tokens":21440,"cache_read_input_tokens":0,"output_tokens":25,"reasoning_tokens":20,"total_tokens":21465},"modelUsage":{"grok-4.5-build":{"inputTokens":21440,"cacheReadInputTokens":0,"outputTokens":25,"modelCalls":1,"costUSD":0.01}},"total_cost_usd":0.01,"total_cost_usd_ticks":10000}


### PR DESCRIPTION
## Motivation

Grok Build native hooks expose lifecycle boundaries but no provider usage, while the verified 0.2.106 headless terminal stream exposes authoritative request totals. Traceary needs to capture that source without retaining private stream bodies or guessing unavailable hook usage.

## Changes

- add a bounded, body-free `streaming-json` terminal adapter that forwards stdout unchanged
- persist one additive run observation from `end.usage`, including cache-read and reasoning counters
- persist excluded unavailable observations for missing terminal usage and stable native Stop boundaries
- suppress native-hook availability rows during Traceary-owned headless runs
- document retry, subagent, compact, terminal, multi-model, and TUI availability limits

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/traceary-go-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go vet ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go build ./...`
- `GOCACHE=/private/tmp/traceary-go-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-go-cache go run ./cmd/repo-tooling integrations verify`

Closes #1450
