### PR TITLE
test: isolate CLI hook state from live spool

### DIFF
--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -16,6 +17,15 @@ var ExpectedCodexPluginHookCount = expectedCodexPluginHookCount
 // SetUserHomeDirFunc replaces the home-directory lookup function for tests.
 func SetUserHomeDirFunc(f func() (string, error)) {
 	userHomeDirFunc = f
+	if os.Getenv(hookStateDirEnvKey) != testDefaultHookStateDir {
+		return
+	}
+	homeDir, err := f()
+	if err != nil {
+		_ = os.Unsetenv(hookStateDirEnvKey)
+		return
+	}
+	_ = os.Setenv(hookStateDirEnvKey, filepath.Join(homeDir, ".config", "traceary", "hooks"))
 }
 
 // CallUserHomeDirFunc exposes the current user-home-directory lookup for
@@ -28,6 +38,7 @@ func CallUserHomeDirFunc() (string, error) {
 // ResetUserHomeDirFunc restores the default home-directory lookup function for tests.
 func ResetUserHomeDirFunc() {
 	userHomeDirFunc = os.UserHomeDir
+	_ = os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir)
 }
 
 // SetAntigravityBundleExistsFunc replaces the Antigravity bundle existence

--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -17,7 +18,8 @@ var ExpectedCodexPluginHookCount = expectedCodexPluginHookCount
 // SetUserHomeDirFunc replaces the home-directory lookup function for tests.
 func SetUserHomeDirFunc(f func() (string, error)) {
 	userHomeDirFunc = f
-	if os.Getenv(hookStateDirEnvKey) != testDefaultHookStateDir {
+	stateDir, configured := os.LookupEnv(hookStateDirEnvKey)
+	if configured && strings.TrimSpace(stateDir) != "" && stateDir != testDefaultHookStateDir {
 		return
 	}
 	homeDir, err := f()
@@ -37,7 +39,7 @@ func CallUserHomeDirFunc() (string, error) {
 
 // ResetUserHomeDirFunc restores the default home-directory lookup function for tests.
 func ResetUserHomeDirFunc() {
-	userHomeDirFunc = os.UserHomeDir
+	userHomeDirFunc = testDefaultUserHomeDirFunc
 	_ = os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir)
 }
 

--- a/presentation/cli/hook_antigravity_test.go
+++ b/presentation/cli/hook_antigravity_test.go
@@ -231,7 +231,7 @@ func TestRootCLI_HookAntigravityConcurrentPreInvocationsProtectAllActiveSessions
 			"TRACEARY_ANTIGRAVITY_GC_PAYLOAD={\"conversationId\":\""+sessionID+"\",\"workspacePaths\":[\"/repo\"]}",
 			"TRACEARY_TEST_HOOK_STATE_DIR="+stateDir,
 			"TRACEARY_HOOK_STATE_KEY="+key,
-			"TRACEARY_DB_PATH="+dbPath,
+			"TRACEARY_TEST_DB_PATH="+dbPath,
 			"TRACEARY_WORKSPACE=github.com/duck8823/traceary",
 		)
 		output := &bytes.Buffer{}

--- a/presentation/cli/hook_antigravity_test.go
+++ b/presentation/cli/hook_antigravity_test.go
@@ -229,7 +229,7 @@ func TestRootCLI_HookAntigravityConcurrentPreInvocationsProtectAllActiveSessions
 		cmd.Env = append(os.Environ(),
 			"TRACEARY_ANTIGRAVITY_GC_HELPER=1",
 			"TRACEARY_ANTIGRAVITY_GC_PAYLOAD={\"conversationId\":\""+sessionID+"\",\"workspacePaths\":[\"/repo\"]}",
-			"TRACEARY_HOOK_STATE_DIR="+stateDir,
+			"TRACEARY_TEST_HOOK_STATE_DIR="+stateDir,
 			"TRACEARY_HOOK_STATE_KEY="+key,
 			"TRACEARY_DB_PATH="+dbPath,
 			"TRACEARY_WORKSPACE=github.com/duck8823/traceary",

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -201,6 +201,7 @@ func TestRootCLI_HookAntigravityStatusline_DelegatesToUsageCapture(t *testing.T)
 }
 
 func TestRootCLI_HookUsageCommand_DelegatesBodyFreeCodexIdentity(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "codex-usage-key")
 	store := &storeManagementUsecaseStub{}
 	usage := &codexUsageCaptureStub{}
@@ -225,6 +226,7 @@ func TestRootCLI_HookUsageCommand_DelegatesBodyFreeCodexIdentity(t *testing.T) {
 }
 
 func TestRootCLI_HookUsageCommand_DelegatesBodyFreeClaudeIdentity(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "claude-usage-key")
 	store := &storeManagementUsecaseStub{}
 	usage := &claudeUsageCaptureStub{}

--- a/presentation/cli/hook_spool_test.go
+++ b/presentation/cli/hook_spool_test.go
@@ -903,7 +903,7 @@ func TestHookSpoolSurvivesSIGTERM(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv(hookStateDirEnvKey, stateDir)
 	cmd := exec.Command(os.Args[0], "-test.run=^TestHookSpoolSurvivesSIGTERM$")
-	cmd.Env = append(os.Environ(), "TRACEARY_HOOK_SPOOL_SIGNAL_HELPER=1", hookStateDirEnvKey+"="+stateDir)
+	cmd.Env = append(os.Environ(), "TRACEARY_HOOK_SPOOL_SIGNAL_HELPER=1", testHookStateDirEnvKey+"="+stateDir)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/presentation/cli/hook_state_internal_test.go
+++ b/presentation/cli/hook_state_internal_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -26,7 +27,9 @@ func TestResolveHookStateDir_UsesHomeFallbackWhenEnvironmentIsEmpty(t *testing.T
 func TestResolveHookStateDir_ErrorInjectedHomeCannotUseTestProcessHome(t *testing.T) {
 	SetUserHomeDirFunc(func() (string, error) { return "", errors.New("home unavailable") })
 	t.Cleanup(ResetUserHomeDirFunc)
-	t.Setenv(hookStateDirEnvKey, "")
+	if _, configured := os.LookupEnv(hookStateDirEnvKey); configured {
+		t.Fatal("SetUserHomeDirFunc(error) must clear the hook-state environment")
+	}
 
 	if _, err := resolveHookStateDir(); err == nil {
 		t.Fatal("resolveHookStateDir() error = nil, want home lookup error")

--- a/presentation/cli/hook_state_internal_test.go
+++ b/presentation/cli/hook_state_internal_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveHookStateDir_UsesHomeFallbackWhenEnvironmentIsEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	originalHomeDirFunc := userHomeDirFunc
+	userHomeDirFunc = func() (string, error) { return homeDir, nil }
+	t.Cleanup(func() { userHomeDirFunc = originalHomeDirFunc })
+	t.Setenv(hookStateDirEnvKey, "")
+
+	got, err := resolveHookStateDir()
+	if err != nil {
+		t.Fatalf("resolveHookStateDir() error = %v", err)
+	}
+	want := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if got != want {
+		t.Fatalf("resolveHookStateDir() = %q, want %q", got, want)
+	}
+}

--- a/presentation/cli/hook_state_internal_test.go
+++ b/presentation/cli/hook_state_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -17,6 +18,30 @@ func TestResolveHookStateDir_UsesHomeFallbackWhenEnvironmentIsEmpty(t *testing.T
 		t.Fatalf("resolveHookStateDir() error = %v", err)
 	}
 	want := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if got != want {
+		t.Fatalf("resolveHookStateDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHookStateDir_ErrorInjectedHomeCannotUseTestProcessHome(t *testing.T) {
+	SetUserHomeDirFunc(func() (string, error) { return "", errors.New("home unavailable") })
+	t.Cleanup(ResetUserHomeDirFunc)
+	t.Setenv(hookStateDirEnvKey, "")
+
+	if _, err := resolveHookStateDir(); err == nil {
+		t.Fatal("resolveHookStateDir() error = nil, want home lookup error")
+	}
+}
+
+func TestResetUserHomeDirFunc_UsesTestHomeWhenStateEnvironmentIsBlank(t *testing.T) {
+	ResetUserHomeDirFunc()
+	t.Setenv(hookStateDirEnvKey, "")
+
+	got, err := resolveHookStateDir()
+	if err != nil {
+		t.Fatalf("resolveHookStateDir() error = %v", err)
+	}
+	want := filepath.Join(testDefaultUserHomeDir, ".config", "traceary", "hooks")
 	if got != want {
 		t.Fatalf("resolveHookStateDir() = %q, want %q", got, want)
 	}

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -12,6 +13,8 @@ var (
 	testDefaultUserHomeDir     string
 	testDefaultUserHomeDirFunc func() (string, error)
 )
+
+const testHookStateDirEnvKey = "TRACEARY_TEST_HOOK_STATE_DIR"
 
 // TestMain pins the CLI locale to English for this package's tests unless the
 // environment already sets TRACEARY_LANG. Locale resolution falls back to the
@@ -38,29 +41,33 @@ func TestMain(m *testing.M) {
 	testDefaultUserHomeDirFunc = func() (string, error) { return testDefaultUserHomeDir, nil }
 	userHomeDirFunc = testDefaultUserHomeDirFunc
 
-	removeTestHookStateDir := false
-	if stateDir, ok := os.LookupEnv(hookStateDirEnvKey); ok && strings.TrimSpace(stateDir) != "" {
+	if stateDir := strings.TrimSpace(os.Getenv(testHookStateDirEnvKey)); stateDir != "" {
 		testDefaultHookStateDir = stateDir
 	} else {
 		testDefaultHookStateDir, err = os.MkdirTemp("", "traceary-cli-test-hooks-")
 		if err != nil {
-			_ = os.RemoveAll(testDefaultHookStateDir)
 			_ = os.RemoveAll(testDefaultUserHomeDir)
 			fmt.Fprintf(os.Stderr, "create isolated Traceary CLI hook state: %v\n", err)
 			os.Exit(1)
 		}
-		if err := os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir); err != nil {
-			_ = os.RemoveAll(testDefaultHookStateDir)
-			_ = os.RemoveAll(testDefaultUserHomeDir)
-			fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI hook state: %v\n", err)
-			os.Exit(1)
-		}
-		removeTestHookStateDir = true
+	}
+	if err := os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir); err != nil {
+		_ = os.RemoveAll(testDefaultHookStateDir)
+		_ = os.RemoveAll(testDefaultUserHomeDir)
+		fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI hook state: %v\n", err)
+		os.Exit(1)
 	}
 	code := m.Run()
-	if removeTestHookStateDir {
+	if os.Getenv(testHookStateDirEnvKey) == "" {
 		_ = os.RemoveAll(testDefaultHookStateDir)
 	}
 	_ = os.RemoveAll(testDefaultUserHomeDir)
 	os.Exit(code)
+}
+
+func TestMain_UsesTestOwnedHookStateDirectory(t *testing.T) {
+	relativePath, err := filepath.Rel(os.TempDir(), testDefaultHookStateDir)
+	if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
+		t.Fatalf("testDefaultHookStateDir = %q, want a test-owned temporary directory", testDefaultHookStateDir)
+	}
 }

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -14,7 +14,10 @@ var (
 	testDefaultUserHomeDirFunc func() (string, error)
 )
 
-const testHookStateDirEnvKey = "TRACEARY_TEST_HOOK_STATE_DIR"
+const (
+	testHookStateDirEnvKey = "TRACEARY_TEST_HOOK_STATE_DIR"
+	testDBPathEnvKey       = "TRACEARY_TEST_DB_PATH"
+)
 
 // TestMain pins the CLI locale to English for this package's tests unless the
 // environment already sets TRACEARY_LANG. Locale resolution falls back to the
@@ -55,6 +58,15 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(testDefaultHookStateDir)
 		_ = os.RemoveAll(testDefaultUserHomeDir)
 		fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI hook state: %v\n", err)
+		os.Exit(1)
+	}
+	if dbPath := strings.TrimSpace(os.Getenv(testDBPathEnvKey)); dbPath != "" {
+		if err := os.Setenv(dbPathEnvKey, dbPath); err != nil {
+			fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI database: %v\n", err)
+			os.Exit(1)
+		}
+	} else if err := os.Unsetenv(dbPathEnvKey); err != nil {
+		fmt.Fprintf(os.Stderr, "clear ambient Traceary CLI database: %v\n", err)
 		os.Exit(1)
 	}
 	code := m.Run()

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -1,12 +1,17 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 )
 
-var testDefaultHookStateDir string
+var (
+	testDefaultHookStateDir    string
+	testDefaultUserHomeDir     string
+	testDefaultUserHomeDirFunc func() (string, error)
+)
 
 // TestMain pins the CLI locale to English for this package's tests unless the
 // environment already sets TRACEARY_LANG. Locale resolution falls back to the
@@ -24,14 +29,30 @@ func TestMain(m *testing.M) {
 		_ = os.Setenv(cliLanguageEnvKey, "en")
 	}
 
+	var err error
+	testDefaultUserHomeDir, err = os.MkdirTemp("", "traceary-cli-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create isolated Traceary CLI test home: %v\n", err)
+		os.Exit(1)
+	}
+	testDefaultUserHomeDirFunc = func() (string, error) { return testDefaultUserHomeDir, nil }
+	userHomeDirFunc = testDefaultUserHomeDirFunc
+
 	removeTestHookStateDir := false
 	if stateDir, ok := os.LookupEnv(hookStateDirEnvKey); ok && strings.TrimSpace(stateDir) != "" {
 		testDefaultHookStateDir = stateDir
 	} else {
-		var err error
 		testDefaultHookStateDir, err = os.MkdirTemp("", "traceary-cli-test-hooks-")
-		if err != nil || os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir) != nil {
+		if err != nil {
 			_ = os.RemoveAll(testDefaultHookStateDir)
+			_ = os.RemoveAll(testDefaultUserHomeDir)
+			fmt.Fprintf(os.Stderr, "create isolated Traceary CLI hook state: %v\n", err)
+			os.Exit(1)
+		}
+		if err := os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir); err != nil {
+			_ = os.RemoveAll(testDefaultHookStateDir)
+			_ = os.RemoveAll(testDefaultUserHomeDir)
+			fmt.Fprintf(os.Stderr, "configure isolated Traceary CLI hook state: %v\n", err)
 			os.Exit(1)
 		}
 		removeTestHookStateDir = true
@@ -40,5 +61,6 @@ func TestMain(m *testing.M) {
 	if removeTestHookStateDir {
 		_ = os.RemoveAll(testDefaultHookStateDir)
 	}
+	_ = os.RemoveAll(testDefaultUserHomeDir)
 	os.Exit(code)
 }

--- a/presentation/cli/main_test.go
+++ b/presentation/cli/main_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
+
+var testDefaultHookStateDir string
 
 // TestMain pins the CLI locale to English for this package's tests unless the
 // environment already sets TRACEARY_LANG. Locale resolution falls back to the
@@ -21,5 +24,21 @@ func TestMain(m *testing.M) {
 		_ = os.Setenv(cliLanguageEnvKey, "en")
 	}
 
-	os.Exit(m.Run())
+	removeTestHookStateDir := false
+	if stateDir, ok := os.LookupEnv(hookStateDirEnvKey); ok && strings.TrimSpace(stateDir) != "" {
+		testDefaultHookStateDir = stateDir
+	} else {
+		var err error
+		testDefaultHookStateDir, err = os.MkdirTemp("", "traceary-cli-test-hooks-")
+		if err != nil || os.Setenv(hookStateDirEnvKey, testDefaultHookStateDir) != nil {
+			_ = os.RemoveAll(testDefaultHookStateDir)
+			os.Exit(1)
+		}
+		removeTestHookStateDir = true
+	}
+	code := m.Run()
+	if removeTestHookStateDir {
+		_ = os.RemoveAll(testDefaultHookStateDir)
+	}
+	os.Exit(code)
 }


### PR DESCRIPTION
Parent release: #1550

## Problem

`TestRootCLI_HookUsageCommand_DelegatesBodyFreeClaudeIdentity` does not isolate
`TRACEARY_HOOK_STATE_DIR`.  A local full-suite run can therefore use the real
hook spool under the developer's home directory and opportunistically replay or
delete a queued delivery.

## Acceptance criteria

- [ ] every hook-runtime test uses a test-owned hook state directory
- [ ] the affected test cannot inspect, replay, or delete the user's live spool
- [ ] regression coverage verifies the isolated directory is used
- [ ] `go test ./...` is safe to run locally without a live-spool side effect

Priority: P0 release safety.
Structure-Behavior risk: Medium.
