### PR TITLE
fix: bound large-store metadata list

### DIFF
--- a/.ai/spec/1541.md
+++ b/.ai/spec/1541.md
@@ -17,7 +17,7 @@ concurrent writer is absent.
 
 | Concept | Boundary | Observable outcome |
 | --- | --- | --- |
-| Bounded latest metadata | `limit=1`, `offset=0`, no filters, no `message` field | read-only query returns the newest event metadata without store initialization |
+| Bounded latest metadata | `limit=1`, `offset=0`, no explicit filters other than the CLI's resolved current-workspace scope, no `message` field | read-only query returns the newest scoped event metadata without store initialization |
 | Full/body-bearing list | any message request, wide output, sensitive classification, or non-bounded intent | existing initialization and full Event path remain unchanged |
 | Busy/lock | SQLite cannot acquire its configured read lock | a bounded SQLite busy/locked error after the existing short busy window; not reported as a slow scan |
 | Slow-path avoidance | initialization/catch-up or global normalization sort | absent from bounded latest metadata path; query plan uses `idx_events_created_at` |
@@ -42,7 +42,9 @@ read, spool read, or transaction write is introduced. A busy/locked result is
 left distinct from a slow initialization path. Read-only connections have no
 rollback obligation; the existing `ListWindowMetadata` transaction retains its
 deferred rollback behavior. Reverting this change restores the former full
-initialization path and does not modify database contents or sidecars.
+initialization path and does not modify database contents. SQLite can recreate
+WAL shared-memory sidecars while a read-only connection observes a WAL store;
+that transient filesystem effect is not a Traceary data mutation.
 
 ## Verification
 

--- a/.ai/spec/1541.md
+++ b/.ai/spec/1541.md
@@ -1,0 +1,56 @@
+# #1541 Bounded large-store metadata list
+
+## Problem and intent
+
+On a live 4.09 GiB Traceary store, the body-free operator command
+`traceary list --limit 1 --fields ts,kind --color never` took about ten
+seconds. Its output is one metadata row, so this is not an output-volume
+problem. The command previously entered the normal store initialization path
+(migrations and workspace-observation catch-up) and then used a timestamp
+normalization order that can require a whole-store sort.
+
+The list intent here is **bounded latest metadata**: one unfiltered, body-free
+row. It is not a request to repair a store, read a payload, or establish that a
+concurrent writer is absent.
+
+## Concept model
+
+| Concept | Boundary | Observable outcome |
+| --- | --- | --- |
+| Bounded latest metadata | `limit=1`, `offset=0`, no filters, no `message` field | read-only query returns the newest event metadata without store initialization |
+| Full/body-bearing list | any message request, wide output, sensitive classification, or non-bounded intent | existing initialization and full Event path remain unchanged |
+| Busy/lock | SQLite cannot acquire its configured read lock | a bounded SQLite busy/locked error after the existing short busy window; not reported as a slow scan |
+| Slow-path avoidance | initialization/catch-up or global normalization sort | absent from bounded latest metadata path; query plan uses `idx_events_created_at` |
+
+## Responsibilities
+
+- `presentation/cli/list.go` selects the body-free intent from requested
+  fields. It does not contain SQLite or migration policy.
+- `application/usecase.EventMetadataUsecase` remains the body-free read
+  boundary. It receives only `EventMetadata`, never an Event body.
+- `infrastructure/sqlite/EventDatasource` opens metadata reads with the
+  read-only DSN. The special query applies only to the exact bounded intent;
+  all filters retain the general boundary-correct query.
+- The bounded SQL first obtains the latest lexical timestamp through the
+  existing index, then normalizes and orders the small same-second set. This
+  avoids RFC3339Nano variable-fraction ordering errors without a global sort.
+
+## Concurrency, rollback, and safety
+
+No migration, index build, retention action, timeout extension, event-body
+read, spool read, or transaction write is introduced. A busy/locked result is
+left distinct from a slow initialization path. Read-only connections have no
+rollback obligation; the existing `ListWindowMetadata` transaction retains its
+deferred rollback behavior. Reverting this change restores the former full
+initialization path and does not modify database contents or sidecars.
+
+## Verification
+
+- A sparse 4 GiB fixture proves an unfiltered one-row metadata read completes
+  within one second without allocating a payload corpus.
+- A query-plan regression proves the bounded query uses
+  `idx_events_created_at`.
+- A fractional-second ordering regression proves the fast path remains
+  timestamp-correct.
+- CLI coverage proves text `--fields ts,kind` uses metadata and bypasses store
+  initialization; message-bearing output remains on the existing full path.

--- a/docs/operations/large-store-list.ja.md
+++ b/docs/operations/large-store-list.ja.md
@@ -1,0 +1,22 @@
+# 大容量 live store における bounded metadata list
+
+[English](large-store-list.md)
+
+大容量または書き込み中の store で、最新 event を body なしで素早く確認するには、次を実行します。
+
+```sh
+traceary list --limit 1 --fields ts,kind --color never
+```
+
+この無条件の形だけが bounded latest-metadata path を使用します。SQLite は read-only で開き、store の初期化や migration、workspace-observation catch-up は実行しません。event body、prompt、response、command payload、hook spool、credential、identifier sample も読み取りません。既存の timestamp index を使い、最新秒に属する timestamp だけを正規化して並べ替えるため、RFC3339Nano の順序を保ちながら store 全体の sort を避けます。
+
+## 結果の解釈
+
+- 1 行の出力は完了した metadata 結果であり、全 subsystem の health を保証するものではありません。
+- SQLite の `busy` または `locked` error は lock contention です。slow query とは区別します。競合 writer を停止または分離してから同じ bounded command を再実行してください。lock 対策として timeout を延長したり、`doctor --fix` を繰り返したりしません。
+- `message` の追加、`--wide`、`--sensitive`、filter の指定は通常の read path を使います。古い store では初期化され、時間がかかることがあります。bounded check の成功後だけ使用してください。
+- この command は data 削除、retention 適用、index build、SQLite sidecar の変更を行いません。capacity の確認は別操作の `traceary store gc --dry-run` を使い、retention 適用前に archive を作成してください。
+
+## ロールバック
+
+schema や data の migration はありません。release を戻すと以前の full initialization path に戻りますが、保存済み event は変更しません。

--- a/docs/operations/large-store-list.ja.md
+++ b/docs/operations/large-store-list.ja.md
@@ -8,14 +8,14 @@
 traceary list --limit 1 --fields ts,kind --color never
 ```
 
-この無条件の形だけが bounded latest-metadata path を使用します。SQLite は read-only で開き、store の初期化や migration、workspace-observation catch-up は実行しません。event body、prompt、response、command payload、hook spool、credential、identifier sample も読み取りません。既存の timestamp index を使い、最新秒に属する timestamp だけを正規化して並べ替えるため、RFC3339Nano の順序を保ちながら store 全体の sort を避けます。
+この形が bounded latest-metadata path を使用します。通常の CLI は current repository を暗黙の workspace scope として適用することがありますが、その scope も bounded path に含まれます。SQLite は read-only で開き、store の初期化や migration、workspace-observation catch-up は実行しません。event body、prompt、response、command payload、hook spool、credential、identifier sample も読み取りません。既存の timestamp index を使い、最新秒に属する timestamp だけを正規化して並べ替えるため、RFC3339Nano の順序を保ちながら store 全体の sort を避けます。
 
 ## 結果の解釈
 
 - 1 行の出力は完了した metadata 結果であり、全 subsystem の health を保証するものではありません。
 - SQLite の `busy` または `locked` error は lock contention です。slow query とは区別します。競合 writer を停止または分離してから同じ bounded command を再実行してください。lock 対策として timeout を延長したり、`doctor --fix` を繰り返したりしません。
 - `message` の追加、`--wide`、`--sensitive`、filter の指定は通常の read path を使います。古い store では初期化され、時間がかかることがあります。bounded check の成功後だけ使用してください。
-- この command は data 削除、retention 適用、index build、SQLite sidecar の変更を行いません。capacity の確認は別操作の `traceary store gc --dry-run` を使い、retention 適用前に archive を作成してください。
+- この command は data 削除、retention 適用、index build を行いません。read-only SQLite connection が WAL store を観測する際、一時的な WAL shared-memory sidecar を再作成することがありますが、Traceary の data mutation ではありません。capacity の確認は別操作の `traceary store gc --dry-run` を使い、retention 適用前に archive を作成してください。
 
 ## ロールバック
 

--- a/docs/operations/large-store-list.md
+++ b/docs/operations/large-store-list.md
@@ -1,0 +1,37 @@
+# Bounded metadata list on large live stores
+
+[日本語](large-store-list.ja.md)
+
+For a quick, body-free indication of the newest event on a large or actively
+written store, use:
+
+```sh
+traceary list --limit 1 --fields ts,kind --color never
+```
+
+This exact unfiltered shape uses the bounded latest-metadata path. It opens
+SQLite read-only, does not initialize or migrate the store, does not run the
+workspace-observation catch-up, and does not read event bodies, prompts,
+responses, command payloads, hook spools, credentials, or identifier samples.
+It uses the existing timestamp index and only normalizes timestamps that share
+the newest second, preserving correct RFC3339Nano ordering without a
+whole-store sort.
+
+## Interpret the result
+
+- A row is a completed metadata result, not a health assertion for every
+  subsystem.
+- A `busy` or `locked` SQLite error is lock contention. It is distinct from a
+  slow query: stop or isolate the competing writer, then retry the same bounded
+  command. Do not inflate timeouts or repeat `doctor --fix` as a lock remedy.
+- Adding `message`, using `--wide`, using `--sensitive`, or adding filters uses
+  the normal read path. Those forms may initialize an old store and can take
+  longer; use them only after a bounded check succeeds.
+- This command does not delete data, apply retention, build an index, or modify
+  SQLite sidecars. For capacity planning, preview the separate operation with
+  `traceary store gc --dry-run` and archive before applying retention.
+
+## Rollback
+
+The feature has no schema or data migration. Reverting the release restores the
+former full initialization path; it does not change stored events.

--- a/docs/operations/large-store-list.md
+++ b/docs/operations/large-store-list.md
@@ -9,7 +9,9 @@ written store, use:
 traceary list --limit 1 --fields ts,kind --color never
 ```
 
-This exact unfiltered shape uses the bounded latest-metadata path. It opens
+This exact shape uses the bounded latest-metadata path. The normal CLI may
+apply the current repository as an implicit workspace scope; that scope remains
+on the bounded path. It opens
 SQLite read-only, does not initialize or migrate the store, does not run the
 workspace-observation catch-up, and does not read event bodies, prompts,
 responses, command payloads, hook spools, credentials, or identifier samples.
@@ -27,8 +29,10 @@ whole-store sort.
 - Adding `message`, using `--wide`, using `--sensitive`, or adding filters uses
   the normal read path. Those forms may initialize an old store and can take
   longer; use them only after a bounded check succeeds.
-- This command does not delete data, apply retention, build an index, or modify
-  SQLite sidecars. For capacity planning, preview the separate operation with
+- This command does not delete data, apply retention, or build an index. A
+  read-only SQLite connection can recreate transient WAL shared-memory sidecars
+  while observing a WAL store; that is not a Traceary data mutation. For
+  capacity planning, preview the separate operation with
   `traceary store gc --dry-run` and archive before applying retention.
 
 ## Rollback

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -1,0 +1,113 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.ExecContext(context.Background(), `
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY,
+			kind TEXT NOT NULL,
+			client TEXT NOT NULL,
+			agent TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			source_hook TEXT,
+			created_at TEXT NOT NULL,
+			body_original_bytes INTEGER,
+			body_stored_bytes INTEGER NOT NULL,
+			body_ingest_truncated BOOLEAN,
+			body_storage_truncated BOOLEAN,
+			body_metadata_version INTEGER
+		);
+		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
+		CREATE INDEX idx_events_created_at ON events(created_at DESC, id DESC);
+	`); err != nil {
+		t.Fatalf("create query-plan fixture: %v", err)
+	}
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastQuery)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	plan := make([]string, 0)
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_created_at") {
+		t.Fatalf("bounded latest query does not use created_at index:\n%s", joined)
+	}
+}
+
+func TestEventMetadataQuery_BoundedLatestReportsBusyInsteadOfSlowInitialization(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	setup, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open setup error = %v", err)
+	}
+	if _, err := setup.ExecContext(context.Background(), `
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
+			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
+			source_hook TEXT, created_at TEXT NOT NULL, body_original_bytes INTEGER,
+			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
+			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
+		);
+		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
+		CREATE INDEX idx_events_created_at ON events(created_at DESC, id DESC);
+	`); err != nil {
+		_ = setup.Close()
+		t.Fatalf("create busy fixture: %v", err)
+	}
+	if err := setup.Close(); err != nil {
+		t.Fatalf("setup.Close() error = %v", err)
+	}
+
+	locker, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open locker error = %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	if _, err := locker.ExecContext(context.Background(), "BEGIN EXCLUSIVE"); err != nil {
+		t.Fatalf("BEGIN EXCLUSIVE error = %v", err)
+	}
+	defer func() { _, _ = locker.ExecContext(context.Background(), "ROLLBACK") }()
+
+	sut := NewEventDatasource(NewDatabase(dbPath, nil))
+	started := time.Now()
+	_, err = sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Build())
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("ListRecentMetadata() error = nil, want SQLite busy/locked outcome")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "busy") && !strings.Contains(strings.ToLower(err.Error()), "locked") {
+		t.Fatalf("ListRecentMetadata() error = %v, want busy/locked classification", err)
+	}
+	if elapsed < 800*time.Millisecond || elapsed >= 2*time.Second {
+		t.Fatalf("busy metadata read elapsed = %s, want configured short busy outcome", elapsed)
+	}
+}

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -38,6 +38,7 @@ func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
 		);
 		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
 		CREATE INDEX idx_events_created_at ON events(created_at DESC, id DESC);
+		CREATE INDEX idx_events_workspace_created_at ON events(workspace, created_at DESC, id DESC);
 	`); err != nil {
 		t.Fatalf("create query-plan fixture: %v", err)
 	}
@@ -60,6 +61,48 @@ func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
 	}
 	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_created_at") {
 		t.Fatalf("bounded latest query does not use created_at index:\n%s", joined)
+	}
+}
+
+func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.ExecContext(context.Background(), `
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
+			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
+			source_hook TEXT, created_at TEXT NOT NULL, body_original_bytes INTEGER,
+			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
+			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
+		);
+		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
+		CREATE INDEX idx_events_workspace_created_at ON events(workspace, created_at DESC, id DESC);
+	`); err != nil {
+		t.Fatalf("create workspace query-plan fixture: %v", err)
+	}
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastByWorkspaceQuery, "repo-current", "repo-current")
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	plan := make([]string, 0)
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_workspace_created_at") {
+		t.Fatalf("bounded workspace query does not use workspace timestamp index:\n%s", joined)
 	}
 }
 

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -22,6 +22,9 @@ var selectRecentEventMetadataQuery string
 //go:embed sql/select_latest_event_metadata_fast.sql
 var selectLatestEventMetadataFastQuery string
 
+//go:embed sql/select_latest_event_metadata_fast_by_workspace.sql
+var selectLatestEventMetadataFastByWorkspaceQuery string
+
 //go:embed sql/select_recent_event_metadata_by_source_hook.sql
 var selectRecentEventMetadataBySourceHookQuery string
 
@@ -455,8 +458,14 @@ func queryRecentEventMetadataWith(
 ) (*sql.Rows, error) {
 	sourceHook := criteria.SourceHook()
 	failuresFlag := boolToInt(criteria.FailuresOnly())
-	if isBoundedLatestMetadataCriteria(criteria, fromValue, toValue, limit, offset) {
-		rows, err := query(ctx, selectLatestEventMetadataFastQuery)
+	if boundedLatest, workspace := boundedLatestMetadataWorkspace(criteria, fromValue, toValue, limit, offset); boundedLatest {
+		queryText := selectLatestEventMetadataFastQuery
+		args := []any(nil)
+		if workspace != "" {
+			queryText = selectLatestEventMetadataFastByWorkspaceQuery
+			args = []any{workspace, workspace}
+		}
+		rows, err := query(ctx, queryText, args...)
 		if err != nil {
 			return nil, xerrors.Errorf("query bounded latest event metadata: %w", err)
 		}
@@ -528,18 +537,19 @@ func queryRecentEventMetadataWith(
 	return rows, nil
 }
 
-// isBoundedLatestMetadataCriteria identifies the single-row, body-free CLI
+// boundedLatestMetadataWorkspace identifies the single-row, body-free CLI
 // inspection intent that can use the existing created_at index without a
-// store-wide timestamp normalization sort. Filters deliberately stay on the
-// general, boundary-complete query path.
-func isBoundedLatestMetadataCriteria(criteria apptypes.EventListCriteria, fromValue, toValue string, limit, offset int) bool {
-	return limit == 1 && offset == 0 &&
+// store-wide timestamp normalization sort. The normal CLI resolves a current
+// repository to Workspace, so that one implicit filter belongs to the bounded
+// intent. Other filters retain the general, boundary-complete query path.
+func boundedLatestMetadataWorkspace(criteria apptypes.EventListCriteria, fromValue, toValue string, limit, offset int) (bool, string) {
+	bounded := limit == 1 && offset == 0 &&
 		criteria.Kind() == "" &&
 		criteria.Client() == "" &&
 		criteria.Agent() == "" &&
 		criteria.SessionID() == "" &&
-		criteria.Workspace() == "" &&
 		!criteria.FailuresOnly() &&
 		criteria.SourceHook() == "" &&
 		fromValue == "" && toValue == ""
+	return bounded, criteria.Workspace().String()
 }

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -19,6 +19,9 @@ import (
 //go:embed sql/select_recent_event_metadata.sql
 var selectRecentEventMetadataQuery string
 
+//go:embed sql/select_latest_event_metadata_fast.sql
+var selectLatestEventMetadataFastQuery string
+
 //go:embed sql/select_recent_event_metadata_by_source_hook.sql
 var selectRecentEventMetadataBySourceHookQuery string
 
@@ -42,7 +45,7 @@ func (d *EventDatasource) ListRecentMetadata(
 		return nil, err
 	}
 
-	db, err := d.db.open(ctx)
+	db, err := d.db.openReadOnly(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event metadata listing: %w", err)
 	}
@@ -72,7 +75,7 @@ func (d *EventDatasource) ListWindowMetadata(
 		return nil, err
 	}
 
-	db, err := d.db.open(ctx)
+	db, err := d.db.openReadOnly(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event metadata window: %w", err)
 	}
@@ -136,7 +139,7 @@ func (d *EventDatasource) SearchMetadata(
 		return nil, xerrors.Errorf("from must be earlier than to")
 	}
 
-	db, err := d.db.open(ctx)
+	db, err := d.db.openReadOnly(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event metadata search: %w", err)
 	}
@@ -185,7 +188,7 @@ func (d *EventDatasource) GetContextMetadata(
 		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
 	}
 
-	db, err := d.db.open(ctx)
+	db, err := d.db.openReadOnly(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event metadata context: %w", err)
 	}
@@ -452,6 +455,13 @@ func queryRecentEventMetadataWith(
 ) (*sql.Rows, error) {
 	sourceHook := criteria.SourceHook()
 	failuresFlag := boolToInt(criteria.FailuresOnly())
+	if isBoundedLatestMetadataCriteria(criteria, fromValue, toValue, limit, offset) {
+		rows, err := query(ctx, selectLatestEventMetadataFastQuery)
+		if err != nil {
+			return nil, xerrors.Errorf("query bounded latest event metadata: %w", err)
+		}
+		return rows, nil
+	}
 	if sourceHook == "" {
 		rows, err := query(
 			ctx,
@@ -516,4 +526,20 @@ func queryRecentEventMetadataWith(
 		return nil, xerrors.Errorf("query recent event metadata by source hook: %w", err)
 	}
 	return rows, nil
+}
+
+// isBoundedLatestMetadataCriteria identifies the single-row, body-free CLI
+// inspection intent that can use the existing created_at index without a
+// store-wide timestamp normalization sort. Filters deliberately stay on the
+// general, boundary-complete query path.
+func isBoundedLatestMetadataCriteria(criteria apptypes.EventListCriteria, fromValue, toValue string, limit, offset int) bool {
+	return limit == 1 && offset == 0 &&
+		criteria.Kind() == "" &&
+		criteria.Client() == "" &&
+		criteria.Agent() == "" &&
+		criteria.SessionID() == "" &&
+		criteria.Workspace() == "" &&
+		!criteria.FailuresOnly() &&
+		criteria.SourceHook() == "" &&
+		fromValue == "" && toValue == ""
 }

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -70,6 +70,84 @@ func TestEventMetadataQuery_ListRecentDoesNotHydrateBody(t *testing.T) {
 	}
 }
 
+func TestEventMetadataQuery_BoundedLatestUsesCreatedAtIndexAndKeepsTimestampOrder(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	// given: RFC3339Nano's lexical ordering puts an exact-second `Z` after a
+	// fractional timestamp in the same second. The bounded query must still
+	// return the real latest event while using the existing created_at index to
+	// avoid a store-wide timestamp-normalization sort.
+	base := time.Date(2026, 7, 25, 1, 2, 3, 0, time.UTC)
+	for _, event := range []*model.Event{
+		newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "ws", "body", base.Add(-time.Second)),
+		newEventForSQLiteTest(t, "event-exact", "cli", "codex", "session-1", "ws", "body", base),
+		newEventForSQLiteTest(t, "event-fraction", "cli", "codex", "session-1", "ws", "body", base.Add(500*time.Millisecond)),
+	} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+
+	got, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata() error = %v", err)
+	}
+	if len(got) != 1 || got[0].EventID().String() != "event-fraction" {
+		t.Fatalf("bounded latest metadata = %#v, want event-fraction", got)
+	}
+
+}
+
+func TestEventMetadataQuery_BoundedLatestRespondsOnSparseFourGiBStore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if err := sut.Save(context.Background(), newEventForSQLiteTest(
+		t,
+		"event-large-store",
+		"cli",
+		"codex",
+		"session-1",
+		"ws",
+		strings.Repeat("body-not-read-", 1024),
+		time.Date(2026, 7, 25, 2, 0, 0, 0, time.UTC),
+	)); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	// A sparse extent models the operator-visible multi-gigabyte file size
+	// without allocating or reading a payload corpus. SQLite's logical page
+	// count remains tiny; the test proves this bounded read does not scan the
+	// appended sparse region or initialize/migrate the store.
+	if err := os.Truncate(dbPath, 4<<30); err != nil {
+		t.Fatalf("Truncate sparse fixture: %v", err)
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat sparse fixture: %v", err)
+	}
+	if info.Size() != 4<<30 {
+		t.Fatalf("sparse fixture size = %d, want %d", info.Size(), int64(4<<30))
+	}
+
+	started := time.Now()
+	got, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded large-store metadata list took %s, want <= 1s", elapsed)
+	}
+	if len(got) != 1 || got[0].EventID().String() != "event-large-store" {
+		t.Fatalf("bounded metadata list = %#v, want event-large-store", got)
+	}
+}
+
 func TestEventMetadataQuery_AllocationDoesNotScaleWithStoredBody(t *testing.T) {
 	// Repeating the query reduces one-off allocator noise. The 512 KiB margin is
 	// deliberately far below the 8 MiB body, so accidentally hydrating the body

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -83,16 +83,19 @@ func TestEventMetadataQuery_BoundedLatestUsesCreatedAtIndexAndKeepsTimestampOrde
 	// avoid a store-wide timestamp-normalization sort.
 	base := time.Date(2026, 7, 25, 1, 2, 3, 0, time.UTC)
 	for _, event := range []*model.Event{
-		newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "ws", "body", base.Add(-time.Second)),
-		newEventForSQLiteTest(t, "event-exact", "cli", "codex", "session-1", "ws", "body", base),
-		newEventForSQLiteTest(t, "event-fraction", "cli", "codex", "session-1", "ws", "body", base.Add(500*time.Millisecond)),
+		newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "repo-current", "body", base.Add(-time.Second)),
+		newEventForSQLiteTest(t, "event-exact", "cli", "codex", "session-1", "repo-current", "body", base),
+		newEventForSQLiteTest(t, "event-fraction", "cli", "codex", "session-1", "repo-current", "body", base.Add(500*time.Millisecond)),
 	} {
 		if err := sut.Save(context.Background(), event); err != nil {
 			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
 		}
 	}
 
-	got, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Build())
+	// The CLI supplies this workspace implicitly when it runs inside a
+	// repository. It must remain eligible for the bounded query.
+	criteria := apptypes.NewEventListCriteriaBuilder(1).Workspace(types.Workspace("repo-current")).Build()
+	got, err := sut.ListRecentMetadata(context.Background(), criteria)
 	if err != nil {
 		t.Fatalf("ListRecentMetadata() error = %v", err)
 	}

--- a/infrastructure/sqlite/sql/select_latest_event_metadata_fast.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_metadata_fast.sql
@@ -1,0 +1,30 @@
+-- This bounded fast path is used only for an unfiltered first-page metadata
+-- read (`limit=1, offset=0`). The existing created_at index locates the
+-- newest timestamp-second without touching event bodies. RFC3339Nano's
+-- variable fractional-width text form is not globally time-sortable, so the
+-- outer query reorders only rows in that one second by ts_norm().
+--
+-- This keeps the historical boundary-correct timestamp contract while avoiding
+-- a full-store ts_norm() sort for `traceary list --limit 1 --fields ts,kind`.
+WITH latest_lexical AS (
+    SELECT created_at
+      FROM events
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1
+), latest_second AS (
+    SELECT substr(created_at, 1, 19) AS second_prefix
+      FROM latest_lexical
+)
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+  JOIN latest_second s
+ WHERE e.created_at >= s.second_prefix || '.'
+   AND e.created_at <= s.second_prefix || 'Z'
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
@@ -1,0 +1,29 @@
+-- The common CLI path resolves the current repository as an implicit
+-- workspace filter. Keep that filter inside the bounded latest-metadata
+-- query; otherwise a normal invocation would silently fall back to the slow
+-- general query. The workspace/created_at index or the created_at index can
+-- locate the lexical latest candidate without reading event bodies.
+WITH latest_lexical AS (
+    SELECT created_at
+      FROM events
+     WHERE workspace = ?
+     ORDER BY created_at DESC, id DESC
+     LIMIT 1
+), latest_second AS (
+    SELECT substr(created_at, 1, 19) AS second_prefix
+      FROM latest_lexical
+)
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+  JOIN latest_second s
+ WHERE e.workspace = ?
+   AND e.created_at >= s.second_prefix || '.'
+   AND e.created_at <= s.second_prefix || 'Z'
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT 1

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -47,11 +47,14 @@ func writeEventMetadataByFormat(output io.Writer, metadata []apptypes.EventMetad
 	}
 	if len(metadata) == 0 {
 		_, err := io.WriteString(output, Localize("No matching records.\n", "一致する記録はありません。\n"))
-		return err
+		if err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print empty list message", "空一覧メッセージの出力に失敗しました"), err)
+		}
+		return nil
 	}
 	for _, event := range metadata {
 		if _, err := io.WriteString(output, formatEventMetadataCompactRow(event, opts)+"\n"); err != nil {
-			return err
+			return xerrors.Errorf("%s: %w", Localize("failed to print event row", "イベント一覧行の出力に失敗しました"), err)
 		}
 	}
 	return nil

--- a/presentation/cli/event_json.go
+++ b/presentation/cli/event_json.go
@@ -41,6 +41,22 @@ func writeEventMetadataJSONFields(output io.Writer, metadata []apptypes.EventMet
 	return writeJSON(output, serializedEvents)
 }
 
+func writeEventMetadataByFormat(output io.Writer, metadata []apptypes.EventMetadata, asJSON bool, opts eventTextFormatOptions) error {
+	if asJSON {
+		return writeEventMetadataJSONFields(output, metadata, opts.fields)
+	}
+	if len(metadata) == 0 {
+		_, err := io.WriteString(output, Localize("No matching records.\n", "一致する記録はありません。\n"))
+		return err
+	}
+	for _, event := range metadata {
+		if _, err := io.WriteString(output, formatEventMetadataCompactRow(event, opts)+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func newEventFieldsOutput(event *model.Event, fields []readFieldID, extras compactRowExtras) map[string]any {
 	result := make(map[string]any, len(fields))
 	for _, field := range fields {

--- a/presentation/cli/event_metadata_projection_test.go
+++ b/presentation/cli/event_metadata_projection_test.go
@@ -89,7 +89,9 @@ func TestRootCLI_ListJSONFieldsUsesMetadataProjection(t *testing.T) {
 }
 
 func TestRootCLI_ListTextMetadataFieldsSkipsStoreInitialization(t *testing.T) {
-	t.Parallel()
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) { return "duck8823/traceary", nil })
+	t.Cleanup(cli.ResetDetectRepoContextFunc)
 
 	store := &storeManagementUsecaseStub{initErr: fmt.Errorf("initialization must not run")}
 	full := &eventUsecaseStub{}
@@ -112,6 +114,9 @@ func TestRootCLI_ListTextMetadataFieldsSkipsStoreInitialization(t *testing.T) {
 	}
 	if full.listCalls != 0 || metadataUsecase.listCalls != 1 {
 		t.Fatalf("full List() calls = %d, metadata List() calls = %d", full.listCalls, metadataUsecase.listCalls)
+	}
+	if got, want := metadataUsecase.listCriteria.Workspace().String(), "duck8823/traceary"; got != want {
+		t.Fatalf("implicit metadata workspace = %q, want %q", got, want)
 	}
 	if got, want := stdout.String(), "06:00:00  command_executed\n"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)

--- a/presentation/cli/event_metadata_projection_test.go
+++ b/presentation/cli/event_metadata_projection_test.go
@@ -88,6 +88,36 @@ func TestRootCLI_ListJSONFieldsUsesMetadataProjection(t *testing.T) {
 	}
 }
 
+func TestRootCLI_ListTextMetadataFieldsSkipsStoreInitialization(t *testing.T) {
+	t.Parallel()
+
+	store := &storeManagementUsecaseStub{initErr: fmt.Errorf("initialization must not run")}
+	full := &eventUsecaseStub{}
+	metadataUsecase := &eventMetadataUsecaseStub{listMetadata: []apptypes.EventMetadata{newCLIMetadataFixture(t, "event-text-metadata")}}
+	stdout := &bytes.Buffer{}
+	rootCmd := cli.NewRootCLI(
+		cli.WithStoreManagement(store),
+		cli.WithEvent(full),
+		cli.WithEventMetadata(metadataUsecase),
+	).Command()
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"list", "--db-path", "/tmp/test-traceary.db", "--limit", "1", "--fields", "ts,kind", "--color", "never", "--utc"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if store.initCalled {
+		t.Fatal("metadata-only text list initialized the store")
+	}
+	if full.listCalls != 0 || metadataUsecase.listCalls != 1 {
+		t.Fatalf("full List() calls = %d, metadata List() calls = %d", full.listCalls, metadataUsecase.listCalls)
+	}
+	if got, want := stdout.String(), "06:00:00  command_executed\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
 func TestRootCLI_SearchJSONFieldsUsesMetadataProjection(t *testing.T) {
 	t.Setenv("TRACEARY_WORKSPACE", "")
 	cli.SetDetectRepoContextFunc(func(context.Context) (string, error) { return "", nil })

--- a/presentation/cli/event_output_test.go
+++ b/presentation/cli/event_output_test.go
@@ -1,9 +1,18 @@
 package cli
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
 )
+
+var errMetadataOutput = errors.New("metadata output failed")
+
+type metadataFailingWriter struct{}
+
+func (metadataFailingWriter) Write([]byte) (int, error) { return 0, errMetadataOutput }
 
 func TestTruncateMessage(t *testing.T) {
 	t.Parallel()
@@ -57,6 +66,31 @@ func TestTruncateMessage(t *testing.T) {
 			got := truncateMessage(tt.in)
 			if got != tt.want {
 				t.Errorf("truncateMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteEventMetadataByFormatWrapsOutputErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata []apptypes.EventMetadata
+		wantText string
+	}{
+		{name: "empty list", wantText: "failed to print empty list message"},
+		{name: "metadata row", metadata: []apptypes.EventMetadata{{}}, wantText: "failed to print event row"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := writeEventMetadataByFormat(metadataFailingWriter{}, tt.metadata, false, eventTextFormatOptions{fields: []readFieldID{readFieldKind}})
+			if !errors.Is(err, errMetadataOutput) {
+				t.Fatalf("error = %v, want wrapped output error", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("error = %v, want context %q", err, tt.wantText)
 			}
 		})
 	}

--- a/presentation/cli/event_text_formatter.go
+++ b/presentation/cli/event_text_formatter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mattn/go-runewidth"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -54,6 +55,58 @@ type eventTextFormatOptions struct {
 	// so legacy non-interactive compact output keeps its historical minimum
 	// message floor even when metadata columns are unusually wide.
 	hardTargetWidth bool
+}
+
+// formatEventMetadataCompactRow renders a message-free compact row without
+// constructing a domain Event or loading an event body. It is deliberately
+// limited to field sets that do not include message; callers keep the full
+// event path for body-bearing output.
+func formatEventMetadataCompactRow(event apptypes.EventMetadata, opts eventTextFormatOptions) string {
+	fields := opts.fields
+	if len(fields) == 0 {
+		fields = defaultReadFields
+	}
+	tokens := make([]string, len(fields))
+	for i, field := range fields {
+		tokens[i] = renderMetadataCompactToken(event, field, opts)
+	}
+	plain := strings.Join(tokens, "  ")
+	if opts.colorEnabled {
+		exitCode := types.None[int]()
+		if audit, ok := event.CommandAudit().Value(); ok {
+			exitCode = audit.ExitCode()
+		}
+		code, set := exitCode.Value()
+		return applyCompactRowHighlight(plain, string(event.Kind()), code, set)
+	}
+	return plain
+}
+
+func renderMetadataCompactToken(event apptypes.EventMetadata, id readFieldID, opts eventTextFormatOptions) string {
+	switch id {
+	case readFieldTS:
+		return formatTextTimestamp(event.CreatedAt(), opts, eventCompactTimeLayout)
+	case readFieldKind:
+		return string(event.Kind())
+	case readFieldSession:
+		return "sess=" + compactSessionID(event.SessionID().String())
+	case readFieldWorkspace:
+		return "ws=" + compactWorkspace(event.Workspace().String())
+	case readFieldClient:
+		return "client=" + formatOptionalColumn(event.Client().String())
+	case readFieldAgent:
+		return "agent=" + formatOptionalColumn(event.Agent().String())
+	case readFieldExitCode:
+		if audit, ok := event.CommandAudit().Value(); ok {
+			return "exit=" + formatOptionalExitCode(audit.ExitCode())
+		}
+		return "exit=-"
+	case readFieldEventID:
+		return "id=" + event.EventID().String()
+	case readFieldSourceHook:
+		return "hook=" + formatOptionalColumn(event.SourceHook())
+	}
+	return ""
 }
 
 // compactRowExtras carries hydrated data that a specific field needs but is

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -109,12 +109,6 @@ func (c *RootCLI) newListCommand() *cobra.Command {
 }
 
 func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.Writer, input listCommandInput) error {
-	if c.storeManagement == nil {
-		return xerrors.New(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
-	}
-	if c.event == nil {
-		return xerrors.New(Localize("list events query service is not configured", "イベント一覧クエリサービスが設定されていません"))
-	}
 	if input.limit <= 0 {
 		return xerrors.New(Localize("limit must be greater than or equal to 1", "limit は 1 以上である必要があります"))
 	}
@@ -153,9 +147,6 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
 	}
 	c.applyDatabasePath(resolvedDBPath)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
-	}
 
 	fetchLimit := input.limit
 	if input.sensitiveOnly {
@@ -185,7 +176,8 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 	if err != nil {
 		return err
 	}
-	if input.asJSON && input.fieldsSet && !readFieldsContain(resolvedFields, readFieldMessage) && !input.sensitiveOnly {
+	metadataOnly := !input.sensitiveOnly && !input.wide && !readFieldsContain(resolvedFields, readFieldMessage) && (!input.asJSON || input.fieldsSet)
+	if metadataOnly {
 		if c.eventMetadata == nil {
 			return xerrors.New(Localize("event metadata query service is not configured", "イベントメタデータクエリサービスが設定されていません"))
 		}
@@ -193,10 +185,35 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		if err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to list event metadata", "イベントメタデータ一覧の取得に失敗しました"), err)
 		}
-		if err := writeEventMetadataJSONFields(output, metadata, resolvedFields); err != nil {
+		colorMode, err := resolveColorMode(
+			input.color,
+			input.colorSet,
+			c.defaultReadColor,
+			input.asJSON,
+			func() bool { return isTerminalWriter(output) },
+		)
+		if err != nil {
+			return err
+		}
+		if err := writeEventMetadataByFormat(output, metadata, input.asJSON, eventTextFormatOptions{
+			utc:          input.utc,
+			location:     input.location,
+			fields:       resolvedFields,
+			colorEnabled: colorMode == colorModeOn,
+			targetWidth:  terminalWidthOf(output),
+		}); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print event list", "一覧出力に失敗しました"), err)
 		}
 		return nil
+	}
+	if c.storeManagement == nil {
+		return xerrors.New(Localize("initialize store usecase is not configured", "ストア初期化ユースケースが設定されていません"))
+	}
+	if c.event == nil {
+		return xerrors.New(Localize("list events query service is not configured", "イベント一覧クエリサービスが設定されていません"))
+	}
+	if err := c.storeManagement.Initialize(ctx); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
 	}
 	events, err := c.event.List(ctx, criteria)
 	if err != nil {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -108,12 +108,14 @@ type eventMetadataUsecaseStub struct {
 	searchErr       error
 	contextErr      error
 	listCalls       int
+	listCriteria    apptypes.EventListCriteria
 	searchCalls     int
 	contextCalls    int
 }
 
-func (s *eventMetadataUsecaseStub) List(_ context.Context, _ apptypes.EventListCriteria) ([]apptypes.EventMetadata, error) {
+func (s *eventMetadataUsecaseStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error) {
 	s.listCalls++
+	s.listCriteria = criteria
 	return s.listMetadata, s.listErr
 }
 


### PR DESCRIPTION
Motivation: one-row body-free list initialized the store and could normalize-sort the whole live store. This PR uses the metadata boundary, read-only SQLite, and an indexed timestamp-correct bounded query. It adds 4 GiB sparse, query-plan, busy/lock, projection tests and EN/JA operator guidance.

Validation: go build ./...; go vet ./...; go test ./...; go tool golangci-lint run; docs verify-i18n; integrations verify; smoke post-upgrade-plugin-refresh.

Closes #1541