### PR TITLE
test: isolate hook audit spool state

### DIFF
--- a/presentation/cli/hook_runtime_self_inspection_test.go
+++ b/presentation/cli/hook_runtime_self_inspection_test.go
@@ -66,6 +66,10 @@ func TestRootCLI_HookAuditCommand_SuppressesSelfInspectionNoise(t *testing.T) {
 }
 
 func TestRootCLI_HookAuditCommand_RecordsGenericSearchTool(t *testing.T) {
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
 	eventStub := &eventUsecaseStub{}
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),


### PR DESCRIPTION
## Motivation

The v0.32.0 release validation exposed that one focused hook audit test read the operator's production spool. A queued real command could overwrite the stub's last call and fail the test even though the focused `search` payload was recorded.

## Changes

- Redirect the test's user home to `t.TempDir()`.
- Restore the global home resolver during cleanup.
- Keep production behavior unchanged.

## Validation

- Targeted test passed 10 consecutive runs with the real production spool populated.
- `go test ./... -count=1`: 3,797 tests passed.
- `go tool golangci-lint run`: 0 issues.
- `git diff --check`: passed.

Closes #1509
