### PR TITLE
test: add v0.33.0 multi-GiB release evidence

### DIFF
--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -30,10 +30,12 @@
   250 ms p95 is a gate.
 - **Phase D:** Exercise the MCP aggregate response with a requested limit of
   100, the 65,536-byte encoded body budget, multibyte text, canonical
-  `body_blocks`, and continuation traversal that proves no duplicate or skipped
-  item.
+  `body_blocks`, observable response-truncation metadata, and continuation
+  traversal that proves no duplicate or skipped item.
 - **Phase E:** Verify all six packaged hosts retain the same MCP command and
   record only the host count and parity result.
+- **Tagged-release gate:** The v0.33.0 release workflow must validate the
+  committed pass artifact before GoReleaser can publish the tagged release.
 - **Privacy:** The durable artifact is a metrics-only `BodyFreeEvidence`
   document. It never contains bodies, prompts, responses, event/session IDs,
   workspaces, local paths, continuations, raw command output, or fixture logs.
@@ -53,9 +55,10 @@
 | Copied migration store | Private pre-31 source plus an isolated copy | Applies migrations 31 through 34 and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated; projection count equals event count |
 | FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
 | Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts | Measures one public read shape 25 times | Metadata reports zero returned body bytes; Phase-C p95 is observation-only |
-| Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; all synthetic items are visited once |
+| Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page, truncation-metadata, and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; truncation metadata is observable; all synthetic items are visited once |
 | `BodyFreeEvidence` | Versioned pass or blocked JSON document | Carries only fixed enums, booleans, counts, durations, and public runtime dimensions | Sensitive keys and arbitrary strings are rejected before write |
 | Private scratch | Owner-only temporary directory | Contains synthetic stores and Go test temporary files only while the run is active | Mode is private before any fixture write and the directory is absent before pass evidence is emitted |
+| Tagged-release gate | v0.33.0 tag or explicit recovery dispatch | Runs the strict artifact verifier before GoReleaser | A missing, blocked, malformed, or privacy-invalid artifact stops publication |
 
 ### Responsibility assignment
 
@@ -65,6 +68,7 @@
 | Aggregate/body-block/continuation evidence marker | `presentation/mcpserver` integration test | It observes the actual MCP response budget and opaque continuation behavior | SQLite does not own transport aggregation |
 | Preflight, child orchestration, scratch lifecycle, host parity, evidence merge/validation | `cmd/repo-tooling release` | This is maintainer-only release automation | The shipped `traceary` binary must not expose a QA command |
 | Evidence interpretation and release boundary | bilingual release documentation | Operators need a stable procedure and explicit non-claims | Test logs are not durable release documentation |
+| Tagged-release enforcement | `.github/workflows/release.yml` | Publication order and tag recovery are workflow concerns | Documentation cannot block GoReleaser |
 
 ### Boundaries / interfaces
 
@@ -87,10 +91,11 @@
 | Body-free metadata | List/context/search metadata probes | Results are counted | Returned body bytes are zero in every metadata series |
 | Bounded projections | List/context/search bounded probes | Results are measured | Only bounded synthetic prefixes cross the query boundary |
 | Observation-only Phase C | No accepted latency targets | Phase-C evidence validates | p95 values are retained without pass/fail comparisons |
-| Aggregate budget | 100 multibyte canonical events | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks appear; all items appear exactly once |
+| Aggregate budget | 100 multibyte events, including canonical blocks and an over-limit body | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks and response-truncation metadata appear; all items appear exactly once |
 | Metrics-only serialization | Evidence contains unknown/sensitive fields or arbitrary path-like strings | Validator runs | Validation fails and no pass artifact is written |
 | Scratch cleanup | Success or any phase failure | Runner terminates | Scratch directory is removed; pass requires cleanup confirmation |
 | Host parity | Six packaged manifests | Integration verifier runs | All advertise `traceary mcp-server`; evidence records count=6 and parity=true |
+| Tagged-release enforcement | A v0.33.0 tag or recovery dispatch | The release job reaches the evidence step | Strict verification passes before GoReleaser; blocked evidence stops the job |
 
 ### TDD plan
 
@@ -102,6 +107,7 @@
 | Migration/FTS probes | No release-sized copied-store phase marker exists | Add opt-in source/copy migration and incomplete/complete probe series | Centralize metrics-only marker encoding |
 | Aggregate traversal | Existing tests cover pieces but do not emit one release marker with multibyte blocks | Add one integration scenario over the actual MCP page loader | Reuse existing server/continuation helpers |
 | Host parity | Runtime verifier passes without entering evidence | Call existing integration verifier and record only count/pass | Do not add a second manifest parser |
+| Tagged-release gate | GoReleaser can run without checking the artifact | Run the strict verifier before GoReleaser for exactly `v0.33.0` | Keep later-version policy out of this version-specific evidence PR |
 
 ### Risks / rollback
 
@@ -189,7 +195,7 @@ carried forward.
 - Phase A recorded 2,418,774,016 managed bytes, 2,147,483,648 stored-body
   bytes, eight event/projection rows, zero missing metadata, a projection-only
   ordered plan, zero returned body bytes, and 25 measurements.
-- Phase-A p95 was 0.107333 ms against the unchanged 250 ms target.
+- Phase-A p95 was 0.077708 ms against the unchanged 250 ms target.
 - Phase B applied migrations 31 through 34 to the copy, recorded 130 projection
   rows for 130 events, preserved the source byte-for-byte, passed integrity and
   foreign-key checks, and completed the resumed 128-to-130 FTS transition.
@@ -197,6 +203,8 @@ carried forward.
   latencies remain observations only.
 - The owner-only scratch directory was absent before the validated artifact was
   written.
+- The tagged-release workflow verifies this committed pass artifact before
+  GoReleaser when `RELEASE_TAG` is exactly `v0.33.0`.
 
 This checkpoint satisfies the #1558 gate. It does not decide unrelated release
 checks, and any change to the merged projection, migrations, FTS behavior,

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -33,7 +33,8 @@
   `body_blocks`, observable response-truncation metadata, and continuation
   traversal that proves no duplicate or skipped item.
 - **Phase E:** Verify all six packaged hosts retain the same MCP command and
-  record only the host count and parity result.
+  byte-identical staged-retrieval skills whose semantic contract requires
+  Discovery, bounded Inspection, and single-event Detail.
 - **Tagged-release gate:** The v0.33.0 release workflow must validate the
   committed pass artifact before GoReleaser can publish the tagged release.
 - **Privacy:** The durable artifact is a metrics-only `BodyFreeEvidence`
@@ -56,6 +57,7 @@
 | FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
 | Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts | Measures one public read shape 25 times | Metadata reports zero returned body bytes; Phase-C p95 is observation-only |
 | Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page, truncation-metadata, and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; truncation metadata is observable; all synthetic items are visited once |
+| Host integration parity | Six packaged host copies | Runs the shared integration and staged-retrieval semantic verifier | MCP registration and Discovery → Inspection → Detail guidance agree across every host |
 | `BodyFreeEvidence` | Versioned pass or blocked JSON document | Carries only fixed enums, booleans, counts, durations, and public runtime dimensions | Sensitive keys and arbitrary strings are rejected before write |
 | Private scratch | Owner-only temporary directory | Contains synthetic stores and Go test temporary files only while the run is active | Mode is private before any fixture write and the directory is absent before pass evidence is emitted |
 | Tagged-release gate | v0.33.0 tag or explicit recovery dispatch | Runs the strict artifact verifier before GoReleaser | A missing, blocked, malformed, or privacy-invalid artifact stops publication |
@@ -94,7 +96,7 @@
 | Aggregate budget | 100 multibyte events, including canonical blocks and an over-limit body | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks and response-truncation metadata appear; all items appear exactly once |
 | Metrics-only serialization | Evidence contains unknown/sensitive fields or arbitrary path-like strings | Validator runs | Validation fails and no pass artifact is written |
 | Scratch cleanup | Success or any phase failure | Runner terminates | Scratch directory is removed; pass requires cleanup confirmation |
-| Host parity | Six packaged manifests | Integration verifier runs | All advertise `traceary mcp-server`; evidence records count=6 and parity=true |
+| Host parity | Six packaged manifests and session-history skills | Integration verifier runs | All advertise `traceary mcp-server`; staged-retrieval copies are byte-identical and satisfy the semantic contract; evidence records both parity results |
 | Tagged-release enforcement | A v0.33.0 tag or recovery dispatch | The release job reaches the evidence step | Strict verification passes before GoReleaser; blocked evidence stops the job |
 
 ### TDD plan
@@ -195,7 +197,7 @@ carried forward.
 - Phase A recorded 2,418,774,016 managed bytes, 2,147,483,648 stored-body
   bytes, eight event/projection rows, zero missing metadata, a projection-only
   ordered plan, zero returned body bytes, and 25 measurements.
-- Phase-A p95 was 0.077708 ms against the unchanged 250 ms target.
+- Phase-A p95 was 0.073834 ms against the unchanged 250 ms target.
 - Phase B applied migrations 31 through 34 to the copy, recorded 130 projection
   rows for 130 events, preserved the source byte-for-byte, passed integrity and
   foreign-key checks, and completed the resumed 128-to-130 FTS transition.

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -15,8 +15,9 @@
 - **Phase A:** Run the existing opt-in direct metadata benchmark with eight
   synthetic 256 MiB extents. Both SQLite-managed bytes and stored-body metadata
   must reach 2 GiB, all eight event rows must have matching projection rows,
-  the ordered plan must read only the projection, returned body bytes must be
-  zero, 25 measurements are required, and p95 must remain below 250 ms.
+  the ordered plan must read only the projection, every timed scan must return
+  all eight rows without an iteration error, returned body bytes must be zero,
+  25 measurements are required, and p95 must remain below 250 ms.
 - **Phase B:** Create a private synthetic pre-migration store, copy it, apply
   migrations 31 through 34 on the copy, and record only migration duration,
   projection-row parity, integrity/foreign-key results, scratch extent, FTS
@@ -25,9 +26,12 @@
   batch completes it.
 - **Phase C:** Record 25-run p95 observations for metadata and bounded
   list/context/search projections. Search is measured separately while FTS
-  backfill is incomplete and complete. These surface observations have no
-  release pass/fail latency target until the Issue fixes one; only Phase A's
-  250 ms p95 is a gate.
+  backfill is incomplete and complete. Every probe uses the 130-event fixture
+  with limit 20, returns exactly 20 items, and preserves identical membership
+  between metadata and bounded projections. Metadata returns zero body bytes;
+  bounded projections return a positive byte count. These surface observations
+  have no release pass/fail latency target until the Issue fixes one; only Phase
+  A's 250 ms p95 is a gate.
 - **Phase D:** Exercise the MCP aggregate response with a requested limit of
   100, the 65,536-byte encoded body budget, multibyte text, canonical
   `body_blocks`, observable response-truncation metadata, and continuation
@@ -40,7 +44,9 @@
 - **Privacy:** The durable artifact is a metrics-only `BodyFreeEvidence`
   document. It never contains bodies, prompts, responses, event/session IDs,
   workspaces, local paths, continuations, raw command output, or fixture logs.
-  Scratch storage is owner-only and is removed on every terminal path.
+  Verification reads at most the 1 MiB artifact limit plus one detection byte
+  and rejects oversized input before JSON decoding. Scratch storage is
+  owner-only and is removed on every terminal path.
 - **Blocked hosts:** Disk/capability preflight produces a sanitized blocked
   evidence document instead of attempting the multi-GiB run. It contains only
   required/available byte counts and a fixed reason.
@@ -52,10 +58,10 @@
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Synthetic extent | Eight generated, content-free 256 MiB SQLite values plus eight trigger-maintained projection rows | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; event/projection counts match; the measured plan is projection-only |
+| Synthetic extent | Eight generated, content-free 256 MiB SQLite values plus eight trigger-maintained projection rows | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; event/projection counts match; the measured plan is projection-only; each timed scan returns all eight rows without iteration error |
 | Copied migration store | Private pre-31 source plus an isolated copy | Applies migrations 31 through 34 and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated; projection count equals event count |
 | FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
-| Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts | Measures one public read shape 25 times | Metadata reports zero returned body bytes; Phase-C p95 is observation-only |
+| Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts, in-memory membership digest | Measures one public read shape 25 times | All eight series return 20 items from the 130-event fixture; metadata and bounded membership match; metadata bytes are zero and bounded bytes are positive; Phase-C p95 is observation-only |
 | Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page, truncation-metadata, and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; truncation metadata is observable; all synthetic items are visited once |
 | Host integration parity | Six packaged host copies | Runs the shared integration and staged-retrieval semantic verifier | MCP registration and Discovery → Inspection → Detail guidance agree across every host |
 | `BodyFreeEvidence` | Versioned pass or blocked JSON document | Carries only fixed enums, booleans, counts, durations, and public runtime dimensions | Sensitive keys and arbitrary strings are rejected before write |
@@ -78,7 +84,7 @@
 | --- | --- | --- | --- |
 | Opt-in benchmark markers | repo-tooling runner | Store paths, synthetic IDs, SQL, raw child output | Missing/malformed markers become a fixed phase failure; captured output is not echoed |
 | Aggregate test marker | repo-tooling runner | Bodies, body blocks, event IDs, encrypted cursor | Reports only counts/booleans and fails before emitting on duplicate/skip or budget breach |
-| `BodyFreeEvidence` validator | release workflow/operator | Child process output and scratch location | Rejects unknown fields, sensitive keys, invalid enums, failed gates, or nonzero metadata body bytes |
+| `BodyFreeEvidence` validator | release workflow/operator | Child process output and scratch location | Reads max+1 bytes, rejects input over 1 MiB before decoding, and rejects unknown fields, sensitive keys, invalid enums, failed gates, incorrect probe counts, or invalid projection byte counts |
 | Disk preflight | evidence runner | Filesystem path and mount identity | Below the fixed scratch headroom returns `status=blocked` with numeric capacity only |
 | Scratch directory | benchmark child | Local temporary path | Creation/privacy/cleanup failures prevent `status=pass` |
 
@@ -86,12 +92,13 @@
 
 | Behavior | Given | When | Then | Level |
 | --- | --- | --- | --- | --- |
-| Phase-A gate | Opt-in eight-extent fixture | Direct metadata range is measured 25 times | managed/stored bytes >= 2 GiB, event/projection rows=8, projection-only plan, returned body bytes=0, p95 <250 ms |
+| Phase-A gate | Opt-in eight-extent fixture | Direct metadata range is measured 25 times | managed/stored bytes >= 2 GiB, event/projection rows=8, every scan returns 8 rows without `rows.Err`, projection-only plan, returned body bytes=0, p95 <250 ms |
 | Preflight block | Available scratch bytes below the fixed requirement | Evidence run starts | No benchmark runs; sanitized `insufficient_disk` evidence is written |
 | Source isolation | A pre-31 synthetic source and private copy | Current initialization runs | Migrations 31-34 are applied, projection/event counts match, source digest is unchanged, and the copy passes integrity with zero FK violations |
 | FTS separation | 130 historical rows and batch size 128 | First and resumed initialization run | First state is incomplete at 128; second state is complete at 130 |
+| Phase-C retrieval correctness | A 130-event fixture and limit 20 | All eight list/context/search probes run | Every probe returns exactly 20 items; metadata and bounded membership match for list, context, incomplete search, and complete search |
 | Body-free metadata | List/context/search metadata probes | Results are counted | Returned body bytes are zero in every metadata series |
-| Bounded projections | List/context/search bounded probes | Results are measured | Only bounded synthetic prefixes cross the query boundary |
+| Bounded projections | List/context/search bounded probes | Results are measured | Every bounded series returns a positive byte count and only bounded synthetic prefixes cross the query boundary |
 | Observation-only Phase C | No accepted latency targets | Phase-C evidence validates | p95 values are retained without pass/fail comparisons |
 | Aggregate budget | 100 multibyte events, including canonical blocks and an over-limit body | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks and response-truncation metadata appear; all items appear exactly once |
 | Metrics-only serialization | Evidence contains unknown/sensitive fields or arbitrary path-like strings | Validator runs | Validation fails and no pass artifact is written |
@@ -103,10 +110,11 @@
 
 | Behavior | Red | Green | Refactor target |
 | --- | --- | --- | --- |
-| Evidence schema/privacy | Validator tests accept pass/block fixtures but reject sensitive/unknown fields and invalid gates | Add typed `BodyFreeEvidence` plus strict decoder and invariant validation | Keep release-only policy in repo tooling |
+| Evidence schema/privacy | Validator tests accept pass/block fixtures but reject sensitive/unknown fields, oversized input, and invalid gates | Add typed `BodyFreeEvidence`, max+1 bounded reading, and strict decoder/invariant validation | Keep release-only policy in repo tooling |
 | Scratch/preflight | Runner tests cannot distinguish capacity block or cleanup result | Inject capacity/phase runners around one private scratch lifecycle | Keep paths out of returned evidence/errors |
-| Phase A | Existing benchmark allocates a 256 MiB Go string and can be killed before evidence | Use SQLite synthetic extents and emit a numeric marker | Share duration/fixture helpers with Phase B/C where it reduces drift |
+| Phase A | Existing benchmark allocates a 256 MiB Go string and can be killed before evidence | Use SQLite synthetic extents, verify scan completion/count, and emit a numeric marker | Share duration/fixture helpers with Phase B/C where it reduces drift |
 | Migration/FTS probes | No release-sized copied-store phase marker exists | Add opt-in source/copy migration and incomplete/complete probe series | Centralize metrics-only marker encoding |
+| Phase-C retrieval correctness | A syntactically complete artifact can report empty results or divergent projections | Require 20 items, projection-specific body-byte invariants, and metadata/bounded membership parity in the generator and validator | Keep identity digests in memory and serialize only counts |
 | Aggregate traversal | Existing tests cover pieces but do not emit one release marker with multibyte blocks | Add one integration scenario over the actual MCP page loader | Reuse existing server/continuation helpers |
 | Host parity | Runtime verifier passes without entering evidence | Call existing integration verifier and record only count/pass | Do not add a second manifest parser |
 | Tagged-release gate | GoReleaser can run without checking the artifact | Run the strict verifier before GoReleaser for exactly `v0.33.0` | Keep later-version policy out of this version-specific evidence PR |
@@ -118,7 +126,8 @@
   Phase C has no `passed` field.
 - **Privacy risk:** Child Go output can contain local paths or synthetic IDs on
   failure. Repo tooling captures it in memory, never includes it in evidence,
-  and requires confirmed scratch removal before writing a validated artifact.
+  requires confirmed scratch removal before writing a validated artifact, and
+  rejects artifact input over 1 MiB before parsing any valid prefix.
 - **Resource risk:** A true 2 GiB SQLite fixture needs substantially more free
   space while copying and indexing. Preflight requires conservative headroom
   and emits blocked evidence rather than filling the disk.
@@ -196,13 +205,17 @@ carried forward.
 
 - Phase A recorded 2,418,774,016 managed bytes, 2,147,483,648 stored-body
   bytes, eight event/projection rows, zero missing metadata, a projection-only
-  ordered plan, zero returned body bytes, and 25 measurements.
-- Phase-A p95 was 0.073834 ms against the unchanged 250 ms target.
+  ordered plan, eight returned items per scan, zero returned body bytes, and 25
+  measurements.
+- Phase-A p95 was 0.074625 ms against the unchanged 250 ms target.
 - Phase B applied migrations 31 through 34 to the copy, recorded 130 projection
   rows for 130 events, preserved the source byte-for-byte, passed integrity and
   foreign-key checks, and completed the resumed 128-to-130 FTS transition.
-- Phases C through E completed without changing their contracts. Phase-C
-  latencies remain observations only.
+- Phase C completed all eight 25-run probes against the 130-event fixture with
+  limit 20. Every probe returned exactly 20 items; metadata/bounded membership
+  matched for list, context, incomplete search, and complete search; metadata
+  bytes were zero; bounded bytes were positive. Its latencies remain
+  observations only. Phases D and E also passed.
 - The owner-only scratch directory was absent before the validated artifact was
   written.
 - The tagged-release workflow verifies this committed pass artifact before

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -61,7 +61,7 @@
 | Synthetic extent | Eight generated, content-free 256 MiB SQLite values plus eight trigger-maintained projection rows | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; event/projection counts match; the measured plan is projection-only; each timed scan returns all eight rows without iteration error |
 | Copied migration store | Private pre-31 source plus an isolated copy | Applies migrations 31 through 34 and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated; projection count equals event count |
 | FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
-| Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts, in-memory membership digest | Measures one public read shape 25 times | All eight series return 20 items from the 130-event fixture; metadata and bounded membership match; metadata bytes are zero and bounded bytes are positive; Phase-C p95 is observation-only |
+| Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts, in-memory membership digest | Measures one public read shape 25 times | Eight standard series return 20 items from the 130-event fixture; the additional huge-body bounded series returns one item within its explicit 500-byte budget and records the returned row's stored-body bytes; metadata and bounded membership match where paired; Phase-C p95 is observation-only |
 | Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page, truncation-metadata, and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; truncation metadata is observable; all synthetic items are visited once |
 | Host integration parity | Six packaged host copies | Runs the shared integration and staged-retrieval semantic verifier | MCP registration and Discovery → Inspection → Detail guidance agree across every host |
 | `BodyFreeEvidence` | Versioned pass or blocked JSON document | Carries only fixed enums, booleans, counts, durations, and public runtime dimensions | Sensitive keys and arbitrary strings are rejected before write |
@@ -96,14 +96,14 @@
 | Preflight block | Available scratch bytes below the fixed requirement | Evidence run starts | No benchmark runs; sanitized `insufficient_disk` evidence is written |
 | Source isolation | A pre-31 synthetic source and private copy | Current initialization runs | Migrations 31-34 are applied, projection/event counts match, source digest is unchanged, and the copy passes integrity with zero FK violations |
 | FTS separation | 130 historical rows and batch size 128 | First and resumed initialization run | First state is incomplete at 128; second state is complete at 130 |
-| Phase-C retrieval correctness | A 130-event fixture and limit 20 | All eight list/context/search probes run | Every probe returns exactly 20 items; metadata and bounded membership match for list, context, incomplete search, and complete search |
+| Phase-C retrieval correctness | A 130-event fixture and limit 20 | Eight paired list/context/search probes run, then one huge-body bounded probe runs | Every paired probe returns exactly 20 items and preserves metadata/bounded membership; the huge probe returns exactly one row, derives its stored-body extent from that row, and returns no more than its 500-byte budget |
 | Body-free metadata | List/context/search metadata probes | Results are counted | Returned body bytes are zero in every metadata series |
 | Bounded projections | List/context/search bounded probes | Results are measured | Every bounded series returns a positive byte count and only bounded synthetic prefixes cross the query boundary |
 | Observation-only Phase C | No accepted latency targets | Phase-C evidence validates | p95 values are retained without pass/fail comparisons |
 | Aggregate budget | 100 multibyte events, including canonical blocks and an over-limit body | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks and response-truncation metadata appear; all items appear exactly once |
 | Metrics-only serialization | Evidence contains unknown/sensitive fields or arbitrary path-like strings | Validator runs | Validation fails and no pass artifact is written |
 | Scratch cleanup | Success or any phase failure | Runner terminates | Scratch directory is removed; pass requires cleanup confirmation |
-| Host parity | Six packaged manifests and session-history skills | Integration verifier runs | All advertise `traceary mcp-server`; staged-retrieval copies are byte-identical and satisfy the semantic contract; evidence records both parity results |
+| Host parity | Six packaged manifests and session-history skills | Integration verifier runs before the probes | All advertise `traceary mcp-server`; staged-retrieval copies are byte-identical and satisfy the semantic contract; verifier success is a runner precondition rather than a fabricated artifact phase |
 | Tagged-release enforcement | A v0.33.0 tag or recovery dispatch | The release job reaches the evidence step | Strict verification passes before GoReleaser; blocked evidence stops the job |
 
 ### TDD plan
@@ -207,15 +207,17 @@ carried forward.
   bytes, eight event/projection rows, zero missing metadata, a projection-only
   ordered plan, eight returned items per scan, zero returned body bytes, and 25
   measurements.
-- Phase-A p95 was 0.074625 ms against the unchanged 250 ms target.
+- Phase-A p95 was 0.079708 ms against the unchanged 250 ms target.
 - Phase B applied migrations 31 through 34 to the copy, recorded 130 projection
   rows for 130 events, preserved the source byte-for-byte, passed integrity and
   foreign-key checks, and completed the resumed 128-to-130 FTS transition.
-- Phase C completed all eight 25-run probes against the 130-event fixture with
-  limit 20. Every probe returned exactly 20 items; metadata/bounded membership
-  matched for list, context, incomplete search, and complete search; metadata
-  bytes were zero; bounded bytes were positive. Its latencies remain
-  observations only. Phases D and E also passed.
+- Phase C completed eight paired 25-run probes against the 130-event fixture
+  with limit 20 and one huge-body bounded probe. The paired probes returned
+  exactly 20 items; the huge probe derived its 256 MiB stored-body extent from
+  the returned row and returned 500 bytes. Metadata/bounded membership matched
+  for list, context, incomplete search, and complete search; metadata bytes
+  were zero; bounded bytes were positive. Its latencies remain observations
+  only. Phase D passed, and host verification was a precondition.
 - The owner-only scratch directory was absent before the validated artifact was
   written.
 - The tagged-release workflow verifies this committed pass artifact before

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -8,20 +8,21 @@
   inspection, indexed search, and aggregate MCP responses remain bounded on a
   multi-GiB-class SQLite store without publishing event content or local
   identities.
-- **Dependency:** The evidence branch is based on the unmerged #1556/#1567
-  durable-memory-hygiene branch (`bd798569`). The event projection, FTS, and
-  aggregate response dependencies from #1551 and #1552 are already present in
-  that base. This PR must not be rebased directly onto `main` until #1567 is
-  merged or its commits are otherwise retained.
+- **Dependency:** The evidence branch is rebased onto `main` at `6641c6d7`,
+  which contains the merged #1567 memory-hygiene work and the #1570 persistent
+  event-metadata projection. The evidence must exercise those merged runtime
+  paths rather than carrying either implementation in this PR.
 - **Phase A:** Run the existing opt-in direct metadata benchmark with eight
   synthetic 256 MiB extents. Both SQLite-managed bytes and stored-body metadata
-  must reach 2 GiB, all eight rows must have body metadata, 25 measurements are
-  required, and p95 must remain below 250 ms.
+  must reach 2 GiB, all eight event rows must have matching projection rows,
+  the ordered plan must read only the projection, returned body bytes must be
+  zero, 25 measurements are required, and p95 must remain below 250 ms.
 - **Phase B:** Create a private synthetic pre-migration store, copy it, apply
-  migrations 31 and 32 on the copy, and record only migration duration,
-  integrity/foreign-key results, scratch extent, FTS progress, and whether the
-  source stayed byte-identical. The first 128-document backfill must remain
-  observably incomplete before a resumed batch completes it.
+  migrations 31 through 34 on the copy, and record only migration duration,
+  projection-row parity, integrity/foreign-key results, scratch extent, FTS
+  progress, and whether the source stayed byte-identical. The first
+  128-document backfill must remain observably incomplete before a resumed
+  batch completes it.
 - **Phase C:** Record 25-run p95 observations for metadata and bounded
   list/context/search projections. Search is measured separately while FTS
   backfill is incomplete and complete. These surface observations have no
@@ -41,15 +42,15 @@
   evidence document instead of attempting the multi-GiB run. It contains only
   required/available byte counts and a fixed reason.
 - **Out of scope:** Reading a live user store, publishing raw benchmark output,
-  setting new latency targets for Phase C, changing runtime event/search
-  behavior, or treating this branch as independent of #1567.
+  setting new latency targets for Phase C, or changing the merged runtime
+  event/search/projection behavior.
 
 ### Conceptual model
 
 | Concept | State | Behavior | Constraint / invariant |
 | --- | --- | --- | --- |
-| Synthetic extent | Eight generated, content-free 256 MiB SQLite values | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; exactly eight Phase-A rows have non-NULL metadata |
-| Copied migration store | Private pre-31 source plus an isolated copy | Applies current migrations and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated |
+| Synthetic extent | Eight generated, content-free 256 MiB SQLite values plus eight trigger-maintained projection rows | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; event/projection counts match; the measured plan is projection-only |
+| Copied migration store | Private pre-31 source plus an isolated copy | Applies migrations 31 through 34 and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated; projection count equals event count |
 | FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
 | Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts | Measures one public read shape 25 times | Metadata reports zero returned body bytes; Phase-C p95 is observation-only |
 | Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; all synthetic items are visited once |
@@ -79,9 +80,9 @@
 
 | Behavior | Given | When | Then | Level |
 | --- | --- | --- | --- | --- |
-| Phase-A gate | Opt-in eight-extent fixture | Direct metadata range is measured 25 times | managed/stored bytes >= 2 GiB, metadata rows=8, p95 <250 ms |
+| Phase-A gate | Opt-in eight-extent fixture | Direct metadata range is measured 25 times | managed/stored bytes >= 2 GiB, event/projection rows=8, projection-only plan, returned body bytes=0, p95 <250 ms |
 | Preflight block | Available scratch bytes below the fixed requirement | Evidence run starts | No benchmark runs; sanitized `insufficient_disk` evidence is written |
-| Source isolation | A pre-31 synthetic source and private copy | Current initialization runs | Source digest is unchanged; copy passes integrity and has zero FK violations |
+| Source isolation | A pre-31 synthetic source and private copy | Current initialization runs | Migrations 31-34 are applied, projection/event counts match, source digest is unchanged, and the copy passes integrity with zero FK violations |
 | FTS separation | 130 historical rows and batch size 128 | First and resumed initialization run | First state is incomplete at 128; second state is complete at 130 |
 | Body-free metadata | List/context/search metadata probes | Results are counted | Returned body bytes are zero in every metadata series |
 | Bounded projections | List/context/search bounded probes | Results are measured | Only bounded synthetic prefixes cross the query boundary |
@@ -114,10 +115,12 @@
   space while copying and indexing. Preflight requires conservative headroom
   and emits blocked evidence rather than filling the disk.
 - **Migration/compatibility:** This PR changes tests, repo tooling, and docs
-  only. It does not add a runtime migration or mutate a live store.
-- **Dependency/rollback:** #1558 is based on #1567. If #1567 changes, rebase the
-  evidence branch and rerun every phase. Reverting this PR removes only release
-  automation/evidence; no user data rollback exists.
+  only. Migration 34 is already merged through #1570; this evidence applies it
+  only to a synthetic copy and never mutates a live store.
+- **Dependency/rollback:** #1567 and #1570 are merged dependencies. Any change
+  to their main-branch revisions requires a complete evidence rerun. Reverting
+  this PR removes only release automation/evidence; no user data rollback
+  exists.
 - **Rollback trigger:** Any body/ID/path/cursor in the durable artifact,
   scratch surviving termination, source-copy mismatch, Phase-A p95 failure,
   integrity/FK failure, FTS phase ambiguity, aggregate overflow, continuation
@@ -132,15 +135,15 @@ Proceed with repo-tooling-owned orchestration, test-only SQLite/MCP probes, and
 strict metrics-only serialization. Do not add a user-facing command, read a
 live store, or assign Phase-C latency pass/fail targets.
 
-## Phase-A blocker diagnosis checkpoint
+## Historical Phase-A blocker and accepted resolution
 
 The accepted-host run proved that the Phase-A failure is not setup time leaking
 into the measurement. Fixture creation, migration, checkpointing, extent
 verification, and query-plan inspection all occur before the 25 manual timers.
 Each timer covers only `QueryContext`, row scanning, and `Rows.Close`.
 
-The production query plan uses
-`idx_events_workspace_created_at_norm_id_desc`, seeks both timestamp bounds,
+The pre-#1570 production query plan used
+`idx_events_workspace_created_at_norm_id_desc`, sought both timestamp bounds,
 and creates no temporary order-by tree. It is not a covering plan. SQLite's
 `events` record stores `body` before `created_at`, client/workspace metadata,
 and the body-extent metadata. SQLite's documented table-lookup and linked
@@ -156,15 +159,45 @@ evidence because the temporary index is not part of the production schema. It
 isolates the non-covering table lookup as the blocker while showing that host
 I/O conditions affect the magnitude.
 
+Issue #1569 selected a narrow, trigger-maintained metadata projection and PR
+#1570 merged it as migration 34. Metadata list/context queries now read the
+projection through ordered projection indexes without consulting `events`.
+This evidence PR does not reimplement that decision; it makes projection-only
+planning, row parity, zero returned body bytes, and the original 250 ms target
+observable release gates.
+
 ### Options considered
 
 | Option | Decision | Reason |
 | --- | --- | --- |
 | Change the fixture, timer, or 250 ms target | reject | The fixture and timing match the accepted #1553/#1558 contract; weakening them would hide the physical body read |
-| Rebuild the five ordered indexes as covering indexes | follow-up candidate | It preserves query membership and ordering and fixes every documented scope, but rebuilding five wider indexes on existing stores has material disk, write-lock, and migration-duration impact |
-| Add one metadata-cover index plus self-join query variants | follow-up alternative | It reduces index duplication, but changes every list/context SQL boundary and needs explicit compatibility tests for pre-FTS fixtures |
-| Add a mirrored metadata table | reject for the release fix | It needs backfill and ongoing triggers and creates a larger consistency boundary |
+| Rebuild the five ordered indexes as covering indexes | rejected by #1569 | Wider duplicated indexes increase steady-state storage and write cost |
+| Add one metadata-cover index plus explicit joins | rejected by #1569 | Query joins add another compatibility and planner boundary |
+| Add a narrow maintained metadata projection | accepted in #1569/#1570 | It makes payload-free reads explicit; migration, trigger parity, lock behavior, and rollback are independently tested |
 
-No runtime migration belongs in this evidence PR without an independently
-approved migration budget and rollback plan. The release remains blocked and
-the proposed runtime optimization must use a separate Issue/PR.
+The previous blocked artifact remains historical evidence only. Release
+readiness now depends on a complete rerun against merged migration 34; no
+pre-#1570 latency may be reused.
+
+## Post-#1570 evidence checkpoint
+
+The branch was rebased onto `main` at `6641c6d7`, which contains merged PRs
+#1567 and #1570. The complete runner then produced a new metrics-only artifact
+with `status=pass`; no value from the pre-projection blocked artifact was
+carried forward.
+
+- Phase A recorded 2,418,774,016 managed bytes, 2,147,483,648 stored-body
+  bytes, eight event/projection rows, zero missing metadata, a projection-only
+  ordered plan, zero returned body bytes, and 25 measurements.
+- Phase-A p95 was 0.107333 ms against the unchanged 250 ms target.
+- Phase B applied migrations 31 through 34 to the copy, recorded 130 projection
+  rows for 130 events, preserved the source byte-for-byte, passed integrity and
+  foreign-key checks, and completed the resumed 128-to-130 FTS transition.
+- Phases C through E completed without changing their contracts. Phase-C
+  latencies remain observations only.
+- The owner-only scratch directory was absent before the validated artifact was
+  written.
+
+This checkpoint satisfies the #1558 gate. It does not decide unrelated release
+checks, and any change to the merged projection, migrations, FTS behavior,
+aggregate budget, host manifests, or Go runtime requires a complete rerun.

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -131,3 +131,40 @@
 Proceed with repo-tooling-owned orchestration, test-only SQLite/MCP probes, and
 strict metrics-only serialization. Do not add a user-facing command, read a
 live store, or assign Phase-C latency pass/fail targets.
+
+## Phase-A blocker diagnosis checkpoint
+
+The accepted-host run proved that the Phase-A failure is not setup time leaking
+into the measurement. Fixture creation, migration, checkpointing, extent
+verification, and query-plan inspection all occur before the 25 manual timers.
+Each timer covers only `QueryContext`, row scanning, and `Rows.Close`.
+
+The production query plan uses
+`idx_events_workspace_created_at_norm_id_desc`, seeks both timestamp bounds,
+and creates no temporary order-by tree. It is not a covering plan. SQLite's
+`events` record stores `body` before `created_at`, client/workspace metadata,
+and the body-extent metadata. SQLite's documented table-lookup and linked
+overflow-page mechanics, combined with the controlled result below, support
+the inference that restoring those selected columns follows each 256 MiB
+body's overflow chain even though `body` is absent from the SELECT list.
+
+A local diagnostic created one temporary covering workspace index on the same
+2 GiB fixture outside the measurement timer. The identical 25-run query
+measured p95 0.088750 ms. Production-schema runs measured 605.756875 ms and,
+under heavier host I/O pressure, 4,159.414709 ms. This diagnostic is not release
+evidence because the temporary index is not part of the production schema. It
+isolates the non-covering table lookup as the blocker while showing that host
+I/O conditions affect the magnitude.
+
+### Options considered
+
+| Option | Decision | Reason |
+| --- | --- | --- |
+| Change the fixture, timer, or 250 ms target | reject | The fixture and timing match the accepted #1553/#1558 contract; weakening them would hide the physical body read |
+| Rebuild the five ordered indexes as covering indexes | follow-up candidate | It preserves query membership and ordering and fixes every documented scope, but rebuilding five wider indexes on existing stores has material disk, write-lock, and migration-duration impact |
+| Add one metadata-cover index plus self-join query variants | follow-up alternative | It reduces index duplication, but changes every list/context SQL boundary and needs explicit compatibility tests for pre-FTS fixtures |
+| Add a mirrored metadata table | reject for the release fix | It needs backfill and ongoing triggers and creates a larger consistency boundary |
+
+No runtime migration belongs in this evidence PR without an independently
+approved migration budget and rollback plan. The release remains blocked and
+the proposed runtime optimization must use a separate Issue/PR.

--- a/.ai/spec/1558.md
+++ b/.ai/spec/1558.md
@@ -1,0 +1,133 @@
+# #1558 Multi-GiB release evidence
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- **Purpose:** Produce release evidence that metadata discovery, bounded event
+  inspection, indexed search, and aggregate MCP responses remain bounded on a
+  multi-GiB-class SQLite store without publishing event content or local
+  identities.
+- **Dependency:** The evidence branch is based on the unmerged #1556/#1567
+  durable-memory-hygiene branch (`bd798569`). The event projection, FTS, and
+  aggregate response dependencies from #1551 and #1552 are already present in
+  that base. This PR must not be rebased directly onto `main` until #1567 is
+  merged or its commits are otherwise retained.
+- **Phase A:** Run the existing opt-in direct metadata benchmark with eight
+  synthetic 256 MiB extents. Both SQLite-managed bytes and stored-body metadata
+  must reach 2 GiB, all eight rows must have body metadata, 25 measurements are
+  required, and p95 must remain below 250 ms.
+- **Phase B:** Create a private synthetic pre-migration store, copy it, apply
+  migrations 31 and 32 on the copy, and record only migration duration,
+  integrity/foreign-key results, scratch extent, FTS progress, and whether the
+  source stayed byte-identical. The first 128-document backfill must remain
+  observably incomplete before a resumed batch completes it.
+- **Phase C:** Record 25-run p95 observations for metadata and bounded
+  list/context/search projections. Search is measured separately while FTS
+  backfill is incomplete and complete. These surface observations have no
+  release pass/fail latency target until the Issue fixes one; only Phase A's
+  250 ms p95 is a gate.
+- **Phase D:** Exercise the MCP aggregate response with a requested limit of
+  100, the 65,536-byte encoded body budget, multibyte text, canonical
+  `body_blocks`, and continuation traversal that proves no duplicate or skipped
+  item.
+- **Phase E:** Verify all six packaged hosts retain the same MCP command and
+  record only the host count and parity result.
+- **Privacy:** The durable artifact is a metrics-only `BodyFreeEvidence`
+  document. It never contains bodies, prompts, responses, event/session IDs,
+  workspaces, local paths, continuations, raw command output, or fixture logs.
+  Scratch storage is owner-only and is removed on every terminal path.
+- **Blocked hosts:** Disk/capability preflight produces a sanitized blocked
+  evidence document instead of attempting the multi-GiB run. It contains only
+  required/available byte counts and a fixed reason.
+- **Out of scope:** Reading a live user store, publishing raw benchmark output,
+  setting new latency targets for Phase C, changing runtime event/search
+  behavior, or treating this branch as independent of #1567.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+| --- | --- | --- | --- |
+| Synthetic extent | Eight generated, content-free 256 MiB SQLite values | Makes page and stored-byte scale real without using user data | Managed and stored bytes are each at least 2 GiB; exactly eight Phase-A rows have non-NULL metadata |
+| Copied migration store | Private pre-31 source plus an isolated copy | Applies current migrations and resumable FTS backfill only to the copy | Source digest is unchanged; only the copy is mutated |
+| FTS phase | `incomplete` after the first 128-document batch, then `complete` | Labels search probe series | Incomplete and complete observations are never merged into one latency sample |
+| Projection probe | Operation, projection, FTS phase, run count, p95, returned item/body-byte counts | Measures one public read shape 25 times | Metadata reports zero returned body bytes; Phase-C p95 is observation-only |
+| Aggregate evidence | Maximum and observed item/body-byte counts plus content-shape booleans | Proves page and continuation invariants | At most 100 items and 65,536 encoded body bytes per page; all synthetic items are visited once |
+| `BodyFreeEvidence` | Versioned pass or blocked JSON document | Carries only fixed enums, booleans, counts, durations, and public runtime dimensions | Sensitive keys and arbitrary strings are rejected before write |
+| Private scratch | Owner-only temporary directory | Contains synthetic stores and Go test temporary files only while the run is active | Mode is private before any fixture write and the directory is absent before pass evidence is emitted |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+| --- | --- | --- | --- |
+| Multi-GiB fixture, migration, query probes, and numeric phase markers | `infrastructure/sqlite` opt-in benchmarks | Query plans, migrations, FTS state, and store bytes are SQLite concerns | Repo tooling must not duplicate production SQL |
+| Aggregate/body-block/continuation evidence marker | `presentation/mcpserver` integration test | It observes the actual MCP response budget and opaque continuation behavior | SQLite does not own transport aggregation |
+| Preflight, child orchestration, scratch lifecycle, host parity, evidence merge/validation | `cmd/repo-tooling release` | This is maintainer-only release automation | The shipped `traceary` binary must not expose a QA command |
+| Evidence interpretation and release boundary | bilingual release documentation | Operators need a stable procedure and explicit non-claims | Test logs are not durable release documentation |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+| --- | --- | --- | --- |
+| Opt-in benchmark markers | repo-tooling runner | Store paths, synthetic IDs, SQL, raw child output | Missing/malformed markers become a fixed phase failure; captured output is not echoed |
+| Aggregate test marker | repo-tooling runner | Bodies, body blocks, event IDs, encrypted cursor | Reports only counts/booleans and fails before emitting on duplicate/skip or budget breach |
+| `BodyFreeEvidence` validator | release workflow/operator | Child process output and scratch location | Rejects unknown fields, sensitive keys, invalid enums, failed gates, or nonzero metadata body bytes |
+| Disk preflight | evidence runner | Filesystem path and mount identity | Below the fixed scratch headroom returns `status=blocked` with numeric capacity only |
+| Scratch directory | benchmark child | Local temporary path | Creation/privacy/cleanup failures prevent `status=pass` |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+| --- | --- | --- | --- | --- |
+| Phase-A gate | Opt-in eight-extent fixture | Direct metadata range is measured 25 times | managed/stored bytes >= 2 GiB, metadata rows=8, p95 <250 ms |
+| Preflight block | Available scratch bytes below the fixed requirement | Evidence run starts | No benchmark runs; sanitized `insufficient_disk` evidence is written |
+| Source isolation | A pre-31 synthetic source and private copy | Current initialization runs | Source digest is unchanged; copy passes integrity and has zero FK violations |
+| FTS separation | 130 historical rows and batch size 128 | First and resumed initialization run | First state is incomplete at 128; second state is complete at 130 |
+| Body-free metadata | List/context/search metadata probes | Results are counted | Returned body bytes are zero in every metadata series |
+| Bounded projections | List/context/search bounded probes | Results are measured | Only bounded synthetic prefixes cross the query boundary |
+| Observation-only Phase C | No accepted latency targets | Phase-C evidence validates | p95 values are retained without pass/fail comparisons |
+| Aggregate budget | 100 multibyte canonical events | MCP pages are followed to completion | Each page <=65,536 body bytes and <=100 items; blocks appear; all items appear exactly once |
+| Metrics-only serialization | Evidence contains unknown/sensitive fields or arbitrary path-like strings | Validator runs | Validation fails and no pass artifact is written |
+| Scratch cleanup | Success or any phase failure | Runner terminates | Scratch directory is removed; pass requires cleanup confirmation |
+| Host parity | Six packaged manifests | Integration verifier runs | All advertise `traceary mcp-server`; evidence records count=6 and parity=true |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+| --- | --- | --- | --- |
+| Evidence schema/privacy | Validator tests accept pass/block fixtures but reject sensitive/unknown fields and invalid gates | Add typed `BodyFreeEvidence` plus strict decoder and invariant validation | Keep release-only policy in repo tooling |
+| Scratch/preflight | Runner tests cannot distinguish capacity block or cleanup result | Inject capacity/phase runners around one private scratch lifecycle | Keep paths out of returned evidence/errors |
+| Phase A | Existing benchmark allocates a 256 MiB Go string and can be killed before evidence | Use SQLite synthetic extents and emit a numeric marker | Share duration/fixture helpers with Phase B/C where it reduces drift |
+| Migration/FTS probes | No release-sized copied-store phase marker exists | Add opt-in source/copy migration and incomplete/complete probe series | Centralize metrics-only marker encoding |
+| Aggregate traversal | Existing tests cover pieces but do not emit one release marker with multibyte blocks | Add one integration scenario over the actual MCP page loader | Reuse existing server/continuation helpers |
+| Host parity | Runtime verifier passes without entering evidence | Call existing integration verifier and record only count/pass | Do not add a second manifest parser |
+
+### Risks / rollback
+
+- **Procedural-logic risk:** An orchestrator could accidentally treat Phase-C
+  observations as gates. Validation applies a latency threshold only to Phase A;
+  Phase C has no `passed` field.
+- **Privacy risk:** Child Go output can contain local paths or synthetic IDs on
+  failure. Repo tooling captures it in memory, never includes it in evidence,
+  and requires confirmed scratch removal before writing a validated artifact.
+- **Resource risk:** A true 2 GiB SQLite fixture needs substantially more free
+  space while copying and indexing. Preflight requires conservative headroom
+  and emits blocked evidence rather than filling the disk.
+- **Migration/compatibility:** This PR changes tests, repo tooling, and docs
+  only. It does not add a runtime migration or mutate a live store.
+- **Dependency/rollback:** #1558 is based on #1567. If #1567 changes, rebase the
+  evidence branch and rerun every phase. Reverting this PR removes only release
+  automation/evidence; no user data rollback exists.
+- **Rollback trigger:** Any body/ID/path/cursor in the durable artifact,
+  scratch surviving termination, source-copy mismatch, Phase-A p95 failure,
+  integrity/FK failure, FTS phase ambiguity, aggregate overflow, continuation
+  gap/duplicate, or host parity failure blocks release.
+- **Split PR plan:** Keep the schema/runner, opt-in probes, aggregate marker,
+  and release documentation in this one #1558 PR because none is meaningful
+  release evidence without the privacy validator and cleanup owner.
+
+## Implementation checkpoint
+
+Proceed with repo-tooling-owned orchestration, test-only SQLite/MCP probes, and
+strict metrics-only serialization. Do not add a user-facing command, read a
+live store, or assign Phase-C latency pass/fail targets.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Verify landing page in sync with VERSION
         run: go run ./cmd/repo-tooling docs verify-landing
 
+      - name: Verify v0.33.0 multi-GiB release evidence
+        if: env.IS_TAG_RELEASE == 'true' && env.RELEASE_TAG == 'v0.33.0'
+        run: go run ./cmd/repo-tooling release verify-body-free-evidence --input docs/release/v0.33.0-multigib-evidence.json
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9a127d869fb706213d29cdf8eef3a4ea2b869415 # v7
         with:

--- a/cmd/repo-tooling/release.go
+++ b/cmd/repo-tooling/release.go
@@ -83,6 +83,7 @@ func newReleaseCommand() *cobra.Command {
 
 	cmd.AddCommand(verifyChangelog)
 	cmd.AddCommand(bumpVersion)
+	addReleaseEvidenceCommands(cmd)
 	return cmd
 }
 

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -49,7 +49,6 @@ type BodyFreeEvidence struct {
 	PhaseB      *bodyFreeEvidencePhaseB   `json:"phase_b,omitempty"`
 	PhaseC      []bodyFreeEvidenceProbe   `json:"phase_c,omitempty"`
 	PhaseD      *bodyFreeEvidencePhaseD   `json:"phase_d,omitempty"`
-	PhaseE      *bodyFreeEvidencePhaseE   `json:"phase_e,omitempty"`
 	Privacy     bodyFreeEvidencePrivacy   `json:"privacy"`
 }
 
@@ -122,12 +121,6 @@ type bodyFreeEvidencePhaseD struct {
 	BodyBlocksObserved            bool `json:"body_blocks_observed"`
 	TruncationMetadataObserved    bool `json:"truncation_metadata_observed"`
 	ContinuationNoDuplicateOrSkip bool `json:"continuation_no_duplicate_or_skip"`
-}
-
-type bodyFreeEvidencePhaseE struct {
-	HostCount             int  `json:"host_count"`
-	ManifestParity        bool `json:"manifest_parity"`
-	StagedRetrievalParity bool `json:"staged_retrieval_parity"`
 }
 
 type bodyFreeEvidencePrivacy struct {
@@ -293,21 +286,18 @@ func collectV0330BodyFreeEvidence(
 		evidence.Privacy.ScratchPrivate = true
 	}
 
+	hostsVerified := false
 	if evidence.BlockReason == "" {
 		if err := deps.verifyHosts(root); err != nil {
 			evidence.BlockReason = "host_parity_failed"
 		} else {
-			evidence.PhaseE = &bodyFreeEvidencePhaseE{
-				HostCount:             6,
-				ManifestParity:        true,
-				StagedRetrievalParity: true,
-			}
+			hostsVerified = true
 		}
 	}
 
 	phaseCtx, cancel := context.WithTimeout(ctx, v0330EvidenceRunTimeout)
 	defer cancel()
-	phasesAllowed := evidence.Privacy.ScratchPrivate && evidence.PhaseE != nil
+	phasesAllowed := evidence.Privacy.ScratchPrivate && hostsVerified
 	setBlockReason := func(reason string) {
 		if evidence.BlockReason == "" {
 			evidence.BlockReason = reason
@@ -365,7 +355,6 @@ func collectV0330BodyFreeEvidence(
 		evidence.PhaseB = nil
 		evidence.PhaseC = nil
 		evidence.PhaseD = nil
-		evidence.PhaseE = nil
 	}
 	return evidence
 }
@@ -548,7 +537,7 @@ func validateBodyFreeEvidence(evidence BodyFreeEvidence) error {
 		evidence.Preflight.Reason != "insufficient_disk" {
 		return xerrors.Errorf("body-free release evidence preflight reason is invalid")
 	}
-	if !evidence.Privacy.MetricsOnly || !evidence.Privacy.ScratchCleaned {
+	if !evidence.Privacy.MetricsOnly {
 		return xerrors.Errorf("body-free release evidence privacy contract is incomplete")
 	}
 
@@ -572,12 +561,6 @@ func validateBodyFreeEvidence(evidence BodyFreeEvidence) error {
 			return err
 		}
 	}
-	if evidence.PhaseE != nil {
-		if err := validateBodyFreeEvidencePhaseE(*evidence.PhaseE); err != nil {
-			return err
-		}
-	}
-
 	if evidence.Status == "blocked" {
 		allowed := map[string]bool{
 			"filesystem_preflight_unavailable": true,
@@ -608,15 +591,22 @@ func validateBodyFreeEvidence(evidence BodyFreeEvidence) error {
 				evidence.BlockReason == "insufficient_disk") {
 			return xerrors.Errorf("body-free release evidence preflight reason is missing")
 		}
+		if !evidence.Privacy.ScratchCleaned && evidence.BlockReason != "scratch_cleanup_failed" {
+			return xerrors.Errorf("body-free release evidence scratch cleanup state is inconsistent")
+		}
+		if evidence.Privacy.ScratchCleaned && evidence.BlockReason == "scratch_cleanup_failed" {
+			return xerrors.Errorf("body-free release evidence scratch cleanup state is inconsistent")
+		}
 		return nil
 	}
 
 	if evidence.BlockReason != "" || !evidence.Preflight.Capable ||
 		evidence.Preflight.AvailableScratchBytes < evidence.Preflight.RequiredScratchBytes ||
-		evidence.Preflight.Reason != "" || !evidence.Privacy.ScratchPrivate {
+		evidence.Preflight.Reason != "" || !evidence.Privacy.ScratchPrivate ||
+		!evidence.Privacy.ScratchCleaned {
 		return xerrors.Errorf("body-free release evidence pass preconditions are incomplete")
 	}
-	if evidence.PhaseA == nil || evidence.PhaseB == nil || evidence.PhaseD == nil || evidence.PhaseE == nil {
+	if evidence.PhaseA == nil || evidence.PhaseB == nil || evidence.PhaseD == nil {
 		return xerrors.Errorf("body-free release evidence is missing a phase")
 	}
 	if !evidence.PhaseA.Passed {
@@ -690,13 +680,6 @@ func validateBodyFreeEvidencePhaseD(phaseD bodyFreeEvidencePhaseD) error {
 		!phaseD.TruncationMetadataObserved ||
 		!phaseD.ContinuationNoDuplicateOrSkip {
 		return xerrors.Errorf("body-free release evidence phase D failed")
-	}
-	return nil
-}
-
-func validateBodyFreeEvidencePhaseE(phaseE bodyFreeEvidencePhaseE) error {
-	if phaseE.HostCount != 6 || !phaseE.ManifestParity || !phaseE.StagedRetrievalParity {
-		return xerrors.Errorf("body-free release evidence phase E failed")
 	}
 	return nil
 }

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -112,6 +112,7 @@ type bodyFreeEvidencePhaseD struct {
 	TotalItems                    int  `json:"total_items"`
 	MultibyteObserved             bool `json:"multibyte_observed"`
 	BodyBlocksObserved            bool `json:"body_blocks_observed"`
+	TruncationMetadataObserved    bool `json:"truncation_metadata_observed"`
 	ContinuationNoDuplicateOrSkip bool `json:"continuation_no_duplicate_or_skip"`
 }
 
@@ -664,6 +665,7 @@ func validateBodyFreeEvidencePhaseD(phaseD bodyFreeEvidencePhaseD) error {
 		phaseD.ObservedMaxAggregateBodyBytes > phaseD.MaxAggregateBodyBytes ||
 		phaseD.Pages < 2 || phaseD.TotalItems != 100 ||
 		!phaseD.MultibyteObserved || !phaseD.BodyBlocksObserved ||
+		!phaseD.TruncationMetadataObserved ||
 		!phaseD.ContinuationNoDuplicateOrSkip {
 		return xerrors.Errorf("body-free release evidence phase D failed")
 	}

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -66,9 +66,10 @@ type bodyFreeEvidencePhaseA struct {
 	ManagedBytes        int64   `json:"managed_bytes"`
 	StoredBodyBytes     int64   `json:"stored_body_bytes"`
 	Events              int64   `json:"events"`
+	ProjectionRows      int64   `json:"projection_rows"`
 	MissingBodyMetadata int64   `json:"missing_body_metadata"`
-	OrderedIndex        bool    `json:"ordered_index"`
-	CoveringIndex       bool    `json:"covering_index"`
+	ProjectionOnly      bool    `json:"projection_only"`
+	ReturnedBodyBytes   int64   `json:"returned_body_bytes"`
 	Runs                int     `json:"runs"`
 	P95MS               float64 `json:"p95_ms"`
 	TargetP95MS         float64 `json:"target_p95_ms"`
@@ -81,7 +82,8 @@ type bodyFreeEvidencePhaseB struct {
 	Events                      int64   `json:"events"`
 	MigrationMS                 float64 `json:"migration_ms"`
 	ResumeBackfillMS            float64 `json:"resume_backfill_ms"`
-	Migrations31And32           bool    `json:"migrations_31_32_applied"`
+	Migrations31Through34       bool    `json:"migrations_31_34_applied"`
+	ProjectionRows              int64   `json:"projection_rows"`
 	IntegrityOK                 bool    `json:"integrity_ok"`
 	ForeignKeyViolations        int64   `json:"foreign_key_violations"`
 	SourceUnchanged             bool    `json:"source_unchanged"`
@@ -632,8 +634,9 @@ func validBodyFreeEvidenceGOARCH(value string) bool {
 
 func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 	if phaseA.ManagedBytes < 2<<30 || phaseA.StoredBodyBytes < 2<<30 ||
-		phaseA.Events != 8 || phaseA.MissingBodyMetadata != 0 ||
-		!phaseA.OrderedIndex ||
+		phaseA.Events != 8 || phaseA.ProjectionRows != phaseA.Events ||
+		phaseA.MissingBodyMetadata != 0 || !phaseA.ProjectionOnly ||
+		phaseA.ReturnedBodyBytes != 0 ||
 		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 || phaseA.P95MS < 0 ||
 		phaseA.Passed != (phaseA.P95MS < phaseA.TargetP95MS) {
 		return xerrors.Errorf("body-free release evidence phase A is invalid")
@@ -645,7 +648,8 @@ func validateBodyFreeEvidencePhaseB(phaseB bodyFreeEvidencePhaseB) error {
 	if phaseB.SourceManagedBytes < 2<<30 ||
 		phaseB.ScratchBytesAfterCheckpoint < 2*phaseB.SourceManagedBytes ||
 		phaseB.Events != 130 || phaseB.MigrationMS < 0 || phaseB.ResumeBackfillMS < 0 ||
-		!phaseB.Migrations31And32 || !phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
+		!phaseB.Migrations31Through34 || phaseB.ProjectionRows != phaseB.Events ||
+		!phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
 		!phaseB.SourceUnchanged || phaseB.InitialFTSDocuments != 128 || phaseB.InitialFTSComplete ||
 		phaseB.FinalFTSDocuments != phaseB.Events || !phaseB.FinalFTSComplete {
 		return xerrors.Errorf("body-free release evidence phase B failed")

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -96,6 +96,7 @@ type bodyFreeEvidencePhaseB struct {
 	InitialFTSComplete          bool    `json:"initial_fts_complete"`
 	FinalFTSDocuments           int64   `json:"final_fts_documents"`
 	FinalFTSComplete            bool    `json:"final_fts_complete"`
+	PreProjectionWriterOK       bool    `json:"pre_projection_writer_ok"`
 }
 
 type bodyFreeEvidenceProbe struct {
@@ -671,7 +672,7 @@ func validateBodyFreeEvidencePhaseB(phaseB bodyFreeEvidencePhaseB) error {
 		!phaseB.Migrations31Through34 || phaseB.ProjectionRows != phaseB.Events ||
 		!phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
 		!phaseB.SourceUnchanged || phaseB.InitialFTSDocuments != 128 || phaseB.InitialFTSComplete ||
-		phaseB.FinalFTSDocuments != phaseB.Events || !phaseB.FinalFTSComplete {
+		phaseB.FinalFTSDocuments != phaseB.Events || !phaseB.FinalFTSComplete || !phaseB.PreProjectionWriterOK {
 		return xerrors.Errorf("body-free release evidence phase B failed")
 	}
 	return nil

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -117,8 +117,9 @@ type bodyFreeEvidencePhaseD struct {
 }
 
 type bodyFreeEvidencePhaseE struct {
-	HostCount      int  `json:"host_count"`
-	ManifestParity bool `json:"manifest_parity"`
+	HostCount             int  `json:"host_count"`
+	ManifestParity        bool `json:"manifest_parity"`
+	StagedRetrievalParity bool `json:"staged_retrieval_parity"`
 }
 
 type bodyFreeEvidencePrivacy struct {
@@ -288,7 +289,11 @@ func collectV0330BodyFreeEvidence(
 		if err := deps.verifyHosts(root); err != nil {
 			evidence.BlockReason = "host_parity_failed"
 		} else {
-			evidence.PhaseE = &bodyFreeEvidencePhaseE{HostCount: 6, ManifestParity: true}
+			evidence.PhaseE = &bodyFreeEvidencePhaseE{
+				HostCount:             6,
+				ManifestParity:        true,
+				StagedRetrievalParity: true,
+			}
 		}
 	}
 
@@ -673,7 +678,7 @@ func validateBodyFreeEvidencePhaseD(phaseD bodyFreeEvidencePhaseD) error {
 }
 
 func validateBodyFreeEvidencePhaseE(phaseE bodyFreeEvidencePhaseE) error {
-	if phaseE.HostCount != 6 || !phaseE.ManifestParity {
+	if phaseE.HostCount != 6 || !phaseE.ManifestParity || !phaseE.StagedRetrievalParity {
 		return xerrors.Errorf("body-free release evidence phase E failed")
 	}
 	return nil

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -100,13 +100,15 @@ type bodyFreeEvidencePhaseB struct {
 }
 
 type bodyFreeEvidenceProbe struct {
-	Operation         string  `json:"operation"`
-	Projection        string  `json:"projection"`
-	FTSPhase          string  `json:"fts_phase"`
-	Runs              int     `json:"runs"`
-	P95MS             float64 `json:"p95_ms"`
-	ReturnedItems     int     `json:"returned_items"`
-	ReturnedBodyBytes int     `json:"returned_body_bytes"`
+	Operation          string  `json:"operation"`
+	Projection         string  `json:"projection"`
+	FTSPhase           string  `json:"fts_phase"`
+	Runs               int     `json:"runs"`
+	P95MS              float64 `json:"p95_ms"`
+	ReturnedItems      int     `json:"returned_items"`
+	ReturnedBodyBytes  int     `json:"returned_body_bytes"`
+	SourceBodyBytes    int64   `json:"source_body_bytes,omitempty"`
+	BoundedBudgetBytes int     `json:"bounded_budget_bytes,omitempty"`
 }
 
 type bodyFreeEvidencePhaseD struct {
@@ -701,14 +703,15 @@ func validateBodyFreeEvidencePhaseE(phaseE bodyFreeEvidencePhaseE) error {
 
 func validateBodyFreeEvidenceProbes(probes []bodyFreeEvidenceProbe) error {
 	expected := map[string]bool{
-		"list|metadata|not_applicable":    true,
-		"list|bounded|not_applicable":     true,
-		"context|metadata|not_applicable": true,
-		"context|bounded|not_applicable":  true,
-		"search|metadata|incomplete":      true,
-		"search|bounded|incomplete":       true,
-		"search|metadata|complete":        true,
-		"search|bounded|complete":         true,
+		"list|metadata|not_applicable":     true,
+		"list|bounded|not_applicable":      true,
+		"list|bounded_huge|not_applicable": true,
+		"context|metadata|not_applicable":  true,
+		"context|bounded|not_applicable":   true,
+		"search|metadata|incomplete":       true,
+		"search|bounded|incomplete":        true,
+		"search|metadata|complete":         true,
+		"search|bounded|complete":          true,
 	}
 	seen := make(map[string]bool, len(probes))
 	for _, probe := range probes {
@@ -718,8 +721,19 @@ func validateBodyFreeEvidenceProbes(probes []bodyFreeEvidenceProbe) error {
 		}
 		seen[key] = true
 		if probe.Runs != 25 || probe.P95MS < 0 ||
-			probe.ReturnedItems != v0330EvidenceProbeLimit ||
 			probe.ReturnedBodyBytes < 0 {
+			return xerrors.Errorf("body-free release evidence phase C probe is invalid")
+		}
+		if probe.Projection == "bounded_huge" {
+			if probe.ReturnedItems != 1 || probe.ReturnedBodyBytes <= 0 ||
+				probe.SourceBodyBytes != 256<<20 || probe.BoundedBudgetBytes <= 0 ||
+				probe.ReturnedBodyBytes > probe.BoundedBudgetBytes ||
+				int64(probe.ReturnedBodyBytes) >= probe.SourceBodyBytes {
+				return xerrors.Errorf("body-free release evidence huge-body probe is invalid")
+			}
+			continue
+		}
+		if probe.ReturnedItems != v0330EvidenceProbeLimit || probe.SourceBodyBytes != 0 || probe.BoundedBudgetBytes != 0 {
 			return xerrors.Errorf("body-free release evidence phase C probe is invalid")
 		}
 		if probe.Projection == "metadata" && probe.ReturnedBodyBytes != 0 {

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -24,10 +24,13 @@ const (
 	bodyFreeEvidencePhaseAMarker  = "TRACEARY_PHASE_A_EVIDENCE="
 	bodyFreeEvidencePhaseBCMarker = "TRACEARY_PHASE_BC_EVIDENCE="
 	bodyFreeEvidencePhaseDMarker  = "TRACEARY_PHASE_D_EVIDENCE="
+	bodyFreeEvidenceMaxBytes      = 1 << 20
 
 	v0330EvidenceRequiredScratchBytes uint64 = 12 << 30
 	v0330EvidenceCommandOutputBytes          = 2 << 20
 	v0330EvidenceRunTimeout                  = 45 * time.Minute
+	v0330EvidenceFixtureEvents               = 130
+	v0330EvidenceProbeLimit                  = 20
 )
 
 var bodyFreeEvidenceGoVersionRe = regexp.MustCompile(`^go[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[a-z0-9.-]+)?$`)
@@ -69,6 +72,7 @@ type bodyFreeEvidencePhaseA struct {
 	ProjectionRows      int64   `json:"projection_rows"`
 	MissingBodyMetadata int64   `json:"missing_body_metadata"`
 	ProjectionOnly      bool    `json:"projection_only"`
+	ReturnedItems       int64   `json:"returned_items"`
 	ReturnedBodyBytes   int64   `json:"returned_body_bytes"`
 	Runs                int     `json:"runs"`
 	P95MS               float64 `json:"p95_ms"`
@@ -468,9 +472,12 @@ func writeBodyFreeEvidence(out io.Writer, outputPath string, evidence BodyFreeEv
 }
 
 func decodeBodyFreeEvidence(reader io.Reader) (BodyFreeEvidence, error) {
-	data, err := io.ReadAll(io.LimitReader(reader, 1<<20))
+	data, err := io.ReadAll(io.LimitReader(reader, bodyFreeEvidenceMaxBytes+1))
 	if err != nil {
 		return BodyFreeEvidence{}, xerrors.Errorf("failed to read body-free release evidence")
+	}
+	if len(data) > bodyFreeEvidenceMaxBytes {
+		return BodyFreeEvidence{}, xerrors.Errorf("body-free release evidence exceeds size limit")
 	}
 	var generic any
 	if err := json.Unmarshal(data, &generic); err != nil {
@@ -642,7 +649,7 @@ func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 	if phaseA.ManagedBytes < 2<<30 || phaseA.StoredBodyBytes < 2<<30 ||
 		phaseA.Events != 8 || phaseA.ProjectionRows != phaseA.Events ||
 		phaseA.MissingBodyMetadata != 0 || !phaseA.ProjectionOnly ||
-		phaseA.ReturnedBodyBytes != 0 ||
+		phaseA.ReturnedItems != phaseA.Events || phaseA.ReturnedBodyBytes != 0 ||
 		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 || phaseA.P95MS < 0 ||
 		phaseA.Passed != (phaseA.P95MS < phaseA.TargetP95MS) {
 		return xerrors.Errorf("body-free release evidence phase A is invalid")
@@ -653,7 +660,8 @@ func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 func validateBodyFreeEvidencePhaseB(phaseB bodyFreeEvidencePhaseB) error {
 	if phaseB.SourceManagedBytes < 2<<30 ||
 		phaseB.ScratchBytesAfterCheckpoint < 2*phaseB.SourceManagedBytes ||
-		phaseB.Events != 130 || phaseB.MigrationMS < 0 || phaseB.ResumeBackfillMS < 0 ||
+		phaseB.Events != v0330EvidenceFixtureEvents ||
+		phaseB.MigrationMS < 0 || phaseB.ResumeBackfillMS < 0 ||
 		!phaseB.Migrations31Through34 || phaseB.ProjectionRows != phaseB.Events ||
 		!phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
 		!phaseB.SourceUnchanged || phaseB.InitialFTSDocuments != 128 || phaseB.InitialFTSComplete ||
@@ -703,12 +711,15 @@ func validateBodyFreeEvidenceProbes(probes []bodyFreeEvidenceProbe) error {
 		}
 		seen[key] = true
 		if probe.Runs != 25 || probe.P95MS < 0 ||
-			probe.ReturnedItems < 0 || probe.ReturnedItems > 100 ||
+			probe.ReturnedItems != v0330EvidenceProbeLimit ||
 			probe.ReturnedBodyBytes < 0 {
 			return xerrors.Errorf("body-free release evidence phase C probe is invalid")
 		}
 		if probe.Projection == "metadata" && probe.ReturnedBodyBytes != 0 {
 			return xerrors.Errorf("body-free release evidence metadata probe returned body bytes")
+		}
+		if probe.Projection == "bounded" && probe.ReturnedBodyBytes == 0 {
+			return xerrors.Errorf("body-free release evidence bounded probe returned no body bytes")
 		}
 	}
 	if len(seen) != len(expected) {

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"regexp"
@@ -650,9 +651,14 @@ func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 		phaseA.Events != 8 || phaseA.ProjectionRows != phaseA.Events ||
 		phaseA.MissingBodyMetadata != 0 || !phaseA.ProjectionOnly ||
 		phaseA.ReturnedItems != phaseA.Events || phaseA.ReturnedBodyBytes != 0 ||
-		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 || phaseA.P95MS < 0 ||
-		phaseA.Passed != (phaseA.P95MS < phaseA.TargetP95MS) {
+		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 {
 		return xerrors.Errorf("body-free release evidence phase A is invalid")
+	}
+	if math.IsNaN(phaseA.P95MS) || math.IsInf(phaseA.P95MS, 0) || phaseA.P95MS <= 0 {
+		return xerrors.Errorf("body-free release evidence phase A p95 is missing or invalid")
+	}
+	if phaseA.P95MS >= phaseA.TargetP95MS || !phaseA.Passed {
+		return xerrors.Errorf("body-free release evidence phase A did not meet the p95 target")
 	}
 	return nil
 }

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -350,7 +350,14 @@ func collectV0330BodyFreeEvidence(
 	}
 	if err := validateBodyFreeEvidence(evidence); err != nil {
 		evidence.Status = "blocked"
-		evidence.BlockReason = "evidence_validation_failed"
+		// Cleanup failure remains the primary reportable condition: preserving an
+		// uncleared private scratch directory must never make the sanitized
+		// artifact itself unwritable, even when a phase marker is also invalid.
+		if evidence.Privacy.ScratchCleaned {
+			evidence.BlockReason = "evidence_validation_failed"
+		} else {
+			evidence.BlockReason = "scratch_cleanup_failed"
+		}
 		evidence.PhaseA = nil
 		evidence.PhaseB = nil
 		evidence.PhaseC = nil

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -1,0 +1,710 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+)
+
+const (
+	bodyFreeEvidenceSchema        = "traceary.body-free-release-evidence.v1"
+	bodyFreeEvidencePhaseAMarker  = "TRACEARY_PHASE_A_EVIDENCE="
+	bodyFreeEvidencePhaseBCMarker = "TRACEARY_PHASE_BC_EVIDENCE="
+	bodyFreeEvidencePhaseDMarker  = "TRACEARY_PHASE_D_EVIDENCE="
+
+	v0330EvidenceRequiredScratchBytes uint64 = 12 << 30
+	v0330EvidenceCommandOutputBytes          = 2 << 20
+	v0330EvidenceRunTimeout                  = 45 * time.Minute
+)
+
+var bodyFreeEvidenceGoVersionRe = regexp.MustCompile(`^go[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[a-z0-9.-]+)?$`)
+
+// BodyFreeEvidence is the only durable artifact emitted by the v0.33.0
+// multi-GiB release probe. It deliberately has no free-form string, identity,
+// cursor, body, prompt, workspace, or path field.
+type BodyFreeEvidence struct {
+	Schema      string                    `json:"schema"`
+	Status      string                    `json:"status"`
+	BlockReason string                    `json:"block_reason,omitempty"`
+	Host        bodyFreeEvidenceHost      `json:"host"`
+	Preflight   bodyFreeEvidencePreflight `json:"preflight"`
+	PhaseA      *bodyFreeEvidencePhaseA   `json:"phase_a,omitempty"`
+	PhaseB      *bodyFreeEvidencePhaseB   `json:"phase_b,omitempty"`
+	PhaseC      []bodyFreeEvidenceProbe   `json:"phase_c,omitempty"`
+	PhaseD      *bodyFreeEvidencePhaseD   `json:"phase_d,omitempty"`
+	PhaseE      *bodyFreeEvidencePhaseE   `json:"phase_e,omitempty"`
+	Privacy     bodyFreeEvidencePrivacy   `json:"privacy"`
+}
+
+type bodyFreeEvidenceHost struct {
+	GOOS      string `json:"goos"`
+	GOARCH    string `json:"goarch"`
+	GoVersion string `json:"go_version"`
+}
+
+type bodyFreeEvidencePreflight struct {
+	RequiredScratchBytes  uint64 `json:"required_scratch_bytes"`
+	AvailableScratchBytes uint64 `json:"available_scratch_bytes"`
+	Capable               bool   `json:"capable"`
+	Reason                string `json:"reason,omitempty"`
+}
+
+type bodyFreeEvidencePhaseA struct {
+	ManagedBytes        int64   `json:"managed_bytes"`
+	StoredBodyBytes     int64   `json:"stored_body_bytes"`
+	Events              int64   `json:"events"`
+	MissingBodyMetadata int64   `json:"missing_body_metadata"`
+	Runs                int     `json:"runs"`
+	P95MS               float64 `json:"p95_ms"`
+	TargetP95MS         float64 `json:"target_p95_ms"`
+	Passed              bool    `json:"passed"`
+}
+
+type bodyFreeEvidencePhaseB struct {
+	SourceManagedBytes   int64   `json:"source_managed_bytes"`
+	ScratchPeakBytes     int64   `json:"scratch_peak_bytes"`
+	Events               int64   `json:"events"`
+	MigrationMS          float64 `json:"migration_ms"`
+	ResumeBackfillMS     float64 `json:"resume_backfill_ms"`
+	Migrations31And32    bool    `json:"migrations_31_32_applied"`
+	IntegrityOK          bool    `json:"integrity_ok"`
+	ForeignKeyViolations int64   `json:"foreign_key_violations"`
+	SourceUnchanged      bool    `json:"source_unchanged"`
+	InitialFTSDocuments  int64   `json:"initial_fts_documents"`
+	InitialFTSComplete   bool    `json:"initial_fts_complete"`
+	FinalFTSDocuments    int64   `json:"final_fts_documents"`
+	FinalFTSComplete     bool    `json:"final_fts_complete"`
+}
+
+type bodyFreeEvidenceProbe struct {
+	Operation         string  `json:"operation"`
+	Projection        string  `json:"projection"`
+	FTSPhase          string  `json:"fts_phase"`
+	Runs              int     `json:"runs"`
+	P95MS             float64 `json:"p95_ms"`
+	ReturnedItems     int     `json:"returned_items"`
+	ReturnedBodyBytes int     `json:"returned_body_bytes"`
+}
+
+type bodyFreeEvidencePhaseD struct {
+	MaxItems                      int  `json:"max_items"`
+	MaxAggregateBodyBytes         int  `json:"max_aggregate_body_bytes"`
+	ObservedMaxItems              int  `json:"observed_max_items"`
+	ObservedMaxAggregateBodyBytes int  `json:"observed_max_aggregate_body_bytes"`
+	Pages                         int  `json:"pages"`
+	TotalItems                    int  `json:"total_items"`
+	MultibyteObserved             bool `json:"multibyte_observed"`
+	BodyBlocksObserved            bool `json:"body_blocks_observed"`
+	ContinuationNoDuplicateOrSkip bool `json:"continuation_no_duplicate_or_skip"`
+}
+
+type bodyFreeEvidencePhaseE struct {
+	HostCount      int  `json:"host_count"`
+	ManifestParity bool `json:"manifest_parity"`
+}
+
+type bodyFreeEvidencePrivacy struct {
+	MetricsOnly    bool `json:"metrics_only"`
+	ScratchPrivate bool `json:"scratch_private"`
+	ScratchCleaned bool `json:"scratch_cleaned"`
+}
+
+type bodyFreeEvidencePhaseBC struct {
+	PhaseB bodyFreeEvidencePhaseB  `json:"phase_b"`
+	PhaseC []bodyFreeEvidenceProbe `json:"phase_c"`
+}
+
+type releaseEvidencePhase string
+
+const (
+	releaseEvidencePhaseA  releaseEvidencePhase = "phase_a"
+	releaseEvidencePhaseBC releaseEvidencePhase = "phase_bc"
+	releaseEvidencePhaseD  releaseEvidencePhase = "phase_d"
+)
+
+type releaseEvidenceDependencies struct {
+	availableScratchBytes func(string) (uint64, error)
+	runPhase              func(context.Context, string, string, releaseEvidencePhase) ([]byte, error)
+	verifyHosts           func(string) error
+	makeTemp              func(string, string) (string, error)
+	removeAll             func(string) error
+	stat                  func(string) (os.FileInfo, error)
+}
+
+func defaultReleaseEvidenceDependencies() releaseEvidenceDependencies {
+	return releaseEvidenceDependencies{
+		availableScratchBytes: availableScratchBytes,
+		runPhase:              runReleaseEvidencePhase,
+		verifyHosts: func(root string) error {
+			return verifyIntegrations(root, false)
+		},
+		makeTemp:  os.MkdirTemp,
+		removeAll: os.RemoveAll,
+		stat:      os.Stat,
+	}
+}
+
+func addReleaseEvidenceCommands(release *cobra.Command) {
+	var runOutput string
+	var scratchRoot string
+	run := &cobra.Command{
+		Use:   "run-v0.33.0-evidence",
+		Short: "Run private multi-GiB release probes and write metrics-only evidence",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := findRepoRoot()
+			if err != nil {
+				return err
+			}
+			evidence := collectV0330BodyFreeEvidence(
+				cmd.Context(),
+				root,
+				scratchRoot,
+				defaultReleaseEvidenceDependencies(),
+			)
+			if err := writeBodyFreeEvidence(cmd.OutOrStdout(), runOutput, evidence); err != nil {
+				return err
+			}
+			if evidence.Status != "pass" {
+				return xerrors.Errorf("v0.33.0 release evidence is blocked: %s", evidence.BlockReason)
+			}
+			return nil
+		},
+	}
+	run.Flags().StringVar(&runOutput, "output", "", "write the metrics-only JSON artifact to this file (default: stdout)")
+	run.Flags().StringVar(&scratchRoot, "scratch-root", "", "private temporary parent directory (default: operating-system temp directory)")
+
+	var verifyInput string
+	var allowBlocked bool
+	verify := &cobra.Command{
+		Use:   "verify-body-free-evidence",
+		Short: "Validate a metrics-only release evidence artifact",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			file, err := os.Open(verifyInput) // #nosec G304 -- explicit maintainer-supplied evidence path
+			if err != nil {
+				return xerrors.Errorf("failed to open evidence input")
+			}
+			defer func() { _ = file.Close() }()
+			evidence, err := decodeBodyFreeEvidence(file)
+			if err != nil {
+				return err
+			}
+			if evidence.Status != "pass" && !allowBlocked {
+				return xerrors.Errorf("release evidence status is %s", evidence.Status)
+			}
+			message := "ok: body-free release evidence is complete"
+			if evidence.Status == "blocked" {
+				message = "ok: blocked body-free release evidence is structurally valid"
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), message); err != nil {
+				return xerrors.Errorf("failed to write evidence verification result: %w", err)
+			}
+			return nil
+		},
+	}
+	verify.Flags().StringVar(&verifyInput, "input", "", "metrics-only evidence JSON")
+	verify.Flags().BoolVar(&allowBlocked, "allow-blocked", false, "validate a sanitized blocked artifact without declaring release readiness")
+	if err := verify.MarkFlagRequired("input"); err != nil {
+		panic(err) // programming error: the flag was just registered
+	}
+
+	release.AddCommand(run)
+	release.AddCommand(verify)
+}
+
+func collectV0330BodyFreeEvidence(
+	ctx context.Context,
+	root string,
+	scratchParent string,
+	deps releaseEvidenceDependencies,
+) BodyFreeEvidence {
+	evidence := BodyFreeEvidence{
+		Schema: bodyFreeEvidenceSchema,
+		Status: "blocked",
+		Host: bodyFreeEvidenceHost{
+			GOOS:      runtime.GOOS,
+			GOARCH:    runtime.GOARCH,
+			GoVersion: runtime.Version(),
+		},
+		Preflight: bodyFreeEvidencePreflight{
+			RequiredScratchBytes: v0330EvidenceRequiredScratchBytes,
+		},
+		Privacy: bodyFreeEvidencePrivacy{
+			MetricsOnly:    true,
+			ScratchCleaned: true,
+		},
+	}
+	if scratchParent == "" {
+		scratchParent = os.TempDir()
+	}
+
+	available, err := deps.availableScratchBytes(scratchParent)
+	evidence.Preflight.AvailableScratchBytes = available
+	if err != nil {
+		evidence.Preflight.Reason = "filesystem_preflight_unavailable"
+		evidence.BlockReason = evidence.Preflight.Reason
+		return evidence
+	}
+	if available < v0330EvidenceRequiredScratchBytes {
+		evidence.Preflight.Reason = "insufficient_disk"
+		evidence.BlockReason = evidence.Preflight.Reason
+		return evidence
+	}
+	evidence.Preflight.Capable = true
+
+	scratch, err := deps.makeTemp(scratchParent, "traceary-v0330-evidence-")
+	if err != nil {
+		evidence.BlockReason = "scratch_create_failed"
+		return evidence
+	}
+	if err := os.Chmod(scratch, 0o700); err != nil {
+		evidence.BlockReason = "scratch_privacy_failed"
+	} else if info, statErr := deps.stat(scratch); statErr != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		evidence.BlockReason = "scratch_privacy_failed"
+	} else {
+		evidence.Privacy.ScratchPrivate = true
+	}
+
+	if evidence.BlockReason == "" {
+		if err := deps.verifyHosts(root); err != nil {
+			evidence.BlockReason = "host_parity_failed"
+		} else {
+			evidence.PhaseE = &bodyFreeEvidencePhaseE{HostCount: 6, ManifestParity: true}
+		}
+	}
+
+	phaseCtx, cancel := context.WithTimeout(ctx, v0330EvidenceRunTimeout)
+	defer cancel()
+	phasesAllowed := evidence.Privacy.ScratchPrivate && evidence.PhaseE != nil
+	setBlockReason := func(reason string) {
+		if evidence.BlockReason == "" {
+			evidence.BlockReason = reason
+		}
+	}
+	if phasesAllowed {
+		output, phaseErr := deps.runPhase(phaseCtx, root, scratch, releaseEvidencePhaseA)
+		parseErr := extractEvidenceMarker(output, bodyFreeEvidencePhaseAMarker, &evidence.PhaseA)
+		if phaseErr != nil {
+			setBlockReason("phase_a_failed")
+		} else if parseErr != nil {
+			evidence.PhaseA = nil
+			setBlockReason("phase_a_evidence_missing")
+		}
+	}
+	if phasesAllowed {
+		output, phaseErr := deps.runPhase(phaseCtx, root, scratch, releaseEvidencePhaseBC)
+		var combined bodyFreeEvidencePhaseBC
+		parseErr := extractEvidenceMarker(output, bodyFreeEvidencePhaseBCMarker, &combined)
+		if parseErr == nil {
+			evidence.PhaseB = &combined.PhaseB
+			evidence.PhaseC = combined.PhaseC
+		}
+		if phaseErr != nil {
+			setBlockReason("phase_bc_failed")
+		} else if parseErr != nil {
+			setBlockReason("phase_bc_evidence_missing")
+		}
+	}
+	if phasesAllowed {
+		output, phaseErr := deps.runPhase(phaseCtx, root, scratch, releaseEvidencePhaseD)
+		parseErr := extractEvidenceMarker(output, bodyFreeEvidencePhaseDMarker, &evidence.PhaseD)
+		if phaseErr != nil {
+			setBlockReason("phase_d_failed")
+		} else if parseErr != nil {
+			evidence.PhaseD = nil
+			setBlockReason("phase_d_evidence_missing")
+		}
+	}
+
+	removeErr := deps.removeAll(scratch)
+	_, statErr := deps.stat(scratch)
+	evidence.Privacy.ScratchCleaned = removeErr == nil && errors.Is(statErr, os.ErrNotExist)
+	if !evidence.Privacy.ScratchCleaned {
+		evidence.BlockReason = "scratch_cleanup_failed"
+	}
+
+	if evidence.BlockReason == "" {
+		evidence.Status = "pass"
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		evidence.Status = "blocked"
+		evidence.BlockReason = "evidence_validation_failed"
+		evidence.PhaseA = nil
+		evidence.PhaseB = nil
+		evidence.PhaseC = nil
+		evidence.PhaseD = nil
+		evidence.PhaseE = nil
+	}
+	return evidence
+}
+
+func runReleaseEvidencePhase(
+	ctx context.Context,
+	root string,
+	scratch string,
+	phase releaseEvidencePhase,
+) ([]byte, error) {
+	var args []string
+	extraEnv := []string{"TMPDIR=" + scratch}
+	switch phase {
+	case releaseEvidencePhaseA:
+		args = []string{
+			"test", "-v", "./infrastructure/sqlite", "-run", "^$",
+			"-bench", "^BenchmarkMetadataDirectRangeMultiGiB$", "-benchtime=1x",
+			"-count=1", "-timeout=45m",
+		}
+		extraEnv = append(extraEnv, "TRACEARY_RUN_MULTI_GIB_BENCHMARK=1")
+	case releaseEvidencePhaseBC:
+		args = []string{
+			"test", "-v", "./infrastructure/sqlite", "-run", "^$",
+			"-bench", "^BenchmarkV0330CopiedStoreReleaseEvidence$", "-benchtime=1x",
+			"-count=1", "-timeout=45m",
+		}
+		extraEnv = append(extraEnv, "TRACEARY_RUN_V0330_RELEASE_EVIDENCE=1")
+	case releaseEvidencePhaseD:
+		args = []string{
+			"test", "-v", "./presentation/mcpserver",
+			"-run", "^TestV0330AggregateReleaseEvidence$", "-count=1", "-timeout=5m",
+		}
+	default:
+		return nil, xerrors.Errorf("unsupported release evidence phase")
+	}
+
+	command := exec.CommandContext(ctx, "go", args...)
+	command.Dir = root
+	command.Env = append(os.Environ(), extraEnv...)
+	output := &cappedEvidenceBuffer{remaining: v0330EvidenceCommandOutputBytes}
+	command.Stdout = output
+	command.Stderr = output
+	err := command.Run()
+	return output.Bytes(), err
+}
+
+type cappedEvidenceBuffer struct {
+	bytes.Buffer
+	remaining int
+}
+
+func (b *cappedEvidenceBuffer) Write(data []byte) (int, error) {
+	original := len(data)
+	if b.remaining > 0 {
+		write := data
+		if len(write) > b.remaining {
+			write = write[:b.remaining]
+		}
+		_, _ = b.Buffer.Write(write)
+		b.remaining -= len(write)
+	}
+	return original, nil
+}
+
+func extractEvidenceMarker(data []byte, marker string, target any) error {
+	index := bytes.LastIndex(data, []byte(marker))
+	if index < 0 {
+		return xerrors.Errorf("release evidence marker is missing")
+	}
+	value := data[index+len(marker):]
+	if newline := bytes.IndexByte(value, '\n'); newline >= 0 {
+		value = value[:newline]
+	}
+	value = bytes.TrimSpace(value)
+	if len(value) == 0 {
+		return xerrors.Errorf("release evidence marker is empty")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return xerrors.Errorf("release evidence marker is invalid")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return xerrors.Errorf("release evidence marker has trailing data")
+	}
+	return nil
+}
+
+func writeBodyFreeEvidence(out io.Writer, outputPath string, evidence BodyFreeEvidence) error {
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(evidence, "", "  ")
+	if err != nil {
+		return xerrors.Errorf("failed to encode body-free release evidence: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	if outputPath == "" {
+		if _, err := out.Write(encoded); err != nil {
+			return xerrors.Errorf("failed to write body-free release evidence: %w", err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(outputPath, encoded, 0o600); err != nil {
+		return xerrors.Errorf("failed to write body-free release evidence")
+	}
+	return nil
+}
+
+func decodeBodyFreeEvidence(reader io.Reader) (BodyFreeEvidence, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, 1<<20))
+	if err != nil {
+		return BodyFreeEvidence{}, xerrors.Errorf("failed to read body-free release evidence")
+	}
+	var generic any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return BodyFreeEvidence{}, xerrors.Errorf("body-free release evidence is invalid JSON")
+	}
+	if err := rejectSensitiveEvidenceKeys(generic); err != nil {
+		return BodyFreeEvidence{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var evidence BodyFreeEvidence
+	if err := decoder.Decode(&evidence); err != nil {
+		return BodyFreeEvidence{}, xerrors.Errorf("body-free release evidence has unknown or invalid fields")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return BodyFreeEvidence{}, xerrors.Errorf("body-free release evidence has trailing data")
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		return BodyFreeEvidence{}, err
+	}
+	return evidence, nil
+}
+
+func rejectSensitiveEvidenceKeys(value any) error {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			switch key {
+			case "body", "raw_body", "prompt", "response", "event_id", "session_id",
+				"workspace", "path", "cursor", "continuation", "ids":
+				return xerrors.Errorf("body-free release evidence contains a forbidden field")
+			}
+			if err := rejectSensitiveEvidenceKeys(nested); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if err := rejectSensitiveEvidenceKeys(nested); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateBodyFreeEvidence(evidence BodyFreeEvidence) error {
+	if evidence.Schema != bodyFreeEvidenceSchema {
+		return xerrors.Errorf("body-free release evidence schema is invalid")
+	}
+	if evidence.Status != "pass" && evidence.Status != "blocked" {
+		return xerrors.Errorf("body-free release evidence status is invalid")
+	}
+	if !validBodyFreeEvidenceGOOS(evidence.Host.GOOS) ||
+		!validBodyFreeEvidenceGOARCH(evidence.Host.GOARCH) ||
+		!bodyFreeEvidenceGoVersionRe.MatchString(evidence.Host.GoVersion) {
+		return xerrors.Errorf("body-free release evidence host value is invalid")
+	}
+	if evidence.Preflight.RequiredScratchBytes != v0330EvidenceRequiredScratchBytes {
+		return xerrors.Errorf("body-free release evidence scratch requirement is invalid")
+	}
+	if evidence.Preflight.Reason != "" &&
+		evidence.Preflight.Reason != "filesystem_preflight_unavailable" &&
+		evidence.Preflight.Reason != "insufficient_disk" {
+		return xerrors.Errorf("body-free release evidence preflight reason is invalid")
+	}
+	if !evidence.Privacy.MetricsOnly || !evidence.Privacy.ScratchCleaned {
+		return xerrors.Errorf("body-free release evidence privacy contract is incomplete")
+	}
+
+	if evidence.PhaseA != nil {
+		if err := validateBodyFreeEvidencePhaseA(*evidence.PhaseA); err != nil {
+			return err
+		}
+	}
+	if evidence.PhaseB != nil {
+		if err := validateBodyFreeEvidencePhaseB(*evidence.PhaseB); err != nil {
+			return err
+		}
+	}
+	if len(evidence.PhaseC) > 0 {
+		if err := validateBodyFreeEvidenceProbes(evidence.PhaseC); err != nil {
+			return err
+		}
+	}
+	if evidence.PhaseD != nil {
+		if err := validateBodyFreeEvidencePhaseD(*evidence.PhaseD); err != nil {
+			return err
+		}
+	}
+	if evidence.PhaseE != nil {
+		if err := validateBodyFreeEvidencePhaseE(*evidence.PhaseE); err != nil {
+			return err
+		}
+	}
+
+	if evidence.Status == "blocked" {
+		allowed := map[string]bool{
+			"filesystem_preflight_unavailable": true,
+			"insufficient_disk":                true,
+			"scratch_create_failed":            true,
+			"scratch_privacy_failed":           true,
+			"host_parity_failed":               true,
+			"phase_a_failed":                   true,
+			"phase_a_evidence_missing":         true,
+			"phase_bc_failed":                  true,
+			"phase_bc_evidence_missing":        true,
+			"phase_d_failed":                   true,
+			"phase_d_evidence_missing":         true,
+			"scratch_cleanup_failed":           true,
+			"evidence_validation_failed":       true,
+		}
+		if !allowed[evidence.BlockReason] {
+			return xerrors.Errorf("body-free release evidence block reason is invalid")
+		}
+		if evidence.Preflight.Capable && evidence.BlockReason == "insufficient_disk" {
+			return xerrors.Errorf("body-free release evidence preflight state is inconsistent")
+		}
+		if evidence.Preflight.Reason != "" && evidence.Preflight.Reason != evidence.BlockReason {
+			return xerrors.Errorf("body-free release evidence preflight reason is inconsistent")
+		}
+		if evidence.Preflight.Reason == "" &&
+			(evidence.BlockReason == "filesystem_preflight_unavailable" ||
+				evidence.BlockReason == "insufficient_disk") {
+			return xerrors.Errorf("body-free release evidence preflight reason is missing")
+		}
+		return nil
+	}
+
+	if evidence.BlockReason != "" || !evidence.Preflight.Capable ||
+		evidence.Preflight.AvailableScratchBytes < evidence.Preflight.RequiredScratchBytes ||
+		evidence.Preflight.Reason != "" || !evidence.Privacy.ScratchPrivate {
+		return xerrors.Errorf("body-free release evidence pass preconditions are incomplete")
+	}
+	if evidence.PhaseA == nil || evidence.PhaseB == nil || evidence.PhaseD == nil || evidence.PhaseE == nil {
+		return xerrors.Errorf("body-free release evidence is missing a phase")
+	}
+	if !evidence.PhaseA.Passed {
+		return xerrors.Errorf("body-free release evidence phase A failed")
+	}
+	if len(evidence.PhaseC) == 0 {
+		return xerrors.Errorf("body-free release evidence is missing phase C")
+	}
+	return nil
+}
+
+func validBodyFreeEvidenceGOOS(value string) bool {
+	switch value {
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos",
+		"ios", "js", "linux", "netbsd", "openbsd", "plan9", "solaris", "wasip1",
+		"windows":
+		return true
+	default:
+		return false
+	}
+}
+
+func validBodyFreeEvidenceGOARCH(value string) bool {
+	switch value {
+	case "386", "amd64", "arm", "arm64", "loong64", "mips", "mips64",
+		"mips64le", "mipsle", "ppc64", "ppc64le", "riscv64", "s390x", "wasm":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
+	if phaseA.ManagedBytes < 2<<30 || phaseA.StoredBodyBytes < 2<<30 ||
+		phaseA.Events != 8 || phaseA.MissingBodyMetadata != 0 ||
+		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 || phaseA.P95MS < 0 ||
+		phaseA.Passed != (phaseA.P95MS < phaseA.TargetP95MS) {
+		return xerrors.Errorf("body-free release evidence phase A is invalid")
+	}
+	return nil
+}
+
+func validateBodyFreeEvidencePhaseB(phaseB bodyFreeEvidencePhaseB) error {
+	if phaseB.SourceManagedBytes < 2<<30 || phaseB.ScratchPeakBytes < phaseB.SourceManagedBytes ||
+		phaseB.Events != 130 || phaseB.MigrationMS < 0 || phaseB.ResumeBackfillMS < 0 ||
+		!phaseB.Migrations31And32 || !phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
+		!phaseB.SourceUnchanged || phaseB.InitialFTSDocuments != 128 || phaseB.InitialFTSComplete ||
+		phaseB.FinalFTSDocuments != phaseB.Events || !phaseB.FinalFTSComplete {
+		return xerrors.Errorf("body-free release evidence phase B failed")
+	}
+	return nil
+}
+
+func validateBodyFreeEvidencePhaseD(phaseD bodyFreeEvidencePhaseD) error {
+	if phaseD.MaxItems != 100 || phaseD.MaxAggregateBodyBytes != 64*1024 ||
+		phaseD.ObservedMaxItems <= 0 || phaseD.ObservedMaxItems > phaseD.MaxItems ||
+		phaseD.ObservedMaxAggregateBodyBytes <= 0 ||
+		phaseD.ObservedMaxAggregateBodyBytes > phaseD.MaxAggregateBodyBytes ||
+		phaseD.Pages < 2 || phaseD.TotalItems != 100 ||
+		!phaseD.MultibyteObserved || !phaseD.BodyBlocksObserved ||
+		!phaseD.ContinuationNoDuplicateOrSkip {
+		return xerrors.Errorf("body-free release evidence phase D failed")
+	}
+	return nil
+}
+
+func validateBodyFreeEvidencePhaseE(phaseE bodyFreeEvidencePhaseE) error {
+	if phaseE.HostCount != 6 || !phaseE.ManifestParity {
+		return xerrors.Errorf("body-free release evidence phase E failed")
+	}
+	return nil
+}
+
+func validateBodyFreeEvidenceProbes(probes []bodyFreeEvidenceProbe) error {
+	expected := map[string]bool{
+		"list|metadata|not_applicable":    true,
+		"list|bounded|not_applicable":     true,
+		"context|metadata|not_applicable": true,
+		"context|bounded|not_applicable":  true,
+		"search|metadata|incomplete":      true,
+		"search|bounded|incomplete":       true,
+		"search|metadata|complete":        true,
+		"search|bounded|complete":         true,
+	}
+	seen := make(map[string]bool, len(probes))
+	for _, probe := range probes {
+		key := strings.Join([]string{probe.Operation, probe.Projection, probe.FTSPhase}, "|")
+		if !expected[key] || seen[key] {
+			return xerrors.Errorf("body-free release evidence phase C has an unexpected probe")
+		}
+		seen[key] = true
+		if probe.Runs != 25 || probe.P95MS < 0 ||
+			probe.ReturnedItems < 0 || probe.ReturnedItems > 100 ||
+			probe.ReturnedBodyBytes < 0 {
+			return xerrors.Errorf("body-free release evidence phase C probe is invalid")
+		}
+		if probe.Projection == "metadata" && probe.ReturnedBodyBytes != 0 {
+			return xerrors.Errorf("body-free release evidence metadata probe returned body bytes")
+		}
+	}
+	if len(seen) != len(expected) {
+		keys := make([]string, 0, len(expected)-len(seen))
+		for key := range expected {
+			if !seen[key] {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		return xerrors.Errorf("body-free release evidence phase C is incomplete")
+	}
+	return nil
+}

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -67,6 +67,8 @@ type bodyFreeEvidencePhaseA struct {
 	StoredBodyBytes     int64   `json:"stored_body_bytes"`
 	Events              int64   `json:"events"`
 	MissingBodyMetadata int64   `json:"missing_body_metadata"`
+	OrderedIndex        bool    `json:"ordered_index"`
+	CoveringIndex       bool    `json:"covering_index"`
 	Runs                int     `json:"runs"`
 	P95MS               float64 `json:"p95_ms"`
 	TargetP95MS         float64 `json:"target_p95_ms"`
@@ -74,19 +76,19 @@ type bodyFreeEvidencePhaseA struct {
 }
 
 type bodyFreeEvidencePhaseB struct {
-	SourceManagedBytes   int64   `json:"source_managed_bytes"`
-	ScratchPeakBytes     int64   `json:"scratch_peak_bytes"`
-	Events               int64   `json:"events"`
-	MigrationMS          float64 `json:"migration_ms"`
-	ResumeBackfillMS     float64 `json:"resume_backfill_ms"`
-	Migrations31And32    bool    `json:"migrations_31_32_applied"`
-	IntegrityOK          bool    `json:"integrity_ok"`
-	ForeignKeyViolations int64   `json:"foreign_key_violations"`
-	SourceUnchanged      bool    `json:"source_unchanged"`
-	InitialFTSDocuments  int64   `json:"initial_fts_documents"`
-	InitialFTSComplete   bool    `json:"initial_fts_complete"`
-	FinalFTSDocuments    int64   `json:"final_fts_documents"`
-	FinalFTSComplete     bool    `json:"final_fts_complete"`
+	SourceManagedBytes          int64   `json:"source_managed_bytes"`
+	ScratchBytesAfterCheckpoint int64   `json:"scratch_bytes_after_checkpoint"`
+	Events                      int64   `json:"events"`
+	MigrationMS                 float64 `json:"migration_ms"`
+	ResumeBackfillMS            float64 `json:"resume_backfill_ms"`
+	Migrations31And32           bool    `json:"migrations_31_32_applied"`
+	IntegrityOK                 bool    `json:"integrity_ok"`
+	ForeignKeyViolations        int64   `json:"foreign_key_violations"`
+	SourceUnchanged             bool    `json:"source_unchanged"`
+	InitialFTSDocuments         int64   `json:"initial_fts_documents"`
+	InitialFTSComplete          bool    `json:"initial_fts_complete"`
+	FinalFTSDocuments           int64   `json:"final_fts_documents"`
+	FinalFTSComplete            bool    `json:"final_fts_complete"`
 }
 
 type bodyFreeEvidenceProbe struct {
@@ -631,6 +633,7 @@ func validBodyFreeEvidenceGOARCH(value string) bool {
 func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 	if phaseA.ManagedBytes < 2<<30 || phaseA.StoredBodyBytes < 2<<30 ||
 		phaseA.Events != 8 || phaseA.MissingBodyMetadata != 0 ||
+		!phaseA.OrderedIndex ||
 		phaseA.Runs != 25 || phaseA.TargetP95MS != 250 || phaseA.P95MS < 0 ||
 		phaseA.Passed != (phaseA.P95MS < phaseA.TargetP95MS) {
 		return xerrors.Errorf("body-free release evidence phase A is invalid")
@@ -639,7 +642,8 @@ func validateBodyFreeEvidencePhaseA(phaseA bodyFreeEvidencePhaseA) error {
 }
 
 func validateBodyFreeEvidencePhaseB(phaseB bodyFreeEvidencePhaseB) error {
-	if phaseB.SourceManagedBytes < 2<<30 || phaseB.ScratchPeakBytes < phaseB.SourceManagedBytes ||
+	if phaseB.SourceManagedBytes < 2<<30 ||
+		phaseB.ScratchBytesAfterCheckpoint < 2*phaseB.SourceManagedBytes ||
 		phaseB.Events != 130 || phaseB.MigrationMS < 0 || phaseB.ResumeBackfillMS < 0 ||
 		!phaseB.Migrations31And32 || !phaseB.IntegrityOK || phaseB.ForeignKeyViolations != 0 ||
 		!phaseB.SourceUnchanged || phaseB.InitialFTSDocuments != 128 || phaseB.InitialFTSComplete ||

--- a/cmd/repo-tooling/release_evidence.go
+++ b/cmd/repo-tooling/release_evidence.go
@@ -726,7 +726,7 @@ func validateBodyFreeEvidenceProbes(probes []bodyFreeEvidenceProbe) error {
 		}
 		if probe.Projection == "bounded_huge" {
 			if probe.ReturnedItems != 1 || probe.ReturnedBodyBytes <= 0 ||
-				probe.SourceBodyBytes != 256<<20 || probe.BoundedBudgetBytes <= 0 ||
+				probe.SourceBodyBytes != 256<<20 || probe.BoundedBudgetBytes != 500 ||
 				probe.ReturnedBodyBytes > probe.BoundedBudgetBytes ||
 				int64(probe.ReturnedBodyBytes) >= probe.SourceBodyBytes {
 				return xerrors.Errorf("body-free release evidence huge-body probe is invalid")

--- a/cmd/repo-tooling/release_evidence_disk_other.go
+++ b/cmd/repo-tooling/release_evidence_disk_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+
+package main
+
+import "golang.org/x/xerrors"
+
+func availableScratchBytes(string) (uint64, error) {
+	return 0, xerrors.Errorf("scratch capacity preflight is unavailable on this platform")
+}

--- a/cmd/repo-tooling/release_evidence_disk_unix.go
+++ b/cmd/repo-tooling/release_evidence_disk_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
+)
+
+func availableScratchBytes(path string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, xerrors.Errorf("failed to inspect scratch capacity")
+	}
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
+}

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateBodyFreeEvidence_AcceptsCompleteMetricsOnlyArtifact(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("validateBodyFreeEvidence() error = %v", err)
+	}
+
+	var encoded bytes.Buffer
+	if err := writeBodyFreeEvidence(&encoded, "", evidence); err != nil {
+		t.Fatalf("writeBodyFreeEvidence() error = %v", err)
+	}
+	for _, forbidden := range []string{
+		`"event_id"`, `"session_id"`, `"workspace"`, `"path"`,
+		`"cursor"`, `"continuation"`, `"prompt"`, `"response"`, `"body"`,
+	} {
+		if strings.Contains(encoded.String(), forbidden) {
+			t.Fatalf("evidence contains forbidden key %s:\n%s", forbidden, encoded.String())
+		}
+	}
+	if _, err := decodeBodyFreeEvidence(bytes.NewReader(encoded.Bytes())); err != nil {
+		t.Fatalf("decodeBodyFreeEvidence() error = %v", err)
+	}
+}
+
+func TestDecodeBodyFreeEvidence_RejectsUnknownSensitiveField(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(validBodyFreeEvidenceFixture())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	encoded = bytes.TrimSuffix(encoded, []byte("}"))
+	encoded = append(encoded, []byte(`,"path":"/private/tmp/private-store"}`)...)
+	if _, err := decodeBodyFreeEvidence(bytes.NewReader(encoded)); err == nil {
+		t.Fatal("decodeBodyFreeEvidence() error = nil, want a sensitive-field rejection")
+	}
+}
+
+func TestValidateBodyFreeEvidence_RejectsArbitraryStringFields(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.Preflight.Reason = "/private/tmp/private-store"
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("arbitrary preflight reason unexpectedly passed")
+	}
+
+	evidence = validBodyFreeEvidenceFixture()
+	evidence.Host.GoVersion = "private-secret"
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("arbitrary host version unexpectedly passed")
+	}
+}
+
+func TestExtractEvidenceMarker_RejectsTrailingData(t *testing.T) {
+	t.Parallel()
+
+	valid := validBodyFreeEvidenceFixture()
+	marker := markerFixture(t, bodyFreeEvidencePhaseDMarker, *valid.PhaseD)
+	marker = bytes.Replace(marker, []byte("}\n"), []byte("} unexpected\n"), 1)
+	var phase bodyFreeEvidencePhaseD
+	if err := extractEvidenceMarker(marker, bodyFreeEvidencePhaseDMarker, &phase); err == nil {
+		t.Fatal("marker with trailing data unexpectedly passed")
+	}
+}
+
+func TestValidateBodyFreeEvidence_RejectsMetadataBodyBytesAndPhaseCGatesNoLatency(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	for index := range evidence.PhaseC {
+		if evidence.PhaseC[index].Projection == "metadata" {
+			evidence.PhaseC[index].ReturnedBodyBytes = 1
+			break
+		}
+	}
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("metadata body bytes unexpectedly passed")
+	}
+
+	evidence = validBodyFreeEvidenceFixture()
+	for index := range evidence.PhaseC {
+		evidence.PhaseC[index].P95MS = 999_999
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("Phase-C observation-only p95 unexpectedly failed: %v", err)
+	}
+}
+
+func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.Status = "blocked"
+	evidence.BlockReason = "phase_a_failed"
+	evidence.PhaseA.P95MS = 300
+	evidence.PhaseA.Passed = false
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("valid blocked evidence unexpectedly failed: %v", err)
+	}
+
+	evidence.PhaseB.Events = 0
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("blocked evidence with an invalid present phase unexpectedly passed")
+	}
+}
+
+func TestCollectV0330BodyFreeEvidence_BlocksBeforeScratchWhenDiskIsInsufficient(t *testing.T) {
+	t.Parallel()
+
+	phaseCalled := false
+	deps := defaultReleaseEvidenceDependencies()
+	deps.availableScratchBytes = func(string) (uint64, error) {
+		return v0330EvidenceRequiredScratchBytes - 1, nil
+	}
+	deps.runPhase = func(context.Context, string, string, releaseEvidencePhase) ([]byte, error) {
+		phaseCalled = true
+		return nil, errors.New("must not run")
+	}
+	evidence := collectV0330BodyFreeEvidence(context.Background(), t.TempDir(), t.TempDir(), deps)
+	if evidence.Status != "blocked" || evidence.BlockReason != "insufficient_disk" {
+		t.Fatalf("blocked evidence = %+v", evidence)
+	}
+	if evidence.Preflight.Capable || !evidence.Privacy.MetricsOnly || !evidence.Privacy.ScratchCleaned {
+		t.Fatalf("blocked preflight/privacy = %+v / %+v", evidence.Preflight, evidence.Privacy)
+	}
+	if phaseCalled {
+		t.Fatal("a multi-GiB phase ran after insufficient-disk preflight")
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("sanitized blocked evidence is invalid: %v", err)
+	}
+}
+
+func TestCollectV0330BodyFreeEvidence_CleansPrivateScratchAndMergesMarkers(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	var observedScratch string
+	deps := defaultReleaseEvidenceDependencies()
+	deps.availableScratchBytes = func(string) (uint64, error) {
+		return v0330EvidenceRequiredScratchBytes, nil
+	}
+	deps.verifyHosts = func(string) error { return nil }
+	deps.runPhase = func(_ context.Context, _ string, scratch string, phase releaseEvidencePhase) ([]byte, error) {
+		observedScratch = scratch
+		info, err := os.Stat(scratch)
+		if err != nil {
+			t.Fatalf("Stat(scratch) error = %v", err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("scratch mode = %o, want 0700", info.Mode().Perm())
+		}
+		switch phase {
+		case releaseEvidencePhaseA:
+			return markerFixture(t, bodyFreeEvidencePhaseAMarker, *validBodyFreeEvidenceFixture().PhaseA), nil
+		case releaseEvidencePhaseBC:
+			valid := validBodyFreeEvidenceFixture()
+			return markerFixture(t, bodyFreeEvidencePhaseBCMarker, bodyFreeEvidencePhaseBC{
+				PhaseB: *valid.PhaseB,
+				PhaseC: valid.PhaseC,
+			}), nil
+		case releaseEvidencePhaseD:
+			return markerFixture(t, bodyFreeEvidencePhaseDMarker, *validBodyFreeEvidenceFixture().PhaseD), nil
+		default:
+			return nil, errors.New("unsupported phase")
+		}
+	}
+
+	evidence := collectV0330BodyFreeEvidence(context.Background(), t.TempDir(), parent, deps)
+	if evidence.Status != "pass" {
+		t.Fatalf("collectV0330BodyFreeEvidence() = %+v", evidence)
+	}
+	if observedScratch == "" {
+		t.Fatal("no scratch directory was observed")
+	}
+	if _, err := os.Stat(observedScratch); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("scratch still exists or returned an unexpected error: %v", err)
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("validateBodyFreeEvidence() error = %v", err)
+	}
+
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), filepath.ToSlash(observedScratch)) {
+		t.Fatalf("evidence exposed scratch path: %s", encoded)
+	}
+}
+
+func TestCollectV0330BodyFreeEvidence_SanitizesInvalidPhaseMetrics(t *testing.T) {
+	t.Parallel()
+
+	deps := defaultReleaseEvidenceDependencies()
+	deps.availableScratchBytes = func(string) (uint64, error) {
+		return v0330EvidenceRequiredScratchBytes, nil
+	}
+	deps.verifyHosts = func(string) error { return nil }
+	deps.runPhase = func(_ context.Context, _ string, _ string, phase releaseEvidencePhase) ([]byte, error) {
+		valid := validBodyFreeEvidenceFixture()
+		switch phase {
+		case releaseEvidencePhaseA:
+			valid.PhaseA.P95MS = -1
+			return markerFixture(t, bodyFreeEvidencePhaseAMarker, *valid.PhaseA), nil
+		case releaseEvidencePhaseBC:
+			return markerFixture(t, bodyFreeEvidencePhaseBCMarker, bodyFreeEvidencePhaseBC{
+				PhaseB: *valid.PhaseB,
+				PhaseC: valid.PhaseC,
+			}), nil
+		case releaseEvidencePhaseD:
+			return markerFixture(t, bodyFreeEvidencePhaseDMarker, *valid.PhaseD), nil
+		default:
+			return nil, errors.New("unsupported phase")
+		}
+	}
+
+	evidence := collectV0330BodyFreeEvidence(context.Background(), t.TempDir(), t.TempDir(), deps)
+	if evidence.Status != "blocked" || evidence.BlockReason != "evidence_validation_failed" {
+		t.Fatalf("invalid phase evidence = %+v", evidence)
+	}
+	if evidence.PhaseA != nil || evidence.PhaseB != nil || len(evidence.PhaseC) != 0 ||
+		evidence.PhaseD != nil || evidence.PhaseE != nil {
+		t.Fatalf("invalid phase metrics were retained: %+v", evidence)
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("sanitized blocker is invalid: %v", err)
+	}
+}
+
+func markerFixture(t *testing.T, marker string, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(marker) error = %v", err)
+	}
+	return append(append([]byte("test output\n"+marker), encoded...), '\n')
+}
+
+func validBodyFreeEvidenceFixture() BodyFreeEvidence {
+	probes := make([]bodyFreeEvidenceProbe, 0, 8)
+	for _, row := range []struct {
+		operation, projection, fts string
+	}{
+		{"list", "metadata", "not_applicable"},
+		{"list", "bounded", "not_applicable"},
+		{"context", "metadata", "not_applicable"},
+		{"context", "bounded", "not_applicable"},
+		{"search", "metadata", "incomplete"},
+		{"search", "bounded", "incomplete"},
+		{"search", "metadata", "complete"},
+		{"search", "bounded", "complete"},
+	} {
+		bodyBytes := 0
+		if row.projection == "bounded" {
+			bodyBytes = 512
+		}
+		probes = append(probes, bodyFreeEvidenceProbe{
+			Operation: row.operation, Projection: row.projection, FTSPhase: row.fts,
+			Runs: 25, P95MS: 1.25, ReturnedItems: 20, ReturnedBodyBytes: bodyBytes,
+		})
+	}
+	return BodyFreeEvidence{
+		Schema: bodyFreeEvidenceSchema,
+		Status: "pass",
+		Host: bodyFreeEvidenceHost{
+			GOOS: "darwin", GOARCH: "arm64", GoVersion: "go1.26.3",
+		},
+		Preflight: bodyFreeEvidencePreflight{
+			RequiredScratchBytes:  v0330EvidenceRequiredScratchBytes,
+			AvailableScratchBytes: v0330EvidenceRequiredScratchBytes,
+			Capable:               true,
+		},
+		PhaseA: &bodyFreeEvidencePhaseA{
+			ManagedBytes: 2 << 30, StoredBodyBytes: 2 << 30,
+			Events: 8, MissingBodyMetadata: 0, Runs: 25,
+			P95MS: 1.5, TargetP95MS: 250, Passed: true,
+		},
+		PhaseB: &bodyFreeEvidencePhaseB{
+			SourceManagedBytes: 2 << 30, ScratchPeakBytes: 4 << 30,
+			Events: 130, MigrationMS: 25, ResumeBackfillMS: 2,
+			Migrations31And32: true, IntegrityOK: true, ForeignKeyViolations: 0,
+			SourceUnchanged: true, InitialFTSDocuments: 128, InitialFTSComplete: false,
+			FinalFTSDocuments: 130, FinalFTSComplete: true,
+		},
+		PhaseC: probes,
+		PhaseD: &bodyFreeEvidencePhaseD{
+			MaxItems: 100, MaxAggregateBodyBytes: 64 * 1024,
+			ObservedMaxItems: 24, ObservedMaxAggregateBodyBytes: 64_000,
+			Pages: 5, TotalItems: 100, MultibyteObserved: true,
+			BodyBlocksObserved: true, ContinuationNoDuplicateOrSkip: true,
+		},
+		PhaseE: &bodyFreeEvidencePhaseE{HostCount: 6, ManifestParity: true},
+		Privacy: bodyFreeEvidencePrivacy{
+			MetricsOnly: true, ScratchPrivate: true, ScratchCleaned: true,
+		},
+	}
+}

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -494,7 +494,7 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 			Migrations31Through34: true, ProjectionRows: 130,
 			IntegrityOK: true, ForeignKeyViolations: 0,
 			SourceUnchanged: true, InitialFTSDocuments: 128, InitialFTSComplete: false,
-			FinalFTSDocuments: 130, FinalFTSComplete: true,
+			FinalFTSDocuments: 130, FinalFTSComplete: true, PreProjectionWriterOK: true,
 		},
 		PhaseC: probes,
 		PhaseD: &bodyFreeEvidencePhaseD{

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -471,6 +471,11 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 			Runs: 25, P95MS: 1.25, ReturnedItems: 20, ReturnedBodyBytes: bodyBytes,
 		})
 	}
+	probes = append(probes, bodyFreeEvidenceProbe{
+		Operation: "list", Projection: "bounded_huge", FTSPhase: "not_applicable",
+		Runs: 25, P95MS: 1.25, ReturnedItems: 1, ReturnedBodyBytes: 500,
+		SourceBodyBytes: 256 << 20, BoundedBudgetBytes: 64 * 1024,
+	})
 	return BodyFreeEvidence{
 		Schema: bodyFreeEvidenceSchema,
 		Status: "pass",

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -101,18 +101,41 @@ func TestValidateBodyFreeEvidence_RejectsMetadataBodyBytesAndPhaseCGatesNoLatenc
 	}
 }
 
-func TestValidateBodyFreeEvidence_RequiresOrderedIndexButOnlyObservesCoveringIndex(t *testing.T) {
+func TestValidateBodyFreeEvidence_RequiresProjectionOnlyPlanAndBodyFreeResults(t *testing.T) {
 	t.Parallel()
 
 	evidence := validBodyFreeEvidenceFixture()
-	evidence.PhaseA.CoveringIndex = false
-	if err := validateBodyFreeEvidence(evidence); err != nil {
-		t.Fatalf("non-covering Phase-A plan unexpectedly failed validation: %v", err)
+	evidence.PhaseA.ProjectionOnly = false
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase-A plan using the authoritative event table unexpectedly passed")
 	}
 
-	evidence.PhaseA.OrderedIndex = false
+	evidence = validBodyFreeEvidenceFixture()
+	evidence.PhaseA.ReturnedBodyBytes = 1
 	if err := validateBodyFreeEvidence(evidence); err == nil {
-		t.Fatal("Phase-A plan without its ordered index unexpectedly passed")
+		t.Fatal("Phase-A result containing body bytes unexpectedly passed")
+	}
+
+	evidence = validBodyFreeEvidenceFixture()
+	evidence.PhaseA.ProjectionRows--
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase-A projection row mismatch unexpectedly passed")
+	}
+}
+
+func TestValidateBodyFreeEvidence_RequiresProjectionMigrationParity(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.PhaseB.Migrations31Through34 = false
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase B without migration 34 unexpectedly passed")
+	}
+
+	evidence = validBodyFreeEvidenceFixture()
+	evidence.PhaseB.ProjectionRows--
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase-B projection row mismatch unexpectedly passed")
 	}
 }
 
@@ -303,14 +326,15 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 		},
 		PhaseA: &bodyFreeEvidencePhaseA{
 			ManagedBytes: 2 << 30, StoredBodyBytes: 2 << 30,
-			Events: 8, MissingBodyMetadata: 0,
-			OrderedIndex: true, CoveringIndex: true, Runs: 25,
+			Events: 8, ProjectionRows: 8, MissingBodyMetadata: 0,
+			ProjectionOnly: true, ReturnedBodyBytes: 0, Runs: 25,
 			P95MS: 1.5, TargetP95MS: 250, Passed: true,
 		},
 		PhaseB: &bodyFreeEvidencePhaseB{
 			SourceManagedBytes: 2 << 30, ScratchBytesAfterCheckpoint: 4 << 30,
 			Events: 130, MigrationMS: 25, ResumeBackfillMS: 2,
-			Migrations31And32: true, IntegrityOK: true, ForeignKeyViolations: 0,
+			Migrations31Through34: true, ProjectionRows: 130,
+			IntegrityOK: true, ForeignKeyViolations: 0,
 			SourceUnchanged: true, InitialFTSDocuments: 128, InitialFTSComplete: false,
 			FinalFTSDocuments: 130, FinalFTSComplete: true,
 		},

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -474,7 +474,7 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 	probes = append(probes, bodyFreeEvidenceProbe{
 		Operation: "list", Projection: "bounded_huge", FTSPhase: "not_applicable",
 		Runs: 25, P95MS: 1.25, ReturnedItems: 1, ReturnedBodyBytes: 500,
-		SourceBodyBytes: 256 << 20, BoundedBudgetBytes: 64 * 1024,
+		SourceBodyBytes: 256 << 20, BoundedBudgetBytes: 500,
 	})
 	return BodyFreeEvidence{
 		Schema: bodyFreeEvidenceSchema,

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -139,6 +139,16 @@ func TestValidateBodyFreeEvidence_RequiresProjectionMigrationParity(t *testing.T
 	}
 }
 
+func TestValidateBodyFreeEvidence_RequiresAggregateTruncationMetadata(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.PhaseD.TruncationMetadataObserved = false
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase D without observable truncation metadata unexpectedly passed")
+	}
+}
+
 func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -343,7 +353,8 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 			MaxItems: 100, MaxAggregateBodyBytes: 64 * 1024,
 			ObservedMaxItems: 24, ObservedMaxAggregateBodyBytes: 64_000,
 			Pages: 5, TotalItems: 100, MultibyteObserved: true,
-			BodyBlocksObserved: true, ContinuationNoDuplicateOrSkip: true,
+			BodyBlocksObserved: true, TruncationMetadataObserved: true,
+			ContinuationNoDuplicateOrSkip: true,
 		},
 		PhaseE: &bodyFreeEvidencePhaseE{HostCount: 6, ManifestParity: true},
 		Privacy: bodyFreeEvidencePrivacy{

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +34,65 @@ func TestValidateBodyFreeEvidence_AcceptsCompleteMetricsOnlyArtifact(t *testing.
 	}
 	if _, err := decodeBodyFreeEvidence(bytes.NewReader(encoded.Bytes())); err != nil {
 		t.Fatalf("decodeBodyFreeEvidence() error = %v", err)
+	}
+}
+
+func TestValidateBodyFreeEvidence_EnforcesPhaseAP95Gate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		p95MS   float64
+		passed  bool
+		wantErr bool
+	}{
+		{name: "accepts a measured value below the target", p95MS: 249.999, passed: true},
+		{name: "rejects the target boundary", p95MS: 250, passed: true, wantErr: true},
+		{name: "rejects a value above the target", p95MS: 250.001, passed: true, wantErr: true},
+		{name: "rejects an omitted measurement decoded as zero", p95MS: 0, passed: true, wantErr: true},
+		{name: "rejects a negative measurement", p95MS: -1, passed: false, wantErr: true},
+		{name: "rejects NaN", p95MS: math.NaN(), passed: false, wantErr: true},
+		{name: "rejects positive infinity", p95MS: math.Inf(1), passed: true, wantErr: true},
+		{name: "rejects negative infinity", p95MS: math.Inf(-1), passed: false, wantErr: true},
+		{name: "rejects a failed under-target measurement", p95MS: 249.999, passed: false, wantErr: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := validBodyFreeEvidenceFixture()
+			evidence.PhaseA.P95MS = test.p95MS
+			evidence.PhaseA.Passed = test.passed
+			err := validateBodyFreeEvidence(evidence)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateBodyFreeEvidence() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeBodyFreeEvidence_RejectsMissingPhaseAP95Measurement(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(validBodyFreeEvidenceFixture())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	phaseA, ok := document["phase_a"].(map[string]any)
+	if !ok {
+		t.Fatal("phase_a is missing from the fixture")
+	}
+	delete(phaseA, "p95_ms")
+	encoded, err = json.Marshal(document)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if _, err := decodeBodyFreeEvidence(bytes.NewReader(encoded)); err == nil {
+		t.Fatal("evidence without a Phase-A p95 measurement unexpectedly passed")
 	}
 }
 
@@ -244,9 +304,7 @@ func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *tes
 
 	evidence := validBodyFreeEvidenceFixture()
 	evidence.Status = "blocked"
-	evidence.BlockReason = "phase_a_failed"
-	evidence.PhaseA.P95MS = 300
-	evidence.PhaseA.Passed = false
+	evidence.BlockReason = "phase_bc_failed"
 	if err := validateBodyFreeEvidence(evidence); err != nil {
 		t.Fatalf("valid blocked evidence unexpectedly failed: %v", err)
 	}

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -149,6 +149,16 @@ func TestValidateBodyFreeEvidence_RequiresAggregateTruncationMetadata(t *testing
 	}
 }
 
+func TestValidateBodyFreeEvidence_RequiresStagedRetrievalParity(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.PhaseE.StagedRetrievalParity = false
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase E without staged-retrieval parity unexpectedly passed")
+	}
+}
+
 func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -356,7 +366,9 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 			BodyBlocksObserved: true, TruncationMetadataObserved: true,
 			ContinuationNoDuplicateOrSkip: true,
 		},
-		PhaseE: &bodyFreeEvidencePhaseE{HostCount: 6, ManifestParity: true},
+		PhaseE: &bodyFreeEvidencePhaseE{
+			HostCount: 6, ManifestParity: true, StagedRetrievalParity: true,
+		},
 		Privacy: bodyFreeEvidencePrivacy{
 			MetricsOnly: true, ScratchPrivate: true, ScratchCleaned: true,
 		},

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -50,6 +50,51 @@ func TestDecodeBodyFreeEvidence_RejectsUnknownSensitiveField(t *testing.T) {
 	}
 }
 
+func TestDecodeBodyFreeEvidence_EnforcesSizeLimitBeforeDecode(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(validBodyFreeEvidenceFixture())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if len(encoded) >= bodyFreeEvidenceMaxBytes {
+		t.Fatalf("fixture bytes = %d, want below %d", len(encoded), bodyFreeEvidenceMaxBytes)
+	}
+
+	t.Run("accepts exactly the size limit", func(t *testing.T) {
+		t.Parallel()
+
+		input := append(bytes.Clone(encoded), bytes.Repeat([]byte(" "), bodyFreeEvidenceMaxBytes-len(encoded))...)
+		if _, err := decodeBodyFreeEvidence(bytes.NewReader(input)); err != nil {
+			t.Fatalf("decodeBodyFreeEvidence() error = %v", err)
+		}
+	})
+
+	t.Run("rejects a valid prefix before padded trailing sensitive data", func(t *testing.T) {
+		t.Parallel()
+
+		input := append(
+			bytes.Clone(encoded),
+			bytes.Repeat([]byte(" "), bodyFreeEvidenceMaxBytes-len(encoded))...,
+		)
+		input = append(input, []byte(`{"path":"private-store"}`)...)
+		if _, err := decodeBodyFreeEvidence(bytes.NewReader(input)); err == nil ||
+			!strings.Contains(err.Error(), "exceeds size limit") {
+			t.Fatalf("decodeBodyFreeEvidence() error = %v, want size-limit rejection", err)
+		}
+	})
+
+	t.Run("rejects size limit plus one", func(t *testing.T) {
+		t.Parallel()
+
+		input := bytes.Repeat([]byte(" "), bodyFreeEvidenceMaxBytes+1)
+		if _, err := decodeBodyFreeEvidence(bytes.NewReader(input)); err == nil ||
+			!strings.Contains(err.Error(), "exceeds size limit") {
+			t.Fatalf("decodeBodyFreeEvidence() error = %v, want size-limit rejection", err)
+		}
+	})
+}
+
 func TestValidateBodyFreeEvidence_RejectsArbitraryStringFields(t *testing.T) {
 	t.Parallel()
 
@@ -101,6 +146,35 @@ func TestValidateBodyFreeEvidence_RejectsMetadataBodyBytesAndPhaseCGatesNoLatenc
 	}
 }
 
+func TestValidateBodyFreeEvidence_RequiresPhaseCRetrievalResults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects zero returned items", func(t *testing.T) {
+		t.Parallel()
+
+		evidence := validBodyFreeEvidenceFixture()
+		evidence.PhaseC[0].ReturnedItems = 0
+		if err := validateBodyFreeEvidence(evidence); err == nil {
+			t.Fatal("Phase-C zero-item result unexpectedly passed")
+		}
+	})
+
+	t.Run("rejects zero bounded body bytes", func(t *testing.T) {
+		t.Parallel()
+
+		evidence := validBodyFreeEvidenceFixture()
+		for index := range evidence.PhaseC {
+			if evidence.PhaseC[index].Projection == "bounded" {
+				evidence.PhaseC[index].ReturnedBodyBytes = 0
+				break
+			}
+		}
+		if err := validateBodyFreeEvidence(evidence); err == nil {
+			t.Fatal("Phase-C bounded result with zero body bytes unexpectedly passed")
+		}
+	})
+}
+
 func TestValidateBodyFreeEvidence_RequiresProjectionOnlyPlanAndBodyFreeResults(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +194,12 @@ func TestValidateBodyFreeEvidence_RequiresProjectionOnlyPlanAndBodyFreeResults(t
 	evidence.PhaseA.ProjectionRows--
 	if err := validateBodyFreeEvidence(evidence); err == nil {
 		t.Fatal("Phase-A projection row mismatch unexpectedly passed")
+	}
+
+	evidence = validBodyFreeEvidenceFixture()
+	evidence.PhaseA.ReturnedItems--
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase-A incomplete result set unexpectedly passed")
 	}
 }
 
@@ -347,7 +427,7 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 		PhaseA: &bodyFreeEvidencePhaseA{
 			ManagedBytes: 2 << 30, StoredBodyBytes: 2 << 30,
 			Events: 8, ProjectionRows: 8, MissingBodyMetadata: 0,
-			ProjectionOnly: true, ReturnedBodyBytes: 0, Runs: 25,
+			ProjectionOnly: true, ReturnedItems: 8, ReturnedBodyBytes: 0, Runs: 25,
 			P95MS: 1.5, TargetP95MS: 250, Passed: true,
 		},
 		PhaseB: &bodyFreeEvidencePhaseB{

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -101,6 +101,21 @@ func TestValidateBodyFreeEvidence_RejectsMetadataBodyBytesAndPhaseCGatesNoLatenc
 	}
 }
 
+func TestValidateBodyFreeEvidence_RequiresOrderedIndexButOnlyObservesCoveringIndex(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.PhaseA.CoveringIndex = false
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("non-covering Phase-A plan unexpectedly failed validation: %v", err)
+	}
+
+	evidence.PhaseA.OrderedIndex = false
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("Phase-A plan without its ordered index unexpectedly passed")
+	}
+}
+
 func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -288,11 +303,12 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 		},
 		PhaseA: &bodyFreeEvidencePhaseA{
 			ManagedBytes: 2 << 30, StoredBodyBytes: 2 << 30,
-			Events: 8, MissingBodyMetadata: 0, Runs: 25,
+			Events: 8, MissingBodyMetadata: 0,
+			OrderedIndex: true, CoveringIndex: true, Runs: 25,
 			P95MS: 1.5, TargetP95MS: 250, Passed: true,
 		},
 		PhaseB: &bodyFreeEvidencePhaseB{
-			SourceManagedBytes: 2 << 30, ScratchPeakBytes: 4 << 30,
+			SourceManagedBytes: 2 << 30, ScratchBytesAfterCheckpoint: 4 << 30,
 			Events: 130, MigrationMS: 25, ResumeBackfillMS: 2,
 			Migrations31And32: true, IntegrityOK: true, ForeignKeyViolations: 0,
 			SourceUnchanged: true, InitialFTSDocuments: 128, InitialFTSComplete: false,

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -448,6 +448,49 @@ func TestCollectV0330BodyFreeEvidence_PreservesScratchCleanupFailureArtifact(t *
 	}
 }
 
+func TestCollectV0330BodyFreeEvidence_PreservesCleanupFailureWhenPhaseMarkerIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	var scratch string
+	deps := defaultReleaseEvidenceDependencies()
+	deps.availableScratchBytes = func(string) (uint64, error) {
+		return v0330EvidenceRequiredScratchBytes, nil
+	}
+	deps.verifyHosts = func(string) error { return nil }
+	deps.runPhase = func(_ context.Context, _ string, observedScratch string, phase releaseEvidencePhase) ([]byte, error) {
+		scratch = observedScratch
+		valid := validBodyFreeEvidenceFixture()
+		switch phase {
+		case releaseEvidencePhaseA:
+			valid.PhaseA.P95MS = valid.PhaseA.TargetP95MS
+			valid.PhaseA.Passed = false
+			return markerFixture(t, bodyFreeEvidencePhaseAMarker, *valid.PhaseA), nil
+		case releaseEvidencePhaseBC:
+			return markerFixture(t, bodyFreeEvidencePhaseBCMarker, bodyFreeEvidencePhaseBC{
+				PhaseB: *valid.PhaseB,
+				PhaseC: valid.PhaseC,
+			}), nil
+		case releaseEvidencePhaseD:
+			return markerFixture(t, bodyFreeEvidencePhaseDMarker, *valid.PhaseD), nil
+		default:
+			return nil, errors.New("unsupported phase")
+		}
+	}
+	deps.removeAll = func(string) error { return errors.New("injected cleanup failure") }
+
+	evidence := collectV0330BodyFreeEvidence(context.Background(), t.TempDir(), parent, deps)
+	if evidence.Status != "blocked" || evidence.BlockReason != "scratch_cleanup_failed" || evidence.Privacy.ScratchCleaned {
+		t.Fatalf("combined cleanup and marker failure evidence = %+v", evidence)
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("combined cleanup and marker failure artifact is not serializable: %v", err)
+	}
+	if err := os.RemoveAll(scratch); err != nil {
+		t.Fatalf("RemoveAll(scratch) error = %v", err)
+	}
+}
+
 func TestCollectV0330BodyFreeEvidence_SanitizesInvalidPhaseMetrics(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/repo-tooling/release_evidence_test.go
+++ b/cmd/repo-tooling/release_evidence_test.go
@@ -289,16 +289,6 @@ func TestValidateBodyFreeEvidence_RequiresAggregateTruncationMetadata(t *testing
 	}
 }
 
-func TestValidateBodyFreeEvidence_RequiresStagedRetrievalParity(t *testing.T) {
-	t.Parallel()
-
-	evidence := validBodyFreeEvidenceFixture()
-	evidence.PhaseE.StagedRetrievalParity = false
-	if err := validateBodyFreeEvidence(evidence); err == nil {
-		t.Fatal("Phase E without staged-retrieval parity unexpectedly passed")
-	}
-}
-
 func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -312,6 +302,23 @@ func TestValidateBodyFreeEvidence_ValidatesPresentPhasesInBlockedArtifact(t *tes
 	evidence.PhaseB.Events = 0
 	if err := validateBodyFreeEvidence(evidence); err == nil {
 		t.Fatal("blocked evidence with an invalid present phase unexpectedly passed")
+	}
+}
+
+func TestValidateBodyFreeEvidence_AcceptsOnlyDeclaredScratchCleanupFailure(t *testing.T) {
+	t.Parallel()
+
+	evidence := validBodyFreeEvidenceFixture()
+	evidence.Status = "blocked"
+	evidence.BlockReason = "scratch_cleanup_failed"
+	evidence.Privacy.ScratchCleaned = false
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("cleanup-failure evidence unexpectedly failed: %v", err)
+	}
+
+	evidence.BlockReason = "phase_a_failed"
+	if err := validateBodyFreeEvidence(evidence); err == nil {
+		t.Fatal("non-cleanup block reason unexpectedly accepted uncleared scratch")
 	}
 }
 
@@ -400,6 +407,47 @@ func TestCollectV0330BodyFreeEvidence_CleansPrivateScratchAndMergesMarkers(t *te
 	}
 }
 
+func TestCollectV0330BodyFreeEvidence_PreservesScratchCleanupFailureArtifact(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	var scratch string
+	deps := defaultReleaseEvidenceDependencies()
+	deps.availableScratchBytes = func(string) (uint64, error) {
+		return v0330EvidenceRequiredScratchBytes, nil
+	}
+	deps.verifyHosts = func(string) error { return nil }
+	deps.runPhase = func(_ context.Context, _ string, observedScratch string, phase releaseEvidencePhase) ([]byte, error) {
+		scratch = observedScratch
+		valid := validBodyFreeEvidenceFixture()
+		switch phase {
+		case releaseEvidencePhaseA:
+			return markerFixture(t, bodyFreeEvidencePhaseAMarker, *valid.PhaseA), nil
+		case releaseEvidencePhaseBC:
+			return markerFixture(t, bodyFreeEvidencePhaseBCMarker, bodyFreeEvidencePhaseBC{
+				PhaseB: *valid.PhaseB,
+				PhaseC: valid.PhaseC,
+			}), nil
+		case releaseEvidencePhaseD:
+			return markerFixture(t, bodyFreeEvidencePhaseDMarker, *valid.PhaseD), nil
+		default:
+			return nil, errors.New("unsupported phase")
+		}
+	}
+	deps.removeAll = func(string) error { return errors.New("injected cleanup failure") }
+
+	evidence := collectV0330BodyFreeEvidence(context.Background(), t.TempDir(), parent, deps)
+	if evidence.Status != "blocked" || evidence.BlockReason != "scratch_cleanup_failed" || evidence.Privacy.ScratchCleaned {
+		t.Fatalf("cleanup failure evidence = %+v", evidence)
+	}
+	if err := validateBodyFreeEvidence(evidence); err != nil {
+		t.Fatalf("cleanup failure artifact is not serializable: %v", err)
+	}
+	if err := os.RemoveAll(scratch); err != nil {
+		t.Fatalf("RemoveAll(scratch) error = %v", err)
+	}
+}
+
 func TestCollectV0330BodyFreeEvidence_SanitizesInvalidPhaseMetrics(t *testing.T) {
 	t.Parallel()
 
@@ -431,7 +479,7 @@ func TestCollectV0330BodyFreeEvidence_SanitizesInvalidPhaseMetrics(t *testing.T)
 		t.Fatalf("invalid phase evidence = %+v", evidence)
 	}
 	if evidence.PhaseA != nil || evidence.PhaseB != nil || len(evidence.PhaseC) != 0 ||
-		evidence.PhaseD != nil || evidence.PhaseE != nil {
+		evidence.PhaseD != nil {
 		t.Fatalf("invalid phase metrics were retained: %+v", evidence)
 	}
 	if err := validateBodyFreeEvidence(evidence); err != nil {
@@ -508,9 +556,6 @@ func validBodyFreeEvidenceFixture() BodyFreeEvidence {
 			Pages: 5, TotalItems: 100, MultibyteObserved: true,
 			BodyBlocksObserved: true, TruncationMetadataObserved: true,
 			ContinuationNoDuplicateOrSkip: true,
-		},
-		PhaseE: &bodyFreeEvidencePhaseE{
-			HostCount: 6, ManifestParity: true, StagedRetrievalParity: true,
 		},
 		Privacy: bodyFreeEvidencePrivacy{
 			MetricsOnly: true, ScratchPrivate: true, ScratchCleaned: true,

--- a/docs/operations/repo-tooling.ja.md
+++ b/docs/operations/repo-tooling.ja.md
@@ -40,6 +40,7 @@ maintainer-only の repository automation は性質が異なります。
 - docs i18n pairing check
 - changelog coverage check
 - version bump のような release-prep helper
+- private かつ metrics-only の release evidence probe
 
 逆に、ここへ入れないもの:
 
@@ -60,6 +61,8 @@ maintainer-only の repository automation は性質が異なります。
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`
 - `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+- `go run ./cmd/repo-tooling release run-v0.33.0-evidence --output FILE`
+- `go run ./cmd/repo-tooling release verify-body-free-evidence --input FILE`
 
 実際の package layout は調整してよいですが、documented entrypoint は 1 つに揃えます。
 

--- a/docs/operations/repo-tooling.md
+++ b/docs/operations/repo-tooling.md
@@ -40,6 +40,7 @@ Examples that belong under `cmd/repo-tooling`:
 - docs i18n pairing checks
 - changelog coverage checks
 - release-preparation helpers such as version bumps
+- private, metrics-only release evidence probes
 
 Examples that do **not** belong there:
 
@@ -60,6 +61,8 @@ The repository should converge on subcommands shaped like these:
 - `go run ./cmd/repo-tooling docs verify-antigravity-status`
 - `go run ./cmd/repo-tooling release verify-changelog`
 - `go run ./cmd/repo-tooling release bump-version --version X.Y.Z`
+- `go run ./cmd/repo-tooling release run-v0.33.0-evidence --output FILE`
+- `go run ./cmd/repo-tooling release verify-body-free-evidence --input FILE`
 
 The exact package layout can evolve, but the documented entrypoint should stay singular.
 

--- a/docs/release/README.ja.md
+++ b/docs/release/README.ja.md
@@ -4,6 +4,10 @@
 
 Traceary では、CLI 本体の公開導線を 3 つ用意し、あわせて release と同じ version の agent package も配布します。
 
+現在のリリース証跡:
+
+- [v0.33.0 multi-GiB リリース証跡](./v0.33.0-multigib-evidence.ja.md)
+
 ## バイナリ upgrade のあと
 
 ホスト plugin は Homebrew や `go install` では更新されません。次の二言語チェックリストに従ってください。

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -4,6 +4,10 @@
 
 Traceary supports three public CLI installation paths and release-coupled agent packages.
 
+Current release evidence:
+
+- [v0.33.0 multi-GiB release evidence](./v0.33.0-multigib-evidence.md)
+
 ## After upgrading the binary
 
 Host plugins are **not** upgraded by Homebrew or `go install`. Follow the bilingual checklist:

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -6,7 +6,7 @@
 
 **合格です。**
 Go 1.26.3、darwin/arm64で実行した#1558の全証跡は、定義済みのrelease gateをすべて満たしました。
-2 GiBのprojection-only直接metadata benchmarkはp95 **0.073834 ms**で、固定済みの**250 ms未満**という基準を満たしました。
+2 GiBのprojection-only直接metadata benchmarkはp95 **0.074625 ms**で、固定済みの**250 ms未満**という基準を満たしました。
 copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、6 packageのhost parity、privacy、scratch cleanupも合格しました。
 
 Phase Cのlatencyは観測値です。
@@ -27,7 +27,7 @@ maintainer専用runnerは次の順で実行します。
 2. ownerだけが読める一時directoryを作る。
 3. event 8件、2 GiBのprojection-only metadata benchmarkを実行する。
 4. syntheticなmigration 31適用前storeをcopyし、copyだけにmigration 31から34を適用する。
-5. event/projection件数一致を確認し、metadata/boundedのlist、context、searchを各25回計測する。
+5. event/projection件数一致を確認し、130 eventのfixtureにlimit 20を指定してmetadata/boundedのlist、context、searchを各25回計測し、返却件数とmembershipの一致を検証する。
 6. FTSが不完全な状態と完全な状態のsearch観測を分離する。
 7. multibyte canonical blockを含む100件のMCP requestを実行し、aggregate budgetによるcontinuationを最後までたどる。
 8. 6個のpackageで`traceary mcp-server`登録とstaged-retrieval semantic contractが一致することを確認する。
@@ -57,13 +57,15 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | projection row数 | 8 | event数と一致 | pass |
 | missing body metadata | 0 | 0 | pass |
 | projection-only ordered plan | true | true | pass |
+| 返却item | 8 | 8 | pass |
 | 返却body bytes | 0 | 0 | pass |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 0.073834 ms | 250 ms未満 | **pass** |
+| p95 | 0.074625 ms | 250 ms未満 | **pass** |
 
 fixtureは生成したcontent-free SQLite extentを使い、user event contentをcopyしません。
 fixture作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN`は25回のtimerより前に実行します。
 各sampleが含むのはquery実行、全rowのscan、row closeだけです。
+すべての計測で8 rowを返し、iteration errorがないことも確認しました。
 
 planは`idx_event_metadata_workspace_created_at_norm_id_desc`を使い、一時sortを作らず、authoritativeな`events` tableを参照しません。
 merge済みPR #1570のtrigger-maintained projectionにより、metadata選択は2 GiBのbody extentから独立します。
@@ -81,8 +83,8 @@ overflow chainからmetadataを分離できることは検証しますが、別�
 | source managed bytes | 2,418,642,944 |
 | final checkpoint後のscratch bytes | 4,837,355,520 |
 | historical event数 | 130 |
-| migration/current initialization | 17,885.589958 ms |
-| resumed FTS batch | 1.713250 ms |
+| migration/current initialization | 17,477.897125 ms |
+| resumed FTS batch | 1.847500 ms |
 | migration 31から34 | applied |
 | projection row数 | 130 |
 | integrity check | pass |
@@ -103,17 +105,20 @@ scratch値はfinal WAL checkpoint後に残るsourceとcopyの合計であり、s
 
 | 操作 | projection | FTS phase | p95 | 返却item | 返却body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.101709 ms | 20 | 0 |
-| list | bounded | not applicable | 1.581958 ms | 20 | 920 |
-| context | metadata | not applicable | 0.991750 ms | 20 | 0 |
-| context | bounded | not applicable | 1.309917 ms | 20 | 920 |
-| search | metadata | incomplete | 6.645958 ms | 20 | 0 |
-| search | bounded | incomplete | 7.146250 ms | 20 | 920 |
-| search | metadata | complete | 2.441209 ms | 20 | 0 |
-| search | bounded | complete | 2.792541 ms | 20 | 920 |
+| list | metadata | not applicable | 1.248375 ms | 20 | 0 |
+| list | bounded | not applicable | 1.491583 ms | 20 | 920 |
+| context | metadata | not applicable | 0.929292 ms | 20 | 0 |
+| context | bounded | not applicable | 1.311833 ms | 20 | 920 |
+| search | metadata | incomplete | 6.671917 ms | 20 | 0 |
+| search | bounded | incomplete | 6.858000 ms | 20 | 920 |
+| search | metadata | complete | 2.428042 ms | 20 | 0 |
+| search | bounded | complete | 2.761833 ms | 20 | 920 |
 
-metadata projectionの返却body bytesはすべて0でした。
-FTS incomplete/completeで内部のsearch membershipが一致することも確認しましたが、identity自体はserializeしていません。
+8個のprobeはすべて130 eventのfixtureにlimit 20を指定し、20 itemを返しました。
+list、context、incomplete search、complete searchの各組でmetadata projectionとbounded projectionの内部membershipが一致しました。
+FTS incomplete/complete間でもsearch membershipを維持しました。
+identityはmemory内でだけ比較し、serializeしていません。
+metadata projectionの返却body bytesはすべて0で、bounded projectionはすべて正のbyte数でした。
 この短いsingle-host seriesはmetadata projectionとbounded projectionの性能比較を目的としていません。
 p95は観測値であり、相対性能を示す根拠には使いません。
 

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -140,3 +140,7 @@ Phase Aとcopy migrationの時間は実装とhostに依存するため、一部m
 
 `v0.33.0`のtagged-release workflowは、GoReleaserより前にartifactをstrict modeで検証します。
 artifactがmissing、blocked、malformed、またはprivacy contract違反ならpublishを停止し、operatorの記憶だけに依存しません。
+
+### Projection rollback 証跡
+
+Phase B は rollback 互換性も検証します。pre-projection event column shape を使う writer が移行済みの private copy に INSERT し、trigger-maintained projection がその行を記録し、transaction rollback 後に event/projection の件数が復元されることを確認します。永続 evidence には `pre_projection_writer_ok` のみを記録します。

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -5,7 +5,7 @@
 ## 結論
 
 **リリース不可です。**
-2 GiB の直接 metadata benchmark 自体は完了しましたが、25 回計測の p95 は **605.756875 ms** で、固定済みの release target **250 ms 未満**を超えました。
+2 GiB の直接 metadata benchmark 自体は完了しましたが、25 回計測の p95 は **4,159.414709 ms** で、固定済みの release target **250 ms 未満**を超えました。
 copy 上の migration、不完全/完全 FTS の分離 probe、MCP aggregate response budget、6 package の host parity、privacy、scratch cleanup はすべて通過しました。
 Phase C の latency は観測値であり、Issue で target が固定されるまでは release gate に使いません。
 
@@ -54,23 +54,43 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | stored-body metadata bytes | 2,147,483,648 | 2 GiB 以上 | pass |
 | event 数 | 8 | 8 | pass |
 | missing body metadata | 0 | 0 | pass |
+| ordered direct-range index | true | true | pass |
+| covering event-metadata index | false | 観測のみ | diagnostic |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 605.756875 ms | 250 ms 未満 | **fail** |
+| p95 | 4,159.414709 ms | 250 ms 未満 | **fail** |
 
 fixture は生成した content-free SQLite extent を使います。
 Phase A に user event content はコピーしません。
 この run で確認した release blocker は latency target の失敗だけです。
-この証跡から原因までは断定しません。
+以下ではrelease計測値と原因分離用のquery診断を分けて示します。
+
+### Phase A の原因調査
+
+計測範囲は固定済みの benchmark 契約と一致します。
+fixture 作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN` は 25 回の timer より前に実行します。
+各 sample が含むのは query 実行、全 row の scan、row close だけです。
+
+query は `idx_events_workspace_created_at_norm_id_desc` で時刻の上下限を seek し、一時 sort を作りません。
+ただし、この ordered index は covering index ではありません。
+SQLite の table record では `events.body` が `created_at`、client/workspace field、body-extent metadata より前にあります。
+SQLite が文書化している [table lookup][sqlite-query-planner] と [linked overflow-page][sqlite-file-format] の仕組みと、以下の controlled result を合わせると、SQL projection から `body` を外しても、後方の field を table lookup で取得すると大容量 body の overflow chain をたどると推定できます。
+
+原因分離用の run では、fixture setup 後かつ timer 外で一時的な covering workspace index を作りました。
+それ以外が同じ 25 回 query の p95 は **0.088750 ms** でした。
+production schema の run は **605.756875 ms**、host I/O 負荷が大きい canonical run は **4,159.414709 ms** でした。
+一時 index は production schema に存在しないため、この値を release evidence には使いません。
+この結果は non-covering table lookup が blocker であり、host I/O 条件が遅延の大きさに影響することを示しています。
+timer、fixture、target の変更では解決しません。
 
 ## Phase B: copy 上の migration と FTS progress
 
 | 指標 | 観測値 |
 | --- | ---: |
 | source managed bytes | 2,418,642,944 |
-| peak scratch bytes | 4,837,355,520 |
+| final checkpoint 後の scratch bytes | 4,837,355,520 |
 | historical event 数 | 130 |
-| migration/current initialization | 35,953.925333 ms |
-| resumed FTS batch | 1.585000 ms |
+| migration/current initialization | 246,959.606292 ms |
+| resumed FTS batch | 12.320959 ms |
 | migration 31 / 32 | applied |
 | integrity check | pass |
 | foreign-key violation | 0 |
@@ -81,6 +101,8 @@ Phase A に user event content はコピーしません。
 source は private な synthetic store です。
 migrate するのは copy だけです。
 大容量の synthetic row は retention-unavailable extent とし、2 GiB の searchable text を複製せずに FTS の bounded progress を計測しました。
+scratch 値は final WAL checkpoint 後に残る source と copy の合計であり、sampling した high-water mark ではありません。
+12 GiB の preflight は transient WAL と test-build file の headroom を別に確保します。
 
 ## Phase C: projection / FTS 観測
 
@@ -88,14 +110,14 @@ migrate するのは copy だけです。
 
 | 操作 | projection | FTS phase | p95 | 返却 item | 返却 body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 2.236417 ms | 20 | 0 |
-| list | bounded | not applicable | 3.210250 ms | 20 | 920 |
-| context | metadata | not applicable | 1.655833 ms | 20 | 0 |
-| context | bounded | not applicable | 2.550958 ms | 20 | 920 |
-| search | metadata | incomplete | 10.063250 ms | 20 | 0 |
-| search | bounded | incomplete | 10.164250 ms | 20 | 920 |
-| search | metadata | complete | 4.212625 ms | 20 | 0 |
-| search | bounded | complete | 4.610834 ms | 20 | 920 |
+| list | metadata | not applicable | 47.614375 ms | 20 | 0 |
+| list | bounded | not applicable | 286.277792 ms | 20 | 920 |
+| context | metadata | not applicable | 10.367166 ms | 20 | 0 |
+| context | bounded | not applicable | 185.714708 ms | 20 | 920 |
+| search | metadata | incomplete | 395.929291 ms | 20 | 0 |
+| search | bounded | incomplete | 607.974292 ms | 20 | 920 |
+| search | metadata | complete | 294.954666 ms | 20 | 0 |
+| search | bounded | complete | 214.790167 ms | 20 | 920 |
 
 metadata projection の返却 body bytes はすべて 0 でした。
 FTS incomplete/complete で内部の検索 membership が一致することも確認しましたが、identity 自体は serialize していません。
@@ -114,3 +136,15 @@ FTS incomplete/complete で内部の検索 membership が一致することも�
 accepted capable host で Phase A の direct metadata p95 が 250 ms 未満になるまで release を止めます。
 performance fix は別 Issue/PR で実施し、その後この evidence workflow を全 phase 再実行してください。
 Phase A と copy migration の時間は host と実装に依存するため、部分的な再利用は認めません。
+
+具体的な follow-up Issue 候補は次です。
+
+- **Title:** `v0.33.0-10: avoid event-body overflow reads in metadata queries`
+- general、workspace、session、workspace+session、primary source-hook の metadata read で covering plan と一時 sort 不使用を必須にする
+- wider ordered index と単一 metadata-cover index + 明示 join を比較し、migration 時間、peak scratch、定常時 index bytes、insert cost を計測する
+- copy した multi-GiB migration 前 store で実行し、source 不変と disk/write-lock の rollback 手順を証明する
+- #1551 の staged retrieval、#1552 の indexed-search membership/fallback、#1553 の ordering/range semantics を保つ
+- #1558 の全 phase を再実行し、release 前に Phase A p95 250 ms 未満を必須にする
+
+[sqlite-query-planner]: https://www.sqlite.org/queryplanner.html
+[sqlite-file-format]: https://www.sqlite.org/fileformat.html

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -6,7 +6,7 @@
 
 **合格です。**
 Go 1.26.3、darwin/arm64で実行した#1558の全証跡は、定義済みのrelease gateをすべて満たしました。
-2 GiBのprojection-only直接metadata benchmarkはp95 **0.107333 ms**で、固定済みの**250 ms未満**という基準を満たしました。
+2 GiBのprojection-only直接metadata benchmarkはp95 **0.077708 ms**で、固定済みの**250 ms未満**という基準を満たしました。
 copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、6 packageのhost parity、privacy、scratch cleanupも合格しました。
 
 Phase Cのlatencyは観測値です。
@@ -59,7 +59,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | projection-only ordered plan | true | true | pass |
 | 返却body bytes | 0 | 0 | pass |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 0.107333 ms | 250 ms未満 | **pass** |
+| p95 | 0.077708 ms | 250 ms未満 | **pass** |
 
 fixtureは生成したcontent-free SQLite extentを使い、user event contentをcopyしません。
 fixture作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN`は25回のtimerより前に実行します。
@@ -71,6 +71,9 @@ merge済みPR #1570のtrigger-maintained projectionにより、metadata選択は
 #1570より前のartifactはauthoritative-table pathを計測し、正しくblockedになりました。
 今回の合格値はmetricの差替えではなく、全Phaseを再実行して得た値です。
 
+このfixtureは、8 rowが2 GiBのbody extentを持つfew-huge-rows shapeを意図的に表現します。
+overflow chainからmetadataを分離できることは検証しますが、別のmany-small-rows shapeまで検証したとは主張しません。
+
 ## Phase B: copy上のmigrationとFTS進捗
 
 | 指標 | 観測値 |
@@ -78,8 +81,8 @@ merge済みPR #1570のtrigger-maintained projectionにより、metadata選択は
 | source managed bytes | 2,418,642,944 |
 | final checkpoint後のscratch bytes | 4,837,355,520 |
 | historical event数 | 130 |
-| migration/current initialization | 24,221.061416 ms |
-| resumed FTS batch | 2.036708 ms |
+| migration/current initialization | 19,756.783292 ms |
+| resumed FTS batch | 1.685667 ms |
 | migration 31から34 | applied |
 | projection row数 | 130 |
 | integrity check | pass |
@@ -100,23 +103,26 @@ scratch値はfinal WAL checkpoint後に残るsourceとcopyの合計であり、s
 
 | 操作 | projection | FTS phase | p95 | 返却item | 返却body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.661583 ms | 20 | 0 |
-| list | bounded | not applicable | 3.333792 ms | 20 | 920 |
-| context | metadata | not applicable | 2.508583 ms | 20 | 0 |
-| context | bounded | not applicable | 2.537625 ms | 20 | 920 |
-| search | metadata | incomplete | 10.069708 ms | 20 | 0 |
-| search | bounded | incomplete | 11.207792 ms | 20 | 920 |
-| search | metadata | complete | 5.192000 ms | 20 | 0 |
-| search | bounded | complete | 5.955291 ms | 20 | 920 |
+| list | metadata | not applicable | 1.395625 ms | 20 | 0 |
+| list | bounded | not applicable | 1.809792 ms | 20 | 920 |
+| context | metadata | not applicable | 1.191000 ms | 20 | 0 |
+| context | bounded | not applicable | 3.267334 ms | 20 | 920 |
+| search | metadata | incomplete | 12.655750 ms | 20 | 0 |
+| search | bounded | incomplete | 7.904375 ms | 20 | 920 |
+| search | metadata | complete | 4.126625 ms | 20 | 0 |
+| search | bounded | complete | 3.696125 ms | 20 | 920 |
 
 metadata projectionの返却body bytesはすべて0でした。
 FTS incomplete/completeで内部のsearch membershipが一致することも確認しましたが、identity自体はserializeしていません。
+この短いsingle-host seriesはmetadata projectionとbounded projectionの性能比較を目的としていません。
+p95は観測値であり、相対性能を示す根拠には使いません。
 
 ## Phase DとPhase E
 
 - 100件を要求したMCP pageは、encoded body/block bytesが65,536以下でした。
 - 3 pageのobserved maximumは35 items、65,536 bytesでした。
 - multibyte canonical blockを持つ100 eventがcontinuation chain全体に重複も欠落もなく1回ずつ現れました。
+- requestしたevent単位の上限を超えるbodyでは`body_truncated`と元の`body_length`を確認し、ほかのcanonical eventでは`body_blocks`を確認しました。
 - 6個のpackageが共通MCP command verifierに合格しました。
 - scratchはprivateで、artifactを書き込む前に削除済みでした。
 
@@ -126,3 +132,6 @@ FTS incomplete/completeで内部のsearch membershipが一致することも確�
 残る独立したrelease checkも満たす場合、このartifactをmulti-GiB body-free evidenceとしてtagged releaseの判断に使えます。
 metadata projection、migration 31から34、FTS backfill、aggregate response budget、host manifest、Go runtimeのいずれかが変わった場合は、全workflowを再実行してください。
 Phase Aとcopy migrationの時間は実装とhostに依存するため、一部metricだけの再利用は認めません。
+
+`v0.33.0`のtagged-release workflowは、GoReleaserより前にartifactをstrict modeで検証します。
+artifactがmissing、blocked、malformed、またはprivacy contract違反ならpublishを停止し、operatorの記憶だけに依存しません。

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -1,0 +1,116 @@
+# v0.33.0 multi-GiB リリース証跡
+
+[English](./v0.33.0-multigib-evidence.md)
+
+## 結論
+
+**リリース不可です。**
+2 GiB の直接 metadata benchmark 自体は完了しましたが、25 回計測の p95 は **605.756875 ms** で、固定済みの release target **250 ms 未満**を超えました。
+copy 上の migration、不完全/完全 FTS の分離 probe、MCP aggregate response budget、6 package の host parity、privacy、scratch cleanup はすべて通過しました。
+Phase C の latency は観測値であり、Issue で target が固定されるまでは release gate に使いません。
+
+この evidence branch は、未 merge の #1556 実装である PR #1567 の `bd798569` を base にしています。
+#1567 が merge されるまで、この依存を外せません。
+
+machine-readable artifact は [`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json) です。
+数値と真偽値などの metrics だけを含みます。
+
+## 手順と privacy boundary
+
+maintainer 専用 runner は次を行います。
+
+1. scratch の空き容量を最低 12 GiB 要求する
+2. owner だけがアクセスできる temporary directory を作る
+3. 8 event、合計 2 GiB の既存 direct metadata benchmark を実行する
+4. migration 前の synthetic store を作って copy し、copy だけを current schema に migrate する
+5. metadata/bounded の list/context/search を各 25 回計測し、search は FTS の incomplete/complete を別系列にする
+6. multibyte canonical block を含む 100 item の MCP request を実行し、aggregate-budget continuation を最後までたどる
+7. 6 host package が同じ `traceary mcp-server` を登録することを検証する
+8. scratch を削除してから最終 artifact を書く
+
+child output は上限付きの memory buffer にだけ保持します。
+artifact schema には event/session identity、workspace、path、cursor、continuation、body、prompt、response の field がありません。
+source/copy の同一性は内部で検証し、digest は公開しません。
+
+実行と検証には次を使います。
+
+```sh
+go run ./cmd/repo-tooling release run-v0.33.0-evidence \
+  --output docs/release/v0.33.0-multigib-evidence.json
+
+# 現在の blocked artifact に対する structure/privacy 検証:
+go run ./cmd/repo-tooling release verify-body-free-evidence \
+  --input docs/release/v0.33.0-multigib-evidence.json \
+  --allow-blocked
+```
+
+`--allow-blocked` を付けない検証は、全 release gate が通るまで意図どおり失敗します。
+
+## Phase A: direct metadata gate
+
+| 指標 | 観測値 | 必須条件 | 結果 |
+| --- | ---: | ---: | --- |
+| SQLite-managed bytes | 2,418,733,056 | 2 GiB 以上 | pass |
+| stored-body metadata bytes | 2,147,483,648 | 2 GiB 以上 | pass |
+| event 数 | 8 | 8 | pass |
+| missing body metadata | 0 | 0 | pass |
+| 計測回数 | 25 | 25 | pass |
+| p95 | 605.756875 ms | 250 ms 未満 | **fail** |
+
+fixture は生成した content-free SQLite extent を使います。
+Phase A に user event content はコピーしません。
+この run で確認した release blocker は latency target の失敗だけです。
+この証跡から原因までは断定しません。
+
+## Phase B: copy 上の migration と FTS progress
+
+| 指標 | 観測値 |
+| --- | ---: |
+| source managed bytes | 2,418,642,944 |
+| peak scratch bytes | 4,837,355,520 |
+| historical event 数 | 130 |
+| migration/current initialization | 35,953.925333 ms |
+| resumed FTS batch | 1.585000 ms |
+| migration 31 / 32 | applied |
+| integrity check | pass |
+| foreign-key violation | 0 |
+| copy migration 後の source | byte-identical |
+| 1 回目の FTS batch | 128 documents、incomplete |
+| resume 後の FTS state | 130 documents、complete |
+
+source は private な synthetic store です。
+migrate するのは copy だけです。
+大容量の synthetic row は retention-unavailable extent とし、2 GiB の searchable text を複製せずに FTS の bounded progress を計測しました。
+
+## Phase C: projection / FTS 観測
+
+各系列は 25 回計測です。
+
+| 操作 | projection | FTS phase | p95 | 返却 item | 返却 body bytes |
+| --- | --- | --- | ---: | ---: | ---: |
+| list | metadata | not applicable | 2.236417 ms | 20 | 0 |
+| list | bounded | not applicable | 3.210250 ms | 20 | 920 |
+| context | metadata | not applicable | 1.655833 ms | 20 | 0 |
+| context | bounded | not applicable | 2.550958 ms | 20 | 920 |
+| search | metadata | incomplete | 10.063250 ms | 20 | 0 |
+| search | bounded | incomplete | 10.164250 ms | 20 | 920 |
+| search | metadata | complete | 4.212625 ms | 20 | 0 |
+| search | bounded | complete | 4.610834 ms | 20 | 920 |
+
+metadata projection の返却 body bytes はすべて 0 でした。
+FTS incomplete/complete で内部の検索 membership が一致することも確認しましたが、identity 自体は serialize していません。
+
+## Phase D / E
+
+- MCP に 100 item を要求した場合も、1 page の encoded body/block は 65,536 bytes 以下でした。
+  3 page のうち最大値は 35 item、65,536 bytes です。
+- multibyte canonical block を持つ 100 event は continuation 全体で各 1 回だけ現れました。
+- 6 host package は shared MCP command verifier を通過しました。
+- scratch は private で、artifact 書き込み前に削除済みです。
+
+## release follow-up
+
+この証跡では v0.33.0 を tag できません。
+accepted capable host で Phase A の direct metadata p95 が 250 ms 未満になるまで release を止めます。
+performance fix は別 Issue/PR で実施し、その後この evidence workflow を全 phase 再実行してください。
+Phase A と copy migration の時間は host と実装に依存するため、部分的な再利用は認めません。

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -6,7 +6,7 @@
 
 **合格です。**
 Go 1.26.3、darwin/arm64で実行した#1558の全証跡は、定義済みのrelease gateをすべて満たしました。
-2 GiBのprojection-only直接metadata benchmarkはp95 **0.077708 ms**で、固定済みの**250 ms未満**という基準を満たしました。
+2 GiBのprojection-only直接metadata benchmarkはp95 **0.073834 ms**で、固定済みの**250 ms未満**という基準を満たしました。
 copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、6 packageのhost parity、privacy、scratch cleanupも合格しました。
 
 Phase Cのlatencyは観測値です。
@@ -30,7 +30,7 @@ maintainer専用runnerは次の順で実行します。
 5. event/projection件数一致を確認し、metadata/boundedのlist、context、searchを各25回計測する。
 6. FTSが不完全な状態と完全な状態のsearch観測を分離する。
 7. multibyte canonical blockを含む100件のMCP requestを実行し、aggregate budgetによるcontinuationを最後までたどる。
-8. 6個のpackageで`traceary mcp-server`登録が一致することを確認する。
+8. 6個のpackageで`traceary mcp-server`登録とstaged-retrieval semantic contractが一致することを確認する。
 9. 最終artifactの書込み前にscratchを削除する。
 
 child processの出力は上限付きmemory bufferだけに保持します。
@@ -59,7 +59,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | projection-only ordered plan | true | true | pass |
 | 返却body bytes | 0 | 0 | pass |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 0.077708 ms | 250 ms未満 | **pass** |
+| p95 | 0.073834 ms | 250 ms未満 | **pass** |
 
 fixtureは生成したcontent-free SQLite extentを使い、user event contentをcopyしません。
 fixture作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN`は25回のtimerより前に実行します。
@@ -81,8 +81,8 @@ overflow chainからmetadataを分離できることは検証しますが、別�
 | source managed bytes | 2,418,642,944 |
 | final checkpoint後のscratch bytes | 4,837,355,520 |
 | historical event数 | 130 |
-| migration/current initialization | 19,756.783292 ms |
-| resumed FTS batch | 1.685667 ms |
+| migration/current initialization | 17,885.589958 ms |
+| resumed FTS batch | 1.713250 ms |
 | migration 31から34 | applied |
 | projection row数 | 130 |
 | integrity check | pass |
@@ -103,14 +103,14 @@ scratch値はfinal WAL checkpoint後に残るsourceとcopyの合計であり、s
 
 | 操作 | projection | FTS phase | p95 | 返却item | 返却body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.395625 ms | 20 | 0 |
-| list | bounded | not applicable | 1.809792 ms | 20 | 920 |
-| context | metadata | not applicable | 1.191000 ms | 20 | 0 |
-| context | bounded | not applicable | 3.267334 ms | 20 | 920 |
-| search | metadata | incomplete | 12.655750 ms | 20 | 0 |
-| search | bounded | incomplete | 7.904375 ms | 20 | 920 |
-| search | metadata | complete | 4.126625 ms | 20 | 0 |
-| search | bounded | complete | 3.696125 ms | 20 | 920 |
+| list | metadata | not applicable | 1.101709 ms | 20 | 0 |
+| list | bounded | not applicable | 1.581958 ms | 20 | 920 |
+| context | metadata | not applicable | 0.991750 ms | 20 | 0 |
+| context | bounded | not applicable | 1.309917 ms | 20 | 920 |
+| search | metadata | incomplete | 6.645958 ms | 20 | 0 |
+| search | bounded | incomplete | 7.146250 ms | 20 | 920 |
+| search | metadata | complete | 2.441209 ms | 20 | 0 |
+| search | bounded | complete | 2.792541 ms | 20 | 920 |
 
 metadata projectionの返却body bytesはすべて0でした。
 FTS incomplete/completeで内部のsearch membershipが一致することも確認しましたが、identity自体はserializeしていません。
@@ -123,7 +123,7 @@ p95は観測値であり、相対性能を示す根拠には使いません。
 - 3 pageのobserved maximumは35 items、65,536 bytesでした。
 - multibyte canonical blockを持つ100 eventがcontinuation chain全体に重複も欠落もなく1回ずつ現れました。
 - requestしたevent単位の上限を超えるbodyでは`body_truncated`と元の`body_length`を確認し、ほかのcanonical eventでは`body_blocks`を確認しました。
-- 6個のpackageが共通MCP command verifierに合格しました。
+- 6個のpackageでMCP registrationが一致し、byte-identicalなDiscovery → Inspection → Detailのstaged-retrieval contractにも合格しました。
 - scratchはprivateで、artifactを書き込む前に削除済みでした。
 
 ## リリース判断

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -6,8 +6,8 @@
 
 **合格です。**
 Go 1.26.3、darwin/arm64で実行した#1558の全証跡は、定義済みのrelease gateをすべて満たしました。
-2 GiBのprojection-only直接metadata benchmarkはp95 **0.074625 ms**で、固定済みの**250 ms未満**という基準を満たしました。
-copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、6 packageのhost parity、privacy、scratch cleanupも合格しました。
+2 GiBのprojection-only直接metadata benchmarkはp95 **0.079708 ms**で、固定済みの**250 ms未満**という基準を満たしました。
+copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、host verifierの事前条件、privacy、scratch cleanupも合格しました。
 
 Phase Cのlatencyは観測値です。
 #1558はPhase Cのrelease基準を定義していないため、合否には使いません。
@@ -30,7 +30,7 @@ maintainer専用runnerは次の順で実行します。
 5. event/projection件数一致を確認し、130 eventのfixtureにlimit 20を指定してmetadata/boundedのlist、context、searchを各25回計測し、返却件数とmembershipの一致を検証する。
 6. FTSが不完全な状態と完全な状態のsearch観測を分離する。
 7. multibyte canonical blockを含む100件のMCP requestを実行し、aggregate budgetによるcontinuationを最後までたどる。
-8. 6個のpackageで`traceary mcp-server`登録とstaged-retrieval semantic contractが一致することを確認する。
+8. probe実行前に、6個のpackageで`traceary mcp-server`登録とstaged-retrieval semantic contractが一致することを確認する。
 9. 最終artifactの書込み前にscratchを削除する。
 
 child processの出力は上限付きmemory bufferだけに保持します。
@@ -60,7 +60,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | 返却item | 8 | 8 | pass |
 | 返却body bytes | 0 | 0 | pass |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 0.074625 ms | 250 ms未満 | **pass** |
+| p95 | 0.079708 ms | 250 ms未満 | **pass** |
 
 fixtureは生成したcontent-free SQLite extentを使い、user event contentをcopyしません。
 fixture作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN`は25回のtimerより前に実行します。
@@ -81,10 +81,10 @@ overflow chainからmetadataを分離できることは検証しますが、別�
 | 指標 | 観測値 |
 | --- | ---: |
 | source managed bytes | 2,418,642,944 |
-| final checkpoint後のscratch bytes | 4,837,355,520 |
+| final checkpoint後のscratch bytes | 6,718,570,496 |
 | historical event数 | 130 |
-| migration/current initialization | 17,477.897125 ms |
-| resumed FTS batch | 1.847500 ms |
+| migration/current initialization | 71,677.088917 ms |
+| resumed FTS batch | 3.266625 ms |
 | migration 31から34 | applied |
 | projection row数 | 130 |
 | integrity check | pass |
@@ -105,16 +105,17 @@ scratch値はfinal WAL checkpoint後に残るsourceとcopyの合計であり、s
 
 | 操作 | projection | FTS phase | p95 | 返却item | 返却body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.248375 ms | 20 | 0 |
-| list | bounded | not applicable | 1.491583 ms | 20 | 920 |
-| context | metadata | not applicable | 0.929292 ms | 20 | 0 |
-| context | bounded | not applicable | 1.311833 ms | 20 | 920 |
-| search | metadata | incomplete | 6.671917 ms | 20 | 0 |
-| search | bounded | incomplete | 6.858000 ms | 20 | 920 |
-| search | metadata | complete | 2.428042 ms | 20 | 0 |
-| search | bounded | complete | 2.761833 ms | 20 | 920 |
+| list | metadata | not applicable | 1.923000 ms | 20 | 0 |
+| list | bounded | not applicable | 2.827000 ms | 20 | 920 |
+| list | bounded_huge | not applicable | 206.746458 ms | 1 | 500 |
+| context | metadata | not applicable | 1.013833 ms | 20 | 0 |
+| context | bounded | not applicable | 1.467375 ms | 20 | 920 |
+| search | metadata | incomplete | 6.759792 ms | 20 | 0 |
+| search | bounded | incomplete | 7.027250 ms | 20 | 920 |
+| search | metadata | complete | 2.630417 ms | 20 | 0 |
+| search | bounded | complete | 2.844167 ms | 20 | 920 |
 
-8個のprobeはすべて130 eventのfixtureにlimit 20を指定し、20 itemを返しました。
+8個の標準probeは130 eventのfixtureにlimit 20を指定し、20 itemを返しました。9個目の`list/bounded_huge` probeは256 MiBのsource bodyを1件選択し、明示された500 byte budget以下だけを返しました。
 list、context、incomplete search、complete searchの各組でmetadata projectionとbounded projectionの内部membershipが一致しました。
 FTS incomplete/complete間でもsearch membershipを維持しました。
 identityはmemory内でだけ比較し、serializeしていません。
@@ -122,13 +123,13 @@ metadata projectionの返却body bytesはすべて0で、bounded projectionは�
 この短いsingle-host seriesはmetadata projectionとbounded projectionの性能比較を目的としていません。
 p95は観測値であり、相対性能を示す根拠には使いません。
 
-## Phase DとPhase E
+## Phase Dとhost verifierの事前条件
 
 - 100件を要求したMCP pageは、encoded body/block bytesが65,536以下でした。
 - 3 pageのobserved maximumは35 items、65,536 bytesでした。
 - multibyte canonical blockを持つ100 eventがcontinuation chain全体に重複も欠落もなく1回ずつ現れました。
 - requestしたevent単位の上限を超えるbodyでは`body_truncated`と元の`body_length`を確認し、ほかのcanonical eventでは`body_blocks`を確認しました。
-- 6個のpackageでMCP registrationが一致し、byte-identicalなDiscovery → Inspection → Detailのstaged-retrieval contractにも合格しました。
+- probe実行前に、6個のpackageでMCP registrationが一致し、byte-identicalなDiscovery → Inspection → Detailのstaged-retrieval contractにも合格しました。これはrunnerの事前条件であり、公開artifactに作為的なmetrics phaseとして記録しません。
 - scratchはprivateで、artifactを書き込む前に削除済みでした。
 
 ## リリース判断

--- a/docs/release/v0.33.0-multigib-evidence.ja.md
+++ b/docs/release/v0.33.0-multigib-evidence.ja.md
@@ -4,147 +4,125 @@
 
 ## 結論
 
-**リリース不可です。**
-2 GiB の直接 metadata benchmark 自体は完了しましたが、25 回計測の p95 は **4,159.414709 ms** で、固定済みの release target **250 ms 未満**を超えました。
-copy 上の migration、不完全/完全 FTS の分離 probe、MCP aggregate response budget、6 package の host parity、privacy、scratch cleanup はすべて通過しました。
-Phase C の latency は観測値であり、Issue で target が固定されるまでは release gate に使いません。
+**合格です。**
+Go 1.26.3、darwin/arm64で実行した#1558の全証跡は、定義済みのrelease gateをすべて満たしました。
+2 GiBのprojection-only直接metadata benchmarkはp95 **0.107333 ms**で、固定済みの**250 ms未満**という基準を満たしました。
+copy上のmigration、event/projection件数一致、不完全/完全FTSの分離probe、MCP aggregate response budget、6 packageのhost parity、privacy、scratch cleanupも合格しました。
 
-この evidence branch は、未 merge の #1556 実装である PR #1567 の `bd798569` を base にしています。
-#1567 が merge されるまで、この依存を外せません。
+Phase Cのlatencyは観測値です。
+#1558はPhase Cのrelease基準を定義していないため、合否には使いません。
+この証跡によって#1558のblockerは解消しましたが、v0.33.0のほかのrelease gateは独立して判定します。
 
-machine-readable artifact は [`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json) です。
-数値と真偽値などの metrics だけを含みます。
+このbranchは、#1567と#1570を含む`main`の`6641c6d7`へrebaseしました。
+projection導入前のblocked artifactにあるmetricは再利用していません。
 
-## 手順と privacy boundary
+機械可読な証跡は[`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json)です。
+metricsだけを含みます。
 
-maintainer 専用 runner は次を行います。
+## 手順とprivacy境界
 
-1. scratch の空き容量を最低 12 GiB 要求する
-2. owner だけがアクセスできる temporary directory を作る
-3. 8 event、合計 2 GiB の既存 direct metadata benchmark を実行する
-4. migration 前の synthetic store を作って copy し、copy だけを current schema に migrate する
-5. metadata/bounded の list/context/search を各 25 回計測し、search は FTS の incomplete/complete を別系列にする
-6. multibyte canonical block を含む 100 item の MCP request を実行し、aggregate-budget continuation を最後までたどる
-7. 6 host package が同じ `traceary mcp-server` を登録することを検証する
-8. scratch を削除してから最終 artifact を書く
+maintainer専用runnerは次の順で実行します。
 
-child output は上限付きの memory buffer にだけ保持します。
-artifact schema には event/session identity、workspace、path、cursor、continuation、body、prompt、response の field がありません。
-source/copy の同一性は内部で検証し、digest は公開しません。
+1. scratchの空き容量が12 GiB以上であることを確認する。
+2. ownerだけが読める一時directoryを作る。
+3. event 8件、2 GiBのprojection-only metadata benchmarkを実行する。
+4. syntheticなmigration 31適用前storeをcopyし、copyだけにmigration 31から34を適用する。
+5. event/projection件数一致を確認し、metadata/boundedのlist、context、searchを各25回計測する。
+6. FTSが不完全な状態と完全な状態のsearch観測を分離する。
+7. multibyte canonical blockを含む100件のMCP requestを実行し、aggregate budgetによるcontinuationを最後までたどる。
+8. 6個のpackageで`traceary mcp-server`登録が一致することを確認する。
+9. 最終artifactの書込み前にscratchを削除する。
 
-実行と検証には次を使います。
+child processの出力は上限付きmemory bufferだけに保持します。
+artifact schemaにはevent/session identity、workspace、path、cursor、continuation、body、prompt、responseのfieldがありません。
+sourceとcopyの一致は内部で検証し、digestは公開しません。
+
+実行と検証には次のcommandを使います。
 
 ```sh
 go run ./cmd/repo-tooling release run-v0.33.0-evidence \
   --output docs/release/v0.33.0-multigib-evidence.json
 
-# 現在の blocked artifact に対する structure/privacy 検証:
 go run ./cmd/repo-tooling release verify-body-free-evidence \
-  --input docs/release/v0.33.0-multigib-evidence.json \
-  --allow-blocked
+  --input docs/release/v0.33.0-multigib-evidence.json
 ```
 
-`--allow-blocked` を付けない検証は、全 release gate が通るまで意図どおり失敗します。
-
-## Phase A: direct metadata gate
+## Phase A: 直接metadata gate
 
 | 指標 | 観測値 | 必須条件 | 結果 |
 | --- | ---: | ---: | --- |
-| SQLite-managed bytes | 2,418,733,056 | 2 GiB 以上 | pass |
-| stored-body metadata bytes | 2,147,483,648 | 2 GiB 以上 | pass |
-| event 数 | 8 | 8 | pass |
+| SQLite managed bytes | 2,418,774,016 | 2 GiB以上 | pass |
+| stored-body metadata bytes | 2,147,483,648 | 2 GiB以上 | pass |
+| event数 | 8 | 8 | pass |
+| projection row数 | 8 | event数と一致 | pass |
 | missing body metadata | 0 | 0 | pass |
-| ordered direct-range index | true | true | pass |
-| covering event-metadata index | false | 観測のみ | diagnostic |
+| projection-only ordered plan | true | true | pass |
+| 返却body bytes | 0 | 0 | pass |
 | 計測回数 | 25 | 25 | pass |
-| p95 | 4,159.414709 ms | 250 ms 未満 | **fail** |
+| p95 | 0.107333 ms | 250 ms未満 | **pass** |
 
-fixture は生成した content-free SQLite extent を使います。
-Phase A に user event content はコピーしません。
-この run で確認した release blocker は latency target の失敗だけです。
-以下ではrelease計測値と原因分離用のquery診断を分けて示します。
+fixtureは生成したcontent-free SQLite extentを使い、user event contentをcopyしません。
+fixture作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN`は25回のtimerより前に実行します。
+各sampleが含むのはquery実行、全rowのscan、row closeだけです。
 
-### Phase A の原因調査
+planは`idx_event_metadata_workspace_created_at_norm_id_desc`を使い、一時sortを作らず、authoritativeな`events` tableを参照しません。
+merge済みPR #1570のtrigger-maintained projectionにより、metadata選択は2 GiBのbody extentから独立します。
 
-計測範囲は固定済みの benchmark 契約と一致します。
-fixture 作成、migration、checkpoint、容量確認、`EXPLAIN QUERY PLAN` は 25 回の timer より前に実行します。
-各 sample が含むのは query 実行、全 row の scan、row close だけです。
+#1570より前のartifactはauthoritative-table pathを計測し、正しくblockedになりました。
+今回の合格値はmetricの差替えではなく、全Phaseを再実行して得た値です。
 
-query は `idx_events_workspace_created_at_norm_id_desc` で時刻の上下限を seek し、一時 sort を作りません。
-ただし、この ordered index は covering index ではありません。
-SQLite の table record では `events.body` が `created_at`、client/workspace field、body-extent metadata より前にあります。
-SQLite が文書化している [table lookup][sqlite-query-planner] と [linked overflow-page][sqlite-file-format] の仕組みと、以下の controlled result を合わせると、SQL projection から `body` を外しても、後方の field を table lookup で取得すると大容量 body の overflow chain をたどると推定できます。
-
-原因分離用の run では、fixture setup 後かつ timer 外で一時的な covering workspace index を作りました。
-それ以外が同じ 25 回 query の p95 は **0.088750 ms** でした。
-production schema の run は **605.756875 ms**、host I/O 負荷が大きい canonical run は **4,159.414709 ms** でした。
-一時 index は production schema に存在しないため、この値を release evidence には使いません。
-この結果は non-covering table lookup が blocker であり、host I/O 条件が遅延の大きさに影響することを示しています。
-timer、fixture、target の変更では解決しません。
-
-## Phase B: copy 上の migration と FTS progress
+## Phase B: copy上のmigrationとFTS進捗
 
 | 指標 | 観測値 |
 | --- | ---: |
 | source managed bytes | 2,418,642,944 |
-| final checkpoint 後の scratch bytes | 4,837,355,520 |
-| historical event 数 | 130 |
-| migration/current initialization | 246,959.606292 ms |
-| resumed FTS batch | 12.320959 ms |
-| migration 31 / 32 | applied |
+| final checkpoint後のscratch bytes | 4,837,355,520 |
+| historical event数 | 130 |
+| migration/current initialization | 24,221.061416 ms |
+| resumed FTS batch | 2.036708 ms |
+| migration 31から34 | applied |
+| projection row数 | 130 |
 | integrity check | pass |
 | foreign-key violation | 0 |
-| copy migration 後の source | byte-identical |
-| 1 回目の FTS batch | 128 documents、incomplete |
-| resume 後の FTS state | 130 documents、complete |
+| copy migration後のsource | byte-identical |
+| 1回目のFTS batch | 128 documents、incomplete |
+| resume後のFTS state | 130 documents、complete |
 
-source は private な synthetic store です。
-migrate するのは copy だけです。
-大容量の synthetic row は retention-unavailable extent とし、2 GiB の searchable text を複製せずに FTS の bounded progress を計測しました。
-scratch 値は final WAL checkpoint 後に残る source と copy の合計であり、sampling した high-water mark ではありません。
-12 GiB の preflight は transient WAL と test-build file の headroom を別に確保します。
+sourceはsyntheticかつprivateです。
+migrateするのはcopyだけです。
+大容量のsynthetic rowはretention-unavailable extentとし、2 GiBのsearchable textを複製せずにFTSのbounded progressを計測しました。
+scratch値はfinal WAL checkpoint後に残るsourceとcopyの合計であり、samplingしたhigh-water markではありません。
+12 GiBのpreflightはtransient WALとtest-build fileのheadroomを別に確保します。
 
-## Phase C: projection / FTS 観測
+## Phase C: projectionとFTSの観測
 
-各系列は 25 回計測です。
+各系列は25回計測です。
 
-| 操作 | projection | FTS phase | p95 | 返却 item | 返却 body bytes |
+| 操作 | projection | FTS phase | p95 | 返却item | 返却body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 47.614375 ms | 20 | 0 |
-| list | bounded | not applicable | 286.277792 ms | 20 | 920 |
-| context | metadata | not applicable | 10.367166 ms | 20 | 0 |
-| context | bounded | not applicable | 185.714708 ms | 20 | 920 |
-| search | metadata | incomplete | 395.929291 ms | 20 | 0 |
-| search | bounded | incomplete | 607.974292 ms | 20 | 920 |
-| search | metadata | complete | 294.954666 ms | 20 | 0 |
-| search | bounded | complete | 214.790167 ms | 20 | 920 |
+| list | metadata | not applicable | 1.661583 ms | 20 | 0 |
+| list | bounded | not applicable | 3.333792 ms | 20 | 920 |
+| context | metadata | not applicable | 2.508583 ms | 20 | 0 |
+| context | bounded | not applicable | 2.537625 ms | 20 | 920 |
+| search | metadata | incomplete | 10.069708 ms | 20 | 0 |
+| search | bounded | incomplete | 11.207792 ms | 20 | 920 |
+| search | metadata | complete | 5.192000 ms | 20 | 0 |
+| search | bounded | complete | 5.955291 ms | 20 | 920 |
 
-metadata projection の返却 body bytes はすべて 0 でした。
-FTS incomplete/complete で内部の検索 membership が一致することも確認しましたが、identity 自体は serialize していません。
+metadata projectionの返却body bytesはすべて0でした。
+FTS incomplete/completeで内部のsearch membershipが一致することも確認しましたが、identity自体はserializeしていません。
 
-## Phase D / E
+## Phase DとPhase E
 
-- MCP に 100 item を要求した場合も、1 page の encoded body/block は 65,536 bytes 以下でした。
-  3 page のうち最大値は 35 item、65,536 bytes です。
-- multibyte canonical block を持つ 100 event は continuation 全体で各 1 回だけ現れました。
-- 6 host package は shared MCP command verifier を通過しました。
-- scratch は private で、artifact 書き込み前に削除済みです。
+- 100件を要求したMCP pageは、encoded body/block bytesが65,536以下でした。
+- 3 pageのobserved maximumは35 items、65,536 bytesでした。
+- multibyte canonical blockを持つ100 eventがcontinuation chain全体に重複も欠落もなく1回ずつ現れました。
+- 6個のpackageが共通MCP command verifierに合格しました。
+- scratchはprivateで、artifactを書き込む前に削除済みでした。
 
-## release follow-up
+## リリース判断
 
-この証跡では v0.33.0 を tag できません。
-accepted capable host で Phase A の direct metadata p95 が 250 ms 未満になるまで release を止めます。
-performance fix は別 Issue/PR で実施し、その後この evidence workflow を全 phase 再実行してください。
-Phase A と copy migration の時間は host と実装に依存するため、部分的な再利用は認めません。
-
-具体的な follow-up Issue 候補は次です。
-
-- **Title:** `v0.33.0-10: avoid event-body overflow reads in metadata queries`
-- general、workspace、session、workspace+session、primary source-hook の metadata read で covering plan と一時 sort 不使用を必須にする
-- wider ordered index と単一 metadata-cover index + 明示 join を比較し、migration 時間、peak scratch、定常時 index bytes、insert cost を計測する
-- copy した multi-GiB migration 前 store で実行し、source 不変と disk/write-lock の rollback 手順を証明する
-- #1551 の staged retrieval、#1552 の indexed-search membership/fallback、#1553 の ordering/range semantics を保つ
-- #1558 の全 phase を再実行し、release 前に Phase A p95 250 ms 未満を必須にする
-
-[sqlite-query-planner]: https://www.sqlite.org/queryplanner.html
-[sqlite-file-format]: https://www.sqlite.org/fileformat.html
+#1558のrelease gateは合格です。
+残る独立したrelease checkも満たす場合、このartifactをmulti-GiB body-free evidenceとしてtagged releaseの判断に使えます。
+metadata projection、migration 31から34、FTS backfill、aggregate response budget、host manifest、Go runtimeのいずれかが変わった場合は、全workflowを再実行してください。
+Phase Aとcopy migrationの時間は実装とhostに依存するため、一部metricだけの再利用は認めません。

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -9,7 +9,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 34020667392,
+    "available_scratch_bytes": 33745166336,
     "capable": true
   },
   "phase_a": {
@@ -17,17 +17,19 @@
     "stored_body_bytes": 2147483648,
     "events": 8,
     "missing_body_metadata": 0,
+    "ordered_index": true,
+    "covering_index": false,
     "runs": 25,
-    "p95_ms": 605.756875,
+    "p95_ms": 4159.414709,
     "target_p95_ms": 250,
     "passed": false
   },
   "phase_b": {
     "source_managed_bytes": 2418642944,
-    "scratch_peak_bytes": 4837355520,
+    "scratch_bytes_after_checkpoint": 4837355520,
     "events": 130,
-    "migration_ms": 35953.925333,
-    "resume_backfill_ms": 1.585,
+    "migration_ms": 246959.606292,
+    "resume_backfill_ms": 12.320959,
     "migrations_31_32_applied": true,
     "integrity_ok": true,
     "foreign_key_violations": 0,
@@ -43,7 +45,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 2.236417,
+      "p95_ms": 47.614375,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -52,7 +54,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 3.21025,
+      "p95_ms": 286.277792,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -61,7 +63,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.655833,
+      "p95_ms": 10.367166,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -70,7 +72,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 2.550958,
+      "p95_ms": 185.714708,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -79,7 +81,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 10.06325,
+      "p95_ms": 395.929291,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -88,7 +90,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 10.16425,
+      "p95_ms": 607.974292,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -97,7 +99,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 4.212625,
+      "p95_ms": 294.954666,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -106,7 +108,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 4.610834,
+      "p95_ms": 214.790167,
       "returned_items": 20,
       "returned_body_bytes": 920
     }

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -8,7 +8,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 69186424832,
+    "available_scratch_bytes": 183564062720,
     "capable": true
   },
   "phase_a": {
@@ -20,7 +20,7 @@
     "projection_only": true,
     "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 0.107333,
+    "p95_ms": 0.077708,
     "target_p95_ms": 250,
     "passed": true
   },
@@ -28,8 +28,8 @@
     "source_managed_bytes": 2418642944,
     "scratch_bytes_after_checkpoint": 4837355520,
     "events": 130,
-    "migration_ms": 24221.061416,
-    "resume_backfill_ms": 2.036708,
+    "migration_ms": 19756.783292,
+    "resume_backfill_ms": 1.685667,
     "migrations_31_34_applied": true,
     "projection_rows": 130,
     "integrity_ok": true,
@@ -46,7 +46,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.661583,
+      "p95_ms": 1.395625,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -55,7 +55,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 3.333792,
+      "p95_ms": 1.809792,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -64,7 +64,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 2.508583,
+      "p95_ms": 1.191,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -73,7 +73,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 2.537625,
+      "p95_ms": 3.267334,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -82,7 +82,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 10.069708,
+      "p95_ms": 12.65575,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -91,7 +91,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 11.207792,
+      "p95_ms": 7.904375,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -100,7 +100,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 5.192,
+      "p95_ms": 4.126625,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -109,7 +109,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 5.955291,
+      "p95_ms": 3.696125,
       "returned_items": 20,
       "returned_body_bytes": 920
     }
@@ -123,6 +123,7 @@
     "total_items": 100,
     "multibyte_observed": true,
     "body_blocks_observed": true,
+    "truncation_metadata_observed": true,
     "continuation_no_duplicate_or_skip": true
   },
   "phase_e": {

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -8,7 +8,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 84308983808,
+    "available_scratch_bytes": 84002865152,
     "capable": true
   },
   "phase_a": {
@@ -21,7 +21,7 @@
     "returned_items": 8,
     "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 0.083958,
+    "p95_ms": 0.079708,
     "target_p95_ms": 250,
     "passed": true
   },
@@ -29,8 +29,8 @@
     "source_managed_bytes": 2418642944,
     "scratch_bytes_after_checkpoint": 6718570496,
     "events": 130,
-    "migration_ms": 61964.362709,
-    "resume_backfill_ms": 2.166166,
+    "migration_ms": 71677.088917,
+    "resume_backfill_ms": 3.266625,
     "migrations_31_34_applied": true,
     "projection_rows": 130,
     "integrity_ok": true,
@@ -48,7 +48,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.413459,
+      "p95_ms": 1.923,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -57,7 +57,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.549,
+      "p95_ms": 2.827,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -66,7 +66,7 @@
       "projection": "bounded_huge",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 206.701792,
+      "p95_ms": 206.746458,
       "returned_items": 1,
       "returned_body_bytes": 500,
       "source_body_bytes": 268435456,
@@ -77,7 +77,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.059917,
+      "p95_ms": 1.013833,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -86,7 +86,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.393292,
+      "p95_ms": 1.467375,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -95,7 +95,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 7.149292,
+      "p95_ms": 6.759792,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -104,7 +104,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 7.146875,
+      "p95_ms": 7.02725,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -113,7 +113,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.466041,
+      "p95_ms": 2.630417,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -122,7 +122,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.779167,
+      "p95_ms": 2.844167,
       "returned_items": 20,
       "returned_body_bytes": 920
     }

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -8,7 +8,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 181527982080,
+    "available_scratch_bytes": 84308983808,
     "capable": true
   },
   "phase_a": {
@@ -21,16 +21,16 @@
     "returned_items": 8,
     "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 0.074625,
+    "p95_ms": 0.083958,
     "target_p95_ms": 250,
     "passed": true
   },
   "phase_b": {
     "source_managed_bytes": 2418642944,
-    "scratch_bytes_after_checkpoint": 4837355520,
+    "scratch_bytes_after_checkpoint": 6718570496,
     "events": 130,
-    "migration_ms": 17477.897125,
-    "resume_backfill_ms": 1.8475,
+    "migration_ms": 61964.362709,
+    "resume_backfill_ms": 2.166166,
     "migrations_31_34_applied": true,
     "projection_rows": 130,
     "integrity_ok": true,
@@ -39,7 +39,8 @@
     "initial_fts_documents": 128,
     "initial_fts_complete": false,
     "final_fts_documents": 130,
-    "final_fts_complete": true
+    "final_fts_complete": true,
+    "pre_projection_writer_ok": true
   },
   "phase_c": [
     {
@@ -47,7 +48,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.248375,
+      "p95_ms": 1.413459,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -56,16 +57,27 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.491583,
+      "p95_ms": 1.549,
       "returned_items": 20,
       "returned_body_bytes": 920
+    },
+    {
+      "operation": "list",
+      "projection": "bounded_huge",
+      "fts_phase": "not_applicable",
+      "runs": 25,
+      "p95_ms": 206.701792,
+      "returned_items": 1,
+      "returned_body_bytes": 500,
+      "source_body_bytes": 268435456,
+      "bounded_budget_bytes": 500
     },
     {
       "operation": "context",
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 0.929292,
+      "p95_ms": 1.059917,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -74,7 +86,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.311833,
+      "p95_ms": 1.393292,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -83,7 +95,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 6.671917,
+      "p95_ms": 7.149292,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -92,7 +104,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 6.858,
+      "p95_ms": 7.146875,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -101,7 +113,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.428042,
+      "p95_ms": 2.466041,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -110,7 +122,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.761833,
+      "p95_ms": 2.779167,
       "returned_items": 20,
       "returned_body_bytes": 920
     }
@@ -126,11 +138,6 @@
     "body_blocks_observed": true,
     "truncation_metadata_observed": true,
     "continuation_no_duplicate_or_skip": true
-  },
-  "phase_e": {
-    "host_count": 6,
-    "manifest_parity": true,
-    "staged_retrieval_parity": true
   },
   "privacy": {
     "metrics_only": true,

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -8,7 +8,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 183564062720,
+    "available_scratch_bytes": 183289978880,
     "capable": true
   },
   "phase_a": {
@@ -20,7 +20,7 @@
     "projection_only": true,
     "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 0.077708,
+    "p95_ms": 0.073834,
     "target_p95_ms": 250,
     "passed": true
   },
@@ -28,8 +28,8 @@
     "source_managed_bytes": 2418642944,
     "scratch_bytes_after_checkpoint": 4837355520,
     "events": 130,
-    "migration_ms": 19756.783292,
-    "resume_backfill_ms": 1.685667,
+    "migration_ms": 17885.589958,
+    "resume_backfill_ms": 1.71325,
     "migrations_31_34_applied": true,
     "projection_rows": 130,
     "integrity_ok": true,
@@ -46,7 +46,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.395625,
+      "p95_ms": 1.101709,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -55,7 +55,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.809792,
+      "p95_ms": 1.581958,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -64,7 +64,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.191,
+      "p95_ms": 0.99175,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -73,7 +73,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 3.267334,
+      "p95_ms": 1.309917,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -82,7 +82,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 12.65575,
+      "p95_ms": 6.645958,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -91,7 +91,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 7.904375,
+      "p95_ms": 7.14625,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -100,7 +100,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 4.126625,
+      "p95_ms": 2.441209,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -109,7 +109,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 3.696125,
+      "p95_ms": 2.792541,
       "returned_items": 20,
       "returned_body_bytes": 920
     }
@@ -128,7 +128,8 @@
   },
   "phase_e": {
     "host_count": 6,
-    "manifest_parity": true
+    "manifest_parity": true,
+    "staged_retrieval_parity": true
   },
   "privacy": {
     "metrics_only": true,

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -8,7 +8,7 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 183289978880,
+    "available_scratch_bytes": 181527982080,
     "capable": true
   },
   "phase_a": {
@@ -18,9 +18,10 @@
     "projection_rows": 8,
     "missing_body_metadata": 0,
     "projection_only": true,
+    "returned_items": 8,
     "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 0.073834,
+    "p95_ms": 0.074625,
     "target_p95_ms": 250,
     "passed": true
   },
@@ -28,8 +29,8 @@
     "source_managed_bytes": 2418642944,
     "scratch_bytes_after_checkpoint": 4837355520,
     "events": 130,
-    "migration_ms": 17885.589958,
-    "resume_backfill_ms": 1.71325,
+    "migration_ms": 17477.897125,
+    "resume_backfill_ms": 1.8475,
     "migrations_31_34_applied": true,
     "projection_rows": 130,
     "integrity_ok": true,
@@ -46,7 +47,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.101709,
+      "p95_ms": 1.248375,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -55,7 +56,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.581958,
+      "p95_ms": 1.491583,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -64,7 +65,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 0.99175,
+      "p95_ms": 0.929292,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -73,7 +74,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 1.309917,
+      "p95_ms": 1.311833,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -82,7 +83,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 6.645958,
+      "p95_ms": 6.671917,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -91,7 +92,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 7.14625,
+      "p95_ms": 6.858,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -100,7 +101,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.441209,
+      "p95_ms": 2.428042,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -109,7 +110,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 2.792541,
+      "p95_ms": 2.761833,
       "returned_items": 20,
       "returned_body_bytes": 920
     }

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -1,7 +1,6 @@
 {
   "schema": "traceary.body-free-release-evidence.v1",
-  "status": "blocked",
-  "block_reason": "phase_a_failed",
+  "status": "pass",
   "host": {
     "goos": "darwin",
     "goarch": "arm64",
@@ -9,28 +8,30 @@
   },
   "preflight": {
     "required_scratch_bytes": 12884901888,
-    "available_scratch_bytes": 33745166336,
+    "available_scratch_bytes": 69186424832,
     "capable": true
   },
   "phase_a": {
-    "managed_bytes": 2418733056,
+    "managed_bytes": 2418774016,
     "stored_body_bytes": 2147483648,
     "events": 8,
+    "projection_rows": 8,
     "missing_body_metadata": 0,
-    "ordered_index": true,
-    "covering_index": false,
+    "projection_only": true,
+    "returned_body_bytes": 0,
     "runs": 25,
-    "p95_ms": 4159.414709,
+    "p95_ms": 0.107333,
     "target_p95_ms": 250,
-    "passed": false
+    "passed": true
   },
   "phase_b": {
     "source_managed_bytes": 2418642944,
     "scratch_bytes_after_checkpoint": 4837355520,
     "events": 130,
-    "migration_ms": 246959.606292,
-    "resume_backfill_ms": 12.320959,
-    "migrations_31_32_applied": true,
+    "migration_ms": 24221.061416,
+    "resume_backfill_ms": 2.036708,
+    "migrations_31_34_applied": true,
+    "projection_rows": 130,
     "integrity_ok": true,
     "foreign_key_violations": 0,
     "source_unchanged": true,
@@ -45,7 +46,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 47.614375,
+      "p95_ms": 1.661583,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -54,7 +55,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 286.277792,
+      "p95_ms": 3.333792,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -63,7 +64,7 @@
       "projection": "metadata",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 10.367166,
+      "p95_ms": 2.508583,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -72,7 +73,7 @@
       "projection": "bounded",
       "fts_phase": "not_applicable",
       "runs": 25,
-      "p95_ms": 185.714708,
+      "p95_ms": 2.537625,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -81,7 +82,7 @@
       "projection": "metadata",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 395.929291,
+      "p95_ms": 10.069708,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -90,7 +91,7 @@
       "projection": "bounded",
       "fts_phase": "incomplete",
       "runs": 25,
-      "p95_ms": 607.974292,
+      "p95_ms": 11.207792,
       "returned_items": 20,
       "returned_body_bytes": 920
     },
@@ -99,7 +100,7 @@
       "projection": "metadata",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 294.954666,
+      "p95_ms": 5.192,
       "returned_items": 20,
       "returned_body_bytes": 0
     },
@@ -108,7 +109,7 @@
       "projection": "bounded",
       "fts_phase": "complete",
       "runs": 25,
-      "p95_ms": 214.790167,
+      "p95_ms": 5.955291,
       "returned_items": 20,
       "returned_body_bytes": 920
     }

--- a/docs/release/v0.33.0-multigib-evidence.json
+++ b/docs/release/v0.33.0-multigib-evidence.json
@@ -1,0 +1,134 @@
+{
+  "schema": "traceary.body-free-release-evidence.v1",
+  "status": "blocked",
+  "block_reason": "phase_a_failed",
+  "host": {
+    "goos": "darwin",
+    "goarch": "arm64",
+    "go_version": "go1.26.3"
+  },
+  "preflight": {
+    "required_scratch_bytes": 12884901888,
+    "available_scratch_bytes": 34020667392,
+    "capable": true
+  },
+  "phase_a": {
+    "managed_bytes": 2418733056,
+    "stored_body_bytes": 2147483648,
+    "events": 8,
+    "missing_body_metadata": 0,
+    "runs": 25,
+    "p95_ms": 605.756875,
+    "target_p95_ms": 250,
+    "passed": false
+  },
+  "phase_b": {
+    "source_managed_bytes": 2418642944,
+    "scratch_peak_bytes": 4837355520,
+    "events": 130,
+    "migration_ms": 35953.925333,
+    "resume_backfill_ms": 1.585,
+    "migrations_31_32_applied": true,
+    "integrity_ok": true,
+    "foreign_key_violations": 0,
+    "source_unchanged": true,
+    "initial_fts_documents": 128,
+    "initial_fts_complete": false,
+    "final_fts_documents": 130,
+    "final_fts_complete": true
+  },
+  "phase_c": [
+    {
+      "operation": "list",
+      "projection": "metadata",
+      "fts_phase": "not_applicable",
+      "runs": 25,
+      "p95_ms": 2.236417,
+      "returned_items": 20,
+      "returned_body_bytes": 0
+    },
+    {
+      "operation": "list",
+      "projection": "bounded",
+      "fts_phase": "not_applicable",
+      "runs": 25,
+      "p95_ms": 3.21025,
+      "returned_items": 20,
+      "returned_body_bytes": 920
+    },
+    {
+      "operation": "context",
+      "projection": "metadata",
+      "fts_phase": "not_applicable",
+      "runs": 25,
+      "p95_ms": 1.655833,
+      "returned_items": 20,
+      "returned_body_bytes": 0
+    },
+    {
+      "operation": "context",
+      "projection": "bounded",
+      "fts_phase": "not_applicable",
+      "runs": 25,
+      "p95_ms": 2.550958,
+      "returned_items": 20,
+      "returned_body_bytes": 920
+    },
+    {
+      "operation": "search",
+      "projection": "metadata",
+      "fts_phase": "incomplete",
+      "runs": 25,
+      "p95_ms": 10.06325,
+      "returned_items": 20,
+      "returned_body_bytes": 0
+    },
+    {
+      "operation": "search",
+      "projection": "bounded",
+      "fts_phase": "incomplete",
+      "runs": 25,
+      "p95_ms": 10.16425,
+      "returned_items": 20,
+      "returned_body_bytes": 920
+    },
+    {
+      "operation": "search",
+      "projection": "metadata",
+      "fts_phase": "complete",
+      "runs": 25,
+      "p95_ms": 4.212625,
+      "returned_items": 20,
+      "returned_body_bytes": 0
+    },
+    {
+      "operation": "search",
+      "projection": "bounded",
+      "fts_phase": "complete",
+      "runs": 25,
+      "p95_ms": 4.610834,
+      "returned_items": 20,
+      "returned_body_bytes": 920
+    }
+  ],
+  "phase_d": {
+    "max_items": 100,
+    "max_aggregate_body_bytes": 65536,
+    "observed_max_items": 35,
+    "observed_max_aggregate_body_bytes": 65536,
+    "pages": 3,
+    "total_items": 100,
+    "multibyte_observed": true,
+    "body_blocks_observed": true,
+    "continuation_no_duplicate_or_skip": true
+  },
+  "phase_e": {
+    "host_count": 6,
+    "manifest_parity": true
+  },
+  "privacy": {
+    "metrics_only": true,
+    "scratch_private": true,
+    "scratch_cleaned": true
+  }
+}

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -166,3 +166,7 @@ the exact implementation and host.
 For `v0.33.0`, the tagged-release workflow runs the strict artifact verifier
 before GoReleaser. A missing, blocked, malformed, or privacy-invalid artifact
 therefore stops publication rather than relying on an operator reminder.
+
+### Projection rollback proof
+
+Phase B also proves rollback compatibility: a writer using the pre-projection event column shape inserts into the migrated private copy, the trigger-maintained projection records that row, and the transaction rollback restores both event and projection counts. The durable evidence records this only as `pre_projection_writer_ok`.

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -6,7 +6,7 @@
 
 **Pass.** The complete #1558 evidence artifact passes every defined release
 gate on Go 1.26.3, darwin/arm64. The 2 GiB projection-only direct metadata
-benchmark measured p95 **0.077708 ms**, below the fixed **250 ms** target. The
+benchmark measured p95 **0.073834 ms**, below the fixed **250 ms** target. The
 copied migration, event/projection parity, incomplete/complete FTS probes,
 aggregate response budget, six-package host parity, privacy, and scratch cleanup
 also passed.
@@ -36,8 +36,8 @@ The maintainer-only runner:
 6. keeps incomplete and complete FTS search observations separate;
 7. exercises a 100-item MCP request with multibyte canonical blocks and follows
    aggregate-budget continuations to completion;
-8. verifies the same `traceary mcp-server` registration across six packaged
-   hosts;
+8. verifies the same `traceary mcp-server` registration and staged-retrieval
+   semantic contract across six packaged hosts;
 9. removes scratch storage before writing the final artifact.
 
 The runner retains child output only in a capped in-memory buffer. The artifact
@@ -67,7 +67,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | Projection-only ordered plan | true | true | pass |
 | Returned body bytes | 0 | 0 | pass |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 0.077708 ms | below 250 ms | **pass** |
+| p95 | 0.073834 ms | below 250 ms | **pass** |
 
 The fixture uses generated content-free SQLite extents and copies no user event
 content. Fixture creation, migrations, checkpointing, extent checks, and
@@ -94,8 +94,8 @@ coverage of the separate many-small-rows shape.
 | Source managed bytes | 2,418,642,944 |
 | Scratch bytes after final checkpoint | 4,837,355,520 |
 | Historical events | 130 |
-| Migration/current initialization | 19,756.783292 ms |
-| Resumed FTS batch | 1.685667 ms |
+| Migration/current initialization | 17,885.589958 ms |
+| Resumed FTS batch | 1.713250 ms |
 | Migrations 31 through 34 | applied |
 | Projection rows | 130 |
 | Integrity check | pass |
@@ -117,14 +117,14 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.395625 ms | 20 | 0 |
-| list | bounded | not applicable | 1.809792 ms | 20 | 920 |
-| context | metadata | not applicable | 1.191000 ms | 20 | 0 |
-| context | bounded | not applicable | 3.267334 ms | 20 | 920 |
-| search | metadata | incomplete | 12.655750 ms | 20 | 0 |
-| search | bounded | incomplete | 7.904375 ms | 20 | 920 |
-| search | metadata | complete | 4.126625 ms | 20 | 0 |
-| search | bounded | complete | 3.696125 ms | 20 | 920 |
+| list | metadata | not applicable | 1.101709 ms | 20 | 0 |
+| list | bounded | not applicable | 1.581958 ms | 20 | 920 |
+| context | metadata | not applicable | 0.991750 ms | 20 | 0 |
+| context | bounded | not applicable | 1.309917 ms | 20 | 920 |
+| search | metadata | incomplete | 6.645958 ms | 20 | 0 |
+| search | bounded | incomplete | 7.146250 ms | 20 | 920 |
+| search | metadata | complete | 2.441209 ms | 20 | 0 |
+| search | bounded | complete | 2.792541 ms | 20 | 920 |
 
 Metadata projections returned zero body bytes. Incomplete and complete FTS
 searches returned the same internal membership; identities were compared but
@@ -141,7 +141,8 @@ not relative-performance claims.
 - A body exceeding the requested per-event limit exposed `body_truncated` and
   its original `body_length`, while other canonical events retained
   `body_blocks`.
-- All six packaged hosts passed the shared MCP command verifier.
+- All six packaged hosts passed both MCP registration parity and the
+  byte-identical Discovery → Inspection → Detail staged-retrieval contract.
 - Scratch was private and absent before the artifact was written.
 
 ## Release disposition

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -1,0 +1,127 @@
+# v0.33.0 multi-GiB release evidence
+
+[日本語](./v0.33.0-multigib-evidence.ja.md)
+
+## Verdict
+
+**Blocked.** The 2 GiB direct metadata benchmark completed, but its 25-run p95
+was **605.756875 ms**, above the fixed **250 ms** release target. The copied
+migration, incomplete/complete FTS probes, aggregate response budget,
+six-package host parity, privacy, and scratch-cleanup checks all passed. Phase-C
+latencies are observations only and are not release gates until their targets
+are fixed in the Issue.
+
+This evidence branch is based on the unmerged #1556 implementation in PR #1567
+at `bd798569`. It must retain that dependency until #1567 is merged.
+
+The machine-readable artifact is
+[`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json).
+It contains metrics only.
+
+## Procedure and privacy boundary
+
+The maintainer-only runner:
+
+1. requires at least 12 GiB of available scratch capacity;
+2. creates an owner-only temporary directory;
+3. runs the existing eight-event, 2 GiB direct metadata benchmark;
+4. creates a synthetic pre-migration store, copies it, and applies the current
+   migrations only to the copy;
+5. records separate 25-run list/context/search series for metadata and bounded
+   projections, with incomplete and complete FTS search kept separate;
+6. exercises a 100-item MCP page request with multibyte canonical blocks and
+   follows aggregate-budget continuations to completion;
+7. verifies the same `traceary mcp-server` registration across six packaged
+   hosts;
+8. removes scratch storage before writing the final artifact.
+
+The runner retains child output only in a capped in-memory buffer. The artifact
+schema has no event/session identity, workspace, path, cursor, continuation,
+body, prompt, or response field. Source/copy equality is checked internally;
+the digest is not published.
+
+Run and validate it with:
+
+```sh
+go run ./cmd/repo-tooling release run-v0.33.0-evidence \
+  --output docs/release/v0.33.0-multigib-evidence.json
+
+# Structural/privacy validation of the current blocked artifact:
+go run ./cmd/repo-tooling release verify-body-free-evidence \
+  --input docs/release/v0.33.0-multigib-evidence.json \
+  --allow-blocked
+```
+
+Without `--allow-blocked`, verification intentionally fails until every
+release gate passes.
+
+## Phase A: direct metadata gate
+
+| Metric | Observed | Required | Result |
+| --- | ---: | ---: | --- |
+| SQLite-managed bytes | 2,418,733,056 | at least 2 GiB | pass |
+| Stored-body metadata bytes | 2,147,483,648 | at least 2 GiB | pass |
+| Events | 8 | 8 | pass |
+| Missing body metadata | 0 | 0 | pass |
+| Measurement runs | 25 | 25 | pass |
+| p95 | 605.756875 ms | below 250 ms | **fail** |
+
+The fixture uses generated content-free SQLite extents. It does not copy user
+event content into Phase A. The failed latency target is the sole observed
+release blocker in this run; this evidence does not claim its root cause.
+
+## Phase B: copied migration and FTS progress
+
+| Metric | Observation |
+| --- | ---: |
+| Source managed bytes | 2,418,642,944 |
+| Peak scratch bytes | 4,837,355,520 |
+| Historical events | 130 |
+| Migration/current initialization | 35,953.925333 ms |
+| Resumed FTS batch | 1.585000 ms |
+| Migrations 31 and 32 | applied |
+| Integrity check | pass |
+| Foreign-key violations | 0 |
+| Source after copy migration | byte-identical |
+| First FTS batch | 128 documents, incomplete |
+| Resumed FTS state | 130 documents, complete |
+
+The source is synthetic and private. Only the copy is migrated. Large synthetic
+rows are retention-unavailable extents so the FTS phase measures bounded
+progress without duplicating 2 GiB of searchable text.
+
+## Phase C: projection and FTS observations
+
+Every series contains 25 runs.
+
+| Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
+| --- | --- | --- | ---: | ---: | ---: |
+| list | metadata | not applicable | 2.236417 ms | 20 | 0 |
+| list | bounded | not applicable | 3.210250 ms | 20 | 920 |
+| context | metadata | not applicable | 1.655833 ms | 20 | 0 |
+| context | bounded | not applicable | 2.550958 ms | 20 | 920 |
+| search | metadata | incomplete | 10.063250 ms | 20 | 0 |
+| search | bounded | incomplete | 10.164250 ms | 20 | 920 |
+| search | metadata | complete | 4.212625 ms | 20 | 0 |
+| search | bounded | complete | 4.610834 ms | 20 | 920 |
+
+Metadata projections returned zero body bytes. Incomplete and complete FTS
+searches returned the same internal membership; identities were compared but
+not serialized.
+
+## Phases D and E
+
+- A requested 100-item MCP page remained at or below 65,536 encoded body/block
+  bytes. The observed maximum was 35 items and 65,536 bytes over three pages.
+- All 100 multibyte canonical-block events appeared exactly once across the
+  continuation chain.
+- All six packaged hosts passed the shared MCP command verifier.
+- Scratch was private and absent before the artifact was written.
+
+## Release follow-up
+
+Do not tag v0.33.0 from this evidence. Keep the release blocked until the Phase-A
+direct metadata p95 is below 250 ms on an accepted capable-host rerun. Any
+performance fix must be delivered under its own Issue/PR, then this entire
+evidence workflow must be rerun because Phase-A data and copied migration
+timing are host- and implementation-sensitive.

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -4,19 +4,23 @@
 
 ## Verdict
 
-**Blocked.** The 2 GiB direct metadata benchmark completed, but its 25-run p95
-was **4,159.414709 ms**, above the fixed **250 ms** release target. The copied
-migration, incomplete/complete FTS probes, aggregate response budget,
-six-package host parity, privacy, and scratch-cleanup checks all passed. Phase-C
-latencies are observations only and are not release gates until their targets
-are fixed in the Issue.
+**Pass.** The complete #1558 evidence artifact passes every defined release
+gate on Go 1.26.3, darwin/arm64. The 2 GiB projection-only direct metadata
+benchmark measured p95 **0.107333 ms**, below the fixed **250 ms** target. The
+copied migration, event/projection parity, incomplete/complete FTS probes,
+aggregate response budget, six-package host parity, privacy, and scratch cleanup
+also passed.
 
-This evidence branch is based on the unmerged #1556 implementation in PR #1567
-at `bd798569`. It must retain that dependency until #1567 is merged.
+Phase-C latencies remain observations only because #1558 defines no release
+threshold for them. This evidence removes the #1558 blocker; other v0.33.0
+release gates remain independent.
+
+This branch was rebased onto `main` at `6641c6d7`, which contains merged PRs
+#1567 and #1570. No metric from the pre-projection blocked artifact was reused.
 
 The machine-readable artifact is
-[`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json).
-It contains metrics only.
+[`v0.33.0-multigib-evidence.json`](./v0.33.0-multigib-evidence.json). It contains
+metrics only.
 
 ## Procedure and privacy boundary
 
@@ -24,16 +28,17 @@ The maintainer-only runner:
 
 1. requires at least 12 GiB of available scratch capacity;
 2. creates an owner-only temporary directory;
-3. runs the existing eight-event, 2 GiB direct metadata benchmark;
-4. creates a synthetic pre-migration store, copies it, and applies the current
-   migrations only to the copy;
-5. records separate 25-run list/context/search series for metadata and bounded
-   projections, with incomplete and complete FTS search kept separate;
-6. exercises a 100-item MCP page request with multibyte canonical blocks and
-   follows aggregate-budget continuations to completion;
-7. verifies the same `traceary mcp-server` registration across six packaged
+3. runs the eight-event, 2 GiB projection-only metadata benchmark;
+4. creates a synthetic pre-31 store, copies it, and applies migrations 31
+   through 34 only to the copy;
+5. verifies event/projection parity and records separate 25-run
+   list/context/search series for metadata and bounded projections;
+6. keeps incomplete and complete FTS search observations separate;
+7. exercises a 100-item MCP request with multibyte canonical blocks and follows
+   aggregate-budget continuations to completion;
+8. verifies the same `traceary mcp-server` registration across six packaged
    hosts;
-8. removes scratch storage before writing the final artifact.
+9. removes scratch storage before writing the final artifact.
 
 The runner retains child output only in a capped in-memory buffer. The artifact
 schema has no event/session identity, workspace, path, cursor, continuation,
@@ -46,58 +51,37 @@ Run and validate it with:
 go run ./cmd/repo-tooling release run-v0.33.0-evidence \
   --output docs/release/v0.33.0-multigib-evidence.json
 
-# Structural/privacy validation of the current blocked artifact:
 go run ./cmd/repo-tooling release verify-body-free-evidence \
-  --input docs/release/v0.33.0-multigib-evidence.json \
-  --allow-blocked
+  --input docs/release/v0.33.0-multigib-evidence.json
 ```
-
-Without `--allow-blocked`, verification intentionally fails until every
-release gate passes.
 
 ## Phase A: direct metadata gate
 
 | Metric | Observed | Required | Result |
 | --- | ---: | ---: | --- |
-| SQLite-managed bytes | 2,418,733,056 | at least 2 GiB | pass |
+| SQLite-managed bytes | 2,418,774,016 | at least 2 GiB | pass |
 | Stored-body metadata bytes | 2,147,483,648 | at least 2 GiB | pass |
 | Events | 8 | 8 | pass |
+| Projection rows | 8 | equal to events | pass |
 | Missing body metadata | 0 | 0 | pass |
-| Ordered direct-range index | true | true | pass |
-| Covering event-metadata index | false | observation | diagnostic |
+| Projection-only ordered plan | true | true | pass |
+| Returned body bytes | 0 | 0 | pass |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 4,159.414709 ms | below 250 ms | **fail** |
+| p95 | 0.107333 ms | below 250 ms | **pass** |
 
-The fixture uses generated content-free SQLite extents. It does not copy user
-event content into Phase A. The failed latency target is the sole observed
-release blocker in this run. The diagnostic below separates its physical query
-mechanism from the release measurement.
+The fixture uses generated content-free SQLite extents and copies no user event
+content. Fixture creation, migrations, checkpointing, extent checks, and
+`EXPLAIN QUERY PLAN` execute before the 25 timers. Each sample contains only
+query execution, complete row scanning, and row closure.
 
-### Phase-A diagnosis
+The plan uses `idx_event_metadata_workspace_created_at_norm_id_desc`, creates no
+temporary sort, and does not consult the authoritative `events` table. The
+trigger-maintained projection from merged PR #1570 therefore keeps metadata
+selection independent of the 2 GiB body extent.
 
-The measurement scope matches the fixed benchmark contract. Fixture creation,
-migrations, checkpointing, extent checks, and `EXPLAIN QUERY PLAN` execute
-before the 25 timers. Each sample contains only query execution, all row scans,
-and row closure.
-
-The query seeks both timestamp bounds through
-`idx_events_workspace_created_at_norm_id_desc` and does not create a temporary
-sort. That ordered index is not covering. SQLite stores `events.body` before
-`created_at`, client/workspace fields, and body-extent metadata in the table
-record. SQLite's documented [table-lookup][sqlite-query-planner] and
-[linked overflow-page][sqlite-file-format] mechanics, together with the
-controlled result below, support the inference that fetching those selected
-fields follows the large body's overflow chain even though the SQL projection
-excludes `body`.
-
-A diagnostic-only run created a temporary covering workspace index after
-fixture setup and outside the timers. The otherwise identical 25-run query
-measured p95 **0.088750 ms**. Production-schema runs measured **605.756875 ms**
-and, under heavier host I/O pressure, the canonical **4,159.414709 ms** shown
-above. The diagnostic value is not release evidence because the temporary index
-is not part of the production schema. It isolates the non-covering table lookup
-as the blocker while showing that host I/O conditions affect the magnitude;
-changing the timer, fixture, or target would conceal the problem.
+The previous pre-#1570 artifact measured the authoritative-table path and was
+correctly blocked. A complete rerun, rather than metric substitution, produced
+the passing result above.
 
 ## Phase B: copied migration and FTS progress
 
@@ -106,9 +90,10 @@ changing the timer, fixture, or target would conceal the problem.
 | Source managed bytes | 2,418,642,944 |
 | Scratch bytes after final checkpoint | 4,837,355,520 |
 | Historical events | 130 |
-| Migration/current initialization | 246,959.606292 ms |
-| Resumed FTS batch | 12.320959 ms |
-| Migrations 31 and 32 | applied |
+| Migration/current initialization | 24,221.061416 ms |
+| Resumed FTS batch | 2.036708 ms |
+| Migrations 31 through 34 | applied |
+| Projection rows | 130 |
 | Integrity check | pass |
 | Foreign-key violations | 0 |
 | Source after copy migration | byte-identical |
@@ -116,11 +101,11 @@ changing the timer, fixture, or target would conceal the problem.
 | Resumed FTS state | 130 documents, complete |
 
 The source is synthetic and private. Only the copy is migrated. Large synthetic
-rows are retention-unavailable extents so the FTS phase measures bounded
-progress without duplicating 2 GiB of searchable text.
-The scratch value is the retained source-plus-copy extent after the final WAL
-checkpoint, not a sampled high-water mark. The 12 GiB preflight separately
-reserves headroom for transient WAL and test-build files.
+rows are retention-unavailable extents, so the FTS phase measures bounded
+progress without duplicating 2 GiB of searchable text. The scratch value is the
+retained source-plus-copy extent after the final WAL checkpoint, not a sampled
+high-water mark. The 12 GiB preflight separately reserves headroom for transient
+WAL and test-build files.
 
 ## Phase C: projection and FTS observations
 
@@ -128,14 +113,14 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 47.614375 ms | 20 | 0 |
-| list | bounded | not applicable | 286.277792 ms | 20 | 920 |
-| context | metadata | not applicable | 10.367166 ms | 20 | 0 |
-| context | bounded | not applicable | 185.714708 ms | 20 | 920 |
-| search | metadata | incomplete | 395.929291 ms | 20 | 0 |
-| search | bounded | incomplete | 607.974292 ms | 20 | 920 |
-| search | metadata | complete | 294.954666 ms | 20 | 0 |
-| search | bounded | complete | 214.790167 ms | 20 | 920 |
+| list | metadata | not applicable | 1.661583 ms | 20 | 0 |
+| list | bounded | not applicable | 3.333792 ms | 20 | 920 |
+| context | metadata | not applicable | 2.508583 ms | 20 | 0 |
+| context | bounded | not applicable | 2.537625 ms | 20 | 920 |
+| search | metadata | incomplete | 10.069708 ms | 20 | 0 |
+| search | bounded | incomplete | 11.207792 ms | 20 | 920 |
+| search | metadata | complete | 5.192000 ms | 20 | 0 |
+| search | bounded | complete | 5.955291 ms | 20 | 920 |
 
 Metadata projections returned zero body bytes. Incomplete and complete FTS
 searches returned the same internal membership; identities were compared but
@@ -150,27 +135,11 @@ not serialized.
 - All six packaged hosts passed the shared MCP command verifier.
 - Scratch was private and absent before the artifact was written.
 
-## Release follow-up
+## Release disposition
 
-Do not tag v0.33.0 from this evidence. Keep the release blocked until the Phase-A
-direct metadata p95 is below 250 ms on an accepted capable-host rerun. Any
-performance fix must be delivered under its own Issue/PR, then this entire
-evidence workflow must be rerun because Phase-A data and copied migration
-timing are host- and implementation-sensitive.
-
-Concrete follow-up Issue candidate:
-
-- **Title:** `v0.33.0-10: avoid event-body overflow reads in metadata queries`
-- require covering, no-temporary-sort plans for general, workspace, session,
-  workspace+session, and primary source-hook metadata reads;
-- choose between wider ordered indexes and one metadata-cover index with
-  explicit query joins by measuring migration duration, peak scratch,
-  steady-state index bytes, and insert cost;
-- run the change against a copied multi-GiB pre-migration store, prove the
-  source is unchanged, and document disk/write-lock rollback behavior;
-- preserve #1551 staged retrieval, #1552 indexed-search membership/fallback,
-  and #1553 ordering/range semantics;
-- rerun all #1558 phases and require Phase-A p95 below 250 ms before release.
-
-[sqlite-query-planner]: https://www.sqlite.org/queryplanner.html
-[sqlite-file-format]: https://www.sqlite.org/fileformat.html
+The #1558 release gate is satisfied. A tagged release may use this artifact as
+its multi-GiB body-free evidence, subject to the remaining independent release
+checks. Rerun the entire workflow if the metadata projection, migrations 31-34,
+FTS backfill, aggregate response budget, host manifests, or Go runtime changes.
+Partial reuse is not valid because Phase-A and copied-migration timing depend on
+the exact implementation and host.

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -6,9 +6,9 @@
 
 **Pass.** The complete #1558 evidence artifact passes every defined release
 gate on Go 1.26.3, darwin/arm64. The 2 GiB projection-only direct metadata
-benchmark measured p95 **0.074625 ms**, below the fixed **250 ms** target. The
+benchmark measured p95 **0.079708 ms**, below the fixed **250 ms** target. The
 copied migration, event/projection parity, incomplete/complete FTS probes,
-aggregate response budget, six-package host parity, privacy, and scratch cleanup
+aggregate response budget, host-verifier preflight, privacy, and scratch cleanup
 also passed.
 
 Phase-C latencies remain observations only because #1558 defines no release
@@ -39,7 +39,7 @@ The maintainer-only runner:
 7. exercises a 100-item MCP request with multibyte canonical blocks and follows
    aggregate-budget continuations to completion;
 8. verifies the same `traceary mcp-server` registration and staged-retrieval
-   semantic contract across six packaged hosts;
+   semantic contract across six packaged hosts before running the probes;
 9. removes scratch storage before writing the final artifact.
 
 The runner retains child output only in a capped in-memory buffer. The artifact
@@ -70,7 +70,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | Returned items | 8 | 8 | pass |
 | Returned body bytes | 0 | 0 | pass |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 0.074625 ms | below 250 ms | **pass** |
+| p95 | 0.079708 ms | below 250 ms | **pass** |
 
 The fixture uses generated content-free SQLite extents and copies no user event
 content. Fixture creation, migrations, checkpointing, extent checks, and
@@ -97,10 +97,10 @@ coverage of the separate many-small-rows shape.
 | Metric | Observation |
 | --- | ---: |
 | Source managed bytes | 2,418,642,944 |
-| Scratch bytes after final checkpoint | 4,837,355,520 |
+| Scratch bytes after final checkpoint | 6,718,570,496 |
 | Historical events | 130 |
-| Migration/current initialization | 17,477.897125 ms |
-| Resumed FTS batch | 1.847500 ms |
+| Migration/current initialization | 71,677.088917 ms |
+| Resumed FTS batch | 3.266625 ms |
 | Migrations 31 through 34 | applied |
 | Projection rows | 130 |
 | Integrity check | pass |
@@ -122,26 +122,29 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.248375 ms | 20 | 0 |
-| list | bounded | not applicable | 1.491583 ms | 20 | 920 |
-| context | metadata | not applicable | 0.929292 ms | 20 | 0 |
-| context | bounded | not applicable | 1.311833 ms | 20 | 920 |
-| search | metadata | incomplete | 6.671917 ms | 20 | 0 |
-| search | bounded | incomplete | 6.858000 ms | 20 | 920 |
-| search | metadata | complete | 2.428042 ms | 20 | 0 |
-| search | bounded | complete | 2.761833 ms | 20 | 920 |
+| list | metadata | not applicable | 1.923000 ms | 20 | 0 |
+| list | bounded | not applicable | 2.827000 ms | 20 | 920 |
+| list | bounded_huge | not applicable | 206.746458 ms | 1 | 500 |
+| context | metadata | not applicable | 1.013833 ms | 20 | 0 |
+| context | bounded | not applicable | 1.467375 ms | 20 | 920 |
+| search | metadata | incomplete | 6.759792 ms | 20 | 0 |
+| search | bounded | incomplete | 7.027250 ms | 20 | 920 |
+| search | metadata | complete | 2.630417 ms | 20 | 0 |
+| search | bounded | complete | 2.844167 ms | 20 | 920 |
 
-All eight probes used the 130-event fixture with limit 20 and returned exactly
-20 items. For list, context, incomplete search, and complete search, metadata
-and bounded projections returned identical internal membership. Incomplete and
-complete FTS searches also retained membership. Identities were compared only
-in memory and were not serialized. Metadata projections returned zero body
-bytes, while every bounded projection returned a positive byte count. These
-short, single-host series are not powered to compare
+Eight standard probes used the 130-event fixture with limit 20 and returned
+exactly 20 items. A ninth `list/bounded_huge` probe selected one 256 MiB source
+body and returned at most its explicit 500-byte budget. For list, context,
+incomplete search, and complete search, metadata and bounded projections
+returned identical internal membership. Incomplete and complete FTS searches
+also retained membership. Identities were compared only in memory and were not
+serialized. Metadata projections returned zero body bytes, while every bounded
+projection returned a positive byte count. These short, single-host series are
+not powered to compare
 metadata and bounded projection performance; their p95 values are observations,
 not relative-performance claims.
 
-## Phases D and E
+## Phase D and host-verifier preflight
 
 - A requested 100-item MCP page remained at or below 65,536 encoded body/block
   bytes. The observed maximum was 35 items and 65,536 bytes over three pages.
@@ -150,8 +153,10 @@ not relative-performance claims.
 - A body exceeding the requested per-event limit exposed `body_truncated` and
   its original `body_length`, while other canonical events retained
   `body_blocks`.
-- All six packaged hosts passed both MCP registration parity and the
-  byte-identical Discovery → Inspection → Detail staged-retrieval contract.
+- Before the probes ran, all six packaged hosts passed MCP registration parity
+  and the byte-identical Discovery → Inspection → Detail staged-retrieval
+  contract. This is a runner precondition, not a fabricated metrics phase in
+  the published artifact.
 - Scratch was private and absent before the artifact was written.
 
 ## Release disposition

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -5,7 +5,7 @@
 ## Verdict
 
 **Blocked.** The 2 GiB direct metadata benchmark completed, but its 25-run p95
-was **605.756875 ms**, above the fixed **250 ms** release target. The copied
+was **4,159.414709 ms**, above the fixed **250 ms** release target. The copied
 migration, incomplete/complete FTS probes, aggregate response budget,
 six-package host parity, privacy, and scratch-cleanup checks all passed. Phase-C
 latencies are observations only and are not release gates until their targets
@@ -63,22 +63,51 @@ release gate passes.
 | Stored-body metadata bytes | 2,147,483,648 | at least 2 GiB | pass |
 | Events | 8 | 8 | pass |
 | Missing body metadata | 0 | 0 | pass |
+| Ordered direct-range index | true | true | pass |
+| Covering event-metadata index | false | observation | diagnostic |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 605.756875 ms | below 250 ms | **fail** |
+| p95 | 4,159.414709 ms | below 250 ms | **fail** |
 
 The fixture uses generated content-free SQLite extents. It does not copy user
 event content into Phase A. The failed latency target is the sole observed
-release blocker in this run; this evidence does not claim its root cause.
+release blocker in this run. The diagnostic below separates its physical query
+mechanism from the release measurement.
+
+### Phase-A diagnosis
+
+The measurement scope matches the fixed benchmark contract. Fixture creation,
+migrations, checkpointing, extent checks, and `EXPLAIN QUERY PLAN` execute
+before the 25 timers. Each sample contains only query execution, all row scans,
+and row closure.
+
+The query seeks both timestamp bounds through
+`idx_events_workspace_created_at_norm_id_desc` and does not create a temporary
+sort. That ordered index is not covering. SQLite stores `events.body` before
+`created_at`, client/workspace fields, and body-extent metadata in the table
+record. SQLite's documented [table-lookup][sqlite-query-planner] and
+[linked overflow-page][sqlite-file-format] mechanics, together with the
+controlled result below, support the inference that fetching those selected
+fields follows the large body's overflow chain even though the SQL projection
+excludes `body`.
+
+A diagnostic-only run created a temporary covering workspace index after
+fixture setup and outside the timers. The otherwise identical 25-run query
+measured p95 **0.088750 ms**. Production-schema runs measured **605.756875 ms**
+and, under heavier host I/O pressure, the canonical **4,159.414709 ms** shown
+above. The diagnostic value is not release evidence because the temporary index
+is not part of the production schema. It isolates the non-covering table lookup
+as the blocker while showing that host I/O conditions affect the magnitude;
+changing the timer, fixture, or target would conceal the problem.
 
 ## Phase B: copied migration and FTS progress
 
 | Metric | Observation |
 | --- | ---: |
 | Source managed bytes | 2,418,642,944 |
-| Peak scratch bytes | 4,837,355,520 |
+| Scratch bytes after final checkpoint | 4,837,355,520 |
 | Historical events | 130 |
-| Migration/current initialization | 35,953.925333 ms |
-| Resumed FTS batch | 1.585000 ms |
+| Migration/current initialization | 246,959.606292 ms |
+| Resumed FTS batch | 12.320959 ms |
 | Migrations 31 and 32 | applied |
 | Integrity check | pass |
 | Foreign-key violations | 0 |
@@ -89,6 +118,9 @@ release blocker in this run; this evidence does not claim its root cause.
 The source is synthetic and private. Only the copy is migrated. Large synthetic
 rows are retention-unavailable extents so the FTS phase measures bounded
 progress without duplicating 2 GiB of searchable text.
+The scratch value is the retained source-plus-copy extent after the final WAL
+checkpoint, not a sampled high-water mark. The 12 GiB preflight separately
+reserves headroom for transient WAL and test-build files.
 
 ## Phase C: projection and FTS observations
 
@@ -96,14 +128,14 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 2.236417 ms | 20 | 0 |
-| list | bounded | not applicable | 3.210250 ms | 20 | 920 |
-| context | metadata | not applicable | 1.655833 ms | 20 | 0 |
-| context | bounded | not applicable | 2.550958 ms | 20 | 920 |
-| search | metadata | incomplete | 10.063250 ms | 20 | 0 |
-| search | bounded | incomplete | 10.164250 ms | 20 | 920 |
-| search | metadata | complete | 4.212625 ms | 20 | 0 |
-| search | bounded | complete | 4.610834 ms | 20 | 920 |
+| list | metadata | not applicable | 47.614375 ms | 20 | 0 |
+| list | bounded | not applicable | 286.277792 ms | 20 | 920 |
+| context | metadata | not applicable | 10.367166 ms | 20 | 0 |
+| context | bounded | not applicable | 185.714708 ms | 20 | 920 |
+| search | metadata | incomplete | 395.929291 ms | 20 | 0 |
+| search | bounded | incomplete | 607.974292 ms | 20 | 920 |
+| search | metadata | complete | 294.954666 ms | 20 | 0 |
+| search | bounded | complete | 214.790167 ms | 20 | 920 |
 
 Metadata projections returned zero body bytes. Incomplete and complete FTS
 searches returned the same internal membership; identities were compared but
@@ -125,3 +157,20 @@ direct metadata p95 is below 250 ms on an accepted capable-host rerun. Any
 performance fix must be delivered under its own Issue/PR, then this entire
 evidence workflow must be rerun because Phase-A data and copied migration
 timing are host- and implementation-sensitive.
+
+Concrete follow-up Issue candidate:
+
+- **Title:** `v0.33.0-10: avoid event-body overflow reads in metadata queries`
+- require covering, no-temporary-sort plans for general, workspace, session,
+  workspace+session, and primary source-hook metadata reads;
+- choose between wider ordered indexes and one metadata-cover index with
+  explicit query joins by measuring migration duration, peak scratch,
+  steady-state index bytes, and insert cost;
+- run the change against a copied multi-GiB pre-migration store, prove the
+  source is unchanged, and document disk/write-lock rollback behavior;
+- preserve #1551 staged retrieval, #1552 indexed-search membership/fallback,
+  and #1553 ordering/range semantics;
+- rerun all #1558 phases and require Phase-A p95 below 250 ms before release.
+
+[sqlite-query-planner]: https://www.sqlite.org/queryplanner.html
+[sqlite-file-format]: https://www.sqlite.org/fileformat.html

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -6,7 +6,7 @@
 
 **Pass.** The complete #1558 evidence artifact passes every defined release
 gate on Go 1.26.3, darwin/arm64. The 2 GiB projection-only direct metadata
-benchmark measured p95 **0.073834 ms**, below the fixed **250 ms** target. The
+benchmark measured p95 **0.074625 ms**, below the fixed **250 ms** target. The
 copied migration, event/projection parity, incomplete/complete FTS probes,
 aggregate response budget, six-package host parity, privacy, and scratch cleanup
 also passed.
@@ -32,7 +32,9 @@ The maintainer-only runner:
 4. creates a synthetic pre-31 store, copies it, and applies migrations 31
    through 34 only to the copy;
 5. verifies event/projection parity and records separate 25-run
-   list/context/search series for metadata and bounded projections;
+   list/context/search series for metadata and bounded projections against a
+   130-event fixture with limit 20, requiring exact result-count and membership
+   parity;
 6. keeps incomplete and complete FTS search observations separate;
 7. exercises a 100-item MCP request with multibyte canonical blocks and follows
    aggregate-budget continuations to completion;
@@ -65,14 +67,17 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | Projection rows | 8 | equal to events | pass |
 | Missing body metadata | 0 | 0 | pass |
 | Projection-only ordered plan | true | true | pass |
+| Returned items | 8 | 8 | pass |
 | Returned body bytes | 0 | 0 | pass |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 0.073834 ms | below 250 ms | **pass** |
+| p95 | 0.074625 ms | below 250 ms | **pass** |
 
 The fixture uses generated content-free SQLite extents and copies no user event
 content. Fixture creation, migrations, checkpointing, extent checks, and
 `EXPLAIN QUERY PLAN` execute before the 25 timers. Each sample contains only
 query execution, complete row scanning, and row closure.
+Every timed scan returned all eight rows and completed without an iteration
+error.
 
 The plan uses `idx_event_metadata_workspace_created_at_norm_id_desc`, creates no
 temporary sort, and does not consult the authoritative `events` table. The
@@ -94,8 +99,8 @@ coverage of the separate many-small-rows shape.
 | Source managed bytes | 2,418,642,944 |
 | Scratch bytes after final checkpoint | 4,837,355,520 |
 | Historical events | 130 |
-| Migration/current initialization | 17,885.589958 ms |
-| Resumed FTS batch | 1.713250 ms |
+| Migration/current initialization | 17,477.897125 ms |
+| Resumed FTS batch | 1.847500 ms |
 | Migrations 31 through 34 | applied |
 | Projection rows | 130 |
 | Integrity check | pass |
@@ -117,18 +122,22 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.101709 ms | 20 | 0 |
-| list | bounded | not applicable | 1.581958 ms | 20 | 920 |
-| context | metadata | not applicable | 0.991750 ms | 20 | 0 |
-| context | bounded | not applicable | 1.309917 ms | 20 | 920 |
-| search | metadata | incomplete | 6.645958 ms | 20 | 0 |
-| search | bounded | incomplete | 7.146250 ms | 20 | 920 |
-| search | metadata | complete | 2.441209 ms | 20 | 0 |
-| search | bounded | complete | 2.792541 ms | 20 | 920 |
+| list | metadata | not applicable | 1.248375 ms | 20 | 0 |
+| list | bounded | not applicable | 1.491583 ms | 20 | 920 |
+| context | metadata | not applicable | 0.929292 ms | 20 | 0 |
+| context | bounded | not applicable | 1.311833 ms | 20 | 920 |
+| search | metadata | incomplete | 6.671917 ms | 20 | 0 |
+| search | bounded | incomplete | 6.858000 ms | 20 | 920 |
+| search | metadata | complete | 2.428042 ms | 20 | 0 |
+| search | bounded | complete | 2.761833 ms | 20 | 920 |
 
-Metadata projections returned zero body bytes. Incomplete and complete FTS
-searches returned the same internal membership; identities were compared but
-not serialized. These short, single-host series are not powered to compare
+All eight probes used the 130-event fixture with limit 20 and returned exactly
+20 items. For list, context, incomplete search, and complete search, metadata
+and bounded projections returned identical internal membership. Incomplete and
+complete FTS searches also retained membership. Identities were compared only
+in memory and were not serialized. Metadata projections returned zero body
+bytes, while every bounded projection returned a positive byte count. These
+short, single-host series are not powered to compare
 metadata and bounded projection performance; their p95 values are observations,
 not relative-performance claims.
 

--- a/docs/release/v0.33.0-multigib-evidence.md
+++ b/docs/release/v0.33.0-multigib-evidence.md
@@ -6,7 +6,7 @@
 
 **Pass.** The complete #1558 evidence artifact passes every defined release
 gate on Go 1.26.3, darwin/arm64. The 2 GiB projection-only direct metadata
-benchmark measured p95 **0.107333 ms**, below the fixed **250 ms** target. The
+benchmark measured p95 **0.077708 ms**, below the fixed **250 ms** target. The
 copied migration, event/projection parity, incomplete/complete FTS probes,
 aggregate response budget, six-package host parity, privacy, and scratch cleanup
 also passed.
@@ -67,7 +67,7 @@ go run ./cmd/repo-tooling release verify-body-free-evidence \
 | Projection-only ordered plan | true | true | pass |
 | Returned body bytes | 0 | 0 | pass |
 | Measurement runs | 25 | 25 | pass |
-| p95 | 0.107333 ms | below 250 ms | **pass** |
+| p95 | 0.077708 ms | below 250 ms | **pass** |
 
 The fixture uses generated content-free SQLite extents and copies no user event
 content. Fixture creation, migrations, checkpointing, extent checks, and
@@ -83,6 +83,10 @@ The previous pre-#1570 artifact measured the authoritative-table path and was
 correctly blocked. A complete rerun, rather than metric substitution, produced
 the passing result above.
 
+This fixture deliberately represents the few-huge-rows shape: eight rows hold
+2 GiB of body extents. It validates overflow-chain isolation but does not claim
+coverage of the separate many-small-rows shape.
+
 ## Phase B: copied migration and FTS progress
 
 | Metric | Observation |
@@ -90,8 +94,8 @@ the passing result above.
 | Source managed bytes | 2,418,642,944 |
 | Scratch bytes after final checkpoint | 4,837,355,520 |
 | Historical events | 130 |
-| Migration/current initialization | 24,221.061416 ms |
-| Resumed FTS batch | 2.036708 ms |
+| Migration/current initialization | 19,756.783292 ms |
+| Resumed FTS batch | 1.685667 ms |
 | Migrations 31 through 34 | applied |
 | Projection rows | 130 |
 | Integrity check | pass |
@@ -113,18 +117,20 @@ Every series contains 25 runs.
 
 | Operation | Projection | FTS phase | p95 | Returned items | Returned body bytes |
 | --- | --- | --- | ---: | ---: | ---: |
-| list | metadata | not applicable | 1.661583 ms | 20 | 0 |
-| list | bounded | not applicable | 3.333792 ms | 20 | 920 |
-| context | metadata | not applicable | 2.508583 ms | 20 | 0 |
-| context | bounded | not applicable | 2.537625 ms | 20 | 920 |
-| search | metadata | incomplete | 10.069708 ms | 20 | 0 |
-| search | bounded | incomplete | 11.207792 ms | 20 | 920 |
-| search | metadata | complete | 5.192000 ms | 20 | 0 |
-| search | bounded | complete | 5.955291 ms | 20 | 920 |
+| list | metadata | not applicable | 1.395625 ms | 20 | 0 |
+| list | bounded | not applicable | 1.809792 ms | 20 | 920 |
+| context | metadata | not applicable | 1.191000 ms | 20 | 0 |
+| context | bounded | not applicable | 3.267334 ms | 20 | 920 |
+| search | metadata | incomplete | 12.655750 ms | 20 | 0 |
+| search | bounded | incomplete | 7.904375 ms | 20 | 920 |
+| search | metadata | complete | 4.126625 ms | 20 | 0 |
+| search | bounded | complete | 3.696125 ms | 20 | 920 |
 
 Metadata projections returned zero body bytes. Incomplete and complete FTS
 searches returned the same internal membership; identities were compared but
-not serialized.
+not serialized. These short, single-host series are not powered to compare
+metadata and bounded projection performance; their p95 values are observations,
+not relative-performance claims.
 
 ## Phases D and E
 
@@ -132,6 +138,9 @@ not serialized.
   bytes. The observed maximum was 35 items and 65,536 bytes over three pages.
 - All 100 multibyte canonical-block events appeared exactly once across the
   continuation chain.
+- A body exceeding the requested per-event limit exposed `body_truncated` and
+  its original `body_length`, while other canonical events retained
+  `body_blocks`.
 - All six packaged hosts passed the shared MCP command verifier.
 - Scratch was private and absent before the artifact was written.
 
@@ -143,3 +152,7 @@ checks. Rerun the entire workflow if the metadata projection, migrations 31-34,
 FTS backfill, aggregate response budget, host manifests, or Go runtime changes.
 Partial reuse is not valid because Phase-A and copied-migration timing depend on
 the exact implementation and host.
+
+For `v0.33.0`, the tagged-release workflow runs the strict artifact verifier
+before GoReleaser. A missing, blocked, malformed, or privacy-invalid artifact
+therefore stops publication rather than relying on an operator reminder.

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -472,6 +472,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		b.Fatal("multi-GiB metadata plan is not projection-only and index ordered")
 	}
 	durations := make([]time.Duration, 0, measurementRuns)
+	var returnedItems int64
 	b.ResetTimer()
 	for range measurementRuns {
 		started := time.Now()
@@ -479,6 +480,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		if err != nil {
 			b.Fatalf("range query: %v", err)
 		}
+		var currentReturnedItems int64
 		for rows.Next() {
 			var values [16]any
 			pointers := make([]any, len(values))
@@ -489,10 +491,19 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 				_ = rows.Close()
 				b.Fatalf("scan range row: %v", err)
 			}
+			currentReturnedItems++
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			b.Fatalf("iterate range rows: %v", err)
 		}
 		if err := rows.Close(); err != nil {
 			b.Fatalf("rows.Close() error = %v", err)
 		}
+		if currentReturnedItems != storedEvents {
+			b.Fatalf("range query returned %d rows, want %d", currentReturnedItems, storedEvents)
+		}
+		returnedItems = currentReturnedItems
 		durations = append(durations, time.Since(started))
 	}
 	b.StopTimer()
@@ -504,6 +515,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	b.ReportMetric(float64(missingStoredBodyBytes), "missing_body_metadata")
 	b.ReportMetric(float64(storedBodyBytes), "stored_body_bytes")
 	b.ReportMetric(1, "projection_only")
+	b.ReportMetric(float64(returnedItems), "returned_items")
 	b.ReportMetric(0, "returned_body_bytes")
 	b.ReportMetric(measurementRuns, "measurement_runs")
 	b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
@@ -515,6 +527,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		ProjectionRows      int64   `json:"projection_rows"`
 		MissingBodyMetadata int64   `json:"missing_body_metadata"`
 		ProjectionOnly      bool    `json:"projection_only"`
+		ReturnedItems       int64   `json:"returned_items"`
 		ReturnedBodyBytes   int64   `json:"returned_body_bytes"`
 		Runs                int     `json:"runs"`
 		P95MS               float64 `json:"p95_ms"`
@@ -527,6 +540,7 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		ProjectionRows:      projectionRows,
 		MissingBodyMetadata: missingStoredBodyBytes,
 		ProjectionOnly:      projectionOnly,
+		ReturnedItems:       returnedItems,
 		ReturnedBodyBytes:   0,
 		Runs:                measurementRuns,
 		P95MS:               float64(p95) / float64(time.Millisecond),

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -505,7 +506,31 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 	b.ReportMetric(0, "returned_body_bytes")
 	b.ReportMetric(measurementRuns, "measurement_runs")
 	b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
-	if p95 >= 250*time.Millisecond {
+	passed := p95 < 250*time.Millisecond
+	marker, err := json.Marshal(struct {
+		ManagedBytes        int64   `json:"managed_bytes"`
+		StoredBodyBytes     int64   `json:"stored_body_bytes"`
+		Events              int64   `json:"events"`
+		MissingBodyMetadata int64   `json:"missing_body_metadata"`
+		Runs                int     `json:"runs"`
+		P95MS               float64 `json:"p95_ms"`
+		TargetP95MS         float64 `json:"target_p95_ms"`
+		Passed              bool    `json:"passed"`
+	}{
+		ManagedBytes:        pageCount * pageSize,
+		StoredBodyBytes:     storedBodyBytes,
+		Events:              storedEvents,
+		MissingBodyMetadata: missingStoredBodyBytes,
+		Runs:                measurementRuns,
+		P95MS:               float64(p95) / float64(time.Millisecond),
+		TargetP95MS:         250,
+		Passed:              passed,
+	})
+	if err != nil {
+		b.Fatalf("marshal Phase-A evidence: %v", err)
+	}
+	b.Logf("TRACEARY_PHASE_A_EVIDENCE=%s", marker)
+	if !passed {
 		b.Fatalf("multi-GiB direct range p95=%s, want < 250ms", p95)
 	}
 }

--- a/infrastructure/sqlite/event_metadata_bounded_internal_test.go
+++ b/infrastructure/sqlite/event_metadata_bounded_internal_test.go
@@ -465,9 +465,10 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		Build()
 	query, args := scopedRecentEventMetadataQuery(criteria, 0, formatMetadataOptionalTimestamp(criteria.From()), formatMetadataOptionalTimestamp(criteria.To()), criteria.Limit(), criteria.Offset())
 	plan := strings.Join(explainQueryPlan(b, db, query, args...), "\n")
-	if !strings.Contains(plan, "idx_event_metadata_workspace_created_at_norm_id_desc") ||
-		strings.Contains(plan, "events") ||
-		strings.Contains(plan, "USE TEMP B-TREE") {
+	projectionOnly := strings.Contains(plan, "idx_event_metadata_workspace_created_at_norm_id_desc") &&
+		!strings.Contains(plan, "events") &&
+		!strings.Contains(plan, "USE TEMP B-TREE")
+	if !projectionOnly {
 		b.Fatal("multi-GiB metadata plan is not projection-only and index ordered")
 	}
 	durations := make([]time.Duration, 0, measurementRuns)
@@ -511,7 +512,10 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		ManagedBytes        int64   `json:"managed_bytes"`
 		StoredBodyBytes     int64   `json:"stored_body_bytes"`
 		Events              int64   `json:"events"`
+		ProjectionRows      int64   `json:"projection_rows"`
 		MissingBodyMetadata int64   `json:"missing_body_metadata"`
+		ProjectionOnly      bool    `json:"projection_only"`
+		ReturnedBodyBytes   int64   `json:"returned_body_bytes"`
 		Runs                int     `json:"runs"`
 		P95MS               float64 `json:"p95_ms"`
 		TargetP95MS         float64 `json:"target_p95_ms"`
@@ -520,7 +524,10 @@ func BenchmarkMetadataDirectRangeMultiGiB(b *testing.B) {
 		ManagedBytes:        pageCount * pageSize,
 		StoredBodyBytes:     storedBodyBytes,
 		Events:              storedEvents,
+		ProjectionRows:      projectionRows,
 		MissingBodyMetadata: missingStoredBodyBytes,
+		ProjectionOnly:      projectionOnly,
+		ReturnedBodyBytes:   0,
 		Runs:                measurementRuns,
 		P95MS:               float64(p95) / float64(time.Millisecond),
 		TargetP95MS:         250,

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -24,6 +24,7 @@ const (
 	v0330ReleaseEvidenceBodyBytes       = 256 << 20
 	v0330ReleaseEvidenceMinimumDBBytes  = int64(2 << 30)
 	v0330ReleaseEvidenceMeasurementRuns = 25
+	v0330ReleaseEvidenceProbeLimit      = 20
 )
 
 type v0330ReleaseEvidencePhaseB struct {
@@ -62,6 +63,62 @@ type v0330ReleaseEvidenceSample struct {
 	items     int
 	bodyBytes int
 	identity  [sha256.Size]byte
+}
+
+func TestValidateV0330ReleaseEvidenceProjectionPair(t *testing.T) {
+	t.Parallel()
+
+	identity := sha256.Sum256([]byte("synthetic fixture membership"))
+	validMetadata := v0330ReleaseEvidenceSample{
+		items:    v0330ReleaseEvidenceProbeLimit,
+		identity: identity,
+	}
+	validBounded := v0330ReleaseEvidenceSample{
+		items:     v0330ReleaseEvidenceProbeLimit,
+		bodyBytes: 512,
+		identity:  identity,
+	}
+	if err := validateV0330ReleaseEvidenceProjectionPair(validMetadata, validBounded); err != nil {
+		t.Fatalf("valid projection pair rejected: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		metadata v0330ReleaseEvidenceSample
+		bounded  v0330ReleaseEvidenceSample
+	}{
+		{
+			name:     "zero metadata items",
+			metadata: v0330ReleaseEvidenceSample{identity: identity},
+			bounded:  validBounded,
+		},
+		{
+			name:     "zero bounded body bytes",
+			metadata: validMetadata,
+			bounded: v0330ReleaseEvidenceSample{
+				items:    v0330ReleaseEvidenceProbeLimit,
+				identity: identity,
+			},
+		},
+		{
+			name:     "different membership",
+			metadata: validMetadata,
+			bounded: v0330ReleaseEvidenceSample{
+				items:     v0330ReleaseEvidenceProbeLimit,
+				bodyBytes: 512,
+				identity:  sha256.Sum256([]byte("different synthetic membership")),
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateV0330ReleaseEvidenceProjectionPair(test.metadata, test.bounded); err == nil {
+				t.Fatal("invalid projection pair unexpectedly passed")
+			}
+		})
+	}
 }
 
 // BenchmarkV0330CopiedStoreReleaseEvidence is intentionally opt-in. It creates
@@ -169,23 +226,23 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
 	workspace := domtypes.Workspace("release-evidence")
 	sessionID := domtypes.SessionID("release-session")
-	listCriteria := apptypes.NewEventListCriteriaBuilder(20).
+	listCriteria := apptypes.NewEventListCriteriaBuilder(v0330ReleaseEvidenceProbeLimit).
 		Workspace(workspace).
 		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
 		Build()
-	contextCriteria := apptypes.NewEventContextCriteriaBuilder(20).
+	contextCriteria := apptypes.NewEventContextCriteriaBuilder(v0330ReleaseEvidenceProbeLimit).
 		Workspace(workspace).
 		SessionID(sessionID).
 		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
 		Build()
-	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(20).
+	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(v0330ReleaseEvidenceProbeLimit).
 		Query("release needle").
 		Workspace(workspace).
 		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
 		Build()
 
 	probes := make([]v0330ReleaseEvidenceProbe, 0, 8)
-	listMetadataProbe, _ := measureV0330ReleaseEvidenceProbe(
+	listMetadataProbe, listMetadata := measureV0330ReleaseEvidenceProbe(
 		b, "list", "metadata", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
 			events, err := datasource.ListRecentMetadata(ctx, listCriteria)
@@ -193,7 +250,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, listMetadataProbe)
-	listBoundedProbe, _ := measureV0330ReleaseEvidenceProbe(
+	listBoundedProbe, listBounded := measureV0330ReleaseEvidenceProbe(
 		b, "list", "bounded", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
 			events, err := datasource.ListRecentBounded(ctx, listCriteria, 500)
@@ -201,7 +258,11 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, listBoundedProbe)
-	contextMetadataProbe, _ := measureV0330ReleaseEvidenceProbe(
+	if err := validateV0330ReleaseEvidenceProjectionPair(listMetadata, listBounded); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("list retrieval correctness gate failed: %v", err)
+	}
+	contextMetadataProbe, contextMetadata := measureV0330ReleaseEvidenceProbe(
 		b, "context", "metadata", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
 			events, err := datasource.GetContextMetadata(ctx, contextCriteria)
@@ -209,7 +270,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, contextMetadataProbe)
-	contextBoundedProbe, _ := measureV0330ReleaseEvidenceProbe(
+	contextBoundedProbe, contextBounded := measureV0330ReleaseEvidenceProbe(
 		b, "context", "bounded", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
 			events, err := datasource.GetContextBounded(ctx, contextCriteria, 500)
@@ -217,6 +278,10 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, contextBoundedProbe)
+	if err := validateV0330ReleaseEvidenceProjectionPair(contextMetadata, contextBounded); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("context retrieval correctness gate failed: %v", err)
+	}
 	searchMetadataIncompleteProbe, searchMetadataIncomplete := measureV0330ReleaseEvidenceProbe(
 		b, "search", "metadata", "incomplete",
 		func() (v0330ReleaseEvidenceSample, error) {
@@ -233,6 +298,13 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, searchBoundedIncompleteProbe)
+	if err := validateV0330ReleaseEvidenceProjectionPair(
+		searchMetadataIncomplete,
+		searchBoundedIncomplete,
+	); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("incomplete search retrieval correctness gate failed: %v", err)
+	}
 
 	resumeStarted := time.Now()
 	if err := store.Initialize(ctx); err != nil {
@@ -266,6 +338,13 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 	)
 	probes = append(probes, searchBoundedCompleteProbe)
+	if err := validateV0330ReleaseEvidenceProjectionPair(
+		searchMetadataComplete,
+		searchBoundedComplete,
+	); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("complete search retrieval correctness gate failed: %v", err)
+	}
 	if searchMetadataIncomplete.identity != searchMetadataComplete.identity ||
 		searchBoundedIncomplete.identity != searchBoundedComplete.identity ||
 		searchMetadataIncomplete.items != searchMetadataComplete.items ||
@@ -518,6 +597,20 @@ func measureV0330ReleaseEvidenceProbe(
 		ReturnedItems:     first.items,
 		ReturnedBodyBytes: first.bodyBytes,
 	}, first
+}
+
+func validateV0330ReleaseEvidenceProjectionPair(
+	metadata v0330ReleaseEvidenceSample,
+	bounded v0330ReleaseEvidenceSample,
+) error {
+	if metadata.items != v0330ReleaseEvidenceProbeLimit ||
+		bounded.items != v0330ReleaseEvidenceProbeLimit ||
+		metadata.bodyBytes != 0 ||
+		bounded.bodyBytes <= 0 ||
+		metadata.identity != bounded.identity {
+		return fmt.Errorf("metadata and bounded retrieval results violate the release-evidence contract")
+	}
+	return nil
 }
 
 func v0330ReleaseEvidenceMetadataSample(events []apptypes.EventMetadata) v0330ReleaseEvidenceSample {

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -32,7 +32,8 @@ type v0330ReleaseEvidencePhaseB struct {
 	Events                      int64   `json:"events"`
 	MigrationMS                 float64 `json:"migration_ms"`
 	ResumeBackfillMS            float64 `json:"resume_backfill_ms"`
-	Migrations31And32           bool    `json:"migrations_31_32_applied"`
+	Migrations31Through34       bool    `json:"migrations_31_34_applied"`
+	ProjectionRows              int64   `json:"projection_rows"`
 	IntegrityOK                 bool    `json:"integrity_ok"`
 	ForeignKeyViolations        int64   `json:"foreign_key_violations"`
 	SourceUnchanged             bool    `json:"source_unchanged"`
@@ -134,10 +135,15 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 	if err != nil {
 		b.Fatalf("open copied current store: %v", err)
 	}
-	migrations31And32, err := v0330ReleaseEvidenceMigrationsApplied(ctx, copyDB)
+	migrations31Through34, err := v0330ReleaseEvidenceMigrationsApplied(ctx, copyDB)
 	if err != nil {
 		_ = copyDB.Close()
 		b.Fatalf("inspect copied migrations: %v", err)
+	}
+	projectionRows, err := v0330ReleaseEvidenceProjectionRows(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect copied metadata projection: %v", err)
 	}
 	integrityOK, err := v0330ReleaseEvidenceIntegrityOK(ctx, copyDB)
 	if err != nil {
@@ -291,7 +297,8 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 			Events:                      sourceEvents,
 			MigrationMS:                 float64(migrationElapsed) / float64(time.Millisecond),
 			ResumeBackfillMS:            float64(resumeElapsed) / float64(time.Millisecond),
-			Migrations31And32:           migrations31And32,
+			Migrations31Through34:       migrations31Through34,
+			ProjectionRows:              projectionRows,
 			IntegrityOK:                 integrityOK,
 			ForeignKeyViolations:        foreignKeyViolations,
 			SourceUnchanged:             sourceDigestBefore == sourceDigestAfter,
@@ -302,7 +309,8 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		},
 		PhaseC: probes,
 	}
-	if !evidence.PhaseB.Migrations31And32 ||
+	if !evidence.PhaseB.Migrations31Through34 ||
+		evidence.PhaseB.ProjectionRows != evidence.PhaseB.Events ||
 		!evidence.PhaseB.IntegrityOK ||
 		evidence.PhaseB.ForeignKeyViolations != 0 ||
 		!evidence.PhaseB.SourceUnchanged {
@@ -405,11 +413,19 @@ func v0330ReleaseEvidenceMigrationsApplied(ctx context.Context, db *sql.DB) (boo
 	if err := db.QueryRowContext(ctx, `
 		SELECT COUNT(*)
 		  FROM schema_migrations
-		 WHERE version IN (31, 32)`,
+		 WHERE version IN (31, 32, 33, 34)`,
 	).Scan(&count); err != nil {
 		return false, fmt.Errorf("read copied migration versions: %w", err)
 	}
-	return count == 2, nil
+	return count == 4, nil
+}
+
+func v0330ReleaseEvidenceProjectionRows(ctx context.Context, db *sql.DB) (int64, error) {
+	var rows int64
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM event_metadata_projection").Scan(&rows); err != nil {
+		return 0, fmt.Errorf("read copied metadata projection rows: %w", err)
+	}
+	return rows, nil
 }
 
 func v0330ReleaseEvidenceIntegrityOK(ctx context.Context, db *sql.DB) (bool, error) {

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -1,0 +1,598 @@
+package sqlite_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	domtypes "github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+)
+
+const (
+	v0330ReleaseEvidenceEvents          = 130
+	v0330ReleaseEvidenceLargeEvents     = 8
+	v0330ReleaseEvidenceBodyBytes       = 256 << 20
+	v0330ReleaseEvidenceMinimumDBBytes  = int64(2 << 30)
+	v0330ReleaseEvidenceMeasurementRuns = 25
+)
+
+type v0330ReleaseEvidencePhaseB struct {
+	SourceManagedBytes   int64   `json:"source_managed_bytes"`
+	ScratchPeakBytes     int64   `json:"scratch_peak_bytes"`
+	Events               int64   `json:"events"`
+	MigrationMS          float64 `json:"migration_ms"`
+	ResumeBackfillMS     float64 `json:"resume_backfill_ms"`
+	Migrations31And32    bool    `json:"migrations_31_32_applied"`
+	IntegrityOK          bool    `json:"integrity_ok"`
+	ForeignKeyViolations int64   `json:"foreign_key_violations"`
+	SourceUnchanged      bool    `json:"source_unchanged"`
+	InitialFTSDocuments  int64   `json:"initial_fts_documents"`
+	InitialFTSComplete   bool    `json:"initial_fts_complete"`
+	FinalFTSDocuments    int64   `json:"final_fts_documents"`
+	FinalFTSComplete     bool    `json:"final_fts_complete"`
+}
+
+type v0330ReleaseEvidenceProbe struct {
+	Operation         string  `json:"operation"`
+	Projection        string  `json:"projection"`
+	FTSPhase          string  `json:"fts_phase"`
+	Runs              int     `json:"runs"`
+	P95MS             float64 `json:"p95_ms"`
+	ReturnedItems     int     `json:"returned_items"`
+	ReturnedBodyBytes int     `json:"returned_body_bytes"`
+}
+
+type v0330ReleaseEvidencePhaseBC struct {
+	PhaseB v0330ReleaseEvidencePhaseB  `json:"phase_b"`
+	PhaseC []v0330ReleaseEvidenceProbe `json:"phase_c"`
+}
+
+type v0330ReleaseEvidenceSample struct {
+	items     int
+	bodyBytes int
+	identity  [sha256.Size]byte
+}
+
+// BenchmarkV0330CopiedStoreReleaseEvidence is intentionally opt-in. It creates
+// a genuine multi-GiB pre-31 SQLite store from synthetic extents, mutates only
+// a private copy, and emits a single metrics-only marker. The repo-tooling
+// runner captures all other output privately and removes its scratch root.
+func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
+	if os.Getenv("TRACEARY_RUN_V0330_RELEASE_EVIDENCE") != "1" {
+		b.Skip("set TRACEARY_RUN_V0330_RELEASE_EVIDENCE=1 to create the multi-GiB copied-store fixture")
+	}
+	b.StopTimer()
+	ctx := context.Background()
+	root := b.TempDir()
+	sourcePath := filepath.Join(root, "source.db")
+	copyPath := filepath.Join(root, "copy.db")
+
+	source := infra.NewDatabase(sourcePath, onDiskSQLiteMigrationsBefore(b, 31))
+	if err := infra.NewStoreManagementDatasource(source).Initialize(ctx); err != nil {
+		b.Fatalf("initialize pre-31 source: %v", err)
+	}
+	sourceDB, err := sql.Open("sqlite", sourcePath)
+	if err != nil {
+		b.Fatalf("open pre-31 source: %v", err)
+	}
+	if err := seedV0330ReleaseEvidenceStore(ctx, sourceDB); err != nil {
+		_ = sourceDB.Close()
+		b.Fatalf("seed pre-31 source: %v", err)
+	}
+	if _, err := sourceDB.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = sourceDB.Close()
+		b.Fatalf("checkpoint pre-31 source: %v", err)
+	}
+	sourceManagedBytes, sourceEvents, sourceStoredBytes, missingMetadata, err := v0330ReleaseEvidenceStoreExtent(ctx, sourceDB)
+	if err != nil {
+		_ = sourceDB.Close()
+		b.Fatalf("inspect pre-31 source extent: %v", err)
+	}
+	if sourceManagedBytes < v0330ReleaseEvidenceMinimumDBBytes ||
+		sourceEvents != v0330ReleaseEvidenceEvents ||
+		sourceStoredBytes < v0330ReleaseEvidenceMinimumDBBytes ||
+		missingMetadata != 0 {
+		_ = sourceDB.Close()
+		b.Fatalf(
+			"pre-31 source extent is invalid: managed=%d events=%d stored=%d missing_metadata=%d",
+			sourceManagedBytes,
+			sourceEvents,
+			sourceStoredBytes,
+			missingMetadata,
+		)
+	}
+	if err := sourceDB.Close(); err != nil {
+		b.Fatalf("close pre-31 source: %v", err)
+	}
+	sourceDigestBefore, err := v0330ReleaseEvidenceFileDigest(sourcePath)
+	if err != nil {
+		b.Fatalf("digest pre-31 source: %v", err)
+	}
+	if err := v0330ReleaseEvidenceCopyFile(sourcePath, copyPath); err != nil {
+		b.Fatalf("copy pre-31 source: %v", err)
+	}
+
+	current := infra.NewDatabase(copyPath, onDiskSQLiteMigrations(b))
+	store := infra.NewStoreManagementDatasource(current)
+	migrationStarted := time.Now()
+	if err := store.Initialize(ctx); err != nil {
+		b.Fatalf("initialize copied current store: %v", err)
+	}
+	migrationElapsed := time.Since(migrationStarted)
+
+	copyDB, err := sql.Open("sqlite", copyPath)
+	if err != nil {
+		b.Fatalf("open copied current store: %v", err)
+	}
+	migrations31And32, err := v0330ReleaseEvidenceMigrationsApplied(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect copied migrations: %v", err)
+	}
+	integrityOK, err := v0330ReleaseEvidenceIntegrityOK(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect copied integrity: %v", err)
+	}
+	foreignKeyViolations, err := v0330ReleaseEvidenceForeignKeyViolations(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect copied foreign keys: %v", err)
+	}
+	initialDocuments, initialComplete, err := v0330ReleaseEvidenceFTSProgress(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect initial FTS progress: %v", err)
+	}
+	if initialDocuments != 128 || initialComplete {
+		_ = copyDB.Close()
+		b.Fatalf("initial FTS progress = (%d,%v), want (128,false)", initialDocuments, initialComplete)
+	}
+
+	datasource := infra.NewEventDatasource(current)
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	workspace := domtypes.Workspace("release-evidence")
+	sessionID := domtypes.SessionID("release-session")
+	listCriteria := apptypes.NewEventListCriteriaBuilder(20).
+		Workspace(workspace).
+		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
+		Build()
+	contextCriteria := apptypes.NewEventContextCriteriaBuilder(20).
+		Workspace(workspace).
+		SessionID(sessionID).
+		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
+		Build()
+	searchCriteria := apptypes.NewEventSearchCriteriaBuilder(20).
+		Query("release needle").
+		Workspace(workspace).
+		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
+		Build()
+
+	probes := make([]v0330ReleaseEvidenceProbe, 0, 8)
+	listMetadataProbe, _ := measureV0330ReleaseEvidenceProbe(
+		b, "list", "metadata", "not_applicable",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.ListRecentMetadata(ctx, listCriteria)
+			return v0330ReleaseEvidenceMetadataSample(events), err
+		},
+	)
+	probes = append(probes, listMetadataProbe)
+	listBoundedProbe, _ := measureV0330ReleaseEvidenceProbe(
+		b, "list", "bounded", "not_applicable",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.ListRecentBounded(ctx, listCriteria, 500)
+			return v0330ReleaseEvidenceBoundedSample(events), err
+		},
+	)
+	probes = append(probes, listBoundedProbe)
+	contextMetadataProbe, _ := measureV0330ReleaseEvidenceProbe(
+		b, "context", "metadata", "not_applicable",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.GetContextMetadata(ctx, contextCriteria)
+			return v0330ReleaseEvidenceMetadataSample(events), err
+		},
+	)
+	probes = append(probes, contextMetadataProbe)
+	contextBoundedProbe, _ := measureV0330ReleaseEvidenceProbe(
+		b, "context", "bounded", "not_applicable",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.GetContextBounded(ctx, contextCriteria, 500)
+			return v0330ReleaseEvidenceBoundedSample(events), err
+		},
+	)
+	probes = append(probes, contextBoundedProbe)
+	searchMetadataIncompleteProbe, searchMetadataIncomplete := measureV0330ReleaseEvidenceProbe(
+		b, "search", "metadata", "incomplete",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.SearchMetadata(ctx, searchCriteria)
+			return v0330ReleaseEvidenceMetadataSample(events), err
+		},
+	)
+	probes = append(probes, searchMetadataIncompleteProbe)
+	searchBoundedIncompleteProbe, searchBoundedIncomplete := measureV0330ReleaseEvidenceProbe(
+		b, "search", "bounded", "incomplete",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.SearchBounded(ctx, searchCriteria, 500)
+			return v0330ReleaseEvidenceBoundedSample(events), err
+		},
+	)
+	probes = append(probes, searchBoundedIncompleteProbe)
+
+	resumeStarted := time.Now()
+	if err := store.Initialize(ctx); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("resume copied FTS backfill: %v", err)
+	}
+	resumeElapsed := time.Since(resumeStarted)
+	finalDocuments, finalComplete, err := v0330ReleaseEvidenceFTSProgress(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("inspect final FTS progress: %v", err)
+	}
+	if finalDocuments != v0330ReleaseEvidenceEvents || !finalComplete {
+		_ = copyDB.Close()
+		b.Fatalf("final FTS progress = (%d,%v), want (%d,true)", finalDocuments, finalComplete, v0330ReleaseEvidenceEvents)
+	}
+
+	searchMetadataCompleteProbe, searchMetadataComplete := measureV0330ReleaseEvidenceProbe(
+		b, "search", "metadata", "complete",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.SearchMetadata(ctx, searchCriteria)
+			return v0330ReleaseEvidenceMetadataSample(events), err
+		},
+	)
+	probes = append(probes, searchMetadataCompleteProbe)
+	searchBoundedCompleteProbe, searchBoundedComplete := measureV0330ReleaseEvidenceProbe(
+		b, "search", "bounded", "complete",
+		func() (v0330ReleaseEvidenceSample, error) {
+			events, err := datasource.SearchBounded(ctx, searchCriteria, 500)
+			return v0330ReleaseEvidenceBoundedSample(events), err
+		},
+	)
+	probes = append(probes, searchBoundedCompleteProbe)
+	if searchMetadataIncomplete.identity != searchMetadataComplete.identity ||
+		searchBoundedIncomplete.identity != searchBoundedComplete.identity ||
+		searchMetadataIncomplete.items != searchMetadataComplete.items ||
+		searchBoundedIncomplete.items != searchBoundedComplete.items {
+		_ = copyDB.Close()
+		b.Fatal("incomplete and complete FTS phases returned different result membership")
+	}
+
+	if _, err := copyDB.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("checkpoint copied current store: %v", err)
+	}
+	if err := copyDB.Close(); err != nil {
+		b.Fatalf("close copied current store: %v", err)
+	}
+	sourceDigestAfter, err := v0330ReleaseEvidenceFileDigest(sourcePath)
+	if err != nil {
+		b.Fatalf("digest source after copy migration: %v", err)
+	}
+	scratchPeakBytes, err := v0330ReleaseEvidenceDirectoryBytes(root)
+	if err != nil {
+		b.Fatalf("inspect scratch extent: %v", err)
+	}
+
+	evidence := v0330ReleaseEvidencePhaseBC{
+		PhaseB: v0330ReleaseEvidencePhaseB{
+			SourceManagedBytes:   sourceManagedBytes,
+			ScratchPeakBytes:     scratchPeakBytes,
+			Events:               sourceEvents,
+			MigrationMS:          float64(migrationElapsed) / float64(time.Millisecond),
+			ResumeBackfillMS:     float64(resumeElapsed) / float64(time.Millisecond),
+			Migrations31And32:    migrations31And32,
+			IntegrityOK:          integrityOK,
+			ForeignKeyViolations: foreignKeyViolations,
+			SourceUnchanged:      sourceDigestBefore == sourceDigestAfter,
+			InitialFTSDocuments:  initialDocuments,
+			InitialFTSComplete:   initialComplete,
+			FinalFTSDocuments:    finalDocuments,
+			FinalFTSComplete:     finalComplete,
+		},
+		PhaseC: probes,
+	}
+	if !evidence.PhaseB.Migrations31And32 ||
+		!evidence.PhaseB.IntegrityOK ||
+		evidence.PhaseB.ForeignKeyViolations != 0 ||
+		!evidence.PhaseB.SourceUnchanged {
+		b.Fatal("copied-store migration evidence failed its safety invariants")
+	}
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		b.Fatalf("marshal Phase-B/C evidence: %v", err)
+	}
+	b.ReportMetric(float64(sourceManagedBytes), "source_managed_bytes")
+	b.ReportMetric(float64(scratchPeakBytes), "scratch_peak_bytes")
+	b.ReportMetric(float64(migrationElapsed)/float64(time.Millisecond), "migration_ms")
+	b.Logf("TRACEARY_PHASE_BC_EVIDENCE=%s", encoded)
+}
+
+func seedV0330ReleaseEvidenceStore(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin fixture transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	large, err := tx.PrepareContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_availability
+		) VALUES (?, 'note', 'cli', 'codex', 'release-session', 'release-evidence',
+			zeroblob(?), ?, 'unavailable_retention')`)
+	if err != nil {
+		return fmt.Errorf("prepare large fixture insert: %w", err)
+	}
+	small, err := tx.PrepareContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_availability
+		) VALUES (?, 'note', 'cli', 'codex', 'release-session', 'release-evidence',
+			?, ?, 'available')`)
+	if err != nil {
+		_ = large.Close()
+		return fmt.Errorf("prepare small fixture insert: %w", err)
+	}
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	for index := 0; index < v0330ReleaseEvidenceEvents; index++ {
+		eventID := fmt.Sprintf("release-event-%05d", index)
+		createdAt := base.Add(time.Duration(index) * time.Second).Format(time.RFC3339Nano)
+		if index < v0330ReleaseEvidenceLargeEvents {
+			if _, err := large.ExecContext(ctx, eventID, v0330ReleaseEvidenceBodyBytes, createdAt); err != nil {
+				_ = large.Close()
+				_ = small.Close()
+				return fmt.Errorf("insert large fixture %d: %w", index, err)
+			}
+			continue
+		}
+		body := fmt.Sprintf("release needle visible 日本語 synthetic %03d", index)
+		if _, err := small.ExecContext(ctx, eventID, body, createdAt); err != nil {
+			_ = large.Close()
+			_ = small.Close()
+			return fmt.Errorf("insert small fixture %d: %w", index, err)
+		}
+	}
+	if err := large.Close(); err != nil {
+		_ = small.Close()
+		return fmt.Errorf("close large fixture statement: %w", err)
+	}
+	if err := small.Close(); err != nil {
+		return fmt.Errorf("close small fixture statement: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit fixture transaction: %w", err)
+	}
+	return nil
+}
+
+func v0330ReleaseEvidenceStoreExtent(ctx context.Context, db *sql.DB) (
+	managedBytes int64,
+	events int64,
+	storedBodyBytes int64,
+	missingMetadata int64,
+	err error,
+) {
+	var pageCount, pageSize int64
+	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("read page count: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("read page size: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COALESCE(SUM(body_stored_bytes), 0),
+		       COALESCE(SUM(CASE WHEN body_stored_bytes IS NULL THEN 1 ELSE 0 END), 0)
+		  FROM events`,
+	).Scan(&events, &storedBodyBytes, &missingMetadata); err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("read fixture extent: %w", err)
+	}
+	return pageCount * pageSize, events, storedBodyBytes, missingMetadata, nil
+}
+
+func v0330ReleaseEvidenceMigrationsApplied(ctx context.Context, db *sql.DB) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM schema_migrations
+		 WHERE version IN (31, 32)`,
+	).Scan(&count); err != nil {
+		return false, fmt.Errorf("read copied migration versions: %w", err)
+	}
+	return count == 2, nil
+}
+
+func v0330ReleaseEvidenceIntegrityOK(ctx context.Context, db *sql.DB) (bool, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA integrity_check")
+	if err != nil {
+		return false, fmt.Errorf("run integrity check: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	count := 0
+	ok := false
+	for rows.Next() {
+		count++
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			return false, fmt.Errorf("read integrity result: %w", err)
+		}
+		ok = result == "ok"
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate integrity results: %w", err)
+	}
+	return count == 1 && ok, nil
+}
+
+func v0330ReleaseEvidenceForeignKeyViolations(ctx context.Context, db *sql.DB) (int64, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		return 0, fmt.Errorf("run foreign-key check: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var violations int64
+	for rows.Next() {
+		violations++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate foreign-key results: %w", err)
+	}
+	return violations, nil
+}
+
+func v0330ReleaseEvidenceFTSProgress(ctx context.Context, db *sql.DB) (int64, bool, error) {
+	var documents int64
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM event_search_documents").Scan(&documents); err != nil {
+		return 0, false, fmt.Errorf("read FTS document count: %w", err)
+	}
+	var complete int
+	if err := db.QueryRowContext(ctx, `
+		SELECT completed
+		  FROM event_search_backfill_state
+		 WHERE singleton = 1`,
+	).Scan(&complete); err != nil {
+		return 0, false, fmt.Errorf("read FTS completion state: %w", err)
+	}
+	return documents, complete != 0, nil
+}
+
+func measureV0330ReleaseEvidenceProbe(
+	b *testing.B,
+	operation string,
+	projection string,
+	ftsPhase string,
+	run func() (v0330ReleaseEvidenceSample, error),
+) (v0330ReleaseEvidenceProbe, v0330ReleaseEvidenceSample) {
+	b.Helper()
+	durations := make([]time.Duration, 0, v0330ReleaseEvidenceMeasurementRuns)
+	var first v0330ReleaseEvidenceSample
+	for index := 0; index < v0330ReleaseEvidenceMeasurementRuns; index++ {
+		started := time.Now()
+		sample, err := run()
+		durations = append(durations, time.Since(started))
+		if err != nil {
+			b.Fatalf("%s/%s/%s probe failed: %v", operation, projection, ftsPhase, err)
+		}
+		if index == 0 {
+			first = sample
+			continue
+		}
+		if sample != first {
+			b.Fatalf("%s/%s/%s probe changed across runs", operation, projection, ftsPhase)
+		}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	p95 := durations[(len(durations)*95+99)/100-1]
+	return v0330ReleaseEvidenceProbe{
+		Operation:         operation,
+		Projection:        projection,
+		FTSPhase:          ftsPhase,
+		Runs:              v0330ReleaseEvidenceMeasurementRuns,
+		P95MS:             float64(p95) / float64(time.Millisecond),
+		ReturnedItems:     first.items,
+		ReturnedBodyBytes: first.bodyBytes,
+	}, first
+}
+
+func v0330ReleaseEvidenceMetadataSample(events []apptypes.EventMetadata) v0330ReleaseEvidenceSample {
+	identities := make([]string, 0, len(events))
+	for _, event := range events {
+		identities = append(identities, event.EventID().String())
+	}
+	return v0330ReleaseEvidenceSample{
+		items:    len(events),
+		identity: v0330ReleaseEvidenceIdentity(identities),
+	}
+}
+
+func v0330ReleaseEvidenceBoundedSample(events []apptypes.BoundedEvent) v0330ReleaseEvidenceSample {
+	identities := make([]string, 0, len(events))
+	bodyBytes := 0
+	for _, event := range events {
+		identities = append(identities, event.Metadata().EventID().String())
+		bodyBytes += len(event.Body())
+	}
+	return v0330ReleaseEvidenceSample{
+		items:     len(events),
+		bodyBytes: bodyBytes,
+		identity:  v0330ReleaseEvidenceIdentity(identities),
+	}
+}
+
+func v0330ReleaseEvidenceIdentity(values []string) [sha256.Size]byte {
+	hasher := sha256.New()
+	for _, value := range values {
+		_, _ = fmt.Fprintf(hasher, "%d:", len(value))
+		_, _ = io.WriteString(hasher, value)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hasher.Sum(nil))
+	return result
+}
+
+func v0330ReleaseEvidenceFileDigest(path string) ([sha256.Size]byte, error) {
+	file, err := os.Open(path) // #nosec G304 -- private synthetic benchmark path
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("open synthetic store for digest: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("digest synthetic store: %w", err)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hasher.Sum(nil))
+	return result, nil
+}
+
+func v0330ReleaseEvidenceCopyFile(source, destination string) error {
+	input, err := os.Open(source) // #nosec G304 -- private synthetic benchmark path
+	if err != nil {
+		return fmt.Errorf("open synthetic source: %w", err)
+	}
+	defer func() { _ = input.Close() }()
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- private synthetic benchmark path
+	if err != nil {
+		return fmt.Errorf("create synthetic copy: %w", err)
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		return fmt.Errorf("copy synthetic store: %w", err)
+	}
+	if err := output.Close(); err != nil {
+		return fmt.Errorf("close synthetic copy: %w", err)
+	}
+	return nil
+}
+
+func v0330ReleaseEvidenceDirectoryBytes(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk synthetic scratch: %w", err)
+		}
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect synthetic scratch entry: %w", err)
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("measure synthetic scratch: %w", err)
+	}
+	return total, nil
+}

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -46,13 +46,15 @@ type v0330ReleaseEvidencePhaseB struct {
 }
 
 type v0330ReleaseEvidenceProbe struct {
-	Operation         string  `json:"operation"`
-	Projection        string  `json:"projection"`
-	FTSPhase          string  `json:"fts_phase"`
-	Runs              int     `json:"runs"`
-	P95MS             float64 `json:"p95_ms"`
-	ReturnedItems     int     `json:"returned_items"`
-	ReturnedBodyBytes int     `json:"returned_body_bytes"`
+	Operation          string  `json:"operation"`
+	Projection         string  `json:"projection"`
+	FTSPhase           string  `json:"fts_phase"`
+	Runs               int     `json:"runs"`
+	P95MS              float64 `json:"p95_ms"`
+	ReturnedItems      int     `json:"returned_items"`
+	ReturnedBodyBytes  int     `json:"returned_body_bytes"`
+	SourceBodyBytes    int64   `json:"source_body_bytes,omitempty"`
+	BoundedBudgetBytes int     `json:"bounded_budget_bytes,omitempty"`
 }
 
 type v0330ReleaseEvidencePhaseBC struct {
@@ -242,7 +244,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		To(base.Add(v0330ReleaseEvidenceEvents * time.Second)).
 		Build()
 
-	probes := make([]v0330ReleaseEvidenceProbe, 0, 8)
+	probes := make([]v0330ReleaseEvidenceProbe, 0, 9)
 	listMetadataProbe, listMetadata := measureV0330ReleaseEvidenceProbe(
 		b, "list", "metadata", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
@@ -263,6 +265,17 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		_ = copyDB.Close()
 		b.Fatalf("list retrieval correctness gate failed: %v", err)
 	}
+	hugeCriteria := apptypes.NewEventListCriteriaBuilder(1).Workspace(workspace).From(base.Add(6500 * time.Millisecond)).To(base.Add(7500 * time.Millisecond)).Build()
+	hugeProbe, _ := measureV0330ReleaseEvidenceProbe(b, "list", "bounded_huge", "not_applicable", func() (v0330ReleaseEvidenceSample, error) {
+		events, err := datasource.ListRecentBounded(ctx, hugeCriteria, 500)
+		return v0330ReleaseEvidenceBoundedSample(events), err
+	})
+	hugeProbe.SourceBodyBytes = v0330ReleaseEvidenceBodyBytes
+	hugeProbe.BoundedBudgetBytes = 64 * 1024
+	if hugeProbe.ReturnedItems != 1 || hugeProbe.ReturnedBodyBytes <= 0 || hugeProbe.ReturnedBodyBytes > hugeProbe.BoundedBudgetBytes {
+		b.Fatal("huge-body bounded probe violated its response budget")
+	}
+	probes = append(probes, hugeProbe)
 	contextMetadataProbe, contextMetadata := measureV0330ReleaseEvidenceProbe(
 		b, "context", "metadata", "not_applicable",
 		func() (v0330ReleaseEvidenceSample, error) {
@@ -423,7 +436,7 @@ func seedV0330ReleaseEvidenceStore(ctx context.Context, db *sql.DB) error {
 			id, kind, client, agent, session_id, workspace, body, created_at,
 			body_availability
 		) VALUES (?, 'note', 'cli', 'codex', 'release-session', 'release-evidence',
-			zeroblob(?), ?, 'unavailable_retention')`)
+			zeroblob(?), ?, 'available')`)
 	if err != nil {
 		return fmt.Errorf("prepare large fixture insert: %w", err)
 	}

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -42,6 +42,7 @@ type v0330ReleaseEvidencePhaseB struct {
 	InitialFTSComplete          bool    `json:"initial_fts_complete"`
 	FinalFTSDocuments           int64   `json:"final_fts_documents"`
 	FinalFTSComplete            bool    `json:"final_fts_complete"`
+	PreProjectionWriterOK       bool    `json:"pre_projection_writer_ok"`
 }
 
 type v0330ReleaseEvidenceProbe struct {
@@ -321,6 +322,11 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		_ = copyDB.Close()
 		b.Fatalf("final FTS progress = (%d,%v), want (%d,true)", finalDocuments, finalComplete, v0330ReleaseEvidenceEvents)
 	}
+	preProjectionWriterOK, err := v0330ReleaseEvidencePreProjectionWriterOK(ctx, copyDB)
+	if err != nil {
+		_ = copyDB.Close()
+		b.Fatalf("verify pre-projection writer compatibility: %v", err)
+	}
 
 	searchMetadataCompleteProbe, searchMetadataComplete := measureV0330ReleaseEvidenceProbe(
 		b, "search", "metadata", "complete",
@@ -385,6 +391,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 			InitialFTSComplete:          initialComplete,
 			FinalFTSDocuments:           finalDocuments,
 			FinalFTSComplete:            finalComplete,
+			PreProjectionWriterOK:       preProjectionWriterOK,
 		},
 		PhaseC: probes,
 	}
@@ -392,7 +399,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		evidence.PhaseB.ProjectionRows != evidence.PhaseB.Events ||
 		!evidence.PhaseB.IntegrityOK ||
 		evidence.PhaseB.ForeignKeyViolations != 0 ||
-		!evidence.PhaseB.SourceUnchanged {
+		!evidence.PhaseB.SourceUnchanged || !evidence.PhaseB.PreProjectionWriterOK {
 		b.Fatal("copied-store migration evidence failed its safety invariants")
 	}
 	encoded, err := json.Marshal(evidence)
@@ -559,6 +566,47 @@ func v0330ReleaseEvidenceFTSProgress(ctx context.Context, db *sql.DB) (int64, bo
 		return 0, false, fmt.Errorf("read FTS completion state: %w", err)
 	}
 	return documents, complete != 0, nil
+}
+
+func v0330ReleaseEvidencePreProjectionWriterOK(ctx context.Context, db *sql.DB) (bool, error) {
+	count := func(table string) (int64, error) {
+		var result int64
+		err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&result)
+		return result, err
+	}
+	eventsBefore, err := count("events")
+	if err != nil {
+		return false, fmt.Errorf("count events before writer probe: %w", err)
+	}
+	projectionBefore, err := count("event_metadata_projection")
+	if err != nil {
+		return false, fmt.Errorf("count projection before writer probe: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin writer probe: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO events (id, kind, client, agent, session_id, workspace, body, created_at, body_availability) VALUES ('release-writer-probe', 'note', 'cli', 'codex', 'release-session', 'release-evidence', 'release needle writer probe', '2026-07-26T00:02:10Z', 'available')`); err != nil {
+		_ = tx.Rollback()
+		return false, fmt.Errorf("run writer probe: %w", err)
+	}
+	var maintained int64
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM event_metadata_projection WHERE id = 'release-writer-probe'").Scan(&maintained); err != nil {
+		_ = tx.Rollback()
+		return false, fmt.Errorf("read writer projection: %w", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		return false, fmt.Errorf("rollback writer probe: %w", err)
+	}
+	eventsAfter, err := count("events")
+	if err != nil {
+		return false, fmt.Errorf("count events after writer probe: %w", err)
+	}
+	projectionAfter, err := count("event_metadata_projection")
+	if err != nil {
+		return false, fmt.Errorf("count projection after writer probe: %w", err)
+	}
+	return maintained == 1 && eventsBefore == eventsAfter && projectionBefore == projectionAfter, nil
 }
 
 func measureV0330ReleaseEvidenceProbe(

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -585,7 +585,10 @@ func v0330ReleaseEvidencePreProjectionWriterOK(ctx context.Context, db *sql.DB) 
 	count := func(table string) (int64, error) {
 		var result int64
 		err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&result)
-		return result, err
+		if err != nil {
+			return 0, fmt.Errorf("count %s: %w", table, err)
+		}
+		return result, nil
 	}
 	eventsBefore, err := count("events")
 	if err != nil {

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -271,7 +271,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		return v0330ReleaseEvidenceBoundedSample(events), err
 	})
 	hugeProbe.SourceBodyBytes = v0330ReleaseEvidenceBodyBytes
-	hugeProbe.BoundedBudgetBytes = 64 * 1024
+	hugeProbe.BoundedBudgetBytes = 500
 	if hugeProbe.ReturnedItems != 1 || hugeProbe.ReturnedBodyBytes <= 0 || hugeProbe.ReturnedBodyBytes > hugeProbe.BoundedBudgetBytes {
 		b.Fatal("huge-body bounded probe violated its response budget")
 	}

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -27,19 +27,19 @@ const (
 )
 
 type v0330ReleaseEvidencePhaseB struct {
-	SourceManagedBytes   int64   `json:"source_managed_bytes"`
-	ScratchPeakBytes     int64   `json:"scratch_peak_bytes"`
-	Events               int64   `json:"events"`
-	MigrationMS          float64 `json:"migration_ms"`
-	ResumeBackfillMS     float64 `json:"resume_backfill_ms"`
-	Migrations31And32    bool    `json:"migrations_31_32_applied"`
-	IntegrityOK          bool    `json:"integrity_ok"`
-	ForeignKeyViolations int64   `json:"foreign_key_violations"`
-	SourceUnchanged      bool    `json:"source_unchanged"`
-	InitialFTSDocuments  int64   `json:"initial_fts_documents"`
-	InitialFTSComplete   bool    `json:"initial_fts_complete"`
-	FinalFTSDocuments    int64   `json:"final_fts_documents"`
-	FinalFTSComplete     bool    `json:"final_fts_complete"`
+	SourceManagedBytes          int64   `json:"source_managed_bytes"`
+	ScratchBytesAfterCheckpoint int64   `json:"scratch_bytes_after_checkpoint"`
+	Events                      int64   `json:"events"`
+	MigrationMS                 float64 `json:"migration_ms"`
+	ResumeBackfillMS            float64 `json:"resume_backfill_ms"`
+	Migrations31And32           bool    `json:"migrations_31_32_applied"`
+	IntegrityOK                 bool    `json:"integrity_ok"`
+	ForeignKeyViolations        int64   `json:"foreign_key_violations"`
+	SourceUnchanged             bool    `json:"source_unchanged"`
+	InitialFTSDocuments         int64   `json:"initial_fts_documents"`
+	InitialFTSComplete          bool    `json:"initial_fts_complete"`
+	FinalFTSDocuments           int64   `json:"final_fts_documents"`
+	FinalFTSComplete            bool    `json:"final_fts_complete"`
 }
 
 type v0330ReleaseEvidenceProbe struct {
@@ -279,26 +279,26 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 	if err != nil {
 		b.Fatalf("digest source after copy migration: %v", err)
 	}
-	scratchPeakBytes, err := v0330ReleaseEvidenceDirectoryBytes(root)
+	scratchBytesAfterCheckpoint, err := v0330ReleaseEvidenceDirectoryBytes(root)
 	if err != nil {
 		b.Fatalf("inspect scratch extent: %v", err)
 	}
 
 	evidence := v0330ReleaseEvidencePhaseBC{
 		PhaseB: v0330ReleaseEvidencePhaseB{
-			SourceManagedBytes:   sourceManagedBytes,
-			ScratchPeakBytes:     scratchPeakBytes,
-			Events:               sourceEvents,
-			MigrationMS:          float64(migrationElapsed) / float64(time.Millisecond),
-			ResumeBackfillMS:     float64(resumeElapsed) / float64(time.Millisecond),
-			Migrations31And32:    migrations31And32,
-			IntegrityOK:          integrityOK,
-			ForeignKeyViolations: foreignKeyViolations,
-			SourceUnchanged:      sourceDigestBefore == sourceDigestAfter,
-			InitialFTSDocuments:  initialDocuments,
-			InitialFTSComplete:   initialComplete,
-			FinalFTSDocuments:    finalDocuments,
-			FinalFTSComplete:     finalComplete,
+			SourceManagedBytes:          sourceManagedBytes,
+			ScratchBytesAfterCheckpoint: scratchBytesAfterCheckpoint,
+			Events:                      sourceEvents,
+			MigrationMS:                 float64(migrationElapsed) / float64(time.Millisecond),
+			ResumeBackfillMS:            float64(resumeElapsed) / float64(time.Millisecond),
+			Migrations31And32:           migrations31And32,
+			IntegrityOK:                 integrityOK,
+			ForeignKeyViolations:        foreignKeyViolations,
+			SourceUnchanged:             sourceDigestBefore == sourceDigestAfter,
+			InitialFTSDocuments:         initialDocuments,
+			InitialFTSComplete:          initialComplete,
+			FinalFTSDocuments:           finalDocuments,
+			FinalFTSComplete:            finalComplete,
 		},
 		PhaseC: probes,
 	}
@@ -313,7 +313,7 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		b.Fatalf("marshal Phase-B/C evidence: %v", err)
 	}
 	b.ReportMetric(float64(sourceManagedBytes), "source_managed_bytes")
-	b.ReportMetric(float64(scratchPeakBytes), "scratch_peak_bytes")
+	b.ReportMetric(float64(scratchBytesAfterCheckpoint), "scratch_bytes_after_checkpoint")
 	b.ReportMetric(float64(migrationElapsed)/float64(time.Millisecond), "migration_ms")
 	b.Logf("TRACEARY_PHASE_BC_EVIDENCE=%s", encoded)
 }

--- a/infrastructure/sqlite/release_evidence_multigib_test.go
+++ b/infrastructure/sqlite/release_evidence_multigib_test.go
@@ -63,9 +63,10 @@ type v0330ReleaseEvidencePhaseBC struct {
 }
 
 type v0330ReleaseEvidenceSample struct {
-	items     int
-	bodyBytes int
-	identity  [sha256.Size]byte
+	items           int
+	bodyBytes       int
+	sourceBodyBytes int64
+	identity        [sha256.Size]byte
 }
 
 func TestValidateV0330ReleaseEvidenceProjectionPair(t *testing.T) {
@@ -266,13 +267,14 @@ func BenchmarkV0330CopiedStoreReleaseEvidence(b *testing.B) {
 		b.Fatalf("list retrieval correctness gate failed: %v", err)
 	}
 	hugeCriteria := apptypes.NewEventListCriteriaBuilder(1).Workspace(workspace).From(base.Add(6500 * time.Millisecond)).To(base.Add(7500 * time.Millisecond)).Build()
-	hugeProbe, _ := measureV0330ReleaseEvidenceProbe(b, "list", "bounded_huge", "not_applicable", func() (v0330ReleaseEvidenceSample, error) {
+	hugeProbe, hugeSample := measureV0330ReleaseEvidenceProbe(b, "list", "bounded_huge", "not_applicable", func() (v0330ReleaseEvidenceSample, error) {
 		events, err := datasource.ListRecentBounded(ctx, hugeCriteria, 500)
 		return v0330ReleaseEvidenceBoundedSample(events), err
 	})
-	hugeProbe.SourceBodyBytes = v0330ReleaseEvidenceBodyBytes
+	hugeProbe.SourceBodyBytes = hugeSample.sourceBodyBytes
 	hugeProbe.BoundedBudgetBytes = 500
-	if hugeProbe.ReturnedItems != 1 || hugeProbe.ReturnedBodyBytes <= 0 || hugeProbe.ReturnedBodyBytes > hugeProbe.BoundedBudgetBytes {
+	if hugeProbe.ReturnedItems != 1 || hugeProbe.SourceBodyBytes <= int64(hugeProbe.BoundedBudgetBytes) || hugeProbe.ReturnedBodyBytes <= 0 || hugeProbe.ReturnedBodyBytes > hugeProbe.BoundedBudgetBytes {
+		_ = copyDB.Close()
 		b.Fatal("huge-body bounded probe violated its response budget")
 	}
 	probes = append(probes, hugeProbe)
@@ -691,14 +693,17 @@ func v0330ReleaseEvidenceMetadataSample(events []apptypes.EventMetadata) v0330Re
 func v0330ReleaseEvidenceBoundedSample(events []apptypes.BoundedEvent) v0330ReleaseEvidenceSample {
 	identities := make([]string, 0, len(events))
 	bodyBytes := 0
+	var sourceBodyBytes int64
 	for _, event := range events {
 		identities = append(identities, event.Metadata().EventID().String())
 		bodyBytes += len(event.Body())
+		sourceBodyBytes += int64(event.Metadata().BodyExtent().StoredBytes())
 	}
 	return v0330ReleaseEvidenceSample{
-		items:     len(events),
-		bodyBytes: bodyBytes,
-		identity:  v0330ReleaseEvidenceIdentity(identities),
+		items:           len(events),
+		bodyBytes:       bodyBytes,
+		sourceBodyBytes: sourceBodyBytes,
+		identity:        v0330ReleaseEvidenceIdentity(identities),
 	}
 }
 

--- a/presentation/mcpserver/release_evidence_test.go
+++ b/presentation/mcpserver/release_evidence_test.go
@@ -1,0 +1,127 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+type v0330AggregateReleaseEvidence struct {
+	MaxItems                      int  `json:"max_items"`
+	MaxAggregateBodyBytes         int  `json:"max_aggregate_body_bytes"`
+	ObservedMaxItems              int  `json:"observed_max_items"`
+	ObservedMaxAggregateBodyBytes int  `json:"observed_max_aggregate_body_bytes"`
+	Pages                         int  `json:"pages"`
+	TotalItems                    int  `json:"total_items"`
+	MultibyteObserved             bool `json:"multibyte_observed"`
+	BodyBlocksObserved            bool `json:"body_blocks_observed"`
+	ContinuationNoDuplicateOrSkip bool `json:"continuation_no_duplicate_or_skip"`
+}
+
+// TestV0330AggregateReleaseEvidence exercises the actual MCP list page path
+// with 100 multibyte canonical events. It emits only numeric and boolean
+// evidence; bodies, IDs, body blocks, and opaque continuations stay in-memory.
+func TestV0330AggregateReleaseEvidence(t *testing.T) {
+	server, datasource := newEventContinuationIntegrationServer(t)
+	createdAt := time.Date(2026, 7, 26, 6, 0, 0, 0, time.UTC)
+	visible := strings.Repeat("日本語", 100)
+	envelopeBytes, err := json.Marshal(map[string]any{
+		"blocks": []map[string]string{
+			{"type": "text", "text": visible},
+			{"type": "thinking", "text": "synthetic private thinking"},
+			{"type": "text", "text": "bounded release evidence"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal canonical fixture: %v", err)
+	}
+	expected := make(map[string]struct{}, apptypes.MaxEventResponseItemLimit)
+	for index := 0; index < apptypes.MaxEventResponseItemLimit; index++ {
+		eventID := fmt.Sprintf("release-event-%03d", index)
+		expected[eventID] = struct{}{}
+		saveEventContinuationFixture(t, datasource, eventID, string(envelopeBytes), createdAt)
+	}
+
+	bodyLimit := 500
+	continuation := ""
+	seen := make(map[string]struct{}, len(expected))
+	evidence := v0330AggregateReleaseEvidence{
+		MaxItems:              apptypes.MaxEventResponseItemLimit,
+		MaxAggregateBodyBytes: apptypes.MaxEventResponseAggregateBodyBytes,
+	}
+	for {
+		_, page, err := server.listEvents()(
+			context.Background(),
+			nil,
+			listEventsInput{
+				Workspace:    "repo",
+				Projection:   "bounded",
+				Limit:        apptypes.MaxEventResponseItemLimit,
+				BodyLimit:    &bodyLimit,
+				Continuation: continuation,
+			},
+		)
+		if err != nil {
+			t.Fatalf("listEvents() page error = %v", err)
+		}
+		evidence.Pages++
+		if len(page.Events) > evidence.ObservedMaxItems {
+			evidence.ObservedMaxItems = len(page.Events)
+		}
+		if page.Coverage.AggregateBodyBytes > evidence.ObservedMaxAggregateBodyBytes {
+			evidence.ObservedMaxAggregateBodyBytes = page.Coverage.AggregateBodyBytes
+		}
+		if len(page.Events) > apptypes.MaxEventResponseItemLimit {
+			t.Fatalf("page items = %d, want <= %d", len(page.Events), apptypes.MaxEventResponseItemLimit)
+		}
+		if page.Coverage.AggregateBodyBytes > apptypes.MaxEventResponseAggregateBodyBytes {
+			t.Fatalf(
+				"page aggregate body bytes = %d, want <= %d",
+				page.Coverage.AggregateBodyBytes,
+				apptypes.MaxEventResponseAggregateBodyBytes,
+			)
+		}
+		for _, event := range page.Events {
+			if _, duplicate := seen[event.EventID]; duplicate {
+				t.Fatal("aggregate continuation returned a duplicate item")
+			}
+			if _, known := expected[event.EventID]; !known {
+				t.Fatal("aggregate continuation returned an unexpected item")
+			}
+			seen[event.EventID] = struct{}{}
+			if event.Body != nil && strings.Contains(*event.Body, "日本語") {
+				evidence.MultibyteObserved = true
+			}
+			if len(event.BodyBlocks) > 0 {
+				evidence.BodyBlocksObserved = true
+			}
+		}
+		if page.Continuation == "" {
+			break
+		}
+		continuation = page.Continuation
+	}
+	for eventID := range expected {
+		if _, ok := seen[eventID]; !ok {
+			t.Fatal("aggregate continuation skipped an item")
+		}
+	}
+	evidence.TotalItems = len(seen)
+	evidence.ContinuationNoDuplicateOrSkip = len(seen) == len(expected)
+	if evidence.Pages < 2 ||
+		!evidence.MultibyteObserved ||
+		!evidence.BodyBlocksObserved ||
+		!evidence.ContinuationNoDuplicateOrSkip {
+		t.Fatalf("aggregate release evidence invariants failed: %+v", evidence)
+	}
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatalf("marshal aggregate release evidence: %v", err)
+	}
+	t.Logf("TRACEARY_PHASE_D_EVIDENCE=%s", encoded)
+}

--- a/presentation/mcpserver/release_evidence_test.go
+++ b/presentation/mcpserver/release_evidence_test.go
@@ -20,6 +20,7 @@ type v0330AggregateReleaseEvidence struct {
 	TotalItems                    int  `json:"total_items"`
 	MultibyteObserved             bool `json:"multibyte_observed"`
 	BodyBlocksObserved            bool `json:"body_blocks_observed"`
+	TruncationMetadataObserved    bool `json:"truncation_metadata_observed"`
 	ContinuationNoDuplicateOrSkip bool `json:"continuation_no_duplicate_or_skip"`
 }
 
@@ -44,7 +45,11 @@ func TestV0330AggregateReleaseEvidence(t *testing.T) {
 	for index := 0; index < apptypes.MaxEventResponseItemLimit; index++ {
 		eventID := fmt.Sprintf("release-event-%03d", index)
 		expected[eventID] = struct{}{}
-		saveEventContinuationFixture(t, datasource, eventID, string(envelopeBytes), createdAt)
+		body := string(envelopeBytes)
+		if index == 0 {
+			body = strings.Repeat("長", 700)
+		}
+		saveEventContinuationFixture(t, datasource, eventID, body, createdAt)
 	}
 
 	bodyLimit := 500
@@ -100,6 +105,12 @@ func TestV0330AggregateReleaseEvidence(t *testing.T) {
 			if len(event.BodyBlocks) > 0 {
 				evidence.BodyBlocksObserved = true
 			}
+			if event.BodyTruncated &&
+				event.BodyLength > 0 &&
+				event.Body != nil &&
+				len([]rune(*event.Body)) < event.BodyLength {
+				evidence.TruncationMetadataObserved = true
+			}
 		}
 		if page.Continuation == "" {
 			break
@@ -116,6 +127,7 @@ func TestV0330AggregateReleaseEvidence(t *testing.T) {
 	if evidence.Pages < 2 ||
 		!evidence.MultibyteObserved ||
 		!evidence.BodyBlocksObserved ||
+		!evidence.TruncationMetadataObserved ||
 		!evidence.ContinuationNoDuplicateOrSkip {
 		t.Fatalf("aggregate release evidence invariants failed: %+v", evidence)
 	}


### PR DESCRIPTION
## Motivation

v0.33.0 needs reproducible release evidence that metadata discovery, bounded inspection, indexed search, copied-store migration/backfill, and aggregate MCP responses stay bounded on a multi-GiB SQLite store without publishing event content or local identities.

## What changed

- added a maintainer-only `repo-tooling release` runner with a 12 GiB capacity preflight, owner-only scratch lifecycle, capped child output, strict metrics-only schema, max+1 bounded artifact reads, and fail-closed oversized-input validation before decode;
- exercised the merged #1570 metadata projection with an eight-event, 2 GiB body fixture and required event/projection parity, a projection-only ordered plan, eight error-free returned rows per timed scan, zero returned body bytes, 25 measurements, and p95 below 250 ms;
- migrated a copied pre-31 synthetic store through migrations 31-34, verified source immutability, projection parity, integrity, foreign keys, and resumable 128-to-130 FTS backfill;
- recorded separate 25-run list/context/search observations for metadata and bounded projections, requiring exactly 20 returned items and metadata/bounded membership parity for every pair, without assigning unsupported Phase-C latency gates;
- verified MCP aggregate item/byte budgets, multibyte bodies, canonical blocks, response-truncation metadata, and continuation traversal over 100 events;
- recorded six-host MCP registration and staged-retrieval semantic parity;
- wired the strict committed-artifact verifier before GoReleaser for the exact `v0.33.0` tagged-release path;
- documented the privacy boundary, the few-huge-rows fixture limitation, and the non-comparative Phase-C interpretation in English and Japanese.

## Release evidence

**Status: pass.**

- Phase A committed artifact: 2,418,774,016 managed bytes, 2,147,483,648 stored-body bytes, 8 event/projection rows, 8 returned items per scan, 0 missing metadata, projection-only ordered plan, 0 returned body bytes, 25 runs, p95 **0.074625 ms** against the fixed **250 ms** target.
- The exact acceptance benchmark was rerun separately on the final head and measured p95 **0.079708 ms**, also below 250 ms.
- Phase B applied migrations 31-34 to the copy, produced 130 projection rows for 130 events, preserved the source byte-for-byte, passed integrity and foreign-key checks, and resumed FTS from 128 incomplete to 130 complete documents.
- Phase C completed all eight 25-run series against the 130-event fixture with limit 20. Every probe returned exactly 20 items; metadata/bounded membership matched for list, context, incomplete search, and complete search; metadata bytes were zero; bounded bytes were positive. These are single-host observations, not metadata-versus-bounded performance claims.
- Phase D returned all 100 items exactly once over three pages, stayed within 100 items and 65,536 encoded body/block bytes per page, and exposed both canonical blocks and response-truncation metadata.
- Phase E verified MCP registration and the staged Discovery → Inspection → Detail contract across all six packaged hosts.

## Privacy boundary

The committed artifact contains fixed enums, booleans, counts, byte sizes, and durations only. It contains no event body, prompt, response, event/session identity, workspace, local path, cursor, continuation, raw child output, or digest. The verifier reads at most 1 MiB plus one detection byte and rejects oversized input before JSON decoding. The owner-only scratch directory was absent before the artifact was written.

## Review follow-up

- rebased onto `main` at `6641c6d7`, which contains merged #1567 and #1570;
- replaced the stale blocked evidence with a complete pass rerun rather than reusing prior metrics;
- made projection-only planning and event/projection parity release gates;
- made Phase-A scan completion/count and Phase-C result-count, body-byte, and projection-membership invariants release-evidence gates;
- made the artifact verifier reject input over 1 MiB before decoding a valid prefix;
- added a tagged-release workflow gate before GoReleaser;
- documented that Phase C is not powered for relative performance comparisons and that Phase A covers the few-huge-rows shape, not the many-small-rows shape.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...` (4,130 tests in 23 packages)
- `go test -race ./cmd/repo-tooling ./infrastructure/sqlite ./presentation/mcpserver` (553 tests)
- `go tool golangci-lint run --timeout=5m` (`0 issues`)
- `go run ./cmd/repo-tooling docs verify-i18n`
- `go run ./cmd/repo-tooling docs verify-antigravity-status`
- `go run ./cmd/repo-tooling docs verify-host-coverage`
- `python3 scripts/verify_docs_no_removed_aliases.py`
- `go run ./cmd/repo-tooling release verify-changelog`
- `go run ./cmd/repo-tooling docs verify-landing`
- `python3 scripts/verify_release_drafter_workflow.py`
- `python3 scripts/verify_release_manifests.py`
- `go run ./cmd/repo-tooling integrations verify`
- `./scripts/smoke_test_integrations.sh post-upgrade-plugin-refresh`
- `go test ./presentation/mcpserver -run TestServer_ToolAdvertisementBudget -v`
- `go run ./cmd/repo-tooling release run-v0.33.0-evidence --output docs/release/v0.33.0-multigib-evidence.json`
- `go run ./cmd/repo-tooling release verify-body-free-evidence --input docs/release/v0.33.0-multigib-evidence.json`
- `TRACEARY_RUN_MULTI_GIB_BENCHMARK=1 go test ./infrastructure/sqlite -run '^$' -bench BenchmarkMetadataDirectRangeMultiGiB -benchtime=1x`
- forbidden artifact-key scan, scratch-residue scan, bilingual artifact/doc consistency check, workflow YAML parse, and `git diff --check`

Closes #1558
