### PR TITLE
fix: expose exact spool drain metrics

### DIFF
--- a/.ai/spec/1525.md
+++ b/.ai/spec/1525.md
@@ -13,7 +13,7 @@
 | JSON/text rendering | doctor report writer |
 
 ### Interface
-`doctorFixFunc` returns a structured result containing the human action and optional integer metrics. Existing fixes return only the action. Hook spool returns `replayed`, `failed`, `remaining`, and `unreadable`.
+Hook spool adds a structured fix result alongside the legacy action-only fix interface. `failed` counts replay/remove failures, `unreadable` is disjoint, and `remaining` is the post-invocation queue snapshot including concurrent arrivals.
 
 ### Behavior tests
 - JSON fix log preserves zero-valued counters.

--- a/.ai/spec/1525.md
+++ b/.ai/spec/1525.md
@@ -1,0 +1,28 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Expose exact, body-free spool drain counters in `doctor --fix --json`.
+- Do not infer failures from queue-size deltas while new deliveries and opportunistic replay run concurrently.
+- Preserve retained records and existing fail-soft hook behavior.
+
+### Responsibilities
+| Responsibility | Owner |
+|---|---|
+| Replay and unreadable classification | hook spool infrastructure in `presentation/cli` |
+| Structured remediation result | doctor fix boundary |
+| JSON/text rendering | doctor report writer |
+
+### Interface
+`doctorFixFunc` returns a structured result containing the human action and optional integer metrics. Existing fixes return only the action. Hook spool returns `replayed`, `failed`, `remaining`, and `unreadable`.
+
+### Behavior tests
+- JSON fix log preserves zero-valued counters.
+- Partial replay failure reports exact retained failures.
+- Unreadable records are included separately and remain durable.
+- Concurrent queue changes do not affect counters returned by the invocation.
+- If post-fix reinspection is cancelled, the already-completed fix result remains reportable.
+
+### Risks and rollback
+- JSON addition is backward-compatible and optional.
+- Existing human-readable action remains unchanged.
+- Rollback is code-only; no persisted format or spool record changes.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -28,25 +28,33 @@ const (
 )
 
 type doctorCheck struct {
-	Name             string        `json:"name"`
-	Status           string        `json:"status"`
-	Severity         string        `json:"severity"`
-	Section          string        `json:"section"`
-	Message          string        `json:"message"`
-	Hint             string        `json:"hint"`
-	FixCommand       string        `json:"fix_command"`
-	AutoFixAvailable bool          `json:"auto_fix_available"`
-	FixFunc          doctorFixFunc `json:"-"`
+	Name              string                  `json:"name"`
+	Status            string                  `json:"status"`
+	Severity          string                  `json:"severity"`
+	Section           string                  `json:"section"`
+	Message           string                  `json:"message"`
+	Hint              string                  `json:"hint"`
+	FixCommand        string                  `json:"fix_command"`
+	AutoFixAvailable  bool                    `json:"auto_fix_available"`
+	FixFunc           doctorFixFunc           `json:"-"`
+	StructuredFixFunc doctorStructuredFixFunc `json:"-"`
+}
+
+type doctorFixResult struct {
+	Action  string         `json:"action"`
+	Metrics map[string]int `json:"metrics,omitempty"`
 }
 
 type doctorFixFunc func(context.Context, bool) (string, error)
+type doctorStructuredFixFunc func(context.Context, bool) (doctorFixResult, error)
 
 type doctorFixLog struct {
-	Name   string `json:"name"`
-	Action string `json:"action"`
-	Before string `json:"before"`
-	After  string `json:"after"`
-	Error  string `json:"error,omitempty"`
+	Name    string         `json:"name"`
+	Action  string         `json:"action"`
+	Metrics map[string]int `json:"metrics,omitempty"`
+	Before  string         `json:"before"`
+	After   string         `json:"after"`
+	Error   string         `json:"error,omitempty"`
 }
 
 type doctorSection struct {
@@ -192,8 +200,15 @@ func (c *RootCLI) applyDoctorFixes(ctx context.Context, report *doctorReport, dr
 			fixes = append(fixes, log)
 			continue
 		}
-		action, err := check.FixFunc(ctx, dryRun)
-		log.Action = action
+		var err error
+		if check.StructuredFixFunc != nil {
+			result, structuredErr := check.StructuredFixFunc(ctx, dryRun)
+			log.Action = result.Action
+			log.Metrics = result.Metrics
+			err = structuredErr
+		} else {
+			log.Action, err = check.FixFunc(ctx, dryRun)
+		}
 		if err != nil {
 			log.Error = err.Error()
 		}

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -154,6 +154,13 @@ func (c *RootCLI) runDoctor(ctx context.Context, output io.Writer, input doctorC
 		fixes := c.applyDoctorFixes(ctx, report, input.dryRun)
 		after, err := c.buildDoctorReport(ctx, input)
 		if err != nil {
+			// The remediation has already happened. Preserve its exact result
+			// even when a cancelled or failed reinspection cannot produce the
+			// post-fix status.
+			report.Fixes = fixes
+			if writeErr := writeDoctorReport(output, report, input.asJSON, input.warningsOK); writeErr != nil {
+				return writeErr
+			}
 			return err
 		}
 		annotateDoctorFixesAfter(fixes, after)
@@ -195,7 +202,7 @@ func (c *RootCLI) applyDoctorFixes(ctx context.Context, report *doctorReport, dr
 			continue
 		}
 		log := doctorFixLog{Name: check.Name, Before: check.Status}
-		if !check.AutoFixAvailable || check.FixFunc == nil {
+		if !check.AutoFixAvailable || (check.FixFunc == nil && check.StructuredFixFunc == nil) {
 			log.Action = guidedDoctorFixAction(check)
 			fixes = append(fixes, log)
 			continue

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -52,11 +52,12 @@ type doctorCheck struct {
 }
 
 type doctorFixLog struct {
-	Name   string `json:"name"`
-	Action string `json:"action"`
-	Before string `json:"before"`
-	After  string `json:"after"`
-	Error  string `json:"error"`
+	Name    string         `json:"name"`
+	Action  string         `json:"action"`
+	Metrics map[string]int `json:"metrics"`
+	Before  string         `json:"before"`
+	After   string         `json:"after"`
+	Error   string         `json:"error"`
 }
 
 func executeDoctorAllowWarnings(t *testing.T, cmd interface{ Execute() error }) {

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -126,7 +126,10 @@ type hookSpoolDrainResult struct {
 // records. Returns counts of successful replays and retained failures.
 func (c *RootCLI) drainHookSpoolRecords(ctx context.Context, limit int) (replayed, failed int) {
 	result := c.drainHookSpoolRecordsDetailed(ctx, limit)
-	return result.Replayed, result.Failed
+	// Preserve the legacy aggregate used by opportunistic debug logging while
+	// the structured result keeps replay failures and unreadable records
+	// disjoint.
+	return result.Replayed, result.Failed + result.Unreadable
 }
 
 func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) hookSpoolDrainResult {
@@ -146,7 +149,6 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 		if ctx.Err() != nil {
 			break
 		}
-		result.Failed++
 		if err := requeueHookSpoolRecord(path); err != nil {
 			slog.Debug("unreadable hook spool requeue failed", "path", path, "error", err)
 		}
@@ -587,19 +589,18 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		if result.Err != nil {
 			return doctorFixResult{}, result.Err
 		}
-		replayFailed := max(result.Failed-result.Unreadable, 0)
 		return doctorFixResult{
 			Action: localizef(
 				"drained hook spool: replayed=%d failed=%d unreadable=%d remaining=%d",
 				"hook spool を drain しました: replayed=%d failed=%d unreadable=%d remaining=%d",
 				result.Replayed,
-				replayFailed,
+				result.Failed,
 				result.Unreadable,
 				result.Remaining,
 			),
 			Metrics: map[string]int{
 				"replayed":   result.Replayed,
-				"failed":     replayFailed,
+				"failed":     result.Failed,
 				"remaining":  result.Remaining,
 				"unreadable": result.Unreadable,
 			},

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -113,10 +113,11 @@ func (c *RootCLI) runHookDurably(
 }
 
 type hookSpoolDrainResult struct {
-	Replayed  int
-	Failed    int
-	Remaining int
-	Err       error
+	Replayed   int
+	Failed     int
+	Unreadable int
+	Remaining  int
+	Err        error
 }
 
 // drainHookSpoolRecords replays up to limit pending spool records in filename
@@ -140,7 +141,7 @@ func (c *RootCLI) drainHookSpoolRecordsDetailed(ctx context.Context, limit int) 
 	if err != nil {
 		return hookSpoolDrainResult{Err: err}
 	}
-	result := hookSpoolDrainResult{}
+	result := hookSpoolDrainResult{Unreadable: len(unreadable)}
 	for _, path := range unreadable {
 		if ctx.Err() != nil {
 			break
@@ -573,6 +574,35 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 	if len(records) == 0 && len(unreadable) == 0 {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending hook spool records found", "未処理の hook spool record はありません")}
 	}
+	structuredFix := func(ctx context.Context, dryRun bool) (doctorFixResult, error) {
+		pending, err := countHookSpoolPendingPaths(time.Now().UTC())
+		if err != nil {
+			return doctorFixResult{}, err
+		}
+		if dryRun {
+			return doctorFixResult{Action: localizef("would drain up to %d pending hook spool record(s)", "未処理 hook spool record 最大 %d 件を drain します", min(pending, 200))}, nil
+		}
+		limit := min(pending, 200)
+		result := c.drainHookSpoolRecordsDetailed(ctx, limit)
+		if result.Err != nil {
+			return doctorFixResult{}, result.Err
+		}
+		return doctorFixResult{
+			Action: localizef(
+				"drained hook spool: replayed=%d failed=%d remaining=%d",
+				"hook spool を drain しました: replayed=%d failed=%d remaining=%d",
+				result.Replayed,
+				result.Failed,
+				result.Remaining,
+			),
+			Metrics: map[string]int{
+				"replayed":   result.Replayed,
+				"failed":     result.Failed,
+				"remaining":  result.Remaining,
+				"unreadable": result.Unreadable,
+			},
+		}, nil
+	}
 	latest := "-"
 	if len(records) > 0 {
 		latest = fmt.Sprintf("client=%s command=%s action=%s created_at=%s path=%s", emptyAsDash(records[0].Client), emptyAsDash(records[0].Command), emptyAsDash(records[0].Action), records[0].CreatedAt.Format(time.RFC3339Nano), records[0].Path)
@@ -592,29 +622,9 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		FixCommand:       "traceary doctor --fix",
 		AutoFixAvailable: true,
 		FixFunc: func(ctx context.Context, dryRun bool) (string, error) {
-			pending, err := countHookSpoolPendingPaths(time.Now().UTC())
-			if err != nil {
-				return "", err
-			}
-			if dryRun {
-				return localizef("would drain up to %d pending hook spool record(s)", "未処理 hook spool record 最大 %d 件を drain します", min(pending, 200)), nil
-			}
-			// Force path: allow a larger batch than the per-hook opportunistic drain.
-			limit := pending
-			if limit > 200 {
-				limit = 200
-			}
-			result := c.drainHookSpoolRecordsDetailed(ctx, limit)
-			if result.Err != nil {
-				return "", result.Err
-			}
-			return localizef(
-				"drained hook spool: replayed=%d failed=%d remaining=%d",
-				"hook spool を drain しました: replayed=%d failed=%d remaining=%d",
-				result.Replayed,
-				result.Failed,
-				result.Remaining,
-			), nil
+			result, err := structuredFix(ctx, dryRun)
+			return result.Action, err
 		},
+		StructuredFixFunc: structuredFix,
 	}
 }

--- a/presentation/cli/hook_spool.go
+++ b/presentation/cli/hook_spool.go
@@ -587,17 +587,19 @@ func (c *RootCLI) inspectHookSpoolDiagnosticsFromScan(
 		if result.Err != nil {
 			return doctorFixResult{}, result.Err
 		}
+		replayFailed := max(result.Failed-result.Unreadable, 0)
 		return doctorFixResult{
 			Action: localizef(
-				"drained hook spool: replayed=%d failed=%d remaining=%d",
-				"hook spool を drain しました: replayed=%d failed=%d remaining=%d",
+				"drained hook spool: replayed=%d failed=%d unreadable=%d remaining=%d",
+				"hook spool を drain しました: replayed=%d failed=%d unreadable=%d remaining=%d",
 				result.Replayed,
-				result.Failed,
+				replayFailed,
+				result.Unreadable,
 				result.Remaining,
 			),
 			Metrics: map[string]int{
 				"replayed":   result.Replayed,
-				"failed":     result.Failed,
+				"failed":     replayFailed,
 				"remaining":  result.Remaining,
 				"unreadable": result.Unreadable,
 			},

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -802,12 +802,12 @@ func TestInspectHookSpoolDiagnostics_FixReportsUnreadableRemaining(t *testing.T)
 		t.Fatalf("StructuredFixFunc() error = %v", err)
 	}
 	message := result.Action
-	for _, expected := range []string{"replayed=1", "failed=1", "remaining=1"} {
+	for _, expected := range []string{"replayed=1", "failed=0", "unreadable=1", "remaining=1"} {
 		if !strings.Contains(message, expected) {
 			t.Fatalf("message=%q, missing %q", message, expected)
 		}
 	}
-	wantMetrics := map[string]int{"replayed": 1, "failed": 1, "remaining": 1, "unreadable": 1}
+	wantMetrics := map[string]int{"replayed": 1, "failed": 0, "remaining": 1, "unreadable": 1}
 	if !reflect.DeepEqual(result.Metrics, wantMetrics) {
 		t.Fatalf("metrics=%v, want %v", result.Metrics, wantMetrics)
 	}
@@ -846,6 +846,33 @@ func TestApplyDoctorFixes_PreservesHookSpoolMetrics(t *testing.T) {
 	want := map[string]int{"replayed": 0, "failed": 2, "remaining": 2, "unreadable": 0}
 	if !reflect.DeepEqual(fixes[0].Metrics, want) {
 		t.Fatalf("metrics=%v, want %v", fixes[0].Metrics, want)
+	}
+	encoded, err := json.Marshal(fixes[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	for _, zeroField := range []string{`"replayed":0`, `"unreadable":0`} {
+		if !bytes.Contains(encoded, []byte(zeroField)) {
+			t.Fatalf("JSON=%s, missing zero-valued field %s", encoded, zeroField)
+		}
+	}
+}
+
+func TestApplyDoctorFixes_AcceptsStructuredOnlyFix(t *testing.T) {
+	root := NewRootCLI(WithStoreManagement(&spoolStoreManagementStub{}))
+	check := doctorCheck{
+		Name:             "structured-only",
+		Status:           doctorStatusWarn,
+		Severity:         doctorSeverityWarn,
+		AutoFixAvailable: true,
+		StructuredFixFunc: func(context.Context, bool) (doctorFixResult, error) {
+			return doctorFixResult{Action: "structured action"}, nil
+		},
+	}
+
+	fixes := root.applyDoctorFixes(context.Background(), &doctorReport{Checks: []doctorCheck{check}}, false)
+	if len(fixes) != 1 || fixes[0].Action != "structured action" {
+		t.Fatalf("fixes=%v, want structured action", fixes)
 	}
 }
 

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"syscall"
@@ -744,7 +745,7 @@ func TestInspectHookSpoolDiagnostics_FixFuncDrains(t *testing.T) {
 	}
 
 	check := root.inspectHookSpoolDiagnostics([]string{"claude"})
-	if check.Status != doctorStatusWarn || check.FixFunc == nil {
+	if check.Status != doctorStatusWarn || check.FixFunc == nil || check.StructuredFixFunc == nil {
 		t.Fatalf("check = %#v", check)
 	}
 	dryMsg, err := check.FixFunc(context.Background(), true)
@@ -793,20 +794,58 @@ func TestInspectHookSpoolDiagnostics_FixReportsUnreadableRemaining(t *testing.T)
 	}
 
 	check := root.inspectHookSpoolDiagnostics([]string{"claude"})
-	if check.FixFunc == nil {
-		t.Fatal("expected fix function")
+	if check.FixFunc == nil || check.StructuredFixFunc == nil {
+		t.Fatal("expected fix functions")
 	}
-	message, err := check.FixFunc(context.Background(), false)
+	result, err := check.StructuredFixFunc(context.Background(), false)
 	if err != nil {
-		t.Fatalf("FixFunc() error = %v", err)
+		t.Fatalf("StructuredFixFunc() error = %v", err)
 	}
+	message := result.Action
 	for _, expected := range []string{"replayed=1", "failed=1", "remaining=1"} {
 		if !strings.Contains(message, expected) {
 			t.Fatalf("message=%q, missing %q", message, expected)
 		}
 	}
+	wantMetrics := map[string]int{"replayed": 1, "failed": 1, "remaining": 1, "unreadable": 1}
+	if !reflect.DeepEqual(result.Metrics, wantMetrics) {
+		t.Fatalf("metrics=%v, want %v", result.Metrics, wantMetrics)
+	}
 	if strings.Contains(message, "private") {
 		t.Fatalf("message leaked payload body: %q", message)
+	}
+}
+
+func TestApplyDoctorFixes_PreservesHookSpoolMetrics(t *testing.T) {
+	root := NewRootCLI(WithStoreManagement(&spoolStoreManagementStub{}))
+	check := doctorCheck{
+		Name:             "hook-spool",
+		Status:           doctorStatusWarn,
+		Severity:         doctorSeverityWarn,
+		AutoFixAvailable: true,
+		FixFunc: func(context.Context, bool) (string, error) {
+			return "legacy action", nil
+		},
+		StructuredFixFunc: func(context.Context, bool) (doctorFixResult, error) {
+			return doctorFixResult{
+				Action: "drained hook spool",
+				Metrics: map[string]int{
+					"replayed":   0,
+					"failed":     2,
+					"remaining":  2,
+					"unreadable": 0,
+				},
+			}, nil
+		},
+	}
+
+	fixes := root.applyDoctorFixes(context.Background(), &doctorReport{Checks: []doctorCheck{check}}, false)
+	if len(fixes) != 1 {
+		t.Fatalf("fixes=%v, want one", fixes)
+	}
+	want := map[string]int{"replayed": 0, "failed": 2, "remaining": 2, "unreadable": 0}
+	if !reflect.DeepEqual(fixes[0].Metrics, want) {
+		t.Fatalf("metrics=%v, want %v", fixes[0].Metrics, want)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The v0.32.0 dogfood drain had to infer failures from net queue-size changes. That inference is invalid while new hook deliveries and opportunistic replay run concurrently.

## Changes

- add optional structured metrics to doctor fix logs
- report exact `replayed`, `failed`, `remaining`, and `unreadable` counters for the hook-spool fix
- preserve the existing human-readable action for text-mode and compatibility
- count unreadable records separately while retaining them for retry
- add regression tests for partial failure, zero-valued fields, and body-free output
- record the structure/behavior boundary and rollback plan

## Validation

- `go test ./presentation/cli -run 'TestInspectHookSpoolDiagnostics|TestApplyDoctorFixes|TestRootCLI_DoctorFix'`
- `go vet ./...`
- `go test ./...`
- `go tool golangci-lint run`
- `git diff --check`

Closes #1525
