### PR TITLE
fix: make workspace catch-up lock tolerant

### DIFF
--- a/.ai/spec/1514.md
+++ b/.ai/spec/1514.md
@@ -1,0 +1,49 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Purpose: keep additive workspace-observation catch-up from competing with normal ingestion during store initialization.
+- Current behavior: one transaction reads up to 1,000 historical events and then upgrades the same snapshot to a writer; a concurrent commit can produce `SQLITE_BUSY_SNAPSHOT`.
+- Expected behavior: read candidates outside the write transaction, write a bounded batch in a short transaction, and retry only SQLite busy-class errors a bounded number of times.
+- Non-goals: changing schemas, public interfaces, host timeouts, or suppressing non-retryable failures.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Catch-up batch | selected rows | reads candidates without holding a write transaction | bounded by 1,000 |
+| Write attempt | transaction | inserts missing observations and commits | short-lived; idempotent |
+| Contention retry | attempt count | retries SQLite busy-class failures | maximum three attempts; context-aware |
+| Observation | durable row | uniquely identifies a primary observed event | duplicate delivery creates no duplicate row |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Candidate SQL and transaction boundary | `infrastructure/sqlite` | SQLite concurrency detail | application/domain do not know SQL |
+| Retry classification | `infrastructure/sqlite` | driver error codes | presentation must not own DB retry policy |
+| Fail-soft initialization | database initializer | catch-up is additive diagnostics | hook ingestion must remain available |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `catchUpWorkspaceObservations` | store initialization | query, transaction, retry | returns non-retryable or exhausted error |
+| SQLite driver | catch-up | extended result codes | retry only primary `SQLITE_BUSY` class |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Snapshot is not upgraded | candidates are read and another writer commits | catch-up writes | catch-up converges without 517 | integration |
+| Duplicate convergence | another writer inserts the same observation | catch-up writes | one durable observation remains | integration |
+| Cancellation | retry wait has a cancelled context | catch-up retries | cancellation returns promptly | unit/integration |
+| Non-retryable failure | insert trigger returns an error | catch-up runs | failure remains visible and initialization stays fail-soft | integration |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| concurrent writer convergence | reproduce read/write overlap | split selection from write transaction | small candidate reader |
+| bounded busy retry | force a write lock beyond one attempt | typed busy classifier and context-aware retry | shared retry helper only if reused |
+
+### Risks / rollback
+- Procedural risk: retry loops can hide permanent failures; typed classification and a fixed attempt ceiling prevent this.
+- Premature abstraction: keep the policy local to this catch-up until another store path needs the same contract.
+- Migration/compatibility: no schema or persisted-format change.
+- Rollback trigger: increased initialization latency, swallowed non-busy errors, or duplicate observations.
+- Rollback: revert the code-only change; the operation is additive and idempotent.

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -200,11 +200,25 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string) (err error
 	if err := d.migrate(ctx, db); err != nil {
 		return xerrors.Errorf("failed to run SQLite migrations: %w", err)
 	}
-	if err := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize); err != nil {
+	catchUpResult, catchUpErr := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize)
+	if catchUpErr != nil {
 		// Catch-up is additive diagnostic coverage. A malformed historical row
 		// must not block normal ingestion after the schema migration succeeded;
 		// the next initialization retries the still-missing batch.
-		slog.Error("workspace observation catch-up incomplete; retrying on next initialization", "error", err)
+		slog.Error("workspace observation catch-up incomplete; retrying on next initialization",
+			"selected", catchUpResult.Selected,
+			"inserted", catchUpResult.Inserted,
+			"retries", catchUpResult.Retries,
+			"more_pending", catchUpResult.MorePending,
+			"error", catchUpErr,
+		)
+	} else if catchUpResult.Selected > 0 || catchUpResult.Retries > 0 {
+		slog.Debug("workspace observation catch-up completed",
+			"selected", catchUpResult.Selected,
+			"inserted", catchUpResult.Inserted,
+			"retries", catchUpResult.Retries,
+			"more_pending", catchUpResult.MorePending,
+		)
 	}
 
 	return nil

--- a/infrastructure/sqlite/workspace_observation_backfill.go
+++ b/infrastructure/sqlite/workspace_observation_backfill.go
@@ -115,6 +115,7 @@ func catchUpWorkspaceObservationsOnce(ctx context.Context, db *sql.DB, batchSize
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	inserted := 0
 	for _, row := range batch {
 		relationship := model.ClassifyWorkspaceRelationship(types.Workspace(row.canonical), types.Workspace(row.workspace))
 		_, err := tx.ExecContext(ctx, `
@@ -140,12 +141,15 @@ func catchUpWorkspaceObservationsOnce(ctx context.Context, db *sql.DB, batchSize
 			}
 			return result, xerrors.Errorf("failed to insert backfill workspace observation for event %s: %w", row.eventID, err)
 		}
-		result.Inserted++
+		inserted++
 	}
 
 	if err := tx.Commit(); err != nil {
 		return result, xerrors.Errorf("failed to commit workspace observation catch-up: %w", err)
 	}
+	// Report only durable inserts. An exhausted busy retry may have executed
+	// statements in a transaction that was rolled back before commit.
+	result.Inserted = inserted
 	return result, nil
 }
 

--- a/infrastructure/sqlite/workspace_observation_backfill.go
+++ b/infrastructure/sqlite/workspace_observation_backfill.go
@@ -4,14 +4,25 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"golang.org/x/xerrors"
+	sqlitelib "modernc.org/sqlite"
 
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 const workspaceObservationCatchUpBatchSize = 1000
+const workspaceObservationCatchUpMaxAttempts = 3
+const workspaceObservationCatchUpRetryDelay = 25 * time.Millisecond
+
+type workspaceObservationCatchUpResult struct {
+	Selected    int
+	Inserted    int
+	Retries     int
+	MorePending bool
+}
 
 const workspaceObservationCatchUpBatchQuery = `
 	SELECT e.id, e.session_id, e.workspace, e.created_at, e.agent,
@@ -29,27 +40,41 @@ const workspaceObservationCatchUpBatchQuery = `
 	 ORDER BY ts_norm(e.created_at), e.id
 	 LIMIT ?`
 
-func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int) error {
+func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int) (workspaceObservationCatchUpResult, error) {
 	if batchSize <= 0 {
-		return xerrors.Errorf("workspace observation catch-up batch size must be positive")
+		return workspaceObservationCatchUpResult{}, xerrors.Errorf("workspace observation catch-up batch size must be positive")
 	}
 	exists, err := sqliteTableExists(ctx, db, "session_workspace_observations")
 	if err != nil {
-		return err
+		return workspaceObservationCatchUpResult{}, err
 	}
 	if !exists {
-		return nil
+		return workspaceObservationCatchUpResult{}, nil
 	}
 
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return xerrors.Errorf("failed to begin workspace observation catch-up: %w", err)
+	for attempt := 1; attempt <= workspaceObservationCatchUpMaxAttempts; attempt++ {
+		result, err := catchUpWorkspaceObservationsOnce(ctx, db, batchSize)
+		result.Retries = attempt - 1
+		if err == nil || !isSQLiteBusy(err) || attempt == workspaceObservationCatchUpMaxAttempts {
+			return result, err
+		}
+		timer := time.NewTimer(workspaceObservationCatchUpRetryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return result, xerrors.Errorf("workspace observation catch-up retry cancelled: %w", ctx.Err())
+		case <-timer.C:
+		}
 	}
-	defer func() { _ = tx.Rollback() }()
+	return workspaceObservationCatchUpResult{}, nil
+}
 
-	rows, err := tx.QueryContext(ctx, workspaceObservationCatchUpBatchQuery, batchSize)
+func catchUpWorkspaceObservationsOnce(ctx context.Context, db *sql.DB, batchSize int) (workspaceObservationCatchUpResult, error) {
+	rows, err := db.QueryContext(ctx, workspaceObservationCatchUpBatchQuery, batchSize+1)
 	if err != nil {
-		return xerrors.Errorf("failed to query workspace observation catch-up batch: %w", err)
+		return workspaceObservationCatchUpResult{}, xerrors.Errorf("failed to query workspace observation catch-up batch: %w", err)
 	}
 
 	type catchUpRow struct {
@@ -60,17 +85,35 @@ func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int
 		var row catchUpRow
 		if err := rows.Scan(&row.eventID, &row.sessionID, &row.workspace, &row.createdAt, &row.agent, &row.sourceHook, &row.canonical); err != nil {
 			_ = rows.Close()
-			return xerrors.Errorf("failed to scan workspace observation catch-up row: %w", err)
+			return workspaceObservationCatchUpResult{}, xerrors.Errorf("failed to scan workspace observation catch-up row: %w", err)
 		}
 		batch = append(batch, row)
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return xerrors.Errorf("failed to iterate workspace observation catch-up rows: %w", err)
+		return workspaceObservationCatchUpResult{}, xerrors.Errorf("failed to iterate workspace observation catch-up rows: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		return xerrors.Errorf("failed to close workspace observation catch-up rows: %w", err)
+		return workspaceObservationCatchUpResult{}, xerrors.Errorf("failed to close workspace observation catch-up rows: %w", err)
 	}
+	result := workspaceObservationCatchUpResult{Selected: len(batch)}
+	if len(batch) > batchSize {
+		result.MorePending = true
+		batch = batch[:batchSize]
+		result.Selected = batchSize
+	}
+	if len(batch) == 0 {
+		return result, nil
+	}
+
+	// Do not upgrade the candidate-selection snapshot into a writer. A
+	// concurrent hook commit between SELECT and INSERT would otherwise turn
+	// the upgrade into SQLITE_BUSY_SNAPSHOT even with busy_timeout enabled.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, xerrors.Errorf("failed to begin workspace observation catch-up: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
 
 	for _, row := range batch {
 		relationship := model.ClassifyWorkspaceRelationship(types.Workspace(row.canonical), types.Workspace(row.workspace))
@@ -95,14 +138,26 @@ func catchUpWorkspaceObservations(ctx context.Context, db *sql.DB, batchSize int
 			if isSQLiteUniqueOrPKConflict(err) {
 				continue
 			}
-			return xerrors.Errorf("failed to insert backfill workspace observation for event %s: %w", row.eventID, err)
+			return result, xerrors.Errorf("failed to insert backfill workspace observation for event %s: %w", row.eventID, err)
 		}
+		result.Inserted++
 	}
 
 	if err := tx.Commit(); err != nil {
-		return xerrors.Errorf("failed to commit workspace observation catch-up: %w", err)
+		return result, xerrors.Errorf("failed to commit workspace observation catch-up: %w", err)
 	}
-	return nil
+	return result, nil
+}
+
+func isSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr *sqlitelib.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	return sqliteErr.Code()&0xff == 5
 }
 
 func sqliteTableExists(ctx context.Context, db *sql.DB, table string) (bool, error) {

--- a/infrastructure/sqlite/workspace_observation_backfill_test.go
+++ b/infrastructure/sqlite/workspace_observation_backfill_test.go
@@ -170,3 +170,77 @@ func TestCatchUpWorkspaceObservations_RetriesConcurrentWriterContention(t *testi
 		t.Fatalf("observation count = %d, want 1", count)
 	}
 }
+
+func TestCatchUpWorkspaceObservations_DoesNotReportRolledBackInserts(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`
+		CREATE TABLE sessions (
+			session_id TEXT PRIMARY KEY,
+			workspace TEXT NOT NULL
+		);
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			agent TEXT NOT NULL,
+			source_hook TEXT
+		);
+		CREATE TABLE session_workspace_observations (
+			observation_id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			raw_workspace TEXT,
+			observation_kind TEXT NOT NULL,
+			observation_origin TEXT NOT NULL,
+			observed_relationship TEXT NOT NULL,
+			observed_event_id TEXT,
+			delivery_record_id TEXT,
+			attribution_fingerprint TEXT NOT NULL,
+			diagnostic_reason TEXT NOT NULL,
+			observed_at TEXT NOT NULL,
+			source_client TEXT NOT NULL,
+			source_hook TEXT
+		);
+		CREATE UNIQUE INDEX idx_session_workspace_observations_primary_event
+			ON session_workspace_observations(observed_event_id)
+			WHERE observation_kind = 'primary'
+			  AND observed_event_id IS NOT NULL
+			  AND observed_event_id <> '';
+		CREATE TRIGGER reject_second_observation
+			BEFORE INSERT ON session_workspace_observations
+			WHEN NEW.observed_event_id = 'event-2'
+			BEGIN
+				SELECT RAISE(ABORT, 'forced catch-up failure');
+			END;
+		INSERT INTO sessions (session_id, workspace) VALUES ('session-1', '/repo');
+		INSERT INTO events (id, session_id, workspace, created_at, agent, source_hook)
+		VALUES
+			('event-1', 'session-1', '/repo', '2026-07-24T00:00:00Z', 'codex', 'user_prompt_submit'),
+			('event-2', 'session-1', '/repo', '2026-07-24T00:00:01Z', 'codex', 'user_prompt_submit');
+	`); err != nil {
+		t.Fatalf("create catch-up schema: %v", err)
+	}
+
+	result, err := catchUpWorkspaceObservations(context.Background(), db, 10)
+	if err == nil || !strings.Contains(err.Error(), "forced catch-up failure") {
+		t.Fatalf("catchUpWorkspaceObservations() error = %v, want forced failure", err)
+	}
+	if result.Selected != 2 || result.Inserted != 0 || result.Retries != 0 {
+		t.Fatalf("catch-up result = %+v, want selected=2 inserted=0 retries=0", result)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM session_workspace_observations`).Scan(&count); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("observation count = %d, want 0 after rollback", count)
+	}
+}

--- a/infrastructure/sqlite/workspace_observation_backfill_test.go
+++ b/infrastructure/sqlite/workspace_observation_backfill_test.go
@@ -3,8 +3,10 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWorkspaceObservationCatchUpBatchQuery_UsesPrimaryEventPartialIndex(t *testing.T) {
@@ -75,5 +77,96 @@ func TestWorkspaceObservationCatchUpBatchQuery_UsesPrimaryEventPartialIndex(t *t
 		if strings.Contains(detail, "SCAN o") {
 			t.Errorf("query plan scans session_workspace_observations in correlated lookup:\n%s", joined)
 		}
+	}
+}
+
+func TestCatchUpWorkspaceObservations_RetriesConcurrentWriterContention(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "catch-up.db")
+	lockDB, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = lockDB.Close() })
+	lockDB.SetMaxOpenConns(1)
+
+	if _, err := lockDB.Exec(`
+		CREATE TABLE sessions (
+			session_id TEXT PRIMARY KEY,
+			workspace TEXT NOT NULL
+		);
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			agent TEXT NOT NULL,
+			source_hook TEXT
+		);
+		CREATE TABLE session_workspace_observations (
+			observation_id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			raw_workspace TEXT,
+			observation_kind TEXT NOT NULL,
+			observation_origin TEXT NOT NULL,
+			observed_relationship TEXT NOT NULL,
+			observed_event_id TEXT,
+			delivery_record_id TEXT,
+			attribution_fingerprint TEXT NOT NULL,
+			diagnostic_reason TEXT NOT NULL,
+			observed_at TEXT NOT NULL,
+			source_client TEXT NOT NULL,
+			source_hook TEXT
+		);
+		CREATE UNIQUE INDEX idx_session_workspace_observations_primary_event
+			ON session_workspace_observations(observed_event_id)
+			WHERE observation_kind = 'primary'
+			  AND observed_event_id IS NOT NULL
+			  AND observed_event_id <> '';
+		CREATE TABLE writer_lock (id INTEGER PRIMARY KEY);
+		INSERT INTO sessions (session_id, workspace) VALUES ('session-1', '/repo');
+		INSERT INTO events (id, session_id, workspace, created_at, agent, source_hook)
+		VALUES ('event-1', 'session-1', '/repo', '2026-07-24T00:00:00Z', 'codex', 'user_prompt_submit');
+	`); err != nil {
+		t.Fatalf("create catch-up schema: %v", err)
+	}
+
+	fastBusyDSN := strings.Replace(sqliteDSN(dbPath), "busy_timeout%281000%29", "busy_timeout%281%29", 1)
+	catchUpDB, err := sql.Open("sqlite", fastBusyDSN)
+	if err != nil {
+		t.Fatalf("open catch-up DB: %v", err)
+	}
+	t.Cleanup(func() { _ = catchUpDB.Close() })
+	catchUpDB.SetMaxOpenConns(1)
+
+	locker, err := lockDB.Begin()
+	if err != nil {
+		t.Fatalf("begin writer lock: %v", err)
+	}
+	if _, err := locker.Exec(`INSERT INTO writer_lock (id) VALUES (1)`); err != nil {
+		t.Fatalf("hold writer lock: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		_ = locker.Commit()
+		close(released)
+	}()
+
+	result, err := catchUpWorkspaceObservations(context.Background(), catchUpDB, 10)
+	if err != nil {
+		t.Fatalf("catchUpWorkspaceObservations() error = %v", err)
+	}
+	<-released
+	if result.Selected != 1 || result.Inserted != 1 || result.Retries == 0 || result.MorePending {
+		t.Fatalf("catch-up result = %+v, want selected=1 inserted=1 retries>0 more_pending=false", result)
+	}
+
+	var count int
+	if err := catchUpDB.QueryRow(`SELECT COUNT(*) FROM session_workspace_observations WHERE observed_event_id = 'event-1'`).Scan(&count); err != nil {
+		t.Fatalf("count observations: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("observation count = %d, want 1", count)
 	}
 }


### PR DESCRIPTION
## Motivation

Workspace-observation catch-up currently selects and writes in one transaction. If normal hook ingestion commits after the catch-up read snapshot, SQLite can reject the snapshot upgrade with `SQLITE_BUSY_SNAPSHOT`, leaving additive diagnostics incomplete.

## Changes

- select catch-up candidates outside the write transaction
- keep the write transaction short and retry only typed SQLite busy-class errors
- bound retries to three attempts with context-aware waits
- expose body-free progress fields for initialization diagnostics
- add an integration test that forces concurrent writer contention and verifies convergence
- record the structure/behavior design and rollback boundary

## Validation

- `go test ./infrastructure/sqlite -run 'TestCatchUpWorkspaceObservations|TestWorkspaceObservationCatchUpBatchQuery'`
- `go vet ./...`
- `go test ./...`
- `GOLANGCI_LINT_CACHE=/private/tmp/traceary-1514-lint-cache go tool golangci-lint run`
- `git diff --check`

Closes #1514
