### PR TITLE
perf: bound session resume queries

### DIFF
--- a/.ai/spec/1608.md
+++ b/.ai/spec/1608.md
@@ -1,0 +1,55 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- 目的: active/latest/handoff の読み取りを要求された件数に限定し、巨大な event body と無関係に index-backed で完了させる。
+- 現状: latest candidate 選択や session summary が event body を含む行・correlated subquery・N+1 hydration に依存し、store の payload 増加に比例して遅くなる。
+- 期待する振る舞い: 公開 CLI/MCP の結果と tie/filter/late-event semantics を維持し、metadata-only candidate selection の後に必要な最終行だけを hydrate する。handoff は preset/limit 内の records のみ読む。
+- 非対象: payload codec、search redesign、GC、compaction。既存 migration 34 で plan が成立する限り migration は追加しない。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Session candidate | session identity, normalized latest timestamp, lifecycle metadata | filters/ties を解決して最新 session を一意選択 | body を candidate ordering/filtering に使わない |
+| Hydrated session | selected session plus required details | public resultを構築 | candidate 確定後の一行だけ hydrate |
+| Handoff slice | bounded sessions/events/commands/memories | preset/limitに応じ context pack を構築 | requested bound 外の body を decode しない |
+| Event metadata projection | body-free event fields | ordering/filtering/summaryを供給 | source event semantics と同期し index-backed |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| candidate selection と set-based summaries | sqlite repository/query SQL | query plan と storage layout が変更理由 | usecase は SQLite detail を知らない |
+| active/latest policy | SessionUsecase | CLI/MCP 共通 semantics が変更理由 | handlers は transport adapter |
+| handoff limits/preset orchestration | ContextUsecase/contextPackBuilder | context contract が変更理由 | repository は preset policy を持たない |
+| CLI/MCP presentation | presentation adapters | encoding/transport が変更理由 | selection logic を重複させない |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| Session repository latest lookup | SessionUsecase | metadata projection/index/tie ordering | existing not-found/storage errorsを維持 |
+| Context queries | ContextUsecase | bounded SQL/set-based hydration | existing query errorsをwrapして維持 |
+| CLI/MCP active/latest/handoff | users/clients | query implementation | output schemaとstatus semanticsを維持 |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| latest filters/ties | equal normalized timestamps and filters | latest lookup | deterministic existing winner/filter result | repository/usecase |
+| ended session with late event | ended session receives later event | active/latest lookup | existing lifecycle/latest semantics preserved | integration |
+| GC/ancestor paging | deleted/ancestor-rich store | handoff/session listing | deleted rows excluded and paging stable | integration |
+| CLI/MCP parity | same store/request | both transports queried | equivalent result | presentation integration |
+| large-body independence | unrelated oversized bodies | active/latest/handoff | unrelated body is not decoded/required | repository integration |
+| indexed plan | production-shaped schema | EXPLAIN query plan | metadata indexes used; no unrelated body scan | query-plan test/evidence |
+| bounded commands | more commands than requested | handoff limit 10 | at most 10 recent commands hydrated | usecase/integration |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| metadata-only latest | plan/body-independence test exposes current scan/hydration | split candidate SQL from final hydration | shared deterministic ordering expression |
+| set-based session summaries | query-count/body test exposes N+1 | aggregate/project summaries in one bounded query | row mapping helper |
+| bounded handoff | oversized fixture exceeds requested reads/latency | push limits into queries and hydrate selected IDs only | explicit bounded query request value |
+| compatibility | parity/tie/late tests fail on semantic drift | restore ordering/filter invariants | keep transport adapters thin |
+
+### Risks / rollback
+- 手続き化リスク: builder/usecase が SQL-specific branching と manual N+1 を抱えること。selection/aggregation は repository query に置く。
+- premature abstraction リスク: 一般的 query framework は作らず active/latest/handoff の既存 consumer-oriented interfacesを維持する。
+- migration / compatibility: migration 34 の projection/index を第一候補とし、EXPLAIN で不足が証明された場合だけ additive migrationを検討する。API/schemaは変更しない。
+- rollback trigger: parity、tie/lifecycle semantics、query plan、latency thresholdのいずれかを満たさない場合は query変更をrevert可能。projection migration自体は#1607由来のため変更しない。

--- a/application/usecase/context_pack_builder.go
+++ b/application/usecase/context_pack_builder.go
@@ -10,8 +10,13 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	domtypes "github.com/duck8823/traceary/domain/types"
 )
+
+type compactSummaryPreviewQuery interface {
+	FindLatestPostCompactSummary(context.Context, domtypes.SessionID, domtypes.Workspace) (domtypes.Optional[*model.Event], error)
+}
 
 type contextPackBuilder struct {
 	sessionQuery queryservice.SessionQueryService
@@ -148,6 +153,16 @@ func (b *contextPackBuilder) loadRecentCommands(ctx context.Context, session app
 }
 
 func (b *contextPackBuilder) loadCompactSummary(ctx context.Context, session apptypes.SessionSummary) (string, error) {
+	if previewQuery, ok := b.eventQuery.(compactSummaryPreviewQuery); ok {
+		result, err := previewQuery.FindLatestPostCompactSummary(ctx, session.SessionID(), session.Workspace())
+		if err != nil {
+			return "", xerrors.Errorf("failed to find compact summary preview for context pack: %w", err)
+		}
+		if event, found := result.Value(); found {
+			return extractCompactSummarySignal(event.Body()), nil
+		}
+		return "", nil
+	}
 	// Pull a small window of compact_summary events and skip
 	// pre-compact snapshots so the handoff path always returns the
 	// most recent POST-compact digest even when a cancelled compact

--- a/cmd/store-benchmark/main_test.go
+++ b/cmd/store-benchmark/main_test.go
@@ -33,19 +33,21 @@ func TestSyntheticFixtureAndBenchmarkEvidence(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	for _, benchmarkCase := range benchmarkCases {
-		if benchmarkCase.Name == "active" || benchmarkCase.Name == "latest" {
-			matched, err := queryHasRows(context.Background(), path, benchmarkCase.SQL, benchmarkCase.Args)
-			if err != nil || !matched {
-				t.Fatalf("%s preflight matched=%v error=%v", benchmarkCase.Name, matched, err)
+	for cycle := 0; cycle < 2; cycle++ {
+		for _, benchmarkCase := range benchmarkCases {
+			if benchmarkCase.Name == "active" || benchmarkCase.Name == "latest" {
+				matched, err := queryHasRows(context.Background(), path, benchmarkCase.SQL, benchmarkCase.Args)
+				if err != nil || !matched {
+					t.Fatalf("%s preflight matched=%v error=%v", benchmarkCase.Name, matched, err)
+				}
 			}
-		}
-		result, err := benchmark(context.Background(), path, 2, benchmarkCase.Name, benchmarkCase.SQL, benchmarkCase.Args)
-		if err != nil {
-			t.Fatalf("benchmark(%s) error = %v", benchmarkCase.Name, err)
-		}
-		if len(result.QueryPlan) == 0 {
-			t.Fatalf("benchmark(%s) has no query-plan evidence", benchmarkCase.Name)
+			result, err := benchmark(context.Background(), path, 2, benchmarkCase.Name, benchmarkCase.SQL, benchmarkCase.Args)
+			if err != nil {
+				t.Fatalf("benchmark(%s) error = %v", benchmarkCase.Name, err)
+			}
+			if len(result.QueryPlan) == 0 {
+				t.Fatalf("benchmark cycle %d (%s) has no query-plan evidence", cycle, benchmarkCase.Name)
+			}
 		}
 	}
 	before := snapshotStoreFiles(t, path)

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -29,7 +29,7 @@ func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchm
 	}
 	return []CapacityBenchmarkQuery{
 		{Name: "active", SQL: findLatestSessionQuery, Args: []any{"session_started", "session_ended", "session_started", "session_ended", "session_started", "", "", "", "", "", "", "session_started", true, "session_ended", true, true}},
-		{Name: "latest", SQL: findLatestSessionQuery, Args: []any{"session_started", "session_ended", "session_started", "session_ended", "session_started", "", "", "", "", "", "", "session_started", false, "session_ended", false, false}},
+		{Name: "latest", SQL: findLatestSessionBoundaryQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started"}},
 		{Name: "search", SQL: searchSQL, Args: searchArgs},
 	}, nil
 }

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -38,6 +38,6 @@ func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchm
 func CapacityHandoffPlanQueries() []CapacityBenchmarkQuery {
 	return []CapacityBenchmarkQuery{
 		{Name: "session_resolution", SQL: listSessionsQuery, Args: []any{"", "", "", "", "", "", "", "", "", "", "", "", false, "", "", "", "", 1, 0}},
-		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{512, "", "", 5}},
+		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{"", "", 5, 512}},
 	}
 }

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -39,5 +39,6 @@ func CapacityHandoffPlanQueries() []CapacityBenchmarkQuery {
 	return []CapacityBenchmarkQuery{
 		{Name: "session_resolution", SQL: listSessionsQuery, Args: []any{"", "", "", "", "", "", "", "", "", "", "", "", false, "", "", "", "", 1, 0}},
 		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{"", "", 5, 512}},
+		{Name: "compact_summary", SQL: selectLatestPostCompactSummaryQuery, Args: []any{"", "", ""}},
 	}
 }

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -27,9 +27,10 @@ func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchm
 	if !complete {
 		searchSQL, searchArgs = buildIncompleteFTSEventIDsQuery(searchCriteria, searchCriteria.Query())
 	}
+	latestSQL := latestSessionBoundarySQL(ctx, db)
 	return []CapacityBenchmarkQuery{
 		{Name: "active", SQL: findActiveSessionQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started", "session_ended"}},
-		{Name: "latest", SQL: findLatestSessionBoundaryQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started"}},
+		{Name: "latest", SQL: latestSQL, Args: []any{"session_started", "", "", "", "", "", "", "session_started"}},
 		{Name: "search", SQL: searchSQL, Args: searchArgs},
 	}, nil
 }

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -40,6 +40,6 @@ func CapacityHandoffPlanQueries() []CapacityBenchmarkQuery {
 	return []CapacityBenchmarkQuery{
 		{Name: "session_resolution", SQL: listSessionsQuery, Args: []any{"", "", "", "", "", "", "", "", "", "", "", "", false, "", "", "", "", 1, 0}},
 		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{"", "", 5, 512}},
-		{Name: "compact_summary", SQL: selectLatestPostCompactSummaryQuery, Args: []any{"", "", ""}},
+		{Name: "compact_summary", SQL: selectLatestPostCompactSummaryQuery, Args: []any{"", "", "", "", "", "", "", 32}},
 	}
 }

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -28,7 +28,7 @@ func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchm
 		searchSQL, searchArgs = buildIncompleteFTSEventIDsQuery(searchCriteria, searchCriteria.Query())
 	}
 	return []CapacityBenchmarkQuery{
-		{Name: "active", SQL: findLatestSessionQuery, Args: []any{"session_started", "session_ended", "session_started", "session_ended", "session_started", "", "", "", "", "", "", "session_started", true, "session_ended", true, true}},
+		{Name: "active", SQL: findActiveSessionQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started", "session_ended"}},
 		{Name: "latest", SQL: findLatestSessionBoundaryQuery, Args: []any{"session_started", "", "", "", "", "", "", "session_started"}},
 		{Name: "search", SQL: searchSQL, Args: searchArgs},
 	}, nil

--- a/infrastructure/sqlite/capacity_benchmark_queries_internal_test.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries_internal_test.go
@@ -26,7 +26,7 @@ func TestCapacityBenchmarkQueriesShareProductionSources(t *testing.T) {
 	if len(queries) != 3 {
 		t.Fatalf("query count = %d", len(queries))
 	}
-	if queries[0].SQL != findLatestSessionQuery || queries[1].SQL != findLatestSessionBoundaryQuery {
+	if queries[0].SQL != findActiveSessionQuery || queries[1].SQL != findLatestSessionBoundaryQuery {
 		t.Fatal("active/latest do not use their production FindLatest sources")
 	}
 	plans := CapacityHandoffPlanQueries()

--- a/infrastructure/sqlite/capacity_benchmark_queries_internal_test.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries_internal_test.go
@@ -26,11 +26,8 @@ func TestCapacityBenchmarkQueriesShareProductionSources(t *testing.T) {
 	if len(queries) != 3 {
 		t.Fatalf("query count = %d", len(queries))
 	}
-	if queries[0].SQL != findLatestSessionQuery || queries[1].SQL != findLatestSessionQuery {
-		t.Fatal("active/latest do not share production FindLatest source")
-	}
-	if queries[1].Args[12] != false {
-		t.Fatal("latest must use production activeOnly=false binding")
+	if queries[0].SQL != findLatestSessionQuery || queries[1].SQL != findLatestSessionBoundaryQuery {
+		t.Fatal("active/latest do not use their production FindLatest sources")
 	}
 	plans := CapacityHandoffPlanQueries()
 	if plans[0].SQL != listSessionsQuery || plans[1].SQL != selectRecentCommandPreviewsQuery {

--- a/infrastructure/sqlite/compact_summary_preview_internal_test.go
+++ b/infrastructure/sqlite/compact_summary_preview_internal_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,7 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 )
 
-func TestCompactSummaryPreviewSkipsNewerPreCompactSnapshot(t *testing.T) {
+func TestCompactSummaryPreviewSkipsLeadingWhitespaceLegacyMarkersAcrossPages(t *testing.T) {
 	ctx := context.Background()
 	database := NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
 	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
@@ -20,10 +21,15 @@ func TestCompactSummaryPreviewSkipsNewerPreCompactSnapshot(t *testing.T) {
 	}
 	events := NewEventDatasource(database)
 	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
-	for _, event := range []*model.Event{
-		model.EventOfWithSourceHook("post", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "usable summary", base, "post_compact"),
-		model.EventOfWithSourceHook("pre", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "newer snapshot", base.Add(time.Second), "pre_compact"),
-	} {
+	post := model.EventOfWithSourceHook("post", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "usable summary", base, "post_compact")
+	if err := events.Save(ctx, post); err != nil {
+		t.Fatal(err)
+	}
+	// More than one candidate page proves continuation cannot false-select a
+	// whitespace-prefixed legacy pre-compact snapshot.
+	for index := 0; index < 33; index++ {
+		body := " \n\t" + types.EventBodyMarkerCompactPreSnapshot + " private snapshot"
+		event := model.EventOf(types.EventID(fmt.Sprintf("legacy-pre-%02d", index)), types.EventKindCompactSummary, "cli", "codex", "session", "workspace", body, base.Add(time.Duration(index+1)*time.Second))
 		if err := events.Save(ctx, event); err != nil {
 			t.Fatal(err)
 		}
@@ -34,21 +40,20 @@ func TestCompactSummaryPreviewSkipsNewerPreCompactSnapshot(t *testing.T) {
 	}
 	event, ok := result.Value()
 	if !ok || event.EventID() != "post" || event.Body() != "usable summary" {
-		t.Fatalf("preview did not return the latest usable post-compact summary")
+		t.Fatalf("preview did not continue to the latest usable post-compact summary")
 	}
 }
 
 func TestCompactSummaryPreviewSelectsMetadataBeforeHydration(t *testing.T) {
-	normalized := strings.Join(strings.Fields(strings.ToLower(selectLatestPostCompactSummaryQuery)), " ")
-	selectedEnd := strings.Index(normalized, ") select e.id")
-	if selectedEnd < 0 {
-		t.Fatalf("query has no bounded candidate phase: %s", normalized)
-	}
-	candidate := normalized[:selectedEnd]
+	candidate := strings.Join(strings.Fields(strings.ToLower(selectLatestPostCompactSummaryQuery)), " ")
 	if !strings.Contains(candidate, "from event_metadata_projection m") || strings.Contains(candidate, " from events ") || strings.Contains(candidate, ".body") {
-		t.Fatalf("candidate phase is not body-free: %s", candidate)
+		t.Fatalf("candidate query is not body-free: %s", candidate)
 	}
-	if !strings.Contains(normalized, "limit 1") || !strings.Contains(normalized, "join events e on e.id = selected.id") {
-		t.Fatalf("query does not hydrate exactly one selected identity: %s", normalized)
+	if !strings.Contains(candidate, "m.created_at_norm < ?") || !strings.Contains(candidate, "m.id < ?") || !strings.Contains(candidate, "limit ?") {
+		t.Fatalf("candidate query lacks bounded keyset continuation: %s", candidate)
+	}
+	hydration := strings.Join(strings.Fields(strings.ToLower(selectEventByIDQuery)), " ")
+	if !strings.Contains(hydration, "from events e where e.id = ?") {
+		t.Fatalf("candidate hydration is not an identity lookup: %s", hydration)
 	}
 }

--- a/infrastructure/sqlite/compact_summary_preview_internal_test.go
+++ b/infrastructure/sqlite/compact_summary_preview_internal_test.go
@@ -25,6 +25,10 @@ func TestCompactSummaryPreviewSkipsLeadingWhitespaceLegacyMarkersAcrossPages(t *
 	if err := events.Save(ctx, post); err != nil {
 		t.Fatal(err)
 	}
+	knownPre := model.EventOfWithSourceHook("known-pre", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "known private snapshot", base.Add(40*time.Second), "pre_compact")
+	if err := events.Save(ctx, knownPre); err != nil {
+		t.Fatal(err)
+	}
 	// More than one candidate page proves continuation cannot false-select a
 	// whitespace-prefixed legacy pre-compact snapshot.
 	for index := 0; index < 33; index++ {
@@ -48,6 +52,9 @@ func TestCompactSummaryPreviewSelectsMetadataBeforeHydration(t *testing.T) {
 	candidate := strings.Join(strings.Fields(strings.ToLower(selectLatestPostCompactSummaryQuery)), " ")
 	if !strings.Contains(candidate, "from event_metadata_projection m") || strings.Contains(candidate, " from events ") || strings.Contains(candidate, ".body") {
 		t.Fatalf("candidate query is not body-free: %s", candidate)
+	}
+	if !strings.Contains(candidate, "coalesce(m.source_hook, m.legacy_source_hook, '') <> 'pre_compact'") {
+		t.Fatalf("known pre-compact candidates are not excluded by metadata: %s", candidate)
 	}
 	if !strings.Contains(candidate, "m.created_at_norm < ?") || !strings.Contains(candidate, "m.id < ?") || !strings.Contains(candidate, "limit ?") {
 		t.Fatalf("candidate query lacks bounded keyset continuation: %s", candidate)

--- a/infrastructure/sqlite/compact_summary_preview_internal_test.go
+++ b/infrastructure/sqlite/compact_summary_preview_internal_test.go
@@ -1,0 +1,54 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestCompactSummaryPreviewSkipsNewerPreCompactSnapshot(t *testing.T) {
+	ctx := context.Background()
+	database := NewDatabase(filepath.Join(t.TempDir(), "traceary.db"), os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	events := NewEventDatasource(database)
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	for _, event := range []*model.Event{
+		model.EventOfWithSourceHook("post", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "usable summary", base, "post_compact"),
+		model.EventOfWithSourceHook("pre", types.EventKindCompactSummary, "cli", "codex", "session", "workspace", "newer snapshot", base.Add(time.Second), "pre_compact"),
+	} {
+		if err := events.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := events.FindLatestPostCompactSummary(ctx, "session", "workspace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, ok := result.Value()
+	if !ok || event.EventID() != "post" || event.Body() != "usable summary" {
+		t.Fatalf("preview did not return the latest usable post-compact summary")
+	}
+}
+
+func TestCompactSummaryPreviewSelectsMetadataBeforeHydration(t *testing.T) {
+	normalized := strings.Join(strings.Fields(strings.ToLower(selectLatestPostCompactSummaryQuery)), " ")
+	selectedEnd := strings.Index(normalized, ") select e.id")
+	if selectedEnd < 0 {
+		t.Fatalf("query has no bounded candidate phase: %s", normalized)
+	}
+	candidate := normalized[:selectedEnd]
+	if !strings.Contains(candidate, "from event_metadata_projection m") || strings.Contains(candidate, " from events ") || strings.Contains(candidate, ".body") {
+		t.Fatalf("candidate phase is not body-free: %s", candidate)
+	}
+	if !strings.Contains(normalized, "limit 1") || !strings.Contains(normalized, "join events e on e.id = selected.id") {
+		t.Fatalf("query does not hydrate exactly one selected identity: %s", normalized)
+	}
+}

--- a/infrastructure/sqlite/event_preview_datasource.go
+++ b/infrastructure/sqlite/event_preview_datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -11,11 +12,15 @@ import (
 
 	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
 
 //go:embed sql/select_recent_command_previews.sql
 var selectRecentCommandPreviewsQuery string
+
+//go:embed sql/select_latest_post_compact_summary.sql
+var selectLatestPostCompactSummaryQuery string
 
 var _ queryservice.EventPreviewQueryService = (*EventDatasource)(nil)
 
@@ -87,4 +92,23 @@ func scanEventBodyPreview(row interface{ Scan(...any) error }) (apptypes.EventBo
 		return apptypes.EventBodyPreview{}, xerrors.Errorf("failed to restore event body preview: %w", err)
 	}
 	return preview, nil
+}
+
+// FindLatestPostCompactSummary selects the newest usable compact summary on
+// the body-free projection and hydrates only that event.
+func (d *EventDatasource) FindLatestPostCompactSummary(ctx context.Context, sessionID types.SessionID, workspace types.Workspace) (types.Optional[*model.Event], error) {
+	db, err := d.db.open(ctx)
+	if err != nil {
+		return types.None[*model.Event](), xerrors.Errorf("failed to open DB for compact summary preview: %w", err)
+	}
+	defer d.db.release(db)
+	row := db.QueryRowContext(ctx, selectLatestPostCompactSummaryQuery, sessionID.String(), workspace.String(), workspace.String())
+	event, err := scanEvent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return types.None[*model.Event](), nil
+	}
+	if err != nil {
+		return types.None[*model.Event](), xerrors.Errorf("failed to restore compact summary preview: %w", err)
+	}
+	return types.Some(event), nil
 }

--- a/infrastructure/sqlite/event_preview_datasource.go
+++ b/infrastructure/sqlite/event_preview_datasource.go
@@ -32,7 +32,7 @@ func (d *EventDatasource) ListRecentCommandPreviews(ctx context.Context, session
 		return nil, xerrors.Errorf("failed to open DB for command previews: %w", err)
 	}
 	defer d.db.release(db)
-	rows, err := db.QueryContext(ctx, selectRecentCommandPreviewsQuery, bodyRuneLimit, sessionID.String(), sessionID.String(), limit)
+	rows, err := db.QueryContext(ctx, selectRecentCommandPreviewsQuery, sessionID.String(), sessionID.String(), limit, bodyRuneLimit)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query recent command previews: %w", err)
 	}

--- a/infrastructure/sqlite/event_preview_datasource.go
+++ b/infrastructure/sqlite/event_preview_datasource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
-	"errors"
 	"log/slog"
+	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -21,6 +21,9 @@ var selectRecentCommandPreviewsQuery string
 
 //go:embed sql/select_latest_post_compact_summary.sql
 var selectLatestPostCompactSummaryQuery string
+
+//go:embed sql/select_event_by_id.sql
+var selectEventByIDQuery string
 
 var _ queryservice.EventPreviewQueryService = (*EventDatasource)(nil)
 
@@ -94,21 +97,58 @@ func scanEventBodyPreview(row interface{ Scan(...any) error }) (apptypes.EventBo
 	return preview, nil
 }
 
-// FindLatestPostCompactSummary selects the newest usable compact summary on
-// the body-free projection and hydrates only that event.
+// FindLatestPostCompactSummary pages over body-free candidates and hydrates
+// only candidates needed to find the newest usable post-compact summary.
 func (d *EventDatasource) FindLatestPostCompactSummary(ctx context.Context, sessionID types.SessionID, workspace types.Workspace) (types.Optional[*model.Event], error) {
 	db, err := d.db.open(ctx)
 	if err != nil {
 		return types.None[*model.Event](), xerrors.Errorf("failed to open DB for compact summary preview: %w", err)
 	}
 	defer d.db.release(db)
-	row := db.QueryRowContext(ctx, selectLatestPostCompactSummaryQuery, sessionID.String(), workspace.String(), workspace.String())
-	event, err := scanEvent(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return types.None[*model.Event](), nil
+
+	const candidateBatchSize = 32
+	anchorTime, anchorID := "", ""
+	for {
+		rows, queryErr := db.QueryContext(ctx, selectLatestPostCompactSummaryQuery,
+			sessionID.String(), workspace.String(), workspace.String(),
+			anchorTime, anchorTime, anchorTime, anchorID, candidateBatchSize,
+		)
+		if queryErr != nil {
+			return types.None[*model.Event](), xerrors.Errorf("failed to query compact summary candidates: %w", queryErr)
+		}
+		type candidate struct{ id, createdAtNorm string }
+		candidates := make([]candidate, 0, candidateBatchSize)
+		for rows.Next() {
+			var item candidate
+			if scanErr := rows.Scan(&item.id, &item.createdAtNorm); scanErr != nil {
+				_ = rows.Close()
+				return types.None[*model.Event](), xerrors.Errorf("failed to scan compact summary candidate: %w", scanErr)
+			}
+			candidates = append(candidates, item)
+		}
+		iterationErr := rows.Err()
+		closeErr := rows.Close()
+		if iterationErr != nil {
+			return types.None[*model.Event](), xerrors.Errorf("failed to iterate compact summary candidates: %w", iterationErr)
+		}
+		if closeErr != nil {
+			return types.None[*model.Event](), xerrors.Errorf("failed to close compact summary candidates: %w", closeErr)
+		}
+		for _, item := range candidates {
+			event, scanErr := scanEvent(db.QueryRowContext(ctx, selectEventByIDQuery, item.id))
+			if scanErr != nil {
+				return types.None[*model.Event](), xerrors.Errorf("failed to restore compact summary candidate: %w", scanErr)
+			}
+			body := strings.TrimSpace(event.Body())
+			if event.SourceHook() == "pre_compact" || strings.HasPrefix(body, types.EventBodyMarkerCompactPreSnapshot) {
+				continue
+			}
+			return types.Some(event), nil
+		}
+		if len(candidates) < candidateBatchSize {
+			return types.None[*model.Event](), nil
+		}
+		last := candidates[len(candidates)-1]
+		anchorTime, anchorID = last.createdAtNorm, last.id
 	}
-	if err != nil {
-		return types.None[*model.Event](), xerrors.Errorf("failed to restore compact summary preview: %w", err)
-	}
-	return types.Some(event), nil
 }

--- a/infrastructure/sqlite/event_preview_query_internal_test.go
+++ b/infrastructure/sqlite/event_preview_query_internal_test.go
@@ -11,6 +11,9 @@ func TestEventPreviewQuery_SelectsOnlyBoundedBodyPrefix(t *testing.T) {
 	if !strings.Contains(normalized, "substr(e.body, 1, ?)") {
 		t.Fatalf("preview query must select a bounded body prefix: %s", normalized)
 	}
+	if !strings.Contains(normalized, "from event_metadata_projection m") || !strings.Contains(normalized, "join events e on e.id = selected.id") {
+		t.Fatalf("preview query must select metadata candidates before hydrating bounded bodies: %s", normalized)
+	}
 	if strings.Contains(normalized, "select e.body,") || strings.Contains(normalized, ", e.body,") {
 		t.Fatalf("preview query selects an unbounded body column: %s", normalized)
 	}

--- a/infrastructure/sqlite/find_active_session_internal_test.go
+++ b/infrastructure/sqlite/find_active_session_internal_test.go
@@ -1,0 +1,53 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestActiveSessionQueryStreamsStartedCandidatesBeforeHydration(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(path, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	args := []any{"session_started", "", "", "", "", "", "", "session_started", "session_ended"}
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+findActiveSessionQuery, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	normalized := strings.ToLower(plan.String())
+	if !strings.Contains(normalized, "search started using index idx_event_metadata_kind_created_at_norm_id_desc (kind=?)") {
+		t.Fatalf("active candidates are not streamed in time order from the body-free kind index:\n%s", plan.String())
+	}
+	if strings.Contains(normalized, "use temp b-tree for order by") {
+		t.Fatalf("active lookup sorts all candidates instead of stopping at the first match:\n%s", plan.String())
+	}
+	if !strings.Contains(normalized, "search e using index sqlite_autoindex_events_1 (id=?)") {
+		t.Fatalf("active lookup does not hydrate only the selected identity:\n%s", plan.String())
+	}
+}

--- a/infrastructure/sqlite/find_latest_session_boundary_internal_test.go
+++ b/infrastructure/sqlite/find_latest_session_boundary_internal_test.go
@@ -1,0 +1,50 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLatestSessionBoundaryQueryUsesBodyFreeBoundaryIndex(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "traceary.db")
+	database := NewDatabase(path, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	args := []any{"session_started", "", "", "", "", "", "", "session_started"}
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+findLatestSessionBoundaryQuery, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	normalized := strings.ToLower(plan.String())
+	if !strings.Contains(normalized, "idx_event_metadata_kind_created_at_norm_id_desc") || !strings.Contains(normalized, "idx_event_metadata_workspace_session_created_at_norm_id_desc") {
+		t.Fatalf("latest lookup candidate phases are not index-backed on the body-free projection:\n%s", plan.String())
+	}
+	if !strings.Contains(normalized, "search e using index sqlite_autoindex_events_1 (id=?)") {
+		t.Fatalf("latest lookup does not hydrate only the selected event identity:\n%s", plan.String())
+	}
+}

--- a/infrastructure/sqlite/find_latest_session_boundary_internal_test.go
+++ b/infrastructure/sqlite/find_latest_session_boundary_internal_test.go
@@ -40,6 +40,10 @@ func TestLatestSessionBoundaryQueryUsesBodyFreeBoundaryIndex(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatal(err)
 	}
+	selectedSQL := latestSessionBoundarySQL(ctx, db)
+	if !strings.Contains(selectedSQL, "INDEXED BY "+latestSessionBoundaryIndex) {
+		t.Fatalf("migration-35 store did not select the deterministic boundary index")
+	}
 	normalized := strings.ToLower(plan.String())
 	if !strings.Contains(normalized, "idx_event_metadata_kind_created_at_norm_id_desc") || !strings.Contains(normalized, "idx_event_metadata_workspace_session_created_at_norm_id_desc") {
 		t.Fatalf("latest lookup candidate phases are not index-backed on the body-free projection:\n%s", plan.String())

--- a/infrastructure/sqlite/list_sessions_test.go
+++ b/infrastructure/sqlite/list_sessions_test.go
@@ -108,6 +108,25 @@ ON events(session_id, created_at DESC, id DESC);`),
 ALTER TABLE sessions ADD COLUMN terminal_reason TEXT NOT NULL DEFAULT '' CHECK (terminal_reason IN ('', 'success', 'failure', 'timeout', 'signal', 'aborted_stream', 'legacy_unknown'));
 UPDATE sessions SET terminal_reason = 'legacy_unknown' WHERE ended_at IS NOT NULL AND terminal_reason = '';`),
 		},
+		"000025_add_normalized_event_timestamp.sql": {
+			Data: []byte(`ALTER TABLE events ADD COLUMN created_at_norm TEXT;
+UPDATE events SET created_at_norm = ts_norm(created_at);`),
+		},
+		"000034_create_event_metadata_projection.sql": {
+			Data: []byte(`CREATE TABLE event_metadata_projection (
+    id TEXT PRIMARY KEY, kind TEXT NOT NULL, client TEXT NOT NULL, agent TEXT NOT NULL,
+    session_id TEXT NOT NULL, workspace TEXT NOT NULL, created_at TEXT NOT NULL,
+    created_at_norm TEXT NOT NULL
+);
+INSERT INTO event_metadata_projection
+SELECT id, kind, client, agent, session_id, workspace, created_at, created_at_norm FROM events;
+CREATE INDEX idx_event_metadata_created_at_norm_id_desc ON event_metadata_projection(created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_session_created_at_norm_id_desc ON event_metadata_projection(session_id, created_at_norm DESC, id DESC);
+CREATE INDEX idx_event_metadata_kind_created_at_norm_id_desc ON event_metadata_projection(kind, created_at_norm DESC, id DESC);
+CREATE TRIGGER event_metadata_projection_events_after_insert AFTER INSERT ON events BEGIN
+    INSERT INTO event_metadata_projection VALUES (NEW.id, NEW.kind, NEW.client, NEW.agent, NEW.session_id, NEW.workspace, NEW.created_at, ts_norm(NEW.created_at));
+END;`),
+		},
 	}
 }
 

--- a/infrastructure/sqlite/session_bounded_query_internal_test.go
+++ b/infrastructure/sqlite/session_bounded_query_internal_test.go
@@ -1,0 +1,37 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindLatestSelectsCandidatesWithoutEventBodies(t *testing.T) {
+	normalized := strings.Join(strings.Fields(strings.ToLower(findLatestSessionQuery)), " ")
+	selectedAt := strings.Index(normalized, "), selected as (")
+	if selectedAt < 0 {
+		t.Fatalf("FindLatest query has no bounded selection phase: %s", normalized)
+	}
+	candidatePhase := normalized[:selectedAt]
+	if !strings.Contains(candidatePhase, "from event_metadata_projection started") {
+		t.Fatalf("candidate selection does not use the body-free projection: %s", candidatePhase)
+	}
+	if strings.Contains(candidatePhase, " from events ") || strings.Contains(candidatePhase, " join events ") || strings.Contains(candidatePhase, ".body") {
+		t.Fatalf("candidate selection opens body-bearing event rows: %s", candidatePhase)
+	}
+	if count := strings.Count(normalized, "join events e on e.id = selected.id"); count != 1 {
+		t.Fatalf("FindLatest must hydrate exactly the selected event, hydration joins = %d: %s", count, normalized)
+	}
+}
+
+func TestListSessionsHydratesOnlyLatestBodiesForBoundedPage(t *testing.T) {
+	normalized := strings.Join(strings.Fields(strings.ToLower(listSessionsQuery)), " ")
+	if !strings.Contains(normalized, "from filtered_sessions fs cross join event_metadata_projection e") {
+		t.Fatalf("session aggregation is not driven by the bounded page and metadata projection: %s", normalized)
+	}
+	if count := strings.Count(normalized, "left join events latest_body on latest_body.id = latest.latest_event_id"); count != 1 {
+		t.Fatalf("session list must hydrate only each selected session's latest event, hydration joins = %d: %s", count, normalized)
+	}
+	if strings.Contains(normalized, "select session_id, id as latest_event_id, created_at as latest_event_at, kind as latest_event_kind, body") {
+		t.Fatalf("latest-event candidate selection includes body: %s", normalized)
+	}
+}

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -38,6 +38,9 @@ var selectSessionByIDQuery string
 //go:embed sql/find_latest_session.sql
 var findLatestSessionQuery string
 
+//go:embed sql/find_latest_session_boundary.sql
+var findLatestSessionBoundaryQuery string
+
 //go:embed sql/list_sessions.sql
 var listSessionsQuery string
 
@@ -537,6 +540,22 @@ func (d *SessionDatasource) FindLatest(
 			slog.Debug("failed to close resource", "error", err)
 		}
 	}()
+
+	if !activeOnly {
+		row := db.QueryRowContext(ctx, findLatestSessionBoundaryQuery,
+			types.EventKindSessionStarted.String(),
+			client.String(), client.String(), agent.String(), agent.String(), workspace.String(), workspace.String(),
+			types.EventKindSessionStarted.String(),
+		)
+		event, scanErr := scanEvent(row)
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return types.None[*model.Event](), nil
+		}
+		if scanErr != nil {
+			return types.None[*model.Event](), xerrors.Errorf("failed to restore latest session event: %w", scanErr)
+		}
+		return types.Some(event), nil
+	}
 
 	row := db.QueryRowContext(
 		ctx,

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -527,6 +527,17 @@ func (d *SessionDatasource) UpdateModelIfEmpty(ctx context.Context, sessionID ty
 	return rows > 0, nil
 }
 
+const latestSessionBoundaryIndex = "idx_event_metadata_boundary_time_context"
+
+func latestSessionBoundarySQL(ctx context.Context, db *sql.DB) string {
+	var exists int
+	err := db.QueryRowContext(ctx, "SELECT 1 FROM sqlite_schema WHERE type = 'index' AND name = ?", latestSessionBoundaryIndex).Scan(&exists)
+	if err != nil || exists != 1 {
+		return findLatestSessionBoundaryQuery
+	}
+	return strings.Replace(findLatestSessionBoundaryQuery, "event_metadata_projection boundary", "event_metadata_projection boundary INDEXED BY "+latestSessionBoundaryIndex, 1)
+}
+
 // FindLatest returns the session_started event for the latest matching
 // session. Returns an empty Optional when no matching session exists.
 func (d *SessionDatasource) FindLatest(
@@ -545,7 +556,7 @@ func (d *SessionDatasource) FindLatest(
 	}()
 
 	if !activeOnly {
-		row := db.QueryRowContext(ctx, findLatestSessionBoundaryQuery,
+		row := db.QueryRowContext(ctx, latestSessionBoundarySQL(ctx, db),
 			types.EventKindSessionStarted.String(),
 			client.String(), client.String(), agent.String(), agent.String(), workspace.String(), workspace.String(),
 			types.EventKindSessionStarted.String(),

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -38,6 +38,9 @@ var selectSessionByIDQuery string
 //go:embed sql/find_latest_session.sql
 var findLatestSessionQuery string
 
+//go:embed sql/find_active_session.sql
+var findActiveSessionQuery string
+
 //go:embed sql/find_latest_session_boundary.sql
 var findLatestSessionBoundaryQuery string
 
@@ -557,22 +560,10 @@ func (d *SessionDatasource) FindLatest(
 		return types.Some(event), nil
 	}
 
-	row := db.QueryRowContext(
-		ctx,
-		findLatestSessionQuery,
+	row := db.QueryRowContext(ctx, findActiveSessionQuery,
 		types.EventKindSessionStarted.String(),
-		types.EventKindSessionEnded.String(),
-		types.EventKindSessionStarted.String(),
-		types.EventKindSessionEnded.String(),
-		types.EventKindSessionStarted.String(),
-		client.String(), client.String(),
-		agent.String(), agent.String(),
-		workspace.String(), workspace.String(),
-		types.EventKindSessionStarted.String(),
-		activeOnly,
-		types.EventKindSessionEnded.String(),
-		activeOnly,
-		activeOnly,
+		client.String(), client.String(), agent.String(), agent.String(), workspace.String(), workspace.String(),
+		types.EventKindSessionStarted.String(), types.EventKindSessionEnded.String(),
 	)
 
 	event, err := scanEvent(row)

--- a/infrastructure/sqlite/sql/find_active_session.sql
+++ b/infrastructure/sqlite/sql/find_active_session.sql
@@ -1,0 +1,49 @@
+WITH selected AS (
+    SELECT started.id
+      FROM event_metadata_projection started
+     WHERE started.kind = ?
+       AND (? = '' OR started.client = ?)
+       AND (? = '' OR started.agent = ?)
+       AND (? = '' OR started.workspace = ?)
+       AND NOT EXISTS (
+           SELECT 1 FROM event_metadata_projection newer_started
+            WHERE newer_started.kind = ?
+              AND newer_started.session_id = started.session_id
+              AND newer_started.client = started.client
+              AND newer_started.agent = started.agent
+              AND newer_started.workspace = started.workspace
+              AND (newer_started.created_at_norm > started.created_at_norm OR
+                  (newer_started.created_at_norm = started.created_at_norm AND newer_started.id > started.id))
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM event_metadata_projection ended
+            WHERE ended.kind = ?
+              AND ended.session_id = started.session_id
+              AND ended.client = started.client
+              AND ended.agent = started.agent
+              AND ended.workspace = started.workspace
+              AND (ended.created_at_norm > started.created_at_norm OR
+                  (ended.created_at_norm = started.created_at_norm AND ended.id > started.id))
+              AND NOT EXISTS (
+                  SELECT 1 FROM event_metadata_projection later_ev
+                   WHERE later_ev.session_id = started.session_id
+                     AND (later_ev.created_at_norm > ended.created_at_norm OR
+                         (later_ev.created_at_norm = ended.created_at_norm AND later_ev.id > ended.id))
+              )
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM sessions ended_row
+            WHERE ended_row.session_id = started.session_id
+              AND ended_row.ended_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM event_metadata_projection row_later
+                   WHERE row_later.session_id = started.session_id
+                     AND row_later.created_at_norm > ts_norm(ended_row.ended_at)
+              )
+       )
+     ORDER BY started.created_at_norm DESC, started.id DESC
+     LIMIT 1
+)
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.body, e.body_availability, e.source_hook, e.created_at
+  FROM selected JOIN events e ON e.id = selected.id

--- a/infrastructure/sqlite/sql/find_latest_session.sql
+++ b/infrastructure/sqlite/sql/find_latest_session.sql
@@ -1,95 +1,74 @@
 WITH candidate_sessions AS (
      SELECT started.id,
-            started.kind,
+            started.session_id,
             started.client,
             started.agent,
-            started.session_id,
             started.workspace,
-            started.body,
-            started.body_availability,
-            started.source_hook,
-            started.created_at,
+            started.created_at_norm,
             (
-              SELECT boundary.created_at
-                FROM events boundary
+              SELECT boundary.created_at_norm
+                FROM event_metadata_projection boundary
                WHERE boundary.session_id = started.session_id
                  AND boundary.client = started.client
                  AND boundary.agent = started.agent
                  AND boundary.workspace = started.workspace
                  AND boundary.kind IN (?, ?)
-               ORDER BY ts_norm(boundary.created_at) DESC, boundary.id DESC
+               ORDER BY boundary.created_at_norm DESC, boundary.id DESC
                LIMIT 1
-            ) AS latest_boundary_created_at,
+            ) AS latest_boundary_created_at_norm,
             (
               SELECT boundary.id
-                FROM events boundary
+                FROM event_metadata_projection boundary
                WHERE boundary.session_id = started.session_id
                  AND boundary.client = started.client
                  AND boundary.agent = started.agent
                  AND boundary.workspace = started.workspace
                  AND boundary.kind IN (?, ?)
-               ORDER BY ts_norm(boundary.created_at) DESC, boundary.id DESC
+               ORDER BY boundary.created_at_norm DESC, boundary.id DESC
                LIMIT 1
             ) AS latest_boundary_id
-       FROM events started
+       FROM event_metadata_projection started
       WHERE started.kind = ?
         AND (? = '' OR started.client = ?)
         AND (? = '' OR started.agent = ?)
         AND (? = '' OR started.workspace = ?)
         AND NOT EXISTS (
              SELECT 1
-               FROM events newer_started
+               FROM event_metadata_projection newer_started
               WHERE newer_started.kind = ?
                 AND newer_started.session_id = started.session_id
                 AND newer_started.client = started.client
                 AND newer_started.agent = started.agent
                 AND newer_started.workspace = started.workspace
                 AND (
-                     ts_norm(newer_started.created_at) > ts_norm(started.created_at) OR
-                     (ts_norm(newer_started.created_at) = ts_norm(started.created_at) AND newer_started.id > started.id)
+                     newer_started.created_at_norm > started.created_at_norm OR
+                     (newer_started.created_at_norm = started.created_at_norm AND newer_started.id > started.id)
                 )
         )
         AND (
              ? = 0 OR (
-                 -- A session is active unless it is terminally ended by EITHER
-                 -- signal, matching the CLI snapshot's row-based rule so MCP
-                 -- session_status(action="active") and `sessions --snapshot`
-                 -- agree on inclusion.
-                 --
-                 -- (1) Event signal: a session_ended event with no later event.
-                 -- Late events (prompts, audits) after the end marker keep the
-                 -- session active (ended_with_late_events).
                  NOT EXISTS (
                      SELECT 1
-                       FROM events ended
+                       FROM event_metadata_projection ended
                       WHERE ended.kind = ?
                         AND ended.session_id = started.session_id
                         AND ended.client = started.client
                         AND ended.agent = started.agent
                         AND ended.workspace = started.workspace
                         AND (
-                             ts_norm(ended.created_at) > ts_norm(started.created_at) OR
-                             (ts_norm(ended.created_at) = ts_norm(started.created_at) AND ended.id > started.id)
+                             ended.created_at_norm > started.created_at_norm OR
+                             (ended.created_at_norm = started.created_at_norm AND ended.id > started.id)
                         )
-                        -- The "later event" check is session_id-only so it
-                        -- matches list_sessions.sql's late-event rule exactly.
-                        -- A same-session event from a different agent/workspace
-                        -- after the end marker must keep the session active on
-                        -- both surfaces (CLI snapshot and MCP active).
                         AND NOT EXISTS (
                              SELECT 1
-                               FROM events later_ev
+                               FROM event_metadata_projection later_ev
                               WHERE later_ev.session_id = started.session_id
                                 AND (
-                                     ts_norm(later_ev.created_at) > ts_norm(ended.created_at) OR
-                                     (ts_norm(later_ev.created_at) = ts_norm(ended.created_at) AND later_ev.id > ended.id)
+                                     later_ev.created_at_norm > ended.created_at_norm OR
+                                     (later_ev.created_at_norm = ended.created_at_norm AND later_ev.id > ended.id)
                                 )
                         )
                  )
-                 -- (2) Row signal: sessions.ended_at set with no later event.
-                 -- Covers `session gc`, which writes ended_at directly without a
-                 -- session_ended event; the CLI snapshot already excludes such a
-                 -- session, so the active query must too.
                  AND NOT EXISTS (
                      SELECT 1
                        FROM sessions ended_row
@@ -97,25 +76,29 @@ WITH candidate_sessions AS (
                         AND ended_row.ended_at IS NOT NULL
                         AND NOT EXISTS (
                              SELECT 1
-                               FROM events row_later
+                               FROM event_metadata_projection row_later
                               WHERE row_later.session_id = started.session_id
-                                AND ts_norm(row_later.created_at) > ts_norm(ended_row.ended_at)
+                                AND row_later.created_at_norm > ts_norm(ended_row.ended_at)
                         )
                  )
              )
         )
+), selected AS (
+    SELECT id
+      FROM candidate_sessions
+     ORDER BY CASE WHEN ? THEN created_at_norm ELSE latest_boundary_created_at_norm END DESC,
+              CASE WHEN ? THEN id ELSE latest_boundary_id END DESC
+     LIMIT 1
 )
-SELECT id,
-       kind,
-       client,
-       agent,
-       session_id,
-       workspace,
-       body,
-       body_availability,
-       source_hook,
-       created_at
-  FROM candidate_sessions
- ORDER BY ts_norm(CASE WHEN ? THEN created_at ELSE latest_boundary_created_at END) DESC,
-          CASE WHEN ? THEN id ELSE latest_boundary_id END DESC
- LIMIT 1
+SELECT e.id,
+       e.kind,
+       e.client,
+       e.agent,
+       e.session_id,
+       e.workspace,
+       e.body,
+       e.body_availability,
+       e.source_hook,
+       e.created_at
+  FROM selected
+  JOIN events e ON e.id = selected.id

--- a/infrastructure/sqlite/sql/find_latest_session_boundary.sql
+++ b/infrastructure/sqlite/sql/find_latest_session_boundary.sql
@@ -1,0 +1,29 @@
+WITH selected AS (
+    SELECT started.id
+      FROM event_metadata_projection boundary
+      JOIN event_metadata_projection started
+        ON started.session_id = boundary.session_id
+       AND started.client = boundary.client
+       AND started.agent = boundary.agent
+       AND started.workspace = boundary.workspace
+       AND started.kind = ?
+     WHERE boundary.kind IN ('session_started', 'session_ended')
+       AND (? = '' OR started.client = ?)
+       AND (? = '' OR started.agent = ?)
+       AND (? = '' OR started.workspace = ?)
+       AND NOT EXISTS (
+           SELECT 1 FROM event_metadata_projection newer_started
+            WHERE newer_started.kind = ?
+              AND newer_started.session_id = started.session_id
+              AND newer_started.client = started.client
+              AND newer_started.agent = started.agent
+              AND newer_started.workspace = started.workspace
+              AND (newer_started.created_at_norm > started.created_at_norm OR
+                  (newer_started.created_at_norm = started.created_at_norm AND newer_started.id > started.id))
+       )
+     ORDER BY boundary.created_at_norm DESC, boundary.id DESC
+     LIMIT 1
+)
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.body, e.body_availability, e.source_hook, e.created_at
+  FROM selected JOIN events e ON e.id = selected.id

--- a/infrastructure/sqlite/sql/list_sessions.sql
+++ b/infrastructure/sqlite/sql/list_sessions.sql
@@ -5,13 +5,13 @@ WITH
     WHERE (? = '' OR s.session_id = ?)
       AND (? = '' OR s.workspace = ?)
       AND (? = '' OR s.client = ?)
-      AND (? = '' OR s.agent = ? OR s.subagent_kind = ? OR EXISTS (SELECT 1 FROM events agent_events WHERE agent_events.session_id = s.session_id AND agent_events.agent = ?))
+      AND (? = '' OR s.agent = ? OR s.subagent_kind = ? OR EXISTS (SELECT 1 FROM event_metadata_projection agent_events WHERE agent_events.session_id = s.session_id AND agent_events.agent = ?))
       AND (? = '' OR s.label = ?)
       AND (? = 0 OR s.ended_at IS NULL OR EXISTS (
             SELECT 1
-              FROM events late_ev
+              FROM event_metadata_projection late_ev
              WHERE late_ev.session_id = s.session_id
-               AND ts_norm(late_ev.created_at) > ts_norm(s.ended_at)
+               AND late_ev.created_at_norm > ts_norm(s.ended_at)
           ))
       AND (? = '' OR ts_norm(s.started_at) >= ts_norm(?))
       AND (? = '' OR ts_norm(s.started_at) < ts_norm(?))
@@ -24,25 +24,24 @@ WITH
       COUNT(*) AS total_events,
       SUM(CASE WHEN e.kind = 'command_executed' THEN 1 ELSE 0 END) AS command_count,
       GROUP_CONCAT(DISTINCT e.agent) AS agents
-    FROM events e
-    JOIN filtered_sessions fs ON fs.session_id = e.session_id
+    FROM filtered_sessions fs
+    CROSS JOIN event_metadata_projection e ON e.session_id = fs.session_id
     GROUP BY e.session_id
   ),
   latest_events AS (
-    SELECT session_id, id AS latest_event_id, created_at AS latest_event_at, kind AS latest_event_kind, body AS latest_event_body
+    SELECT session_id, id AS latest_event_id, created_at AS latest_event_at, kind AS latest_event_kind
     FROM (
       SELECT
         e.session_id,
         e.id,
         e.created_at,
         e.kind,
-        e.body,
         ROW_NUMBER() OVER (
           PARTITION BY e.session_id
-          ORDER BY ts_norm(e.created_at) DESC, e.id DESC
+          ORDER BY e.created_at_norm DESC, e.id DESC
         ) AS rn
-      FROM events e
-      JOIN filtered_sessions fs ON fs.session_id = e.session_id
+      FROM filtered_sessions fs
+      CROSS JOIN event_metadata_projection e ON e.session_id = fs.session_id
     )
     WHERE rn = 1
   )
@@ -65,8 +64,9 @@ SELECT
   COALESCE(s.model, '') AS model,
   COALESCE(latest.latest_event_kind, '') AS latest_event_kind,
   COALESCE(latest.latest_event_id, '') AS latest_event_id,
-  COALESCE(latest.latest_event_body, '') AS latest_event_body
+  COALESCE(latest_body.body, '') AS latest_event_body
 FROM filtered_sessions s
 LEFT JOIN event_agg agg ON agg.session_id = s.session_id
 LEFT JOIN latest_events latest ON latest.session_id = s.session_id
+LEFT JOIN events latest_body ON latest_body.id = latest.latest_event_id
 ORDER BY s.started_at DESC

--- a/infrastructure/sqlite/sql/select_event_by_id.sql
+++ b/infrastructure/sqlite/sql/select_event_by_id.sql
@@ -1,0 +1,4 @@
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace,
+       e.body, e.body_availability, e.source_hook, e.created_at
+  FROM events e
+ WHERE e.id = ?

--- a/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
+++ b/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
@@ -2,6 +2,7 @@ SELECT m.id, m.created_at_norm
   FROM event_metadata_projection m
  WHERE m.kind = 'compact_summary'
    AND m.session_id = ?
+   AND COALESCE(m.source_hook, m.legacy_source_hook, '') <> 'pre_compact'
    AND (? = '' OR m.workspace = ?)
    AND (? = '' OR m.created_at_norm < ? OR (m.created_at_norm = ? AND m.id < ?))
  ORDER BY m.created_at_norm DESC, m.id DESC

--- a/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
+++ b/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
@@ -1,0 +1,13 @@
+WITH selected AS (
+    SELECT m.id
+      FROM event_metadata_projection m
+     WHERE m.kind = 'compact_summary'
+       AND m.session_id = ?
+       AND (? = '' OR m.workspace = ?)
+       AND COALESCE(m.source_hook, m.legacy_source_hook, '') <> 'pre_compact'
+     ORDER BY m.created_at_norm DESC, m.id DESC
+     LIMIT 1
+)
+SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
+  FROM selected
+  JOIN events e ON e.id = selected.id

--- a/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
+++ b/infrastructure/sqlite/sql/select_latest_post_compact_summary.sql
@@ -1,13 +1,8 @@
-WITH selected AS (
-    SELECT m.id
-      FROM event_metadata_projection m
-     WHERE m.kind = 'compact_summary'
-       AND m.session_id = ?
-       AND (? = '' OR m.workspace = ?)
-       AND COALESCE(m.source_hook, m.legacy_source_hook, '') <> 'pre_compact'
-     ORDER BY m.created_at_norm DESC, m.id DESC
-     LIMIT 1
-)
-SELECT e.id, e.kind, e.client, e.agent, e.session_id, e.workspace, e.body, e.body_availability, e.source_hook, e.created_at
-  FROM selected
-  JOIN events e ON e.id = selected.id
+SELECT m.id, m.created_at_norm
+  FROM event_metadata_projection m
+ WHERE m.kind = 'compact_summary'
+   AND m.session_id = ?
+   AND (? = '' OR m.workspace = ?)
+   AND (? = '' OR m.created_at_norm < ? OR (m.created_at_norm = ? AND m.id < ?))
+ ORDER BY m.created_at_norm DESC, m.id DESC
+ LIMIT ?

--- a/infrastructure/sqlite/sql/select_recent_command_previews.sql
+++ b/infrastructure/sqlite/sql/select_recent_command_previews.sql
@@ -1,12 +1,24 @@
-SELECT e.id,
+WITH selected AS (
+    SELECT m.id,
+           m.body_stored_bytes,
+           m.body_original_bytes,
+           m.body_ingest_truncated,
+           m.body_storage_truncated,
+           m.created_at,
+           m.created_at_norm
+      FROM event_metadata_projection m
+     WHERE m.kind = 'command_executed'
+       AND (? = '' OR m.session_id = ?)
+     ORDER BY m.created_at_norm DESC, m.id DESC
+     LIMIT ?
+)
+SELECT selected.id,
        substr(e.body, 1, ?),
-       e.body_stored_bytes,
-       e.body_original_bytes,
-       e.body_ingest_truncated,
-       e.body_storage_truncated,
-       e.created_at
-  FROM events e
- WHERE e.kind = 'command_executed'
-   AND (? = '' OR e.session_id = ?)
- ORDER BY ts_norm(e.created_at) DESC, e.id DESC
- LIMIT ?
+       selected.body_stored_bytes,
+       selected.body_original_bytes,
+       selected.body_ingest_truncated,
+       selected.body_storage_truncated,
+       selected.created_at
+  FROM selected
+  JOIN events e ON e.id = selected.id
+ ORDER BY selected.created_at_norm DESC, selected.id DESC

--- a/schema/sqlite/migrations/000035_add_session_lookup_projection_index.sql
+++ b/schema/sqlite/migrations/000035_add_session_lookup_projection_index.sql
@@ -1,0 +1,5 @@
+-- FindLatest first narrows the body-free projection to lifecycle events before
+-- it orders candidates. Keep that selection index-backed even when the events
+-- table contains mostly prompts, transcripts, and command audits.
+CREATE INDEX idx_event_metadata_kind_created_at_norm_id_desc
+    ON event_metadata_projection(kind, created_at_norm DESC, id DESC);

--- a/schema/sqlite/migrations/000035_add_session_lookup_projection_index.sql
+++ b/schema/sqlite/migrations/000035_add_session_lookup_projection_index.sql
@@ -3,3 +3,9 @@
 -- table contains mostly prompts, transcripts, and command audits.
 CREATE INDEX idx_event_metadata_kind_created_at_norm_id_desc
     ON event_metadata_projection(kind, created_at_norm DESC, id DESC);
+
+-- Global lifecycle ordering for latest-session lookup. The context columns
+-- keep boundary-to-start matching off body-bearing event pages.
+CREATE INDEX idx_event_metadata_boundary_time_context
+    ON event_metadata_projection(created_at_norm DESC, id DESC, session_id, client, agent, workspace)
+    WHERE kind IN ('session_started', 'session_ended');


### PR DESCRIPTION
## Summary

- select active/latest session candidates from the body-free metadata projection and hydrate only the winning event
- make session summary and recent-command selection bounded and projection-backed
- add the measured metadata kind/timestamp index required by the production query plan
- record Structure-Behavior design and synthetic production-harness before/after evidence

## Dependency

This PR is stacked on #1616 / #1607 and must not become Ready or merge until #1616 is merged and this branch is rebased onto `main` with same-head validation repeated.

## Validation

- `GOCACHE=/private/tmp/traceary-1608-gocache go test ./...`
- `GOCACHE=/private/tmp/traceary-1608-gocache GOLANGCI_LINT_CACHE=/private/tmp/traceary-1608-lintcache go tool golangci-lint run`
- `GOCACHE=/private/tmp/traceary-1608-gocache go vet ./...`
- synthetic production harness: active/latest/handoff p95 remain below #1608 thresholds

## AI routing

Kimi K3 max remains unavailable in the installed Kimi runtime (`kimi-k3` is not configured), so the scoped internal Codex worker fallback implemented this issue. Independent review remains required.

Closes #1608
