### PR TITLE
fix: bound large-store doctor diagnostics

### DIFF
--- a/.ai/spec/1537.md
+++ b/.ai/spec/1537.md
@@ -1,0 +1,38 @@
+# #1537 Bounded large-store doctor
+
+## Problem
+
+A live multi-gigabyte SQLite store can make `traceary doctor --json` appear to
+hang. The former path initialized SQLite and then ran several diagnostics that
+list events or inspect command/content payloads. That is inappropriate for the
+first operator response to a capacity or lock incident.
+
+## Concept model
+
+| Concept | Meaning | Observable output |
+| --- | --- | --- |
+| Metadata-only outcome | A regular SQLite file at least 2 GiB is classified using `stat` only. | `mode=metadata_only_large_store`, `large-store-diagnostics=warn` |
+| Progress/result | The command completes after the metadata classification rather than silently waiting for a deep scan. | JSON report with explicit bounded-result text |
+| Busy/timeout | A metadata-only result does **not** claim that the store is unlocked. A content diagnostic must first remove competing writers or use a reviewed bounded copy. | Hint distinguishes capacity from lock contention |
+| Non-destructive boundary | The default path does not open SQLite, migrate, list events, read event bodies, command payloads, hook spools, credentials, or identifier samples. | No store initialization or event list calls in regression test |
+
+## Responsibilities and boundaries
+
+- `presentation/cli/doctor_store_size.go` owns the filesystem-metadata policy
+  and its operator-facing status. It does not open SQLite.
+- `presentation/cli/doctor.go` selects the bounded path before dependency
+  initialization and before every content-bearing diagnostic.
+- SQLite/query services are intentionally not called in this mode. This avoids
+  lock acquisition, schema migration, rollback work, and accidental body reads.
+
+## Rollback and migration
+
+This is a read-path behavior change with no schema/data migration. Reverting
+the change restores the old deep default; it does not alter DB contents or
+sidecars. `doctor --fix` does not perform a store action in metadata-only mode.
+
+## Verification
+
+The regression test uses a sparse 2 GiB fixture, asserts a sub-second JSON
+outcome, and proves that neither SQLite initialization nor event listing runs.
+The fixture contains no event body/payload/identifier data.

--- a/docs/operations/large-store-doctor.ja.md
+++ b/docs/operations/large-store-doctor.ja.md
@@ -1,0 +1,32 @@
+# 大容量 live store における bounded `doctor`
+
+[English](large-store-doctor.md)
+
+live SQLite store が遅い、または lock contention が疑われる場合、最初に安全に
+実行するコマンドは `traceary doctor --json` です。regular な store file が 2 GiB
+以上の場合は、bounded な metadata-only report を返します。
+
+```sh
+traceary doctor --json --warnings-ok
+```
+
+report には `mode: "metadata_only_large_store"` と
+`large-store-diagnostics` の警告が含まれます。これは出力欠落ではなく完了した
+結果です。filesystem metadata だけを使い、SQLite の open、migration、event の
+list、event body や command payload の読み取り、hook spool の検査、credential や
+identifier sample の出力を行いません。
+
+## 結果の解釈
+
+- **容量:** 警告は live store が大きいことを示します。1 GiB の上限ではなく、data
+  を削除することもありません。最初に `traceary store gc --dry-run` を実行し、
+  retention を適用する前に archive を作成してください。
+- **lock contention:** metadata-only の結果は、DB が unlocked であるとは主張しません。
+  content-level の調査前に競合 writer を停止または分離してください。busy incident
+  中に `doctor --fix` を繰り返し実行しないでください。
+- **深い調査:** contention 解消後に、review 済みの bounded copy または狭く限定した
+  read command を使用してください。raw event body、prompt/response payload、credential、
+  identifier list を incident report にコピーしないでください。
+
+この mode の既定コマンドは data を変更しません。`--fix` は small store では従来どおり
+ですが、metadata-only の結果から retention 操作には進みません。

--- a/docs/operations/large-store-doctor.md
+++ b/docs/operations/large-store-doctor.md
@@ -1,0 +1,35 @@
+# Bounded `doctor` behavior for large live stores
+
+[日本語](large-store-doctor.ja.md)
+
+`traceary doctor --json` is the first safe command when a live SQLite store is
+slow or suspected to be lock-contended. For a regular store file of 2 GiB or
+more, it returns a bounded metadata-only report:
+
+```sh
+traceary doctor --json --warnings-ok
+```
+
+The report has `mode: "metadata_only_large_store"` and the
+`large-store-diagnostics` warning. This is a completed result, not missing
+output. It uses filesystem metadata only; it does not open SQLite, run
+migrations, list events, read event bodies or command payloads, inspect hook
+spools, or print credentials or identifier samples.
+
+## Interpret the result
+
+- **Capacity:** the warning says the live store is large. It is not a 1 GiB
+  limit and it does not delete anything. Start with
+  `traceary store gc --dry-run`; archive before applying retention.
+- **Lock contention:** the metadata-only result deliberately does not claim
+  that the database is unlocked. Stop or isolate competing writers before a
+  content-level investigation. Do not keep rerunning `doctor --fix` during a
+  busy incident.
+- **Deep investigation:** use a reviewed bounded copy or a narrowly scoped
+  read command after contention is resolved. Do not copy raw event bodies,
+  prompt/response payloads, credentials, or identifier lists into incident
+  reports.
+
+The default command never changes data in this mode. `--fix` retains its normal
+meaning for small stores, but does not turn the metadata-only outcome into a
+retention operation.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -69,8 +69,13 @@ type doctorSummary struct {
 }
 
 type doctorReport struct {
-	DBPath   string          `json:"db_path"`
-	Clients  []string        `json:"clients"`
+	DBPath  string   `json:"db_path"`
+	Clients []string `json:"clients"`
+	// Mode makes a bounded early outcome machine-readable.  In particular, a
+	// large live store is deliberately not opened by the default doctor path:
+	// opening it can run migrations and content diagnostics that are neither
+	// necessary nor safe for a quick operator health check.
+	Mode     string          `json:"mode,omitempty"`
 	Checks   []doctorCheck   `json:"checks"`
 	Sections []doctorSection `json:"sections"`
 	Summary  doctorSummary   `json:"summary"`
@@ -278,6 +283,16 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 	})
 	report.Checks = append(report.Checks, inspectStoreSizeBudget(resolvedDBPath))
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
+	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
+		report.Mode = doctorModeMetadataOnlyLargeStore
+		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(resolvedDBPath))
+		// This is an intentional, successful bounded outcome. Do not initialize
+		// SQLite, list events, scan hook spools, or inspect client state here:
+		// those operations can block behind a live writer and some inspect event
+		// bodies/payloads. The result is useful precisely because it is based on
+		// filesystem metadata only and cannot mutate or expose store content.
+		return report, nil
+	}
 
 	report.Checks = append(report.Checks, inspectDoctorConfig())
 

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -10,6 +10,48 @@ import (
 // stores around 2.4 GB already spend 2–4 s on cold open alone.
 const storeSizeWarnBytes int64 = 1 << 30 // 1 GiB
 
+const (
+	doctorModeMetadataOnlyLargeStore = "metadata_only_large_store"
+	// doctorLargeStoreMetadataOnlyBytes is an operational threshold, not a
+	// retention target or a store-size limit. Above it, the default doctor
+	// command returns a finite metadata-only result instead of opening SQLite
+	// and traversing content-bearing diagnostics.
+	doctorLargeStoreMetadataOnlyBytes int64 = 2 << 30 // 2 GiB
+)
+
+// isLargeStoreForBoundedDoctor uses only filesystem metadata. It must remain
+// independent of SQLite so the bounded doctor outcome is still available when
+// a writer holds the database lock or the store is otherwise unhealthy.
+func isLargeStoreForBoundedDoctor(dbPath string) bool {
+	info, err := os.Stat(dbPath)
+	return err == nil && info.Mode().IsRegular() && info.Size() >= doctorLargeStoreMetadataOnlyBytes
+}
+
+func boundedLargeStoreDoctorCheck(dbPath string) doctorCheck {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return doctorCheck{
+			Name:    "large-store-diagnostics",
+			Status:  doctorStatusFail,
+			Message: localizef("failed to stat large SQLite store metadata: %v", "大容量 SQLite ストアの metadata を確認できませんでした: %v", err),
+		}
+	}
+	return doctorCheck{
+		Name:   "large-store-diagnostics",
+		Status: doctorStatusWarn,
+		Message: localizef(
+			"bounded metadata-only doctor result for %s store: SQLite open, migrations, event bodies, command payloads, hook spools, credentials, and identifier samples were not read",
+			"%s のストアに対する bounded metadata-only doctor 結果です。SQLite の open、migration、event body、command payload、hook spool、credential、identifier sample は読み取りませんでした",
+			formatByteSize(info.Size()),
+		),
+		Hint: Localize(
+			"this is capacity-safe, not a lock diagnosis. If an application needs a content diagnostic, first stop competing writers or use a reviewed bounded copy; then run the specific read command. Preview safe remediation with `traceary store gc --dry-run` and archive before applying retention.",
+			"これは capacity-safe な結果であり lock 診断ではありません。content diagnostic が必要なら、競合 writer を停止するか、review 済みの bounded copy を使用してから個別の read command を実行してください。安全な remediation は `traceary store gc --dry-run` でプレビューし、retention を適用する前に archive を作成してください。",
+		),
+		FixCommand: "traceary store gc --dry-run",
+	}
+}
+
 func inspectStoreSizeBudget(dbPath string) doctorCheck {
 	const name = "store-size"
 	info, err := os.Stat(dbPath)

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -502,6 +502,11 @@ enabled = true
 
 func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) {
 	t.Setenv("TRACEARY_LANG", "en")
+	// The bounded large-store result intentionally still includes the normal
+	// environment checks. Give the PATH check its healthy fixture so
+	// --warnings-ok exercises the expected warning-only exit semantics rather
+	// than inheriting a CI runner's unrelated missing `traceary` binary.
+	setTracearyPathToCurrentExecutable(t)
 	largeStore := filepath.Join(t.TempDir(), "large-metadata-only.db")
 	file, err := os.OpenFile(largeStore, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -22,6 +22,7 @@ import (
 type doctorReport struct {
 	DBPath   string          `json:"db_path"`
 	Clients  []string        `json:"clients"`
+	Mode     string          `json:"mode"`
 	Checks   []doctorCheck   `json:"checks"`
 	Sections []doctorSection `json:"sections"`
 	Summary  doctorSummary   `json:"summary"`
@@ -497,6 +498,59 @@ enabled = true
 			t.Fatalf("doctor statuses mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) {
+	t.Setenv("TRACEARY_LANG", "en")
+	largeStore := filepath.Join(t.TempDir(), "large-metadata-only.db")
+	file, err := os.OpenFile(largeStore, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	// A sparse fixture exercises the multi-GB decision path without allocating
+	// a multi-GB test artifact. It intentionally is not a valid SQLite file:
+	// doctor must return before trying to open or migrate it.
+	if err := file.Truncate(2 << 30); err != nil {
+		_ = file.Close()
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	store := &storeManagementUsecaseStub{}
+	events := &eventUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithEvent(events),
+	).Command()
+	stdout := &bytes.Buffer{}
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	// Even --fix must stay non-destructive in metadata-only mode.
+	rootCmd.SetArgs([]string{"doctor", "--db-path", largeStore, "--json", "--warnings-ok", "--fix"})
+
+	started := time.Now()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded metadata-only doctor took %s, want <= 1s", elapsed)
+	}
+	report := decodeDoctorReport(t, stdout.Bytes())
+	if report.Mode != "metadata_only_large_store" {
+		t.Fatalf("report.Mode = %q, want metadata_only_large_store", report.Mode)
+	}
+	if store.initCalled {
+		t.Fatal("large-store doctor initialized SQLite, want metadata-only outcome")
+	}
+	if events.listCalls != 0 {
+		t.Fatalf("large-store doctor listed %d events, want no event/payload reads", events.listCalls)
+	}
+	check := statusByName(report, "large-store-diagnostics")
+	if check.Status != "warn" || !strings.Contains(check.Message, "were not read") {
+		t.Fatalf("large-store-diagnostics = %#v, want explicit metadata-only warning", check)
+	}
 }
 
 func TestRootCLI_DoctorCommand_ClaudeHookCancellationDiagnostics(t *testing.T) {


### PR DESCRIPTION
Motivation: doctor must return a bounded, observable, non-destructive outcome for a multi-GB live store. Changes: metadata-only large-store mode, no SQLite/payload/spool reads, sparse fixture, and EN/JA operator guidance. Validation: go build ./..., go vet ./..., go test ./..., golangci-lint, docs, integrations, diff check. Closes #1537.