### PR TITLE
fix: bound Kimi usage capture work

### DIFF
--- a/infrastructure/filesystem/kimi_usage_source.go
+++ b/infrastructure/filesystem/kimi_usage_source.go
@@ -30,16 +30,26 @@ const (
 )
 
 type kimiUsageSource struct {
-	root func() (string, error)
+	root          func() (string, error)
+	maxSourceSize int64
+	maxLineBytes  int
 }
 
 // NewKimiUsageSource creates the contained, body-free Kimi wire adapter.
 func NewKimiUsageSource() application.KimiUsageSource {
-	return &kimiUsageSource{root: defaultKimiUsageRoot}
+	return &kimiUsageSource{
+		root:          defaultKimiUsageRoot,
+		maxSourceSize: kimiUsageMaxSourceSize,
+		maxLineBytes:  kimiUsageMaxLineBytes,
+	}
 }
 
 func newKimiUsageSourceWithRoot(root string) *kimiUsageSource {
-	return &kimiUsageSource{root: func() (string, error) { return root, nil }}
+	return &kimiUsageSource{
+		root:          func() (string, error) { return root, nil },
+		maxSourceSize: kimiUsageMaxSourceSize,
+		maxLineBytes:  kimiUsageMaxLineBytes,
+	}
 }
 
 func defaultKimiUsageRoot() (string, error) {
@@ -110,7 +120,7 @@ func (s *kimiUsageSource) Load(
 	}
 	defer func() { _ = sessionsRoot.Close() }()
 
-	sessionDir, found, err := findKimiUsageSessionDir(ctx, homeRoot, providerSessionID)
+	sessionDir, found, err := s.findKimiUsageSessionDir(ctx, homeRoot, providerSessionID)
 	if err != nil {
 		return application.KimiUsageLoadResult{}, err
 	}
@@ -122,7 +132,7 @@ func (s *kimiUsageSource) Load(
 	if err != nil {
 		return application.KimiUsageLoadResult{}, err
 	}
-	file, found, err := openKimiUsageRegularFile(sessionsRoot, wirePath)
+	file, found, err := s.openKimiUsageRegularFile(sessionsRoot, wirePath)
 	if err != nil {
 		return application.KimiUsageLoadResult{}, xerrors.Errorf("failed to open Kimi usage wire")
 	}
@@ -130,15 +140,15 @@ func (s *kimiUsageSource) Load(
 		return application.KimiUsageLoadResult{}, nil
 	}
 	defer func() { _ = file.Close() }()
-	return loadKimiUsageWire(ctx, file, providerSessionID)
+	return s.loadKimiUsageWire(ctx, file, providerSessionID)
 }
 
-func findKimiUsageSessionDir(
+func (s *kimiUsageSource) findKimiUsageSessionDir(
 	ctx context.Context,
 	root *os.Root,
 	providerSessionID string,
 ) (string, bool, error) {
-	file, found, err := openKimiUsageRegularFile(root, kimiUsageSessionIndex)
+	file, found, err := s.openKimiUsageRegularFile(root, kimiUsageSessionIndex)
 	if err != nil {
 		return "", false, xerrors.Errorf("failed to open Kimi usage session index")
 	}
@@ -148,7 +158,7 @@ func findKimiUsageSessionDir(
 	defer func() { _ = file.Close() }()
 
 	sessionDir := ""
-	scanner, limited := boundedKimiUsageScanner(file)
+	scanner, limited := s.boundedKimiUsageScanner(file)
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			return "", false, xerrors.Errorf("Kimi usage session index scan cancelled: %w", err)
@@ -181,7 +191,7 @@ func relativeKimiUsageWire(sessionsRoot, sessionDir string) (string, error) {
 	return filepath.Join(rel, "agents", "main", "wire.jsonl"), nil
 }
 
-func openKimiUsageRegularFile(root *os.Root, name string) (*os.File, bool, error) {
+func (s *kimiUsageSource) openKimiUsageRegularFile(root *os.Root, name string) (*os.File, bool, error) {
 	// os.Root keeps every path component inside root across renames and symlink
 	// changes. O_NONBLOCK prevents a hostile FIFO from blocking before fstat.
 	file, err := root.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
@@ -192,14 +202,14 @@ func openKimiUsageRegularFile(root *os.Root, name string) (*os.File, bool, error
 		return nil, false, xerrors.Errorf("failed to open contained Kimi usage source")
 	}
 	info, err := file.Stat()
-	if err != nil || !info.Mode().IsRegular() || info.Size() > kimiUsageMaxSourceSize {
+	if err != nil || !info.Mode().IsRegular() || info.Size() > s.maxSourceSize {
 		_ = file.Close()
 		return nil, false, xerrors.Errorf("Kimi usage source is not a bounded regular file")
 	}
 	return file, true, nil
 }
 
-func loadKimiUsageWire(
+func (s *kimiUsageSource) loadKimiUsageWire(
 	ctx context.Context,
 	file *os.File,
 	providerSessionID string,
@@ -207,7 +217,7 @@ func loadKimiUsageWire(
 	result := application.KimiUsageLoadResult{}
 	usageOrdinal := int64(0)
 	turnOrdinal := int64(0)
-	scanner, limited := boundedKimiUsageScanner(file)
+	scanner, limited := s.boundedKimiUsageScanner(file)
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			return application.KimiUsageLoadResult{}, xerrors.Errorf("Kimi usage wire scan cancelled: %w", err)
@@ -287,10 +297,10 @@ func decodeKimiUsageRecord(
 	}, nil
 }
 
-func boundedKimiUsageScanner(reader io.Reader) (*bufio.Scanner, *io.LimitedReader) {
-	limited := &io.LimitedReader{R: reader, N: kimiUsageMaxSourceSize + 1}
+func (s *kimiUsageSource) boundedKimiUsageScanner(reader io.Reader) (*bufio.Scanner, *io.LimitedReader) {
+	limited := &io.LimitedReader{R: reader, N: s.maxSourceSize + 1}
 	scanner := bufio.NewScanner(limited)
-	scanner.Buffer(make([]byte, 0, 64*1024), kimiUsageMaxLineBytes)
+	scanner.Buffer(make([]byte, 0, 64*1024), s.maxLineBytes)
 	return scanner, limited
 }
 

--- a/infrastructure/filesystem/kimi_usage_source_test.go
+++ b/infrastructure/filesystem/kimi_usage_source_test.go
@@ -272,9 +272,12 @@ func TestKimiUsageSource_LoadRejectsFIFOWithoutBlocking(t *testing.T) {
 func TestKimiUsageSource_LoadRejectsOversizedSourceWithoutLeakingBody(t *testing.T) {
 	t.Run("wire", func(t *testing.T) {
 		root, sessionDir := writeKimiUsageTestSession(t, "provider-session")
+		var body strings.Builder
+		for range 64 {
+			body.WriteString(`{"type":"turn.prompt","padding":"PRIVATE-SENTINEL"}` + "\n")
+		}
 		if err := os.WriteFile(
-			filepath.Join(sessionDir, "agents", "main", "wire.jsonl"),
-			[]byte(strings.Repeat("PRIVATE-SENTINEL", 256)), 0o600,
+			filepath.Join(sessionDir, "agents", "main", "wire.jsonl"), []byte(body.String()), 0o600,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -282,24 +285,31 @@ func TestKimiUsageSource_LoadRejectsOversizedSourceWithoutLeakingBody(t *testing
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = newKimiUsageSourceForBoundTest(root, indexInfo.Size(), 1024).
+		// The line cap stays above every individual line so only the
+		// open-time source size check can reject this input.
+		_, err = newKimiUsageSourceForBoundTest(root, indexInfo.Size(), 1<<20).
 			Load(context.Background(), "provider-session")
-		if err == nil || strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
-			t.Fatalf("Load() error = %v, want oversized wire rejection without body leak", err)
+		if err == nil || !strings.Contains(err.Error(), "failed to open Kimi usage wire") ||
+			strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
+			t.Fatalf("Load() error = %v, want open-time oversized wire rejection without body leak", err)
 		}
 	})
 	t.Run("session index", func(t *testing.T) {
 		root, _ := writeKimiUsageTestSession(t, "provider-session")
+		var body strings.Builder
+		for range 64 {
+			body.WriteString(`{"sessionId":"other-session","sessionDir":"PRIVATE-SENTINEL"}` + "\n")
+		}
 		if err := os.WriteFile(
-			filepath.Join(root, kimiUsageSessionIndex),
-			[]byte(strings.Repeat("PRIVATE-SENTINEL", 256)), 0o600,
+			filepath.Join(root, kimiUsageSessionIndex), []byte(body.String()), 0o600,
 		); err != nil {
 			t.Fatal(err)
 		}
-		_, err := newKimiUsageSourceForBoundTest(root, 16, 1024).
+		_, err := newKimiUsageSourceForBoundTest(root, 16, 1<<20).
 			Load(context.Background(), "provider-session")
-		if err == nil || strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
-			t.Fatalf("Load() error = %v, want oversized index rejection without body leak", err)
+		if err == nil || !strings.Contains(err.Error(), "failed to open Kimi usage session index") ||
+			strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
+			t.Fatalf("Load() error = %v, want open-time oversized index rejection without body leak", err)
 		}
 	})
 }

--- a/infrastructure/filesystem/kimi_usage_source_test.go
+++ b/infrastructure/filesystem/kimi_usage_source_test.go
@@ -269,6 +269,64 @@ func TestKimiUsageSource_LoadRejectsFIFOWithoutBlocking(t *testing.T) {
 	}
 }
 
+func TestKimiUsageSource_LoadRejectsOversizedSourceWithoutLeakingBody(t *testing.T) {
+	t.Run("wire", func(t *testing.T) {
+		root, sessionDir := writeKimiUsageTestSession(t, "provider-session")
+		if err := os.WriteFile(
+			filepath.Join(sessionDir, "agents", "main", "wire.jsonl"),
+			[]byte(strings.Repeat("PRIVATE-SENTINEL", 256)), 0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+		indexInfo, err := os.Stat(filepath.Join(root, kimiUsageSessionIndex))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = newKimiUsageSourceForBoundTest(root, indexInfo.Size(), 1024).
+			Load(context.Background(), "provider-session")
+		if err == nil || strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
+			t.Fatalf("Load() error = %v, want oversized wire rejection without body leak", err)
+		}
+	})
+	t.Run("session index", func(t *testing.T) {
+		root, _ := writeKimiUsageTestSession(t, "provider-session")
+		if err := os.WriteFile(
+			filepath.Join(root, kimiUsageSessionIndex),
+			[]byte(strings.Repeat("PRIVATE-SENTINEL", 256)), 0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+		_, err := newKimiUsageSourceForBoundTest(root, 16, 1024).
+			Load(context.Background(), "provider-session")
+		if err == nil || strings.Contains(err.Error(), "PRIVATE-SENTINEL") {
+			t.Fatalf("Load() error = %v, want oversized index rejection without body leak", err)
+		}
+	})
+}
+
+func TestKimiUsageSource_LoadRejectsOversizedLine(t *testing.T) {
+	root, sessionDir := writeKimiUsageTestSession(t, "provider-session")
+	line := `{"type":"turn.prompt","padding":"` + strings.Repeat("x", 128*1024) + `"}`
+	if err := os.WriteFile(
+		filepath.Join(sessionDir, "agents", "main", "wire.jsonl"), []byte(line+"\n"), 0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, err := newKimiUsageSourceForBoundTest(root, 1<<20, 1024).
+		Load(context.Background(), "provider-session")
+	if err == nil {
+		t.Fatal("Load() error = nil, want oversized line rejection")
+	}
+}
+
+func newKimiUsageSourceForBoundTest(root string, maxSourceSize int64, maxLineBytes int) *kimiUsageSource {
+	return &kimiUsageSource{
+		root:          func() (string, error) { return root, nil },
+		maxSourceSize: maxSourceSize,
+		maxLineBytes:  maxLineBytes,
+	}
+}
+
 func writeKimiUsageTestSession(t *testing.T, providerSessionID string) (string, string) {
 	t.Helper()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- Make the existing Kimi usage capture bounds configurable for regression testing.
- Preserve the production limits and existing success and unavailable behavior.
- Add coverage for oversized sources, oversized lines, and error-content leakage.

## Changes

- `infrastructure/filesystem/kimi_usage_source.go`
  - Store the maximum source size and line size on `kimiUsageSource`.
  - Initialize both fields with the existing production constants.
  - Apply the configured limits when opening and scanning Kimi usage files.

- `infrastructure/filesystem/kimi_usage_source_test.go`
  - Verify oversized wire files are rejected during open without exposing their contents.
  - Verify oversized session indexes are rejected during open without exposing their contents.
  - Verify oversized JSONL lines fail closed.
  - Add a test helper for configuring small capture bounds.

## Test plan

- Run the filesystem package test suite.
- Confirm normal Kimi usage loading continues to succeed.
- Confirm unavailable sources retain the existing empty-result behavior.
- Confirm oversized sources and lines return errors without leaking file contents.

Codex verifier: ✅ PASS (round 2; round-1 finding on open-time rejection proof addressed in 74b87516)

Closes #1577
