### PR TITLE
docs: stage history retrieval guidance

### DIFF
--- a/.ai/spec/1555.md
+++ b/.ai/spec/1555.md
@@ -20,9 +20,9 @@
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Discovery | Initial history question | Lists a small metadata-only candidate set | Scope by workspace and, when known, time or session; no body fields |
-| Inspection | Candidate IDs known | Reads a small body prefix only for relevant candidates | A positive 300–500 rune `body_limit`; never a broad full-body list |
-| Detail | One event selected | Retrieves the full stored event for a stated reason | Single event or equivalently narrow scope; CLI `traceary show` is preferred |
+| Discovery | Initial history question | Lists a small metadata-only candidate set | `list_events` accepts workspace/time/session filters; `search` accepts workspace/time/query but no `session_id`; no body fields |
+| Inspection | Narrow session/time scope known | Reads a small body prefix only for relevant candidates | A positive 300–500 rune `body_limit`; the example names its target tool; `get_context` narrows only by workspace/session/limit and has no `event_id` |
+| Detail | One event selected | Retrieves the full stored event for a stated reason | No MCP history read accepts `event_id`; CLI `traceary show` is the explicit event-detail path |
 | Session recap | Operator requested recap | Applies the same staged rules before summarising | Does not issue a bare `get_context` call |
 
 ### Responsibility assignment
@@ -38,8 +38,8 @@
 
 | Boundary or interface | Consumer | Hidden detail | Error contract |
 | --- | --- | --- | --- |
-| `list_events` / `search` metadata projection | Agent discovery | SQLite body storage and projection implementation | Empty results are valid; refine scope/query instead of escalating body reads |
-| Bounded `body_limit` read | Agent inspection | Stored body representation | Positive bounded limit only; choose candidate IDs first |
+| `list_events` / `search` metadata projection | Agent discovery | SQLite body storage and projection implementation | Empty results are valid; `session_id` is valid for `list_events`, not `search` |
+| `get_context` bounded read | Agent inspection | Stored body representation | Positive bounded limit only; selection filters are workspace/session/limit, not event ID |
 | `traceary show <event-id>` | Agent detail | Full stored event retrieval | Requires a selected event ID and a stated investigation reason |
 | Packaged skill parity checker | Host packages | Copy locations | Fails when any copy diverges or lacks a required stage/guardrail |
 
@@ -48,8 +48,9 @@
 | Behavior | Given | When | Then | Level |
 | --- | --- | --- | --- | --- |
 | Cross-host skill parity | Six packaged copies | Integration verification runs | All six session-history copies are byte-identical | Repository tooling |
-| Discovery contract | Shared session-history prose | Semantic validation runs | It requires metadata projection, small limit, workspace scope, and optional time/session refinement | Repository tooling |
-| Inspection/detail contract | Shared session-history prose | Semantic validation runs | It requires a positive bounded body limit and `traceary show` for one selected event | Repository tooling |
+| Discovery contract | Shared session-history prose | Semantic validation runs | It requires metadata projection, small limit, workspace scope, and the `search`/session-filter boundary | Repository tooling |
+| Inspection/detail contract | Shared session-history prose | Semantic validation runs | It names the Inspection example tool, pins `get_context` scope inputs/no `event_id`, and requires `traceary show` for one selected event | Repository tooling |
+| Semantic wording flexibility | Equivalent contract prose | Semantic validation runs | Concept-level wording variants pass without pinning one full sentence; omission of a safety concept fails | Repository tooling |
 | Recap guardrail | Shared memory-review prose | Semantic validation runs | It references staged retrieval and forbids a bare `get_context` recap read | Repository tooling |
 | Documentation parity | English/Japanese MCP docs | i18n verification runs | Both documents remain paired and describe the same staged workflow | Documentation |
 
@@ -57,7 +58,8 @@
 
 | Behavior | Red | Green | Refactor target |
 | --- | --- | --- | --- |
-| Session-history stages | Add semantic assertions for all mandatory stage markers | Write one canonical skill and copy it verbatim to all hosts | Keep the shared-copy list as the single host matrix |
+| Session-history stages | Add semantic assertions for all mandatory behaviors and tool boundaries | Write one canonical skill and copy it verbatim to all hosts | Validate stage sections by concept groups instead of full-sentence literals |
+| Tool input accuracy | Omit the `search`/session or `get_context`/event-ID constraint | Make each tool's supported narrowing inputs explicit and name the Inspection example target | Keep runtime schemas as source of truth; do not add imagined filters |
 | Recap guardrail | Assert the old bare-context wording is rejected | Replace it with a reference to the session-history stages | Keep recap-specific curation rules in memory-review |
 | Docs explanation | Add paired MCP documentation section | Describe the existing projections and CLI detail path | Avoid duplicating runtime schema details |
 
@@ -67,8 +69,8 @@
   contract. The guidance only uses current additive parameters and the existing
   `traceary show` command; it does not invent a new API.
 - **Premature-abstraction risk:** A generic skill-generation system would be
-  excessive for two shared documents. Byte parity plus narrow semantic checks
-  are sufficient.
+  excessive for two shared documents. Byte parity plus narrow, section-scoped
+  semantic concept checks are sufficient.
 - **Migration / compatibility:** No runtime, schema, manifest, or migration
   changes occur. Existing clients keep their current defaults.
 - **Rollback trigger:** If a host cannot consume the revised skill frontmatter

--- a/.ai/spec/1555.md
+++ b/.ai/spec/1555.md
@@ -1,0 +1,81 @@
+# #1555 Staged retrieval guidance for packaged skills
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Make history inspection safe by default across every packaged
+  host skill without changing the MCP runtime contract, schema, or manifests.
+- **Current behavior:** The shared session-history skill names useful read tools
+  but does not prescribe an escalation order. The memory-review recap text can
+  imply a bare `get_context` call.
+- **Expected behavior:** Every packaged `traceary-session-history` skill uses
+  the same three stages: metadata-only Discovery, bounded-body Inspection, and
+  explicit Detail. Session recap refers to those rules instead of starting with
+  an unscoped context read.
+- **Out of scope:** MCP tool input/output changes, SQLite changes, manifests,
+  runtime defaults, and automatic full-body retrieval.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Discovery | Initial history question | Lists a small metadata-only candidate set | Scope by workspace and, when known, time or session; no body fields |
+| Inspection | Candidate IDs known | Reads a small body prefix only for relevant candidates | A positive 300–500 rune `body_limit`; never a broad full-body list |
+| Detail | One event selected | Retrieves the full stored event for a stated reason | Single event or equivalently narrow scope; CLI `traceary show` is preferred |
+| Session recap | Operator requested recap | Applies the same staged rules before summarising | Does not issue a bare `get_context` call |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Retrieval order and guardrails | Shared session-history skill | This is the agent-facing workflow contract | MCP runtime remains unchanged |
+| Recap cross-reference | Shared memory-review skill | It selects the history workflow for recap | It does not own event-read defaults |
+| Cross-host equality and semantic assertions | `cmd/repo-tooling` | Prevent one package from weakening the shared contract | Packaging manifests do not encode skill prose |
+| User-facing MCP explanation | Bilingual MCP docs | Documents the existing projection controls and recommended use | It does not add a tool parameter |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| `list_events` / `search` metadata projection | Agent discovery | SQLite body storage and projection implementation | Empty results are valid; refine scope/query instead of escalating body reads |
+| Bounded `body_limit` read | Agent inspection | Stored body representation | Positive bounded limit only; choose candidate IDs first |
+| `traceary show <event-id>` | Agent detail | Full stored event retrieval | Requires a selected event ID and a stated investigation reason |
+| Packaged skill parity checker | Host packages | Copy locations | Fails when any copy diverges or lacks a required stage/guardrail |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Cross-host skill parity | Six packaged copies | Integration verification runs | All six session-history copies are byte-identical | Repository tooling |
+| Discovery contract | Shared session-history prose | Semantic validation runs | It requires metadata projection, small limit, workspace scope, and optional time/session refinement | Repository tooling |
+| Inspection/detail contract | Shared session-history prose | Semantic validation runs | It requires a positive bounded body limit and `traceary show` for one selected event | Repository tooling |
+| Recap guardrail | Shared memory-review prose | Semantic validation runs | It references staged retrieval and forbids a bare `get_context` recap read | Repository tooling |
+| Documentation parity | English/Japanese MCP docs | i18n verification runs | Both documents remain paired and describe the same staged workflow | Documentation |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Session-history stages | Add semantic assertions for all mandatory stage markers | Write one canonical skill and copy it verbatim to all hosts | Keep the shared-copy list as the single host matrix |
+| Recap guardrail | Assert the old bare-context wording is rejected | Replace it with a reference to the session-history stages | Keep recap-specific curation rules in memory-review |
+| Docs explanation | Add paired MCP documentation section | Describe the existing projections and CLI detail path | Avoid duplicating runtime schema details |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** Documentation can drift from the actual MCP
+  contract. The guidance only uses current additive parameters and the existing
+  `traceary show` command; it does not invent a new API.
+- **Premature-abstraction risk:** A generic skill-generation system would be
+  excessive for two shared documents. Byte parity plus narrow semantic checks
+  are sufficient.
+- **Migration / compatibility:** No runtime, schema, manifest, or migration
+  changes occur. Existing clients keep their current defaults.
+- **Rollback trigger:** If a host cannot consume the revised skill frontmatter
+  or validation detects a contradiction, revert this documentation-only commit.
+
+## Implementation checkpoint
+
+Proceed with one byte-identical shared session-history skill, a small
+memory-review cross-reference, bilingual MCP documentation, and repository
+tooling checks that pin the staged retrieval semantics.

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -150,6 +150,9 @@ func verifyIntegrations(root string, runCLISmoke bool) error {
 	if err := checkSharedSkillParity(root); err != nil {
 		return err
 	}
+	if err := checkSharedSkillSemanticContracts(root); err != nil {
+		return err
+	}
 	return checkDocs(root)
 }
 
@@ -244,6 +247,70 @@ func checkSharedSkillParity(root string) error {
 				return xerrors.Errorf("shared %s skill copies diverged: %s does not match %s", skill, rel, paths[0])
 			}
 		}
+	}
+	return nil
+}
+
+// checkSharedSkillSemanticContracts pins the safety-critical retrieval guidance
+// that byte parity alone cannot prove. Every host copy must tell agents to
+// discover metadata before bounded inspection, and memory recap guidance must
+// refer back to that staged flow rather than suggesting a bare context read.
+func checkSharedSkillSemanticContracts(root string) error {
+	for _, rel := range sharedSkillPaths["traceary-session-history"] {
+		data, err := os.ReadFile(filepath.Join(root, rel)) // #nosec G304 -- fixed package path under repo root
+		if err != nil {
+			return xerrors.Errorf("missing session-history skill: %s: %w", rel, err)
+		}
+		if err := validateSessionHistorySkillContract(rel, string(data)); err != nil {
+			return err
+		}
+	}
+	for _, rel := range sharedSkillPaths["traceary-memory-review"] {
+		data, err := os.ReadFile(filepath.Join(root, rel)) // #nosec G304 -- fixed package path under repo root
+		if err != nil {
+			return xerrors.Errorf("missing memory-review skill: %s: %w", rel, err)
+		}
+		if err := validateMemoryReviewRecapContract(rel, string(data)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSessionHistorySkillContract(rel, body string) error {
+	for _, required := range []string{
+		"### 1. Discovery",
+		"projection=\"metadata\"",
+		"\"limit\": 5",
+		"workspace",
+		"time range",
+		"session_id",
+		"### 2. Inspection",
+		"positive `body_limit`",
+		"`300`–`500`",
+		"### 3. Detail",
+		"single event",
+		"traceary show <event-id>",
+	} {
+		if !strings.Contains(body, required) {
+			return xerrors.Errorf("%s must include staged retrieval contract marker %q", rel, required)
+		}
+	}
+	return nil
+}
+
+func validateMemoryReviewRecapContract(rel, body string) error {
+	for _, required := range []string{
+		"traceary-session-history",
+		"Discovery → Inspection → Detail",
+		"bare `get_context`",
+	} {
+		if !strings.Contains(body, required) {
+			return xerrors.Errorf("%s must include recap retrieval contract marker %q", rel, required)
+		}
+	}
+	if strings.Contains(body, "events visible via `get_context` / `query_memory(pack)`") {
+		return xerrors.Errorf("%s must not recommend a bare get_context recap read", rel)
 	}
 	return nil
 }

--- a/cmd/repo-tooling/integrations.go
+++ b/cmd/repo-tooling/integrations.go
@@ -278,41 +278,144 @@ func checkSharedSkillSemanticContracts(root string) error {
 }
 
 func validateSessionHistorySkillContract(rel, body string) error {
-	for _, required := range []string{
-		"### 1. Discovery",
-		"projection=\"metadata\"",
-		"\"limit\": 5",
-		"workspace",
-		"time range",
-		"session_id",
-		"### 2. Inspection",
-		"positive `body_limit`",
-		"`300`–`500`",
-		"### 3. Detail",
-		"single event",
-		"traceary show <event-id>",
+	discovery, err := markdownContractSection(rel, body, "### 1. Discovery", "### 2. Inspection")
+	if err != nil {
+		return err
+	}
+	inspection, err := markdownContractSection(rel, body, "### 2. Inspection", "### 3. Detail")
+	if err != nil {
+		return err
+	}
+	detail, err := markdownContractSection(rel, body, "### 3. Detail", "## Preferred tools")
+	if err != nil {
+		return err
+	}
+
+	for _, requirement := range []struct {
+		section  string
+		body     string
+		concept  string
+		variants [][]string
+	}{
+		{
+			section: "Discovery",
+			body:    discovery,
+			concept: "a workspace-scoped metadata-only list_events query with a small limit",
+			variants: [][]string{
+				{"list_events", "workspace", `projection="metadata"`, "limit", "5"},
+			},
+		},
+		{
+			section: "Discovery",
+			body:    discovery,
+			concept: "search rejecting session_id while list_events and get_context support it",
+			variants: [][]string{
+				{"search", "does not accept", "session_id", "only", "list_events", "get_context"},
+				{"search", "has no", "session_id", "only", "list_events", "get_context"},
+				{"search", "cannot", "session_id", "only", "list_events", "get_context"},
+			},
+		},
+		{
+			section: "Inspection",
+			body:    inspection,
+			concept: "an explicitly named get_context example",
+			variants: [][]string{
+				{"example", "get_context"},
+			},
+		},
+		{
+			section: "Inspection",
+			body:    inspection,
+			concept: "a positive bounded body_limit of approximately 300 to 500 runes",
+			variants: [][]string{
+				{"positive", "body_limit", "300", "500"},
+			},
+		},
+		{
+			section: "Inspection",
+			body:    inspection,
+			concept: "get_context lacking event_id and narrowing only by workspace, session_id, and limit",
+			variants: [][]string{
+				{"get_context", "has no", "event_id", "only", "workspace", "session_id", "limit"},
+				{"get_context", "does not accept", "event_id", "only", "workspace", "session_id", "limit"},
+				{"get_context", "cannot target", "event_id", "only", "workspace", "session_id", "limit"},
+			},
+		},
+		{
+			section: "Detail",
+			body:    detail,
+			concept: "explicit CLI detail retrieval for one selected event",
+			variants: [][]string{
+				{"one event", "traceary show <event-id>"},
+				{"single event", "traceary show <event-id>"},
+			},
+		},
 	} {
-		if !strings.Contains(body, required) {
-			return xerrors.Errorf("%s must include staged retrieval contract marker %q", rel, required)
+		if err := requireSemanticConcept(rel, requirement.section, requirement.body, requirement.concept, requirement.variants...); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
 func validateMemoryReviewRecapContract(rel, body string) error {
-	for _, required := range []string{
-		"traceary-session-history",
-		"Discovery → Inspection → Detail",
-		"bare `get_context`",
-	} {
-		if !strings.Contains(body, required) {
-			return xerrors.Errorf("%s must include recap retrieval contract marker %q", rel, required)
-		}
+	if err := requireSemanticConcept(
+		rel,
+		"session recap",
+		body,
+		"the traceary-session-history staged workflow",
+		[]string{"traceary-session-history", "discovery", "inspection", "detail"},
+	); err != nil {
+		return err
+	}
+	if err := requireSemanticConcept(
+		rel,
+		"session recap",
+		body,
+		"an explicit prohibition on a bare get_context starting read",
+		[]string{"bare", "get_context", "not"},
+		[]string{"bare", "get_context", "do not"},
+	); err != nil {
+		return err
 	}
 	if strings.Contains(body, "events visible via `get_context` / `query_memory(pack)`") {
 		return xerrors.Errorf("%s must not recommend a bare get_context recap read", rel)
 	}
 	return nil
+}
+
+func markdownContractSection(rel, body, heading, nextHeading string) (string, error) {
+	start := strings.Index(body, heading)
+	if start < 0 {
+		return "", xerrors.Errorf("%s must include %s", rel, heading)
+	}
+	start += len(heading)
+	endOffset := strings.Index(body[start:], nextHeading)
+	if endOffset < 0 {
+		return "", xerrors.Errorf("%s must place %s after %s", rel, nextHeading, heading)
+	}
+	return body[start : start+endOffset], nil
+}
+
+// requireSemanticConcept checks a small set of wording variants for one
+// contract concept. This keeps the validator tied to the safety behavior rather
+// than one exact sentence while deliberately avoiding a general Markdown/NLP
+// parser for six byte-identical copies.
+func requireSemanticConcept(rel, section, body, concept string, variants ...[]string) error {
+	normalized := strings.ToLower(body)
+	for _, variant := range variants {
+		matches := true
+		for _, term := range variant {
+			if !strings.Contains(normalized, strings.ToLower(term)) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return nil
+		}
+	}
+	return xerrors.Errorf("%s %s must express %s", rel, section, concept)
 }
 
 func checkGrok(root, version string) error {

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -56,6 +56,55 @@ func TestValidateSessionHistorySkillContract_RejectsMissingDiscoveryMetadata(t *
 	}
 }
 
+func TestValidateSessionHistorySkillContract_AcceptsEquivalentContractWording(t *testing.T) {
+	t.Parallel()
+
+	body := `
+### 1. Discovery
+Use list_events for the workspace with projection="metadata" and a limit of 5.
+Search cannot filter by session_id; only list_events and get_context support it.
+
+### 2. Inspection
+Example tool: get_context.
+Use a positive body_limit between 300 and 500 runes.
+Get_context does not accept event_id and narrows only with workspace, session_id, and limit.
+
+### 3. Detail
+For a single event, run traceary show <event-id>.
+
+## Preferred tools
+`
+	if err := validateSessionHistorySkillContract("skill", body); err != nil {
+		t.Fatalf("validateSessionHistorySkillContract() error = %v, want nil for equivalent wording", err)
+	}
+}
+
+func TestValidateSessionHistorySkillContract_RejectsMissingGetContextScope(t *testing.T) {
+	t.Parallel()
+
+	body := `
+### 1. Discovery
+Use list_events for the workspace with projection="metadata" and a limit of 5.
+Search cannot filter by session_id; only list_events and get_context support it.
+
+### 2. Inspection
+Example tool: get_context.
+Use a positive body_limit between 300 and 500 runes.
+
+### 3. Detail
+For one event, run traceary show <event-id>.
+
+## Preferred tools
+`
+	err := validateSessionHistorySkillContract("skill", body)
+	if err == nil {
+		t.Fatal("validateSessionHistorySkillContract() error = nil, want missing get_context scope error")
+	}
+	if !strings.Contains(err.Error(), "get_context lacking event_id") {
+		t.Fatalf("error = %v, want get_context scope concept", err)
+	}
+}
+
 func TestValidateMemoryReviewRecapContract_RejectsBareContextGuidance(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/repo-tooling/integrations_test.go
+++ b/cmd/repo-tooling/integrations_test.go
@@ -36,6 +36,35 @@ func TestVerifyIntegrations_FailsWhenRootIncomplete(t *testing.T) {
 	}
 }
 
+func TestSharedSkillSemanticContracts_PassOnCurrentTree(t *testing.T) {
+	t.Parallel()
+
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot() error = %v", err)
+	}
+	if err := checkSharedSkillSemanticContracts(root); err != nil {
+		t.Fatalf("checkSharedSkillSemanticContracts() error = %v", err)
+	}
+}
+
+func TestValidateSessionHistorySkillContract_RejectsMissingDiscoveryMetadata(t *testing.T) {
+	t.Parallel()
+
+	if err := validateSessionHistorySkillContract("skill", "### 1. Discovery"); err == nil {
+		t.Fatal("validateSessionHistorySkillContract() error = nil, want missing marker error")
+	}
+}
+
+func TestValidateMemoryReviewRecapContract_RejectsBareContextGuidance(t *testing.T) {
+	t.Parallel()
+
+	body := "traceary-session-history Discovery → Inspection → Detail bare `get_context` events visible via `get_context` / `query_memory(pack)`"
+	if err := validateMemoryReviewRecapContract("skill", body); err == nil {
+		t.Fatal("validateMemoryReviewRecapContract() error = nil, want bare context guidance error")
+	}
+}
+
 func TestCheckNoDuplicateTracearyHookEntries_FailsOnDuplicateManagedEntry(t *testing.T) {
 	t.Parallel()
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -37,18 +37,23 @@ Traceary が公開する MCP tool は 9 個で、golden snapshot `presentation/m
 
 過去の session、event、command audit を調査するときは、次の順序で読み取ります。
 
-1. **Discovery:** 現在の `workspace` から始め、分かっている `from` / `to`
-   または `session_id` filter を追加します。`list_events`（または絞り込んだ
-   literal `search`）を `projection="metadata"` と `5` 程度の小さい `limit`
-   で呼びます。これにより、event body を読まずに candidate ID と metadata を
-   取得できます。
-2. **Inspection:** 選んだ filter を維持し、文脈が必要な candidate だけを
-   `300`–`500` 程度の正の `body_limit` で確認します。`get_context` は event
-   または同等に狭い scope を選んだ後にだけ使います。広い範囲の最初の read には
-   使いません。
+1. **Discovery:** 現在の `workspace` から始めます。`list_events` では、
+   分かっている `from` / `to` または `session_id` filter を追加し、
+   `projection="metadata"` と `5` 程度の小さい `limit` を使います。絞り込んだ
+   literal `search` には workspace と time filter を使えますが、
+   `session_id` input はありません。session filter を使えるのは
+   `list_events` と `get_context` だけです。これにより、event body を読まずに
+   candidate ID と metadata を取得できます。
+2. **Inspection:** `list_events` または `search` を、各 tool が対応する
+   Discovery filter と `300`–`500` 程度の正の `body_limit` で再実行します。
+   `get_context` は上限付きの周辺 context を読む場合だけ使います。
+   `event_id`、kind、time-range filter はないため、対象 event を絞る入力は
+   `workspace`、`session_id`、`limit` だけです。選んだ event ID を直接取得する
+   tool ではなく、広い範囲の最初の read にも使いません。
 3. **Detail:** 保存済み body の全文は、調査理由を明示して 1 件の event を
    選んだ場合だけ取得します。明示的な CLI detail path である
-   `traceary show <event-id>` を優先します。広い history query に対して
+   `traceary show <event-id>` を優先します。MCP の history read tool には
+   `event_id` input がないためです。広い history query に対して
    `full_body=true` や `body_limit=0` から始めてはいけません。
 
 session recap でも同じ順序を使います。metadata を発見してから選んだ context を

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -33,6 +33,28 @@ Traceary が公開する MCP tool は 9 個で、golden snapshot `presentation/m
 
 `session_status(action="handoff", ...)` と `query_memory(action="pack", ...)` は互換用の `recent_commands` 文字列配列を維持し、`recent_command_items` も返します。構造化された兄弟フィールドには `event_id`、本文を安全に短縮した `summary`、応答・保存・元データの byte 数、取り込み・保存・応答時の切り詰め情報、`retrieval_hint` が含まれます。不明な過去データの情報は省略します。保存済み本文の全文取得には `traceary show <event-id>` または event detail の明示的な呼び出しが必要で、handoff 自体は上限付きの本文先頭部分だけを読みます。
 
+### 段階的な event 取得
+
+過去の session、event、command audit を調査するときは、次の順序で読み取ります。
+
+1. **Discovery:** 現在の `workspace` から始め、分かっている `from` / `to`
+   または `session_id` filter を追加します。`list_events`（または絞り込んだ
+   literal `search`）を `projection="metadata"` と `5` 程度の小さい `limit`
+   で呼びます。これにより、event body を読まずに candidate ID と metadata を
+   取得できます。
+2. **Inspection:** 選んだ filter を維持し、文脈が必要な candidate だけを
+   `300`–`500` 程度の正の `body_limit` で確認します。`get_context` は event
+   または同等に狭い scope を選んだ後にだけ使います。広い範囲の最初の read には
+   使いません。
+3. **Detail:** 保存済み body の全文は、調査理由を明示して 1 件の event を
+   選んだ場合だけ取得します。明示的な CLI detail path である
+   `traceary show <event-id>` を優先します。広い history query に対して
+   `full_body=true` や `body_limit=0` から始めてはいけません。
+
+session recap でも同じ順序を使います。metadata を発見してから選んだ context を
+確認し、上限付きの evidence だけでは recap を支えられない場合にだけ detail を
+取得します。
+
 ### Search query semantics
 
 `search.query` は literal text query であり、boolean query language ではありません。`failure OR timeout` のような文字列は `failure` または `timeout` の any-match expression として解釈されず、1つの検索文字列として扱われます。複数語を調べたい場合は、より狭い `search` call を複数回実行するか、CLI JSON output を local file に保存して `jq` などの local tools で集計してください。

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -37,18 +37,24 @@ Traceary exposes 9 MCP tools, enforced by a golden snapshot (`presentation/mcpse
 
 Use a staged read when investigating prior sessions, events, or command audits:
 
-1. **Discovery:** start with the current `workspace` and add known `from` / `to`
-   or `session_id` filters. Call `list_events` (or a narrow literal `search`)
-   with `projection="metadata"` and a small `limit` such as `5`. This returns
-   candidate IDs and metadata without reading event bodies.
-2. **Inspection:** keep the selected filters and inspect only the candidates
-   that need context with a positive `body_limit` of roughly `300`–`500`.
-   `get_context` belongs here only after an event or equivalently narrow scope
-   is selected; it is not a broad first read.
+1. **Discovery:** start with the current `workspace`. For `list_events`, add
+   known `from` / `to` or `session_id` filters, then use
+   `projection="metadata"` and a small `limit` such as `5`. A narrow literal
+   `search` can use workspace and time filters, but it has no `session_id`
+   input; session filtering is available only through `list_events` and
+   `get_context`. This returns candidate IDs and metadata without reading event
+   bodies.
+2. **Inspection:** repeat `list_events` or `search` with only its supported
+   Discovery filters and a positive `body_limit` of roughly `300`–`500`.
+   Use `get_context` only for bounded surrounding context: it has no `event_id`,
+   kind, or time-range filter, so it can narrow the matched events only by
+   `workspace`, `session_id`, and `limit`. It cannot retrieve a selected event
+   ID directly and is not a broad first read.
 3. **Detail:** retrieve a full stored body only for one selected event and a
    stated investigation reason. Prefer `traceary show <event-id>` for this
-   explicit CLI detail path. Do not begin with `full_body=true` or
-   `body_limit=0` across a broad history query.
+   explicit CLI detail path because no MCP history-read tool accepts
+   `event_id`. Do not begin with `full_body=true` or `body_limit=0` across a
+   broad history query.
 
 The same order applies when composing a session recap: discover metadata first,
 inspect selected context second, and retrieve detail only when the recap cannot

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -33,6 +33,27 @@ Traceary exposes 9 MCP tools, enforced by a golden snapshot (`presentation/mcpse
 
 `session_status(action="handoff", ...)` and `query_memory(action="pack", ...)` preserve the legacy `recent_commands` string array and also return `recent_command_items`. The structured sibling includes `event_id`, a body-safe `summary`, returned/stored/original byte extent, ingestion/storage/response truncation facts, and a `retrieval_hint`. Unknown historical facts are omitted. Full stored content requires explicit `traceary show <event-id>` or event-detail retrieval; handoff itself reads only a bounded body prefix.
 
+### Staged event retrieval
+
+Use a staged read when investigating prior sessions, events, or command audits:
+
+1. **Discovery:** start with the current `workspace` and add known `from` / `to`
+   or `session_id` filters. Call `list_events` (or a narrow literal `search`)
+   with `projection="metadata"` and a small `limit` such as `5`. This returns
+   candidate IDs and metadata without reading event bodies.
+2. **Inspection:** keep the selected filters and inspect only the candidates
+   that need context with a positive `body_limit` of roughly `300`–`500`.
+   `get_context` belongs here only after an event or equivalently narrow scope
+   is selected; it is not a broad first read.
+3. **Detail:** retrieve a full stored body only for one selected event and a
+   stated investigation reason. Prefer `traceary show <event-id>` for this
+   explicit CLI detail path. Do not begin with `full_body=true` or
+   `body_limit=0` across a broad history query.
+
+The same order applies when composing a session recap: discover metadata first,
+inspect selected context second, and retrieve detail only when the recap cannot
+be supported by the bounded evidence.
+
 ### Search query semantics
 
 `search.query` is a literal text query, not a boolean query language. A string such as `failure OR timeout` is not interpreted as an any-match expression for `failure` or `timeout`; treat it as one search string. For multi-term inspection, issue multiple narrower `search` calls or save CLI JSON output to a local file and aggregate it with local tools such as `jq`.

--- a/integrations/antigravity-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/antigravity-plugin/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.

--- a/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/claude-plugin/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.

--- a/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
+++ b/integrations/gemini-extension/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.

--- a/integrations/grok-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/grok-plugin/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.

--- a/integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
+++ b/integrations/kimi-plugin/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.

--- a/plugins/traceary/skills/traceary-memory-review/SKILL.md
+++ b/plugins/traceary/skills/traceary-memory-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traceary-memory-review
 description: Use when the user asks to review Traceary memory candidates, pending memory inbox items, or to generate a session summary/handoff from current Traceary context. Trigger phrases — "Traceary inbox", "memory inbox", "pending memories", "review memory candidates", "記憶候補", "メモリ候補", "保留中の記憶", "session recap", "セッションまとめ", "summarize this session for next time". Do not trigger for generic status / cleanup / progress requests unless Traceary memory/session review is explicit.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Traceary memory review
@@ -25,7 +25,7 @@ Use this skill when the operator explicitly asks to look at Traceary's pending m
    - Accept: `manage_memory({"action": "accept", "ids": ["<id>", ...]})`
    - Reject: `manage_memory({"action": "reject", "ids": ["<id>", ...]})`
    - Re-scope or amend: reject the original, then call `manage_memory({"action": "remember", ...})` (or ask the operator to invoke `traceary-memory-remember`) with the corrected scope / fact text.
-5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": compose a 3–5 sentence summary from the events visible via `get_context` / `query_memory(pack)` and present it inline. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
+5. **(Optional) session recap** when the operator says "session recap" / "summarize for next time": follow `traceary-session-history`'s Discovery → Inspection → Detail retrieval rules before composing a 3–5 sentence inline summary. Start with a workspace-scoped metadata query and inspect only selected candidates with a positive bounded `body_limit`; do not make a bare `get_context` call. Persistent storage of session summaries is wired through compact-summary events (see hook contract); a dedicated MCP write path for `sessions.summary` is not exposed today.
 
 ## Human fallback: `traceary memory inbox review`
 
@@ -65,4 +65,5 @@ traceary memory inbox reject --ids id1,id2,id3
 - **Distinguish the two CLI fallbacks.** `traceary memory inbox review` is the human-driven interactive walk; `memory inbox list` + `memory inbox accept|reject` is the script/batch path. Recommend the right one for the operator's environment instead of bundling both.
 - **Do not propose new memories here.** That is `traceary-memory-remember`'s job. If the operator says "save this", route to that skill instead of writing yourself.
 - **Stay scoped.** Default to the current workspace. Wider scopes need an explicit operator instruction.
+- **Recap in stages.** For a session recap, use `traceary-session-history`'s Discovery → Inspection → Detail rules; a bare `get_context` call is not a recap starting point.
 - **Skip empty inboxes.** If `query_memory(retrieve, status=["candidate"])` is empty, say so plainly — do not invent placeholder candidates.

--- a/plugins/traceary/skills/traceary-session-history/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-history/SKILL.md
@@ -1,23 +1,90 @@
 ---
 name: traceary-session-history
 description: Use when the user asks about prior Traceary sessions, event history, command audits, or what happened earlier in the workspace. Trigger on phrases like "Traceary", "session history", "audit trail", "recent events", or "what happened earlier".
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Traceary session history
 
 Use the packaged `traceary` MCP server as the default read path when the user asks about local agent history.
 
+## Staged retrieval
+
+Read history in stages. Start with the narrowest useful metadata query, inspect
+only the candidates it identifies, and fetch full detail only after selecting a
+single event. The same rule applies to prior sessions, event history, command
+audits, and "what happened earlier" questions.
+
+### 1. Discovery — metadata only
+
+Start with the current workspace whenever it is known. Add a time range or
+`session_id` when the question provides one, then use `projection="metadata"`
+and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
+timestamps, and stored-size/truncation facts without reading bodies.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "from": "<known start, if any>",
+  "to": "<known end, if any>",
+  "projection": "metadata",
+  "limit": 5
+}
+```
+
+Use this shape with `list_events`, or add a narrow literal `query` for
+`search`. Omit unknown filters rather than guessing them. Use
+`session_status(action="latest")` first when the task is specifically about the
+most recent session; use `session_status(action="active")` only when it asks
+about an open session.
+
+### 2. Inspection — bounded bodies for selected candidates
+
+After Discovery identifies relevant event IDs or an equivalently narrow
+session/time slice, make one bounded read with a **positive** `body_limit` of
+`300`–`500` runes. Keep the Discovery filters and reduce the limit further
+when one candidate is enough. Do not turn a broad result set into a full-body
+read.
+
+```json
+{
+  "workspace": "<current workspace>",
+  "session_id": "<selected session, if known>",
+  "body_limit": 400,
+  "limit": 1
+}
+```
+
+Use `get_context` only with this selected and bounded scope when surrounding
+events are needed. If its output still leaves several plausible candidates,
+refine the metadata search instead of requesting full bodies for all of them.
+
+### 3. Detail — one selected event, with a reason
+
+Retrieve full stored content only after stating why it is needed and selecting
+one event ID (or an equivalently single-candidate scope). Prefer the CLI detail
+path:
+
+```sh
+traceary show <event-id>
+```
+
+An MCP full-body read is an exception for the same single selected candidate;
+do not use `full_body=true` or `body_limit=0` as the first history query.
+
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: quick recent history without a keyword query
-- `search`: keyword-driven lookups
-- `get_context`: summarize the lead-up around an event
+- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
+- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
+- Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.
 - Automatic hooks already cover session boundaries and shell command audits.

--- a/plugins/traceary/skills/traceary-session-history/SKILL.md
+++ b/plugins/traceary/skills/traceary-session-history/SKILL.md
@@ -17,10 +17,11 @@ audits, and "what happened earlier" questions.
 
 ### 1. Discovery — metadata only
 
-Start with the current workspace whenever it is known. Add a time range or
-`session_id` when the question provides one, then use `projection="metadata"`
-and a small limit (normally `5`). Metadata lets you select event IDs, kinds,
-timestamps, and stored-size/truncation facts without reading bodies.
+Start with the current workspace whenever it is known, then use
+`projection="metadata"` and a small limit (normally `5`). With `list_events`,
+add a time range or `session_id` when the question provides one. Metadata lets
+you select event IDs, kinds, timestamps, and stored-size/truncation facts
+without reading bodies.
 
 ```json
 {
@@ -32,19 +33,21 @@ timestamps, and stored-size/truncation facts without reading bodies.
 }
 ```
 
-Use this shape with `list_events`, or add a narrow literal `query` for
-`search`. Omit unknown filters rather than guessing them. Use
-`session_status(action="latest")` first when the task is specifically about the
-most recent session; use `session_status(action="active")` only when it asks
-about an open session.
+Use this shape with `list_events`. For `search`, add a narrow literal `query`
+and omit `session_id`: `search` does not accept a session filter. Only
+`list_events` and `get_context` accept `session_id`. Omit unknown filters rather
+than guessing them. Use `session_status(action="latest")` first when the task is
+specifically about the most recent session; use
+`session_status(action="active")` only when it asks about an open session.
 
 ### 2. Inspection — bounded bodies for selected candidates
 
-After Discovery identifies relevant event IDs or an equivalently narrow
-session/time slice, make one bounded read with a **positive** `body_limit` of
-`300`–`500` runes. Keep the Discovery filters and reduce the limit further
-when one candidate is enough. Do not turn a broad result set into a full-body
-read.
+After Discovery identifies a narrow session/time slice, make one bounded read
+with a **positive** `body_limit` of `300`–`500` runes. Keep only filters
+supported by the chosen tool and reduce the limit further when one candidate is
+enough. Do not turn a broad result set into a full-body read.
+
+Example (`get_context`, for bounded surrounding context):
 
 ```json
 {
@@ -55,9 +58,14 @@ read.
 }
 ```
 
-Use `get_context` only with this selected and bounded scope when surrounding
-events are needed. If its output still leaves several plausible candidates,
-refine the metadata search instead of requesting full bodies for all of them.
+`get_context` has no `event_id`, kind, or time-range filter. It can narrow
+context only with `workspace`, `session_id`, and `limit`; `projection` and
+`body_limit` control the returned representation, not which events match. Use
+it only for bounded surrounding context in a selected workspace/session. If
+Discovery selected one event ID, use the Detail path below rather than implying
+that `get_context` can target that event. If its output still leaves several
+plausible candidates, refine the metadata query instead of requesting full
+bodies for all of them.
 
 ### 3. Detail — one selected event, with a reason
 
@@ -69,21 +77,24 @@ path:
 traceary show <event-id>
 ```
 
-An MCP full-body read is an exception for the same single selected candidate;
-do not use `full_body=true` or `body_limit=0` as the first history query.
+No MCP history-read tool accepts `event_id`. A full-body MCP read is an
+exception only when other supported filters produce an equivalently
+single-candidate scope; do not use `full_body=true` or `body_limit=0` as the
+first history query.
 
 ## Preferred tools
 
 - `session_status(action="latest")`: most recent session metadata for the current workspace
 - `session_status(action="active")`: only when the question is specifically about an open session
-- `list_events`: Discovery for recent metadata; bounded Inspection after candidates are known
-- `search`: Discovery for a narrow literal query; bounded Inspection after candidates are known
-- `get_context`: bounded surrounding context for a selected candidate, never a bare first read
+- `list_events`: Discovery for recent metadata; supports workspace, time, and session filters; bounded Inspection after candidates are known
+- `search`: Discovery for a narrow literal query; supports workspace and time filters, but not `session_id`
+- `get_context`: bounded surrounding context narrowed only by `workspace`, `session_id`, and `limit`; it cannot target an `event_id`
 
 ## Guardrails
 
 - Prefer MCP reads before direct SQLite inspection.
-- Follow Discovery → Inspection → Detail; scope by workspace first and add time/session filters whenever the question supplies them.
+- Follow Discovery → Inspection → Detail; scope by workspace first and add only filters supported by the chosen tool.
+- Apply a session filter only through `list_events` or `get_context`; `search` has no `session_id` input.
 - Keep `projection="metadata"` and a small limit for first reads. A positive `body_limit` is for candidate inspection, not bulk history retrieval.
 - Use `traceary show <event-id>` for full detail after a single candidate and a reason have been identified.
 - Use `record_event(type="log")` / `record_event(type="audit")` only when the user explicitly wants to record something.


### PR DESCRIPTION
## Motivation

Prevent broad event-body reads by making staged metadata discovery, bounded inspection, and explicit detail retrieval consistent across all packaged skills.

## Validation

- go test ./...
- go tool golangci-lint run
- go build ./...
- go run ./cmd/repo-tooling integrations verify
- go run ./cmd/repo-tooling docs verify-i18n
- git diff --check

Closes #1555