### PR TITLE
fix: derive Codex rollout exclusivity only from intended evidence

### DIFF
--- a/infrastructure/filesystem/codex_usage_source.go
+++ b/infrastructure/filesystem/codex_usage_source.go
@@ -66,8 +66,25 @@ func (s *codexUsageSource) Load(
 		return application.CodexUsageLoadResult{}, xerrors.Errorf("failed to match Codex usage source")
 	}
 	sort.Strings(paths)
-	result := application.CodexUsageLoadResult{}
+	// A bare suffix match can select another session's rollout whose file name
+	// merely ends with the requested session ID. Require a name boundary so
+	// exclusivity is derived only from the intended rollout evidence.
+	nameSuffix := sessionID + ".jsonl"
+	matched := make([]string, 0, len(paths))
 	for _, path := range paths {
+		base := filepath.Base(path)
+		if base == nameSuffix || strings.HasSuffix(base, "-"+nameSuffix) {
+			matched = append(matched, path)
+		}
+	}
+	// Multiple matching rollouts are ambiguous evidence: per-file turn ordinals
+	// would collide under one suppression identity. Fail closed instead of
+	// silently merging claims or masking an unterminated rollout.
+	if len(matched) > 1 {
+		return application.CodexUsageLoadResult{}, xerrors.Errorf("ambiguous Codex usage source: %d rollouts match the session", len(matched))
+	}
+	result := application.CodexUsageLoadResult{}
+	for _, path := range matched {
 		loaded, err := s.loadFile(ctx, root, path, sessionID)
 		if err != nil {
 			return application.CodexUsageLoadResult{}, err
@@ -196,6 +213,7 @@ type codexUsageEnvelope struct {
 }
 
 type codexSessionMetaPayload struct {
+	ID         string `json:"id"`
 	CLIVersion string `json:"cli_version"`
 }
 
@@ -272,6 +290,12 @@ func parseCodexRolloutUsageJSONL(
 			var payload codexSessionMetaPayload
 			if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 				return application.CodexUsageLoadResult{}, xerrors.Errorf("invalid Codex session metadata at line %d", lineNumber)
+			}
+			// A declared session identity that conflicts with the requested
+			// session means this rollout is not the intended evidence. Fail
+			// closed without echoing the foreign identity.
+			if id := strings.TrimSpace(payload.ID); id != "" && id != sessionID {
+				return application.CodexUsageLoadResult{}, xerrors.Errorf("Codex session metadata at line %d does not match the requested session", lineNumber)
 			}
 			if strings.TrimSpace(payload.CLIVersion) != "" {
 				version = strings.TrimSpace(payload.CLIVersion)

--- a/infrastructure/filesystem/codex_usage_source_test.go
+++ b/infrastructure/filesystem/codex_usage_source_test.go
@@ -150,6 +150,83 @@ func TestCodexUsageSource_TreatsSessionIDAsLiteralRolloutSuffix(t *testing.T) {
 	}
 }
 
+func TestCodexUsageSource_IgnoresForeignRolloutMatchingOnlySuffixTail(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	sessionID := "tail-session"
+	path := filepath.Join(home, ".codex", "sessions", "2026", "07", "23", "rollout-2026-07-23T01-00-00-foreign"+sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture := strings.Join([]string{
+		`{"timestamp":"2026-07-23T01:00:00Z","type":"session_meta","payload":{"id":"foreign-` + sessionID + `","cli_version":"0.145.0"}}`,
+		`{"timestamp":"2026-07-23T01:00:01Z","type":"turn_context","payload":{"turn_id":"turn-foreign","model":"gpt"}}`,
+		`{"timestamp":"2026-07-23T01:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}}`,
+		`{"timestamp":"2026-07-23T01:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-foreign"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := filesystem.NewCodexUsageSourceForTest(func() (string, error) { return home, nil }, 1024*1024, 1024*1024).Load(context.Background(), application.CodexUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Samples) != 0 {
+		t.Fatalf("Samples = %+v, want no claims from a foreign rollout", result.Samples)
+	}
+}
+
+func TestCodexUsageSource_RejectsConflictingSessionMetadata(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	sessionID := "renamed-rollout-session"
+	foreignID := "private-foreign-session"
+	path := filepath.Join(home, ".codex", "sessions", "2026", "07", "23", "rollout-"+sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture := strings.Join([]string{
+		`{"timestamp":"2026-07-23T01:00:00Z","type":"session_meta","payload":{"id":"` + foreignID + `","cli_version":"0.145.0"}}`,
+		`{"timestamp":"2026-07-23T01:00:01Z","type":"turn_context","payload":{"turn_id":"turn-1","model":"gpt"}}`,
+		`{"timestamp":"2026-07-23T01:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}}`,
+		`{"timestamp":"2026-07-23T01:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := filesystem.NewCodexUsageSourceForTest(func() (string, error) { return home, nil }, 1024*1024, 1024*1024).Load(context.Background(), application.CodexUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err == nil || !strings.Contains(err.Error(), "does not match the requested session") || strings.Contains(err.Error(), foreignID) {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
+func TestCodexUsageSource_RejectsMultipleMatchingRollouts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	sessionID := "duplicated-rollout-session"
+	writeRollout := func(month, day string) {
+		t.Helper()
+		path := filepath.Join(home, ".codex", "sessions", "2026", month, day, "rollout-2026-"+month+"-"+day+"T01-00-00-"+sessionID+".jsonl")
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		fixture := strings.Join([]string{
+			`{"timestamp":"2026-07-23T01:00:00Z","type":"turn_context","payload":{"turn_id":"turn-1","model":"gpt"}}`,
+			`{"timestamp":"2026-07-23T01:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}}`,
+			`{"timestamp":"2026-07-23T01:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"}}`,
+		}, "\n") + "\n"
+		if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeRollout("07", "23")
+	writeRollout("07", "24")
+	_, err := filesystem.NewCodexUsageSourceForTest(func() (string, error) { return home, nil }, 1024*1024, 1024*1024).Load(context.Background(), application.CodexUsageLoadCriteria{SessionID: types.SessionID(sessionID)})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous Codex usage source") {
+		t.Fatalf("Load() error = %v", err)
+	}
+}
+
 func TestCodexUsageSource_CounterRegressionBecomesUnavailable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", "")


### PR DESCRIPTION
## Summary

- Require a rollout filename boundary when matching a Codex session ID.
- Reject rollout metadata that declares a conflicting session identity.
- Fail closed when multiple rollouts match the requested session.
- Add regression coverage for foreign, conflicting, and ambiguous rollout evidence.

## Changes

### `infrastructure/filesystem/codex_usage_source.go`

- Accept only `<sessionID>.jsonl` or filenames ending in `-<sessionID>.jsonl`.
- Return an explicit ambiguity error when multiple rollouts match.
- Validate `session_meta.payload.id` when present.
- Avoid exposing conflicting session identities or rollout paths in errors.

### `infrastructure/filesystem/codex_usage_source_test.go`

- Verify that boundaryless suffix matches are ignored.
- Verify that conflicting session metadata is rejected without identity leakage.
- Verify that multiple matching rollouts are rejected as ambiguous.

## Test plan

```sh
go test ./infrastructure/filesystem/...
go test ./...
```

Codex verifier: ✅ PASS

Closes #1580
