### PR TITLE
fix: bound metadata-only list latency on large stores

### DIFF
--- a/.ai/spec/1544.md
+++ b/.ai/spec/1544.md
@@ -46,6 +46,8 @@
 | --- | --- | --- | --- |
 | Legacy workspace index | scoped bounded query is explained | no CTE temporary sort for `id` tie breaker | SQLite query-plan regression |
 | Exact second | newest scoped row has `.0` timestamp | bounded query returns it | SQLite behavior regression |
+| Filter and pagination | bounded-looking fields with a limit, offset, or filter | existing metadata list path retains its semantics | CLI regression |
+| Fractional ordering | exact and fractional values share a second | `ts_norm()` selects the later fractional value | SQLite behavior regression |
 | Repository context | normal CLI metadata list | workspace scope remains forwarded and store initialization is skipped | CLI regression (existing coverage) |
 
 ### Risks / rollback

--- a/.ai/spec/1544.md
+++ b/.ai/spec/1544.md
@@ -1,0 +1,59 @@
+# #1544 Bounded workspace metadata-list latency
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **目的:** 大容量 DB で通常の repository cwd から実行する metadata-only の
+  `traceary list --limit 1 --fields ts,kind --color never` を、本文を読まずに
+  bounded read として完了させる。
+- **現状:** current repository は暗黙の workspace scope になる。既存 DB の
+  `idx_events_workspace_created_at(workspace, created_at)` に対して、bounded SQL
+  の CTE が `id` まで順序指定していたため、SQLite が scoped rows 全体を
+  temporary B-tree で並べ替えていた。
+- **期待する振る舞い:** CTE は legacy index だけで最新 timestamp を選び、
+  outer query がその一秒だけを `ts_norm()` で最終順序付けする。exact-second
+  timestamp も返す。
+- **非対象:** retention/apply、doctor fix、migration/index build、本文/prompt/
+  response の read、通常 list の filter semantics の変更。
+
+### Conceptual model
+
+| Concept | State | Behavior | Invariant |
+| --- | --- | --- | --- |
+| Bounded scoped latest metadata | one row, implicit workspace | legacy index selects latest timestamp second | full workspace sort is not allowed |
+| Same-second ordering | exact and fractional RFC3339Nano values | outer query uses `ts_norm()` then `id` | timestamp order remains correct |
+| General list | any non-bounded criteria | existing general query remains in use | workspace/filter semantics do not change |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason |
+| --- | --- | --- |
+| Decide bounded CLI intent | `presentation/cli/list.go` | presentation selection remains unchanged |
+| Preserve body-free boundary | `EventMetadataUsecase` | only metadata crosses the application boundary |
+| Select latest scoped timestamp efficiently | workspace bounded SQL | SQLite index detail belongs in infrastructure |
+
+### Boundaries / interfaces
+
+| Boundary | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| CLI to metadata usecase | normal list | implicit repository workspace | existing metadata errors |
+| metadata datasource to SQLite | metadata usecase | legacy-index-compatible CTE | existing read-only SQLite errors |
+
+### Behavior tests and TDD plan
+
+| Behavior | Given / When | Then | Level |
+| --- | --- | --- | --- |
+| Legacy workspace index | scoped bounded query is explained | no CTE temporary sort for `id` tie breaker | SQLite query-plan regression |
+| Exact second | newest scoped row has `.0` timestamp | bounded query returns it | SQLite behavior regression |
+| Repository context | normal CLI metadata list | workspace scope remains forwarded and store initialization is skipped | CLI regression (existing coverage) |
+
+### Risks / rollback
+
+- The CTE no longer uses `id` because it returns only `created_at`; equal
+  timestamps therefore cannot change the selected second. The outer query keeps
+  the original `ts_norm(), id` ordering.
+- No schema migration is needed, so existing large DBs improve immediately and
+  no index build or DB mutation is introduced.
+- Revert this scoped SQL change to restore the previous query if a SQLite
+  planner compatibility issue is observed.

--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -32,6 +32,7 @@ type EventQueryService interface {
 // It is separate from EventQueryService so consumers cannot accidentally
 // request a partial domain Event through an include-body flag.
 type EventMetadataQueryService interface {
+	ListRecentTimestampKinds(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error)
 	// ListRecentMetadata returns body-free events in descending time order.
 	ListRecentMetadata(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error)
 	// ListWindowMetadata returns every matching body-free event under one

--- a/application/types/event_timestamp_kind.go
+++ b/application/types/event_timestamp_kind.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"time"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// EventTimestampKind is the smallest body-free projection needed by compact
+// timestamp/kind list output.
+type EventTimestampKind struct {
+	createdAt time.Time
+	kind      domtypes.EventKind
+}
+
+// EventTimestampKindOf creates a compact timestamp/kind projection.
+func EventTimestampKindOf(createdAt time.Time, kind domtypes.EventKind) (EventTimestampKind, error) {
+	if createdAt.IsZero() {
+		return EventTimestampKind{}, xerrors.Errorf("created at must not be zero")
+	}
+	return EventTimestampKind{createdAt: createdAt, kind: kind}, nil
+}
+
+// CreatedAt returns the event timestamp.
+func (e EventTimestampKind) CreatedAt() time.Time { return e.createdAt }
+
+// Kind returns the event kind.
+func (e EventTimestampKind) Kind() domtypes.EventKind { return e.kind }

--- a/application/usecase/event_metadata_usecase.go
+++ b/application/usecase/event_metadata_usecase.go
@@ -11,9 +11,24 @@ import (
 
 // EventMetadataUsecase exposes body-free event reads to presentation adapters.
 type EventMetadataUsecase interface {
+	ListTimestampKinds(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error)
 	List(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error)
 	Search(ctx context.Context, criteria apptypes.EventSearchCriteria) ([]apptypes.EventMetadata, error)
 	Context(ctx context.Context, criteria apptypes.EventContextCriteria) ([]apptypes.EventMetadata, error)
+}
+
+func (u *eventMetadataUsecase) ListTimestampKinds(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error) {
+	if u.query == nil {
+		return nil, xerrors.Errorf("event metadata query service is not configured")
+	}
+	if criteria.Limit() != 1 || criteria.Offset() != 0 {
+		return nil, xerrors.Errorf("timestamp/kind projection requires limit 1 and offset 0")
+	}
+	rows, err := u.query.ListRecentTimestampKinds(ctx, criteria)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list event timestamp/kind: %w", err)
+	}
+	return rows, nil
 }
 
 type eventMetadataUsecase struct {

--- a/application/usecase/event_metadata_usecase_test.go
+++ b/application/usecase/event_metadata_usecase_test.go
@@ -52,6 +52,10 @@ type eventMetadataQueryStub struct {
 	searchCriteria types.EventSearchCriteria
 }
 
+func (*eventMetadataQueryStub) ListRecentTimestampKinds(context.Context, types.EventListCriteria) ([]types.EventTimestampKind, error) {
+	return nil, nil
+}
+
 func (s *eventMetadataQueryStub) ListRecentMetadata(context.Context, types.EventListCriteria) ([]types.EventMetadata, error) {
 	s.listCalls++
 	return nil, nil

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -84,7 +84,7 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 	`); err != nil {
 		t.Fatalf("create workspace query-plan fixture: %v", err)
 	}
-	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastByWorkspaceQuery, "repo-current", "repo-current")
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastByWorkspaceQuery, "repo-current", "repo-current", "repo-current")
 	if err != nil {
 		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
 	}
@@ -103,6 +103,9 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 	}
 	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_workspace_created_at") {
 		t.Fatalf("bounded workspace query does not use workspace timestamp index:\n%s", joined)
+	}
+	if joined := strings.Join(plan, "\n"); strings.Contains(joined, "USE TEMP B-TREE FOR LAST TERM OF ORDER BY") {
+		t.Fatalf("legacy workspace index must not sort every scoped row to choose the latest second:\n%s", joined)
 	}
 }
 

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -25,6 +25,12 @@ var selectLatestEventMetadataFastQuery string
 //go:embed sql/select_latest_event_metadata_fast_by_workspace.sql
 var selectLatestEventMetadataFastByWorkspaceQuery string
 
+//go:embed sql/select_latest_event_timestamp_kind_by_workspace.sql
+var selectLatestEventTimestampKindByWorkspaceQuery string
+
+//go:embed sql/select_latest_event_timestamp_kind.sql
+var selectLatestEventTimestampKindQuery string
+
 //go:embed sql/select_recent_event_metadata_by_source_hook.sql
 var selectRecentEventMetadataBySourceHookQuery string
 
@@ -38,6 +44,60 @@ var searchEventMetadataQuery string
 var getContextEventMetadataQuery string
 
 var _ queryservice.EventMetadataQueryService = (*EventDatasource)(nil)
+
+// ListRecentTimestampKinds returns the minimal compact-list projection.
+func (d *EventDatasource) ListRecentTimestampKinds(ctx context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error) {
+	if err := validateMetadataListCriteria(criteria, false); err != nil {
+		return nil, err
+	}
+	// The CLI supplies a snapshot upper bound for an otherwise unbounded list.
+	// This projection is invoked only after the presentation layer verified that
+	// the operator did not request date filters, so ignore that internal bound.
+	bounded, workspace := boundedLatestMetadataWorkspace(criteria, "", "", criteria.Limit(), criteria.Offset())
+	if !bounded {
+		return nil, xerrors.Errorf("timestamp/kind projection requires a bounded list")
+	}
+	db, err := d.db.openReadOnly(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for event timestamp/kind listing: %w", err)
+	}
+	defer closeMetadataResource(db)
+	query := selectLatestEventTimestampKindQuery
+	args := []any(nil)
+	if workspace != "" {
+		query = selectLatestEventTimestampKindByWorkspaceQuery
+		args = []any{workspace, workspace, workspace}
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("query latest event timestamp/kind: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]apptypes.EventTimestampKind, 0, 1)
+	for rows.Next() {
+		var kindValue, createdAtValue string
+		if err := rows.Scan(&kindValue, &createdAtValue); err != nil {
+			return nil, xerrors.Errorf("scan latest event timestamp/kind: %w", err)
+		}
+		kind, err := types.EventKindFrom(kindValue)
+		if err != nil {
+			return nil, xerrors.Errorf("restore event kind: %w", err)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
+		if err != nil {
+			return nil, xerrors.Errorf("parse event timestamp: %w", err)
+		}
+		value, err := apptypes.EventTimestampKindOf(createdAt, kind)
+		if err != nil {
+			return nil, xerrors.Errorf("build event timestamp/kind: %w", err)
+		}
+		result = append(result, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("iterate latest event timestamp/kind: %w", err)
+	}
+	return result, nil
+}
 
 // ListRecentMetadata returns body-free event metadata in descending time order.
 func (d *EventDatasource) ListRecentMetadata(
@@ -463,7 +523,7 @@ func queryRecentEventMetadataWith(
 		args := []any(nil)
 		if workspace != "" {
 			queryText = selectLatestEventMetadataFastByWorkspaceQuery
-			args = []any{workspace, workspace}
+			args = []any{workspace, workspace, workspace}
 		}
 		rows, err := query(ctx, queryText, args...)
 		if err != nil {

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -105,6 +105,32 @@ func TestEventMetadataQuery_BoundedLatestUsesCreatedAtIndexAndKeepsTimestampOrde
 
 }
 
+func TestEventMetadataQuery_BoundedLatestReturnsExactSecondWhenNoFractionExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 25, 1, 2, 3, 0, time.UTC)
+	for _, event := range []*model.Event{
+		newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "repo-current", "body", base.Add(-time.Second)),
+		newEventForSQLiteTest(t, "event-exact", "cli", "codex", "session-1", "repo-current", "body", base),
+	} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+
+	got, err := sut.ListRecentMetadata(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Workspace(types.Workspace("repo-current")).Build())
+	if err != nil {
+		t.Fatalf("ListRecentMetadata() error = %v", err)
+	}
+	if len(got) != 1 || got[0].EventID().String() != "event-exact" {
+		t.Fatalf("bounded latest metadata = %#v, want event-exact", got)
+	}
+}
+
 func TestEventMetadataQuery_BoundedLatestRespondsOnSparseFourGiBStore(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
 	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -131,6 +131,31 @@ func TestEventMetadataQuery_BoundedLatestReturnsExactSecondWhenNoFractionExists(
 	}
 }
 
+func TestEventMetadataQuery_BoundedTimestampKindKeepsFractionalSecondOrder(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	base := time.Date(2026, 7, 25, 1, 2, 3, 0, time.UTC)
+	for _, event := range []*model.Event{
+		newEventForSQLiteTest(t, "event-before", "cli", "codex", "session-1", "repo-current", "body", base.Add(-time.Second)),
+		newEventForSQLiteTest(t, "event-exact", "cli", "codex", "session-1", "repo-current", "body", base),
+		newEventForSQLiteTest(t, "event-fraction", "cli", "codex", "session-1", "repo-current", "body", base.Add(500*time.Millisecond)),
+	} {
+		if err := sut.Save(context.Background(), event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+	got, err := sut.ListRecentTimestampKinds(context.Background(), apptypes.NewEventListCriteriaBuilder(1).Workspace(types.Workspace("repo-current")).Build())
+	if err != nil {
+		t.Fatalf("ListRecentTimestampKinds() error = %v", err)
+	}
+	if len(got) != 1 || !got[0].CreatedAt().Equal(base.Add(500*time.Millisecond)) {
+		t.Fatalf("timestamp/kind projection = %#v, want fractional latest timestamp", got)
+	}
+}
+
 func TestEventMetadataQuery_BoundedLatestRespondsOnSparseFourGiBStore(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
 	sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))

--- a/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
@@ -7,11 +7,32 @@ WITH latest_lexical AS (
     SELECT created_at
       FROM events
      WHERE workspace = ?
-     ORDER BY created_at DESC, id DESC
+     -- Keep this order limited to the legacy `(workspace, created_at)` index.
+     -- The timestamp alone selects the latest second; ties have the same
+     -- created_at value, so id cannot affect the second that the outer query
+     -- normalizes and orders. Adding id here forces SQLite to sort every row
+     -- in a large workspace when that legacy index is present.
+     ORDER BY created_at DESC
      LIMIT 1
 ), latest_second AS (
     SELECT substr(created_at, 1, 19) AS second_prefix
       FROM latest_lexical
+), same_second_ids AS (
+    -- Exact-second values sort after fractional RFC3339Nano text. Keep this
+    -- equality probe separate from the fractional range so SQLite can retain
+    -- a lower and upper created_at index bound for the latter.
+    SELECT e.id
+      FROM latest_second s
+     CROSS JOIN events e
+     WHERE e.workspace = ?
+       AND e.created_at = s.second_prefix || 'Z'
+    UNION ALL
+    SELECT e.id
+      FROM latest_second s
+     CROSS JOIN events e
+     WHERE e.workspace = ?
+       AND e.created_at >= s.second_prefix || '.'
+       AND e.created_at <= s.second_prefix || 'Z'
 )
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.source_hook, e.created_at,
@@ -19,11 +40,11 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
        ca.event_id, ca.exit_code, ca.failed
-  FROM events e
+  FROM same_second_ids candidate
+  -- CROSS JOIN preserves candidate-first evaluation. A plain INNER JOIN lets
+  -- SQLite reverse the join and scan all events before probing the tiny
+  -- same-second candidate set.
+ CROSS JOIN events e ON e.id = candidate.id
   LEFT JOIN command_audits ca ON ca.event_id = e.id
-  JOIN latest_second s
- WHERE e.workspace = ?
-   AND e.created_at >= s.second_prefix || '.'
-   AND e.created_at <= s.second_prefix || 'Z'
  ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
@@ -10,4 +10,4 @@ WITH latest_lexical AS (
 )
 SELECT e.kind, e.created_at FROM same_second_ids candidate
  CROSS JOIN events e ON e.id = candidate.id
- ORDER BY e.created_at DESC, e.id DESC LIMIT 1
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
@@ -1,0 +1,13 @@
+WITH latest_lexical AS (
+    SELECT created_at FROM events ORDER BY created_at DESC, id DESC LIMIT 1
+), latest_second AS (
+    SELECT substr(created_at, 1, 19) AS second_prefix FROM latest_lexical
+), same_second_ids AS (
+    SELECT e.id FROM latest_second s CROSS JOIN events e WHERE e.created_at = s.second_prefix || 'Z'
+    UNION ALL
+    SELECT e.id FROM latest_second s CROSS JOIN events e
+     WHERE e.created_at >= s.second_prefix || '.' AND e.created_at <= s.second_prefix || 'Z'
+)
+SELECT e.kind, e.created_at FROM same_second_ids candidate
+ CROSS JOIN events e ON e.id = candidate.id
+ ORDER BY e.created_at DESC, e.id DESC LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
@@ -12,5 +12,5 @@ WITH latest_lexical AS (
 SELECT e.kind, e.created_at
   FROM same_second_ids candidate
  CROSS JOIN events e ON e.id = candidate.id
- ORDER BY e.created_at DESC, e.id DESC
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
@@ -1,0 +1,16 @@
+WITH latest_lexical AS (
+    SELECT created_at FROM events WHERE workspace = ? ORDER BY created_at DESC LIMIT 1
+), latest_second AS (
+    SELECT substr(created_at, 1, 19) AS second_prefix FROM latest_lexical
+), same_second_ids AS (
+    SELECT e.id FROM latest_second s CROSS JOIN events e
+     WHERE e.workspace = ? AND e.created_at = s.second_prefix || 'Z'
+    UNION ALL
+    SELECT e.id FROM latest_second s CROSS JOIN events e
+     WHERE e.workspace = ? AND e.created_at >= s.second_prefix || '.' AND e.created_at <= s.second_prefix || 'Z'
+)
+SELECT e.kind, e.created_at
+  FROM same_second_ids candidate
+ CROSS JOIN events e ON e.id = candidate.id
+ ORDER BY e.created_at DESC, e.id DESC
+ LIMIT 1

--- a/presentation/cli/event_metadata_projection_test.go
+++ b/presentation/cli/event_metadata_projection_test.go
@@ -46,6 +46,28 @@ func TestRootCLI_ListMetadataProjectionBoundsTenThousandLargeEvents(t *testing.T
 	}
 }
 
+func TestRootCLI_ListTimestampKindProjectionKeepsFilteredAndPagedListsOnMetadataPath(t *testing.T) {
+	for _, args := range [][]string{
+		{"list", "--db-path", "/tmp/test-traceary.db", "--fields", "ts,kind"},
+		{"list", "--db-path", "/tmp/test-traceary.db", "--limit", "1", "--kind", "note", "--fields", "ts,kind"},
+		{"list", "--db-path", "/tmp/test-traceary.db", "--limit", "1", "--offset", "1", "--fields", "ts,kind"},
+	} {
+		t.Run(fmt.Sprint(args), func(t *testing.T) {
+			metadataUsecase := &eventMetadataUsecaseStub{listMetadata: []apptypes.EventMetadata{newCLIMetadataFixture(t, "event-metadata")}}
+			rootCmd := cli.NewRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(&eventUsecaseStub{}), cli.WithEventMetadata(metadataUsecase)).Command()
+			rootCmd.SetOut(&bytes.Buffer{})
+			rootCmd.SetErr(&bytes.Buffer{})
+			rootCmd.SetArgs(args)
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if metadataUsecase.timestampKindCalls != 0 || metadataUsecase.listCalls != 1 {
+				t.Fatalf("timestamp/kind calls = %d, metadata list calls = %d", metadataUsecase.timestampKindCalls, metadataUsecase.listCalls)
+			}
+		})
+	}
+}
+
 func TestRootCLI_ListJSONFieldsUsesMetadataProjection(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/cli/event_metadata_projection_test.go
+++ b/presentation/cli/event_metadata_projection_test.go
@@ -95,7 +95,11 @@ func TestRootCLI_ListTextMetadataFieldsSkipsStoreInitialization(t *testing.T) {
 
 	store := &storeManagementUsecaseStub{initErr: fmt.Errorf("initialization must not run")}
 	full := &eventUsecaseStub{}
-	metadataUsecase := &eventMetadataUsecaseStub{listMetadata: []apptypes.EventMetadata{newCLIMetadataFixture(t, "event-text-metadata")}}
+	timestampKind, err := apptypes.EventTimestampKindOf(time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC), types.EventKindCommandExecuted)
+	if err != nil {
+		t.Fatalf("EventTimestampKindOf() error = %v", err)
+	}
+	metadataUsecase := &eventMetadataUsecaseStub{timestampKinds: []apptypes.EventTimestampKind{timestampKind}}
 	stdout := &bytes.Buffer{}
 	rootCmd := cli.NewRootCLI(
 		cli.WithStoreManagement(store),
@@ -112,10 +116,10 @@ func TestRootCLI_ListTextMetadataFieldsSkipsStoreInitialization(t *testing.T) {
 	if store.initCalled {
 		t.Fatal("metadata-only text list initialized the store")
 	}
-	if full.listCalls != 0 || metadataUsecase.listCalls != 1 {
+	if full.listCalls != 0 || metadataUsecase.listCalls != 0 {
 		t.Fatalf("full List() calls = %d, metadata List() calls = %d", full.listCalls, metadataUsecase.listCalls)
 	}
-	if got, want := metadataUsecase.listCriteria.Workspace().String(), "duck8823/traceary"; got != want {
+	if got, want := metadataUsecase.timestampKindCriteria.Workspace().String(), "duck8823/traceary"; got != want {
 		t.Fatalf("implicit metadata workspace = %q, want %q", got, want)
 	}
 	if got, want := stdout.String(), "06:00:00  command_executed\n"; got != want {

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -181,7 +181,7 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		if c.eventMetadata == nil {
 			return xerrors.New(Localize("event metadata query service is not configured", "イベントメタデータクエリサービスが設定されていません"))
 		}
-		if !input.asJSON && fromValue == "" && toValue == "" && isTimestampKindFields(resolvedFields) {
+		if isBoundedTimestampKindList(input, resolvedKind, fromValue, toValue, resolvedFields) {
 			entries, err := c.eventMetadata.ListTimestampKinds(ctx, criteria)
 			if err != nil {
 				return xerrors.Errorf("%s: %w", Localize("failed to list event timestamp/kind", "イベント時刻・種別一覧の取得に失敗しました"), err)
@@ -259,6 +259,17 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 	}
 
 	return nil
+}
+
+// isBoundedTimestampKindList guards the minimal projection. Every other list
+// shape retains the general metadata path and its established filtering
+// semantics.
+func isBoundedTimestampKindList(input listCommandInput, resolvedKind, fromValue, toValue string, fields []readFieldID) bool {
+	return !input.asJSON && input.limit == 1 && input.offset == 0 &&
+		resolvedKind == "" && strings.TrimSpace(input.client) == "" &&
+		strings.TrimSpace(input.agent) == "" && strings.TrimSpace(input.sessionID) == "" &&
+		!input.failuresOnly && strings.TrimSpace(input.sourceHook) == "" &&
+		fromValue == "" && toValue == "" && isTimestampKindFields(fields)
 }
 
 func isTimestampKindFields(fields []readFieldID) bool {

--- a/presentation/cli/list.go
+++ b/presentation/cli/list.go
@@ -181,6 +181,18 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 		if c.eventMetadata == nil {
 			return xerrors.New(Localize("event metadata query service is not configured", "イベントメタデータクエリサービスが設定されていません"))
 		}
+		if !input.asJSON && fromValue == "" && toValue == "" && isTimestampKindFields(resolvedFields) {
+			entries, err := c.eventMetadata.ListTimestampKinds(ctx, criteria)
+			if err != nil {
+				return xerrors.Errorf("%s: %w", Localize("failed to list event timestamp/kind", "イベント時刻・種別一覧の取得に失敗しました"), err)
+			}
+			for _, entry := range entries {
+				if _, err := io.WriteString(output, formatTextTimestamp(entry.CreatedAt(), eventTextFormatOptions{utc: input.utc, location: input.location}, eventCompactTimeLayout)+"  "+string(entry.Kind())+"\n"); err != nil {
+					return xerrors.Errorf("write event timestamp/kind: %w", err)
+				}
+			}
+			return nil
+		}
 		metadata, err := c.eventMetadata.List(ctx, criteria)
 		if err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to list event metadata", "イベントメタデータ一覧の取得に失敗しました"), err)
@@ -247,6 +259,10 @@ func (c *RootCLI) runList(ctx context.Context, warnWriter io.Writer, output io.W
 	}
 
 	return nil
+}
+
+func isTimestampKindFields(fields []readFieldID) bool {
+	return len(fields) == 2 && fields[0] == readFieldTS && fields[1] == readFieldKind
 }
 
 // resolveListKind delegates to validateSearchKind so that both list and

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -101,16 +101,23 @@ func (s *eventUsecaseStub) List(_ context.Context, criteria apptypes.EventListCr
 }
 
 type eventMetadataUsecaseStub struct {
-	listMetadata    []apptypes.EventMetadata
-	searchMetadata  []apptypes.EventMetadata
-	contextMetadata []apptypes.EventMetadata
-	listErr         error
-	searchErr       error
-	contextErr      error
-	listCalls       int
-	listCriteria    apptypes.EventListCriteria
-	searchCalls     int
-	contextCalls    int
+	timestampKinds        []apptypes.EventTimestampKind
+	listMetadata          []apptypes.EventMetadata
+	searchMetadata        []apptypes.EventMetadata
+	contextMetadata       []apptypes.EventMetadata
+	listErr               error
+	searchErr             error
+	contextErr            error
+	listCalls             int
+	listCriteria          apptypes.EventListCriteria
+	timestampKindCriteria apptypes.EventListCriteria
+	searchCalls           int
+	contextCalls          int
+}
+
+func (s *eventMetadataUsecaseStub) ListTimestampKinds(_ context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error) {
+	s.timestampKindCriteria = criteria
+	return s.timestampKinds, nil
 }
 
 func (s *eventMetadataUsecaseStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventMetadata, error) {

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -111,11 +111,13 @@ type eventMetadataUsecaseStub struct {
 	listCalls             int
 	listCriteria          apptypes.EventListCriteria
 	timestampKindCriteria apptypes.EventListCriteria
+	timestampKindCalls    int
 	searchCalls           int
 	contextCalls          int
 }
 
 func (s *eventMetadataUsecaseStub) ListTimestampKinds(_ context.Context, criteria apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error) {
+	s.timestampKindCalls++
 	s.timestampKindCriteria = criteria
 	return s.timestampKinds, nil
 }

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -290,6 +290,10 @@ type projectionMetadataUsecaseStub struct {
 	contextCalls int
 }
 
+func (*projectionMetadataUsecaseStub) ListTimestampKinds(context.Context, apptypes.EventListCriteria) ([]apptypes.EventTimestampKind, error) {
+	return nil, nil
+}
+
 func (s *projectionMetadataUsecaseStub) List(context.Context, apptypes.EventListCriteria) ([]apptypes.EventMetadata, error) {
 	s.listCalls++
 	return s.list, nil


### PR DESCRIPTION
Motivation: prevent metadata-only limit-one listing from loading event payload overflow pages or sorting the full workspace history.

Closes #1544