### PR TITLE
fix: converge Grok local repository plugin refresh

### DIFF
--- a/docs/integrations/1538-grok-local-repository-identity.ja.md
+++ b/docs/integrations/1538-grok-local-repository-identity.ja.md
@@ -1,0 +1,36 @@
+# 設計メモ: Grok local-repository identity の移行 (#1538)
+
+[English](./1538-grok-local-repository-identity.md)
+
+## 問題
+
+Grok Build は local checkout を repository scope で導入します。
+`#integrations/grok-plugin` subdirectory selector を付けないと、host が
+`traceary-grok` package 名ではなく repository identity を登録することがあります。
+後から canonical package を導入しようとしても、すでに導入済みとして拒否されます。
+
+## 境界と判断
+
+plugin list には別の概念が二つあります。
+
+| 概念 | source | 用途 |
+| --- | --- | --- |
+| package 名 | manifest package entry | canonical `traceary-grok` の識別 |
+| local-repository identity | `repo_key` と local `source` の inventory metadata | 旧 repository-scope install の識別 |
+
+doctor が読むのはこの inventory metadata と hook contract metadata だけです。
+導入済み plugin file、prompt、transcript、credential、plugin payload は検査しません。
+
+既定の installer は破壊的に動作しません。現在の checkout の plugin subdirectory が
+non-canonical な local identity として登録されている場合、exit 78 で停止します。
+明示的な `--migrate-local-repo-identity` はその source の完全一致だけを削除し、
+`repository#integrations/grok-plugin` を導入します。別 source の legacy package は
+選択も削除もされません。
+
+## 観測可能な受け入れテスト
+
+- clean home は subdirectory selector 経由で canonical package を導入する。
+- canonical package の refresh は `traceary-grok` だけを置き換える。
+- 旧 local-repository identity は uninstall せずに停止する。
+- 明示的な移行は source が完全一致する local identity だけを削除し、canonical hook、MCP、skill へ収束する。
+- 別 source の legacy `traceary` package はそのまま残る。

--- a/docs/integrations/1538-grok-local-repository-identity.md
+++ b/docs/integrations/1538-grok-local-repository-identity.md
@@ -1,0 +1,38 @@
+# Design note: Grok local-repository identity migration (#1538)
+
+[日本語](./1538-grok-local-repository-identity.ja.md)
+
+## Problem
+
+Grok Build installs a local checkout at repository scope. Without its
+`#integrations/grok-plugin` subdirectory selector, the host can register the
+repository identity instead of the `traceary-grok` package name. A later
+canonical install is then rejected as already installed.
+
+## Boundary and decision
+
+The plugin list has two separate concepts:
+
+| Concept | Source | Use |
+| --- | --- | --- |
+| Package name | manifest package entry | identifies canonical `traceary-grok` |
+| Local-repository identity | `repo_key` plus local `source` inventory metadata | identifies an older repository-scope install |
+
+Doctor reads only this inventory metadata and hook contract metadata. It does
+not inspect installed plugin files, prompts, transcripts, credentials, or
+plugin payloads.
+
+The default installer is non-destructive. It stops with exit 78 when the
+current checkout's plugin subdirectory is registered as a non-canonical local
+identity. The explicit `--migrate-local-repo-identity` operation removes only
+that exact source match, then installs `repository#integrations/grok-plugin`.
+A legacy package with another source is never selected or removed.
+
+## Observable acceptance tests
+
+- clean home installs the canonical package via the subdirectory selector;
+- canonical package refresh replaces only `traceary-grok`;
+- an old local-repository identity stops without an uninstall;
+- an explicit migration removes only the exact local source and converges to
+  canonical hooks, MCP, and skills;
+- a legacy `traceary` package with another source remains untouched.

--- a/docs/integrations/grok-plugin.ja.md
+++ b/docs/integrations/grok-plugin.ja.md
@@ -106,7 +106,8 @@ cd traceary
 ./scripts/install-grok-plugin.sh
 ```
 
-installer は `grok plugin install --trust` を実行します。信頼した command hook は
+installer は repository の `#integrations/grok-plugin` selector を付けて
+`grok plugin install --trust` を実行します。信頼した command hook は
 ローカルで実行されるため、実行前にパッケージを確認してください。現行パッケージは
 文書化された Traceary hook entrypoint のみを呼び出し、Grok の認証情報やブラウザ状態を
 読み取ったり送信したりしません。
@@ -171,13 +172,35 @@ grok plugin uninstall traceary-grok
 hook-only で導入した project/global ファイルは plugin と独立しているため、使用した
 場合は別途削除してください。
 
+#### local-repository identity の移行
+
+過去に `#integrations/grok-plugin` selector を付けずに local install した場合、Grok は
+package 名 `traceary-grok` ではなく `traceary` などの repository identity として表示する
+ことがあります。`traceary doctor --client grok --json` はこれを本文を含まない
+`grok-plugin-resolution` の警告として報告します。読むのは inventory の名前、repository
+key、source path、hook path、component 数だけで、plugin payload、prompt、transcript、
+credential は読みません。
+
+通常の installer は何も削除せずに停止します。`grok plugin list --json` を確認したうえで、
+旧 install に使った同じ checkout から次の限定移行を実行してください。
+
+```sh
+./scripts/install-grok-plugin.sh --migrate-local-repo-identity
+```
+
+この操作が削除するのは、その checkout の `integrations/grok-plugin` directory を source と
+する identity だけです。その後 repository subdirectory selector から canonical package を
+導入します。別 source の `traceary` package は選択も削除もされません。doctor を再実行し、
+`grok-plugin`、`grok-plugin-resolution`、`grok-hooks`、`grok-mcp`、`grok-skills` がすべて
+pass であることを確認してください。
+
 ## トラブルシュート
 
 | Doctor check | 意味と対応 |
 | --- | --- |
 | `grok-cli` が失敗 | Grok Build を導入し、`grok` を `PATH` に追加する |
 | `grok-plugin` が警告 | パッケージを導入し直す。バージョン不一致の場合は同じ Traceary リリースのパッケージを使う |
-| `grok-plugin-resolution` が警告 | Grok が native 以外の path class、または同名の legacy package を解決しています。`scripts/install-grok-plugin.sh` を実行し、`traceary-grok` が有効 route になったことを確認してください。doctor は package path、名前、inventory 件数だけを読みます。 |
+| `grok-plugin-resolution` が警告 | Grok が native 以外の path class、同名の legacy package、または local-repository identity を解決しています。local-repository identity の場合は `grok plugin list --json` を確認し、その checkout で `scripts/install-grok-plugin.sh --migrate-local-repo-identity` を実行してください。それ以外は通常の installer を実行し、`traceary-grok` が有効 route になったことを確認してください。doctor が読むのは inventory metadata だけです。 |
 | `grok-hook-trust` が警告 | project hook を確認して `/hooks-trust` を実行するか、未使用の project route を削除する |
 | `grok-hooks` が警告 | 導入済み hook file が不足しているか、7 event の厳密な契約からずれている。plugin を再導入する |
 | `grok-mcp` / `grok-skills` が警告 | 導入済みパッケージの内容が不足している。plugin を再導入する |

--- a/docs/integrations/grok-plugin.md
+++ b/docs/integrations/grok-plugin.md
@@ -109,7 +109,8 @@ cd traceary
 ./scripts/install-grok-plugin.sh
 ```
 
-The installer runs `grok plugin install --trust`. Review the checked-out
+The installer runs `grok plugin install --trust` with the repository
+`#integrations/grok-plugin` selector. Review the checked-out
 package before running it because trusted command hooks execute locally. The
 current package invokes only the documented Traceary hook entrypoints and does
 not read or transmit Grok credentials or browser state.
@@ -173,6 +174,28 @@ it never removes a legacy `traceary` package because Grok can resolve that
 same-name package from another host. A converged native installation reports
 seven hook boundaries, one MCP server, and three skills.
 
+#### Local-repository identity migration
+
+Older local installs that omitted the `#integrations/grok-plugin` selector can
+be shown by Grok as a repository identity such as `traceary`, rather than the
+package name `traceary-grok`. `traceary doctor --client grok --json` reports
+this as a body-free `grok-plugin-resolution` warning. It reads only inventory
+names, repository keys, source paths, hook paths, and component counts; it
+does not read plugin payloads, prompts, transcripts, or credentials.
+
+The normal installer stops without removing anything. After reviewing
+`grok plugin list --json`, run this bounded migration from the same checkout:
+
+```sh
+./scripts/install-grok-plugin.sh --migrate-local-repo-identity
+```
+
+It removes only an identity whose source is exactly that checkout's
+`integrations/grok-plugin` directory, then installs the canonical package from
+the repository subdirectory selector. It never selects or removes a `traceary`
+package from another source. Re-run doctor and confirm that `grok-plugin`,
+`grok-plugin-resolution`, `grok-hooks`, `grok-mcp`, and `grok-skills` pass.
+
 To remove only the native Grok package:
 
 ```sh
@@ -188,7 +211,7 @@ removed separately if they were installed.
 | --- | --- |
 | `grok-cli` fails | Install Grok Build and ensure `grok` is on `PATH` |
 | `grok-plugin` warns | Install/reinstall the package; a version mismatch requires the package from the same Traceary release |
-| `grok-plugin-resolution` warns | Grok resolved a non-native path class or a same-name legacy package. Run `scripts/install-grok-plugin.sh`, then confirm `traceary-grok` is the enabled route; doctor reads only package paths, names, and inventory counts. |
+| `grok-plugin-resolution` warns | Grok resolved a non-native path class, a same-name legacy package, or a local-repository identity. For a local-repository identity, review `grok plugin list --json` and run `scripts/install-grok-plugin.sh --migrate-local-repo-identity` from that checkout; otherwise run the normal installer and confirm `traceary-grok` is the enabled route. Doctor reads only inventory metadata. |
 | `grok-hook-trust` warns | Review the project hook file and use `/hooks-trust`, or remove the unused project route |
 | `grok-hooks` warns | The installed hook file is missing or has drifted from the exact seven-event contract; reinstall the plugin |
 | `grok-mcp` / `grok-skills` warns | The installed package inventory is incomplete; reinstall it |

--- a/presentation/cli/doctor_grok.go
+++ b/presentation/cli/doctor_grok.go
@@ -43,6 +43,7 @@ type grokDoctorState struct {
 	PluginPath           string
 	ResolvedPathClass    string
 	LegacyPluginDetected bool
+	LocalRepoConflict    bool
 	ProjectTrusted       bool
 	ProjectHooks         bool
 	NativeHooks          bool
@@ -52,8 +53,10 @@ type grokDoctorState struct {
 
 type grokPluginListEntry struct {
 	Name    string `json:"name"`
+	RepoKey string `json:"repo_key"`
 	Version string `json:"version"`
 	Path    string `json:"path"`
+	Source  string `json:"source"`
 }
 
 type grokInspectDocument struct {
@@ -102,7 +105,9 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 			state.PluginInstalled = true
 			state.PluginVersion = plugin.Version
 			state.PluginPath = plugin.Path
-			break
+		}
+		if grokIsLocalRepositoryIdentity(plugin) {
+			state.LocalRepoConflict = true
 		}
 	}
 	inspectOutput, err := grokDoctorOutput(ctx, "--cwd", projectDir, "inspect", "--json")
@@ -141,6 +146,17 @@ func probeGrokDoctorState(ctx context.Context, projectDir string) (grokDoctorSta
 		}
 	}
 	return state, nil
+}
+
+// grokIsLocalRepositoryIdentity distinguishes Grok's repository-level local
+// install identity from a package manifest name. It uses only the plugin list
+// inventory fields and never reads installed plugin contents or hook payloads.
+func grokIsLocalRepositoryIdentity(plugin grokPluginListEntry) bool {
+	if plugin.Name == grokTracearyPluginName || !strings.HasPrefix(plugin.RepoKey, "grok-plugin-") {
+		return false
+	}
+	normalizedSource := filepath.ToSlash(plugin.Source)
+	return strings.HasSuffix(normalizedSource, "/integrations/grok-plugin")
 }
 
 // grokPluginPathClass classifies only the installation host encoded in a hook
@@ -218,17 +234,26 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	checks := []doctorCheck{{Name: "grok-cli", Status: doctorStatusPass, Message: localizef("detected Grok CLI %s", "Grok CLI %s を検出しました", state.HostVersion)}}
 	if !state.PluginInstalled {
 		message := Localize("native Traceary Grok plugin traceary-grok is not installed", "native Traceary Grok plugin traceary-grok がインストールされていません")
+		hint := Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")
 		if state.LegacyPluginDetected {
 			message = Localize("legacy Traceary Grok plugin traceary is resolved but canonical traceary-grok is not installed", "legacy Traceary Grok plugin traceary が解決されていますが canonical traceary-grok はインストールされていません")
 		}
-		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: message, Hint: Localize("install the native plugin with scripts/install-grok-plugin.sh", "scripts/install-grok-plugin.sh で native plugin をインストールしてください")})
+		if state.LocalRepoConflict {
+			message = Localize("a local-repository Grok identity conflicts with canonical traceary-grok", "ローカルリポジトリ由来の Grok identity が canonical traceary-grok と競合しています")
+			hint = "scripts/install-grok-plugin.sh --migrate-local-repo-identity"
+		}
+		checks = append(checks, doctorCheck{Name: "grok-plugin", Status: doctorStatusWarn, Message: message, Hint: hint})
 	} else {
 		pluginStatus := doctorStatusPass
 		pluginMessage := localizef("native Traceary Grok plugin traceary-grok %s is installed and enabled", "native Traceary Grok plugin traceary-grok %s はインストール済みで有効です", state.PluginVersion)
 		pluginHint := ""
-		if !state.PluginEnabled || state.LegacyPluginDetected {
+		if !state.PluginEnabled || state.LegacyPluginDetected || state.LocalRepoConflict {
 			pluginStatus, pluginMessage = doctorStatusWarn, Localize("native Traceary Grok plugin traceary-grok is installed but a legacy traceary route is also resolved, or the canonical route is disabled", "native Traceary Grok plugin traceary-grok はインストール済みですが legacy traceary route も解決されているか、canonical route が無効です")
 			pluginHint = "grok plugin enable traceary-grok"
+			if state.LocalRepoConflict {
+				pluginMessage = Localize("a local-repository Grok identity conflicts with canonical traceary-grok", "ローカルリポジトリ由来の Grok identity が canonical traceary-grok と競合しています")
+				pluginHint = "scripts/install-grok-plugin.sh --migrate-local-repo-identity"
+			}
 		} else if releaseTracearyVersionPattern.MatchString(tracearyVersion) && strings.TrimPrefix(state.PluginVersion, "v") != strings.TrimPrefix(tracearyVersion, "v") {
 			pluginStatus = doctorStatusWarn
 			pluginMessage = localizef("native Traceary Grok plugin version %s does not match Traceary %s", "native Traceary Grok plugin version %s は Traceary %s と一致しません", state.PluginVersion, tracearyVersion)
@@ -239,7 +264,11 @@ func buildGrokDoctorChecks(state grokDoctorState, tracearyVersion string) []doct
 	resolutionStatus := doctorStatusPass
 	resolutionMessage := localizef("native plugin installed path: %s; resolved path class: %s", "native plugin のインストール path: %s、解決された path class: %s", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
 	resolutionHint := ""
-	if state.ResolvedPathClass != grokPluginPathClassNative || state.LegacyPluginDetected {
+	if state.LocalRepoConflict {
+		resolutionStatus = doctorStatusWarn
+		resolutionMessage = Localize("Grok has a local-repository identity from the plugin subdirectory; canonical traceary-grok cannot converge until it is explicitly migrated", "Grok は plugin subdirectory 由来のローカルリポジトリ identity を持っています。明示的に移行するまで canonical traceary-grok へ収束できません")
+		resolutionHint = "scripts/install-grok-plugin.sh --migrate-local-repo-identity"
+	} else if state.ResolvedPathClass != grokPluginPathClassNative || state.LegacyPluginDetected {
 		resolutionStatus = doctorStatusWarn
 		resolutionMessage = localizef("native plugin installed path: %s; resolved path class: %s; same-name legacy traceary may be shadowed by another host", "native plugin のインストール path: %s、解決された path class: %s。同名の legacy traceary が別 host により shadow されている可能性があります", grokDoctorDisplayPath(state.PluginPath), state.ResolvedPathClass)
 		resolutionHint = "scripts/install-grok-plugin.sh"

--- a/presentation/cli/doctor_grok_internal_test.go
+++ b/presentation/cli/doctor_grok_internal_test.go
@@ -337,3 +337,65 @@ func TestProbeGrokDoctorStateWarnsForLegacyTracearyRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestProbeGrokDoctorStateDiagnosesLocalRepositoryIdentitySeparately(t *testing.T) {
+	originalLookPath, originalOutput := grokDoctorLookPath, grokDoctorOutput
+	t.Cleanup(func() { grokDoctorLookPath, grokDoctorOutput = originalLookPath, originalOutput })
+	grokDoctorLookPath = func(string) (string, error) { return "/usr/local/bin/grok", nil }
+	projectDir := t.TempDir()
+	grokDoctorOutput = func(_ context.Context, args ...string) ([]byte, error) {
+		switch strings.Join(args, " ") {
+		case "--version":
+			return []byte("grok 0.2.111\n"), nil
+		case "plugin list --json":
+			return []byte(`[{"name":"traceary","repo_key":"grok-plugin-4d1bd2fe","version":"0.32.0","path":"/Users/operator/.grok/installed-plugins/grok-plugin-4d1bd2fe","source":"/Users/operator/Repositories/traceary/integrations/grok-plugin"}]`), nil
+		default:
+			return []byte(`{"projectTrusted":true,"plugins":[{"name":"traceary","enabled":true,"provides":{"skills":3,"mcpServers":1}}],"hooks":[]}`), nil
+		}
+	}
+
+	state, err := probeGrokDoctorState(context.Background(), projectDir)
+	if err != nil {
+		t.Fatalf("probeGrokDoctorState() error = %v", err)
+	}
+	if state.PluginInstalled || !state.LocalRepoConflict {
+		t.Fatalf("state = %+v, want only a local-repository identity conflict", state)
+	}
+	checks := buildGrokDoctorChecks(state, "0.32.1")
+	found := map[string]bool{}
+	for _, check := range checks {
+		if check.Name != "grok-plugin" && check.Name != "grok-plugin-resolution" {
+			continue
+		}
+		found[check.Name] = true
+		if check.Status != doctorStatusWarn || check.Hint != "scripts/install-grok-plugin.sh --migrate-local-repo-identity" {
+			t.Fatalf("%s = %+v, want bounded migration warning", check.Name, check)
+		}
+		if strings.Contains(check.Message+check.Hint, "4d1bd2fe") || strings.Contains(check.Message+check.Hint, "/Users/") {
+			t.Fatalf("%s leaked inventory identifier or path: %+v", check.Name, check)
+		}
+	}
+	if !found["grok-plugin"] || !found["grok-plugin-resolution"] {
+		t.Fatalf("checks = %+v, want plugin and resolution migration checks", checks)
+	}
+}
+
+func TestGrokIsLocalRepositoryIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		plugin grokPluginListEntry
+		want   bool
+	}{
+		{name: "subdirectory local repository identity", plugin: grokPluginListEntry{Name: "traceary", RepoKey: "grok-plugin-4d1bd2fe", Source: "/repo/integrations/grok-plugin"}, want: true},
+		{name: "canonical package", plugin: grokPluginListEntry{Name: "traceary-grok", RepoKey: "grok-plugin-4d1bd2fe", Source: "/repo"}},
+		{name: "legacy package from another host", plugin: grokPluginListEntry{Name: "traceary", RepoKey: "marketplace-traceary", Source: "duck8823/traceary"}},
+		{name: "local repository root with canonical subdirectory", plugin: grokPluginListEntry{Name: "traceary-grok", RepoKey: "grok-plugin-4d1bd2fe", Source: "/repo"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := grokIsLocalRepositoryIdentity(tc.plugin); got != tc.want {
+				t.Fatalf("grokIsLocalRepositoryIdentity(%+v) = %v, want %v", tc.plugin, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/install-grok-plugin.sh
+++ b/scripts/install-grok-plugin.sh
@@ -4,6 +4,29 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_DIR="${ROOT_DIR}/integrations/grok-plugin"
 PLUGIN_NAME="traceary-grok"
+PLUGIN_SOURCE="${ROOT_DIR}#integrations/grok-plugin"
+MIGRATE_LOCAL_REPO_IDENTITY=false
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/install-grok-plugin.sh [--migrate-local-repo-identity]
+
+Installs the canonical traceary-grok package from this checkout.
+
+Without the migration flag, the installer never removes a package named
+traceary. If Grok previously installed this checkout without its subdirectory
+selector, it is reported as a local-repository identity conflict instead.
+Review the bounded migration and rerun with --migrate-local-repo-identity to
+remove only that exact checkout-local conflict before installing traceary-grok.
+EOF
+}
+
+case "${1:-}" in
+  "") ;;
+  --migrate-local-repo-identity) MIGRATE_LOCAL_REPO_IDENTITY=true ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage; exit 64 ;;
+esac
 
 command -v grok >/dev/null 2>&1 || {
   echo 'error: grok CLI is not installed' >&2
@@ -11,10 +34,61 @@ command -v grok >/dev/null 2>&1 || {
 }
 
 grok plugin validate "${PLUGIN_DIR}"
-if grok plugin list --json | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
+plugin_list="$(grok plugin list --json)"
+
+# A source ending at integrations/grok-plugin makes Grok clone the repository
+# root without the required #subdir selector. Grok then exposes the repository
+# identity (usually traceary), rather than this package's traceary-grok name.
+# Inspect only inventory metadata; never read installed plugin files or payloads.
+if ! local_repo_conflict="$(PLUGIN_LIST="${plugin_list}" python3 - "${PLUGIN_DIR}" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+plugin_dir = pathlib.Path(sys.argv[1]).resolve()
+try:
+    plugins = json.loads(os.environ["PLUGIN_LIST"])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+
+for plugin in plugins:
+    source = plugin.get("source")
+    name = plugin.get("name")
+    if not isinstance(source, str) or not isinstance(name, str):
+        continue
+    try:
+        same_source = pathlib.Path(source).resolve() == plugin_dir
+    except OSError:
+        same_source = False
+    if same_source and name != "traceary-grok":
+        print(name)
+        break
+PY
+)"; then
+  echo 'error: Grok plugin inventory was not valid JSON' >&2
+  exit 65
+fi
+
+if [[ -n "${local_repo_conflict}" ]]; then
+  if [[ "${MIGRATE_LOCAL_REPO_IDENTITY}" != true ]]; then
+    cat >&2 <<'EOF'
+error: this checkout is installed through Grok's local-repository identity, not as traceary-grok.
+No package was removed. Review the installed plugin inventory, then rerun:
+  scripts/install-grok-plugin.sh --migrate-local-repo-identity
+The migration removes only the conflicting identity whose source is this checkout's
+integrations/grok-plugin directory. It never removes another legacy traceary package.
+EOF
+    exit 78
+  fi
+  echo 'info: removing the explicitly approved local-repository identity for this checkout' >&2
+  grok plugin uninstall --confirm "${local_repo_conflict}"
+fi
+
+if printf '%s' "${plugin_list}" | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
   grok plugin uninstall "${PLUGIN_NAME}"
 fi
-grok plugin install --trust "${PLUGIN_DIR}"
+grok plugin install --trust "${PLUGIN_SOURCE}"
 grok plugin details "${PLUGIN_NAME}"
 echo 'installed traceary-grok: 7 native hook boundaries, 1 MCP server, and 3 skills'
 echo 'note: the installer intentionally does not uninstall a legacy plugin named traceary because it may belong to another host'

--- a/scripts/smoke_test_integrations.sh
+++ b/scripts/smoke_test_integrations.sh
@@ -90,7 +90,7 @@ run_grok() {
   local tmp_home
   tmp_home="$(mktemp -d)"
   HOME="${tmp_home}" grok plugin validate "${ROOT_DIR}/integrations/grok-plugin"
-  HOME="${tmp_home}" grok plugin install --trust "${ROOT_DIR}/integrations/grok-plugin"
+  HOME="${tmp_home}" grok plugin install --trust "${ROOT_DIR}#integrations/grok-plugin"
   local list_output details_output inspect_output tmp_cwd
   list_output="$(HOME="${tmp_home}" grok plugin list --json)"
   details_output="$(HOME="${tmp_home}" grok plugin details traceary-grok)"

--- a/scripts/test-install-grok-plugin.sh
+++ b/scripts/test-install-grok-plugin.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Contract tests for the safe Grok local-repository migration (#1538).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="${ROOT_DIR}/scripts/install-grok-plugin.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/traceary-grok-installer-test.XXXXXX")"
+cleanup() { rm -rf "${TMP_DIR}"; }
+trap cleanup EXIT
+
+make_fake_grok() {
+  local scenario="$1"
+  local bin_dir="${TMP_DIR}/${scenario}/bin"
+  mkdir -p "${bin_dir}"
+  cat >"${bin_dir}/grok" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_GROK_LOG}"
+case "$1 ${2:-} ${3:-}" in
+  'plugin validate '*) exit 0 ;;
+  'plugin list --json') printf '%s\n' "${FAKE_GROK_LIST}"; exit 0 ;;
+  'plugin uninstall --confirm') exit 0 ;;
+  'plugin uninstall traceary-grok') exit 0 ;;
+  'plugin install --trust') exit 0 ;;
+  'plugin details traceary-grok') exit 0 ;;
+  *) printf 'unexpected fake grok arguments: %s\n' "$*" >&2; exit 64 ;;
+esac
+SCRIPT
+  chmod +x "${bin_dir}/grok"
+  export PATH="${bin_dir}:${ORIGINAL_PATH}"
+  export FAKE_GROK_LOG="${TMP_DIR}/${scenario}.log"
+}
+
+assert_contains() {
+  local needle="$1" haystack="$2"
+  grep -F -- "${needle}" "${haystack}" >/dev/null || {
+    printf 'expected %q in %s\n' "${needle}" "${haystack}" >&2
+    cat "${haystack}" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  local needle="$1" haystack="$2"
+  if grep -F -- "${needle}" "${haystack}" >/dev/null; then
+    printf 'did not expect %q in %s\n' "${needle}" "${haystack}" >&2
+    cat "${haystack}" >&2
+    exit 1
+  fi
+}
+
+ORIGINAL_PATH="${PATH}"
+plugin_dir="${ROOT_DIR}/integrations/grok-plugin"
+
+# Clean homes and canonical packages install from repository#subdirectory.
+make_fake_grok clean-home
+export FAKE_GROK_LIST='[]'
+"${INSTALLER}"
+assert_contains "plugin install --trust ${ROOT_DIR}#integrations/grok-plugin" "${FAKE_GROK_LOG}"
+
+# Invalid host inventory must fail closed before an install or uninstall.
+make_fake_grok invalid-inventory
+export FAKE_GROK_LIST='not-json'
+if "${INSTALLER}" >"${TMP_DIR}/invalid-inventory.out" 2>"${TMP_DIR}/invalid-inventory.err"; then
+  echo 'expected invalid inventory to fail closed' >&2
+  exit 1
+else
+  status=$?
+  [[ "${status}" -eq 65 ]] || { echo "expected exit 65, got ${status}" >&2; exit 1; }
+fi
+assert_not_contains 'plugin uninstall' "${FAKE_GROK_LOG}"
+assert_not_contains 'plugin install' "${FAKE_GROK_LOG}"
+
+make_fake_grok canonical
+export FAKE_GROK_LIST='[{"name":"traceary-grok","repo_key":"grok-plugin-a","source":"/repo"}]'
+"${INSTALLER}"
+assert_contains 'plugin uninstall traceary-grok' "${FAKE_GROK_LOG}"
+assert_contains "plugin install --trust ${ROOT_DIR}#integrations/grok-plugin" "${FAKE_GROK_LOG}"
+
+# A previous install from the plugin subdirectory must not be removed implicitly.
+make_fake_grok local-repository
+export FAKE_GROK_LIST="[{\"name\":\"traceary\",\"repo_key\":\"grok-plugin-4d1bd2fe\",\"source\":\"${plugin_dir}\"}]"
+if "${INSTALLER}" >"${TMP_DIR}/local-repository.out" 2>"${TMP_DIR}/local-repository.err"; then
+  echo 'expected local repository identity to require explicit migration' >&2
+  exit 1
+else
+  status=$?
+  [[ "${status}" -eq 78 ]] || { echo "expected exit 78, got ${status}" >&2; exit 1; }
+fi
+assert_not_contains 'plugin uninstall' "${FAKE_GROK_LOG}"
+assert_contains '--migrate-local-repo-identity' "${TMP_DIR}/local-repository.err"
+
+# The explicit flag removes only the exact checkout-local identity, then uses
+# the canonical source selector. An unrelated legacy traceary package remains.
+make_fake_grok migrate
+export FAKE_GROK_LIST="[{\"name\":\"traceary\",\"repo_key\":\"grok-plugin-4d1bd2fe\",\"source\":\"${plugin_dir}\"},{\"name\":\"traceary\",\"repo_key\":\"marketplace-traceary\",\"source\":\"duck8823/traceary\"}]"
+"${INSTALLER}" --migrate-local-repo-identity
+assert_contains 'plugin uninstall --confirm traceary' "${FAKE_GROK_LOG}"
+assert_contains "plugin install --trust ${ROOT_DIR}#integrations/grok-plugin" "${FAKE_GROK_LOG}"
+
+# A legacy package from a different source is never selected for migration.
+make_fake_grok legacy
+export FAKE_GROK_LIST='[{"name":"traceary","repo_key":"marketplace-traceary","source":"duck8823/traceary"}]'
+"${INSTALLER}"
+assert_not_contains 'plugin uninstall traceary' "${FAKE_GROK_LOG}"
+assert_contains "plugin install --trust ${ROOT_DIR}#integrations/grok-plugin" "${FAKE_GROK_LOG}"
+
+echo 'OK: Grok installer separates package names from local-repository identities'

--- a/scripts/verify-grok-plugin-clean-home.sh
+++ b/scripts/verify-grok-plugin-clean-home.sh
@@ -32,7 +32,7 @@ echo "== install (clean home) =="
 if grok plugin list --json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"traceary-grok"'; then
   grok plugin uninstall "${PLUGIN_NAME}" || true
 fi
-grok plugin install --trust "${PLUGIN_DIR}"
+grok plugin install --trust "${ROOT_DIR}#integrations/grok-plugin"
 
 echo "== details =="
 grok plugin details "${PLUGIN_NAME}"
@@ -44,7 +44,7 @@ echo "== reinstall (update path) =="
 # Host rejects double install of the same local path; uninstall then install
 # models the post-upgrade refresh path operators use after a binary bump.
 grok plugin uninstall "${PLUGIN_NAME}"
-grok plugin install --trust "${PLUGIN_DIR}"
+grok plugin install --trust "${ROOT_DIR}#integrations/grok-plugin"
 grok plugin details "${PLUGIN_NAME}"
 
 echo "== doctor native plugin checks =="


### PR DESCRIPTION
## Motivation

Grok treats a checkout installed without the repository subdirectory selector as a local-repository identity. That conflicts with the canonical `traceary-grok` package during v0.32.1 plugin refresh.

Closes #1538

## Changes

- install canonical Grok package from `repository#integrations/grok-plugin`
- stop non-destructively for the old local-repository identity; migrate only with an explicit, source-bounded flag
- diagnose package name and local repository identity separately without reading payloads
- add clean-home, migration contract, doctor, and documentation coverage

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go tool golangci-lint run`
- `go run ./cmd/repo-tooling integrations verify`
- `go run ./cmd/repo-tooling docs verify-i18n`
- `./scripts/test-install-grok-plugin.sh`
- `./scripts/verify-grok-plugin-clean-home.sh`
- `git diff --check`
