### PR TITLE
fix: timestamp Grok headless usage observations

### DIFF
--- a/.ai/spec/1506.md
+++ b/.ai/spec/1506.md
@@ -1,0 +1,59 @@
+# Issue #1506: make Grok headless observations reportable
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- A Traceary-owned Grok `streaming-json` run already persists terminal usage, but the adapter records `observed_at` as the Unix epoch.
+- Period reports therefore exclude otherwise valid live observations.
+- Timestamp the observation when the body-free terminal event is ingested, without changing provider identity, counters, accounting, stdout forwarding, or privacy boundaries.
+- Do not rewrite the two local QA rows created before this fix; they remain valid historical evidence with an incorrect event time and are excluded from release totals.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Terminal usage event | provider request/session identity, counters, terminal code | becomes one finalized usage sample | provider identity and counters come only from the terminal event |
+| Observation time | local ingestion clock | places the sample in a report interval | must be UTC and represent terminal ingestion, never a fabricated provider timestamp |
+| Portable observation identity | hash of request and session identity | reconciles re-delivery across Traceary sessions | time is not part of identity; an exact replay remains idempotent |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Assign ingestion time | Grok headless stream adapter | the source event has no timestamp | report query must not repair source rows |
+| Reconcile portable identity | Grok usage capture use case | owns idempotent persistence | stream adapter must not query SQLite |
+| Select period rows | report query | owns interval semantics | capture use case must not know report windows |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `GrokHeadlessUsageStreamFactory.New` | `session run` | local clock and bounded JSONL parser | malformed/conflicting terminal metadata fails closed |
+| `GrokUsageCaptureUsecase.CaptureHeadless` | CLI finalizer | SQLite reconciliation | exact provider replay is a no-op; changed payload conflicts |
+| `report --json` | QA/operator | complete body-free SQL projection | interval inclusion follows `observed_at` |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Current observation time | versioned Grok terminal fixture | stream completes | sample time is between adapter creation and completion, in UTC, and not epoch | filesystem |
+| Flag-order compatibility | `-p` before or after `--output-format streaming-json` | command is classified | both select headless capture | CLI |
+| Period visibility | current terminal sample | complete report covers ingestion time | exactly one Grok additive observation appears with matching counters | live QA |
+| Replay safety | same request/session terminal is delivered twice | persistence reconciles | totals are counted once | use case |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| Current observation time | assert fixture sample falls inside a measured wall-clock window | inject `time.Now` through the factory/stream and assign at terminal parse | mirror the established Codex headless clock ownership |
+| Flag-order compatibility | extend classifier cases with the live command shapes | retain current parser behavior | keep parsing local to command classification |
+| Period visibility | run a body-free live probe and report | rebuild the candidate with the clock fix | no production-only QA branch |
+
+### Risks / rollback
+
+- Procedural risk: repairing timestamps inside reporting would mix source correction with read behavior. The adapter owns the fix.
+- Premature abstraction risk: a shared clock framework is unnecessary; use the same small factory field as the Codex adapter.
+- Migration / compatibility: no schema or identity change. Existing epoch rows are not rewritten.
+- Rollback trigger: re-delivery starts conflicting solely because ingestion times differ, stdout changes, or report totals duplicate a provider identity.
+- Split plan: #1506 contains only the adapter timestamp regression and its tests; #1457 remains the QA evidence issue.

--- a/application/usecase/grok_usage_capture.go
+++ b/application/usecase/grok_usage_capture.go
@@ -135,20 +135,15 @@ func reconcilePortableGrokObservation(
 	proposedDescriptor := proposed.Descriptor()
 	currentTerminal, currentTerminalPresent := current.TerminalCode().Value()
 	proposedTerminal, proposedTerminalPresent := proposed.TerminalCode().Value()
-	currentFinalizedAt, currentFinalizedPresent := current.FinalizedAt().Value()
-	proposedFinalizedAt, proposedFinalizedPresent := proposed.FinalizedAt().Value()
 	equivalent := currentDescriptor.ObservationID() == proposedDescriptor.ObservationID() &&
 		currentDescriptor.Source() == proposedDescriptor.Source() &&
 		currentDescriptor.Scope() == proposedDescriptor.Scope() &&
 		currentDescriptor.Accounting() == proposedDescriptor.Accounting() &&
-		currentDescriptor.ObservedAt().Equal(proposedDescriptor.ObservedAt()) &&
 		current.Status() == proposed.Status() &&
 		current.Counters() == proposed.Counters() &&
 		current.Cost() == proposed.Cost() &&
 		currentTerminalPresent == proposedTerminalPresent &&
-		(!currentTerminalPresent || currentTerminal == proposedTerminal) &&
-		currentFinalizedPresent == proposedFinalizedPresent &&
-		(!currentFinalizedPresent || currentFinalizedAt.Equal(proposedFinalizedAt))
+		(!currentTerminalPresent || currentTerminal == proposedTerminal)
 	if equivalent {
 		return model.UsageObservationTransitionAlreadyApplied, nil
 	}

--- a/application/usecase/grok_usage_capture_test.go
+++ b/application/usecase/grok_usage_capture_test.go
@@ -56,6 +56,9 @@ func TestGrokUsageCapture_DeduplicatesProviderTerminalAcrossTracearySessions(t *
 	if err != nil || first.Applied != 1 {
 		t.Fatalf("first capture = (%+v, %v)", first, err)
 	}
+	replayedSample := grokUsageSampleFixture()
+	replayedSample.ObservedAt = replayedSample.ObservedAt.Add(time.Minute)
+	loaded.Samples = []application.GrokUsageSample{replayedSample}
 	replayed, err := capture.CaptureHeadless(
 		context.Background(),
 		usecase.GrokUsageCaptureInput{SessionID: "traceary-session-2", DeliveryID: "session_run"},

--- a/infrastructure/filesystem/grok_headless_usage_stream.go
+++ b/infrastructure/filesystem/grok_headless_usage_stream.go
@@ -19,13 +19,14 @@ import (
 const defaultGrokUsageMaxLineBytes = 8 * 1024 * 1024
 
 type grokHeadlessUsageStreamFactory struct {
+	now          func() time.Time
 	maxLineBytes int
 }
 
 // NewGrokHeadlessUsageStreamFactory creates body-free adapters for
 // Traceary-owned Grok `streaming-json` invocations.
 func NewGrokHeadlessUsageStreamFactory() application.GrokHeadlessUsageStreamFactory {
-	return &grokHeadlessUsageStreamFactory{maxLineBytes: defaultGrokUsageMaxLineBytes}
+	return &grokHeadlessUsageStreamFactory{now: time.Now, maxLineBytes: defaultGrokUsageMaxLineBytes}
 }
 
 func (f *grokHeadlessUsageStreamFactory) New(destination io.Writer) application.GrokHeadlessUsageStream {
@@ -34,12 +35,14 @@ func (f *grokHeadlessUsageStreamFactory) New(destination io.Writer) application.
 	}
 	return &grokHeadlessUsageStream{
 		destination: destination,
+		now:         f.now,
 		maxLine:     f.maxLineBytes,
 	}
 }
 
 type grokHeadlessUsageStream struct {
 	destination       io.Writer
+	now               func() time.Time
 	maxLine           int
 	buffer            []byte
 	result            application.GrokUsageLoadResult
@@ -189,7 +192,7 @@ func (s *grokHeadlessUsageStream) parseEnd(end grokStreamEnd) error {
 			SourceName:    "headless_stream",
 			SourceVersion: "0.2.106",
 			Model:         model,
-			ObservedAt:    time.Unix(0, 0).UTC(),
+			ObservedAt:    s.now().UTC(),
 			TerminalCode:  terminal,
 			Available:     true,
 			Counters: application.GrokUsageCounters{

--- a/infrastructure/filesystem/grok_headless_usage_stream_test.go
+++ b/infrastructure/filesystem/grok_headless_usage_stream_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/filesystem"
@@ -15,6 +16,7 @@ func TestGrokHeadlessUsageStream_UsesVersionedTerminalFixture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	before := time.Now().UTC()
 	output := &bytes.Buffer{}
 	stream := filesystem.NewGrokHeadlessUsageStreamFactory().New(output)
 	for _, chunk := range [][]byte{fixture[:13], fixture[13:87], fixture[87:]} {
@@ -23,6 +25,7 @@ func TestGrokHeadlessUsageStream_UsesVersionedTerminalFixture(t *testing.T) {
 		}
 	}
 	result, err := stream.Complete()
+	after := time.Now().UTC()
 	if err != nil {
 		t.Fatalf("Complete() error = %v", err)
 	}
@@ -33,6 +36,10 @@ func TestGrokHeadlessUsageStream_UsesVersionedTerminalFixture(t *testing.T) {
 		t.Fatalf("result = %+v", result)
 	}
 	sample := result.Samples[0]
+	if sample.ObservedAt.Before(before) || sample.ObservedAt.After(after) ||
+		sample.ObservedAt.Location() != time.UTC {
+		t.Fatalf("sample observed_at = %s, want UTC ingestion time in [%s, %s]", sample.ObservedAt, before, after)
+	}
 	if !sample.Available ||
 		sample.RecordID != "headless_stream:ae531a76b3e09738546f60434a97e5090e00833f09aeb76ff382b98bc7d5911a" ||
 		sample.Model != "grok-4.5-build" || sample.TerminalCode != types.UsageTerminalSuccess {

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -96,6 +96,8 @@ func TestIsGrokHeadlessUsageCommand_RequiresSingleAndStreamingJSON(t *testing.T)
 		want    bool
 	}{
 		{name: "short single", command: []string{"grok", "-p", "prompt", "--output-format", "streaming-json"}, want: true},
+		{name: "live flags prompt last", command: []string{"grok", "--cwd", "/private/tmp", "--permission-mode", "plan", "--no-memory", "--no-subagents", "--disable-web-search", "--output-format", "streaming-json", "-p", "prompt"}, want: true},
+		{name: "live flags prompt first", command: []string{"grok", "-p", "prompt", "--output-format", "streaming-json", "--cwd", "/private/tmp", "--permission-mode", "plan", "--no-memory", "--no-subagents", "--disable-web-search"}, want: true},
 		{name: "attached short single", command: []string{"grok", "-pprompt", "--output-format", "streaming-json"}, want: true},
 		{name: "long single", command: []string{"/usr/local/bin/grok", "--single=prompt", "--output-format=streaming-json"}, want: true},
 		{name: "prompt file", command: []string{"grok", "--prompt-file", "prompt.md", "--output-format=streaming-json"}, want: true},


### PR DESCRIPTION
## Motivation

The v0.32.0 seven-day QA report excluded successful Grok headless usage even though `session run` had parsed and persisted the terminal counters. The adapter assigned the Unix epoch to every Grok terminal observation, placing valid live rows outside any current report interval.

## Changes

- Timestamp Grok terminal usage at local ingestion time, matching the body-free Codex adapter boundary.
- Keep portable provider identity independent of ingestion/finalization time so an exact cross-session replay remains idempotent.
- Cover both live-supported Grok flag orders and assert a current UTC observation time.
- Document the structure/behavior decision and rollback conditions.

## QA

- Live Grok Build 0.2.106 terminal metadata: input 21,537; cache-read 0; output 25; reasoning 20; total 21,562.
- The rebuilt candidate produced one current-period `xai/grok` additive observation with the same counters and no duplicate/excluded row.
- Raw prompt, response, thinking, and tool bodies were not used in the report or committed evidence.

## Validation

- `GOCACHE=/private/tmp/traceary-go-cache go vet ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-go-cache go build ./...`
- `GOCACHE=/private/tmp/traceary-go-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-golangci-cache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-go-cache make integrations/check`
- `GOCACHE=/private/tmp/traceary-go-cache make docs/check`

Closes #1506
