### PR TITLE
fix: bound and resume memory hygiene scans

### DIFF
--- a/.ai/spec/1556.md
+++ b/.ai/spec/1556.md
@@ -11,18 +11,22 @@
   similarity checks. `apply` repeats that full scan before changing selected
   IDs. CLI and MCP return complete raw facts without a response-size bound.
 - **Expected behavior:** Each invocation has explicit row, scanned-byte,
-  returned-suggestion-byte, comparison, and wall-time ceilings. A partial
-  result carries an opaque continuation cursor and a stable stop reason.
-  Continuing an unchanged store visits every phase/key exactly once.
+  returned-suggestion-byte, comparison, and wall-time ceilings. MCP partial
+  results carry an opaque continuation cursor and a stable stop reason.
+  Standalone CLI scans are deliberately single-invocation and report bounded
+  re-run guidance instead of exposing an unusable cross-process cursor.
+  Continuing an unchanged MCP scan visits every phase/key exactly once.
 - **Cursor trust:** A process-owned AES-GCM key authenticates and encrypts every
   continuation. The scan creation time is selected by the CLI/MCP boundary and
   restored only from authenticated cursor plaintext. Legacy checksum cursors,
   modified cursors, and cursors from an earlier process require a new scan.
 - **Concurrent-write behavior:** A revision change no longer discards progress
-  back to phase one. It returns a partial `best_effort` result with
-  `revision_changed`, preserving the keyset in a continuation rebound to the
-  current revision. The consistency downgrade remains visible on every later
-  page. Apply does not use this relaxation.
+  back to phase one. The use case binds the current revision, permanently
+  downgrades the chain to `best_effort`, and retries the same source page
+  inside the original invocation and budget. A successful retry reports the
+  actual bound that stops it. `revision_changed` is returned only when revision
+  churn consumes the invocation duration before the page can advance. Apply
+  does not use this relaxation.
 - **Pair semantics:** Exact duplicates remain exhaustive and emit one
   suggestion per duplicate member. Similarity and validity-overlap detection
   exhaustively visit every unordered same-scope pair across continuations,
@@ -48,14 +52,14 @@
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Memory revision | Monotonic integer in a singleton SQLite table | Increments transactionally after every memory insert/update/delete | A mismatch returns an explicit best-effort continuation at the same keyset and current revision instead of restarting phase one |
+| Memory revision | Monotonic integer in a singleton SQLite table | Increments transactionally after every memory insert/update/delete | A mismatch rebinds and retries the same page as best-effort without restarting phase one; only budget exhaustion may return a continuation at that keyset |
 | Scan budget | Positive row, scan-byte, result-byte, comparison, and duration limits | Accounts for each source unit and returned suggestion | Zero-value caller input resolves to finite defaults; no unlimited mode |
 | Scan phase | `accepted_rows`, `exact_duplicates`, `similarity_pairs`, `candidate_rows` | Owns one deterministic kind of traversal | Accepted and candidate phases never share status filters |
 | Keyset | Last completed memory ID, or current anchor/peer position for a pair phase | Resumes strictly after completed work | Contains identities/counters only, never fact text |
 | Opaque cursor | Encrypted version, memory revision, criteria digest, fixed scan time, phase, keyset, and consistency state | Restores deterministic continuation | AES-GCM authentication, payload shape, and criteria must validate before any row is read; keys never leave the process |
 | Source unit | One row, exact-duplicate anchor, or prefiltered unordered pair | Advances one observable keyset step | Unit byte extent is known before raw text is returned |
 | Similarity pair traversal | Every unordered same-scope pair, ordered by anchor ID then partner ID | Stops and resumes at `(anchor_id, partner_after_id)` | A completed continuation chain has no approximation, duplicate, or skipped pair; each invocation remains bounded even though exhaustive total work can be quadratic |
-| Scan result | Suggestions, counters, resource usage, completion, stop reason, consistency, consistency reason, next cursor | Makes partial and mixed-revision coverage operator-visible | `complete=true` has no cursor; `best_effort` remains sticky after the first revision change |
+| Scan result | Suggestions, counters, resource usage, completion, stop reason, consistency, consistency reason, and an MCP continuation | Makes partial and mixed-revision coverage operator-visible | `complete=true` has no cursor; `best_effort` remains sticky after the first revision change; CLI suppresses cursor input/output |
 | Targeted revalidation | Requested row plus exact peer and bounded neighboring peers | Recomputes current suggestion immediately before apply | It never scans unrelated scopes or every memory |
 | Safe preview | Sanitized fact prefix plus truncation marker | Gives enough operator context to identify a suggestion | Raw fact bytes are absent from public result and cursor |
 
@@ -69,7 +73,7 @@
 | Read revision and deterministic bounded source units | SQLite `MemoryHygieneScanSource` | Transactions, indexes, keysets, byte lengths, and peer ordering are storage concerns | Generic `MemoryQueryService.List` is not a safe scan primitive |
 | Maintain revision and hygiene indexes | additive migration 33 and triggers | Store mutation and index compatibility must be transactional | Runtime migration code must not rewrite memory facts |
 | Revalidate selected IDs and mutate via existing lifecycle methods | hygiene use case plus narrow source query | Apply owns orchestration; existing domain/repository methods own status transitions | Scan remains read-only and cannot share a boolean apply switch |
-| Render completeness, usage, cursor, and previews | CLI/MCP presentation | Protocol shape and localized text belong at the edge | Presentation does not receive raw facts |
+| Render completeness, usage, continuation/guidance, and previews | CLI/MCP presentation | MCP owns resumable paging while each standalone CLI process owns one bounded scan and re-run guidance | Presentation does not receive raw facts; CLI never exposes cursor input/output |
 
 ### Boundaries / interfaces
 
@@ -79,7 +83,7 @@
 | `MemoryHygieneScanSource.ScanPage` | hygiene use case | SQLite transaction, revision table, indexes, fact-length probes, pair traversal | Revision mismatch is typed; source never returns units past a requested hard bound |
 | `MemoryHygieneScanSource.Revalidate` | apply path | Exact-peer lookup and target-anchored bounded pair checks | Missing/oversized target is a per-ID apply failure, not a full scan; if the requested ID needs more peer checks than the apply bound, apply fails closed rather than using a partial finding |
 | Cursor codec | scan use case | Process-local AES-GCM key, nonce, and encrypted Base64url payload | Malformed/newer payloads fail closed; authentication failure returns a typed rescan-required error without echoing cursor contents |
-| `MemoryHygieneScanResult` | CLI/MCP | Internal raw facts and source rows | Additive complete/partial/stop/consistency/usage/cursor fields; suggestions contain previews only |
+| `MemoryHygieneScanResult` | CLI/MCP | Internal raw facts and source rows | Additive complete/partial/stop/consistency/usage fields; only MCP projects the cursor and CLI projects re-run guidance; suggestions contain previews only |
 | Existing memory lifecycle writer | targeted apply | Repository/transaction implementation | Candidate reject and accepted supersede/expire guards remain authoritative under races |
 
 ### Behavior tests
@@ -89,7 +93,8 @@
 | Finite defaults and validation | Zero-value or invalid budget input | Resolve scan criteria | Zero value becomes finite defaults; explicit non-positive limits fail |
 | Row-bound continuation | More accepted rows than one invocation permits | Repeatedly scan with returned cursors | All row keys are processed once, in order, with no duplicate/skip |
 | Byte/result/time/comparison stops | A next unit or suggestion would cross a ceiling | Scan | Stop before that unit, return `partial` plus the matching stable reason and resumable cursor |
-| Revision stability | A memory changes between pages | Continue with the old cursor | Return partial `best_effort` / `revision_changed`, preserve the keyset in a current-revision cursor, and keep the downgrade on later pages |
+| Revision stability | A memory changes between pages | Continue with the old MCP cursor | Rebind the current revision, retry the same page in-loop under the remaining invocation budget, and keep `best_effort` / `revision_changed` consistency metadata on later pages |
+| Revision churn bound | The revision changes again on every same-page retry | Continue with the old MCP cursor until duration is exhausted | Return partial `stop_reason=revision_changed` at the retained keyset and latest revision rather than spin or restart |
 | Cursor binding | Cursor is malformed, modified, newer, from an earlier process, or reused with different scopes/thresholds | Scan | Fail closed before source traversal; authentication failures clearly require a new scan; no raw cursor is logged/echoed |
 | Server-owned scan time | A client supplies or modifies a cursor | Start and continue a scan | New scans use the boundary-owned clock; continuations restore only the authenticated original scan time |
 | Duplicate semantics | Two- and three-member exact duplicate groups across page boundaries | Continue through duplicate phase | Every member appears once with a deterministic peer; candidate rows never appear |
@@ -98,7 +103,7 @@
 | Preview safety | Facts contain configured secrets and very long Unicode text | Scan via CLI and MCP | Secret/raw tail absent; preview is sanitized, valid UTF-8, bounded, and marks truncation |
 | Candidate trust | Noisy accepted row and noisy extracted candidate | Scan/apply candidate phase | Only candidate is suggested/rejected; accepted row stays untouched |
 | Targeted apply | Large store and one requested ID | Apply | Source revalidates only target plus bounded peers; no whole-store page scan occurs |
-| Operator visibility | Any budget stops the invocation | Render text and JSON/MCP | Output says incomplete, reports stop reason/usage, and includes a continuation cursor |
+| Operator visibility | Any budget stops the invocation | Render text and JSON/MCP | Output says incomplete and reports stop reason/usage; MCP includes a continuation cursor while CLI includes bounded re-run guidance |
 | Dry run | Scan with any detector match | Inspect store revision/statuses | No memory mutation and no revision increment |
 
 ### TDD plan
@@ -110,7 +115,7 @@
 | Detector continuation | Add duplicate/validity overlap tests split across small pages | Implement phase reducer over source units | Move precedence and preview building into focused owners, not one procedural handler |
 | Bound enforcement | Add row/byte/result/comparison/time stop tests | Account before committing each unit/suggestion and encode the last completed keyset | One accounting object owns all ceilings |
 | Targeted apply | Assert the full scan source is not called | Add target revalidation and reuse existing lifecycle writers | Keep raw replacement facts in an internal match only |
-| Presentation safety | Add CLI/MCP JSON and text tests with secret/long facts | Render additive completeness/usage/cursor fields and previews | Share application preview semantics; do not re-sanitize independently |
+| Presentation safety | Add CLI/MCP JSON and text tests with secret/long facts | Render additive completeness/usage fields and previews, plus MCP cursor or CLI re-run guidance | Share application preview semantics; do not re-sanitize independently |
 | Large-scope behavior | Add synthetic test and benchmark | Use indexed anchor/partner keysets with a hard per-page comparison limit | Assert fixed-budget comparison count and query plans rather than timing alone |
 
 ### Risks / rollback
@@ -157,11 +162,14 @@
 Implemented in this draft: the additive revision migration, finite scan budget,
 process-authenticated encrypted cursor value objects, indexed SQLite scan
 source, exhaustive anchor/partner-keyset pair traversal, bounded source reads,
-safe previews, and additive CLI/MCP completeness and consistency fields.
+safe previews, additive CLI/MCP completeness and consistency fields, CLI
+bounded re-run guidance, and MCP-only cursor projection.
 Tampered, legacy, and earlier-process continuations fail closed with explicit
-rescan guidance. A store revision change returns a best-effort continuation at
-the retained keyset instead of discarding progress. `apply` uses the targeted
-revalidation source for each requested ID, completes every requested
+rescan guidance. A store revision change rebinds and retries the retained
+source page inside the same budget while keeping the best-effort downgrade;
+only revision churn through duration exhaustion returns a
+`revision_changed` continuation. `apply` uses the targeted revalidation source
+for each requested ID, completes every requested
 revalidation before the first lifecycle mutation, and fails the full request
 closed on partial or cross-target revision mismatch.
 

--- a/.ai/spec/1556.md
+++ b/.ai/spec/1556.md
@@ -1,0 +1,153 @@
+# #1556 Bounded resumable durable-memory hygiene
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Make `memory admin hygiene scan` safe on large stores by bounding
+  every invocation and making incomplete work explicitly resumable.
+- **Current behavior:** The scanner pages every accepted and candidate memory
+  into slices, builds unbounded duplicate indexes, and performs all-pairs
+  similarity checks. `apply` repeats that full scan before changing selected
+  IDs. CLI and MCP return complete raw facts without a response-size bound.
+- **Expected behavior:** Each invocation has explicit row, scanned-byte,
+  returned-suggestion-byte, comparison, and wall-time ceilings. A partial
+  result carries an opaque continuation cursor and a stable stop reason.
+  Continuing an unchanged store visits every phase/key exactly once.
+- **Pair semantics:** Exact duplicates remain exhaustive and emit one
+  suggestion per duplicate member. Similarity and validity-overlap detection
+  exhaustively visit every unordered same-scope pair across continuations,
+  using `(anchor_id, partner_after_id)` keysets so one invocation never owns an
+  unbounded pair set. A validity-overlap match takes precedence over the
+  generic supersede signal; half-open disjoint windows remain silent.
+- **Trust separation:** Accepted-memory detectors and candidate-noise
+  detectors remain separate phases. Candidate cleanup can only reject a row
+  that is still `status=candidate`; accepted memories cannot enter that path.
+- **Safe output:** Scanner results expose only current-rule-sanitized,
+  UTF-8-safe bounded previews. Raw facts and replacement facts remain internal
+  to revalidation/apply and never enter output, cursors, errors, or logs.
+- **Apply behavior:** `apply` revalidates only explicitly requested memory IDs
+  plus their bounded deterministic peers. It does not invoke a whole-store
+  scan. Scan remains dry-run/read-only.
+- **Out of scope:** Fuzzy/semantic similarity, background cleanup, automatic
+  mutation from scan, changing accepted/candidate lifecycle meaning, or
+  persisting scanner results.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Memory revision | Monotonic integer in a singleton SQLite table | Increments transactionally after every memory insert/update/delete | A continuation is valid only while the current revision equals its captured revision |
+| Scan budget | Positive row, scan-byte, result-byte, comparison, and duration limits | Accounts for each source unit and returned suggestion | Zero-value caller input resolves to finite defaults; no unlimited mode |
+| Scan phase | `accepted_rows`, `exact_duplicates`, `similarity_pairs`, `candidate_rows` | Owns one deterministic kind of traversal | Accepted and candidate phases never share status filters |
+| Keyset | Last completed memory ID, or current anchor/peer position for a pair phase | Resumes strictly after completed work | Contains identities/counters only, never fact text |
+| Opaque cursor | Version, memory revision, criteria digest, fixed scan time, phase, keyset, checksum | Restores deterministic continuation | Cursor version/shape/checksum and criteria must validate before any row is read |
+| Source unit | One row, exact-duplicate anchor, or prefiltered unordered pair | Advances one observable keyset step | Unit byte extent is known before raw text is returned |
+| Similarity pair traversal | Every unordered same-scope pair, ordered by anchor ID then partner ID | Stops and resumes at `(anchor_id, partner_after_id)` | A completed continuation chain has no approximation, duplicate, or skipped pair; each invocation remains bounded even though exhaustive total work can be quadratic |
+| Scan result | Suggestions, counters, resource usage, completion, stop reason, next cursor | Makes partial coverage operator-visible | `complete=true` has no cursor; `partial=true` never claims full-store counts |
+| Targeted revalidation | Requested row plus exact peer and bounded neighboring peers | Recomputes current suggestion immediately before apply | It never scans unrelated scopes or every memory |
+| Safe preview | Sanitized fact prefix plus truncation marker | Gives enough operator context to identify a suggestion | Raw fact bytes are absent from public result and cursor |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Validate/default budgets and completion vocabulary | `application/types` value objects | These are consumer-visible scanner contracts | CLI/MCP must not invent independent defaults or stop reasons |
+| Encode/decode cursor and bind criteria | hygiene use case | Continuation is application behavior independent of SQLite syntax | Presentation treats the cursor as opaque |
+| Orchestrate phases, account budgets, classify rows/pairs, make safe previews | hygiene use case | Detector precedence and accepted/candidate trust are core behavior | SQLite must not decide lifecycle suggestions |
+| Read revision and deterministic bounded source units | SQLite `MemoryHygieneScanSource` | Transactions, indexes, keysets, byte lengths, and peer ordering are storage concerns | Generic `MemoryQueryService.List` is not a safe scan primitive |
+| Maintain revision and hygiene indexes | additive migration 33 and triggers | Store mutation and index compatibility must be transactional | Runtime migration code must not rewrite memory facts |
+| Revalidate selected IDs and mutate via existing lifecycle methods | hygiene use case plus narrow source query | Apply owns orchestration; existing domain/repository methods own status transitions | Scan remains read-only and cannot share a boolean apply switch |
+| Render completeness, usage, cursor, and previews | CLI/MCP presentation | Protocol shape and localized text belong at the edge | Presentation does not receive raw facts |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| `MemoryHygieneScanBudget` | CLI, MCP, use case | Default ceilings and validation | Invalid/non-positive or overflowed values fail before scanning |
+| `MemoryHygieneScanSource.ScanPage` | hygiene use case | SQLite transaction, revision table, indexes, fact-length probes, pair traversal | Revision mismatch is typed; source never returns units past a requested hard bound |
+| `MemoryHygieneScanSource.Revalidate` | apply path | Exact-peer lookup and target-anchored bounded pair checks | Missing/oversized target is a per-ID apply failure, not a full scan; if the requested ID needs more peer checks than the apply bound, apply fails closed rather than using a partial finding |
+| Cursor codec | scan use case | Base64url JSON and checksum | Malformed, newer-version, tampered, or criteria-mismatched cursors fail closed without echoing cursor contents |
+| `MemoryHygieneScanResult` | CLI/MCP | Internal raw facts and source rows | Additive complete/partial/stop/usage/cursor fields; suggestions contain previews only |
+| Existing memory lifecycle writer | targeted apply | Repository/transaction implementation | Candidate reject and accepted supersede/expire guards remain authoritative under races |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Finite defaults and validation | Zero-value or invalid budget input | Resolve scan criteria | Zero value becomes finite defaults; explicit non-positive limits fail |
+| Row-bound continuation | More accepted rows than one invocation permits | Repeatedly scan with returned cursors | All row keys are processed once, in order, with no duplicate/skip |
+| Byte/result/time/comparison stops | A next unit or suggestion would cross a ceiling | Scan | Stop before that unit, return `partial` plus the matching stable reason and resumable cursor |
+| Revision stability | A memory changes between pages | Continue with the old cursor | Typed stale-revision failure; no silently mixed snapshot |
+| Cursor binding | Cursor is malformed, modified, newer, or reused with different scopes/thresholds | Scan | Fail closed before source traversal; no raw cursor is logged/echoed |
+| Duplicate semantics | Two- and three-member exact duplicate groups across page boundaries | Continue through duplicate phase | Every member appears once with a deterministic peer; candidate rows never appear |
+| Validity precedence | Similar same-scope/type memories with overlapping, touching, disjoint, and open windows | Continue pair phase | Overlap emits only validity kind; touching/disjoint are silent; both-open emits generic supersede |
+| Bounded large-scope invocation | A large single scope and a fixed per-invocation comparison budget | Run one similarity page | Work/allocations track the fixed budget rather than the total possible pair count; cursor resumes at the next exact unordered pair |
+| Preview safety | Facts contain configured secrets and very long Unicode text | Scan via CLI and MCP | Secret/raw tail absent; preview is sanitized, valid UTF-8, bounded, and marks truncation |
+| Candidate trust | Noisy accepted row and noisy extracted candidate | Scan/apply candidate phase | Only candidate is suggested/rejected; accepted row stays untouched |
+| Targeted apply | Large store and one requested ID | Apply | Source revalidates only target plus bounded peers; no whole-store page scan occurs |
+| Operator visibility | Any budget stops the invocation | Render text and JSON/MCP | Output says incomplete, reports stop reason/usage, and includes a continuation cursor |
+| Dry run | Scan with any detector match | Inspect store revision/statuses | No memory mutation and no revision increment |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Budget/cursor contract | Add value-object and cursor round-trip/tamper/criteria tests | Implement finite defaults, canonical criteria digest, checksum codec | Keep cursor payload free of presentation/raw-memory fields |
+| Revision and source keysets | Add migration trigger, revision mismatch, page-boundary, and query-plan tests | Add migration 33 and SQLite scan source | Keep SQL/index/keyset ownership in infrastructure |
+| Detector continuation | Add duplicate/validity overlap tests split across small pages | Implement phase reducer over source units | Move precedence and preview building into focused owners, not one procedural handler |
+| Bound enforcement | Add row/byte/result/comparison/time stop tests | Account before committing each unit/suggestion and encode the last completed keyset | One accounting object owns all ceilings |
+| Targeted apply | Assert the full scan source is not called | Add target revalidation and reuse existing lifecycle writers | Keep raw replacement facts in an internal match only |
+| Presentation safety | Add CLI/MCP JSON and text tests with secret/long facts | Render additive completeness/usage/cursor fields and previews | Share application preview semantics; do not re-sanitize independently |
+| Large-scope behavior | Add synthetic test and benchmark | Use indexed anchor/partner keysets with a hard per-page comparison limit | Assert fixed-budget comparison count and query plans rather than timing alone |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** Phase traversal, budget accounting, and detector
+  precedence could accumulate in one large method. Separate cursor codec,
+  accounting value, source-page reducer, and targeted revalidator; tests assert
+  observable results rather than private call order.
+- **Premature-abstraction risk:** This issue needs one SQLite consumer-oriented
+  scan source, not a general batch-processing framework. Keep phase/unit types
+  specific to durable-memory hygiene.
+- **Exhaustive-cost risk:** A complete scan of one very large scope can require
+  quadratic total comparisons. No invocation may perform that unbounded work:
+  the comparison/time/byte ceilings stop at an exact pair keyset and require
+  explicit continuation. Counts are never presented as complete until the full
+  unordered-pair traversal finishes.
+- **Migration / compatibility:** Migration 33 adds a singleton revision table,
+  three memory triggers, and supporting indexes. It does not change memory
+  rows or lifecycle data. Existing column-list inserts continue to work.
+- **Concurrent writes:** Old cursors are rejected after any memory mutation,
+  preventing mixed revisions and silent duplicate/skip. Operators restart the
+  scan; apply still revalidates each selected row against current state.
+- **Rollback trigger:** Stop rollout if triggers fail to advance revision,
+  continuation duplicates/skips on an unchanged store, bounded previews expose
+  raw secrets, comparison counts exceed the explicit per-invocation budget, or candidate apply
+  can mutate an accepted row.
+- **Rollback procedure:** Before release, revert application code and drop only
+  migration-33 triggers/state/indexes in test stores. After release, use a
+  forward migration to remove unused objects; existing `memories` rows remain
+  authoritative and need no data recovery.
+- **Split-PR plan:** Keep schema/source/usecase/presentation in one issue/PR
+  because revision validity and cursor correctness form one contract. If the
+  change must be staged, first ship dormant migration/source support, then
+  enable the resumable scanner in a follow-up issue without changing existing
+  memory data.
+
+## Implementation checkpoint
+
+Implemented in this draft: the additive revision migration, finite scan budget
+and opaque cursor value objects, indexed SQLite scan source, exhaustive
+anchor/partner-keyset pair traversal, bounded source reads, safe previews, and
+additive CLI/MCP completeness fields. Stale/tampered continuations fail closed,
+and a stopped scan returns an explicit partial result rather than claiming
+complete coverage.
+
+**Blocked acceptance criterion:** the SQLite source now exposes bounded
+targeted revalidation, but wiring `apply` to that source requires changing the
+memory-mutating decision path. The local Guardian rejected that patch even
+after the orchestrator relayed user approval, so this draft intentionally
+retains the existing full-scan apply behavior plus its fail-closed rejection of
+partial scans. The issue must not be marked complete or merged until targeted
+apply wiring is explicitly authorized at the mutation boundary and validated.

--- a/.ai/spec/1556.md
+++ b/.ai/spec/1556.md
@@ -27,8 +27,10 @@
   UTF-8-safe bounded previews. Raw facts and replacement facts remain internal
   to revalidation/apply and never enter output, cursors, errors, or logs.
 - **Apply behavior:** `apply` revalidates only explicitly requested memory IDs
-  plus their bounded deterministic peers. It does not invoke a whole-store
-  scan. Scan remains dry-run/read-only.
+  plus every same-scope peer needed to classify each target. It does not invoke
+  a whole-store scan. If a target's bounded revalidation is partial or the
+  requested targets observe different revisions, it performs no mutation.
+  Scan remains dry-run/read-only.
 - **Out of scope:** Fuzzy/semantic similarity, background cleanup, automatic
   mutation from scan, changing accepted/candidate lifecycle meaning, or
   persisting scanner results.
@@ -142,12 +144,12 @@ and opaque cursor value objects, indexed SQLite scan source, exhaustive
 anchor/partner-keyset pair traversal, bounded source reads, safe previews, and
 additive CLI/MCP completeness fields. Stale/tampered continuations fail closed,
 and a stopped scan returns an explicit partial result rather than claiming
-complete coverage.
+complete coverage. `apply` now uses the targeted revalidation source for each
+requested ID, completes every requested revalidation before the first
+lifecycle mutation, and fails the full request closed on partial or
+cross-target revision mismatch.
 
-**Blocked acceptance criterion:** the SQLite source now exposes bounded
-targeted revalidation, but wiring `apply` to that source requires changing the
-memory-mutating decision path. The local Guardian rejected that patch even
-after the orchestrator relayed user approval, so this draft intentionally
-retains the existing full-scan apply behavior plus its fail-closed rejection of
-partial scans. The issue must not be marked complete or merged until targeted
-apply wiring is explicitly authorized at the mutation boundary and validated.
+Residual race boundary: existing lifecycle writers remain authoritative for a
+concurrent change after the final read-side revalidation and before a write;
+this change does not widen their mutation scope or introduce a cross-ID write
+transaction.

--- a/.ai/spec/1556.md
+++ b/.ai/spec/1556.md
@@ -14,6 +14,15 @@
   returned-suggestion-byte, comparison, and wall-time ceilings. A partial
   result carries an opaque continuation cursor and a stable stop reason.
   Continuing an unchanged store visits every phase/key exactly once.
+- **Cursor trust:** A process-owned AES-GCM key authenticates and encrypts every
+  continuation. The scan creation time is selected by the CLI/MCP boundary and
+  restored only from authenticated cursor plaintext. Legacy checksum cursors,
+  modified cursors, and cursors from an earlier process require a new scan.
+- **Concurrent-write behavior:** A revision change no longer discards progress
+  back to phase one. It returns a partial `best_effort` result with
+  `revision_changed`, preserving the keyset in a continuation rebound to the
+  current revision. The consistency downgrade remains visible on every later
+  page. Apply does not use this relaxation.
 - **Pair semantics:** Exact duplicates remain exhaustive and emit one
   suggestion per duplicate member. Similarity and validity-overlap detection
   exhaustively visit every unordered same-scope pair across continuations,
@@ -39,14 +48,14 @@
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Memory revision | Monotonic integer in a singleton SQLite table | Increments transactionally after every memory insert/update/delete | A continuation is valid only while the current revision equals its captured revision |
+| Memory revision | Monotonic integer in a singleton SQLite table | Increments transactionally after every memory insert/update/delete | A mismatch returns an explicit best-effort continuation at the same keyset and current revision instead of restarting phase one |
 | Scan budget | Positive row, scan-byte, result-byte, comparison, and duration limits | Accounts for each source unit and returned suggestion | Zero-value caller input resolves to finite defaults; no unlimited mode |
 | Scan phase | `accepted_rows`, `exact_duplicates`, `similarity_pairs`, `candidate_rows` | Owns one deterministic kind of traversal | Accepted and candidate phases never share status filters |
 | Keyset | Last completed memory ID, or current anchor/peer position for a pair phase | Resumes strictly after completed work | Contains identities/counters only, never fact text |
-| Opaque cursor | Version, memory revision, criteria digest, fixed scan time, phase, keyset, checksum | Restores deterministic continuation | Cursor version/shape/checksum and criteria must validate before any row is read |
+| Opaque cursor | Encrypted version, memory revision, criteria digest, fixed scan time, phase, keyset, and consistency state | Restores deterministic continuation | AES-GCM authentication, payload shape, and criteria must validate before any row is read; keys never leave the process |
 | Source unit | One row, exact-duplicate anchor, or prefiltered unordered pair | Advances one observable keyset step | Unit byte extent is known before raw text is returned |
 | Similarity pair traversal | Every unordered same-scope pair, ordered by anchor ID then partner ID | Stops and resumes at `(anchor_id, partner_after_id)` | A completed continuation chain has no approximation, duplicate, or skipped pair; each invocation remains bounded even though exhaustive total work can be quadratic |
-| Scan result | Suggestions, counters, resource usage, completion, stop reason, next cursor | Makes partial coverage operator-visible | `complete=true` has no cursor; `partial=true` never claims full-store counts |
+| Scan result | Suggestions, counters, resource usage, completion, stop reason, consistency, consistency reason, next cursor | Makes partial and mixed-revision coverage operator-visible | `complete=true` has no cursor; `best_effort` remains sticky after the first revision change |
 | Targeted revalidation | Requested row plus exact peer and bounded neighboring peers | Recomputes current suggestion immediately before apply | It never scans unrelated scopes or every memory |
 | Safe preview | Sanitized fact prefix plus truncation marker | Gives enough operator context to identify a suggestion | Raw fact bytes are absent from public result and cursor |
 
@@ -69,8 +78,8 @@
 | `MemoryHygieneScanBudget` | CLI, MCP, use case | Default ceilings and validation | Invalid/non-positive or overflowed values fail before scanning |
 | `MemoryHygieneScanSource.ScanPage` | hygiene use case | SQLite transaction, revision table, indexes, fact-length probes, pair traversal | Revision mismatch is typed; source never returns units past a requested hard bound |
 | `MemoryHygieneScanSource.Revalidate` | apply path | Exact-peer lookup and target-anchored bounded pair checks | Missing/oversized target is a per-ID apply failure, not a full scan; if the requested ID needs more peer checks than the apply bound, apply fails closed rather than using a partial finding |
-| Cursor codec | scan use case | Base64url JSON and checksum | Malformed, newer-version, tampered, or criteria-mismatched cursors fail closed without echoing cursor contents |
-| `MemoryHygieneScanResult` | CLI/MCP | Internal raw facts and source rows | Additive complete/partial/stop/usage/cursor fields; suggestions contain previews only |
+| Cursor codec | scan use case | Process-local AES-GCM key, nonce, and encrypted Base64url payload | Malformed/newer payloads fail closed; authentication failure returns a typed rescan-required error without echoing cursor contents |
+| `MemoryHygieneScanResult` | CLI/MCP | Internal raw facts and source rows | Additive complete/partial/stop/consistency/usage/cursor fields; suggestions contain previews only |
 | Existing memory lifecycle writer | targeted apply | Repository/transaction implementation | Candidate reject and accepted supersede/expire guards remain authoritative under races |
 
 ### Behavior tests
@@ -80,8 +89,9 @@
 | Finite defaults and validation | Zero-value or invalid budget input | Resolve scan criteria | Zero value becomes finite defaults; explicit non-positive limits fail |
 | Row-bound continuation | More accepted rows than one invocation permits | Repeatedly scan with returned cursors | All row keys are processed once, in order, with no duplicate/skip |
 | Byte/result/time/comparison stops | A next unit or suggestion would cross a ceiling | Scan | Stop before that unit, return `partial` plus the matching stable reason and resumable cursor |
-| Revision stability | A memory changes between pages | Continue with the old cursor | Typed stale-revision failure; no silently mixed snapshot |
-| Cursor binding | Cursor is malformed, modified, newer, or reused with different scopes/thresholds | Scan | Fail closed before source traversal; no raw cursor is logged/echoed |
+| Revision stability | A memory changes between pages | Continue with the old cursor | Return partial `best_effort` / `revision_changed`, preserve the keyset in a current-revision cursor, and keep the downgrade on later pages |
+| Cursor binding | Cursor is malformed, modified, newer, from an earlier process, or reused with different scopes/thresholds | Scan | Fail closed before source traversal; authentication failures clearly require a new scan; no raw cursor is logged/echoed |
+| Server-owned scan time | A client supplies or modifies a cursor | Start and continue a scan | New scans use the boundary-owned clock; continuations restore only the authenticated original scan time |
 | Duplicate semantics | Two- and three-member exact duplicate groups across page boundaries | Continue through duplicate phase | Every member appears once with a deterministic peer; candidate rows never appear |
 | Validity precedence | Similar same-scope/type memories with overlapping, touching, disjoint, and open windows | Continue pair phase | Overlap emits only validity kind; touching/disjoint are silent; both-open emits generic supersede |
 | Bounded large-scope invocation | A large single scope and a fixed per-invocation comparison budget | Run one similarity page | Work/allocations track the fixed budget rather than the total possible pair count; cursor resumes at the next exact unordered pair |
@@ -95,7 +105,7 @@
 
 | Behavior | Red | Green | Refactor target |
 | --- | --- | --- | --- |
-| Budget/cursor contract | Add value-object and cursor round-trip/tamper/criteria tests | Implement finite defaults, canonical criteria digest, checksum codec | Keep cursor payload free of presentation/raw-memory fields |
+| Budget/cursor contract | Add value-object and cursor round-trip/tamper/restart/criteria tests | Implement finite defaults, canonical criteria digest, process-local AES-GCM codec | Keep cursor payload free of presentation/raw-memory fields and the key out of all output |
 | Revision and source keysets | Add migration trigger, revision mismatch, page-boundary, and query-plan tests | Add migration 33 and SQLite scan source | Keep SQL/index/keyset ownership in infrastructure |
 | Detector continuation | Add duplicate/validity overlap tests split across small pages | Implement phase reducer over source units | Move precedence and preview building into focused owners, not one procedural handler |
 | Bound enforcement | Add row/byte/result/comparison/time stop tests | Account before committing each unit/suggestion and encode the last completed keyset | One accounting object owns all ceilings |
@@ -120,9 +130,14 @@
 - **Migration / compatibility:** Migration 33 adds a singleton revision table,
   three memory triggers, and supporting indexes. It does not change memory
   rows or lifecycle data. Existing column-list inserts continue to work.
-- **Concurrent writes:** Old cursors are rejected after any memory mutation,
-  preventing mixed revisions and silent duplicate/skip. Operators restart the
-  scan; apply still revalidates each selected row against current state.
+  Cursor v1 is intentionally removed: pre-change and pre-restart cursors return
+  a clear rescan-required error rather than falling back to an unauthenticated
+  compatibility path.
+- **Concurrent writes:** Scan preserves its phase/keyset across revision
+  changes but explicitly downgrades to `best_effort`; inserts or deletes before
+  the retained keyset can therefore make the completed chain differ from any
+  single snapshot. Apply remains fail-closed: every selected target must be
+  completely revalidated at the same revision before the first mutation.
 - **Rollback trigger:** Stop rollout if triggers fail to advance revision,
   continuation duplicates/skips on an unchanged store, bounded previews expose
   raw secrets, comparison counts exceed the explicit per-invocation budget, or candidate apply
@@ -139,15 +154,16 @@
 
 ## Implementation checkpoint
 
-Implemented in this draft: the additive revision migration, finite scan budget
-and opaque cursor value objects, indexed SQLite scan source, exhaustive
-anchor/partner-keyset pair traversal, bounded source reads, safe previews, and
-additive CLI/MCP completeness fields. Stale/tampered continuations fail closed,
-and a stopped scan returns an explicit partial result rather than claiming
-complete coverage. `apply` now uses the targeted revalidation source for each
-requested ID, completes every requested revalidation before the first
-lifecycle mutation, and fails the full request closed on partial or
-cross-target revision mismatch.
+Implemented in this draft: the additive revision migration, finite scan budget,
+process-authenticated encrypted cursor value objects, indexed SQLite scan
+source, exhaustive anchor/partner-keyset pair traversal, bounded source reads,
+safe previews, and additive CLI/MCP completeness and consistency fields.
+Tampered, legacy, and earlier-process continuations fail closed with explicit
+rescan guidance. A store revision change returns a best-effort continuation at
+the retained keyset instead of discarding progress. `apply` uses the targeted
+revalidation source for each requested ID, completes every requested
+revalidation before the first lifecycle mutation, and fails the full request
+closed on partial or cross-target revision mismatch.
 
 Residual race boundary: existing lifecycle writers remain authoritative for a
 concurrent change after the final read-side revalidation and before a write;

--- a/application/queryservice/memory_hygiene_scan.go
+++ b/application/queryservice/memory_hygiene_scan.go
@@ -11,6 +11,12 @@ import (
 // revision no longer matches. Callers must restart without the old cursor.
 var ErrMemoryHygieneRevisionChanged = errors.New("memory hygiene revision changed")
 
+// ErrMemoryHygieneContinuationCannotProgress identifies a finite scan budget
+// that stopped before its cursor position advanced. Retrying that cursor with
+// the same budget would repeat the same work indefinitely, so callers must
+// increase the relevant budget or narrow the scan instead.
+var ErrMemoryHygieneContinuationCannotProgress = errors.New("memory hygiene continuation cannot progress")
+
 // MemoryHygieneScanSource is the narrow read boundary consumed by the bounded
 // hygiene use case. Generic List cannot express a revision-stable keyset or
 // exhaustive pair continuation, so production scanners must implement this

--- a/application/queryservice/memory_hygiene_scan.go
+++ b/application/queryservice/memory_hygiene_scan.go
@@ -1,0 +1,24 @@
+package queryservice
+
+import (
+	"context"
+	"errors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// ErrMemoryHygieneRevisionChanged identifies a continuation whose store
+// revision no longer matches. Callers must restart without the old cursor.
+var ErrMemoryHygieneRevisionChanged = errors.New("memory hygiene revision changed")
+
+// MemoryHygieneScanSource is the narrow read boundary consumed by the bounded
+// hygiene use case. Generic List cannot express a revision-stable keyset or
+// exhaustive pair continuation, so production scanners must implement this
+// source explicitly.
+type MemoryHygieneScanSource interface {
+	// ScanMemoryHygienePage returns one revision-consistent bounded page.
+	ScanMemoryHygienePage(ctx context.Context, criteria apptypes.MemoryHygieneScanPageCriteria) (apptypes.MemoryHygieneScanSourcePage, error)
+	// RevalidateMemoryHygiene loads only a requested target and its relevant
+	// peers for apply. Complete=false means the apply path must fail closed.
+	RevalidateMemoryHygiene(ctx context.Context, criteria apptypes.MemoryHygieneRevalidationCriteria) (apptypes.MemoryHygieneRevalidationSourceResult, error)
+}

--- a/application/queryservice/memory_hygiene_scan.go
+++ b/application/queryservice/memory_hygiene_scan.go
@@ -3,13 +3,41 @@ package queryservice
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
 // ErrMemoryHygieneRevisionChanged identifies a continuation whose store
-// revision no longer matches. Callers must restart without the old cursor.
+// revision no longer matches. Read-only scans may preserve their keyset in an
+// explicit best-effort continuation; apply callers must fail closed.
 var ErrMemoryHygieneRevisionChanged = errors.New("memory hygiene revision changed")
+
+// MemoryHygieneRevisionChangedError carries the revision a best-effort scan
+// continuation must bind before it resumes at the retained keyset.
+type MemoryHygieneRevisionChangedError struct {
+	CurrentRevision int64
+}
+
+// Error implements error without exposing any memory content.
+func (e *MemoryHygieneRevisionChangedError) Error() string {
+	return fmt.Sprintf("%s: current revision %d", ErrMemoryHygieneRevisionChanged, e.CurrentRevision)
+}
+
+// Unwrap preserves errors.Is compatibility for strict apply callers.
+func (e *MemoryHygieneRevisionChangedError) Unwrap() error {
+	return ErrMemoryHygieneRevisionChanged
+}
+
+// NewMemoryHygieneRevisionChangedError builds the typed scan-source mismatch.
+func NewMemoryHygieneRevisionChangedError(currentRevision int64) error {
+	return &MemoryHygieneRevisionChangedError{CurrentRevision: currentRevision}
+}
+
+// ErrMemoryHygieneRescanRequired identifies a cursor that cannot be
+// authenticated by this process. Retrying it cannot succeed; callers must
+// start a new scan without the cursor.
+var ErrMemoryHygieneRescanRequired = errors.New("memory hygiene rescan required")
 
 // ErrMemoryHygieneContinuationCannotProgress identifies a finite scan budget
 // that stopped before its cursor position advanced. Retrying that cursor with

--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -70,14 +70,16 @@ type MemoryHygieneScanCriteria struct {
 	SimilarityThreshold     float64
 	Now                     time.Time
 	IncludeHiddenCandidates bool
+	Budget                  MemoryHygieneScanBudget
+	Cursor                  string
 }
 
-// MemoryHygieneSuggestion is the serializable view of a single scan hit.
-// SanitizedFact is populated for redaction hits so the apply path can
-// propose a supersede with the masked content; DuplicateMemoryID is set
-// on duplicate hits so the reader sees both sides of the pair;
-// ReplacementMemoryID and ReplacementFact are set on supersede_candidate
-// hits so the apply path knows which memory becomes the replacement.
+// MemoryHygieneSuggestion is one scan hit. The raw Fact, SanitizedFact, and
+// ReplacementFact fields are internal apply inputs and intentionally excluded
+// from JSON. Their corresponding Preview fields are current-rule-sanitized,
+// UTF-8-safe, bounded values suitable for CLI and MCP output.
+// DuplicateMemoryID is set on duplicate hits so the reader sees both sides of
+// the pair; ReplacementMemoryID is set on supersede candidates.
 // Similarity is the computed word-Jaccard score (0.0-1.0) — zero on
 // everything except supersede_candidate.
 //
@@ -88,20 +90,26 @@ type MemoryHygieneScanCriteria struct {
 // classified the candidate as low-quality — the same vocabulary the
 // extractor diagnostics expose (#857).
 type MemoryHygieneSuggestion struct {
-	MemoryID            domtypes.MemoryID
-	Kind                MemoryHygieneSuggestionKind
-	Reason              string
-	Fact                string
-	SanitizedFact       string
-	DuplicateMemoryID   domtypes.MemoryID
-	ReplacementMemoryID domtypes.MemoryID
-	ReplacementFact     string
-	Similarity          float64
-	Scope               domtypes.MemoryScope
-	UpdatedAt           time.Time
-	Status              domtypes.MemoryStatus
-	Source              domtypes.MemorySource
-	QualityReasons      []string
+	MemoryID                    domtypes.MemoryID           `json:"memory_id"`
+	Kind                        MemoryHygieneSuggestionKind `json:"kind"`
+	Reason                      string                      `json:"reason"`
+	Fact                        string                      `json:"-"`
+	FactPreview                 string                      `json:"fact_preview"`
+	FactPreviewTruncated        bool                        `json:"fact_preview_truncated,omitempty"`
+	SanitizedFact               string                      `json:"-"`
+	SanitizedFactPreview        string                      `json:"sanitized_fact_preview,omitempty"`
+	SanitizedPreviewTruncated   bool                        `json:"sanitized_preview_truncated,omitempty"`
+	DuplicateMemoryID           domtypes.MemoryID           `json:"duplicate_memory_id,omitempty"`
+	ReplacementMemoryID         domtypes.MemoryID           `json:"replacement_memory_id,omitempty"`
+	ReplacementFact             string                      `json:"-"`
+	ReplacementFactPreview      string                      `json:"replacement_fact_preview,omitempty"`
+	ReplacementPreviewTruncated bool                        `json:"replacement_preview_truncated,omitempty"`
+	Similarity                  float64                     `json:"similarity,omitempty"`
+	Scope                       domtypes.MemoryScope        `json:"-"`
+	UpdatedAt                   time.Time                   `json:"updated_at"`
+	Status                      domtypes.MemoryStatus       `json:"status,omitempty"`
+	Source                      domtypes.MemorySource       `json:"source,omitempty"`
+	QualityReasons              []string                    `json:"quality_reasons,omitempty"`
 }
 
 // MemoryHygieneScanResult summarises a single scan run. Suggestions keeps
@@ -116,6 +124,11 @@ type MemoryHygieneScanResult struct {
 	SupersedeCandidateCount       int
 	ValidityOverlapSupersedeCount int
 	LowQualityCandidateCount      int
+	Complete                      bool
+	Partial                       bool
+	StopReason                    MemoryHygieneStopReason
+	NextCursor                    string
+	Usage                         MemoryHygieneScanUsage
 }
 
 // MemoryHygieneApplyCriteria carries the inputs to the apply path. Ids

--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -127,6 +127,8 @@ type MemoryHygieneScanResult struct {
 	Complete                      bool
 	Partial                       bool
 	StopReason                    MemoryHygieneStopReason
+	Consistency                   MemoryHygieneScanConsistency
+	ConsistencyReason             MemoryHygieneConsistencyReason
 	NextCursor                    string
 	Usage                         MemoryHygieneScanUsage
 }

--- a/application/types/memory_hygiene.go
+++ b/application/types/memory_hygiene.go
@@ -131,14 +131,14 @@ type MemoryHygieneScanResult struct {
 	Usage                         MemoryHygieneScanUsage
 }
 
-// MemoryHygieneApplyCriteria carries the inputs to the apply path. Ids
-// reference memories the caller already saw in a Scan result; the
-// usecase re-runs the scan to make sure the transition still applies.
+// MemoryHygieneApplyCriteria carries the inputs to the apply path. IDs
+// reference memories the caller already saw in a Scan result; the usecase
+// revalidates each requested ID and its same-scope peers before applying a
+// transition.
 //
 // IncludeHiddenCandidates mirrors the scan flag so an apply targeting a
-// previously-hidden candidate id still finds the suggestion when the
-// re-scan runs. Without it, the re-scan would miss the row and the
-// apply would fail with "no current hygiene suggestion".
+// previously-hidden candidate ID includes it in targeted revalidation. Without
+// it, the apply fails with "no current hygiene suggestion".
 type MemoryHygieneApplyCriteria struct {
 	MemoryIDs               []string
 	StalenessThreshold      time.Duration

--- a/application/types/memory_hygiene_scan.go
+++ b/application/types/memory_hygiene_scan.go
@@ -1,0 +1,227 @@
+package types
+
+import (
+	"time"
+
+	"golang.org/x/xerrors"
+
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	defaultMemoryHygieneMaxRows        = 2_000
+	defaultMemoryHygieneMaxScanBytes   = 4 * 1024 * 1024
+	defaultMemoryHygieneMaxResultBytes = 256 * 1024
+	defaultMemoryHygieneMaxComparisons = 20_000
+	defaultMemoryHygieneMaxDuration    = 2 * time.Second
+)
+
+// MemoryHygieneScanBudgetParams is the external representation used to build a
+// finite per-invocation hygiene budget. A completely zero value selects the
+// finite defaults; otherwise every field must be positive.
+type MemoryHygieneScanBudgetParams struct {
+	MaxRows        int
+	MaxScanBytes   int64
+	MaxResultBytes int64
+	MaxComparisons int
+	MaxDuration    time.Duration
+}
+
+// MemoryHygieneScanBudget owns the five hard ceilings for one scan invocation.
+// Its fields are private so an invalid or accidentally unlimited budget cannot
+// cross the application boundary.
+type MemoryHygieneScanBudget struct {
+	maxRows        int
+	maxScanBytes   int64
+	maxResultBytes int64
+	maxComparisons int
+	maxDuration    time.Duration
+}
+
+// MemoryHygieneScanBudgetFrom validates explicit limits or resolves the
+// completely zero value to finite defaults.
+func MemoryHygieneScanBudgetFrom(params MemoryHygieneScanBudgetParams) (MemoryHygieneScanBudget, error) {
+	if params == (MemoryHygieneScanBudgetParams{}) {
+		return DefaultMemoryHygieneScanBudget(), nil
+	}
+	if params.MaxRows < 2 {
+		return MemoryHygieneScanBudget{}, xerrors.Errorf("memory hygiene max rows must be greater than or equal to 2")
+	}
+	if params.MaxScanBytes < 1 {
+		return MemoryHygieneScanBudget{}, xerrors.Errorf("memory hygiene max scan bytes must be greater than or equal to 1")
+	}
+	if params.MaxResultBytes < 1 {
+		return MemoryHygieneScanBudget{}, xerrors.Errorf("memory hygiene max result bytes must be greater than or equal to 1")
+	}
+	if params.MaxComparisons < 1 {
+		return MemoryHygieneScanBudget{}, xerrors.Errorf("memory hygiene max comparisons must be greater than or equal to 1")
+	}
+	if params.MaxDuration <= 0 {
+		return MemoryHygieneScanBudget{}, xerrors.Errorf("memory hygiene max duration must be greater than 0")
+	}
+	return MemoryHygieneScanBudget{
+		maxRows:        params.MaxRows,
+		maxScanBytes:   params.MaxScanBytes,
+		maxResultBytes: params.MaxResultBytes,
+		maxComparisons: params.MaxComparisons,
+		maxDuration:    params.MaxDuration,
+	}, nil
+}
+
+// DefaultMemoryHygieneScanBudget returns the finite operator defaults.
+func DefaultMemoryHygieneScanBudget() MemoryHygieneScanBudget {
+	return MemoryHygieneScanBudget{
+		maxRows:        defaultMemoryHygieneMaxRows,
+		maxScanBytes:   defaultMemoryHygieneMaxScanBytes,
+		maxResultBytes: defaultMemoryHygieneMaxResultBytes,
+		maxComparisons: defaultMemoryHygieneMaxComparisons,
+		maxDuration:    defaultMemoryHygieneMaxDuration,
+	}
+}
+
+// MaxRows returns the source-row ceiling for one invocation.
+func (b MemoryHygieneScanBudget) MaxRows() int { return b.maxRows }
+
+// MaxScanBytes returns the raw source-byte ceiling for one invocation.
+func (b MemoryHygieneScanBudget) MaxScanBytes() int64 { return b.maxScanBytes }
+
+// MaxResultBytes returns the serialized suggestion-byte ceiling.
+func (b MemoryHygieneScanBudget) MaxResultBytes() int64 { return b.maxResultBytes }
+
+// MaxComparisons returns the duplicate/similarity comparison ceiling.
+func (b MemoryHygieneScanBudget) MaxComparisons() int { return b.maxComparisons }
+
+// MaxDuration returns the wall-clock ceiling for one invocation.
+func (b MemoryHygieneScanBudget) MaxDuration() time.Duration { return b.maxDuration }
+
+// IsZero reports whether a caller left the budget unset.
+func (b MemoryHygieneScanBudget) IsZero() bool {
+	return b == (MemoryHygieneScanBudget{})
+}
+
+// MemoryHygieneScanPhase is the stable traversal phase encoded in cursors and
+// consumed by the SQLite scan source.
+type MemoryHygieneScanPhase string
+
+const (
+	// MemoryHygieneScanPhaseAcceptedRows starts the accepted-memory row pass.
+	MemoryHygieneScanPhaseAcceptedRows MemoryHygieneScanPhase = "accepted_rows"
+	// MemoryHygieneScanPhaseExactDuplicates traverses accepted rows for exact peers.
+	MemoryHygieneScanPhaseExactDuplicates MemoryHygieneScanPhase = "exact_duplicates"
+	// MemoryHygieneScanPhaseSimilarityPairs traverses every unordered same-scope pair.
+	MemoryHygieneScanPhaseSimilarityPairs MemoryHygieneScanPhase = "similarity_pairs"
+	// MemoryHygieneScanPhaseCandidateRows traverses candidate-noise rows.
+	MemoryHygieneScanPhaseCandidateRows MemoryHygieneScanPhase = "candidate_rows"
+)
+
+// IsKnown reports whether the phase can be resumed by this build.
+func (p MemoryHygieneScanPhase) IsKnown() bool {
+	switch p {
+	case MemoryHygieneScanPhaseAcceptedRows,
+		MemoryHygieneScanPhaseExactDuplicates,
+		MemoryHygieneScanPhaseSimilarityPairs,
+		MemoryHygieneScanPhaseCandidateRows:
+		return true
+	default:
+		return false
+	}
+}
+
+// MemoryHygieneScanKeyset contains identities only. Similarity traversal keeps
+// the current anchor and last completed partner so every unordered pair can be
+// resumed without putting fact text in the cursor.
+type MemoryHygieneScanKeyset struct {
+	AfterMemoryID  string
+	AnchorMemoryID string
+	AfterPartnerID string
+}
+
+// MemoryHygieneScanPageCriteria is the consumer-oriented bounded request passed
+// to the persistence scan source.
+type MemoryHygieneScanPageCriteria struct {
+	Phase                   MemoryHygieneScanPhase
+	Keyset                  MemoryHygieneScanKeyset
+	Scopes                  []domtypes.MemoryScope
+	IncludeHiddenCandidates bool
+	ExpectedRevision        domtypes.Optional[int64]
+	MaxRows                 int
+	MaxScanBytes            int64
+	MaxComparisons          int
+}
+
+// MemoryHygieneScanUnit is one cursor-advancing source unit. Peer is populated
+// only by the similarity phase; RelatedMemoryID is populated only by the exact
+// duplicate phase.
+type MemoryHygieneScanUnit struct {
+	Row             MemorySummary
+	Peer            domtypes.Optional[MemorySummary]
+	RelatedMemoryID domtypes.Optional[domtypes.MemoryID]
+	NextKeyset      MemoryHygieneScanKeyset
+}
+
+// MemoryHygieneScanSourcePage is a revision-consistent bounded page. The source
+// accounts raw fact bytes before returning them to the use case.
+type MemoryHygieneScanSourcePage struct {
+	Revision       int64
+	Units          []MemoryHygieneScanUnit
+	ProgressKeyset MemoryHygieneScanKeyset
+	Done           bool
+	StopReason     MemoryHygieneStopReason
+	ScannedRows    int
+	ScannedBytes   int64
+	Comparisons    int
+}
+
+// MemoryHygieneRevalidationCriteria scopes the apply path to a requested
+// memory and its relevant peers. It has finite row, byte, and comparison
+// ceilings.
+type MemoryHygieneRevalidationCriteria struct {
+	MemoryID                domtypes.MemoryID
+	IncludeHiddenCandidates bool
+	MaxRows                 int
+	MaxScanBytes            int64
+	MaxComparisons          int
+}
+
+// MemoryHygieneRevalidationSourceResult contains the current target and every
+// same-scope peer inspected for targeted apply. Complete=false must fail apply
+// closed; it is never interpreted as "no suggestion".
+type MemoryHygieneRevalidationSourceResult struct {
+	Revision               int64
+	Target                 MemorySummary
+	ExactDuplicateMemoryID domtypes.Optional[domtypes.MemoryID]
+	Peers                  []MemorySummary
+	Complete               bool
+	StopReason             MemoryHygieneStopReason
+	ScannedRows            int
+	ScannedBytes           int64
+	Comparisons            int
+}
+
+// MemoryHygieneStopReason explains why one invocation stopped.
+type MemoryHygieneStopReason string
+
+const (
+	// MemoryHygieneStopReasonComplete means every scan phase finished.
+	MemoryHygieneStopReasonComplete MemoryHygieneStopReason = "complete"
+	// MemoryHygieneStopReasonRowLimit means the source-row ceiling stopped the invocation.
+	MemoryHygieneStopReasonRowLimit MemoryHygieneStopReason = "row_limit"
+	// MemoryHygieneStopReasonScanByteLimit means the raw source-byte ceiling stopped the invocation.
+	MemoryHygieneStopReasonScanByteLimit MemoryHygieneStopReason = "scan_byte_limit"
+	// MemoryHygieneStopReasonResultByteLimit means the suggestion-byte ceiling stopped the invocation.
+	MemoryHygieneStopReasonResultByteLimit MemoryHygieneStopReason = "result_byte_limit"
+	// MemoryHygieneStopReasonComparisonLimit means the comparison ceiling stopped the invocation.
+	MemoryHygieneStopReasonComparisonLimit MemoryHygieneStopReason = "comparison_limit"
+	// MemoryHygieneStopReasonTimeLimit means the wall-clock ceiling stopped the invocation.
+	MemoryHygieneStopReasonTimeLimit MemoryHygieneStopReason = "time_limit"
+)
+
+// MemoryHygieneScanUsage reports actual work charged to one invocation.
+type MemoryHygieneScanUsage struct {
+	ScannedRows   int           `json:"scanned_rows"`
+	ScannedBytes  int64         `json:"scanned_bytes"`
+	ResultBytes   int64         `json:"result_bytes"`
+	Comparisons   int           `json:"comparisons"`
+	Elapsed       time.Duration `json:"-"`
+	ElapsedMillis int64         `json:"elapsed_ms"`
+}

--- a/application/types/memory_hygiene_scan.go
+++ b/application/types/memory_hygiene_scan.go
@@ -141,6 +141,7 @@ type MemoryHygieneScanKeyset struct {
 type MemoryHygieneScanPageCriteria struct {
 	Phase                   MemoryHygieneScanPhase
 	Keyset                  MemoryHygieneScanKeyset
+	Consistency             MemoryHygieneScanConsistency
 	Scopes                  []domtypes.MemoryScope
 	IncludeHiddenCandidates bool
 	ExpectedRevision        domtypes.Optional[int64]
@@ -214,6 +215,38 @@ const (
 	MemoryHygieneStopReasonComparisonLimit MemoryHygieneStopReason = "comparison_limit"
 	// MemoryHygieneStopReasonTimeLimit means the wall-clock ceiling stopped the invocation.
 	MemoryHygieneStopReasonTimeLimit MemoryHygieneStopReason = "time_limit"
+	// MemoryHygieneStopReasonRevisionChanged means the scan preserved its
+	// keyset but rebound the continuation to a newer store revision.
+	MemoryHygieneStopReasonRevisionChanged MemoryHygieneStopReason = "revision_changed"
+)
+
+// MemoryHygieneScanConsistency states whether one continuation chain is still
+// bound to a single store revision.
+type MemoryHygieneScanConsistency string
+
+const (
+	// MemoryHygieneScanConsistencyConsistent means every completed unit was
+	// read at the revision captured by the initial scan.
+	MemoryHygieneScanConsistencyConsistent MemoryHygieneScanConsistency = "consistent"
+	// MemoryHygieneScanConsistencyBestEffort means a revision change preserved
+	// traversal progress, so the completed chain may span multiple snapshots.
+	MemoryHygieneScanConsistencyBestEffort MemoryHygieneScanConsistency = "best_effort"
+)
+
+// IsKnown reports whether the consistency value is part of the public scan
+// contract.
+func (c MemoryHygieneScanConsistency) IsKnown() bool {
+	return c == MemoryHygieneScanConsistencyConsistent ||
+		c == MemoryHygieneScanConsistencyBestEffort
+}
+
+// MemoryHygieneConsistencyReason explains why consistency was downgraded.
+type MemoryHygieneConsistencyReason string
+
+const (
+	// MemoryHygieneConsistencyReasonRevisionChanged records that the store
+	// changed after traversal had already advanced.
+	MemoryHygieneConsistencyReasonRevisionChanged MemoryHygieneConsistencyReason = "revision_changed"
 )
 
 // MemoryHygieneScanUsage reports actual work charged to one invocation.

--- a/application/types/memory_hygiene_scan_test.go
+++ b/application/types/memory_hygiene_scan_test.go
@@ -1,0 +1,90 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestMemoryHygieneScanBudgetFrom_ZeroValueUsesFiniteDefaults(t *testing.T) {
+	t.Parallel()
+
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{})
+	if err != nil {
+		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
+	}
+	if budget.MaxRows() < 2 {
+		t.Fatalf("MaxRows() = %d, want >= 2", budget.MaxRows())
+	}
+	if budget.MaxScanBytes() <= 0 {
+		t.Fatalf("MaxScanBytes() = %d, want > 0", budget.MaxScanBytes())
+	}
+	if budget.MaxResultBytes() <= 0 {
+		t.Fatalf("MaxResultBytes() = %d, want > 0", budget.MaxResultBytes())
+	}
+	if budget.MaxComparisons() <= 0 {
+		t.Fatalf("MaxComparisons() = %d, want > 0", budget.MaxComparisons())
+	}
+	if budget.MaxDuration() <= 0 {
+		t.Fatalf("MaxDuration() = %s, want > 0", budget.MaxDuration())
+	}
+}
+
+func TestMemoryHygieneScanBudgetFrom_RejectsInvalidExplicitLimits(t *testing.T) {
+	t.Parallel()
+
+	valid := apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        2,
+		MaxScanBytes:   1,
+		MaxResultBytes: 1,
+		MaxComparisons: 1,
+		MaxDuration:    time.Millisecond,
+	}
+	tests := map[string]func(*apptypes.MemoryHygieneScanBudgetParams){
+		"rows":         func(params *apptypes.MemoryHygieneScanBudgetParams) { params.MaxRows = 1 },
+		"scan bytes":   func(params *apptypes.MemoryHygieneScanBudgetParams) { params.MaxScanBytes = 0 },
+		"result bytes": func(params *apptypes.MemoryHygieneScanBudgetParams) { params.MaxResultBytes = 0 },
+		"comparisons":  func(params *apptypes.MemoryHygieneScanBudgetParams) { params.MaxComparisons = 0 },
+		"duration":     func(params *apptypes.MemoryHygieneScanBudgetParams) { params.MaxDuration = 0 },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			params := valid
+			mutate(&params)
+			if _, err := apptypes.MemoryHygieneScanBudgetFrom(params); err == nil {
+				t.Fatal("MemoryHygieneScanBudgetFrom() error = nil, want validation error")
+			}
+		})
+	}
+}
+
+func TestMemoryHygieneScanBudgetFrom_PreservesExplicitLimits(t *testing.T) {
+	t.Parallel()
+
+	params := apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        17,
+		MaxScanBytes:   1_024,
+		MaxResultBytes: 512,
+		MaxComparisons: 19,
+		MaxDuration:    125 * time.Millisecond,
+	}
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(params)
+	if err != nil {
+		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
+	}
+	if budget.MaxRows() != params.MaxRows ||
+		budget.MaxScanBytes() != params.MaxScanBytes ||
+		budget.MaxResultBytes() != params.MaxResultBytes ||
+		budget.MaxComparisons() != params.MaxComparisons ||
+		budget.MaxDuration() != params.MaxDuration {
+		t.Fatalf("resolved budget = (%d,%d,%d,%d,%s), want explicit params",
+			budget.MaxRows(),
+			budget.MaxScanBytes(),
+			budget.MaxResultBytes(),
+			budget.MaxComparisons(),
+			budget.MaxDuration(),
+		)
+	}
+}

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -2,9 +2,12 @@ package usecase
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/xerrors"
 
@@ -33,400 +36,445 @@ const defaultStalenessThreshold = 90 * 24 * time.Hour
 // steering clear of shared-keyword coincidences.
 const defaultSupersedeSimilarityThreshold = 0.6
 
-// hygieneScanPageSize caps the number of accepted memories the scanner
-// walks in one run. Real memory stores stay well under this bound; the
-// ceiling is here to keep the single-shot scan deterministic.
-const hygieneScanPageSize = 2000
+const memoryHygienePreviewMaxBytes = 240
 
-// Scan loads every accepted memory in scope and emits one suggestion per
-// memory that trips any of the three hygiene rules. The function is
-// deliberately simple: each rule is independent so an operator can
-// triage the suggestions without the scanner second-guessing them.
-//
-// Candidate hygiene runs as a separate pass on status=candidate rows so
-// the deterministic low-quality classifier (#857) can flag noisy
-// auto-extractions. The candidate pass never inspects accepted memories,
-// so the apply path that consumes its suggestions cannot mutate them.
+// Scan traverses revision-stable source pages until a finite invocation budget
+// is exhausted or all four phases complete. A partial result owns an opaque
+// cursor whose keyset points after the last unit whose suggestions were
+// committed to the result.
 func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
-	if u.memoryQuery == nil {
-		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory query service is not configured")
+	source, ok := u.memoryQuery.(queryservice.MemoryHygieneScanSource)
+	if !ok {
+		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("bounded memory hygiene scan source is not configured")
 	}
-
-	now := criteria.Now
-	if now.IsZero() {
-		now = time.Now().UTC()
+	budget := criteria.Budget
+	if budget.IsZero() {
+		budget = apptypes.DefaultMemoryHygieneScanBudget()
 	}
 	staleness := criteria.StalenessThreshold
 	if staleness <= 0 {
 		staleness = defaultStalenessThreshold
 	}
-
-	summaries, err := u.loadAcceptedSummaries(ctx, criteria.Scopes)
-	if err != nil {
-		return apptypes.MemoryHygieneScanResult{}, err
+	similarity := criteria.SimilarityThreshold
+	if similarity <= 0 {
+		similarity = defaultSupersedeSimilarityThreshold
+	}
+	if similarity > 1 {
+		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene similarity threshold must be less than or equal to 1")
 	}
 
-	result := apptypes.MemoryHygieneScanResult{
-		Suggestions: make([]apptypes.MemoryHygieneSuggestion, 0, len(summaries)),
-	}
-
-	duplicateIndex := make(map[duplicateKey][]apptypes.MemorySummary, len(summaries))
-	for _, summary := range summaries {
-		// Redaction re-scan: sanitize the stored fact with the current
-		// pattern set and flag any memory whose sanitized output is
-		// different from what the store already holds.
-		sanitizedFact, _, _, err := sanitizeMemoryPayload(summary.Fact(), nil, nil, u.extraRedactPatterns)
+	now := criteria.Now.UTC()
+	phase := apptypes.MemoryHygieneScanPhaseAcceptedRows
+	keyset := apptypes.MemoryHygieneScanKeyset{}
+	revision := domtypes.None[int64]()
+	var cursorPayload memoryHygieneCursorPayload
+	if criteria.Cursor != "" {
+		decoded, err := decodeMemoryHygieneCursor(criteria.Cursor)
 		if err != nil {
-			result.Suggestions = append(result.Suggestions, apptypes.MemoryHygieneSuggestion{
-				MemoryID:  summary.MemoryID(),
-				Kind:      apptypes.MemoryHygieneSuggestionRedactionHit,
-				Reason:    fmt.Sprintf("sanitizer failed: %v", err),
-				Fact:      summary.Fact(),
-				Scope:     summary.Scope(),
-				UpdatedAt: summary.UpdatedAt(),
-			})
-			result.RedactionHitCount++
+			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("failed to decode memory hygiene cursor: %w", err)
+		}
+		cursorPayload = decoded
+		cursorTime, _ := time.Parse(time.RFC3339Nano, decoded.ScanAt)
+		if !criteria.Now.IsZero() && !criteria.Now.UTC().Equal(cursorTime) {
+			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene cursor criteria mismatch")
+		}
+		now = cursorTime
+		phase = decoded.Phase
+		keyset = decoded.Keyset
+		revision = domtypes.Some(decoded.Revision)
+	} else if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	digest := memoryHygieneCriteriaDigest(criteria.Scopes, staleness, similarity, criteria.IncludeHiddenCandidates)
+	if criteria.Cursor != "" && cursorPayload.CriteriaDigest != digest {
+		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene cursor criteria mismatch")
+	}
+
+	result := apptypes.MemoryHygieneScanResult{Suggestions: []apptypes.MemoryHygieneSuggestion{}}
+	startedAt := time.Now()
+	scanCtx, cancel := context.WithTimeout(ctx, budget.MaxDuration())
+	defer cancel()
+
+	for {
+		if time.Since(startedAt) >= budget.MaxDuration() {
+			if _, hasRevision := revision.Value(); hasRevision {
+				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+			}
+		}
+		remainingRows := budget.MaxRows() - result.Usage.ScannedRows
+		remainingScanBytes := budget.MaxScanBytes() - result.Usage.ScannedBytes
+		remainingComparisons := budget.MaxComparisons() - result.Usage.Comparisons
+		if remainingRows < 1 {
+			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonRowLimit, phase, keyset, revision, digest, now, startedAt)
+		}
+		if remainingScanBytes < 1 {
+			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonScanByteLimit, phase, keyset, revision, digest, now, startedAt)
+		}
+		if (phase == apptypes.MemoryHygieneScanPhaseExactDuplicates || phase == apptypes.MemoryHygieneScanPhaseSimilarityPairs) && remainingComparisons < 1 {
+			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonComparisonLimit, phase, keyset, revision, digest, now, startedAt)
+		}
+		sourceComparisons := remainingComparisons
+		if sourceComparisons < 1 {
+			sourceComparisons = 1
+		}
+		page, err := source.ScanMemoryHygienePage(scanCtx, apptypes.MemoryHygieneScanPageCriteria{
+			Phase:                   phase,
+			Keyset:                  keyset,
+			Scopes:                  criteria.Scopes,
+			IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
+			ExpectedRevision:        revision,
+			MaxRows:                 remainingRows,
+			MaxScanBytes:            remainingScanBytes,
+			MaxComparisons:          sourceComparisons,
+		})
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(scanCtx.Err(), context.DeadlineExceeded) {
+				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+			}
+			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("failed to scan memory hygiene source page: %w", err)
+		}
+		if _, hasRevision := revision.Value(); !hasRevision {
+			revision = domtypes.Some(page.Revision)
+		}
+		result.Usage.ScannedRows += page.ScannedRows
+		result.Usage.ScannedBytes += page.ScannedBytes
+		result.Usage.Comparisons += page.Comparisons
+
+		for _, unit := range page.Units {
+			if time.Since(startedAt) >= budget.MaxDuration() {
+				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+			}
+			matches := u.matchesForScanUnit(phase, unit, now, staleness, similarity)
+			safeSuggestions := make([]apptypes.MemoryHygieneSuggestion, 0, len(matches))
+			var suggestionBytes int64
+			for _, match := range matches {
+				suggestion := u.safeMemoryHygieneSuggestion(match)
+				encoded, marshalErr := json.Marshal(suggestion)
+				if marshalErr != nil {
+					return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("failed to size memory hygiene suggestion")
+				}
+				suggestionBytes += int64(len(encoded) + 1)
+				safeSuggestions = append(safeSuggestions, suggestion)
+			}
+			if result.Usage.ResultBytes+suggestionBytes > budget.MaxResultBytes() {
+				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonResultByteLimit, phase, keyset, revision, digest, now, startedAt)
+			}
+			for _, suggestion := range safeSuggestions {
+				result.Suggestions = append(result.Suggestions, suggestion)
+				incrementMemoryHygieneCount(&result, suggestion.Kind)
+			}
+			result.Usage.ResultBytes += suggestionBytes
+			keyset = unit.NextKeyset
+		}
+		keyset = page.ProgressKeyset
+
+		if page.Done {
+			nextPhase, complete := nextMemoryHygieneScanPhase(phase)
+			if complete {
+				result.Complete = true
+				result.Partial = false
+				result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+				result.Usage.Elapsed = time.Since(startedAt)
+				result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()
+				return result, nil
+			}
+			phase = nextPhase
+			keyset = apptypes.MemoryHygieneScanKeyset{}
 			continue
 		}
-		if sanitizedFact != summary.Fact() {
-			result.Suggestions = append(result.Suggestions, apptypes.MemoryHygieneSuggestion{
-				MemoryID:      summary.MemoryID(),
-				Kind:          apptypes.MemoryHygieneSuggestionRedactionHit,
-				Reason:        "current redaction patterns mask this fact",
-				Fact:          summary.Fact(),
-				SanitizedFact: sanitizedFact,
-				Scope:         summary.Scope(),
-				UpdatedAt:     summary.UpdatedAt(),
-			})
-			result.RedactionHitCount++
+		if page.StopReason == "" {
+			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan source stopped without a reason")
 		}
-
-		// Expiry suggestion: use updated_at as a staleness proxy. The
-		// store does not yet track retrieval timestamps, so
-		// conservative-leaning updated_at is the honest signal.
-		if now.Sub(summary.UpdatedAt()) > staleness {
-			result.Suggestions = append(result.Suggestions, apptypes.MemoryHygieneSuggestion{
-				MemoryID:  summary.MemoryID(),
-				Kind:      apptypes.MemoryHygieneSuggestionExpiryCandidate,
-				Reason:    fmt.Sprintf("no updates for more than %s", staleness),
-				Fact:      summary.Fact(),
-				Scope:     summary.Scope(),
-				UpdatedAt: summary.UpdatedAt(),
-			})
-			result.ExpiryCandidateCount++
-		}
-
-		// Duplicate suggestion: group by scope + fact. Any bucket with
-		// more than one entry becomes a pair of suggestions so the
-		// reviewer sees both sides. Summaries are expected to carry a
-		// non-nil scope (MemorySummaryOf rejects nil), but the scanner
-		// falls back to a sentinel key so a malformed row still surfaces
-		// in the duplicate bucket instead of panicking here.
-		key := duplicateKey{Fact: summary.Fact()}
-		if summary.Scope() != nil {
-			key.ScopeKind = summary.Scope().Kind()
-			key.ScopeKey = summary.Scope().Key()
-		}
-		duplicateIndex[key] = append(duplicateIndex[key], summary)
+		return finishPartialMemoryHygieneResult(result, page.StopReason, phase, keyset, revision, digest, now, startedAt)
 	}
-
-	for _, bucket := range duplicateIndex {
-		if len(bucket) < 2 {
-			continue
-		}
-		for i, summary := range bucket {
-			other := bucket[(i+1)%len(bucket)]
-			result.Suggestions = append(result.Suggestions, apptypes.MemoryHygieneSuggestion{
-				MemoryID:          summary.MemoryID(),
-				Kind:              apptypes.MemoryHygieneSuggestionDuplicate,
-				Reason:            fmt.Sprintf("shares fact with %s", other.MemoryID().String()),
-				Fact:              summary.Fact(),
-				DuplicateMemoryID: other.MemoryID(),
-				Scope:             summary.Scope(),
-				UpdatedAt:         summary.UpdatedAt(),
-			})
-			result.DuplicateCount++
-		}
-	}
-
-	// Supersede candidate: pair accepted memories whose fact text differs
-	// but shares enough word-level overlap to likely be re-phrasings of
-	// the same idea. The older memory becomes the one to supersede; the
-	// newer memory's content is the suggested replacement. Memories that
-	// already collided as exact duplicates are excluded so both detectors
-	// stay additive and the reviewer sees a clean split between "same
-	// content" and "overlapping content".
-	similarityThreshold := criteria.SimilarityThreshold
-	if similarityThreshold <= 0 {
-		similarityThreshold = defaultSupersedeSimilarityThreshold
-	}
-	// Validity-annotated classifier runs first because it produces the
-	// more specific signal: (scope, type) match plus explicit temporal
-	// evidence splits pairs cleanly into "same policy, overlapping"
-	// (emit validity_overlap_supersede) and "separate historical
-	// facts, disjoint" (silent). Both outcomes are then excluded from
-	// the generic supersede_candidate pass so the reviewer never sees
-	// a temporally-bounded pair reported under the weaker kind.
-	validityOverlapSuggestions, temporalDisjointPairs := classifyValidityAnnotatedPairs(summaries, similarityThreshold)
-	validityPairs := make(map[string]struct{}, len(validityOverlapSuggestions))
-	for _, suggestion := range validityOverlapSuggestions {
-		validityPairs[pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())] = struct{}{}
-	}
-
-	supersedeSuggestions := detectSupersedeCandidates(summaries, duplicateIndex, similarityThreshold)
-	filteredSupersede := make([]apptypes.MemoryHygieneSuggestion, 0, len(supersedeSuggestions))
-	for _, suggestion := range supersedeSuggestions {
-		key := pairKey(suggestion.MemoryID.String(), suggestion.ReplacementMemoryID.String())
-		if _, captured := validityPairs[key]; captured {
-			continue
-		}
-		if _, disjoint := temporalDisjointPairs[key]; disjoint {
-			continue
-		}
-		filteredSupersede = append(filteredSupersede, suggestion)
-	}
-	result.Suggestions = append(result.Suggestions, filteredSupersede...)
-	result.SupersedeCandidateCount = len(filteredSupersede)
-
-	result.Suggestions = append(result.Suggestions, validityOverlapSuggestions...)
-	result.ValidityOverlapSupersedeCount = len(validityOverlapSuggestions)
-
-	candidateSuggestions, err := u.scanLowQualityCandidates(ctx, criteria)
-	if err != nil {
-		return apptypes.MemoryHygieneScanResult{}, err
-	}
-	result.Suggestions = append(result.Suggestions, candidateSuggestions...)
-	result.LowQualityCandidateCount = len(candidateSuggestions)
-
-	return result, nil
 }
 
-// scanLowQualityCandidates walks every status=candidate memory in scope
-// and emits a low_quality_candidate suggestion for each row whose fact
-// matches the deterministic extraction-noise classifier (#857). The
-// default pass restricts the source to MemorySourceExtracted because
-// extracted-hidden rows are already suppressed from the inbox; callers
-// who explicitly opt into IncludeHiddenCandidates also see those rows
-// so they can clean up backlog from before the extractor learned to
-// hide them.
-//
-// The candidate pass is a separate read so the existing redaction /
-// expiry / duplicate / supersede passes keep operating on accepted
-// memories only — there is no path through this scan that mutates an
-// accepted row, satisfying the issue's guarantee that the candidate
-// cleanup path cannot touch accepted memories.
-func (u *memoryHygieneUsecase) scanLowQualityCandidates(
-	ctx context.Context,
-	criteria apptypes.MemoryHygieneScanCriteria,
-) ([]apptypes.MemoryHygieneSuggestion, error) {
-	sources := []domtypes.MemorySource{domtypes.MemorySourceExtracted}
-	if criteria.IncludeHiddenCandidates {
-		sources = append(sources, domtypes.MemorySourceExtractedHidden)
-	}
-	candidates, err := u.loadCandidateSummaries(ctx, criteria.Scopes, sources)
-	if err != nil {
-		return nil, err
-	}
-	suggestions := make([]apptypes.MemoryHygieneSuggestion, 0, len(candidates))
-	for _, candidate := range candidates {
-		reasons := classifyExtractionNoise(candidate.Fact())
-		if len(reasons) == 0 {
-			continue
+type memoryHygieneMatch struct {
+	MemoryID            domtypes.MemoryID
+	Kind                apptypes.MemoryHygieneSuggestionKind
+	Reason              string
+	rawFact             string
+	sanitizedFact       string
+	DuplicateMemoryID   domtypes.MemoryID
+	ReplacementMemoryID domtypes.MemoryID
+	replacementFact     string
+	Similarity          float64
+	Scope               domtypes.MemoryScope
+	UpdatedAt           time.Time
+	Status              domtypes.MemoryStatus
+	Source              domtypes.MemorySource
+	QualityReasons      []string
+}
+
+func (u *memoryHygieneUsecase) matchesForScanUnit(
+	phase apptypes.MemoryHygieneScanPhase,
+	unit apptypes.MemoryHygieneScanUnit,
+	now time.Time,
+	staleness time.Duration,
+	similarity float64,
+) []memoryHygieneMatch {
+	switch phase {
+	case apptypes.MemoryHygieneScanPhaseAcceptedRows:
+		return u.acceptedRowHygieneMatches(unit.Row, now, staleness)
+	case apptypes.MemoryHygieneScanPhaseExactDuplicates:
+		peerID, ok := unit.RelatedMemoryID.Value()
+		if !ok {
+			return nil
 		}
-		suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
-			MemoryID:       candidate.MemoryID(),
+		return []memoryHygieneMatch{{
+			MemoryID:          unit.Row.MemoryID(),
+			Kind:              apptypes.MemoryHygieneSuggestionDuplicate,
+			Reason:            fmt.Sprintf("shares fact with %s", peerID.String()),
+			rawFact:           unit.Row.Fact(),
+			DuplicateMemoryID: peerID,
+			Scope:             unit.Row.Scope(),
+			UpdatedAt:         unit.Row.UpdatedAt(),
+		}}
+	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:
+		peer, ok := unit.Peer.Value()
+		if !ok {
+			return nil
+		}
+		match, matched := similarityPairHygieneMatch(unit.Row, peer, similarity)
+		if !matched {
+			return nil
+		}
+		return []memoryHygieneMatch{match}
+	case apptypes.MemoryHygieneScanPhaseCandidateRows:
+		reasons := classifyExtractionNoise(unit.Row.Fact())
+		if len(reasons) == 0 {
+			return nil
+		}
+		return []memoryHygieneMatch{{
+			MemoryID:       unit.Row.MemoryID(),
 			Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
 			Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
-			Fact:           candidate.Fact(),
-			Scope:          candidate.Scope(),
-			UpdatedAt:      candidate.UpdatedAt(),
-			Status:         candidate.Status(),
-			Source:         candidate.Source(),
+			rawFact:        unit.Row.Fact(),
+			Scope:          unit.Row.Scope(),
+			UpdatedAt:      unit.Row.UpdatedAt(),
+			Status:         unit.Row.Status(),
+			Source:         unit.Row.Source(),
 			QualityReasons: reasons,
-		})
-	}
-	return suggestions, nil
-}
-
-// detectSupersedeCandidates groups accepted memories by scope, computes
-// pairwise word-Jaccard similarity, and emits a supersede_candidate for
-// every pair above the threshold. The older memory is the one that gets
-// superseded; the newer memory's fact is the replacement. Pairs are
-// de-duplicated so only one direction is emitted per memory pair.
-func detectSupersedeCandidates(summaries []apptypes.MemorySummary, duplicateBuckets map[duplicateKey][]apptypes.MemorySummary, threshold float64) []apptypes.MemoryHygieneSuggestion {
-	if threshold <= 0 || threshold > 1 {
+		}}
+	default:
 		return nil
 	}
-	exactDuplicatePairs := make(map[string]struct{}, len(duplicateBuckets))
-	for _, bucket := range duplicateBuckets {
-		if len(bucket) < 2 {
-			continue
-		}
-		for i := range bucket {
-			for j := i + 1; j < len(bucket); j++ {
-				exactDuplicatePairs[pairKey(bucket[i].MemoryID().String(), bucket[j].MemoryID().String())] = struct{}{}
-			}
-		}
-	}
-
-	scopeGroups := make(map[string][]apptypes.MemorySummary, len(summaries))
-	for _, summary := range summaries {
-		if summary.Scope() == nil {
-			continue
-		}
-		key := string(summary.Scope().Kind()) + "|" + summary.Scope().Key()
-		scopeGroups[key] = append(scopeGroups[key], summary)
-	}
-
-	var suggestions []apptypes.MemoryHygieneSuggestion
-	for _, group := range scopeGroups {
-		if len(group) < 2 {
-			continue
-		}
-		wordSets := make([]map[string]struct{}, len(group))
-		for i, summary := range group {
-			wordSets[i] = toWordSet(summary.Fact())
-		}
-		for i := 0; i < len(group); i++ {
-			for j := i + 1; j < len(group); j++ {
-				if group[i].Fact() == group[j].Fact() {
-					continue
-				}
-				if _, ok := exactDuplicatePairs[pairKey(group[i].MemoryID().String(), group[j].MemoryID().String())]; ok {
-					continue
-				}
-				sim := jaccardSimilarity(wordSets[i], wordSets[j])
-				if sim < threshold {
-					continue
-				}
-				older, newer := group[i], group[j]
-				if older.UpdatedAt().After(newer.UpdatedAt()) {
-					older, newer = newer, older
-				} else if older.UpdatedAt().Equal(newer.UpdatedAt()) {
-					// Tiebreak on memory id so two memories with the
-					// exact same updated_at (common when the store is
-					// bulk-imported in a single transaction) produce
-					// deterministic suggestions on every scan run.
-					if older.MemoryID().String() > newer.MemoryID().String() {
-						older, newer = newer, older
-					}
-				}
-				suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
-					MemoryID:            older.MemoryID(),
-					Kind:                apptypes.MemoryHygieneSuggestionSupersedeCandidate,
-					Reason:              fmt.Sprintf("scope overlap with %s at similarity %.2f", newer.MemoryID().String(), sim),
-					Fact:                older.Fact(),
-					ReplacementMemoryID: newer.MemoryID(),
-					ReplacementFact:     newer.Fact(),
-					Similarity:          sim,
-					Scope:               older.Scope(),
-					UpdatedAt:           older.UpdatedAt(),
-				})
-			}
-		}
-	}
-	return suggestions
 }
 
-// classifyValidityAnnotatedPairs groups accepted memories by
-// (scope, type), inspects each pair whose similarity meets the
-// threshold and where at least one side carries an explicit valid_to,
-// and returns:
-//
-//   - validity_overlap_supersede suggestions for pairs whose windows
-//     overlap under half-open semantics (aligned with runtime validity
-//     evaluation), and
-//   - a set of pair keys whose windows are disjoint under the same
-//     semantics. The caller excludes those pairs from the generic
-//     supersede_candidate pass: they are separate historical facts
-//     the operator intentionally time-bounded, not merge candidates.
-//
-// Pairs where neither side carries an explicit valid_to fall through
-// (not reported in either output) so the caller's supersede_candidate
-// pipeline still handles them.
-func classifyValidityAnnotatedPairs(
-	summaries []apptypes.MemorySummary,
+func (u *memoryHygieneUsecase) acceptedRowHygieneMatches(
+	summary apptypes.MemorySummary,
+	now time.Time,
+	staleness time.Duration,
+) []memoryHygieneMatch {
+	sanitized, _, _, err := sanitizeMemoryPayload(summary.Fact(), nil, nil, u.extraRedactPatterns)
+	if err != nil {
+		return []memoryHygieneMatch{{
+			MemoryID:  summary.MemoryID(),
+			Kind:      apptypes.MemoryHygieneSuggestionRedactionHit,
+			Reason:    "sanitizer could not evaluate this fact",
+			rawFact:   summary.Fact(),
+			Scope:     summary.Scope(),
+			UpdatedAt: summary.UpdatedAt(),
+		}}
+	}
+	matches := make([]memoryHygieneMatch, 0, 2)
+	if sanitized != summary.Fact() {
+		matches = append(matches, memoryHygieneMatch{
+			MemoryID:      summary.MemoryID(),
+			Kind:          apptypes.MemoryHygieneSuggestionRedactionHit,
+			Reason:        "current redaction patterns mask this fact",
+			rawFact:       summary.Fact(),
+			sanitizedFact: sanitized,
+			Scope:         summary.Scope(),
+			UpdatedAt:     summary.UpdatedAt(),
+		})
+	}
+	if now.Sub(summary.UpdatedAt()) > staleness {
+		matches = append(matches, memoryHygieneMatch{
+			MemoryID:  summary.MemoryID(),
+			Kind:      apptypes.MemoryHygieneSuggestionExpiryCandidate,
+			Reason:    fmt.Sprintf("no updates for more than %s", staleness),
+			rawFact:   summary.Fact(),
+			Scope:     summary.Scope(),
+			UpdatedAt: summary.UpdatedAt(),
+		})
+	}
+	return matches
+}
+
+func similarityPairHygieneMatch(
+	a apptypes.MemorySummary,
+	b apptypes.MemorySummary,
 	threshold float64,
-) ([]apptypes.MemoryHygieneSuggestion, map[string]struct{}) {
-	if threshold <= 0 || threshold > 1 {
-		return nil, nil
+) (memoryHygieneMatch, bool) {
+	if a.Fact() == b.Fact() || threshold <= 0 || threshold > 1 {
+		return memoryHygieneMatch{}, false
 	}
-	disjointPairs := map[string]struct{}{}
+	similarity := jaccardSimilarity(toWordSet(a.Fact()), toWordSet(b.Fact()))
+	if similarity < threshold {
+		return memoryHygieneMatch{}, false
+	}
+	older, newer := orderedMemoryHygienePair(a, b)
+	_, aHasTo := a.ValidTo().Value()
+	_, bHasTo := b.ValidTo().Value()
+	if a.MemoryType() == b.MemoryType() && (aHasTo || bHasTo) {
+		if !validityWindowsOverlap(a, b) {
+			return memoryHygieneMatch{}, false
+		}
+		return memoryHygieneMatch{
+			MemoryID:            older.MemoryID(),
+			Kind:                apptypes.MemoryHygieneSuggestionValidityOverlapSupersede,
+			Reason:              fmt.Sprintf("validity window overlaps %s at similarity %.2f", newer.MemoryID().String(), similarity),
+			rawFact:             older.Fact(),
+			ReplacementMemoryID: newer.MemoryID(),
+			replacementFact:     newer.Fact(),
+			Similarity:          similarity,
+			Scope:               older.Scope(),
+			UpdatedAt:           older.UpdatedAt(),
+		}, true
+	}
+	return memoryHygieneMatch{
+		MemoryID:            older.MemoryID(),
+		Kind:                apptypes.MemoryHygieneSuggestionSupersedeCandidate,
+		Reason:              fmt.Sprintf("scope overlap with %s at similarity %.2f", newer.MemoryID().String(), similarity),
+		rawFact:             older.Fact(),
+		ReplacementMemoryID: newer.MemoryID(),
+		replacementFact:     newer.Fact(),
+		Similarity:          similarity,
+		Scope:               older.Scope(),
+		UpdatedAt:           older.UpdatedAt(),
+	}, true
+}
 
-	type scopeTypeKey struct {
-		ScopeKind  domtypes.MemoryScopeKind
-		ScopeKey   string
-		MemoryType domtypes.MemoryType
+func orderedMemoryHygienePair(a, b apptypes.MemorySummary) (apptypes.MemorySummary, apptypes.MemorySummary) {
+	older, newer := a, b
+	if older.UpdatedAt().After(newer.UpdatedAt()) ||
+		(older.UpdatedAt().Equal(newer.UpdatedAt()) && older.MemoryID().String() > newer.MemoryID().String()) {
+		older, newer = newer, older
 	}
-	groups := make(map[scopeTypeKey][]apptypes.MemorySummary, len(summaries))
-	for _, summary := range summaries {
-		if summary.Scope() == nil {
-			continue
-		}
-		key := scopeTypeKey{
-			ScopeKind:  summary.Scope().Kind(),
-			ScopeKey:   summary.Scope().Key(),
-			MemoryType: summary.MemoryType(),
-		}
-		groups[key] = append(groups[key], summary)
-	}
+	return older, newer
+}
 
-	var suggestions []apptypes.MemoryHygieneSuggestion
-	for _, group := range groups {
-		if len(group) < 2 {
-			continue
-		}
-		wordSets := make([]map[string]struct{}, len(group))
-		for i, summary := range group {
-			wordSets[i] = toWordSet(summary.Fact())
-		}
-		for i := 0; i < len(group); i++ {
-			for j := i + 1; j < len(group); j++ {
-				if group[i].Fact() == group[j].Fact() {
-					continue
-				}
-				_, aHasTo := group[i].ValidTo().Value()
-				_, bHasTo := group[j].ValidTo().Value()
-				// Pairs without any explicit upper bound are handled
-				// by the generic supersede_candidate pipeline — the
-				// operator has not expressed temporal intent yet.
-				if !aHasTo && !bHasTo {
-					continue
-				}
-				sim := jaccardSimilarity(wordSets[i], wordSets[j])
-				if sim < threshold {
-					continue
-				}
-				older, newer := group[i], group[j]
-				if older.UpdatedAt().After(newer.UpdatedAt()) {
-					older, newer = newer, older
-				} else if older.UpdatedAt().Equal(newer.UpdatedAt()) {
-					if older.MemoryID().String() > newer.MemoryID().String() {
-						older, newer = newer, older
-					}
-				}
-				if !validityWindowsOverlap(group[i], group[j]) {
-					// Temporally-bounded but disjoint — historical
-					// fact, exclude from supersede_candidate so the
-					// generic pass cannot report it either.
-					disjointPairs[pairKey(older.MemoryID().String(), newer.MemoryID().String())] = struct{}{}
-					continue
-				}
-				suggestions = append(suggestions, apptypes.MemoryHygieneSuggestion{
-					MemoryID:            older.MemoryID(),
-					Kind:                apptypes.MemoryHygieneSuggestionValidityOverlapSupersede,
-					Reason:              fmt.Sprintf("validity window overlaps %s at similarity %.2f", newer.MemoryID().String(), sim),
-					Fact:                older.Fact(),
-					ReplacementMemoryID: newer.MemoryID(),
-					ReplacementFact:     newer.Fact(),
-					Similarity:          sim,
-					Scope:               older.Scope(),
-					UpdatedAt:           older.UpdatedAt(),
-				})
-			}
-		}
+func (u *memoryHygieneUsecase) safeMemoryHygieneSuggestion(match memoryHygieneMatch) apptypes.MemoryHygieneSuggestion {
+	factPreview, factTruncated := u.safeMemoryHygienePreview(match.rawFact)
+	sanitizedPreview, sanitizedTruncated := "", false
+	if match.sanitizedFact != "" {
+		sanitizedPreview, sanitizedTruncated = u.safeMemoryHygienePreview(match.sanitizedFact)
 	}
-	return suggestions, disjointPairs
+	replacementPreview, replacementTruncated := "", false
+	if match.replacementFact != "" {
+		replacementPreview, replacementTruncated = u.safeMemoryHygienePreview(match.replacementFact)
+	}
+	return apptypes.MemoryHygieneSuggestion{
+		MemoryID:                    match.MemoryID,
+		Kind:                        match.Kind,
+		Reason:                      match.Reason,
+		Fact:                        match.rawFact,
+		FactPreview:                 factPreview,
+		FactPreviewTruncated:        factTruncated,
+		SanitizedFact:               match.sanitizedFact,
+		SanitizedFactPreview:        sanitizedPreview,
+		SanitizedPreviewTruncated:   sanitizedTruncated,
+		DuplicateMemoryID:           match.DuplicateMemoryID,
+		ReplacementMemoryID:         match.ReplacementMemoryID,
+		ReplacementFact:             match.replacementFact,
+		ReplacementFactPreview:      replacementPreview,
+		ReplacementPreviewTruncated: replacementTruncated,
+		Similarity:                  match.Similarity,
+		Scope:                       match.Scope,
+		UpdatedAt:                   match.UpdatedAt,
+		Status:                      match.Status,
+		Source:                      match.Source,
+		QualityReasons:              append([]string(nil), match.QualityReasons...),
+	}
+}
+
+func (u *memoryHygieneUsecase) safeMemoryHygienePreview(raw string) (string, bool) {
+	sanitized, _, _, err := sanitizeMemoryPayload(raw, nil, nil, u.extraRedactPatterns)
+	if err != nil {
+		return "[preview unavailable]", false
+	}
+	return truncateMemoryHygienePreview(sanitized, memoryHygienePreviewMaxBytes)
+}
+
+func truncateMemoryHygienePreview(value string, maxBytes int) (string, bool) {
+	if len(value) <= maxBytes {
+		return value, false
+	}
+	const marker = "…"
+	cut := maxBytes - len(marker)
+	if cut < 0 {
+		cut = 0
+	}
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut] + marker, true
+}
+
+func incrementMemoryHygieneCount(result *apptypes.MemoryHygieneScanResult, kind apptypes.MemoryHygieneSuggestionKind) {
+	switch kind {
+	case apptypes.MemoryHygieneSuggestionRedactionHit:
+		result.RedactionHitCount++
+	case apptypes.MemoryHygieneSuggestionExpiryCandidate:
+		result.ExpiryCandidateCount++
+	case apptypes.MemoryHygieneSuggestionDuplicate:
+		result.DuplicateCount++
+	case apptypes.MemoryHygieneSuggestionSupersedeCandidate:
+		result.SupersedeCandidateCount++
+	case apptypes.MemoryHygieneSuggestionValidityOverlapSupersede:
+		result.ValidityOverlapSupersedeCount++
+	case apptypes.MemoryHygieneSuggestionLowQualityCandidate:
+		result.LowQualityCandidateCount++
+	}
+}
+
+func nextMemoryHygieneScanPhase(phase apptypes.MemoryHygieneScanPhase) (apptypes.MemoryHygieneScanPhase, bool) {
+	switch phase {
+	case apptypes.MemoryHygieneScanPhaseAcceptedRows:
+		return apptypes.MemoryHygieneScanPhaseExactDuplicates, false
+	case apptypes.MemoryHygieneScanPhaseExactDuplicates:
+		return apptypes.MemoryHygieneScanPhaseSimilarityPairs, false
+	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:
+		return apptypes.MemoryHygieneScanPhaseCandidateRows, false
+	case apptypes.MemoryHygieneScanPhaseCandidateRows:
+		return "", true
+	default:
+		return "", true
+	}
+}
+
+func finishPartialMemoryHygieneResult(
+	result apptypes.MemoryHygieneScanResult,
+	reason apptypes.MemoryHygieneStopReason,
+	phase apptypes.MemoryHygieneScanPhase,
+	keyset apptypes.MemoryHygieneScanKeyset,
+	revision domtypes.Optional[int64],
+	digest string,
+	now time.Time,
+	startedAt time.Time,
+) (apptypes.MemoryHygieneScanResult, error) {
+	revisionValue, ok := revision.Value()
+	if !ok {
+		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan stopped before reading a revision")
+	}
+	cursor, err := encodeMemoryHygieneCursor(memoryHygieneCursorPayload{
+		Revision:       revisionValue,
+		CriteriaDigest: digest,
+		ScanAt:         now.UTC().Format(time.RFC3339Nano),
+		Phase:          phase,
+		Keyset:         keyset,
+	})
+	if err != nil {
+		return apptypes.MemoryHygieneScanResult{}, err
+	}
+	result.Complete = false
+	result.Partial = true
+	result.StopReason = reason
+	result.NextCursor = cursor
+	result.Usage.Elapsed = time.Since(startedAt)
+	result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()
+	return result, nil
 }
 
 // validityWindowsOverlap reports whether the half-open temporal
@@ -453,16 +501,6 @@ func validityWindowsOverlap(a, b apptypes.MemorySummary) bool {
 		return false
 	}
 	return true
-}
-
-// pairKey returns a stable key for an unordered pair of memory ids so
-// the duplicate-exclusion set and future pair de-duplication do not
-// depend on traversal order.
-func pairKey(a, b string) string {
-	if a < b {
-		return a + "\x00" + b
-	}
-	return b + "\x00" + a
 }
 
 // toWordSet splits fact text into lowercase word tokens and drops empty
@@ -511,12 +549,6 @@ func jaccardSimilarity(a, b map[string]struct{}) float64 {
 	return float64(intersect) / float64(union)
 }
 
-type duplicateKey struct {
-	ScopeKind domtypes.MemoryScopeKind
-	ScopeKey  string
-	Fact      string
-}
-
 // Apply walks the requested memory ids, re-scans to confirm the
 // transition is still appropriate, and applies the lifecycle verb that
 // matches the suggestion kind. Unknown or stale ids land in Failures so
@@ -532,6 +564,9 @@ func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.Memo
 	})
 	if err != nil {
 		return apptypes.MemoryHygieneApplyResult{}, err
+	}
+	if !scanResult.Complete {
+		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory hygiene apply requires a complete revalidation scan; scan stopped at %s", scanResult.StopReason)
 	}
 	suggestionByID := make(map[string]apptypes.MemoryHygieneSuggestion, len(scanResult.Suggestions))
 	for _, suggestion := range scanResult.Suggestions {
@@ -669,60 +704,4 @@ func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.M
 	default:
 		return apptypes.MemoryHygieneApplied{}, xerrors.Errorf("unknown suggestion kind: %s", suggestion.Kind)
 	}
-}
-
-// loadAcceptedSummaries walks every accepted memory in scope in
-// hygieneScanPageSize-sized pages so a store with more than one page
-// worth of memories is still scanned in full. The scan stops when the
-// datasource returns fewer rows than the requested page size.
-func (u *memoryHygieneUsecase) loadAcceptedSummaries(ctx context.Context, scopes []domtypes.MemoryScope) ([]apptypes.MemorySummary, error) {
-	return u.loadSummariesPage(ctx, scopes, []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}, nil, "accepted")
-}
-
-// loadCandidateSummaries walks every candidate memory in scope and
-// (optional) sources in hygieneScanPageSize-sized pages. Sources is
-// applied as an inclusive filter — passing only MemorySourceExtracted
-// excludes manually-proposed candidates from the noise pass so a
-// reviewer's deliberate proposal is never tagged as low-quality.
-func (u *memoryHygieneUsecase) loadCandidateSummaries(
-	ctx context.Context,
-	scopes []domtypes.MemoryScope,
-	sources []domtypes.MemorySource,
-) ([]apptypes.MemorySummary, error) {
-	return u.loadSummariesPage(ctx, scopes, []domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, sources, "candidate")
-}
-
-func (u *memoryHygieneUsecase) loadSummariesPage(
-	ctx context.Context,
-	scopes []domtypes.MemoryScope,
-	statuses []domtypes.MemoryStatus,
-	sources []domtypes.MemorySource,
-	label string,
-) ([]apptypes.MemorySummary, error) {
-	var all []apptypes.MemorySummary
-	offset := 0
-	for {
-		builder := apptypes.NewMemoryListCriteriaBuilder(hygieneScanPageSize).
-			Offset(offset).
-			Statuses(statuses)
-		if len(scopes) > 0 {
-			builder = builder.Scopes(scopes)
-		}
-		if len(sources) > 0 {
-			builder = builder.Sources(sources)
-		}
-		page, err := u.memoryQuery.List(ctx, builder.Build())
-		if err != nil {
-			return nil, xerrors.Errorf("failed to list %s memories: %w", label, err)
-		}
-		if len(page) == 0 {
-			break
-		}
-		all = append(all, page...)
-		if len(page) < hygieneScanPageSize {
-			break
-		}
-		offset += hygieneScanPageSize
-	}
-	return all, nil
 }

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -549,50 +549,43 @@ func jaccardSimilarity(a, b map[string]struct{}) float64 {
 	return float64(intersect) / float64(union)
 }
 
-// Apply walks the requested memory ids, re-scans to confirm the
-// transition is still appropriate, and applies the lifecycle verb that
-// matches the suggestion kind. Unknown or stale ids land in Failures so
-// the caller sees exactly which memories moved.
+// Apply revalidates only requested memory IDs and their same-scope peers
+// before applying a lifecycle transition. Every requested revalidation must
+// complete at the same revision before the first mutation, so a partial or
+// stale result fails closed without applying a prefix of the request.
 func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.MemoryHygieneApplyCriteria) (apptypes.MemoryHygieneApplyResult, error) {
 	if u.memory == nil {
 		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory usecase is not configured")
 	}
-	scanResult, err := u.Scan(ctx, apptypes.MemoryHygieneScanCriteria{
-		StalenessThreshold:      criteria.StalenessThreshold,
-		Now:                     criteria.Now,
-		IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
-	})
-	if err != nil {
-		return apptypes.MemoryHygieneApplyResult{}, err
-	}
-	if !scanResult.Complete {
-		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory hygiene apply requires a complete revalidation scan; scan stopped at %s", scanResult.StopReason)
-	}
-	suggestionByID := make(map[string]apptypes.MemoryHygieneSuggestion, len(scanResult.Suggestions))
-	for _, suggestion := range scanResult.Suggestions {
-		// Prefer redaction_hit when the same id has multiple
-		// suggestions — rewriting the fact is the safer default
-		// because it also satisfies the duplicate / expiry reasons.
-		if existing, ok := suggestionByID[suggestion.MemoryID.String()]; ok {
-			if existing.Kind == apptypes.MemoryHygieneSuggestionRedactionHit {
-				continue
-			}
-		}
-		suggestionByID[suggestion.MemoryID.String()] = suggestion
+	source, ok := u.memoryQuery.(queryservice.MemoryHygieneScanSource)
+	if !ok {
+		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("bounded memory hygiene revalidation source is not configured")
 	}
 
+	now := criteria.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	staleness := criteria.StalenessThreshold
+	if staleness <= 0 {
+		staleness = defaultStalenessThreshold
+	}
+	budget := apptypes.DefaultMemoryHygieneScanBudget()
+	revalidationCtx, cancel := context.WithTimeout(ctx, budget.MaxDuration())
+	defer cancel()
+
 	result := apptypes.MemoryHygieneApplyResult{}
+	type applyPlan struct {
+		memoryID   domtypes.MemoryID
+		suggestion apptypes.MemoryHygieneSuggestion
+	}
+	plans := make([]applyPlan, 0, len(criteria.MemoryIDs))
+	var revision int64
+	hasRevision := false
+
 	for _, rawID := range criteria.MemoryIDs {
 		trimmed := strings.TrimSpace(rawID)
 		if trimmed == "" {
-			continue
-		}
-		suggestion, ok := suggestionByID[trimmed]
-		if !ok {
-			result.Failures = append(result.Failures, apptypes.MemoryHygieneApplyFailure{
-				MemoryID: trimmed,
-				Error:    "no current hygiene suggestion for this memory",
-			})
 			continue
 		}
 		memoryID, err := domtypes.MemoryIDFrom(trimmed)
@@ -603,10 +596,61 @@ func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.Memo
 			})
 			continue
 		}
-		applied, err := u.applyOne(ctx, memoryID, suggestion)
+
+		revalidation, err := source.RevalidateMemoryHygiene(revalidationCtx, apptypes.MemoryHygieneRevalidationCriteria{
+			MemoryID:                memoryID,
+			IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
+			MaxRows:                 budget.MaxRows(),
+			MaxScanBytes:            budget.MaxScanBytes(),
+			MaxComparisons:          budget.MaxComparisons(),
+		})
+		if !hasRevision {
+			revision = revalidation.Revision
+			hasRevision = true
+		} else if revalidation.Revision != revision {
+			return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("%w", queryservice.ErrMemoryHygieneRevisionChanged)
+		}
 		if err != nil {
+			if errors.Is(err, queryservice.ErrMemoryHygieneRevisionChanged) {
+				return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("failed to revalidate memory hygiene: %w", err)
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(revalidationCtx.Err(), context.DeadlineExceeded) {
+				return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory hygiene apply revalidation stopped at %s", apptypes.MemoryHygieneStopReasonTimeLimit)
+			}
 			result.Failures = append(result.Failures, apptypes.MemoryHygieneApplyFailure{
 				MemoryID: trimmed,
+				Error:    err.Error(),
+			})
+			continue
+		}
+		if !revalidation.Complete {
+			return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory hygiene apply revalidation stopped at %s", revalidation.StopReason)
+		}
+		suggestion, found := u.suggestionForMemoryHygieneRevalidation(
+			revalidation,
+			now,
+			staleness,
+			defaultSupersedeSimilarityThreshold,
+			criteria.IncludeHiddenCandidates,
+		)
+		if !found {
+			result.Failures = append(result.Failures, apptypes.MemoryHygieneApplyFailure{
+				MemoryID: trimmed,
+				Error:    "no current hygiene suggestion for this memory",
+			})
+			continue
+		}
+		plans = append(plans, applyPlan{memoryID: memoryID, suggestion: suggestion})
+	}
+	if errors.Is(revalidationCtx.Err(), context.DeadlineExceeded) {
+		return apptypes.MemoryHygieneApplyResult{}, xerrors.Errorf("memory hygiene apply revalidation stopped at %s", apptypes.MemoryHygieneStopReasonTimeLimit)
+	}
+
+	for _, plan := range plans {
+		applied, err := u.applyOne(ctx, plan.memoryID, plan.suggestion)
+		if err != nil {
+			result.Failures = append(result.Failures, apptypes.MemoryHygieneApplyFailure{
+				MemoryID: plan.memoryID.String(),
 				Error:    err.Error(),
 			})
 			continue
@@ -614,6 +658,72 @@ func (u *memoryHygieneUsecase) Apply(ctx context.Context, criteria apptypes.Memo
 		result.Applied = append(result.Applied, applied)
 	}
 	return result, nil
+}
+
+func (u *memoryHygieneUsecase) suggestionForMemoryHygieneRevalidation(
+	revalidation apptypes.MemoryHygieneRevalidationSourceResult,
+	now time.Time,
+	staleness time.Duration,
+	similarity float64,
+	includeHiddenCandidates bool,
+) (apptypes.MemoryHygieneSuggestion, bool) {
+	target := revalidation.Target
+	var selected memoryHygieneMatch
+	hasSelected := false
+	selectMatch := func(match memoryHygieneMatch) {
+		if hasSelected && selected.Kind == apptypes.MemoryHygieneSuggestionRedactionHit {
+			return
+		}
+		selected = match
+		hasSelected = true
+	}
+
+	switch target.Status() {
+	case domtypes.MemoryStatusAccepted:
+		for _, match := range u.acceptedRowHygieneMatches(target, now, staleness) {
+			selectMatch(match)
+		}
+		if peerID, ok := revalidation.ExactDuplicateMemoryID.Value(); ok {
+			selectMatch(memoryHygieneMatch{
+				MemoryID:          target.MemoryID(),
+				Kind:              apptypes.MemoryHygieneSuggestionDuplicate,
+				Reason:            fmt.Sprintf("shares fact with %s", peerID.String()),
+				rawFact:           target.Fact(),
+				DuplicateMemoryID: peerID,
+				Scope:             target.Scope(),
+				UpdatedAt:         target.UpdatedAt(),
+			})
+		}
+		for _, peer := range revalidation.Peers {
+			match, matched := similarityPairHygieneMatch(target, peer, similarity)
+			if matched && match.MemoryID == target.MemoryID() {
+				selectMatch(match)
+			}
+		}
+	case domtypes.MemoryStatusCandidate:
+		if target.Source() != domtypes.MemorySourceExtracted &&
+			(!includeHiddenCandidates || target.Source() != domtypes.MemorySourceExtractedHidden) {
+			return apptypes.MemoryHygieneSuggestion{}, false
+		}
+		reasons := classifyExtractionNoise(target.Fact())
+		if len(reasons) > 0 {
+			selectMatch(memoryHygieneMatch{
+				MemoryID:       target.MemoryID(),
+				Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
+				Reason:         fmt.Sprintf("low-quality extraction: %s", strings.Join(reasons, ",")),
+				rawFact:        target.Fact(),
+				Scope:          target.Scope(),
+				UpdatedAt:      target.UpdatedAt(),
+				Status:         target.Status(),
+				Source:         target.Source(),
+				QualityReasons: reasons,
+			})
+		}
+	}
+	if !hasSelected {
+		return apptypes.MemoryHygieneSuggestion{}, false
+	}
+	return u.safeMemoryHygieneSuggestion(selected), true
 }
 
 func (u *memoryHygieneUsecase) applyOne(ctx context.Context, memoryID domtypes.MemoryID, suggestion apptypes.MemoryHygieneSuggestion) (apptypes.MemoryHygieneApplied, error) {

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -89,29 +89,34 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	if criteria.Cursor != "" && cursorPayload.CriteriaDigest != digest {
 		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene cursor criteria mismatch")
 	}
+	initialPhase := phase
+	initialKeyset := keyset
 
 	result := apptypes.MemoryHygieneScanResult{Suggestions: []apptypes.MemoryHygieneSuggestion{}}
 	startedAt := time.Now()
+	finishPartial := func(reason apptypes.MemoryHygieneStopReason) (apptypes.MemoryHygieneScanResult, error) {
+		return finishPartialMemoryHygieneResult(result, reason, phase, keyset, revision, digest, now, startedAt, initialPhase, initialKeyset)
+	}
 	scanCtx, cancel := context.WithTimeout(ctx, budget.MaxDuration())
 	defer cancel()
 
 	for {
 		if time.Since(startedAt) >= budget.MaxDuration() {
 			if _, hasRevision := revision.Value(); hasRevision {
-				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
 		}
 		remainingRows := budget.MaxRows() - result.Usage.ScannedRows
 		remainingScanBytes := budget.MaxScanBytes() - result.Usage.ScannedBytes
 		remainingComparisons := budget.MaxComparisons() - result.Usage.Comparisons
 		if remainingRows < 1 {
-			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonRowLimit, phase, keyset, revision, digest, now, startedAt)
+			return finishPartial(apptypes.MemoryHygieneStopReasonRowLimit)
 		}
 		if remainingScanBytes < 1 {
-			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonScanByteLimit, phase, keyset, revision, digest, now, startedAt)
+			return finishPartial(apptypes.MemoryHygieneStopReasonScanByteLimit)
 		}
 		if (phase == apptypes.MemoryHygieneScanPhaseExactDuplicates || phase == apptypes.MemoryHygieneScanPhaseSimilarityPairs) && remainingComparisons < 1 {
-			return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonComparisonLimit, phase, keyset, revision, digest, now, startedAt)
+			return finishPartial(apptypes.MemoryHygieneStopReasonComparisonLimit)
 		}
 		sourceComparisons := remainingComparisons
 		if sourceComparisons < 1 {
@@ -129,7 +134,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		})
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(scanCtx.Err(), context.DeadlineExceeded) {
-				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
 			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("failed to scan memory hygiene source page: %w", err)
 		}
@@ -142,7 +147,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 
 		for _, unit := range page.Units {
 			if time.Since(startedAt) >= budget.MaxDuration() {
-				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonTimeLimit, phase, keyset, revision, digest, now, startedAt)
+				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
 			matches := u.matchesForScanUnit(phase, unit, now, staleness, similarity)
 			safeSuggestions := make([]apptypes.MemoryHygieneSuggestion, 0, len(matches))
@@ -157,7 +162,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 				safeSuggestions = append(safeSuggestions, suggestion)
 			}
 			if result.Usage.ResultBytes+suggestionBytes > budget.MaxResultBytes() {
-				return finishPartialMemoryHygieneResult(result, apptypes.MemoryHygieneStopReasonResultByteLimit, phase, keyset, revision, digest, now, startedAt)
+				return finishPartial(apptypes.MemoryHygieneStopReasonResultByteLimit)
 			}
 			for _, suggestion := range safeSuggestions {
 				result.Suggestions = append(result.Suggestions, suggestion)
@@ -185,7 +190,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		if page.StopReason == "" {
 			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan source stopped without a reason")
 		}
-		return finishPartialMemoryHygieneResult(result, page.StopReason, phase, keyset, revision, digest, now, startedAt)
+		return finishPartial(page.StopReason)
 	}
 }
 
@@ -453,7 +458,12 @@ func finishPartialMemoryHygieneResult(
 	digest string,
 	now time.Time,
 	startedAt time.Time,
+	initialPhase apptypes.MemoryHygieneScanPhase,
+	initialKeyset apptypes.MemoryHygieneScanKeyset,
 ) (apptypes.MemoryHygieneScanResult, error) {
+	if phase == initialPhase && keyset == initialKeyset {
+		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("%w: %s budget stopped before advancing the cursor", queryservice.ErrMemoryHygieneContinuationCannotProgress, reason)
+	}
 	revisionValue, ok := revision.Value()
 	if !ok {
 		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan stopped before reading a revision")

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -38,10 +38,11 @@ const defaultSupersedeSimilarityThreshold = 0.6
 
 const memoryHygienePreviewMaxBytes = 240
 
-// Scan traverses revision-stable source pages until a finite invocation budget
-// is exhausted or all four phases complete. A partial result owns an opaque
-// cursor whose keyset points after the last unit whose suggestions were
-// committed to the result.
+// Scan traverses revision-consistent source pages until a finite invocation
+// budget is exhausted or all four phases complete. A partial result owns an
+// authenticated encrypted cursor whose keyset points after the last unit whose
+// suggestions were committed to the result. A cross-page revision change
+// preserves that keyset but permanently marks the chain best-effort.
 func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
 	source, ok := u.memoryQuery.(queryservice.MemoryHygieneScanSource)
 	if !ok {
@@ -67,6 +68,8 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	phase := apptypes.MemoryHygieneScanPhaseAcceptedRows
 	keyset := apptypes.MemoryHygieneScanKeyset{}
 	revision := domtypes.None[int64]()
+	consistency := apptypes.MemoryHygieneScanConsistencyConsistent
+	var consistencyReason apptypes.MemoryHygieneConsistencyReason
 	var cursorPayload memoryHygieneCursorPayload
 	if criteria.Cursor != "" {
 		decoded, err := decodeMemoryHygieneCursor(criteria.Cursor)
@@ -75,13 +78,12 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		}
 		cursorPayload = decoded
 		cursorTime, _ := time.Parse(time.RFC3339Nano, decoded.ScanAt)
-		if !criteria.Now.IsZero() && !criteria.Now.UTC().Equal(cursorTime) {
-			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene cursor criteria mismatch")
-		}
 		now = cursorTime
 		phase = decoded.Phase
 		keyset = decoded.Keyset
 		revision = domtypes.Some(decoded.Revision)
+		consistency = decoded.Consistency
+		consistencyReason = decoded.ConsistencyReason
 	} else if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -91,11 +93,30 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 	}
 	initialPhase := phase
 	initialKeyset := keyset
+	initialRevision := revision
 
-	result := apptypes.MemoryHygieneScanResult{Suggestions: []apptypes.MemoryHygieneSuggestion{}}
+	result := apptypes.MemoryHygieneScanResult{
+		Suggestions:       []apptypes.MemoryHygieneSuggestion{},
+		Consistency:       consistency,
+		ConsistencyReason: consistencyReason,
+	}
 	startedAt := time.Now()
 	finishPartial := func(reason apptypes.MemoryHygieneStopReason) (apptypes.MemoryHygieneScanResult, error) {
-		return finishPartialMemoryHygieneResult(result, reason, phase, keyset, revision, digest, now, startedAt, initialPhase, initialKeyset)
+		return finishPartialMemoryHygieneResult(
+			result,
+			reason,
+			phase,
+			keyset,
+			revision,
+			consistency,
+			consistencyReason,
+			digest,
+			now,
+			startedAt,
+			initialPhase,
+			initialKeyset,
+			initialRevision,
+		)
 	}
 	scanCtx, cancel := context.WithTimeout(ctx, budget.MaxDuration())
 	defer cancel()
@@ -125,6 +146,7 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		page, err := source.ScanMemoryHygienePage(scanCtx, apptypes.MemoryHygieneScanPageCriteria{
 			Phase:                   phase,
 			Keyset:                  keyset,
+			Consistency:             consistency,
 			Scopes:                  criteria.Scopes,
 			IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
 			ExpectedRevision:        revision,
@@ -133,6 +155,18 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 			MaxComparisons:          sourceComparisons,
 		})
 		if err != nil {
+			var revisionChanged *queryservice.MemoryHygieneRevisionChangedError
+			if errors.As(err, &revisionChanged) {
+				if revisionChanged.CurrentRevision < 0 {
+					return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan source returned an invalid revision")
+				}
+				revision = domtypes.Some(revisionChanged.CurrentRevision)
+				consistency = apptypes.MemoryHygieneScanConsistencyBestEffort
+				consistencyReason = apptypes.MemoryHygieneConsistencyReasonRevisionChanged
+				result.Consistency = consistency
+				result.ConsistencyReason = consistencyReason
+				return finishPartial(apptypes.MemoryHygieneStopReasonRevisionChanged)
+			}
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(scanCtx.Err(), context.DeadlineExceeded) {
 				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
@@ -179,6 +213,8 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 				result.Complete = true
 				result.Partial = false
 				result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+				result.Consistency = consistency
+				result.ConsistencyReason = consistencyReason
 				result.Usage.Elapsed = time.Since(startedAt)
 				result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()
 				return result, nil
@@ -455,25 +491,34 @@ func finishPartialMemoryHygieneResult(
 	phase apptypes.MemoryHygieneScanPhase,
 	keyset apptypes.MemoryHygieneScanKeyset,
 	revision domtypes.Optional[int64],
+	consistency apptypes.MemoryHygieneScanConsistency,
+	consistencyReason apptypes.MemoryHygieneConsistencyReason,
 	digest string,
 	now time.Time,
 	startedAt time.Time,
 	initialPhase apptypes.MemoryHygieneScanPhase,
 	initialKeyset apptypes.MemoryHygieneScanKeyset,
+	initialRevision domtypes.Optional[int64],
 ) (apptypes.MemoryHygieneScanResult, error) {
 	if phase == initialPhase && keyset == initialKeyset {
-		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("%w: %s budget stopped before advancing the cursor", queryservice.ErrMemoryHygieneContinuationCannotProgress, reason)
+		revisionValue, hasRevision := revision.Value()
+		initialRevisionValue, hadInitialRevision := initialRevision.Value()
+		if !hasRevision || !hadInitialRevision || revisionValue == initialRevisionValue {
+			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("%w: %s budget stopped before advancing the cursor", queryservice.ErrMemoryHygieneContinuationCannotProgress, reason)
+		}
 	}
 	revisionValue, ok := revision.Value()
 	if !ok {
 		return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("memory hygiene scan stopped before reading a revision")
 	}
 	cursor, err := encodeMemoryHygieneCursor(memoryHygieneCursorPayload{
-		Revision:       revisionValue,
-		CriteriaDigest: digest,
-		ScanAt:         now.UTC().Format(time.RFC3339Nano),
-		Phase:          phase,
-		Keyset:         keyset,
+		Revision:          revisionValue,
+		CriteriaDigest:    digest,
+		ScanAt:            now.UTC().Format(time.RFC3339Nano),
+		Phase:             phase,
+		Keyset:            keyset,
+		Consistency:       consistency,
+		ConsistencyReason: consistencyReason,
 	})
 	if err != nil {
 		return apptypes.MemoryHygieneScanResult{}, err
@@ -481,6 +526,8 @@ func finishPartialMemoryHygieneResult(
 	result.Complete = false
 	result.Partial = true
 	result.StopReason = reason
+	result.Consistency = consistency
+	result.ConsistencyReason = consistencyReason
 	result.NextCursor = cursor
 	result.Usage.Elapsed = time.Since(startedAt)
 	result.Usage.ElapsedMillis = result.Usage.Elapsed.Milliseconds()

--- a/application/usecase/memory_hygiene.go
+++ b/application/usecase/memory_hygiene.go
@@ -42,7 +42,8 @@ const memoryHygienePreviewMaxBytes = 240
 // budget is exhausted or all four phases complete. A partial result owns an
 // authenticated encrypted cursor whose keyset points after the last unit whose
 // suggestions were committed to the result. A cross-page revision change
-// preserves that keyset but permanently marks the chain best-effort.
+// preserves that keyset, permanently marks the chain best-effort, and retries
+// the same source page inside the remaining invocation budget.
 func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
 	source, ok := u.memoryQuery.(queryservice.MemoryHygieneScanSource)
 	if !ok {
@@ -143,18 +144,24 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 		if sourceComparisons < 1 {
 			sourceComparisons = 1
 		}
-		page, err := source.ScanMemoryHygienePage(scanCtx, apptypes.MemoryHygieneScanPageCriteria{
-			Phase:                   phase,
-			Keyset:                  keyset,
-			Consistency:             consistency,
-			Scopes:                  criteria.Scopes,
-			IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
-			ExpectedRevision:        revision,
-			MaxRows:                 remainingRows,
-			MaxScanBytes:            remainingScanBytes,
-			MaxComparisons:          sourceComparisons,
-		})
-		if err != nil {
+		var page apptypes.MemoryHygieneScanSourcePage
+		revisionChangedWhileRetrying := false
+		for {
+			var err error
+			page, err = source.ScanMemoryHygienePage(scanCtx, apptypes.MemoryHygieneScanPageCriteria{
+				Phase:                   phase,
+				Keyset:                  keyset,
+				Consistency:             consistency,
+				Scopes:                  criteria.Scopes,
+				IncludeHiddenCandidates: criteria.IncludeHiddenCandidates,
+				ExpectedRevision:        revision,
+				MaxRows:                 remainingRows,
+				MaxScanBytes:            remainingScanBytes,
+				MaxComparisons:          sourceComparisons,
+			})
+			if err == nil {
+				break
+			}
 			var revisionChanged *queryservice.MemoryHygieneRevisionChangedError
 			if errors.As(err, &revisionChanged) {
 				if revisionChanged.CurrentRevision < 0 {
@@ -165,9 +172,16 @@ func (u *memoryHygieneUsecase) Scan(ctx context.Context, criteria apptypes.Memor
 				consistencyReason = apptypes.MemoryHygieneConsistencyReasonRevisionChanged
 				result.Consistency = consistency
 				result.ConsistencyReason = consistencyReason
-				return finishPartial(apptypes.MemoryHygieneStopReasonRevisionChanged)
+				revisionChangedWhileRetrying = true
+				if errors.Is(scanCtx.Err(), context.DeadlineExceeded) || time.Since(startedAt) >= budget.MaxDuration() {
+					return finishPartial(apptypes.MemoryHygieneStopReasonRevisionChanged)
+				}
+				continue
 			}
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(scanCtx.Err(), context.DeadlineExceeded) {
+				if revisionChangedWhileRetrying {
+					return finishPartial(apptypes.MemoryHygieneStopReasonRevisionChanged)
+				}
 				return finishPartial(apptypes.MemoryHygieneStopReasonTimeLimit)
 			}
 			return apptypes.MemoryHygieneScanResult{}, xerrors.Errorf("failed to scan memory hygiene source page: %w", err)

--- a/application/usecase/memory_hygiene_cursor.go
+++ b/application/usecase/memory_hygiene_cursor.go
@@ -1,0 +1,163 @@
+package usecase
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+const (
+	memoryHygieneCursorVersion   = 1
+	maxMemoryHygieneCursorLength = 4096
+)
+
+type memoryHygieneCursorPayload struct {
+	Version        int                              `json:"v"`
+	Revision       int64                            `json:"r"`
+	CriteriaDigest string                           `json:"c"`
+	ScanAt         string                           `json:"at"`
+	Phase          apptypes.MemoryHygieneScanPhase  `json:"p"`
+	Keyset         apptypes.MemoryHygieneScanKeyset `json:"k"`
+}
+
+type memoryHygieneCursorEnvelope struct {
+	Payload  memoryHygieneCursorPayload `json:"payload"`
+	Checksum string                     `json:"checksum"`
+}
+
+func encodeMemoryHygieneCursor(payload memoryHygieneCursorPayload) (string, error) {
+	payload.Version = memoryHygieneCursorVersion
+	checksum, err := memoryHygieneCursorChecksum(payload)
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(memoryHygieneCursorEnvelope{Payload: payload, Checksum: checksum})
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode memory hygiene cursor")
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func decodeMemoryHygieneCursor(encoded string) (memoryHygieneCursorPayload, error) {
+	if encoded == "" || len(encoded) > maxMemoryHygieneCursorLength {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	var envelope memoryHygieneCursorEnvelope
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&envelope); err != nil {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	payload := envelope.Payload
+	if payload.Version != memoryHygieneCursorVersion ||
+		payload.Revision < 0 ||
+		!payload.Phase.IsKnown() ||
+		!validMemoryHygieneCriteriaDigest(payload.CriteriaDigest) ||
+		!validMemoryHygieneCursorKeyset(payload.Phase, payload.Keyset) {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("unsupported memory hygiene cursor")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.ScanAt); err != nil {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	wantChecksum, err := memoryHygieneCursorChecksum(payload)
+	if err != nil || subtle.ConstantTimeCompare([]byte(envelope.Checksum), []byte(wantChecksum)) != 1 {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor checksum")
+	}
+	return payload, nil
+}
+
+func validMemoryHygieneCriteriaDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func validMemoryHygieneCursorKeyset(
+	phase apptypes.MemoryHygieneScanPhase,
+	keyset apptypes.MemoryHygieneScanKeyset,
+) bool {
+	for _, value := range []string{keyset.AfterMemoryID, keyset.AnchorMemoryID, keyset.AfterPartnerID} {
+		if value == "" {
+			continue
+		}
+		if _, err := domtypes.MemoryIDFrom(value); err != nil {
+			return false
+		}
+	}
+	switch phase {
+	case apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		apptypes.MemoryHygieneScanPhaseExactDuplicates,
+		apptypes.MemoryHygieneScanPhaseCandidateRows:
+		return keyset.AnchorMemoryID == "" && keyset.AfterPartnerID == ""
+	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:
+		if keyset.AnchorMemoryID == "" {
+			return keyset.AfterPartnerID == ""
+		}
+		if keyset.AfterPartnerID == "" || keyset.AnchorMemoryID >= keyset.AfterPartnerID {
+			return false
+		}
+		return keyset.AfterMemoryID == "" || keyset.AfterMemoryID < keyset.AnchorMemoryID
+	default:
+		return false
+	}
+}
+
+func memoryHygieneCursorChecksum(payload memoryHygieneCursorPayload) (string, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", xerrors.Errorf("failed to checksum memory hygiene cursor")
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:16]), nil
+}
+
+func memoryHygieneCriteriaDigest(
+	scopes []domtypes.MemoryScope,
+	staleness time.Duration,
+	similarity float64,
+	includeHidden bool,
+) string {
+	normalizedScopes := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if scope == nil {
+			continue
+		}
+		normalizedScopes = append(normalizedScopes, scope.Kind().String()+"\x00"+scope.Key())
+	}
+	sort.Strings(normalizedScopes)
+	payload := struct {
+		Scopes        []string `json:"scopes"`
+		Staleness     int64    `json:"staleness_ns"`
+		Similarity    string   `json:"similarity"`
+		IncludeHidden bool     `json:"include_hidden"`
+	}{
+		Scopes:        normalizedScopes,
+		Staleness:     int64(staleness),
+		Similarity:    strconv.FormatFloat(similarity, 'g', -1, 64),
+		IncludeHidden: includeHidden,
+	}
+	raw, _ := json.Marshal(payload)
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}

--- a/application/usecase/memory_hygiene_cursor.go
+++ b/application/usecase/memory_hygiene_cursor.go
@@ -1,56 +1,84 @@
 package usecase
 
 import (
-	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"io"
 	"sort"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
 const (
-	memoryHygieneCursorVersion   = 1
-	maxMemoryHygieneCursorLength = 4096
+	memoryHygieneCursorVersion        = 2
+	maxMemoryHygieneCursorLength      = 4096
+	memoryHygieneCursorAdditionalData = "traceary:memory-hygiene-cursor:v2"
 )
 
 type memoryHygieneCursorPayload struct {
-	Version        int                              `json:"v"`
-	Revision       int64                            `json:"r"`
-	CriteriaDigest string                           `json:"c"`
-	ScanAt         string                           `json:"at"`
-	Phase          apptypes.MemoryHygieneScanPhase  `json:"p"`
-	Keyset         apptypes.MemoryHygieneScanKeyset `json:"k"`
+	Version           int                                     `json:"v"`
+	Revision          int64                                   `json:"r"`
+	CriteriaDigest    string                                  `json:"c"`
+	ScanAt            string                                  `json:"at"`
+	Phase             apptypes.MemoryHygieneScanPhase         `json:"p"`
+	Keyset            apptypes.MemoryHygieneScanKeyset        `json:"k"`
+	Consistency       apptypes.MemoryHygieneScanConsistency   `json:"s"`
+	ConsistencyReason apptypes.MemoryHygieneConsistencyReason `json:"sr,omitempty"`
 }
 
-type memoryHygieneCursorEnvelope struct {
-	Payload  memoryHygieneCursorPayload `json:"payload"`
-	Checksum string                     `json:"checksum"`
-}
+var loadMemoryHygieneCursorAEAD = sync.OnceValues(func() (cipher.AEAD, error) {
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, xerrors.Errorf("failed to generate memory hygiene cursor key: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to initialize memory hygiene cursor cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to initialize memory hygiene cursor authentication: %w", err)
+	}
+	return aead, nil
+})
 
 func encodeMemoryHygieneCursor(payload memoryHygieneCursorPayload) (string, error) {
 	payload.Version = memoryHygieneCursorVersion
-	checksum, err := memoryHygieneCursorChecksum(payload)
+	aead, err := loadMemoryHygieneCursorAEAD()
 	if err != nil {
 		return "", err
 	}
-	encoded, err := json.Marshal(memoryHygieneCursorEnvelope{Payload: payload, Checksum: checksum})
+	return encodeMemoryHygieneCursorWithAEAD(payload, aead)
+}
+
+func encodeMemoryHygieneCursorWithAEAD(payload memoryHygieneCursorPayload, aead cipher.AEAD) (string, error) {
+	plaintext, err := json.Marshal(payload)
 	if err != nil {
 		return "", xerrors.Errorf("failed to encode memory hygiene cursor")
 	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", xerrors.Errorf("failed to generate memory hygiene cursor nonce: %w", err)
+	}
+	encoded := aead.Seal(nonce, nonce, plaintext, []byte(memoryHygieneCursorAdditionalData))
 	return base64.RawURLEncoding.EncodeToString(encoded), nil
 }
 
 func decodeMemoryHygieneCursor(encoded string) (memoryHygieneCursorPayload, error) {
+	encoded = strings.TrimSpace(encoded)
 	if encoded == "" || len(encoded) > maxMemoryHygieneCursorLength {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
 	}
@@ -58,31 +86,61 @@ func decodeMemoryHygieneCursor(encoded string) (memoryHygieneCursorPayload, erro
 	if err != nil {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
 	}
-	var envelope memoryHygieneCursorEnvelope
-	decoder := json.NewDecoder(bytes.NewReader(raw))
+	aead, err := loadMemoryHygieneCursorAEAD()
+	if err != nil {
+		return memoryHygieneCursorPayload{}, err
+	}
+	return decodeMemoryHygieneCursorWithAEAD(raw, aead)
+}
+
+func decodeMemoryHygieneCursorWithAEAD(raw []byte, aead cipher.AEAD) (memoryHygieneCursorPayload, error) {
+	if len(raw) < aead.NonceSize()+aead.Overhead() {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
+	}
+	nonce := raw[:aead.NonceSize()]
+	plaintext, err := aead.Open(nil, nonce, raw[aead.NonceSize():], []byte(memoryHygieneCursorAdditionalData))
+	if err != nil {
+		return memoryHygieneCursorPayload{}, xerrors.Errorf(
+			"%w: cursor cannot be authenticated; start a new scan because it may have been modified or issued before this server or CLI process restarted",
+			queryservice.ErrMemoryHygieneRescanRequired,
+		)
+	}
+	var payload memoryHygieneCursorPayload
+	decoder := json.NewDecoder(strings.NewReader(string(plaintext)))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&envelope); err != nil {
+	if err := decoder.Decode(&payload); err != nil {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
 	}
-	payload := envelope.Payload
 	if payload.Version != memoryHygieneCursorVersion ||
 		payload.Revision < 0 ||
 		!payload.Phase.IsKnown() ||
 		!validMemoryHygieneCriteriaDigest(payload.CriteriaDigest) ||
-		!validMemoryHygieneCursorKeyset(payload.Phase, payload.Keyset) {
+		!validMemoryHygieneCursorKeyset(payload.Phase, payload.Keyset) ||
+		!validMemoryHygieneCursorConsistency(payload.Consistency, payload.ConsistencyReason) {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("unsupported memory hygiene cursor")
 	}
-	if _, err := time.Parse(time.RFC3339Nano, payload.ScanAt); err != nil {
+	scanAt, err := time.Parse(time.RFC3339Nano, payload.ScanAt)
+	if err != nil || scanAt.IsZero() {
 		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor")
 	}
-	wantChecksum, err := memoryHygieneCursorChecksum(payload)
-	if err != nil || subtle.ConstantTimeCompare([]byte(envelope.Checksum), []byte(wantChecksum)) != 1 {
-		return memoryHygieneCursorPayload{}, xerrors.Errorf("invalid memory hygiene cursor checksum")
-	}
 	return payload, nil
+}
+
+func validMemoryHygieneCursorConsistency(
+	consistency apptypes.MemoryHygieneScanConsistency,
+	reason apptypes.MemoryHygieneConsistencyReason,
+) bool {
+	switch consistency {
+	case apptypes.MemoryHygieneScanConsistencyConsistent:
+		return reason == ""
+	case apptypes.MemoryHygieneScanConsistencyBestEffort:
+		return reason == apptypes.MemoryHygieneConsistencyReasonRevisionChanged
+	default:
+		return false
+	}
 }
 
 func validMemoryHygieneCriteriaDigest(value string) bool {
@@ -121,15 +179,6 @@ func validMemoryHygieneCursorKeyset(
 	default:
 		return false
 	}
-}
-
-func memoryHygieneCursorChecksum(payload memoryHygieneCursorPayload) (string, error) {
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return "", xerrors.Errorf("failed to checksum memory hygiene cursor")
-	}
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:16]), nil
 }
 
 func memoryHygieneCriteriaDigest(

--- a/application/usecase/memory_hygiene_cursor_test.go
+++ b/application/usecase/memory_hygiene_cursor_test.go
@@ -1,0 +1,196 @@
+package usecase
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+func TestMemoryHygieneCursor_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	payload := memoryHygieneCursorPayload{
+		Version:        memoryHygieneCursorVersion,
+		Revision:       42,
+		CriteriaDigest: strings.Repeat("a", 64),
+		ScanAt:         time.Date(2026, 7, 26, 8, 0, 0, 123, time.UTC).Format(time.RFC3339Nano),
+		Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		Keyset: apptypes.MemoryHygieneScanKeyset{
+			AfterMemoryID:  "mem-a",
+			AnchorMemoryID: "mem-b",
+			AfterPartnerID: "mem-c",
+		},
+	}
+	cursor, err := encodeMemoryHygieneCursor(payload)
+	if err != nil {
+		t.Fatalf("encodeMemoryHygieneCursor() error = %v", err)
+	}
+	if strings.Contains(cursor, "memory fact") {
+		t.Fatalf("cursor leaked fact text: %q", cursor)
+	}
+	rawCursor, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		t.Fatalf("DecodeString(cursor) error = %v", err)
+	}
+	if strings.Contains(string(rawCursor), "fact") {
+		t.Fatalf("decoded cursor contains a fact field: %s", rawCursor)
+	}
+	got, err := decodeMemoryHygieneCursor(cursor)
+	if err != nil {
+		t.Fatalf("decodeMemoryHygieneCursor() error = %v", err)
+	}
+	if got != payload {
+		t.Fatalf("decoded payload = %#v, want %#v", got, payload)
+	}
+}
+
+func TestMemoryHygieneCursor_RejectsTamperingWithoutEchoingInput(t *testing.T) {
+	t.Parallel()
+
+	cursor, err := encodeMemoryHygieneCursor(memoryHygieneCursorPayload{
+		Revision:       9,
+		CriteriaDigest: strings.Repeat("b", 64),
+		ScanAt:         "2026-07-26T00:00:00Z",
+		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+	})
+	if err != nil {
+		t.Fatalf("encodeMemoryHygieneCursor() error = %v", err)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	var envelope memoryHygieneCursorEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	envelope.Payload.Revision++
+	tamperedRaw, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	tampered := base64.RawURLEncoding.EncodeToString(tamperedRaw)
+	_, err = decodeMemoryHygieneCursor(tampered)
+	if err == nil {
+		t.Fatal("decodeMemoryHygieneCursor() error = nil, want checksum error")
+	}
+	if strings.Contains(err.Error(), tampered) {
+		t.Fatalf("error echoed opaque cursor: %v", err)
+	}
+}
+
+func TestMemoryHygieneCursor_RejectsUnknownPhaseAndVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]memoryHygieneCursorEnvelope{
+		"version": {
+			Payload: memoryHygieneCursorPayload{
+				Version:        2,
+				Revision:       1,
+				CriteriaDigest: strings.Repeat("c", 64),
+				ScanAt:         "2026-07-26T00:00:00Z",
+				Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+			},
+		},
+		"phase": {
+			Payload: memoryHygieneCursorPayload{
+				Version:        memoryHygieneCursorVersion,
+				Revision:       1,
+				CriteriaDigest: strings.Repeat("d", 64),
+				ScanAt:         "2026-07-26T00:00:00Z",
+				Phase:          apptypes.MemoryHygieneScanPhase("unknown"),
+			},
+		},
+	}
+	for name, envelope := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			checksum, err := memoryHygieneCursorChecksum(envelope.Payload)
+			if err != nil {
+				t.Fatalf("memoryHygieneCursorChecksum() error = %v", err)
+			}
+			envelope.Checksum = checksum
+			raw, err := json.Marshal(envelope)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			_, err = decodeMemoryHygieneCursor(base64.RawURLEncoding.EncodeToString(raw))
+			if err == nil {
+				t.Fatal("decodeMemoryHygieneCursor() error = nil, want validation error")
+			}
+		})
+	}
+}
+
+func TestMemoryHygieneCursor_RejectsInconsistentKeyset(t *testing.T) {
+	t.Parallel()
+
+	payload := memoryHygieneCursorPayload{
+		Version:        memoryHygieneCursorVersion,
+		Revision:       1,
+		CriteriaDigest: strings.Repeat("e", 64),
+		ScanAt:         "2026-07-26T00:00:00Z",
+		Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		Keyset: apptypes.MemoryHygieneScanKeyset{
+			AfterMemoryID:  "mem-b",
+			AnchorMemoryID: "mem-a",
+			AfterPartnerID: "mem-c",
+		},
+	}
+	checksum, err := memoryHygieneCursorChecksum(payload)
+	if err != nil {
+		t.Fatalf("memoryHygieneCursorChecksum() error = %v", err)
+	}
+	raw, err := json.Marshal(memoryHygieneCursorEnvelope{Payload: payload, Checksum: checksum})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if _, err := decodeMemoryHygieneCursor(base64.RawURLEncoding.EncodeToString(raw)); err == nil {
+		t.Fatal("decodeMemoryHygieneCursor() error = nil, want inconsistent-keyset error")
+	}
+}
+
+func TestMemoryHygieneCriteriaDigest_IsOrderIndependentAndCriteriaBound(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := domtypes.WorkspaceFrom("github.com/duck8823/traceary")
+	if err != nil {
+		t.Fatalf("WorkspaceFrom() error = %v", err)
+	}
+	agent, err := domtypes.AgentFrom("codex")
+	if err != nil {
+		t.Fatalf("AgentFrom() error = %v", err)
+	}
+	workspaceScope := domtypes.WorkspaceScopeOf(workspace)
+	agentScope := domtypes.AgentScopeOf(agent)
+
+	first := memoryHygieneCriteriaDigest(
+		[]domtypes.MemoryScope{workspaceScope, agentScope},
+		90*24*time.Hour,
+		0.6,
+		false,
+	)
+	reordered := memoryHygieneCriteriaDigest(
+		[]domtypes.MemoryScope{agentScope, workspaceScope},
+		90*24*time.Hour,
+		0.6,
+		false,
+	)
+	if first != reordered {
+		t.Fatalf("criteria digest depends on scope order: %q != %q", first, reordered)
+	}
+	changed := memoryHygieneCriteriaDigest(
+		[]domtypes.MemoryScope{workspaceScope, agentScope},
+		30*24*time.Hour,
+		0.6,
+		false,
+	)
+	if first == changed {
+		t.Fatal("criteria digest did not bind staleness threshold")
+	}
+}

--- a/application/usecase/memory_hygiene_cursor_test.go
+++ b/application/usecase/memory_hygiene_cursor_test.go
@@ -1,12 +1,16 @@
 package usecase
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
@@ -25,20 +29,21 @@ func TestMemoryHygieneCursor_RoundTrip(t *testing.T) {
 			AnchorMemoryID: "mem-b",
 			AfterPartnerID: "mem-c",
 		},
+		Consistency: apptypes.MemoryHygieneScanConsistencyConsistent,
 	}
 	cursor, err := encodeMemoryHygieneCursor(payload)
 	if err != nil {
 		t.Fatalf("encodeMemoryHygieneCursor() error = %v", err)
 	}
-	if strings.Contains(cursor, "memory fact") {
-		t.Fatalf("cursor leaked fact text: %q", cursor)
+	if strings.Contains(cursor, "mem-b") || strings.Contains(cursor, payload.CriteriaDigest) {
+		t.Fatalf("cursor leaked plaintext fields: %q", cursor)
 	}
 	rawCursor, err := base64.RawURLEncoding.DecodeString(cursor)
 	if err != nil {
 		t.Fatalf("DecodeString(cursor) error = %v", err)
 	}
-	if strings.Contains(string(rawCursor), "fact") {
-		t.Fatalf("decoded cursor contains a fact field: %s", rawCursor)
+	if strings.Contains(string(rawCursor), "mem-b") || strings.Contains(string(rawCursor), payload.CriteriaDigest) {
+		t.Fatal("decoded cursor exposed plaintext fields")
 	}
 	got, err := decodeMemoryHygieneCursor(cursor)
 	if err != nil {
@@ -57,6 +62,7 @@ func TestMemoryHygieneCursor_RejectsTamperingWithoutEchoingInput(t *testing.T) {
 		CriteriaDigest: strings.Repeat("b", 64),
 		ScanAt:         "2026-07-26T00:00:00Z",
 		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		Consistency:    apptypes.MemoryHygieneScanConsistencyConsistent,
 	})
 	if err != nil {
 		t.Fatalf("encodeMemoryHygieneCursor() error = %v", err)
@@ -65,61 +71,96 @@ func TestMemoryHygieneCursor_RejectsTamperingWithoutEchoingInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeString() error = %v", err)
 	}
-	var envelope memoryHygieneCursorEnvelope
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		t.Fatalf("json.Unmarshal() error = %v", err)
-	}
-	envelope.Payload.Revision++
-	tamperedRaw, err := json.Marshal(envelope)
-	if err != nil {
-		t.Fatalf("json.Marshal() error = %v", err)
-	}
-	tampered := base64.RawURLEncoding.EncodeToString(tamperedRaw)
+	raw[len(raw)-1] ^= 0x01
+	tampered := base64.RawURLEncoding.EncodeToString(raw)
 	_, err = decodeMemoryHygieneCursor(tampered)
-	if err == nil {
-		t.Fatal("decodeMemoryHygieneCursor() error = nil, want checksum error")
+	if !errors.Is(err, queryservice.ErrMemoryHygieneRescanRequired) {
+		t.Fatalf("decodeMemoryHygieneCursor() error = %v, want rescan required", err)
 	}
 	if strings.Contains(err.Error(), tampered) {
 		t.Fatalf("error echoed opaque cursor: %v", err)
+	}
+	if !strings.Contains(err.Error(), "start a new scan") {
+		t.Fatalf("authentication error has no rescan guidance: %v", err)
+	}
+}
+
+func TestMemoryHygieneCursor_RejectsEarlierProcessAndLegacyChecksumCursor(t *testing.T) {
+	t.Parallel()
+
+	foreignAEAD := newMemoryHygieneTestAEAD(t, 1)
+	foreign, err := encodeMemoryHygieneCursorWithAEAD(memoryHygieneCursorPayload{
+		Version:        memoryHygieneCursorVersion,
+		Revision:       1,
+		CriteriaDigest: strings.Repeat("c", 64),
+		ScanAt:         "2026-07-26T00:00:00Z",
+		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		Consistency:    apptypes.MemoryHygieneScanConsistencyConsistent,
+	}, foreignAEAD)
+	if err != nil {
+		t.Fatalf("encodeMemoryHygieneCursorWithAEAD() error = %v", err)
+	}
+	if _, err := decodeMemoryHygieneCursor(foreign); !errors.Is(err, queryservice.ErrMemoryHygieneRescanRequired) ||
+		!strings.Contains(err.Error(), "process restarted") {
+		t.Fatalf("earlier-process cursor error = %v, want restart rescan guidance", err)
+	}
+
+	legacyRaw, err := json.Marshal(struct {
+		Payload  map[string]any `json:"payload"`
+		Checksum string         `json:"checksum"`
+	}{
+		Payload: map[string]any{
+			"v": 1, "r": 1, "c": strings.Repeat("d", 64), "at": "2026-07-26T00:00:00Z",
+			"p": "accepted_rows", "k": map[string]any{},
+		},
+		Checksum: strings.Repeat("0", 32),
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(legacy cursor) error = %v", err)
+	}
+	legacy := base64.RawURLEncoding.EncodeToString(legacyRaw)
+	if _, err := decodeMemoryHygieneCursor(legacy); !errors.Is(err, queryservice.ErrMemoryHygieneRescanRequired) {
+		t.Fatalf("legacy cursor error = %v, want rescan required", err)
 	}
 }
 
 func TestMemoryHygieneCursor_RejectsUnknownPhaseAndVersion(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]memoryHygieneCursorEnvelope{
+	aead, err := loadMemoryHygieneCursorAEAD()
+	if err != nil {
+		t.Fatalf("loadMemoryHygieneCursorAEAD() error = %v", err)
+	}
+	tests := map[string]memoryHygieneCursorPayload{
 		"version": {
-			Payload: memoryHygieneCursorPayload{
-				Version:        2,
-				Revision:       1,
-				CriteriaDigest: strings.Repeat("c", 64),
-				ScanAt:         "2026-07-26T00:00:00Z",
-				Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
-			},
+			Version:        2,
+			Revision:       1,
+			CriteriaDigest: strings.Repeat("c", 64),
+			ScanAt:         "2026-07-26T00:00:00Z",
+			Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+			Consistency:    apptypes.MemoryHygieneScanConsistencyConsistent,
 		},
 		"phase": {
-			Payload: memoryHygieneCursorPayload{
-				Version:        memoryHygieneCursorVersion,
-				Revision:       1,
-				CriteriaDigest: strings.Repeat("d", 64),
-				ScanAt:         "2026-07-26T00:00:00Z",
-				Phase:          apptypes.MemoryHygieneScanPhase("unknown"),
-			},
+			Version:        memoryHygieneCursorVersion,
+			Revision:       1,
+			CriteriaDigest: strings.Repeat("d", 64),
+			ScanAt:         "2026-07-26T00:00:00Z",
+			Phase:          apptypes.MemoryHygieneScanPhase("unknown"),
+			Consistency:    apptypes.MemoryHygieneScanConsistencyConsistent,
 		},
 	}
-	for name, envelope := range tests {
+	tests["version"] = func(payload memoryHygieneCursorPayload) memoryHygieneCursorPayload {
+		payload.Version = memoryHygieneCursorVersion + 1
+		return payload
+	}(tests["version"])
+	for name, payload := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			checksum, err := memoryHygieneCursorChecksum(envelope.Payload)
+			encoded, err := encodeMemoryHygieneCursorWithAEAD(payload, aead)
 			if err != nil {
-				t.Fatalf("memoryHygieneCursorChecksum() error = %v", err)
+				t.Fatalf("encodeMemoryHygieneCursorWithAEAD() error = %v", err)
 			}
-			envelope.Checksum = checksum
-			raw, err := json.Marshal(envelope)
-			if err != nil {
-				t.Fatalf("json.Marshal() error = %v", err)
-			}
-			_, err = decodeMemoryHygieneCursor(base64.RawURLEncoding.EncodeToString(raw))
+			_, err = decodeMemoryHygieneCursor(encoded)
 			if err == nil {
 				t.Fatal("decodeMemoryHygieneCursor() error = nil, want validation error")
 			}
@@ -141,17 +182,52 @@ func TestMemoryHygieneCursor_RejectsInconsistentKeyset(t *testing.T) {
 			AnchorMemoryID: "mem-a",
 			AfterPartnerID: "mem-c",
 		},
+		Consistency: apptypes.MemoryHygieneScanConsistencyConsistent,
 	}
-	checksum, err := memoryHygieneCursorChecksum(payload)
+	aead, err := loadMemoryHygieneCursorAEAD()
 	if err != nil {
-		t.Fatalf("memoryHygieneCursorChecksum() error = %v", err)
+		t.Fatalf("loadMemoryHygieneCursorAEAD() error = %v", err)
 	}
-	raw, err := json.Marshal(memoryHygieneCursorEnvelope{Payload: payload, Checksum: checksum})
+	encoded, err := encodeMemoryHygieneCursorWithAEAD(payload, aead)
 	if err != nil {
-		t.Fatalf("json.Marshal() error = %v", err)
+		t.Fatalf("encodeMemoryHygieneCursorWithAEAD() error = %v", err)
 	}
-	if _, err := decodeMemoryHygieneCursor(base64.RawURLEncoding.EncodeToString(raw)); err == nil {
+	if _, err := decodeMemoryHygieneCursor(encoded); err == nil {
 		t.Fatal("decodeMemoryHygieneCursor() error = nil, want inconsistent-keyset error")
+	}
+}
+
+func TestMemoryHygieneCursor_RejectsInconsistentConsistencyState(t *testing.T) {
+	t.Parallel()
+
+	aead, err := loadMemoryHygieneCursorAEAD()
+	if err != nil {
+		t.Fatalf("loadMemoryHygieneCursorAEAD() error = %v", err)
+	}
+	tests := map[string]memoryHygieneCursorPayload{
+		"consistent with reason": {
+			Version: memoryHygieneCursorVersion, Revision: 1, CriteriaDigest: strings.Repeat("f", 64),
+			ScanAt: "2026-07-26T00:00:00Z", Phase: apptypes.MemoryHygieneScanPhaseAcceptedRows,
+			Consistency:       apptypes.MemoryHygieneScanConsistencyConsistent,
+			ConsistencyReason: apptypes.MemoryHygieneConsistencyReasonRevisionChanged,
+		},
+		"best effort without reason": {
+			Version: memoryHygieneCursorVersion, Revision: 1, CriteriaDigest: strings.Repeat("f", 64),
+			ScanAt: "2026-07-26T00:00:00Z", Phase: apptypes.MemoryHygieneScanPhaseAcceptedRows,
+			Consistency: apptypes.MemoryHygieneScanConsistencyBestEffort,
+		},
+	}
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			encoded, encodeErr := encodeMemoryHygieneCursorWithAEAD(payload, aead)
+			if encodeErr != nil {
+				t.Fatalf("encodeMemoryHygieneCursorWithAEAD() error = %v", encodeErr)
+			}
+			if _, decodeErr := decodeMemoryHygieneCursor(encoded); decodeErr == nil {
+				t.Fatal("decodeMemoryHygieneCursor() error = nil, want consistency validation error")
+			}
+		})
 	}
 }
 
@@ -193,4 +269,19 @@ func TestMemoryHygieneCriteriaDigest_IsOrderIndependentAndCriteriaBound(t *testi
 	if first == changed {
 		t.Fatal("criteria digest did not bind staleness threshold")
 	}
+}
+
+func newMemoryHygieneTestAEAD(t *testing.T, firstByte byte) cipher.AEAD {
+	t.Helper()
+	key := make([]byte, 32)
+	key[0] = firstByte
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher() error = %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("cipher.NewGCM() error = %v", err)
+	}
+	return aead
 }

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -545,6 +545,109 @@ func TestMemoryHygieneScan_RowBoundContinuationHasNoDuplicateOrSkippedCandidate(
 	}
 }
 
+func TestMemoryHygieneScan_RevisionChangeReturnsStickyBestEffortContinuation(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		scanRevision: 1,
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-a", scope, "git status", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-b", scope, "go test ./...", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-c", scope, "gh pr checks", domtypes.MemorySourceExtracted, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	criteria := apptypes.MemoryHygieneScanCriteria{
+		Now:    now,
+		Budget: memoryHygieneTestBudget(t, 2, 1<<20, 100),
+	}
+
+	first, err := sut.Scan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if !first.Partial || first.Consistency != apptypes.MemoryHygieneScanConsistencyConsistent ||
+		first.StopReason != apptypes.MemoryHygieneStopReasonRowLimit || first.NextCursor == "" {
+		t.Fatalf("first result = %#v, want consistent row-bound continuation", first)
+	}
+
+	query.scanRevision = 2
+	criteria.Cursor = first.NextCursor
+	second, err := sut.Scan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("revision-changed Scan() error = %v", err)
+	}
+	if !second.Partial || second.StopReason != apptypes.MemoryHygieneStopReasonRevisionChanged ||
+		second.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort ||
+		second.ConsistencyReason != apptypes.MemoryHygieneConsistencyReasonRevisionChanged ||
+		second.NextCursor == "" || second.NextCursor == first.NextCursor {
+		t.Fatalf("revision-changed result = %#v, want rebound best-effort continuation", second)
+	}
+	if second.Usage.ScannedRows != 0 || len(second.Suggestions) != 0 {
+		t.Fatalf("revision change consumed source units: %#v", second)
+	}
+
+	criteria.Cursor = second.NextCursor
+	third, err := sut.Scan(context.Background(), criteria)
+	if err != nil {
+		t.Fatalf("best-effort resume Scan() error = %v", err)
+	}
+	if !third.Complete || third.Partial ||
+		third.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort ||
+		third.ConsistencyReason != apptypes.MemoryHygieneConsistencyReasonRevisionChanged {
+		t.Fatalf("best-effort completion did not retain downgrade: %#v", third)
+	}
+	if len(third.Suggestions) != 1 || third.Suggestions[0].MemoryID.String() != "mem-c" {
+		t.Fatalf("best-effort resume suggestions = %#v, want remaining mem-c", third.Suggestions)
+	}
+	lastCriteria := query.scanPageCriteria[len(query.scanPageCriteria)-1]
+	if lastCriteria.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort {
+		t.Fatalf("source consistency = %q, want best_effort", lastCriteria.Consistency)
+	}
+}
+
+func TestMemoryHygieneScan_ContinuationUsesAuthenticatedInitialScanTime(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	initialNow := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			acceptedSummaryAt(t, "mem-a", scope, "fact a", initialNow),
+			acceptedSummaryAt(t, "mem-b", scope, "fact b", initialNow),
+			acceptedSummaryAt(t, "mem-c", scope, "fact c", initialNow),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	budget := memoryHygieneTestBudget(t, 2, 1<<20, 100)
+	first, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now: initialNow, Budget: budget,
+	})
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first Scan() returned no continuation")
+	}
+
+	resumed, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now:    initialNow.Add(365 * 24 * time.Hour),
+		Budget: budget,
+		Cursor: first.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("resumed Scan() error = %v", err)
+	}
+	for _, suggestion := range resumed.Suggestions {
+		if suggestion.MemoryID.String() == "mem-c" &&
+			suggestion.Kind == apptypes.MemoryHygieneSuggestionExpiryCandidate {
+			t.Fatalf("continuation used caller time instead of authenticated scan time: %#v", suggestion)
+		}
+	}
+}
+
 func TestMemoryHygieneScan_ResultByteLimitWithoutCursorProgressReturnsTypedError(t *testing.T) {
 	t.Parallel()
 

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -545,7 +545,7 @@ func TestMemoryHygieneScan_RowBoundContinuationHasNoDuplicateOrSkippedCandidate(
 	}
 }
 
-func TestMemoryHygieneScan_RevisionChangeReturnsStickyBestEffortContinuation(t *testing.T) {
+func TestMemoryHygieneScan_RevisionChangeRetriesSamePageAndKeepsBestEffort(t *testing.T) {
 	t.Parallel()
 
 	scope := workspaceScope(t, "github.com/example/repo")
@@ -575,36 +575,98 @@ func TestMemoryHygieneScan_RevisionChangeReturnsStickyBestEffortContinuation(t *
 
 	query.scanRevision = 2
 	criteria.Cursor = first.NextCursor
+	callsBeforeResume := query.scanPageCalls
 	second, err := sut.Scan(context.Background(), criteria)
 	if err != nil {
 		t.Fatalf("revision-changed Scan() error = %v", err)
 	}
-	if !second.Partial || second.StopReason != apptypes.MemoryHygieneStopReasonRevisionChanged ||
+	if !second.Complete || second.Partial || second.StopReason != apptypes.MemoryHygieneStopReasonComplete ||
 		second.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort ||
 		second.ConsistencyReason != apptypes.MemoryHygieneConsistencyReasonRevisionChanged ||
-		second.NextCursor == "" || second.NextCursor == first.NextCursor {
-		t.Fatalf("revision-changed result = %#v, want rebound best-effort continuation", second)
+		second.NextCursor != "" {
+		t.Fatalf("revision-changed result = %#v, want in-loop best-effort completion", second)
 	}
-	if second.Usage.ScannedRows != 0 || len(second.Suggestions) != 0 {
-		t.Fatalf("revision change consumed source units: %#v", second)
+	if second.Usage.ScannedRows != 1 || len(second.Suggestions) != 1 ||
+		second.Suggestions[0].MemoryID.String() != "mem-c" {
+		t.Fatalf("revision change did not retry the retained page: %#v", second)
+	}
+	if query.scanPageCalls != callsBeforeResume+2 {
+		t.Fatalf("source calls after revision change = %d, want mismatch plus same-page retry", query.scanPageCalls-callsBeforeResume)
+	}
+	mismatchCriteria := query.scanPageCriteria[callsBeforeResume]
+	retryCriteria := query.scanPageCriteria[callsBeforeResume+1]
+	if mismatchCriteria.Phase != retryCriteria.Phase ||
+		mismatchCriteria.Keyset != retryCriteria.Keyset ||
+		mismatchCriteria.MaxRows != retryCriteria.MaxRows ||
+		mismatchCriteria.MaxScanBytes != retryCriteria.MaxScanBytes ||
+		mismatchCriteria.MaxComparisons != retryCriteria.MaxComparisons {
+		t.Fatalf("same-page retry changed invocation budget/keyset: mismatch=%#v retry=%#v", mismatchCriteria, retryCriteria)
+	}
+	expectedRevision, ok := retryCriteria.ExpectedRevision.Value()
+	if !ok || expectedRevision != 2 {
+		t.Fatalf("retry expected revision = %v/%t, want 2/true", expectedRevision, ok)
+	}
+	if retryCriteria.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort {
+		t.Fatalf("retry consistency = %q, want best_effort", retryCriteria.Consistency)
+	}
+}
+
+func TestMemoryHygieneScan_RevisionChurnReturnsPartialOnlyAfterDurationExhausts(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		scanRevision: 1,
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-a", scope, "git status", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-b", scope, "go test ./...", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-c", scope, "gh pr checks", domtypes.MemorySourceExtracted, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	first, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now:    now,
+		Budget: memoryHygieneTestBudget(t, 2, 1<<20, 100),
+	})
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first Scan() returned no continuation cursor")
 	}
 
-	criteria.Cursor = second.NextCursor
-	third, err := sut.Scan(context.Background(), criteria)
+	shortBudget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        2,
+		MaxScanBytes:   1 << 20,
+		MaxResultBytes: 1 << 20,
+		MaxComparisons: 100,
+		MaxDuration:    time.Millisecond,
+	})
 	if err != nil {
-		t.Fatalf("best-effort resume Scan() error = %v", err)
+		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
 	}
-	if !third.Complete || third.Partial ||
-		third.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort ||
-		third.ConsistencyReason != apptypes.MemoryHygieneConsistencyReasonRevisionChanged {
-		t.Fatalf("best-effort completion did not retain downgrade: %#v", third)
+	query.advanceScanRevision = true
+	query.scanDelay = 5 * time.Millisecond
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Cursor: first.NextCursor,
+		Budget: shortBudget,
+	})
+	if err != nil {
+		t.Fatalf("revision-churn Scan() error = %v", err)
 	}
-	if len(third.Suggestions) != 1 || third.Suggestions[0].MemoryID.String() != "mem-c" {
-		t.Fatalf("best-effort resume suggestions = %#v, want remaining mem-c", third.Suggestions)
+	if !result.Partial || result.Complete ||
+		result.StopReason != apptypes.MemoryHygieneStopReasonRevisionChanged ||
+		result.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort ||
+		result.ConsistencyReason != apptypes.MemoryHygieneConsistencyReasonRevisionChanged ||
+		result.NextCursor == "" {
+		t.Fatalf("revision-churn result = %#v, want bounded best-effort continuation", result)
 	}
-	lastCriteria := query.scanPageCriteria[len(query.scanPageCriteria)-1]
-	if lastCriteria.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort {
-		t.Fatalf("source consistency = %q, want best_effort", lastCriteria.Consistency)
+	if result.Usage.Elapsed < shortBudget.MaxDuration() {
+		t.Fatalf("revision-churn elapsed = %s, want exhausted duration >= %s", result.Usage.Elapsed, shortBudget.MaxDuration())
+	}
+	if result.Usage.ScannedRows != 0 || len(result.Suggestions) != 0 {
+		t.Fatalf("revision churn consumed source units before page retry: %#v", result)
 	}
 }
 

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -952,6 +952,80 @@ func TestMemoryHygieneApply_RejectsLowQualityCandidate(t *testing.T) {
 	if len(rejected) != 1 || rejected[0] != "mem-noise" {
 		t.Fatalf("rejected ids = %v, want [mem-noise]", rejected)
 	}
+	if query.scanPageCalls != 0 || len(query.revalidationCalls) != 1 {
+		t.Fatalf("scan/revalidation calls = %d/%d, want 0/1", query.scanPageCalls, len(query.revalidationCalls))
+	}
+}
+
+func TestMemoryHygieneApply_FailsClosedBeforeMutationWhenAnyTargetIsPartial(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	first := candidateSummary(t, "mem-first", scope, "+def first():", domtypes.MemorySourceExtracted, now)
+	second := candidateSummary(t, "mem-second", scope, "+def second():", domtypes.MemorySourceExtracted, now)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{first, second},
+		revalidationResults: map[string]apptypes.MemoryHygieneRevalidationSourceResult{
+			"mem-second": {
+				Revision:   1,
+				Target:     second,
+				Complete:   false,
+				StopReason: apptypes.MemoryHygieneStopReasonRowLimit,
+			},
+		},
+	}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{
+		"mem-first":  "+def first():",
+		"mem-second": "+def second():",
+	})
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	_, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"mem-first", "mem-second"},
+		Now:       now,
+	})
+	if err == nil || !strings.Contains(err.Error(), "row_limit") {
+		t.Fatalf("Apply() error = %v, want partial row_limit failure", err)
+	}
+	if rejected := repo.rejectedIDs(); len(rejected) != 0 {
+		t.Fatalf("rejected ids = %v, want none before all revalidations complete", rejected)
+	}
+	if query.scanPageCalls != 0 || len(query.revalidationCalls) != 2 {
+		t.Fatalf("scan/revalidation calls = %d/%d, want 0/2", query.scanPageCalls, len(query.revalidationCalls))
+	}
+}
+
+func TestMemoryHygieneApply_FailsClosedWhenTargetRevisionsDiffer(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	first := candidateSummary(t, "mem-first", scope, "+def first():", domtypes.MemorySourceExtracted, now)
+	second := candidateSummary(t, "mem-second", scope, "+def second():", domtypes.MemorySourceExtracted, now)
+	query := &stubMemoryQueryService{
+		summaries:             []apptypes.MemorySummary{first, second},
+		revalidationRevisions: []int64{7, 8},
+	}
+	repo := newCandidateApplyMemoryRepository(t, scope, map[string]string{
+		"mem-first":  "+def first():",
+		"mem-second": "+def second():",
+	})
+	sut := usecase.NewMemoryUsecase(repo, query, nil)
+
+	_, err := sut.Apply(context.Background(), apptypes.MemoryHygieneApplyCriteria{
+		MemoryIDs: []string{"mem-first", "mem-second"},
+		Now:       now,
+	})
+	if err == nil || !strings.Contains(err.Error(), "revision changed") {
+		t.Fatalf("Apply() error = %v, want stale revision failure", err)
+	}
+	if rejected := repo.rejectedIDs(); len(rejected) != 0 {
+		t.Fatalf("rejected ids = %v, want none after stale revalidation", rejected)
+	}
+	if query.scanPageCalls != 0 || len(query.revalidationCalls) != 2 {
+		t.Fatalf("scan/revalidation calls = %d/%d, want 0/2", query.scanPageCalls, len(query.revalidationCalls))
+	}
 }
 
 func TestMemoryHygieneApply_AcceptedMemoriesUntouchedByCandidatePath(t *testing.T) {

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -3,11 +3,13 @@ package usecase_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
@@ -543,14 +545,14 @@ func TestMemoryHygieneScan_RowBoundContinuationHasNoDuplicateOrSkippedCandidate(
 	}
 }
 
-func TestMemoryHygieneScan_ResultByteStopCanResumeWithLargerBudget(t *testing.T) {
+func TestMemoryHygieneScan_ResultByteLimitWithoutCursorProgressReturnsTypedError(t *testing.T) {
 	t.Parallel()
 
 	scope := workspaceScope(t, "github.com/example/repo")
 	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
 	query := &stubMemoryQueryService{
 		summaries: []apptypes.MemorySummary{
-			candidateSummary(t, "mem-noise", scope, "git status", domtypes.MemorySourceExtracted, now),
+			acceptedSummaryAt(t, "mem-noise", scope, "git status", now.Add(-365*24*time.Hour)),
 		},
 	}
 	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
@@ -559,24 +561,11 @@ func TestMemoryHygieneScan_ResultByteStopCanResumeWithLargerBudget(t *testing.T)
 		Budget: memoryHygieneTestBudget(t, 2, 1, 100),
 	}
 	first, err := sut.Scan(context.Background(), limited)
-	if err != nil {
-		t.Fatalf("first Scan() error = %v", err)
+	if !errors.Is(err, queryservice.ErrMemoryHygieneContinuationCannotProgress) {
+		t.Fatalf("Scan() error = %v, want ErrMemoryHygieneContinuationCannotProgress", err)
 	}
-	if !first.Partial || first.StopReason != apptypes.MemoryHygieneStopReasonResultByteLimit || first.NextCursor == "" {
-		t.Fatalf("first result = %#v, want resumable result_byte_limit", first)
-	}
-	if len(first.Suggestions) != 0 || first.Usage.ResultBytes != 0 {
-		t.Fatalf("first result crossed byte bound: suggestions=%d bytes=%d", len(first.Suggestions), first.Usage.ResultBytes)
-	}
-
-	limited.Cursor = first.NextCursor
-	limited.Budget = memoryHygieneTestBudget(t, 2, 1<<20, 100)
-	second, err := sut.Scan(context.Background(), limited)
-	if err != nil {
-		t.Fatalf("resumed Scan() error = %v", err)
-	}
-	if len(second.Suggestions) != 1 || second.Suggestions[0].MemoryID.String() != "mem-noise" {
-		t.Fatalf("resumed suggestions = %#v, want mem-noise", second.Suggestions)
+	if first.NextCursor != "" || first.Partial {
+		t.Fatalf("non-progressing result = %#v, want no resumable cursor", first)
 	}
 }
 
@@ -612,10 +601,16 @@ func TestMemoryHygieneScan_CursorIsBoundToCriteria(t *testing.T) {
 	}
 }
 
-func TestMemoryHygieneScan_TimeBoundReturnsResumablePartialAfterRevisionCapture(t *testing.T) {
+func TestMemoryHygieneScan_TimeLimitWithoutCursorProgressReturnsTypedError(t *testing.T) {
 	t.Parallel()
 
-	query := &stubMemoryQueryService{scanDelay: 5 * time.Millisecond}
+	scope := workspaceScope(t, "github.com/example/repo")
+	query := &stubMemoryQueryService{
+		scanDelay: 5 * time.Millisecond,
+		summaries: []apptypes.MemorySummary{
+			acceptedSummaryAt(t, "mem-a", scope, "git status", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
 	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
 	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
 		MaxRows:        2,
@@ -631,11 +626,11 @@ func TestMemoryHygieneScan_TimeBoundReturnsResumablePartialAfterRevisionCapture(
 		Now:    time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
 		Budget: budget,
 	})
-	if err != nil {
-		t.Fatalf("Scan() error = %v", err)
+	if !errors.Is(err, queryservice.ErrMemoryHygieneContinuationCannotProgress) {
+		t.Fatalf("Scan() error = %v, want ErrMemoryHygieneContinuationCannotProgress", err)
 	}
-	if !result.Partial || result.StopReason != apptypes.MemoryHygieneStopReasonTimeLimit || result.NextCursor == "" {
-		t.Fatalf("time-bounded result = %#v, want resumable time_limit", result)
+	if result.NextCursor != "" || result.Partial {
+		t.Fatalf("non-progressing result = %#v, want no resumable cursor", result)
 	}
 }
 

--- a/application/usecase/memory_usecase_hygiene_test.go
+++ b/application/usecase/memory_usecase_hygiene_test.go
@@ -2,14 +2,37 @@ package usecase_test
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
+
+func memoryHygieneTestBudget(
+	t *testing.T,
+	rows int,
+	resultBytes int64,
+	comparisons int,
+) apptypes.MemoryHygieneScanBudget {
+	t.Helper()
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        rows,
+		MaxScanBytes:   1 << 20,
+		MaxResultBytes: resultBytes,
+		MaxComparisons: comparisons,
+		MaxDuration:    time.Second,
+	})
+	if err != nil {
+		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
+	}
+	return budget
+}
 
 func acceptedSummaryAt(t *testing.T, id string, scope domtypes.MemoryScope, fact string, updatedAt time.Time) apptypes.MemorySummary {
 	t.Helper()
@@ -470,6 +493,196 @@ func TestMemoryHygieneScan_EmptyStoreReturnsEmptyResult(t *testing.T) {
 	}
 	if result.RedactionHitCount+result.ExpiryCandidateCount+result.DuplicateCount+result.LowQualityCandidateCount != 0 {
 		t.Fatalf("expected zero counts across all suggestion kinds, got r=%d e=%d d=%d l=%d", result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.LowQualityCandidateCount)
+	}
+}
+
+func TestMemoryHygieneScan_RowBoundContinuationHasNoDuplicateOrSkippedCandidate(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-a", scope, "git status", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-b", scope, "go test ./...", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-c", scope, "gh pr checks", domtypes.MemorySourceExtracted, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	budget := memoryHygieneTestBudget(t, 2, 1<<20, 100)
+	criteria := apptypes.MemoryHygieneScanCriteria{Now: now, Budget: budget}
+
+	var ids []string
+	for invocation := 0; invocation < 10; invocation++ {
+		result, err := sut.Scan(context.Background(), criteria)
+		if err != nil {
+			t.Fatalf("Scan(invocation=%d) error = %v", invocation, err)
+		}
+		if result.Usage.ScannedRows > budget.MaxRows() {
+			t.Fatalf("ScannedRows = %d, max = %d", result.Usage.ScannedRows, budget.MaxRows())
+		}
+		for _, suggestion := range result.Suggestions {
+			if suggestion.Kind == apptypes.MemoryHygieneSuggestionLowQualityCandidate {
+				ids = append(ids, suggestion.MemoryID.String())
+			}
+		}
+		if result.Complete {
+			if result.Partial || result.NextCursor != "" || result.StopReason != apptypes.MemoryHygieneStopReasonComplete {
+				t.Fatalf("complete result has inconsistent coverage: %#v", result)
+			}
+			break
+		}
+		if !result.Partial || result.StopReason != apptypes.MemoryHygieneStopReasonRowLimit || result.NextCursor == "" {
+			t.Fatalf("partial result has inconsistent coverage: %#v", result)
+		}
+		criteria.Cursor = result.NextCursor
+	}
+	want := []string{"mem-a", "mem-b", "mem-c"}
+	if strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Fatalf("candidate ids across continuations = %v, want %v", ids, want)
+	}
+}
+
+func TestMemoryHygieneScan_ResultByteStopCanResumeWithLargerBudget(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-noise", scope, "git status", domtypes.MemorySourceExtracted, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	limited := apptypes.MemoryHygieneScanCriteria{
+		Now:    now,
+		Budget: memoryHygieneTestBudget(t, 2, 1, 100),
+	}
+	first, err := sut.Scan(context.Background(), limited)
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if !first.Partial || first.StopReason != apptypes.MemoryHygieneStopReasonResultByteLimit || first.NextCursor == "" {
+		t.Fatalf("first result = %#v, want resumable result_byte_limit", first)
+	}
+	if len(first.Suggestions) != 0 || first.Usage.ResultBytes != 0 {
+		t.Fatalf("first result crossed byte bound: suggestions=%d bytes=%d", len(first.Suggestions), first.Usage.ResultBytes)
+	}
+
+	limited.Cursor = first.NextCursor
+	limited.Budget = memoryHygieneTestBudget(t, 2, 1<<20, 100)
+	second, err := sut.Scan(context.Background(), limited)
+	if err != nil {
+		t.Fatalf("resumed Scan() error = %v", err)
+	}
+	if len(second.Suggestions) != 1 || second.Suggestions[0].MemoryID.String() != "mem-noise" {
+		t.Fatalf("resumed suggestions = %#v, want mem-noise", second.Suggestions)
+	}
+}
+
+func TestMemoryHygieneScan_CursorIsBoundToCriteria(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			candidateSummary(t, "mem-a", scope, "git status", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-b", scope, "go test ./...", domtypes.MemorySourceExtracted, now),
+			candidateSummary(t, "mem-c", scope, "gh pr checks", domtypes.MemorySourceExtracted, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	budget := memoryHygieneTestBudget(t, 2, 1<<20, 100)
+	first, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: now, Budget: budget})
+	if err != nil {
+		t.Fatalf("first Scan() error = %v", err)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first scan returned no cursor")
+	}
+	_, err = sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now:                     now,
+		Budget:                  budget,
+		Cursor:                  first.NextCursor,
+		IncludeHiddenCandidates: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "criteria mismatch") {
+		t.Fatalf("criteria-mismatched continuation error = %v, want mismatch", err)
+	}
+}
+
+func TestMemoryHygieneScan_TimeBoundReturnsResumablePartialAfterRevisionCapture(t *testing.T) {
+	t.Parallel()
+
+	query := &stubMemoryQueryService{scanDelay: 5 * time.Millisecond}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, nil)
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        2,
+		MaxScanBytes:   1 << 20,
+		MaxResultBytes: 1 << 20,
+		MaxComparisons: 1,
+		MaxDuration:    time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("MemoryHygieneScanBudgetFrom() error = %v", err)
+	}
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{
+		Now:    time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+		Budget: budget,
+	})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if !result.Partial || result.StopReason != apptypes.MemoryHygieneStopReasonTimeLimit || result.NextCursor == "" {
+		t.Fatalf("time-bounded result = %#v, want resumable time_limit", result)
+	}
+}
+
+func TestMemoryHygieneScan_PreviewsAreSanitizedBoundedAndJSONSafe(t *testing.T) {
+	t.Parallel()
+
+	scope := workspaceScope(t, "github.com/example/repo")
+	now := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	const secret = "internal-token-8675309"
+	rawFact := "keep " + secret + " " + strings.Repeat("日本語", 200)
+	query := &stubMemoryQueryService{
+		summaries: []apptypes.MemorySummary{
+			acceptedSummaryAt(t, "mem-secret", scope, rawFact, now),
+		},
+	}
+	sut := usecase.NewMemoryUsecase(&stubImportMemoryUsecase{}, query, []string{`internal-token-\d+`})
+
+	result, err := sut.Scan(context.Background(), apptypes.MemoryHygieneScanCriteria{Now: now})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if !result.Complete {
+		t.Fatalf("Complete = false, stop = %s", result.StopReason)
+	}
+	if len(result.Suggestions) != 1 {
+		t.Fatalf("Suggestions = %d, want one redaction hit", len(result.Suggestions))
+	}
+	suggestion := result.Suggestions[0]
+	if suggestion.Kind != apptypes.MemoryHygieneSuggestionRedactionHit {
+		t.Fatalf("Kind = %q, want redaction_hit", suggestion.Kind)
+	}
+	if strings.Contains(suggestion.FactPreview, secret) || strings.Contains(suggestion.SanitizedFactPreview, secret) {
+		t.Fatalf("preview leaked secret: fact=%q sanitized=%q", suggestion.FactPreview, suggestion.SanitizedFactPreview)
+	}
+	if !suggestion.FactPreviewTruncated || len(suggestion.FactPreview) > 240 || !utf8.ValidString(suggestion.FactPreview) {
+		t.Fatalf("fact preview is not bounded UTF-8: bytes=%d truncated=%t valid=%t",
+			len(suggestion.FactPreview),
+			suggestion.FactPreviewTruncated,
+			utf8.ValidString(suggestion.FactPreview),
+		)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), secret) || strings.Contains(string(encoded), rawFact) {
+		t.Fatalf("serialized result leaked raw fact: %s", encoded)
 	}
 }
 

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
@@ -23,9 +24,12 @@ func (s *stubCodexSource) Load(_ context.Context, _ apptypes.CodexImportCriteria
 }
 
 type stubMemoryQueryService struct {
-	summaries []apptypes.MemorySummary
-	details   map[domtypes.MemoryID]apptypes.MemoryDetails
-	calls     []apptypes.MemoryListCriteria
+	summaries         []apptypes.MemorySummary
+	details           map[domtypes.MemoryID]apptypes.MemoryDetails
+	calls             []apptypes.MemoryListCriteria
+	scanPageCalls     int
+	scanDelay         time.Duration
+	revalidationCalls []apptypes.MemoryHygieneRevalidationCriteria
 }
 
 func (s *stubMemoryQueryService) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -75,6 +79,199 @@ func (s *stubMemoryQueryService) GetDetails(_ context.Context, memoryID domtypes
 		return details, nil
 	}
 	return apptypes.MemoryDetails{}, nil
+}
+
+func (s *stubMemoryQueryService) ScanMemoryHygienePage(
+	_ context.Context,
+	criteria apptypes.MemoryHygieneScanPageCriteria,
+) (apptypes.MemoryHygieneScanSourcePage, error) {
+	s.scanPageCalls++
+	if s.scanDelay > 0 {
+		time.Sleep(s.scanDelay)
+	}
+	page := apptypes.MemoryHygieneScanSourcePage{
+		Revision:       1,
+		ProgressKeyset: criteria.Keyset,
+	}
+	summaries := append([]apptypes.MemorySummary(nil), s.summaries...)
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].MemoryID().String() < summaries[j].MemoryID().String()
+	})
+	inScope := func(summary apptypes.MemorySummary) bool {
+		if len(criteria.Scopes) == 0 {
+			return true
+		}
+		for _, scope := range criteria.Scopes {
+			if scope != nil && summary.Scope().Kind() == scope.Kind() && summary.Scope().Key() == scope.Key() {
+				return true
+			}
+		}
+		return false
+	}
+	charge := func(rows int, bytes int64, comparisons int) bool {
+		if page.ScannedRows+rows > criteria.MaxRows {
+			page.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+			return false
+		}
+		if page.ScannedBytes+bytes > criteria.MaxScanBytes {
+			page.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return false
+		}
+		if page.Comparisons+comparisons > criteria.MaxComparisons {
+			page.StopReason = apptypes.MemoryHygieneStopReasonComparisonLimit
+			return false
+		}
+		page.ScannedRows += rows
+		page.ScannedBytes += bytes
+		page.Comparisons += comparisons
+		return true
+	}
+	rowBytes := func(summary apptypes.MemorySummary) int64 {
+		return int64(len(summary.MemoryID().String()) + len(summary.Fact()) + len(summary.Scope().Key()))
+	}
+
+	switch criteria.Phase {
+	case apptypes.MemoryHygieneScanPhaseAcceptedRows, apptypes.MemoryHygieneScanPhaseCandidateRows:
+		for _, summary := range summaries {
+			if summary.MemoryID().String() <= criteria.Keyset.AfterMemoryID || !inScope(summary) {
+				continue
+			}
+			if criteria.Phase == apptypes.MemoryHygieneScanPhaseAcceptedRows && summary.Status() != domtypes.MemoryStatusAccepted {
+				continue
+			}
+			if criteria.Phase == apptypes.MemoryHygieneScanPhaseCandidateRows {
+				if summary.Status() != domtypes.MemoryStatusCandidate || (summary.Source() != domtypes.MemorySourceExtracted &&
+					(!criteria.IncludeHiddenCandidates || summary.Source() != domtypes.MemorySourceExtractedHidden)) {
+					continue
+				}
+			}
+			if !charge(1, rowBytes(summary), 0) {
+				return page, nil
+			}
+			next := apptypes.MemoryHygieneScanKeyset{AfterMemoryID: summary.MemoryID().String()}
+			page.Units = append(page.Units, apptypes.MemoryHygieneScanUnit{
+				Row: summary, Peer: domtypes.None[apptypes.MemorySummary](),
+				RelatedMemoryID: domtypes.None[domtypes.MemoryID](), NextKeyset: next,
+			})
+			page.ProgressKeyset = next
+		}
+	case apptypes.MemoryHygieneScanPhaseExactDuplicates:
+		for _, summary := range summaries {
+			if summary.MemoryID().String() <= criteria.Keyset.AfterMemoryID ||
+				summary.Status() != domtypes.MemoryStatusAccepted || !inScope(summary) {
+				continue
+			}
+			if !charge(1, rowBytes(summary), 1) {
+				return page, nil
+			}
+			peerID := domtypes.None[domtypes.MemoryID]()
+			for _, peer := range summaries {
+				if peer.MemoryID() != summary.MemoryID() && peer.Status() == domtypes.MemoryStatusAccepted &&
+					peer.Scope().Kind() == summary.Scope().Kind() && peer.Scope().Key() == summary.Scope().Key() &&
+					peer.Fact() == summary.Fact() {
+					peerID = domtypes.Some(peer.MemoryID())
+					break
+				}
+			}
+			next := apptypes.MemoryHygieneScanKeyset{AfterMemoryID: summary.MemoryID().String()}
+			page.Units = append(page.Units, apptypes.MemoryHygieneScanUnit{
+				Row: summary, Peer: domtypes.None[apptypes.MemorySummary](),
+				RelatedMemoryID: peerID, NextKeyset: next,
+			})
+			page.ProgressKeyset = next
+		}
+	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:
+		for i, anchor := range summaries {
+			if anchor.Status() != domtypes.MemoryStatusAccepted || !inScope(anchor) {
+				continue
+			}
+			if criteria.Keyset.AnchorMemoryID == "" && anchor.MemoryID().String() <= criteria.Keyset.AfterMemoryID {
+				continue
+			}
+			if criteria.Keyset.AnchorMemoryID != "" && anchor.MemoryID().String() < criteria.Keyset.AnchorMemoryID {
+				continue
+			}
+			if criteria.Keyset.AnchorMemoryID != "" && anchor.MemoryID().String() > criteria.Keyset.AnchorMemoryID {
+				criteria.Keyset.AfterPartnerID = ""
+			}
+			for j := i + 1; j < len(summaries); j++ {
+				peer := summaries[j]
+				if peer.Status() != domtypes.MemoryStatusAccepted ||
+					peer.Scope().Kind() != anchor.Scope().Kind() || peer.Scope().Key() != anchor.Scope().Key() ||
+					(anchor.MemoryID().String() == criteria.Keyset.AnchorMemoryID && peer.MemoryID().String() <= criteria.Keyset.AfterPartnerID) {
+					continue
+				}
+				if !charge(2, rowBytes(anchor)+rowBytes(peer), 1) {
+					return page, nil
+				}
+				next := apptypes.MemoryHygieneScanKeyset{
+					AfterMemoryID: criteria.Keyset.AfterMemoryID, AnchorMemoryID: anchor.MemoryID().String(),
+					AfterPartnerID: peer.MemoryID().String(),
+				}
+				page.Units = append(page.Units, apptypes.MemoryHygieneScanUnit{
+					Row: anchor, Peer: domtypes.Some(peer),
+					RelatedMemoryID: domtypes.None[domtypes.MemoryID](), NextKeyset: next,
+				})
+				page.ProgressKeyset = next
+			}
+			page.ProgressKeyset = apptypes.MemoryHygieneScanKeyset{AfterMemoryID: anchor.MemoryID().String()}
+			criteria.Keyset = page.ProgressKeyset
+		}
+	}
+	page.Done = true
+	return page, nil
+}
+
+func (s *stubMemoryQueryService) RevalidateMemoryHygiene(
+	_ context.Context,
+	criteria apptypes.MemoryHygieneRevalidationCriteria,
+) (apptypes.MemoryHygieneRevalidationSourceResult, error) {
+	s.revalidationCalls = append(s.revalidationCalls, criteria)
+	var result apptypes.MemoryHygieneRevalidationSourceResult
+	result.Revision = 1
+	for _, summary := range s.summaries {
+		if summary.MemoryID() == criteria.MemoryID {
+			result.Target = summary
+			result.ScannedRows = 1
+			result.ScannedBytes = int64(len(summary.Fact()))
+			break
+		}
+	}
+	if result.Target.MemoryID().String() == "" {
+		return result, errors.New("memory not found")
+	}
+	if result.Target.Status() == domtypes.MemoryStatusAccepted {
+		for _, peer := range s.summaries {
+			if peer.MemoryID() == result.Target.MemoryID() || peer.Status() != domtypes.MemoryStatusAccepted ||
+				peer.Scope().Kind() != result.Target.Scope().Kind() || peer.Scope().Key() != result.Target.Scope().Key() {
+				continue
+			}
+			if result.ScannedRows >= criteria.MaxRows {
+				result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+				return result, nil
+			}
+			if result.Comparisons >= criteria.MaxComparisons {
+				result.StopReason = apptypes.MemoryHygieneStopReasonComparisonLimit
+				return result, nil
+			}
+			if result.ScannedBytes+int64(len(peer.Fact())) > criteria.MaxScanBytes {
+				result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+				return result, nil
+			}
+			result.Peers = append(result.Peers, peer)
+			result.ScannedRows++
+			result.ScannedBytes += int64(len(peer.Fact()))
+			result.Comparisons++
+			if peer.Fact() == result.Target.Fact() {
+				if _, ok := result.ExactDuplicateMemoryID.Value(); !ok {
+					result.ExactDuplicateMemoryID = domtypes.Some(peer.MemoryID())
+				}
+			}
+		}
+	}
+	result.Complete = true
+	result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+	return result, nil
 }
 
 type importProposeCall struct {

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
@@ -28,6 +29,8 @@ type stubMemoryQueryService struct {
 	details               map[domtypes.MemoryID]apptypes.MemoryDetails
 	calls                 []apptypes.MemoryListCriteria
 	scanPageCalls         int
+	scanPageCriteria      []apptypes.MemoryHygieneScanPageCriteria
+	scanRevision          int64
 	scanDelay             time.Duration
 	revalidationCalls     []apptypes.MemoryHygieneRevalidationCriteria
 	revalidationResults   map[string]apptypes.MemoryHygieneRevalidationSourceResult
@@ -89,11 +92,19 @@ func (s *stubMemoryQueryService) ScanMemoryHygienePage(
 	criteria apptypes.MemoryHygieneScanPageCriteria,
 ) (apptypes.MemoryHygieneScanSourcePage, error) {
 	s.scanPageCalls++
+	s.scanPageCriteria = append(s.scanPageCriteria, criteria)
 	if s.scanDelay > 0 {
 		time.Sleep(s.scanDelay)
 	}
+	revision := s.scanRevision
+	if revision == 0 {
+		revision = 1
+	}
+	if expected, ok := criteria.ExpectedRevision.Value(); ok && expected != revision {
+		return apptypes.MemoryHygieneScanSourcePage{}, queryservice.NewMemoryHygieneRevisionChangedError(revision)
+	}
 	page := apptypes.MemoryHygieneScanSourcePage{
-		Revision:       1,
+		Revision:       revision,
 		ProgressKeyset: criteria.Keyset,
 	}
 	summaries := append([]apptypes.MemorySummary(nil), s.summaries...)

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
@@ -31,6 +33,7 @@ type stubMemoryQueryService struct {
 	scanPageCalls         int
 	scanPageCriteria      []apptypes.MemoryHygieneScanPageCriteria
 	scanRevision          int64
+	advanceScanRevision   bool
 	scanDelay             time.Duration
 	revalidationCalls     []apptypes.MemoryHygieneRevalidationCriteria
 	revalidationResults   map[string]apptypes.MemoryHygieneRevalidationSourceResult
@@ -96,12 +99,18 @@ func (s *stubMemoryQueryService) ScanMemoryHygienePage(
 	if s.scanDelay > 0 {
 		time.Sleep(s.scanDelay)
 	}
+	if s.advanceScanRevision {
+		s.scanRevision++
+	}
 	revision := s.scanRevision
 	if revision == 0 {
 		revision = 1
 	}
 	if expected, ok := criteria.ExpectedRevision.Value(); ok && expected != revision {
-		return apptypes.MemoryHygieneScanSourcePage{}, queryservice.NewMemoryHygieneRevisionChangedError(revision)
+		return apptypes.MemoryHygieneScanSourcePage{}, xerrors.Errorf(
+			"stub memory hygiene scan revision changed: %w",
+			queryservice.NewMemoryHygieneRevisionChangedError(revision),
+		)
 	}
 	page := apptypes.MemoryHygieneScanSourcePage{
 		Revision:       revision,

--- a/application/usecase/memory_usecase_import_test.go
+++ b/application/usecase/memory_usecase_import_test.go
@@ -24,12 +24,15 @@ func (s *stubCodexSource) Load(_ context.Context, _ apptypes.CodexImportCriteria
 }
 
 type stubMemoryQueryService struct {
-	summaries         []apptypes.MemorySummary
-	details           map[domtypes.MemoryID]apptypes.MemoryDetails
-	calls             []apptypes.MemoryListCriteria
-	scanPageCalls     int
-	scanDelay         time.Duration
-	revalidationCalls []apptypes.MemoryHygieneRevalidationCriteria
+	summaries             []apptypes.MemorySummary
+	details               map[domtypes.MemoryID]apptypes.MemoryDetails
+	calls                 []apptypes.MemoryListCriteria
+	scanPageCalls         int
+	scanDelay             time.Duration
+	revalidationCalls     []apptypes.MemoryHygieneRevalidationCriteria
+	revalidationResults   map[string]apptypes.MemoryHygieneRevalidationSourceResult
+	revalidationErrors    map[string]error
+	revalidationRevisions []int64
 }
 
 func (s *stubMemoryQueryService) List(_ context.Context, criteria apptypes.MemoryListCriteria) ([]apptypes.MemorySummary, error) {
@@ -227,6 +230,12 @@ func (s *stubMemoryQueryService) RevalidateMemoryHygiene(
 	criteria apptypes.MemoryHygieneRevalidationCriteria,
 ) (apptypes.MemoryHygieneRevalidationSourceResult, error) {
 	s.revalidationCalls = append(s.revalidationCalls, criteria)
+	if result, ok := s.revalidationResults[criteria.MemoryID.String()]; ok {
+		if revisions := s.revalidationRevisions; len(revisions) >= len(s.revalidationCalls) {
+			result.Revision = revisions[len(s.revalidationCalls)-1]
+		}
+		return result, s.revalidationErrors[criteria.MemoryID.String()]
+	}
 	var result apptypes.MemoryHygieneRevalidationSourceResult
 	result.Revision = 1
 	for _, summary := range s.summaries {
@@ -271,7 +280,10 @@ func (s *stubMemoryQueryService) RevalidateMemoryHygiene(
 	}
 	result.Complete = true
 	result.StopReason = apptypes.MemoryHygieneStopReasonComplete
-	return result, nil
+	if revisions := s.revalidationRevisions; len(revisions) >= len(s.revalidationCalls) {
+		result.Revision = revisions[len(s.revalidationCalls)-1]
+	}
+	return result, s.revalidationErrors[criteria.MemoryID.String()]
 }
 
 type importProposeCall struct {

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -603,11 +603,29 @@ traceary memory admin activate --target gemini --path /path/to/GEMINI.md --apply
 - `--workspace` — scope filter (未指定時は env/検出 workspace。空なら全 scope)
 - `--expiry-days` — staleness 閾値 (既定 90 日)
 - `--similarity` — supersede_candidate 検出の word-Jaccard 閾値 (0.0-1.0、0 は既定値 0.6)
+- `--max-scan-rows` / `--max-scan-bytes` / `--max-result-bytes` / `--max-comparisons` / `--max-duration` — 1 回の実行に対する有限の処理量・応答量上限
+- `--cursor` — `next_cursor` を発行したプロセス内で途中 scan を再開
 - `--json` — JSON 形式で suggestion のメタデータ付きに出力
+
+すべての結果は `complete` / `partial` / `stop_reason` / `consistency` と実際の
+`usage` を返します。store が変化しなければ `consistency=consistent` です。
+ページ間の memory write により global revision が変わっても、scan は保持済みの
+phase / keyset を破棄しません。代わりに
+`stop_reason=revision_changed`、`consistency=best_effort`、
+`consistency_reason=revision_changed` と、現在の revision に束縛し直した
+continuation を持つ partial result を返します。この continuation chain は単一の
+database snapshot を表せないため、以後のページも downgrade を明示します。
+
+hygiene cursor は、発行プロセスだけが保持する AES-GCM key で暗号化・認証されます。
+改変済み cursor、旧 checksum cursor、以前のプロセスが発行した cursor は、新しい
+scan が必要であることを明示する error になります。長時間動作する MCP server は
+再起動までページを継続できます。一方、standalone CLI は呼び出しごとに新しい
+process を開始するため、ある CLI 呼び出しが返した cursor を次の standalone CLI
+呼び出しで再利用できません。複数ページが必要な scan には MCP surface を使います。
 
 #### `traceary memory admin hygiene apply`
 
-`--ids` に指定した memory id について、該当する suggestion の lifecycle transition を適用します。usecase は内部で scan を再実行し、すでに解決済みの id は失敗一覧に回るので状態を黙って壊すことはありません。適用される transition:
+`--ids` に指定した memory id について、該当する suggestion の lifecycle transition を適用します。最初の mutation より前に、usecase は全 target と同一 scope の peer を 1 つの revision で完全に再検証します。再検証が partial、または revision が不一致なら request 全体を fail-closed にするため、scan の best-effort continuation が apply の安全性を弱めることはありません。適用される transition:
 
 - `redaction_hit` → `supersede`（sanitized fact に差し替え、scope / type / refs は継承）
 - `expiry_candidate` → `expire`（現在時刻で失効）

--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -604,24 +604,27 @@ traceary memory admin activate --target gemini --path /path/to/GEMINI.md --apply
 - `--expiry-days` — staleness 閾値 (既定 90 日)
 - `--similarity` — supersede_candidate 検出の word-Jaccard 閾値 (0.0-1.0、0 は既定値 0.6)
 - `--max-scan-rows` / `--max-scan-bytes` / `--max-result-bytes` / `--max-comparisons` / `--max-duration` — 1 回の実行に対する有限の処理量・応答量上限
-- `--cursor` — `next_cursor` を発行したプロセス内で途中 scan を再開
 - `--json` — JSON 形式で suggestion のメタデータ付きに出力
 
 すべての結果は `complete` / `partial` / `stop_reason` / `consistency` と実際の
-`usage` を返します。store が変化しなければ `consistency=consistent` です。
-ページ間の memory write により global revision が変わっても、scan は保持済みの
-phase / keyset を破棄しません。代わりに
-`stop_reason=revision_changed`、`consistency=best_effort`、
-`consistency_reason=revision_changed` と、現在の revision に束縛し直した
-continuation を持つ partial result を返します。この continuation chain は単一の
-database snapshot を表せないため、以後のページも downgrade を明示します。
+`usage` を返します。CLI の partial result は `rerun_guidance` も返します。
+`--workspace` を狭める、必要な有限上限だけを引き上げる、または再開可能な MCP
+surface を使ってください。store が変化しなければ `consistency=consistent` です。
+実行中の memory write により global revision が変わっても、scan は保持済みの
+phase / keyset を破棄しません。現在の revision に束縛し直し、
+`consistency=best_effort` / `consistency_reason=revision_changed` へ恒久的に
+downgrade して、同じ source page を残りの実行予算内で再試行します。再試行が
+成功した場合、後で実際に停止させた上限を `stop_reason` で返します。page が前進
+する前に revision 変更が繰り返されて duration を使い切った場合だけ、
+`stop_reason=revision_changed` を返します。
 
 hygiene cursor は、発行プロセスだけが保持する AES-GCM key で暗号化・認証されます。
 改変済み cursor、旧 checksum cursor、以前のプロセスが発行した cursor は、新しい
 scan が必要であることを明示する error になります。長時間動作する MCP server は
-再起動までページを継続できます。一方、standalone CLI は呼び出しごとに新しい
-process を開始するため、ある CLI 呼び出しが返した cursor を次の standalone CLI
-呼び出しで再利用できません。複数ページが必要な scan には MCP surface を使います。
+再起動までページを継続できます。standalone CLI は `--cursor` を受け付けず、
+`next_cursor` も出力しません。各 command は 1 回の上限付き scan です。複数の
+process 認証済み page が必要な場合は
+`query_memory(action="scan_hygiene")` を使います。
 
 #### `traceary memory admin hygiene apply`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -611,11 +611,31 @@ Useful flags:
 - `--workspace` — scope filter (defaults to env/detected workspace; leave empty to scan every scope)
 - `--expiry-days` — staleness threshold in days (default 90)
 - `--similarity` — word-Jaccard threshold for supersede_candidate detection, between 0.0 and 1.0 (0 uses the built-in default 0.6)
+- `--max-scan-rows`, `--max-scan-bytes`, `--max-result-bytes`, `--max-comparisons`, `--max-duration` — finite per-invocation work and response ceilings
+- `--cursor` — resume a partial scan inside the process that issued `next_cursor`
 - `--json` — print JSON output with per-suggestion metadata
+
+Every result reports `complete`, `partial`, `stop_reason`, `consistency`, and
+actual `usage`. An unchanged store reports `consistency=consistent`. If a
+memory write changes the global revision between pages, the scanner does not
+discard the retained phase/keyset: it returns a partial
+`stop_reason=revision_changed` result with
+`consistency=best_effort`, `consistency_reason=revision_changed`, and a
+continuation rebound to the current revision. The downgrade remains visible on
+all later pages because that chain can no longer represent one database
+snapshot.
+
+Hygiene cursors are encrypted and authenticated with an AES-GCM key that exists
+only in the issuing process. Modified cursors, legacy checksum cursors, and
+cursors from an earlier process fail with explicit new-scan guidance. A
+long-running MCP server can therefore resume pages until it restarts. A
+standalone CLI command starts a new process for each invocation, so its cursor
+cannot be reused by a later standalone invocation; use the MCP surface when a
+scan requires multiple process-authenticated pages.
 
 #### `traceary memory admin hygiene apply`
 
-Commit the lifecycle transition implied by each suggestion for the memories in `--ids`. The usecase re-runs the scan first so stale ids (memories the operator already resolved) land in the failure list instead of silently mutating state. Transitions applied:
+Commit the lifecycle transition implied by each suggestion for the memories in `--ids`. Before the first mutation, the usecase completely revalidates every requested target and its same-scope peers at one revision. A partial revalidation or a revision mismatch fails the whole request closed, so scan's best-effort continuation never weakens apply safety. Transitions applied:
 
 - `redaction_hit` → `supersede` with the sanitized fact, inheriting the existing scope / type / refs.
 - `expiry_candidate` → `expire` at the current time.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -612,26 +612,27 @@ Useful flags:
 - `--expiry-days` — staleness threshold in days (default 90)
 - `--similarity` — word-Jaccard threshold for supersede_candidate detection, between 0.0 and 1.0 (0 uses the built-in default 0.6)
 - `--max-scan-rows`, `--max-scan-bytes`, `--max-result-bytes`, `--max-comparisons`, `--max-duration` — finite per-invocation work and response ceilings
-- `--cursor` — resume a partial scan inside the process that issued `next_cursor`
 - `--json` — print JSON output with per-suggestion metadata
 
 Every result reports `complete`, `partial`, `stop_reason`, `consistency`, and
-actual `usage`. An unchanged store reports `consistency=consistent`. If a
-memory write changes the global revision between pages, the scanner does not
-discard the retained phase/keyset: it returns a partial
-`stop_reason=revision_changed` result with
-`consistency=best_effort`, `consistency_reason=revision_changed`, and a
-continuation rebound to the current revision. The downgrade remains visible on
-all later pages because that chain can no longer represent one database
-snapshot.
+actual `usage`. A partial CLI result also reports `rerun_guidance`: narrow
+`--workspace`, raise only the finite bounds that are appropriate, or use the
+MCP surface for resumable paging. An unchanged store reports
+`consistency=consistent`. If a memory write changes the global revision while
+the invocation is scanning, the scanner keeps the retained phase/keyset,
+rebinds to the current revision, permanently marks the scan `best_effort` with
+`consistency_reason=revision_changed`, and retries that same source page inside
+the remaining invocation budget. A successful retry reports the actual bound
+that later stops it. Only continuing revision churn that consumes the duration
+before page progress reports `stop_reason=revision_changed`.
 
 Hygiene cursors are encrypted and authenticated with an AES-GCM key that exists
 only in the issuing process. Modified cursors, legacy checksum cursors, and
 cursors from an earlier process fail with explicit new-scan guidance. A
-long-running MCP server can therefore resume pages until it restarts. A
-standalone CLI command starts a new process for each invocation, so its cursor
-cannot be reused by a later standalone invocation; use the MCP surface when a
-scan requires multiple process-authenticated pages.
+long-running MCP server can therefore resume pages until it restarts. The
+standalone CLI neither accepts `--cursor` nor emits `next_cursor`; each command
+is one bounded scan. Use `query_memory(action="scan_hygiene")` when a scan
+requires multiple process-authenticated pages.
 
 #### `traceary memory admin hygiene apply`
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -71,11 +71,15 @@ comparison、duration に有限の上限を適用します。partial response �
 
 `consistency=consistent` は continuation chain が 1 つの memory revision に
 留まったことを示します。ページ間に hook または別 client が memory を書き込むと、
-次の call は `stop_reason=revision_changed`、
-`consistency=best_effort`、`consistency_reason=revision_changed` と、保持済み
-keyset / 現在 revision に束縛した新しい cursor を返します。以後のページも
-best-effort marker を維持します。これは read-only scan の振る舞いです。mutation
-path は、何かを適用する前に 1 つの revision で対象を完全に再検証します。
+次の call は保持済み keyset を維持し、現在 revision に束縛し直して、
+`consistency=best_effort` / `consistency_reason=revision_changed` へ恒久的に
+downgrade したうえで、同じ source page を残りの実行予算内で再試行します。
+再試行が成功した場合、後で実際に停止させた上限を `stop_reason` で返します。
+page が前進する前に revision 変更が繰り返されて duration を使い切った場合は、
+partial response が `stop_reason=revision_changed` と最新の確認済み revision に
+束縛した cursor を返します。以後のページも best-effort marker を維持します。
+これは read-only scan の振る舞いです。mutation path は、何かを適用する前に
+1 つの revision で対象を完全に再検証します。
 
 ### Search query semantics
 

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -60,6 +60,23 @@ session recap でも同じ順序を使います。metadata を発見してから
 確認し、上限付きの evidence だけでは recap を支えられない場合にだけ detail を
 取得します。
 
+### Durable memory hygiene の continuation
+
+`query_memory(action="scan_hygiene")` は row、source byte、result byte、
+comparison、duration に有限の上限を適用します。partial response には暗号化済みの
+`next_cursor` が含まれます。cursor は実行中の MCP process が所有する AES-GCM key
+で認証され、memory fact の平文を含みません。server 再起動後は利用できず、認証に
+失敗した場合は新しい scan が必要であることを明示します。旧 checksum cursor は
+受理しません。
+
+`consistency=consistent` は continuation chain が 1 つの memory revision に
+留まったことを示します。ページ間に hook または別 client が memory を書き込むと、
+次の call は `stop_reason=revision_changed`、
+`consistency=best_effort`、`consistency_reason=revision_changed` と、保持済み
+keyset / 現在 revision に束縛した新しい cursor を返します。以後のページも
+best-effort marker を維持します。これは read-only scan の振る舞いです。mutation
+path は、何かを適用する前に 1 つの revision で対象を完全に再検証します。
+
 ### Search query semantics
 
 `search.query` は literal text query であり、boolean query language ではありません。`failure OR timeout` のような文字列は `failure` または `timeout` の any-match expression として解釈されず、1つの検索文字列として扱われます。複数語を調べたい場合は、より狭い `search` call を複数回実行するか、CLI JSON output を local file に保存して `jq` などの local tools で集計してください。

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -60,6 +60,23 @@ The same order applies when composing a session recap: discover metadata first,
 inspect selected context second, and retrieve detail only when the recap cannot
 be supported by the bounded evidence.
 
+### Durable-memory hygiene continuations
+
+`query_memory(action="scan_hygiene")` applies finite row, source-byte,
+result-byte, comparison, and duration ceilings. A partial response includes an
+encrypted `next_cursor`. The cursor is authenticated by an AES-GCM key owned by
+the running MCP process, contains no plaintext memory fact, and becomes
+unusable after that server restarts. Authentication failure explicitly
+requires a new scan; legacy checksum cursors are not accepted.
+
+`consistency=consistent` means the continuation chain stayed at one memory
+revision. If a hook or another client writes memory between pages, the next
+call returns `stop_reason=revision_changed`,
+`consistency=best_effort`, `consistency_reason=revision_changed`, and a new
+cursor at the retained keyset and current revision. Later pages keep the
+best-effort marker. This behavior is read-only; mutation paths still require
+complete targeted revalidation at one revision before applying anything.
+
 ### Search query semantics
 
 `search.query` is a literal text query, not a boolean query language. A string such as `failure OR timeout` is not interpreted as an any-match expression for `failure` or `timeout`; treat it as one search string. For multi-term inspection, issue multiple narrower `search` calls or save CLI JSON output to a local file and aggregate it with local tools such as `jq`.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -71,9 +71,13 @@ requires a new scan; legacy checksum cursors are not accepted.
 
 `consistency=consistent` means the continuation chain stayed at one memory
 revision. If a hook or another client writes memory between pages, the next
-call returns `stop_reason=revision_changed`,
-`consistency=best_effort`, `consistency_reason=revision_changed`, and a new
-cursor at the retained keyset and current revision. Later pages keep the
+call retains the keyset, binds the current revision, permanently marks the
+chain `consistency=best_effort` with
+`consistency_reason=revision_changed`, and retries that same source page inside
+the remaining invocation budget. A successful retry reports the actual bound
+that later stops it. If revision churn consumes the duration before page
+progress, the partial response uses `stop_reason=revision_changed` and returns
+a cursor bound to the latest observed revision. Later pages keep the
 best-effort marker. This behavior is read-only; mutation paths still require
 complete targeted revalidation at one revision before applying anything.
 

--- a/infrastructure/sqlite/memory_datasource.go
+++ b/infrastructure/sqlite/memory_datasource.go
@@ -107,6 +107,7 @@ func NewMemoryDatasourceWithClock(db *Database, clock types.Clock) *MemoryDataso
 var (
 	_ model.MemoryRepository               = (*MemoryDatasource)(nil)
 	_ queryservice.MemoryQueryService      = (*MemoryDatasource)(nil)
+	_ queryservice.MemoryHygieneScanSource = (*MemoryDatasource)(nil)
 	_ queryservice.StaleMemoryQueryService = (*MemoryDatasource)(nil)
 )
 

--- a/infrastructure/sqlite/memory_hygiene_scan_source.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source.go
@@ -1,0 +1,733 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+)
+
+const selectMemoryHygieneRevisionQuery = `
+SELECT revision
+FROM memory_hygiene_revision
+WHERE singleton = 1`
+
+const memoryHygieneSourceBytesExpression = `(
+    length(CAST(m.id AS BLOB)) +
+    length(CAST(m.type AS BLOB)) +
+    length(CAST(m.scope_kind AS BLOB)) +
+    length(CAST(m.scope_value AS BLOB)) +
+    length(CAST(m.fact AS BLOB)) +
+    length(CAST(m.status AS BLOB)) +
+    length(CAST(m.confidence AS BLOB)) +
+    length(CAST(m.source AS BLOB)) +
+    COALESCE(length(CAST(m.supersedes_memory_id AS BLOB)), 0) +
+    COALESCE(length(CAST(m.expires_at AS BLOB)), 0) +
+    COALESCE(length(CAST(m.valid_from AS BLOB)), 0) +
+    COALESCE(length(CAST(m.valid_to AS BLOB)), 0) +
+    length(CAST(m.created_at AS BLOB)) +
+    length(CAST(m.updated_at AS BLOB))
+)`
+
+const selectMemoryHygieneSummaryProbeQuery = `
+SELECT
+    CASE WHEN ` + memoryHygieneSourceBytesExpression + ` <= ?1 THEN m.id ELSE NULL END,
+    ` + memoryHygieneSourceBytesExpression + `
+FROM memories m
+WHERE 1 = 1`
+
+// ScanMemoryHygienePage returns one bounded, revision-consistent source page.
+// Pair traversal is exhaustive across continuations: an anchor is retained in
+// the keyset until every greater same-scope partner has been visited.
+func (d *MemoryDatasource) ScanMemoryHygienePage(
+	ctx context.Context,
+	criteria apptypes.MemoryHygieneScanPageCriteria,
+) (result apptypes.MemoryHygieneScanSourcePage, err error) {
+	if !criteria.Phase.IsKnown() {
+		return result, xerrors.Errorf("unknown memory hygiene scan phase")
+	}
+	if criteria.MaxRows < 1 || criteria.MaxScanBytes < 1 || criteria.MaxComparisons < 1 {
+		return result, xerrors.Errorf("memory hygiene source limits must be positive")
+	}
+
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return result, xerrors.Errorf("failed to open DB for memory hygiene scan")
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			slog.Debug("failed to close resource", "error", closeErr)
+		}
+	}()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return result, xerrors.Errorf("failed to begin memory hygiene scan transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	revision, err := memoryHygieneRevision(ctx, tx)
+	if err != nil {
+		return result, err
+	}
+	if expected, ok := criteria.ExpectedRevision.Value(); ok && expected != revision {
+		return result, xerrors.Errorf("%w", queryservice.ErrMemoryHygieneRevisionChanged)
+	}
+	result.Revision = revision
+	result.ProgressKeyset = criteria.Keyset
+
+	switch criteria.Phase {
+	case apptypes.MemoryHygieneScanPhaseAcceptedRows:
+		err = scanMemoryHygieneRows(ctx, tx, criteria, []domtypes.MemoryStatus{domtypes.MemoryStatusAccepted}, nil, &result)
+	case apptypes.MemoryHygieneScanPhaseCandidateRows:
+		sources := []domtypes.MemorySource{domtypes.MemorySourceExtracted}
+		if criteria.IncludeHiddenCandidates {
+			sources = append(sources, domtypes.MemorySourceExtractedHidden)
+		}
+		err = scanMemoryHygieneRows(ctx, tx, criteria, []domtypes.MemoryStatus{domtypes.MemoryStatusCandidate}, sources, &result)
+	case apptypes.MemoryHygieneScanPhaseExactDuplicates:
+		err = scanMemoryHygieneDuplicates(ctx, tx, criteria, &result)
+	case apptypes.MemoryHygieneScanPhaseSimilarityPairs:
+		err = scanMemoryHygienePairs(ctx, tx, criteria, &result)
+	default:
+		err = xerrors.Errorf("unknown memory hygiene scan phase")
+	}
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			result.Done = false
+			result.StopReason = apptypes.MemoryHygieneStopReasonTimeLimit
+			return result, nil
+		}
+		return apptypes.MemoryHygieneScanSourcePage{}, err
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		result.Done = false
+		result.StopReason = apptypes.MemoryHygieneStopReasonTimeLimit
+		return result, nil
+	}
+	if err = tx.Commit(); err != nil {
+		return apptypes.MemoryHygieneScanSourcePage{}, xerrors.Errorf("failed to commit memory hygiene scan transaction: %w", err)
+	}
+	return result, nil
+}
+
+// RevalidateMemoryHygiene loads only the requested target and its same-scope
+// peers. It fails closed through Complete=false when the peer set cannot be
+// exhausted inside the explicit byte/comparison bounds.
+func (d *MemoryDatasource) RevalidateMemoryHygiene(
+	ctx context.Context,
+	criteria apptypes.MemoryHygieneRevalidationCriteria,
+) (result apptypes.MemoryHygieneRevalidationSourceResult, err error) {
+	if criteria.MaxRows < 1 || criteria.MaxScanBytes < 1 || criteria.MaxComparisons < 1 {
+		return result, xerrors.Errorf("memory hygiene revalidation limits must be positive")
+	}
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return result, xerrors.Errorf("failed to open DB for memory hygiene revalidation")
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			slog.Debug("failed to close resource", "error", closeErr)
+		}
+	}()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return result, xerrors.Errorf("failed to begin memory hygiene revalidation transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result.Revision, err = memoryHygieneRevision(ctx, tx)
+	if err != nil {
+		return result, err
+	}
+	target, found, oversized, targetBytes, err := loadMemoryHygieneSummaryByID(
+		ctx,
+		tx,
+		criteria.MemoryID.String(),
+		criteria.MaxScanBytes,
+	)
+	if err != nil {
+		return result, err
+	}
+	if !found {
+		return result, xerrors.Errorf("memory not found")
+	}
+	if oversized {
+		result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+		return result, nil
+	}
+	if targetBytes > criteria.MaxScanBytes {
+		result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+		return result, nil
+	}
+	result.Target = target
+	result.ScannedRows = 1
+	result.ScannedBytes = targetBytes
+
+	if target.Status() == domtypes.MemoryStatusCandidate {
+		result.Complete = true
+		result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+		if err = tx.Commit(); err != nil {
+			return apptypes.MemoryHygieneRevalidationSourceResult{}, xerrors.Errorf("failed to commit memory hygiene revalidation transaction: %w", err)
+		}
+		return result, nil
+	}
+	if target.Status() != domtypes.MemoryStatusAccepted {
+		result.Complete = true
+		result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+		if err = tx.Commit(); err != nil {
+			return apptypes.MemoryHygieneRevalidationSourceResult{}, xerrors.Errorf("failed to commit memory hygiene revalidation transaction: %w", err)
+		}
+		return result, nil
+	}
+
+	afterID := ""
+	for {
+		if result.ScannedRows >= criteria.MaxRows {
+			more, moreErr := hasMemoryHygienePeer(ctx, tx, target, afterID)
+			if moreErr != nil {
+				return result, moreErr
+			}
+			if more {
+				result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+				return result, nil
+			}
+			break
+		}
+		if result.Comparisons >= criteria.MaxComparisons {
+			more, moreErr := hasMemoryHygienePeer(ctx, tx, target, afterID)
+			if moreErr != nil {
+				return result, moreErr
+			}
+			if more {
+				result.StopReason = apptypes.MemoryHygieneStopReasonComparisonLimit
+				return result, nil
+			}
+			break
+		}
+		remainingBytes := criteria.MaxScanBytes - result.ScannedBytes
+		peer, found, oversized, peerBytes, loadErr := nextMemoryHygienePeer(
+			ctx,
+			tx,
+			target,
+			afterID,
+			false,
+			remainingBytes,
+		)
+		if loadErr != nil {
+			return result, loadErr
+		}
+		if !found {
+			break
+		}
+		if oversized {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return result, nil
+		}
+		if result.ScannedBytes+peerBytes > criteria.MaxScanBytes {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return result, nil
+		}
+		result.Peers = append(result.Peers, peer)
+		result.ScannedRows++
+		result.ScannedBytes += peerBytes
+		result.Comparisons++
+		afterID = peer.MemoryID().String()
+		if target.Fact() == peer.Fact() {
+			existing, hasDuplicate := result.ExactDuplicateMemoryID.Value()
+			if !hasDuplicate ||
+				(existing.String() < target.MemoryID().String() && peer.MemoryID().String() > target.MemoryID().String()) {
+				result.ExactDuplicateMemoryID = domtypes.Some(peer.MemoryID())
+			}
+		}
+	}
+	result.Complete = true
+	result.StopReason = apptypes.MemoryHygieneStopReasonComplete
+	if err = tx.Commit(); err != nil {
+		return apptypes.MemoryHygieneRevalidationSourceResult{}, xerrors.Errorf("failed to commit memory hygiene revalidation transaction: %w", err)
+	}
+	return result, nil
+}
+
+func memoryHygieneRevision(ctx context.Context, tx *sql.Tx) (int64, error) {
+	var revision int64
+	if err := tx.QueryRowContext(ctx, selectMemoryHygieneRevisionQuery).Scan(&revision); err != nil {
+		return 0, xerrors.Errorf("failed to read memory hygiene revision: %w", err)
+	}
+	return revision, nil
+}
+
+func scanMemoryHygieneRows(
+	ctx context.Context,
+	tx *sql.Tx,
+	criteria apptypes.MemoryHygieneScanPageCriteria,
+	statuses []domtypes.MemoryStatus,
+	sources []domtypes.MemorySource,
+	result *apptypes.MemoryHygieneScanSourcePage,
+) error {
+	afterID := criteria.Keyset.AfterMemoryID
+	for {
+		if result.ScannedRows >= criteria.MaxRows {
+			result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+			return nil
+		}
+		remainingBytes := criteria.MaxScanBytes - result.ScannedBytes
+		summary, found, oversized, sourceBytes, err := nextMemoryHygieneSummary(
+			ctx,
+			tx,
+			afterID,
+			criteria.Scopes,
+			statuses,
+			sources,
+			remainingBytes,
+		)
+		if err != nil {
+			return err
+		}
+		if !found {
+			result.Done = true
+			return nil
+		}
+		if oversized {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		if result.ScannedBytes+sourceBytes > criteria.MaxScanBytes {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		next := apptypes.MemoryHygieneScanKeyset{AfterMemoryID: summary.MemoryID().String()}
+		result.Units = append(result.Units, apptypes.MemoryHygieneScanUnit{
+			Row:             summary,
+			Peer:            domtypes.None[apptypes.MemorySummary](),
+			RelatedMemoryID: domtypes.None[domtypes.MemoryID](),
+			NextKeyset:      next,
+		})
+		result.ScannedRows++
+		result.ScannedBytes += sourceBytes
+		result.ProgressKeyset = next
+		afterID = summary.MemoryID().String()
+	}
+}
+
+func scanMemoryHygieneDuplicates(
+	ctx context.Context,
+	tx *sql.Tx,
+	criteria apptypes.MemoryHygieneScanPageCriteria,
+	result *apptypes.MemoryHygieneScanSourcePage,
+) error {
+	afterID := criteria.Keyset.AfterMemoryID
+	for {
+		if result.ScannedRows >= criteria.MaxRows {
+			result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+			return nil
+		}
+		if result.Comparisons >= criteria.MaxComparisons {
+			result.StopReason = apptypes.MemoryHygieneStopReasonComparisonLimit
+			return nil
+		}
+		remainingBytes := criteria.MaxScanBytes - result.ScannedBytes
+		summary, found, oversized, sourceBytes, err := nextMemoryHygieneSummary(
+			ctx,
+			tx,
+			afterID,
+			criteria.Scopes,
+			[]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+			nil,
+			remainingBytes,
+		)
+		if err != nil {
+			return err
+		}
+		if !found {
+			result.Done = true
+			return nil
+		}
+		if oversized {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		if result.ScannedBytes+sourceBytes > criteria.MaxScanBytes {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		peerID, hasPeer, err := exactMemoryHygienePeerID(ctx, tx, summary)
+		if err != nil {
+			return err
+		}
+		next := apptypes.MemoryHygieneScanKeyset{AfterMemoryID: summary.MemoryID().String()}
+		related := domtypes.None[domtypes.MemoryID]()
+		if hasPeer {
+			related = domtypes.Some(peerID)
+		}
+		result.Units = append(result.Units, apptypes.MemoryHygieneScanUnit{
+			Row:             summary,
+			Peer:            domtypes.None[apptypes.MemorySummary](),
+			RelatedMemoryID: related,
+			NextKeyset:      next,
+		})
+		result.ScannedRows++
+		result.ScannedBytes += sourceBytes
+		result.Comparisons++
+		result.ProgressKeyset = next
+		afterID = summary.MemoryID().String()
+	}
+}
+
+func scanMemoryHygienePairs(
+	ctx context.Context,
+	tx *sql.Tx,
+	criteria apptypes.MemoryHygieneScanPageCriteria,
+	result *apptypes.MemoryHygieneScanSourcePage,
+) error {
+	keyset := criteria.Keyset
+	for {
+		if result.ScannedRows >= criteria.MaxRows {
+			result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+			return nil
+		}
+		if result.Comparisons >= criteria.MaxComparisons {
+			result.StopReason = apptypes.MemoryHygieneStopReasonComparisonLimit
+			return nil
+		}
+
+		var anchor apptypes.MemorySummary
+		var found bool
+		var oversized bool
+		var anchorBytes int64
+		var err error
+		remainingBytes := criteria.MaxScanBytes - result.ScannedBytes
+		if keyset.AnchorMemoryID != "" {
+			anchor, found, oversized, anchorBytes, err = loadMemoryHygieneSummaryByID(
+				ctx,
+				tx,
+				keyset.AnchorMemoryID,
+				remainingBytes,
+			)
+			if err != nil {
+				return err
+			}
+			if oversized {
+				result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+				return nil
+			}
+			if !found || anchor.Status() != domtypes.MemoryStatusAccepted || !memoryHygieneScopeIncluded(anchor.Scope(), criteria.Scopes) {
+				return xerrors.Errorf("%w", queryservice.ErrMemoryHygieneRevisionChanged)
+			}
+		} else {
+			anchor, found, oversized, anchorBytes, err = nextMemoryHygieneSummary(
+				ctx,
+				tx,
+				keyset.AfterMemoryID,
+				criteria.Scopes,
+				[]domtypes.MemoryStatus{domtypes.MemoryStatusAccepted},
+				nil,
+				remainingBytes,
+			)
+			if err != nil {
+				return err
+			}
+			if !found {
+				result.Done = true
+				result.ProgressKeyset = keyset
+				return nil
+			}
+			if oversized {
+				result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+				return nil
+			}
+			keyset.AnchorMemoryID = anchor.MemoryID().String()
+			keyset.AfterPartnerID = ""
+		}
+
+		partnerBudget := remainingBytes - anchorBytes
+		if partnerBudget < 0 {
+			partnerBudget = 0
+		}
+		partner, hasPartner, oversized, partnerBytes, err := nextMemoryHygienePeer(
+			ctx,
+			tx,
+			anchor,
+			keyset.AfterPartnerID,
+			true,
+			partnerBudget,
+		)
+		if err != nil {
+			return err
+		}
+		if !hasPartner {
+			if result.ScannedBytes+anchorBytes > criteria.MaxScanBytes {
+				result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+				return nil
+			}
+			next := apptypes.MemoryHygieneScanKeyset{AfterMemoryID: anchor.MemoryID().String()}
+			result.Units = append(result.Units, apptypes.MemoryHygieneScanUnit{
+				Row:             anchor,
+				Peer:            domtypes.None[apptypes.MemorySummary](),
+				RelatedMemoryID: domtypes.None[domtypes.MemoryID](),
+				NextKeyset:      next,
+			})
+			result.ScannedRows++
+			result.ScannedBytes += anchorBytes
+			result.ProgressKeyset = next
+			keyset = next
+			continue
+		}
+		if oversized {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		if result.ScannedRows+2 > criteria.MaxRows {
+			result.StopReason = apptypes.MemoryHygieneStopReasonRowLimit
+			return nil
+		}
+		pairBytes := anchorBytes + partnerBytes
+		if result.ScannedBytes+pairBytes > criteria.MaxScanBytes {
+			result.StopReason = apptypes.MemoryHygieneStopReasonScanByteLimit
+			return nil
+		}
+		next := apptypes.MemoryHygieneScanKeyset{
+			AfterMemoryID:  keyset.AfterMemoryID,
+			AnchorMemoryID: anchor.MemoryID().String(),
+			AfterPartnerID: partner.MemoryID().String(),
+		}
+		result.Units = append(result.Units, apptypes.MemoryHygieneScanUnit{
+			Row:             anchor,
+			Peer:            domtypes.Some(partner),
+			RelatedMemoryID: domtypes.None[domtypes.MemoryID](),
+			NextKeyset:      next,
+		})
+		result.ScannedRows += 2
+		result.ScannedBytes += pairBytes
+		result.Comparisons++
+		result.ProgressKeyset = next
+		keyset = next
+	}
+}
+
+func nextMemoryHygieneSummary(
+	ctx context.Context,
+	tx *sql.Tx,
+	afterID string,
+	scopes []domtypes.MemoryScope,
+	statuses []domtypes.MemoryStatus,
+	sources []domtypes.MemorySource,
+	maxSourceBytes int64,
+) (apptypes.MemorySummary, bool, bool, int64, error) {
+	var builder strings.Builder
+	builder.WriteString(selectMemoryHygieneSummaryProbeQuery)
+	builder.WriteString(" AND m.id > ?")
+	args := []any{maxSourceBytes, afterID}
+	var err error
+	args, err = appendMemoryFilters(&builder, args, scopes, statuses, nil, sources)
+	if err != nil {
+		return apptypes.MemorySummary{}, false, false, 0, err
+	}
+	builder.WriteString(" ORDER BY m.id ASC LIMIT 1")
+	memoryID, oversized, sourceBytes, err := scanMemoryHygieneSummaryProbe(tx.QueryRowContext(ctx, builder.String(), args...))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apptypes.MemorySummary{}, false, false, 0, nil
+		}
+		return apptypes.MemorySummary{}, false, false, 0, xerrors.Errorf("failed to scan memory hygiene row: %w", err)
+	}
+	if oversized {
+		return apptypes.MemorySummary{}, true, true, sourceBytes, nil
+	}
+	summary, err := loadProbedMemoryHygieneSummary(ctx, tx, memoryID)
+	if err != nil {
+		return apptypes.MemorySummary{}, false, false, 0, err
+	}
+	return summary, true, oversized, sourceBytes, nil
+}
+
+func loadMemoryHygieneSummaryByID(
+	ctx context.Context,
+	tx *sql.Tx,
+	memoryID string,
+	maxSourceBytes int64,
+) (apptypes.MemorySummary, bool, bool, int64, error) {
+	query := selectMemoryHygieneSummaryProbeQuery + " AND m.id = ?"
+	probedID, oversized, sourceBytes, err := scanMemoryHygieneSummaryProbe(tx.QueryRowContext(ctx, query, maxSourceBytes, memoryID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apptypes.MemorySummary{}, false, false, 0, nil
+		}
+		return apptypes.MemorySummary{}, false, false, 0, xerrors.Errorf("failed to scan memory hygiene target: %w", err)
+	}
+	if oversized {
+		return apptypes.MemorySummary{}, true, true, sourceBytes, nil
+	}
+	summary, err := loadProbedMemoryHygieneSummary(ctx, tx, probedID)
+	if err != nil {
+		return apptypes.MemorySummary{}, false, false, 0, err
+	}
+	return summary, true, oversized, sourceBytes, nil
+}
+
+func exactMemoryHygienePeerID(
+	ctx context.Context,
+	tx *sql.Tx,
+	summary apptypes.MemorySummary,
+) (domtypes.MemoryID, bool, error) {
+	const greaterQuery = `
+SELECT id
+FROM memories
+WHERE status = ?
+  AND scope_kind = ?
+  AND scope_value = ?
+  AND fact = ?
+  AND id > ?
+ORDER BY id ASC
+LIMIT 1`
+	const lowerQuery = `
+SELECT id
+FROM memories
+WHERE status = ?
+  AND scope_kind = ?
+  AND scope_value = ?
+  AND fact = ?
+  AND id < ?
+ORDER BY id ASC
+LIMIT 1`
+	args := []any{
+		domtypes.MemoryStatusAccepted.String(),
+		summary.Scope().Kind().String(),
+		summary.Scope().Key(),
+		summary.Fact(),
+		summary.MemoryID().String(),
+	}
+	var peerID string
+	err := tx.QueryRowContext(ctx, greaterQuery, args...).Scan(&peerID)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = tx.QueryRowContext(ctx, lowerQuery, args...).Scan(&peerID)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, xerrors.Errorf("failed to query exact memory hygiene peer: %w", err)
+	}
+	return domtypes.MemoryID(peerID), true, nil
+}
+
+func nextMemoryHygienePeer(
+	ctx context.Context,
+	tx *sql.Tx,
+	anchor apptypes.MemorySummary,
+	afterID string,
+	greaterThanAnchor bool,
+	maxSourceBytes int64,
+) (apptypes.MemorySummary, bool, bool, int64, error) {
+	var builder strings.Builder
+	builder.WriteString(selectMemoryHygieneSummaryProbeQuery)
+	builder.WriteString(" AND m.status = ? AND m.scope_kind = ? AND m.scope_value = ? AND m.id > ?")
+	args := []any{
+		maxSourceBytes,
+		domtypes.MemoryStatusAccepted.String(),
+		anchor.Scope().Kind().String(),
+		anchor.Scope().Key(),
+		afterID,
+	}
+	if greaterThanAnchor {
+		builder.WriteString(" AND m.id > ?")
+		args = append(args, anchor.MemoryID().String())
+	} else {
+		builder.WriteString(" AND m.id <> ?")
+		args = append(args, anchor.MemoryID().String())
+	}
+	builder.WriteString(" ORDER BY m.id ASC LIMIT 1")
+	memoryID, oversized, sourceBytes, err := scanMemoryHygieneSummaryProbe(tx.QueryRowContext(ctx, builder.String(), args...))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apptypes.MemorySummary{}, false, false, 0, nil
+		}
+		return apptypes.MemorySummary{}, false, false, 0, xerrors.Errorf("failed to scan memory hygiene peer: %w", err)
+	}
+	if oversized {
+		return apptypes.MemorySummary{}, true, true, sourceBytes, nil
+	}
+	summary, err := loadProbedMemoryHygieneSummary(ctx, tx, memoryID)
+	if err != nil {
+		return apptypes.MemorySummary{}, false, false, 0, err
+	}
+	return summary, true, oversized, sourceBytes, nil
+}
+
+func scanMemoryHygieneSummaryProbe(rowScanner interface {
+	Scan(dest ...any) error
+}) (string, bool, int64, error) {
+	var memoryID sql.NullString
+	var sourceBytes int64
+	if err := rowScanner.Scan(&memoryID, &sourceBytes); err != nil {
+		return "", false, 0, xerrors.Errorf("failed to scan bounded memory hygiene row probe: %w", err)
+	}
+	if !memoryID.Valid {
+		return "", true, sourceBytes, nil
+	}
+	return memoryID.String, false, sourceBytes, nil
+}
+
+func loadProbedMemoryHygieneSummary(
+	ctx context.Context,
+	tx *sql.Tx,
+	memoryID string,
+) (apptypes.MemorySummary, error) {
+	query := selectMemorySummaryColumnsQuery + " AND m.id = ?"
+	summary, err := scanMemorySummary(tx.QueryRowContext(ctx, query, memoryID))
+	if err != nil {
+		return apptypes.MemorySummary{}, xerrors.Errorf("failed to load probed memory hygiene row: %w", err)
+	}
+	return summary, nil
+}
+
+func hasMemoryHygienePeer(ctx context.Context, tx *sql.Tx, target apptypes.MemorySummary, afterID string) (bool, error) {
+	const query = `
+SELECT 1
+FROM memories
+WHERE status = ?
+  AND scope_kind = ?
+  AND scope_value = ?
+  AND id <> ?
+  AND id > ?
+LIMIT 1`
+	var one int
+	err := tx.QueryRowContext(
+		ctx,
+		query,
+		domtypes.MemoryStatusAccepted.String(),
+		target.Scope().Kind().String(),
+		target.Scope().Key(),
+		target.MemoryID().String(),
+		afterID,
+	).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, xerrors.Errorf("failed to check memory hygiene peers: %w", err)
+	}
+	return true, nil
+}
+
+func memoryHygieneScopeIncluded(scope domtypes.MemoryScope, scopes []domtypes.MemoryScope) bool {
+	if len(scopes) == 0 {
+		return true
+	}
+	if scope == nil {
+		return false
+	}
+	for _, candidate := range scopes {
+		if candidate != nil && candidate.Kind() == scope.Kind() && candidate.Key() == scope.Key() {
+			return true
+		}
+	}
+	return false
+}

--- a/infrastructure/sqlite/memory_hygiene_scan_source.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source.go
@@ -78,7 +78,10 @@ func (d *MemoryDatasource) ScanMemoryHygienePage(
 		return result, err
 	}
 	if expected, ok := criteria.ExpectedRevision.Value(); ok && expected != revision {
-		return result, queryservice.NewMemoryHygieneRevisionChangedError(revision)
+		return result, xerrors.Errorf(
+			"memory hygiene scan revision changed before reading the source page: %w",
+			queryservice.NewMemoryHygieneRevisionChangedError(revision),
+		)
 	}
 	result.Revision = revision
 	result.ProgressKeyset = criteria.Keyset
@@ -420,7 +423,10 @@ func scanMemoryHygienePairs(
 			}
 			if !found || anchor.Status() != domtypes.MemoryStatusAccepted || !memoryHygieneScopeIncluded(anchor.Scope(), criteria.Scopes) {
 				if criteria.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort {
-					return queryservice.NewMemoryHygieneRevisionChangedError(result.Revision)
+					return xerrors.Errorf(
+						"memory hygiene pair anchor changed before continuation: %w",
+						queryservice.NewMemoryHygieneRevisionChangedError(result.Revision),
+					)
 				}
 				// A best-effort continuation may point at an anchor deleted,
 				// hidden, or moved after an earlier revision change. Treat the

--- a/infrastructure/sqlite/memory_hygiene_scan_source.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source.go
@@ -78,7 +78,7 @@ func (d *MemoryDatasource) ScanMemoryHygienePage(
 		return result, err
 	}
 	if expected, ok := criteria.ExpectedRevision.Value(); ok && expected != revision {
-		return result, xerrors.Errorf("%w", queryservice.ErrMemoryHygieneRevisionChanged)
+		return result, queryservice.NewMemoryHygieneRevisionChangedError(revision)
 	}
 	result.Revision = revision
 	result.ProgressKeyset = criteria.Keyset
@@ -419,7 +419,16 @@ func scanMemoryHygienePairs(
 				return nil
 			}
 			if !found || anchor.Status() != domtypes.MemoryStatusAccepted || !memoryHygieneScopeIncluded(anchor.Scope(), criteria.Scopes) {
-				return xerrors.Errorf("%w", queryservice.ErrMemoryHygieneRevisionChanged)
+				if criteria.Consistency != apptypes.MemoryHygieneScanConsistencyBestEffort {
+					return queryservice.NewMemoryHygieneRevisionChangedError(result.Revision)
+				}
+				// A best-effort continuation may point at an anchor deleted,
+				// hidden, or moved after an earlier revision change. Treat the
+				// old anchor ID as completed so the retained keyset still makes
+				// forward progress without restarting the pair phase.
+				keyset = apptypes.MemoryHygieneScanKeyset{AfterMemoryID: criteria.Keyset.AnchorMemoryID}
+				result.ProgressKeyset = keyset
+				continue
 			}
 		} else {
 			anchor, found, oversized, anchorBytes, err = nextMemoryHygieneSummary(

--- a/infrastructure/sqlite/memory_hygiene_scan_source_test.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source_test.go
@@ -1,0 +1,449 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+func TestMemoryHygieneRevision_AdvancesForEveryMemoryMutation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "revision.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	if got := memoryHygieneRevisionForTest(t, db); got != 0 {
+		t.Fatalf("initial revision = %d, want 0", got)
+	}
+	insertMemoryHygieneRows(t, db, 1, "same fact")
+	if got := memoryHygieneRevisionForTest(t, db); got != 1 {
+		t.Fatalf("revision after insert = %d, want 1", got)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE memories SET fact = ? WHERE id = ?`, "updated fact", "mem-0000"); err != nil {
+		t.Fatalf("UPDATE memories error = %v", err)
+	}
+	if got := memoryHygieneRevisionForTest(t, db); got != 2 {
+		t.Fatalf("revision after update = %d, want 2", got)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM memories WHERE id = ?`, "mem-0000"); err != nil {
+		t.Fatalf("DELETE memories error = %v", err)
+	}
+	if got := memoryHygieneRevisionForTest(t, db); got != 3 {
+		t.Fatalf("revision after delete = %d, want 3", got)
+	}
+
+	page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		MaxRows:        2,
+		MaxScanBytes:   1_024,
+		MaxComparisons: 1,
+	})
+	if err != nil {
+		t.Fatalf("ScanMemoryHygienePage() error = %v", err)
+	}
+	if !page.Done {
+		t.Fatalf("empty read-only scan Done = false, page = %#v", page)
+	}
+	if got := memoryHygieneRevisionForTest(t, db); got != 3 {
+		t.Fatalf("read-only scan changed revision to %d, want 3", got)
+	}
+}
+
+func TestMemoryHygieneScanSource_RejectsRevisionChangedBetweenPages(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "stale.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 2, "fact")
+
+	first, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		MaxRows:        1,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 1,
+	})
+	if err != nil {
+		t.Fatalf("first ScanMemoryHygienePage() error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE memories SET fact = ? WHERE id = ?`, "changed", "mem-0001"); err != nil {
+		t.Fatalf("UPDATE memories error = %v", err)
+	}
+	_, err = source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:            apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		Keyset:           first.ProgressKeyset,
+		ExpectedRevision: domtypes.Some(first.Revision),
+		MaxRows:          1,
+		MaxScanBytes:     1 << 20,
+		MaxComparisons:   1,
+	})
+	if !errors.Is(err, queryservice.ErrMemoryHygieneRevisionChanged) {
+		t.Fatalf("continuation error = %v, want ErrMemoryHygieneRevisionChanged", err)
+	}
+}
+
+func TestMemoryHygieneScanSource_SimilarityPairsResumeWithoutDuplicateOrSkip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "pairs.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 3, "shared words")
+
+	keyset := apptypes.MemoryHygieneScanKeyset{}
+	expectedRevision := domtypes.None[int64]()
+	pairs := make([]string, 0, 3)
+	for invocation := 0; invocation < 10; invocation++ {
+		page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+			Phase:            apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+			Keyset:           keyset,
+			ExpectedRevision: expectedRevision,
+			MaxRows:          4,
+			MaxScanBytes:     1 << 20,
+			MaxComparisons:   1,
+		})
+		if err != nil {
+			t.Fatalf("ScanMemoryHygienePage(invocation=%d) error = %v", invocation, err)
+		}
+		if _, ok := expectedRevision.Value(); !ok {
+			expectedRevision = domtypes.Some(page.Revision)
+		}
+		for _, unit := range page.Units {
+			peer, ok := unit.Peer.Value()
+			if !ok {
+				continue
+			}
+			pairs = append(pairs, unit.Row.MemoryID().String()+"-"+peer.MemoryID().String())
+		}
+		keyset = page.ProgressKeyset
+		if page.Done {
+			break
+		}
+		if page.StopReason != apptypes.MemoryHygieneStopReasonComparisonLimit {
+			t.Fatalf("partial pair page stop reason = %q, want comparison_limit", page.StopReason)
+		}
+	}
+	want := []string{"mem-0000-mem-0001", "mem-0000-mem-0002", "mem-0001-mem-0002"}
+	if fmt.Sprint(pairs) != fmt.Sprint(want) {
+		t.Fatalf("pairs = %v, want %v", pairs, want)
+	}
+}
+
+func TestMemoryHygieneScanSource_ExactDuplicateMembersResumeOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "duplicates.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 3, "same exact fact")
+
+	keyset := apptypes.MemoryHygieneScanKeyset{}
+	expectedRevision := domtypes.None[int64]()
+	members := make([]string, 0, 3)
+	for invocation := 0; invocation < 10; invocation++ {
+		page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+			Phase:            apptypes.MemoryHygieneScanPhaseExactDuplicates,
+			Keyset:           keyset,
+			ExpectedRevision: expectedRevision,
+			MaxRows:          1,
+			MaxScanBytes:     1 << 20,
+			MaxComparisons:   1,
+		})
+		if err != nil {
+			t.Fatalf("ScanMemoryHygienePage(invocation=%d) error = %v", invocation, err)
+		}
+		if _, ok := expectedRevision.Value(); !ok {
+			expectedRevision = domtypes.Some(page.Revision)
+		}
+		for _, unit := range page.Units {
+			if _, ok := unit.RelatedMemoryID.Value(); !ok {
+				t.Fatalf("duplicate member %s has no deterministic peer", unit.Row.MemoryID())
+			}
+			members = append(members, unit.Row.MemoryID().String())
+		}
+		keyset = page.ProgressKeyset
+		if page.Done {
+			break
+		}
+	}
+	want := []string{"mem-0000", "mem-0001", "mem-0002"}
+	if fmt.Sprint(members) != fmt.Sprint(want) {
+		t.Fatalf("duplicate members = %v, want %v", members, want)
+	}
+}
+
+func TestMemoryHygieneScanSource_LargeScopeHonorsFixedInvocationBudget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "large.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 256, "same scope fact")
+
+	page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		MaxRows:        16,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 7,
+	})
+	if err != nil {
+		t.Fatalf("ScanMemoryHygienePage() error = %v", err)
+	}
+	if page.Done {
+		t.Fatal("large-scope page Done = true, want bounded partial page")
+	}
+	if page.StopReason != apptypes.MemoryHygieneStopReasonComparisonLimit {
+		t.Fatalf("StopReason = %q, want comparison_limit", page.StopReason)
+	}
+	if page.Comparisons != 7 || len(page.Units) != 7 || page.ScannedRows != 14 {
+		t.Fatalf("usage = comparisons:%d units:%d rows:%d, want 7/7/14", page.Comparisons, len(page.Units), page.ScannedRows)
+	}
+}
+
+func TestMemoryHygieneScanSource_SingletonScopesChargeAnchorRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "singleton-scopes.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 4, "independent fact")
+	for i := 0; i < 4; i++ {
+		if _, err := db.ExecContext(
+			ctx,
+			`UPDATE memories SET scope_value = ? WHERE id = ?`,
+			fmt.Sprintf("github.com/example/repo-%d", i),
+			fmt.Sprintf("mem-%04d", i),
+		); err != nil {
+			t.Fatalf("move singleton %d error = %v", i, err)
+		}
+	}
+
+	page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		MaxRows:        2,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 10,
+	})
+	if err != nil {
+		t.Fatalf("ScanMemoryHygienePage() error = %v", err)
+	}
+	if page.StopReason != apptypes.MemoryHygieneStopReasonRowLimit || page.ScannedRows != 2 || len(page.Units) != 2 {
+		t.Fatalf("singleton page = stop:%q rows:%d units:%d, want row_limit/2/2",
+			page.StopReason,
+			page.ScannedRows,
+			len(page.Units),
+		)
+	}
+	if page.Comparisons != 0 {
+		t.Fatalf("singleton comparisons = %d, want 0", page.Comparisons)
+	}
+}
+
+func TestMemoryHygieneScanSource_OversizedFactStopsBeforeReturningRawRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "oversized.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 1, strings.Repeat("secret-tail-", 1_000))
+
+	page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseAcceptedRows,
+		MaxRows:        2,
+		MaxScanBytes:   64,
+		MaxComparisons: 1,
+	})
+	if err != nil {
+		t.Fatalf("ScanMemoryHygienePage() error = %v", err)
+	}
+	if page.StopReason != apptypes.MemoryHygieneStopReasonScanByteLimit {
+		t.Fatalf("StopReason = %q, want scan_byte_limit", page.StopReason)
+	}
+	if len(page.Units) != 0 || page.ScannedBytes != 0 || page.ProgressKeyset != (apptypes.MemoryHygieneScanKeyset{}) {
+		t.Fatalf("oversized row crossed source boundary: %#v", page)
+	}
+}
+
+func TestMemoryHygieneScanSource_TargetedRevalidationFailsClosedAtPeerBound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "revalidate.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 4, "same exact fact")
+	if _, err := db.ExecContext(
+		ctx,
+		`UPDATE memories SET scope_value = ? WHERE id = ?`,
+		"github.com/example/other",
+		"mem-0003",
+	); err != nil {
+		t.Fatalf("move unrelated peer error = %v", err)
+	}
+
+	result, err := source.RevalidateMemoryHygiene(ctx, apptypes.MemoryHygieneRevalidationCriteria{
+		MemoryID:       domtypes.MemoryID("mem-0000"),
+		MaxRows:        2,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 10,
+	})
+	if err != nil {
+		t.Fatalf("RevalidateMemoryHygiene() error = %v", err)
+	}
+	if result.Complete || result.StopReason != apptypes.MemoryHygieneStopReasonRowLimit {
+		t.Fatalf("bounded revalidation = complete:%t stop:%q, want partial row_limit", result.Complete, result.StopReason)
+	}
+	if result.ScannedRows != 2 || len(result.Peers) != 1 {
+		t.Fatalf("bounded revalidation rows=%d peers=%d, want 2/1", result.ScannedRows, len(result.Peers))
+	}
+	if peerID, ok := result.ExactDuplicateMemoryID.Value(); !ok || peerID.String() != "mem-0001" {
+		t.Fatalf("ExactDuplicateMemoryID = (%s,%t), want mem-0001", peerID, ok)
+	}
+
+	complete, err := source.RevalidateMemoryHygiene(ctx, apptypes.MemoryHygieneRevalidationCriteria{
+		MemoryID:       domtypes.MemoryID("mem-0000"),
+		MaxRows:        10,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 10,
+	})
+	if err != nil {
+		t.Fatalf("complete RevalidateMemoryHygiene() error = %v", err)
+	}
+	if !complete.Complete || complete.StopReason != apptypes.MemoryHygieneStopReasonComplete {
+		t.Fatalf("complete revalidation = %#v", complete)
+	}
+	if len(complete.Peers) != 2 {
+		t.Fatalf("same-scope peers = %d, want 2 (unrelated scope excluded)", len(complete.Peers))
+	}
+}
+
+func BenchmarkMemoryHygieneScanSource_LargeScopeFixedBudget(b *testing.B) {
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "benchmark.db")
+	database := infra.NewDatabase(dbPath, onDiskSQLiteMigrations(b))
+	source := infra.NewMemoryDatasource(database)
+	store := infra.NewStoreManagementDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		b.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(b, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(b, db, 1_000, "benchmark fact")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		page, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+			Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+			MaxRows:        128,
+			MaxScanBytes:   1 << 20,
+			MaxComparisons: 64,
+		})
+		if err != nil {
+			b.Fatalf("ScanMemoryHygienePage() error = %v", err)
+		}
+		if page.Comparisons != 64 {
+			b.Fatalf("Comparisons = %d, want 64", page.Comparisons)
+		}
+	}
+}
+
+func openMemoryHygieneTestDB(t testing.TB, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	return db
+}
+
+func memoryHygieneRevisionForTest(t testing.TB, db *sql.DB) int64 {
+	t.Helper()
+	var revision int64
+	if err := db.QueryRow(`SELECT revision FROM memory_hygiene_revision WHERE singleton = 1`).Scan(&revision); err != nil {
+		t.Fatalf("query memory hygiene revision error = %v", err)
+	}
+	return revision
+}
+
+func insertMemoryHygieneRows(t testing.TB, db *sql.DB, count int, fact string) {
+	t.Helper()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	stmt, err := tx.Prepare(`
+INSERT INTO memories (
+    id, type, scope_kind, scope_value, fact, status, confidence, source,
+    valid_from, created_at, updated_at
+) VALUES (?, 'decision', 'workspace', 'github.com/duck8823/traceary', ?,
+          'accepted', 'verified', 'manual',
+          '2026-07-01T00:00:00.000000000Z',
+          '2026-07-01T00:00:00Z',
+          '2026-07-01T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for i := 0; i < count; i++ {
+		if _, err := stmt.Exec(fmt.Sprintf("mem-%04d", i), fact); err != nil {
+			t.Fatalf("insert memory %d error = %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+}
+
+var _ interface {
+	ScanMemoryHygienePage(context.Context, apptypes.MemoryHygieneScanPageCriteria) (apptypes.MemoryHygieneScanSourcePage, error)
+} = (*infra.MemoryDatasource)(nil)

--- a/infrastructure/sqlite/memory_hygiene_scan_source_test.go
+++ b/infrastructure/sqlite/memory_hygiene_scan_source_test.go
@@ -100,6 +100,63 @@ func TestMemoryHygieneScanSource_RejectsRevisionChangedBetweenPages(t *testing.T
 	if !errors.Is(err, queryservice.ErrMemoryHygieneRevisionChanged) {
 		t.Fatalf("continuation error = %v, want ErrMemoryHygieneRevisionChanged", err)
 	}
+	var revisionChanged *queryservice.MemoryHygieneRevisionChangedError
+	if !errors.As(err, &revisionChanged) || revisionChanged.CurrentRevision != first.Revision+1 {
+		t.Fatalf("continuation error = %#v, want current revision %d", err, first.Revision+1)
+	}
+}
+
+func TestMemoryHygieneScanSource_BestEffortSkipsDeletedPairAnchor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "best-effort-deleted-anchor.db")
+	source, store := newMemoryDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openMemoryHygieneTestDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	insertMemoryHygieneRows(t, db, 3, "shared words")
+
+	first, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:          apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		MaxRows:        4,
+		MaxScanBytes:   1 << 20,
+		MaxComparisons: 1,
+	})
+	if err != nil {
+		t.Fatalf("first ScanMemoryHygienePage() error = %v", err)
+	}
+	if first.ProgressKeyset.AnchorMemoryID != "mem-0000" ||
+		first.ProgressKeyset.AfterPartnerID != "mem-0001" {
+		t.Fatalf("first keyset = %#v, want mem-0000/mem-0001", first.ProgressKeyset)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM memories WHERE id = ?`, "mem-0000"); err != nil {
+		t.Fatalf("DELETE anchor error = %v", err)
+	}
+	currentRevision := memoryHygieneRevisionForTest(t, db)
+
+	resumed, err := source.ScanMemoryHygienePage(ctx, apptypes.MemoryHygieneScanPageCriteria{
+		Phase:            apptypes.MemoryHygieneScanPhaseSimilarityPairs,
+		Keyset:           first.ProgressKeyset,
+		Consistency:      apptypes.MemoryHygieneScanConsistencyBestEffort,
+		ExpectedRevision: domtypes.Some(currentRevision),
+		MaxRows:          4,
+		MaxScanBytes:     1 << 20,
+		MaxComparisons:   1,
+	})
+	if err != nil {
+		t.Fatalf("best-effort ScanMemoryHygienePage() error = %v", err)
+	}
+	if len(resumed.Units) != 1 {
+		t.Fatalf("best-effort units = %d, want one remaining pair", len(resumed.Units))
+	}
+	peer, ok := resumed.Units[0].Peer.Value()
+	if !ok || resumed.Units[0].Row.MemoryID().String() != "mem-0001" ||
+		peer.MemoryID().String() != "mem-0002" {
+		t.Fatalf("best-effort pair = %#v, want mem-0001/mem-0002", resumed.Units[0])
+	}
 }
 
 func TestMemoryHygieneScanSource_SimilarityPairsResumeWithoutDuplicateOrSkip(t *testing.T) {

--- a/presentation/cli/golden_test.go
+++ b/presentation/cli/golden_test.go
@@ -319,19 +319,30 @@ func TestMemoryFamily_JSON_Goldens(t *testing.T) {
 		ExportedCount: 1,
 	}
 	hygieneSuggestion := apptypes.MemoryHygieneSuggestion{
-		MemoryID:            accepted.Summary().MemoryID(),
-		Kind:                apptypes.MemoryHygieneSuggestionSupersedeCandidate,
-		Reason:              "newer overlapping decision",
-		Fact:                "Accepted golden memory",
-		ReplacementMemoryID: candidate.Summary().MemoryID(),
-		ReplacementFact:     "Candidate golden memory",
-		Similarity:          0.75,
-		Scope:               accepted.Summary().Scope(),
-		UpdatedAt:           time.Date(2026, 4, 14, 15, 0, 0, 0, time.UTC),
+		MemoryID:               accepted.Summary().MemoryID(),
+		Kind:                   apptypes.MemoryHygieneSuggestionSupersedeCandidate,
+		Reason:                 "newer overlapping decision",
+		Fact:                   "Accepted golden memory",
+		FactPreview:            "Accepted golden memory",
+		ReplacementMemoryID:    candidate.Summary().MemoryID(),
+		ReplacementFact:        "Candidate golden memory",
+		ReplacementFactPreview: "Candidate golden memory",
+		Similarity:             0.75,
+		Scope:                  accepted.Summary().Scope(),
+		UpdatedAt:              time.Date(2026, 4, 14, 15, 0, 0, 0, time.UTC),
 	}
 	hygieneResult := apptypes.MemoryHygieneScanResult{
 		Suggestions:             []apptypes.MemoryHygieneSuggestion{hygieneSuggestion},
 		SupersedeCandidateCount: 1,
+		Complete:                true,
+		StopReason:              apptypes.MemoryHygieneStopReasonComplete,
+		Usage: apptypes.MemoryHygieneScanUsage{
+			ScannedRows:   2,
+			ScannedBytes:  48,
+			ResultBytes:   320,
+			Comparisons:   1,
+			ElapsedMillis: 3,
+		},
 	}
 	hygieneApplyResult := apptypes.MemoryHygieneApplyResult{
 		Applied: []apptypes.MemoryHygieneApplied{{

--- a/presentation/cli/golden_test.go
+++ b/presentation/cli/golden_test.go
@@ -336,6 +336,7 @@ func TestMemoryFamily_JSON_Goldens(t *testing.T) {
 		SupersedeCandidateCount: 1,
 		Complete:                true,
 		StopReason:              apptypes.MemoryHygieneStopReasonComplete,
+		Consistency:             apptypes.MemoryHygieneScanConsistencyConsistent,
 		Usage: apptypes.MemoryHygieneScanUsage{
 			ScannedRows:   2,
 			ScannedBytes:  48,

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -533,17 +533,23 @@ type memoryImportInstructionsCommandInput struct {
 }
 
 // memoryHygieneScanCommandInput is the resolved input to the
-// `traceary memory hygiene scan` command. includeHidden expands the
+// `traceary memory admin hygiene scan` command. includeHidden expands the
 // candidate-noise pass (#864) to inspect extracted-hidden rows so an
 // operator can clean up the backlog of low-quality candidates from
 // before the extractor learned to hide them.
 type memoryHygieneScanCommandInput struct {
-	dbPath        string
-	workspace     string
-	expiryDays    int
-	similarity    float64
-	includeHidden bool
-	asJSON        bool
+	dbPath         string
+	workspace      string
+	expiryDays     int
+	similarity     float64
+	includeHidden  bool
+	cursor         string
+	maxRows        int
+	maxScanBytes   int64
+	maxResultBytes int64
+	maxComparisons int
+	maxDuration    time.Duration
+	asJSON         bool
 }
 
 // memoryHygieneApplyCommandInput is the resolved input to

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -543,7 +543,6 @@ type memoryHygieneScanCommandInput struct {
 	expiryDays     int
 	similarity     float64
 	includeHidden  bool
-	cursor         string
 	maxRows        int
 	maxScanBytes   int64
 	maxResultBytes int64

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -16,6 +16,8 @@ import (
 
 const defaultHygieneExpiryDays = 90
 
+const memoryHygieneScanRerunGuidance = `rerun with a narrower --workspace or larger finite scan bounds; use MCP query_memory(action="scan_hygiene") for resumable paging`
+
 func (c *RootCLI) newMemoryHygieneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hygiene",
@@ -160,10 +162,6 @@ func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
 		"inspect extracted-hidden candidates as well (default scans visible candidates only)",
 		"extracted-hidden のメモリ候補も検査対象に含める (既定では visible メモリ候補のみ)",
 	))
-	cmd.Flags().StringVar(&input.cursor, "cursor", "", Localize(
-		"process-authenticated cursor returned by a partial hygiene scan; restart requires a new scan",
-		"途中で終了した hygiene scan が返したプロセス認証済みカーソル。プロセス再起動後は新しい scan が必要",
-	))
 	cmd.Flags().IntVar(&input.maxRows, "max-scan-rows", defaultBudget.MaxRows(), Localize(
 		"maximum source rows charged to one invocation",
 		"1 回の実行で読み取る source row の上限",
@@ -221,10 +219,7 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 		SimilarityThreshold:     input.similarity,
 		IncludeHiddenCandidates: input.includeHidden,
 		Budget:                  budget,
-		Cursor:                  input.cursor,
-	}
-	if input.cursor == "" {
-		criteria.Now = time.Now().UTC()
+		Now:                     time.Now().UTC(),
 	}
 	if scope != nil {
 		criteria.Scopes = []domtypes.MemoryScope{scope}
@@ -251,7 +246,6 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 			StopReason:                    string(result.StopReason),
 			Consistency:                   string(result.Consistency),
 			ConsistencyReason:             string(result.ConsistencyReason),
-			NextCursor:                    result.NextCursor,
 			Usage: memoryHygieneUsageOutput{
 				ScannedRows:   result.Usage.ScannedRows,
 				ScannedBytes:  result.Usage.ScannedBytes,
@@ -260,6 +254,9 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 				ElapsedMillis: result.Usage.ElapsedMillis,
 			},
 			Suggestions: make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
+		}
+		if result.Partial {
+			payload.RerunGuidance = memoryHygieneScanRerunGuidance
 		}
 		for _, suggestion := range result.Suggestions {
 			payload.Suggestions = append(payload.Suggestions, newMemoryHygieneOutputEntry(suggestion))
@@ -294,8 +291,8 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene coverage", "hygiene scan の完了状態を出力できませんでした"), err)
 	}
 	if result.Partial {
-		if _, err := fmt.Fprintf(output, "next_cursor=%s\n", result.NextCursor); err != nil {
-			return xerrors.Errorf("%s: %w", Localize("failed to print hygiene continuation cursor", "hygiene scan の継続カーソルを出力できませんでした"), err)
+		if _, err := fmt.Fprintf(output, "rerun_guidance=%s\n", memoryHygieneScanRerunGuidance); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print hygiene re-run guidance", "hygiene scan の再実行ガイダンスを出力できませんでした"), err)
 		}
 	}
 	for _, suggestion := range result.Suggestions {

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -161,8 +161,8 @@ func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
 		"extracted-hidden のメモリ候補も検査対象に含める (既定では visible メモリ候補のみ)",
 	))
 	cmd.Flags().StringVar(&input.cursor, "cursor", "", Localize(
-		"opaque cursor returned by a partial hygiene scan",
-		"途中で終了した hygiene scan が返した不透明カーソル",
+		"process-authenticated cursor returned by a partial hygiene scan; restart requires a new scan",
+		"途中で終了した hygiene scan が返したプロセス認証済みカーソル。プロセス再起動後は新しい scan が必要",
 	))
 	cmd.Flags().IntVar(&input.maxRows, "max-scan-rows", defaultBudget.MaxRows(), Localize(
 		"maximum source rows charged to one invocation",
@@ -223,6 +223,9 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 		Budget:                  budget,
 		Cursor:                  input.cursor,
 	}
+	if input.cursor == "" {
+		criteria.Now = time.Now().UTC()
+	}
 	if scope != nil {
 		criteria.Scopes = []domtypes.MemoryScope{scope}
 	}
@@ -246,6 +249,8 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 			Complete:                      result.Complete,
 			Partial:                       result.Partial,
 			StopReason:                    string(result.StopReason),
+			Consistency:                   string(result.Consistency),
+			ConsistencyReason:             string(result.ConsistencyReason),
 			NextCursor:                    result.NextCursor,
 			Usage: memoryHygieneUsageOutput{
 				ScannedRows:   result.Usage.ScannedRows,
@@ -274,10 +279,12 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene summary", "hygiene サマリの出力に失敗しました"), err)
 	}
 	if _, err := fmt.Fprintf(output,
-		"complete=%t partial=%t stop_reason=%s scanned_rows=%d scanned_bytes=%d result_bytes=%d comparisons=%d elapsed_ms=%d\n",
+		"complete=%t partial=%t stop_reason=%s consistency=%s consistency_reason=%s scanned_rows=%d scanned_bytes=%d result_bytes=%d comparisons=%d elapsed_ms=%d\n",
 		result.Complete,
 		result.Partial,
 		result.StopReason,
+		result.Consistency,
+		memoryHygieneConsistencyReasonLabel(result.ConsistencyReason),
 		result.Usage.ScannedRows,
 		result.Usage.ScannedBytes,
 		result.Usage.ResultBytes,
@@ -320,6 +327,13 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		}
 	}
 	return nil
+}
+
+func memoryHygieneConsistencyReasonLabel(reason apptypes.MemoryHygieneConsistencyReason) string {
+	if reason == "" {
+		return "-"
+	}
+	return string(reason)
 }
 
 type memoryHygieneOutputEntry struct {

--- a/presentation/cli/memory_hygiene.go
+++ b/presentation/cli/memory_hygiene.go
@@ -126,7 +126,15 @@ func writeMemoryHygieneApplyResult(output io.Writer, result apptypes.MemoryHygie
 }
 
 func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
-	input := memoryHygieneScanCommandInput{expiryDays: defaultHygieneExpiryDays}
+	defaultBudget := apptypes.DefaultMemoryHygieneScanBudget()
+	input := memoryHygieneScanCommandInput{
+		expiryDays:     defaultHygieneExpiryDays,
+		maxRows:        defaultBudget.MaxRows(),
+		maxScanBytes:   defaultBudget.MaxScanBytes(),
+		maxResultBytes: defaultBudget.MaxResultBytes(),
+		maxComparisons: defaultBudget.MaxComparisons(),
+		maxDuration:    defaultBudget.MaxDuration(),
+	}
 	cmd := &cobra.Command{
 		Use:   "scan",
 		Short: Localize("Scan accepted memories for redaction / expiry / duplicate / supersede / validity-overlap and memory candidates for low-quality noise", "accepted memory に対して redaction / expiry / duplicate / supersede / validity-overlap、メモリ候補に対して低品質ノイズの hygiene 候補を検出する"),
@@ -152,6 +160,30 @@ func (c *RootCLI) newMemoryHygieneScanCommand() *cobra.Command {
 		"inspect extracted-hidden candidates as well (default scans visible candidates only)",
 		"extracted-hidden のメモリ候補も検査対象に含める (既定では visible メモリ候補のみ)",
 	))
+	cmd.Flags().StringVar(&input.cursor, "cursor", "", Localize(
+		"opaque cursor returned by a partial hygiene scan",
+		"途中で終了した hygiene scan が返した不透明カーソル",
+	))
+	cmd.Flags().IntVar(&input.maxRows, "max-scan-rows", defaultBudget.MaxRows(), Localize(
+		"maximum source rows charged to one invocation",
+		"1 回の実行で読み取る source row の上限",
+	))
+	cmd.Flags().Int64Var(&input.maxScanBytes, "max-scan-bytes", defaultBudget.MaxScanBytes(), Localize(
+		"maximum raw source bytes charged to one invocation",
+		"1 回の実行で読み取る raw source byte の上限",
+	))
+	cmd.Flags().Int64Var(&input.maxResultBytes, "max-result-bytes", defaultBudget.MaxResultBytes(), Localize(
+		"maximum serialized suggestion bytes returned by one invocation",
+		"1 回の実行で返す suggestion の serialize 後 byte 上限",
+	))
+	cmd.Flags().IntVar(&input.maxComparisons, "max-comparisons", defaultBudget.MaxComparisons(), Localize(
+		"maximum duplicate or similarity comparisons per invocation",
+		"1 回の実行で行う duplicate / similarity 比較の上限",
+	))
+	cmd.Flags().DurationVar(&input.maxDuration, "max-duration", defaultBudget.MaxDuration(), Localize(
+		"maximum wall-clock duration for one invocation",
+		"1 回の実行に許す最大経過時間",
+	))
 	cmd.Flags().BoolVar(&input.asJSON, "json", false, Localize("print JSON output", "JSON 形式で出力する"))
 	return cmd
 }
@@ -166,6 +198,16 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 	if input.expiryDays <= 0 {
 		return xerrors.New(Localize("--expiry-days must be greater than 0", "--expiry-days は 0 より大きい必要があります"))
 	}
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        input.maxRows,
+		MaxScanBytes:   input.maxScanBytes,
+		MaxResultBytes: input.maxResultBytes,
+		MaxComparisons: input.maxComparisons,
+		MaxDuration:    input.maxDuration,
+	})
+	if err != nil {
+		return xerrors.Errorf("%s: %w", Localize("invalid hygiene scan budget", "hygiene scan budget が不正です"), err)
+	}
 	if err := c.initializeStore(ctx, input.dbPath); err != nil {
 		return err
 	}
@@ -178,6 +220,8 @@ func (c *RootCLI) runMemoryHygieneScan(ctx context.Context, output io.Writer, in
 		StalenessThreshold:      time.Duration(input.expiryDays) * 24 * time.Hour,
 		SimilarityThreshold:     input.similarity,
 		IncludeHiddenCandidates: input.includeHidden,
+		Budget:                  budget,
+		Cursor:                  input.cursor,
 	}
 	if scope != nil {
 		criteria.Scopes = []domtypes.MemoryScope{scope}
@@ -199,7 +243,18 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 			SupersedeCandidateCount:       result.SupersedeCandidateCount,
 			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
 			LowQualityCandidateCount:      result.LowQualityCandidateCount,
-			Suggestions:                   make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
+			Complete:                      result.Complete,
+			Partial:                       result.Partial,
+			StopReason:                    string(result.StopReason),
+			NextCursor:                    result.NextCursor,
+			Usage: memoryHygieneUsageOutput{
+				ScannedRows:   result.Usage.ScannedRows,
+				ScannedBytes:  result.Usage.ScannedBytes,
+				ResultBytes:   result.Usage.ResultBytes,
+				Comparisons:   result.Usage.Comparisons,
+				ElapsedMillis: result.Usage.ElapsedMillis,
+			},
+			Suggestions: make([]memoryHygieneOutputEntry, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
 			payload.Suggestions = append(payload.Suggestions, newMemoryHygieneOutputEntry(suggestion))
@@ -218,6 +273,24 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 	), result.RedactionHitCount, result.ExpiryCandidateCount, result.DuplicateCount, result.SupersedeCandidateCount, result.ValidityOverlapSupersedeCount, result.LowQualityCandidateCount); err != nil {
 		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene summary", "hygiene サマリの出力に失敗しました"), err)
 	}
+	if _, err := fmt.Fprintf(output,
+		"complete=%t partial=%t stop_reason=%s scanned_rows=%d scanned_bytes=%d result_bytes=%d comparisons=%d elapsed_ms=%d\n",
+		result.Complete,
+		result.Partial,
+		result.StopReason,
+		result.Usage.ScannedRows,
+		result.Usage.ScannedBytes,
+		result.Usage.ResultBytes,
+		result.Usage.Comparisons,
+		result.Usage.ElapsedMillis,
+	); err != nil {
+		return xerrors.Errorf("%s: %w", Localize("failed to print hygiene coverage", "hygiene scan の完了状態を出力できませんでした"), err)
+	}
+	if result.Partial {
+		if _, err := fmt.Fprintf(output, "next_cursor=%s\n", result.NextCursor); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to print hygiene continuation cursor", "hygiene scan の継続カーソルを出力できませんでした"), err)
+		}
+	}
 	for _, suggestion := range result.Suggestions {
 		extra := ""
 		if suggestion.DuplicateMemoryID != "" {
@@ -226,8 +299,8 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 		if suggestion.ReplacementMemoryID != "" {
 			extra += fmt.Sprintf(" replacement=%s similarity=%.2f", suggestion.ReplacementMemoryID.String(), suggestion.Similarity)
 		}
-		if suggestion.SanitizedFact != "" {
-			extra += fmt.Sprintf(" sanitized=%q", truncateMessage(suggestion.SanitizedFact))
+		if suggestion.SanitizedFactPreview != "" {
+			extra += fmt.Sprintf(" sanitized_preview=%q", suggestion.SanitizedFactPreview)
 		}
 		if suggestion.Status != "" {
 			extra += fmt.Sprintf(" status=%s", suggestion.Status)
@@ -241,7 +314,7 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 			memoryScopeLabelOrDash(suggestion.Scope),
 			suggestion.Reason,
 			extra,
-			truncateMessage(suggestion.Fact),
+			suggestion.FactPreview,
 		); err != nil {
 			return xerrors.Errorf("%s: %w", Localize("failed to print hygiene suggestion row", "hygiene 候補行の出力に失敗しました"), err)
 		}
@@ -250,39 +323,45 @@ func writeMemoryHygieneScanResult(output io.Writer, result apptypes.MemoryHygien
 }
 
 type memoryHygieneOutputEntry struct {
-	MemoryID            string   `json:"memory_id"`
-	Kind                string   `json:"kind"`
-	Reason              string   `json:"reason"`
-	Fact                string   `json:"fact"`
-	SanitizedFact       string   `json:"sanitized_fact,omitempty"`
-	DuplicateMemoryID   string   `json:"duplicate_memory_id,omitempty"`
-	ReplacementMemoryID string   `json:"replacement_memory_id,omitempty"`
-	ReplacementFact     string   `json:"replacement_fact,omitempty"`
-	Similarity          float64  `json:"similarity,omitempty"`
-	ScopeKind           string   `json:"scope_kind,omitempty"`
-	ScopeValue          string   `json:"scope_value,omitempty"`
-	UpdatedAt           string   `json:"updated_at"`
-	Status              string   `json:"status,omitempty"`
-	Source              string   `json:"source,omitempty"`
-	QualityReasons      []string `json:"quality_reasons,omitempty"`
+	MemoryID                    string   `json:"memory_id"`
+	Kind                        string   `json:"kind"`
+	Reason                      string   `json:"reason"`
+	Fact                        string   `json:"fact"`
+	FactPreviewTruncated        bool     `json:"fact_preview_truncated,omitempty"`
+	SanitizedFact               string   `json:"sanitized_fact,omitempty"`
+	SanitizedPreviewTruncated   bool     `json:"sanitized_preview_truncated,omitempty"`
+	DuplicateMemoryID           string   `json:"duplicate_memory_id,omitempty"`
+	ReplacementMemoryID         string   `json:"replacement_memory_id,omitempty"`
+	ReplacementFact             string   `json:"replacement_fact,omitempty"`
+	ReplacementPreviewTruncated bool     `json:"replacement_preview_truncated,omitempty"`
+	Similarity                  float64  `json:"similarity,omitempty"`
+	ScopeKind                   string   `json:"scope_kind,omitempty"`
+	ScopeValue                  string   `json:"scope_value,omitempty"`
+	UpdatedAt                   string   `json:"updated_at"`
+	Status                      string   `json:"status,omitempty"`
+	Source                      string   `json:"source,omitempty"`
+	QualityReasons              []string `json:"quality_reasons,omitempty"`
 }
 
 func newMemoryHygieneOutputEntry(suggestion apptypes.MemoryHygieneSuggestion) memoryHygieneOutputEntry {
 	entry := memoryHygieneOutputEntry{
-		MemoryID:      suggestion.MemoryID.String(),
-		Kind:          string(suggestion.Kind),
-		Reason:        suggestion.Reason,
-		Fact:          suggestion.Fact,
-		SanitizedFact: suggestion.SanitizedFact,
-		Similarity:    suggestion.Similarity,
-		UpdatedAt:     formatJSONTime(suggestion.UpdatedAt),
+		MemoryID:                  suggestion.MemoryID.String(),
+		Kind:                      string(suggestion.Kind),
+		Reason:                    suggestion.Reason,
+		Fact:                      suggestion.FactPreview,
+		FactPreviewTruncated:      suggestion.FactPreviewTruncated,
+		SanitizedFact:             suggestion.SanitizedFactPreview,
+		SanitizedPreviewTruncated: suggestion.SanitizedPreviewTruncated,
+		Similarity:                suggestion.Similarity,
+		UpdatedAt:                 formatJSONTime(suggestion.UpdatedAt),
 	}
 	if suggestion.DuplicateMemoryID != "" {
 		entry.DuplicateMemoryID = suggestion.DuplicateMemoryID.String()
 	}
 	if suggestion.ReplacementMemoryID != "" {
 		entry.ReplacementMemoryID = suggestion.ReplacementMemoryID.String()
-		entry.ReplacementFact = suggestion.ReplacementFact
+		entry.ReplacementFact = suggestion.ReplacementFactPreview
+		entry.ReplacementPreviewTruncated = suggestion.ReplacementPreviewTruncated
 	}
 	if suggestion.Scope != nil {
 		entry.ScopeKind = suggestion.Scope.Kind().String()

--- a/presentation/cli/memory_hygiene_command_test.go
+++ b/presentation/cli/memory_hygiene_command_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
-func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
+func TestMemoryHygieneScanCommand_PassesExplicitBoundsWithoutCursor(t *testing.T) {
 	t.Parallel()
 
 	memoryStub := &memoryUsecaseStub{
@@ -32,7 +33,6 @@ func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
 		"--expiry-days", "30",
 		"--similarity", "0.75",
 		"--include-hidden",
-		"--cursor", "opaque-cursor",
 		"--max-scan-rows", "12",
 		"--max-scan-bytes", "4096",
 		"--max-result-bytes", "2048",
@@ -45,7 +45,7 @@ func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
 	}
 
 	got := memoryStub.scanCriteria
-	if got.Cursor != "opaque-cursor" ||
+	if got.Cursor != "" ||
 		got.Budget.MaxRows() != 12 ||
 		got.Budget.MaxScanBytes() != 4_096 ||
 		got.Budget.MaxResultBytes() != 2_048 ||
@@ -56,11 +56,36 @@ func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
 	if got.SimilarityThreshold != 0.75 || !got.IncludeHiddenCandidates {
 		t.Fatalf("scan criteria = %#v, want similarity/include-hidden", got)
 	}
-	if !got.Now.IsZero() {
-		t.Fatalf("continuation criteria Now = %s, want authenticated cursor time to remain authoritative", got.Now)
+	if got.Now.IsZero() {
+		t.Fatal("initial scan Now is zero, want boundary-owned scan time")
 	}
 	if len(got.Scopes) != 1 || got.Scopes[0].Key() != "github.com/example/repo" {
 		t.Fatalf("Scopes = %#v, want explicit workspace", got.Scopes)
+	}
+}
+
+func TestMemoryHygieneScanCommand_RejectsCursorFlag(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"memory", "admin", "hygiene", "scan",
+		"--cursor", "opaque-cursor",
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --cursor") {
+		t.Fatalf("Execute() error = %v, want unknown --cursor flag", err)
+	}
+	if !memoryStub.scanCriteria.Now.IsZero() {
+		t.Fatalf("Scan() was called for rejected cursor flag: %#v", memoryStub.scanCriteria)
 	}
 }
 

--- a/presentation/cli/memory_hygiene_command_test.go
+++ b/presentation/cli/memory_hygiene_command_test.go
@@ -1,0 +1,62 @@
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/presentation/cli"
+)
+
+func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{
+		scanResult: apptypes.MemoryHygieneScanResult{
+			Complete:   true,
+			StopReason: apptypes.MemoryHygieneStopReasonComplete,
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"memory", "admin", "hygiene", "scan",
+		"--db-path", t.TempDir() + "/traceary.db",
+		"--workspace", "github.com/example/repo",
+		"--expiry-days", "30",
+		"--similarity", "0.75",
+		"--include-hidden",
+		"--cursor", "opaque-cursor",
+		"--max-scan-rows", "12",
+		"--max-scan-bytes", "4096",
+		"--max-result-bytes", "2048",
+		"--max-comparisons", "21",
+		"--max-duration", "750ms",
+		"--json",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := memoryStub.scanCriteria
+	if got.Cursor != "opaque-cursor" ||
+		got.Budget.MaxRows() != 12 ||
+		got.Budget.MaxScanBytes() != 4_096 ||
+		got.Budget.MaxResultBytes() != 2_048 ||
+		got.Budget.MaxComparisons() != 21 ||
+		got.Budget.MaxDuration() != 750*time.Millisecond {
+		t.Fatalf("scan criteria did not preserve explicit bounds: %#v", got)
+	}
+	if got.SimilarityThreshold != 0.75 || !got.IncludeHiddenCandidates {
+		t.Fatalf("scan criteria = %#v, want similarity/include-hidden", got)
+	}
+	if len(got.Scopes) != 1 || got.Scopes[0].Key() != "github.com/example/repo" {
+		t.Fatalf("Scopes = %#v, want explicit workspace", got.Scopes)
+	}
+}

--- a/presentation/cli/memory_hygiene_command_test.go
+++ b/presentation/cli/memory_hygiene_command_test.go
@@ -56,7 +56,46 @@ func TestMemoryHygieneScanCommand_PassesExplicitBoundsAndCursor(t *testing.T) {
 	if got.SimilarityThreshold != 0.75 || !got.IncludeHiddenCandidates {
 		t.Fatalf("scan criteria = %#v, want similarity/include-hidden", got)
 	}
+	if !got.Now.IsZero() {
+		t.Fatalf("continuation criteria Now = %s, want authenticated cursor time to remain authoritative", got.Now)
+	}
 	if len(got.Scopes) != 1 || got.Scopes[0].Key() != "github.com/example/repo" {
 		t.Fatalf("Scopes = %#v, want explicit workspace", got.Scopes)
+	}
+}
+
+func TestMemoryHygieneScanCommand_OwnsInitialScanTime(t *testing.T) {
+	t.Parallel()
+
+	memoryStub := &memoryUsecaseStub{
+		scanResult: apptypes.MemoryHygieneScanResult{
+			Complete:    true,
+			StopReason:  apptypes.MemoryHygieneStopReasonComplete,
+			Consistency: apptypes.MemoryHygieneScanConsistencyConsistent,
+		},
+	}
+	root := cli.NewRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithMemory(memoryStub),
+	)
+	cmd := root.Command()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"memory", "admin", "hygiene", "scan",
+		"--db-path", t.TempDir() + "/traceary.db",
+		"--json",
+	})
+	before := time.Now().UTC()
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	after := time.Now().UTC()
+	if memoryStub.scanCriteria.Now.Before(before) || memoryStub.scanCriteria.Now.After(after) {
+		t.Fatalf("initial scan Now = %s, want boundary-owned time in [%s,%s]",
+			memoryStub.scanCriteria.Now,
+			before,
+			after,
+		)
 	}
 }

--- a/presentation/cli/memory_hygiene_test.go
+++ b/presentation/cli/memory_hygiene_test.go
@@ -194,8 +194,11 @@ func TestWriteMemoryHygieneScanResult_NeverRendersRawFacts(t *testing.T) {
 		if !strings.Contains(output, "[REDACTED]") {
 			t.Fatalf("output(json=%t) omitted safe preview: %s", asJSON, output)
 		}
-		if !strings.Contains(output, "opaque_cursor") {
-			t.Fatalf("output(json=%t) omitted continuation cursor: %s", asJSON, output)
+		if strings.Contains(output, "opaque_cursor") || strings.Contains(output, "next_cursor") {
+			t.Fatalf("output(json=%t) exposed a process-local continuation cursor: %s", asJSON, output)
+		}
+		if !strings.Contains(output, "rerun_guidance") || !strings.Contains(output, "resumable paging") {
+			t.Fatalf("output(json=%t) omitted bounded re-run guidance: %s", asJSON, output)
 		}
 		if !strings.Contains(output, "best_effort") || !strings.Contains(output, "revision_changed") {
 			t.Fatalf("output(json=%t) omitted consistency downgrade: %s", asJSON, output)

--- a/presentation/cli/memory_hygiene_test.go
+++ b/presentation/cli/memory_hygiene_test.go
@@ -43,6 +43,7 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
 		LowQualityCandidateCount: 1,
 		Complete:                 true,
 		StopReason:               apptypes.MemoryHygieneStopReasonComplete,
+		Consistency:              apptypes.MemoryHygieneScanConsistencyConsistent,
 	}
 
 	var buf bytes.Buffer
@@ -51,7 +52,8 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
 	}
 
 	var payload struct {
-		LowQualityCandidateCount int `json:"low_quality_candidate_count"`
+		LowQualityCandidateCount int    `json:"low_quality_candidate_count"`
+		Consistency              string `json:"consistency"`
 		Suggestions              []struct {
 			MemoryID       string   `json:"memory_id"`
 			Kind           string   `json:"kind"`
@@ -67,6 +69,9 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
 	}
 	if payload.LowQualityCandidateCount != 1 {
 		t.Fatalf("low_quality_candidate_count = %d, want 1", payload.LowQualityCandidateCount)
+	}
+	if payload.Consistency != "consistent" {
+		t.Fatalf("consistency = %q, want consistent", payload.Consistency)
 	}
 	if len(payload.Suggestions) != 1 {
 		t.Fatalf("suggestions = %d, want 1", len(payload.Suggestions))
@@ -118,6 +123,7 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
 		LowQualityCandidateCount: 1,
 		Complete:                 true,
 		StopReason:               apptypes.MemoryHygieneStopReasonComplete,
+		Consistency:              apptypes.MemoryHygieneScanConsistencyConsistent,
 	}
 
 	var buf bytes.Buffer
@@ -130,6 +136,7 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
 		"mem-noise",
 		"status=candidate",
 		"source=extracted",
+		"consistency=consistent",
 		"git pull --ff-only origin main",
 	} {
 		if !strings.Contains(out, want) {
@@ -163,6 +170,8 @@ func TestWriteMemoryHygieneScanResult_NeverRendersRawFacts(t *testing.T) {
 		RedactionHitCount: 1,
 		Partial:           true,
 		StopReason:        apptypes.MemoryHygieneStopReasonResultByteLimit,
+		Consistency:       apptypes.MemoryHygieneScanConsistencyBestEffort,
+		ConsistencyReason: apptypes.MemoryHygieneConsistencyReasonRevisionChanged,
 		NextCursor:        "opaque_cursor",
 		Usage: apptypes.MemoryHygieneScanUsage{
 			ScannedRows:   2,
@@ -187,6 +196,9 @@ func TestWriteMemoryHygieneScanResult_NeverRendersRawFacts(t *testing.T) {
 		}
 		if !strings.Contains(output, "opaque_cursor") {
 			t.Fatalf("output(json=%t) omitted continuation cursor: %s", asJSON, output)
+		}
+		if !strings.Contains(output, "best_effort") || !strings.Contains(output, "revision_changed") {
+			t.Fatalf("output(json=%t) omitted consistency downgrade: %s", asJSON, output)
 		}
 	}
 }

--- a/presentation/cli/memory_hygiene_test.go
+++ b/presentation/cli/memory_hygiene_test.go
@@ -31,6 +31,7 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
 		Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
 		Reason:         "low-quality extraction: diff_fragment",
 		Fact:           "+def _required_env(name):",
+		FactPreview:    "+def _required_env(name):",
 		Scope:          scope,
 		UpdatedAt:      updatedAt,
 		Status:         domtypes.MemoryStatusCandidate,
@@ -40,6 +41,8 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateJSON(t *testing.T) {
 	result := apptypes.MemoryHygieneScanResult{
 		Suggestions:              []apptypes.MemoryHygieneSuggestion{suggestion},
 		LowQualityCandidateCount: 1,
+		Complete:                 true,
+		StopReason:               apptypes.MemoryHygieneStopReasonComplete,
 	}
 
 	var buf bytes.Buffer
@@ -103,6 +106,7 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
 		Kind:           apptypes.MemoryHygieneSuggestionLowQualityCandidate,
 		Reason:         "low-quality extraction: standalone_command",
 		Fact:           "git pull --ff-only origin main",
+		FactPreview:    "git pull --ff-only origin main",
 		Scope:          scope,
 		UpdatedAt:      time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC),
 		Status:         domtypes.MemoryStatusCandidate,
@@ -112,6 +116,8 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
 	result := apptypes.MemoryHygieneScanResult{
 		Suggestions:              []apptypes.MemoryHygieneSuggestion{suggestion},
 		LowQualityCandidateCount: 1,
+		Complete:                 true,
+		StopReason:               apptypes.MemoryHygieneStopReasonComplete,
 	}
 
 	var buf bytes.Buffer
@@ -132,5 +138,55 @@ func TestWriteMemoryHygieneScanResult_LowQualityCandidateText(t *testing.T) {
 	}
 	if !strings.Contains(out, "低品質") && !strings.Contains(out, "low_quality_candidates=1") {
 		t.Fatalf("summary line missing low-quality counter: %s", out)
+	}
+}
+
+func TestWriteMemoryHygieneScanResult_NeverRendersRawFacts(t *testing.T) {
+	t.Parallel()
+
+	const rawSecret = "raw-secret-must-not-leave-application"
+	result := apptypes.MemoryHygieneScanResult{
+		Suggestions: []apptypes.MemoryHygieneSuggestion{{
+			MemoryID:               domtypes.MemoryID("mem-private"),
+			Kind:                   apptypes.MemoryHygieneSuggestionRedactionHit,
+			Reason:                 "current redaction patterns mask this fact",
+			Fact:                   rawSecret,
+			FactPreview:            "safe [REDACTED] preview…",
+			FactPreviewTruncated:   true,
+			SanitizedFact:          rawSecret,
+			SanitizedFactPreview:   "safe [REDACTED] preview…",
+			ReplacementMemoryID:    domtypes.MemoryID("mem-replacement"),
+			ReplacementFact:        rawSecret,
+			ReplacementFactPreview: "replacement [REDACTED]",
+			UpdatedAt:              time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+		}},
+		RedactionHitCount: 1,
+		Partial:           true,
+		StopReason:        apptypes.MemoryHygieneStopReasonResultByteLimit,
+		NextCursor:        "opaque_cursor",
+		Usage: apptypes.MemoryHygieneScanUsage{
+			ScannedRows:   2,
+			ScannedBytes:  128,
+			ResultBytes:   200,
+			Comparisons:   1,
+			ElapsedMillis: 5,
+		},
+	}
+
+	for _, asJSON := range []bool{false, true} {
+		var buf bytes.Buffer
+		if err := writeMemoryHygieneScanResult(&buf, result, asJSON); err != nil {
+			t.Fatalf("writeMemoryHygieneScanResult(json=%t) error = %v", asJSON, err)
+		}
+		output := buf.String()
+		if strings.Contains(output, rawSecret) {
+			t.Fatalf("output(json=%t) leaked raw fact: %s", asJSON, output)
+		}
+		if !strings.Contains(output, "[REDACTED]") {
+			t.Fatalf("output(json=%t) omitted safe preview: %s", asJSON, output)
+		}
+		if !strings.Contains(output, "opaque_cursor") {
+			t.Fatalf("output(json=%t) omitted continuation cursor: %s", asJSON, output)
+		}
 	}
 }

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -392,7 +392,7 @@ type memoryHygieneScanOutput struct {
 	StopReason                    string                     `json:"stop_reason"`
 	Consistency                   string                     `json:"consistency"`
 	ConsistencyReason             string                     `json:"consistency_reason,omitempty"`
-	NextCursor                    string                     `json:"next_cursor,omitempty"`
+	RerunGuidance                 string                     `json:"rerun_guidance,omitempty"`
 	Usage                         memoryHygieneUsageOutput   `json:"usage"`
 	Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
 }

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -390,6 +390,8 @@ type memoryHygieneScanOutput struct {
 	Complete                      bool                       `json:"complete"`
 	Partial                       bool                       `json:"partial"`
 	StopReason                    string                     `json:"stop_reason"`
+	Consistency                   string                     `json:"consistency"`
+	ConsistencyReason             string                     `json:"consistency_reason,omitempty"`
 	NextCursor                    string                     `json:"next_cursor,omitempty"`
 	Usage                         memoryHygieneUsageOutput   `json:"usage"`
 	Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`

--- a/presentation/cli/output.go
+++ b/presentation/cli/output.go
@@ -387,7 +387,20 @@ type memoryHygieneScanOutput struct {
 	SupersedeCandidateCount       int                        `json:"supersede_candidate_count"`
 	ValidityOverlapSupersedeCount int                        `json:"validity_overlap_supersede_count"`
 	LowQualityCandidateCount      int                        `json:"low_quality_candidate_count"`
+	Complete                      bool                       `json:"complete"`
+	Partial                       bool                       `json:"partial"`
+	StopReason                    string                     `json:"stop_reason"`
+	NextCursor                    string                     `json:"next_cursor,omitempty"`
+	Usage                         memoryHygieneUsageOutput   `json:"usage"`
 	Suggestions                   []memoryHygieneOutputEntry `json:"suggestions"`
+}
+
+type memoryHygieneUsageOutput struct {
+	ScannedRows   int   `json:"scanned_rows"`
+	ScannedBytes  int64 `json:"scanned_bytes"`
+	ResultBytes   int64 `json:"result_bytes"`
+	Comparisons   int   `json:"comparisons"`
+	ElapsedMillis int64 `json:"elapsed_ms"`
 }
 
 // memoryInboxBatchOutput is the JSON shape of a memory inbox batch result.

--- a/presentation/cli/testdata/memory/hygiene-scan.golden.json
+++ b/presentation/cli/testdata/memory/hygiene-scan.golden.json
@@ -5,6 +5,16 @@
   "supersede_candidate_count": 1,
   "validity_overlap_supersede_count": 0,
   "low_quality_candidate_count": 0,
+  "complete": true,
+  "partial": false,
+  "stop_reason": "complete",
+  "usage": {
+    "scanned_rows": 2,
+    "scanned_bytes": 48,
+    "result_bytes": 320,
+    "comparisons": 1,
+    "elapsed_ms": 3
+  },
   "suggestions": [
     {
       "memory_id": "memory-golden-accepted",

--- a/presentation/cli/testdata/memory/hygiene-scan.golden.json
+++ b/presentation/cli/testdata/memory/hygiene-scan.golden.json
@@ -8,6 +8,7 @@
   "complete": true,
   "partial": false,
   "stop_reason": "complete",
+  "consistency": "consistent",
   "usage": {
     "scanned_rows": 2,
     "scanned_bytes": 48,

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -508,6 +508,7 @@ type memoryUsecaseStub struct {
 	extractCriteria       apptypes.MemoryExtractionCriteria
 	importCalls           []apptypes.CodexImportCriteria
 	bridgeImportCalls     []apptypes.MemoryBridgeImportCriteria
+	scanCriteria          apptypes.MemoryHygieneScanCriteria
 	exportCalls           []apptypes.MemoryExportCriteria
 	activationPlanCalls   []apptypes.MemoryActivationCriteria
 	activationCalls       []apptypes.MemoryActivationCriteria
@@ -634,7 +635,8 @@ func (s *memoryUsecaseStub) ImportInstructions(_ context.Context, criteria appty
 	return s.bridgeImportResult, s.bridgeImportErr
 }
 
-func (s *memoryUsecaseStub) Scan(_ context.Context, _ apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
+func (s *memoryUsecaseStub) Scan(_ context.Context, criteria apptypes.MemoryHygieneScanCriteria) (apptypes.MemoryHygieneScanResult, error) {
+	s.scanCriteria = criteria
 	return s.scanResult, s.scanErr
 }
 

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -56,6 +56,13 @@ type queryMemoryInput struct {
 	RecentCommandsLimit *int     `json:"recent_commands_limit,omitempty" jsonschema:"maximum recent commands to include"`
 	MemoryLimit         *int     `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
 	ExpiryDays          int      `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
+	Similarity          float64  `json:"similarity,omitempty" jsonschema:"word-Jaccard threshold for hygiene supersede suggestions (0 uses the default 0.6)"`
+	Cursor              string   `json:"cursor,omitempty" jsonschema:"opaque continuation cursor returned by a partial hygiene scan"`
+	MaxScanRows         int      `json:"max_scan_rows,omitempty" jsonschema:"maximum source rows charged to one hygiene invocation"`
+	MaxScanBytes        int64    `json:"max_scan_bytes,omitempty" jsonschema:"maximum raw source bytes charged to one hygiene invocation"`
+	MaxResultBytes      int64    `json:"max_result_bytes,omitempty" jsonschema:"maximum serialized suggestion bytes returned by one hygiene invocation"`
+	MaxComparisons      int      `json:"max_comparisons,omitempty" jsonschema:"maximum duplicate or similarity comparisons per hygiene invocation"`
+	MaxDurationMillis   int64    `json:"max_duration_ms,omitempty" jsonschema:"maximum wall-clock duration for one hygiene invocation in milliseconds"`
 	Target              string   `json:"target,omitempty" jsonschema:"export target host (claude / codex / gemini)"`
 	IncludeGlobal       *bool    `json:"include_global,omitempty" jsonschema:"include global memories alongside a workspace export (default true)"`
 	NoGlobal            bool     `json:"no_global,omitempty" jsonschema:"export only the explicit workspace scope; do not include global memories"`
@@ -316,9 +323,16 @@ type rejectMemoriesBatchInput struct {
 // before deciding whether to drive supersede / expire / reject via the
 // single-memory tools or the candidate apply path.
 type scanMemoryHygieneInput struct {
-	Workspace     string `json:"workspace,omitempty" jsonschema:"workspace scope to scan (omitted scans every scope)"`
-	ExpiryDays    int    `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
-	IncludeHidden bool   `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates in the low-quality candidate pass (default omits them)"`
+	Workspace         string  `json:"workspace,omitempty" jsonschema:"workspace scope to scan (omitted scans every scope)"`
+	ExpiryDays        int     `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
+	Similarity        float64 `json:"similarity,omitempty" jsonschema:"word-Jaccard threshold for supersede suggestions (0 uses the default 0.6)"`
+	IncludeHidden     bool    `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates in the low-quality candidate pass (default omits them)"`
+	Cursor            string  `json:"cursor,omitempty" jsonschema:"opaque continuation cursor returned by a partial hygiene scan"`
+	MaxScanRows       int     `json:"max_scan_rows,omitempty" jsonschema:"maximum source rows charged to one invocation (0 uses the finite default)"`
+	MaxScanBytes      int64   `json:"max_scan_bytes,omitempty" jsonschema:"maximum raw source bytes charged to one invocation (0 uses the finite default)"`
+	MaxResultBytes    int64   `json:"max_result_bytes,omitempty" jsonschema:"maximum serialized suggestion bytes returned by one invocation (0 uses the finite default)"`
+	MaxComparisons    int     `json:"max_comparisons,omitempty" jsonschema:"maximum duplicate or similarity comparisons per invocation (0 uses the finite default)"`
+	MaxDurationMillis int64   `json:"max_duration_ms,omitempty" jsonschema:"maximum wall-clock duration per invocation in milliseconds (0 uses the finite default)"`
 }
 
 // exportMemoriesInput is the MCP input for the export_memories tool that

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -57,7 +57,7 @@ type queryMemoryInput struct {
 	MemoryLimit         *int     `json:"memory_limit,omitempty" jsonschema:"maximum durable memories to include"`
 	ExpiryDays          int      `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
 	Similarity          float64  `json:"similarity,omitempty" jsonschema:"word-Jaccard threshold for hygiene supersede suggestions (0 uses the default 0.6)"`
-	Cursor              string   `json:"cursor,omitempty" jsonschema:"opaque continuation cursor returned by a partial hygiene scan"`
+	Cursor              string   `json:"cursor,omitempty" jsonschema:"process-authenticated continuation returned by a partial hygiene scan; start a new scan if the server restarted"`
 	MaxScanRows         int      `json:"max_scan_rows,omitempty" jsonschema:"maximum source rows charged to one hygiene invocation"`
 	MaxScanBytes        int64    `json:"max_scan_bytes,omitempty" jsonschema:"maximum raw source bytes charged to one hygiene invocation"`
 	MaxResultBytes      int64    `json:"max_result_bytes,omitempty" jsonschema:"maximum serialized suggestion bytes returned by one hygiene invocation"`
@@ -327,7 +327,7 @@ type scanMemoryHygieneInput struct {
 	ExpiryDays        int     `json:"expiry_days,omitempty" jsonschema:"staleness threshold in days (default 90)"`
 	Similarity        float64 `json:"similarity,omitempty" jsonschema:"word-Jaccard threshold for supersede suggestions (0 uses the default 0.6)"`
 	IncludeHidden     bool    `json:"include_hidden,omitempty" jsonschema:"include extracted-hidden candidates in the low-quality candidate pass (default omits them)"`
-	Cursor            string  `json:"cursor,omitempty" jsonschema:"opaque continuation cursor returned by a partial hygiene scan"`
+	Cursor            string  `json:"cursor,omitempty" jsonschema:"process-authenticated continuation returned by a partial hygiene scan; start a new scan if the server restarted"`
 	MaxScanRows       int     `json:"max_scan_rows,omitempty" jsonschema:"maximum source rows charged to one invocation (0 uses the finite default)"`
 	MaxScanBytes      int64   `json:"max_scan_bytes,omitempty" jsonschema:"maximum raw source bytes charged to one invocation (0 uses the finite default)"`
 	MaxResultBytes    int64   `json:"max_result_bytes,omitempty" jsonschema:"maximum serialized suggestion bytes returned by one invocation (0 uses the finite default)"`

--- a/presentation/mcpserver/memory_hygiene_internal_test.go
+++ b/presentation/mcpserver/memory_hygiene_internal_test.go
@@ -1,0 +1,62 @@
+package mcpserver
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestMemoryHygieneBudgetFromInput_UsesFiniteDefaultsAndOverridesIndividually(t *testing.T) {
+	t.Parallel()
+
+	defaults, err := memoryHygieneBudgetFromInput(scanMemoryHygieneInput{})
+	if err != nil {
+		t.Fatalf("memoryHygieneBudgetFromInput(defaults) error = %v", err)
+	}
+	if defaults.MaxRows() < 2 ||
+		defaults.MaxScanBytes() <= 0 ||
+		defaults.MaxResultBytes() <= 0 ||
+		defaults.MaxComparisons() <= 0 ||
+		defaults.MaxDuration() <= 0 {
+		t.Fatalf("defaults are not finite: rows=%d scan=%d result=%d comparisons=%d duration=%s",
+			defaults.MaxRows(),
+			defaults.MaxScanBytes(),
+			defaults.MaxResultBytes(),
+			defaults.MaxComparisons(),
+			defaults.MaxDuration(),
+		)
+	}
+
+	overridden, err := memoryHygieneBudgetFromInput(scanMemoryHygieneInput{
+		MaxScanRows:       17,
+		MaxDurationMillis: 250,
+	})
+	if err != nil {
+		t.Fatalf("memoryHygieneBudgetFromInput(overrides) error = %v", err)
+	}
+	if overridden.MaxRows() != 17 || overridden.MaxDuration() != 250*time.Millisecond {
+		t.Fatalf("overrides = rows:%d duration:%s, want 17/250ms", overridden.MaxRows(), overridden.MaxDuration())
+	}
+	if overridden.MaxScanBytes() != apptypes.DefaultMemoryHygieneScanBudget().MaxScanBytes() {
+		t.Fatalf("unspecified scan-byte limit changed to %d", overridden.MaxScanBytes())
+	}
+}
+
+func TestMemoryHygieneBudgetFromInput_RejectsInvalidAndOverflowedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]scanMemoryHygieneInput{
+		"row minimum":       {MaxScanRows: 1},
+		"negative bytes":    {MaxScanBytes: -1},
+		"duration overflow": {MaxDurationMillis: int64((1<<63)-1)/int64(time.Millisecond) + 1},
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := memoryHygieneBudgetFromInput(input); err == nil {
+				t.Fatal("memoryHygieneBudgetFromInput() error = nil, want validation error")
+			}
+		})
+	}
+}

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -267,8 +267,8 @@ type memoryHygieneOutput struct {
 	ValidityOverlapSupersedeCount int                             `json:"validity_overlap_supersede_count" jsonschema:"number of accepted memories paired by (scope, type) with overlapping validity windows"`
 	LowQualityCandidateCount      int                             `json:"low_quality_candidate_count" jsonschema:"number of candidate memories flagged by the deterministic low-quality classifier"`
 	Complete                      bool                            `json:"complete" jsonschema:"true only when every hygiene phase finished under the declared consistency"`
-	Partial                       bool                            `json:"partial" jsonschema:"true when a bound or revision change stopped the invocation and next_cursor can resume it"`
-	StopReason                    string                          `json:"stop_reason" jsonschema:"complete, revision_changed, or the first bound that stopped this invocation"`
+	Partial                       bool                            `json:"partial" jsonschema:"true when a bound stopped the invocation and next_cursor can resume it"`
+	StopReason                    string                          `json:"stop_reason" jsonschema:"complete, the first resource bound that stopped this invocation, or revision_changed when revision churn exhausted the duration before page progress"`
 	Consistency                   string                          `json:"consistency" jsonschema:"consistent when the chain stayed at one revision; best_effort after a revision change"`
 	ConsistencyReason             string                          `json:"consistency_reason,omitempty" jsonschema:"revision_changed when consistency was downgraded to best_effort"`
 	NextCursor                    string                          `json:"next_cursor,omitempty" jsonschema:"process-authenticated encrypted continuation; contains no stored fact text and requires a new scan after server restart"`

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -266,23 +266,39 @@ type memoryHygieneOutput struct {
 	SupersedeCandidateCount       int                             `json:"supersede_candidate_count" jsonschema:"number of accepted memories paired by word-Jaccard similarity"`
 	ValidityOverlapSupersedeCount int                             `json:"validity_overlap_supersede_count" jsonschema:"number of accepted memories paired by (scope, type) with overlapping validity windows"`
 	LowQualityCandidateCount      int                             `json:"low_quality_candidate_count" jsonschema:"number of candidate memories flagged by the deterministic low-quality classifier"`
+	Complete                      bool                            `json:"complete" jsonschema:"true only when every hygiene phase finished at the captured revision"`
+	Partial                       bool                            `json:"partial" jsonschema:"true when the invocation stopped at an explicit bound and next_cursor can resume it"`
+	StopReason                    string                          `json:"stop_reason" jsonschema:"complete or the first bound that stopped this invocation"`
+	NextCursor                    string                          `json:"next_cursor,omitempty" jsonschema:"opaque continuation cursor; contains no stored fact text"`
+	Usage                         memoryHygieneUsageOutput        `json:"usage" jsonschema:"actual work charged to this invocation"`
 	Suggestions                   []memoryHygieneSuggestionOutput `json:"suggestions" jsonschema:"per-memory hygiene suggestions"`
 }
 
+type memoryHygieneUsageOutput struct {
+	ScannedRows   int   `json:"scanned_rows" jsonschema:"source rows charged to this invocation"`
+	ScannedBytes  int64 `json:"scanned_bytes" jsonschema:"raw source bytes charged to this invocation"`
+	ResultBytes   int64 `json:"result_bytes" jsonschema:"serialized suggestion bytes charged to this invocation"`
+	Comparisons   int   `json:"comparisons" jsonschema:"duplicate or similarity comparisons charged to this invocation"`
+	ElapsedMillis int64 `json:"elapsed_ms" jsonschema:"wall-clock milliseconds spent in this invocation"`
+}
+
 type memoryHygieneSuggestionOutput struct {
-	MemoryID            string   `json:"memory_id" jsonschema:"memory identifier"`
-	Kind                string   `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate / validity_overlap_supersede / low_quality_candidate)"`
-	Reason              string   `json:"reason" jsonschema:"human-readable reason the scanner flagged this memory"`
-	Fact                string   `json:"fact" jsonschema:"stored fact at scan time"`
-	SanitizedFact       string   `json:"sanitized_fact,omitempty" jsonschema:"masked fact the apply path would write via supersede"`
-	DuplicateMemoryID   string   `json:"duplicate_memory_id,omitempty" jsonschema:"paired duplicate when kind=duplicate"`
-	ReplacementMemoryID string   `json:"replacement_memory_id,omitempty" jsonschema:"newer memory whose fact is suggested as the supersede replacement"`
-	ReplacementFact     string   `json:"replacement_fact,omitempty" jsonschema:"fact the apply path would write via supersede"`
-	Similarity          float64  `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate / validity_overlap_supersede only)"`
-	ScopeKind           string   `json:"scope_kind,omitempty" jsonschema:"scope kind"`
-	ScopeValue          string   `json:"scope_value,omitempty" jsonschema:"scope value"`
-	UpdatedAt           string   `json:"updated_at" jsonschema:"last update timestamp (RFC3339)"`
-	Status              string   `json:"status,omitempty" jsonschema:"memory lifecycle status (only populated for candidate-side suggestions)"`
-	Source              string   `json:"source,omitempty" jsonschema:"memory source (only populated for candidate-side suggestions)"`
-	QualityReasons      []string `json:"quality_reasons,omitempty" jsonschema:"deterministic noise markers from the extraction-quality classifier (low_quality_candidate only)"`
+	MemoryID                    string   `json:"memory_id" jsonschema:"memory identifier"`
+	Kind                        string   `json:"kind" jsonschema:"suggestion kind (redaction_hit / expiry_candidate / duplicate / supersede_candidate / validity_overlap_supersede / low_quality_candidate)"`
+	Reason                      string   `json:"reason" jsonschema:"human-readable reason the scanner flagged this memory"`
+	Fact                        string   `json:"fact" jsonschema:"bounded UTF-8-safe current-rule-sanitized fact preview; never the stored raw fact"`
+	FactPreviewTruncated        bool     `json:"fact_preview_truncated,omitempty" jsonschema:"true when the fact preview was shortened"`
+	SanitizedFact               string   `json:"sanitized_fact,omitempty" jsonschema:"bounded UTF-8-safe preview of the masked replacement"`
+	SanitizedPreviewTruncated   bool     `json:"sanitized_preview_truncated,omitempty" jsonschema:"true when the sanitized preview was shortened"`
+	DuplicateMemoryID           string   `json:"duplicate_memory_id,omitempty" jsonschema:"paired duplicate when kind=duplicate"`
+	ReplacementMemoryID         string   `json:"replacement_memory_id,omitempty" jsonschema:"newer memory whose fact is suggested as the supersede replacement"`
+	ReplacementFact             string   `json:"replacement_fact,omitempty" jsonschema:"bounded UTF-8-safe current-rule-sanitized replacement preview"`
+	ReplacementPreviewTruncated bool     `json:"replacement_preview_truncated,omitempty" jsonschema:"true when the replacement preview was shortened"`
+	Similarity                  float64  `json:"similarity,omitempty" jsonschema:"word-Jaccard similarity score (supersede_candidate / validity_overlap_supersede only)"`
+	ScopeKind                   string   `json:"scope_kind,omitempty" jsonschema:"scope kind"`
+	ScopeValue                  string   `json:"scope_value,omitempty" jsonschema:"scope value"`
+	UpdatedAt                   string   `json:"updated_at" jsonschema:"last update timestamp (RFC3339)"`
+	Status                      string   `json:"status,omitempty" jsonschema:"memory lifecycle status (only populated for candidate-side suggestions)"`
+	Source                      string   `json:"source,omitempty" jsonschema:"memory source (only populated for candidate-side suggestions)"`
+	QualityReasons              []string `json:"quality_reasons,omitempty" jsonschema:"deterministic noise markers from the extraction-quality classifier (low_quality_candidate only)"`
 }

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -266,10 +266,12 @@ type memoryHygieneOutput struct {
 	SupersedeCandidateCount       int                             `json:"supersede_candidate_count" jsonschema:"number of accepted memories paired by word-Jaccard similarity"`
 	ValidityOverlapSupersedeCount int                             `json:"validity_overlap_supersede_count" jsonschema:"number of accepted memories paired by (scope, type) with overlapping validity windows"`
 	LowQualityCandidateCount      int                             `json:"low_quality_candidate_count" jsonschema:"number of candidate memories flagged by the deterministic low-quality classifier"`
-	Complete                      bool                            `json:"complete" jsonschema:"true only when every hygiene phase finished at the captured revision"`
-	Partial                       bool                            `json:"partial" jsonschema:"true when the invocation stopped at an explicit bound and next_cursor can resume it"`
-	StopReason                    string                          `json:"stop_reason" jsonschema:"complete or the first bound that stopped this invocation"`
-	NextCursor                    string                          `json:"next_cursor,omitempty" jsonschema:"opaque continuation cursor; contains no stored fact text"`
+	Complete                      bool                            `json:"complete" jsonschema:"true only when every hygiene phase finished under the declared consistency"`
+	Partial                       bool                            `json:"partial" jsonschema:"true when a bound or revision change stopped the invocation and next_cursor can resume it"`
+	StopReason                    string                          `json:"stop_reason" jsonschema:"complete, revision_changed, or the first bound that stopped this invocation"`
+	Consistency                   string                          `json:"consistency" jsonschema:"consistent when the chain stayed at one revision; best_effort after a revision change"`
+	ConsistencyReason             string                          `json:"consistency_reason,omitempty" jsonschema:"revision_changed when consistency was downgraded to best_effort"`
+	NextCursor                    string                          `json:"next_cursor,omitempty" jsonschema:"process-authenticated encrypted continuation; contains no stored fact text and requires a new scan after server restart"`
 	Usage                         memoryHygieneUsageOutput        `json:"usage" jsonschema:"actual work charged to this invocation"`
 	Suggestions                   []memoryHygieneSuggestionOutput `json:"suggestions" jsonschema:"per-memory hygiene suggestions"`
 }

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -353,7 +353,18 @@ func (s *Server) queryMemory() mcp.ToolHandlerFor[queryMemoryInput, any] {
 			_, out, err := s.memoryPack()(ctx, req, memoryPackInput{SessionID: input.SessionID, Workspace: input.Workspace, RecentCommandsLimit: input.RecentCommandsLimit, MemoryLimit: input.MemoryLimit, Preset: input.Preset, IncludeCandidates: input.IncludeCandidates, AsOf: input.AsOf})
 			return nil, out, err
 		case "scan_hygiene":
-			_, out, err := s.scanMemoryHygiene()(ctx, req, scanMemoryHygieneInput{Workspace: input.Workspace, ExpiryDays: input.ExpiryDays, IncludeHidden: input.IncludeHidden})
+			_, out, err := s.scanMemoryHygiene()(ctx, req, scanMemoryHygieneInput{
+				Workspace:         input.Workspace,
+				ExpiryDays:        input.ExpiryDays,
+				Similarity:        input.Similarity,
+				IncludeHidden:     input.IncludeHidden,
+				Cursor:            input.Cursor,
+				MaxScanRows:       input.MaxScanRows,
+				MaxScanBytes:      input.MaxScanBytes,
+				MaxResultBytes:    input.MaxResultBytes,
+				MaxComparisons:    input.MaxComparisons,
+				MaxDurationMillis: input.MaxDurationMillis,
+			})
 			return nil, out, err
 		default:
 			return nil, nil, xerrors.Errorf("query_memory action must be one of retrieve, export, pack, scan_hygiene")
@@ -1247,7 +1258,16 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 		if s.memory == nil {
 			return nil, memoryHygieneOutput{}, xerrors.Errorf("memory usecase is not configured")
 		}
-		criteria := apptypes.MemoryHygieneScanCriteria{IncludeHiddenCandidates: input.IncludeHidden}
+		budget, err := memoryHygieneBudgetFromInput(input)
+		if err != nil {
+			return nil, memoryHygieneOutput{}, err
+		}
+		criteria := apptypes.MemoryHygieneScanCriteria{
+			SimilarityThreshold:     input.Similarity,
+			IncludeHiddenCandidates: input.IncludeHidden,
+			Budget:                  budget,
+			Cursor:                  input.Cursor,
+		}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
 			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
@@ -1269,24 +1289,38 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			SupersedeCandidateCount:       result.SupersedeCandidateCount,
 			ValidityOverlapSupersedeCount: result.ValidityOverlapSupersedeCount,
 			LowQualityCandidateCount:      result.LowQualityCandidateCount,
-			Suggestions:                   make([]memoryHygieneSuggestionOutput, 0, len(result.Suggestions)),
+			Complete:                      result.Complete,
+			Partial:                       result.Partial,
+			StopReason:                    string(result.StopReason),
+			NextCursor:                    result.NextCursor,
+			Usage: memoryHygieneUsageOutput{
+				ScannedRows:   result.Usage.ScannedRows,
+				ScannedBytes:  result.Usage.ScannedBytes,
+				ResultBytes:   result.Usage.ResultBytes,
+				Comparisons:   result.Usage.Comparisons,
+				ElapsedMillis: result.Usage.ElapsedMillis,
+			},
+			Suggestions: make([]memoryHygieneSuggestionOutput, 0, len(result.Suggestions)),
 		}
 		for _, suggestion := range result.Suggestions {
 			entry := memoryHygieneSuggestionOutput{
-				MemoryID:      suggestion.MemoryID.String(),
-				Kind:          string(suggestion.Kind),
-				Reason:        suggestion.Reason,
-				Fact:          suggestion.Fact,
-				SanitizedFact: suggestion.SanitizedFact,
-				Similarity:    suggestion.Similarity,
-				UpdatedAt:     suggestion.UpdatedAt.UTC().Format(time.RFC3339),
+				MemoryID:                  suggestion.MemoryID.String(),
+				Kind:                      string(suggestion.Kind),
+				Reason:                    suggestion.Reason,
+				Fact:                      suggestion.FactPreview,
+				FactPreviewTruncated:      suggestion.FactPreviewTruncated,
+				SanitizedFact:             suggestion.SanitizedFactPreview,
+				SanitizedPreviewTruncated: suggestion.SanitizedPreviewTruncated,
+				Similarity:                suggestion.Similarity,
+				UpdatedAt:                 suggestion.UpdatedAt.UTC().Format(time.RFC3339),
 			}
 			if suggestion.DuplicateMemoryID != "" {
 				entry.DuplicateMemoryID = suggestion.DuplicateMemoryID.String()
 			}
 			if suggestion.ReplacementMemoryID != "" {
 				entry.ReplacementMemoryID = suggestion.ReplacementMemoryID.String()
-				entry.ReplacementFact = suggestion.ReplacementFact
+				entry.ReplacementFact = suggestion.ReplacementFactPreview
+				entry.ReplacementPreviewTruncated = suggestion.ReplacementPreviewTruncated
 			}
 			if suggestion.Scope != nil {
 				entry.ScopeKind = suggestion.Scope.Kind().String()
@@ -1305,6 +1339,41 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 		}
 		return nil, out, nil
 	}
+}
+
+func memoryHygieneBudgetFromInput(input scanMemoryHygieneInput) (apptypes.MemoryHygieneScanBudget, error) {
+	defaults := apptypes.DefaultMemoryHygieneScanBudget()
+	params := apptypes.MemoryHygieneScanBudgetParams{
+		MaxRows:        defaults.MaxRows(),
+		MaxScanBytes:   defaults.MaxScanBytes(),
+		MaxResultBytes: defaults.MaxResultBytes(),
+		MaxComparisons: defaults.MaxComparisons(),
+		MaxDuration:    defaults.MaxDuration(),
+	}
+	if input.MaxScanRows != 0 {
+		params.MaxRows = input.MaxScanRows
+	}
+	if input.MaxScanBytes != 0 {
+		params.MaxScanBytes = input.MaxScanBytes
+	}
+	if input.MaxResultBytes != 0 {
+		params.MaxResultBytes = input.MaxResultBytes
+	}
+	if input.MaxComparisons != 0 {
+		params.MaxComparisons = input.MaxComparisons
+	}
+	if input.MaxDurationMillis != 0 {
+		const maxDurationMillis = int64((1<<63)-1) / int64(time.Millisecond)
+		if input.MaxDurationMillis < 0 || input.MaxDurationMillis > maxDurationMillis {
+			return apptypes.MemoryHygieneScanBudget{}, xerrors.Errorf("max_duration_ms is outside the supported range")
+		}
+		params.MaxDuration = time.Duration(input.MaxDurationMillis) * time.Millisecond
+	}
+	budget, err := apptypes.MemoryHygieneScanBudgetFrom(params)
+	if err != nil {
+		return apptypes.MemoryHygieneScanBudget{}, xerrors.Errorf("invalid memory hygiene scan budget: %w", err)
+	}
+	return budget, nil
 }
 
 // exportMemories mirrors the CLI `memory export` command over MCP. The

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -1268,6 +1268,9 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			Budget:                  budget,
 			Cursor:                  input.Cursor,
 		}
+		if input.Cursor == "" {
+			criteria.Now = time.Now().UTC()
+		}
 		if workspace := strings.TrimSpace(input.Workspace); workspace != "" {
 			resolvedWorkspace, err := types.WorkspaceFrom(workspace)
 			if err != nil {
@@ -1292,6 +1295,8 @@ func (s *Server) scanMemoryHygiene() mcp.ToolHandlerFor[scanMemoryHygieneInput, 
 			Complete:                      result.Complete,
 			Partial:                       result.Partial,
 			StopReason:                    string(result.StopReason),
+			Consistency:                   string(result.Consistency),
+			ConsistencyReason:             string(result.ConsistencyReason),
 			NextCursor:                    result.NextCursor,
 			Usage: memoryHygieneUsageOutput{
 				ScannedRows:   result.Usage.ScannedRows,

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -146,6 +146,50 @@ func TestServer_BuildAndTools(t *testing.T) {
 		}
 	})
 
+	t.Run("scan_memory_hygiene reports bounded completion metadata", func(t *testing.T) {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "query_memory",
+			Arguments: map[string]any{
+				"action":           "scan_hygiene",
+				"max_scan_rows":    2,
+				"max_scan_bytes":   1024,
+				"max_result_bytes": 1024,
+				"max_comparisons":  1,
+				"max_duration_ms":  500,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(scan_memory_hygiene) error = %v", err)
+		}
+		if result.IsError {
+			t.Fatal("CallTool(scan_memory_hygiene) IsError = true, want false")
+		}
+		payload := decodeJSONPayload(t, result)
+		if payload["complete"] != true || payload["partial"] != false || payload["stop_reason"] != "complete" {
+			t.Fatalf("coverage = complete:%#v partial:%#v stop:%#v", payload["complete"], payload["partial"], payload["stop_reason"])
+		}
+		usage, ok := payload["usage"].(map[string]any)
+		if !ok {
+			t.Fatalf("usage = %#v, want object", payload["usage"])
+		}
+		if usage["scanned_rows"] != float64(0) || usage["comparisons"] != float64(0) {
+			t.Fatalf("empty scan usage = %#v", usage)
+		}
+	})
+
+	t.Run("scan_memory_hygiene rejects an invalid explicit row bound", func(t *testing.T) {
+		result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "query_memory",
+			Arguments: map[string]any{"action": "scan_hygiene", "max_scan_rows": 1},
+		})
+		if err != nil {
+			t.Fatalf("CallTool(scan_memory_hygiene invalid bound) error = %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("CallTool(scan_memory_hygiene invalid bound) IsError = false, want true")
+		}
+	})
+
 	t.Run("get_report enforces page size boundaries before report execution", func(t *testing.T) {
 		acceptedResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 			Name:      "get_report",
@@ -1860,6 +1904,27 @@ ALTER TABLE memories ADD COLUMN valid_from TEXT;
 ALTER TABLE memories ADD COLUMN valid_to TEXT;
 UPDATE memories SET valid_from = created_at WHERE valid_from IS NULL;
 CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
+		},
+		"000033_add_memory_hygiene_revision.sql": {
+			Data: []byte(`
+CREATE TABLE memory_hygiene_revision (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision INTEGER NOT NULL CHECK (revision >= 0)
+);
+INSERT INTO memory_hygiene_revision(singleton, revision) VALUES (1, 0);
+CREATE TRIGGER memories_hygiene_revision_after_insert AFTER INSERT ON memories BEGIN
+    UPDATE memory_hygiene_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+CREATE TRIGGER memories_hygiene_revision_after_update AFTER UPDATE ON memories BEGIN
+    UPDATE memory_hygiene_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+CREATE TRIGGER memories_hygiene_revision_after_delete AFTER DELETE ON memories BEGIN
+    UPDATE memory_hygiene_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+CREATE INDEX idx_memories_hygiene_status_id ON memories(status, id);
+CREATE INDEX idx_memories_hygiene_scope_id ON memories(status, scope_kind, scope_value, id);
+CREATE INDEX idx_memories_hygiene_exact ON memories(status, scope_kind, scope_value, fact, id);
+CREATE INDEX idx_memories_hygiene_candidate_source_id ON memories(status, source, id);`),
 		},
 	}
 	dbPath := filepath.Join(t.TempDir(), "traceary", "traceary.db")

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -1576,14 +1576,14 @@ func TestServer_MemoryHygieneRevisionChangeReturnsBestEffortContinuation(t *test
 	}
 	second := decodeJSONPayload(t, secondResult)
 	if second["partial"] != true ||
-		second["stop_reason"] != "revision_changed" ||
+		second["stop_reason"] != "row_limit" ||
 		second["consistency"] != "best_effort" ||
 		second["consistency_reason"] != "revision_changed" {
-		t.Fatalf("revision-changed scan coverage = %#v", second)
+		t.Fatalf("revision-changed same-invocation retry coverage = %#v", second)
 	}
 	nextCursor, ok := second["next_cursor"].(string)
 	if !ok || nextCursor == "" || nextCursor == cursor {
-		t.Fatalf("revision-changed next_cursor = %#v, want rebound cursor", second["next_cursor"])
+		t.Fatalf("best-effort next_cursor = %#v, want progressed cursor", second["next_cursor"])
 	}
 }
 

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -168,6 +168,9 @@ func TestServer_BuildAndTools(t *testing.T) {
 		if payload["complete"] != true || payload["partial"] != false || payload["stop_reason"] != "complete" {
 			t.Fatalf("coverage = complete:%#v partial:%#v stop:%#v", payload["complete"], payload["partial"], payload["stop_reason"])
 		}
+		if payload["consistency"] != "consistent" {
+			t.Fatalf("consistency = %#v, want consistent", payload["consistency"])
+		}
 		usage, ok := payload["usage"].(map[string]any)
 		if !ok {
 			t.Fatalf("usage = %#v, want object", payload["usage"])
@@ -1489,6 +1492,101 @@ func TestServer_BuildAndTools(t *testing.T) {
 // passes no body_limit still gets a capped, body_truncated projection so a
 // noisy command/tool payload is not re-amplified into the next agent context.
 // The full body stays retrievable by re-issuing with full_body=true.
+func TestServer_MemoryHygieneRevisionChangeReturnsBestEffortContinuation(t *testing.T) {
+	t.Parallel()
+
+	server, _, _ := newTestServerWithDBPath(t)
+	ctx := context.Background()
+	mcpServer, err := server.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := mcpServer.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("Connect(server) error = %v", err)
+	}
+	defer func() { _ = serverSession.Wait() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("Connect(client) error = %v", err)
+	}
+	defer func() { _ = clientSession.Close() }()
+
+	remember := func(fact string) {
+		t.Helper()
+		result, callErr := clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: "manage_memory",
+			Arguments: map[string]any{
+				"action":    "remember",
+				"type":      "decision",
+				"workspace": "github.com/duck8823/traceary",
+				"fact":      fact,
+				"evidence_refs": []any{
+					map[string]any{"kind": "issue", "value": "#1556"},
+				},
+			},
+		})
+		if callErr != nil {
+			t.Fatalf("CallTool(remember) error = %v", callErr)
+		}
+		if result.IsError {
+			t.Fatalf("CallTool(remember) returned tool error for %q", fact)
+		}
+	}
+	remember("memory hygiene revision fixture a")
+	remember("memory hygiene revision fixture b")
+	remember("memory hygiene revision fixture c")
+
+	firstResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query_memory",
+		Arguments: map[string]any{
+			"action":        "scan_hygiene",
+			"max_scan_rows": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("first CallTool(scan_hygiene) error = %v", err)
+	}
+	if firstResult.IsError {
+		t.Fatal("first CallTool(scan_hygiene) returned tool error")
+	}
+	first := decodeJSONPayload(t, firstResult)
+	cursor, ok := first["next_cursor"].(string)
+	if !ok || cursor == "" || first["partial"] != true || first["consistency"] != "consistent" {
+		t.Fatalf("first scan coverage = %#v", first)
+	}
+
+	remember("memory hygiene revision fixture d")
+
+	secondResult, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "query_memory",
+		Arguments: map[string]any{
+			"action":        "scan_hygiene",
+			"cursor":        cursor,
+			"max_scan_rows": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("revision-changed CallTool(scan_hygiene) error = %v", err)
+	}
+	if secondResult.IsError {
+		t.Fatal("revision-changed CallTool(scan_hygiene) returned tool error")
+	}
+	second := decodeJSONPayload(t, secondResult)
+	if second["partial"] != true ||
+		second["stop_reason"] != "revision_changed" ||
+		second["consistency"] != "best_effort" ||
+		second["consistency_reason"] != "revision_changed" {
+		t.Fatalf("revision-changed scan coverage = %#v", second)
+	}
+	nextCursor, ok := second["next_cursor"].(string)
+	if !ok || nextCursor == "" || nextCursor == cursor {
+		t.Fatalf("revision-changed next_cursor = %#v, want rebound cursor", second["next_cursor"])
+	}
+}
+
 func TestServer_GetContextDefaultBodyLimitCaps(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/testdata/tool_registry.golden.json
+++ b/presentation/mcpserver/testdata/tool_registry.golden.json
@@ -1765,7 +1765,7 @@
           "type": "string"
         },
         "cursor": {
-          "description": "opaque continuation cursor returned by a partial hygiene scan",
+          "description": "process-authenticated continuation returned by a partial hygiene scan; start a new scan if the server restarted",
           "type": "string"
         },
         "expiry_days": {

--- a/presentation/mcpserver/testdata/tool_registry.golden.json
+++ b/presentation/mcpserver/testdata/tool_registry.golden.json
@@ -1764,6 +1764,10 @@
           "description": "evaluate content validity at this timestamp",
           "type": "string"
         },
+        "cursor": {
+          "description": "opaque continuation cursor returned by a partial hygiene scan",
+          "type": "string"
+        },
         "expiry_days": {
           "description": "staleness threshold in days (default 90)",
           "type": "integer"
@@ -1789,6 +1793,26 @@
         },
         "limit": {
           "description": "maximum number of memories to return (default: 20)",
+          "type": "integer"
+        },
+        "max_comparisons": {
+          "description": "maximum duplicate or similarity comparisons per hygiene invocation",
+          "type": "integer"
+        },
+        "max_duration_ms": {
+          "description": "maximum wall-clock duration for one hygiene invocation in milliseconds",
+          "type": "integer"
+        },
+        "max_result_bytes": {
+          "description": "maximum serialized suggestion bytes returned by one hygiene invocation",
+          "type": "integer"
+        },
+        "max_scan_bytes": {
+          "description": "maximum raw source bytes charged to one hygiene invocation",
+          "type": "integer"
+        },
+        "max_scan_rows": {
+          "description": "maximum source rows charged to one hygiene invocation",
           "type": "integer"
         },
         "memory_id": {
@@ -1832,6 +1856,10 @@
         "session_id": {
           "description": "session identifier filter",
           "type": "string"
+        },
+        "similarity": {
+          "description": "word-Jaccard threshold for hygiene supersede suggestions (0 uses the default 0.6)",
+          "type": "number"
         },
         "source": {
           "description": "memory source filters: manual, extracted, extracted-hidden, imported",

--- a/presentation/mcpserver/testdata/tool_schema_budget.golden.json
+++ b/presentation/mcpserver/testdata/tool_schema_budget.golden.json
@@ -1,6 +1,6 @@
 {
-  "listToolsBytes": 45503,
-  "inputSchemaBytes": 14949,
+  "listToolsBytes": 45553,
+  "inputSchemaBytes": 14999,
   "tools": [
     {
       "name": "get_context",
@@ -34,8 +34,8 @@
     },
     {
       "name": "query_memory",
-      "toolBytes": 3317,
-      "inputSchemaBytes": 3145,
+      "toolBytes": 3367,
+      "inputSchemaBytes": 3195,
       "outputSchemaBytes": 0
     },
     {

--- a/presentation/mcpserver/testdata/tool_schema_budget.golden.json
+++ b/presentation/mcpserver/testdata/tool_schema_budget.golden.json
@@ -1,6 +1,6 @@
 {
-  "listToolsBytes": 44684,
-  "inputSchemaBytes": 14130,
+  "listToolsBytes": 45503,
+  "inputSchemaBytes": 14949,
   "tools": [
     {
       "name": "get_context",
@@ -34,8 +34,8 @@
     },
     {
       "name": "query_memory",
-      "toolBytes": 2498,
-      "inputSchemaBytes": 2326,
+      "toolBytes": 3317,
+      "inputSchemaBytes": 3145,
       "outputSchemaBytes": 0
     },
     {

--- a/presentation/mcpserver/tool_schema_budget_test.go
+++ b/presentation/mcpserver/tool_schema_budget_test.go
@@ -43,7 +43,11 @@ var maxToolAdvertisementBytes = map[string]int{
 	"list_events":    8 * 1024,
 	"manage_memory":  3200,
 	"manage_session": 3100,
-	"query_memory":   3000,
+	// Bounded hygiene scans add resumability and five explicit resource limits
+	// to this public input schema. Keep roughly the same reviewed headroom as
+	// the adjacent management tools rather than letting this intentional growth
+	// permanently occupy the warning band.
+	"query_memory":   4 * 1024,
 	"record_event":   4000,
 	"search":         7680,
 	"session_status": 2300,

--- a/schema/sqlite/migrations/000033_add_memory_hygiene_revision.sql
+++ b/schema/sqlite/migrations/000033_add_memory_hygiene_revision.sql
@@ -1,0 +1,47 @@
+-- A continuation cursor is valid only while durable-memory state is unchanged.
+-- The singleton revision is incremented inside the same transaction as every
+-- memory insert/update/delete; the scanner compares it before reading a page.
+CREATE TABLE memory_hygiene_revision (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision INTEGER NOT NULL CHECK (revision >= 0)
+);
+
+INSERT INTO memory_hygiene_revision(singleton, revision) VALUES (1, 0);
+
+CREATE TRIGGER memories_hygiene_revision_after_insert
+AFTER INSERT ON memories
+BEGIN
+    UPDATE memory_hygiene_revision
+    SET revision = revision + 1
+    WHERE singleton = 1;
+END;
+
+CREATE TRIGGER memories_hygiene_revision_after_update
+AFTER UPDATE ON memories
+BEGIN
+    UPDATE memory_hygiene_revision
+    SET revision = revision + 1
+    WHERE singleton = 1;
+END;
+
+CREATE TRIGGER memories_hygiene_revision_after_delete
+AFTER DELETE ON memories
+BEGIN
+    UPDATE memory_hygiene_revision
+    SET revision = revision + 1
+    WHERE singleton = 1;
+END;
+
+-- Keyset traversal first orders all rows by status/id, then finds same-scope
+-- partners by id. Exact duplicate lookup additionally constrains fact.
+CREATE INDEX idx_memories_hygiene_status_id
+    ON memories(status, id);
+
+CREATE INDEX idx_memories_hygiene_scope_id
+    ON memories(status, scope_kind, scope_value, id);
+
+CREATE INDEX idx_memories_hygiene_exact
+    ON memories(status, scope_kind, scope_value, fact, id);
+
+CREATE INDEX idx_memories_hygiene_candidate_source_id
+    ON memories(status, source, id);


### PR DESCRIPTION
## Motivation\n\nLarge durable-memory hygiene scans must be explicitly bounded and resumable so they do not transfer or retain an unbounded store snapshot.\n\nCloses #1556\n\n## Changes\n\n- add revision-stable, cursor-resumable bounded scan phases\n- expose finite CLI/MCP budgets, completion state, and safe previews\n- revalidate only requested memory IDs and all same-scope peers before Apply; partial or stale revalidation fails closed before mutation\n\n## Validation\n\n- go build ./...\n- go test ./...\n- go tool golangci-lint run\n- go test -race ./application/usecase ./infrastructure/sqlite -run MemoryHygiene