### PR TITLE
v0.33.0-10: add persistent covering metadata access

### DIFF
--- a/.ai/spec/1569.md
+++ b/.ai/spec/1569.md
@@ -1,0 +1,171 @@
+# #1569 Persistent covering metadata access
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Make event metadata list and context reads independent of the
+  `events` table payload so a large event body cannot make a body-free read
+  traverse its overflow chain.
+- **Current behavior:** Migration 31 supplies ordered indexes, but the metadata
+  SQL still selects non-key columns from `events`. Those indexes are therefore
+  not covering, and SQLite must visit the body-bearing table record.
+- **Expected behavior:** An additive, persistent metadata projection is
+  backfilled from existing events and command-audit metadata, maintained in the
+  same transaction by triggers, and used by every list/context metadata query.
+  Result membership, ordering, filters, body-extent facts, command-failure
+  facts, offset paging, and keyset paging remain unchanged.
+- **Legacy hook behavior:** The two supported body-prefix fallbacks are reduced
+  to a fixed classification in the projection. Runtime metadata reads compare
+  that classification and never evaluate the event body.
+- **Migration evidence:** A copied pre-migration synthetic store must upgrade
+  without changing the source copy, pass integrity and foreign-key checks,
+  preserve row semantics, and expose sanitized duration, database growth,
+  temporary write extent, and lock observations.
+- **Performance gate:** The sanitized Phase-A fixture contains at least 2 GiB
+  of SQLite-managed and stored body bytes. Twenty-five direct metadata range
+  observations must have p95 below 250 ms and the query plan must use the
+  projection without opening the body-bearing event table.
+- **Privacy:** Durable design, commit, PR, and benchmark summaries contain
+  metrics and fixed booleans only. They do not contain bodies, event/session
+  identities, workspaces, local paths, search text, SQL text, continuations, or
+  raw command output.
+- **Out of scope:** Moving bounded/full event reads to the projection, changing
+  event or command-audit retention, changing FTS membership, removing legacy
+  indexes, or making migrations run online without a write lock.
+
+### Dependency decision
+
+- This branch starts at `origin/main` commit `a37ad721`; PR #1567 and PR #1568
+  are not in that base.
+- PR #1567 reserves migration 33 for durable-memory revision state. This issue
+  therefore uses migration 34. The migration runner supports applying a
+  previously absent lower version, so #1567 and this issue have no runtime code
+  dependency and may merge in either order.
+- PR #1568 is release-evidence work based on #1567. It diagnoses the
+  non-covering Phase-A plan that this issue fixes. Its evidence must be rebased
+  or rerun after this change; this PR does not copy #1568 tooling or memory
+  hygiene changes.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Authoritative event | Existing `events` row including body | Owns the durable event and every full/bounded body read | Projection never becomes an event write API |
+| Metadata projection | One row per event with metadata, normalized order key, legacy-hook class, and optional command-audit facts | Serves list/context metadata reads without opening the authoritative event table | No body, command text, input, or output column exists; projected row count and identity match events |
+| Legacy hook class | `subagent_stop`, `pre_compact`, or NULL | Preserves the two historical body-prefix fallbacks | It is derived transactionally on backfill and relevant body/kind/source-hook writes; arbitrary body text is never copied |
+| Projection maintenance | Event and command-audit triggers | Inserts, replaces, clears, or deletes the matching projection row in the writer transaction | A committed authoritative mutation and projection state cannot diverge |
+| Projection ordering path | General, workspace, session, workspace-session, and source-hook indexes | Provides the existing `(created_at_norm DESC, id DESC)` order and keyset seek | List/context plans do not open `events` or create an order-by temporary tree |
+| Migration observation | Counts, bytes, elapsed durations, lock classifications, integrity booleans | Describes copied-store upgrade cost without content | Metrics-only; the original copied source remains byte-identical |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Projection schema, backfill, indexes, and maintenance | migration 34 | These are persistent SQLite compatibility and writer-order concerns | Application types must not know table or trigger names |
+| Metadata list/context SQL | SQLite metadata datasource SQL | It owns read plans and storage projection hydration | Use case retains criteria validation and orchestration only |
+| Result semantics | Existing `EventMetadata` application type and metadata use case | It is the consumer-visible body-free contract | Migration does not introduce a second DTO |
+| Migration and plan verification | SQLite integration tests and opt-in benchmark | They can inspect copied stores, query plans, locks, and byte extents | Presentation tests cannot prove overflow-table avoidance |
+| Release evidence summary | Sanitized local validation and Draft PR body | Operators need measurements and compatibility outcome | Raw fixtures and command output remain temporary |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| `event_metadata_projection` | Metadata datasource | Backfill expressions, trigger order, legacy body-prefix classification | Missing migration fails as an ordinary SQLite schema error; initialization must apply it before reads |
+| Projection maintenance triggers | Existing event/audit writers, including older binaries | Upsert/clear/delete statements and normalized timestamp expression | Any maintenance failure aborts the authoritative writer transaction |
+| Metadata SQL | CLI/MCP metadata use cases | Projection table and index selection | Existing validation and restoration errors remain unchanged |
+| Copied-store validator | Maintainer/test runner | Fixture identities, paths, SQL, and source digest | Emits only fixed booleans, counts, byte sizes, and durations |
+| Phase-A benchmark | Release QA | Synthetic extents and direct query inputs | Fails if extent/count/plan/privacy/p95 gates are not satisfied |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Existing-row backfill | A pre-34 store with events, body metadata, audit metadata, and both legacy hook prefixes | Upgrade a private copy | Projection has one semantically equal row per event; source digest is unchanged |
+| Event maintenance | Insert, metadata update, body-prefix change, primary-key change, and delete | Commit the authoritative mutation | Projection is inserted/reclassified/moved/deleted in the same transaction |
+| Audit maintenance | Audit insert, failure update, event reassignment, and delete | Commit the audit mutation | Optional audit facts are set, moved, updated, or cleared without command payload |
+| Writer rollback | A projection constraint rejects a synthetic authoritative update | Commit | The event mutation also rolls back; no divergent committed state |
+| Read semantics | Equivalent list/context criteria before and after migration | Query metadata | Membership, order, filters, offsets, anchors, extents, and failure facts match |
+| Persistent covering plan | Representative general/workspace/session/workspace-session/source-hook list and context pages | Explain the query | Plan opens projection indexes only, never `events`, and never uses an order-by temporary tree |
+| Legacy fallback | Historical untagged events classified by the two supported prefixes | Filter by source hook | Same membership as before without runtime body access |
+| Code rollback | A current store containing migration 34 | Open and write it with pre-34 SQL/writer behavior | Extra objects are ignored and triggers maintain the projection; authoritative rows remain readable |
+| Lock behavior | A reader is active and a competing writer is attempted while copied-store migration owns its transaction | Apply migration | Reader behavior and writer busy/wait outcome are classified within the configured timeout; no partial schema is committed |
+| Disk/write extent | A copied pre-34 synthetic store | Apply migration and checkpoint | Report source bytes, final bytes, peak sidecar/scratch bytes, growth bytes, and elapsed time only |
+| Multi-GiB Phase A | Eight synthetic 256 MiB extents and 25 measurements | Run a direct metadata range | Managed/stored bytes are at least 2 GiB, plan is projection-only, returned body bytes are zero, and p95 is below 250 ms |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Projection schema/backfill | Add pre-34 copied-store test that cannot find a projection or migration 34 | Add table, backfill, and ordering indexes | Keep projection expressions centralized within the migration |
+| Transactional maintenance | Add insert/update/delete and forced-rollback assertions | Add event and audit maintenance triggers | Keep writer code unchanged; persistence policy stays in SQLite |
+| Runtime body avoidance | Make SQL/plan guards reject every list/context reference to `events` and body columns | Route list/context, fast latest, timestamp-kind, and legacy hook reads to projection | Reuse existing scan/restoration path |
+| Semantic parity | Seed representative filters, audit facts, extent facts, and pagination boundaries | Preserve current result DTO and criteria helpers | Do not add projection flags to application interfaces |
+| Migration operations | Add copied-store, source-digest, integrity, size, and lock assertions | Add metrics-only migration benchmark/validator | Share only metrics helpers, never fixture content |
+| Phase-A gate | Require projection-only plan plus 25-run p95 | Use SQLite-generated extents and projection query | Avoid allocating one multi-hundred-MiB Go string |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** Duplicating query semantics between authoritative
+  and projected paths would drift. Only list/context metadata SQL changes its
+  storage relation; criteria builders, scan restoration, and application DTOs
+  remain unchanged.
+- **Trigger-order risk:** Existing body-size and normalized-time triggers also
+  update events after insert. Projection event triggers compute those two facts
+  from the authoritative `NEW` row and replace the projection on every relevant
+  follow-up update, so final state does not depend on trigger creation order.
+- **Write amplification:** Each event write updates one narrow projection row
+  and its ordering indexes. Stop rollout if representative writer latency or
+  WAL growth becomes operationally unacceptable.
+- **Migration disk/lock risk:** Backfill and index creation run in one SQLite
+  migration transaction and temporarily block competing writers. The copied
+  store benchmark records elapsed time, database growth, peak sidecar/scratch
+  extent, and busy behavior. A failed migration rolls back all new objects.
+- **Compatibility:** Migration 34 is additive. Older binaries ignore the table,
+  indexes, and triggers; their writes still maintain the projection. Existing
+  authoritative rows and columns are unchanged.
+- **Rollback trigger:** Revert application reads if projection semantics differ,
+  a plan opens `events`, p95 reaches 250 ms, writer rollback can commit
+  divergence, integrity/foreign-key validation fails, or migration resource
+  growth exceeds the measured operational envelope.
+- **Rollback procedure:** Before release, revert application SQL and remove
+  migration 34 only in disposable test stores. After release, roll application
+  code back first and leave additive objects in place; remove them only through
+  a later forward migration after confirming no deployed reader uses the
+  projection.
+- **Split-PR plan:** Keep schema, trigger maintenance, metadata SQL switch, and
+  verification in one issue because enabling the read path without
+  transactional maintenance can return stale metadata. PR #1568 remains the
+  separate release-evidence integration.
+
+## Implementation checkpoint
+
+Implemented as the approved additive SQLite projection. Migration 34 backfills
+event metadata, the two fixed legacy-hook classifications, and optional
+command-audit facts; five scoped ordering indexes and six event/audit triggers
+maintain it transactionally. List/context, bounded-latest, timestamp/kind, and
+indexed-search metadata hydration now read the projection. The event aggregate,
+application interfaces, CLI/MCP contracts, bounded/full body reads, and FTS
+membership are unchanged.
+
+Verification on Go 1.26.3, macOS 26.5, darwin/arm64, Apple M4:
+
+- 10,000-row projection smoke: 25-run p95 0.41225 ms, target below 50 ms.
+- Copied 256 MiB-class pre-34 store: 8 events/projection rows, migration
+  309.6 ms, source/copy sizes 302,714,880 bytes, main-file growth 0 bytes,
+  peak scratch 605,528,480 bytes and post-checkpoint scratch 605,429,760
+  bytes, integrity true, foreign-key violations zero, source byte-identical.
+- Competing write lock: busy observed after 1,012.467 ms, zero partial
+  projection objects, retry succeeded after release.
+- Multi-GiB Phase A: managed bytes 2,418,753,536; stored body bytes
+  2,147,483,648; 8 event/projection rows; 25 projection-only observations;
+  missing body metadata and returned body bytes zero; p95 0.2921 ms against the
+  250 ms gate.
+
+Migration 34 avoids the migration-33 slot reserved by PR #1567. PR #1568 must
+rerun its release evidence after this branch lands. Residual operational risk:
+the measured copied-store migration extent is 256 MiB rather than multi-GiB;
+the separate multi-GiB gate proves runtime metadata access, not worst-case
+migration time. Production rollout must retain free-space and writer-quiescing
+guidance for larger stores.

--- a/.ai/spec/1569.md
+++ b/.ai/spec/1569.md
@@ -115,13 +115,30 @@
   update events after insert. Projection event triggers compute those two facts
   from the authoritative `NEW` row and replace the projection on every relevant
   follow-up update, so final state does not depend on trigger creation order.
+- **Retention extent invariant:** A prune changes `body` while making
+  `body_availability` unavailable, but migration 26 intentionally retains the
+  original `body_stored_bytes`. Projection maintenance mirrors that rule and
+  recomputes the extent only when the resulting availability is `available`.
+  The regression executes the same guarded update shape as retention apply,
+  asserts authoritative/projection parity, and then verifies available-body
+  restoration recomputes both rows.
+- **Availability/drift-check decision:** The projection does not store
+  `body_availability` because no `EventMetadata` consumer reads it and the
+  trigger has the authoritative `NEW` value. Duplicating an unused field would
+  increase the drift surface. An unbounded projection-to-events comparison in
+  normal `doctor` execution is also not a minimal safe addition for multi-GiB
+  stores, so parity remains enforced by migration/trigger integration tests.
 - **Write amplification:** Each event write updates one narrow projection row
   and its ordering indexes. Stop rollout if representative writer latency or
   WAL growth becomes operationally unacceptable.
 - **Migration disk/lock risk:** Backfill and index creation run in one SQLite
-  migration transaction and temporarily block competing writers. The copied
-  store benchmark records elapsed time, database growth, peak sidecar/scratch
-  extent, and busy behavior. A failed migration rolls back all new objects.
+  migration transaction as a one-time, non-resumable scan and temporarily block
+  competing writers. Relevant untagged historical bodies are also inspected for
+  legacy-hook classification. The copied store benchmark records elapsed time,
+  database growth, peak sidecar/scratch extent, and busy behavior. A failed or
+  interrupted migration rolls back all new objects; the next initialization
+  retries it from the beginning, so large-store upgrades require free space and
+  writer quiescing.
 - **Compatibility:** Migration 34 is additive. Older binaries ignore the table,
   indexes, and triggers; their writes still maintain the projection. Existing
   authoritative rows and columns are unchanged.
@@ -149,18 +166,23 @@ indexed-search metadata hydration now read the projection. The event aggregate,
 application interfaces, CLI/MCP contracts, bounded/full body reads, and FTS
 membership are unchanged.
 
+The review correction aligns projection updates with migration 26: retention
+pruning keeps the historical stored extent, while available body edits and
+restores recompute it. The regression covers both transitions against the
+authoritative `events` row.
+
 Verification on Go 1.26.3, macOS 26.5, darwin/arm64, Apple M4:
 
 - 10,000-row projection smoke: 25-run p95 0.41225 ms, target below 50 ms.
 - Copied 256 MiB-class pre-34 store: 8 events/projection rows, migration
-  309.6 ms, source/copy sizes 302,714,880 bytes, main-file growth 0 bytes,
+  113.1 ms, source/copy sizes 302,714,880 bytes, main-file growth 0 bytes,
   peak scratch 605,528,480 bytes and post-checkpoint scratch 605,429,760
   bytes, integrity true, foreign-key violations zero, source byte-identical.
 - Competing write lock: busy observed after 1,012.467 ms, zero partial
   projection objects, retry succeeded after release.
 - Multi-GiB Phase A: managed bytes 2,418,753,536; stored body bytes
   2,147,483,648; 8 event/projection rows; 25 projection-only observations;
-  missing body metadata and returned body bytes zero; p95 0.2921 ms against the
+  missing body metadata and returned body bytes zero; p95 0.07242 ms against the
   250 ms gate.
 
 Migration 34 avoids the migration-33 slot reserved by PR #1567. PR #1568 must

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -1,4 +1,4 @@
-# インデックス利用のメタデータ list/context クエリ
+# list/context クエリ用の永続メタデータ投影
 
 [English](index-backed-metadata-list.md)
 
@@ -6,44 +6,84 @@
 
 ### 要求
 
-- 一般的なメタデータ list/context 読取は、RFC3339Nano の境界を正しく並べつつ全件一時ソートを行わない。
-- workspace/session 絞り込みと offset ページングでも本文を読まない。
-- スキーマ更新は追加だけで行い、アプリケーションのロールバック後も既存ストアを読める。
+- 一般的なメタデータ list/context 読取は、RFC3339Nano の境界を正しく
+  並べつつ、本文を持つ `events` レコードを開かない。
+- workspace/session/source-hook 絞り込み、offset ページ、keyset ページの
+  対象件数と順序を維持する。
+- 過去互換の2種類の source-hook 本文prefix判定は維持するが、読取時には
+  本文を評価しない。
+- スキーマ更新は追加だけで行い、アプリケーションを戻した後も更新済み
+  ストアを読み書きできる。
 
 ### 概念と責務
 
 | 概念 | 責務 | 不変条件 |
 | --- | --- | --- |
-| 正規化時刻順 | 永続化した event 時刻列と SQLite インデックス | `created_at_norm, id` を唯一の順序契約にする |
-| 絞り込み済みメタデータページ | metadata datasource | `events.body` を SELECT しない |
-| インデックス配布 | migration 000031 | `created_at_norm` を追加・バックフィルし、trigger で維持する |
+| 正規化時刻 | migration 000031 と event trigger | `created_at_norm, id` を event 順序の唯一の契約にする |
+| 永続メタデータ投影 | migration 000034 | eventごとにmetadata、過去互換hook分類、任意のcommand-audit属性を1行保持する。本文やcommand payloadは保持しない |
+| 絞り込み済みmetadata page | metadata datasource | list/context SQLは投影だけを開き、既存の`EventMetadata`契約を返す |
+| transaction内の同期 | event/command-audit trigger | authoritative rowのcommit結果と投影を乖離させない |
 
 ### 対応するクエリ計画
 
-| クエリ形状 | 順序インデックス |
+| クエリ形状 | 投影の順序インデックス |
 | --- | --- |
-| 一般メタデータ list（limit/offset を含む） | `idx_events_created_at_norm_id_desc` |
-| workspace list/context | `idx_events_workspace_created_at_norm_id_desc` |
-| session list/context | `idx_events_session_created_at_norm_id_desc` |
-| workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
-| source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
+| 一般metadata list（limit/offsetを含む） | `idx_event_metadata_created_at_norm_id_desc` |
+| workspace list/context | `idx_event_metadata_workspace_created_at_norm_id_desc` |
+| session list/context | `idx_event_metadata_session_created_at_norm_id_desc` |
+| workspace + session list/context | `idx_event_metadata_workspace_session_created_at_norm_id_desc` |
+| 明示source-hook list | `idx_event_metadata_source_hook_created_at_norm_id_desc` |
 
-公開済みフィルタの意味を保つため、list の条件は任意のままとする。ただし時刻境界が指定された場合は、順序インデックス内をseekできる直接範囲predicateのSQL variantを選ぶ。計画は順序インデックスを走査し、scope だけのページでは `offset + limit` に達したら終了する。scope 以外のフィルタはその順序走査中に適用する。組み合わせごとの SQL を増やして結果の意味を変えない。
+時刻境界が指定された場合は直接predicateのSQLを選び、対象の順序index内を
+seekする。scope以外のfilterはseek後に適用し、公開済みの結果を変えない。
+過去互換hookはmigration時またはevent書込み時に固定分類へ変換する。
+metadata読取はその分類だけを比較し、event本文を評価しない。
 
 ### 振る舞いテスト
 
-1. migration済みストアに対する代表的な list/context とlegacy source-hook fallbackの `EXPLAIN QUERY PLAN` が対象インデックスを使い、order-by 用の一時 B-tree を作らないことを確認する。
-2. 通常 list と scope/offset ページの時刻順を確認する。
-3. metadata SQL の SELECT リストで `body` と command payload 列を禁止する。
-4. 000031 前のストアを更新し、固定幅時刻がバックフィルされ、insert と時刻更新後も維持されることを確認する。
-5. 10k eventの直接range queryをCI smokeとしてp95 50 ms未満に保つ。migration済みDBのplan testでは、時刻の下限・上限が直接predicateであり、partial order-by sortを含む一時B-treeがないことも確認する。
-6. release QAではopt-inのmulti-GiB benchmarkを実行する。これは一時ディレクトリにSQLiteが実際に管理するpageとevent bodyを作成し、`page_count * page_size`、NULLでない`body_stored_bytes`、`SUM(body_stored_bytes)`を検証する。CIでは実行しない。
+1. 000034適用前ストアのprivate copyだけを更新し、source digest不変、
+   event/投影件数一致、`integrity_check=ok`、外部キー違反0を確認する。
+2. 既存rowのbackfillと、event/auditのinsert/update/deleteが同じtransaction
+   で投影へ反映されることを確認する。
+3. 代表的なlist/context SQLとplanが投影だけを使い、`events`を開かず、
+   ORDER BY用の一時treeを作らないことを確認する。
+4. 時刻順、filter、失敗のみの絞り込み、過去互換hook、offset、
+   composite keysetの意味を維持する。
+5. 10k eventの直接range queryをCI smokeとしてp95 50 ms未満に保つ。
+6. 外部write lock中はbusy/lockedとなり、投影objectが部分作成されない。
+   lock解除後のretryは成功する。
+7. 更新済みストアを投影導入前のmigration setで開き、その後のevent書込みも
+   永続triggerで投影へ反映されることを確認する。
+8. release前に2つのopt-in運用benchmarkを実行する。残す要約は数値と固定
+   booleanだけに限定する。
 
-### 性能証跡
+### 性能とmigration証跡
 
-2026-07-25にGo 1.26.3、macOS 26.5（darwin/arm64）、modernc SQLite driverでCI smokeを測定した。index済みevent metadata 10,000行に対し、workspaceを絞った2秒の直接range、`limit=50`、25回反復のp95は**416.125us**で、目標は50 ms未満である。
+2026-07-26にGo 1.26.3、macOS 26.5（darwin/arm64、Apple M4）、
+modernc SQLite driverでCI smokeを測定した。投影済みevent 10,000件に対し、
+workspaceを絞った2秒間の直接range、`limit=50`、25回反復のp95は
+**412.25 µs**で、50 msの目標を満たした。
 
-release QAのopt-in benchmarkは256 MiB bodyを持つeventを8件（body合計2 GiB以上）作成し、測定前に`page_count * page_size >= 2 GiB`、event件数、NULLでないbody metadata、`SUM(body_stored_bytes)`を検証する。その後、直接rangeを25回測定する。実行コマンドは次のとおり。
+copied-store migration benchmarkは、privateな256 MiBのsynthetic body領域を
+持つ000034適用前sourceを複製し、copyだけを更新する。
+
+```sh
+TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK=1 \
+  go test -v ./infrastructure/sqlite -run '^$' \
+  -bench BenchmarkEventMetadataProjectionCopiedStoreMigration -benchtime=1x
+```
+
+同じhostでは8 eventのmigration 34が**309.6 ms**で完了した。
+source、更新前copy、更新後copyはすべて302,714,880 bytesで、既存の空きpageに
+細い投影が収まったためmain fileの増加量は0 bytesだった。scratchのpeakは
+605,528,480 bytes、checkpoint後は605,429,760 bytesだった。integrity成功、
+外部キー違反0、sourceはbyte単位で不変だった。外部write lock中は
+**1,012.467 ms**後に想定どおりbusyとなり、部分作成objectは0件、
+lock解除後のretryは成功した。
+
+Phase-A benchmarkはSQLiteが生成する256 MiB領域を8件作り、managed/stored
+body bytesがともに2 GiB以上であること、event/投影件数一致、投影だけを使う
+順序planを確認してから、直接metadata rangeを25回測定する。
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
@@ -51,8 +91,26 @@ TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
   -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
 ```
 
-成功時のbenchmark出力は`managed_bytes`、`events`、`non_null_body_metadata`、`stored_body_bytes`、`p95_ms`を含むため、host環境とともに#1558へ記録する。p95の目標は250 ms未満である。2026-07-25にこの制約付きrunnerで実行を試みたが、fixture生成の完了前にprocessが終了したため、有効なmulti-GiB p95は記録できなかった。空き容量は7.8 GiBあったが、必要な長時間benchmark processを許可しないrunner制限である。release QAでは、このcommandを実行可能なhostで実行し、release前にp95を記録する。生成物はGo testの一時ディレクトリだけに置かれ、終了後に削除されるためcommitしない。またCIでは実行しない。full-scan退行は直接rangeのplan assertionを主な検出器とし、10k smokeのp95閾値はローカル遅延を検出する。
+出力はmanaged/stored bytes、event/投影件数、body metadata欠落数、
+返却body bytes、plan分類、反復回数、p95だけである。p95基準は250 ms未満。
+fixtureはGo testの一時directoryだけに置き、終了後に削除する。CIでは実行
+しない。
+
+同じhostでのPhase Aはmanaged 2,418,753,536 bytes、stored body
+2,147,483,648 bytes、event/投影各8件だった。25回すべてが投影だけを使う
+planで、body metadata欠落と返却body bytesはいずれも0、p95は
+**0.2921 ms**で250 ms基準を満たした。
 
 ### ロールバックと残リスク
 
-000031 は追加かつ冪等である。旧アプリは追加列、trigger、インデックスを無視するため、アプリのロールバック後もストアを読める。巨大ストアでのインデックス作成には一時的に容量と書込みロックが必要である。
+000034は追加migrationである。旧binaryは追加table/indexを無視し、永続
+triggerが旧binaryの書込みも投影へ反映する。release後はschema objectを
+削除せず、applicationだけをauthoritative-table読取へ戻せる。投影を削除
+する場合は、利用中のreaderがないことを確認した後、別のforward migration
+で行う。
+
+backfillとindex作成は1つのmigration transactionで実行する。巨大storeでは
+一時容量が必要で、競合writerはbusy timeoutまで待つ可能性がある。失敗時は
+table、index、trigger、migration recordをまとめてrollbackする。eventごとに
+細い1 rowと5本の順序indexを追加するため、展開後もwrite latencyと
+WAL/checkpoint増加を監視する。

--- a/docs/architecture/index-backed-metadata-list.ja.md
+++ b/docs/architecture/index-backed-metadata-list.ja.md
@@ -73,7 +73,7 @@ TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK=1 \
   -bench BenchmarkEventMetadataProjectionCopiedStoreMigration -benchtime=1x
 ```
 
-同じhostでは8 eventのmigration 34が**309.6 ms**で完了した。
+同じhostでは8 eventのmigration 34が**113.1 ms**で完了した。
 source、更新前copy、更新後copyはすべて302,714,880 bytesで、既存の空きpageに
 細い投影が収まったためmain fileの増加量は0 bytesだった。scratchのpeakは
 605,528,480 bytes、checkpoint後は605,429,760 bytesだった。integrity成功、
@@ -99,7 +99,7 @@ fixtureはGo testの一時directoryだけに置き、終了後に削除する。
 同じhostでのPhase Aはmanaged 2,418,753,536 bytes、stored body
 2,147,483,648 bytes、event/投影各8件だった。25回すべてが投影だけを使う
 planで、body metadata欠落と返却body bytesはいずれも0、p95は
-**0.2921 ms**で250 ms基準を満たした。
+**0.07242 ms**で250 ms基準を満たした。
 
 ### ロールバックと残リスク
 
@@ -109,8 +109,20 @@ triggerが旧binaryの書込みも投影へ反映する。release後はschema ob
 する場合は、利用中のreaderがないことを確認した後、別のforward migration
 で行う。
 
-backfillとindex作成は1つのmigration transactionで実行する。巨大storeでは
-一時容量が必要で、競合writerはbusy timeoutまで待つ可能性がある。失敗時は
-table、index、trigger、migration recordをまとめてrollbackする。eventごとに
+backfillとindex作成は1回限りで、再開機能のない全件scanとして、1つの
+migration transaction内で実行する。既存eventとcommand-audit metadataを
+すべて読み、過去互換hookの分類では該当する未tagの過去event本文も検査する。
+初期化が中断された場合はtable、index、trigger、migration recordをまとめて
+rollbackし、次回の初期化で000034を最初から再実行する。巨大storeを更新する
+前にwriterを止め、一時容量を確保する必要がある。競合writerは設定済みの
+busy timeoutまで待つ可能性がある。
+
+投影には`body_availability`を重複保持しない。metadata consumerはこの値を
+公開せず、保守triggerはauthoritativeな`NEW` rowを参照できるためである。
+retentionによるpruneでは過去の`body_stored_bytes`を維持し、更新後の
+availabilityが`available`の場合だけ新しいbodyから再計算する。未使用の
+availability列を増やすと乖離面が増え、通常の`doctor`に無制限の投影乖離
+scanを加えると巨大storeの全件scanになるため、いずれもこのmigrationには
+含めない。migration/triggerのparity testで不変条件を検証する。eventごとに
 細い1 rowと5本の順序indexを追加するため、展開後もwrite latencyと
 WAL/checkpoint増加を監視する。

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -1,4 +1,4 @@
-# Index-backed metadata list and context queries
+# Persistent metadata projection for list and context queries
 
 [日本語](index-backed-metadata-list.ja.md)
 
@@ -7,67 +7,88 @@
 ### Requirement summary
 
 - General metadata list and context reads must retain boundary-correct
-  RFC3339Nano ordering without a whole-store temporary sort.
-- Workspace/session scopes and page offsets must remain metadata-only.
-- Schema rollout must be additive; a code rollback must not make an existing
-  store unreadable.
+  RFC3339Nano ordering without opening body-bearing `events` records.
+- Workspace/session/source-hook scopes, offset pages, and keyset pages must
+  preserve their existing membership and ordering.
+- The two historical source-hook body-prefix fallbacks must remain available
+  without evaluating bodies at read time.
+- Schema rollout must be additive, and a code rollback must leave an upgraded
+  store readable and writable.
 
-### Conceptual model and responsibilities
+### Concepts and responsibilities
 
 | Concept | Owner | Invariant |
 | --- | --- | --- |
-| Normalized timestamp order | persisted event timestamp and SQLite indexes | `created_at_norm, id` is the one ordering contract |
-| Scoped metadata page | metadata datasource | selects metadata/audit columns, never `events.body` |
-| Index rollout | migration 000031 | adds and backfills `created_at_norm`, then maintains it with triggers |
+| Normalized timestamp | migration 000031 and event triggers | `created_at_norm, id` remains the one event-ordering contract |
+| Persistent metadata projection | migration 000034 | one narrow row per event contains metadata, legacy-hook classification, and optional command-audit facts, but no body or command payload |
+| Scoped metadata page | metadata datasource | list/context SQL opens only the projection and returns the existing `EventMetadata` contract |
+| Transactional maintenance | event and command-audit triggers | an authoritative committed mutation and its projection cannot diverge |
 
-### Boundaries and supported plans
+### Supported plans
 
-| Query shape | Ordered index |
+| Query shape | Projection ordering index |
 | --- | --- |
-| general metadata list (including limit/offset) | `idx_events_created_at_norm_id_desc` |
-| workspace list/context | `idx_events_workspace_created_at_norm_id_desc` |
-| session list/context | `idx_events_session_created_at_norm_id_desc` |
-| workspace + session context | `idx_events_workspace_session_created_at_norm_id_desc` |
-| source-hook list | `idx_events_source_hook_created_at_norm_id_desc` |
+| general metadata list, including limit/offset | `idx_event_metadata_created_at_norm_id_desc` |
+| workspace list/context | `idx_event_metadata_workspace_created_at_norm_id_desc` |
+| session list/context | `idx_event_metadata_session_created_at_norm_id_desc` |
+| workspace + session list/context | `idx_event_metadata_workspace_session_created_at_norm_id_desc` |
+| directly tagged source-hook list | `idx_event_metadata_source_hook_created_at_norm_id_desc` |
 
-The list predicates remain optional for public filters, but supplied timestamp
-bounds select direct SQL variants so the planner can seek within the matching
-ordering index. The planner can scan the matching ordering index;
-for an unfiltered scoped page it stops after `offset + limit`, while filters
-that are not an indexed scope are applied during that ordered scan. This is
-preferable to duplicating every filter combination or changing result
-membership.
+Supplied timestamp boundaries select direct-predicate SQL variants so SQLite
+can seek inside the matching ordering index. Filters that are not part of the
+selected scope remain post-seek predicates, preserving the public result
+semantics. Legacy hook fallback scans the narrow general projection order and
+compares a fixed classification populated during migration or event writes; it
+does not evaluate an event body.
 
-### Behavior tests and TDD plan
+### Behavior tests
 
-1. Assert representative list/context and legacy source-hook fallback
-   `EXPLAIN QUERY PLAN` output from a migrated store uses the
-   documented ordering index and does not build a temporary order-by tree.
-2. Assert normal list and scoped/offset pages preserve timestamp order.
-3. Keep the metadata SQL select-list guard: `body` and command payload columns
-   are forbidden in every metadata query.
-4. Upgrade a pre-000031 store and assert the fixed-width timestamp is
-   backfilled and maintained after inserts and timestamp updates.
-5. Keep the 10k-event direct-range p95 below 50 ms as a CI smoke test. The
-   migrated-store plan test also requires direct lower and upper timestamp
-   constraints and rejects every temporary B-tree, including partial order-by
-   sorts.
-6. Run the opt-in multi-GiB benchmark before release. It writes actual SQLite
-   pages and event bodies under a temporary directory, verifies both
-   `page_count * page_size`, non-NULL `body_stored_bytes`, and
-   `SUM(body_stored_bytes)`, and is never run by CI.
+1. Upgrade only a private copy of a pre-000034 store; require an unchanged
+   source digest, equal event/projection counts, `integrity_check=ok`, and zero
+   foreign-key violations.
+2. Verify existing-row backfill and transactional event/audit
+   insert/update/delete maintenance.
+3. Assert representative list/context SQL and plans use the projection, never
+   open `events`, and do not build a temporary order-by tree.
+4. Preserve timestamp order, filters, failures-only semantics, legacy hook
+   membership, offset paging, and composite keyset paging.
+5. Keep the 10k-event direct-range p95 below 50 ms as a CI smoke test.
+6. Exercise an external write lock, require a busy/locked result with no partial
+   projection object, then retry successfully after releasing the lock.
+7. Open an upgraded store through the pre-projection migration set and verify
+   its subsequent event write is maintained by the persisted triggers.
+8. Run both opt-in operational benchmarks before release. Their durable
+   summaries contain numeric metrics and fixed booleans only.
 
-### Performance evidence
+### Performance and migration evidence
 
-The CI smoke measurement on 2026-07-25 used Go 1.26.3 on macOS 26.5
-(darwin/arm64) with the modernc SQLite driver. It contains 10,000 indexed event
-metadata rows; 25 workspace-scoped, two-second direct ranges with `limit=50`
-measured p95 **416.125us** against a 50 ms target.
+The CI smoke measurement on 2026-07-26 used Go 1.26.3 on macOS 26.5
+(darwin/arm64, Apple M4) with the modernc SQLite driver. It contained 10,000
+projected event rows; 25 workspace-scoped two-second direct ranges with
+`limit=50` measured p95 **412.25 µs** against the 50 ms target.
 
-The release-QA benchmark is opt-in and creates 8 events with 256 MiB bodies
-(at least 2 GiB total), then verifies `page_count * page_size >= 2 GiB`, the
-event count, non-NULL body metadata, and `SUM(body_stored_bytes)` before
-measuring 25 direct ranges. Run:
+The copied-store migration benchmark creates a private synthetic 256 MiB body
+extent, copies the pre-000034 source, and migrates only the copy:
+
+```sh
+TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK=1 \
+  go test -v ./infrastructure/sqlite -run '^$' \
+  -bench BenchmarkEventMetadataProjectionCopiedStoreMigration -benchtime=1x
+```
+
+On the same host, migration 34 completed in **309.6 ms** for 8 events. Source,
+copy-before, and copy-after sizes were each 302,714,880 bytes; measured main-file
+growth was 0 bytes because existing free pages held the narrow projection.
+Peak scratch extent was 605,528,480 bytes and post-checkpoint scratch was
+605,429,760 bytes. Integrity passed, foreign-key violations were zero, and the
+source stayed byte-identical. An externally held write lock returned the
+expected busy outcome after **1,012.467 ms**, exposed zero partial projection
+objects, and the retry succeeded after release.
+
+The Phase-A benchmark creates eight SQLite-generated 256 MiB extents (at least
+2 GiB managed and stored body bytes), verifies equal event/projection counts,
+requires a projection-only ordered plan, and measures 25 direct metadata
+ranges:
 
 ```sh
 TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
@@ -75,23 +96,27 @@ TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 \
   -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x
 ```
 
-Successful benchmark output reports `managed_bytes`, `events`,
-`non_null_body_metadata`, `stored_body_bytes`, and `p95_ms`; attach those
-values to #1558 with the host environment. Its p95 goal is below 250 ms. A
-2026-07-25 attempt in this constrained runner
-reached benchmark setup but was terminated before fixture completion, so it has
-no valid multi-GiB p95 to report. The runner had 7.8 GiB free but does not allow
-the required long-lived benchmark process; release QA must run the command on a
-host that permits it and record the p95 before release. The command creates its
-artifact only in the Go test temporary directory and deletes it afterwards; no
-large fixture is committed or run by CI. The direct-range plan assertion is the
-primary full-scan regression guard, while the 10k smoke threshold detects local
-latency regressions.
+It reports managed/stored bytes, event/projection counts, missing body metadata,
+returned body bytes, plan classification, run count, and p95. The p95 gate is
+below 250 ms. The fixture lives only in the Go test temporary directory and is
+removed after the benchmark; CI never creates it.
+
+On the same host, Phase A measured 2,418,753,536 managed bytes and
+2,147,483,648 stored body bytes across 8 event/projection rows. All 25
+measurements used the projection-only plan, missing body metadata and returned
+body bytes were both zero, and p95 was **0.2921 ms**, passing the 250 ms gate.
 
 ### Rollback and residual risk
 
-Migration 000031 is additive and idempotent. Reverting application code keeps
-the store readable because older readers ignore the added column, triggers, and
-indexes. Index creation can temporarily require disk and write-lock
-capacity on very large stores; operators should retry after freeing capacity or
-quiescing writers.
+Migration 000034 is additive. Older binaries ignore its table and indexes while
+the persisted triggers continue to maintain projection rows for their writes.
+After release, application code can therefore roll back to authoritative-table
+reads without removing schema objects. Removing the projection requires a later
+forward migration after no deployed reader depends on it.
+
+Backfill and index creation execute in one migration transaction. Large stores
+therefore need temporary disk capacity and can make competing writers wait up
+to the configured busy timeout. Any migration failure rolls back the table,
+indexes, triggers, and migration record together. The projection adds one
+narrow row and five ordering indexes per event, so deployments must still
+monitor write latency and WAL/checkpoint growth.

--- a/docs/architecture/index-backed-metadata-list.md
+++ b/docs/architecture/index-backed-metadata-list.md
@@ -76,7 +76,7 @@ TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK=1 \
   -bench BenchmarkEventMetadataProjectionCopiedStoreMigration -benchtime=1x
 ```
 
-On the same host, migration 34 completed in **309.6 ms** for 8 events. Source,
+On the same host, migration 34 completed in **113.1 ms** for 8 events. Source,
 copy-before, and copy-after sizes were each 302,714,880 bytes; measured main-file
 growth was 0 bytes because existing free pages held the narrow projection.
 Peak scratch extent was 605,528,480 bytes and post-checkpoint scratch was
@@ -104,7 +104,7 @@ removed after the benchmark; CI never creates it.
 On the same host, Phase A measured 2,418,753,536 managed bytes and
 2,147,483,648 stored body bytes across 8 event/projection rows. All 25
 measurements used the projection-only plan, missing body metadata and returned
-body bytes were both zero, and p95 was **0.2921 ms**, passing the 250 ms gate.
+body bytes were both zero, and p95 was **0.07242 ms**, passing the 250 ms gate.
 
 ### Rollback and residual risk
 
@@ -114,9 +114,22 @@ After release, application code can therefore roll back to authoritative-table
 reads without removing schema objects. Removing the projection requires a later
 forward migration after no deployed reader depends on it.
 
-Backfill and index creation execute in one migration transaction. Large stores
-therefore need temporary disk capacity and can make competing writers wait up
-to the configured busy timeout. Any migration failure rolls back the table,
-indexes, triggers, and migration record together. The projection adds one
-narrow row and five ordering indexes per event, so deployments must still
+Backfill and index creation are a one-time, non-resumable scan executed in one
+migration transaction. The scan reads every existing event and command-audit
+metadata row; legacy-hook classification also inspects bodies for relevant
+untagged historical events. If initialization is interrupted, SQLite rolls back
+the table, indexes, triggers, and migration record together, and the next
+initialization retries migration 000034 from the beginning. Operators should
+quiesce writers and reserve temporary disk capacity before upgrading a large
+store. Competing writers can wait up to the configured busy timeout.
+
+The projection deliberately does not duplicate `body_availability`: metadata
+consumers do not expose it, and maintenance triggers can use the authoritative
+`NEW` row. A retention prune preserves the historical `body_stored_bytes`
+extent; only an update whose resulting availability is `available` recomputes
+that extent from the new body. Adding the unused availability field or an
+unbounded projection-drift scan to the normal `doctor` path would add another
+drift surface or a large-store scan, so neither is part of this migration.
+Migration and trigger parity tests enforce the invariant. The projection still
+adds one narrow row and five ordering indexes per event, so deployments must
 monitor write latency and WAL/checkpoint growth.

--- a/infrastructure/sqlite/event_bounded_query_test.go
+++ b/infrastructure/sqlite/event_bounded_query_test.go
@@ -18,7 +18,11 @@ func TestEventBoundedQuery_ReturnsSmallPrefixFromLargeStoredBody(t *testing.T) {
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	sut, store := newEventDatasource(
+		t,
+		dbPath,
+		migrationsInRangeExcluding(t, onDiskSQLiteMigrationDir(t), 1, 34, 32),
+	)
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -102,7 +106,11 @@ func TestEventBoundedQuery_MatchesCanonicalVisibleTextProjection(t *testing.T) {
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	sut, store := newEventDatasource(
+		t,
+		dbPath,
+		migrationsInRangeExcluding(t, onDiskSQLiteMigrationDir(t), 1, 34, 32),
+	)
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -254,7 +262,11 @@ func TestEventBoundedQuery_PreservesRetentionUnavailability(t *testing.T) {
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "traceary.db")
-	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 32))
+	sut, store := newEventDatasource(
+		t,
+		dbPath,
+		migrationsInRangeExcluding(t, onDiskSQLiteMigrationDir(t), 1, 34, 32),
+	)
 	if err := store.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -25,7 +25,7 @@ func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.ExecContext(context.Background(), `
-		CREATE TABLE events (
+		CREATE TABLE event_metadata_projection (
 			id TEXT PRIMARY KEY,
 			kind TEXT NOT NULL,
 			client TEXT NOT NULL,
@@ -34,15 +34,20 @@ func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
 			workspace TEXT NOT NULL,
 			source_hook TEXT,
 			created_at TEXT NOT NULL,
+			created_at_norm TEXT NOT NULL,
 			body_original_bytes INTEGER,
 			body_stored_bytes INTEGER NOT NULL,
 			body_ingest_truncated BOOLEAN,
 			body_storage_truncated BOOLEAN,
-			body_metadata_version INTEGER
+			body_metadata_version INTEGER,
+			command_audit_event_id TEXT,
+			command_exit_code INTEGER,
+			command_failed BOOLEAN
 		);
-		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
-		CREATE INDEX idx_events_created_at ON events(created_at DESC, id DESC);
-		CREATE INDEX idx_events_workspace_created_at ON events(workspace, created_at DESC, id DESC);
+		CREATE INDEX idx_event_metadata_created_at_norm_id_desc
+			ON event_metadata_projection(created_at_norm DESC, id DESC);
+		CREATE INDEX idx_event_metadata_workspace_created_at_norm_id_desc
+			ON event_metadata_projection(workspace, created_at_norm DESC, id DESC);
 	`); err != nil {
 		t.Fatalf("create query-plan fixture: %v", err)
 	}
@@ -63,8 +68,8 @@ func TestBoundedLatestEventMetadataQueryPlanUsesCreatedAtIndex(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate query plan: %v", err)
 	}
-	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_created_at") {
-		t.Fatalf("bounded latest query does not use created_at index:\n%s", joined)
+	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_event_metadata_created_at_norm_id_desc") {
+		t.Fatalf("bounded latest query does not use projection timestamp index:\n%s", joined)
 	}
 }
 
@@ -76,19 +81,20 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.ExecContext(context.Background(), `
-		CREATE TABLE events (
+		CREATE TABLE event_metadata_projection (
 			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
 			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
 			source_hook TEXT, created_at TEXT NOT NULL, created_at_norm TEXT NOT NULL, body_original_bytes INTEGER,
 			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
-			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
+			body_storage_truncated BOOLEAN, body_metadata_version INTEGER,
+			command_audit_event_id TEXT, command_exit_code INTEGER, command_failed BOOLEAN
 		);
-		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
-		CREATE INDEX idx_events_workspace_created_at ON events(workspace, created_at DESC, id DESC);
+		CREATE INDEX idx_event_metadata_workspace_created_at_norm_id_desc
+			ON event_metadata_projection(workspace, created_at_norm DESC, id DESC);
 	`); err != nil {
 		t.Fatalf("create workspace query-plan fixture: %v", err)
 	}
-	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastByWorkspaceQuery, "repo-current", "repo-current", "repo-current")
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+selectLatestEventMetadataFastByWorkspaceQuery, "repo-current")
 	if err != nil {
 		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
 	}
@@ -105,8 +111,8 @@ func TestBoundedLatestEventMetadataByWorkspaceQueryPlanUsesTimestampIndex(t *tes
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate query plan: %v", err)
 	}
-	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_events_workspace_created_at") {
-		t.Fatalf("bounded workspace query does not use workspace timestamp index:\n%s", joined)
+	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "idx_event_metadata_workspace_created_at_norm_id_desc") {
+		t.Fatalf("bounded workspace query does not use projection timestamp index:\n%s", joined)
 	}
 	if joined := strings.Join(plan, "\n"); strings.Contains(joined, "USE TEMP B-TREE FOR LAST TERM OF ORDER BY") {
 		t.Fatalf("legacy workspace index must not sort every scoped row to choose the latest second:\n%s", joined)
@@ -121,24 +127,24 @@ func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t 
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.ExecContext(context.Background(), `
-		CREATE TABLE events (
+		CREATE TABLE event_metadata_projection (
 			id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL,
 			agent TEXT NOT NULL, session_id TEXT NOT NULL, workspace TEXT NOT NULL,
-			source_hook TEXT, created_at TEXT NOT NULL, created_at_norm TEXT NOT NULL, body_original_bytes INTEGER,
+			source_hook TEXT, legacy_source_hook TEXT, created_at TEXT NOT NULL, created_at_norm TEXT NOT NULL, body_original_bytes INTEGER,
 			body_stored_bytes INTEGER NOT NULL, body_ingest_truncated BOOLEAN,
-			body_storage_truncated BOOLEAN, body_metadata_version INTEGER
+			body_storage_truncated BOOLEAN, body_metadata_version INTEGER,
+			command_audit_event_id TEXT, command_exit_code INTEGER, command_failed BOOLEAN
 		);
-		CREATE TABLE command_audits (event_id TEXT PRIMARY KEY, exit_code INTEGER, failed BOOLEAN);
-		CREATE INDEX idx_events_created_at_norm_id_desc
-			ON events(created_at_norm DESC, id DESC);
-		CREATE INDEX idx_events_workspace_created_at_norm_id_desc
-			ON events(workspace, created_at_norm DESC, id DESC);
-		CREATE INDEX idx_events_session_created_at_norm_id_desc
-			ON events(session_id, created_at_norm DESC, id DESC);
-		CREATE INDEX idx_events_workspace_session_created_at_norm_id_desc
-			ON events(workspace, session_id, created_at_norm DESC, id DESC);
-		CREATE INDEX idx_events_source_hook_created_at_norm_id_desc
-			ON events(source_hook, created_at_norm DESC, id DESC)
+		CREATE INDEX idx_event_metadata_created_at_norm_id_desc
+			ON event_metadata_projection(created_at_norm DESC, id DESC);
+		CREATE INDEX idx_event_metadata_workspace_created_at_norm_id_desc
+			ON event_metadata_projection(workspace, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_event_metadata_session_created_at_norm_id_desc
+			ON event_metadata_projection(session_id, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_event_metadata_workspace_session_created_at_norm_id_desc
+			ON event_metadata_projection(workspace, session_id, created_at_norm DESC, id DESC);
+		CREATE INDEX idx_event_metadata_source_hook_created_at_norm_id_desc
+			ON event_metadata_projection(source_hook, created_at_norm DESC, id DESC)
 			WHERE source_hook IS NOT NULL;
 	`); err != nil {
 		t.Fatalf("create query-plan fixture: %v", err)
@@ -154,31 +160,31 @@ func TestGeneralMetadataListAndContextQueryPlansUseNormalizedTimestampIndexes(t 
 			name:      "general list with offset",
 			query:     metadataPageQuery(selectRecentEventMetadataQuery, apptypes.EventPageAnchor{}),
 			args:      []any{"", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_created_at_norm_id_desc",
+			wantIndex: "idx_event_metadata_created_at_norm_id_desc",
 		},
 		{
 			name:      "workspace list with offset",
 			query:     metadataPageQuery(selectRecentEventMetadataByWorkspaceQuery, apptypes.EventPageAnchor{}),
 			args:      []any{"repo-current", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_workspace_created_at_norm_id_desc",
+			wantIndex: "idx_event_metadata_workspace_created_at_norm_id_desc",
 		},
 		{
 			name:      "session list with offset",
 			query:     metadataPageQuery(selectRecentEventMetadataBySessionQuery, apptypes.EventPageAnchor{}),
 			args:      []any{"session-1", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_session_created_at_norm_id_desc",
+			wantIndex: "idx_event_metadata_session_created_at_norm_id_desc",
 		},
 		{
 			name:      "workspace session context",
 			query:     metadataPageQuery(getContextEventMetadataByWorkspaceSessionQuery, apptypes.EventPageAnchor{}),
 			args:      []any{"repo-current", "session-1", "", "", 25, 0},
-			wantIndex: "idx_events_workspace_session_created_at_norm_id_desc",
+			wantIndex: "idx_event_metadata_workspace_session_created_at_norm_id_desc",
 		},
 		{
 			name:      "source hook list with offset",
 			query:     metadataPageQuery(selectRecentEventMetadataBySourceHookQuery, apptypes.EventPageAnchor{}),
 			args:      []any{"stop", "", "", "", "", "", "", "", "", "", "", 0, "", "", "", "", 25, 100},
-			wantIndex: "idx_events_source_hook_created_at_norm_id_desc",
+			wantIndex: "idx_event_metadata_source_hook_created_at_norm_id_desc",
 		},
 	}
 	for _, tt := range tests {
@@ -232,7 +238,7 @@ func TestAnchoredMetadataPageQueryPlanUsesCompositeKeysetSeek(t *testing.T) {
 	}
 
 	plan := explainQueryPlan(t, db, query, args...)
-	assertPlanUsesOrderedIndex(t, plan, "idx_events_workspace_created_at_norm_id_desc")
+	assertPlanUsesOrderedIndex(t, plan, "idx_event_metadata_workspace_created_at_norm_id_desc")
 	if joined := strings.Join(plan, "\n"); !strings.Contains(joined, "(created_at_norm,id)<(?,?)") {
 		t.Fatalf("anchored query plan does not use the composite keyset seek:\n%s", joined)
 	}
@@ -270,7 +276,7 @@ func TestMetadataRangeAndLegacyFallbackPlansUseProductionMigrationIndexes(t *tes
 		To(time.Date(2026, 7, 25, 0, 0, 3, 0, time.UTC)).
 		Build()
 	query, args := scopedRecentEventMetadataQuery(criteria, 0, from, to, 25, 0)
-	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, query, args...), "idx_events_workspace_created_at_norm_id_desc")
+	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, query, args...), "idx_event_metadata_workspace_created_at_norm_id_desc")
 
 	legacyQuery := metadataPageQuery(
 		metadataTimeRangeQuery(selectRecentEventMetadataBySourceHookWithLegacyQuery, from, to),
@@ -279,7 +285,7 @@ func TestMetadataRangeAndLegacyFallbackPlansUseProductionMigrationIndexes(t *tes
 	legacyArgs := metadataSourceHookLegacyQueryArgs(
 		"subagent_stop", "", "", "", "", "", 0, from, to, apptypes.EventPageAnchor{}, 25, 0,
 	)
-	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, legacyQuery, legacyArgs...), "idx_events_created_at_norm_id_desc")
+	assertPlanUsesDirectRangeIndex(t, explainQueryPlan(t, db, legacyQuery, legacyArgs...), "idx_event_metadata_created_at_norm_id_desc")
 }
 
 func assertPlanUsesOrderedIndex(t *testing.T, plan []string, index string) {
@@ -402,20 +408,19 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		b.Fatalf("sql.Open() error = %v", err)
 	}
 	b.Cleanup(func() { _ = db.Close() })
-	payload := strings.Repeat("x", bodyBytes)
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		b.Fatalf("BeginTx() error = %v", err)
 	}
 	statement, err := tx.PrepareContext(ctx, `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, body_availability)
-		VALUES (?, 'note', 'hook', 'codex', 'session-1', 'repo-current', ?, ?, 'available')`)
+		VALUES (?, 'note', 'hook', 'codex', 'session-1', 'repo-current', zeroblob(?), ?, 'unavailable_retention')`)
 	if err != nil {
 		_ = tx.Rollback()
 		b.Fatalf("PrepareContext() error = %v", err)
 	}
 	base := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
 	for i := 0; i < eventCount; i++ {
-		if _, err := statement.ExecContext(ctx, fmt.Sprintf("large-event-%03d", i), payload, base.Add(time.Duration(i)*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
+		if _, err := statement.ExecContext(ctx, fmt.Sprintf("large-event-%03d", i), bodyBytes, base.Add(time.Duration(i)*time.Millisecond).Format(time.RFC3339Nano)); err != nil {
 			_ = statement.Close()
 			_ = tx.Rollback()
 			b.Fatalf("insert fixture %d: %v", i, err)
@@ -430,7 +435,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
 		b.Fatalf("checkpoint large fixture: %v", err)
 	}
-	var pageCount, pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes int64
+	var pageCount, pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes, projectionRows int64
 	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
 		b.Fatalf("read page_count: %v", err)
 	}
@@ -442,20 +447,28 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		FROM events`).Scan(&storedEvents, &storedBodyBytes, &missingStoredBodyBytes); err != nil {
 		b.Fatalf("verify large fixture: %v", err)
 	}
-	if pageCount*pageSize < minimumDBBytes || storedEvents != eventCount || missingStoredBodyBytes != 0 || storedBodyBytes < minimumDBBytes {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM event_metadata_projection`).Scan(&projectionRows); err != nil {
+		b.Fatalf("verify metadata projection extent: %v", err)
+	}
+	if pageCount*pageSize < minimumDBBytes ||
+		storedEvents != eventCount ||
+		projectionRows != storedEvents ||
+		missingStoredBodyBytes != 0 ||
+		storedBodyBytes < minimumDBBytes {
 		b.Fatalf("large fixture verification failed: page_count=%d page_size=%d managed_bytes=%d events=%d stored_body_bytes=%d missing_stored_body_bytes=%d", pageCount, pageSize, pageCount*pageSize, storedEvents, storedBodyBytes, missingStoredBodyBytes)
 	}
-	b.ReportMetric(float64(pageCount*pageSize), "managed_bytes")
-	b.ReportMetric(float64(storedEvents), "events")
-	b.ReportMetric(float64(storedEvents-missingStoredBodyBytes), "non_null_body_metadata")
-	b.ReportMetric(float64(storedBodyBytes), "stored_body_bytes")
-
 	criteria := apptypes.NewEventListCriteriaBuilder(50).
 		Workspace(types.Workspace("repo-current")).
 		From(base).
 		To(base.Add(time.Second)).
 		Build()
 	query, args := scopedRecentEventMetadataQuery(criteria, 0, formatMetadataOptionalTimestamp(criteria.From()), formatMetadataOptionalTimestamp(criteria.To()), criteria.Limit(), criteria.Offset())
+	plan := strings.Join(explainQueryPlan(b, db, query, args...), "\n")
+	if !strings.Contains(plan, "idx_event_metadata_workspace_created_at_norm_id_desc") ||
+		strings.Contains(plan, "events") ||
+		strings.Contains(plan, "USE TEMP B-TREE") {
+		b.Fatal("multi-GiB metadata plan is not projection-only and index ordered")
+	}
 	durations := make([]time.Duration, 0, measurementRuns)
 	b.ResetTimer()
 	for range measurementRuns {
@@ -483,13 +496,21 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	b.StopTimer()
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	p95 := durations[(len(durations)*95+99)/100-1]
+	b.ReportMetric(float64(pageCount*pageSize), "managed_bytes")
+	b.ReportMetric(float64(storedEvents), "events")
+	b.ReportMetric(float64(projectionRows), "projection_rows")
+	b.ReportMetric(float64(missingStoredBodyBytes), "missing_body_metadata")
+	b.ReportMetric(float64(storedBodyBytes), "stored_body_bytes")
+	b.ReportMetric(1, "projection_only")
+	b.ReportMetric(0, "returned_body_bytes")
+	b.ReportMetric(measurementRuns, "measurement_runs")
 	b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
 	if p95 >= 250*time.Millisecond {
 		b.Fatalf("multi-GiB direct range p95=%s, want < 250ms", p95)
 	}
 }
 
-func explainQueryPlan(t *testing.T, db *sql.DB, query string, args ...any) []string {
+func explainQueryPlan(t testing.TB, db *sql.DB, query string, args ...any) []string {
 	t.Helper()
 	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
 	if err != nil {

--- a/infrastructure/sqlite/event_metadata_datasource.go
+++ b/infrastructure/sqlite/event_metadata_datasource.go
@@ -84,7 +84,7 @@ func (d *EventDatasource) ListRecentTimestampKinds(ctx context.Context, criteria
 	args := []any(nil)
 	if workspace != "" {
 		query = selectLatestEventTimestampKindByWorkspaceQuery
-		args = []any{workspace, workspace, workspace}
+		args = []any{workspace}
 	}
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -574,7 +574,7 @@ func queryRecentEventMetadataWith(
 		args := []any(nil)
 		if workspace != "" {
 			queryText = selectLatestEventMetadataFastByWorkspaceQuery
-			args = []any{workspace, workspace, workspace}
+			args = []any{workspace}
 		}
 		rows, err := query(ctx, queryText, args...)
 		if err != nil {

--- a/infrastructure/sqlite/event_metadata_projection_migration_test.go
+++ b/infrastructure/sqlite/event_metadata_projection_migration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	domtypes "github.com/duck8823/traceary/domain/types"
 	_ "modernc.org/sqlite"
 )
 
@@ -94,6 +95,7 @@ func TestMigrations_EventMetadataProjectionBackfillsAndMaintainsRows(t *testing.
 		storedBodyBytes:  int64(len("[phase:pre-compact] complete")),
 		legacySourceHook: "pre_compact",
 	})
+	assertStoredBodyBytesParity(t, db, "projection-a", int64(len("[phase:pre-compact] complete")))
 	assertProjectionRow(t, db, "projection-b", projectionRowExpectation{
 		kind:            "note",
 		workspace:       "workspace-b",
@@ -112,6 +114,34 @@ func TestMigrations_EventMetadataProjectionBackfillsAndMaintainsRows(t *testing.
 		createdAtNorm:   "2026-07-26T00:00:01.500000000Z",
 		storedBodyBytes: int64(len("metadata only")),
 	})
+
+	originalStoredBodyBytes := int64(len("metadata only"))
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET body = ?,
+		       body_availability = 'unavailable_retention',
+		       body_pruned_at = '2026-07-26T00:00:03Z',
+		       body_pruned_plan_id = 'projection-plan'
+		 WHERE id = 'projection-b'
+		   AND body_availability = 'available'
+		   AND body = 'metadata only'
+	`, domtypes.EventBodyUnavailableRetentionMarker); err != nil {
+		t.Fatalf("prune authoritative event body: %v", err)
+	}
+	assertStoredBodyBytesParity(t, db, "projection-b", originalStoredBodyBytes)
+
+	const restoredBody = "restored body with a different byte length"
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET body = ?,
+		       body_availability = 'available',
+		       body_pruned_at = NULL,
+		       body_pruned_plan_id = NULL
+		 WHERE id = 'projection-b'
+	`, restoredBody); err != nil {
+		t.Fatalf("restore authoritative event body: %v", err)
+	}
+	assertStoredBodyBytesParity(t, db, "projection-b", int64(len(restoredBody)))
 
 	if _, err := db.ExecContext(ctx, `DELETE FROM events WHERE id = 'projection-a'`); err != nil {
 		t.Fatalf("delete event: %v", err)
@@ -568,6 +598,28 @@ func assertProjectionRow(t *testing.T, db *sql.DB, id string, want projectionRow
 			auditEventID.Valid,
 			exitCode.Int64,
 			failed.Bool,
+		)
+	}
+}
+
+func assertStoredBodyBytesParity(t *testing.T, db *sql.DB, id string, want int64) {
+	t.Helper()
+	var eventStoredBodyBytes, projectionStoredBodyBytes int64
+	if err := db.QueryRow(`
+		SELECT events.body_stored_bytes, event_metadata_projection.body_stored_bytes
+		  FROM events
+		  JOIN event_metadata_projection
+		    ON event_metadata_projection.id = events.id
+		 WHERE events.id = ?
+	`, id).Scan(&eventStoredBodyBytes, &projectionStoredBodyBytes); err != nil {
+		t.Fatalf("read stored body byte parity: %v", err)
+	}
+	if eventStoredBodyBytes != want || projectionStoredBodyBytes != want {
+		t.Fatalf(
+			"stored body bytes = event:%d projection:%d, want %d",
+			eventStoredBodyBytes,
+			projectionStoredBodyBytes,
+			want,
 		)
 	}
 }

--- a/infrastructure/sqlite/event_metadata_projection_migration_test.go
+++ b/infrastructure/sqlite/event_metadata_projection_migration_test.go
@@ -1,0 +1,657 @@
+package sqlite_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestMigrations_EventMetadataProjectionBackfillsAndMaintainsRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	preProjection := onDiskSQLiteMigrationsBefore(t, 34)
+	if err := newStoreManagementDatasource(t, dbPath, preProjection).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-projection) error = %v", err)
+	}
+	db := openProjectionMigrationDB(t, dbPath)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			source_hook, body_original_bytes, body_ingest_truncated,
+			body_storage_truncated, body_metadata_version, body_availability
+		) VALUES
+			('projection-a', 'session_ended', 'hook', 'codex', 'session-a',
+			 'workspace-a', '[phase:subagent] complete',
+			 '2026-07-26T00:00:00Z', NULL, 128, 0, 0, 1, 'available'),
+			('projection-b', 'note', 'cli', 'codex', 'session-b',
+			 'workspace-b', 'metadata only',
+			 '2026-07-26T00:00:01.5Z', 'stop', 64, 0, 0, 1, 'available');
+		INSERT INTO command_audits(
+			event_id, command_text, input_text, output_text, exit_code, failed
+		) VALUES ('projection-b', 'synthetic', '', '', 9, 1);
+	`); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed pre-projection store: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close pre-projection store: %v", err)
+	}
+
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(current) error = %v", err)
+	}
+	db = openProjectionMigrationDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	assertMigrationApplied(t, db, 34)
+	assertProjectionSchemaIsPayloadFree(t, db)
+	assertProjectionRow(t, db, "projection-a", projectionRowExpectation{
+		kind:             "session_ended",
+		workspace:        "workspace-a",
+		createdAtNorm:    "2026-07-26T00:00:00.000000000Z",
+		storedBodyBytes:  int64(len("[phase:subagent] complete")),
+		legacySourceHook: "subagent_stop",
+	})
+	assertProjectionRow(t, db, "projection-b", projectionRowExpectation{
+		kind:            "note",
+		workspace:       "workspace-b",
+		createdAtNorm:   "2026-07-26T00:00:01.500000000Z",
+		storedBodyBytes: int64(len("metadata only")),
+		auditPresent:    true,
+		exitCode:        9,
+		failed:          true,
+	})
+
+	if _, err := db.ExecContext(ctx, `
+		UPDATE events
+		   SET kind = 'compact_summary',
+		       workspace = 'workspace-updated',
+		       body = '[phase:pre-compact] complete',
+		       created_at = '2026-07-26T00:00:02.25Z',
+		       source_hook = NULL
+		 WHERE id = 'projection-a';
+		UPDATE command_audits
+		   SET exit_code = NULL, failed = 0
+		 WHERE event_id = 'projection-b';
+	`); err != nil {
+		t.Fatalf("update authoritative rows: %v", err)
+	}
+	assertProjectionRow(t, db, "projection-a", projectionRowExpectation{
+		kind:             "compact_summary",
+		workspace:        "workspace-updated",
+		createdAtNorm:    "2026-07-26T00:00:02.250000000Z",
+		storedBodyBytes:  int64(len("[phase:pre-compact] complete")),
+		legacySourceHook: "pre_compact",
+	})
+	assertProjectionRow(t, db, "projection-b", projectionRowExpectation{
+		kind:            "note",
+		workspace:       "workspace-b",
+		createdAtNorm:   "2026-07-26T00:00:01.500000000Z",
+		storedBodyBytes: int64(len("metadata only")),
+		auditPresent:    true,
+		failed:          false,
+	})
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM command_audits WHERE event_id = 'projection-b'`); err != nil {
+		t.Fatalf("delete command audit: %v", err)
+	}
+	assertProjectionRow(t, db, "projection-b", projectionRowExpectation{
+		kind:            "note",
+		workspace:       "workspace-b",
+		createdAtNorm:   "2026-07-26T00:00:01.500000000Z",
+		storedBodyBytes: int64(len("metadata only")),
+	})
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM events WHERE id = 'projection-a'`); err != nil {
+		t.Fatalf("delete event: %v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM event_metadata_projection WHERE id = 'projection-a'
+	`).Scan(&count); err != nil {
+		t.Fatalf("count deleted projection row: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("deleted projection row count = %d, want 0", count)
+	}
+}
+
+func TestMigrations_EventMetadataProjectionUpgradesOnlyCopiedStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source.db")
+	copyPath := filepath.Join(root, "copy.db")
+	if err := newStoreManagementDatasource(t, sourcePath, onDiskSQLiteMigrationsBefore(t, 34)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(source) error = %v", err)
+	}
+	source := openProjectionMigrationDB(t, sourcePath)
+	if _, err := source.ExecContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_availability
+		) VALUES ('copy-event', 'note', 'cli', 'codex', 'copy-session',
+		          'copy-workspace', zeroblob(1048576),
+		          '2026-07-26T00:00:00Z', 'unavailable_retention')
+	`); err != nil {
+		_ = source.Close()
+		t.Fatalf("seed copied-store source: %v", err)
+	}
+	if _, err := source.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = source.Close()
+		t.Fatalf("checkpoint source: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("close source: %v", err)
+	}
+	before := projectionFileDigest(t, sourcePath)
+	copyProjectionFile(t, sourcePath, copyPath)
+	sourceInfo := projectionFileInfo(t, sourcePath)
+	copyBeforeInfo := projectionFileInfo(t, copyPath)
+
+	started := time.Now()
+	if err := newStoreManagementDatasource(t, copyPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(copy) error = %v", err)
+	}
+	migrationElapsed := time.Since(started)
+	after := projectionFileDigest(t, sourcePath)
+	if before != after {
+		t.Fatal("source store changed while migrating its private copy")
+	}
+
+	copyDB := openProjectionMigrationDB(t, copyPath)
+	defer func() { _ = copyDB.Close() }()
+	var integrity string
+	if err := copyDB.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&integrity); err != nil {
+		t.Fatalf("integrity_check: %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("integrity_check = %q, want ok", integrity)
+	}
+	rows, err := copyDB.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		t.Fatalf("foreign_key_check: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		t.Fatal("copied store has a foreign-key violation")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate foreign_key_check: %v", err)
+	}
+	var eventCount, projectionCount int
+	if err := copyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&eventCount); err != nil {
+		t.Fatalf("count copied events: %v", err)
+	}
+	if err := copyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM event_metadata_projection").Scan(&projectionCount); err != nil {
+		t.Fatalf("count copied projection: %v", err)
+	}
+	if eventCount != projectionCount {
+		t.Fatalf("copied event/projection counts = %d/%d, want equal", eventCount, projectionCount)
+	}
+	if _, err := copyDB.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatalf("checkpoint copied store: %v", err)
+	}
+	copyAfterInfo := projectionFileInfo(t, copyPath)
+	t.Logf(
+		"projection migration metrics: source_bytes=%d copy_before_bytes=%d copy_after_bytes=%d growth_bytes=%d migration_ms=%.3f",
+		sourceInfo.Size(),
+		copyBeforeInfo.Size(),
+		copyAfterInfo.Size(),
+		copyAfterInfo.Size()-copyBeforeInfo.Size(),
+		float64(migrationElapsed)/float64(time.Millisecond),
+	)
+}
+
+func TestMigrations_EventMetadataProjectionFailsAtomicallyUnderWriteLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 34)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-projection) error = %v", err)
+	}
+	locker := openProjectionMigrationDB(t, dbPath)
+	defer func() { _ = locker.Close() }()
+	if _, err := locker.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+
+	started := time.Now()
+	err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx)
+	elapsed := time.Since(started)
+	if err == nil {
+		_, _ = locker.ExecContext(ctx, "ROLLBACK")
+		t.Fatal("Initialize(current) error = nil under competing write lock")
+	}
+	lowerError := strings.ToLower(err.Error())
+	if !strings.Contains(lowerError, "busy") && !strings.Contains(lowerError, "locked") {
+		_, _ = locker.ExecContext(ctx, "ROLLBACK")
+		t.Fatalf("Initialize(current) error = %v, want busy/locked classification", err)
+	}
+	var partialObjects int
+	if err := locker.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM sqlite_master
+		 WHERE name = 'event_metadata_projection'
+		    OR name LIKE 'event_metadata_projection_%'
+	`).Scan(&partialObjects); err != nil {
+		_, _ = locker.ExecContext(ctx, "ROLLBACK")
+		t.Fatalf("inspect partial projection schema: %v", err)
+	}
+	if partialObjects != 0 {
+		_, _ = locker.ExecContext(ctx, "ROLLBACK")
+		t.Fatalf("partial projection object count = %d, want 0", partialObjects)
+	}
+	if _, err := locker.ExecContext(ctx, "ROLLBACK"); err != nil {
+		t.Fatalf("ROLLBACK competing writer: %v", err)
+	}
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(current) after lock release error = %v", err)
+	}
+	t.Logf(
+		"projection migration lock metrics: busy_observed=true partial_objects=%d wait_ms=%.3f",
+		partialObjects,
+		float64(elapsed)/float64(time.Millisecond),
+	)
+}
+
+func TestMigrations_EventMetadataProjectionSupportsPreProjectionWriterRollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrations(t)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(current) error = %v", err)
+	}
+	if err := newStoreManagementDatasource(t, dbPath, onDiskSQLiteMigrationsBefore(t, 34)).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize(pre-projection writer) error = %v", err)
+	}
+	db := openProjectionMigrationDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_availability
+		) VALUES ('rollback-event', 'note', 'cli', 'codex', 'rollback-session',
+		          'rollback-workspace', 'synthetic',
+		          '2026-07-26T00:00:00Z', 'available')
+	`); err != nil {
+		t.Fatalf("insert through pre-projection writer: %v", err)
+	}
+	assertProjectionRow(t, db, "rollback-event", projectionRowExpectation{
+		kind:            "note",
+		workspace:       "rollback-workspace",
+		createdAtNorm:   "2026-07-26T00:00:00.000000000Z",
+		storedBodyBytes: int64(len("synthetic")),
+	})
+}
+
+// BenchmarkEventMetadataProjectionCopiedStoreMigration is opt-in because it
+// writes a 256 MiB-class synthetic source plus a private copy. It reports only
+// counts, byte extents, booleans, and elapsed time.
+func BenchmarkEventMetadataProjectionCopiedStoreMigration(b *testing.B) {
+	if os.Getenv("TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK") != "1" {
+		b.Skip("set TRACEARY_RUN_METADATA_PROJECTION_MIGRATION_BENCHMARK=1 to create the copied-store fixture")
+	}
+	const (
+		eventCount = 8
+		bodyBytes  = 32 << 20
+	)
+	b.StopTimer()
+	ctx := context.Background()
+	root := b.TempDir()
+	sourcePath := filepath.Join(root, "source.db")
+	copyPath := filepath.Join(root, "copy.db")
+	if err := newStoreManagementDatasource(b, sourcePath, onDiskSQLiteMigrationsBefore(b, 34)).Initialize(ctx); err != nil {
+		b.Fatalf("Initialize(source) error = %v", err)
+	}
+	source := openProjectionMigrationDB(b, sourcePath)
+	tx, err := source.BeginTx(ctx, nil)
+	if err != nil {
+		_ = source.Close()
+		b.Fatalf("BeginTx(source) error = %v", err)
+	}
+	statement, err := tx.PrepareContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_availability
+		) VALUES (?, 'note', 'cli', 'codex', 'migration-session',
+		          'migration-workspace', zeroblob(?), ?, 'unavailable_retention')
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		_ = source.Close()
+		b.Fatalf("prepare synthetic source: %v", err)
+	}
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	for index := 0; index < eventCount; index++ {
+		if _, err := statement.ExecContext(
+			ctx,
+			fmt.Sprintf("migration-event-%03d", index),
+			bodyBytes,
+			base.Add(time.Duration(index)*time.Millisecond).Format(time.RFC3339Nano),
+		); err != nil {
+			_ = statement.Close()
+			_ = tx.Rollback()
+			_ = source.Close()
+			b.Fatalf("insert synthetic extent %d: %v", index, err)
+		}
+	}
+	if err := statement.Close(); err != nil {
+		_ = tx.Rollback()
+		_ = source.Close()
+		b.Fatalf("close synthetic statement: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		_ = source.Close()
+		b.Fatalf("commit synthetic source: %v", err)
+	}
+	if _, err := source.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = source.Close()
+		b.Fatalf("checkpoint synthetic source: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		b.Fatalf("close synthetic source: %v", err)
+	}
+
+	sourceDigest := projectionFileDigest(b, sourcePath)
+	sourceBytes := projectionFileInfo(b, sourcePath).Size()
+	copyProjectionFile(b, sourcePath, copyPath)
+	copyBeforeBytes := projectionFileInfo(b, copyPath).Size()
+	peakScratchBytes := projectionDirectoryBytes(b, root)
+	migrationDone := make(chan error, 1)
+	copyStore := newStoreManagementDatasource(b, copyPath, onDiskSQLiteMigrations(b))
+	started := time.Now()
+	go func() {
+		migrationDone <- copyStore.Initialize(ctx)
+	}()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	migrationComplete := false
+	for !migrationComplete {
+		select {
+		case err := <-migrationDone:
+			if err != nil {
+				b.Fatalf("Initialize(copy) error = %v", err)
+			}
+			migrationComplete = true
+		case <-ticker.C:
+			currentScratchBytes, err := projectionDirectoryBytesValue(root)
+			if err != nil {
+				b.Fatalf("measure migration scratch extent: %v", err)
+			}
+			if currentScratchBytes > peakScratchBytes {
+				peakScratchBytes = currentScratchBytes
+			}
+		}
+	}
+	migrationElapsed := time.Since(started)
+	if currentScratchBytes := projectionDirectoryBytes(b, root); currentScratchBytes > peakScratchBytes {
+		peakScratchBytes = currentScratchBytes
+	}
+	copyDB := openProjectionMigrationDB(b, copyPath)
+	var events, projectionRows, migrationApplied int64
+	if err := copyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&events); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("count copied events: %v", err)
+	}
+	if err := copyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM event_metadata_projection").Scan(&projectionRows); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("count copied projection: %v", err)
+	}
+	if err := copyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM schema_migrations WHERE version = 34").Scan(&migrationApplied); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect projection migration: %v", err)
+	}
+	var integrity string
+	if err := copyDB.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&integrity); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("integrity_check: %v", err)
+	}
+	foreignRows, err := copyDB.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("foreign_key_check: %v", err)
+	}
+	foreignKeyViolations := int64(0)
+	for foreignRows.Next() {
+		foreignKeyViolations++
+	}
+	if err := foreignRows.Err(); err != nil {
+		_ = foreignRows.Close()
+		_ = copyDB.Close()
+		b.Fatalf("iterate foreign_key_check: %v", err)
+	}
+	if err := foreignRows.Close(); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("close foreign_key_check: %v", err)
+	}
+	if _, err := copyDB.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("checkpoint copied store: %v", err)
+	}
+	if err := copyDB.Close(); err != nil {
+		b.Fatalf("close copied store: %v", err)
+	}
+	copyAfterBytes := projectionFileInfo(b, copyPath).Size()
+	scratchAfterBytes := projectionDirectoryBytes(b, root)
+	sourceUnchanged := projectionFileDigest(b, sourcePath) == sourceDigest
+	if events != eventCount ||
+		projectionRows != events ||
+		migrationApplied != 1 ||
+		integrity != "ok" ||
+		foreignKeyViolations != 0 ||
+		!sourceUnchanged {
+		b.Fatal("copied-store projection migration failed its safety invariants")
+	}
+	b.ReportMetric(float64(events), "events")
+	b.ReportMetric(float64(projectionRows), "projection_rows")
+	b.ReportMetric(float64(sourceBytes), "source_bytes")
+	b.ReportMetric(float64(copyBeforeBytes), "copy_before_bytes")
+	b.ReportMetric(float64(copyAfterBytes), "copy_after_bytes")
+	b.ReportMetric(float64(copyAfterBytes-copyBeforeBytes), "growth_bytes")
+	b.ReportMetric(float64(scratchAfterBytes), "scratch_after_bytes")
+	b.ReportMetric(float64(peakScratchBytes), "peak_scratch_bytes")
+	b.ReportMetric(float64(migrationElapsed)/float64(time.Millisecond), "migration_ms")
+	b.ReportMetric(float64(foreignKeyViolations), "foreign_key_violations")
+	if integrity == "ok" {
+		b.ReportMetric(1, "integrity_ok")
+	}
+	if sourceUnchanged {
+		b.ReportMetric(1, "source_unchanged")
+	}
+}
+
+func assertProjectionSchemaIsPayloadFree(t *testing.T, db *sql.DB) {
+	t.Helper()
+	rows, err := db.Query(`PRAGMA table_info(event_metadata_projection)`)
+	if err != nil {
+		t.Fatalf("inspect projection schema: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			position     int
+			name         string
+			columnType   string
+			notNull      int
+			defaultValue sql.NullString
+			primaryKey   int
+		)
+		if err := rows.Scan(
+			&position,
+			&name,
+			&columnType,
+			&notNull,
+			&defaultValue,
+			&primaryKey,
+		); err != nil {
+			t.Fatalf("scan projection schema: %v", err)
+		}
+		switch name {
+		case "body", "command_text", "input_text", "output_text":
+			t.Fatalf("projection contains payload column %q", name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate projection schema: %v", err)
+	}
+}
+
+type projectionRowExpectation struct {
+	kind             string
+	workspace        string
+	createdAtNorm    string
+	storedBodyBytes  int64
+	legacySourceHook string
+	auditPresent     bool
+	exitCode         int64
+	failed           bool
+}
+
+func assertProjectionRow(t *testing.T, db *sql.DB, id string, want projectionRowExpectation) {
+	t.Helper()
+	var (
+		kind, workspace, createdAtNorm string
+		storedBodyBytes                int64
+		legacySourceHook               sql.NullString
+		auditEventID                   sql.NullString
+		exitCode                       sql.NullInt64
+		failed                         sql.NullBool
+	)
+	if err := db.QueryRow(`
+		SELECT kind, workspace, created_at_norm, body_stored_bytes,
+		       legacy_source_hook, command_audit_event_id,
+		       command_exit_code, command_failed
+		  FROM event_metadata_projection
+		 WHERE id = ?
+	`, id).Scan(
+		&kind,
+		&workspace,
+		&createdAtNorm,
+		&storedBodyBytes,
+		&legacySourceHook,
+		&auditEventID,
+		&exitCode,
+		&failed,
+	); err != nil {
+		t.Fatalf("read projection row: %v", err)
+	}
+	if kind != want.kind ||
+		workspace != want.workspace ||
+		createdAtNorm != want.createdAtNorm ||
+		storedBodyBytes != want.storedBodyBytes ||
+		legacySourceHook.String != want.legacySourceHook ||
+		auditEventID.Valid != want.auditPresent ||
+		exitCode.Int64 != want.exitCode ||
+		failed.Bool != want.failed {
+		t.Fatalf(
+			"projection row = kind:%q workspace:%q normalized:%q stored:%d legacy:%q audit:%v exit:%d failed:%v",
+			kind,
+			workspace,
+			createdAtNorm,
+			storedBodyBytes,
+			legacySourceHook.String,
+			auditEventID.Valid,
+			exitCode.Int64,
+			failed.Bool,
+		)
+	}
+}
+
+func openProjectionMigrationDB(t testing.TB, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open SQLite store: %v", err)
+	}
+	return db
+}
+
+func projectionFileDigest(t testing.TB, path string) [sha256.Size]byte {
+	t.Helper()
+	file, err := os.Open(path) // #nosec G304 -- test-owned synthetic store
+	if err != nil {
+		t.Fatalf("open synthetic store for digest: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		t.Fatalf("digest synthetic store: %v", err)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hasher.Sum(nil))
+	return result
+}
+
+func copyProjectionFile(t testing.TB, source, destination string) {
+	t.Helper()
+	input, err := os.Open(source) // #nosec G304 -- test-owned synthetic store
+	if err != nil {
+		t.Fatalf("open synthetic source: %v", err)
+	}
+	defer func() { _ = input.Close() }()
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- test-owned synthetic store
+	if err != nil {
+		t.Fatalf("create synthetic copy: %v", err)
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		t.Fatalf("copy synthetic store: %v", err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatalf("close synthetic copy: %v", err)
+	}
+}
+
+func projectionFileInfo(t testing.TB, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat synthetic store: %v", err)
+	}
+	return info
+}
+
+func projectionDirectoryBytes(t testing.TB, root string) int64 {
+	t.Helper()
+	total, err := projectionDirectoryBytesValue(root)
+	if err != nil {
+		t.Fatalf("measure synthetic scratch extent: %v", err)
+	}
+	return total
+}
+
+func projectionDirectoryBytesValue(root string) (int64, error) {
+	var total int64
+	if err := filepath.WalkDir(root, func(_ string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk synthetic scratch: %w", err)
+		}
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect synthetic scratch entry: %w", err)
+		}
+		total += info.Size()
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("measure synthetic scratch extent: %w", err)
+	}
+	return total, nil
+}

--- a/infrastructure/sqlite/event_metadata_query_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_query_internal_test.go
@@ -49,6 +49,42 @@ func TestMetadataQueries_DoNotSelectBodyColumns(t *testing.T) {
 	}
 }
 
+func TestMetadataListAndContextQueriesUsePersistentProjection(t *testing.T) {
+	t.Parallel()
+
+	queries := map[string]string{
+		"latest":                    selectLatestEventMetadataFastQuery,
+		"latest workspace":          selectLatestEventMetadataFastByWorkspaceQuery,
+		"latest timestamp kind":     selectLatestEventTimestampKindQuery,
+		"latest workspace kind":     selectLatestEventTimestampKindByWorkspaceQuery,
+		"recent":                    selectRecentEventMetadataQuery,
+		"recent workspace":          selectRecentEventMetadataByWorkspaceQuery,
+		"recent session":            selectRecentEventMetadataBySessionQuery,
+		"recent workspace session":  selectRecentEventMetadataByWorkspaceSessionQuery,
+		"recent source hook":        selectRecentEventMetadataBySourceHookQuery,
+		"recent legacy hook":        selectRecentEventMetadataBySourceHookWithLegacyQuery,
+		"context":                   getContextEventMetadataQuery,
+		"context workspace":         getContextEventMetadataByWorkspaceQuery,
+		"context session":           getContextEventMetadataBySessionQuery,
+		"context workspace session": getContextEventMetadataByWorkspaceSessionQuery,
+	}
+	for name, query := range queries {
+		name, query := name, query
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			normalized := strings.Join(strings.Fields(strings.ToLower(query)), " ")
+			if !strings.Contains(normalized, "event_metadata_projection") {
+				t.Fatalf("metadata query does not use persistent projection: %s", normalized)
+			}
+			for _, forbidden := range []string{" from events ", " join events "} {
+				if strings.Contains(" "+normalized+" ", forbidden) {
+					t.Fatalf("metadata query opens body-bearing events table: %s", normalized)
+				}
+			}
+		})
+	}
+}
+
 func TestMetadataPageQueriesRenderCompositeAnchorWithoutSentinelOrOffset(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -23,18 +23,16 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
  WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
  ORDER BY e.created_at_norm DESC, e.id DESC`
 
-// This result projection intentionally contains no e.body reference. Candidate
-// selection is shared with full search, but metadata hydration cannot
-// accidentally materialize stored event bodies.
+// Candidate selection is shared with full search, but metadata hydration uses
+// the persistent projection so it cannot open body-bearing event rows.
 const hydrateEventSearchMetadataCandidatesQuery = `
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.source_hook, e.created_at,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       a.event_id, a.exit_code, a.failed
-  FROM events e
-  LEFT JOIN command_audits a ON a.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
  ORDER BY e.created_at_norm DESC, e.id DESC`
 

--- a/infrastructure/sqlite/migrate_test.go
+++ b/infrastructure/sqlite/migrate_test.go
@@ -71,7 +71,7 @@ func TestMigrations_applyToEmptyDatabase(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	tables := []string{"events", "command_audits", "sessions", "usage_observations", "run_lineages", "usage_observation_runs", "schema_migrations"}
+	tables := []string{"events", "event_metadata_projection", "command_audits", "sessions", "usage_observations", "run_lineages", "usage_observation_runs", "schema_migrations"}
 	for _, table := range tables {
 		var count int
 		if err := db.QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&count); err != nil {

--- a/infrastructure/sqlite/sql/get_context_event_metadata.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata.sql
@@ -3,9 +3,8 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE (? = '' OR e.workspace = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.created_at_norm < ?)

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_session.sql
@@ -3,9 +3,8 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.session_id = ?
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace.sql
@@ -3,9 +3,8 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.workspace = ?
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/get_context_event_metadata_by_workspace_session.sql
@@ -3,9 +3,8 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.workspace = ?
    AND e.session_id = ?
    AND (? = '' OR e.created_at_norm < ?)

--- a/infrastructure/sqlite/sql/select_latest_event_metadata_fast.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_metadata_fast.sql
@@ -1,30 +1,9 @@
--- This bounded fast path is used only for an unfiltered first-page metadata
--- read (`limit=1, offset=0`). The existing created_at index locates the
--- newest timestamp-second without touching event bodies. RFC3339Nano's
--- variable fractional-width text form is not globally time-sortable, so the
--- outer query reorders only rows in that one second by ts_norm().
---
--- This keeps the historical boundary-correct timestamp contract while avoiding
--- a full-store ts_norm() sort for `traceary list --limit 1 --fields ts,kind`.
-WITH latest_lexical AS (
-    SELECT created_at
-      FROM events
-     ORDER BY created_at DESC, id DESC
-     LIMIT 1
-), latest_second AS (
-    SELECT substr(created_at, 1, 19) AS second_prefix
-      FROM latest_lexical
-)
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.source_hook, e.created_at,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
-  JOIN latest_second s
- WHERE e.created_at >= s.second_prefix || '.'
-   AND e.created_at <= s.second_prefix || 'Z'
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_metadata_fast_by_workspace.sql
@@ -1,50 +1,10 @@
--- The common CLI path resolves the current repository as an implicit
--- workspace filter. Keep that filter inside the bounded latest-metadata
--- query; otherwise a normal invocation would silently fall back to the slow
--- general query. The workspace/created_at index or the created_at index can
--- locate the lexical latest candidate without reading event bodies.
-WITH latest_lexical AS (
-    SELECT created_at
-      FROM events
-     WHERE workspace = ?
-     -- Keep this order limited to the legacy `(workspace, created_at)` index.
-     -- The timestamp alone selects the latest second; ties have the same
-     -- created_at value, so id cannot affect the second that the outer query
-     -- normalizes and orders. Adding id here forces SQLite to sort every row
-     -- in a large workspace when that legacy index is present.
-     ORDER BY created_at DESC
-     LIMIT 1
-), latest_second AS (
-    SELECT substr(created_at, 1, 19) AS second_prefix
-      FROM latest_lexical
-), same_second_ids AS (
-    -- Exact-second values sort after fractional RFC3339Nano text. Keep this
-    -- equality probe separate from the fractional range so SQLite can retain
-    -- a lower and upper created_at index bound for the latter.
-    SELECT e.id
-      FROM latest_second s
-     CROSS JOIN events e
-     WHERE e.workspace = ?
-       AND e.created_at = s.second_prefix || 'Z'
-    UNION ALL
-    SELECT e.id
-      FROM latest_second s
-     CROSS JOIN events e
-     WHERE e.workspace = ?
-       AND e.created_at >= s.second_prefix || '.'
-       AND e.created_at <= s.second_prefix || 'Z'
-)
 SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.source_hook, e.created_at,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM same_second_ids candidate
-  -- CROSS JOIN preserves candidate-first evaluation. A plain INNER JOIN lets
-  -- SQLite reverse the join and scan all events before probing the tiny
-  -- same-second candidate set.
- CROSS JOIN events e ON e.id = candidate.id
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
+ WHERE e.workspace = ?
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind.sql
@@ -1,13 +1,4 @@
-WITH latest_lexical AS (
-    SELECT created_at FROM events ORDER BY created_at DESC, id DESC LIMIT 1
-), latest_second AS (
-    SELECT substr(created_at, 1, 19) AS second_prefix FROM latest_lexical
-), same_second_ids AS (
-    SELECT e.id FROM latest_second s CROSS JOIN events e WHERE e.created_at = s.second_prefix || 'Z'
-    UNION ALL
-    SELECT e.id FROM latest_second s CROSS JOIN events e
-     WHERE e.created_at >= s.second_prefix || '.' AND e.created_at <= s.second_prefix || 'Z'
-)
-SELECT e.kind, e.created_at FROM same_second_ids candidate
- CROSS JOIN events e ON e.id = candidate.id
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC LIMIT 1
+SELECT e.kind, e.created_at
+  FROM event_metadata_projection e
+ ORDER BY e.created_at_norm DESC, e.id DESC
+ LIMIT 1

--- a/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_latest_event_timestamp_kind_by_workspace.sql
@@ -1,16 +1,5 @@
-WITH latest_lexical AS (
-    SELECT created_at FROM events WHERE workspace = ? ORDER BY created_at DESC LIMIT 1
-), latest_second AS (
-    SELECT substr(created_at, 1, 19) AS second_prefix FROM latest_lexical
-), same_second_ids AS (
-    SELECT e.id FROM latest_second s CROSS JOIN events e
-     WHERE e.workspace = ? AND e.created_at = s.second_prefix || 'Z'
-    UNION ALL
-    SELECT e.id FROM latest_second s CROSS JOIN events e
-     WHERE e.workspace = ? AND e.created_at >= s.second_prefix || '.' AND e.created_at <= s.second_prefix || 'Z'
-)
 SELECT e.kind, e.created_at
-  FROM same_second_ids candidate
- CROSS JOIN events e ON e.id = candidate.id
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+  FROM event_metadata_projection e
+ WHERE e.workspace = ?
+ ORDER BY e.created_at_norm DESC, e.id DESC
  LIMIT 1

--- a/infrastructure/sqlite/sql/select_recent_event_metadata.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata.sql
@@ -3,15 +3,14 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_session.sql
@@ -3,15 +3,14 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.session_id = ?
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook.sql
@@ -3,16 +3,15 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.source_hook = ?
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_source_hook_with_legacy.sql
@@ -3,22 +3,19 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE (
        e.source_hook = ?
-    OR (e.source_hook IS NULL AND (
-          (? = 'subagent_stop' AND e.kind = 'session_ended' AND e.body LIKE '[phase:subagent]%')
-       OR (? = 'pre_compact' AND e.kind = 'compact_summary' AND e.body LIKE '[phase:pre-compact]%')
-    ))
+    OR (? = 'subagent_stop' AND e.legacy_source_hook = 'subagent_stop')
+    OR (? = 'pre_compact' AND e.legacy_source_hook = 'pre_compact')
  )
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
    AND (? = '' OR e.workspace = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace.sql
@@ -3,15 +3,14 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.workspace = ?
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
    AND (? = '' OR e.session_id = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
+++ b/infrastructure/sqlite/sql/select_recent_event_metadata_by_workspace_session.sql
@@ -3,15 +3,14 @@ SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
        e.body_original_bytes, e.body_stored_bytes,
        e.body_ingest_truncated, e.body_storage_truncated,
        e.body_metadata_version,
-       ca.event_id, ca.exit_code, ca.failed
-  FROM events e
-  LEFT JOIN command_audits ca ON ca.event_id = e.id
+       e.command_audit_event_id, e.command_exit_code, e.command_failed
+  FROM event_metadata_projection e
  WHERE e.workspace = ?
    AND e.session_id = ?
    AND (? = '' OR e.kind = ?)
    AND (? = '' OR e.client = ?)
    AND (? = '' OR e.agent = ?)
-   AND (? = 0 OR ca.failed = 1 OR (ca.exit_code IS NOT NULL AND ca.exit_code != 0))
+   AND (? = 0 OR e.command_failed = 1 OR (e.command_exit_code IS NOT NULL AND e.command_exit_code != 0))
    AND (? = '' OR e.created_at_norm >= ?)
    AND (? = '' OR e.created_at_norm < ?)
    /* traceary:event-page-anchor */

--- a/infrastructure/sqlite/testhelper_test.go
+++ b/infrastructure/sqlite/testhelper_test.go
@@ -172,7 +172,7 @@ func newFullDatasources(
 
 // newStoreManagementDatasource returns a StoreManagementDatasource.
 func newStoreManagementDatasource(
-	t *testing.T,
+	t testing.TB,
 	dbPath string,
 	migrations fs.FS,
 ) *sqlite.StoreManagementDatasource {

--- a/presentation/mcpserver/server_test.go
+++ b/presentation/mcpserver/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1806,6 +1807,9 @@ CREATE INDEX idx_events_source_hook_created_at_norm_id_desc
     ON events(source_hook, created_at_norm DESC, id DESC)
     WHERE source_hook IS NOT NULL;`),
 		},
+		"000034_create_event_metadata_projection.sql": {
+			Data: readMCPServerTestMigration(t, "000034_create_event_metadata_projection.sql"),
+		},
 		"000008_create_memories.sql": {
 			Data: []byte(`
 CREATE TABLE memories (
@@ -1898,4 +1902,13 @@ CREATE INDEX idx_memories_valid_window ON memories(valid_to, valid_from);`),
 	}
 
 	return server, dbPath, reportUsecase
+}
+
+func readMCPServerTestMigration(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "schema", "sqlite", "migrations", name))
+	if err != nil {
+		t.Fatalf("read test migration %q: %v", name, err)
+	}
+	return data
 }

--- a/schema/sqlite/migrations/000034_create_event_metadata_projection.sql
+++ b/schema/sqlite/migrations/000034_create_event_metadata_projection.sql
@@ -1,0 +1,349 @@
+-- Keep body-free event reads off the body-bearing events table. The projection
+-- contains every field required by EventMetadata, including the fixed legacy
+-- hook classification and optional command-audit facts, but no event body or
+-- command payload.
+CREATE TABLE event_metadata_projection (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    client TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    source_hook TEXT,
+    legacy_source_hook TEXT
+        CHECK (legacy_source_hook IS NULL OR legacy_source_hook IN ('subagent_stop', 'pre_compact')),
+    created_at TEXT NOT NULL,
+    created_at_norm TEXT,
+    body_original_bytes INTEGER
+        CHECK (body_original_bytes IS NULL OR body_original_bytes >= 0),
+    body_stored_bytes INTEGER
+        CHECK (body_stored_bytes IS NULL OR body_stored_bytes >= 0),
+    body_ingest_truncated INTEGER
+        CHECK (body_ingest_truncated IS NULL OR body_ingest_truncated IN (0, 1)),
+    body_storage_truncated INTEGER
+        CHECK (body_storage_truncated IS NULL OR body_storage_truncated IN (0, 1)),
+    body_metadata_version INTEGER
+        CHECK (body_metadata_version IS NULL OR body_metadata_version >= 0),
+    command_audit_event_id TEXT,
+    command_exit_code INTEGER,
+    command_failed INTEGER
+        CHECK (command_failed IS NULL OR command_failed IN (0, 1)),
+    CHECK (
+        (command_audit_event_id IS NULL AND command_exit_code IS NULL AND command_failed IS NULL)
+        OR
+        (command_audit_event_id = id AND command_failed IS NOT NULL)
+    )
+);
+
+INSERT INTO event_metadata_projection (
+    id,
+    kind,
+    client,
+    agent,
+    session_id,
+    workspace,
+    source_hook,
+    legacy_source_hook,
+    created_at,
+    created_at_norm,
+    body_original_bytes,
+    body_stored_bytes,
+    body_ingest_truncated,
+    body_storage_truncated,
+    body_metadata_version,
+    command_audit_event_id,
+    command_exit_code,
+    command_failed
+)
+SELECT
+    e.id,
+    e.kind,
+    e.client,
+    e.agent,
+    e.session_id,
+    e.workspace,
+    e.source_hook,
+    CASE
+        WHEN e.source_hook IS NULL
+         AND e.kind = 'session_ended'
+         AND e.body LIKE '[phase:subagent]%'
+        THEN 'subagent_stop'
+        WHEN e.source_hook IS NULL
+         AND e.kind = 'compact_summary'
+         AND e.body LIKE '[phase:pre-compact]%'
+        THEN 'pre_compact'
+        ELSE NULL
+    END,
+    e.created_at,
+    e.created_at_norm,
+    e.body_original_bytes,
+    e.body_stored_bytes,
+    e.body_ingest_truncated,
+    e.body_storage_truncated,
+    e.body_metadata_version,
+    ca.event_id,
+    ca.exit_code,
+    ca.failed
+FROM events e
+LEFT JOIN command_audits ca ON ca.event_id = e.id;
+
+CREATE INDEX idx_event_metadata_created_at_norm_id_desc
+    ON event_metadata_projection(created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_workspace_created_at_norm_id_desc
+    ON event_metadata_projection(workspace, created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_session_created_at_norm_id_desc
+    ON event_metadata_projection(session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_workspace_session_created_at_norm_id_desc
+    ON event_metadata_projection(workspace, session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_source_hook_created_at_norm_id_desc
+    ON event_metadata_projection(source_hook, created_at_norm DESC, id DESC)
+    WHERE source_hook IS NOT NULL;
+
+CREATE TRIGGER event_metadata_projection_events_after_insert
+AFTER INSERT ON events
+FOR EACH ROW
+BEGIN
+    INSERT INTO event_metadata_projection (
+        id,
+        kind,
+        client,
+        agent,
+        session_id,
+        workspace,
+        source_hook,
+        legacy_source_hook,
+        created_at,
+        created_at_norm,
+        body_original_bytes,
+        body_stored_bytes,
+        body_ingest_truncated,
+        body_storage_truncated,
+        body_metadata_version,
+        command_audit_event_id,
+        command_exit_code,
+        command_failed
+    ) VALUES (
+        NEW.id,
+        NEW.kind,
+        NEW.client,
+        NEW.agent,
+        NEW.session_id,
+        NEW.workspace,
+        NEW.source_hook,
+        CASE
+            WHEN NEW.source_hook IS NULL
+             AND NEW.kind = 'session_ended'
+             AND NEW.body LIKE '[phase:subagent]%'
+            THEN 'subagent_stop'
+            WHEN NEW.source_hook IS NULL
+             AND NEW.kind = 'compact_summary'
+             AND NEW.body LIKE '[phase:pre-compact]%'
+            THEN 'pre_compact'
+            ELSE NULL
+        END,
+        NEW.created_at,
+        CASE
+            WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+            THEN substr(NEW.created_at, 1, 19) || '.' ||
+                 substr(
+                     CASE
+                         WHEN substr(NEW.created_at, 20, 1) = '.'
+                         THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                         ELSE ''
+                     END || '000000000',
+                     1, 9
+                 ) || 'Z'
+            ELSE NEW.created_at
+        END,
+        NEW.body_original_bytes,
+        length(CAST(NEW.body AS BLOB)),
+        NEW.body_ingest_truncated,
+        NEW.body_storage_truncated,
+        NEW.body_metadata_version,
+        NULL,
+        NULL,
+        NULL
+    )
+    ON CONFLICT(id) DO UPDATE SET
+        kind = excluded.kind,
+        client = excluded.client,
+        agent = excluded.agent,
+        session_id = excluded.session_id,
+        workspace = excluded.workspace,
+        source_hook = excluded.source_hook,
+        legacy_source_hook = excluded.legacy_source_hook,
+        created_at = excluded.created_at,
+        created_at_norm = excluded.created_at_norm,
+        body_original_bytes = excluded.body_original_bytes,
+        body_stored_bytes = excluded.body_stored_bytes,
+        body_ingest_truncated = excluded.body_ingest_truncated,
+        body_storage_truncated = excluded.body_storage_truncated,
+        body_metadata_version = excluded.body_metadata_version;
+END;
+
+CREATE TRIGGER event_metadata_projection_events_after_update
+AFTER UPDATE OF
+    id,
+    kind,
+    client,
+    agent,
+    session_id,
+    workspace,
+    source_hook,
+    created_at,
+    created_at_norm,
+    body,
+    body_original_bytes,
+    body_stored_bytes,
+    body_ingest_truncated,
+    body_storage_truncated,
+    body_metadata_version
+ON events
+FOR EACH ROW
+BEGIN
+    DELETE FROM event_metadata_projection
+     WHERE id = OLD.id
+       AND OLD.id IS NOT NEW.id;
+
+    INSERT INTO event_metadata_projection (
+        id,
+        kind,
+        client,
+        agent,
+        session_id,
+        workspace,
+        source_hook,
+        legacy_source_hook,
+        created_at,
+        created_at_norm,
+        body_original_bytes,
+        body_stored_bytes,
+        body_ingest_truncated,
+        body_storage_truncated,
+        body_metadata_version,
+        command_audit_event_id,
+        command_exit_code,
+        command_failed
+    ) VALUES (
+        NEW.id,
+        NEW.kind,
+        NEW.client,
+        NEW.agent,
+        NEW.session_id,
+        NEW.workspace,
+        NEW.source_hook,
+        CASE
+            WHEN NEW.source_hook IS NULL
+             AND NEW.kind = 'session_ended'
+             AND NEW.body LIKE '[phase:subagent]%'
+            THEN 'subagent_stop'
+            WHEN NEW.source_hook IS NULL
+             AND NEW.kind = 'compact_summary'
+             AND NEW.body LIKE '[phase:pre-compact]%'
+            THEN 'pre_compact'
+            ELSE NULL
+        END,
+        NEW.created_at,
+        CASE
+            WHEN substr(NEW.created_at, -1) = 'Z' AND length(NEW.created_at) >= 20
+            THEN substr(NEW.created_at, 1, 19) || '.' ||
+                 substr(
+                     CASE
+                         WHEN substr(NEW.created_at, 20, 1) = '.'
+                         THEN substr(NEW.created_at, 21, length(NEW.created_at) - 21)
+                         ELSE ''
+                     END || '000000000',
+                     1, 9
+                 ) || 'Z'
+            ELSE NEW.created_at
+        END,
+        NEW.body_original_bytes,
+        CASE
+            WHEN NEW.body IS NOT OLD.body
+            THEN length(CAST(NEW.body AS BLOB))
+            ELSE NEW.body_stored_bytes
+        END,
+        NEW.body_ingest_truncated,
+        NEW.body_storage_truncated,
+        NEW.body_metadata_version,
+        NULL,
+        NULL,
+        NULL
+    )
+    ON CONFLICT(id) DO UPDATE SET
+        kind = excluded.kind,
+        client = excluded.client,
+        agent = excluded.agent,
+        session_id = excluded.session_id,
+        workspace = excluded.workspace,
+        source_hook = excluded.source_hook,
+        legacy_source_hook = CASE
+            WHEN NEW.kind IS NOT OLD.kind
+              OR NEW.source_hook IS NOT OLD.source_hook
+              OR NEW.body IS NOT OLD.body
+            THEN excluded.legacy_source_hook
+            ELSE event_metadata_projection.legacy_source_hook
+        END,
+        created_at = excluded.created_at,
+        created_at_norm = CASE
+            WHEN NEW.created_at IS NOT OLD.created_at
+            THEN excluded.created_at_norm
+            ELSE COALESCE(NEW.created_at_norm, event_metadata_projection.created_at_norm)
+        END,
+        body_original_bytes = excluded.body_original_bytes,
+        body_stored_bytes = CASE
+            WHEN NEW.body IS NOT OLD.body
+            THEN excluded.body_stored_bytes
+            ELSE NEW.body_stored_bytes
+        END,
+        body_ingest_truncated = excluded.body_ingest_truncated,
+        body_storage_truncated = excluded.body_storage_truncated,
+        body_metadata_version = excluded.body_metadata_version;
+END;
+
+CREATE TRIGGER event_metadata_projection_events_after_delete
+AFTER DELETE ON events
+FOR EACH ROW
+BEGIN
+    DELETE FROM event_metadata_projection WHERE id = OLD.id;
+END;
+
+CREATE TRIGGER event_metadata_projection_command_audits_after_insert
+AFTER INSERT ON command_audits
+FOR EACH ROW
+BEGIN
+    UPDATE event_metadata_projection
+       SET command_audit_event_id = NEW.event_id,
+           command_exit_code = NEW.exit_code,
+           command_failed = NEW.failed
+     WHERE id = NEW.event_id;
+END;
+
+CREATE TRIGGER event_metadata_projection_command_audits_after_update
+AFTER UPDATE OF event_id, exit_code, failed ON command_audits
+FOR EACH ROW
+BEGIN
+    UPDATE event_metadata_projection
+       SET command_audit_event_id = NULL,
+           command_exit_code = NULL,
+           command_failed = NULL
+     WHERE id = OLD.event_id
+       AND OLD.event_id IS NOT NEW.event_id;
+
+    UPDATE event_metadata_projection
+       SET command_audit_event_id = NEW.event_id,
+           command_exit_code = NEW.exit_code,
+           command_failed = NEW.failed
+     WHERE id = NEW.event_id;
+END;
+
+CREATE TRIGGER event_metadata_projection_command_audits_after_delete
+AFTER DELETE ON command_audits
+FOR EACH ROW
+BEGIN
+    UPDATE event_metadata_projection
+       SET command_audit_event_id = NULL,
+           command_exit_code = NULL,
+           command_failed = NULL
+     WHERE id = OLD.event_id;
+END;

--- a/schema/sqlite/migrations/000034_create_event_metadata_projection.sql
+++ b/schema/sqlite/migrations/000034_create_event_metadata_projection.sql
@@ -260,6 +260,7 @@ BEGIN
         NEW.body_original_bytes,
         CASE
             WHEN NEW.body IS NOT OLD.body
+             AND NEW.body_availability = 'available'
             THEN length(CAST(NEW.body AS BLOB))
             ELSE NEW.body_stored_bytes
         END,
@@ -293,6 +294,7 @@ BEGIN
         body_original_bytes = excluded.body_original_bytes,
         body_stored_bytes = CASE
             WHEN NEW.body IS NOT OLD.body
+             AND NEW.body_availability = 'available'
             THEN excluded.body_stored_bytes
             ELSE NEW.body_stored_bytes
         END,


### PR DESCRIPTION
## Motivation

Metadata list and context SQL used ordered event indexes but still had to open
the body-bearing event record for non-key metadata. Large bodies could
therefore make a body-free query traverse event overflow pages.

## Summary

- add migration 34 with a persistent payload-free event metadata projection
- backfill existing events and optional command-audit metadata
- preserve the two historical source-hook fallbacks as fixed classifications
- maintain projection rows transactionally with event and audit triggers
- route list, context, latest timestamp/kind, and metadata hydration through
  the projection while preserving filters, ordering, offsets, and keyset pages
- add copied-store, trigger-maintenance, plan, lock, rollback, and operational
  benchmark coverage

## Migration and rollback

Migration 34 is additive. Older binaries ignore its table and indexes, while
the persisted triggers maintain projection rows for their writes. A code
rollback therefore leaves authoritative events readable and writable without
removing the projection.

The migration backfill and index creation use one transaction. A competing
write lock returned a busy outcome after 1,012.467 ms with zero partial
projection objects; retry succeeded after lock release.

## Dependencies

This branch is based on current `main`. The durable-memory branch in pull
request 1567 reserves migration 33, so this change uses migration 34 and has no
runtime dependency on that branch. The release-evidence branch in pull request
1568 must rerun its evidence after this change; its unrelated tooling is not
copied here.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1` — 4,055 tests passed in 23 packages
- `go tool golangci-lint run` — 0 issues
- `git diff --check`

Copied-store migration benchmark on Go 1.26.3, macOS 26.5, darwin/arm64,
Apple M4:

- 8 event/projection rows
- migration: 309.6 ms
- source/copy main file: 302,714,880 bytes before and after
- main-file growth: 0 bytes
- peak scratch: 605,528,480 bytes
- post-checkpoint scratch: 605,429,760 bytes
- integrity: passed
- foreign-key violations: 0
- source byte-identical: true

Multi-GiB Phase A:

- managed bytes: 2,418,753,536
- stored body bytes: 2,147,483,648
- event/projection rows: 8/8
- measurements: 25
- projection-only plan: true
- missing body metadata: 0
- returned body bytes: 0
- p95: 0.2921 ms (target: below 250 ms)

All benchmark fixtures were synthetic and temporary. Only metrics and fixed
booleans are included here.

## Residual risk

The copied-store migration benchmark is 256 MiB-class; Phase A proves runtime
behavior on a multi-GiB store but does not claim a multi-GiB migration-time
bound. Large-store rollout still requires free-space and writer-quiescing
guidance.

Closes #1569
