### PR TITLE
docs: document report lineage and runtime exit behavior

### DIFF
--- a/docs/cli/README.ja.md
+++ b/docs/cli/README.ja.md
@@ -768,6 +768,50 @@ session end 境界を記録し、生成された event ID を出力します。
 - `--id-only`
 - `--json`
 
+### `traceary session run`
+
+`traceary session run` は、単発セッションを開始し、1つの子プロセスを監視して、
+その usage を取得し、プロセスの終了時にセッションを確定します。terminal
+transition を所有するのは wrapper だけであり、型付きの terminal reason を
+書き込みます。wrapper 配下で実行されるネストしたホストの `SessionEnd` hook は
+何も行わないため、wrapper より先にセッションを確定したり、wrapper の reason を
+置き換えたりすることはできません。
+
+| Terminal reason | プロセスの結果 | Wrapper の exit code |
+| --- | --- | ---: |
+| `success` | 子プロセスが正常終了 | `0` |
+| `failure` | 子プロセスが異常終了 | 子プロセスの exit code |
+| `failure` | 子プロセスを起動できない | `127` |
+| `timeout` | deadline が経過 | `124` |
+| `signal` | Unix で子プロセスが signal `N` により終了 | `128 + N` |
+| `aborted_stream` | 実行がキャンセルされたか、stream が中断された | `74` |
+| `legacy_unknown` | 型付き reason のない従来のセッション | 新しい単発実行では割り当てられない |
+
+分類では、子プロセスの終了と supervisor のキャンセルが競合する場合を考慮します。
+子プロセスが正常終了した場合は、deadline またはキャンセルが同時に ready に
+なっても `success` です。Unix では、子プロセスが自発的に終了したことを確認
+できる場合、非ゼロの exit code を維持し、`failure` に分類します。それ以外では、
+deadline の経過がキャンセルより優先され、続いて signal による終了、その他の
+子プロセス終了エラーの順に扱われます。
+
+非 Unix のフォールバックでは、supervisor による終了として報告された exit code 1
+と、子プロセス自身が code 1 で終了した場合を区別できません。その結果が context
+と競合する場合は、保守的に context の結果を使用し、実行を `timeout` または
+`aborted_stream` に分類します。
+
+セッションの確定処理には5秒の制限があります。それ以外は正常に終了した
+子プロセスについて確定処理が失敗した場合、wrapper は exit code を `0` から
+`1` に引き上げます。既存の非ゼロの子プロセスまたは supervisor の exit code は
+維持されます。usage の取得に失敗した場合は code `1` で終了します。
+
+上記の terminal-reason taxonomy は、コマンド監査の `--failure-reason` enum とは
+異なります。
+
+古い単発セッションの調査と修復には、
+[`traceary session repair-one-shot`](../operations/one-shot-repair.ja.md) を使用します。
+このコマンドはデフォルトでは dry-run です。修復を適用するには、バックアップと
+検証済みの evidence manifest が必要です。
+
 <a id="traceary-top"></a>
 
 ### `traceary sessions`
@@ -1097,6 +1141,38 @@ AI クライアント連携向けに MCP サーバーを stdio で起動しま�
 `usage` オブジェクトは、現在有効な確定済み観測を provider、engine、model、repository、ticket、pull request、batch ごとに集計します。token フィールドは既知の観測件数と取得不能な観測件数を分けるため、既知の 0 と証拠不足を混同しません。`accounted_observations` は加算対象外の代替証拠を除き、`excluded_observations` はその証拠の存在を可視化します。`unavailable_observations` はデータ源をまったく読めなかった観測を数えるため、取得不能を収集成功の 0 と見なしません。cost 行は `origin` ごとに分離し、`estimated` を `provider_reported` として表示しません。run の packet bytes と tool output bytes は run identity で重複排除し、`usage.runs` に出力します。role、round、wall time は正式な値が永続化されていないため、現在は `unavailable` と表示します。
 
 主な flag: `--from`、`--to`、`--timezone`、`--workspace`、`--client`、`--page-size`、`--result-cap`、`--json`。
+
+#### レポートの系譜
+
+レポートは、4つのソースファミリーを読み込みます。sessions セクションは
+`sessions` をソースとし、セッションごとのイベント数は `events` から取得します。
+events セクションは直近のイベントメタデータをソースとし、クライアント別に
+プロンプト、トランスクリプト、コマンドのカバレッジを要約します。commands
+セクションはコマンド監査レコードをソースとし、クライアント別に失敗率を
+要約します。比率と失敗率は、ソースのカバレッジが完全な場合にのみ報告されます。
+
+usage セクションは、確定済みの `usage_observations` をソースとし、実行の識別情報を
+取得するために `usage_observation_runs` と、リポジトリ、チケット、プルリクエスト、
+バッチの帰属情報を取得するために `run_lineages` と結合します。置き換えられた
+observation は除外され、各 observation の最新かつ置き換えられていない
+スナップショットだけが集計されます。
+
+パケットとツール出力のバイト数は、`run_lineages` に記録された不変の実行情報です。
+これらは実行の識別情報によって重複排除され、`usage.runs` 配下に報告されます。
+そのため、同一実行に対して複数の usage observation が存在しても、バイト数が
+重複して加算されることはありません。
+
+sessions、events、commands、usage は、1つの読み取り専用トランザクション内で
+読み込まれます。各ファミリーには、観測件数と時間範囲を含む独立した
+カバレッジ範囲があります。カバレッジは `complete` または `partial` です。
+結果件数の上限によってファミリーが切り詰められた場合、その
+`truncation_reason` は `result_cap` になります。
+
+各 usage 集計には、記録された usage の terminal classification から、それに
+該当する observation 数へのマップである `terminal_classifications` が含まれます。
+テキストレポートでは、このマップを `terminal=...` として表示します。
+`unavailable_observations` は、usage カウンターがすべて利用できない observation の
+件数です。これには、カウンターの合計から除外された observation も含まれます。
 
 ### `traceary report workspace-identity`
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -776,6 +776,49 @@ Useful flags:
 - `--id-only`
 - `--json`
 
+### `traceary session run`
+
+`traceary session run` starts a one-shot session, supervises one child
+process, captures its usage, and finalizes the session when that process
+terminates. The wrapper is the sole owner of the terminal transition and
+writes the typed terminal reason. A nested host `SessionEnd` hook is a no-op
+while running under the wrapper, so it cannot finalize the session first or
+replace the wrapper's reason.
+
+| Terminal reason | Process result | Wrapper exit code |
+| --- | --- | ---: |
+| `success` | Child exits successfully | `0` |
+| `failure` | Child exits unsuccessfully | Child exit code |
+| `failure` | Child cannot be started | `127` |
+| `timeout` | Deadline expires | `124` |
+| `signal` | Child terminates from signal `N` on Unix | `128 + N` |
+| `aborted_stream` | Execution is canceled or its stream is aborted | `74` |
+| `legacy_unknown` | Legacy session without a typed reason | Not assigned by a new one-shot run |
+
+Classification accounts for races between child exit and supervisor
+cancellation. A clean child exit is `success` even if a deadline or
+cancellation becomes ready concurrently. On Unix, a child that can be shown
+to have exited on its own retains its non-zero exit code and is classified as
+`failure`. Otherwise, deadline expiration takes precedence over cancellation,
+followed by signal termination and other child exit errors.
+
+The non-Unix fallback cannot distinguish a supervisor termination reported as
+exit code 1 from a child's own exit with code 1. When that result races with
+the context, it conservatively uses the context result and classifies the run
+as `timeout` or `aborted_stream`.
+
+Session finalization has a five-second budget. If finalization fails after an
+otherwise successful child exit, the wrapper raises the exit code from `0` to
+`1`. A pre-existing non-zero child or supervisor exit code is preserved.
+Usage-capture failure exits with code `1`.
+
+The terminal-reason taxonomy above is distinct from the command-audit
+`--failure-reason` enum.
+
+Use [`traceary session repair-one-shot`](../operations/one-shot-repair.md) to
+inspect and repair stale one-shot sessions. The command is dry-run by default;
+applying a repair requires a backup and a validated evidence manifest.
+
 <a id="traceary-top"></a>
 
 ### `traceary sessions`
@@ -1107,6 +1150,37 @@ Full aggregation is the default. `--page-size` accepts 1 through 100,000, contro
 The `usage` object groups current finalized observations by provider, engine, model, repository, ticket, pull request, and batch. Token fields report known and unavailable observation counts separately, so a known zero is not confused with missing evidence. `accounted_observations` excludes alternative evidence marked for non-additive accounting, while `excluded_observations` keeps that evidence visible. `unavailable_observations` counts observations whose source data could not be read at all, so unavailable collection is never implied to be a successful zero. Cost rows remain separated by `origin`: `estimated` is never presented as `provider_reported`. Run packet and tool-output bytes are deduplicated by run identity and appear under `usage.runs`. Role, round, and wall time currently report `unavailable` because their authoritative values are not persisted.
 
 Useful flags: `--from`, `--to`, `--timezone`, `--workspace`, `--client`, `--page-size`, `--result-cap`, `--json`.
+
+#### Report lineage
+
+The report loads four source families. The sessions section comes from
+`sessions`, with per-session event counts from `events`. The events section
+comes from recent event metadata and summarizes prompt, transcript, and
+command coverage by client. The commands section comes from command-audit
+records and summarizes failure rates by client. Ratios and failure rates are
+reported only when their source coverage is complete.
+
+The usage section comes from finalized `usage_observations`, joined to
+`usage_observation_runs` for the run identity and to `run_lineages` for the
+repository, ticket, pull request, and batch attribution. Superseded
+observations are excluded: only the latest, non-superseded snapshot for an
+observation is aggregated.
+
+Packet and tool-output byte counts are immutable run facts from
+`run_lineages`. They are deduplicated by run identity and reported under
+`usage.runs`, so multiple usage observations for the same run do not multiply
+those byte counts.
+
+Sessions, events, commands, and usage are loaded in one read-only
+transaction. Each family has an independent coverage extent containing its
+observed count and time range. Coverage is `complete` or `partial`; when a
+result cap truncates a family, its `truncation_reason` is `result_cap`.
+
+Each usage aggregate includes `terminal_classifications`, a map from the
+recorded usage terminal classification to the number of matching
+observations. The text report renders this map as `terminal=...`.
+`unavailable_observations` counts observations for which all usage counters
+are unavailable, including observations excluded from counter totals.
 
 ### `traceary report workspace-identity`
 

--- a/docs/hooks/lifecycle-events.ja.md
+++ b/docs/hooks/lifecycle-events.ja.md
@@ -68,6 +68,20 @@ Traceary が終了まで監督できる単発プロセスには `traceary sessio
 
 たとえば `traceary session run -- codex exec "Review this change"` は `codex exec` プロセスの終了を根拠にセッションを閉じる。対話型 Codex の挙動は変わらず、通常の `Stop` はターン境界のままでセッション終了を合成しない。Traceary は transcript の文言やアイドル時間から完了を推測しない。
 
+`traceary session run` によって開始されたセッションでは、terminal transition と
+その型付き reason を所有するのは wrapper だけです。成功時は `0`、失敗時は
+子プロセスの code、timeout 時は `124`、Unix の signal `N` では `128 + N`、
+stream の中断時は `74`、子プロセスを起動できない場合は `127` で終了します。
+wrapper 配下のネストしたホストの `SessionEnd` hook は何も行わず、wrapper の
+terminal reason に先行することはできません。
+
+子プロセスの正常終了は、競合する deadline またはキャンセルより優先されます。
+Unix では、子プロセスが非ゼロで終了したことを確認できる場合、その結果は
+failure のままです。非 Unix のフォールバックでは、その終了と supervisor による
+終了を区別できない場合、保守的に context の結果を使用します。古い単発セッションは、
+[`traceary session repair-one-shot`](../operations/one-shot-repair.ja.md) を使用して
+調査および修復できます。
+
 ## Antigravity（v0.21.1+）
 
 Antigravity は Gemini CLI に代わる Traceary 連携ホストです。v0.21.1 からサポート対象の hook クライアントになりました（v0.21.0 は capability 診断のみ）。Tier 2 host と同様に canonical event kind へマッピングされます。

--- a/docs/hooks/lifecycle-events.md
+++ b/docs/hooks/lifecycle-events.md
@@ -68,6 +68,19 @@ Use `traceary session run -- <command> [args...]` when Traceary can supervise a 
 
 For example, `traceary session run -- codex exec "Review this change"` closes when the `codex exec` process exits. This does not change interactive Codex behavior: a normal Codex `Stop` remains a turn boundary and never becomes synthetic session completion. Traceary does not infer completion from transcript text or idle time.
 
+For a session started by `traceary session run`, the wrapper alone owns the
+terminal transition and its typed reason. It exits with `0` for success, the
+child code for failure, `124` for timeout, `128 + N` for Unix signal `N`,
+`74` for an aborted stream, or `127` when the child cannot be started.
+Nested host `SessionEnd` hooks are no-ops under the wrapper and cannot preempt
+its terminal reason.
+
+A clean child exit wins over a racing deadline or cancellation. On Unix, a
+child's proven non-zero exit remains a failure; the non-Unix fallback uses the
+context result conservatively when it cannot distinguish that exit from
+supervisor termination. Stale one-shot sessions can be inspected and repaired
+with [`traceary session repair-one-shot`](../operations/one-shot-repair.md).
+
 ## Antigravity (v0.21.1+)
 
 Antigravity is the successor to Gemini CLI as a Traceary-integrated host. As of v0.21.1 it is a supported hook client (capability diagnostics only in v0.21.0). It maps onto the canonical event kinds like a Tier 2 host:

--- a/docs/lifecycle.ja.md
+++ b/docs/lifecycle.ja.md
@@ -74,6 +74,21 @@ SessionStart → [AfterTool]* → SessionEnd
 
 > **v0.21 注**: Gemini CLI はレガシー互換パスです。後継ホストの Antigravity は v0.21.1 で Traceary のサポート対象 hook クライアントになりました（v0.21.0 は capability 診断のみ）。詳細は [Antigravity 統合状況](./integrations/antigravity.ja.md) を参照してください。
 
+### 単発セッションのライフサイクル
+
+単発セッションは、`traceary session run` が監視対象の子プロセスを起動した時点で
+開始します。通常の完了を所有するのは wrapper だけであり、型付きの terminal
+reason を記録してセッションを終了します。古いセッションは
+`traceary session gc` で終了できます。証拠に基づく修正が必要な古い単発レコードは、
+[`traceary session repair-one-shot`](operations/one-shot-repair.ja.md) で処理できます。
+
+| ライフサイクル遷移 | 所有者 | 結果 |
+| --- | --- | --- |
+| 単発セッションを開始 | `traceary session run` | 監視対象の単発セッションを作成 |
+| 単発セッションを終了 | 単発 wrapper | 型付きの terminal reason を記録 |
+| 古いセッションを終了 | `traceary session gc` | 古いセッションの終了処理を実行 |
+| 古い単発セッションを修復 | `traceary session repair-one-shot` | 証拠に裏付けられた修復を適用 |
+
 ## イベント種別
 
 | 種別 | 説明 | ソース |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -74,6 +74,22 @@ SessionStart → [AfterTool]* → SessionEnd
 
 > **v0.21 note**: Gemini CLI is the legacy compatibility path. The successor host, Antigravity, became a supported Traceary hook client in v0.21.1 (capability diagnostics only in v0.21.0). See [Antigravity integration status](./integrations/antigravity.md).
 
+### One-shot lifecycle
+
+A one-shot session starts when `traceary session run` launches its supervised
+child process. The wrapper is the sole owner of normal completion and ends
+the session with a typed terminal reason. Stale sessions can be closed by
+`traceary session gc`; stale one-shot records that require evidence-based
+correction can be handled by
+[`traceary session repair-one-shot`](operations/one-shot-repair.md).
+
+| Lifecycle transition | Owner | Result |
+| --- | --- | --- |
+| Start a one-shot session | `traceary session run` | Creates the supervised one-shot session |
+| End a one-shot session | One-shot wrapper | Records the typed terminal reason |
+| Close a stale session | `traceary session gc` | Performs stale-session closure |
+| Repair a stale one-shot session | `traceary session repair-one-shot` | Applies an evidence-backed repair |
+
 ## Event Kinds
 
 | Kind | Description | Source |

--- a/docs/mcp/README.ja.md
+++ b/docs/mcp/README.ja.md
@@ -27,6 +27,17 @@ Traceary が公開する MCP tool は 9 個で、golden snapshot `presentation/m
 
 `get_report` は CLI の `traceary report --json` と同じ応答スキーマを使い、usage と重複排除済み run fact の集計も含みます。`page_size` は 1 以上 100,000 以下で、本文を含まない SQLite 内部読み取りのページサイズだけを変え、既定は全件集計です。正の `result_cap` を指定した場合だけ、データ源ごとの部分集計を明示的に要求します。部分集計は観測件数・時刻範囲と `truncation_reason=result_cap` を返し、不完全な分母に基づく割合は省略します。usage 値は既知・取得不能の件数、加算対象外の会計証拠、provider reported と estimated の cost origin の分離を保持します。
 
+`get_report` は、`traceary report` と同じレポート生成パスとスキーマを使用します。
+sessions、events、commands、usage は、ファミリーごとに独立したカバレッジ範囲を
+持ち、1つの読み取り専用トランザクション内で読み込まれます。usage observation は、
+確定済みで最新かつ置き換えられていないスナップショットに限定されます。また、
+`usage_observation_runs` と `run_lineages` から、リポジトリ、チケット、
+プルリクエスト、バッチの来歴を含む実行の帰属情報を結合します。不変のパケットと
+ツール出力のバイト情報は、実行の識別情報ごとに1回だけカウントされます。
+`terminal_classifications` には、記録された usage の terminal classification ごとに
+グループ化した observation 数が含まれます。一方、`unavailable_observations` は、
+すべての usage カウンターが利用できない observation の件数です。
+
 `session_status(action="tree", session_id="...", depth=N)` は `session_id` を root とする session subtree を `traceary session tree --json` と同じ node array shape で返します。`depth` は任意で、`0` は root のみを返します。
 
 `session_status(action="active", ...)` は end marker 後にイベントを受け取った session を引き続き active として扱い、CLI `sessions --snapshot` の `ended_with_late_events` ルールと一致します。単独の `session_ended` の後に prompt や audit が続く場合、その session は active 結果から除外されません。

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -27,6 +27,17 @@ Traceary exposes 9 MCP tools, enforced by a golden snapshot (`presentation/mcpse
 
 `get_report` shares the CLI `traceary report --json` response schema, including usage and deduplicated run-fact aggregates. Its `page_size` accepts 1 through 100,000 and changes only internal body-free SQLite paging; full aggregation remains the default. A positive `result_cap` explicitly requests a per-source partial aggregate. Partial output includes observed counts/ranges and `truncation_reason=result_cap`, and omits percentages whose denominator is incomplete. Usage values preserve known/unavailable counts, excluded accounting evidence, and separate provider-reported versus estimated cost origins.
 
+`get_report` uses the same report-generation path and schema as
+`traceary report`. Sessions, events, commands, and usage are loaded in one
+read-only transaction with an independent coverage extent for each family.
+Usage observations are limited to finalized, latest non-superseded snapshots
+and join run attribution from `usage_observation_runs` and `run_lineages`,
+including repository, ticket, pull request, and batch provenance. Immutable
+packet and tool-output byte facts are counted once per run identity.
+`terminal_classifications` contains observation counts grouped by recorded
+usage terminal classification, while `unavailable_observations` counts
+observations for which every usage counter is unavailable.
+
 `session_status(action="tree", session_id="...", depth=N)` returns the JSON session subtree rooted at `session_id` using the same node array shape as `traceary session tree --json`; `depth` is optional and `0` returns only the root.
 
 `session_status(action="active", ...)` treats a session that received events after its end marker as still active, matching the CLI `sessions --snapshot` `ended_with_late_events` rule. A lone `session_ended` followed by later prompts or audits does not exclude the session from the active result.


### PR DESCRIPTION
## Summary

- Document report source lineage, coverage, supersession, and run-fact deduplication.
- Document `traceary session run` terminal reasons, exit codes, race handling, and finalization behavior.
- Clarify one-shot lifecycle ownership and repair procedures.
- Keep the English and Japanese documentation aligned.

## Changes

- `docs/cli/README.md` and `docs/cli/README.ja.md`
  - Add the `traceary session run` command reference.
  - Add report-lineage and usage-aggregation details.
- `docs/hooks/lifecycle-events.md` and `docs/hooks/lifecycle-events.ja.md`
  - Document wrapper ownership and terminal behavior for authoritative one-shot sessions.
- `docs/lifecycle.md` and `docs/lifecycle.ja.md`
  - Add the one-shot lifecycle and ownership table.
- `docs/mcp/README.md` and `docs/mcp/README.ja.md`
  - Document `get_report` provenance, coverage, and usage aggregation behavior.

## Test plan

- Review the English and Japanese documentation pairs for semantic consistency.
- Verify the documented exit-code and classification rules against the one-shot session behavior.
- Verify relative links to the one-shot repair documentation.
- Confirm the report and MCP descriptions match the shared report-generation schema.
- `go build ./...`, `go test ./...`, and `go run ./cmd/repo-tooling docs verify-i18n` (plus other docs verifiers) pass.

Codex verifier: ✅ PASS

Closes #1582
