### PR TITLE
fix: finalize Grok transcript jobs

### DIFF
--- a/.ai/spec/1520.md
+++ b/.ai/spec/1520.md
@@ -16,7 +16,7 @@ unavailability.
 | Grok host adapter | `hook_grok.go` | ready / delayed | A ready Stop records one assistant transcript. A delayed Stop schedules one bounded worker. |
 | Queue worker | `hook_grok_transcript_queue.go` | ready / delayed / permanently unavailable / malformed / cancelled | Retries only `delayed` for 20 × 100ms. Terminal states remove the retry job and write a body-free disposition marker. |
 | Terminal disposition | queue state directory | recorded / unavailable / malformed / cancelled | Marker includes only a derived queue key, disposition, and UTC time; it never copies payload, session, prompt, transcript path, or transcript body. |
-| Doctor | queue diagnostic | pass / partial warning | Pending jobs are delayed work. Terminal unavailable/malformed/cancelled markers are explicit partial final-turn coverage, not retry work. |
+| Doctor | queue diagnostic | pass / partial warning | Pending jobs, partial unavailable/malformed/cancelled markers, and unreadable state warn. Recorded-only markers pass as successful receipts. |
 
 `recorded` is stored after a worker persists a transcript so a duplicate Stop
 for the same queue identity cannot create another worker event.  The marker is
@@ -32,6 +32,7 @@ Stop + missing/unreadable path -> queued -> unavailable (no retry job)
 Stop + invalid transcript wire -> queued -> malformed (no retry job)
 worker context cancelled       -> cancelled (no retry job)
 duplicate queued Stop          -> existing job / terminal marker, no new worker
+duplicate terminal Stop        -> recorded/unavailable/malformed/cancelled marker, no new job or worker
 ```
 
 The adapter never guesses content from a prompt, tool result, or an incomplete
@@ -53,8 +54,9 @@ an empty successful transcript.
 
 Exercise ready, delayed, permanently unavailable, malformed, cancelled, and
 duplicate Stop/worker delivery. Assert bounded retry only for delayed input,
-one transcript event for success, no queue job for terminal outcomes, and
-body-free doctor output.
+one transcript event for success, no queue job for every terminal outcome, no
+worker relaunch after each terminal disposition, a pass for recorded-only
+doctor state, and body-free doctor output.
 
 ## Rollback
 

--- a/.ai/spec/1520.md
+++ b/.ai/spec/1520.md
@@ -1,0 +1,65 @@
+# Issue #1520: Grok headless final-turn transcript disposition
+
+## Problem
+
+Grok Build can emit `Stop` before the final `agent_message_chunk` is appended to
+`updates.jsonl`.  Traceary therefore uses a bounded detached worker.  Before
+this change, every terminal failure was retained as a retryable queue job;
+missing or invalid transcript paths could leave private queue payloads pending
+forever and doctor could not distinguish a timing race from permanent
+unavailability.
+
+## Contract
+
+| Concept | Owner | States | Observable contract |
+| --- | --- | --- | --- |
+| Grok host adapter | `hook_grok.go` | ready / delayed | A ready Stop records one assistant transcript. A delayed Stop schedules one bounded worker. |
+| Queue worker | `hook_grok_transcript_queue.go` | ready / delayed / permanently unavailable / malformed / cancelled | Retries only `delayed` for 20 × 100ms. Terminal states remove the retry job and write a body-free disposition marker. |
+| Terminal disposition | queue state directory | recorded / unavailable / malformed / cancelled | Marker includes only a derived queue key, disposition, and UTC time; it never copies payload, session, prompt, transcript path, or transcript body. |
+| Doctor | queue diagnostic | pass / partial warning | Pending jobs are delayed work. Terminal unavailable/malformed/cancelled markers are explicit partial final-turn coverage, not retry work. |
+
+`recorded` is stored after a worker persists a transcript so a duplicate Stop
+for the same queue identity cannot create another worker event.  The marker is
+an operational idempotency boundary; normal event persistence retains its
+existing delivery identity semantics.
+
+## State transition
+
+```
+Stop + ready transcript       -> record transcript once
+Stop + readable but incomplete -> queued -> bounded retry -> recorded | unavailable
+Stop + missing/unreadable path -> queued -> unavailable (no retry job)
+Stop + invalid transcript wire -> queued -> malformed (no retry job)
+worker context cancelled       -> cancelled (no retry job)
+duplicate queued Stop          -> existing job / terminal marker, no new worker
+```
+
+The adapter never guesses content from a prompt, tool result, or an incomplete
+wire row.  A terminal state is deliberately `partial`; it is never reported as
+an empty successful transcript.
+
+## Compatibility and privacy
+
+- Queue jobs keep schema version 1 and remain readable. New marker files are
+  separate from jobs, so an older job is either consumed or preserved without a
+  migration.
+- No database migration and no host configuration changes are required.
+- Doctor aggregates counts only. Queue job payloads and transcript locations
+  remain out of doctor output and terminal markers.
+- Existing hook commands remain fail-open. A detached worker disposes of a
+  terminal job without causing the host hook to fail.
+
+## Tests
+
+Exercise ready, delayed, permanently unavailable, malformed, cancelled, and
+duplicate Stop/worker delivery. Assert bounded retry only for delayed input,
+one transcript event for success, no queue job for terminal outcomes, and
+body-free doctor output.
+
+## Rollback
+
+The change is isolated to the Grok transcript queue and its diagnostics. If a
+host version demonstrates that a currently terminal classification can become
+ready without a new Stop, revert the classifier and marker transition together;
+existing marker files are ignored safely by the previous binary and queue jobs
+are not deleted by rollback.

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -183,6 +183,18 @@ hook-only で導入した project/global ファイルは plugin と独立して�
 | `grok-mcp` / `grok-skills` が警告 | 導入済みパッケージの内容が不足している。plugin を再導入する |
 | `grok-event-coverage` が警告 | 直近の `agent=grok` event と待機中の hook/transcript queue を確認する。導入状態が正常でも実行時配送まで保証しない |
 
+### Stop の最終ターン transcript disposition
+
+Grok は最終 assistant message を `updates.jsonl` に追記している途中で `Stop` を
+発行することがあります。Traceary は ready な最終 message を1回だけ記録します。
+ready でなければ transcript worker を1件起動し、100ms 間隔で最大20回だけ確認します。
+path 不在、wire の malformed、worker の cancel、または最終 message が最後まで現れない
+場合は、本文を含まない **partial** final-turn disposition として記録し、未処理 retry
+job は残しません。`traceary doctor --client grok --json` が報告するのは disposition の
+集計件数だけで、transcript path、session ID、prompt ID、assistant 本文は表示しません。
+warning が残る場合は queue file をコピー・編集せず、`TRACEARY_HOOK_DEBUG=1` を有効にして
+新しい marker turn を実行してください。
+
 読み取り専用で確認できる command は次のとおりです。
 
 ```sh

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -192,8 +192,11 @@ path 不在、wire の malformed、worker の cancel、または最終 message �
 場合は、本文を含まない **partial** final-turn disposition として記録し、未処理 retry
 job は残しません。`traceary doctor --client grok --json` が報告するのは disposition の
 集計件数だけで、transcript path、session ID、prompt ID、assistant 本文は表示しません。
-warning が残る場合は queue file をコピー・編集せず、`TRACEARY_HOOK_DEBUG=1` を有効にして
-新しい marker turn を実行してください。
+`recorded` だけの disposition は正常な冪等性 receipt なので doctor は pass です。待機中の
+job、partial disposition、または読めない queue 状態だけが warning になります。いずれかの
+terminal disposition（`recorded`、`unavailable`、`malformed`、`cancelled`）の後に同じ Stop
+が再配送されても、新しい job や worker は作成されません。warning が残る場合は queue file を
+コピー・編集せず、`TRACEARY_HOOK_DEBUG=1` を有効にして新しい marker turn を実行してください。
 
 読み取り専用で確認できる command は次のとおりです。
 

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -194,6 +194,18 @@ removed separately if they were installed.
 | `grok-mcp` / `grok-skills` warns | The installed package inventory is incomplete; reinstall it |
 | `grok-event-coverage` warns | Inspect recent `agent=grok` events and pending hook/transcript queues; a healthy install alone does not prove runtime delivery |
 
+### Stop final-turn transcript disposition
+
+Grok can emit `Stop` while its `updates.jsonl` file is still receiving the
+final assistant message. Traceary records a ready final message once. Otherwise
+it starts one bounded transcript worker (20 checks at 100ms). A missing path,
+malformed wire, worker cancellation, or a final message that remains absent is
+recorded as a body-free **partial** final-turn disposition and has no pending
+retry job. `traceary doctor --client grok --json` reports aggregate disposition
+counts only; it never exposes the transcript path, session ID, prompt ID, or
+assistant body. Start a new marker turn with `TRACEARY_HOOK_DEBUG=1` when the
+warning remains rather than copying or editing queue files.
+
 Useful read-only checks:
 
 ```sh

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -203,7 +203,11 @@ malformed wire, worker cancellation, or a final message that remains absent is
 recorded as a body-free **partial** final-turn disposition and has no pending
 retry job. `traceary doctor --client grok --json` reports aggregate disposition
 counts only; it never exposes the transcript path, session ID, prompt ID, or
-assistant body. Start a new marker turn with `TRACEARY_HOOK_DEBUG=1` when the
+assistant body. A `recorded` disposition by itself is a healthy idempotency
+receipt and leaves doctor passing. Pending work, partial dispositions, or
+unreadable queue state warn. Re-delivering the same Stop after any terminal
+disposition (`recorded`, `unavailable`, `malformed`, or `cancelled`) creates no
+new job or worker. Start a new marker turn with `TRACEARY_HOOK_DEBUG=1` when a
 warning remains rather than copying or editing queue files.
 
 Useful read-only checks:

--- a/presentation/cli/hook_grok.go
+++ b/presentation/cli/hook_grok.go
@@ -283,30 +283,55 @@ type grokTranscriptUpdate struct {
 	} `json:"params"`
 }
 
+type grokTranscriptDisposition string
+
+const (
+	grokTranscriptReady       grokTranscriptDisposition = "ready"
+	grokTranscriptDelayed     grokTranscriptDisposition = "delayed"
+	grokTranscriptUnavailable grokTranscriptDisposition = "unavailable"
+	grokTranscriptMalformed   grokTranscriptDisposition = "malformed"
+)
+
 // extractGrokTranscript reads Grok's updates.jsonl and joins the streamed
 // agent_message_chunk rows for the Stop payload's promptId. Thought and tool
 // rows are intentionally excluded from the persisted assistant transcript.
 func extractGrokTranscript(payload []byte) ([]apptypes.EventBodyBlock, bool) {
+	blocks, disposition := inspectGrokTranscript(payload)
+	return blocks, disposition == grokTranscriptReady
+}
+
+// inspectGrokTranscript classifies only the availability of the final
+// agent-message boundary. It deliberately does not surface a source path or
+// body in its result: callers use the body only when ready, and queue
+// diagnostics retain only the body-free disposition.
+func inspectGrokTranscript(payload []byte) ([]apptypes.EventBodyBlock, grokTranscriptDisposition) {
 	path := strings.TrimSpace(hookPayloadString(payload, "transcript_path", ""))
 	if path == "" {
-		return nil, false
+		return nil, grokTranscriptUnavailable
 	}
 	targetPromptID := strings.TrimSpace(hookPayloadString(payload, "prompt_id", ""))
 
 	file, err := os.Open(path) // #nosec G304 -- path supplied by the Grok Stop hook
 	if err != nil {
 		slog.Debug("failed to open Grok transcript file", "path", path, "error", err)
-		return nil, false
+		return nil, grokTranscriptUnavailable
 	}
 	defer func() { _ = file.Close() }()
 
 	chunks := map[string]*strings.Builder{}
 	lastPromptID := ""
+	nonEmptyRows := 0
+	malformedRows := 0
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
+		if len(bytes.TrimSpace(scanner.Bytes())) == 0 {
+			continue
+		}
+		nonEmptyRows++
 		var row grokTranscriptUpdate
 		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+			malformedRows++
 			continue
 		}
 		if row.Method != "session/update" || row.Params.Update.SessionUpdate != "agent_message_chunk" || row.Params.Update.Content.Type != "text" {
@@ -326,18 +351,21 @@ func extractGrokTranscript(payload []byte) ([]apptypes.EventBodyBlock, bool) {
 	}
 	if err := scanner.Err(); err != nil {
 		slog.Debug("failed while scanning Grok transcript file", "path", path, "error", err)
-		return nil, false
+		return nil, grokTranscriptMalformed
 	}
 	if targetPromptID == "" {
 		targetPromptID = lastPromptID
 	}
 	builder := chunks[targetPromptID]
 	if builder == nil {
-		return nil, false
+		if nonEmptyRows > 0 && malformedRows == nonEmptyRows {
+			return nil, grokTranscriptMalformed
+		}
+		return nil, grokTranscriptDelayed
 	}
 	text := strings.TrimSpace(builder.String())
 	if text == "" {
-		return nil, false
+		return nil, grokTranscriptDelayed
 	}
-	return []apptypes.EventBodyBlock{{Type: apptypes.EventBodyBlockTypeText, Text: text}}, true
+	return []apptypes.EventBodyBlock{{Type: apptypes.EventBodyBlockTypeText, Text: text}}, grokTranscriptReady
 }

--- a/presentation/cli/hook_grok_test.go
+++ b/presentation/cli/hook_grok_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -401,6 +402,126 @@ func TestRootCLI_HookGrokStopDefersTranscriptUntilHostAppendsFinalMessage(t *tes
 	}
 	if _, err := os.Stat(jobPath); !os.IsNotExist(err) {
 		t.Fatalf("completed deferred job still exists: %v", err)
+	}
+}
+
+func TestRootCLI_HookGrokTranscriptWorkerClassifiesTerminalFinalTurnStates(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		transcript         string
+		removeTranscript   bool
+		cancelWorker       bool
+		wantDisposition    string
+		wantTranscriptLogs int
+	}{
+		{name: "permanently unavailable path", removeTranscript: true, wantDisposition: "unavailable"},
+		{name: "malformed wire", transcript: "not-json\n", wantDisposition: "malformed"},
+		{name: "cancelled worker", transcript: `{"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"prompt"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n", cancelWorker: true, wantDisposition: "cancelled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+			t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-terminal-"+strings.ReplaceAll(tc.name, " ", "-"))
+			t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+			transcriptPath := filepath.Join(t.TempDir(), "updates.jsonl")
+			if !tc.removeTranscript {
+				if err := os.WriteFile(transcriptPath, []byte(tc.transcript), 0o600); err != nil {
+					t.Fatalf("write transcript: %v", err)
+				}
+			}
+			payload := grokFixtureWithField(t, "stop.json", "transcriptPath", transcriptPath)
+			eventStub := &eventUsecaseStub{}
+			jobPath := ""
+			runGrokHook(t, "stop", payload, eventStub, &sessionUsecaseStub{}, cli.WithHookGrokTranscriptLauncher(func(path string) error {
+				jobPath = path
+				return nil
+			}))
+			if jobPath == "" {
+				t.Fatal("Stop did not enqueue terminal transcript job")
+			}
+
+			rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(eventStub)).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			ctx := context.Background()
+			if tc.cancelWorker {
+				cancelled, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = cancelled
+			}
+			rootCmd.SetArgs([]string{"hook", "grok", "transcript-worker", "--job", jobPath})
+			if err := rootCmd.ExecuteContext(ctx); err != nil {
+				t.Fatalf("Execute(Grok transcript worker) error = %v", err)
+			}
+			if _, err := os.Stat(jobPath); !os.IsNotExist(err) {
+				t.Fatalf("terminal transcript job remains retryable: %v", err)
+			}
+			terminals, err := filepath.Glob(filepath.Join(stateDir, "grok-transcript-terminal", "*.json"))
+			if err != nil || len(terminals) != 1 {
+				t.Fatalf("terminal disposition files = %v, %v; want one", terminals, err)
+			}
+			body, err := os.ReadFile(terminals[0])
+			if err != nil {
+				t.Fatalf("read terminal disposition: %v", err)
+			}
+			if !strings.Contains(string(body), `"disposition": "`+tc.wantDisposition+`"`) {
+				t.Fatalf("terminal disposition = %s, want %q", body, tc.wantDisposition)
+			}
+			for _, private := range []string{transcriptPath, "prompt-contract-probe-1", "019f0000-0000-7000-8000-000000000001"} {
+				if strings.Contains(string(body), private) {
+					t.Fatalf("terminal disposition leaked private input %q: %s", private, body)
+				}
+			}
+			if got := len(eventStub.logCalls); got != tc.wantTranscriptLogs {
+				t.Fatalf("transcript log calls = %d, want %d", got, tc.wantTranscriptLogs)
+			}
+		})
+	}
+}
+
+func TestRootCLI_HookGrokTranscriptWorkerRecordsDelayedFinalTurnExactlyOnce(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-delayed-duplicate")
+	t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+	transcriptPath := filepath.Join(t.TempDir(), "updates.jsonl")
+	initial := `{"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"prompt"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial transcript: %v", err)
+	}
+	payload := grokFixtureWithField(t, "stop.json", "transcriptPath", transcriptPath)
+	eventStub := &eventUsecaseStub{}
+	jobPath := ""
+	runGrokHook(t, "stop", payload, eventStub, &sessionUsecaseStub{}, cli.WithHookGrokTranscriptLauncher(func(path string) error {
+		jobPath = path
+		return nil
+	}))
+	final := `{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"final answer"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"
+	file, err := os.OpenFile(transcriptPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	if _, err := file.WriteString(final); err != nil {
+		t.Fatalf("append final transcript: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close transcript: %v", err)
+	}
+
+	for delivery := 0; delivery < 2; delivery++ {
+		rootCmd := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(eventStub)).Command()
+		rootCmd.SetOut(&bytes.Buffer{})
+		rootCmd.SetErr(&bytes.Buffer{})
+		rootCmd.SetArgs([]string{"hook", "grok", "transcript-worker", "--job", jobPath})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("duplicate delivery %d error = %v", delivery, err)
+		}
+	}
+	if got, want := len(eventStub.logCalls), 1; got != want {
+		t.Fatalf("transcript log calls = %d, want %d", got, want)
+	}
+	if got, want := apptypes.ExtractPlainBody(eventStub.logCall.message), "final answer"; got != want {
+		t.Fatalf("transcript body = %q, want %q", got, want)
 	}
 }
 

--- a/presentation/cli/hook_grok_test.go
+++ b/presentation/cli/hook_grok_test.go
@@ -525,6 +525,72 @@ func TestRootCLI_HookGrokTranscriptWorkerRecordsDelayedFinalTurnExactlyOnce(t *t
 	}
 }
 
+func TestRootCLI_HookGrokStopDoesNotRelaunchTerminalTranscriptDelivery(t *testing.T) {
+	for _, disposition := range []string{"recorded", "unavailable", "malformed", "cancelled"} {
+		t.Run(disposition, func(t *testing.T) {
+			stateDir := t.TempDir()
+			t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+			t.Setenv("TRACEARY_HOOK_STATE_KEY", "grok-terminal-redelivery-"+disposition)
+			t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+			transcriptPath := filepath.Join(t.TempDir(), "updates.jsonl")
+			transcript := `{"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"prompt"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"
+			if disposition == "malformed" {
+				transcript = "not-json\n"
+			}
+			if err := os.WriteFile(transcriptPath, []byte(transcript), 0o600); err != nil {
+				t.Fatalf("write transcript: %v", err)
+			}
+			payload := grokFixtureWithField(t, "stop.json", "transcriptPath", transcriptPath)
+			jobPath := ""
+			eventStub := &eventUsecaseStub{}
+			runGrokHook(t, "stop", payload, eventStub, &sessionUsecaseStub{}, cli.WithHookGrokTranscriptLauncher(func(path string) error {
+				jobPath = path
+				return nil
+			}))
+			if jobPath == "" {
+				t.Fatal("initial Stop did not enqueue transcript job")
+			}
+			if disposition == "recorded" {
+				file, err := os.OpenFile(transcriptPath, os.O_APPEND|os.O_WRONLY, 0)
+				if err != nil {
+					t.Fatalf("open transcript: %v", err)
+				}
+				if _, err := file.WriteString(`{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"final answer"}},"_meta":{"promptId":"prompt-contract-probe-1"}}}` + "\n"); err != nil {
+					t.Fatalf("append transcript: %v", err)
+				}
+				if err := file.Close(); err != nil {
+					t.Fatalf("close transcript: %v", err)
+				}
+			}
+			worker := newTestRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(eventStub)).Command()
+			worker.SetOut(&bytes.Buffer{})
+			worker.SetErr(&bytes.Buffer{})
+			worker.SetArgs([]string{"hook", "grok", "transcript-worker", "--job", jobPath})
+			if disposition == "cancelled" {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				if err := worker.ExecuteContext(ctx); err != nil {
+					t.Fatalf("cancelled worker: %v", err)
+				}
+			} else if err := worker.Execute(); err != nil {
+				t.Fatalf("terminal worker: %v", err)
+			}
+
+			launches := 0
+			runGrokHook(t, "stop", payload, &eventUsecaseStub{}, &sessionUsecaseStub{}, cli.WithHookGrokTranscriptLauncher(func(string) error {
+				launches++
+				return nil
+			}))
+			if launches != 0 {
+				t.Fatalf("terminal %s Stop redelivery launched %d worker(s), want zero", disposition, launches)
+			}
+			if _, err := os.Stat(jobPath); !os.IsNotExist(err) {
+				t.Fatalf("terminal %s Stop redelivery recreated job: %v", disposition, err)
+			}
+		})
+	}
+}
+
 func TestRootCLI_HookGrokFailsOpenForMalformedAndMissingPayloads(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)

--- a/presentation/cli/hook_grok_transcript_queue.go
+++ b/presentation/cli/hook_grok_transcript_queue.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	hookGrokTranscriptJobSchemaVersion = 1
-	hookGrokTranscriptRetryCount       = 20
-	hookGrokTranscriptRetryInterval    = 100 * time.Millisecond
+	hookGrokTranscriptJobSchemaVersion      = 1
+	hookGrokTranscriptTerminalSchemaVersion = 1
+	hookGrokTranscriptRetryCount            = 20
+	hookGrokTranscriptRetryInterval         = 100 * time.Millisecond
 )
 
 type hookGrokTranscriptJob struct {
@@ -33,6 +34,12 @@ type hookGrokTranscriptJob struct {
 	Attempts      int       `json:"attempts,omitempty"`
 	LastAttemptAt time.Time `json:"last_attempt_at,omitempty"`
 	LastError     string    `json:"last_error,omitempty"`
+}
+
+type hookGrokTranscriptTerminal struct {
+	SchemaVersion int       `json:"schema_version"`
+	Disposition   string    `json:"disposition"`
+	OccurredAt    time.Time `json:"occurred_at"`
 }
 
 func scanHookGrokTranscriptJobs() ([]hookGrokTranscriptJob, []string, error) {
@@ -72,7 +79,11 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 	if err != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Grok transcript queue: %v", "Grok transcript queue の検査に失敗しました: %v", err)}
 	}
-	if len(jobs) == 0 && len(unreadable) == 0 {
+	terminals, terminalUnreadable, terminalErr := scanHookGrokTranscriptTerminals()
+	if terminalErr != nil {
+		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Grok transcript terminal dispositions: %v", "Grok transcript の終端 disposition 検査に失敗しました: %v", terminalErr)}
+	}
+	if len(jobs) == 0 && len(unreadable) == 0 && len(terminals) == 0 && terminalUnreadable == 0 {
 		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending Grok transcript jobs found", "未処理の Grok transcript job はありません")}
 	}
 	failed := 0
@@ -88,15 +99,20 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 			failed++
 		}
 	}
+	terminalCounts := map[string]int{}
+	for _, terminal := range terminals {
+		terminalCounts[terminal.Disposition]++
+	}
+	partial := terminalCounts["unavailable"] + terminalCounts["malformed"] + terminalCounts["cancelled"]
 	return doctorCheck{
 		Name:   name,
 		Status: doctorStatusWarn,
 		Message: localizef(
-			"found %d pending Grok transcript job(s), %d previously failed job(s), and %d unreadable job(s); oldest age %s",
-			"未処理の Grok transcript job が %d 件、以前失敗した job が %d 件、読めない job が %d 件あります。最古の経過時間は %s です",
-			len(jobs), failed, len(unreadable), oldestAge.Round(time.Second),
+			"found %d pending Grok transcript job(s), %d previously failed job(s), %d unreadable job(s), and %d partial final-turn disposition(s) (%d unavailable, %d malformed, %d cancelled; %d unreadable disposition marker(s)); oldest age %s",
+			"未処理の Grok transcript job が %d 件、以前失敗した job が %d 件、読めない job が %d 件、partial final-turn disposition が %d 件（unavailable %d 件、malformed %d 件、cancelled %d 件、読めない disposition marker %d 件）あります。最古の経過時間は %s です",
+			len(jobs), failed, len(unreadable), partial, terminalCounts["unavailable"], terminalCounts["malformed"], terminalCounts["cancelled"], terminalUnreadable, oldestAge.Round(time.Second),
 		),
-		Hint: Localize("the final Grok transcript remained unavailable after Stop; enable TRACEARY_HOOK_DEBUG for the next turn and remove a pending job only after confirming it is stale", "Stop 後も最終 Grok transcript を取得できませんでした。次の turn で TRACEARY_HOOK_DEBUG を有効にし、未処理 job は不要と確認してから削除してください"),
+		Hint: Localize("a terminal final-turn disposition is partial coverage and has no retry job; enable TRACEARY_HOOK_DEBUG for the next turn. Remove a pending job only after confirming it is stale", "終端 final-turn disposition は partial coverage であり retry job はありません。次の turn で TRACEARY_HOOK_DEBUG を有効にしてください。未処理 job は不要と確認してからだけ削除してください"),
 	}
 }
 
@@ -137,6 +153,14 @@ func hookGrokTranscriptQueueDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(stateDir, "grok-transcript"), nil
+}
+
+func hookGrokTranscriptTerminalDir() (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, "grok-transcript-terminal"), nil
 }
 
 func enqueueHookGrokTranscript(payload []byte, dbPath string, requestedAt time.Time) (string, error) {
@@ -210,22 +234,34 @@ func (c *RootCLI) runHookGrokTranscriptWorker(ctx context.Context, jobPath strin
 	}
 	payload := []byte(job.Payload)
 	for attempt := 0; attempt < hookGrokTranscriptRetryCount; attempt++ {
-		if _, ready := extractGrokTranscript(payload); ready {
+		blocks, disposition := inspectGrokTranscript(payload)
+		if disposition == grokTranscriptReady {
 			if err := c.runHookTranscript(ctx, bytes.NewReader(payload), grokHookClient, job.DBPath); err != nil {
 				return c.failHookGrokTranscriptJob(resolvedJobPath, job, err)
 			}
-			if err := os.Remove(resolvedJobPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return xerrors.Errorf("failed to clear completed Grok transcript job: %w", err)
-			}
-			return nil
+			_ = blocks // body ownership remains in runHookTranscript; this branch is state-only.
+			return finalizeHookGrokTranscriptJob(resolvedJobPath, "recorded")
+		}
+		if disposition == grokTranscriptUnavailable || disposition == grokTranscriptMalformed {
+			return finalizeHookGrokTranscriptJob(resolvedJobPath, string(disposition))
 		}
 		select {
 		case <-ctx.Done():
-			return c.failHookGrokTranscriptJob(resolvedJobPath, job, ctx.Err())
+			return finalizeHookGrokTranscriptJob(resolvedJobPath, "cancelled")
 		case <-time.After(hookGrokTranscriptRetryInterval):
 		}
 	}
-	return c.failHookGrokTranscriptJob(resolvedJobPath, job, xerrors.Errorf("Grok transcript was not ready after %s", hookGrokTranscriptRetryCount*hookGrokTranscriptRetryInterval))
+	return finalizeHookGrokTranscriptJob(resolvedJobPath, "unavailable")
+}
+
+func finalizeHookGrokTranscriptJob(jobPath, disposition string) error {
+	if err := writeHookGrokTranscriptTerminal(jobPath, disposition, time.Now().UTC()); err != nil {
+		return err
+	}
+	if err := os.Remove(jobPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return xerrors.Errorf("failed to clear terminal Grok transcript job: %w", err)
+	}
+	return nil
 }
 
 func validateHookGrokTranscriptJobPath(jobPath string) (string, error) {
@@ -271,6 +307,107 @@ func readHookGrokTranscriptJob(path string) (hookGrokTranscriptJob, error) {
 		return hookGrokTranscriptJob{}, xerrors.Errorf("Grok transcript job has an unsupported shape")
 	}
 	return job, nil
+}
+
+func scanHookGrokTranscriptTerminals() ([]hookGrokTranscriptTerminal, int, error) {
+	dir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		return nil, 0, err
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, xerrors.Errorf("failed to read Grok transcript terminal dispositions: %w", err)
+	}
+	terminals := []hookGrokTranscriptTerminal{}
+	unreadable := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		terminal, readErr := readHookGrokTranscriptTerminal(filepath.Join(dir, entry.Name()))
+		if readErr != nil {
+			unreadable++
+			continue
+		}
+		terminals = append(terminals, terminal)
+	}
+	return terminals, unreadable, nil
+}
+
+func readHookGrokTranscriptTerminal(path string) (hookGrokTranscriptTerminal, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return hookGrokTranscriptTerminal{}, xerrors.Errorf("failed to read Grok transcript terminal disposition: %w", err)
+	}
+	var terminal hookGrokTranscriptTerminal
+	if err := json.Unmarshal(data, &terminal); err != nil {
+		return hookGrokTranscriptTerminal{}, xerrors.Errorf("failed to decode Grok transcript terminal disposition: %w", err)
+	}
+	if terminal.SchemaVersion != hookGrokTranscriptTerminalSchemaVersion || terminal.OccurredAt.IsZero() || !validHookGrokTranscriptTerminalDisposition(terminal.Disposition) {
+		return hookGrokTranscriptTerminal{}, xerrors.Errorf("Grok transcript terminal disposition has an unsupported shape")
+	}
+	return terminal, nil
+}
+
+func validHookGrokTranscriptTerminalDisposition(disposition string) bool {
+	switch disposition {
+	case "recorded", "unavailable", "malformed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeHookGrokTranscriptTerminal(jobPath, disposition string, occurredAt time.Time) error {
+	if !validHookGrokTranscriptTerminalDisposition(disposition) || occurredAt.IsZero() {
+		return xerrors.Errorf("Grok transcript terminal disposition is invalid")
+	}
+	dir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return xerrors.Errorf("failed to create Grok transcript terminal disposition directory: %w", err)
+	}
+	name := filepath.Base(jobPath)
+	if len(name) != 69 || !strings.HasSuffix(name, ".json") {
+		return xerrors.Errorf("Grok transcript terminal disposition job name is invalid")
+	}
+	terminalPath := filepath.Join(dir, name)
+	terminal := hookGrokTranscriptTerminal{
+		SchemaVersion: hookGrokTranscriptTerminalSchemaVersion,
+		Disposition:   disposition,
+		OccurredAt:    occurredAt.UTC(),
+	}
+	encoded, err := json.MarshalIndent(terminal, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode Grok transcript terminal disposition: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	temporaryFile, err := os.CreateTemp(dir, "."+name+".*.tmp")
+	if err != nil {
+		return xerrors.Errorf("failed to create Grok transcript terminal disposition temporary file: %w", err)
+	}
+	temporaryPath := temporaryFile.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporaryFile.Chmod(0o600); err != nil {
+		_ = temporaryFile.Close()
+		return xerrors.Errorf("failed to protect Grok transcript terminal disposition temporary file: %w", err)
+	}
+	if _, err := temporaryFile.Write(encoded); err != nil {
+		_ = temporaryFile.Close()
+		return xerrors.Errorf("failed to write Grok transcript terminal disposition: %w", err)
+	}
+	if err := temporaryFile.Close(); err != nil {
+		return xerrors.Errorf("failed to close Grok transcript terminal disposition: %w", err)
+	}
+	if err := os.Rename(temporaryPath, terminalPath); err != nil {
+		return xerrors.Errorf("failed to publish Grok transcript terminal disposition: %w", err)
+	}
+	return nil
 }
 
 func writeHookGrokTranscriptJob(path string, job hookGrokTranscriptJob) error {

--- a/presentation/cli/hook_grok_transcript_queue.go
+++ b/presentation/cli/hook_grok_transcript_queue.go
@@ -83,9 +83,6 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 	if terminalErr != nil {
 		return doctorCheck{Name: name, Status: doctorStatusFail, Message: localizef("failed to inspect Grok transcript terminal dispositions: %v", "Grok transcript の終端 disposition 検査に失敗しました: %v", terminalErr)}
 	}
-	if len(jobs) == 0 && len(unreadable) == 0 && len(terminals) == 0 && terminalUnreadable == 0 {
-		return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending Grok transcript jobs found", "未処理の Grok transcript job はありません")}
-	}
 	failed := 0
 	oldestAge := time.Duration(0)
 	if len(jobs) > 0 {
@@ -104,6 +101,19 @@ func inspectHookGrokTranscriptDiagnostics(now time.Time) doctorCheck {
 		terminalCounts[terminal.Disposition]++
 	}
 	partial := terminalCounts["unavailable"] + terminalCounts["malformed"] + terminalCounts["cancelled"]
+	// A recorded marker is a successful idempotency receipt, not an operator
+	// warning. Only outstanding work, partial coverage, or unreadable state
+	// requires attention from doctor.
+	if len(jobs) == 0 && len(unreadable) == 0 && partial == 0 && terminalUnreadable == 0 {
+		if terminalCounts["recorded"] == 0 {
+			return doctorCheck{Name: name, Status: doctorStatusPass, Message: Localize("no pending Grok transcript jobs found", "未処理の Grok transcript job はありません")}
+		}
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusPass,
+			Message: localizef("no pending Grok transcript jobs found; %d final-turn transcript(s) already recorded", "未処理の Grok transcript job はありません。final-turn transcript は %d 件記録済みです", terminalCounts["recorded"]),
+		}
+	}
 	return doctorCheck{
 		Name:   name,
 		Status: doctorStatusWarn,
@@ -133,9 +143,12 @@ func (c *RootCLI) newHookGrokTranscriptWorkerCommand() *cobra.Command {
 }
 
 func (c *RootCLI) scheduleHookGrokTranscript(payload []byte, dbPath string) error {
-	jobPath, err := enqueueHookGrokTranscript(payload, dbPath, time.Now().UTC())
+	jobPath, shouldLaunch, err := enqueueHookGrokTranscript(payload, dbPath, time.Now().UTC())
 	if err != nil {
 		return err
+	}
+	if !shouldLaunch {
+		return nil
 	}
 	launcher := c.hookGrokTranscriptLauncher
 	if launcher == nil {
@@ -163,18 +176,22 @@ func hookGrokTranscriptTerminalDir() (string, error) {
 	return filepath.Join(stateDir, "grok-transcript-terminal"), nil
 }
 
-func enqueueHookGrokTranscript(payload []byte, dbPath string, requestedAt time.Time) (string, error) {
+// enqueueHookGrokTranscript creates work only when this delivery has neither a
+// durable job nor a terminal receipt. The boolean is false for either
+// idempotent case, so callers do not launch another detached worker for a
+// redelivered Stop.
+func enqueueHookGrokTranscript(payload []byte, dbPath string, requestedAt time.Time) (string, bool, error) {
 	sessionID := strings.TrimSpace(hookPayloadString(payload, "session_id", ""))
 	transcriptPath := strings.TrimSpace(hookPayloadString(payload, "transcript_path", ""))
 	if sessionID == "" || transcriptPath == "" {
-		return "", xerrors.Errorf("Grok transcript job requires session_id and transcript_path")
+		return "", false, xerrors.Errorf("Grok transcript job requires session_id and transcript_path")
 	}
 	dir, err := hookGrokTranscriptQueueDir()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", xerrors.Errorf("failed to create Grok transcript queue: %w", err)
+		return "", false, xerrors.Errorf("failed to create Grok transcript queue: %w", err)
 	}
 	key := strings.Join([]string{
 		strings.TrimSpace(dbPath),
@@ -184,26 +201,37 @@ func enqueueHookGrokTranscript(payload []byte, dbPath string, requestedAt time.T
 	}, "\x00")
 	digest := sha256.Sum256([]byte(key))
 	jobPath := filepath.Join(dir, hex.EncodeToString(digest[:])+".json")
+	jobLock := flock.New(jobPath + ".lock")
+	if err := jobLock.Lock(); err != nil {
+		return "", false, xerrors.Errorf("failed to lock Grok transcript enqueue: %w", err)
+	}
+	defer func() { _ = jobLock.Unlock() }()
+
+	terminalPath, err := hookGrokTranscriptTerminalPath(jobPath)
+	if err != nil {
+		return "", false, err
+	}
+	if _, readErr := readHookGrokTranscriptTerminal(terminalPath); readErr == nil {
+		return jobPath, false, nil
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		return "", false, readErr
+	}
+
 	job := hookGrokTranscriptJob{
 		SchemaVersion: hookGrokTranscriptJobSchemaVersion,
 		Payload:       string(payload),
 		DBPath:        strings.TrimSpace(dbPath),
 		RequestedAt:   requestedAt,
 	}
-	if existing, readErr := readHookGrokTranscriptJob(jobPath); readErr == nil {
-		job.Attempts = existing.Attempts
-		job.LastAttemptAt = existing.LastAttemptAt
-		job.LastError = existing.LastError
-		if existing.RequestedAt.Before(job.RequestedAt) {
-			job.RequestedAt = existing.RequestedAt
-		}
+	if _, readErr := readHookGrokTranscriptJob(jobPath); readErr == nil {
+		return jobPath, false, nil
 	} else if !errors.Is(readErr, os.ErrNotExist) {
-		return "", readErr
+		return "", false, readErr
 	}
 	if err := writeHookGrokTranscriptJob(jobPath, job); err != nil {
-		return "", err
+		return "", false, err
 	}
-	return jobPath, nil
+	return jobPath, true, nil
 }
 
 func (c *RootCLI) runHookGrokTranscriptWorker(ctx context.Context, jobPath string) error {
@@ -372,11 +400,10 @@ func writeHookGrokTranscriptTerminal(jobPath, disposition string, occurredAt tim
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return xerrors.Errorf("failed to create Grok transcript terminal disposition directory: %w", err)
 	}
-	name := filepath.Base(jobPath)
-	if len(name) != 69 || !strings.HasSuffix(name, ".json") {
-		return xerrors.Errorf("Grok transcript terminal disposition job name is invalid")
+	terminalPath, err := hookGrokTranscriptTerminalPath(jobPath)
+	if err != nil {
+		return err
 	}
-	terminalPath := filepath.Join(dir, name)
 	terminal := hookGrokTranscriptTerminal{
 		SchemaVersion: hookGrokTranscriptTerminalSchemaVersion,
 		Disposition:   disposition,
@@ -387,7 +414,7 @@ func writeHookGrokTranscriptTerminal(jobPath, disposition string, occurredAt tim
 		return xerrors.Errorf("failed to encode Grok transcript terminal disposition: %w", err)
 	}
 	encoded = append(encoded, '\n')
-	temporaryFile, err := os.CreateTemp(dir, "."+name+".*.tmp")
+	temporaryFile, err := os.CreateTemp(dir, "."+filepath.Base(terminalPath)+".*.tmp")
 	if err != nil {
 		return xerrors.Errorf("failed to create Grok transcript terminal disposition temporary file: %w", err)
 	}
@@ -408,6 +435,18 @@ func writeHookGrokTranscriptTerminal(jobPath, disposition string, occurredAt tim
 		return xerrors.Errorf("failed to publish Grok transcript terminal disposition: %w", err)
 	}
 	return nil
+}
+
+func hookGrokTranscriptTerminalPath(jobPath string) (string, error) {
+	name := filepath.Base(jobPath)
+	if len(name) != 69 || !strings.HasSuffix(name, ".json") {
+		return "", xerrors.Errorf("Grok transcript terminal disposition job name is invalid")
+	}
+	dir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
 }
 
 func writeHookGrokTranscriptJob(path string, job hookGrokTranscriptJob) error {

--- a/presentation/cli/hook_grok_transcript_queue_internal_test.go
+++ b/presentation/cli/hook_grok_transcript_queue_internal_test.go
@@ -54,6 +54,38 @@ func TestInspectHookGrokTranscriptDiagnosticsPassesWithoutJobs(t *testing.T) {
 	}
 }
 
+func TestInspectHookGrokTranscriptDiagnosticsReportsBodyFreeTerminalPartialState(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	jobPath := filepath.Join(stateDir, "grok-transcript", strings.Repeat("a", 64)+".json")
+	if err := writeHookGrokTranscriptTerminal(jobPath, "unavailable", now); err != nil {
+		t.Fatalf("writeHookGrokTranscriptTerminal() error = %v", err)
+	}
+	terminalDir, err := hookGrokTranscriptTerminalDir()
+	if err != nil {
+		t.Fatalf("hookGrokTranscriptTerminalDir() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(terminalDir, "broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(broken terminal) error = %v", err)
+	}
+
+	check := inspectHookGrokTranscriptDiagnostics(now)
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("check = %+v, want warning", check)
+	}
+	for _, want := range []string{"1 partial final-turn disposition", "1 unavailable", "1 unreadable disposition marker"} {
+		if !strings.Contains(check.Message, want) {
+			t.Fatalf("check message = %q, want %q", check.Message, want)
+		}
+	}
+	for _, private := range []string{jobPath, stateDir, strings.Repeat("a", 64)} {
+		if strings.Contains(check.Message+check.Hint, private) {
+			t.Fatalf("doctor output exposed terminal input %q: %+v", private, check)
+		}
+	}
+}
+
 func TestScanHookGrokTranscriptJobsRejectsInvalidMetadata(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)

--- a/presentation/cli/hook_grok_transcript_queue_internal_test.go
+++ b/presentation/cli/hook_grok_transcript_queue_internal_test.go
@@ -13,9 +13,12 @@ func TestInspectHookGrokTranscriptDiagnosticsReportsPendingFailureMetadata(t *te
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 	payload := []byte(`{"session_id":"private-session","prompt_id":"prompt-1","transcript_path":"/private/transcript/updates.jsonl"}`)
-	path, err := enqueueHookGrokTranscript(payload, filepath.Join(t.TempDir(), "traceary.db"), now.Add(-3*time.Minute))
+	path, shouldLaunch, err := enqueueHookGrokTranscript(payload, filepath.Join(t.TempDir(), "traceary.db"), now.Add(-3*time.Minute))
 	if err != nil {
 		t.Fatalf("enqueueHookGrokTranscript() error = %v", err)
+	}
+	if !shouldLaunch {
+		t.Fatal("initial enqueue must request a worker launch")
 	}
 	job, err := readHookGrokTranscriptJob(path)
 	if err != nil {
@@ -82,6 +85,26 @@ func TestInspectHookGrokTranscriptDiagnosticsReportsBodyFreeTerminalPartialState
 	for _, private := range []string{jobPath, stateDir, strings.Repeat("a", 64)} {
 		if strings.Contains(check.Message+check.Hint, private) {
 			t.Fatalf("doctor output exposed terminal input %q: %+v", private, check)
+		}
+	}
+}
+
+func TestInspectHookGrokTranscriptDiagnosticsPassesWithRecordedTerminalOnly(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(hookStateDirEnvKey, stateDir)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	jobPath := filepath.Join(stateDir, "grok-transcript", strings.Repeat("b", 64)+".json")
+	if err := writeHookGrokTranscriptTerminal(jobPath, "recorded", now); err != nil {
+		t.Fatalf("writeHookGrokTranscriptTerminal() error = %v", err)
+	}
+
+	check := inspectHookGrokTranscriptDiagnostics(now)
+	if check.Status != doctorStatusPass {
+		t.Fatalf("check = %+v, want pass for recorded-only terminal", check)
+	}
+	for _, want := range []string{"no pending", "1 final-turn transcript"} {
+		if !strings.Contains(check.Message, want) {
+			t.Fatalf("check message = %q, want %q", check.Message, want)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation
Grok can emit Stop before its final assistant update is appended. Terminal paths previously left retry jobs indefinitely.

## Changes
- classify ready, delayed, unavailable, malformed, and cancelled final-turn states
- retry only delayed updates for 20 x 100ms
- persist body-free terminal disposition markers and remove terminal retry jobs
- surface partial final-turn counts through doctor without private identifiers
- cover ready, delayed, permanent unavailable, malformed, cancelled, and duplicate delivery

## Validation
- go vet ./...
- go test ./...
- go tool golangci-lint run
- go build ./...
- ./scripts/smoke_test_integrations.sh grok
- go run ./cmd/repo-tooling docs verify-i18n
- go run ./cmd/repo-tooling docs verify-host-coverage
- go run ./cmd/repo-tooling docs verify-antigravity-status
- go run ./cmd/repo-tooling integrations verify

Closes #1520