### PR TITLE
fix: isolate Grok plugin identity

### DIFF
--- a/.ai/spec/1522.md
+++ b/.ai/spec/1522.md
@@ -1,0 +1,47 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- 目的: Grok が同名の他ホスト plugin を解決した場合、Traceary native plugin を healthy と誤認しない。
+- 現状: `plugin list` の installed inventory と `inspect` の enabled route を同一 identity と仮定している。
+- 期待する振る舞い: installed path、resolved path class、7 hook / 1 MCP / 3 skill を独立に診断し、cross-host shadowing は warning にする。
+- 非対象: Grok または Claude の private config / plugin payload の内容を読むこと、既存の同名 package を自動削除すること。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Installed package | name, version, path | native package の inventory を示す | inventory は activation を意味しない |
+| Resolved route | plugin name, hook target path | Grok が有効化した source を示す | hook target は body を読まず path class のみ判定する |
+| Native health | identity + coverage | health check を決定する | native identity と 7/1/3 の全条件が必要 |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| inspect JSON の最小 projection | `doctor_grok.go` | host 診断 boundary | domain / application は host JSON を知らない |
+| package collision 回避 | Grok plugin manifest + installer | package identity の配布契約 | doctor は package を変更しない |
+| regression fixture | CLI internal test + clean-home script | body-free host response を固定 | 実ユーザー設定を fixture にしない |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `grok plugin list --json` | installed inventory | package payload | unavailable / invalid JSON is probe error |
+| `grok inspect --json` | resolved routes | config body | path/name/count onlyを読む |
+| doctor report | operator | raw inspect JSON | warning + deterministic install command |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| shadowed legacy identity | same-name Claude path resolves `traceary` | doctor probe | native plugin is warning, not pass | CLI unit |
+| collision-free package | `traceary-grok` resolved from Grok path | doctor probe | 7/1/3 passes | CLI unit |
+| installer safety | legacy `traceary` appears | installer runs | it never uninstalls the ambiguous legacy name | shell fixture |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| identity mismatch | add shadow fixture | distinguish installed/resolved identity | path-class helper |
+| package migration | assert canonical name | install canonical package only | shared shell variables |
+
+### Risks / rollback
+- 手続き化リスク: doctor message に path parsing を散在させず `grokPluginPathClass` に閉じ込める。
+- premature abstraction リスク: Grok 専用の schema なので共通 plugin resolver は作らない。
+- migration / compatibility: legacy `traceary` は自動削除せず、canonical `traceary-grok` を並行導入する。
+- rollback trigger: Grok が canonical name を受理しない場合、manifest/installer を戻し doctor は shadow warning を維持する。

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -256,7 +256,7 @@ func checkGrok(root, version string) error {
 	if err := readJSON(root, "integrations/grok-plugin/plugin.json", &manifest); err != nil {
 		return err
 	}
-	if manifest.Name != "traceary" {
+	if manifest.Name != "traceary-grok" {
 		return xerrors.Errorf("unexpected Grok plugin name")
 	}
 	if manifest.Version != version {

--- a/docs/integrations/grok-marketplace-submission.ja.md
+++ b/docs/integrations/grok-marketplace-submission.ja.md
@@ -40,7 +40,12 @@ python3 scripts/validate-catalog.py
 | `source.url` | `https://github.com/duck8823/traceary.git` |
 | `source.sha` | タグ付け release の 40 文字 commit SHA |
 | `source.path` | `integrations/grok-plugin` |
-| `name` | `traceary` |
+| `name` | `traceary-grok` |
+
+`name` は `integrations/grok-plugin/plugin.json` と完全に一致させます。
+Claude marketplace の `traceary` とは意図的に異なる名前です。Grok 0.2.111 は
+native package を `~/.grok/installed-plugins/` 配下へ導入するため、固有 identity
+により同名 package を誤って解決することを防ぎます。
 
 秘密は commit しない。パッケージは Traceary hook と local MCP stdio のみ。
 

--- a/docs/integrations/grok-marketplace-submission.md
+++ b/docs/integrations/grok-marketplace-submission.md
@@ -40,7 +40,12 @@ python3 scripts/validate-catalog.py
 | `source.url` | `https://github.com/duck8823/traceary.git` |
 | `source.sha` | Full 40-char commit SHA of the tagged release |
 | `source.path` | `integrations/grok-plugin` |
-| `name` | `traceary` |
+| `name` | `traceary-grok` |
+
+`name` must match `integrations/grok-plugin/plugin.json` exactly. It is
+intentionally distinct from the Claude marketplace package named `traceary`:
+Grok 0.2.111 installs native packages below `~/.grok/installed-plugins/`, and
+the unique identity prevents a same-name package from being resolved instead.
 
 Never commit secrets. The package only invokes Traceary hook entrypoints and a
 local MCP stdio server.

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -81,6 +81,12 @@ Traceary が載っている場合、本リポジトリを clone せず Grok Buil
 traceary doctor --client grok --project-dir . --json
 ```
 
+ネイティブパッケージ名は `traceary-grok` です。Claude 側の `traceary` と意図的に
+異なる名前にして、同名 package の解決衝突を避けます。installer は
+`traceary-grok` だけを置き換えます。legacy の `traceary` は別 host の package の
+可能性があるため削除しません。収束した native 導入では 7 hook boundary、1 MCP
+server、3 skill が報告されます。
+
 カタログ投稿用メタデータ:
 
 - テンプレート: [`integrations/grok-plugin/marketplace-entry.json`](../../integrations/grok-plugin/marketplace-entry.json)
@@ -156,7 +162,7 @@ traceary doctor --client grok --project-dir . --json
 Grok のネイティブパッケージだけを削除する場合は次を実行します。
 
 ```sh
-grok plugin uninstall traceary
+grok plugin uninstall traceary-grok
 ```
 
 hook-only で導入した project/global ファイルは plugin と独立しているため、使用した
@@ -168,6 +174,7 @@ hook-only で導入した project/global ファイルは plugin と独立して�
 | --- | --- |
 | `grok-cli` が失敗 | Grok Build を導入し、`grok` を `PATH` に追加する |
 | `grok-plugin` が警告 | パッケージを導入し直す。バージョン不一致の場合は同じ Traceary リリースのパッケージを使う |
+| `grok-plugin-resolution` が警告 | Grok が native 以外の path class、または同名の legacy package を解決しています。`scripts/install-grok-plugin.sh` を実行し、`traceary-grok` が有効 route になったことを確認してください。doctor は package path、名前、inventory 件数だけを読みます。 |
 | `grok-hook-trust` が警告 | project hook を確認して `/hooks-trust` を実行するか、未使用の project route を削除する |
 | `grok-hooks` が警告 | 導入済み hook file が不足しているか、7 event の厳密な契約からずれている。plugin を再導入する |
 | `grok-mcp` / `grok-skills` が警告 | 導入済みパッケージの内容が不足している。plugin を再導入する |
@@ -177,7 +184,7 @@ hook-only で導入した project/global ファイルは plugin と独立して�
 
 ```sh
 grok plugin list --json
-grok plugin details traceary
+grok plugin details traceary-grok
 grok --cwd . inspect --json
 traceary list --agent grok --limit 20
 traceary doctor --client grok --project-dir . --json

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -162,10 +162,16 @@ git checkout v0.23.0 # replace with the installed Traceary version
 traceary doctor --client grok --project-dir . --json
 ```
 
+The native package is named `traceary-grok`, deliberately distinct from the
+Claude package named `traceary`. The installer replaces only `traceary-grok`;
+it never removes a legacy `traceary` package because Grok can resolve that
+same-name package from another host. A converged native installation reports
+seven hook boundaries, one MCP server, and three skills.
+
 To remove only the native Grok package:
 
 ```sh
-grok plugin uninstall traceary
+grok plugin uninstall traceary-grok
 ```
 
 Project/global hook-only files are independent of the plugin and must be
@@ -177,6 +183,7 @@ removed separately if they were installed.
 | --- | --- |
 | `grok-cli` fails | Install Grok Build and ensure `grok` is on `PATH` |
 | `grok-plugin` warns | Install/reinstall the package; a version mismatch requires the package from the same Traceary release |
+| `grok-plugin-resolution` warns | Grok resolved a non-native path class or a same-name legacy package. Run `scripts/install-grok-plugin.sh`, then confirm `traceary-grok` is the enabled route; doctor reads only package paths, names, and inventory counts. |
 | `grok-hook-trust` warns | Review the project hook file and use `/hooks-trust`, or remove the unused project route |
 | `grok-hooks` warns | The installed hook file is missing or has drifted from the exact seven-event contract; reinstall the plugin |
 | `grok-mcp` / `grok-skills` warns | The installed package inventory is incomplete; reinstall it |
@@ -186,7 +193,7 @@ Useful read-only checks:
 
 ```sh
 grok plugin list --json
-grok plugin details traceary
+grok plugin details traceary-grok
 grok --cwd . inspect --json
 traceary list --agent grok --limit 20
 traceary doctor --client grok --project-dir . --json

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -95,8 +95,9 @@ Remote source shape (SHA must be a full 40-char commit of this repository; packa
 ### B. Local-source install (deterministic fallback)
 
 Always available from a matching Traceary release tag. The installer validates
-the package, replaces an existing `traceary` plugin, and prints the installed
-inventory.
+the package, replaces only an existing `traceary-grok` package, and prints the
+installed inventory. It intentionally leaves a legacy package named `traceary`
+untouched because that name can belong to another host integration.
 
 ```sh
 git clone --branch v0.27.0 --depth 1 https://github.com/duck8823/traceary.git

--- a/integrations/grok-plugin/marketplace-entry.json
+++ b/integrations/grok-plugin/marketplace-entry.json
@@ -1,5 +1,5 @@
 {
-  "name": "traceary",
+  "name": "traceary-grok",
   "description": "Local-first Traceary integration for Grok Build: native session/audit/transcript/compact hooks, local MCP tools, and shared memory/session skills. Records work logs and command audits to a private SQLite store without sending data to Traceary servers.",
   "category": "development",
   "source": {

--- a/integrations/grok-plugin/plugin.json
+++ b/integrations/grok-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "traceary",
+  "name": "traceary-grok",
   "version": "0.32.0",
   "description": "Local-first Traceary integration for Grok Build with MCP tools and native session, audit, transcript, and compact hooks.",
   "author": {

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -148,7 +148,7 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 func grokPluginPathClass(path string) string {
 	normalized := filepath.ToSlash(path)
 	switch {
-	case strings.Contains(normalized, "/.grok/plugins/"), strings.Contains(normalized, "/integrations/grok-plugin/"):
+	case strings.Contains(normalized, "/.grok/plugins/"), strings.Contains(normalized, "/.grok/installed-plugins/"), strings.Contains(normalized, "/integrations/grok-plugin/"):
 		return grokPluginPathClassNative
 	case strings.Contains(normalized, "/.claude/plugins/"):
 		return grokPluginPathClassClaude

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -42,7 +42,7 @@ type grokDoctorState struct {
 	PluginVersion        string
 	PluginPath           string
 	ResolvedPathClass    string
-	LegacyPluginShadowed bool
+	LegacyPluginDetected bool
 	ProjectTrusted       bool
 	ProjectHooks         bool
 	NativeHooks          bool
@@ -133,8 +133,8 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		if hook.Source.PluginName == grokTracearyPluginName || (hook.Source.PluginName == legacyTracearyPluginName && state.ResolvedPathClass == "") {
 			state.ResolvedPathClass = pathClass
 		}
-		if hook.Source.PluginName == legacyTracearyPluginName && pathClass == grokPluginPathClassClaude {
-			state.LegacyPluginShadowed = true
+		if hook.Source.PluginName == legacyTracearyPluginName {
+			state.LegacyPluginDetected = true
 		}
 		if hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative && grokHookFileHasVerifiedCoverage(hook.Target) {
 			state.NativeHooks = true
@@ -217,25 +217,29 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	}
 	checks := []doctorCheck{{Name: "grok-cli", Status: doctorStatusPass, Message: localizef("detected Grok CLI %s", "Grok CLI %s を検出しました", state.HostVersion)}}
 	if !state.PluginInstalled {
-		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: Localize("native Traceary Grok plugin traceary-grok is not installed", "native Traceary Grok plugin traceary-grok がインストールされていません"), Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
-		return checks
+		message := Localize("native Traceary Grok plugin traceary-grok is not installed", "native Traceary Grok plugin traceary-grok がインストールされていません")
+		if state.LegacyPluginDetected {
+			message = Localize("legacy Traceary Grok plugin traceary is resolved but canonical traceary-grok is not installed", "legacy Traceary Grok plugin traceary が解決されていますが canonical traceary-grok はインストールされていません")
+		}
+		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: message, Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
+	} else {
+		pluginStatus := doctorStatusPass
+		pluginMessage := localizef("native Traceary Grok plugin traceary-grok %s is installed and enabled", "native Traceary Grok plugin traceary-grok %s はインストール済みで有効です", state.PluginVersion)
+		pluginHint := ""
+		if !state.PluginEnabled || state.LegacyPluginDetected {
+			pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin traceary-grok is installed but a legacy traceary route is also resolved, or the canonical route is disabled", "native Traceary Grok plugin traceary-grok はインストール済みですが legacy traceary route も解決されているか、canonical route が無効です")
+			pluginHint = "grok plugin enable traceary-grok"
+		} else if releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
+			pluginStatus = doctorStatusWarn
+			pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
+			pluginHint = "grok plugin update traceary-grok"
+		}
+		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
 	}
-	pluginStatus := doctorStatusPass
-	pluginMessage := localizef("native Traceary Grok plugin traceary-grok %s is installed and enabled", "native Traceary Grok plugin traceary-grok %s はインストール済みで有効です", state.PluginVersion)
-	pluginHint := ""
-	if !state.PluginEnabled || state.LegacyPluginShadowed {
-		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin traceary-grok is installed but disabled, shadowed, or not resolved", "native Traceary Grok plugin traceary-grok はインストール済みですが無効、shadow 済み、または解決されていません")
-		pluginHint = "grok plugin enable traceary-grok"
-	} else if releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
-		pluginStatus = doctorStatusWarn
-		pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
-		pluginHint = "grok plugin update traceary-grok"
-	}
-	checks = append(checks, doctorCheck{Name: "grok-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
 	resolutionStatus := doctorStatusPass
 	resolutionMessage := localizef("native plugin installed path: %s; resolved path class: %s", "native plugin のインストール path: %s、解決された path class: %s", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
 	resolutionHint := ""
-	if state.ResolvedPathClass != grokPluginPathClassNative || state.LegacyPluginShadowed {
+	if state.ResolvedPathClass != grokPluginPathClassNative || state.LegacyPluginDetected {
 		resolutionStatus = doctorStatusWarn
 		resolutionMessage = localizef("native plugin installed path: %s; resolved path class: %s; same-name legacy traceary may be shadowed by another host", "native plugin のインストール path: %s、解決された path class: %s。同名の legacy traceary が別 host により shadow されている可能性があります", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
 		resolutionHint = "scripts/install-grok-plugin.sh"

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -21,27 +21,39 @@ var (
 
 var grokVersionPattern = regexp.MustCompile(`grok\s+([^\s]+)`)
 
+const (
+	grokTracearyPluginName     = "traceary-grok"
+	legacyTracearyPluginName   = "traceary"
+	grokPluginPathClassNative  = "grok-plugin"
+	grokPluginPathClassClaude  = "claude-plugin"
+	grokPluginPathClassUnknown = "unknown"
+)
+
 // releaseTracearyVersionPattern matches released Traceary versions so
 // plugin/binary parity checks can skip development builds. Shared by the
 // host plugin checks (grok, kimi).
 var releaseTracearyVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 type grokDoctorState struct {
-	CLIAvailable    bool
-	HostVersion     string
-	PluginInstalled bool
-	PluginEnabled   bool
-	PluginVersion   string
-	ProjectTrusted  bool
-	ProjectHooks    bool
-	NativeHooks     bool
-	MCPServers      int
-	Skills          int
+	CLIAvailable         bool
+	HostVersion          string
+	PluginInstalled      bool
+	PluginEnabled        bool
+	PluginVersion        string
+	PluginPath           string
+	ResolvedPathClass    string
+	LegacyPluginShadowed bool
+	ProjectTrusted       bool
+	ProjectHooks         bool
+	NativeHooks          bool
+	MCPServers           int
+	Skills               int
 }
 
 type grokPluginListEntry struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
+	Path    string `json:"path"`
 }
 
 type grokInspectDocument struct {
@@ -56,6 +68,7 @@ type grokInspectDocument struct {
 	Plugins []struct {
 		Name     string `json:"name"`
 		Enabled  bool   `json:"enabled"`
+		Path     string `json:"path"`
 		Provides struct {
 			Skills     int `json:"skills"`
 			MCPServers int `json:"mcpServers"`
@@ -85,9 +98,10 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		return state, xerrors.Errorf("failed to decode Grok plugin list: %w", err)
 	}
 	for _, plugin := range plugins {
-		if plugin.Name == "traceary" {
+		if plugin.Name == grokTracearyPluginName {
 			state.PluginInstalled = true
 			state.PluginVersion = plugin.Version
+			state.PluginPath = plugin.Path
 			break
 		}
 	}
@@ -104,7 +118,7 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		state.ProjectHooks = true
 	}
 	for _, plugin := range document.Plugins {
-		if plugin.Name != "traceary" {
+		if plugin.Name != grokTracearyPluginName {
 			continue
 		}
 		state.PluginEnabled = plugin.Enabled
@@ -115,11 +129,39 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		if hook.Source.Type == "project" {
 			state.ProjectHooks = true
 		}
-		if hook.Source.PluginName == "traceary" && grokHookFileHasVerifiedCoverage(hook.Target) {
+		pathClass := grokPluginPathClass(hook.Target)
+		if hook.Source.PluginName == grokTracearyPluginName || (hook.Source.PluginName == legacyTracearyPluginName && state.ResolvedPathClass == "") {
+			state.ResolvedPathClass = pathClass
+		}
+		if hook.Source.PluginName == legacyTracearyPluginName && pathClass == grokPluginPathClassClaude {
+			state.LegacyPluginShadowed = true
+		}
+		if hook.Source.PluginName == grokTracearyPluginName && pathClass == grokPluginPathClassNative && grokHookFileHasVerifiedCoverage(hook.Target) {
 			state.NativeHooks = true
 		}
 	}
 	return state, nil
+}
+
+// grokPluginPathClass classifies only the installation host encoded in a hook
+// target path. It deliberately does not read configuration or plugin payloads.
+func grokPluginPathClass(path string) string {
+	normalized := filepath.ToSlash(path)
+	switch {
+	case strings.Contains(normalized, "/.grok/plugins/"), strings.Contains(normalized, "/integrations/grok-plugin/"):
+		return grokPluginPathClassNative
+	case strings.Contains(normalized, "/.claude/plugins/"):
+		return grokPluginPathClassClaude
+	default:
+		return grokPluginPathClassUnknown
+	}
+}
+
+func grokDoctorDisplayPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return "unreported"
+	}
+	return path
 }
 
 func grokHookFileHasVerifiedCoverage(path string) bool {
@@ -175,21 +217,30 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	}
 	checks := []doctorCheck{{Name: "grok-cli", Status: doctorStatusPass, Message: localizef("detected Grok CLI %s", "Grok CLI %s を検出しました", state.HostVersion)}}
 	if !state.PluginInstalled {
-		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: Localize("native Traceary Grok plugin is not installed", "native Traceary Grok plugin がインストールされていません"), Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
+		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: Localize("native Traceary Grok plugin traceary-grok is not installed", "native Traceary Grok plugin traceary-grok がインストールされていません"), Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
 		return checks
 	}
 	pluginStatus := doctorStatusPass
-	pluginMessage := localizef("native Traceary Grok plugin %s is installed and enabled", "native Traceary Grok plugin %s はインストール済みで有効です", state.PluginVersion)
+	pluginMessage := localizef("native Traceary Grok plugin traceary-grok %s is installed and enabled", "native Traceary Grok plugin traceary-grok %s はインストール済みで有効です", state.PluginVersion)
 	pluginHint := ""
-	if !state.PluginEnabled {
-		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin is installed but disabled", "native Traceary Grok plugin はインストール済みですが無効です")
-		pluginHint = "grok plugin enable traceary"
+	if !state.PluginEnabled || state.LegacyPluginShadowed {
+		pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin traceary-grok is installed but disabled, shadowed, or not resolved", "native Traceary Grok plugin traceary-grok はインストール済みですが無効、shadow 済み、または解決されていません")
+		pluginHint = "grok plugin enable traceary-grok"
 	} else if releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
 		pluginStatus = doctorStatusWarn
 		pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
-		pluginHint = "grok plugin update traceary"
+		pluginHint = "grok plugin update traceary-grok"
 	}
 	checks = append(checks, doctorCheck{Name: "grok-plugin", Status: pluginStatus, Message: pluginMessage, Hint: pluginHint})
+	resolutionStatus := doctorStatusPass
+	resolutionMessage := localizef("native plugin installed path: %s; resolved path class: %s", "native plugin のインストール path: %s、解決された path class: %s", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
+	resolutionHint := ""
+	if state.ResolvedPathClass != grokPluginPathClassNative || state.LegacyPluginShadowed {
+		resolutionStatus = doctorStatusWarn
+		resolutionMessage = localizef("native plugin installed path: %s; resolved path class: %s; same-name legacy traceary may be shadowed by another host", "native plugin のインストール path: %s、解決された path class: %s。同名の legacy traceary が別 host により shadow されている可能性があります", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
+		resolutionHint = "scripts/install-grok-plugin.sh"
+	}
+	checks = append(checks, doctorCheck{Name: "grok-plugin-resolution", Status: resolutionStatus, Message: resolutionMessage, Hint: resolutionHint})
 	trustStatus := doctorStatusPass
 	trustMessage := Localize("Grok project hooks are trusted or no project hook route is configured", "Grok project hook は信頼済み、または project hook route は未設定です")
 	if state.ProjectHooks && !state.ProjectTrusted {

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -68,7 +68,7 @@ func TestProbeGrokDoctorStateUsesHostInventoryAndHookFile(t *testing.T) {
 	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
 
 	projectDir := t.TempDir()
-	pluginHook := filepath.Join(t.TempDir(), "hooks.json")
+	pluginHook := filepath.Join(projectDir, "integrations", "grok-plugin", "hooks", "hooks.json")
 	writeGrokDoctorHookFixture(t, pluginHook, true)
 	calls := []string{}
 	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
@@ -77,9 +77,9 @@ func TestProbeGrokDoctorStateUsesHostInventoryAndHookFile(t *testing.T) {
 		case "--version":
 			return []byte("grok 0.2.99 (build)\n"), nil
 		case "plugin list --json":
-			return []byte(`[{"name":"traceary","version":"0.23.0"}]`), nil
+			return []byte(`[{"name":"traceary-grok","version":"0.23.0","path":"/Users/operator/.grok/plugins/traceary-grok"}]`), nil
 		case "--cwd " + projectDir + " inspect --json":
-			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary"}}]}`), nil
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
 		default:
 			t.Fatalf("unexpected Grok arguments: %v", args)
 			return nil, nil
@@ -90,7 +90,7 @@ func TestProbeGrokDoctorStateUsesHostInventoryAndHookFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("probeGrokDoctorState() error = %v", err)
 	}
-	if !state.CLIAvailable || state.HostVersion != "0.2.99" || !state.PluginInstalled || !state.PluginEnabled || state.PluginVersion != "0.23.0" || !state.NativeHooks || state.MCPServers != 1 || state.Skills != 3 {
+	if !state.CLIAvailable || state.HostVersion != "0.2.99" || !state.PluginInstalled || !state.PluginEnabled || state.PluginVersion != "0.23.0" || !state.NativeHooks || state.ResolvedPathClass != grokPluginPathClassNative || state.MCPServers != 1 || state.Skills != 3 {
 		t.Fatalf("state = %+v, want healthy host inventory", state)
 	}
 	if got, want := strings.Join(calls, "|"), "--version|plugin list --json|--cwd "+projectDir+" inspect --json"; got != want {
@@ -110,7 +110,7 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 	if err := os.WriteFile(projectHook, []byte(`{"hooks":{}}`), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
-	pluginHook := filepath.Join(t.TempDir(), "hooks.json")
+	pluginHook := filepath.Join(projectDir, "integrations", "grok-plugin", "hooks", "hooks.json")
 	writeGrokDoctorHookFixture(t, pluginHook, true)
 	var file map[string]any
 	data, err := os.ReadFile(pluginHook)
@@ -135,9 +135,9 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 		case "--version":
 			return []byte("grok 0.2.99\n"), nil
 		case "plugin list --json":
-			return []byte(`[{"name":"traceary","version":"0.23.0"}]`), nil
+			return []byte(`[{"name":"traceary-grok","version":"0.23.0"}]`), nil
 		default:
-			return []byte(`{"projectTrusted":false,"plugins":[{"name":"traceary","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary"}}]}`), nil
+			return []byte(`{"projectTrusted":false,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"hooks":true,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
 		}
 	}
 	state, err := probeGrokDoctorState(context.Background(), projectDir)
@@ -151,6 +151,9 @@ func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 
 func writeGrokDoctorHookFixture(t *testing.T, path string, complete bool) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
 	contracts := []struct{ event, name, action string }{
 		{"SessionStart", "traceary-session-start", "session-start"},
 		{"UserPromptSubmit", "traceary-prompt", "user-prompt-submit"},
@@ -178,5 +181,39 @@ func writeGrokDoctorHookFixture(t *testing.T, path string, complete bool) {
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func TestProbeGrokDoctorStateDetectsSameNameClaudePluginShadowing(t *testing.T) {
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+	projectDir := t.TempDir()
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.99\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.23.0","path":"/Users/operator/.grok/plugins/traceary-grok"}]`), nil
+		default:
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}},{"name":"traceary","enabled":true,"provides":{"skills":3,"mcpServers":1}}],"hooks":[{"target":"/Users/operator/.claude/plugins/cache/traceary/hooks/hooks.json","source":{"type":"plugin","plugin_name":"traceary"}}]}`), nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.PluginInstalled || !state.PluginEnabled || state.NativeHooks || !state.LegacyPluginShadowed {
+		t.Fatalf("state = %+v, want installed native package with Claude shadowing", state)
+	}
+	checks := buildGrokDoctorChecks(state, "0.23.0")
+	for _, check := range checks {
+		if check.Name == "grok-plugin" && check.Status != doctorStatusWarn {
+			t.Fatalf("grok-plugin = %+v, want warning for shadowed resolution", check)
+		}
+		if check.Name == "grok-plugin-resolution" && (check.Status != doctorStatusWarn || !strings.Contains(check.Message, "claude-plugin")) {
+			t.Fatalf("grok-plugin-resolution = %+v, want Claude path-class warning", check)
+		}
 	}
 }

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -98,6 +98,44 @@ func TestProbeGrokDoctorStateUsesHostInventoryAndHookFile(t *testing.T) {
 	}
 }
 
+func TestProbeGrokDoctorStateAcceptsCleanHomeCanonicalInstalledPluginPath(t *testing.T) {
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+
+	home := t.TempDir()
+	projectDir := t.TempDir()
+	pluginHook := filepath.Join(home, ".grok", "installed-plugins", "grok-plugin-traceary-grok", "hooks", "hooks.json")
+	writeGrokDoctorHookFixture(t, pluginHook, true)
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.111\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary-grok","version":"0.32.0","path":` + strconv.Quote(filepath.Dir(filepath.Dir(pluginHook))) + `}]`), nil
+		case "--cwd " + projectDir + " inspect --json":
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}}],"hooks":[{"target":` + strconv.Quote(pluginHook) + `,"source":{"type":"plugin","plugin_name":"traceary-grok"}}]}`), nil
+		default:
+			t.Fatalf("unexpected Grok arguments: %v", args)
+			return nil, nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if !state.NativeHooks || state.ResolvedPathClass != grokPluginPathClassNative {
+		t.Fatalf("state = %+v, want native clean-home route", state)
+	}
+	checks := buildGrokDoctorChecks(state, "0.32.0")
+	for _, check := range checks {
+		if (check.Name == "grok-plugin-resolution" || check.Name == "grok-hooks") && check.Status != doctorStatusPass {
+			t.Fatalf("%s = %+v, want pass for canonical clean-home path", check.Name, check)
+		}
+	}
+}
+
 func TestProbeGrokDoctorStateDoesNotTrustProvidesHooksBoolean(t *testing.T) {
 	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
 	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -242,7 +242,7 @@ func TestProbeGrokDoctorStateDetectsSameNameClaudePluginShadowing(t *testing.T) 
 	if err != nil {
 		t.Fatalf("probeGrokDoctorState() error = %v", err)
 	}
-	if !state.PluginInstalled || !state.PluginEnabled || state.NativeHooks || !state.LegacyPluginShadowed {
+	if !state.PluginInstalled || !state.PluginEnabled || state.NativeHooks || !state.LegacyPluginDetected {
 		t.Fatalf("state = %+v, want installed native package with Claude shadowing", state)
 	}
 	checks := buildGrokDoctorChecks(state, "0.23.0")
@@ -253,5 +253,87 @@ func TestProbeGrokDoctorStateDetectsSameNameClaudePluginShadowing(t *testing.T) 
 		if check.Name == "grok-plugin-resolution" && (check.Status != doctorStatusWarn || !strings.Contains(check.Message, "claude-plugin")) {
 			t.Fatalf("grok-plugin-resolution = %+v, want Claude path-class warning", check)
 		}
+	}
+}
+
+func TestProbeGrokDoctorStateWarnsForLegacyTracearyRoutes(t *testing.T) {
+	tests := []struct {
+		name           string
+		listPlugins    string
+		plugins        string
+		hookTarget     string
+		hookPluginName string
+		wantInstalled  bool
+		wantPathClass  string
+	}{
+		{
+			name:           "legacy native only",
+			listPlugins:    `[{"name":"traceary","version":"0.32.0"}]`,
+			plugins:        `[{"name":"traceary","enabled":true,"provides":{"skills":3,"mcpServers":1}}]`,
+			hookTarget:     "/Users/operator/.grok/installed-plugins/grok-plugin-legacy/hooks/hooks.json",
+			hookPluginName: legacyTracearyPluginName,
+			wantPathClass:  grokPluginPathClassNative,
+		},
+		{
+			name:           "legacy Claude route only",
+			listPlugins:    `[{"name":"traceary","version":"0.32.0"}]`,
+			plugins:        `[{"name":"traceary","enabled":true,"provides":{"skills":3,"mcpServers":1}}]`,
+			hookTarget:     "/Users/operator/.claude/plugins/cache/traceary/hooks/hooks.json",
+			hookPluginName: legacyTracearyPluginName,
+			wantPathClass:  grokPluginPathClassClaude,
+		},
+		{
+			name:           "canonical only",
+			listPlugins:    `[{"name":"traceary-grok","version":"0.32.0"}]`,
+			plugins:        `[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}}]`,
+			hookTarget:     "/Users/operator/.grok/installed-plugins/grok-plugin-canonical/hooks/hooks.json",
+			hookPluginName: grokTracearyPluginName,
+			wantInstalled:  true,
+			wantPathClass:  grokPluginPathClassNative,
+		},
+		{
+			name:           "canonical and legacy native coexist",
+			listPlugins:    `[{"name":"traceary-grok","version":"0.32.0"},{"name":"traceary","version":"0.32.0"}]`,
+			plugins:        `[{"name":"traceary-grok","enabled":true,"provides":{"skills":3,"mcpServers":1}},{"name":"traceary","enabled":true,"provides":{"skills":3,"mcpServers":1}}]`,
+			hookTarget:     "/Users/operator/.grok/installed-plugins/grok-plugin-legacy/hooks/hooks.json",
+			hookPluginName: legacyTracearyPluginName,
+			wantInstalled:  true,
+			wantPathClass:  grokPluginPathClassNative,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+			t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+			grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+			projectDir := t.TempDir()
+			grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+				switch strings.Join(args, " ") {
+				case "--version":
+					return []byte("grok 0.2.111\n"), nil
+				case "plugin list --json":
+					return []byte(tc.listPlugins), nil
+				default:
+					return []byte(`{"projectTrusted":true,"plugins":` + tc.plugins + `,"hooks":[{"target":` + strconv.Quote(tc.hookTarget) + `,"source":{"type":"plugin","plugin_name":` + strconv.Quote(tc.hookPluginName) + `}}]}`), nil
+				}
+			}
+
+			state, err := probeGrokDoctorState(context.Background(), projectDir)
+			if err != nil {
+				t.Fatalf("probeGrokDoctorState() error = %v", err)
+			}
+			if state.PluginInstalled != tc.wantInstalled || state.ResolvedPathClass != tc.wantPathClass {
+				t.Fatalf("state = %+v, want installed=%v pathClass=%q", state, tc.wantInstalled, tc.wantPathClass)
+			}
+			checks := buildGrokDoctorChecks(state, "0.32.0")
+			for _, check := range checks {
+				if check.Name == "grok-plugin" && tc.name != "canonical only" && check.Status != doctorStatusWarn {
+					t.Fatalf("grok-plugin = %+v, want legacy warning", check)
+				}
+				if check.Name == "grok-plugin" && tc.name == "canonical only" && check.Status != doctorStatusPass {
+					t.Fatalf("grok-plugin = %+v, want canonical pass", check)
+				}
+			}
+		})
 	}
 }

--- a/scripts/generate-grok-marketplace-entry.sh
+++ b/scripts/generate-grok-marketplace-entry.sh
@@ -19,7 +19,7 @@ import sys
 sha = os.environ["TRACEARY_MARKETPLACE_SHA"]
 version = os.environ["TRACEARY_MARKETPLACE_VERSION"]
 entry = {
-  "name": "traceary",
+  "name": "traceary-grok",
   "description": (
     "Local-first Traceary integration for Grok Build: native session/audit/"
     "transcript/compact hooks, local MCP tools, and shared memory/session skills. "

--- a/scripts/install-grok-plugin.sh
+++ b/scripts/install-grok-plugin.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_DIR="${ROOT_DIR}/integrations/grok-plugin"
+PLUGIN_NAME="traceary-grok"
 
 command -v grok >/dev/null 2>&1 || {
   echo 'error: grok CLI is not installed' >&2
@@ -10,8 +11,10 @@ command -v grok >/dev/null 2>&1 || {
 }
 
 grok plugin validate "${PLUGIN_DIR}"
-if grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary"'; then
-  grok plugin uninstall traceary
+if grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
+  grok plugin uninstall "${PLUGIN_NAME}"
 fi
 grok plugin install --trust "${PLUGIN_DIR}"
-grok plugin details traceary
+grok plugin details "${PLUGIN_NAME}"
+echo 'installed traceary-grok: 7 native hook boundaries, 1 MCP server, and 3 skills'
+echo 'note: the installer intentionally does not uninstall a legacy plugin named traceary because it may belong to another host'

--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -93,15 +93,15 @@ run_grok() {
   HOME="${tmp_home}" grok plugin install --trust "${ROOT_DIR}/integrations/grok-plugin"
   local list_output details_output inspect_output tmp_cwd
   list_output="$(HOME="${tmp_home}" grok plugin list --json)"
-  details_output="$(HOME="${tmp_home}" grok plugin details traceary)"
+  details_output="$(HOME="${tmp_home}" grok plugin details traceary-grok)"
   tmp_cwd="$(mktemp -d)"
   inspect_output="$(HOME="${tmp_home}" grok --cwd "${tmp_cwd}" inspect --json)"
-  [[ "${list_output}" == *'"name":"traceary"'* || "${list_output}" == *'"name": "traceary"'* ]]
+  [[ "${list_output}" == *'"name":"traceary-grok"'* || "${list_output}" == *'"name": "traceary-grok"'* ]]
   [[ "${details_output}" == *traceary* ]]
   [[ "${details_output}" == *traceary-session-history* ]]
-  [[ "${inspect_output}" == *'"plugin_name": "traceary"'* ]]
+  [[ "${inspect_output}" == *'"plugin_name": "traceary-grok"'* ]]
   [[ "${inspect_output}" == *'"mcpServers": 1'* ]]
-  HOME="${tmp_home}" grok plugin uninstall traceary
+  HOME="${tmp_home}" grok plugin uninstall traceary-grok
   rm -rf "${tmp_home}" "${tmp_cwd}"
   echo 'ok: grok plugin validation, install, inventory, and uninstall passed'
 }

--- a/scripts/verify-grok-plugin-clean-home.sh
+++ b/scripts/verify-grok-plugin-clean-home.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_DIR="${ROOT_DIR}/integrations/grok-plugin"
+PLUGIN_NAME="traceary-grok"
 TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/traceary-grok-clean-home.XXXXXX")"
 cleanup() { rm -rf "${TMP_HOME}"; }
 trap cleanup EXIT
@@ -31,23 +32,23 @@ echo "== validate package =="
 grok plugin validate "${PLUGIN_DIR}"
 
 echo "== install (clean home) =="
-if grok plugin list --json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary"'; then
-  grok plugin uninstall traceary || true
+if grok plugin list --json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
+  grok plugin uninstall "${PLUGIN_NAME}" || true
 fi
 grok plugin install --trust "${PLUGIN_DIR}"
 
 echo "== details =="
-grok plugin details traceary
+grok plugin details "${PLUGIN_NAME}"
 
 echo "== list contains traceary =="
-grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary"'
+grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'
 
 echo "== reinstall (update path) =="
 # Host rejects double install of the same local path; uninstall then install
 # models the post-upgrade refresh path operators use after a binary bump.
-grok plugin uninstall traceary
+grok plugin uninstall "${PLUGIN_NAME}"
 grok plugin install --trust "${PLUGIN_DIR}"
-grok plugin details traceary
+grok plugin details "${PLUGIN_NAME}"
 
 echo "== doctor (best-effort; may skip host probes in empty home) =="
 if command -v traceary >/dev/null 2>&1; then
@@ -67,9 +68,9 @@ if command -v traceary >/dev/null 2>&1; then
 fi
 
 echo "== uninstall =="
-grok plugin uninstall traceary
-if grok plugin list --json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary"'; then
-  echo "error: traceary still listed after uninstall" >&2
+grok plugin uninstall "${PLUGIN_NAME}"
+if grok plugin list --json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
+  echo "error: ${PLUGIN_NAME} still listed after uninstall" >&2
   exit 1
 fi
 

--- a/scripts/verify-grok-plugin-clean-home.sh
+++ b/scripts/verify-grok-plugin-clean-home.sh
@@ -11,22 +11,19 @@ TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/traceary-grok-clean-home.XXXXXX")"
 cleanup() { rm -rf "${TMP_HOME}"; }
 trap cleanup EXIT
 
-export HOME="${TMP_HOME}"
-export XDG_CONFIG_HOME="${TMP_HOME}/.config"
-mkdir -p "${HOME}" "${XDG_CONFIG_HOME}"
-
 if ! command -v grok >/dev/null 2>&1; then
   echo "skip: grok CLI is not installed (exit 0 for environments without Grok)" >&2
   exit 0
 fi
 
-if ! command -v traceary >/dev/null 2>&1 && [[ ! -x "${ROOT_DIR}/traceary" ]]; then
-  echo "info: building local traceary binary for doctor" >&2
-  (cd "${ROOT_DIR}" && go build -o "${TMP_HOME}/bin/traceary" .)
-  export PATH="${TMP_HOME}/bin:${PATH}"
-elif [[ -x "${ROOT_DIR}/traceary" ]]; then
-  export PATH="${ROOT_DIR}:${PATH}"
-fi
+echo "info: building this checkout's traceary binary for doctor" >&2
+mkdir -p "${TMP_HOME}/bin"
+(cd "${ROOT_DIR}" && go build -o "${TMP_HOME}/bin/traceary" .)
+
+export HOME="${TMP_HOME}"
+export XDG_CONFIG_HOME="${TMP_HOME}/.config"
+mkdir -p "${HOME}" "${XDG_CONFIG_HOME}"
+export PATH="${TMP_HOME}/bin:${PATH}"
 
 echo "== validate package =="
 grok plugin validate "${PLUGIN_DIR}"
@@ -50,21 +47,33 @@ grok plugin uninstall "${PLUGIN_NAME}"
 grok plugin install --trust "${PLUGIN_DIR}"
 grok plugin details "${PLUGIN_NAME}"
 
-echo "== doctor (best-effort; may skip host probes in empty home) =="
+echo "== doctor native plugin checks =="
 if command -v traceary >/dev/null 2>&1; then
-  # Project dir is empty; doctor should still surface plugin presence checks.
-  set +e
-  traceary doctor --client grok --project-dir "${TMP_HOME}" --json >"${TMP_HOME}/doctor.json" 2>"${TMP_HOME}/doctor.err"
-  doctor_rc=$?
-  set -e
-  echo "doctor exit=${doctor_rc}"
-  if [[ -s "${TMP_HOME}/doctor.json" ]]; then
-    # Prefer not hard-failing when grok host version probes are unavailable in CI.
-    if grep -q 'grok-plugin' "${TMP_HOME}/doctor.json"; then
-      echo "doctor reported grok-plugin check"
-    fi
-  fi
-  cat "${TMP_HOME}/doctor.err" >&2 || true
+  mkdir -p "${TMP_HOME}/project"
+  traceary doctor --client grok --project-dir "${TMP_HOME}/project" --json --warnings-ok >"${TMP_HOME}/doctor.json"
+  python3 - "${TMP_HOME}/doctor.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    report = json.load(source)
+
+expected = {
+    "grok-plugin": "pass",
+    "grok-plugin-resolution": "pass",
+    "grok-hooks": "pass",
+    "grok-mcp": "pass",
+    "grok-skills": "pass",
+}
+actual = {check.get("name"): check.get("status") for check in report.get("checks", [])}
+missing = [name for name in expected if name not in actual]
+wrong = {name: actual.get(name) for name, status in expected.items() if actual.get(name) != status}
+if missing or wrong:
+    raise SystemExit(
+        "error: Grok native doctor checks did not converge: "
+        f"missing={missing} wrong={wrong}"
+    )
+PY
 fi
 
 echo "== uninstall =="


### PR DESCRIPTION
## Motivation

Grok can resolve the Claude package named traceary instead of the native Grok package with the same name. Existing diagnostics could report the native package healthy despite that shadowing.

## Changes

- give the native Grok package the collision-free identity traceary-grok
- diagnose installed and resolved package paths separately
- add same-name Claude fixture coverage and safe installer behavior

Closes #1522