### PR TITLE
fix: make gc dry-run read-only

### DIFF
--- a/.ai/spec/1571.md
+++ b/.ai/spec/1571.md
@@ -1,0 +1,56 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Purpose: make `traceary store gc --dry-run` a genuinely read-only preview.
+- Current behavior: the CLI initializes/migrates the store and the SQLite adapter executes deletion/update statements inside a rolled-back transaction.
+- Expected behavior: dry-run opens an existing store read-only, executes only `SELECT COUNT(*)` queries, leaves schema/content/file permissions unchanged, and reports the same affected-row count as apply for the supported targets.
+- Out of scope: changing retention rules, GC apply ordering, `VACUUM`, or automatic event-search backfill policy for commands other than GC dry-run.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| GC preview | cutoff, target | counts rows the apply path would affect | never initializes, migrates, deletes, updates, vacuums, or writes |
+| GC apply | cutoff, target | mutates in the existing transaction order | existing deletion/decay semantics remain unchanged |
+| Read-only store | existing SQLite file | serves preview queries | main DB remains query-only; WAL-mode reads may require SQLite-managed sidecars in a writable directory |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Skip initialization for preview | CLI GC command | selects preview versus apply execution boundary | datasource cannot undo migrations already run by CLI |
+| Open query-only SQLite connection and count candidates | SQLite store-management adapter | owns SQL and transaction snapshot | use case must not know table/query details |
+| Validate preview result contract | infrastructure and CLI behavior tests | observable behavior spans adapter and command boundary | private helper call order is not the contract |
+
+### Boundaries / interfaces
+
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `CollectGarbage(..., dryRun)` | store-management use case | read-only count queries versus apply transaction | contextual wrapped SQLite errors |
+| `Database.openReadOnly` | GC preview adapter | query-only DSN and busy timeout | fails without creating or migrating a store |
+| `runGC` | Cobra command | initialization is apply-only | invalid target/cutoff behavior remains unchanged |
+
+### Behavior tests
+
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| Preview does not initialize | configured GC command | `--dry-run` executes | initializer is not called and count is printed | CLI |
+| Apply still initializes | configured GC command | apply executes | initializer is called before collection | CLI |
+| Preview succeeds read-only | migrated fixture with read-only SQLite access | event GC preview executes | candidate count is returned and rows remain | infrastructure |
+| Preview mirrors ordered `all` apply | events make an ended session empty and memories cascade edges | preview and apply run on equivalent fixtures | affected counts match | infrastructure |
+
+### TDD plan
+
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| CLI preview boundary | assert `Initialize` is not called | guard initialization with `!dryRun` | keep path resolution shared |
+| Query-only preview | force read-only DSN/file and observe current deletion error | add count-only read transaction | isolate preview counting from mutation helper |
+| Ordered target parity | fixture exposing event/session and memory/edge ordering | encode ordered count predicates | keep SQL predicates adjacent to mutation SQL |
+
+### Risks / rollback
+
+- Procedural risk: duplicated count/delete predicates may drift. Keep paired embedded SQL files and parity tests.
+- Premature abstraction risk: do not introduce a generic planner; GC has one preview and one apply path.
+- Migration / compatibility: no schema or public JSON changes.
+- Rollback trigger: preview count differs from apply affected count for a covered target, or any dry-run changes DB content/mtime.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -13,6 +13,7 @@ release note と同じ粒度で、版ごとの要点だけをまとめていま�
 - **token効率のよいhost guidance (#1555, #1557)** — package済みskillはDiscovery → Inspection → Detailの段階的retrievalを強制し、MCP schema sizeを対応host全体でbudget化してregression testします。
 
 ### Fixed
+- **read-onlyなgarbage-collection preview (#1571)** — `traceary store gc --dry-run`はstoreをinitialize、migrate、delete、update、vacuumしません。read-only SQLite connection上のcount-only queryを使い、event、session、memory、memory edgeに対するapply順序のsemanticsを保持します。未作成または未migrationのstoreに対するpreviewはstoreを作成・migrationせず失敗するため、先に`traceary store init`を明示実行してください。
 - **memory hygieneの安全性とcost上限 (#1556)** — scanとsimilarity workはresume可能かつboundedです。applyはexpire/reject/supersedeの前に要求IDと関連candidateだけを再検証し、stale evidenceではfail closedします。
 - **hookとhost packageの正確性 (#1526, #1574, #1575)** — command-auditのpolicy denialを明示分類し、post-upgrade verifierがcanonical Grok inventoryを受理し、Codex rollout session IDをglobではなくliteralとして扱います。
 - **multi-GiB release evidence (#1558)** — privateなsynthetic 2 GiB fixtureでprojection-only metadata path、copy上のmigration 31–34、FTS progress、MCP aggregation、bounded huge-body retrievalを検証します。公開artifactはmetricsだけを含み、固定250 ms gateに対するPhase-A p95 0.079708 msを記録します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ It mirrors the same level of detail as the GitHub release notes, but keeps the h
 - **Token-efficient host guidance (#1555, #1557)** — packaged skills enforce staged Discovery → Inspection → Detail retrieval, and MCP schema size is budgeted and regression-tested across supported hosts.
 
 ### Fixed
+- **Read-only garbage-collection preview (#1571)** — `traceary store gc --dry-run` no longer initializes, migrates, deletes, updates, or vacuums the store. It uses count-only queries over a read-only SQLite connection and preserves apply-order semantics across events, sessions, memories, and memory edges. Previewing a missing or unmigrated store now fails without creating or migrating it; run `traceary store init` explicitly first.
 - **Memory hygiene safety and cost bounds (#1556)** — scans and similarity work are resumable and bounded; apply revalidates only requested IDs and related candidates before expire, reject, or supersede mutations, failing closed on stale evidence.
 - **Hook and host-package correctness (#1526, #1574, #1575)** — command-audit policy denials are classified explicitly, the post-upgrade verifier accepts canonical Grok inventory, and Codex rollout session IDs are treated as literals rather than glob patterns.
 - **Multi-GiB release evidence (#1558)** — a private synthetic 2 GiB fixture verifies the projection-only metadata path, copied migrations 31–34, FTS progress, MCP aggregation, and bounded huge-body retrieval. The published artifact contains metrics only; it records a Phase-A p95 of 0.079708 ms against the fixed 250 ms gate.

--- a/docs/release/v0.33.0-qa.ja.md
+++ b/docs/release/v0.33.0-qa.ja.md
@@ -34,6 +34,22 @@ go tool golangci-lint run
 
 full suiteはrelease-prep commit `a5b19628`でlocalとCIの両方でgreenです。P0フォローアップ #1586（merge済みPR #1587、`129fa58b`）と #1588（merge済みPR #1589、`bcda8f4a`）により、CLI hook-runtimeとhook-scriptのtestをambient hook state、default database path、PATH解決済みのinstalled binaryから隔離しました。localのfull suiteはreal queueのhook deliveryをinspect、replay、deleteしません。
 
+## 最終copied-store dogfood
+
+#1571を最初に再現したlong-lived local storeのSQLite backup copyに対しても、最終release candidateを検証しました。ここにはaggregate metricだけを記録し、event body、prompt、transcript、workspace、session/event identifier、raw rowは公開しません。
+
+- managed backup size: 約7.1 GiB
+- event: 425,106、session: 25,788
+- schema migrationとmetadata projection: migration 34件、projection row 425,106件
+- SQLite integrity check: pass
+- read-only `list --limit 1 --json`: 0.56秒、exit 0
+- read-only `context --limit 20 --json`: 7.46秒、exit 0
+- read-only AI sessions snapshot: 4.16秒、exit 0
+- read-only `store gc --dry-run`: 0.10秒、exit 0
+- 全targetでGC previewのcandidate countが従来のtransactional previewと一致し、main DBのhash、size、mtime、modeは不変
+
+GC dry-runは意図的にstoreをinitialize・migrateしません。古いstoreまたは未作成storeをpreviewする前に、operatorは`traceary store init`を明示実行する必要があります。WAL-mode storeのreadではSQLiteが通常のWAL shared-memory sidecarを維持する場合がありますが、main databaseはquery-onlyのままです。
+
 ## リリース境界
 
 migration 31–34はadditiveであり、既存event/session dataを削除せずにmetadata access pathを維持します。tagged workflowはartifact公開前にstrict evidence verifierを実行し、GitHub Release成功後にだけ#1550をcloseしなければなりません。

--- a/docs/release/v0.33.0-qa.md
+++ b/docs/release/v0.33.0-qa.md
@@ -44,6 +44,31 @@ hook-runtime and hook-script tests from ambient hook state, default database
 paths, and PATH-resolved installed binaries, so a local full suite does not
 inspect, replay, or delete a real queued hook delivery.
 
+## Final copied-store dogfood
+
+The final release candidate was also exercised against a SQLite backup copy of
+the long-lived local store that originally reproduced #1571. Only aggregate
+metrics are recorded here; no event body, prompt, transcript, workspace,
+session/event identifier, or raw row is published.
+
+- managed backup size: about 7.1 GiB
+- events: 425,106; sessions: 25,788
+- schema migrations and metadata projection: 34 migrations and 425,106
+  projection rows
+- SQLite integrity check: pass
+- read-only `list --limit 1 --json`: 0.56 seconds, exit 0
+- read-only `context --limit 20 --json`: 7.46 seconds, exit 0
+- read-only AI sessions snapshot: 4.16 seconds, exit 0
+- read-only `store gc --dry-run`: 0.10 seconds, exit 0
+- GC preview candidate counts matched the prior transactional preview for
+  every target, and the main DB hash, size, modification time, and mode were
+  unchanged
+
+GC dry-run deliberately does not initialize or migrate a store. Operators must
+run `traceary store init` explicitly before previewing an old or missing store.
+SQLite may maintain normal WAL shared-memory sidecars while reading a WAL-mode
+store; the main database remains query-only.
+
 ## Release boundary
 
 Migrations 31–34 are additive and maintain metadata access paths without

--- a/infrastructure/sqlite/gc_store_test.go
+++ b/infrastructure/sqlite/gc_store_test.go
@@ -2,7 +2,9 @@ package sqlite_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
@@ -37,6 +39,84 @@ func TestDatasource_CollectGarbage_DryRun(t *testing.T) {
 
 	if diff := cmp.Diff(2, countEvents(t, dbPath)); diff != "" {
 		t.Fatalf("event count mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDatasource_CollectGarbage_DryRunSucceedsOnReadOnlyStore(t *testing.T) {
+	t.Parallel()
+
+	dbPath, fixture := prepareGCFixture(t)
+	before, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("ReadFile() before dry-run error = %v", err)
+	}
+	beforeDigest := sha256.Sum256(before)
+
+	if err := os.Chmod(dbPath, 0o400); err != nil {
+		t.Fatalf("Chmod(read-only) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(dbPath, 0o600); err != nil {
+			t.Errorf("Chmod(restore) error = %v", err)
+		}
+	})
+	beforeInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat() before dry-run error = %v", err)
+	}
+
+	deletedCount, err := fixture.storeManager.CollectGarbage(
+		context.Background(),
+		time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+		apptypes.GarbageCollectionTargetEvents,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("CollectGarbage() error = %v", err)
+	}
+	if diff := cmp.Diff(1, deletedCount); diff != "" {
+		t.Fatalf("deletedCount mismatch (-want +got):\n%s", diff)
+	}
+
+	after, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after dry-run error = %v", err)
+	}
+	afterDigest := sha256.Sum256(after)
+	if diff := cmp.Diff(beforeDigest, afterDigest); diff != "" {
+		t.Fatalf("database digest changed during dry-run (-before +after):\n%s", diff)
+	}
+	afterInfo, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("Stat() after dry-run error = %v", err)
+	}
+	if beforeInfo.Size() != afterInfo.Size() {
+		t.Fatalf("database size changed during dry-run: before=%d after=%d", beforeInfo.Size(), afterInfo.Size())
+	}
+	if beforeInfo.Mode() != afterInfo.Mode() {
+		t.Fatalf("database mode changed during dry-run: before=%s after=%s", beforeInfo.Mode(), afterInfo.Mode())
+	}
+	if !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
+		t.Fatalf("database mtime changed during dry-run: before=%s after=%s", beforeInfo.ModTime(), afterInfo.ModTime())
+	}
+}
+
+func TestDatasource_CollectGarbage_DryRunDoesNotCreateMissingStore(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "missing", "traceary.db")
+	storeManager := sqlite.NewStoreManagementDatasource(sqlite.NewDatabase(dbPath, fstest.MapFS{}))
+
+	if _, err := storeManager.CollectGarbage(
+		context.Background(),
+		time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+		apptypes.GarbageCollectionTargetEvents,
+		true,
+	); err == nil {
+		t.Fatal("CollectGarbage() error = nil, want missing-store error")
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("Stat() error = %v, want store to remain absent", err)
 	}
 }
 
@@ -247,6 +327,14 @@ func TestDatasource_CollectGarbage_deletesOldEmptySessionsButProtectsActiveAndRe
 	execRetentionSQL(t, db, `INSERT INTO events (id, kind, agent, session_id, body, created_at, source_hook, client, workspace) VALUES
 		('event-recent', 'note', 'codex', 'with-event-old', 'recent', '2026-04-08T00:00:00Z', NULL, 'cli', 'repo')`)
 
+	previewCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetSessions, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(1, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+
 	deletedCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetSessions, false)
 	if err != nil {
 		t.Fatalf("CollectGarbage() error = %v", err)
@@ -269,6 +357,16 @@ func TestDatasource_CollectGarbageAll_deletesEventsThenEmptySessions(t *testing.
 		('old-only', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', 'cli', 'codex', 'repo')`)
 	execRetentionSQL(t, db, `INSERT INTO events (id, kind, agent, session_id, body, created_at, source_hook, client, workspace) VALUES
 		('event-old', 'note', 'codex', 'old-only', 'old', '2026-04-02T00:00:00Z', NULL, 'cli', 'repo')`)
+
+	previewCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetAll, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(2, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "events", "id", []string{"event-old"})
+	assertRetentionIDs(t, db, "sessions", "session_id", []string{"old-only"})
 
 	deletedCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetAll, false)
 	if err != nil {
@@ -301,6 +399,15 @@ func TestDatasource_CollectGarbage_deletesOnlyExpiredSupersededAndRejectedMemori
 	execRetentionSQL(t, db, `INSERT INTO memory_edges (id, from_memory_id, to_memory_id, relation_type, valid_from, valid_to, created_at) VALUES
 		('edge-cascade-from', 'mem-expired-old', 'mem-accepted-old', 'related-to', '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z'),
 		('edge-cascade-to', 'mem-accepted-old', 'mem-superseded-old', 'related-to', '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z')`)
+
+	previewCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetMemories, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(3, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "memory_edges", "id", []string{"edge-cascade-from", "edge-cascade-to"})
 
 	deletedCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetMemories, false)
 	if err != nil {
@@ -351,9 +458,23 @@ func TestDatasource_CollectGarbage_deletesStaleExtractedCandidatesAfter14d(t *te
 	// Use a `before` cutoff far in the past so the operator-controlled
 	// retention does not delete anything; only the 14-day extracted
 	// auto-decay should fire (status update, not hard delete).
+	before := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	previewCount, err := storeManager.CollectGarbage(
+		context.Background(),
+		before,
+		apptypes.GarbageCollectionTargetMemories,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(3, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+
 	deletedCount, err := storeManager.CollectGarbage(
 		context.Background(),
-		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		before,
 		apptypes.GarbageCollectionTargetMemories,
 		false,
 	)
@@ -446,6 +567,14 @@ func TestDatasource_CollectGarbage_deletesOldClosedMemoryEdges(t *testing.T) {
 		('edge-recent-closed', 'mem-a', 'mem-b', 'related-to', '2026-04-01T00:00:00.000000000Z', '2026-04-08T00:00:00.000000000Z', '2026-04-01T00:00:00Z'),
 		('edge-open', 'mem-a', 'mem-b', 'related-to', '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z')`)
 
+	previewCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetMemoryEdges, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(1, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+
 	deletedCount, err := storeManager.CollectGarbage(context.Background(), time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetMemoryEdges, false)
 	if err != nil {
 		t.Fatalf("CollectGarbage() error = %v", err)
@@ -455,6 +584,110 @@ func TestDatasource_CollectGarbage_deletesOldClosedMemoryEdges(t *testing.T) {
 	}
 	assertRetentionIDs(t, db, "memory_edges", "id", []string{"edge-open", "edge-recent-closed"})
 	assertRetentionIDs(t, db, "memories", "id", []string{"mem-a", "mem-b"})
+	assertNoForeignKeyViolations(t, db)
+}
+
+func TestDatasource_CollectGarbageAll_PreviewMatchesApplyAcrossOrderedTargets(t *testing.T) {
+	t.Parallel()
+
+	dbPath, storeManager := prepareRetentionFixture(t)
+	db := openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	cutoff := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	staleCandidate := time.Now().UTC().Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	execRetentionSQL(t, db, `INSERT INTO sessions (session_id, started_at, ended_at, client, agent, repo) VALUES
+		('old-session', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', 'cli', 'codex', 'repo')`)
+	execRetentionSQL(t, db, `INSERT INTO events (id, kind, agent, session_id, body, created_at, source_hook, client, workspace) VALUES
+		('old-event', 'note', 'codex', 'old-session', 'old', '2026-04-02T00:00:00Z', NULL, 'cli', 'repo')`)
+
+	insertRetentionMemory(t, db, "old-memory", "expired", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemory(t, db, "accepted-a", "accepted", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemory(t, db, "accepted-b", "accepted", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemoryWithSource(t, db, "stale-candidate", "candidate", "extracted", "", staleCandidate)
+	execRetentionSQL(t, db, `INSERT INTO memory_edges (id, from_memory_id, to_memory_id, relation_type, valid_from, valid_to, created_at) VALUES
+		('cascade-edge', 'old-memory', 'accepted-a', 'related-to', '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z'),
+		('independent-old-edge', 'accepted-a', 'accepted-b', 'related-to', '2026-04-01T00:00:00.000000000Z', '2026-04-02T00:00:00.000000000Z', '2026-04-01T00:00:00Z')`)
+
+	previewCount, err := storeManager.CollectGarbage(context.Background(), cutoff, apptypes.GarbageCollectionTargetAll, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	if diff := cmp.Diff(5, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "events", "id", []string{"old-event"})
+	assertRetentionIDs(t, db, "sessions", "session_id", []string{"old-session"})
+	assertRetentionIDs(t, db, "memories", "id", []string{"accepted-a", "accepted-b", "old-memory", "stale-candidate"})
+	assertRetentionIDs(t, db, "memory_edges", "id", []string{"cascade-edge", "independent-old-edge"})
+
+	deletedCount, err := storeManager.CollectGarbage(context.Background(), cutoff, apptypes.GarbageCollectionTargetAll, false)
+	if err != nil {
+		t.Fatalf("CollectGarbage() error = %v", err)
+	}
+	if diff := cmp.Diff(previewCount, deletedCount); diff != "" {
+		t.Fatalf("preview/apply count mismatch (-preview +apply):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "events", "id", nil)
+	assertRetentionIDs(t, db, "sessions", "session_id", nil)
+	assertRetentionIDs(t, db, "memories", "id", []string{"accepted-a", "accepted-b", "stale-candidate"})
+	assertRetentionIDs(t, db, "memory_edges", "id", nil)
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM memories WHERE id = 'stale-candidate'`).Scan(&status); err != nil {
+		t.Fatalf("query stale-candidate status: %v", err)
+	}
+	if status != "expired" {
+		t.Fatalf("stale-candidate status = %q, want expired", status)
+	}
+	assertNoForeignKeyViolations(t, db)
+}
+
+func TestDatasource_CollectGarbageAll_PreviewMatchesApplyWithProductionMigrations(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	storeManager := sqlite.NewStoreManagementDatasource(sqlite.NewDatabase(dbPath, onDiskSQLiteMigrations(t)))
+	if err := storeManager.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	db := openRetentionDB(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	cutoff := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	staleCandidate := time.Now().UTC().Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	execRetentionSQL(t, db, `INSERT INTO sessions (session_id, started_at, ended_at, client, agent, workspace) VALUES
+		('old-session', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', 'cli', 'codex', 'repo')`)
+	execRetentionSQL(t, db, `INSERT INTO events (id, kind, agent, session_id, body, created_at, source_hook, client, workspace) VALUES
+		('old-event', 'note', 'codex', 'old-session', 'old', '2026-04-02T00:00:00Z', NULL, 'cli', 'repo')`)
+	insertRetentionMemory(t, db, "old-memory", "expired", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemory(t, db, "accepted-a", "accepted", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemory(t, db, "accepted-b", "accepted", "", "2026-04-01T00:00:00Z")
+	insertRetentionMemoryWithSource(t, db, "stale-candidate", "candidate", "extracted", "", staleCandidate)
+	execRetentionSQL(t, db, `INSERT INTO memory_edges (id, from_memory_id, to_memory_id, relation_type, valid_from, valid_to, created_at) VALUES
+		('cascade-edge', 'old-memory', 'accepted-a', 'related-to', '2026-04-01T00:00:00.000000000Z', NULL, '2026-04-01T00:00:00Z'),
+		('independent-old-edge', 'accepted-a', 'accepted-b', 'related-to', '2026-04-01T00:00:00.000000000Z', '2026-04-02T00:00:00.000000000Z', '2026-04-01T00:00:00Z')`)
+
+	previewCount, err := storeManager.CollectGarbage(context.Background(), cutoff, apptypes.GarbageCollectionTargetAll, true)
+	if err != nil {
+		t.Fatalf("CollectGarbage(dry-run) error = %v", err)
+	}
+	deletedCount, err := storeManager.CollectGarbage(context.Background(), cutoff, apptypes.GarbageCollectionTargetAll, false)
+	if err != nil {
+		t.Fatalf("CollectGarbage() error = %v", err)
+	}
+	if diff := cmp.Diff(5, previewCount); diff != "" {
+		t.Fatalf("previewCount mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(previewCount, deletedCount); diff != "" {
+		t.Fatalf("preview/apply count mismatch (-preview +apply):\n%s", diff)
+	}
+	assertRetentionIDs(t, db, "events", "id", nil)
+	assertRetentionIDs(t, db, "sessions", "session_id", nil)
+	assertRetentionIDs(t, db, "memories", "id", []string{"accepted-a", "accepted-b", "stale-candidate"})
+	assertRetentionIDs(t, db, "memory_edges", "id", nil)
 	assertNoForeignKeyViolations(t, db)
 }
 

--- a/infrastructure/sqlite/sql/count_empty_sessions.sql
+++ b/infrastructure/sqlite/sql/count_empty_sessions.sql
@@ -1,0 +1,14 @@
+SELECT COUNT(*)
+FROM sessions
+WHERE ended_at IS NOT NULL
+  AND COALESCE(ended_at, started_at) < ?
+  AND NOT EXISTS (
+      SELECT 1
+        FROM events
+       WHERE events.session_id = sessions.session_id
+  )
+  AND NOT EXISTS (
+      SELECT 1
+        FROM sessions AS child_sessions
+       WHERE child_sessions.parent_session_id = sessions.session_id
+  )

--- a/infrastructure/sqlite/sql/count_empty_sessions_after_event_gc.sql
+++ b/infrastructure/sqlite/sql/count_empty_sessions_after_event_gc.sql
@@ -1,0 +1,15 @@
+SELECT COUNT(*)
+FROM sessions
+WHERE ended_at IS NOT NULL
+  AND COALESCE(ended_at, started_at) < ?
+  AND NOT EXISTS (
+      SELECT 1
+        FROM events
+       WHERE events.session_id = sessions.session_id
+         AND events.created_at >= ?
+  )
+  AND NOT EXISTS (
+      SELECT 1
+        FROM sessions AS child_sessions
+       WHERE child_sessions.parent_session_id = sessions.session_id
+  )

--- a/infrastructure/sqlite/sql/count_old_events.sql
+++ b/infrastructure/sqlite/sql/count_old_events.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*)
+FROM events
+WHERE created_at < ?

--- a/infrastructure/sqlite/sql/count_old_memories.sql
+++ b/infrastructure/sqlite/sql/count_old_memories.sql
@@ -1,0 +1,4 @@
+SELECT COUNT(*)
+FROM memories
+WHERE status IN ('expired', 'superseded', 'rejected')
+  AND updated_at < ?

--- a/infrastructure/sqlite/sql/count_old_memory_edges.sql
+++ b/infrastructure/sqlite/sql/count_old_memory_edges.sql
@@ -1,0 +1,13 @@
+SELECT COUNT(*)
+FROM memory_edges
+WHERE (valid_to IS NOT NULL AND valid_to < ?)
+   OR NOT EXISTS (
+       SELECT 1
+         FROM memories
+        WHERE memories.id = memory_edges.from_memory_id
+   )
+   OR NOT EXISTS (
+       SELECT 1
+         FROM memories
+        WHERE memories.id = memory_edges.to_memory_id
+   )

--- a/infrastructure/sqlite/sql/count_old_memory_edges_after_memory_gc.sql
+++ b/infrastructure/sqlite/sql/count_old_memory_edges_after_memory_gc.sql
@@ -1,0 +1,29 @@
+SELECT COUNT(*)
+FROM memory_edges
+WHERE (
+       (valid_to IS NOT NULL AND valid_to < ?)
+    OR NOT EXISTS (
+        SELECT 1
+          FROM memories
+         WHERE memories.id = memory_edges.from_memory_id
+    )
+    OR NOT EXISTS (
+        SELECT 1
+          FROM memories
+         WHERE memories.id = memory_edges.to_memory_id
+    )
+)
+AND NOT EXISTS (
+    SELECT 1
+      FROM memories
+     WHERE memories.id = memory_edges.from_memory_id
+       AND memories.status IN ('expired', 'superseded', 'rejected')
+       AND memories.updated_at < ?
+)
+AND NOT EXISTS (
+    SELECT 1
+      FROM memories
+     WHERE memories.id = memory_edges.to_memory_id
+       AND memories.status IN ('expired', 'superseded', 'rejected')
+       AND memories.updated_at < ?
+)

--- a/infrastructure/sqlite/sql/count_stale_extracted_candidates.sql
+++ b/infrastructure/sqlite/sql/count_stale_extracted_candidates.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*)
+FROM memories
+WHERE status = 'candidate'
+  AND source IN ('extracted', 'extracted-hidden', 'compact-summary')
+  AND updated_at < ?

--- a/infrastructure/sqlite/store_management_datasource.go
+++ b/infrastructure/sqlite/store_management_datasource.go
@@ -26,8 +26,17 @@ import (
 //go:embed sql/delete_old_events.sql
 var deleteOldEventsQuery string
 
+//go:embed sql/count_old_events.sql
+var countOldEventsQuery string
+
 //go:embed sql/delete_empty_sessions.sql
 var deleteEmptySessionsQuery string
+
+//go:embed sql/count_empty_sessions.sql
+var countEmptySessionsQuery string
+
+//go:embed sql/count_empty_sessions_after_event_gc.sql
+var countEmptySessionsAfterEventGCQuery string
 
 //go:embed sql/clear_deleted_memory_supersedes_refs.sql
 var clearDeletedMemorySupersedesRefsQuery string
@@ -35,8 +44,14 @@ var clearDeletedMemorySupersedesRefsQuery string
 //go:embed sql/delete_old_memories.sql
 var deleteOldMemoriesQuery string
 
+//go:embed sql/count_old_memories.sql
+var countOldMemoriesQuery string
+
 //go:embed sql/delete_stale_extracted_candidates.sql
 var deleteStaleExtractedCandidatesQuery string
+
+//go:embed sql/count_stale_extracted_candidates.sql
+var countStaleExtractedCandidatesQuery string
 
 //go:embed sql/clear_stale_extracted_candidate_supersedes_refs.sql
 var clearStaleExtractedCandidateSupersedesRefsQuery string
@@ -54,6 +69,12 @@ const staleExtractedCandidateRetention = 14 * 24 * time.Hour
 
 //go:embed sql/delete_old_memory_edges.sql
 var deleteOldMemoryEdgesQuery string
+
+//go:embed sql/count_old_memory_edges.sql
+var countOldMemoryEdgesQuery string
+
+//go:embed sql/count_old_memory_edges_after_memory_gc.sql
+var countOldMemoryEdgesAfterMemoryGCQuery string
 
 //go:embed sql/count_stale_sessions.sql
 var countStaleSessionsQuery string
@@ -275,6 +296,10 @@ func (d *StoreManagementDatasource) CollectGarbage(
 	target apptypes.GarbageCollectionTarget,
 	dryRun bool,
 ) (int, error) {
+	if dryRun {
+		return d.previewGarbage(ctx, before, target)
+	}
+
 	db, err := d.db.open(ctx)
 	if err != nil {
 		return 0, xerrors.Errorf("failed to open DB for garbage collection: %w", err)
@@ -303,9 +328,6 @@ func (d *StoreManagementDatasource) CollectGarbage(
 	if err != nil {
 		return 0, xerrors.Errorf("failed to collect garbage: %w", err)
 	}
-	if dryRun {
-		return deleteCount, nil
-	}
 	if err := tx.Commit(); err != nil {
 		return 0, xerrors.Errorf("failed to commit garbage-collection transaction: %w", err)
 	}
@@ -318,6 +340,130 @@ func (d *StoreManagementDatasource) CollectGarbage(
 	}
 
 	return deleteCount, nil
+}
+
+func (d *StoreManagementDatasource) previewGarbage(
+	ctx context.Context,
+	before time.Time,
+	target apptypes.GarbageCollectionTarget,
+) (int, error) {
+	db, err := d.db.openReadOnly(ctx)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to open DB for garbage-collection preview: %w", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Debug("failed to close resource", "error", err)
+		}
+	}()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return 0, xerrors.Errorf("failed to begin garbage-collection preview transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			slog.Debug("failed to rollback resource", "error", err)
+		}
+	}()
+
+	count, err := d.countGarbageInTx(ctx, tx, before, target)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to preview garbage collection: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, xerrors.Errorf("failed to finish garbage-collection preview: %w", err)
+	}
+	return count, nil
+}
+
+func (d *StoreManagementDatasource) countGarbageInTx(
+	ctx context.Context,
+	tx interface {
+		QueryRowContext(context.Context, string, ...any) *sql.Row
+	},
+	before time.Time,
+	target apptypes.GarbageCollectionTarget,
+) (int, error) {
+	if _, ok := apptypes.GarbageCollectionTargetFrom(target.String()); !ok {
+		return 0, xerrors.Errorf("unsupported garbage-collection target: %s", target)
+	}
+
+	beforeValue := formatTimestamp(before)
+	memoryEdgeBeforeValue := formatMemoryValidityTimestamp(before)
+	total := 0
+	matched := false
+
+	if target == apptypes.GarbageCollectionTargetEvents || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
+		count, err := queryCount(ctx, tx, countOldEventsQuery, beforeValue)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to count old events: %w", err)
+		}
+		total += count
+	}
+	if target == apptypes.GarbageCollectionTargetSessions || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
+		query := countEmptySessionsQuery
+		args := []any{beforeValue}
+		if target == apptypes.GarbageCollectionTargetAll {
+			query = countEmptySessionsAfterEventGCQuery
+			args = append(args, beforeValue)
+		}
+		count, err := queryCount(ctx, tx, query, args...)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to count empty sessions: %w", err)
+		}
+		total += count
+	}
+	if target == apptypes.GarbageCollectionTargetMemories || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
+		count, err := queryCount(ctx, tx, countOldMemoriesQuery, beforeValue)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to count old memories: %w", err)
+		}
+		total += count
+
+		extractedCutoff := formatTimestamp(time.Now().Add(-staleExtractedCandidateRetention))
+		extractedCount, err := queryCount(ctx, tx, countStaleExtractedCandidatesQuery, extractedCutoff)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to count stale extracted candidates: %w", err)
+		}
+		total += extractedCount
+	}
+	if target == apptypes.GarbageCollectionTargetMemoryEdges || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
+		query := countOldMemoryEdgesQuery
+		args := []any{memoryEdgeBeforeValue}
+		if target == apptypes.GarbageCollectionTargetAll {
+			query = countOldMemoryEdgesAfterMemoryGCQuery
+			args = append(args, beforeValue, beforeValue)
+		}
+		count, err := queryCount(ctx, tx, query, args...)
+		if err != nil {
+			return 0, xerrors.Errorf("failed to count old memory edges: %w", err)
+		}
+		total += count
+	}
+	if !matched {
+		return 0, xerrors.Errorf("unsupported garbage-collection target: %s", target)
+	}
+	return total, nil
+}
+
+func queryCount(
+	ctx context.Context,
+	queryer interface {
+		QueryRowContext(context.Context, string, ...any) *sql.Row
+	},
+	query string,
+	args ...any,
+) (int, error) {
+	var count int
+	if err := queryer.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, xerrors.Errorf("failed to execute count query: %w", err)
+	}
+	return count, nil
 }
 
 func (d *StoreManagementDatasource) collectGarbageInTx(
@@ -336,7 +482,9 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 	}
 
 	total := 0
+	matched := false
 	if target == apptypes.GarbageCollectionTargetEvents || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
 		count, err := execRowsAffected(ctx, tx, deleteOldEventsQuery, beforeValue)
 		if err != nil {
 			return 0, xerrors.Errorf("failed to delete old events: %w", err)
@@ -344,6 +492,7 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 		total += count
 	}
 	if target == apptypes.GarbageCollectionTargetSessions || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
 		count, err := execRowsAffected(ctx, tx, deleteEmptySessionsQuery, beforeValue)
 		if err != nil {
 			return 0, xerrors.Errorf("failed to delete empty sessions: %w", err)
@@ -351,6 +500,7 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 		total += count
 	}
 	if target == apptypes.GarbageCollectionTargetMemories || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
 		if _, err := tx.ExecContext(ctx, clearDeletedMemorySupersedesRefsQuery, beforeValue); err != nil {
 			return 0, xerrors.Errorf("failed to clear deleted memory supersedes references: %w", err)
 		}
@@ -376,11 +526,15 @@ func (d *StoreManagementDatasource) collectGarbageInTx(
 		total += extractedCount
 	}
 	if target == apptypes.GarbageCollectionTargetMemoryEdges || target == apptypes.GarbageCollectionTargetAll {
+		matched = true
 		count, err := execRowsAffected(ctx, tx, deleteOldMemoryEdgesQuery, memoryEdgeBeforeValue)
 		if err != nil {
 			return 0, xerrors.Errorf("failed to delete old memory edges: %w", err)
 		}
 		total += count
+	}
+	if !matched {
+		return 0, xerrors.Errorf("unsupported garbage-collection target: %s", target)
 	}
 
 	return total, nil

--- a/presentation/cli/gc.go
+++ b/presentation/cli/gc.go
@@ -40,7 +40,15 @@ func (c *RootCLI) newStoreGCCommand() *cobra.Command {
 	gcCmd.Flags().StringVar(&dbPath, "db-path", "", dbPathFlagUsage())
 	gcCmd.Flags().IntVar(&keepDays, "keep-days", defaultRetentionDays, Localize("number of days to retain", "保持する日数"))
 	gcCmd.Flags().StringVar(&target, "target", "all", Localize("records to prune (events | sessions | memories | memory_edges | all)", "削除対象 (events | sessions | memories | memory_edges | all)"))
-	gcCmd.Flags().BoolVar(&dryRun, "dry-run", false, Localize("print the number of candidate records only", "削除対象件数のみ表示する"))
+	gcCmd.Flags().BoolVar(
+		&dryRun,
+		"dry-run",
+		false,
+		Localize(
+			"count candidates using a read-only connection without initializing or migrating the store",
+			"storeをinitialize・migrationせず、read-only connectionで削除対象件数だけを表示する",
+		),
+	)
 
 	return gcCmd
 }
@@ -58,8 +66,10 @@ func (c *RootCLI) runGC(ctx context.Context, output io.Writer, input gcCommandIn
 		return xerrors.Errorf("%s: %w", Localize("failed to resolve DB path", "DB パスの解決に失敗しました"), err)
 	}
 	c.applyDatabasePath(resolvedDBPath)
-	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+	if !input.dryRun {
+		if err := c.storeManagement.Initialize(ctx); err != nil {
+			return xerrors.Errorf("%s: %w", Localize("failed to initialize store", "ストアの初期化に失敗しました"), err)
+		}
 	}
 
 	target, ok := apptypes.GarbageCollectionTargetFrom(input.target)

--- a/presentation/cli/gc_test.go
+++ b/presentation/cli/gc_test.go
@@ -30,6 +30,9 @@ func TestRootCLI_GCCommand(t *testing.T) {
 		if stdout.String() != "Candidates: 3\n" {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), "Candidates: 3\n")
 		}
+		if storeMaint.initCalled {
+			t.Fatal("Initialize() was called for dry-run")
+		}
 	})
 
 	t.Run("displays deletion count", func(t *testing.T) {
@@ -47,6 +50,9 @@ func TestRootCLI_GCCommand(t *testing.T) {
 		}
 		if stdout.String() != "Deleted: 2\n" {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), "Deleted: 2\n")
+		}
+		if !storeMaint.initCalled {
+			t.Fatal("Initialize() was not called for apply")
 		}
 	})
 }


### PR DESCRIPTION
## Motivation

Final v0.33.0 dogfood reproduced #1571 on a metrics-only 7.1 GiB SQLite backup copy: store gc dry-run attempted deletion SQL and failed on a read-only store.

## Changes

- skip store initialization and migration for GC dry-run
- open SQLite with mode=ro and query_only for preview
- replace rolled-back DELETE and UPDATE statements with count-only SELECT queries
- preserve apply ordering when previewing all targets
- add read-only purity and preview/apply parity tests

## Validation

- go vet ./...
- go test ./... (4154 tests in 23 packages)
- go build ./...
- go tool golangci-lint run (0 issues)
- GC parity tests repeated 20 times
- copied-store read-only dry-run: exit 0 in 0.10 seconds; DB hash, size, mtime, and mode unchanged
- copied-store per-target preview counts match the previous transactional preview counts

## Residual risks

- a dry-run against an unmigrated store now fails read-only instead of migrating it; run store init explicitly before preview
- SQLite may create normal WAL shared-memory sidecars when reading a WAL-mode store, but the main DB remains unchanged

Closes #1571