### PR TITLE
fix: harden hook delivery identity and one-shot exit contracts

### DIFF
--- a/domain/model/hook_delivery.go
+++ b/domain/model/hook_delivery.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"strconv"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -37,7 +38,7 @@ func NewHookDeliveryEvidence(event *Event, nativeID, rawWorkspace string, semant
 	if host == "" || strings.TrimSpace(event.SourceHook()) == "" || event.SessionID().String() == "" {
 		return HookDeliveryEvidence{}, xerrors.Errorf("hook delivery requires host, source hook, and session ID")
 	}
-	reportedID := strings.Join([]string{host, event.SourceHook(), event.SessionID().String(), trimmedNativeID}, ":")
+	reportedID := joinReportedIdentityFields(host, event.SourceHook(), event.SessionID().String(), trimmedNativeID)
 	deliveryFields := []string{
 		event.Kind().String(),
 		event.Client().String(),
@@ -83,6 +84,20 @@ func (e HookDeliveryEvidence) ObservationID() string {
 func rootAgentName(value string) string {
 	root, _, _ := strings.Cut(strings.TrimSpace(value), "/")
 	return strings.TrimSpace(root)
+}
+
+// joinReportedIdentityFields encodes identity components with byte-length
+// prefixes. A plain delimiter join is ambiguous because every component is
+// host-controlled text that may itself contain the delimiter: ("a:b", "c")
+// and ("a", "b:c") would collapse into one reported identity. The length
+// prefix makes each component self-delimiting, so independent deliveries can
+// never collide in the persisted ledger identity.
+func joinReportedIdentityFields(fields ...string) string {
+	encoded := make([]string, 0, len(fields))
+	for _, field := range fields {
+		encoded = append(encoded, strconv.Itoa(len(field))+":"+field)
+	}
+	return strings.Join(encoded, "|")
 }
 
 func digestFields(values ...string) string {

--- a/domain/model/hook_delivery_test.go
+++ b/domain/model/hook_delivery_test.go
@@ -19,7 +19,7 @@ func TestNewHookDeliveryEvidence_SeparatesDeliveryAndAttribution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHookDeliveryEvidence(second) error = %v", err)
 	}
-	if left.ReportedID() != "codex:post_tool_use:session-1:tool-1" {
+	if left.ReportedID() != "5:codex|13:post_tool_use|9:session-1|6:tool-1" {
 		t.Fatalf("ReportedID() = %q", left.ReportedID())
 	}
 	if left.DeliveryFingerprint() != right.DeliveryFingerprint() {
@@ -72,6 +72,83 @@ func TestNewHookDeliveryEvidence_PreservesRawWorkspace(t *testing.T) {
 	if got := model.WorkspaceAttributionFingerprint(event.Workspace(), "/repo/with-space"); got == evidence.AttributionFingerprint() {
 		t.Fatal("attribution fingerprint ignored raw workspace bytes")
 	}
+}
+
+func TestNewHookDeliveryEvidence_ReportedIDIsUnambiguousAcrossIndependentDeliveries(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  deliveryIdentity
+		right deliveryIdentity
+	}{
+		{
+			name:  "colon shifts between session and native ID",
+			left:  deliveryIdentity{agent: "codex", hook: "post_tool_use", sessionID: "session:a", nativeID: "tool-1"},
+			right: deliveryIdentity{agent: "codex", hook: "post_tool_use", sessionID: "session", nativeID: "a:tool-1"},
+		},
+		{
+			name:  "colon shifts between host and hook kind",
+			left:  deliveryIdentity{agent: "codex:exec", hook: "stop", sessionID: "session-1", nativeID: "tool-1"},
+			right: deliveryIdentity{agent: "codex", hook: "exec:stop", sessionID: "session-1", nativeID: "tool-1"},
+		},
+		{
+			name:  "colon shifts between hook kind and session",
+			left:  deliveryIdentity{agent: "codex", hook: "post:tool", sessionID: "use", nativeID: "tool-1"},
+			right: deliveryIdentity{agent: "codex", hook: "post", sessionID: "tool:use", nativeID: "tool-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left := tt.left.evidence(t)
+			right := tt.right.evidence(t)
+			if left.ReportedID() == right.ReportedID() {
+				t.Fatalf("ReportedID() collided for independent deliveries: %q", left.ReportedID())
+			}
+			if left.DeliveryRecordID() == right.DeliveryRecordID() {
+				t.Fatalf("DeliveryRecordID() collided for independent deliveries: %q", left.DeliveryRecordID())
+			}
+		})
+	}
+}
+
+func TestNewHookDeliveryEvidence_ReportedIDStaysStableForOneLogicalDelivery(t *testing.T) {
+	identity := deliveryIdentity{agent: "codex", hook: "post_tool_use", sessionID: "session-1", nativeID: "event_id:delivery-1"}
+	first := identity.evidence(t)
+	second := identity.evidence(t)
+	if first.ReportedID() != second.ReportedID() {
+		t.Fatalf("ReportedID() changed for one logical delivery: %q != %q", first.ReportedID(), second.ReportedID())
+	}
+	if first.DeliveryRecordID() != second.DeliveryRecordID() {
+		t.Fatalf("DeliveryRecordID() changed for one logical delivery: %q != %q", first.DeliveryRecordID(), second.DeliveryRecordID())
+	}
+}
+
+type deliveryIdentity struct {
+	agent     string
+	hook      string
+	sessionID string
+	nativeID  string
+}
+
+func (d deliveryIdentity) evidence(t *testing.T) model.HookDeliveryEvidence {
+	t.Helper()
+	event, err := model.NewEvent(
+		types.EventID("event-1"),
+		types.EventKindCommandExecuted,
+		types.Client("hook"),
+		types.Agent(d.agent),
+		types.SessionID(d.sessionID),
+		types.Workspace("/repo"),
+		"go test ./...",
+	)
+	if err != nil {
+		t.Fatalf("NewEvent() error = %v", err)
+	}
+	event.SetSourceHook(d.hook)
+	evidence, err := model.NewHookDeliveryEvidence(event, d.nativeID, "/repo")
+	if err != nil {
+		t.Fatalf("NewHookDeliveryEvidence() error = %v", err)
+	}
+	return evidence
 }
 
 func TestClassifyWorkspaceRelationship(t *testing.T) {

--- a/infrastructure/filesystem/kimi_usage_open_other.go
+++ b/infrastructure/filesystem/kimi_usage_open_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package filesystem
+
+import "os"
+
+// kimiUsageOpenFlags is a plain read-only open: the Unix-only O_NONBLOCK and
+// O_CLOEXEC flags do not exist on this platform.
+const kimiUsageOpenFlags = os.O_RDONLY

--- a/infrastructure/filesystem/kimi_usage_open_unix.go
+++ b/infrastructure/filesystem/kimi_usage_open_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package filesystem
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// kimiUsageOpenFlags adds O_NONBLOCK so a hostile FIFO cannot block the
+// contained open before fstat, plus O_CLOEXEC so the descriptor never leaks
+// into child processes.
+const kimiUsageOpenFlags = os.O_RDONLY | unix.O_NONBLOCK | unix.O_CLOEXEC

--- a/infrastructure/filesystem/kimi_usage_source.go
+++ b/infrastructure/filesystem/kimi_usage_source.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
@@ -183,8 +182,8 @@ func relativeKimiUsageWire(sessionsRoot, sessionDir string) (string, error) {
 
 func openKimiUsageRegularFile(root *os.Root, name string) (*os.File, bool, error) {
 	// os.Root keeps every path component inside root across renames and symlink
-	// changes. O_NONBLOCK prevents a hostile FIFO from blocking before fstat.
-	file, err := root.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	// changes; kimiUsageOpenFlags adds the platform-specific hardening flags.
+	file, err := root.OpenFile(name, kimiUsageOpenFlags, 0)
 	if os.IsNotExist(err) {
 		return nil, false, nil
 	}

--- a/infrastructure/sqlite/hook_delivery_store_test.go
+++ b/infrastructure/sqlite/hook_delivery_store_test.go
@@ -129,6 +129,34 @@ func TestEventDatasource_HookDeliveryIdentity(t *testing.T) {
 		assertSQLiteCount(t, dbPath, "hook_delivery_attempts", 2)
 	})
 
+	t.Run("colon-bearing identity components stay distinct in the ledger", func(t *testing.T) {
+		t.Parallel()
+		dbPath, eventDS := newHookDeliveryTestStore(t)
+		// A plain ":" join would give both deliveries the reported identity
+		// "codex:user_prompt_submit:session:a:event_id:delivery-1".
+		for _, event := range []*model.Event{
+			hookDeliveryTestEvent(t, "event-1", "session:a", "/repo", "/repo", "same body", "event_id:delivery-1"),
+			hookDeliveryTestEvent(t, "event-2", "session", "/repo", "/repo", "same body", "a:event_id:delivery-1"),
+		} {
+			if err := eventDS.Save(context.Background(), event); err != nil {
+				t.Fatalf("Save(%s) error = %v", event.EventID(), err)
+			}
+		}
+		assertSQLiteCount(t, dbPath, "events", 2)
+		assertSQLiteCount(t, dbPath, "hook_deliveries", 2)
+		assertSQLiteCountWhere(t, dbPath, "hook_deliveries", "identity_status = 'accepted'", 2)
+
+		db := openHookDeliveryTestDB(t, dbPath)
+		defer func() { _ = db.Close() }()
+		var distinctReportedIDs int
+		if err := db.QueryRow(`SELECT COUNT(DISTINCT reported_delivery_id) FROM hook_deliveries`).Scan(&distinctReportedIDs); err != nil {
+			t.Fatalf("count distinct reported IDs: %v", err)
+		}
+		if distinctReportedIDs != 2 {
+			t.Fatalf("distinct reported_delivery_id count = %d, want 2 for independent deliveries", distinctReportedIDs)
+		}
+	})
+
 	t.Run("same native ID is isolated by hook kind", func(t *testing.T) {
 		t.Parallel()
 		dbPath, eventDS := newHookDeliveryTestStore(t)

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -532,6 +532,32 @@ func TestRootCLI_HookSessionCommand_OneShotWrapperOverridesHostIdentity(t *testi
 	}
 }
 
+func TestRootCLI_HookSessionCommand_OneShotWrapperSkipsNestedSessionEnd(t *testing.T) {
+	t.Setenv("TRACEARY_RUNTIME_MODE", "one_shot")
+	t.Setenv("TRACEARY_RUNTIME_SESSION_ID", "wrapper-session")
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	sessionStub := &sessionUsecaseStub{}
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"host-session","cwd":"duck8823/traceary"}`))
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetArgs([]string{"hook", "session", "claude", "end"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v, want nested session end to stay a no-op under the one-shot wrapper", err)
+	}
+	if len(sessionStub.endCalls) != 0 {
+		t.Fatalf("session End calls = %d, want 0 so the wrapper keeps the only terminal transition", len(sessionStub.endCalls))
+	}
+}
+
 func TestRootCLI_HookSessionCommand_StartRunsRateLimitedSessionGC(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "gc-key")
 	t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())

--- a/presentation/cli/hook_session.go
+++ b/presentation/cli/hook_session.go
@@ -150,6 +150,14 @@ func (c *RootCLI) runHookSession(
 		}
 		return nil
 	case "end":
+		if explicitOneShotRuntimeSessionID() != "" {
+			// A nested host SessionEnd fires while the supervised child is
+			// still exiting. Only the one-shot wrapper writes the typed
+			// terminal reason after the child exits; recording a host end
+			// here would either fail on the unknown host session or pre-empt
+			// the wrapper's reason with an untyped success.
+			return nil
+		}
 		agent, err := resolveHookAgent(client, payload)
 		if err != nil {
 			return err

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -246,10 +246,18 @@ func runOneShotProcess(ctx context.Context, stdin io.Reader, stdout, stderr io.W
 // typed terminal reason documented for one-shot sessions. A child that ran to
 // completion is always success, even when the deadline or cancellation fired
 // concurrently: the context error only classifies a process that actually
-// failed to finish on its own.
+// failed to finish on its own. Likewise, an ExitError carrying a real exit
+// code proves the child exited by itself, so a concurrently expired context
+// cannot reclassify that failure as a timeout or aborted stream.
 func classifyOneShotOutcome(ctxErr, runErr error) (types.TerminalReason, int, error) {
 	if runErr == nil {
 		return types.TerminalReasonSuccess, 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		if exitCode, own := oneShotOwnExitCode(exitErr); own {
+			return types.TerminalReasonFailure, exitCode, runErr
+		}
 	}
 	if errors.Is(ctxErr, context.DeadlineExceeded) {
 		return types.TerminalReasonTimeout, oneShotTimeoutExitCode, xerrors.Errorf("one-shot process deadline: %w", ctxErr)
@@ -257,8 +265,7 @@ func classifyOneShotOutcome(ctxErr, runErr error) (types.TerminalReason, int, er
 	if errors.Is(ctxErr, context.Canceled) {
 		return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process canceled: %w", ctxErr)
 	}
-	var exitErr *exec.ExitError
-	if errors.As(runErr, &exitErr) {
+	if exitErr != nil {
 		if exitCode, signaled := oneShotSignalExitCode(exitErr); signaled {
 			return types.TerminalReasonSignal, exitCode, xerrors.Errorf("one-shot process terminated by signal: %w", runErr)
 		}

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -238,28 +238,37 @@ func runOneShotProcess(ctx context.Context, stdin io.Reader, stdout, stderr io.W
 	child.Stderr = stderr
 	child.Env = env
 	configureOneShotProcess(child)
-	err := child.Run()
-	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		return types.TerminalReasonTimeout, oneShotTimeoutExitCode, xerrors.Errorf("one-shot process deadline: %w", runCtx.Err())
-	}
-	if errors.Is(runCtx.Err(), context.Canceled) {
-		return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process canceled: %w", runCtx.Err())
-	}
-	if err == nil {
+	runErr := child.Run()
+	return classifyOneShotOutcome(runCtx.Err(), runErr)
+}
+
+// classifyOneShotOutcome maps the supervised process outcome to the single
+// typed terminal reason documented for one-shot sessions. A child that ran to
+// completion is always success, even when the deadline or cancellation fired
+// concurrently: the context error only classifies a process that actually
+// failed to finish on its own.
+func classifyOneShotOutcome(ctxErr, runErr error) (types.TerminalReason, int, error) {
+	if runErr == nil {
 		return types.TerminalReasonSuccess, 0, nil
 	}
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return types.TerminalReasonTimeout, oneShotTimeoutExitCode, xerrors.Errorf("one-shot process deadline: %w", ctxErr)
+	}
+	if errors.Is(ctxErr, context.Canceled) {
+		return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process canceled: %w", ctxErr)
+	}
 	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if errors.As(runErr, &exitErr) {
 		if exitCode, signaled := oneShotSignalExitCode(exitErr); signaled {
-			return types.TerminalReasonSignal, exitCode, xerrors.Errorf("one-shot process terminated by signal: %w", err)
+			return types.TerminalReasonSignal, exitCode, xerrors.Errorf("one-shot process terminated by signal: %w", runErr)
 		}
-		return types.TerminalReasonFailure, exitErr.ExitCode(), err
+		return types.TerminalReasonFailure, exitErr.ExitCode(), runErr
 	}
 	var pathErr *os.PathError
-	if errors.As(err, &pathErr) {
-		return types.TerminalReasonFailure, oneShotStartExitCode, xerrors.Errorf("failed to start one-shot process: %w", err)
+	if errors.As(runErr, &pathErr) {
+		return types.TerminalReasonFailure, oneShotStartExitCode, xerrors.Errorf("failed to start one-shot process: %w", runErr)
 	}
-	return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process stream aborted: %w", err)
+	return types.TerminalReasonAbortedStream, oneShotStreamExitCode, xerrors.Errorf("one-shot process stream aborted: %w", runErr)
 }
 
 func oneShotProcessEnvironment(

--- a/presentation/cli/session_run.go
+++ b/presentation/cli/session_run.go
@@ -246,9 +246,11 @@ func runOneShotProcess(ctx context.Context, stdin io.Reader, stdout, stderr io.W
 // typed terminal reason documented for one-shot sessions. A child that ran to
 // completion is always success, even when the deadline or cancellation fired
 // concurrently: the context error only classifies a process that actually
-// failed to finish on its own. Likewise, an ExitError carrying a real exit
-// code proves the child exited by itself, so a concurrently expired context
-// cannot reclassify that failure as a timeout or aborted stream.
+// failed to finish on its own. Where the platform can prove the child exited
+// on its own with a real exit status (Unix wait status), an ExitError
+// carrying that status stays the child's failure even when the context
+// expired at the same time; platforms without that proof conservatively let
+// the context error keep priority (see oneShotOwnExitCode).
 func classifyOneShotOutcome(ctxErr, runErr error) (types.TerminalReason, int, error) {
 	if runErr == nil {
 		return types.TerminalReasonSuccess, 0, nil

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/domain/types"
 )
@@ -86,16 +89,33 @@ func TestClassifyOneShotOutcome(t *testing.T) {
 			reason: types.TerminalReasonSuccess, exitCode: 0,
 		},
 		{
-			name:   "deadline classifies killed process as timeout",
+			name:   "child failure wins over expired deadline",
 			ctxErr: context.DeadlineExceeded,
-			runErr: errors.New("signal: killed"),
+			runErr: oneShotTestExitError(t, "exit 7"),
+			reason: types.TerminalReasonFailure, exitCode: 7, wantErr: true,
+		},
+		{
+			name:   "child failure wins over canceled context",
+			ctxErr: context.Canceled,
+			runErr: oneShotTestExitError(t, "exit 3"),
+			reason: types.TerminalReasonFailure, exitCode: 3, wantErr: true,
+		},
+		{
+			name:   "deadline classifies signal-killed process as timeout",
+			ctxErr: context.DeadlineExceeded,
+			runErr: oneShotTestExitError(t, "kill -KILL $$"),
 			reason: types.TerminalReasonTimeout, exitCode: oneShotTimeoutExitCode, wantErr: true,
 		},
 		{
-			name:   "canceled context classifies killed process as aborted stream",
+			name:   "canceled context classifies signal-killed process as aborted stream",
 			ctxErr: context.Canceled,
-			runErr: errors.New("signal: killed"),
+			runErr: oneShotTestExitError(t, "kill -KILL $$"),
 			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode, wantErr: true,
+		},
+		{
+			name:   "signal without context error",
+			runErr: oneShotTestExitError(t, "kill -TERM $$"),
+			reason: types.TerminalReasonSignal, exitCode: 143, wantErr: true,
 		},
 		{
 			name:   "start failure",
@@ -120,6 +140,21 @@ func TestClassifyOneShotOutcome(t *testing.T) {
 			}
 		})
 	}
+}
+
+// oneShotTestExitError runs a command that fails so tests can classify a
+// real *exec.ExitError instead of a fabricated error value.
+func oneShotTestExitError(t *testing.T, command string) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", command).Run()
+	if err == nil {
+		t.Fatalf("sh -c %q error = nil, want exit error", command)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("sh -c %q error = %T, want *exec.ExitError", command, err)
+	}
+	return xerrors.Errorf("test command failed: %w", err)
 }
 
 func TestIsClaudeHeadlessUsageCommand_RequiresPrintAndJSONOutput(t *testing.T) {

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -60,6 +61,64 @@ func TestRunOneShotProcess_ClassifiesStartFailure(t *testing.T) {
 	}
 	if reason != types.TerminalReasonFailure || exitCode != oneShotStartExitCode {
 		t.Fatalf("runOneShotProcess() = (%q, %d), want (failure, %d)", reason, exitCode, oneShotStartExitCode)
+	}
+}
+
+func TestClassifyOneShotOutcome(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ctxErr   error
+		runErr   error
+		reason   types.TerminalReason
+		exitCode int
+		wantErr  bool
+	}{
+		{name: "clean exit", reason: types.TerminalReasonSuccess, exitCode: 0},
+		{
+			name:   "clean exit wins over expired deadline",
+			ctxErr: context.DeadlineExceeded,
+			reason: types.TerminalReasonSuccess, exitCode: 0,
+		},
+		{
+			name:   "clean exit wins over canceled context",
+			ctxErr: context.Canceled,
+			reason: types.TerminalReasonSuccess, exitCode: 0,
+		},
+		{
+			name:   "deadline classifies killed process as timeout",
+			ctxErr: context.DeadlineExceeded,
+			runErr: errors.New("signal: killed"),
+			reason: types.TerminalReasonTimeout, exitCode: oneShotTimeoutExitCode, wantErr: true,
+		},
+		{
+			name:   "canceled context classifies killed process as aborted stream",
+			ctxErr: context.Canceled,
+			runErr: errors.New("signal: killed"),
+			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode, wantErr: true,
+		},
+		{
+			name:   "start failure",
+			runErr: &os.PathError{Op: "fork/exec", Path: "/missing", Err: errors.New("no such file or directory")},
+			reason: types.TerminalReasonFailure, exitCode: oneShotStartExitCode, wantErr: true,
+		},
+		{
+			name:   "stream error",
+			runErr: errors.New("broken pipe"),
+			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode, wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason, exitCode, err := classifyOneShotOutcome(tt.ctxErr, tt.runErr)
+			if reason != tt.reason || exitCode != tt.exitCode {
+				t.Fatalf("classifyOneShotOutcome() = (%q, %d), want (%q, %d)", reason, exitCode, tt.reason, tt.exitCode)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("classifyOneShotOutcome() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/presentation/cli/session_run_internal_test.go
+++ b/presentation/cli/session_run_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -89,33 +90,16 @@ func TestClassifyOneShotOutcome(t *testing.T) {
 			reason: types.TerminalReasonSuccess, exitCode: 0,
 		},
 		{
-			name:   "child failure wins over expired deadline",
+			name:   "deadline classifies unfinished process as timeout",
 			ctxErr: context.DeadlineExceeded,
-			runErr: oneShotTestExitError(t, "exit 7"),
-			reason: types.TerminalReasonFailure, exitCode: 7, wantErr: true,
-		},
-		{
-			name:   "child failure wins over canceled context",
-			ctxErr: context.Canceled,
-			runErr: oneShotTestExitError(t, "exit 3"),
-			reason: types.TerminalReasonFailure, exitCode: 3, wantErr: true,
-		},
-		{
-			name:   "deadline classifies signal-killed process as timeout",
-			ctxErr: context.DeadlineExceeded,
-			runErr: oneShotTestExitError(t, "kill -KILL $$"),
+			runErr: errors.New("signal: killed"),
 			reason: types.TerminalReasonTimeout, exitCode: oneShotTimeoutExitCode, wantErr: true,
 		},
 		{
-			name:   "canceled context classifies signal-killed process as aborted stream",
+			name:   "canceled context classifies unfinished process as aborted stream",
 			ctxErr: context.Canceled,
-			runErr: oneShotTestExitError(t, "kill -KILL $$"),
+			runErr: errors.New("signal: killed"),
 			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode, wantErr: true,
-		},
-		{
-			name:   "signal without context error",
-			runErr: oneShotTestExitError(t, "kill -TERM $$"),
-			reason: types.TerminalReasonSignal, exitCode: 143, wantErr: true,
 		},
 		{
 			name:   "start failure",
@@ -142,17 +126,30 @@ func TestClassifyOneShotOutcome(t *testing.T) {
 	}
 }
 
-// oneShotTestExitError runs a command that fails so tests can classify a
-// real *exec.ExitError instead of a fabricated error value.
-func oneShotTestExitError(t *testing.T, command string) error {
+// TestOneShotHelperProcess is not a test: it runs as the child of
+// oneShotTestExitError and exits with the requested code so tests can
+// classify a real *exec.ExitError on any platform.
+func TestOneShotHelperProcess(_ *testing.T) {
+	code, err := strconv.Atoi(os.Getenv("TRACEARY_TEST_ONESHOT_HELPER_EXIT"))
+	if err != nil {
+		return
+	}
+	os.Exit(code)
+}
+
+// oneShotTestExitError re-executes the test binary as a failing helper
+// process, producing a real *exec.ExitError with the given exit code.
+func oneShotTestExitError(t *testing.T, exitCode int) error {
 	t.Helper()
-	err := exec.Command("sh", "-c", command).Run()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestOneShotHelperProcess$")
+	cmd.Env = append(os.Environ(), "TRACEARY_TEST_ONESHOT_HELPER_EXIT="+strconv.Itoa(exitCode))
+	err := cmd.Run()
 	if err == nil {
-		t.Fatalf("sh -c %q error = nil, want exit error", command)
+		t.Fatalf("helper process error = nil, want exit code %d", exitCode)
 	}
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
-		t.Fatalf("sh -c %q error = %T, want *exec.ExitError", command, err)
+		t.Fatalf("helper process error = %T, want *exec.ExitError", err)
 	}
 	return xerrors.Errorf("test command failed: %w", err)
 }

--- a/presentation/cli/session_run_outcome_fallback_test.go
+++ b/presentation/cli/session_run_outcome_fallback_test.go
@@ -1,0 +1,52 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// On platforms without wait-status signal inspection a supervisor-initiated
+// kill is indistinguishable from a child-owned exit (see oneShotOwnExitCode),
+// so an expired or canceled context keeps classification priority. A plain
+// non-zero exit without a context error still records the child's failure.
+func TestClassifyOneShotOutcome_ContextKeepsPriorityOverExitError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ctxErr   error
+		runErr   error
+		reason   types.TerminalReason
+		exitCode int
+	}{
+		{
+			name:   "expired deadline outranks ambiguous exit error",
+			ctxErr: context.DeadlineExceeded,
+			runErr: oneShotTestExitError(t, 7),
+			reason: types.TerminalReasonTimeout, exitCode: oneShotTimeoutExitCode,
+		},
+		{
+			name:   "canceled context outranks ambiguous exit error",
+			ctxErr: context.Canceled,
+			runErr: oneShotTestExitError(t, 7),
+			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode,
+		},
+		{
+			name:   "plain failure without context error",
+			runErr: oneShotTestExitError(t, 7),
+			reason: types.TerminalReasonFailure, exitCode: 7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason, exitCode, err := classifyOneShotOutcome(tt.ctxErr, tt.runErr)
+			if reason != tt.reason || exitCode != tt.exitCode || err == nil {
+				t.Fatalf("classifyOneShotOutcome() = (%q, %d, %v), want (%q, %d, error)", reason, exitCode, err, tt.reason, tt.exitCode)
+			}
+		})
+	}
+}

--- a/presentation/cli/session_run_outcome_unix_test.go
+++ b/presentation/cli/session_run_outcome_unix_test.go
@@ -1,0 +1,100 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestClassifyOneShotOutcome_ChildOwnedExitWinsOverContext(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ctxErr   error
+		runErr   error
+		reason   types.TerminalReason
+		exitCode int
+	}{
+		{
+			name:   "child failure wins over expired deadline",
+			ctxErr: context.DeadlineExceeded,
+			runErr: oneShotTestExitError(t, 7),
+			reason: types.TerminalReasonFailure, exitCode: 7,
+		},
+		{
+			name:   "child failure wins over canceled context",
+			ctxErr: context.Canceled,
+			runErr: oneShotTestExitError(t, 3),
+			reason: types.TerminalReasonFailure, exitCode: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason, exitCode, err := classifyOneShotOutcome(tt.ctxErr, tt.runErr)
+			if reason != tt.reason || exitCode != tt.exitCode || err == nil {
+				t.Fatalf("classifyOneShotOutcome() = (%q, %d, %v), want (%q, %d, error)", reason, exitCode, err, tt.reason, tt.exitCode)
+			}
+		})
+	}
+}
+
+func TestClassifyOneShotOutcome_SignalClassification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ctxErr   error
+		runErr   error
+		reason   types.TerminalReason
+		exitCode int
+	}{
+		{
+			name:   "deadline classifies signal-killed process as timeout",
+			ctxErr: context.DeadlineExceeded,
+			runErr: oneShotTestShellExitError(t, "kill -KILL $$"),
+			reason: types.TerminalReasonTimeout, exitCode: oneShotTimeoutExitCode,
+		},
+		{
+			name:   "canceled context classifies signal-killed process as aborted stream",
+			ctxErr: context.Canceled,
+			runErr: oneShotTestShellExitError(t, "kill -KILL $$"),
+			reason: types.TerminalReasonAbortedStream, exitCode: oneShotStreamExitCode,
+		},
+		{
+			name:   "signal without context error",
+			runErr: oneShotTestShellExitError(t, "kill -TERM $$"),
+			reason: types.TerminalReasonSignal, exitCode: 143,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason, exitCode, err := classifyOneShotOutcome(tt.ctxErr, tt.runErr)
+			if reason != tt.reason || exitCode != tt.exitCode || err == nil {
+				t.Fatalf("classifyOneShotOutcome() = (%q, %d, %v), want (%q, %d, error)", reason, exitCode, err, tt.reason, tt.exitCode)
+			}
+		})
+	}
+}
+
+// oneShotTestShellExitError runs a shell command that fails so signal-based
+// classification tests can use a real *exec.ExitError wait status.
+func oneShotTestShellExitError(t *testing.T, command string) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", command).Run()
+	if err == nil {
+		t.Fatalf("sh -c %q error = nil, want exit error", command)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("sh -c %q error = %T, want *exec.ExitError", command, err)
+	}
+	return xerrors.Errorf("test command failed: %w", err)
+}

--- a/presentation/cli/session_run_process_fallback.go
+++ b/presentation/cli/session_run_process_fallback.go
@@ -14,3 +14,7 @@ func configureOneShotProcess(command *exec.Cmd) {
 }
 
 func oneShotSignalExitCode(*exec.ExitError) (int, bool) { return 0, false }
+
+// oneShotOwnExitCode cannot prove on this platform whether an exit status
+// came from the child itself, so context errors keep priority there.
+func oneShotOwnExitCode(*exec.ExitError) (int, bool) { return 0, false }

--- a/presentation/cli/session_run_process_fallback.go
+++ b/presentation/cli/session_run_process_fallback.go
@@ -15,6 +15,11 @@ func configureOneShotProcess(command *exec.Cmd) {
 
 func oneShotSignalExitCode(*exec.ExitError) (int, bool) { return 0, false }
 
-// oneShotOwnExitCode cannot prove on this platform whether an exit status
-// came from the child itself, so context errors keep priority there.
+// oneShotOwnExitCode always reports no child-owned exit on this platform.
+// Without wait-status signal inspection, a supervisor-initiated kill
+// (TerminateProcess) surfaces as an ordinary exit code 1, indistinguishable
+// from a child-owned exit. The conservative contract is therefore: a child
+// that ran to completion cleanly still records success, but any non-zero
+// exit racing with an expired deadline or cancellation is classified as
+// timeout or aborted_stream rather than the child's own failure.
 func oneShotOwnExitCode(*exec.ExitError) (int, bool) { return 0, false }

--- a/presentation/cli/session_run_process_unix.go
+++ b/presentation/cli/session_run_process_unix.go
@@ -35,3 +35,15 @@ func oneShotSignalExitCode(exitErr *exec.ExitError) (int, bool) {
 	}
 	return 128 + int(status.Signal()), true
 }
+
+// oneShotOwnExitCode reports the exit code when the child provably exited on
+// its own with a real exit status. A concurrently expired deadline or
+// cancellation must not reclassify that outcome as a timeout or aborted
+// stream.
+func oneShotOwnExitCode(exitErr *exec.ExitError) (int, bool) {
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Exited() {
+		return 0, false
+	}
+	return status.ExitStatus(), true
+}


### PR DESCRIPTION
## Summary

- Encode hook delivery identities with length-prefixed fields to prevent delimiter-based collisions.
- Preserve one-shot lifecycle outcomes when process completion races with cancellation or timeout.
- Ignore nested host session-end hooks while a one-shot wrapper owns the terminal transition.
- Add regression coverage for delivery identity and one-shot exit paths.

## Changes

- `domain/model/hook_delivery.go`
  - Replace delimiter-only reported IDs with byte-length-prefixed identity fields.
- `domain/model/hook_delivery_test.go`
  - Cover ambiguous delimiter placement, identity stability, and delivery record separation.
- `infrastructure/sqlite/hook_delivery_store_test.go`
  - Verify colon-bearing delivery identities remain distinct in the persisted ledger.
- `presentation/cli/session_run.go`
  - Extract one-shot outcome classification and preserve child-owned exits when distinguishable from supervisor termination.
- `presentation/cli/session_run_process_unix.go`
  - Detect normal child exits through Unix wait status.
- `presentation/cli/session_run_process_fallback.go`
  - Retain context priority where child-owned exits cannot be distinguished reliably (documented contract).
- `presentation/cli/session_run_internal_test.go`
  - Cover clean exits, context races, start failures, and stream failures.
- `presentation/cli/session_run_outcome_unix_test.go`
  - Cover Unix child failures and signal-based outcomes.
- `presentation/cli/session_run_outcome_fallback_test.go`
  - Pin fallback-platform context precedence.
- `presentation/cli/hook_session.go`
  - Skip nested session-end handling when the one-shot wrapper owns the runtime session.
- `presentation/cli/hook_runtime_test.go`
  - Verify nested session-end hooks remain no-ops under the wrapper.
- `infrastructure/filesystem/kimi_usage_open_unix.go`, `kimi_usage_open_other.go`, `kimi_usage_source.go`
  - Isolate platform-specific file-open flags; restores the non-Unix build broken on main (required for `GOOS=windows` verification of the fallback contract).

## Test plan

- `go test ./...`
- Verify delimiter-bearing identity components produce distinct reported and persisted delivery IDs.
- Verify clean, failed, signaled, timed-out, and canceled one-shot processes retain the expected terminal reason and exit code.
- Verify nested session-end hooks do not preempt the one-shot wrapper's terminal transition.
- `GOOS=windows go build ./...` and `GOOS=windows go vet ./presentation/cli/` pass.

Codex verifier: ✅ PASS (round 3; earlier rounds' findings addressed in 70901d3e and ae2a7d66)

Closes #1576
