### PR TITLE
fix: preserve exclusivity semantics in usage bundle import

### DIFF
--- a/application/usecase/bundle_usecase_test.go
+++ b/application/usecase/bundle_usecase_test.go
@@ -1164,6 +1164,84 @@ func TestBundleUsecase_ImportRejectsSnapshotRunAttribution(t *testing.T) {
 	}
 }
 
+func TestBundleUsecase_ImportRejectsMalformedUsageExclusivityRows(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	key, err := types.UsageExclusivityKeyFrom("codex:headless_stream:thread-1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		tamper  func(row map[string]any)
+		wantErr string
+	}{
+		{
+			name: "whitespace-only exclusivity key",
+			tamper: func(row map[string]any) {
+				row["exclusivity_key"] = "   "
+			},
+			wantErr: "exclusivity key must not be empty",
+		},
+		{
+			name: "exclusivity key with non-exclusive accounting",
+			tamper: func(row map[string]any) {
+				row["accounting"] = "latest_snapshot"
+			},
+			wantErr: `unsupported accounting "latest_snapshot"`,
+		},
+		{
+			name: "exclusivity key on session snapshot",
+			tamper: func(row map[string]any) {
+				row["scope"] = "session_snapshot"
+				row["accounting"] = "latest_snapshot"
+				row["snapshot_series"] = "codex:session-1"
+				row["snapshot_revision"] = float64(1)
+			},
+			wantErr: "session snapshot cannot carry an exclusivity key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			observation := mustBundleExclusiveUsage(t, "codex:headless_stream:thread-1:1", key, types.UsageAccountingAdditive, ts)
+			out := filepath.Join(t.TempDir(), "exclusive.tbun")
+			repo := &fakeBundleRepo{schema: 29, exportUsageObservations: []*model.UsageObservation{observation}}
+			if err := usecase.NewBundleUsecase(fakeEventQuery{}, repo, nil).Export(context.Background(), usecase.BundleExportOptions{OutPath: out, Passphrase: []byte("pass1")}); err != nil {
+				t.Fatal(err)
+			}
+			files := openTestBundle(t, out, []byte("pass1"))
+			var row map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(files["usage_observations.ndjson"]), &row); err != nil {
+				t.Fatal(err)
+			}
+			tt.tamper(row)
+			usage, err := json.Marshal(row)
+			if err != nil {
+				t.Fatal(err)
+			}
+			usage = append(usage, '\n')
+			bundle := buildBundleWithManifestAndFiles(t, 2, nil, map[string][]byte{"usage_observations.ndjson": usage}, map[string]any{
+				"usage_observations": map[string]any{"table_name": "usage_observations", "file": "usage_observations.ndjson", "row_count": 1, "checksum": hashForTest(usage)},
+			})
+			in := filepath.Join(t.TempDir(), "malformed.tbun")
+			if err := os.WriteFile(in, bundle, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			importRepo := &fakeBundleRepo{schema: 29}
+			_, err = usecase.NewBundleUsecase(fakeEventQuery{}, importRepo, nil).Import(context.Background(), usecase.BundleImportOptions{InPath: in, Passphrase: []byte("testpass")})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Import error = %v, want %q", err, tt.wantErr)
+			}
+			if len(importRepo.usageObservations) != 0 {
+				t.Fatalf("malformed row imported %d usage observations", len(importRepo.usageObservations))
+			}
+		})
+	}
+}
+
 func TestBundleUsecase_ImportRequiresUsageRunInsideBundle(t *testing.T) {
 	t.Parallel()
 	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -434,9 +434,39 @@ func (t *bundleImportTx) ImportUsageObservation(
 		}
 	}
 	if err := insertUsageObservation(ctx, t.tx, observation); err != nil {
+		if isSQLiteUniqueOrPKConflict(err) {
+			// The observation ID was verified absent above, so a unique
+			// violation here means the additive exclusivity claim is already
+			// owned by a different observation (or a concurrent writer won
+			// the identity). Import must never create a second additive
+			// owner: skip keeps the destination claim, every other policy
+			// fails closed.
+			if policy == usecase.BundleConflictSkip {
+				slog.WarnContext(
+					ctx,
+					"bundle import skipped usage observation with conflicting exclusivity claim",
+					"observation_id", observation.Descriptor().ObservationID().String(),
+					"exclusivity_key", optionalUsageExclusivityKey(observation),
+					"policy", string(usecase.BundleConflictSkip),
+				)
+				return false, nil
+			}
+			return false, xerrors.Errorf(
+				"usage observation %s conflicts with an existing exclusivity claim: %w",
+				observation.Descriptor().ObservationID(),
+				errors.Join(model.ErrConflictingUsageObservation, err),
+			)
+		}
 		return false, xerrors.Errorf("failed to import usage observation: %w", err)
 	}
 	return true, nil
+}
+
+func optionalUsageExclusivityKey(observation *model.UsageObservation) string {
+	if key, present := observation.Descriptor().ExclusivityKey().Value(); present {
+		return key.String()
+	}
+	return ""
 }
 
 func sameOptionalRunIdentity(left, right types.Optional[types.RunIdentity]) bool {

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -406,3 +406,147 @@ func TestBundleDatasource_LaterTableFailureRollsBackImportedUsageObservation(t *
 		t.Fatal("usage observation survived rolled-back bundle transaction")
 	}
 }
+
+func TestBundleDatasource_UsageObservationImportPreservesExclusivityClaims(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := sqlite.NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(db).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	bundles := sqlite.NewBundleDatasource(db, sqlite.NewEventDatasource(db))
+	key, err := types.UsageExclusivityKeyFrom("codex:headless_stream:thread-1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKey, err := types.UsageExclusivityKeyFrom("codex:headless_stream:thread-1:2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exclusive := func(id string, claimKey types.UsageExclusivityKey, accounting types.UsageAccounting) *model.UsageObservation {
+		t.Helper()
+		descriptor := sqliteUsageDescriptor(t, id)
+		if descriptor.Accounting() != accounting {
+			descriptor, err = model.NewUsageObservationDescriptor(
+				descriptor.ObservationID(), descriptor.SessionID(), descriptor.Source(),
+				descriptor.Scope(), accounting, descriptor.ObservedAt(),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		descriptor, err = descriptor.WithExclusivityKey(claimKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sqliteFinalizedUsage(t, descriptor, 10)
+	}
+	winner := exclusive("usage-winner", key, types.UsageAccountingAdditive)
+	alternative := exclusive("usage-alternative", key, types.UsageAccountingExcluded)
+
+	tx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, observation := range []*model.UsageObservation{winner, alternative} {
+		imported, err := tx.ImportUsageObservation(ctx, observation, usecase.BundleConflictSkip)
+		if err != nil || !imported {
+			_ = tx.Rollback(ctx)
+			t.Fatalf("ImportUsageObservation(%s) = %t/%v", observation.Descriptor().ObservationID(), imported, err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	replayTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := replayTx.ImportUsageObservation(ctx, winner, usecase.BundleConflictSkip); err != nil || imported {
+		_ = replayTx.Rollback(ctx)
+		t.Fatalf("exact replay = %t/%v, want skipped", imported, err)
+	}
+	if err := replayTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different additive observation claiming the same key must never
+	// become a second owner. Skip keeps the destination claim; error and
+	// replace fail closed.
+	doubleWinner := exclusive("usage-double-winner", key, types.UsageAccountingAdditive)
+	skipTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := skipTx.ImportUsageObservation(ctx, doubleWinner, usecase.BundleConflictSkip); err != nil || imported {
+		_ = skipTx.Rollback(ctx)
+		t.Fatalf("double-claim under skip = %t/%v, want skipped", imported, err)
+	}
+	if err := skipTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, policy := range []usecase.BundleConflictPolicy{usecase.BundleConflictError, usecase.BundleConflictReplace} {
+		policyTx, err := bundles.BeginBundleImport(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = policyTx.ImportUsageObservation(ctx, doubleWinner, policy)
+		if err == nil || !errors.Is(err, model.ErrConflictingUsageObservation) {
+			_ = policyTx.Rollback(ctx)
+			t.Fatalf("double-claim under %s error = %v, want ErrConflictingUsageObservation", policy, err)
+		}
+		if err := policyTx.Rollback(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	storedDoubleWinner, err := sqlite.NewUsageObservationDatasource(db).FindByID(ctx, doubleWinner.Descriptor().ObservationID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := storedDoubleWinner.Value(); present {
+		t.Fatal("double-claim observation reached the store")
+	}
+
+	// Re-owning the stored winner under a different key conflicts on
+	// identity metadata: skip retains the original claim, error fails closed.
+	rekeyed := exclusive("usage-winner", otherKey, types.UsageAccountingAdditive)
+	rekeySkipTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported, err := rekeySkipTx.ImportUsageObservation(ctx, rekeyed, usecase.BundleConflictSkip); err != nil || imported {
+		_ = rekeySkipTx.Rollback(ctx)
+		t.Fatalf("re-keyed winner under skip = %t/%v, want skipped", imported, err)
+	}
+	if err := rekeySkipTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rekeyErrorTx, err := bundles.BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = rekeyErrorTx.ImportUsageObservation(ctx, rekeyed, usecase.BundleConflictError)
+	if err == nil || !errors.Is(err, model.ErrConflictingUsageObservation) {
+		_ = rekeyErrorTx.Rollback(ctx)
+		t.Fatalf("re-keyed winner under error = %v, want ErrConflictingUsageObservation", err)
+	}
+	if err := rekeyErrorTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := bundles.ListBundleUsageObservations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("listed %d usage observations, want winner and excluded alternative", len(listed))
+	}
+	for _, observation := range listed {
+		claimKey, present := observation.Descriptor().ExclusivityKey().Value()
+		if !present || claimKey != key {
+			t.Fatalf("observation %s exclusivity key = %q/%t, want %q", observation.Descriptor().ObservationID(), claimKey, present, key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve additive usage exclusivity claims during bundle import.
- Skip conflicting claims only when the bundle conflict policy is `skip`.
- Fail safely with `ErrConflictingUsageObservation` for other conflict policies.
- Reject malformed exclusivity metadata during bundle import.

## Changes

### `infrastructure/sqlite/bundle_datasource.go`

- Classify SQLite unique and primary-key violations encountered while importing usage observations.
- Treat an additive exclusivity conflict as a skipped observation under the `skip` policy.
- Return an error wrapping `model.ErrConflictingUsageObservation` under `error`, `replace`, and other non-skip policies.
- Include the observation ID and exclusivity key in conflict diagnostics.

### `infrastructure/sqlite/bundle_datasource_test.go`

- Verify preservation of additive and excluded observations sharing an exclusivity key.
- Cover exact replay behavior.
- Cover duplicate additive claims under `skip`, `error`, and `replace`.
- Verify conflicting observations are not persisted.
- Cover attempts to re-key an existing observation.

### `application/usecase/bundle_usecase_test.go`

- Reject whitespace-only exclusivity keys.
- Reject exclusivity keys paired with unsupported accounting modes.
- Reject exclusivity keys attached to session snapshots.
- Verify malformed rows are not imported.

## Test plan

- Run the application bundle use-case tests.
- Run the SQLite bundle datasource tests.
- Run the full Go test suite.

Codex verifier: ✅ PASS

Closes #1581
