### PR TITLE
Fix MCP startup workspace observation catch-up

### DIFF
--- a/.ai/spec/1499.md
+++ b/.ai/spec/1499.md
@@ -1,0 +1,63 @@
+# Spec 1499: Keep Workspace Observation Catch-up Index-backed
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose**: Prevent SQLite workspace-observation catch-up from scanning the observations table for every historical event during database initialization.
+- **Current behavior**: Initialization selects the oldest events without a primary observation in batches of at most 1,000. The correlated `NOT EXISTS` lookup states only one predicate from the partial unique index, so SQLite scans `session_workspace_observations`.
+- **Expected behavior**: The lookup must state the complete partial-index predicate so SQLite selects `idx_session_workspace_observations_primary_event`, while preserving deterministic oldest-first batches, the 1,000-row initialization bound, idempotency, and retry on a later initialization after failure.
+- **Out of scope**: Schema migrations, index changes, existing-row rewrites, asynchronous initialization, and changes to runtime observation writes.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Historical event | Event row with a stable ID and creation time | Becomes eligible when it has no primary observation | Eligibility is evaluated by event ID against primary observations only |
+| Primary observation | Observation row whose kind is `primary` and whose event ID is present | Excludes its event from catch-up | At most one non-empty primary observation per event, enforced by the partial unique index |
+| Catch-up batch | Ordered set of eligible historical events | Inserts backfill observations in one transaction | Oldest-first order is deterministic; size is positive and at most the caller's limit |
+| Initialization retry | A later initialization after a diagnostic catch-up failure | Re-evaluates still-missing observations | A failed transaction must not mark rows as processed |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Select a bounded, deterministic catch-up batch | `infrastructure/sqlite/workspace_observation_backfill.go` | SQL paging and writer order are infrastructure concerns | Application/domain do not own SQLite query planning |
+| Guarantee primary-event uniqueness | Existing partial unique index in migration 22 | Schema already encodes the invariant | This issue must not change migrations |
+| Classify workspace relationship and build observation values | Existing infrastructure catch-up loop using domain helpers | Existing behavior is correct and remains unchanged | Query optimization must not move domain classification into SQL |
+| Verify optimizer selection | Focused SQLite regression test | Query-plan shape is an observable infrastructure performance contract | Runtime code must not inspect or branch on query plans |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| Catch-up batch SQL | `catchUpWorkspaceObservations` | Partial-index predicates and SQLite query plan | Query errors are wrapped and leave the transaction uncommitted |
+| Catch-up transaction | Database initialization | Row selection and per-row inserts | Non-conflict insert errors roll back; unique conflicts remain idempotent |
+| `Database.initializeAt` catch-up call | CLI/MCP initialization | Synchronous bounded repair | Catch-up failure is diagnostic-only and is retried on the next initialization |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Partial index is used | Migrated temporary SQLite schema | Explain the production catch-up selection | The plan names `idx_session_workspace_observations_primary_event` and does not scan observations in the correlated subquery | Infrastructure regression |
+| Batch remains bounded and retryable | 1,005 historical events and no observations | Initialize repeatedly | First run inserts 1,000, second inserts five, third inserts none | Existing integration regression |
+| Duplicate primary observations remain excluded | An event already has a primary observation | Initialize | No second primary observation is created | Existing integration/schema regression |
+| Failure retries later | Backfill inserts fail transactionally, then the fault is removed | Initialize twice | Runtime ingestion stays available and the missing historical observation appears on retry | Existing integration regression |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Optimizer uses the partial index | Add an `EXPLAIN QUERY PLAN` test against the exact production query; current query reports an observations-table scan | State all predicates of the partial index in the correlated lookup | Keep the selection query in one package-level constant so execution and the plan test cannot drift |
+| Existing catch-up invariants are preserved | Run focused bounded-batch and retry tests before and after the change | Keep ordering, limit, transaction, conflict handling, and initialization error handling unchanged | No new abstraction beyond the shared query constant |
+
+### Risks / rollback
+
+- **Procedural-logic risk**: Duplicating the SQL in a plan test could let the test pass while production regresses. The test must explain the same query constant executed by catch-up.
+- **Premature-abstraction risk**: A query-builder or repository interface would add indirection for a two-predicate correction. Use one private constant only.
+- **Migration / compatibility**: No migration or persisted data changes. The fix relies on the existing migration-22 partial index and explicitly mirrors all of its predicates.
+- **Rollback trigger**: If supported SQLite versions fail to select the partial index or behavior tests change batch/idempotency semantics, revert the query predicate and test together. No data rollback is required.
+
+## Implementation checkpoint
+
+Proceed with an infrastructure-only query correction and a focused query-plan regression test. Do not change initialization orchestration, batch size, migrations, or stored data.

--- a/infrastructure/sqlite/workspace_observation_backfill.go
+++ b/infrastructure/sqlite/workspace_observation_backfill.go
@@ -13,6 +13,22 @@ import (
 
 const workspaceObservationCatchUpBatchSize = 1000
 
+const workspaceObservationCatchUpBatchQuery = `
+	SELECT e.id, e.session_id, e.workspace, e.created_at, e.agent,
+	       COALESCE(e.source_hook, ''), COALESCE(s.workspace, '')
+	  FROM events e
+	  LEFT JOIN sessions s ON s.session_id = e.session_id
+	 WHERE NOT EXISTS (
+	       SELECT 1
+	         FROM session_workspace_observations o
+	        WHERE o.observed_event_id = e.id
+	          AND o.observation_kind = 'primary'
+	          AND o.observed_event_id IS NOT NULL
+	          AND o.observed_event_id <> ''
+	 )
+	 ORDER BY ts_norm(e.created_at), e.id
+	 LIMIT ?`
+
 func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int) error {
 	if batchSize <= 0 {
 		return xerrors.Errorf("workspace observation catch-up batch size must be positive")
@@ -31,19 +47,7 @@ func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.QueryContext(ctx, `
-		SELECT e.id, e.session_id, e.workspace, e.created_at, e.agent,
-		       COALESCE(e.source_hook, ''), COALESCE(s.workspace, '')
-		  FROM events e
-		  LEFT JOIN sessions s ON s.session_id = e.session_id
-		 WHERE NOT EXISTS (
-		       SELECT 1
-		         FROM session_workspace_observations o
-		        WHERE o.observed_event_id = e.id
-		          AND o.observation_kind = 'primary'
-		 )
-		 ORDER BY ts_norm(e.created_at), e.id
-		 LIMIT ?`, batchSize)
+	rows, err := tx.QueryContext(ctx, workspaceObservationCatchUpBatchQuery, batchSize)
 	if err != nil {
 		return xerrors.Errorf("failed to query workspace observation catch-up batch: %w", err)
 	}

--- a/infrastructure/sqlite/workspace_observation_backfill_test.go
+++ b/infrastructure/sqlite/workspace_observation_backfill_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceObservationCatchUpBatchQuery_UsesPrimaryEventPartialIndex(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`
+		CREATE TABLE sessions (
+			session_id TEXT PRIMARY KEY,
+			workspace TEXT NOT NULL
+		);
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			agent TEXT NOT NULL,
+			source_hook TEXT
+		);
+		CREATE TABLE session_workspace_observations (
+			observation_id TEXT PRIMARY KEY,
+			observation_kind TEXT NOT NULL,
+			observed_event_id TEXT
+		);
+		CREATE UNIQUE INDEX idx_session_workspace_observations_primary_event
+			ON session_workspace_observations(observed_event_id)
+			WHERE observation_kind = 'primary'
+			  AND observed_event_id IS NOT NULL
+			  AND observed_event_id <> '';
+	`); err != nil {
+		t.Fatalf("create query-plan schema: %v", err)
+	}
+
+	rows, err := db.QueryContext(
+		context.Background(),
+		"EXPLAIN QUERY PLAN "+workspaceObservationCatchUpBatchQuery,
+		workspaceObservationCatchUpBatchSize,
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, "idx_session_workspace_observations_primary_event") {
+		t.Errorf("query plan does not use primary-event partial index:\n%s", joined)
+	}
+	for _, detail := range plan {
+		if strings.Contains(detail, "SCAN o") {
+			t.Errorf("query plan scans session_workspace_observations in correlated lookup:\n%s", joined)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Traceary MCP startup can exceed the host timeout because synchronous workspace-observation catch-up performs a correlated full scan of `workspace_observations` for every candidate event.

## What changed

- Restated every predicate of the primary-event partial index in the catch-up query.
- Shared the runtime query constant with an `EXPLAIN QUERY PLAN` regression test.
- Added a Structure-Behavior design note for the performance contract.

## User-facing impact

MCP initialization should return within the startup budget even when the Traceary database contains a large event history and only part of the workspace-observation backlog has been processed.

## Validation

- Focused SQLite catch-up tests passed.
- `go vet ./...` passed.
- `go test ./...` passed: 23 packages, 3,698 tests.
- `go tool golangci-lint run --timeout=5m` passed.
- Synthetic database with 215,038 events and 30,000 observations:
  - released 0.31.0: no initialize response within 5 seconds
  - patched binary: initialize responses in 1.074 seconds and 0.911 seconds
- Existing 3.2 GiB database, read-only execution of the patched selection query: 1,000 rows in 784 ms.

## Review evidence

- Implementation worker and current orchestrator independently validated the change.
- Preliminary Grok review: approved with no blocking findings.
- Claude review was unavailable due to provider quota; the required review route is re-resolved without lowering the risk lane.

Closes #1499
