### PR TITLE
fix: classify exact hook denial audits

### DIFF
--- a/.ai/spec/1526.md
+++ b/.ai/spec/1526.md
@@ -4,7 +4,7 @@
 
 - Classify a hook audit as `hook_denied` only when the captured structured
   result has `tool_response.exitCode == 2` and a string `tool_response.stderr`
-  begins byte-for-byte with `🚫 [hook]`.
+  begins byte-for-byte with Traceary's own hook-runtime marker, `🚫 [hook]`.
 - Keep all other exit-code and failure classifications unchanged. In
   particular, do not trim, search, or stringify stderr or payload values.
 - Do not add a new copy of raw stderr or payload material to audits, reports,

--- a/.ai/spec/1526.md
+++ b/.ai/spec/1526.md
@@ -1,0 +1,50 @@
+# #1526 Hook-denial audit classification
+
+## Requirement summary
+
+- Classify a hook audit as `hook_denied` only when the captured structured
+  result has `tool_response.exitCode == 2` and a string `tool_response.stderr`
+  begins byte-for-byte with `🚫 [hook]`.
+- Keep all other exit-code and failure classifications unchanged. In
+  particular, do not trim, search, or stringify stderr or payload values.
+- Do not add a new copy of raw stderr or payload material to audits, reports,
+  cursors, or logs. Existing audit redaction and truncation remain the sole
+  storage policy.
+
+## Conceptual model
+
+| Concept | State | Behavior | Invariant |
+| --- | --- | --- | --- |
+| Hook denial evidence | absent or exact | Refines an exit-code-2 audit to `hook_denied` | Both typed fields and the exact byte prefix are required |
+| Audit outcome | structured reason | Is passed unchanged to the existing audit use case | No raw evidence becomes a new output field |
+
+## Responsibilities and boundaries
+
+| Responsibility | Owner | Not owner |
+| --- | --- | --- |
+| Recognize the documented hook-runtime result shape | `presentation/cli` hook payload adapter | domain, use case, database, MCP schema |
+| Redact, truncate, persist, and aggregate audit output | existing application/infrastructure paths | this classifier |
+| Render the reason-only report aggregate | existing report projection | this classifier |
+
+## Behavior tests
+
+| Behavior | Given | Then |
+| --- | --- | --- |
+| Positive classification | numeric exit code 2 and stderr string beginning `🚫 [hook]` | `hook_denied`, failed audit |
+| Exactness/privacy | any non-string stderr, leading newline/space, second-line prefix, wrong exit code, or exit code 0 | existing reason is retained and no raw stderr is copied into the reason |
+| Report aggregation | an audit has `hook_denied` | existing report reason counter includes it without output body fields |
+
+## TDD plan
+
+1. Add positive and negative adapter-level behavior cases, including output
+   equality checks that prove classification does not duplicate stderr.
+2. Add a report aggregation regression for the `hook_denied` reason.
+3. Add the smallest presentation-layer predicate and update bilingual hook
+   documentation.
+
+## Risks and rollback
+
+- The predicate intentionally recognizes one observed protocol marker only;
+  similar text is not a denial.
+- No schema or public MCP shape changes are needed. Rollback is one
+  presentation-layer code change with no data migration.

--- a/application/usecase/report_usecase_test.go
+++ b/application/usecase/report_usecase_test.go
@@ -2,6 +2,7 @@ package usecase_test
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"
@@ -71,6 +72,30 @@ func TestReportUsecaseGenerate_PartialWindowOmitsRates(t *testing.T) {
 	}
 	if !got.Aggregation.Sources.Events.ResponseTruncated || got.Aggregation.Sources.Events.TruncationReason != "result_cap" {
 		t.Fatalf("event extent = %+v", got.Aggregation.Sources.Events)
+	}
+}
+
+func TestReportUsecaseGenerate_HookDeniedReasonIsBodyFree(t *testing.T) {
+	t.Parallel()
+	criteria := reportCriteria(t, 0)
+	command := reportCommandRecord(
+		"event-hook-denied", "cat", types.CommandFailureReasonHookDenied, types.Some(2), true,
+	)
+	window := reportWindow(t, criteria, nil, nil, []apptypes.ReportCommandRecord{command}, false)
+
+	got, err := usecase.NewReportUsecase(&reportQueryStub{window: window}).Generate(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got.Failures.Total != 1 || got.Failures.ByReason["hook_denied"] != 1 {
+		t.Fatalf("failures = %+v, want exactly one hook_denied", got.Failures)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(report) error = %v", err)
+	}
+	if strings.Contains(string(encoded), "🚫 [hook]") {
+		t.Fatalf("report retained raw hook marker: %s", encoded)
 	}
 }
 

--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -73,7 +73,7 @@ Grok Build の versioned かつ機械可読な live contract（fixture は 0.2.9
 - セッション開始時に解決した workspace を state ファイルに保存し、audit はそこから workspace を読み取る
 - エージェントタイプ解決: `agent_type` フィールド → 階層的エージェント名（Claude および Codex の subagent hook）
 - host が提供する場合は `tool_response.exitCode` から exit code を抽出。終了コード `0` は常に成功で、非ゼロは、より具体的な構造化根拠が `signal`、`timeout`、`hook_denied` を示さない限り `exit_code` とする
-- 失敗分類には構造化フィールドだけを使う。host の中断/timeout marker は `signal` / `timeout`、Grok の `PermissionDenied` は `hook_denied`、一般的な構造化 host error は `host_error` とする。payload 本文から失敗語を解析しない
+- 失敗分類には構造化フィールドだけを使う。host の中断/timeout marker は `signal` / `timeout`、Grok の `PermissionDenied` は `hook_denied`、一般的な構造化 host error は `host_error` とする。hook runtime は `tool_response.exitCode == 2` かつ string 型の `tool_response.stderr` の先頭 bytes が厳密に `🚫 [hook]` の場合だけ `hook_denied` とする。stderr の trim や検索はしない。この明示 marker 以外の payload 本文から失敗語を解析せず、marker は report や他の audit field に複製しない
 - MCP ツール名 fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:

--- a/docs/hooks/contract.ja.md
+++ b/docs/hooks/contract.ja.md
@@ -73,7 +73,7 @@ Grok Build の versioned かつ機械可読な live contract（fixture は 0.2.9
 - セッション開始時に解決した workspace を state ファイルに保存し、audit はそこから workspace を読み取る
 - エージェントタイプ解決: `agent_type` フィールド → 階層的エージェント名（Claude および Codex の subagent hook）
 - host が提供する場合は `tool_response.exitCode` から exit code を抽出。終了コード `0` は常に成功で、非ゼロは、より具体的な構造化根拠が `signal`、`timeout`、`hook_denied` を示さない限り `exit_code` とする
-- 失敗分類には構造化フィールドだけを使う。host の中断/timeout marker は `signal` / `timeout`、Grok の `PermissionDenied` は `hook_denied`、一般的な構造化 host error は `host_error` とする。hook runtime は `tool_response.exitCode == 2` かつ string 型の `tool_response.stderr` の先頭 bytes が厳密に `🚫 [hook]` の場合だけ `hook_denied` とする。stderr の trim や検索はしない。この明示 marker 以外の payload 本文から失敗語を解析せず、marker は report や他の audit field に複製しない
+- 失敗分類には構造化フィールドだけを使う。host の中断/timeout marker は `signal` / `timeout`、Grok の `PermissionDenied` は `hook_denied`、一般的な構造化 host error は `host_error` とする。`🚫 [hook]` は Traceary 自身の hook runtime が出す denial marker であり、host 全般の規約ではない。Traceary は `tool_response.exitCode == 2` かつ string 型の `tool_response.stderr` の先頭 bytes がこの marker と厳密に一致する場合だけ `hook_denied` とする。stderr の trim や検索はしない。この明示 marker 以外の payload 本文から失敗語を解析せず、marker は report や他の audit field に複製しない
 - MCP ツール名 fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -73,7 +73,7 @@ All tiers:
 - Session start persists the resolved workspace to the state file; audit reads the workspace from state
 - Agent type resolution: `agent_type` field → hierarchical agent name (Claude and Codex subagent hooks)
 - Exit code extraction from `tool_response.exitCode` when a host provides it. Exit code `0` is authoritative success; a non-zero code is `exit_code` unless more specific structured evidence identifies `signal`, `timeout`, or `hook_denied`.
-- Failure classification uses structured fields only. Traceary maps host interruption/timeout markers to `signal`/`timeout`, Grok `PermissionDenied` to `hook_denied`, and generic structured host errors to `host_error`. Payload text is never parsed for failure words.
+- Failure classification uses structured fields only. Traceary maps host interruption/timeout markers to `signal`/`timeout`, Grok `PermissionDenied` to `hook_denied`, and generic structured host errors to `host_error`. The hook runtime additionally reports `hook_denied` only for `tool_response.exitCode == 2` with a string `tool_response.stderr` whose first bytes are exactly `🚫 [hook]`; it neither trims nor searches stderr. Other payload text is never parsed for failure words, and the marker is not copied into reports or other audit fields.
 - MCP tool name fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:

--- a/docs/hooks/contract.md
+++ b/docs/hooks/contract.md
@@ -73,7 +73,7 @@ All tiers:
 - Session start persists the resolved workspace to the state file; audit reads the workspace from state
 - Agent type resolution: `agent_type` field → hierarchical agent name (Claude and Codex subagent hooks)
 - Exit code extraction from `tool_response.exitCode` when a host provides it. Exit code `0` is authoritative success; a non-zero code is `exit_code` unless more specific structured evidence identifies `signal`, `timeout`, or `hook_denied`.
-- Failure classification uses structured fields only. Traceary maps host interruption/timeout markers to `signal`/`timeout`, Grok `PermissionDenied` to `hook_denied`, and generic structured host errors to `host_error`. The hook runtime additionally reports `hook_denied` only for `tool_response.exitCode == 2` with a string `tool_response.stderr` whose first bytes are exactly `🚫 [hook]`; it neither trims nor searches stderr. Other payload text is never parsed for failure words, and the marker is not copied into reports or other audit fields.
+- Failure classification uses structured fields only. Traceary maps host interruption/timeout markers to `signal`/`timeout`, Grok `PermissionDenied` to `hook_denied`, and generic structured host errors to `host_error`. Traceary's own hook runtime emits the `🚫 [hook]` denial marker; this is not a generic host convention. Traceary reports `hook_denied` for that marker only when `tool_response.exitCode == 2` and string `tool_response.stderr` begins with those exact bytes; it neither trims nor searches stderr. Other payload text is never parsed for failure words, and the marker is not copied into reports or other audit fields.
 - MCP tool name fallback: `tool_input.command` → `tool_name`
 
 Claude Task subagent capture:

--- a/presentation/cli/hook_resolve.go
+++ b/presentation/cli/hook_resolve.go
@@ -13,6 +13,8 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
+const tracearyHookDeniedStderrMarker = "🚫 [hook]"
+
 func resolveHookAgent(client string, payload []byte) (types.Agent, error) {
 	agentType := hookPayloadString(payload, "agent_type", "")
 	agentValue := strings.TrimSpace(client)
@@ -398,8 +400,9 @@ func hookPayloadFailureReason(payload []byte) types.CommandFailureReason {
 }
 
 // hookPayloadHasHookDeniedMarker recognizes the exact denial marker emitted by
-// the hook runtime. This is deliberately a typed, byte-prefix check: it does
-// not trim, search, or stringify stderr, and it never retains the marker text.
+// Traceary's own hook runtime. This is deliberately a typed, byte-prefix check:
+// it does not trim, search, or stringify stderr, and it never retains the
+// marker text.
 func hookPayloadHasHookDeniedMarker(payload []byte) bool {
 	exitCode, ok := hookPayloadExitCode(payload).Value()
 	if !ok || exitCode != 2 {
@@ -410,7 +413,7 @@ func hookPayloadHasHookDeniedMarker(payload []byte) bool {
 		return false
 	}
 	stderr, ok := value.(string)
-	return ok && strings.HasPrefix(stderr, "🚫 [hook]")
+	return ok && strings.HasPrefix(stderr, tracearyHookDeniedStderrMarker)
 }
 
 func hookPayloadBool(payload []byte, path string) bool {

--- a/presentation/cli/hook_resolve.go
+++ b/presentation/cli/hook_resolve.go
@@ -382,6 +382,9 @@ func hookPayloadFailureReason(payload []byte) types.CommandFailureReason {
 			return types.CommandFailureReasonTimeout
 		}
 	}
+	if hookPayloadHasHookDeniedMarker(payload) {
+		return types.CommandFailureReasonHookDenied
+	}
 	if hasExitCode {
 		return types.CommandFailureReasonExitCode
 	}
@@ -392,6 +395,22 @@ func hookPayloadFailureReason(payload []byte) types.CommandFailureReason {
 		return types.CommandFailureReasonHostError
 	}
 	return types.CommandFailureReasonUnknown
+}
+
+// hookPayloadHasHookDeniedMarker recognizes the exact denial marker emitted by
+// the hook runtime. This is deliberately a typed, byte-prefix check: it does
+// not trim, search, or stringify stderr, and it never retains the marker text.
+func hookPayloadHasHookDeniedMarker(payload []byte) bool {
+	exitCode, ok := hookPayloadExitCode(payload).Value()
+	if !ok || exitCode != 2 {
+		return false
+	}
+	value, ok := lookupHookPayloadValue(payload, "tool_response.stderr")
+	if !ok {
+		return false
+	}
+	stderr, ok := value.(string)
+	return ok && strings.HasPrefix(stderr, "🚫 [hook]")
 }
 
 func hookPayloadBool(payload []byte, path string) bool {

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -2023,11 +2023,13 @@ func TestRootCLI_HookAuditCommand_PrefersToolCWDWorkspaceOverSessionState(t *tes
 // first-class failure (failed=true) even though exitCode stays unset.
 func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 	cases := []struct {
-		name       string
-		client     string
-		payload    string
-		wantFailed bool
-		wantReason types.CommandFailureReason
+		name                  string
+		client                string
+		payload               string
+		wantFailed            bool
+		wantReason            types.CommandFailureReason
+		sensitiveOutputMarker string
+		wantOutputMarkerCount int
 	}{
 		{
 			name:       "claude post-tool-use failure with top-level error",
@@ -2086,11 +2088,13 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			wantReason: types.CommandFailureReasonHookDenied,
 		},
 		{
-			name:       "hook stderr marker with exit code two is hook denied",
-			client:     "codex",
-			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":2,"stderr":"🚫 [hook] policy denied; credential=secret-value"}}`,
-			wantFailed: true,
-			wantReason: types.CommandFailureReasonHookDenied,
+			name:                  "hook stderr marker with exit code two is hook denied",
+			client:                "codex",
+			payload:               `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":2,"stderr":"🚫 [hook] policy denied; credential=secret-value"}}`,
+			wantFailed:            true,
+			wantReason:            types.CommandFailureReasonHookDenied,
+			sensitiveOutputMarker: "credential=secret-value",
+			wantOutputMarkerCount: 1,
 		},
 		{
 			name:       "hook stderr marker after a newline remains an exit code failure",
@@ -2194,12 +2198,11 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			if got := eventStub.auditCall.failureReason; got != tc.wantReason {
 				t.Fatalf("audit failure reason = %q, want %q", got, tc.wantReason)
 			}
-			if tc.name == "hook stderr marker with exit code two is hook denied" {
-				const rawMarker = "credential=secret-value"
-				if got := strings.Count(eventStub.auditCall.output, rawMarker); got != 1 {
-					t.Fatalf("audit output raw marker count = %d, want one existing tool_response copy", got)
+			if tc.sensitiveOutputMarker != "" {
+				if got := strings.Count(eventStub.auditCall.output, tc.sensitiveOutputMarker); got != tc.wantOutputMarkerCount {
+					t.Fatalf("audit output sensitive marker count = %d, want %d existing tool_response copies", got, tc.wantOutputMarkerCount)
 				}
-				if strings.Contains(string(eventStub.auditCall.failureReason), rawMarker) {
+				if strings.Contains(string(eventStub.auditCall.failureReason), tc.sensitiveOutputMarker) {
 					t.Fatalf("failure reason leaked raw hook stderr: %q", eventStub.auditCall.failureReason)
 				}
 			}

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -2086,6 +2086,41 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			wantReason: types.CommandFailureReasonHookDenied,
 		},
 		{
+			name:       "hook stderr marker with exit code two is hook denied",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":2,"stderr":"🚫 [hook] policy denied; credential=secret-value"}}`,
+			wantFailed: true,
+			wantReason: types.CommandFailureReasonHookDenied,
+		},
+		{
+			name:       "hook stderr marker after a newline remains an exit code failure",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":2,"stderr":"\n🚫 [hook] policy denied"}}`,
+			wantFailed: true,
+			wantReason: types.CommandFailureReasonExitCode,
+		},
+		{
+			name:       "non-string hook stderr remains an exit code failure",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":2,"stderr":{"message":"🚫 [hook] policy denied"}}}`,
+			wantFailed: true,
+			wantReason: types.CommandFailureReasonExitCode,
+		},
+		{
+			name:       "hook stderr marker with another exit code remains an exit code failure",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":3,"stderr":"🚫 [hook] policy denied"}}`,
+			wantFailed: true,
+			wantReason: types.CommandFailureReasonExitCode,
+		},
+		{
+			name:       "zero exit remains successful despite the hook stderr marker",
+			client:     "codex",
+			payload:    `{"tool_input":{"command":"cat /restricted"},"tool_response":{"exitCode":0,"stderr":"🚫 [hook] policy denied"}}`,
+			wantFailed: false,
+			wantReason: types.CommandFailureReasonNone,
+		},
+		{
 			name:       "empty top-level error is not a failure",
 			client:     "claude",
 			payload:    `{"tool_input":{"command":"go test ./..."},"error":""}`,
@@ -2158,6 +2193,15 @@ func TestRootCLI_HookAuditCommand_FlagsFailureFromErrorPayload(t *testing.T) {
 			}
 			if got := eventStub.auditCall.failureReason; got != tc.wantReason {
 				t.Fatalf("audit failure reason = %q, want %q", got, tc.wantReason)
+			}
+			if tc.name == "hook stderr marker with exit code two is hook denied" {
+				const rawMarker = "credential=secret-value"
+				if got := strings.Count(eventStub.auditCall.output, rawMarker); got != 1 {
+					t.Fatalf("audit output raw marker count = %d, want one existing tool_response copy", got)
+				}
+				if strings.Contains(string(eventStub.auditCall.failureReason), rawMarker) {
+					t.Fatalf("failure reason leaked raw hook stderr: %q", eventStub.auditCall.failureReason)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1526

## Motivation
Classify the documented dotfiles hook-denial contract without exposing audit payloads.

## Validation
- go build ./...
- go test ./...
- go tool golangci-lint run
- git diff --check