### PR TITLE
fix: bound event full-text search

### DIFF
--- a/.ai/spec/1554.md
+++ b/.ai/spec/1554.md
@@ -1,0 +1,134 @@
+# #1554 Bounded resumable FTS event search
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Replace unbounded event-body and command-audit `LIKE` scans with
+  an FTS5 trigram search projection while retaining the existing literal
+  substring meaning and body-free metadata boundary.
+- **Current behavior:** Full and metadata search evaluate JSON extraction and
+  `LIKE '%query%'` across every structurally matching event. Large stores can
+  therefore scan event bodies and command payloads without a bounded scope.
+- **Expected behavior:** New writes maintain a search-only projection. Existing
+  rows are indexed by resumable, rowid-keyset batches with a durable checkpoint.
+  Search is complete only when it can use the projection or can evaluate the
+  remaining legacy rows inside a hard-bounded candidate set.
+- **Literal semantics:** FTS queries use an escaped quoted phrase. The trigram
+  index is configured with `case_sensitive 1`; projected ASCII and ASCII query
+  characters are lower-cased so matching remains ASCII case-insensitive and
+  Unicode case-sensitive, like SQLite's default `LIKE`.
+- **Short queries:** Queries shorter than three runes use legacy `LIKE` only
+  after a metadata-only candidate count proves the structural/time scope has at
+  most 10,000 rows. An unbounded or over-cap scope returns a typed error asking
+  the caller to add `[from,to)`.
+- **Backfill-incomplete searches:** Indexed rows and still-missing rows are
+  searched together only after the same hard-cap check. An unbounded or
+  over-cap scope returns a typed incomplete-index/scope error instead of a
+  silent false negative.
+- **Projection content:** Canonical transcript envelopes contribute text blocks
+  only. Thinking and unknown blocks are omitted. Retention-unavailable bodies
+  contribute an empty body. Command-audit columns contribute exactly the
+  already persisted redacted/truncated values; original content is never
+  reconstructed.
+- **Migration behavior:** Migration 32 creates only the FTS schema, maintenance
+  triggers, and progress state. It does not rewrite or backfill historical
+  event rows during migration.
+- **Out of scope:** Changing retention policy, rehydrating truncated payloads,
+  fuzzy/stemmed/boolean search syntax, Unicode case folding, or reading body in
+  metadata result hydration.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Search document | Stable `search_document_id` plus unique `event_id` in a content table, mirrored by FTS external-content rowid | Matches a literal substring across visible body and saved audit fields | Identity never depends on mutable `events.rowid`; thinking and unavailable-retention body text are absent |
+| Current document | Projection for a newly inserted or updated event/audit | Maintained transactionally by triggers | At most one content row per event; FTS rowid equals stable `search_document_id` |
+| Historical missing document | Event whose TEXT primary key is beyond durable backfill coverage or otherwise absent | Is indexed by a later keyset batch or evaluated by bounded legacy search | It must never be silently omitted |
+| Backfill checkpoint | Durable last processed and fixed target event TEXT IDs | Advances only after a batch's projection writes succeed in one transaction | Keyset is `id > last AND id <= target ORDER BY id`; crash/rollback leaves the prior checkpoint retryable |
+| Literal query | Trimmed user text | Becomes a quoted FTS phrase after quote escaping and ASCII lower-casing | Boolean-looking input is data, never FTS syntax |
+| Bounded legacy scope | Structural/time-filtered metadata candidate set | May evaluate legacy JSON/`LIKE` content | Candidate count must not exceed 10,000 |
+| Search candidate ID | Event identity selected by indexed and/or bounded legacy search | Shared by full and metadata hydration | Final order is `created_at_norm DESC, id DESC` |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Define content table, FTS schema, triggers, and initial progress row | migration 32 | SQLite persistence compatibility | Migration must not perform historical backfill or use `events.rowid` as durable identity |
+| Produce search-safe body/audit text | `infrastructure/sqlite` projection helper and SQL expressions | Stored representation and FTS tokenizer behavior are infrastructure concerns | Presentation must not parse storage envelopes |
+| Run resumable historical batches | SQLite backfill component called after migration | Transaction, TEXT-primary-key keyset, and checkpoint ownership belong together | Migration and request handlers must stay bounded |
+| Choose FTS versus bounded legacy completeness path | SQLite search planner | It depends on query rune length and durable index progress | Usecase only validates consumer criteria |
+| Expose typed unsafe-scope/incomplete-index errors | Application query contract with SQLite implementation | CLI/MCP consumers need stable classification | Error text alone is not a reliable contract |
+| Hydrate full or metadata rows from shared candidate IDs | SQLite search execution | Prevents search semantics from drifting between projections | Metadata hydration must never select `events.body` |
+| Verify query-plan index selection | Infrastructure regression tests | SQLite plan shape is an observable performance constraint | Runtime must not branch on `EXPLAIN` output |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| `EventSearchCriteria` to event query service | full and metadata usecases | FTS phrase encoding, candidate cap, checkpoint state | `errors.Is` identifies unsafe broad scope or incomplete index |
+| Search candidate selector | full and metadata hydration | Stable search-document IDs, FTS virtual table, legacy JSON extraction, de-duplication | Returns ordered event IDs only; no partial results on unsafe scope |
+| Metadata hydrator | MCP/CLI metadata projection | Candidate selection may inspect persisted search text | SQL result projection does not select `events.body` |
+| Backfill batch transaction | database initialization / later retry | TEXT-primary-key keyset query and FTS writes | Failure rolls back checkpoint and batch; next run resumes |
+| Migration 32 | existing stores and stock SQLite tooling | FTS table/triggers/progress rows | Applies without scanning existing `events` or `command_audits` |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Literal substring semantics | punctuation, quotes, `%`, `_`, backslashes, Boolean-looking text, ASCII mixed case, and Unicode case variants | Search a three-rune-or-longer query | Results match legacy literal substring semantics; input is not parsed as FTS syntax | Infrastructure |
+| Thinking exclusion | Canonical envelope with a thinking-only needle and a visible text needle | Search each needle | Thinking-only text never matches; visible text does | Infrastructure |
+| Retention and audit projection | unavailable-retention body plus persisted truncated/redacted audit text | Search original and stored values | Body is absent; only stored audit values match | Infrastructure |
+| Metadata body-free hydration | Matching full and metadata searches | Trace selected SQL / inspect production query | Both return the same IDs, while metadata hydration never selects body | Infrastructure |
+| Migration is immediate | Large historical fixture before migration 32 | Apply migration | Schema/progress exist, no historical FTS documents are inserted | Migration integration |
+| Backfill resumes | Batch transaction is interrupted after a committed batch | Re-open and continue | Processing resumes after durable event ID and eventually completes without duplicates | Infrastructure |
+| Incomplete-index completeness | Some matching rows are indexed and some remain missing within the hard cap | Run bounded search | Combined results include both sets once, in final timestamp/id order | Infrastructure |
+| Unsafe incomplete index | Backfill is incomplete and the search is unbounded or candidate cap is exceeded | Search | Typed error; never partial indexed-only results | Infrastructure/usecase |
+| Short-query safety | Query has fewer than three runes | Search bounded and unbounded scopes | Under-cap bounded scope uses legacy search; unsafe scope returns typed error | Infrastructure |
+| FTS plan | Complete index and a searchable literal query | Explain production candidate SQL | Plan uses the FTS virtual-table index and does not scan event bodies | Infrastructure regression |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Safe schema and projection semantics | Add migration/projection tests before migration 32 exists | Create an external-content trigram FTS table, progress state, triggers, and shared projection SQL | Keep body and audit projection expressions centralized enough to avoid trigger/backfill drift |
+| Resumable keyset backfill | Add partial-batch/reopen test | Freeze a target event ID, process a small TEXT-ID-ordered batch, and advance checkpoint atomically | Isolate batch ownership from database initialization logging |
+| Complete bounded search | Add mixed indexed/missing and short-query tests | Build shared ordered candidate IDs from FTS plus capped legacy path | One candidate selector feeds full and metadata hydration |
+| Typed unsafe scope | Assert `errors.Is` and structured details | Add stable queryservice errors with cap/reason fields | Presentation may later map types without string matching |
+| Metadata/body and plan constraints | Add SQL-shape/trace and `EXPLAIN QUERY PLAN` tests | Separate candidate selection from body-free metadata hydration | Keep production SQL constants directly exercised by tests |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** Trigger, backfill, and legacy projection expressions
+  can drift. Tests compare observable search results across new writes,
+  historical backfill, and incomplete fallback; shared helpers/constants are
+  preferred where SQLite trigger constraints permit.
+- **Premature-abstraction risk:** A general search engine interface would add
+  variation not requested by this issue. Keep one SQLite-specific candidate
+  selector and two narrow hydrators.
+- **Migration / compatibility:** FTS5 trigram availability is required by the
+  bundled modernc SQLite. Migration 32 adds independent tables/triggers only,
+  does not remove legacy columns, and does not backfill existing rows. Durable
+  identity uses `events.id`, never `events.rowid`, because `VACUUM` may rewrite
+  rowids for tables whose primary key is not `INTEGER PRIMARY KEY`.
+- **Rollback trigger:** If migration fails on the supported SQLite build, FTS
+  results diverge from literal semantics, metadata hydration reads bodies, or
+  bounded searches can omit missing documents, stop rollout and revert the
+  application code plus migration before release.
+- **Rollback procedure:** Drop the migration-32 triggers, FTS table, and progress
+  table only on stores that have not been opened by a released build; otherwise
+  ship a forward migration that removes those objects. Existing `events` and
+  `command_audits` remain authoritative, so reverting search code restores the
+  prior legacy `LIKE` behavior without data recovery.
+- **Split PR plan:** This issue remains one PR because schema, writer
+  maintenance, backfill completeness, and reader selection form one correctness
+  unit. If delivery must be staged, first ship dormant schema/backfill support,
+  then enable indexed reads only after a separately versioned migration marks
+  completion.
+
+## Implementation checkpoint
+
+Proceed with migration-safe schema creation, transactionally resumable
+small-batch backfill, and one shared candidate selector. Reject rather than
+return partial results whenever the unindexed legacy remainder cannot be proven
+to fit the hard cap.

--- a/.ai/spec/1554.md
+++ b/.ai/spec/1554.md
@@ -77,7 +77,7 @@
 | Behavior | Given | When | Then | Level |
 | --- | --- | --- | --- | --- |
 | Literal substring semantics | punctuation, quotes, `%`, `_`, backslashes, Boolean-looking text, ASCII mixed case, and Unicode case variants | Search a three-rune-or-longer query | Results match legacy literal substring semantics; input is not parsed as FTS syntax | Infrastructure |
-| Thinking exclusion | Canonical envelope with thinking, unknown tool-use, and visible text blocks | Search thinking and visible needles | Unknown blocks are ignored, thinking text never matches, and visible text does | Infrastructure |
+| Thinking exclusion | Canonical envelope with thinking, empty-text tool-use, and visible text blocks | Search thinking and visible needles | Canonical non-text blocks are ignored, thinking text never matches, and visible text does | Infrastructure |
 | Retention and audit projection | unavailable-retention body plus persisted truncated/redacted audit text | Search original and stored values | Body is absent; only stored audit values match | Infrastructure |
 | Audit mutation synchronization | An indexed command audit is updated or deleted | Search its old and new stored values | Updates remove the old value and expose only the new value; deletion removes the audit value | Infrastructure |
 | Metadata body-free hydration | Matching full and metadata searches | Trace selected SQL / inspect production query | Both return the same IDs, while metadata hydration never selects body | Infrastructure |

--- a/.ai/spec/1554.md
+++ b/.ai/spec/1554.md
@@ -77,7 +77,7 @@
 | Behavior | Given | When | Then | Level |
 | --- | --- | --- | --- | --- |
 | Literal substring semantics | punctuation, quotes, `%`, `_`, backslashes, Boolean-looking text, ASCII mixed case, and Unicode case variants | Search a three-rune-or-longer query | Results match legacy literal substring semantics; input is not parsed as FTS syntax | Infrastructure |
-| Thinking exclusion | Canonical envelope with a thinking-only needle and a visible text needle | Search each needle | Thinking-only text never matches; visible text does | Infrastructure |
+| Thinking exclusion | Canonical envelope with thinking, unknown tool-use, and visible text blocks | Search thinking and visible needles | Unknown blocks are ignored, thinking text never matches, and visible text does | Infrastructure |
 | Retention and audit projection | unavailable-retention body plus persisted truncated/redacted audit text | Search original and stored values | Body is absent; only stored audit values match | Infrastructure |
 | Audit mutation synchronization | An indexed command audit is updated or deleted | Search its old and new stored values | Updates remove the old value and expose only the new value; deletion removes the audit value | Infrastructure |
 | Metadata body-free hydration | Matching full and metadata searches | Trace selected SQL / inspect production query | Both return the same IDs, while metadata hydration never selects body | Infrastructure |

--- a/.ai/spec/1554.md
+++ b/.ai/spec/1554.md
@@ -79,6 +79,7 @@
 | Literal substring semantics | punctuation, quotes, `%`, `_`, backslashes, Boolean-looking text, ASCII mixed case, and Unicode case variants | Search a three-rune-or-longer query | Results match legacy literal substring semantics; input is not parsed as FTS syntax | Infrastructure |
 | Thinking exclusion | Canonical envelope with a thinking-only needle and a visible text needle | Search each needle | Thinking-only text never matches; visible text does | Infrastructure |
 | Retention and audit projection | unavailable-retention body plus persisted truncated/redacted audit text | Search original and stored values | Body is absent; only stored audit values match | Infrastructure |
+| Audit mutation synchronization | An indexed command audit is updated or deleted | Search its old and new stored values | Updates remove the old value and expose only the new value; deletion removes the audit value | Infrastructure |
 | Metadata body-free hydration | Matching full and metadata searches | Trace selected SQL / inspect production query | Both return the same IDs, while metadata hydration never selects body | Infrastructure |
 | Migration is immediate | Large historical fixture before migration 32 | Apply migration | Schema/progress exist, no historical FTS documents are inserted | Migration integration |
 | Backfill resumes | Batch transaction is interrupted after a committed batch | Re-open and continue | Processing resumes after durable event ID and eventually completes without duplicates | Infrastructure |

--- a/application/queryservice/event_search_errors.go
+++ b/application/queryservice/event_search_errors.go
@@ -1,0 +1,64 @@
+package queryservice
+
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+)
+
+// Event search can reject a request instead of returning an incomplete result
+// or evaluating an unbounded legacy body scan.
+var (
+	ErrEventSearchScopeTooBroad   = xerrors.New("event search scope too broad")
+	ErrEventSearchIndexIncomplete = xerrors.New("event search index incomplete")
+)
+
+// EventSearchUnavailableReason is the stable classification exposed to CLI and
+// MCP consumers through EventSearchUnavailableError.
+type EventSearchUnavailableReason string
+
+const (
+	// EventSearchUnavailableScopeTooBroad rejects a legacy fallback whose
+	// structural/time candidate set cannot be proven below the hard cap.
+	EventSearchUnavailableScopeTooBroad EventSearchUnavailableReason = "scope_too_broad"
+	// EventSearchUnavailableIndexIncomplete rejects an unbounded indexed query
+	// while historical search documents are still being backfilled.
+	EventSearchUnavailableIndexIncomplete EventSearchUnavailableReason = "index_incomplete"
+)
+
+// EventSearchUnavailableError describes why indexed search cannot safely
+// satisfy a request. CandidateLimit is the maximum body-bearing legacy scope;
+// CandidateCount is limit+1 when the cap was exceeded.
+type EventSearchUnavailableError struct {
+	Reason         EventSearchUnavailableReason
+	CandidateLimit int
+	CandidateCount int
+}
+
+func (e *EventSearchUnavailableError) Error() string {
+	switch e.Reason {
+	case EventSearchUnavailableIndexIncomplete:
+		return fmt.Sprintf(
+			"event search index backfill is incomplete; add workspace/session and from/to bounds (legacy candidate limit %d)",
+			e.CandidateLimit,
+		)
+	default:
+		if e.CandidateCount > e.CandidateLimit {
+			return fmt.Sprintf(
+				"event search scope has more than %d legacy candidates; add narrower from/to bounds",
+				e.CandidateLimit,
+			)
+		}
+		return fmt.Sprintf(
+			"event search scope is unbounded; add workspace/session and from/to bounds (legacy candidate limit %d)",
+			e.CandidateLimit,
+		)
+	}
+}
+
+func (e *EventSearchUnavailableError) Unwrap() error {
+	if e.Reason == EventSearchUnavailableIndexIncomplete {
+		return ErrEventSearchIndexIncomplete
+	}
+	return ErrEventSearchScopeTooBroad
+}

--- a/application/types/event_body_blocks.go
+++ b/application/types/event_body_blocks.go
@@ -59,9 +59,11 @@ func DecodeCanonicalEnvelope(body string) ([]EventBodyBlock, bool) {
 //     (encoding/json matches tags case-insensitively, so we probe the
 //     raw key set ourselves — "Blocks" or "BLOCKS" must NOT be
 //     recognized as envelopes)
-//   - each element must be a JSON object with string "type" and
-//     string "text" fields — anything else is treated as foreign JSON
-//     that happens to share the key name
+//   - each element must be a JSON object with a string "type" field
+//   - text / thinking elements must also carry a string "text" field
+//   - unknown block types may omit "text" (for example tool_use); they
+//     remain canonical but their provider-specific fields are ignored by
+//     this text-oriented projection
 //
 // Returned ok=false means the payload is not our envelope and callers
 // should preserve the raw body. Unknown block types are preserved to
@@ -87,16 +89,28 @@ func decodeCanonicalEnvelope(body string) ([]EventBodyBlock, bool) {
 	blocks := make([]EventBodyBlock, 0, len(rawElements))
 	for _, raw := range rawElements {
 		typeRaw, hasType := raw["type"]
-		textRaw, hasText := raw["text"]
-		if !hasType || !hasText {
+		if !hasType {
 			return nil, false
 		}
-		var blockType, blockText string
+		var blockType string
 		if err := json.Unmarshal(typeRaw, &blockType); err != nil {
 			return nil, false
 		}
-		if err := json.Unmarshal(textRaw, &blockText); err != nil {
-			return nil, false
+		blockText := ""
+		textRaw, hasText := raw["text"]
+		switch EventBodyBlockType(blockType) {
+		case EventBodyBlockTypeText, EventBodyBlockTypeThinking:
+			if !hasText || json.Unmarshal(textRaw, &blockText) != nil {
+				return nil, false
+			}
+		default:
+			// Provider-specific blocks such as tool_use are not part of the
+			// plain-text projection. Preserve a string text value when one
+			// exists, but do not reject an otherwise canonical envelope when
+			// the unknown block omits text or stores a structured payload.
+			if hasText {
+				_ = json.Unmarshal(textRaw, &blockText)
+			}
 		}
 		blocks = append(blocks, EventBodyBlock{
 			Type: EventBodyBlockType(blockType),

--- a/application/types/event_body_blocks.go
+++ b/application/types/event_body_blocks.go
@@ -59,11 +59,9 @@ func DecodeCanonicalEnvelope(body string) ([]EventBodyBlock, bool) {
 //     (encoding/json matches tags case-insensitively, so we probe the
 //     raw key set ourselves — "Blocks" or "BLOCKS" must NOT be
 //     recognized as envelopes)
-//   - each element must be a JSON object with a string "type" field
-//   - text / thinking elements must also carry a string "text" field
-//   - unknown block types may omit "text" (for example tool_use); they
-//     remain canonical but their provider-specific fields are ignored by
-//     this text-oriented projection
+//   - each element must be a JSON object with string "type" and
+//     string "text" fields — anything else is treated as foreign JSON
+//     that happens to share the key name
 //
 // Returned ok=false means the payload is not our envelope and callers
 // should preserve the raw body. Unknown block types are preserved to
@@ -89,28 +87,16 @@ func decodeCanonicalEnvelope(body string) ([]EventBodyBlock, bool) {
 	blocks := make([]EventBodyBlock, 0, len(rawElements))
 	for _, raw := range rawElements {
 		typeRaw, hasType := raw["type"]
-		if !hasType {
+		textRaw, hasText := raw["text"]
+		if !hasType || !hasText {
 			return nil, false
 		}
-		var blockType string
+		var blockType, blockText string
 		if err := json.Unmarshal(typeRaw, &blockType); err != nil {
 			return nil, false
 		}
-		blockText := ""
-		textRaw, hasText := raw["text"]
-		switch EventBodyBlockType(blockType) {
-		case EventBodyBlockTypeText, EventBodyBlockTypeThinking:
-			if !hasText || json.Unmarshal(textRaw, &blockText) != nil {
-				return nil, false
-			}
-		default:
-			// Provider-specific blocks such as tool_use are not part of the
-			// plain-text projection. Preserve a string text value when one
-			// exists, but do not reject an otherwise canonical envelope when
-			// the unknown block omits text or stores a structured payload.
-			if hasText {
-				_ = json.Unmarshal(textRaw, &blockText)
-			}
+		if err := json.Unmarshal(textRaw, &blockText); err != nil {
+			return nil, false
 		}
 		blocks = append(blocks, EventBodyBlock{
 			Type: EventBodyBlockType(blockType),

--- a/application/types/event_body_blocks_test.go
+++ b/application/types/event_body_blocks_test.go
@@ -45,6 +45,11 @@ func TestExtractPlainBody(t *testing.T) {
 			want: "first\n\nsecond",
 		},
 		{
+			name: "unknown block without text does not expose adjacent thinking",
+			body: `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible response"}]}`,
+			want: "visible response",
+		},
+		{
 			name: "envelope with empty blocks array collapses to empty",
 			body: `{"blocks":[]}`,
 			want: "",
@@ -95,6 +100,7 @@ func TestDecodeCanonicalEnvelope(t *testing.T) {
 		{"non-string type not envelope", `{"blocks":[{"type":42,"text":"x"}]}`, false, 0},
 		{"empty blocks array is envelope", `{"blocks":[]}`, true, 0},
 		{"canonical envelope returns blocks", `{"blocks":[{"type":"thinking","text":"a"},{"type":"text","text":"b"}]}`, true, 2},
+		{"unknown block may omit text", `{"blocks":[{"type":"thinking","text":"a"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"b"}]}`, true, 3},
 	}
 
 	for _, tc := range cases {
@@ -138,6 +144,15 @@ func TestParseEventBodyBlocks(t *testing.T) {
 			name: "envelope blocks are returned as-is",
 			body: `{"blocks":[{"type":"text","text":"hi"}]}`,
 			want: []EventBodyBlock{{Type: EventBodyBlockTypeText, Text: "hi"}},
+		},
+		{
+			name: "unknown block without text remains canonical",
+			body: `{"blocks":[{"type":"thinking","text":"hidden"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible"}]}`,
+			want: []EventBodyBlock{
+				{Type: EventBodyBlockTypeThinking, Text: "hidden"},
+				{Type: EventBodyBlockType("tool_use"), Text: ""},
+				{Type: EventBodyBlockTypeText, Text: "visible"},
+			},
 		},
 		{
 			name: "capital-B key falls back to legacy single text block",

--- a/application/types/event_body_blocks_test.go
+++ b/application/types/event_body_blocks_test.go
@@ -45,8 +45,8 @@ func TestExtractPlainBody(t *testing.T) {
 			want: "first\n\nsecond",
 		},
 		{
-			name: "unknown block without text does not expose adjacent thinking",
-			body: `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible response"}]}`,
+			name: "canonical unknown block does not expose adjacent thinking",
+			body: `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","text":"","id":"call-1"},{"type":"text","text":"visible response"}]}`,
 			want: "visible response",
 		},
 		{
@@ -63,6 +63,11 @@ func TestExtractPlainBody(t *testing.T) {
 			name: "blocks key with foreign shape elements is not treated as envelope",
 			body: `{"blocks":[{"foo":"bar"}]}`,
 			want: `{"blocks":[{"foo":"bar"}]}`,
+		},
+		{
+			name: "textless custom block remains foreign JSON",
+			body: `{"blocks":[{"type":"custom","payload":"foreign-json-marker"}]}`,
+			want: `{"blocks":[{"type":"custom","payload":"foreign-json-marker"}]}`,
 		},
 		{
 			name: "blocks:null is not treated as envelope",
@@ -97,10 +102,11 @@ func TestDecodeCanonicalEnvelope(t *testing.T) {
 		{"capital-B Blocks is not envelope", `{"Blocks":[{"type":"text","text":"hi"}]}`, false, 0},
 		{"blocks:null not envelope", `{"blocks":null}`, false, 0},
 		{"element missing type/text not envelope", `{"blocks":[{"foo":"bar"}]}`, false, 0},
+		{"textless custom block not envelope", `{"blocks":[{"type":"custom","payload":"foreign-json-marker"}]}`, false, 0},
 		{"non-string type not envelope", `{"blocks":[{"type":42,"text":"x"}]}`, false, 0},
 		{"empty blocks array is envelope", `{"blocks":[]}`, true, 0},
 		{"canonical envelope returns blocks", `{"blocks":[{"type":"thinking","text":"a"},{"type":"text","text":"b"}]}`, true, 2},
-		{"unknown block may omit text", `{"blocks":[{"type":"thinking","text":"a"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"b"}]}`, true, 3},
+		{"canonical unknown block carries empty text", `{"blocks":[{"type":"thinking","text":"a"},{"type":"tool_use","text":"","id":"call-1"},{"type":"text","text":"b"}]}`, true, 3},
 	}
 
 	for _, tc := range cases {
@@ -146,8 +152,8 @@ func TestParseEventBodyBlocks(t *testing.T) {
 			want: []EventBodyBlock{{Type: EventBodyBlockTypeText, Text: "hi"}},
 		},
 		{
-			name: "unknown block without text remains canonical",
-			body: `{"blocks":[{"type":"thinking","text":"hidden"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible"}]}`,
+			name: "canonical unknown block is preserved",
+			body: `{"blocks":[{"type":"thinking","text":"hidden"},{"type":"tool_use","text":"","id":"call-1"},{"type":"text","text":"visible"}]}`,
 			want: []EventBodyBlock{
 				{Type: EventBodyBlockTypeThinking, Text: "hidden"},
 				{Type: EventBodyBlockType("tool_use"), Text: ""},
@@ -163,6 +169,11 @@ func TestParseEventBodyBlocks(t *testing.T) {
 			name: "non-block-shaped element falls back to legacy single text block",
 			body: `{"blocks":[{"foo":"bar"}]}`,
 			want: []EventBodyBlock{{Type: EventBodyBlockTypeText, Text: `{"blocks":[{"foo":"bar"}]}`}},
+		},
+		{
+			name: "textless custom block falls back to raw body",
+			body: `{"blocks":[{"type":"custom","payload":"foreign-json-marker"}]}`,
+			want: []EventBodyBlock{{Type: EventBodyBlockTypeText, Text: `{"blocks":[{"type":"custom","payload":"foreign-json-marker"}]}`}},
 		},
 	}
 

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -200,6 +200,27 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string) (err error
 	if err := d.migrate(ctx, db); err != nil {
 		return xerrors.Errorf("failed to run SQLite migrations: %w", err)
 	}
+	searchBackfillResult, searchBackfillErr := catchUpEventSearchDocuments(ctx, db, eventSearchBackfillBatchSize)
+	if searchBackfillErr != nil {
+		// Indexed search remains fail-closed while the durable backfill is
+		// incomplete: only hard-bounded legacy fallback is allowed. A transient
+		// catch-up failure therefore must not block event ingestion.
+		slog.Error("event search backfill incomplete; retrying on next initialization",
+			"selected", searchBackfillResult.Selected,
+			"inserted", searchBackfillResult.Inserted,
+			"last_event_id", searchBackfillResult.LastEventID,
+			"target_event_id", searchBackfillResult.TargetID,
+			"error", searchBackfillErr,
+		)
+	} else if searchBackfillResult.Selected > 0 {
+		slog.Debug("event search backfill batch completed",
+			"selected", searchBackfillResult.Selected,
+			"inserted", searchBackfillResult.Inserted,
+			"last_event_id", searchBackfillResult.LastEventID,
+			"target_event_id", searchBackfillResult.TargetID,
+			"completed", searchBackfillResult.Completed,
+		)
+	}
 	catchUpResult, catchUpErr := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize)
 	if catchUpErr != nil {
 		// Catch-up is additive diagnostic coverage. A malformed historical row

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -288,6 +288,16 @@ func (d *EventDatasource) Search(
 	limit, offset int,
 	failuresOnly bool,
 ) ([]*model.Event, error) {
+	if limit <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if offset < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !from.IsZero() && !to.IsZero() && from.After(to) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+
 	db, err := d.db.open(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open DB for event search: %w", err)
@@ -297,6 +307,46 @@ func (d *EventDatasource) Search(
 			slog.Debug("failed to close resource", "error", err)
 		}
 	}()
+
+	searchSchemaAvailable, err := eventSearchSchemaAvailable(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if searchSchemaAvailable {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to begin indexed event search: %w", err)
+		}
+		defer func() {
+			if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+				slog.Debug("failed to rollback indexed event search", "error", err)
+			}
+		}()
+		criteria := apptypes.NewEventSearchCriteriaBuilder(limit).
+			Query(query).
+			Workspace(workspace).
+			SessionID(sessionID).
+			Client(client).
+			Agent(agent).
+			Kind(kind).
+			From(from).
+			To(to).
+			Offset(offset).
+			FailuresOnly(failuresOnly).
+			Build()
+		candidateIDs, err := selectEventSearchCandidateIDs(ctx, tx, criteria)
+		if err != nil {
+			return nil, err
+		}
+		events, err := hydrateEventSearchCandidates(ctx, tx, candidateIDs)
+		if err != nil {
+			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to finish indexed event search: %w", err)
+		}
+		return events, nil
+	}
 
 	queryValue := strings.TrimSpace(query)
 	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"

--- a/infrastructure/sqlite/event_delivery_store.go
+++ b/infrastructure/sqlite/event_delivery_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -13,6 +14,7 @@ import (
 )
 
 const maxDeliveryDecisionAttempts = 3
+const eventDeliveryBusyRetryDelay = 25 * time.Millisecond
 
 var errHookDeliveryIdentityRace = errors.New("hook delivery identity race")
 
@@ -47,9 +49,23 @@ func saveEventTransaction(
 		}
 		if persistErr != nil {
 			rollbackErr := tx.Rollback()
-			if errors.Is(persistErr, errHookDeliveryIdentityRace) {
+			if errors.Is(persistErr, errHookDeliveryIdentityRace) || isSQLiteBusy(persistErr) {
 				if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-					return xerrors.Errorf("failed to rollback delivery identity race: %w", rollbackErr)
+					return xerrors.Errorf("failed to rollback retryable event delivery: %w", rollbackErr)
+				}
+				if attempt == maxDeliveryDecisionAttempts-1 {
+					return xerrors.Errorf("event delivery remained retryable after %d attempts: %w", maxDeliveryDecisionAttempts, persistErr)
+				}
+				if isSQLiteBusy(persistErr) {
+					timer := time.NewTimer(eventDeliveryBusyRetryDelay)
+					select {
+					case <-ctx.Done():
+						if !timer.Stop() {
+							<-timer.C
+						}
+						return xerrors.Errorf("event delivery retry cancelled: %w", ctx.Err())
+					case <-timer.C:
+					}
 				}
 				continue
 			}

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -226,6 +226,34 @@ func (d *EventDatasource) SearchMetadata(
 	}
 	defer closeMetadataResource(db)
 
+	searchSchemaAvailable, err := eventSearchSchemaAvailable(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if searchSchemaAvailable {
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to begin indexed event metadata search: %w", err)
+		}
+		defer func() {
+			if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+				slog.Debug("failed to rollback indexed event metadata search", "error", err)
+			}
+		}()
+		candidateIDs, err := selectEventSearchCandidateIDs(ctx, tx, criteria)
+		if err != nil {
+			return nil, err
+		}
+		metadata, err := hydrateEventSearchMetadataCandidates(ctx, tx, criteria, candidateIDs)
+		if err != nil {
+			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, xerrors.Errorf("failed to finish indexed event metadata search: %w", err)
+		}
+		return metadata, nil
+	}
+
 	queryValue := strings.TrimSpace(criteria.Query())
 	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
 	rows, err := db.QueryContext(

--- a/infrastructure/sqlite/event_metadata_query_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_query_internal_test.go
@@ -20,6 +20,7 @@ func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
 		"recent source hook":        selectRecentEventMetadataBySourceHookQuery,
 		"recent legacy hook":        selectRecentEventMetadataBySourceHookWithLegacyQuery,
 		"search":                    searchEventMetadataQuery,
+		"indexed search hydration":  hydrateEventSearchMetadataCandidatesQuery,
 		"context":                   getContextEventMetadataQuery,
 		"context workspace":         getContextEventMetadataByWorkspaceQuery,
 		"context session":           getContextEventMetadataBySessionQuery,

--- a/infrastructure/sqlite/event_search_backfill.go
+++ b/infrastructure/sqlite/event_search_backfill.go
@@ -1,0 +1,227 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// eventSearchBackfillBatchSize bounds the body-bearing work performed by one
+// store initialization. Later initializations resume from the durable TEXT
+// event-ID checkpoint; request-time search remains complete through its
+// separately capped legacy fallback while this state is incomplete.
+const eventSearchBackfillBatchSize = 128
+
+type eventSearchBackfillResult struct {
+	Selected    int
+	Inserted    int64
+	LastEventID string
+	TargetID    string
+	Completed   bool
+}
+
+func catchUpEventSearchDocuments(
+	ctx context.Context,
+	db *sql.DB,
+	batchSize int,
+) (eventSearchBackfillResult, error) {
+	if batchSize <= 0 {
+		return eventSearchBackfillResult{}, xerrors.Errorf("event search backfill batch size must be positive")
+	}
+	exists, err := sqliteTableExists(ctx, db, "event_search_backfill_state")
+	if err != nil {
+		return eventSearchBackfillResult{}, err
+	}
+	if !exists {
+		// Focused historical-schema tests may omit migration 32.
+		return eventSearchBackfillResult{Completed: true}, nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return eventSearchBackfillResult{}, xerrors.Errorf("failed to begin event search backfill: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		lastEventID string
+		targetID    sql.NullString
+		completed   int
+	)
+	if err := tx.QueryRowContext(ctx, `
+		SELECT last_event_id, target_event_id, completed
+		  FROM event_search_backfill_state
+		 WHERE singleton = 1`,
+	).Scan(&lastEventID, &targetID, &completed); err != nil {
+		return eventSearchBackfillResult{}, xerrors.Errorf("failed to read event search backfill state: %w", err)
+	}
+	result := eventSearchBackfillResult{
+		LastEventID: lastEventID,
+		Completed:   completed != 0,
+	}
+	if targetID.Valid {
+		result.TargetID = targetID.String
+	}
+	if result.Completed {
+		if err := tx.Commit(); err != nil {
+			return result, xerrors.Errorf("failed to finish completed event search backfill check: %w", err)
+		}
+		return result, nil
+	}
+
+	if !targetID.Valid {
+		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), '') FROM events`).Scan(&result.TargetID); err != nil {
+			return result, xerrors.Errorf("failed to freeze event search backfill target: %w", err)
+		}
+		if result.TargetID == "" {
+			result.Completed = true
+			if err := updateEventSearchBackfillState(ctx, tx, "", "", true); err != nil {
+				return result, err
+			}
+			if err := tx.Commit(); err != nil {
+				return result, xerrors.Errorf("failed to commit empty event search backfill: %w", err)
+			}
+			return result, nil
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE event_search_backfill_state
+			   SET target_event_id = ?, updated_at = ?
+			 WHERE singleton = 1`,
+			result.TargetID,
+			formatTimestamp(time.Now()),
+		); err != nil {
+			return result, xerrors.Errorf("failed to persist event search backfill target: %w", err)
+		}
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id
+		  FROM events
+		 WHERE id > ? AND id <= ?
+		 ORDER BY id
+		 LIMIT ?`,
+		lastEventID,
+		result.TargetID,
+		batchSize,
+	)
+	if err != nil {
+		return result, xerrors.Errorf("failed to select event search backfill batch: %w", err)
+	}
+	selectedIDs := make([]string, 0, batchSize)
+	for rows.Next() {
+		var eventID string
+		if err := rows.Scan(&eventID); err != nil {
+			_ = rows.Close()
+			return result, xerrors.Errorf("failed to scan event search backfill event ID: %w", err)
+		}
+		selectedIDs = append(selectedIDs, eventID)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return result, xerrors.Errorf("failed to iterate event search backfill event IDs: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return result, xerrors.Errorf("failed to close event search backfill event IDs: %w", err)
+	}
+	result.Selected = len(selectedIDs)
+
+	if len(selectedIDs) == 0 {
+		result.Completed = true
+		if err := updateEventSearchBackfillState(ctx, tx, lastEventID, result.TargetID, true); err != nil {
+			return result, err
+		}
+		if err := tx.Commit(); err != nil {
+			return result, xerrors.Errorf("failed to commit completed event search backfill: %w", err)
+		}
+		return result, nil
+	}
+
+	result.LastEventID = selectedIDs[len(selectedIDs)-1]
+	insertResult, err := tx.ExecContext(ctx, `
+		INSERT INTO event_search_documents(
+			event_id, body_text, command_text, input_text, output_text
+		)
+		SELECT event_id, body_text, command_text, input_text, output_text
+		  FROM event_search_projection
+		 WHERE event_id > ? AND event_id <= ?
+		 ORDER BY event_id
+		ON CONFLICT(event_id) DO NOTHING`,
+		lastEventID,
+		result.LastEventID,
+	)
+	if err != nil {
+		return result, xerrors.Errorf("failed to materialize event search backfill batch: %w", err)
+	}
+	result.Inserted, err = insertResult.RowsAffected()
+	if err != nil {
+		return result, xerrors.Errorf("failed to count event search backfill inserts: %w", err)
+	}
+
+	result.Completed = result.LastEventID >= result.TargetID
+	if err := updateEventSearchBackfillState(
+		ctx,
+		tx,
+		result.LastEventID,
+		result.TargetID,
+		result.Completed,
+	); err != nil {
+		return result, err
+	}
+	if err := tx.Commit(); err != nil {
+		return result, xerrors.Errorf("failed to commit event search backfill: %w", err)
+	}
+	return result, nil
+}
+
+func updateEventSearchBackfillState(
+	ctx context.Context,
+	tx *sql.Tx,
+	lastEventID string,
+	targetID string,
+	completed bool,
+) error {
+	result, err := tx.ExecContext(ctx, `
+		UPDATE event_search_backfill_state
+		   SET last_event_id = ?,
+		       target_event_id = ?,
+		       completed = ?,
+		       updated_at = ?
+		 WHERE singleton = 1`,
+		lastEventID,
+		targetID,
+		boolToInt(completed),
+		formatTimestamp(time.Now()),
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to update event search backfill state: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return xerrors.Errorf("failed to count event search backfill state updates: %w", err)
+	}
+	if updated != 1 {
+		return xerrors.Errorf("event search backfill state updated %d rows, want 1", updated)
+	}
+	return nil
+}
+
+func eventSearchBackfillComplete(ctx context.Context, queryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (bool, error) {
+	var completed int
+	err := queryer.QueryRowContext(ctx, `
+		SELECT completed
+		  FROM event_search_backfill_state
+		 WHERE singleton = 1`,
+	).Scan(&completed)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, xerrors.Errorf("event search backfill state is missing")
+		}
+		return false, xerrors.Errorf("failed to inspect event search backfill state: %w", err)
+	}
+	return completed != 0, nil
+}

--- a/infrastructure/sqlite/event_search_fts_test.go
+++ b/infrastructure/sqlite/event_search_fts_test.go
@@ -157,6 +157,85 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 	}
 }
 
+func TestEventSearchFTS_SynchronizesCommandAuditUpdatesAndDeletes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	event, audit := newSearchAuditFixture(
+		t,
+		"event-audit-mutation",
+		workspace.String(),
+		time.Date(2026, 7, 25, 1, 0, 0, 0, time.UTC),
+	)
+	if err := sut.SaveWithAudit(ctx, event, audit); err != nil {
+		t.Fatalf("SaveWithAudit() error = %v", err)
+	}
+
+	searchIDs := func(query string) []string {
+		t.Helper()
+		events, err := sut.Search(
+			ctx,
+			query,
+			workspace,
+			"",
+			"",
+			"",
+			"",
+			time.Time{},
+			time.Time{},
+			20,
+			0,
+			false,
+		)
+		if err != nil {
+			t.Fatalf("Search(%q) error = %v", query, err)
+		}
+		return eventIDs(events)
+	}
+	if diff := cmp.Diff(
+		[]string{"event-audit-mutation"},
+		searchIDs("stdout with details"),
+	); diff != "" {
+		t.Fatalf("initial audit IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `
+		UPDATE command_audits
+		   SET output_text = 'replacement audit marker'
+		 WHERE event_id = 'event-audit-mutation'`); err != nil {
+		t.Fatalf("update command audit: %v", err)
+	}
+	if got := searchIDs("stdout with details"); len(got) != 0 {
+		t.Fatalf("old audit text IDs after update = %v, want none", got)
+	}
+	if diff := cmp.Diff(
+		[]string{"event-audit-mutation"},
+		searchIDs("replacement audit marker"),
+	); diff != "" {
+		t.Fatalf("updated audit IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		DELETE FROM command_audits
+		 WHERE event_id = 'event-audit-mutation'`); err != nil {
+		t.Fatalf("delete command audit: %v", err)
+	}
+	if got := searchIDs("replacement audit marker"); len(got) != 0 {
+		t.Fatalf("deleted audit text IDs = %v, want none", got)
+	}
+}
+
 func TestEventSearchBackfill_IsBoundedCompleteAndResumable(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/event_search_fts_test.go
+++ b/infrastructure/sqlite/event_search_fts_test.go
@@ -46,6 +46,22 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 			`{"blocks":[{"type":"thinking","text":"secret-thinking needle"},{"type":"text","text":"visible needle response"}]}`,
 			base.Add(time.Second),
 		),
+		newSearchEventFixture(
+			t,
+			"event-envelope-tool",
+			types.EventKindTranscript,
+			workspace.String(),
+			`{"blocks":[{"type":"thinking","text":"tool-secret-thinking"},{"type":"tool_use","id":"call-1","name":"Read"},{"type":"text","text":"visible tool response"}]}`,
+			base.Add(2*time.Second),
+		),
+		newSearchEventFixture(
+			t,
+			"event-foreign-blocks",
+			types.EventKindNote,
+			workspace.String(),
+			`{"blocks":[{"foo":"foreign-json-marker"}]}`,
+			base.Add(3*time.Second),
+		),
 	}
 	for _, event := range fixtures {
 		if err := sut.Save(ctx, event); err != nil {
@@ -74,6 +90,9 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 		{name: "matching non-ASCII case", query: "ÄBC", want: []string{"event-literal"}},
 		{name: "non-ASCII remains case sensitive", query: "äbc", want: []string{}},
 		{name: "thinking text is excluded", query: "secret-thinking", want: []string{}},
+		{name: "thinking beside unknown block is excluded", query: "tool-secret-thinking", want: []string{}},
+		{name: "visible text beside unknown block is indexed", query: "visible tool response", want: []string{"event-envelope-tool"}},
+		{name: "foreign blocks JSON remains raw-searchable", query: "foreign-json-marker", want: []string{"event-foreign-blocks"}},
 		{name: "persisted audit text is indexed", query: "stdout with details", want: []string{"event-audit"}},
 		{name: "final timestamp and ID order", query: "visible needle", want: []string{"event-envelope", "event-literal"}},
 	}
@@ -246,7 +265,13 @@ func TestEventSearchBackfill_IsBoundedCompleteAndResumable(t *testing.T) {
 		t.Fatalf("initialize pre-32 store: %v", err)
 	}
 	seedHistoricalSearchEvents(t, dbPath, 130, func(index int) string {
-		if index == 0 || index == 129 {
+		if index == 129 {
+			return `{"blocks":[{"type":"thinking","text":"legacy-secret-thinking"},{"type":"tool_use","id":"call-legacy"},{"type":"text","text":"historical needle visible legacy response"}]}`
+		}
+		if index == 128 {
+			return `{"blocks":[{"foo":"legacy-foreign-json-marker"}]}`
+		}
+		if index == 0 {
 			return "historical needle"
 		}
 		return "ordinary historical body"
@@ -284,6 +309,46 @@ func TestEventSearchBackfill_IsBoundedCompleteAndResumable(t *testing.T) {
 	wantIDs := []string{"event-00129", "event-00000"}
 	if diff := cmp.Diff(wantIDs, eventIDs(full)); diff != "" {
 		t.Fatalf("bounded incomplete IDs mismatch (-want +got):\n%s", diff)
+	}
+	thinkingOnly, err := sut.Search(
+		ctx,
+		"legacy-secret-thinking",
+		workspace,
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("bounded incomplete thinking Search() error = %v", err)
+	}
+	if len(thinkingOnly) != 0 {
+		t.Fatalf("bounded incomplete thinking IDs = %v, want none", eventIDs(thinkingOnly))
+	}
+	foreignJSON, err := sut.Search(
+		ctx,
+		"legacy-foreign-json-marker",
+		workspace,
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("bounded incomplete foreign JSON Search() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"event-00128"}, eventIDs(foreignJSON)); diff != "" {
+		t.Fatalf("bounded incomplete foreign JSON IDs mismatch (-want +got):\n%s", diff)
 	}
 	metadata, err := sut.SearchMetadata(
 		ctx,

--- a/infrastructure/sqlite/event_search_fts_test.go
+++ b/infrastructure/sqlite/event_search_fts_test.go
@@ -51,7 +51,7 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 			"event-envelope-tool",
 			types.EventKindTranscript,
 			workspace.String(),
-			`{"blocks":[{"type":"thinking","text":"tool-secret-thinking"},{"type":"tool_use","id":"call-1","name":"Read"},{"type":"text","text":"visible tool response"}]}`,
+			`{"blocks":[{"type":"thinking","text":"tool-secret-thinking"},{"type":"tool_use","text":"","id":"call-1","name":"Read"},{"type":"text","text":"visible tool response"}]}`,
 			base.Add(2*time.Second),
 		),
 		newSearchEventFixture(
@@ -61,6 +61,14 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 			workspace.String(),
 			`{"blocks":[{"foo":"foreign-json-marker"}]}`,
 			base.Add(3*time.Second),
+		),
+		newSearchEventFixture(
+			t,
+			"event-foreign-custom",
+			types.EventKindNote,
+			workspace.String(),
+			`{"blocks":[{"type":"custom","payload":"foreign-custom-marker"}]}`,
+			base.Add(4*time.Second),
 		),
 	}
 	for _, event := range fixtures {
@@ -93,6 +101,7 @@ func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
 		{name: "thinking beside unknown block is excluded", query: "tool-secret-thinking", want: []string{}},
 		{name: "visible text beside unknown block is indexed", query: "visible tool response", want: []string{"event-envelope-tool"}},
 		{name: "foreign blocks JSON remains raw-searchable", query: "foreign-json-marker", want: []string{"event-foreign-blocks"}},
+		{name: "textless custom block remains raw-searchable", query: "foreign-custom-marker", want: []string{"event-foreign-custom"}},
 		{name: "persisted audit text is indexed", query: "stdout with details", want: []string{"event-audit"}},
 		{name: "final timestamp and ID order", query: "visible needle", want: []string{"event-envelope", "event-literal"}},
 	}
@@ -266,10 +275,10 @@ func TestEventSearchBackfill_IsBoundedCompleteAndResumable(t *testing.T) {
 	}
 	seedHistoricalSearchEvents(t, dbPath, 130, func(index int) string {
 		if index == 129 {
-			return `{"blocks":[{"type":"thinking","text":"legacy-secret-thinking"},{"type":"tool_use","id":"call-legacy"},{"type":"text","text":"historical needle visible legacy response"}]}`
+			return `{"blocks":[{"type":"thinking","text":"legacy-secret-thinking"},{"type":"tool_use","text":"","id":"call-legacy"},{"type":"text","text":"historical needle visible legacy response"}]}`
 		}
 		if index == 128 {
-			return `{"blocks":[{"foo":"legacy-foreign-json-marker"}]}`
+			return `{"blocks":[{"type":"custom","payload":"legacy-foreign-json-marker"}]}`
 		}
 		if index == 0 {
 			return "historical needle"

--- a/infrastructure/sqlite/event_search_fts_test.go
+++ b/infrastructure/sqlite/event_search_fts_test.go
@@ -1,0 +1,381 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestEventSearchFTS_PreservesLiteralVisibleTextSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	base := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+	fixtures := []*model.Event{
+		newSearchEventFixture(
+			t,
+			"event-literal",
+			types.EventKindNote,
+			workspace.String(),
+			`literal boolean OR; say "quoted"; 100%_; C:\Traceary; ÄBC; visible needle`,
+			base,
+		),
+		newSearchEventFixture(
+			t,
+			"event-envelope",
+			types.EventKindTranscript,
+			workspace.String(),
+			`{"blocks":[{"type":"thinking","text":"secret-thinking needle"},{"type":"text","text":"visible needle response"}]}`,
+			base.Add(time.Second),
+		),
+	}
+	for _, event := range fixtures {
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+		}
+	}
+	auditEvent, audit := newSearchAuditFixture(
+		t,
+		"event-audit",
+		workspace.String(),
+		base.Add(2*time.Second),
+	)
+	if err := sut.SaveWithAudit(ctx, auditEvent, audit); err != nil {
+		t.Fatalf("SaveWithAudit() error = %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{name: "boolean-looking phrase is literal", query: "boolean OR", want: []string{"event-literal"}},
+		{name: "quotes are escaped as phrase data", query: `"quoted"`, want: []string{"event-literal"}},
+		{name: "LIKE wildcards stay literal", query: "100%_", want: []string{"event-literal"}},
+		{name: "ASCII remains case insensitive", query: `C:\TRACEARY`, want: []string{"event-literal"}},
+		{name: "matching non-ASCII case", query: "ÄBC", want: []string{"event-literal"}},
+		{name: "non-ASCII remains case sensitive", query: "äbc", want: []string{}},
+		{name: "thinking text is excluded", query: "secret-thinking", want: []string{}},
+		{name: "persisted audit text is indexed", query: "stdout with details", want: []string{"event-audit"}},
+		{name: "final timestamp and ID order", query: "visible needle", want: []string{"event-envelope", "event-literal"}},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sut.Search(
+				ctx,
+				tc.query,
+				workspace,
+				"",
+				"",
+				"",
+				"",
+				time.Time{},
+				time.Time{},
+				20,
+				0,
+				false,
+			)
+			if err != nil {
+				t.Fatalf("Search(%q) error = %v", tc.query, err)
+			}
+			if diff := cmp.Diff(tc.want, eventIDs(got)); diff != "" {
+				t.Fatalf("Search(%q) IDs mismatch (-want +got):\n%s", tc.query, diff)
+			}
+		})
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+		Query("visible needle").
+		Workspace(workspace).
+		Build()
+	metadata, err := sut.SearchMetadata(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff(
+		[]string{"event-envelope", "event-literal"},
+		metadataIDs(metadata),
+	); diff != "" {
+		t.Fatalf("metadata IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET body = ?, body_availability = 'unavailable_retention'
+		 WHERE id = ?`,
+		types.EventBodyUnavailableRetentionMarker,
+		"event-literal",
+	); err != nil {
+		_ = db.Close()
+		t.Fatalf("mark retention-unavailable: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close direct DB: %v", err)
+	}
+	got, err := sut.Search(
+		ctx,
+		"boolean OR",
+		workspace,
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("Search(retention-unavailable) error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Search(retention-unavailable) IDs = %v, want none", eventIDs(got))
+	}
+}
+
+func TestEventSearchBackfill_IsBoundedCompleteAndResumable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	preMigration := infra.NewDatabase(dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	if err := infra.NewStoreManagementDatasource(preMigration).Initialize(ctx); err != nil {
+		t.Fatalf("initialize pre-32 store: %v", err)
+	}
+	seedHistoricalSearchEvents(t, dbPath, 130, func(index int) string {
+		if index == 0 || index == 129 {
+			return "historical needle"
+		}
+		return "ordinary historical body"
+	})
+
+	current := infra.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	store := infra.NewStoreManagementDatasource(current)
+	sut := infra.NewEventDatasource(current)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("first current Initialize() error = %v", err)
+	}
+	documentCount, completed := eventSearchProgress(t, dbPath)
+	if documentCount != 128 || completed {
+		t.Fatalf("first bounded backfill = (documents=%d, completed=%v), want (128, false)", documentCount, completed)
+	}
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	full, err := sut.Search(
+		ctx,
+		"historical needle",
+		workspace,
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("bounded incomplete Search() error = %v", err)
+	}
+	wantIDs := []string{"event-00129", "event-00000"}
+	if diff := cmp.Diff(wantIDs, eventIDs(full)); diff != "" {
+		t.Fatalf("bounded incomplete IDs mismatch (-want +got):\n%s", diff)
+	}
+	metadata, err := sut.SearchMetadata(
+		ctx,
+		apptypes.NewEventSearchCriteriaBuilder(20).
+			Query("historical needle").
+			Workspace(workspace).
+			Build(),
+	)
+	if err != nil {
+		t.Fatalf("bounded incomplete SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff(wantIDs, metadataIDs(metadata)); diff != "" {
+		t.Fatalf("bounded incomplete metadata IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = sut.Search(
+		ctx,
+		"historical needle",
+		"",
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if !errors.Is(err, queryservice.ErrEventSearchIndexIncomplete) {
+		t.Fatalf("unbounded incomplete Search() error = %v, want ErrEventSearchIndexIncomplete", err)
+	}
+
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("resumed Initialize() error = %v", err)
+	}
+	documentCount, completed = eventSearchProgress(t, dbPath)
+	if documentCount != 130 || !completed {
+		t.Fatalf("resumed backfill = (documents=%d, completed=%v), want (130, true)", documentCount, completed)
+	}
+	full, err = sut.Search(
+		ctx,
+		"historical needle",
+		"",
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("complete unbounded Search() error = %v", err)
+	}
+	if diff := cmp.Diff(wantIDs, eventIDs(full)); diff != "" {
+		t.Fatalf("complete IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEventSearchShortQuery_RejectsCandidateScopeAboveHardCap(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	preMigration := infra.NewDatabase(dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	if err := infra.NewStoreManagementDatasource(preMigration).Initialize(ctx); err != nil {
+		t.Fatalf("initialize pre-32 store: %v", err)
+	}
+	seedHistoricalSearchEvents(t, dbPath, 10_001, func(int) string { return "xy" })
+
+	current := infra.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	if err := infra.NewStoreManagementDatasource(current).Initialize(ctx); err != nil {
+		t.Fatalf("current Initialize() error = %v", err)
+	}
+	sut := infra.NewEventDatasource(current)
+	_, err := sut.Search(
+		ctx,
+		"xy",
+		types.Workspace("github.com/duck8823/traceary"),
+		"",
+		"",
+		"",
+		"",
+		time.Time{},
+		time.Time{},
+		20,
+		0,
+		false,
+	)
+	if !errors.Is(err, queryservice.ErrEventSearchScopeTooBroad) {
+		t.Fatalf("Search() error = %v, want ErrEventSearchScopeTooBroad", err)
+	}
+	var unavailable *queryservice.EventSearchUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.CandidateCount != 10_001 {
+		t.Fatalf("Search() typed error = %#v, want candidate_count=10001", unavailable)
+	}
+}
+
+func seedHistoricalSearchEvents(
+	t *testing.T,
+	dbPath string,
+	count int,
+	bodyFor func(index int) string,
+) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed transaction: %v", err)
+	}
+	statement, err := tx.Prepare(`
+		INSERT INTO events(
+			id, kind, agent, session_id, body, created_at,
+			client, workspace, body_availability
+		) VALUES (?, 'note', 'codex', 'session-history', ?, ?, 'cli', ?, 'available')`)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("prepare historical event insert: %v", err)
+	}
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	for index := 0; index < count; index++ {
+		if _, err := statement.Exec(
+			fmt.Sprintf("event-%05d", index),
+			bodyFor(index),
+			base.Add(time.Duration(index)*time.Second).Format(time.RFC3339Nano),
+			"github.com/duck8823/traceary",
+		); err != nil {
+			_ = statement.Close()
+			_ = tx.Rollback()
+			t.Fatalf("insert historical event %d: %v", index, err)
+		}
+	}
+	if err := statement.Close(); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("close historical insert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit historical events: %v", err)
+	}
+}
+
+func eventSearchProgress(t *testing.T, dbPath string) (documents int, completed bool) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.QueryRow(`SELECT COUNT(*) FROM event_search_documents`).Scan(&documents); err != nil {
+		t.Fatalf("count event search documents: %v", err)
+	}
+	var completedValue int
+	if err := db.QueryRow(`
+		SELECT completed
+		  FROM event_search_backfill_state
+		 WHERE singleton = 1`,
+	).Scan(&completedValue); err != nil {
+		t.Fatalf("read event search backfill state: %v", err)
+	}
+	return documents, completedValue != 0
+}
+
+func eventIDs(events []*model.Event) []string {
+	ids := make([]string, len(events))
+	for index, event := range events {
+		ids[index] = event.EventID().String()
+	}
+	return ids
+}

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -1,0 +1,439 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+)
+
+const eventSearchLegacyCandidateLimit = 10_000
+
+const hydrateEventSearchCandidatesQuery = `
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.body, e.body_availability, e.source_hook, e.created_at
+  FROM events e
+ WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+ ORDER BY e.created_at_norm DESC, e.id DESC`
+
+// This result projection intentionally contains no e.body reference. Candidate
+// selection is shared with full search, but metadata hydration cannot
+// accidentally materialize stored event bodies.
+const hydrateEventSearchMetadataCandidatesQuery = `
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.source_hook, e.created_at,
+       e.body_original_bytes, e.body_stored_bytes,
+       e.body_ingest_truncated, e.body_storage_truncated,
+       e.body_metadata_version,
+       a.event_id, a.exit_code, a.failed
+  FROM events e
+  LEFT JOIN command_audits a ON a.event_id = e.id
+ WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+ ORDER BY e.created_at_norm DESC, e.id DESC`
+
+// eventSearchLegacyContentPredicate deliberately remains the same literal LIKE
+// projection used before FTS. It is evaluated only after a metadata-only
+// candidate count proves the scope contains at most
+// eventSearchLegacyCandidateLimit rows.
+const eventSearchLegacyContentPredicate = `
+(
+    (CASE
+        WHEN e.body_availability = 'unavailable_retention' THEN ''
+        WHEN json_valid(e.body)
+             AND json_type(e.body, '$') = 'object'
+             AND json_type(e.body, '$.blocks') = 'array'
+             AND NOT EXISTS (
+                 SELECT 1
+                   FROM json_each(json_extract(e.body, '$.blocks'))
+                  WHERE typeof(json_extract(value, '$.type')) != 'text'
+                     OR typeof(json_extract(value, '$.text')) != 'text'
+             )
+        THEN COALESCE(
+            (
+                SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
+                  FROM json_each(json_extract(e.body, '$.blocks'))
+                 WHERE json_extract(value, '$.type') = 'text'
+            ),
+            ''
+        )
+        ELSE e.body
+     END) LIKE ? ESCAPE '\' OR
+    COALESCE(a.command_text, '') LIKE ? ESCAPE '\' OR
+    COALESCE(a.input_text, '') LIKE ? ESCAPE '\' OR
+    COALESCE(a.output_text, '') LIKE ? ESCAPE '\'
+)`
+
+type eventSearchQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func eventSearchSchemaAvailable(ctx context.Context, queryer eventSearchQueryer) (bool, error) {
+	var count int
+	if err := queryer.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM sqlite_master
+		 WHERE type = 'table'
+		   AND name IN ('event_search_documents', 'event_search_fts', 'event_search_backfill_state')`,
+	).Scan(&count); err != nil {
+		return false, xerrors.Errorf("failed to inspect event search schema: %w", err)
+	}
+	return count == 3, nil
+}
+
+func selectEventSearchCandidateIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+) ([]string, error) {
+	queryValue := strings.TrimSpace(criteria.Query())
+	if queryValue == "" {
+		return queryStructuralEventIDs(ctx, queryer, criteria)
+	}
+
+	complete, err := eventSearchBackfillComplete(ctx, queryer)
+	if err != nil {
+		return nil, err
+	}
+	shortQuery := utf8.RuneCountInString(queryValue) < 3
+	needsLegacyCompleteness := shortQuery || !complete
+	if needsLegacyCompleteness {
+		if !hasBoundedLegacySearchScope(criteria) {
+			reason := queryservice.EventSearchUnavailableScopeTooBroad
+			if !shortQuery {
+				reason = queryservice.EventSearchUnavailableIndexIncomplete
+			}
+			return nil, &queryservice.EventSearchUnavailableError{
+				Reason:         reason,
+				CandidateLimit: eventSearchLegacyCandidateLimit,
+			}
+		}
+		candidateCount, err := countBoundedLegacyCandidates(ctx, queryer, criteria)
+		if err != nil {
+			return nil, err
+		}
+		if candidateCount > eventSearchLegacyCandidateLimit {
+			return nil, &queryservice.EventSearchUnavailableError{
+				Reason:         queryservice.EventSearchUnavailableScopeTooBroad,
+				CandidateLimit: eventSearchLegacyCandidateLimit,
+				CandidateCount: candidateCount,
+			}
+		}
+	}
+
+	if shortQuery {
+		return queryLegacyEventIDs(ctx, queryer, criteria, queryValue)
+	}
+	if complete {
+		return queryFTSEventIDs(ctx, queryer, criteria, queryValue)
+	}
+	return queryIncompleteFTSEventIDs(ctx, queryer, criteria, queryValue)
+}
+
+func hasBoundedLegacySearchScope(criteria apptypes.EventSearchCriteria) bool {
+	return strings.TrimSpace(criteria.Workspace().String()) != "" ||
+		strings.TrimSpace(criteria.SessionID().String()) != "" ||
+		(!criteria.From().IsZero() && !criteria.To().IsZero())
+}
+
+func countBoundedLegacyCandidates(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+) (int, error) {
+	var builder strings.Builder
+	builder.WriteString("SELECT e.id FROM events e INDEXED BY ")
+	builder.WriteString(eventSearchScopeIndex(criteria))
+	builder.WriteString(" LEFT JOIN command_audits a ON a.event_id = e.id WHERE 1 = 1")
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	builder.WriteString(" ORDER BY e.created_at_norm DESC, e.id DESC LIMIT ?")
+	args = append(args, eventSearchLegacyCandidateLimit+1)
+
+	rows, err := queryer.QueryContext(ctx, builder.String(), args...)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to count bounded legacy event search candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, xerrors.Errorf("failed to iterate bounded legacy event search candidates: %w", err)
+	}
+	return count, nil
+}
+
+func eventSearchScopeIndex(criteria apptypes.EventSearchCriteria) string {
+	hasWorkspace := strings.TrimSpace(criteria.Workspace().String()) != ""
+	hasSession := strings.TrimSpace(criteria.SessionID().String()) != ""
+	switch {
+	case hasWorkspace && hasSession:
+		return "idx_events_workspace_session_created_at_norm_id_desc"
+	case hasWorkspace:
+		return "idx_events_workspace_created_at_norm_id_desc"
+	case hasSession:
+		return "idx_events_session_created_at_norm_id_desc"
+	default:
+		return "idx_events_created_at_norm_id_desc"
+	}
+}
+
+func queryStructuralEventIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+) ([]string, error) {
+	var builder strings.Builder
+	builder.WriteString(`
+		SELECT e.id
+		  FROM events e
+		  LEFT JOIN command_audits a ON a.event_id = e.id
+		 WHERE 1 = 1`)
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	appendEventSearchOrderAndPage(&builder)
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return collectEventSearchIDs(ctx, queryer, builder.String(), args, "structural event search")
+}
+
+func queryLegacyEventIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+) ([]string, error) {
+	var builder strings.Builder
+	builder.WriteString(`
+		SELECT e.id
+		  FROM events e
+		  LEFT JOIN command_audits a ON a.event_id = e.id
+		 WHERE 1 = 1`)
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	builder.WriteString(" AND ")
+	builder.WriteString(eventSearchLegacyContentPredicate)
+	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
+	args = append(args, likeQuery, likeQuery, likeQuery, likeQuery)
+	appendEventSearchOrderAndPage(&builder)
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return collectEventSearchIDs(ctx, queryer, builder.String(), args, "bounded legacy event search")
+}
+
+func queryFTSEventIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+) ([]string, error) {
+	query, args := buildFTSEventIDsQuery(criteria, queryValue)
+	return collectEventSearchIDs(ctx, queryer, query, args, "indexed event search")
+}
+
+func buildFTSEventIDsQuery(
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+) (string, []any) {
+	var builder strings.Builder
+	builder.WriteString(`
+		SELECT e.id
+		  FROM event_search_fts
+		  JOIN event_search_documents d
+		    ON d.search_document_id = event_search_fts.rowid
+		  JOIN events e ON e.id = d.event_id
+		  LEFT JOIN command_audits a ON a.event_id = e.id
+		 WHERE event_search_fts MATCH ?`)
+	args := []any{eventSearchFTSPhrase(queryValue)}
+	args = appendEventSearchFilters(&builder, args, criteria)
+	appendEventSearchOrderAndPage(&builder)
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return builder.String(), args
+}
+
+func queryIncompleteFTSEventIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+) ([]string, error) {
+	var builder strings.Builder
+	builder.WriteString(`
+		WITH matching_event_ids(event_id) AS (
+		    SELECT d.event_id
+		      FROM event_search_fts
+		      JOIN event_search_documents d
+		        ON d.search_document_id = event_search_fts.rowid
+		      JOIN events e ON e.id = d.event_id
+		      LEFT JOIN command_audits a ON a.event_id = e.id
+		     WHERE event_search_fts MATCH ?`)
+	args := []any{eventSearchFTSPhrase(queryValue)}
+	args = appendEventSearchFilters(&builder, args, criteria)
+	builder.WriteString(`
+		    UNION
+		    SELECT e.id
+		      FROM events e
+		      LEFT JOIN command_audits a ON a.event_id = e.id
+		     WHERE NOT EXISTS (
+		           SELECT 1
+		             FROM event_search_documents missing_document
+		            WHERE missing_document.event_id = e.id
+		     )`)
+	args = appendEventSearchFilters(&builder, args, criteria)
+	builder.WriteString(" AND ")
+	builder.WriteString(eventSearchLegacyContentPredicate)
+	likeQuery := "%" + escapeLikeQuery(queryValue) + "%"
+	args = append(args, likeQuery, likeQuery, likeQuery, likeQuery)
+	builder.WriteString(`
+		)
+		SELECT e.id
+		  FROM matching_event_ids matching
+		  JOIN events e ON e.id = matching.event_id
+		 ORDER BY e.created_at_norm DESC, e.id DESC
+		 LIMIT ? OFFSET ?`)
+	args = append(args, criteria.Limit(), criteria.Offset())
+	return collectEventSearchIDs(ctx, queryer, builder.String(), args, "incomplete indexed event search")
+}
+
+func appendEventSearchFilters(
+	builder *strings.Builder,
+	args []any,
+	criteria apptypes.EventSearchCriteria,
+) []any {
+	if value := strings.TrimSpace(criteria.Workspace().String()); value != "" {
+		builder.WriteString(" AND e.workspace = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(criteria.SessionID().String()); value != "" {
+		builder.WriteString(" AND e.session_id = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(criteria.Client().String()); value != "" {
+		builder.WriteString(" AND e.client = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(criteria.Agent().String()); value != "" {
+		builder.WriteString(" AND e.agent = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(criteria.Kind().String()); value != "" {
+		builder.WriteString(" AND e.kind = ?")
+		args = append(args, value)
+	}
+	if !criteria.From().IsZero() {
+		builder.WriteString(" AND e.created_at_norm >= ?")
+		args = append(args, normalizeRFC3339NanoForCompare(formatTimestamp(criteria.From())))
+	}
+	if !criteria.To().IsZero() {
+		builder.WriteString(" AND e.created_at_norm < ?")
+		args = append(args, normalizeRFC3339NanoForCompare(formatTimestamp(criteria.To())))
+	}
+	if criteria.FailuresOnly() {
+		builder.WriteString(" AND (a.failed = 1 OR (a.exit_code IS NOT NULL AND a.exit_code != 0))")
+	}
+	return args
+}
+
+func appendEventSearchOrderAndPage(builder *strings.Builder) {
+	builder.WriteString(" ORDER BY e.created_at_norm DESC, e.id DESC LIMIT ? OFFSET ?")
+}
+
+func collectEventSearchIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	query string,
+	args []any,
+	operation string,
+) ([]string, error) {
+	rows, err := queryer.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query %s candidates: %w", operation, err)
+	}
+	defer func() { _ = rows.Close() }()
+	ids := make([]string, 0)
+	for rows.Next() {
+		var eventID string
+		if err := rows.Scan(&eventID); err != nil {
+			return nil, xerrors.Errorf("failed to scan %s candidate: %w", operation, err)
+		}
+		ids = append(ids, eventID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate %s candidates: %w", operation, err)
+	}
+	return ids, nil
+}
+
+func eventSearchFTSPhrase(query string) string {
+	lowerASCII := strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}, strings.TrimSpace(query))
+	return `"` + strings.ReplaceAll(lowerASCII, `"`, `""`) + `"`
+}
+
+func marshalEventSearchCandidateIDs(ids []string) (string, error) {
+	encoded, err := json.Marshal(ids)
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode event search candidate IDs: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func hydrateEventSearchCandidates(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	ids []string,
+) ([]*model.Event, error) {
+	if len(ids) == 0 {
+		return []*model.Event{}, nil
+	}
+	encoded, err := marshalEventSearchCandidateIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := queryer.QueryContext(ctx, hydrateEventSearchCandidatesQuery, encoded)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to hydrate event search candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	events := make([]*model.Event, 0, len(ids))
+	for rows.Next() {
+		event, err := scanEvent(rows)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore event search candidate: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate event search candidates: %w", err)
+	}
+	return events, nil
+}
+
+func hydrateEventSearchMetadataCandidates(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+	ids []string,
+) ([]apptypes.EventMetadata, error) {
+	if len(ids) == 0 {
+		return []apptypes.EventMetadata{}, nil
+	}
+	encoded, err := marshalEventSearchCandidateIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := queryer.QueryContext(ctx, hydrateEventSearchMetadataCandidatesQuery, encoded)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to hydrate event metadata search candidates: %w", err)
+	}
+	return collectEventMetadata(rows, criteria.Limit(), "event metadata search candidates")
+}

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -51,22 +51,15 @@ const eventSearchLegacyContentPredicate = `
              AND json_type(e.body, '$.blocks') = 'array'
              AND NOT EXISTS (
                  SELECT 1
-                   FROM json_each(json_extract(e.body, '$.blocks')) AS block
-                  WHERE CASE
-                      WHEN block.type != 'object' THEN 1
-                      WHEN json_type(block.value, '$.type') IS NOT 'text' THEN 1
-                      WHEN json_extract(block.value, '$.type') IN ('text', 'thinking')
-                           AND json_type(block.value, '$.text') IS NOT 'text'
-                      THEN 1
-                      ELSE 0
-                  END = 1
+                   FROM json_each(json_extract(e.body, '$.blocks'))
+                  WHERE typeof(json_extract(value, '$.type')) != 'text'
+                     OR typeof(json_extract(value, '$.text')) != 'text'
              )
         THEN COALESCE(
             (
                 SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
                   FROM json_each(json_extract(e.body, '$.blocks'))
                  WHERE json_extract(value, '$.type') = 'text'
-                   AND json_type(value, '$.text') = 'text'
             ),
             ''
         )

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -51,15 +51,22 @@ const eventSearchLegacyContentPredicate = `
              AND json_type(e.body, '$.blocks') = 'array'
              AND NOT EXISTS (
                  SELECT 1
-                   FROM json_each(json_extract(e.body, '$.blocks'))
-                  WHERE typeof(json_extract(value, '$.type')) != 'text'
-                     OR typeof(json_extract(value, '$.text')) != 'text'
+                   FROM json_each(json_extract(e.body, '$.blocks')) AS block
+                  WHERE CASE
+                      WHEN block.type != 'object' THEN 1
+                      WHEN json_type(block.value, '$.type') IS NOT 'text' THEN 1
+                      WHEN json_extract(block.value, '$.type') IN ('text', 'thinking')
+                           AND json_type(block.value, '$.text') IS NOT 'text'
+                      THEN 1
+                      ELSE 0
+                  END = 1
              )
         THEN COALESCE(
             (
                 SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
                   FROM json_each(json_extract(e.body, '$.blocks'))
                  WHERE json_extract(value, '$.type') = 'text'
+                   AND json_type(value, '$.text') = 'text'
             ),
             ''
         )

--- a/infrastructure/sqlite/event_search_query_internal_test.go
+++ b/infrastructure/sqlite/event_search_query_internal_test.go
@@ -1,0 +1,104 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestBoundedLegacySearchScope_RequiresWorkspaceSessionOrClosedInterval(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tests := []struct {
+		name     string
+		criteria apptypes.EventSearchCriteria
+		want     bool
+	}{
+		{
+			name:     "workspace",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(1).Workspace("workspace").Build(),
+			want:     true,
+		},
+		{
+			name:     "session",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(1).SessionID("session").Build(),
+			want:     true,
+		},
+		{
+			name:     "closed interval",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(1).From(now).To(now.Add(time.Hour)).Build(),
+			want:     true,
+		},
+		{
+			name:     "from only",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(1).From(now).Build(),
+		},
+		{
+			name:     "to only",
+			criteria: apptypes.NewEventSearchCriteriaBuilder(1).To(now).Build(),
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasBoundedLegacySearchScope(tc.criteria); got != tc.want {
+				t.Fatalf("hasBoundedLegacySearchScope() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEventSearchFTSQuery_UsesVirtualTableIndex(t *testing.T) {
+	t.Parallel()
+
+	database := NewDatabase(
+		filepath.Join(t.TempDir(), "traceary.db"),
+		os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")),
+	)
+	if err := NewStoreManagementDatasource(database).Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := database.open(context.Background())
+	if err != nil {
+		t.Fatalf("open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+		Query("literal needle").
+		Workspace(types.Workspace("github.com/duck8823/traceary")).
+		Build()
+	query, args := buildFTSEventIDsQuery(criteria, criteria.Query())
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	normalized := strings.ToLower(plan.String())
+	if !strings.Contains(normalized, "event_search_fts") ||
+		!strings.Contains(normalized, "virtual table index") {
+		t.Fatalf("query plan does not use the FTS virtual-table index:\n%s", plan.String())
+	}
+}

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -152,7 +152,7 @@ func TestSearchAndContext_MetadataProjectionUseBodyFreeQueries(t *testing.T) {
 func TestSearchProjection_OmitsThinkingBesideUnknownBlocks(t *testing.T) {
 	t.Parallel()
 
-	body := `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible response"}]}`
+	body := `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","text":"","id":"call-1"},{"type":"text","text":"visible response"}]}`
 	event := model.EventOf(
 		types.EventID("event-tool-envelope"),
 		types.EventKindTranscript,

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -149,6 +149,51 @@ func TestSearchAndContext_MetadataProjectionUseBodyFreeQueries(t *testing.T) {
 	}
 }
 
+func TestSearchProjection_OmitsThinkingBesideUnknownBlocks(t *testing.T) {
+	t.Parallel()
+
+	body := `{"blocks":[{"type":"thinking","text":"hidden-tool-reasoning"},{"type":"tool_use","id":"call-1"},{"type":"text","text":"visible response"}]}`
+	event := model.EventOf(
+		types.EventID("event-tool-envelope"),
+		types.EventKindTranscript,
+		types.Client("hook"),
+		types.Agent("codex"),
+		types.SessionID("session-1"),
+		types.Workspace("duck8823/traceary"),
+		body,
+		time.Date(2026, 7, 25, 1, 0, 0, 0, time.UTC),
+	)
+	full := &projectionEventUsecaseStub{search: []*model.Event{event}}
+	server := &Server{event: full}
+
+	_, output, err := server.search()(
+		context.Background(),
+		nil,
+		searchInput{Query: "visible response", FullBody: true},
+	)
+	if err != nil {
+		t.Fatalf("search() error = %v", err)
+	}
+	if full.searchCalls != 1 || len(output.Events) != 1 {
+		t.Fatalf("search calls/output = %d/%+v, want one event", full.searchCalls, output.Events)
+	}
+	got := output.Events[0]
+	if got.Body == nil || *got.Body != "visible response" {
+		t.Fatalf("search body = %v, want visible response only", got.Body)
+	}
+	if len(got.BodyBlocks) != 0 {
+		t.Fatalf("search body_blocks = %+v, want omitted", got.BodyBlocks)
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), "hidden-tool-reasoning") ||
+		strings.Contains(string(encoded), "tool_use") {
+		t.Fatalf("search output leaked non-visible blocks: %s", encoded)
+	}
+}
+
 func TestListEventsAndSearchShareRequestedIntervalSemantics(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +292,7 @@ type projectionEventUsecaseStub struct {
 	searchCalls    int
 	contextCalls   int
 	list           []*model.Event
+	search         []*model.Event
 	listCriteria   apptypes.EventListCriteria
 	searchCriteria apptypes.EventSearchCriteria
 }
@@ -260,7 +306,7 @@ func (*projectionEventUsecaseStub) Audit(context.Context, apptypes.AuditInput, a
 func (s *projectionEventUsecaseStub) Search(_ context.Context, criteria apptypes.EventSearchCriteria) ([]*model.Event, error) {
 	s.searchCalls++
 	s.searchCriteria = criteria
-	return nil, nil
+	return s.search, nil
 }
 func (s *projectionEventUsecaseStub) List(_ context.Context, criteria apptypes.EventListCriteria) ([]*model.Event, error) {
 	s.listCalls++

--- a/schema/sqlite/migrations/000032_add_event_search_fts.sql
+++ b/schema/sqlite/migrations/000032_add_event_search_fts.sql
@@ -40,22 +40,15 @@ SELECT
                  AND json_type(e.body, '$.blocks') = 'array'
                  AND NOT EXISTS (
                      SELECT 1
-                       FROM json_each(json_extract(e.body, '$.blocks')) AS block
-                      WHERE CASE
-                          WHEN block.type != 'object' THEN 1
-                          WHEN json_type(block.value, '$.type') IS NOT 'text' THEN 1
-                          WHEN json_extract(block.value, '$.type') IN ('text', 'thinking')
-                               AND json_type(block.value, '$.text') IS NOT 'text'
-                          THEN 1
-                          ELSE 0
-                      END = 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
                  )
             THEN COALESCE(
                 (
                     SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
                       FROM json_each(json_extract(e.body, '$.blocks'))
                      WHERE json_extract(value, '$.type') = 'text'
-                       AND json_type(value, '$.text') = 'text'
                 ),
                 ''
             )

--- a/schema/sqlite/migrations/000032_add_event_search_fts.sql
+++ b/schema/sqlite/migrations/000032_add_event_search_fts.sql
@@ -172,6 +172,38 @@ BEGIN
      WHERE event_id = NEW.event_id;
 END;
 
+CREATE TRIGGER command_audits_search_after_update
+AFTER UPDATE OF command_text, input_text, output_text ON command_audits
+BEGIN
+    INSERT INTO event_search_documents(
+        event_id, body_text, command_text, input_text, output_text
+    )
+    SELECT event_id, body_text, command_text, input_text, output_text
+      FROM event_search_projection
+     WHERE event_id = NEW.event_id
+    ON CONFLICT(event_id) DO NOTHING;
+
+    UPDATE event_search_documents
+       SET (body_text, command_text, input_text, output_text) = (
+           SELECT body_text, command_text, input_text, output_text
+             FROM event_search_projection
+            WHERE event_id = NEW.event_id
+       )
+     WHERE event_id = NEW.event_id;
+END;
+
+CREATE TRIGGER command_audits_search_after_delete
+AFTER DELETE ON command_audits
+BEGIN
+    UPDATE event_search_documents
+       SET (body_text, command_text, input_text, output_text) = (
+           SELECT body_text, command_text, input_text, output_text
+             FROM event_search_projection
+            WHERE event_id = OLD.event_id
+       )
+     WHERE event_id = OLD.event_id;
+END;
+
 CREATE TABLE event_search_backfill_state (
     singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
     last_event_id TEXT NOT NULL DEFAULT '',

--- a/schema/sqlite/migrations/000032_add_event_search_fts.sql
+++ b/schema/sqlite/migrations/000032_add_event_search_fts.sql
@@ -40,15 +40,22 @@ SELECT
                  AND json_type(e.body, '$.blocks') = 'array'
                  AND NOT EXISTS (
                      SELECT 1
-                       FROM json_each(json_extract(e.body, '$.blocks'))
-                      WHERE typeof(json_extract(value, '$.type')) != 'text'
-                         OR typeof(json_extract(value, '$.text')) != 'text'
+                       FROM json_each(json_extract(e.body, '$.blocks')) AS block
+                      WHERE CASE
+                          WHEN block.type != 'object' THEN 1
+                          WHEN json_type(block.value, '$.type') IS NOT 'text' THEN 1
+                          WHEN json_extract(block.value, '$.type') IN ('text', 'thinking')
+                               AND json_type(block.value, '$.text') IS NOT 'text'
+                          THEN 1
+                          ELSE 0
+                      END = 1
                  )
             THEN COALESCE(
                 (
                     SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
                       FROM json_each(json_extract(e.body, '$.blocks'))
                      WHERE json_extract(value, '$.type') = 'text'
+                       AND json_type(value, '$.text') = 'text'
                 ),
                 ''
             )

--- a/schema/sqlite/migrations/000032_add_event_search_fts.sql
+++ b/schema/sqlite/migrations/000032_add_event_search_fts.sql
@@ -1,0 +1,185 @@
+-- Add a stable search-document projection and an FTS5 trigram index without
+-- scanning historical event bodies during migration. Historical rows are
+-- filled by the resumable application backfill in small TEXT-primary-key
+-- batches. events.rowid is intentionally not persisted because VACUUM may
+-- rewrite it.
+CREATE TABLE event_search_documents (
+    search_document_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE REFERENCES events(id) ON DELETE CASCADE,
+    body_text TEXT NOT NULL DEFAULT '',
+    command_text TEXT NOT NULL DEFAULT '',
+    input_text TEXT NOT NULL DEFAULT '',
+    output_text TEXT NOT NULL DEFAULT ''
+);
+
+CREATE VIRTUAL TABLE event_search_fts USING fts5(
+    body_text,
+    command_text,
+    input_text,
+    output_text,
+    content='event_search_documents',
+    content_rowid='search_document_id',
+    tokenize='trigram case_sensitive 1'
+);
+
+-- SQLite lower() folds ASCII only in the bundled build. Lowering both the
+-- projection and the FTS query therefore preserves the legacy LIKE behavior:
+-- ASCII is case-insensitive while non-ASCII remains case-sensitive.
+--
+-- A canonical transcript envelope contributes text blocks only. Foreign JSON
+-- and legacy plain text remain raw-searchable. Retention-unavailable bodies
+-- contribute no body text.
+CREATE VIEW event_search_projection AS
+SELECT
+    e.id AS event_id,
+    lower(
+        CASE
+            WHEN e.body_availability = 'unavailable_retention' THEN ''
+            WHEN json_valid(e.body)
+                 AND json_type(e.body, '$') = 'object'
+                 AND json_type(e.body, '$.blocks') = 'array'
+                 AND NOT EXISTS (
+                     SELECT 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
+                 )
+            THEN COALESCE(
+                (
+                    SELECT group_concat(json_extract(value, '$.text'), X'0A0A')
+                      FROM json_each(json_extract(e.body, '$.blocks'))
+                     WHERE json_extract(value, '$.type') = 'text'
+                ),
+                ''
+            )
+            ELSE e.body
+        END
+    ) AS body_text,
+    lower(COALESCE(a.command_text, '')) AS command_text,
+    lower(COALESCE(a.input_text, '')) AS input_text,
+    lower(COALESCE(a.output_text, '')) AS output_text
+FROM events e
+LEFT JOIN command_audits a ON a.event_id = e.id;
+
+-- Standard external-content FTS maintenance. The stable INTEGER PRIMARY KEY
+-- belongs to the search document, not to events.rowid.
+CREATE TRIGGER event_search_documents_after_insert
+AFTER INSERT ON event_search_documents
+BEGIN
+    INSERT INTO event_search_fts(
+        rowid, body_text, command_text, input_text, output_text
+    ) VALUES (
+        NEW.search_document_id,
+        NEW.body_text,
+        NEW.command_text,
+        NEW.input_text,
+        NEW.output_text
+    );
+END;
+
+CREATE TRIGGER event_search_documents_after_delete
+AFTER DELETE ON event_search_documents
+BEGIN
+    INSERT INTO event_search_fts(
+        event_search_fts, rowid, body_text, command_text, input_text, output_text
+    ) VALUES (
+        'delete',
+        OLD.search_document_id,
+        OLD.body_text,
+        OLD.command_text,
+        OLD.input_text,
+        OLD.output_text
+    );
+END;
+
+CREATE TRIGGER event_search_documents_after_update
+AFTER UPDATE OF body_text, command_text, input_text, output_text
+ON event_search_documents
+BEGIN
+    INSERT INTO event_search_fts(
+        event_search_fts, rowid, body_text, command_text, input_text, output_text
+    ) VALUES (
+        'delete',
+        OLD.search_document_id,
+        OLD.body_text,
+        OLD.command_text,
+        OLD.input_text,
+        OLD.output_text
+    );
+    INSERT INTO event_search_fts(
+        rowid, body_text, command_text, input_text, output_text
+    ) VALUES (
+        NEW.search_document_id,
+        NEW.body_text,
+        NEW.command_text,
+        NEW.input_text,
+        NEW.output_text
+    );
+END;
+
+-- New writes are indexed transactionally. INSERT ... DO NOTHING makes this
+-- safe when a backfill batch already materialized the same event; the following
+-- UPDATE refreshes an existing document from the canonical projection.
+CREATE TRIGGER events_search_after_insert
+AFTER INSERT ON events
+BEGIN
+    INSERT INTO event_search_documents(
+        event_id, body_text, command_text, input_text, output_text
+    )
+    SELECT event_id, body_text, command_text, input_text, output_text
+      FROM event_search_projection
+     WHERE event_id = NEW.id
+    ON CONFLICT(event_id) DO NOTHING;
+END;
+
+CREATE TRIGGER events_search_after_body_update
+AFTER UPDATE OF body, body_availability ON events
+BEGIN
+    INSERT INTO event_search_documents(
+        event_id, body_text, command_text, input_text, output_text
+    )
+    SELECT event_id, body_text, command_text, input_text, output_text
+      FROM event_search_projection
+     WHERE event_id = NEW.id
+    ON CONFLICT(event_id) DO NOTHING;
+
+    UPDATE event_search_documents
+       SET (body_text, command_text, input_text, output_text) = (
+           SELECT body_text, command_text, input_text, output_text
+             FROM event_search_projection
+            WHERE event_id = NEW.id
+       )
+     WHERE event_id = NEW.id;
+END;
+
+CREATE TRIGGER command_audits_search_after_insert
+AFTER INSERT ON command_audits
+BEGIN
+    INSERT INTO event_search_documents(
+        event_id, body_text, command_text, input_text, output_text
+    )
+    SELECT event_id, body_text, command_text, input_text, output_text
+      FROM event_search_projection
+     WHERE event_id = NEW.event_id
+    ON CONFLICT(event_id) DO NOTHING;
+
+    UPDATE event_search_documents
+       SET (body_text, command_text, input_text, output_text) = (
+           SELECT body_text, command_text, input_text, output_text
+             FROM event_search_projection
+            WHERE event_id = NEW.event_id
+       )
+     WHERE event_id = NEW.event_id;
+END;
+
+CREATE TABLE event_search_backfill_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    last_event_id TEXT NOT NULL DEFAULT '',
+    target_event_id TEXT,
+    completed INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+    updated_at TEXT NOT NULL
+);
+
+INSERT INTO event_search_backfill_state(
+    singleton, last_event_id, target_event_id, completed, updated_at
+) VALUES (1, '', NULL, 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));


### PR DESCRIPTION
Motivation: Large-store search reconstructed event JSON before timestamp ordering. This adds FTS5 trigram projection with resumable bounded backfill and preserves literal search, redaction, thinking-content exclusion, ordering, and body-free metadata. Validation: go test ./..., golangci-lint, build, vet, diff check. Closes #1554.