### PR TITLE
v0.32.1-8: isolate Codex rollout matching from glob metacharacters

### DIFF
--- a/infrastructure/filesystem/codex_usage_source.go
+++ b/infrastructure/filesystem/codex_usage_source.go
@@ -61,7 +61,7 @@ func (s *codexUsageSource) Load(
 	if err != nil {
 		return application.CodexUsageLoadResult{}, err
 	}
-	paths, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "*"+sessionID+".jsonl"))
+	paths, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "*"+escapeFilepathGlobLiteral(sessionID)+".jsonl"))
 	if err != nil {
 		return application.CodexUsageLoadResult{}, xerrors.Errorf("failed to match Codex usage source")
 	}
@@ -76,6 +76,26 @@ func (s *codexUsageSource) Load(
 		result.BoundaryObserved = loaded.BoundaryObserved
 	}
 	return result, nil
+}
+
+// escapeFilepathGlobLiteral encodes filepath glob operators as character
+// classes. Unlike backslash escaping, character classes work on Windows too.
+func escapeFilepathGlobLiteral(value string) string {
+	var escaped strings.Builder
+	escaped.Grow(len(value))
+	for _, character := range value {
+		switch character {
+		case '*', '?':
+			escaped.WriteRune('[')
+			escaped.WriteRune(character)
+			escaped.WriteRune(']')
+		case '[':
+			escaped.WriteString("[[]")
+		default:
+			escaped.WriteRune(character)
+		}
+	}
+	return escaped.String()
 }
 
 func (s *codexUsageSource) resolveSessionsRoot() (string, error) {

--- a/infrastructure/filesystem/codex_usage_source_test.go
+++ b/infrastructure/filesystem/codex_usage_source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -71,6 +72,81 @@ func TestCodexUsageSource_LoadsFinalCumulativeTurnDeltasWithoutBodies(t *testing
 		if strings.Contains(sample.RecordID, "private") || strings.Contains(sample.Model, "private") {
 			t.Fatalf("private fixture field escaped: %+v", sample)
 		}
+	}
+}
+
+func TestCodexUsageSource_TreatsSessionIDAsLiteralRolloutSuffix(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionID        string
+		foreignSessionID string
+	}{
+		{
+			name:      "normal session ID",
+			sessionID: "literal-session",
+		},
+		{
+			name:             "asterisk",
+			sessionID:        "literal*session",
+			foreignSessionID: "literal-foreign-session",
+		},
+		{
+			name:             "question mark",
+			sessionID:        "literal?session",
+			foreignSessionID: "literal1session",
+		},
+		{
+			name:             "character class",
+			sessionID:        "literal[1]session",
+			foreignSessionID: "literal1session",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(tc.sessionID, "*?") {
+				t.Skip("Windows filenames cannot contain this glob metacharacter")
+			}
+
+			home := t.TempDir()
+			t.Setenv("CODEX_HOME", "")
+			writeRollout := func(sessionID, model string) {
+				t.Helper()
+				path := filepath.Join(home, ".codex", "sessions", "2026", "07", "23", "rollout-"+sessionID+".jsonl")
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				fixture := strings.Join([]string{
+					`{"timestamp":"2026-07-23T01:00:00Z","type":"turn_context","payload":{"turn_id":"turn-1","model":"` + model + `"}}`,
+					`{"timestamp":"2026-07-23T01:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}}`,
+					`{"timestamp":"2026-07-23T01:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}`,
+				}, "\n") + "\n"
+				if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeRollout(tc.sessionID, "literal-model")
+			if tc.foreignSessionID != "" {
+				writeRollout(tc.foreignSessionID, "foreign-model")
+			}
+
+			result, err := filesystem.NewCodexUsageSourceForTest(
+				func() (string, error) { return home, nil },
+				1024*1024,
+				1024*1024,
+			).Load(
+				context.Background(),
+				application.CodexUsageLoadCriteria{SessionID: types.SessionID(tc.sessionID)},
+			)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if len(result.Samples) != 1 {
+				t.Fatalf("len(Samples) = %d, want 1: %+v", len(result.Samples), result.Samples)
+			}
+			if got := result.Samples[0].Model; got != "literal-model" {
+				t.Fatalf("Model = %q, want literal-model", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- encode Codex session ID glob operators as portable literal character classes before rollout discovery
- preserve fixed-depth rollout selection, parsing, and existing path defenses
- add black-box regressions for ordinary IDs plus `*`, `?`, and `[` IDs, proving foreign rollouts are excluded while literal rollouts remain ingestible

## Structure and behavior

The filesystem adapter owns glob-syntax encoding because the domain session ID remains a general literal value. No public interface, rollout format, or session-ID validation changes.

## Validation

- `go test ./infrastructure/filesystem -run TestCodexUsageSource_TreatsSessionIDAsLiteralRolloutSuffix -count=1`
- `go test ./...`
- `go build ./...`
- `go tool golangci-lint run` (`0 issues`)
- `git diff --check`

Independent AI review is intentionally left to the orchestrator.

## Process friction

- avoided: branch-prefix collision and writable-root preflight passed; isolated worktree used from the start
- occurred: the default Go build cache was outside the sandbox write scope, so validation was rerun once with a scoped `/private/tmp` cache
- follow-up: none

Closes #1575
