### PR TITLE
v0.33.0-3: avoid full body hydration in bounded MCP reads

### DIFF
--- a/.ai/spec/1552.md
+++ b/.ai/spec/1552.md
@@ -1,0 +1,118 @@
+# #1552 Body-free bounded MCP event retrieval
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Make the default bounded `list_events`, `search`, and
+  `get_context` projections cap SQLite-to-Go body transfer and allocation, not
+  only the final MCP JSON.
+- **Current behavior:** MCP resolves an omitted body option to `bounded`, but
+  still calls the full `EventUsecase`. SQLite selects every complete stored
+  body, Go restores domain `Event` values, and presentation truncates only
+  after canonical visible-text extraction.
+- **Expected behavior:** Presentation selects `metadata`, `bounded`, or `full`
+  before issuing a query. Bounded reads return a dedicated application read
+  model whose visible body is truncated in SQLite. Search uses FTS only to
+  select event IDs and hydrates bounded content from authoritative event rows.
+  Full/detail reads retain the existing domain `Event` path.
+- **Compatibility:** The bounded visible-text projection preserves
+  `ExtractPlainBody` semantics for canonical transcript envelopes, legacy
+  plain text, foreign/malformed JSON, thinking exclusion, and text-block
+  joining. Response truncation and persisted ingest/storage truncation remain
+  separate facts.
+- **Explicit fallback:** `list_events` may fetch a full raw body only for a
+  canonical envelope whose visible-text response was not truncated, solely to
+  preserve `body_blocks`. `search` and `get_context` never perform this
+  fallback.
+- **Out of scope:** Schema migration, retention-policy changes, restoration of
+  payload bytes already removed at ingestion/storage, CLI projection changes,
+  or changing full event/detail semantics.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Metadata projection | Body-free event facts | Returns identity, attribution, extent, and audit outcome | No stored body text crosses the query boundary |
+| Bounded event | Metadata plus a visible-text prefix and total visible rune count | Reports response truncation independently from persisted truncation | Returned prefix never exceeds the requested positive rune limit |
+| Full event | Existing domain `Event` | Returns the complete available stored body | Selected only by explicit full compatibility controls |
+| Canonical envelope | Exact lowercase `blocks` JSON envelope with string `type` and `text` fields | Joins nonblank `text` blocks with a blank line and excludes all other block types | SQL visible text must match `ExtractPlainBody` |
+| Search candidate | Event ID selected by FTS or bounded legacy matching | Feeds authoritative event-row bounded hydration | FTS document text is never returned as event content |
+| Canonical-block fallback | Canonical, available, response-untruncated list row | Loads and decodes the full envelope after the bounded query | List-only; search/context do not call it |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Select metadata/bounded/full before querying | `presentation/mcpserver` | Projection is an MCP request contract | SQLite must not interpret presentation compatibility flags |
+| Validate and orchestrate bounded list/search/context | `EventBoundedUsecase` | Consumer-oriented application boundary | Full `EventUsecase` must remain unchanged |
+| Preserve bounded read-model invariants | `application/types.BoundedEvent` | State and truncation facts belong together | Presentation must not infer persistence facts from strings |
+| Select candidates and project visible prefixes | `infrastructure/sqlite` | Filtering, JSON extraction, substring, and FTS are storage concerns | Application must not receive SQL/FTS DTOs |
+| Decode optional canonical block fallback | `EventBoundedUsecase` | It owns the explicit list compatibility flow | Search/context and SQLite candidate selection do not expose blocks |
+| Render MCP output | `presentation/mcpserver` | Maps read-model facts to stable JSON | It does not truncate full stored bodies |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| `EventBoundedUsecase` | MCP list/search/context | Query sequencing and canonical fallback | Rejects nonpositive body limits and invalid criteria |
+| `EventBoundedQueryService` | bounded usecase | Read-only SQLite snapshot, visible-text SQL, FTS candidate IDs | Existing typed search-scope errors propagate through wrapping |
+| `BoundedEvent` | MCP renderer | Prefix/original-length relationship and availability | Constructor rejects impossible sizes and unavailable bodies with content |
+| Canonical-body loader | bounded list orchestration | Full raw envelope query by selected IDs | Missing/noncanonical rows are omitted, not synthesized |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Default projection is body-bounded before query | Omitted projection/body flags | MCP list/search/context runs | Bounded usecase is called; full usecase is not |
+| Full compatibility controls | `full_body=true`, `body_limit=0`, or `projection=full` | MCP read runs | Existing full `EventUsecase` is called |
+| Large plain body | Multi-megabyte stored body and small rune limit | Bounded list/context hydrates | Returned Go body is only the prefix, with exact total rune count and extent |
+| Canonical compatibility | Thinking, unknown, empty/whitespace text, malformed/foreign JSON fixtures | Bounded projection runs without truncation | Body equals `ExtractPlainBody` |
+| Response versus persisted truncation | Stored extent flags plus a response prefix | MCP output is serialized | `body_truncated/body_length` and ingest/storage flags remain distinct |
+| FTS candidate-only use | Search document selects an event | Bounded search hydrates | Returned body comes from `events`, not the FTS document |
+| Canonical blocks | Untruncated canonical list row | Bounded list runs | Explicit fallback supplies `body_blocks`; truncated list rows do not |
+| No search/context fallback | Canonical untruncated rows | Search/context runs | Canonical-body loader is never called |
+| Retention unavailable | Body availability is retention-unavailable | Bounded read runs | Body is absent with the retention reason |
+| Query shape/plan | Production bounded hydration SQL | Inspect SQL and `EXPLAIN QUERY PLAN` | No raw body result column; selected IDs use the event identity index |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Read-model invariant | Constructor tests for limit, availability, and truncation | Add `BoundedEvent` around existing `EventMetadata` | Keep persistence and response truncation vocabulary separate |
+| Bounded orchestration | Stub tests for list fallback and no search/context fallback | Add dedicated query/usecase interfaces | Share validation without adding projection booleans |
+| SQLite projection | SQL-shape and integration fixtures fail without bounded methods | Add ID-first metadata/candidate selection and bounded visible-text hydration | Centralize canonical SQL expression in one embedded query |
+| MCP routing | Default calls still reach full stubs | Add explicit three-way projection switches and bounded conversion | Keep full converters only on the full branch |
+| Compatibility | Existing server/tool schema tests fail | Wire production/test DI and update descriptions/golden data | Avoid compatibility fallback outside list |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** Canonical-envelope recognition exists in Go and
+  SQL. Cross-fixture tests compare bounded SQL output directly with
+  `ExtractPlainBody`, including Go's Unicode whitespace set.
+- **Allocation risk:** Computing canonical visible text may still require
+  SQLite-internal JSON work, but full stored bodies no longer cross the
+  SQLite-row-to-Go boundary on the bounded path. The list-only block fallback
+  remains an explicit compatibility exception.
+- **Snapshot/race risk:** Candidate metadata and bounded bodies are hydrated in
+  one read transaction. The later optional block fallback revalidates the
+  canonical envelope and availability before attaching blocks.
+- **Migration/compatibility:** No migration is introduced. Existing event
+  tables and FTS search documents remain authoritative for their current
+  roles. Full and detail APIs are not changed.
+- **Rollback trigger:** Stop rollout if bounded output diverges from canonical
+  visible text, a bounded SQL row contains more than the requested prefix,
+  search returns FTS-normalized content, truncation provenance is lost, or
+  default MCP reads invoke the full event query.
+- **Rollback procedure:** Revert the bounded usecase/query wiring to the former
+  full-event MCP path. No data rollback is required.
+- **Split-PR plan:** Keep this as one issue/PR because the application boundary,
+  SQLite projection, and MCP routing form one safety invariant. A partial
+  rollout could silently retain full-body hydration.
+
+## Implementation checkpoint
+
+Proceed without a migration. Add the dedicated bounded read model/usecase,
+hydrate only selected event IDs through one bounded SQLite projection, retain
+the full domain-event path only for explicit full requests, and restrict raw
+canonical fallback to untruncated `list_events` rows.

--- a/.ai/spec/1552.md
+++ b/.ai/spec/1552.md
@@ -15,7 +15,10 @@
   before issuing a query. Bounded reads return a dedicated application read
   model whose visible body is truncated in SQLite. Search uses FTS only to
   select event IDs and hydrates bounded content from authoritative event rows.
-  Full/detail reads retain the existing domain `Event` path.
+  Full/detail reads retain the existing domain `Event` path. This bounds the
+  SQLite-to-Go result and Go allocation; canonical envelopes still require
+  SQLite to materialize the complete joined visible text before applying
+  `substr` and `length`.
 - **Compatibility:** The bounded visible-text projection preserves
   `ExtractPlainBody` semantics for canonical transcript envelopes, legacy
   plain text, foreign/malformed JSON, thinking exclusion, and text-block
@@ -27,16 +30,17 @@
   fallback.
 - **Out of scope:** Schema migration, retention-policy changes, restoration of
   payload bytes already removed at ingestion/storage, CLI projection changes,
-  or changing full event/detail semantics.
+  changing full event/detail semantics, or eliminating SQLite-internal
+  materialization of the complete visible text.
 
 ### Conceptual model
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Metadata projection | Body-free event facts | Returns identity, attribution, extent, and audit outcome | No stored body text crosses the query boundary |
-| Bounded event | Metadata plus a visible-text prefix and total visible rune count | Reports response truncation independently from persisted truncation | Returned prefix never exceeds the requested positive rune limit |
+| Metadata projection | Body-free event facts | Explicitly returns identity, attribution, persisted extent, and audit outcome | No stored body text crosses the query boundary |
+| Bounded event | Metadata plus a visible-text prefix and total visible rune count | Preserves response and persisted truncation as separate application facts | Returned prefix never exceeds the requested positive rune limit; the legacy default MCP response omits metadata-only extent keys |
 | Full event | Existing domain `Event` | Returns the complete available stored body | Selected only by explicit full compatibility controls |
-| Canonical envelope | Exact lowercase `blocks` JSON envelope with string `type` and `text` fields | Joins nonblank `text` blocks with a blank line and excludes all other block types | SQL visible text must match `ExtractPlainBody` |
+| Canonical envelope | Available exact lowercase `blocks` JSON envelope with string `type` and `text` fields | Joins nonblank `text` blocks in array-index order with a blank line and excludes all other block types | Classification has one SQL predicate shared by the flag and visible-body branch; SQL visible text must match `ExtractPlainBody` |
 | Search candidate | Event ID selected by FTS or bounded legacy matching | Feeds authoritative event-row bounded hydration | FTS document text is never returned as event content |
 | Canonical-block fallback | Canonical, available, response-untruncated list row | Loads and decodes the full envelope after the bounded query | List-only; search/context do not call it |
 
@@ -47,7 +51,7 @@
 | Select metadata/bounded/full before querying | `presentation/mcpserver` | Projection is an MCP request contract | SQLite must not interpret presentation compatibility flags |
 | Validate and orchestrate bounded list/search/context | `EventBoundedUsecase` | Consumer-oriented application boundary | Full `EventUsecase` must remain unchanged |
 | Preserve bounded read-model invariants | `application/types.BoundedEvent` | State and truncation facts belong together | Presentation must not infer persistence facts from strings |
-| Select candidates and project visible prefixes | `infrastructure/sqlite` | Filtering, JSON extraction, substring, and FTS are storage concerns | Application must not receive SQL/FTS DTOs |
+| Select candidates, classify availability/envelopes once, and project visible prefixes | `infrastructure/sqlite` | Filtering, ordered JSON aggregation, substring, and FTS are storage concerns | Application must not receive SQL/FTS DTOs or duplicate availability decisions |
 | Decode optional canonical block fallback | `EventBoundedUsecase` | It owns the explicit list compatibility flow | Search/context and SQLite candidate selection do not expose blocks |
 | Render MCP output | `presentation/mcpserver` | Maps read-model facts to stable JSON | It does not truncate full stored bodies |
 
@@ -68,7 +72,10 @@
 | Full compatibility controls | `full_body=true`, `body_limit=0`, or `projection=full` | MCP read runs | Existing full `EventUsecase` is called |
 | Large plain body | Multi-megabyte stored body and small rune limit | Bounded list/context hydrates | Returned Go body is only the prefix, with exact total rune count and extent |
 | Canonical compatibility | Thinking, unknown, empty/whitespace text, malformed/foreign JSON fixtures | Bounded projection runs without truncation | Body equals `ExtractPlainBody` |
-| Response versus persisted truncation | Stored extent flags plus a response prefix | MCP output is serialized | `body_truncated/body_length` and ingest/storage flags remain distinct |
+| Canonical block order | More than ten text blocks make lexical and numeric keys differ | Bounded projection runs | Visible text follows JSON array-index order |
+| Unavailable canonical-shaped body | Retention-unavailable row still contains envelope-shaped JSON | Bounded projection runs | Body is absent and the row is not classified as canonical |
+| Lean default bounded response | Stored extent flags plus a response prefix | Default MCP output is serialized | `body_truncated/body_length` remain; metadata-only byte/truncation keys are omitted |
+| Explicit metadata extent | Metadata projection is requested | MCP output is serialized | Persisted byte/truncation facts remain available without body hydration |
 | FTS candidate-only use | Search document selects an event | Bounded search hydrates | Returned body comes from `events`, not the FTS document |
 | Canonical blocks | Untruncated canonical list row | Bounded list runs | Explicit fallback supplies `body_blocks`; truncated list rows do not |
 | No search/context fallback | Canonical untruncated rows | Search/context runs | Canonical-body loader is never called |
@@ -81,19 +88,22 @@
 | --- | --- | --- | --- |
 | Read-model invariant | Constructor tests for limit, availability, and truncation | Add `BoundedEvent` around existing `EventMetadata` | Keep persistence and response truncation vocabulary separate |
 | Bounded orchestration | Stub tests for list fallback and no search/context fallback | Add dedicated query/usecase interfaces | Share validation without adding projection booleans |
-| SQLite projection | SQL-shape and integration fixtures fail without bounded methods | Add ID-first metadata/candidate selection and bounded visible-text hydration | Centralize canonical SQL expression in one embedded query |
+| SQLite projection | SQL-shape and integration fixtures fail without bounded methods, ordered aggregation, and shared classification | Add ID-first metadata/candidate selection and bounded visible-text hydration | Centralize availability/canonical classification and order `group_concat` inside the aggregate |
 | MCP routing | Default calls still reach full stubs | Add explicit three-way projection switches and bounded conversion | Keep full converters only on the full branch |
-| Compatibility | Existing server/tool schema tests fail | Wire production/test DI and update descriptions/golden data | Avoid compatibility fallback outside list |
+| Compatibility | Existing server/tool schema tests fail | Wire production/test DI and update descriptions/golden data | Avoid compatibility fallback outside list and metadata-only extent keys in default bounded output |
 
 ### Risks / rollback
 
 - **Procedural-logic risk:** Canonical-envelope recognition exists in Go and
   SQL. Cross-fixture tests compare bounded SQL output directly with
   `ExtractPlainBody`, including Go's Unicode whitespace set.
-- **Allocation risk:** Computing canonical visible text may still require
-  SQLite-internal JSON work, but full stored bodies no longer cross the
-  SQLite-row-to-Go boundary on the bounded path. The list-only block fallback
-  remains an explicit compatibility exception.
+- **Allocation risk:** For canonical envelopes, the query still builds the
+  complete `group_concat` visible text inside SQLite so that `length` can report
+  exact response-truncation provenance; `substr` is applied only after that
+  materialization. This PR therefore does not bound SQLite-internal temporary
+  text allocation or JSON CPU. It bounds the SQLite-row-to-Go transfer and Go
+  allocation. The list-only block fallback remains an explicit compatibility
+  exception.
 - **Snapshot/race risk:** Candidate metadata and bounded bodies are hydrated in
   one read transaction. The later optional block fallback revalidates the
   canonical envelope and availability before attaching blocks.
@@ -115,4 +125,6 @@
 Proceed without a migration. Add the dedicated bounded read model/usecase,
 hydrate only selected event IDs through one bounded SQLite projection, retain
 the full domain-event path only for explicit full requests, and restrict raw
-canonical fallback to untruncated `list_events` rows.
+canonical fallback to untruncated `list_events` rows. Keep persisted extent
+keys on the explicit metadata projection, not the legacy default bounded MCP
+response.

--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -51,3 +51,15 @@ type EventMetadataQueryService interface {
 type EventPreviewQueryService interface {
 	ListRecentCommandPreviews(ctx context.Context, sessionID types.SessionID, limit, bodyRuneLimit int) ([]apptypes.EventBodyPreview, error)
 }
+
+// EventBoundedQueryService provides body-limited event reads without
+// materializing full domain Events. Search documents may select candidate IDs,
+// but bounded bodies always come from authoritative event rows.
+type EventBoundedQueryService interface {
+	ListRecentBounded(ctx context.Context, criteria apptypes.EventListCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+	SearchBounded(ctx context.Context, criteria apptypes.EventSearchCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+	GetContextBounded(ctx context.Context, criteria apptypes.EventContextCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+	// LoadCanonicalBodies is the explicit list-only compatibility fallback for
+	// canonical envelopes whose visible body was not response-truncated.
+	LoadCanonicalBodies(ctx context.Context, eventIDs []types.EventID) (map[types.EventID]string, error)
+}

--- a/application/types/bounded_event.go
+++ b/application/types/bounded_event.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"unicode/utf8"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+// BoundedEvent is the read model for event content whose visible-text body was
+// capped before crossing the persistence boundary. Persisted body truncation
+// belongs to Metadata().BodyExtent(); BodyResponseTruncated reports only the
+// current read projection.
+type BoundedEvent struct {
+	metadata          EventMetadata
+	body              string
+	bodyRuneLimit     int
+	visibleBodyRunes  int
+	bodyAvailability  domtypes.BodyAvailability
+	canonicalEnvelope bool
+	bodyBlocks        []EventBodyBlock
+}
+
+// BoundedEventOf creates a bounded event projection.
+func BoundedEventOf(
+	metadata EventMetadata,
+	body string,
+	bodyRuneLimit int,
+	visibleBodyRunes int,
+	bodyAvailability domtypes.BodyAvailability,
+	canonicalEnvelope bool,
+) (BoundedEvent, error) {
+	if bodyRuneLimit <= 0 {
+		return BoundedEvent{}, xerrors.Errorf("body rune limit must be greater than or equal to 1")
+	}
+	if utf8.RuneCountInString(body) > bodyRuneLimit {
+		return BoundedEvent{}, xerrors.Errorf("bounded body exceeds its rune limit")
+	}
+	if visibleBodyRunes < 0 {
+		return BoundedEvent{}, xerrors.Errorf("visible body runes must be greater than or equal to 0")
+	}
+	if utf8.RuneCountInString(body) > visibleBodyRunes {
+		return BoundedEvent{}, xerrors.Errorf("bounded body exceeds its visible body length")
+	}
+	if _, err := domtypes.BodyAvailabilityFrom(bodyAvailability.String()); err != nil {
+		return BoundedEvent{}, xerrors.Errorf("invalid body availability: %w", err)
+	}
+	if !bodyAvailability.IsAvailable() {
+		if body != "" || visibleBodyRunes != 0 {
+			return BoundedEvent{}, xerrors.Errorf("unavailable body must not expose content or length")
+		}
+		if canonicalEnvelope {
+			return BoundedEvent{}, xerrors.Errorf("unavailable body must not be marked as a canonical envelope")
+		}
+	}
+	return BoundedEvent{
+		metadata:          metadata,
+		body:              body,
+		bodyRuneLimit:     bodyRuneLimit,
+		visibleBodyRunes:  visibleBodyRunes,
+		bodyAvailability:  bodyAvailability,
+		canonicalEnvelope: canonicalEnvelope,
+	}, nil
+}
+
+// Metadata returns body-free event facts and persisted truncation provenance.
+func (e BoundedEvent) Metadata() EventMetadata { return e.metadata }
+
+// Body returns the visible-text prefix without a response ellipsis.
+func (e BoundedEvent) Body() string { return e.body }
+
+// BodyRuneLimit returns the maximum body prefix requested from persistence.
+func (e BoundedEvent) BodyRuneLimit() int { return e.bodyRuneLimit }
+
+// VisibleBodyRunes returns the complete visible-text rune count before
+// response truncation.
+func (e BoundedEvent) VisibleBodyRunes() int { return e.visibleBodyRunes }
+
+// BodyAvailability reports whether the raw event body remains available.
+func (e BoundedEvent) BodyAvailability() domtypes.BodyAvailability {
+	return e.bodyAvailability
+}
+
+// BodyResponseTruncated reports whether the current projection omitted visible
+// body runes. It is independent from ingest/storage truncation.
+func (e BoundedEvent) BodyResponseTruncated() bool {
+	return e.bodyAvailability.IsAvailable() &&
+		utf8.RuneCountInString(e.body) < e.visibleBodyRunes
+}
+
+// CanonicalEnvelope reports whether the stored body was recognized as the
+// canonical block envelope by the bounded SQLite projection.
+func (e BoundedEvent) CanonicalEnvelope() bool { return e.canonicalEnvelope }
+
+// BodyBlocks returns canonical blocks attached by the list-only compatibility
+// fallback. Search and context projections leave it empty.
+func (e BoundedEvent) BodyBlocks() []EventBodyBlock {
+	return append([]EventBodyBlock(nil), e.bodyBlocks...)
+}
+
+// WithCanonicalBodyBlocks attaches an explicitly loaded canonical envelope.
+// Full blocks are permitted only when the visible-text response is available
+// and untruncated, so blocks cannot bypass the bounded response contract.
+func (e BoundedEvent) WithCanonicalBodyBlocks(blocks []EventBodyBlock) (BoundedEvent, error) {
+	if !e.bodyAvailability.IsAvailable() {
+		return BoundedEvent{}, xerrors.Errorf("cannot attach blocks to an unavailable body")
+	}
+	if !e.canonicalEnvelope {
+		return BoundedEvent{}, xerrors.Errorf("cannot attach blocks to a non-canonical body")
+	}
+	if e.BodyResponseTruncated() {
+		return BoundedEvent{}, xerrors.Errorf("cannot attach blocks to a response-truncated body")
+	}
+	e.bodyBlocks = append([]EventBodyBlock(nil), blocks...)
+	return e, nil
+}

--- a/application/types/bounded_event_test.go
+++ b/application/types/bounded_event_test.go
@@ -1,0 +1,186 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestBoundedEventOf_PreservesSeparateResponseAndPersistenceTruncation(t *testing.T) {
+	t.Parallel()
+
+	metadata := boundedEventMetadataFixture(t, types.Some(true), types.Some(false))
+	event, err := apptypes.BoundedEventOf(
+		metadata,
+		"visible",
+		7,
+		20,
+		types.BodyAvailabilityAvailable,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf() error = %v", err)
+	}
+	if !event.BodyResponseTruncated() {
+		t.Fatal("BodyResponseTruncated() = false, want true")
+	}
+	if got := event.VisibleBodyRunes(); got != 20 {
+		t.Fatalf("VisibleBodyRunes() = %d, want 20", got)
+	}
+	ingest, ok := event.Metadata().BodyExtent().IngestTruncated().Value()
+	if !ok || !ingest {
+		t.Fatalf("persisted ingest truncation = (%t, %t), want (true, true)", ingest, ok)
+	}
+	storage, ok := event.Metadata().BodyExtent().StorageTruncated().Value()
+	if !ok || storage {
+		t.Fatalf("persisted storage truncation = (%t, %t), want (false, true)", storage, ok)
+	}
+}
+
+func TestBoundedEventOf_RejectsImpossibleBodyProjection(t *testing.T) {
+	t.Parallel()
+
+	metadata := boundedEventMetadataFixture(t, types.None[bool](), types.None[bool]())
+	tests := []struct {
+		name         string
+		body         string
+		visibleRunes int
+		availability types.BodyAvailability
+		canonical    bool
+	}{
+		{
+			name:         "prefix exceeds visible length",
+			body:         "too long",
+			visibleRunes: 2,
+			availability: types.BodyAvailabilityAvailable,
+		},
+		{
+			name:         "negative visible length",
+			visibleRunes: -1,
+			availability: types.BodyAvailabilityAvailable,
+		},
+		{
+			name:         "retention unavailable body contains content",
+			body:         "hidden",
+			visibleRunes: 6,
+			availability: types.BodyAvailabilityUnavailableRetention,
+		},
+		{
+			name:         "retention unavailable row marked canonical",
+			availability: types.BodyAvailabilityUnavailableRetention,
+			canonical:    true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := apptypes.BoundedEventOf(
+				metadata,
+				tt.body,
+				max(1, len([]rune(tt.body))),
+				tt.visibleRunes,
+				tt.availability,
+				tt.canonical,
+			); err == nil {
+				t.Fatal("BoundedEventOf() error = nil")
+			}
+		})
+	}
+}
+
+func TestBoundedEvent_WithCanonicalBodyBlocksRequiresUntruncatedCanonicalBody(t *testing.T) {
+	t.Parallel()
+
+	metadata := boundedEventMetadataFixture(t, types.None[bool](), types.None[bool]())
+	blocks := []apptypes.EventBodyBlock{{Type: apptypes.EventBodyBlockTypeText, Text: "visible"}}
+
+	canonical, err := apptypes.BoundedEventOf(
+		metadata,
+		"visible",
+		7,
+		7,
+		types.BodyAvailabilityAvailable,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf(canonical) error = %v", err)
+	}
+	withBlocks, err := canonical.WithCanonicalBodyBlocks(blocks)
+	if err != nil {
+		t.Fatalf("WithCanonicalBodyBlocks() error = %v", err)
+	}
+	if len(withBlocks.BodyBlocks()) != 1 || withBlocks.BodyBlocks()[0].Text != "visible" {
+		t.Fatalf("BodyBlocks() = %+v", withBlocks.BodyBlocks())
+	}
+
+	truncated, err := apptypes.BoundedEventOf(
+		metadata,
+		"vis",
+		3,
+		7,
+		types.BodyAvailabilityAvailable,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf(truncated) error = %v", err)
+	}
+	if _, err := truncated.WithCanonicalBodyBlocks(blocks); err == nil {
+		t.Fatal("WithCanonicalBodyBlocks(truncated) error = nil")
+	}
+
+	plain, err := apptypes.BoundedEventOf(
+		metadata,
+		"visible",
+		7,
+		7,
+		types.BodyAvailabilityAvailable,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf(plain) error = %v", err)
+	}
+	if _, err := plain.WithCanonicalBodyBlocks(blocks); err == nil {
+		t.Fatal("WithCanonicalBodyBlocks(noncanonical) error = nil")
+	}
+}
+
+func boundedEventMetadataFixture(
+	t *testing.T,
+	ingestTruncated types.Optional[bool],
+	storageTruncated types.Optional[bool],
+) apptypes.EventMetadata {
+	t.Helper()
+	extent, err := apptypes.EventBodyExtentOf(
+		types.Some(4096),
+		2048,
+		ingestTruncated,
+		storageTruncated,
+		types.Some(1),
+	)
+	if err != nil {
+		t.Fatalf("EventBodyExtentOf() error = %v", err)
+	}
+	metadata, err := apptypes.EventMetadataOf(
+		types.EventID("event-bounded"),
+		types.EventKindTranscript,
+		types.Client("hook"),
+		types.Agent("codex"),
+		types.SessionID("session-1"),
+		types.Workspace("duck8823/traceary"),
+		"stop",
+		time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+		extent,
+		types.None[apptypes.CommandAuditMetadata](),
+	)
+	if err != nil {
+		t.Fatalf("EventMetadataOf() error = %v", err)
+	}
+	if strings.TrimSpace(metadata.EventID().String()) == "" {
+		t.Fatal("metadata fixture has empty event ID")
+	}
+	return metadata
+}

--- a/application/usecase/event_bounded_usecase.go
+++ b/application/usecase/event_bounded_usecase.go
@@ -1,0 +1,163 @@
+package usecase
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// EventBoundedUsecase exposes event reads whose visible body is capped before
+// it crosses the persistence boundary.
+type EventBoundedUsecase interface {
+	// List preserves list_events body_blocks compatibility through an explicit
+	// fallback only for canonical, available, response-untruncated rows.
+	List(ctx context.Context, criteria apptypes.EventListCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+	// Search returns bounded visible text without canonical body-block fallback.
+	Search(ctx context.Context, criteria apptypes.EventSearchCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+	// Context returns bounded visible text without canonical body-block fallback.
+	Context(ctx context.Context, criteria apptypes.EventContextCriteria, bodyRuneLimit int) ([]apptypes.BoundedEvent, error)
+}
+
+type eventBoundedUsecase struct {
+	query queryservice.EventBoundedQueryService
+}
+
+// NewEventBoundedUsecase creates the bounded event read usecase.
+func NewEventBoundedUsecase(query queryservice.EventBoundedQueryService) EventBoundedUsecase {
+	return &eventBoundedUsecase{query: query}
+}
+
+func (u *eventBoundedUsecase) List(
+	ctx context.Context,
+	criteria apptypes.EventListCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedRead(u.query, bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+
+	events, err := u.query.ListRecentBounded(ctx, criteria, bodyRuneLimit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to list bounded events: %w", err)
+	}
+	canonicalIDs := make([]types.EventID, 0)
+	for _, event := range events {
+		if event.BodyAvailability().IsAvailable() &&
+			event.CanonicalEnvelope() &&
+			!event.BodyResponseTruncated() {
+			canonicalIDs = append(canonicalIDs, event.Metadata().EventID())
+		}
+	}
+	if len(canonicalIDs) == 0 {
+		return events, nil
+	}
+
+	bodies, err := u.query.LoadCanonicalBodies(ctx, canonicalIDs)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load canonical event bodies: %w", err)
+	}
+	for index, event := range events {
+		body, ok := bodies[event.Metadata().EventID()]
+		if !ok {
+			continue
+		}
+		blocks, canonical := apptypes.DecodeCanonicalEnvelope(body)
+		if !canonical || apptypes.ExtractPlainBody(body) != event.Body() {
+			// A concurrent retention/body update can invalidate the earlier
+			// projection. Omit blocks instead of attaching stale/raw content
+			// whose visible-text form no longer matches this response.
+			continue
+		}
+		withBlocks, err := event.WithCanonicalBodyBlocks(blocks)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to attach canonical body blocks for %s: %w", event.Metadata().EventID(), err)
+		}
+		events[index] = withBlocks
+	}
+	return events, nil
+}
+
+func (u *eventBoundedUsecase) Search(
+	ctx context.Context,
+	criteria apptypes.EventSearchCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedRead(u.query, bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if !hasSearchConstraint(criteria) {
+		return nil, xerrors.Errorf("at least one search filter is required")
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+	resolvedKind, err := resolveOptionalSearchKind(criteria.Kind().String())
+	if err != nil {
+		return nil, err
+	}
+	resolvedCriteria := apptypes.NewEventSearchCriteriaBuilder(criteria.Limit()).
+		Query(criteria.Query()).
+		Workspace(criteria.Workspace()).
+		SessionID(criteria.SessionID()).
+		Client(criteria.Client()).
+		Agent(criteria.Agent()).
+		Kind(resolvedKind).
+		From(criteria.From()).
+		To(criteria.To()).
+		Offset(criteria.Offset()).
+		FailuresOnly(criteria.FailuresOnly()).
+		Build()
+
+	events, err := u.query.SearchBounded(ctx, resolvedCriteria, bodyRuneLimit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to search bounded events: %w", err)
+	}
+	return events, nil
+}
+
+func (u *eventBoundedUsecase) Context(
+	ctx context.Context,
+	criteria apptypes.EventContextCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedRead(u.query, bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	events, err := u.query.GetContextBounded(ctx, criteria, bodyRuneLimit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get bounded context events: %w", err)
+	}
+	return events, nil
+}
+
+func validateBoundedRead(query queryservice.EventBoundedQueryService, bodyRuneLimit int) error {
+	if query == nil {
+		return xerrors.Errorf("event bounded query service is not configured")
+	}
+	if bodyRuneLimit <= 0 {
+		return xerrors.Errorf("body rune limit must be greater than or equal to 1")
+	}
+	return nil
+}

--- a/application/usecase/event_bounded_usecase_test.go
+++ b/application/usecase/event_bounded_usecase_test.go
@@ -1,0 +1,196 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestEventBoundedUsecase_ListLoadsBlocksOnlyForCanonicalUntruncatedRows(t *testing.T) {
+	t.Parallel()
+
+	canonical := boundedUsecaseEventFixture(t, "canonical", "visible", 7, true)
+	truncated := boundedUsecaseEventFixture(t, "truncated", "visible", 10, true)
+	plain := boundedUsecaseEventFixture(t, "plain", "visible", 7, false)
+	query := &eventBoundedQueryStub{
+		list: []apptypes.BoundedEvent{canonical, truncated, plain},
+		canonicalBodies: map[types.EventID]string{
+			types.EventID("canonical"): `{"blocks":[{"type":"thinking","text":"hidden"},{"type":"text","text":"visible"}]}`,
+		},
+	}
+	sut := usecase.NewEventBoundedUsecase(query)
+
+	got, err := sut.List(
+		context.Background(),
+		apptypes.NewEventListCriteriaBuilder(3).Build(),
+		7,
+	)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(query.loadedCanonicalIDs) != 1 || query.loadedCanonicalIDs[0] != types.EventID("canonical") {
+		t.Fatalf("LoadCanonicalBodies() IDs = %v, want canonical only", query.loadedCanonicalIDs)
+	}
+	if len(got) != 3 || len(got[0].BodyBlocks()) != 2 {
+		t.Fatalf("List() bounded events = %+v", got)
+	}
+	if len(got[1].BodyBlocks()) != 0 || len(got[2].BodyBlocks()) != 0 {
+		t.Fatalf("non-fallback blocks = truncated:%+v plain:%+v", got[1].BodyBlocks(), got[2].BodyBlocks())
+	}
+}
+
+func TestEventBoundedUsecase_SearchAndContextNeverLoadCanonicalBodies(t *testing.T) {
+	t.Parallel()
+
+	canonical := boundedUsecaseEventFixture(t, "canonical", "visible", 7, true)
+	query := &eventBoundedQueryStub{
+		search:  []apptypes.BoundedEvent{canonical},
+		context: []apptypes.BoundedEvent{canonical},
+		canonicalBodies: map[types.EventID]string{
+			types.EventID("canonical"): `{"blocks":[{"type":"text","text":"visible"}]}`,
+		},
+	}
+	sut := usecase.NewEventBoundedUsecase(query)
+
+	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(1).
+		Query("visible").
+		Kind(types.EventKind("audit")).
+		Build()
+	search, err := sut.Search(context.Background(), searchCriteria, 7)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(search) != 1 {
+		t.Fatalf("Search() len = %d, want 1", len(search))
+	}
+	if query.searchCriteria.Kind() != types.EventKindCommandExecuted {
+		t.Fatalf("SearchBounded() kind = %q, want command_executed", query.searchCriteria.Kind())
+	}
+
+	contextEvents, err := sut.Context(
+		context.Background(),
+		apptypes.NewEventContextCriteriaBuilder(1).SessionID("session-1").Build(),
+		7,
+	)
+	if err != nil {
+		t.Fatalf("Context() error = %v", err)
+	}
+	if len(contextEvents) != 1 {
+		t.Fatalf("Context() len = %d, want 1", len(contextEvents))
+	}
+	if len(query.loadedCanonicalIDs) != 0 {
+		t.Fatalf("LoadCanonicalBodies() IDs = %v, want none", query.loadedCanonicalIDs)
+	}
+}
+
+func TestEventBoundedUsecase_RejectsUnboundedBodyLimitBeforeQuery(t *testing.T) {
+	t.Parallel()
+
+	query := &eventBoundedQueryStub{}
+	sut := usecase.NewEventBoundedUsecase(query)
+	if _, err := sut.List(
+		context.Background(),
+		apptypes.NewEventListCriteriaBuilder(1).Build(),
+		0,
+	); err == nil {
+		t.Fatal("List(bodyRuneLimit=0) error = nil")
+	}
+	if query.listCalls != 0 {
+		t.Fatalf("ListRecentBounded() calls = %d, want 0", query.listCalls)
+	}
+}
+
+type eventBoundedQueryStub struct {
+	list               []apptypes.BoundedEvent
+	search             []apptypes.BoundedEvent
+	context            []apptypes.BoundedEvent
+	canonicalBodies    map[types.EventID]string
+	loadedCanonicalIDs []types.EventID
+	searchCriteria     apptypes.EventSearchCriteria
+	listCalls          int
+}
+
+func (s *eventBoundedQueryStub) ListRecentBounded(
+	context.Context,
+	apptypes.EventListCriteria,
+	int,
+) ([]apptypes.BoundedEvent, error) {
+	s.listCalls++
+	return s.list, nil
+}
+
+func (s *eventBoundedQueryStub) SearchBounded(
+	_ context.Context,
+	criteria apptypes.EventSearchCriteria,
+	_ int,
+) ([]apptypes.BoundedEvent, error) {
+	s.searchCriteria = criteria
+	return s.search, nil
+}
+
+func (s *eventBoundedQueryStub) GetContextBounded(
+	context.Context,
+	apptypes.EventContextCriteria,
+	int,
+) ([]apptypes.BoundedEvent, error) {
+	return s.context, nil
+}
+
+func (s *eventBoundedQueryStub) LoadCanonicalBodies(
+	_ context.Context,
+	eventIDs []types.EventID,
+) (map[types.EventID]string, error) {
+	s.loadedCanonicalIDs = append([]types.EventID(nil), eventIDs...)
+	return s.canonicalBodies, nil
+}
+
+func boundedUsecaseEventFixture(
+	t *testing.T,
+	eventID string,
+	body string,
+	visibleRunes int,
+	canonical bool,
+) apptypes.BoundedEvent {
+	t.Helper()
+	extent, err := apptypes.EventBodyExtentOf(
+		types.None[int](),
+		len(body),
+		types.None[bool](),
+		types.None[bool](),
+		types.None[int](),
+	)
+	if err != nil {
+		t.Fatalf("EventBodyExtentOf() error = %v", err)
+	}
+	metadata, err := apptypes.EventMetadataOf(
+		types.EventID(eventID),
+		types.EventKindTranscript,
+		types.Client("hook"),
+		types.Agent("codex"),
+		types.SessionID("session-1"),
+		types.Workspace("duck8823/traceary"),
+		"stop",
+		time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+		extent,
+		types.None[apptypes.CommandAuditMetadata](),
+	)
+	if err != nil {
+		t.Fatalf("EventMetadataOf() error = %v", err)
+	}
+	event, err := apptypes.BoundedEventOf(
+		metadata,
+		body,
+		len([]rune(body)),
+		visibleRunes,
+		types.BodyAvailabilityAvailable,
+		canonical,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf() error = %v", err)
+	}
+	return event
+}

--- a/infrastructure/sqlite/event_bounded_datasource.go
+++ b/infrastructure/sqlite/event_bounded_datasource.go
@@ -1,0 +1,351 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"log/slog"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+//go:embed sql/select_bounded_event_bodies.sql
+var selectBoundedEventBodiesQuery string
+
+//go:embed sql/select_canonical_event_bodies.sql
+var selectCanonicalEventBodiesQuery string
+
+var _ queryservice.EventBoundedQueryService = (*EventDatasource)(nil)
+
+// ListRecentBounded selects body-free event metadata first, then hydrates only
+// the requested visible-text prefix for those IDs under the same read snapshot.
+func (d *EventDatasource) ListRecentBounded(
+	ctx context.Context,
+	criteria apptypes.EventListCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedBodyLimit(bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if err := validateMetadataListCriteria(criteria, false); err != nil {
+		return nil, err
+	}
+	db, tx, err := d.beginBoundedEventRead(ctx, "event listing")
+	if err != nil {
+		return nil, err
+	}
+	defer closeBoundedRead(db, tx)
+
+	rows, err := queryRecentEventMetadataTx(
+		ctx,
+		tx,
+		criteria,
+		formatMetadataOptionalTimestamp(criteria.From()),
+		formatMetadataOptionalTimestamp(criteria.To()),
+		criteria.Limit(),
+		criteria.Offset(),
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query bounded event metadata: %w", err)
+	}
+	metadata, err := collectEventMetadata(rows, criteria.Limit(), "bounded event metadata")
+	if err != nil {
+		return nil, err
+	}
+	events, err := hydrateBoundedEvents(ctx, tx, metadata, bodyRuneLimit)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to finish bounded event listing: %w", err)
+	}
+	return events, nil
+}
+
+// SearchBounded uses the existing FTS/legacy search planner only to select
+// event IDs, then projects bounded visible text from authoritative event rows.
+func (d *EventDatasource) SearchBounded(
+	ctx context.Context,
+	criteria apptypes.EventSearchCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedBodyLimit(bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	if criteria.Offset() < 0 {
+		return nil, xerrors.Errorf("offset must be greater than or equal to 0")
+	}
+	if !criteria.From().IsZero() && !criteria.To().IsZero() && criteria.From().After(criteria.To()) {
+		return nil, xerrors.Errorf("from must be earlier than to")
+	}
+	db, tx, err := d.beginBoundedEventRead(ctx, "event search")
+	if err != nil {
+		return nil, err
+	}
+	defer closeBoundedRead(db, tx)
+
+	searchSchemaAvailable, err := eventSearchSchemaAvailable(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	var candidateIDs []string
+	if searchSchemaAvailable {
+		candidateIDs, err = selectEventSearchCandidateIDs(ctx, tx, criteria)
+	} else {
+		// A store initialized before migration 32 retains the pre-FTS literal
+		// search behavior. This query returns IDs only; bounded body hydration
+		// below remains independent from candidate content matching.
+		candidateIDs, err = queryLegacyEventIDs(ctx, tx, criteria, criteria.Query())
+	}
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := hydrateEventSearchMetadataCandidates(ctx, tx, criteria, candidateIDs)
+	if err != nil {
+		return nil, err
+	}
+	events, err := hydrateBoundedEvents(ctx, tx, metadata, bodyRuneLimit)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to finish bounded event search: %w", err)
+	}
+	return events, nil
+}
+
+// GetContextBounded selects body-free context membership first and then
+// hydrates bounded visible text under one read snapshot.
+func (d *EventDatasource) GetContextBounded(
+	ctx context.Context,
+	criteria apptypes.EventContextCriteria,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if err := validateBoundedBodyLimit(bodyRuneLimit); err != nil {
+		return nil, err
+	}
+	if criteria.Limit() <= 0 {
+		return nil, xerrors.Errorf("limit must be greater than or equal to 1")
+	}
+	db, tx, err := d.beginBoundedEventRead(ctx, "event context")
+	if err != nil {
+		return nil, err
+	}
+	defer closeBoundedRead(db, tx)
+
+	workspace := criteria.Workspace().String()
+	sessionID := criteria.SessionID().String()
+	query, args := contextEventMetadataQuery(workspace, sessionID, criteria.Limit())
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query bounded context metadata: %w", err)
+	}
+	metadata, err := collectEventMetadata(rows, criteria.Limit(), "bounded context metadata")
+	if err != nil {
+		return nil, err
+	}
+	events, err := hydrateBoundedEvents(ctx, tx, metadata, bodyRuneLimit)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, xerrors.Errorf("failed to finish bounded event context: %w", err)
+	}
+	return events, nil
+}
+
+// LoadCanonicalBodies performs the explicit list-only compatibility fallback.
+// Callers must supply only canonical, available, response-untruncated IDs and
+// must revalidate each returned envelope before exposing body blocks.
+func (d *EventDatasource) LoadCanonicalBodies(
+	ctx context.Context,
+	eventIDs []types.EventID,
+) (map[types.EventID]string, error) {
+	if len(eventIDs) == 0 {
+		return map[types.EventID]string{}, nil
+	}
+	encoded, err := marshalBoundedEventIDs(eventIDs)
+	if err != nil {
+		return nil, err
+	}
+	db, err := d.db.openReadOnly(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to open DB for canonical event bodies: %w", err)
+	}
+	defer closeMetadataResource(db)
+	rows, err := db.QueryContext(ctx, selectCanonicalEventBodiesQuery, encoded)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query canonical event bodies: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Debug("failed to close canonical event body rows", "error", err)
+		}
+	}()
+	bodies := make(map[types.EventID]string, len(eventIDs))
+	for rows.Next() {
+		var eventIDValue, body string
+		if err := rows.Scan(&eventIDValue, &body); err != nil {
+			return nil, xerrors.Errorf("failed to scan canonical event body: %w", err)
+		}
+		eventID, err := types.EventIDFrom(eventIDValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore canonical event ID: %w", err)
+		}
+		bodies[eventID] = body
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate canonical event bodies: %w", err)
+	}
+	return bodies, nil
+}
+
+func (d *EventDatasource) beginBoundedEventRead(
+	ctx context.Context,
+	operation string,
+) (*sql.DB, *sql.Tx, error) {
+	db, err := d.db.openReadOnly(ctx)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to open DB for bounded %s: %w", operation, err)
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		closeMetadataResource(db)
+		return nil, nil, xerrors.Errorf("failed to begin bounded %s transaction: %w", operation, err)
+	}
+	return db, tx, nil
+}
+
+func closeBoundedRead(db *sql.DB, tx *sql.Tx) {
+	if tx != nil {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.Debug("failed to rollback bounded event transaction", "error", err)
+		}
+	}
+	if db != nil {
+		closeMetadataResource(db)
+	}
+}
+
+func validateBoundedBodyLimit(bodyRuneLimit int) error {
+	if bodyRuneLimit <= 0 {
+		return xerrors.Errorf("body rune limit must be greater than or equal to 1")
+	}
+	return nil
+}
+
+type boundedEventBodyRow struct {
+	body              string
+	visibleBodyRunes  int
+	bodyAvailability  types.BodyAvailability
+	canonicalEnvelope bool
+}
+
+func hydrateBoundedEvents(
+	ctx context.Context,
+	queryer interface {
+		QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	},
+	metadata []apptypes.EventMetadata,
+	bodyRuneLimit int,
+) ([]apptypes.BoundedEvent, error) {
+	if len(metadata) == 0 {
+		return []apptypes.BoundedEvent{}, nil
+	}
+	eventIDs := make([]types.EventID, 0, len(metadata))
+	for _, event := range metadata {
+		eventIDs = append(eventIDs, event.EventID())
+	}
+	encoded, err := marshalBoundedEventIDs(eventIDs)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := queryer.QueryContext(ctx, selectBoundedEventBodiesQuery, encoded, bodyRuneLimit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to query bounded event bodies: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	bodyRows := make(map[types.EventID]boundedEventBodyRow, len(metadata))
+	for rows.Next() {
+		var (
+			eventIDValue      string
+			body              string
+			visibleRunesValue int64
+			availabilityValue string
+			canonicalEnvelope bool
+		)
+		if err := rows.Scan(
+			&eventIDValue,
+			&body,
+			&visibleRunesValue,
+			&availabilityValue,
+			&canonicalEnvelope,
+		); err != nil {
+			return nil, xerrors.Errorf("failed to scan bounded event body: %w", err)
+		}
+		eventID, err := types.EventIDFrom(eventIDValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore bounded event ID: %w", err)
+		}
+		visibleRunes, err := checkedInt(visibleRunesValue, "visible body runes")
+		if err != nil {
+			return nil, err
+		}
+		availability, err := types.BodyAvailabilityFrom(availabilityValue)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to restore bounded body availability: %w", err)
+		}
+		bodyRows[eventID] = boundedEventBodyRow{
+			body:              body,
+			visibleBodyRunes:  visibleRunes,
+			bodyAvailability:  availability,
+			canonicalEnvelope: canonicalEnvelope,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, xerrors.Errorf("failed to iterate bounded event bodies: %w", err)
+	}
+
+	events := make([]apptypes.BoundedEvent, 0, len(metadata))
+	for _, eventMetadata := range metadata {
+		bodyRow, ok := bodyRows[eventMetadata.EventID()]
+		if !ok {
+			return nil, xerrors.Errorf("bounded body is missing for event %s", eventMetadata.EventID())
+		}
+		event, err := apptypes.BoundedEventOf(
+			eventMetadata,
+			bodyRow.body,
+			bodyRuneLimit,
+			bodyRow.visibleBodyRunes,
+			bodyRow.bodyAvailability,
+			bodyRow.canonicalEnvelope,
+		)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to build bounded event %s: %w", eventMetadata.EventID(), err)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func marshalBoundedEventIDs(eventIDs []types.EventID) (string, error) {
+	values := make([]string, 0, len(eventIDs))
+	for _, eventID := range eventIDs {
+		values = append(values, eventID.String())
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode bounded event IDs: %w", err)
+	}
+	return string(encoded), nil
+}

--- a/infrastructure/sqlite/event_bounded_query_internal_test.go
+++ b/infrastructure/sqlite/event_bounded_query_internal_test.go
@@ -1,0 +1,96 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestBoundedEventBodyQuery_SelectsOnlyVisiblePrefix(t *testing.T) {
+	t.Parallel()
+
+	normalized := strings.ToLower(strings.Join(strings.Fields(selectBoundedEventBodiesQuery), " "))
+	if !strings.Contains(normalized, "substr(visible_body, 1, ?)") {
+		t.Fatalf("bounded query must select a visible-text prefix: %s", normalized)
+	}
+	if !strings.Contains(normalized, "length(visible_body)") {
+		t.Fatalf("bounded query must retain response truncation provenance: %s", normalized)
+	}
+	for _, unboundedProjection := range []string{
+		"select e.body,",
+		", e.body,",
+		"select visible_body,",
+	} {
+		if strings.Contains(normalized, unboundedProjection) {
+			t.Fatalf("bounded query selects an unbounded result column %q: %s", unboundedProjection, normalized)
+		}
+	}
+	for _, forbidden := range []string{"command_text", "input_text", "output_text", "event_search_documents.body_text"} {
+		if strings.Contains(normalized, forbidden) {
+			t.Fatalf("bounded hydration selects forbidden payload source %q: %s", forbidden, normalized)
+		}
+	}
+}
+
+func TestBoundedEventBodyQuery_UsesEventIdentityIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(
+		dbPath,
+		os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")),
+	)
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(dbPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	encodedIDs, err := json.Marshal([]string{"event-1"})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	rows, err := db.QueryContext(
+		ctx,
+		"EXPLAIN QUERY PLAN "+selectBoundedEventBodiesQuery,
+		string(encodedIDs),
+		500,
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	normalized := strings.ToLower(plan.String())
+	if !strings.Contains(normalized, "events") ||
+		(!strings.Contains(normalized, "sqlite_autoindex_events_1") &&
+			!strings.Contains(normalized, "primary key")) {
+		t.Fatalf("bounded hydration does not seek events by identity:\n%s", plan.String())
+	}
+	if strings.Contains(normalized, "event_search_documents") ||
+		strings.Contains(normalized, "event_search_fts") {
+		t.Fatalf("bounded hydration reads search-document content:\n%s", plan.String())
+	}
+}

--- a/infrastructure/sqlite/event_bounded_query_internal_test.go
+++ b/infrastructure/sqlite/event_bounded_query_internal_test.go
@@ -22,19 +22,39 @@ func TestBoundedEventBodyQuery_SelectsOnlyVisiblePrefix(t *testing.T) {
 	if !strings.Contains(normalized, "length(visible_body)") {
 		t.Fatalf("bounded query must retain response truncation provenance: %s", normalized)
 	}
+	finalSelectIndex := strings.LastIndex(normalized, ") select ")
+	if finalSelectIndex < 0 {
+		t.Fatalf("bounded query final projection not found: %s", normalized)
+	}
+	finalProjection := normalized[finalSelectIndex+2:]
 	for _, unboundedProjection := range []string{
 		"select e.body,",
 		", e.body,",
 		"select visible_body,",
 	} {
-		if strings.Contains(normalized, unboundedProjection) {
-			t.Fatalf("bounded query selects an unbounded result column %q: %s", unboundedProjection, normalized)
+		if strings.Contains(finalProjection, unboundedProjection) {
+			t.Fatalf("bounded query selects an unbounded result column %q: %s", unboundedProjection, finalProjection)
 		}
 	}
 	for _, forbidden := range []string{"command_text", "input_text", "output_text", "event_search_documents.body_text"} {
 		if strings.Contains(normalized, forbidden) {
 			t.Fatalf("bounded hydration selects forbidden payload source %q: %s", forbidden, normalized)
 		}
+	}
+	if got := strings.Count(normalized, "json_valid("); got != 1 {
+		t.Fatalf("canonical envelope predicate count = %d, want one shared classification: %s", got, normalized)
+	}
+	if !strings.Contains(
+		normalized,
+		"when classified.body_availability <> 'available' then ''",
+	) {
+		t.Fatalf("bounded query does not fail closed for unavailable bodies: %s", normalized)
+	}
+	if !strings.Contains(
+		normalized,
+		"char(10) || char(10) order by cast(key as integer)",
+	) {
+		t.Fatalf("canonical text aggregation does not own array-index order: %s", normalized)
 	}
 }
 

--- a/infrastructure/sqlite/event_bounded_query_test.go
+++ b/infrastructure/sqlite/event_bounded_query_test.go
@@ -106,6 +106,17 @@ func TestEventBoundedQuery_MatchesCanonicalVisibleTextProjection(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
+	orderedBlocks := make([]apptypes.EventBodyBlock, 12)
+	for index := range orderedBlocks {
+		orderedBlocks[index] = apptypes.EventBodyBlock{
+			Type: apptypes.EventBodyBlockTypeText,
+			Text: "block-" + string(rune('a'+index)),
+		}
+	}
+	orderedEnvelope, err := apptypes.MarshalEventBodyBlocks(orderedBlocks)
+	if err != nil {
+		t.Fatalf("MarshalEventBodyBlocks() error = %v", err)
+	}
 	tests := []struct {
 		name string
 		body string
@@ -125,6 +136,10 @@ func TestEventBoundedQuery_MatchesCanonicalVisibleTextProjection(t *testing.T) {
 		{
 			name: "canonical preserves nonblank block whitespace",
 			body: `{"blocks":[{"type":"text","text":"  visible  "}]}`,
+		},
+		{
+			name: "canonical preserves numeric array order beyond ten blocks",
+			body: orderedEnvelope,
 		},
 		{name: "canonical empty envelope", body: `{"blocks":[]}`},
 		{name: "foreign blocks JSON stays raw", body: `{"blocks":[{"foo":"bar"}]}`},
@@ -243,6 +258,7 @@ func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
+	const retainedCanonicalBody = `{"blocks":[{"type":"text","text":"must remain unavailable"}]}`
 	event := newEventForSQLiteTest(
 		t,
 		"event-retention-bounded",
@@ -250,7 +266,7 @@ func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
 		"codex",
 		"session-retention",
 		"repo-retention",
-		"body removed later",
+		retainedCanonicalBody,
 		time.Date(2026, 7, 26, 3, 0, 0, 0, time.UTC),
 	)
 	if err := sut.Save(ctx, event); err != nil {
@@ -261,10 +277,10 @@ func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
 		t.Fatalf("sql.Open() error = %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
-		UPDATE events
-		   SET body = ?, body_availability = ?
-		 WHERE id = ?`,
-		types.EventBodyUnavailableRetentionMarker,
+			UPDATE events
+			   SET body = ?, body_availability = ?
+			 WHERE id = ?`,
+		retainedCanonicalBody,
 		types.BodyAvailabilityUnavailableRetention.String(),
 		event.EventID().String(),
 	); err != nil {
@@ -287,7 +303,8 @@ func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
 		t.Fatalf("GetContextBounded() len = %d, want 1", len(got))
 	}
 	if got[0].Body() != "" || got[0].VisibleBodyRunes() != 0 ||
-		got[0].BodyAvailability() != types.BodyAvailabilityUnavailableRetention {
+		got[0].BodyAvailability() != types.BodyAvailabilityUnavailableRetention ||
+		got[0].CanonicalEnvelope() {
 		t.Fatalf("retention bounded event = %+v", got[0])
 	}
 }

--- a/infrastructure/sqlite/event_bounded_query_test.go
+++ b/infrastructure/sqlite/event_bounded_query_test.go
@@ -1,0 +1,293 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestEventBoundedQuery_ReturnsSmallPrefixFromLargeStoredBody(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	const storedRunes = 8 << 20
+	body := strings.Repeat("x", storedRunes)
+	event := model.EventOf(
+		mustEventIDForSQLite(t, "event-large-bounded"),
+		types.EventKindNote,
+		types.Client("hook"),
+		mustAgentForSQLite(t, "codex"),
+		mustSessionIDForSQLite(t, "session-large"),
+		types.Workspace("repo-large"),
+		body,
+		time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET body_original_bytes = ?,
+		       body_ingest_truncated = 1,
+		       body_storage_truncated = 0
+		 WHERE id = ?`,
+		storedRunes+4096,
+		event.EventID().String(),
+	); err != nil {
+		_ = db.Close()
+		t.Fatalf("update body extent: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close extent DB: %v", err)
+	}
+
+	const bodyLimit = 128
+	got, err := sut.ListRecentBounded(
+		ctx,
+		apptypes.NewEventListCriteriaBuilder(1).
+			SessionID(types.SessionID("session-large")).
+			Build(),
+		bodyLimit,
+	)
+	if err != nil {
+		t.Fatalf("ListRecentBounded() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListRecentBounded() len = %d, want 1", len(got))
+	}
+	if bodyRunes := len([]rune(got[0].Body())); bodyRunes != bodyLimit {
+		t.Fatalf("bounded body runes = %d, want %d", bodyRunes, bodyLimit)
+	}
+	if got[0].VisibleBodyRunes() != storedRunes || !got[0].BodyResponseTruncated() {
+		t.Fatalf(
+			"visible body = (runes=%d, truncated=%t), want (%d, true)",
+			got[0].VisibleBodyRunes(),
+			got[0].BodyResponseTruncated(),
+			storedRunes,
+		)
+	}
+	extent := got[0].Metadata().BodyExtent()
+	if extent.StoredBytes() != len(body) {
+		t.Fatalf("stored bytes = %d, want %d", extent.StoredBytes(), len(body))
+	}
+	originalBytes, ok := extent.OriginalBytes().Value()
+	if !ok || originalBytes != storedRunes+4096 {
+		t.Fatalf("original bytes = (%d, %t), want (%d, true)", originalBytes, ok, storedRunes+4096)
+	}
+	ingest, ok := extent.IngestTruncated().Value()
+	if !ok || !ingest {
+		t.Fatalf("ingest truncation = (%t, %t), want (true, true)", ingest, ok)
+	}
+}
+
+func TestEventBoundedQuery_MatchesCanonicalVisibleTextProjection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "canonical excludes thinking and joins text",
+			body: `{"blocks":[{"type":"thinking","text":"hidden"},{"type":"text","text":"first"},{"type":"text","text":"second"}]}`,
+		},
+		{
+			name: "canonical unknown block stays excluded",
+			body: `{"blocks":[{"type":"tool_use","text":"","id":"call-1"},{"type":"text","text":"visible"}]}`,
+		},
+		{
+			name: "canonical skips Unicode whitespace-only text",
+			body: `{"blocks":[{"type":"text","text":"\u00a0\u2003"},{"type":"text","text":"visible"}]}`,
+		},
+		{
+			name: "canonical preserves nonblank block whitespace",
+			body: `{"blocks":[{"type":"text","text":"  visible  "}]}`,
+		},
+		{name: "canonical empty envelope", body: `{"blocks":[]}`},
+		{name: "foreign blocks JSON stays raw", body: `{"blocks":[{"foo":"bar"}]}`},
+		{name: "capitalized Blocks stays raw", body: `{"Blocks":[{"type":"text","text":"visible"}]}`},
+		{name: "malformed JSON stays raw", body: `{not json`},
+		{name: "legacy plain text stays raw", body: "legacy visible body"},
+	}
+	base := time.Date(2026, 7, 26, 1, 0, 0, 0, time.UTC)
+	for index, tt := range tests {
+		eventID := "event-visible-" + strings.ReplaceAll(tt.name, " ", "-")
+		sessionID := "session-visible-" + string(rune('a'+index))
+		event := model.EventOf(
+			mustEventIDForSQLite(t, eventID),
+			types.EventKindTranscript,
+			types.Client("hook"),
+			mustAgentForSQLite(t, "codex"),
+			mustSessionIDForSQLite(t, sessionID),
+			types.Workspace("repo-visible"),
+			tt.body,
+			base.Add(time.Duration(index)*time.Second),
+		)
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatalf("Save(%s) error = %v", tt.name, err)
+		}
+		got, err := sut.ListRecentBounded(
+			ctx,
+			apptypes.NewEventListCriteriaBuilder(1).SessionID(types.SessionID(sessionID)).Build(),
+			4096,
+		)
+		if err != nil {
+			t.Fatalf("ListRecentBounded(%s) error = %v", tt.name, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("ListRecentBounded(%s) len = %d, want 1", tt.name, len(got))
+		}
+		want := apptypes.ExtractPlainBody(tt.body)
+		if got[0].Body() != want {
+			t.Fatalf("visible body (%s) = %q, want %q", tt.name, got[0].Body(), want)
+		}
+		_, wantCanonical := apptypes.DecodeCanonicalEnvelope(tt.body)
+		if got[0].CanonicalEnvelope() != wantCanonical {
+			t.Fatalf(
+				"CanonicalEnvelope(%s) = %t, want %t",
+				tt.name,
+				got[0].CanonicalEnvelope(),
+				wantCanonical,
+			)
+		}
+	}
+}
+
+func TestEventBoundedSearch_UsesFTSOnlyForCandidateSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := newEventForSQLiteTest(
+		t,
+		"event-search-authoritative",
+		"hook",
+		"codex",
+		"session-search",
+		"repo-search",
+		"Authoritative MixedCase visible body",
+		time.Date(2026, 7, 26, 2, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_search_documents
+		   SET body_text = 'candidate-only needle'
+		 WHERE event_id = ?`,
+		event.EventID().String(),
+	); err != nil {
+		_ = db.Close()
+		t.Fatalf("update search document: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close search DB: %v", err)
+	}
+
+	got, err := sut.SearchBounded(
+		ctx,
+		apptypes.NewEventSearchCriteriaBuilder(1).
+			Query("candidate-only needle").
+			Workspace(types.Workspace("repo-search")).
+			Build(),
+		128,
+	)
+	if err != nil {
+		t.Fatalf("SearchBounded() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Body() != event.Body() {
+		t.Fatalf("SearchBounded() = %+v, want authoritative event body %q", got, event.Body())
+	}
+	if strings.Contains(got[0].Body(), "candidate-only") {
+		t.Fatalf("SearchBounded() returned FTS document content: %q", got[0].Body())
+	}
+}
+
+func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	event := newEventForSQLiteTest(
+		t,
+		"event-retention-bounded",
+		"hook",
+		"codex",
+		"session-retention",
+		"repo-retention",
+		"body removed later",
+		time.Date(2026, 7, 26, 3, 0, 0, 0, time.UTC),
+	)
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET body = ?, body_availability = ?
+		 WHERE id = ?`,
+		types.EventBodyUnavailableRetentionMarker,
+		types.BodyAvailabilityUnavailableRetention.String(),
+		event.EventID().String(),
+	); err != nil {
+		_ = db.Close()
+		t.Fatalf("mark body unavailable: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close retention DB: %v", err)
+	}
+
+	got, err := sut.GetContextBounded(
+		ctx,
+		apptypes.NewEventContextCriteriaBuilder(1).SessionID("session-retention").Build(),
+		100,
+	)
+	if err != nil {
+		t.Fatalf("GetContextBounded() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetContextBounded() len = %d, want 1", len(got))
+	}
+	if got[0].Body() != "" || got[0].VisibleBodyRunes() != 0 ||
+		got[0].BodyAvailability() != types.BodyAvailabilityUnavailableRetention {
+		t.Fatalf("retention bounded event = %+v", got[0])
+	}
+}

--- a/infrastructure/sqlite/sql/select_bounded_event_bodies.sql
+++ b/infrastructure/sqlite/sql/select_bounded_event_bodies.sql
@@ -1,0 +1,71 @@
+-- Hydrate only the visible-text prefix for already-selected event IDs. The
+-- complete stored body is used inside SQLite to recognize canonical envelopes
+-- and compute length, but it is never a result column.
+WITH classified_events AS (
+    SELECT
+        e.id,
+        e.body_availability,
+        CASE
+            WHEN e.body_availability = 'available'
+                 AND json_valid(e.body)
+                 AND json_type(e.body, '$') = 'object'
+                 AND json_type(e.body, '$.blocks') = 'array'
+                 AND NOT EXISTS (
+                     SELECT 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
+                 )
+            THEN 1
+            ELSE 0
+        END AS canonical_envelope,
+        CASE
+            WHEN e.body_availability = 'unavailable_retention' THEN ''
+            WHEN json_valid(e.body)
+                 AND json_type(e.body, '$') = 'object'
+                 AND json_type(e.body, '$.blocks') = 'array'
+                 AND NOT EXISTS (
+                     SELECT 1
+                       FROM json_each(json_extract(e.body, '$.blocks'))
+                      WHERE typeof(json_extract(value, '$.type')) != 'text'
+                         OR typeof(json_extract(value, '$.text')) != 'text'
+                 )
+            THEN COALESCE(
+                (
+                    SELECT group_concat(block_text, X'0A0A')
+                      FROM (
+                          SELECT json_extract(value, '$.text') AS block_text
+                            FROM json_each(json_extract(e.body, '$.blocks'))
+                           WHERE json_extract(value, '$.type') = 'text'
+                             -- Match strings.TrimSpace: Unicode White_Space
+                             -- code points are ignored only when deciding
+                             -- whether a text block is empty. Nonblank block
+                             -- text is preserved byte-for-byte.
+                             AND length(trim(
+                                 json_extract(value, '$.text'),
+                                 char(9) || char(10) || char(11) || char(12) ||
+                                 char(13) || char(32) || char(133) || char(160) ||
+                                 char(5760) || char(8192) || char(8193) ||
+                                 char(8194) || char(8195) || char(8196) ||
+                                 char(8197) || char(8198) || char(8199) ||
+                                 char(8200) || char(8201) || char(8202) ||
+                                 char(8232) || char(8233) || char(8239) ||
+                                 char(8287) || char(12288)
+                             )) > 0
+                           ORDER BY CAST(key AS INTEGER)
+                      )
+                ),
+                ''
+            )
+            ELSE e.body
+        END AS visible_body
+    FROM events e
+    WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+)
+SELECT
+    id,
+    substr(visible_body, 1, ?),
+    length(visible_body),
+    body_availability,
+    canonical_envelope
+FROM classified_events;

--- a/infrastructure/sqlite/sql/select_bounded_event_bodies.sql
+++ b/infrastructure/sqlite/sql/select_bounded_event_bodies.sql
@@ -1,9 +1,11 @@
--- Hydrate only the visible-text prefix for already-selected event IDs. The
--- complete stored body is used inside SQLite to recognize canonical envelopes
--- and compute length, but it is never a result column.
-WITH classified_events AS (
+-- Hydrate only the visible-text prefix for already-selected event IDs. For a
+-- canonical envelope SQLite still materializes the complete joined visible
+-- text before computing substr/length, but neither that text nor the complete
+-- stored body is a result column.
+WITH envelope_classification AS (
     SELECT
         e.id,
+        e.body,
         e.body_availability,
         CASE
             WHEN e.body_availability = 'available'
@@ -18,49 +20,53 @@ WITH classified_events AS (
                  )
             THEN 1
             ELSE 0
-        END AS canonical_envelope,
+        END AS canonical_envelope
+    FROM events e
+    WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+),
+classified_events AS (
+    SELECT
+        classified.id,
+        classified.body_availability,
+        classified.canonical_envelope,
         CASE
-            WHEN e.body_availability = 'unavailable_retention' THEN ''
-            WHEN json_valid(e.body)
-                 AND json_type(e.body, '$') = 'object'
-                 AND json_type(e.body, '$.blocks') = 'array'
-                 AND NOT EXISTS (
-                     SELECT 1
-                       FROM json_each(json_extract(e.body, '$.blocks'))
-                      WHERE typeof(json_extract(value, '$.type')) != 'text'
-                         OR typeof(json_extract(value, '$.text')) != 'text'
-                 )
+            -- Body availability and canonical classification share the same
+            -- owner above. Any current or future unavailable state stays
+            -- body-free instead of falling through to the stored marker/body.
+            WHEN classified.body_availability <> 'available' THEN ''
+            WHEN classified.canonical_envelope = 1
             THEN COALESCE(
                 (
-                    SELECT group_concat(block_text, X'0A0A')
-                      FROM (
-                          SELECT json_extract(value, '$.text') AS block_text
-                            FROM json_each(json_extract(e.body, '$.blocks'))
-                           WHERE json_extract(value, '$.type') = 'text'
-                             -- Match strings.TrimSpace: Unicode White_Space
-                             -- code points are ignored only when deciding
-                             -- whether a text block is empty. Nonblank block
-                             -- text is preserved byte-for-byte.
-                             AND length(trim(
-                                 json_extract(value, '$.text'),
-                                 char(9) || char(10) || char(11) || char(12) ||
-                                 char(13) || char(32) || char(133) || char(160) ||
-                                 char(5760) || char(8192) || char(8193) ||
-                                 char(8194) || char(8195) || char(8196) ||
-                                 char(8197) || char(8198) || char(8199) ||
-                                 char(8200) || char(8201) || char(8202) ||
-                                 char(8232) || char(8233) || char(8239) ||
-                                 char(8287) || char(12288)
-                             )) > 0
-                           ORDER BY CAST(key AS INTEGER)
-                      )
+                    -- Ordering inside the aggregate is the contract; do not
+                    -- depend on subquery presentation order.
+                    SELECT group_concat(
+                               json_extract(value, '$.text'),
+                               char(10) || char(10)
+                               ORDER BY CAST(key AS INTEGER)
+                           )
+                      FROM json_each(json_extract(classified.body, '$.blocks'))
+                     WHERE json_extract(value, '$.type') = 'text'
+                       -- Match strings.TrimSpace: Unicode White_Space code
+                       -- points are ignored only when deciding whether a text
+                       -- block is empty. Nonblank block text is preserved
+                       -- byte-for-byte.
+                       AND length(trim(
+                           json_extract(value, '$.text'),
+                           char(9) || char(10) || char(11) || char(12) ||
+                           char(13) || char(32) || char(133) || char(160) ||
+                           char(5760) || char(8192) || char(8193) ||
+                           char(8194) || char(8195) || char(8196) ||
+                           char(8197) || char(8198) || char(8199) ||
+                           char(8200) || char(8201) || char(8202) ||
+                           char(8232) || char(8233) || char(8239) ||
+                           char(8287) || char(12288)
+                       )) > 0
                 ),
                 ''
             )
-            ELSE e.body
+            ELSE classified.body
         END AS visible_body
-    FROM events e
-    WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+    FROM envelope_classification classified
 )
 SELECT
     id,

--- a/infrastructure/sqlite/sql/select_canonical_event_bodies.sql
+++ b/infrastructure/sqlite/sql/select_canonical_event_bodies.sql
@@ -1,0 +1,7 @@
+-- Explicit list_events compatibility fallback. The caller supplies only IDs
+-- that the bounded projection classified as canonical and response-untruncated,
+-- then revalidates the decoded envelope before attaching body_blocks.
+SELECT e.id, e.body
+  FROM events e
+ WHERE e.body_availability = 'available'
+   AND e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?));

--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func run() error {
 
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
 	eventMetadataUsecase := usecase.NewEventMetadataUsecase(eventDatasource)
+	eventBoundedUsecase := usecase.NewEventBoundedUsecase(eventDatasource)
 	reportUsecase := usecase.NewReportUsecase(reportDatasource)
 	codexCaptureDiagnosticUsecase := usecase.NewCodexCaptureDiagnosticUsecase(codexCaptureDiagnosticDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
@@ -214,6 +215,7 @@ func run() error {
 		contextUsecase,
 		storeManagementUsecase,
 		mcpserver.WithEventMetadata(eventMetadataUsecase),
+		mcpserver.WithEventBounded(eventBoundedUsecase),
 		mcpserver.WithReport(reportUsecase),
 	)
 	if err != nil {

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -149,6 +149,83 @@ func TestSearchAndContext_MetadataProjectionUseBodyFreeQueries(t *testing.T) {
 	}
 }
 
+func TestDefaultBoundedProjectionUsesBoundedQueriesBeforeFullEvents(t *testing.T) {
+	t.Parallel()
+
+	boundedEvent := newMCPBoundedFixture(t, "bounded visible body", 20, false)
+	full := &projectionEventUsecaseStub{}
+	bounded := &projectionBoundedUsecaseStub{
+		list:    []apptypes.BoundedEvent{boundedEvent},
+		search:  []apptypes.BoundedEvent{boundedEvent},
+		context: []apptypes.BoundedEvent{boundedEvent},
+	}
+	server := &Server{event: full, eventBounded: bounded}
+
+	_, listOutput, err := server.listEvents()(context.Background(), nil, listEventsInput{Limit: 1})
+	if err != nil {
+		t.Fatalf("listEvents() error = %v", err)
+	}
+	_, searchOutput, err := server.search()(context.Background(), nil, searchInput{Query: "visible", Limit: 1})
+	if err != nil {
+		t.Fatalf("search() error = %v", err)
+	}
+	_, contextOutput, err := server.getContext()(context.Background(), nil, getContextInput{SessionID: "session-1", Limit: 1})
+	if err != nil {
+		t.Fatalf("getContext() error = %v", err)
+	}
+	if full.listCalls != 0 || full.searchCalls != 0 || full.contextCalls != 0 {
+		t.Fatalf("full calls: list=%d search=%d context=%d, want zero", full.listCalls, full.searchCalls, full.contextCalls)
+	}
+	if bounded.listCalls != 1 || bounded.searchCalls != 1 || bounded.contextCalls != 1 {
+		t.Fatalf("bounded calls: list=%d search=%d context=%d, want one each", bounded.listCalls, bounded.searchCalls, bounded.contextCalls)
+	}
+	for name, events := range map[string][]eventOutput{
+		"list": listOutput.Events, "search": searchOutput.Events, "context": contextOutput.Events,
+	} {
+		if len(events) != 1 || events[0].Body == nil || *events[0].Body != "bounded visible body" {
+			t.Fatalf("%s bounded output = %+v", name, events)
+		}
+	}
+}
+
+func TestConvertBoundedEventsPreservesResponseAndStorageProvenance(t *testing.T) {
+	t.Parallel()
+
+	truncated := newMCPBoundedFixture(t, "visible", 20, true)
+	output := convertBoundedEvents([]apptypes.BoundedEvent{truncated})
+	if len(output) != 1 || output[0].Body == nil {
+		t.Fatalf("convertBoundedEvents() = %+v", output)
+	}
+	if *output[0].Body != "visible…" ||
+		!output[0].BodyTruncated ||
+		output[0].BodyLength != 20 {
+		t.Fatalf("bounded response truncation = %+v", output[0])
+	}
+	if output[0].BodyStoredBytes == nil || *output[0].BodyStoredBytes != 8*1024*1024 {
+		t.Fatalf("bounded stored extent = %+v", output[0])
+	}
+	if len(output[0].BodyBlocks) != 0 {
+		t.Fatalf("response-truncated body_blocks = %+v, want omitted", output[0].BodyBlocks)
+	}
+}
+
+func TestConvertBoundedEventsIncludesExplicitCanonicalBlocksOnlyWhenAttached(t *testing.T) {
+	t.Parallel()
+
+	event := newMCPBoundedFixture(t, "visible", 7, true)
+	withBlocks, err := event.WithCanonicalBodyBlocks([]apptypes.EventBodyBlock{
+		{Type: apptypes.EventBodyBlockTypeThinking, Text: "hidden"},
+		{Type: apptypes.EventBodyBlockTypeText, Text: "visible"},
+	})
+	if err != nil {
+		t.Fatalf("WithCanonicalBodyBlocks() error = %v", err)
+	}
+	output := convertBoundedEvents([]apptypes.BoundedEvent{withBlocks})
+	if len(output) != 1 || len(output[0].BodyBlocks) != 2 {
+		t.Fatalf("canonical bounded output = %+v", output)
+	}
+}
+
 func TestSearchProjection_OmitsThinkingBesideUnknownBlocks(t *testing.T) {
 	t.Parallel()
 
@@ -205,7 +282,7 @@ func TestListEventsAndSearchShareRequestedIntervalSemantics(t *testing.T) {
 		events := &projectionEventUsecaseStub{}
 		server := &Server{event: events}
 		_, output, err := server.listEvents()(context.Background(), nil, listEventsInput{
-			From: "2026-03-08", To: "2026-03-08", Timezone: "America/New_York",
+			From: "2026-03-08", To: "2026-03-08", Timezone: "America/New_York", FullBody: true,
 		})
 		if err != nil {
 			t.Fatalf("listEvents() error = %v", err)
@@ -218,7 +295,7 @@ func TestListEventsAndSearchShareRequestedIntervalSemantics(t *testing.T) {
 		events := &projectionEventUsecaseStub{}
 		server := &Server{event: events}
 		_, output, err := server.search()(context.Background(), nil, searchInput{
-			Query: "needle", From: "2026-03-08", To: "2026-03-08", Timezone: "America/New_York",
+			Query: "needle", From: "2026-03-08", To: "2026-03-08", Timezone: "America/New_York", FullBody: true,
 		})
 		if err != nil {
 			t.Fatalf("search() error = %v", err)
@@ -266,7 +343,10 @@ func TestListEvents_LegacyBodyControlsRemainCompatible(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			full := &projectionEventUsecaseStub{list: []*model.Event{event}}
-			server := &Server{event: full}
+			boundedBody := string([]rune(body)[:defaultListEventBodyLimit])
+			boundedEvent := newMCPBoundedFixture(t, boundedBody, len([]rune(body)), false)
+			bounded := &projectionBoundedUsecaseStub{list: []apptypes.BoundedEvent{boundedEvent}}
+			server := &Server{event: full, eventBounded: bounded}
 			_, output, err := server.listEvents()(context.Background(), nil, listEventsInput{BodyLimit: tt.bodyLimit, FullBody: tt.fullBody})
 			if err != nil {
 				t.Fatalf("listEvents() error = %v", err)
@@ -282,6 +362,13 @@ func TestListEvents_LegacyBodyControlsRemainCompatible(t *testing.T) {
 			}
 			if tt.wantTruncated && len([]rune(*output.Events[0].Body)) > defaultListEventBodyLimit+1 {
 				t.Fatalf("bounded body runes = %d, want <= %d", len([]rune(*output.Events[0].Body)), defaultListEventBodyLimit+1)
+			}
+			if tt.wantTruncated {
+				if bounded.listCalls != 1 || full.listCalls != 0 {
+					t.Fatalf("bounded/full calls = %d/%d, want 1/0", bounded.listCalls, full.listCalls)
+				}
+			} else if bounded.listCalls != 0 || full.listCalls != 1 {
+				t.Fatalf("bounded/full calls = %d/%d, want 0/1", bounded.listCalls, full.listCalls)
 			}
 		})
 	}
@@ -353,6 +440,42 @@ func (s *projectionMetadataUsecaseStub) Context(context.Context, apptypes.EventC
 	return s.context, nil
 }
 
+type projectionBoundedUsecaseStub struct {
+	list         []apptypes.BoundedEvent
+	search       []apptypes.BoundedEvent
+	context      []apptypes.BoundedEvent
+	listCalls    int
+	searchCalls  int
+	contextCalls int
+}
+
+func (s *projectionBoundedUsecaseStub) List(
+	context.Context,
+	apptypes.EventListCriteria,
+	int,
+) ([]apptypes.BoundedEvent, error) {
+	s.listCalls++
+	return s.list, nil
+}
+
+func (s *projectionBoundedUsecaseStub) Search(
+	context.Context,
+	apptypes.EventSearchCriteria,
+	int,
+) ([]apptypes.BoundedEvent, error) {
+	s.searchCalls++
+	return s.search, nil
+}
+
+func (s *projectionBoundedUsecaseStub) Context(
+	context.Context,
+	apptypes.EventContextCriteria,
+	int,
+) ([]apptypes.BoundedEvent, error) {
+	s.contextCalls++
+	return s.context, nil
+}
+
 func newMCPMetadataFixture(t *testing.T) apptypes.EventMetadata {
 	t.Helper()
 	extent, err := apptypes.EventBodyExtentOf(types.None[int](), 8*1024*1024, types.None[bool](), types.None[bool](), types.None[int]())
@@ -369,4 +492,25 @@ func newMCPMetadataFixture(t *testing.T) apptypes.EventMetadata {
 		t.Fatalf("EventMetadataOf() error = %v", err)
 	}
 	return metadata
+}
+
+func newMCPBoundedFixture(
+	t *testing.T,
+	body string,
+	visibleBodyRunes int,
+	canonical bool,
+) apptypes.BoundedEvent {
+	t.Helper()
+	event, err := apptypes.BoundedEventOf(
+		newMCPMetadataFixture(t),
+		body,
+		len([]rune(body)),
+		visibleBodyRunes,
+		types.BodyAvailabilityAvailable,
+		canonical,
+	)
+	if err != nil {
+		t.Fatalf("BoundedEventOf() error = %v", err)
+	}
+	return event
 }

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -115,6 +115,11 @@ func TestListEvents_MetadataProjectionOmitsBodyAndFullQuery(t *testing.T) {
 	if document.Events[0]["body_stored_bytes"] != float64(8*1024*1024) {
 		t.Fatalf("metadata output = %s", encoded)
 	}
+	if document.Events[0]["body_original_bytes"] != float64(9*1024*1024) ||
+		document.Events[0]["body_ingest_truncated"] != true ||
+		document.Events[0]["body_storage_truncated"] != false {
+		t.Fatalf("metadata extent output = %s", encoded)
+	}
 }
 
 func TestSearchAndContext_MetadataProjectionUseBodyFreeQueries(t *testing.T) {
@@ -489,7 +494,13 @@ func (s *projectionBoundedUsecaseStub) Context(
 
 func newMCPMetadataFixture(t *testing.T) apptypes.EventMetadata {
 	t.Helper()
-	extent, err := apptypes.EventBodyExtentOf(types.None[int](), 8*1024*1024, types.None[bool](), types.None[bool](), types.None[int]())
+	extent, err := apptypes.EventBodyExtentOf(
+		types.Some(9*1024*1024),
+		8*1024*1024,
+		types.Some(true),
+		types.Some(false),
+		types.None[int](),
+	)
 	if err != nil {
 		t.Fatalf("EventBodyExtentOf() error = %v", err)
 	}

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -188,7 +188,7 @@ func TestDefaultBoundedProjectionUsesBoundedQueriesBeforeFullEvents(t *testing.T
 	}
 }
 
-func TestConvertBoundedEventsPreservesResponseAndStorageProvenance(t *testing.T) {
+func TestConvertBoundedEventsKeepsDefaultResponseLean(t *testing.T) {
 	t.Parallel()
 
 	truncated := newMCPBoundedFixture(t, "visible", 20, true)
@@ -196,16 +196,27 @@ func TestConvertBoundedEventsPreservesResponseAndStorageProvenance(t *testing.T)
 	if len(output) != 1 || output[0].Body == nil {
 		t.Fatalf("convertBoundedEvents() = %+v", output)
 	}
-	if *output[0].Body != "visible…" ||
+	if *output[0].Body != "visible"+apptypes.TruncationEllipsis ||
 		!output[0].BodyTruncated ||
 		output[0].BodyLength != 20 {
 		t.Fatalf("bounded response truncation = %+v", output[0])
 	}
-	if output[0].BodyStoredBytes == nil || *output[0].BodyStoredBytes != 8*1024*1024 {
-		t.Fatalf("bounded stored extent = %+v", output[0])
-	}
 	if len(output[0].BodyBlocks) != 0 {
 		t.Fatalf("response-truncated body_blocks = %+v, want omitted", output[0].BodyBlocks)
+	}
+	encoded, err := json.Marshal(eventsOutput{Events: output})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	for _, metadataOnlyKey := range []string{
+		"body_original_bytes",
+		"body_stored_bytes",
+		"body_ingest_truncated",
+		"body_storage_truncated",
+	} {
+		if strings.Contains(string(encoded), `"`+metadataOnlyKey+`"`) {
+			t.Fatalf("default bounded output serialized metadata-only key %q: %s", metadataOnlyKey, encoded)
+		}
 	}
 }
 

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -136,7 +136,7 @@ type listEventsInput struct {
 	To         string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
 	Timezone   string `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only bounds (default: UTC)"`
 	SourceHook string `json:"source_hook,omitempty" jsonschema:"filter by hook identifier that produced the event (stop, subagent_stop, pre_compact, post_compact, session_start, session_end, user_prompt_submit, post_tool_use, after_agent, after_tool)"`
-	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
+	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
 	BodyLimit  *int   `json:"body_limit,omitempty" jsonschema:"truncate event body in this response to this many runes; default 500. Set to 0 or pass full_body=true to disable response truncation. Audit payloads truncated at ingestion remain truncated."`
 	FullBody   bool   `json:"full_body,omitempty" jsonschema:"return the full stored body even when it is long. Equivalent to body_limit=0; does not restore audit payload bytes dropped at ingestion"`
 }
@@ -149,7 +149,7 @@ type searchInput struct {
 	To         string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
 	Timezone   string `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only bounds (default: UTC)"`
 	Limit      int    `json:"limit,omitempty" jsonschema:"result limit (default: 20)"`
-	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
+	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
 	BodyLimit  *int   `json:"body_limit,omitempty" jsonschema:"truncate event body in this response to this many runes; default 500. Set to 0 or pass full_body=true to disable response truncation. Audit payloads truncated at ingestion remain truncated."`
 	FullBody   bool   `json:"full_body,omitempty" jsonschema:"return the full stored body even when it is long. Equivalent to body_limit=0; does not restore audit payload bytes dropped at ingestion"`
 }
@@ -159,7 +159,7 @@ type getContextInput struct {
 	Workspace  string `json:"workspace,omitempty" jsonschema:"work context filter"`
 	SessionID  string `json:"session_id,omitempty" jsonschema:"session identifier filter"`
 	Limit      int    `json:"limit,omitempty" jsonschema:"result limit (default: 20)"`
-	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
+	Projection string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
 	BodyLimit  *int   `json:"body_limit,omitempty" jsonschema:"truncate event body in this response to this many runes; default 500. Set to 0 or pass full_body=true to disable response truncation. Audit payloads truncated at ingestion remain truncated."`
 	FullBody   bool   `json:"full_body,omitempty" jsonschema:"return the full stored body even when it is long. Equivalent to body_limit=0; does not restore audit payload bytes dropped at ingestion"`
 }

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -70,7 +70,7 @@ type eventOutput struct {
 	BodyTruncated         bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to disable response truncation; audit payloads truncated at ingestion stay visibly truncated and are not recoverable"`
 	BodyLength            int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
 	BodyOriginalBytes     *int                      `json:"body_original_bytes,omitempty" jsonschema:"original event body byte count when known"`
-	BodyStoredBytes       *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata"`
+	BodyStoredBytes       *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata and projection=bounded"`
 	BodyIngestTruncated   *bool                     `json:"body_ingest_truncated,omitempty" jsonschema:"whether ingestion truncated the event body when known"`
 	BodyStorageTruncated  *bool                     `json:"body_storage_truncated,omitempty" jsonschema:"whether storage policy truncated the event body when known"`
 	ExitCode              *int                      `json:"exit_code,omitempty" jsonschema:"command exit code when available in metadata projection"`

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -70,7 +70,7 @@ type eventOutput struct {
 	BodyTruncated         bool                      `json:"body_truncated,omitempty" jsonschema:"true when body was truncated to fit body_limit. Re-issue the same call with full_body=true (or a larger body_limit) to disable response truncation; audit payloads truncated at ingestion stay visibly truncated and are not recoverable"`
 	BodyLength            int                       `json:"body_length,omitempty" jsonschema:"original body length in runes before any truncation; only emitted when body_truncated is true"`
 	BodyOriginalBytes     *int                      `json:"body_original_bytes,omitempty" jsonschema:"original event body byte count when known"`
-	BodyStoredBytes       *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata and projection=bounded"`
+	BodyStoredBytes       *int                      `json:"body_stored_bytes,omitempty" jsonschema:"stored event body byte count; available for projection=metadata"`
 	BodyIngestTruncated   *bool                     `json:"body_ingest_truncated,omitempty" jsonschema:"whether ingestion truncated the event body when known"`
 	BodyStorageTruncated  *bool                     `json:"body_storage_truncated,omitempty" jsonschema:"whether storage policy truncated the event body when known"`
 	ExitCode              *int                      `json:"exit_code,omitempty" jsonschema:"command exit code when available in metadata projection"`

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	auditMaxOutputBytes   int
 	event                 usecase.EventUsecase
 	eventMetadata         usecase.EventMetadataUsecase
+	eventBounded          usecase.EventBoundedUsecase
 	session               usecase.SessionUsecase
 	memory                usecase.MemoryUsecase
 	context               usecase.ContextUsecase
@@ -96,6 +97,9 @@ func NewServer(
 	for _, opt := range opts {
 		opt(result)
 	}
+	if result.eventBounded == nil {
+		return nil, xerrors.Errorf("event bounded usecase is not configured")
+	}
 	return result, nil
 }
 
@@ -105,6 +109,12 @@ type ServerOption func(*Server)
 // WithEventMetadata configures body-free event reads for metadata projections.
 func WithEventMetadata(eventMetadata usecase.EventMetadataUsecase) ServerOption {
 	return func(server *Server) { server.eventMetadata = eventMetadata }
+}
+
+// WithEventBounded configures body-limited event reads that avoid full Event
+// hydration for the default MCP projection.
+func WithEventBounded(eventBounded usecase.EventBoundedUsecase) ServerOption {
+	return func(server *Server) { server.eventBounded = eventBounded }
 }
 
 // WithReport configures the shared body-free aggregate report.
@@ -632,7 +642,8 @@ func (s *Server) listEvents() mcp.ToolHandlerFor[listEventsInput, eventsOutput] 
 			From(interval.EffectiveFromInclusive()).
 			To(interval.EffectiveToExclusive()).
 			Build()
-		if projection == apptypes.EventProjectionMetadata {
+		switch projection {
+		case apptypes.EventProjectionMetadata:
 			if s.eventMetadata == nil {
 				return nil, eventsOutput{}, xerrors.Errorf("event metadata usecase is not configured")
 			}
@@ -641,14 +652,24 @@ func (s *Server) listEvents() mcp.ToolHandlerFor[listEventsInput, eventsOutput] 
 				return nil, eventsOutput{}, xerrors.Errorf("failed to list event metadata: %w", err)
 			}
 			return nil, eventsOutput{Events: convertEventMetadata(metadata), Interval: &intervalMetadata}, nil
+		case apptypes.EventProjectionBounded:
+			if s.eventBounded == nil {
+				return nil, eventsOutput{}, xerrors.Errorf("event bounded usecase is not configured")
+			}
+			events, err := s.eventBounded.List(ctx, criteria, bodyLimit)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to list bounded events: %w", err)
+			}
+			return nil, eventsOutput{Events: convertBoundedEvents(events), Interval: &intervalMetadata}, nil
+		case apptypes.EventProjectionFull:
+			events, err := s.event.List(ctx, criteria)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to list events: %w", err)
+			}
+			return nil, eventsOutput{Events: convertEventsWithBodyLimit(events, 0), Interval: &intervalMetadata}, nil
+		default:
+			return nil, eventsOutput{}, xerrors.Errorf("unsupported resolved event projection %q", projection)
 		}
-
-		events, err := s.event.List(ctx, criteria)
-		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to list events: %w", err)
-		}
-
-		return nil, eventsOutput{Events: convertEventsWithBodyLimit(events, bodyLimit), Interval: &intervalMetadata}, nil
 	}
 }
 
@@ -763,7 +784,8 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 			From(interval.EffectiveFromInclusive()).
 			To(interval.EffectiveToExclusive()).
 			Build()
-		if projection == apptypes.EventProjectionMetadata {
+		switch projection {
+		case apptypes.EventProjectionMetadata:
 			if s.eventMetadata == nil {
 				return nil, eventsOutput{}, xerrors.Errorf("event metadata usecase is not configured")
 			}
@@ -772,18 +794,26 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 				return nil, eventsOutput{}, xerrors.Errorf("failed to search event metadata: %w", err)
 			}
 			return nil, eventsOutput{Events: convertEventMetadata(metadata), Interval: &intervalMetadata}, nil
+		case apptypes.EventProjectionBounded:
+			if s.eventBounded == nil {
+				return nil, eventsOutput{}, xerrors.Errorf("event bounded usecase is not configured")
+			}
+			events, err := s.eventBounded.Search(ctx, criteria, bodyLimit)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to search bounded events: %w", err)
+			}
+			return nil, eventsOutput{Events: convertBoundedEvents(events), Interval: &intervalMetadata}, nil
+		case apptypes.EventProjectionFull:
+			events, err := s.event.Search(ctx, criteria)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to search events: %w", err)
+			}
+			// Full search intentionally omits body_blocks so thinking content
+			// is not re-exposed through this surface.
+			return nil, eventsOutput{Events: convertEventsWithoutBlocksWithBodyLimit(events, 0), Interval: &intervalMetadata}, nil
+		default:
+			return nil, eventsOutput{}, xerrors.Errorf("unsupported resolved event projection %q", projection)
 		}
-
-		events, err := s.event.Search(ctx, criteria)
-		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to search events: %w", err)
-		}
-
-		// Search intentionally omits body_blocks so thinking content is
-		// not re-exposed through this surface — #682 strips thinking
-		// from the LIKE match, but the envelope is still attached to
-		// the returned event and body_blocks would bypass the gate.
-		return nil, eventsOutput{Events: convertEventsWithoutBlocksWithBodyLimit(events, bodyLimit), Interval: &intervalMetadata}, nil
 	}
 }
 
@@ -797,7 +827,8 @@ func (s *Server) getContext() mcp.ToolHandlerFor[getContextInput, eventsOutput] 
 			Workspace(types.Workspace(strings.TrimSpace(input.Workspace))).
 			SessionID(types.SessionID(strings.TrimSpace(input.SessionID))).
 			Build()
-		if projection == apptypes.EventProjectionMetadata {
+		switch projection {
+		case apptypes.EventProjectionMetadata:
 			if s.eventMetadata == nil {
 				return nil, eventsOutput{}, xerrors.Errorf("event metadata usecase is not configured")
 			}
@@ -806,17 +837,25 @@ func (s *Server) getContext() mcp.ToolHandlerFor[getContextInput, eventsOutput] 
 				return nil, eventsOutput{}, xerrors.Errorf("failed to get context metadata: %w", err)
 			}
 			return nil, eventsOutput{Events: convertEventMetadata(metadata)}, nil
+		case apptypes.EventProjectionBounded:
+			if s.eventBounded == nil {
+				return nil, eventsOutput{}, xerrors.Errorf("event bounded usecase is not configured")
+			}
+			events, err := s.eventBounded.Context(ctx, criteria, bodyLimit)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to get bounded context: %w", err)
+			}
+			return nil, eventsOutput{Events: convertBoundedEvents(events)}, nil
+		case apptypes.EventProjectionFull:
+			events, err := s.event.Context(ctx, criteria)
+			if err != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to get context: %w", err)
+			}
+			// Full get_context omits body_blocks for the same reason as search.
+			return nil, eventsOutput{Events: convertEventsWithoutBlocksWithBodyLimit(events, 0)}, nil
+		default:
+			return nil, eventsOutput{}, xerrors.Errorf("unsupported resolved event projection %q", projection)
 		}
-
-		events, err := s.event.Context(ctx, criteria)
-		if err != nil {
-			return nil, eventsOutput{}, xerrors.Errorf("failed to get context: %w", err)
-		}
-
-		// get_context also omits body_blocks for the same reason as
-		// search: the canonical envelope would re-expose thinking
-		// block text that other surfaces already strip.
-		return nil, eventsOutput{Events: convertEventsWithoutBlocksWithBodyLimit(events, bodyLimit)}, nil
 	}
 }
 
@@ -2016,6 +2055,47 @@ func convertEventsInternal(events []*model.Event, includeBlocks bool, bodyLimit 
 		outputs = append(outputs, output)
 	}
 
+	return outputs
+}
+
+func convertBoundedEvents(events []apptypes.BoundedEvent) []eventOutput {
+	outputs := make([]eventOutput, 0, len(events))
+	for _, event := range events {
+		metadata := event.Metadata()
+		extent := metadata.BodyExtent()
+		output := eventOutput{
+			EventID:              metadata.EventID().String(),
+			Kind:                 metadata.Kind().String(),
+			Client:               metadata.Client().String(),
+			Agent:                metadata.Agent().String(),
+			SessionID:            metadata.SessionID().String(),
+			Workspace:            metadata.Workspace().String(),
+			BodyBlocks:           event.BodyBlocks(),
+			BodyOriginalBytes:    optionalPointer(extent.OriginalBytes()),
+			BodyStoredBytes:      intPointer(extent.StoredBytes()),
+			BodyIngestTruncated:  optionalPointer(extent.IngestTruncated()),
+			BodyStorageTruncated: optionalPointer(extent.StorageTruncated()),
+			SourceHook:           metadata.SourceHook(),
+			CreatedAt:            metadata.CreatedAt().UTC().Format(time.RFC3339Nano),
+		}
+		if event.BodyAvailability().IsAvailable() {
+			body := event.Body()
+			if event.BodyResponseTruncated() {
+				body += "…"
+				output.BodyTruncated = true
+				output.BodyLength = event.VisibleBodyRunes()
+			}
+			output.Body = stringPointer(body)
+		} else {
+			output.BodyUnavailableReason = "retention"
+			output.BodyBlocks = nil
+		}
+		if audit, ok := metadata.CommandAudit().Value(); ok {
+			output.ExitCode = optionalPointer(audit.ExitCode())
+			output.Failed = audit.Failed()
+		}
+		outputs = append(outputs, output)
+	}
 	return outputs
 }
 

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -2062,26 +2062,24 @@ func convertBoundedEvents(events []apptypes.BoundedEvent) []eventOutput {
 	outputs := make([]eventOutput, 0, len(events))
 	for _, event := range events {
 		metadata := event.Metadata()
-		extent := metadata.BodyExtent()
+		// Persisted extent/truncation keys remain an explicit metadata-projection
+		// contract. Bounded is the default response, so keep its legacy lean
+		// shape and emit only request-specific body truncation below.
 		output := eventOutput{
-			EventID:              metadata.EventID().String(),
-			Kind:                 metadata.Kind().String(),
-			Client:               metadata.Client().String(),
-			Agent:                metadata.Agent().String(),
-			SessionID:            metadata.SessionID().String(),
-			Workspace:            metadata.Workspace().String(),
-			BodyBlocks:           event.BodyBlocks(),
-			BodyOriginalBytes:    optionalPointer(extent.OriginalBytes()),
-			BodyStoredBytes:      intPointer(extent.StoredBytes()),
-			BodyIngestTruncated:  optionalPointer(extent.IngestTruncated()),
-			BodyStorageTruncated: optionalPointer(extent.StorageTruncated()),
-			SourceHook:           metadata.SourceHook(),
-			CreatedAt:            metadata.CreatedAt().UTC().Format(time.RFC3339Nano),
+			EventID:    metadata.EventID().String(),
+			Kind:       metadata.Kind().String(),
+			Client:     metadata.Client().String(),
+			Agent:      metadata.Agent().String(),
+			SessionID:  metadata.SessionID().String(),
+			Workspace:  metadata.Workspace().String(),
+			BodyBlocks: event.BodyBlocks(),
+			SourceHook: metadata.SourceHook(),
+			CreatedAt:  metadata.CreatedAt().UTC().Format(time.RFC3339Nano),
 		}
 		if event.BodyAvailability().IsAvailable() {
 			body := event.Body()
 			if event.BodyResponseTruncated() {
-				body += "…"
+				body += apptypes.TruncationEllipsis
 				output.BodyTruncated = true
 				output.BodyLength = event.VisibleBodyRunes()
 			}

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -1782,6 +1782,30 @@ CREATE TRIGGER events_body_metadata_after_body_update AFTER UPDATE OF body ON ev
     UPDATE events SET body_stored_bytes = length(CAST(NEW.body AS BLOB)) WHERE id = NEW.id;
 END;`),
 		},
+		"000031_add_event_metadata_normalized_timestamp_indexes.sql": {
+			Data: []byte(`
+ALTER TABLE events ADD COLUMN created_at_norm TEXT;
+UPDATE events SET created_at_norm = created_at;
+CREATE TRIGGER events_created_at_norm_after_insert
+AFTER INSERT ON events FOR EACH ROW BEGIN
+    UPDATE events SET created_at_norm = NEW.created_at WHERE id = NEW.id;
+END;
+CREATE TRIGGER events_created_at_norm_after_update
+AFTER UPDATE OF created_at ON events FOR EACH ROW BEGIN
+    UPDATE events SET created_at_norm = NEW.created_at WHERE id = NEW.id;
+END;
+CREATE INDEX idx_events_created_at_norm_id_desc
+    ON events(created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_workspace_created_at_norm_id_desc
+    ON events(workspace, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_session_created_at_norm_id_desc
+    ON events(session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_workspace_session_created_at_norm_id_desc
+    ON events(workspace, session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_events_source_hook_created_at_norm_id_desc
+    ON events(source_hook, created_at_norm DESC, id DESC)
+    WHERE source_hook IS NOT NULL;`),
+		},
 		"000008_create_memories.sql": {
 			Data: []byte(`
 CREATE TABLE memories (
@@ -1846,6 +1870,8 @@ CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
 	storeManagementDatasource := sqlite.NewStoreManagementDatasource(db)
 
 	eventUsecase := usecase.NewEventUsecase(eventDatasource, eventDatasource)
+	eventMetadataUsecase := usecase.NewEventMetadataUsecase(eventDatasource)
+	eventBoundedUsecase := usecase.NewEventBoundedUsecase(eventDatasource)
 	sessionUsecase := usecase.NewSessionUsecase(eventDatasource, sessionDatasource, sessionDatasource, eventDatasource)
 	memoryUsecase := usecase.NewMemoryUsecase(memoryDatasource, memoryDatasource, nil)
 	contextUsecase := usecase.NewContextUsecase(sessionDatasource, eventDatasource, memoryDatasource)
@@ -1863,6 +1889,8 @@ CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
 		memoryUsecase,
 		contextUsecase,
 		storeManagementUsecase,
+		mcpserver.WithEventMetadata(eventMetadataUsecase),
+		mcpserver.WithEventBounded(eventBoundedUsecase),
 		mcpserver.WithReport(reportUsecase),
 	)
 	if err != nil {

--- a/presentation/mcpserver/testdata/tool_registry.golden.json
+++ b/presentation/mcpserver/testdata/tool_registry.golden.json
@@ -24,7 +24,7 @@
           "type": "integer"
         },
         "projection": {
-          "description": "event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
+          "description": "event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
           "type": "string"
         },
         "session_id": {
@@ -131,7 +131,7 @@
           "type": "integer"
         },
         "projection": {
-          "description": "event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
+          "description": "event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
           "type": "string"
         },
         "session_id": {
@@ -610,7 +610,7 @@
           "type": "integer"
         },
         "projection": {
-          "description": "event projection: metadata omits body fields, bounded returns a limited body, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
+          "description": "event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility",
           "type": "string"
         },
         "query": {


### PR DESCRIPTION
## Motivation

Default bounded MCP retrieval truncated only after SQLite returned complete stored bodies and Go hydrated domain events. Large persisted payloads therefore still incurred full database-to-process transfer and allocation.

## Changes

- add a dedicated bounded event read model, usecase, and read-only SQLite hydration path
- select metadata or search candidate IDs before projecting a visible-text prefix in SQLite
- preserve canonical transcript visible-text semantics and independent response/ingest/storage truncation provenance
- keep canonical `body_blocks` as an explicit untruncated `list_events` fallback; omit the fallback from `search` and `get_context`
- route metadata, bounded, and full MCP projections before any event query

## Validation

- `go build ./...`
- `go test ./...`
- `go tool golangci-lint run`
- `go vet ./...`
- `git diff --check origin/main...HEAD`

Closes #1552
