### PR TITLE
fix: index metadata list and context queries

### DIFF
--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -14,18 +14,19 @@
 
 | 概念 | 責務 | 不変条件 |
 | --- | --- | --- |
-| 正規化時刻順 | SQLite の式インデックス | `ts_norm(created_at), id` を唯一の順序契約にする |
+| 正規化時刻順 | 永続化した event 時刻列と SQLite インデックス | `created_at_norm, id` を唯一の順序契約にする |
 | 絞り込み済みメタデータページ | metadata datasource | `events.body` を SELECT しない |
-| インデックス配布 | migration 000031 | event 行と既存インデックスを変更しない |
+| インデックス配布 | migration 000031 | `created_at_norm` を追加・バックフィルし、trigger で維持する |
 
 ### 対応するクエリ計画
 
 | クエリ形状 | 順序インデックス |
 | --- | --- |
-| 一般メタデータ list（limit/offset を含む） | `idx_events_ts_norm_created_at_id_desc` |
-| workspace list/context | `idx_events_workspace_ts_norm_created_at_id_desc` |
-| session list/context | `idx_events_session_ts_norm_created_at_id_desc` |
-| workspace + session context | `idx_events_workspace_session_ts_norm_created_at_id_desc` |
+| 一般メタデータ list（limit/offset を含む） | `idx_events_created_at_norm_id_desc` |
+| workspace list/context | `idx_events_workspace_created_at_norm_id_desc` |
+| session list/context | `idx_events_session_created_at_norm_id_desc` |
+| workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
+| source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
 
 公開済みフィルタの意味を保つため、list の条件は任意のままとする。計画は順序インデックスを走査し、scope だけのページでは `offset + limit` に達したら終了する。scope 以外のフィルタはその順序走査中に適用する。組み合わせごとの SQL を増やして結果の意味を変えない。
 
@@ -34,8 +35,8 @@
 1. 代表的な list/context の `EXPLAIN QUERY PLAN` が対象インデックスを使い、order-by 用の一時 B-tree を作らないことを確認する。
 2. 通常 list と scope/offset ページの時刻順を確認する。
 3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
-4. 000031 前のストアを更新し、既存 event と4本のインデックスが残ることを確認する。
+4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
 
 ### ロールバックと残リスク
 
-000031 は追加かつ冪等である。旧アプリは追加インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。
+000031 は追加かつ冪等である。旧アプリは追加列、trigger、置換インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -47,11 +47,11 @@ release QAのopt-in benchmarkは256 MiB bodyを持つeventを8件（body合計2 
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
-  go test ./infrastructure/sqlite -run '^$' \
+  go test -v ./infrastructure/sqlite -run '^$' \
   -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
 ```
 
-p95の目標は250 ms未満である。2026-07-25にこの制約付きrunnerで実行を試みたが、fixture生成の完了前にprocessが終了したため、有効なmulti-GiB p95は記録できなかった。空き容量は7.8 GiBあったが、必要な長時間benchmark processを許可しないrunner制限である。release QAでは、このcommandを実行可能なhostで実行し、release前にp95を記録する。生成物はGo testの一時ディレクトリだけに置かれ、終了後に削除されるためcommitしない。またCIでは実行しない。full-scan退行は直接rangeのplan assertionを主な検出器とし、10k smokeのp95閾値はローカル遅延を検出する。
+成功時のbenchmark出力は`managed_bytes`、`events`、`non_null_body_metadata`、`stored_body_bytes`、`p95_ms`を含むため、host環境とともに#1558へ記録する。p95の目標は250 ms未満である。2026-07-25にこの制約付きrunnerで実行を試みたが、fixture生成の完了前にprocessが終了したため、有効なmulti-GiB p95は記録できなかった。空き容量は7.8 GiBあったが、必要な長時間benchmark processを許可しないrunner制限である。release QAでは、このcommandを実行可能なhostで実行し、release前にp95を記録する。生成物はGo testの一時ディレクトリだけに置かれ、終了後に削除されるためcommitしない。またCIでは実行しない。full-scan退行は直接rangeのplan assertionを主な検出器とし、10k smokeのp95閾値はローカル遅延を検出する。
 
 ### ロールバックと残リスク
 

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -36,11 +36,22 @@
 2. 通常 list と scope/offset ページの時刻順を確認する。
 3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
 4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
-5. migration済みのbody-free 10k event fixtureに、sparse 4 GiBのファイルextentを付与して実行する。workspace直接range queryを25回測定し、CIではp95 50 ms未満を必須にする。migration済みDBのplan testでは、時刻の下限・上限が直接predicateであり、order-by用の一時B-treeがないことも確認する。
+5. 10k eventの直接range queryをCI smokeとしてp95 50 ms未満に保つ。migration済みDBのplan testでは、時刻の下限・上限が直接predicateであり、partial order-by sortを含む一時B-treeがないことも確認する。
+6. release QAではopt-inのmulti-GiB benchmarkを実行する。これは一時ディレクトリにSQLiteが実際に管理するpageとevent bodyを作成し、`page_count * page_size`と`SUM(length(body))`を検証する。CIでは実行しない。
 
 ### 性能証跡
 
-2026-07-25にGo 1.26.3、macOS 26.5（darwin/arm64）、modernc SQLite driverで測定した。fixtureはindex済みevent metadata 10,000行とsparse 4 GiBのDBファイルextentで構成し、大きなbody corpusは含めない。fixtureはtest用の一時ディレクトリだけに生成し、commitしない。負荷はworkspaceを絞った2秒の直接range、`limit=50`、25回反復である。目標はp95 50 ms未満、今回の測定値は**416.125us**だった。full-scan退行は構造的なplan assertionを主な検出器とし、p95閾値はCI smokeとして扱う。
+2026-07-25にGo 1.26.3、macOS 26.5（darwin/arm64）、modernc SQLite driverでCI smokeを測定した。index済みevent metadata 10,000行に対し、workspaceを絞った2秒の直接range、`limit=50`、25回反復のp95は**416.125us**で、目標は50 ms未満である。
+
+release QAのopt-in benchmarkは256 MiB bodyを持つeventを8件（body合計2 GiB以上）作成し、測定前に`page_count * page_size >= 2 GiB`、event件数、body合計を検証する。その後、直接rangeを25回測定する。実行コマンドは次のとおり。
+
+```sh
+TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
+  go test ./infrastructure/sqlite -run '^$' \
+  -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
+```
+
+p95の目標は250 ms未満である。2026-07-25にこの制約付きrunnerで実行を試みたが、fixture生成の完了前にprocessが終了したため、有効なmulti-GiB p95は記録できなかった。空き容量は7.8 GiBあったが、必要な長時間benchmark processを許可しないrunner制限である。release QAでは、このcommandを実行可能なhostで実行し、release前にp95を記録する。生成物はGo testの一時ディレクトリだけに置かれ、終了後に削除されるためcommitしない。またCIでは実行しない。full-scan退行は直接rangeのplan assertionを主な検出器とし、10k smokeのp95閾値はローカル遅延を検出する。
 
 ### ロールバックと残リスク
 

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -28,15 +28,16 @@
 | workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
 | source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
 
-公開済みフィルタの意味を保つため、list の条件は任意のままとする。計画は順序インデックスを走査し、scope だけのページでは `offset + limit` に達したら終了する。scope 以外のフィルタはその順序走査中に適用する。組み合わせごとの SQL を増やして結果の意味を変えない。
+公開済みフィルタの意味を保つため、list の条件は任意のままとする。ただし時刻境界が指定された場合は、順序インデックス内をseekできる直接範囲predicateのSQL variantを選ぶ。計画は順序インデックスを走査し、scope だけのページでは `offset + limit` に達したら終了する。scope 以外のフィルタはその順序走査中に適用する。組み合わせごとの SQL を増やして結果の意味を変えない。
 
 ### 振る舞いテスト
 
-1. 代表的な list/context の `EXPLAIN QUERY PLAN` が対象インデックスを使い、order-by 用の一時 B-tree を作らないことを確認する。
+1. migration済みストアに対する代表的な list/context とlegacy source-hook fallbackの `EXPLAIN QUERY PLAN` が対象インデックスを使い、order-by 用の一時 B-tree を作らないことを確認する。
 2. 通常 list と scope/offset ページの時刻順を確認する。
 3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
 4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
+5. 10k eventのmigration済みfixtureを直接range queryで実行し、p95を回帰証跡として残す（今回の測定値は265.083us）。
 
 ### ロールバックと残リスク
 
-000031 は追加かつ冪等である。旧アプリは追加列、trigger、置換インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。
+000031 は追加かつ冪等である。旧アプリは追加列、trigger、インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -36,8 +36,12 @@
 2. 通常 list と scope/offset ページの時刻順を確認する。
 3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
 4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
-5. 10k eventのmigration済みfixtureを直接range queryで実行し、p95を回帰証跡として残す（今回の測定値は265.083us）。
+5. migration済みのbody-free 10k event fixtureに、sparse 4 GiBのファイルextentを付与して実行する。workspace直接range queryを25回測定し、CIではp95 50 ms未満を必須にする。migration済みDBのplan testでは、時刻の下限・上限が直接predicateであり、order-by用の一時B-treeがないことも確認する。
+
+### 性能証跡
+
+2026-07-25にGo 1.26.3、macOS 26.5（darwin/arm64）、modernc SQLite driverで測定した。fixtureはindex済みevent metadata 10,000行とsparse 4 GiBのDBファイルextentで構成し、大きなbody corpusは含めない。fixtureはtest用の一時ディレクトリだけに生成し、commitしない。負荷はworkspaceを絞った2秒の直接range、`limit=50`、25回反復である。目標はp95 50 ms未満、今回の測定値は**416.125us**だった。full-scan退行は構造的なplan assertionを主な検出器とし、p95閾値はCI smokeとして扱う。
 
 ### ロールバックと残リスク
 
-000031 は追加かつ冪等である。旧アプリは追加列、trigger、インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。
+000031 は追加かつ冪等である。旧アプリは追加列、trigger、インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -37,13 +37,13 @@
 3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
 4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
 5. 10k eventの直接range queryをCI smokeとしてp95 50 ms未満に保つ。migration済みDBのplan testでは、時刻の下限・上限が直接predicateであり、partial order-by sortを含む一時B-treeがないことも確認する。
-6. release QAではopt-inのmulti-GiB benchmarkを実行する。これは一時ディレクトリにSQLiteが実際に管理するpageとevent bodyを作成し、`page_count * page_size`と`SUM(length(body))`を検証する。CIでは実行しない。
+6. release QAではopt-inのmulti-GiB benchmarkを実行する。これは一時ディレクトリにSQLiteが実際に管理するpageとevent bodyを作成し、`page_count * page_size`、NULLでない`body_stored_bytes`、`SUM(body_stored_bytes)`を検証する。CIでは実行しない。
 
 ### 性能証跡
 
 2026-07-25にGo 1.26.3、macOS 26.5（darwin/arm64）、modernc SQLite driverでCI smokeを測定した。index済みevent metadata 10,000行に対し、workspaceを絞った2秒の直接range、`limit=50`、25回反復のp95は**416.125us**で、目標は50 ms未満である。
 
-release QAのopt-in benchmarkは256 MiB bodyを持つeventを8件（body合計2 GiB以上）作成し、測定前に`page_count * page_size >= 2 GiB`、event件数、body合計を検証する。その後、直接rangeを25回測定する。実行コマンドは次のとおり。
+release QAのopt-in benchmarkは256 MiB bodyを持つeventを8件（body合計2 GiB以上）作成し、測定前に`page_count * page_size >= 2 GiB`、event件数、NULLでないbody metadata、`SUM(body_stored_bytes)`を検証する。その後、直接rangeを25回測定する。実行コマンドは次のとおり。
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -1,0 +1,41 @@
+# インデックス利用のメタデータ list/context クエリ
+
+[English](index-backed-metadata-list.md)
+
+## Structure-Behavior 設計メモ
+
+### 要求
+
+- 一般的なメタデータ list/context 読取は、RFC3339Nano の境界を正しく並べつつ全件一時ソートを行わない。
+- workspace/session 絞り込みと offset ページングでも本文を読まない。
+- スキーマ更新は追加だけで行い、アプリケーションのロールバック後も既存ストアを読める。
+
+### 概念と責務
+
+| 概念 | 責務 | 不変条件 |
+| --- | --- | --- |
+| 正規化時刻順 | SQLite の式インデックス | `ts_norm(created_at), id` を唯一の順序契約にする |
+| 絞り込み済みメタデータページ | metadata datasource | `events.body` を SELECT しない |
+| インデックス配布 | migration 000031 | event 行と既存インデックスを変更しない |
+
+### 対応するクエリ計画
+
+| クエリ形状 | 順序インデックス |
+| --- | --- |
+| 一般メタデータ list（limit/offset を含む） | `idx_events_ts_norm_created_at_id_desc` |
+| workspace list/context | `idx_events_workspace_ts_norm_created_at_id_desc` |
+| session list/context | `idx_events_session_ts_norm_created_at_id_desc` |
+| workspace + session context | `idx_events_workspace_session_ts_norm_created_at_id_desc` |
+
+公開済みフィルタの意味を保つため、list の条件は任意のままとする。計画は順序インデックスを走査し、scope だけのページでは `offset + limit` に達したら終了する。scope 以外のフィルタはその順序走査中に適用する。組み合わせごとの SQL を増やして結果の意味を変えない。
+
+### 振る舞いテスト
+
+1. 代表的な list/context の `EXPLAIN QUERY PLAN` が対象インデックスを使い、order-by 用の一時 B-tree を作らないことを確認する。
+2. 通常 list と scope/offset ページの時刻順を確認する。
+3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
+4. 000031 前のストアを更新し、既存 event と4本のインデックスが残ることを確認する。
+
+### ロールバックと残リスク
+
+000031 は追加かつ冪等である。旧アプリは追加インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。p95 は環境依存の時間計測ではなく、インデックスを使う計画で回帰を防ぐ。

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -48,21 +48,40 @@ membership.
    are forbidden in every metadata query.
 4. Upgrade a pre-000031 store and assert the fixed-width timestamp is
    backfilled and maintained after inserts and timestamp updates.
-5. Exercise a migrated, body-free 10k-event fixture with a sparse 4 GiB file
-   extent. The direct workspace-range query is measured 25 times; CI requires
-   p95 below 50 ms, while the migrated-store plan test requires direct lower
-   and upper timestamp constraints and rejects every temporary order-by tree.
+5. Keep the 10k-event direct-range p95 below 50 ms as a CI smoke test. The
+   migrated-store plan test also requires direct lower and upper timestamp
+   constraints and rejects every temporary B-tree, including partial order-by
+   sorts.
+6. Run the opt-in multi-GiB benchmark before release. It writes actual SQLite
+   pages and event bodies under a temporary directory, verifies both
+   `page_count * page_size` and `SUM(length(body))`, and is never run by CI.
 
 ### Performance evidence
 
-Measured on 2026-07-25 with Go 1.26.3 on macOS 26.5 (darwin/arm64), using the
-modernc SQLite driver. The fixture contains 10,000 indexed event metadata rows
-and a sparse 4 GiB database-file extent; it deliberately contains no large body
-corpus and is created only under the test temporary directory. The workload is
-25 repetitions of a workspace-scoped, two-second direct range with `limit=50`.
-The goal is p95 below 50 ms; the measured p95 was **416.125us**. The structural
-plan assertion is the primary full-scan regression guard, and the p95 threshold
-is the CI smoke guard. No generated fixture is committed.
+The CI smoke measurement on 2026-07-25 used Go 1.26.3 on macOS 26.5
+(darwin/arm64) with the modernc SQLite driver. It contains 10,000 indexed event
+metadata rows; 25 workspace-scoped, two-second direct ranges with `limit=50`
+measured p95 **416.125us** against a 50 ms target.
+
+The release-QA benchmark is opt-in and creates 8 events with 256 MiB bodies
+(at least 2 GiB total), then verifies `page_count * page_size >= 2 GiB`, the
+event count, and the stored body total before measuring 25 direct ranges. Run:
+
+```sh
+TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
+  go test ./infrastructure/sqlite -run '^$' \
+  -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
+```
+
+Its p95 goal is below 250 ms. A 2026-07-25 attempt in this constrained runner
+reached benchmark setup but was terminated before fixture completion, so it has
+no valid multi-GiB p95 to report. The runner had 7.8 GiB free but does not allow
+the required long-lived benchmark process; release QA must run the command on a
+host that permits it and record the p95 before release. The command creates its
+artifact only in the Go test temporary directory and deletes it afterwards; no
+large fixture is committed or run by CI. The direct-range plan assertion is the
+primary full-scan regression guard, while the 10k smoke threshold detects local
+latency regressions.
 
 ### Rollback and residual risk
 

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -48,8 +48,21 @@ membership.
    are forbidden in every metadata query.
 4. Upgrade a pre-000031 store and assert the fixed-width timestamp is
    backfilled and maintained after inserts and timestamp updates.
-5. Exercise a 10k-event migrated fixture and retain the direct-range p95 as
-   regression evidence (the current test run recorded 265.083us).
+5. Exercise a migrated, body-free 10k-event fixture with a sparse 4 GiB file
+   extent. The direct workspace-range query is measured 25 times; CI requires
+   p95 below 50 ms, while the migrated-store plan test requires direct lower
+   and upper timestamp constraints and rejects every temporary order-by tree.
+
+### Performance evidence
+
+Measured on 2026-07-25 with Go 1.26.3 on macOS 26.5 (darwin/arm64), using the
+modernc SQLite driver. The fixture contains 10,000 indexed event metadata rows
+and a sparse 4 GiB database-file extent; it deliberately contains no large body
+corpus and is created only under the test temporary directory. The workload is
+25 repetitions of a workspace-scoped, two-second direct range with `limit=50`.
+The goal is p95 below 50 ms; the measured p95 was **416.125us**. The structural
+plan assertion is the primary full-scan regression guard, and the p95 threshold
+is the CI smoke guard. No generated fixture is committed.
 
 ### Rollback and residual risk
 
@@ -57,5 +70,4 @@ Migration 000031 is additive and idempotent. Reverting application code keeps
 the store readable because older readers ignore the added column, triggers, and
 indexes. Index creation can temporarily require disk and write-lock
 capacity on very large stores; operators should retry after freeing capacity or
-quiescing writers. The p95 target is guarded structurally by index plans rather
-than a machine-dependent wall-clock benchmark.
+quiescing writers.

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -1,0 +1,56 @@
+# Index-backed metadata list and context queries
+
+[日本語](index-backed-metadata-list.ja.md)
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- General metadata list and context reads must retain boundary-correct
+  RFC3339Nano ordering without a whole-store temporary sort.
+- Workspace/session scopes and page offsets must remain metadata-only.
+- Schema rollout must be additive; a code rollback must not make an existing
+  store unreadable.
+
+### Conceptual model and responsibilities
+
+| Concept | Owner | Invariant |
+| --- | --- | --- |
+| Normalized timestamp order | SQLite expression indexes | `ts_norm(created_at), id` is the one ordering contract |
+| Scoped metadata page | metadata datasource | selects metadata/audit columns, never `events.body` |
+| Index rollout | migration 000031 | adds indexes only; event rows and existing indexes remain unchanged |
+
+### Boundaries and supported plans
+
+| Query shape | Ordered index |
+| --- | --- |
+| general metadata list (including limit/offset) | `idx_events_ts_norm_created_at_id_desc` |
+| workspace list/context | `idx_events_workspace_ts_norm_created_at_id_desc` |
+| session list/context | `idx_events_session_ts_norm_created_at_id_desc` |
+| workspace + session context | `idx_events_workspace_session_ts_norm_created_at_id_desc` |
+
+The list predicates remain deliberately optional so all public filters keep
+their existing semantics. The planner can scan the matching ordering index;
+for an unfiltered scoped page it stops after `offset + limit`, while filters
+that are not an indexed scope are applied during that ordered scan. This is
+preferable to duplicating every filter combination or changing result
+membership.
+
+### Behavior tests and TDD plan
+
+1. Assert representative list/context `EXPLAIN QUERY PLAN` output uses the
+   documented ordering index and does not build a temporary order-by tree.
+2. Assert normal list and scoped/offset pages preserve timestamp order.
+3. Keep the metadata SQL select-list guard: `body` and command payload columns
+   are forbidden in every metadata query.
+4. Upgrade a pre-000031 store and assert existing event data survives and all
+   four indexes exist.
+
+### Rollback and residual risk
+
+Migration 000031 is additive and idempotent. Reverting application code keeps
+the store readable because older readers ignore extra indexes. Index creation
+can temporarily require disk and write-lock capacity on very large stores;
+operators should retry after freeing capacity or quiescing writers. The p95
+target is guarded structurally by index plans rather than a machine-dependent
+wall-clock benchmark.

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -30,8 +30,9 @@
 | workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
 | source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
 
-The list predicates remain deliberately optional so all public filters keep
-their existing semantics. The planner can scan the matching ordering index;
+The list predicates remain optional for public filters, but supplied timestamp
+bounds select direct SQL variants so the planner can seek within the matching
+ordering index. The planner can scan the matching ordering index;
 for an unfiltered scoped page it stops after `offset + limit`, while filters
 that are not an indexed scope are applied during that ordered scan. This is
 preferable to duplicating every filter combination or changing result
@@ -39,19 +40,22 @@ membership.
 
 ### Behavior tests and TDD plan
 
-1. Assert representative list/context `EXPLAIN QUERY PLAN` output uses the
+1. Assert representative list/context and legacy source-hook fallback
+   `EXPLAIN QUERY PLAN` output from a migrated store uses the
    documented ordering index and does not build a temporary order-by tree.
 2. Assert normal list and scoped/offset pages preserve timestamp order.
 3. Keep the metadata SQL select-list guard: `body` and command payload columns
    are forbidden in every metadata query.
 4. Upgrade a pre-000031 store and assert the fixed-width timestamp is
    backfilled and maintained after inserts and timestamp updates.
+5. Exercise a 10k-event migrated fixture and retain the direct-range p95 as
+   regression evidence (the current test run recorded 265.083us).
 
 ### Rollback and residual risk
 
 Migration 000031 is additive and idempotent. Reverting application code keeps
 the store readable because older readers ignore the added column, triggers, and
-replacement indexes. Index creation can temporarily require disk and write-lock
+indexes. Index creation can temporarily require disk and write-lock
 capacity on very large stores; operators should retry after freeing capacity or
 quiescing writers. The p95 target is guarded structurally by index plans rather
 than a machine-dependent wall-clock benchmark.

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -16,18 +16,19 @@
 
 | Concept | Owner | Invariant |
 | --- | --- | --- |
-| Normalized timestamp order | SQLite expression indexes | `ts_norm(created_at), id` is the one ordering contract |
+| Normalized timestamp order | persisted event timestamp and SQLite indexes | `created_at_norm, id` is the one ordering contract |
 | Scoped metadata page | metadata datasource | selects metadata/audit columns, never `events.body` |
-| Index rollout | migration 000031 | adds indexes only; event rows and existing indexes remain unchanged |
+| Index rollout | migration 000031 | adds and backfills `created_at_norm`, then maintains it with triggers |
 
 ### Boundaries and supported plans
 
 | Query shape | Ordered index |
 | --- | --- |
-| general metadata list (including limit/offset) | `idx_events_ts_norm_created_at_id_desc` |
-| workspace list/context | `idx_events_workspace_ts_norm_created_at_id_desc` |
-| session list/context | `idx_events_session_ts_norm_created_at_id_desc` |
-| workspace + session context | `idx_events_workspace_session_ts_norm_created_at_id_desc` |
+| general metadata list (including limit/offset) | `idx_events_created_at_norm_id_desc` |
+| workspace list/context | `idx_events_workspace_created_at_norm_id_desc` |
+| session list/context | `idx_events_session_created_at_norm_id_desc` |
+| workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
+| source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
 
 The list predicates remain deliberately optional so all public filters keep
 their existing semantics. The planner can scan the matching ordering index;
@@ -43,14 +44,14 @@ membership.
 2. Assert normal list and scoped/offset pages preserve timestamp order.
 3. Keep the metadata SQL select-list guard: `body` and command payload columns
    are forbidden in every metadata query.
-4. Upgrade a pre-000031 store and assert existing event data survives and all
-   four indexes exist.
+4. Upgrade a pre-000031 store and assert the fixed-width timestamp is
+   backfilled and maintained after inserts and timestamp updates.
 
 ### Rollback and residual risk
 
 Migration 000031 is additive and idempotent. Reverting application code keeps
-the store readable because older readers ignore extra indexes. Index creation
-can temporarily require disk and write-lock capacity on very large stores;
-operators should retry after freeing capacity or quiescing writers. The p95
-target is guarded structurally by index plans rather than a machine-dependent
-wall-clock benchmark.
+the store readable because older readers ignore the added column, triggers, and
+replacement indexes. Index creation can temporarily require disk and write-lock
+capacity on very large stores; operators should retry after freeing capacity or
+quiescing writers. The p95 target is guarded structurally by index plans rather
+than a machine-dependent wall-clock benchmark.

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -54,7 +54,8 @@ membership.
    sorts.
 6. Run the opt-in multi-GiB benchmark before release. It writes actual SQLite
    pages and event bodies under a temporary directory, verifies both
-   `page_count * page_size` and `SUM(length(body))`, and is never run by CI.
+   `page_count * page_size`, non-NULL `body_stored_bytes`, and
+   `SUM(body_stored_bytes)`, and is never run by CI.
 
 ### Performance evidence
 
@@ -65,7 +66,8 @@ measured p95 **416.125us** against a 50 ms target.
 
 The release-QA benchmark is opt-in and creates 8 events with 256 MiB bodies
 (at least 2 GiB total), then verifies `page_count * page_size >= 2 GiB`, the
-event count, and the stored body total before measuring 25 direct ranges. Run:
+event count, non-NULL body metadata, and `SUM(body_stored_bytes)` before
+measuring 25 direct ranges. Run:
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -71,11 +71,14 @@ measuring 25 direct ranges. Run:
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
-  go test ./infrastructure/sqlite -run '^$' \
+  go test -v ./infrastructure/sqlite -run '^$' \
   -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
 ```
 
-Its p95 goal is below 250 ms. A 2026-07-25 attempt in this constrained runner
+Successful benchmark output reports `managed_bytes`, `events`,
+`non_null_body_metadata`, `stored_body_bytes`, and `p95_ms`; attach those
+values to #1558 with the host environment. Its p95 goal is below 250 ms. A
+2026-07-25 attempt in this constrained runner
 reached benchmark setup but was terminated before fixture completion, so it has
 no valid multi-GiB p95 to report. The runner had 7.8 GiB free but does not allow
 the required long-lived benchmark process; release QA must run the command on a

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -109,6 +109,101 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 	}
 }
 
+func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.ExecContext(context.Background(), `
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
+			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
+			source_hook TEXT, created_at TEXT NOT NULL, body_original_bytes INTEGER,
+			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
+			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
+		);
+		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
+		CREATE INDEX idx_events_ts_norm_created_at_id_desc
+			ON events(ts_norm(created_at) DESC, id DESC);
+		CREATE INDEX idx_events_workspace_ts_norm_created_at_id_desc
+			ON events(workspace, ts_norm(created_at) DESC, id DESC);
+		CREATE INDEX idx_events_session_ts_norm_created_at_id_desc
+			ON events(session_id, ts_norm(created_at) DESC, id DESC);
+		CREATE INDEX idx_events_workspace_session_ts_norm_created_at_id_desc
+			ON events(workspace, session_id, ts_norm(created_at) DESC, id DESC);
+	`); err != nil {
+		t.Fatalf("create query-plan fixture: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		args      []any
+		wantIndex string
+	}{
+		{
+			name:      "general list with offset",
+			query:     selectRecentEventMetadataQuery,
+			args:      []any{"", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
+			wantIndex: "idx_events_ts_norm_created_at_id_desc",
+		},
+		{
+			name:      "workspace list with offset",
+			query:     selectRecentEventMetadataByWorkspaceQuery,
+			args:      []any{"repo-current", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
+			wantIndex: "idx_events_workspace_ts_norm_created_at_id_desc",
+		},
+		{
+			name:      "session list with offset",
+			query:     selectRecentEventMetadataBySessionQuery,
+			args:      []any{"session-1", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
+			wantIndex: "idx_events_session_ts_norm_created_at_id_desc",
+		},
+		{
+			name:      "workspace session context",
+			query:     getContextEventMetadataByWorkspaceSessionQuery,
+			args:      []any{"repo-current", "session-1", 25},
+			wantIndex: "idx_events_workspace_session_ts_norm_created_at_id_desc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := explainQueryPlan(t, db, tt.query, tt.args...)
+			joined := strings.Join(plan, "\n")
+			if !strings.Contains(joined, tt.wantIndex) {
+				t.Fatalf("query plan does not use %s:\n%s", tt.wantIndex, joined)
+			}
+			if strings.Contains(joined, "USE TEMP B-TREE FOR ORDER BY") {
+				t.Fatalf("query plan sorts metadata rows outside its ordering index:\n%s", joined)
+			}
+		})
+	}
+}
+
+func explainQueryPlan(t *testing.T, db *sql.DB, query string, args ...any) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	plan := make([]string, 0)
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	return plan
+}
+
 func TestEventMetadataQuery_BoundedLatestReportsBusyInsteadOfSlowInitialization(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
 	setup, err := sql.Open("sqlite", "file:"+dbPath)

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -384,18 +384,20 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
 		b.Fatalf("checkpoint large fixture: %v", err)
 	}
-	var pageCount, pageSize, storedEvents, storedBodyBytes int64
+	var pageCount, pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes int64
 	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
 		b.Fatalf("read page_count: %v", err)
 	}
 	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
 		b.Fatalf("read page_size: %v", err)
 	}
-	if err := db.QueryRowContext(ctx, "SELECT COUNT(*), COALESCE(SUM(length(body)), 0) FROM events").Scan(&storedEvents, &storedBodyBytes); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(SUM(body_stored_bytes), 0),
+		SUM(CASE WHEN body_stored_bytes IS NULL THEN 1 ELSE 0 END)
+		FROM events`).Scan(&storedEvents, &storedBodyBytes, &missingStoredBodyBytes); err != nil {
 		b.Fatalf("verify large fixture: %v", err)
 	}
-	if pageCount*pageSize < minimumDBBytes || storedEvents != eventCount || storedBodyBytes < minimumDBBytes {
-		b.Fatalf("large fixture verification failed: page_count=%d page_size=%d managed_bytes=%d events=%d body_bytes=%d", pageCount, pageSize, pageCount*pageSize, storedEvents, storedBodyBytes)
+	if pageCount*pageSize < minimumDBBytes || storedEvents != eventCount || missingStoredBodyBytes != 0 || storedBodyBytes < minimumDBBytes {
+		b.Fatalf("large fixture verification failed: page_count=%d page_size=%d managed_bytes=%d events=%d stored_body_bytes=%d missing_stored_body_bytes=%d", pageCount, pageSize, pageCount*pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes)
 	}
 
 	criteria := apptypes.NewEventListCriteriaBuilder(50).

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -399,6 +399,10 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	if pageCount*pageSize < minimumDBBytes || storedEvents != eventCount || missingStoredBodyBytes != 0 || storedBodyBytes < minimumDBBytes {
 		b.Fatalf("large fixture verification failed: page_count=%d page_size=%d managed_bytes=%d events=%d stored_body_bytes=%d missing_stored_body_bytes=%d", pageCount, pageSize, pageCount*pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes)
 	}
+	b.ReportMetric(float64(pageCount*pageSize), "managed_bytes")
+	b.ReportMetric(float64(storedEvents), "events")
+	b.ReportMetric(float64(storedEvents-missingStoredBodyBytes), "non_null_body_metadata")
+	b.ReportMetric(float64(storedBodyBytes), "stored_body_bytes")
 
 	criteria := apptypes.NewEventListCriteriaBuilder(50).
 		Workspace(types.Workspace("repo-current")).

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -509,7 +509,12 @@ func TestEventMetadataQuery_BoundedLatestReportsBusyInsteadOfSlowInitialization(
 	if !strings.Contains(strings.ToLower(err.Error()), "busy") && !strings.Contains(strings.ToLower(err.Error()), "locked") {
 		t.Fatalf("ListRecentMetadata() error = %v, want busy/locked classification", err)
 	}
-	if elapsed < 800*time.Millisecond || elapsed >= 2*time.Second {
-		t.Fatalf("busy metadata read elapsed = %s, want configured short busy outcome", elapsed)
+	// SQLite's busy handler counts requested sleep durations. An interrupted
+	// platform sleep can therefore return the busy outcome before the full
+	// configured timeout has elapsed in wall-clock time. The DSN tests verify
+	// the exact pragma value; this regression only guards the upper bound.
+	maximumBusyOutcome := 2 * time.Duration(sqliteBusyTimeout) * time.Millisecond
+	if elapsed >= maximumBusyOutcome {
+		t.Fatalf("busy metadata read elapsed = %s, want < %s", elapsed, maximumBusyOutcome)
 	}
 }

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -75,7 +75,7 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 		CREATE TABLE events (
 			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
 			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
-			source_hook TEXT, created_at TEXT NOT NULL, body_original_bytes INTEGER,
+			source_hook TEXT, created_at TEXT NOT NULL, created_at_norm TEXT NOT NULL, body_original_bytes INTEGER,
 			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
 			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
 		);
@@ -120,19 +120,22 @@ func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t 
 		CREATE TABLE events (
 			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
 			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
-			source_hook TEXT, created_at TEXT NOT NULL, body_original_bytes INTEGER,
+			source_hook TEXT, created_at TEXT NOT NULL, created_at_norm TEXT NOT NULL, body_original_bytes INTEGER,
 			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
 			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
 		);
 		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
-		CREATE INDEX idx_events_ts_norm_created_at_id_desc
-			ON events(ts_norm(created_at) DESC, id DESC);
-		CREATE INDEX idx_events_workspace_ts_norm_created_at_id_desc
-			ON events(workspace, ts_norm(created_at) DESC, id DESC);
-		CREATE INDEX idx_events_session_ts_norm_created_at_id_desc
-			ON events(session_id, ts_norm(created_at) DESC, id DESC);
-		CREATE INDEX idx_events_workspace_session_ts_norm_created_at_id_desc
-			ON events(workspace, session_id, ts_norm(created_at) DESC, id DESC);
+		CREATE INDEX idx_events_created_at_norm_id_desc
+			ON events(created_at_norm DESC, id DESC);
+		CREATE INDEX idx_events_workspace_created_at_norm_id_desc
+			ON events(workspace, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_events_session_created_at_norm_id_desc
+			ON events(session_id, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_events_workspace_session_created_at_norm_id_desc
+			ON events(workspace, session_id, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_events_source_hook_created_at_norm_id_desc
+			ON events(source_hook, created_at_norm DESC, id DESC)
+			WHERE source_hook IS NOT NULL;
 	`); err != nil {
 		t.Fatalf("create query-plan fixture: %v", err)
 	}
@@ -147,25 +150,31 @@ func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t 
 			name:      "general list with offset",
 			query:     selectRecentEventMetadataQuery,
 			args:      []any{"", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_ts_norm_created_at_id_desc",
+			wantIndex: "idx_events_created_at_norm_id_desc",
 		},
 		{
 			name:      "workspace list with offset",
 			query:     selectRecentEventMetadataByWorkspaceQuery,
 			args:      []any{"repo-current", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_workspace_ts_norm_created_at_id_desc",
+			wantIndex: "idx_events_workspace_created_at_norm_id_desc",
 		},
 		{
 			name:      "session list with offset",
 			query:     selectRecentEventMetadataBySessionQuery,
 			args:      []any{"session-1", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_session_ts_norm_created_at_id_desc",
+			wantIndex: "idx_events_session_created_at_norm_id_desc",
 		},
 		{
 			name:      "workspace session context",
 			query:     getContextEventMetadataByWorkspaceSessionQuery,
 			args:      []any{"repo-current", "session-1", 25},
-			wantIndex: "idx_events_workspace_session_ts_norm_created_at_id_desc",
+			wantIndex: "idx_events_workspace_session_created_at_norm_id_desc",
+		},
+		{
+			name:      "source hook list with offset",
+			query:     selectRecentEventMetadataBySourceHookQuery,
+			args:      []any{"stop", "", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
+			wantIndex: "idx_events_source_hook_created_at_norm_id_desc",
 		},
 	}
 	for _, tt := range tests {

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -3,7 +3,10 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +14,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
 )
 
 func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
@@ -188,6 +192,136 @@ func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t 
 				t.Fatalf("query plan sorts metadata rows outside its ordering index:\n%s", joined)
 			}
 		})
+	}
+}
+
+func TestMetadataRangeAndLegacyFallbackPlansUseProductionMigrationIndexes(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations := os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations"))
+	if err := NewStoreManagementDatasource(NewDatabase(dbPath, migrations)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, row := range []struct {
+		id, kind, sourceHook, body, createdAt string
+	}{
+		{"tagged", "session_ended", "subagent_stop", "tagged", "2026-07-25T00:00:02Z"},
+		{"legacy", "session_ended", "", "[phase:subagent] legacy", "2026-07-25T00:00:01Z"},
+	} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook, body_availability)
+			VALUES (?, ?, 'hook', 'codex', 'session-1', 'repo-current', ?, ?, NULLIF(?, ''), 'available')`, row.id, row.kind, row.body, row.createdAt, row.sourceHook); err != nil {
+			t.Fatalf("insert %s: %v", row.id, err)
+		}
+	}
+
+	from := "2026-07-25T00:00:00.000000000Z"
+	to := "2026-07-25T00:00:03.000000000Z"
+	criteria := apptypes.NewEventListCriteriaBuilder(25).
+		Workspace(types.Workspace("repo-current")).
+		From(time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)).
+		To(time.Date(2026, 7, 25, 0, 0, 3, 0, time.UTC)).
+		Build()
+	query, args := scopedRecentEventMetadataQuery(criteria, 0, from, to, 25, 0)
+	assertPlanUsesOrderedIndex(t, explainQueryPlan(t, db, query, args...), "idx_events_workspace_created_at_norm_id_desc")
+
+	legacyQuery := metadataTimeRangeQuery(selectRecentEventMetadataBySourceHookWithLegacyQuery, from, to)
+	legacyArgs := metadataSourceHookLegacyQueryArgs(
+		"subagent_stop", "", "", "", "", "", 0, from, to, 25, 0,
+	)
+	assertPlanUsesOrderedIndex(t, explainQueryPlan(t, db, legacyQuery, legacyArgs...), "idx_events_created_at_norm_id_desc")
+}
+
+func assertPlanUsesOrderedIndex(t *testing.T, plan []string, index string) {
+	t.Helper()
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, index) {
+		t.Fatalf("query plan does not use %s:\n%s", index, joined)
+	}
+	if strings.Contains(joined, "USE TEMP B-TREE FOR ORDER BY") {
+		t.Fatalf("query plan sorts outside its ordering index:\n%s", joined)
+	}
+}
+
+func TestMetadataRangeQueryP95OnLargeMigratedStore(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations := os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations"))
+	if err := NewStoreManagementDatasource(NewDatabase(dbPath, migrations)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	statement, err := tx.PrepareContext(ctx, `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, body_availability)
+		VALUES (?, 'note', 'hook', 'codex', 'session-1', 'repo-current', '', ?, 'available')`)
+	if err != nil {
+		t.Fatalf("PrepareContext() error = %v", err)
+	}
+	base := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 10000; i++ {
+		if _, err := statement.ExecContext(ctx, fmt.Sprintf("event-%05d", i), base.Add(time.Duration(i)*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
+			_ = statement.Close()
+			_ = tx.Rollback()
+			t.Fatalf("insert fixture %d: %v", i, err)
+		}
+	}
+	if err := statement.Close(); err != nil {
+		t.Fatalf("statement.Close() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(50).
+		Workspace(types.Workspace("repo-current")).
+		From(base.Add(4 * time.Second)).
+		To(base.Add(6 * time.Second)).
+		Build()
+	query, args := scopedRecentEventMetadataQuery(
+		criteria, 0,
+		formatMetadataOptionalTimestamp(criteria.From()),
+		formatMetadataOptionalTimestamp(criteria.To()),
+		criteria.Limit(), criteria.Offset(),
+	)
+	durations := make([]time.Duration, 0, 25)
+	for range 25 {
+		started := time.Now()
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			t.Fatalf("range query: %v", err)
+		}
+		for rows.Next() {
+			var values [16]any
+			pointers := make([]any, len(values))
+			for i := range values {
+				pointers[i] = &values[i]
+			}
+			if err := rows.Scan(pointers...); err != nil {
+				_ = rows.Close()
+				t.Fatalf("scan range row: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			t.Fatalf("rows.Close() error = %v", err)
+		}
+		durations = append(durations, time.Since(started))
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	p95 := durations[(len(durations)*95+99)/100-1]
+	t.Logf("10k migrated events, workspace direct range query p95=%s", p95)
+	if p95 >= 750*time.Millisecond {
+		t.Fatalf("range query p95=%s, want < 750ms", p95)
 	}
 }
 

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -227,13 +227,13 @@ func TestMetadataRangeAndLegacyFallbackPlansUseProductionMigrationIndexes(t *tes
 		To(time.Date(2026, 7, 25, 0, 0, 3, 0, time.UTC)).
 		Build()
 	query, args := scopedRecentEventMetadataQuery(criteria, 0, from, to, 25, 0)
-	assertPlanUsesOrderedIndex(t, explainQueryPlan(t, db, query, args...), "idx_events_workspace_created_at_norm_id_desc")
+	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, query, args...), "idx_events_workspace_created_at_norm_id_desc")
 
 	legacyQuery := metadataTimeRangeQuery(selectRecentEventMetadataBySourceHookWithLegacyQuery, from, to)
 	legacyArgs := metadataSourceHookLegacyQueryArgs(
 		"subagent_stop", "", "", "", "", "", 0, from, to, 25, 0,
 	)
-	assertPlanUsesOrderedIndex(t, explainQueryPlan(t, db, legacyQuery, legacyArgs...), "idx_events_created_at_norm_id_desc")
+	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, legacyQuery, legacyArgs...), "idx_events_created_at_norm_id_desc")
 }
 
 func assertPlanUsesOrderedIndex(t *testing.T, plan []string, index string) {
@@ -244,6 +244,14 @@ func assertPlanUsesOrderedIndex(t *testing.T, plan []string, index string) {
 	}
 	if strings.Contains(joined, "USE TEMP B-TREE FOR ORDER BY") {
 		t.Fatalf("query plan sorts outside its ordering index:\n%s", joined)
+	}
+}
+
+func assertPlanUsesDirectRangeIndex(t *testing.T, plan []string, index string) {
+	t.Helper()
+	assertPlanUsesOrderedIndex(t, plan, index)
+	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "created_at_norm>? AND created_at_norm<?") {
+		t.Fatalf("query plan does not seek both direct timestamp bounds:\n%s", joined)
 	}
 }
 
@@ -281,6 +289,26 @@ func TestMetadataRangeQueryP95OnLargeMigratedStore(t *testing.T) {
 	}
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("Commit() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded DB: %v", err)
+	}
+	// This is a sparse 4 GiB, body-free equivalent fixture. It retains a 10k-row
+	// metadata index while avoiding a committed multi-gigabyte artifact and makes
+	// accidental whole-file reads observable during local/CI smoke testing.
+	if err := os.Truncate(dbPath, 4<<30); err != nil {
+		t.Fatalf("Truncate sparse fixture: %v", err)
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat sparse fixture: %v", err)
+	}
+	if info.Size() != 4<<30 {
+		t.Fatalf("sparse fixture size = %d, want %d", info.Size(), int64(4<<30))
+	}
+	db, err = sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("reopen sparse fixture: %v", err)
 	}
 
 	criteria := apptypes.NewEventListCriteriaBuilder(50).
@@ -320,8 +348,8 @@ func TestMetadataRangeQueryP95OnLargeMigratedStore(t *testing.T) {
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	p95 := durations[(len(durations)*95+99)/100-1]
 	t.Logf("10k migrated events, workspace direct range query p95=%s", p95)
-	if p95 >= 750*time.Millisecond {
-		t.Fatalf("range query p95=%s, want < 750ms", p95)
+	if p95 >= 50*time.Millisecond {
+		t.Fatalf("range query p95=%s, want < 50ms", p95)
 	}
 }
 

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -242,7 +242,7 @@ func assertPlanUsesOrderedIndex(t *testing.T, plan []string, index string) {
 	if !strings.Contains(joined, index) {
 		t.Fatalf("query plan does not use %s:\n%s", index, joined)
 	}
-	if strings.Contains(joined, "USE TEMP B-TREE FOR ORDER BY") {
+	if strings.Contains(joined, "USE TEMP B-TREE") {
 		t.Fatalf("query plan sorts outside its ordering index:\n%s", joined)
 	}
 }
@@ -290,27 +290,6 @@ func TestMetadataRangeQueryP95OnLargeMigratedStore(t *testing.T) {
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("Commit() error = %v", err)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("close seeded DB: %v", err)
-	}
-	// This is a sparse 4 GiB, body-free equivalent fixture. It retains a 10k-row
-	// metadata index while avoiding a committed multi-gigabyte artifact and makes
-	// accidental whole-file reads observable during local/CI smoke testing.
-	if err := os.Truncate(dbPath, 4<<30); err != nil {
-		t.Fatalf("Truncate sparse fixture: %v", err)
-	}
-	info, err := os.Stat(dbPath)
-	if err != nil {
-		t.Fatalf("Stat sparse fixture: %v", err)
-	}
-	if info.Size() != 4<<30 {
-		t.Fatalf("sparse fixture size = %d, want %d", info.Size(), int64(4<<30))
-	}
-	db, err = sql.Open("sqlite", sqliteDSN(dbPath))
-	if err != nil {
-		t.Fatalf("reopen sparse fixture: %v", err)
-	}
-
 	criteria := apptypes.NewEventListCriteriaBuilder(50).
 		Workspace(types.Workspace("repo-current")).
 		From(base.Add(4 * time.Second)).
@@ -347,9 +326,114 @@ func TestMetadataRangeQueryP95OnLargeMigratedStore(t *testing.T) {
 	}
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	p95 := durations[(len(durations)*95+99)/100-1]
-	t.Logf("10k migrated events, workspace direct range query p95=%s", p95)
+	t.Logf("10k migrated metadata events, workspace direct range query p95=%s", p95)
 	if p95 >= 50*time.Millisecond {
 		t.Fatalf("range query p95=%s, want < 50ms", p95)
+	}
+}
+
+// BenchmarkMetadataDirectRangeMultiGiB creates actual SQLite-managed pages and
+// event bodies. It is intentionally opt-in because the setup writes at least
+// 2 GiB; CI keeps the 10k-event smoke test above and never creates this store.
+func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
+	if os.Getenv("TRACEARY_RUN_MULTI_GIB_BENCHMARK") != "1" {
+		b.Skip("set TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 to create the multi-GiB fixture")
+	}
+	const (
+		bodyBytes       = 256 << 20
+		eventCount      = 8
+		minimumDBBytes  = int64(2 << 30)
+		measurementRuns = 25
+	)
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "traceary.db")
+	migrations := os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations"))
+	if err := NewStoreManagementDatasource(NewDatabase(dbPath, migrations)).Initialize(ctx); err != nil {
+		b.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		b.Fatalf("sql.Open() error = %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	payload := strings.Repeat("x", bodyBytes)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		b.Fatalf("BeginTx() error = %v", err)
+	}
+	statement, err := tx.PrepareContext(ctx, `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, body_availability)
+		VALUES (?, 'note', 'hook', 'codex', 'session-1', 'repo-current', ?, ?, 'available')`)
+	if err != nil {
+		_ = tx.Rollback()
+		b.Fatalf("PrepareContext() error = %v", err)
+	}
+	base := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < eventCount; i++ {
+		if _, err := statement.ExecContext(ctx, fmt.Sprintf("large-event-%03d", i), payload, base.Add(time.Duration(i)*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
+			_ = statement.Close()
+			_ = tx.Rollback()
+			b.Fatalf("insert fixture %d: %v", i, err)
+		}
+	}
+	if err := statement.Close(); err != nil {
+		b.Fatalf("statement.Close() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("Commit() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		b.Fatalf("checkpoint large fixture: %v", err)
+	}
+	var pageCount, pageSize, storedEvents, storedBodyBytes int64
+	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+		b.Fatalf("read page_count: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+		b.Fatalf("read page_size: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*), COALESCE(SUM(length(body)), 0) FROM events").Scan(&storedEvents, &storedBodyBytes); err != nil {
+		b.Fatalf("verify large fixture: %v", err)
+	}
+	if pageCount*pageSize < minimumDBBytes || storedEvents != eventCount || storedBodyBytes < minimumDBBytes {
+		b.Fatalf("large fixture verification failed: page_count=%d page_size=%d managed_bytes=%d events=%d body_bytes=%d", pageCount, pageSize, pageCount*pageSize, storedEvents, storedBodyBytes)
+	}
+
+	criteria := apptypes.NewEventListCriteriaBuilder(50).
+		Workspace(types.Workspace("repo-current")).
+		From(base).
+		To(base.Add(time.Second)).
+		Build()
+	query, args := scopedRecentEventMetadataQuery(criteria, 0, formatMetadataOptionalTimestamp(criteria.From()), formatMetadataOptionalTimestamp(criteria.To()), criteria.Limit(), criteria.Offset())
+	durations := make([]time.Duration, 0, measurementRuns)
+	b.ResetTimer()
+	for range measurementRuns {
+		started := time.Now()
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			b.Fatalf("range query: %v", err)
+		}
+		for rows.Next() {
+			var values [16]any
+			pointers := make([]any, len(values))
+			for i := range values {
+				pointers[i] = &values[i]
+			}
+			if err := rows.Scan(pointers...); err != nil {
+				_ = rows.Close()
+				b.Fatalf("scan range row: %v", err)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatalf("rows.Close() error = %v", err)
+		}
+		durations = append(durations, time.Since(started))
+	}
+	b.StopTimer()
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	p95 := durations[(len(durations)*95+99)/100-1]
+	b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
+	if p95 >= 250*time.Millisecond {
+		b.Fatalf("multi-GiB direct range p95=%s, want < 250ms", p95)
 	}
 }
 

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -566,10 +566,11 @@ func queryRecentEventMetadataWith(
 		return rows, nil
 	}
 	if sourceHookHasLegacyPrefix(sourceHook) {
+		queryText := metadataTimeRangeQuery(selectRecentEventMetadataBySourceHookWithLegacyQuery, fromValue, toValue)
 		rows, err := query(
 			ctx,
-			selectRecentEventMetadataBySourceHookWithLegacyQuery,
-			sourceHookLegacyQueryArgs(
+			queryText,
+			metadataSourceHookLegacyQueryArgs(
 				sourceHook,
 				criteria.Kind(),
 				criteria.Client(),
@@ -588,10 +589,11 @@ func queryRecentEventMetadataWith(
 		}
 		return rows, nil
 	}
+	queryText := metadataTimeRangeQuery(selectRecentEventMetadataBySourceHookQuery, fromValue, toValue)
 	rows, err := query(
 		ctx,
-		selectRecentEventMetadataBySourceHookQuery,
-		sourceHookPrimaryQueryArgs(
+		queryText,
+		metadataSourceHookPrimaryQueryArgs(
 			sourceHook,
 			criteria.Kind(),
 			criteria.Client(),
@@ -628,13 +630,12 @@ func scopedRecentEventMetadataQuery(
 		criteria.Client().String(), criteria.Client().String(),
 		criteria.Agent().String(), criteria.Agent().String(),
 		failuresFlag,
-		fromValue, fromValue,
-		toValue, toValue,
-		limit, offset,
 	}
+	common = append(common, metadataTimeRangeArgs(fromValue, toValue)...)
+	common = append(common, limit, offset)
 	switch {
 	case workspace != "" && sessionID != "":
-		return selectRecentEventMetadataByWorkspaceSessionQuery, append([]any{workspace, sessionID}, common...)
+		return metadataTimeRangeQuery(selectRecentEventMetadataByWorkspaceSessionQuery, fromValue, toValue), append([]any{workspace, sessionID}, common...)
 	case workspace != "":
 		// The workspace query retains session_id as an optional filter.
 		args := []any{workspace,
@@ -642,27 +643,92 @@ func scopedRecentEventMetadataQuery(
 			criteria.Client().String(), criteria.Client().String(),
 			criteria.Agent().String(), criteria.Agent().String(),
 			sessionID, sessionID,
-			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+			failuresFlag,
 		}
-		return selectRecentEventMetadataByWorkspaceQuery, args
+		args = append(args, metadataTimeRangeArgs(fromValue, toValue)...)
+		args = append(args, limit, offset)
+		return metadataTimeRangeQuery(selectRecentEventMetadataByWorkspaceQuery, fromValue, toValue), args
 	case sessionID != "":
 		args := []any{sessionID,
 			criteria.Kind().String(), criteria.Kind().String(),
 			criteria.Client().String(), criteria.Client().String(),
 			criteria.Agent().String(), criteria.Agent().String(),
 			workspace, workspace,
-			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+			failuresFlag,
 		}
-		return selectRecentEventMetadataBySessionQuery, args
+		args = append(args, metadataTimeRangeArgs(fromValue, toValue)...)
+		args = append(args, limit, offset)
+		return metadataTimeRangeQuery(selectRecentEventMetadataBySessionQuery, fromValue, toValue), args
 	default:
-		return selectRecentEventMetadataQuery, []any{
+		args := []any{
 			criteria.Kind().String(), criteria.Kind().String(),
 			criteria.Client().String(), criteria.Client().String(),
 			criteria.Agent().String(), criteria.Agent().String(),
 			"", "", "", "",
-			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+			failuresFlag,
 		}
+		args = append(args, metadataTimeRangeArgs(fromValue, toValue)...)
+		args = append(args, limit, offset)
+		return metadataTimeRangeQuery(selectRecentEventMetadataQuery, fromValue, toValue), args
 	}
+}
+
+const (
+	metadataOptionalFromPredicate = "AND (? = '' OR e.created_at_norm >= ?)"
+	metadataOptionalToPredicate   = "AND (? = '' OR e.created_at_norm < ?)"
+)
+
+// metadataTimeRangeQuery selects a SQL variant with direct range predicates
+// whenever a boundary is supplied. Direct predicates let SQLite seek within
+// the persisted timestamp indexes instead of scanning an ordered index and
+// evaluating optional range expressions row by row.
+func metadataTimeRangeQuery(query, fromValue, toValue string) string {
+	if fromValue != "" {
+		query = strings.Replace(query, metadataOptionalFromPredicate, "AND e.created_at_norm >= ?", 1)
+	}
+	if toValue != "" {
+		query = strings.Replace(query, metadataOptionalToPredicate, "AND e.created_at_norm < ?", 1)
+	}
+	return query
+}
+
+func metadataTimeRangeArgs(fromValue, toValue string) []any {
+	args := make([]any, 0, 4)
+	if fromValue == "" {
+		args = append(args, "", "")
+	} else {
+		args = append(args, fromValue)
+	}
+	if toValue == "" {
+		args = append(args, "", "")
+	} else {
+		args = append(args, toValue)
+	}
+	return args
+}
+
+func metadataSourceHookPrimaryQueryArgs(
+	sourceHook string,
+	kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace,
+	failuresFlag int,
+	fromValue, toValue string,
+	limit, offset int,
+) []any {
+	args := []any{sourceHook, kind.String(), kind.String(), client.String(), client.String(), agent.String(), agent.String(), sessionID.String(), sessionID.String(), workspace.String(), workspace.String(), failuresFlag}
+	args = append(args, metadataTimeRangeArgs(fromValue, toValue)...)
+	return append(args, limit, offset)
+}
+
+func metadataSourceHookLegacyQueryArgs(
+	sourceHook string,
+	kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace,
+	failuresFlag int,
+	fromValue, toValue string,
+	limit, offset int,
+) []any {
+	args := []any{sourceHook, sourceHook, sourceHook, kind.String(), kind.String(), client.String(), client.String(), agent.String(), agent.String(), sessionID.String(), sessionID.String(), workspace.String(), workspace.String(), failuresFlag}
+	args = append(args, metadataTimeRangeArgs(fromValue, toValue)...)
+	return append(args, limit, offset)
 }
 
 func contextEventMetadataQuery(workspace, sessionID string, limit int) (string, []any) {

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -19,6 +19,15 @@ import (
 //go:embed sql/select_recent_event_metadata.sql
 var selectRecentEventMetadataQuery string
 
+//go:embed sql/select_recent_event_metadata_by_workspace.sql
+var selectRecentEventMetadataByWorkspaceQuery string
+
+//go:embed sql/select_recent_event_metadata_by_session.sql
+var selectRecentEventMetadataBySessionQuery string
+
+//go:embed sql/select_recent_event_metadata_by_workspace_session.sql
+var selectRecentEventMetadataByWorkspaceSessionQuery string
+
 //go:embed sql/select_latest_event_metadata_fast.sql
 var selectLatestEventMetadataFastQuery string
 
@@ -42,6 +51,15 @@ var searchEventMetadataQuery string
 
 //go:embed sql/get_context_event_metadata.sql
 var getContextEventMetadataQuery string
+
+//go:embed sql/get_context_event_metadata_by_workspace.sql
+var getContextEventMetadataByWorkspaceQuery string
+
+//go:embed sql/get_context_event_metadata_by_session.sql
+var getContextEventMetadataBySessionQuery string
+
+//go:embed sql/get_context_event_metadata_by_workspace_session.sql
+var getContextEventMetadataByWorkspaceSessionQuery string
 
 var _ queryservice.EventMetadataQueryService = (*EventDatasource)(nil)
 
@@ -259,15 +277,8 @@ func (d *EventDatasource) GetContextMetadata(
 
 	workspace := strings.TrimSpace(criteria.Workspace().String())
 	sessionID := strings.TrimSpace(criteria.SessionID().String())
-	rows, err := db.QueryContext(
-		ctx,
-		getContextEventMetadataQuery,
-		workspace,
-		workspace,
-		sessionID,
-		sessionID,
-		criteria.Limit(),
-	)
+	query, args := contextEventMetadataQuery(workspace, sessionID, criteria.Limit())
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query event metadata context: %w", err)
 	}
@@ -532,19 +543,11 @@ func queryRecentEventMetadataWith(
 		return rows, nil
 	}
 	if sourceHook == "" {
+		queryText, args := scopedRecentEventMetadataQuery(criteria, failuresFlag, fromValue, toValue, limit, offset)
 		rows, err := query(
 			ctx,
-			selectRecentEventMetadataQuery,
-			criteria.Kind().String(), criteria.Kind().String(),
-			criteria.Client().String(), criteria.Client().String(),
-			criteria.Agent().String(), criteria.Agent().String(),
-			criteria.SessionID().String(), criteria.SessionID().String(),
-			criteria.Workspace().String(), criteria.Workspace().String(),
-			failuresFlag,
-			fromValue, fromValue,
-			toValue, toValue,
-			limit,
-			offset,
+			queryText,
+			args...,
 		)
 		if err != nil {
 			return nil, xerrors.Errorf("query recent event metadata: %w", err)
@@ -595,6 +598,73 @@ func queryRecentEventMetadataWith(
 		return nil, xerrors.Errorf("query recent event metadata by source hook: %w", err)
 	}
 	return rows, nil
+}
+
+// scopedRecentEventMetadataQuery selects the most selective stable scope as a
+// top-level predicate. The public optional-filter semantics remain unchanged,
+// while SQLite can use the matching normalized-timestamp ordering index for a
+// bounded metadata page instead of sorting all matching rows.
+func scopedRecentEventMetadataQuery(
+	criteria apptypes.EventListCriteria,
+	failuresFlag int,
+	fromValue, toValue string,
+	limit, offset int,
+) (string, []any) {
+	workspace := criteria.Workspace().String()
+	sessionID := criteria.SessionID().String()
+	common := []any{
+		criteria.Kind().String(), criteria.Kind().String(),
+		criteria.Client().String(), criteria.Client().String(),
+		criteria.Agent().String(), criteria.Agent().String(),
+		failuresFlag,
+		fromValue, fromValue,
+		toValue, toValue,
+		limit, offset,
+	}
+	switch {
+	case workspace != "" && sessionID != "":
+		return selectRecentEventMetadataByWorkspaceSessionQuery, append([]any{workspace, sessionID}, common...)
+	case workspace != "":
+		// The workspace query retains session_id as an optional filter.
+		args := []any{workspace,
+			criteria.Kind().String(), criteria.Kind().String(),
+			criteria.Client().String(), criteria.Client().String(),
+			criteria.Agent().String(), criteria.Agent().String(),
+			sessionID, sessionID,
+			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+		}
+		return selectRecentEventMetadataByWorkspaceQuery, args
+	case sessionID != "":
+		args := []any{sessionID,
+			criteria.Kind().String(), criteria.Kind().String(),
+			criteria.Client().String(), criteria.Client().String(),
+			criteria.Agent().String(), criteria.Agent().String(),
+			workspace, workspace,
+			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+		}
+		return selectRecentEventMetadataBySessionQuery, args
+	default:
+		return selectRecentEventMetadataQuery, []any{
+			criteria.Kind().String(), criteria.Kind().String(),
+			criteria.Client().String(), criteria.Client().String(),
+			criteria.Agent().String(), criteria.Agent().String(),
+			"", "", "", "",
+			failuresFlag, fromValue, fromValue, toValue, toValue, limit, offset,
+		}
+	}
+}
+
+func contextEventMetadataQuery(workspace, sessionID string, limit int) (string, []any) {
+	switch {
+	case workspace != "" && sessionID != "":
+		return getContextEventMetadataByWorkspaceSessionQuery, []any{workspace, sessionID, limit}
+	case workspace != "":
+		return getContextEventMetadataByWorkspaceQuery, []any{workspace, limit}
+	case sessionID != "":
+		return getContextEventMetadataBySessionQuery, []any{sessionID, limit}
+	default:
+		return getContextEventMetadataQuery, []any{"", "", "", "", limit}
+	}
 }
 
 // boundedLatestMetadataWorkspace identifies the single-row, body-free CLI

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -136,8 +136,8 @@ func (d *EventDatasource) ListRecentMetadata(
 		ctx,
 		db,
 		criteria,
-		formatOptionalTimestamp(criteria.From()),
-		formatOptionalTimestamp(criteria.To()),
+		formatMetadataOptionalTimestamp(criteria.From()),
+		formatMetadataOptionalTimestamp(criteria.To()),
 		criteria.Limit(),
 		criteria.Offset(),
 	)
@@ -180,8 +180,8 @@ func (d *EventDatasource) ListWindowMetadata(
 			ctx,
 			tx,
 			criteria,
-			formatOptionalTimestamp(criteria.From()),
-			formatOptionalTimestamp(criteria.To()),
+			formatMetadataOptionalTimestamp(criteria.From()),
+			formatMetadataOptionalTimestamp(criteria.To()),
 			batch,
 			offset,
 		)
@@ -306,6 +306,17 @@ func formatOptionalTimestamp(value time.Time) string {
 		return ""
 	}
 	return formatTimestamp(value)
+}
+
+// formatMetadataOptionalTimestamp matches events.created_at_norm, which is
+// persisted in the fixed-width form used by its ordering indexes. Other event
+// queries still normalize created_at inside SQLite and therefore keep the
+// variable-width RFC3339Nano parameter format.
+func formatMetadataOptionalTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return formatMemoryValidityTimestamp(value)
 }
 
 func closeMetadataResource(db *sql.DB) {

--- a/infrastructure/sqlite/event_metadata_query_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_query_internal_test.go
@@ -13,12 +13,18 @@ func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
 	t.Parallel()
 
 	queries := map[string]string{
-		"recent":             selectRecentEventMetadataQuery,
-		"recent source hook": selectRecentEventMetadataBySourceHookQuery,
-		"recent legacy hook": selectRecentEventMetadataBySourceHookWithLegacyQuery,
-		"search":             searchEventMetadataQuery,
-		"context":            getContextEventMetadataQuery,
-		"report usage":       listReportUsageQuery,
+		"recent":                    selectRecentEventMetadataQuery,
+		"recent workspace":          selectRecentEventMetadataByWorkspaceQuery,
+		"recent session":            selectRecentEventMetadataBySessionQuery,
+		"recent workspace session":  selectRecentEventMetadataByWorkspaceSessionQuery,
+		"recent source hook":        selectRecentEventMetadataBySourceHookQuery,
+		"recent legacy hook":        selectRecentEventMetadataBySourceHookWithLegacyQuery,
+		"search":                    searchEventMetadataQuery,
+		"context":                   getContextEventMetadataQuery,
+		"context workspace":         getContextEventMetadataByWorkspaceQuery,
+		"context session":           getContextEventMetadataBySessionQuery,
+		"context workspace session": getContextEventMetadataByWorkspaceSessionQuery,
+		"report usage":              listReportUsageQuery,
 	}
 	for name, query := range queries {
 		name, query := name, query

--- a/infrastructure/sqlite/event_metadata_query_test.go
+++ b/infrastructure/sqlite/event_metadata_query_test.go
@@ -339,6 +339,158 @@ func TestEventMetadataQuery_ListRecentPreservesFullQueryMembership(t *testing.T)
 	}
 }
 
+func TestEventMetadataQuery_ScopedListAndContextMatchFullQueriesAtExactSecondBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		workspace types.Workspace
+		sessionID types.SessionID
+	}{
+		{
+			name:      "workspace",
+			workspace: types.Workspace("workspace-target"),
+		},
+		{
+			name:      "session",
+			sessionID: types.SessionID("session-target"),
+		},
+		{
+			name:      "workspace and session",
+			workspace: types.Workspace("workspace-target"),
+			sessionID: types.SessionID("session-target"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")
+			sut, storeManager := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+			if err := storeManager.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+
+			workspace := tt.workspace
+			if workspace == "" {
+				workspace = types.Workspace("workspace-in-scope")
+			}
+			sessionID := tt.sessionID
+			if sessionID == "" {
+				sessionID = types.SessionID("session-in-scope")
+			}
+			base := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC)
+			for _, fixture := range []struct {
+				id        string
+				createdAt time.Time
+			}{
+				{id: "event-before", createdAt: base.Add(-time.Second)},
+				{id: "event-from", createdAt: base},
+				{id: "event-fraction", createdAt: base.Add(500 * time.Millisecond)},
+				{id: "event-to", createdAt: base.Add(time.Second)},
+			} {
+				event := newEventForSQLiteTest(
+					t,
+					fixture.id,
+					"cli",
+					"codex",
+					sessionID.String(),
+					workspace.String(),
+					"body",
+					fixture.createdAt,
+				)
+				if err := sut.Save(ctx, event); err != nil {
+					t.Fatalf("Save(%s) error = %v", fixture.id, err)
+				}
+			}
+
+			otherWorkspace := workspace
+			otherSessionID := sessionID
+			if tt.workspace != "" {
+				otherWorkspace = types.Workspace("workspace-out-of-scope")
+			} else {
+				otherSessionID = types.SessionID("session-out-of-scope")
+			}
+			if err := sut.Save(ctx, newEventForSQLiteTest(
+				t,
+				"event-out-of-scope",
+				"cli",
+				"codex",
+				otherSessionID.String(),
+				otherWorkspace.String(),
+				"body",
+				base.Add(750*time.Millisecond),
+			)); err != nil {
+				t.Fatalf("Save(event-out-of-scope) error = %v", err)
+			}
+
+			listBuilder := apptypes.NewEventListCriteriaBuilder(10).
+				From(base).
+				To(base.Add(time.Second))
+			contextBuilder := apptypes.NewEventContextCriteriaBuilder(10)
+			if tt.workspace != "" {
+				listBuilder.Workspace(tt.workspace)
+				contextBuilder.Workspace(tt.workspace)
+			}
+			if tt.sessionID != "" {
+				listBuilder.SessionID(tt.sessionID)
+				contextBuilder.SessionID(tt.sessionID)
+			}
+			listCriteria := listBuilder.Build()
+
+			metadataList, err := sut.ListRecentMetadata(ctx, listCriteria)
+			if err != nil {
+				t.Fatalf("ListRecentMetadata() error = %v", err)
+			}
+			fullList, err := sut.ListRecent(
+				ctx,
+				listCriteria.Limit(),
+				listCriteria.Offset(),
+				listCriteria.Kind(),
+				listCriteria.Client(),
+				listCriteria.Agent(),
+				listCriteria.SessionID(),
+				listCriteria.Workspace(),
+				listCriteria.FailuresOnly(),
+				listCriteria.From(),
+				listCriteria.To(),
+				listCriteria.SourceHook(),
+			)
+			if err != nil {
+				t.Fatalf("ListRecent() error = %v", err)
+			}
+			wantList := []string{"event-fraction", "event-from"}
+			if diff := cmp.Diff(wantList, fullEventIDs(fullList)); diff != "" {
+				t.Fatalf("full list boundary mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(fullEventIDs(fullList), metadataIDs(metadataList)); diff != "" {
+				t.Fatalf("metadata/full list mismatch (-want +got):\n%s", diff)
+			}
+
+			contextCriteria := contextBuilder.Build()
+			metadataContext, err := sut.GetContextMetadata(ctx, contextCriteria)
+			if err != nil {
+				t.Fatalf("GetContextMetadata() error = %v", err)
+			}
+			fullContext, err := sut.GetContext(
+				ctx,
+				contextCriteria.Workspace(),
+				contextCriteria.SessionID(),
+				contextCriteria.Limit(),
+			)
+			if err != nil {
+				t.Fatalf("GetContext() error = %v", err)
+			}
+			wantContext := []string{"event-to", "event-fraction", "event-from", "event-before"}
+			if diff := cmp.Diff(wantContext, fullEventIDs(fullContext)); diff != "" {
+				t.Fatalf("full context order mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(fullEventIDs(fullContext), metadataIDs(metadataContext)); diff != "" {
+				t.Fatalf("metadata/full context mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestEventMetadataQuery_ReturnsBodyFreeCommandAuditMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -626,6 +778,14 @@ CREATE TABLE events (
 func metadataIDs(metadata []apptypes.EventMetadata) []string {
 	ids := make([]string, 0, len(metadata))
 	for _, event := range metadata {
+		ids = append(ids, event.EventID().String())
+	}
+	return ids
+}
+
+func fullEventIDs(events []*model.Event) []string {
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
 		ids = append(ids, event.EventID().String())
 	}
 	return ids

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -222,6 +222,64 @@ func TestMigrations_NormalizedTimestampColumnBackfillsAndMaintainsIndexes(t *tes
 	}
 }
 
+func TestMigrations_NormalizedTimestampMatchesTSNormForLegacyEdgeValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 31)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-v031) error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtures := []struct {
+		id        string
+		createdAt string
+	}{
+		{id: "exact-second", createdAt: "2026-07-25T00:00:00Z"},
+		{id: "fractional-second", createdAt: "2026-07-25T00:00:00.5Z"},
+		{id: "nanosecond", createdAt: "2026-07-25T00:00:00.123456789Z"},
+		{id: "beyond-nanosecond", createdAt: "2026-07-25T00:00:00.123456789123Z"},
+		{id: "legacy-without-zone", createdAt: "2026-07-25T00:00:02.25"},
+	}
+	for _, fixture := range fixtures {
+		if _, err := db.Exec(`INSERT INTO events(id, kind, agent, session_id, body, created_at, client, workspace, body_availability)
+			VALUES (?, 'note', 'codex', 'session-1', 'legacy body', ?, 'hook', 'workspace-1', 'available')`, fixture.id, fixture.createdAt); err != nil {
+			_ = db.Close()
+			t.Fatalf("seed %s: %v", fixture.id, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(v031) error = %v", err)
+	}
+	db, err = sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.id, func(t *testing.T) {
+			var normalized, legacyNormalized string
+			if err := db.QueryRow(
+				`SELECT created_at_norm, ts_norm(created_at) FROM events WHERE id = ?`,
+				fixture.id,
+			).Scan(&normalized, &legacyNormalized); err != nil {
+				t.Fatalf("read normalized timestamp: %v", err)
+			}
+			if normalized != legacyNormalized {
+				t.Fatalf("created_at_norm = %q, ts_norm(created_at) = %q", normalized, legacyNormalized)
+			}
+		})
+	}
+}
+
 func TestMigrations_RunLineageIsAdditiveAndPreservesV27Usage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -142,6 +142,59 @@ func TestMigrations_usageObservationsAreAdditiveAndPreserveExistingRows(t *testi
 	}
 }
 
+func TestMigrations_NormalizedTimestampIndexesAreAdditiveAndRollbackSafe(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 31)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-v031) error = %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO events(id, kind, agent, session_id, body, created_at, client, workspace, body_availability)
+		VALUES ('pre-v031-event', 'note', 'codex', 'session-1', 'existing body', '2026-07-25T00:00:00Z', 'hook', 'workspace-1', 'available')`); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed pre-v031 event: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(v031) error = %v", err)
+	}
+	db, err = sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var eventID string
+	if err := db.QueryRow(`SELECT id FROM events WHERE id = 'pre-v031-event'`).Scan(&eventID); err != nil {
+		t.Fatalf("read upgraded event identity: %v", err)
+	}
+	if eventID != "pre-v031-event" {
+		t.Fatalf("upgraded event id = %q, want preserved identity", eventID)
+	}
+	for _, index := range []string{
+		"idx_events_ts_norm_created_at_id_desc",
+		"idx_events_workspace_ts_norm_created_at_id_desc",
+		"idx_events_session_ts_norm_created_at_id_desc",
+		"idx_events_workspace_session_ts_norm_created_at_id_desc",
+	} {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?`, index).Scan(&count); err != nil {
+			t.Fatalf("look up index %q: %v", index, err)
+		}
+		if count != 1 {
+			t.Errorf("index %q count = %d, want 1", index, count)
+		}
+	}
+}
+
 func TestMigrations_RunLineageIsAdditiveAndPreservesV27Usage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -142,7 +142,7 @@ func TestMigrations_usageObservationsAreAdditiveAndPreserveExistingRows(t *testi
 	}
 }
 
-func TestMigrations_NormalizedTimestampIndexesAreAdditiveAndRollbackSafe(t *testing.T) {
+func TestMigrations_NormalizedTimestampColumnBackfillsAndMaintainsIndexes(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -179,11 +179,38 @@ func TestMigrations_NormalizedTimestampIndexesAreAdditiveAndRollbackSafe(t *test
 	if eventID != "pre-v031-event" {
 		t.Fatalf("upgraded event id = %q, want preserved identity", eventID)
 	}
+	var normalized string
+	if err := db.QueryRow(`SELECT created_at_norm FROM events WHERE id = 'pre-v031-event'`).Scan(&normalized); err != nil {
+		t.Fatalf("read upgraded normalized timestamp: %v", err)
+	}
+	if normalized != "2026-07-25T00:00:00.000000000Z" {
+		t.Fatalf("upgraded normalized timestamp = %q", normalized)
+	}
+	if _, err := db.Exec(`UPDATE events SET created_at = '2026-07-25T00:00:00.5Z' WHERE id = 'pre-v031-event'`); err != nil {
+		t.Fatalf("update migrated event timestamp: %v", err)
+	}
+	if err := db.QueryRow(`SELECT created_at_norm FROM events WHERE id = 'pre-v031-event'`).Scan(&normalized); err != nil {
+		t.Fatalf("read maintained normalized timestamp: %v", err)
+	}
+	if normalized != "2026-07-25T00:00:00.500000000Z" {
+		t.Fatalf("maintained normalized timestamp = %q", normalized)
+	}
+	if _, err := db.Exec(`INSERT INTO events(id, kind, agent, session_id, body, created_at, client, workspace, body_availability)
+		VALUES ('post-v031-event', 'note', 'codex', 'session-1', 'new body', '2026-07-25T00:00:01Z', 'hook', 'workspace-1', 'available')`); err != nil {
+		t.Fatalf("insert post-v031 event: %v", err)
+	}
+	if err := db.QueryRow(`SELECT created_at_norm FROM events WHERE id = 'post-v031-event'`).Scan(&normalized); err != nil {
+		t.Fatalf("read inserted normalized timestamp: %v", err)
+	}
+	if normalized != "2026-07-25T00:00:01.000000000Z" {
+		t.Fatalf("inserted normalized timestamp = %q", normalized)
+	}
 	for _, index := range []string{
-		"idx_events_ts_norm_created_at_id_desc",
-		"idx_events_workspace_ts_norm_created_at_id_desc",
-		"idx_events_session_ts_norm_created_at_id_desc",
-		"idx_events_workspace_session_ts_norm_created_at_id_desc",
+		"idx_events_created_at_norm_id_desc",
+		"idx_events_workspace_created_at_norm_id_desc",
+		"idx_events_session_created_at_norm_id_desc",
+		"idx_events_workspace_session_created_at_norm_id_desc",
+		"idx_events_source_hook_created_at_norm_id_desc",
 	} {
 		var count int
 		if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?`, index).Scan(&count); err != nil {

--- a/infrastructure/sqlite/report_query.go
+++ b/infrastructure/sqlite/report_query.go
@@ -72,8 +72,8 @@ func (d *ReportDatasource) LoadReportWindow(ctx context.Context, criteria apptyp
 	events, eventsTruncated, err := loadCappedReportRows(criteria.PageSize(), criteria.ResultCap(), func(limit, offset int) ([]apptypes.EventMetadata, error) {
 		rows, err := queryRecentEventMetadataTx(
 			ctx, tx, reportEventCriteria(criteria),
-			formatOptionalTimestamp(criteria.Interval().EffectiveFromInclusive()),
-			formatOptionalTimestamp(criteria.Interval().EffectiveToExclusive()),
+			formatMetadataOptionalTimestamp(criteria.Interval().EffectiveFromInclusive()),
+			formatMetadataOptionalTimestamp(criteria.Interval().EffectiveToExclusive()),
 			limit, offset,
 		)
 		if err != nil {

--- a/infrastructure/sqlite/sql/get_context_event_metadata.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata.sql
@@ -8,5 +8,5 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE (? = '' OR e.workspace = ?)
    AND (? = '' OR e.session_id = ?)
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
@@ -7,5 +7,5 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE e.session_id = ?
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
@@ -1,0 +1,11 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.session_id = ?
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
@@ -7,5 +7,5 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
   FROM events e
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE e.workspace = ?
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
@@ -1,0 +1,11 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.workspace = ?
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
@@ -8,5 +8,5 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
   LEFT JOIN command_audits ca ON ca.event_id = e.id
  WHERE e.workspace = ?
    AND e.session_id = ?
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ?

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
@@ -1,0 +1,12 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.workspace = ?
+   AND e.session_id = ?
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata.sql
@@ -12,7 +12,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
@@ -1,0 +1,18 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.session_id = ?
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.workspace = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
@@ -12,7 +12,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.workspace = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
@@ -13,7 +13,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
@@ -20,8 +20,8 @@ SELECT id, kind, client, agent, session_id, workspace,
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
            AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+           AND (? = '' OR e.created_at_norm >= ?)
+           AND (? = '' OR e.created_at_norm < ?)
         UNION ALL
         SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
                e.source_hook, e.created_at,
@@ -44,8 +44,8 @@ SELECT id, kind, client, agent, session_id, workspace,
            AND (? = '' OR e.session_id = ?)
            AND (? = '' OR e.workspace = ?)
            AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-           AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+           AND (? = '' OR e.created_at_norm >= ?)
+           AND (? = '' OR e.created_at_norm < ?)
        ) events_union
  ORDER BY ts_norm(created_at) DESC, id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
@@ -1,51 +1,25 @@
-SELECT id, kind, client, agent, session_id, workspace,
-       source_hook, created_at,
-       body_original_bytes, body_stored_bytes,
-       body_ingest_truncated, body_storage_truncated,
-       body_metadata_version,
-       audit_event_id, exit_code, failed
-  FROM (
-        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
-               e.source_hook, e.created_at,
-               e.body_original_bytes, e.body_stored_bytes,
-               e.body_ingest_truncated, e.body_storage_truncated,
-               e.body_metadata_version,
-               ca.event_id AS audit_event_id, ca.exit_code, ca.failed
-          FROM events e
-          LEFT JOIN command_audits ca ON ca.event_id = e.id
-         WHERE e.source_hook = ?
-           AND (? = '' OR e.kind = ?)
-           AND (? = '' OR e.client = ?)
-           AND (? = '' OR e.agent = ?)
-           AND (? = '' OR e.session_id = ?)
-           AND (? = '' OR e.workspace = ?)
-           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR e.created_at_norm >= ?)
-           AND (? = '' OR e.created_at_norm < ?)
-        UNION ALL
-        SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
-               e.source_hook, e.created_at,
-               e.body_original_bytes, e.body_stored_bytes,
-               e.body_ingest_truncated, e.body_storage_truncated,
-               e.body_metadata_version,
-               ca.event_id AS audit_event_id, ca.exit_code, ca.failed
-          FROM events e
-          LEFT JOIN command_audits ca ON ca.event_id = e.id
-         WHERE e.source_hook IS NULL
-           AND (
-                 (? = 'subagent_stop' AND e.kind = 'session_ended'
-                      AND e.body LIKE '[phase:subagent]%')
-              OR (? = 'pre_compact' AND e.kind = 'compact_summary'
-                      AND e.body LIKE '[phase:pre-compact]%')
-               )
-           AND (? = '' OR e.kind = ?)
-           AND (? = '' OR e.client = ?)
-           AND (? = '' OR e.agent = ?)
-           AND (? = '' OR e.session_id = ?)
-           AND (? = '' OR e.workspace = ?)
-           AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-           AND (? = '' OR e.created_at_norm >= ?)
-           AND (? = '' OR e.created_at_norm < ?)
-       ) events_union
- ORDER BY ts_norm(created_at) DESC, id DESC
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE (
+       e.source_hook = ?
+    OR (e.source_hook IS NULL AND (
+          (? = 'subagent_stop' AND e.kind = 'session_ended' AND e.body LIKE '[phase:subagent]%')
+       OR (? = 'pre_compact' AND e.kind = 'compact_summary' AND e.body LIKE '[phase:pre-compact]%')
+    ))
+ )
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = '' OR e.workspace = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
@@ -12,7 +12,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
@@ -1,0 +1,18 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.workspace = ?
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = '' OR e.session_id = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
@@ -12,7 +12,7 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
-   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
-   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+   AND (? = '' OR e.created_at_norm >= ?)
+   AND (? = '' OR e.created_at_norm < ?)
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT ? OFFSET ?

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
@@ -1,0 +1,18 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       ca.event_id, ca.exit_code, ca.failed
+  FROM events e
+  LEFT JOIN command_audits ca ON ca.event_id = e.id
+ WHERE e.workspace = ?
+   AND e.session_id = ?
+   AND (? = '' OR e.kind = ?)
+   AND (? = '' OR e.client = ?)
+   AND (? = '' OR e.agent = ?)
+   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = '' OR ts_norm(e.created_at) >= ts_norm(?))
+   AND (? = '' OR ts_norm(e.created_at) < ts_norm(?))
+ ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+ LIMIT ? OFFSET ?

--- a/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
+++ b/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
@@ -94,12 +94,6 @@ BEGIN
      WHERE id = NEW.id;
 END;
 
-DROP INDEX IF EXISTS idx_events_ts_norm_created_at_id_desc;
-DROP INDEX IF EXISTS idx_events_workspace_ts_norm_created_at_id_desc;
-DROP INDEX IF EXISTS idx_events_session_ts_norm_created_at_id_desc;
-DROP INDEX IF EXISTS idx_events_workspace_session_ts_norm_created_at_id_desc;
-DROP INDEX IF EXISTS idx_events_source_hook_time;
-
 CREATE INDEX idx_events_created_at_norm_id_desc
     ON events(created_at_norm DESC, id DESC);
 CREATE INDEX idx_events_workspace_created_at_norm_id_desc

--- a/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
+++ b/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
@@ -1,0 +1,20 @@
+-- Metadata list/context queries must preserve RFC3339Nano instant ordering.
+-- created_at itself is variable-width and cannot provide that order around an
+-- exact-second/fractional-second boundary, so index the deterministic
+-- normalization expression used by the query contract.
+--
+-- These indexes are additive: they neither rewrite event rows nor remove
+-- existing indexes. Rolling back application code therefore leaves a fully
+-- readable store; a later maintenance release may drop only these named
+-- indexes after all readers no longer rely on them.
+CREATE INDEX IF NOT EXISTS idx_events_ts_norm_created_at_id_desc
+    ON events(ts_norm(created_at) DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_workspace_ts_norm_created_at_id_desc
+    ON events(workspace, ts_norm(created_at) DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_session_ts_norm_created_at_id_desc
+    ON events(session_id, ts_norm(created_at) DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_workspace_session_ts_norm_created_at_id_desc
+    ON events(workspace, session_id, ts_norm(created_at) DESC, id DESC);

--- a/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
+++ b/schema/sqlite/migrations/000031_add_event_metadata_normalized_timestamp_indexes.sql
@@ -1,20 +1,113 @@
--- Metadata list/context queries must preserve RFC3339Nano instant ordering.
--- created_at itself is variable-width and cannot provide that order around an
--- exact-second/fractional-second boundary, so index the deterministic
--- normalization expression used by the query contract.
+-- Persist a lexically sortable RFC3339Nano timestamp for event metadata reads.
 --
--- These indexes are additive: they neither rewrite event rows nor remove
--- existing indexes. Rolling back application code therefore leaves a fully
--- readable store; a later maintenance release may drop only these named
--- indexes after all readers no longer rely on them.
-CREATE INDEX IF NOT EXISTS idx_events_ts_norm_created_at_id_desc
-    ON events(ts_norm(created_at) DESC, id DESC);
+-- created_at uses Go's variable-width RFC3339Nano representation, which cannot
+-- be ordered correctly as TEXT around an exact-second boundary. This migration
+-- keeps created_at unchanged, backfills a fixed-width companion column, and
+-- maintains it for every later insert or created_at update. The expression is
+-- deliberately SQLite built-in only: migrations must remain valid for stock
+-- sqlite3 tools that do not register Traceary's ts_norm extension.
+--
+-- Traceary writes UTC timestamps ending in Z. Historical malformed values keep
+-- their legacy lexical shape rather than making migration fail.
+ALTER TABLE events ADD COLUMN created_at_norm TEXT;
 
-CREATE INDEX IF NOT EXISTS idx_events_workspace_ts_norm_created_at_id_desc
-    ON events(workspace, ts_norm(created_at) DESC, id DESC);
+UPDATE events
+   SET created_at_norm = CASE
+       WHEN substr(created_at, -1) = 'Z' AND length(created_at) >= 20
+       THEN substr(created_at, 1, 19) || '.' ||
+            substr(
+                CASE
+                    WHEN substr(created_at, 20, 1) = '.'
+                    THEN substr(created_at, 21, length(created_at) - 21)
+                    ELSE ''
+                END || '000000000',
+                1, 9
+            ) || 'Z'
+       ELSE created_at
+   END;
 
-CREATE INDEX IF NOT EXISTS idx_events_session_ts_norm_created_at_id_desc
-    ON events(session_id, ts_norm(created_at) DESC, id DESC);
+CREATE TRIGGER events_created_at_norm_after_insert
+AFTER INSERT ON events
+FOR EACH ROW
+WHEN NEW.created_at_norm IS NULL OR NEW.created_at_norm != CASE
+    WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+    THEN substr(NEW.created_at, 1, 19) || '.' ||
+         substr(
+             CASE
+                 WHEN substr(NEW.created_at, 20, 1) = '.'
+                 THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                 ELSE ''
+             END || '000000000',
+             1, 9
+         ) || 'Z'
+    ELSE NEW.created_at
+END
+BEGIN
+    UPDATE events
+       SET created_at_norm = CASE
+           WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+           THEN substr(NEW.created_at, 1, 19) || '.' ||
+                substr(
+                    CASE
+                        WHEN substr(NEW.created_at, 20, 1) = '.'
+                        THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                        ELSE ''
+                    END || '000000000',
+                    1, 9
+                ) || 'Z'
+           ELSE NEW.created_at
+       END
+     WHERE id = NEW.id;
+END;
 
-CREATE INDEX IF NOT EXISTS idx_events_workspace_session_ts_norm_created_at_id_desc
-    ON events(workspace, session_id, ts_norm(created_at) DESC, id DESC);
+CREATE TRIGGER events_created_at_norm_after_update
+AFTER UPDATE OF created_at ON events
+FOR EACH ROW
+WHEN NEW.created_at_norm IS NULL OR NEW.created_at_norm != CASE
+    WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+    THEN substr(NEW.created_at, 1, 19) || '.' ||
+         substr(
+             CASE
+                 WHEN substr(NEW.created_at, 20, 1) = '.'
+                 THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                 ELSE ''
+             END || '000000000',
+             1, 9
+         ) || 'Z'
+    ELSE NEW.created_at
+END
+BEGIN
+    UPDATE events
+       SET created_at_norm = CASE
+           WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+           THEN substr(NEW.created_at, 1, 19) || '.' ||
+                substr(
+                    CASE
+                        WHEN substr(NEW.created_at, 20, 1) = '.'
+                        THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                        ELSE ''
+                    END || '000000000',
+                    1, 9
+                ) || 'Z'
+           ELSE NEW.created_at
+       END
+     WHERE id = NEW.id;
+END;
+
+DROP INDEX IF EXISTS idx_events_ts_norm_created_at_id_desc;
+DROP INDEX IF EXISTS idx_events_workspace_ts_norm_created_at_id_desc;
+DROP INDEX IF EXISTS idx_events_session_ts_norm_created_at_id_desc;
+DROP INDEX IF EXISTS idx_events_workspace_session_ts_norm_created_at_id_desc;
+DROP INDEX IF EXISTS idx_events_source_hook_time;
+
+CREATE INDEX idx_events_created_at_norm_id_desc
+    ON events(created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_workspace_created_at_norm_id_desc
+    ON events(workspace, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_session_created_at_norm_id_desc
+    ON events(session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_workspace_session_created_at_norm_id_desc
+    ON events(workspace, session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_source_hook_created_at_norm_id_desc
+    ON events(source_hook, created_at_norm DESC, id DESC)
+    WHERE source_hook IS NOT NULL;


### PR DESCRIPTION
## Motivation

General metadata list/context queries could lose index-backed ordering or scan excessive timestamp ranges on large stores.

## Changes

- persist and backfill `events.created_at_norm`, maintaining it with insert/update triggers
- add normalized metadata ordering indexes while preserving the existing `idx_events_source_hook_time` index
- select scope-specific and direct timestamp-range SQL variants
- keep legacy `subagent_stop` / `pre_compact` fallback on an ordering-index plan without a temporary sort
- add migrated-store query-plan coverage that rejects every temporary B-tree and requires direct range seeks
- retain a 10k-event CI p95 smoke test; provide an opt-in actual multi-GiB SQLite benchmark for release QA #1558, not CI

## Validation

- go test ./...
- go tool golangci-lint run
- go build ./...
- go vet ./...
- stock sqlite3 migration plus `PRAGMA integrity_check`
- git diff --check

## Release QA follow-up

The constrained implementation runner could not complete the actual multi-GiB setup despite 7.8 GiB free, so this PR does not claim a synthetic multi-GiB p95. Before release, #1558 must run `BenchmarkMetadataDirectRangeMultiGiB` with `TRACEARY_RUN_MULTI_GIB_BENCHMARK=1` and record managed pages, event/body totals, environment, target, and p95.

Closes #1553
