### PR TITLE
feat: add reader-first payload codec foundation

### DIFF
--- a/.ai/evidence/1609-synthetic-benchmark.json
+++ b/.ai/evidence/1609-synthetic-benchmark.json
@@ -1,0 +1,30 @@
+{
+  "schema": "traceary-payload-codec-benchmark/v1",
+  "ticket": 1609,
+  "data_classification": "deterministic-synthetic",
+  "command": "go test ./infrastructure/sqlite -run '^$' -bench BenchmarkPayloadCodecSynthetic -benchtime=10x -count=1",
+  "payload_generator": "16384 repetitions of a fixed redacted JSON fragment",
+  "metrics": [
+    "identity write ns/op",
+    "zstd write ns/op",
+    "zstd stored/plain ratio",
+    "maximum bounded decode ns/op"
+  ],
+  "invariants": [
+    "no private data",
+    "decoder limit equals declared plaintext size",
+    "canonical writer remains identity"
+  ],
+  "environment": {
+    "goos": "darwin",
+    "goarch": "arm64",
+    "cpu": "Apple M4",
+    "benchtime": "10x"
+  },
+  "results": {
+    "identity_write_ns_per_op": 401854,
+    "zstd_write_ns_per_op": 1199788,
+    "zstd_stored_plain_ratio": 0.0001852,
+    "maximum_bounded_decode_ns_per_op": 678425
+  }
+}

--- a/.ai/evidence/1609-synthetic-benchmark.json
+++ b/.ai/evidence/1609-synthetic-benchmark.json
@@ -3,7 +3,7 @@
   "ticket": 1609,
   "data_classification": "deterministic-synthetic",
   "command": "go test ./infrastructure/sqlite -run '^$' -bench BenchmarkPayloadCodecSynthetic -benchtime=10x -count=1",
-  "payload_generator": "16384 repetitions of a fixed redacted JSON fragment",
+  "payload_generator": "a fixed redacted JSON fragment repeated and truncated to the exact 16 MiB decode limit",
   "metrics": [
     "identity write ns/op",
     "zstd write ns/op",
@@ -22,9 +22,9 @@
     "benchtime": "10x"
   },
   "results": {
-    "identity_write_ns_per_op": 401854,
-    "zstd_write_ns_per_op": 1199788,
-    "zstd_stored_plain_ratio": 0.0001852,
-    "maximum_bounded_decode_ns_per_op": 678425
+    "identity_write_ns_per_op": 6188804,
+    "zstd_write_ns_per_op": 8268308,
+    "zstd_stored_plain_ratio": 0.0001105,
+    "maximum_bounded_decode_ns_per_op": 9567558
   }
 }

--- a/.ai/spec/1609.md
+++ b/.ai/spec/1609.md
@@ -4,7 +4,7 @@
 v0.34 introduces a permanent identity/zstd reader contract without activating compressed canonical writes. Payload corruption, decompression bombs, and an older binary opening a newer store make this high risk.
 
 ## Conceptual model
-A **store format state** is independent of the schema migration number and declares the minimum reader and maximum payload format present. A **payload envelope** consists of stored bytes, codec, format version, plaintext/stored lengths, and SHA-256 of plaintext. Domain objects remain plaintext. Identity and zstd coexist permanently.
+A **store format state** is independent of the schema migration number and declares the minimum reader and maximum payload format present. A **payload row** consists of stored bytes, codec, format version, plaintext/stored lengths, and SHA-256 of plaintext. Domain objects remain plaintext. Identity and zstd coexist permanently.
 
 ## Responsibilities
 | Boundary | Responsibility |
@@ -15,7 +15,7 @@ A **store format state** is independent of the schema migration number and decla
 | Migration 36 | Add format state and per-payload metadata without activating zstd writes |
 | Query adapters | Decode only hydrated bodies; body-free metadata remains available after row corruption |
 | Search projection | Search precomputed plaintext projection; never interpret compressed canonical bytes |
-| Backup/archive | Preserve codec bytes and metadata losslessly; restore behind compatibility gate |
+| Backup/archive | Export logical plaintext behind the codec adapter; restore atomically as identity in v0.34; physical SQLite backups preserve codec bytes and metadata |
 
 ## Behavioral tests
 Identity/zstd round trips are byte exact. Unknown codec/version, corrupt bytes/checksum, length mismatch, and over-limit decode return row-level integrity errors. Mixed identity/zstd rows decode. Metadata queries do not hydrate payloads. Canonical writes assert identity. Redaction tests observe only redacted plaintext reaching the encoder. All open modes reject unsupported format state.
@@ -25,3 +25,10 @@ v0.34 reads identity/zstd but writes identity exclusively. No backfill occurs. D
 
 ## Design checkpoint
 Accepted implementation boundary: infrastructure-only codec and centralized Database compatibility check. Schema version, reader version, and payload format are distinct. Decoding is streaming and capped before allocation. Compression-only activation is explicitly out of scope.
+
+## Implemented row contract and compatibility notes
+The persisted contract is exclusively the physical stored value plus nullable codec, format, plaintext length, encoded length, and checksum columns. There is no magic prefix or payload self-detection. A row whose codec metadata is NULL is a legacy identity row; partially populated metadata is corrupt. Canonical body and metadata changes use one INSERT/UPDATE statement in the same transaction.
+
+Full-body ports hydrate through the centralized row adapter and return a typed row/field-qualified integrity error. Body-free metadata/status ports never read payload columns and remain available when another row is corrupt. Bounded/preview and FTS backfill perform text transformation after bounded decode rather than applying JSON/substr to compressed bytes. Bundle, archive, dedupe, and raw-retention restore logical plaintext and re-encode identity atomically in v0.34.
+
+v0.33 does not understand `store_format_state`, so it cannot mechanically enforce the declared minimum reader. Operational rollback from a v0.34-opened store therefore restores the pre-upgrade backup; opening the upgraded store with v0.33 is unsupported. v0.35 raises/uses the v0.34 reader floor before canonical zstd activation.

--- a/.ai/spec/1609.md
+++ b/.ai/spec/1609.md
@@ -1,0 +1,27 @@
+# #1609 reader-first payload codec design
+
+## Requirement and risk
+v0.34 introduces a permanent identity/zstd reader contract without activating compressed canonical writes. Payload corruption, decompression bombs, and an older binary opening a newer store make this high risk.
+
+## Conceptual model
+A **store format state** is independent of the schema migration number and declares the minimum reader and maximum payload format present. A **payload envelope** consists of stored bytes, codec, format version, plaintext/stored lengths, and SHA-256 of plaintext. Domain objects remain plaintext. Identity and zstd coexist permanently.
+
+## Responsibilities
+| Boundary | Responsibility |
+|---|---|
+| Domain/application | Redact and bound plaintext before persistence; no codec dependency |
+| SQLite codec adapter | Deterministic encode, streaming bounded decode, checksum/integrity errors |
+| Database open boundary | Reject unsupported minimum reader or payload format on writable, read-only and immutable opens |
+| Migration 36 | Add format state and per-payload metadata without activating zstd writes |
+| Query adapters | Decode only hydrated bodies; body-free metadata remains available after row corruption |
+| Search projection | Search precomputed plaintext projection; never interpret compressed canonical bytes |
+| Backup/archive | Preserve codec bytes and metadata losslessly; restore behind compatibility gate |
+
+## Behavioral tests
+Identity/zstd round trips are byte exact. Unknown codec/version, corrupt bytes/checksum, length mismatch, and over-limit decode return row-level integrity errors. Mixed identity/zstd rows decode. Metadata queries do not hydrate payloads. Canonical writes assert identity. Redaction tests observe only redacted plaintext reaching the encoder. All open modes reject unsupported format state.
+
+## Rollback and two-release plan
+v0.34 reads identity/zstd but writes identity exclusively. No backfill occurs. Downgrade to v0.33 is unsupported once the store state exists; rollback restores a pre-upgrade backup. v0.35 may raise minimum reader to 34 and activate zstd writes/backfill with resumable checkpoints. Identity support is never removed.
+
+## Design checkpoint
+Accepted implementation boundary: infrastructure-only codec and centralized Database compatibility check. Schema version, reader version, and payload format are distinct. Decoding is streaming and capped before allocation. Compression-only activation is explicitly out of scope.

--- a/cmd/store-benchmark/main.go
+++ b/cmd/store-benchmark/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -85,7 +86,7 @@ func main() {
 		}
 		dbPath = synthetic
 	}
-	queryDB, err := sql.Open("sqlite", readOnlyDSN(dbPath))
+	queryDB, err := openCompatibleReadOnly(ctx, dbPath)
 	if err != nil {
 		fatal(err.Error())
 	}
@@ -181,7 +182,7 @@ func timeoutResult(name string, limit, elapsed time.Duration, plan []string) cas
 }
 
 func explainCase(ctx context.Context, path, query string, args []any) ([]string, error) {
-	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	db, err := openCompatibleReadOnly(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("open plan store: %w", err)
 	}
@@ -190,7 +191,7 @@ func explainCase(ctx context.Context, path, query string, args []any) ([]string,
 }
 
 func explainHandoff(ctx context.Context, path string) ([]string, error) {
-	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	db, err := openCompatibleReadOnly(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("open handoff plan store: %w", err)
 	}
@@ -209,7 +210,7 @@ func explainHandoff(ctx context.Context, path string) ([]string, error) {
 }
 
 func queryHasRows(ctx context.Context, path, query string, args []any) (bool, error) {
-	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	db, err := openCompatibleReadOnly(ctx, path)
 	if err != nil {
 		return false, fmt.Errorf("open preflight store: %w", err)
 	}
@@ -223,7 +224,7 @@ func queryHasRows(ctx context.Context, path, query string, args []any) (bool, er
 }
 
 func queryRowCount(ctx context.Context, path, query string, args []any) (int64, error) {
-	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	db, err := openCompatibleReadOnly(ctx, path)
 	if err != nil {
 		return 0, fmt.Errorf("open match-count store: %w", err)
 	}
@@ -282,7 +283,7 @@ func benchmarkHandoff(ctx context.Context, path string, iterations int, expected
 			return caseResult{}, fmt.Errorf("close immutable handoff group: %w", err)
 		}
 	}
-	planDB, err := sql.Open("sqlite", readOnlyDSN(path))
+	planDB, err := openCompatibleReadOnly(ctx, path)
 	if err != nil {
 		return caseResult{}, fmt.Errorf("open handoff plan store: %w", err)
 	}
@@ -302,12 +303,30 @@ func benchmarkHandoff(ctx context.Context, path string, iterations int, expected
 
 func readOnlyDSN(path string) string { return "file:" + url.PathEscape(path) + "?immutable=1&mode=ro" }
 
+func openCompatibleReadOnly(ctx context.Context, path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open read-only store: %w", err)
+	}
+	if err := infra.VerifyStoreCompatibility(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("verify store compatibility: %w", err)
+	}
+	return db, nil
+}
+
+func identityPayloadMetadata(payload string) (string, int, int, int, string) {
+	bytes := []byte(payload)
+	digest := sha256.Sum256(bytes)
+	return "identity", 1, len(bytes), len(bytes), fmt.Sprintf("%x", digest)
+}
+
 //nolint:wrapcheck // command boundary adds the benchmark case name before display.
 func benchmark(ctx context.Context, path string, iterations int, name, query string, args []any) (caseResult, error) {
 	cold, warm := make([]int64, 0, iterations), make([]int64, 0, iterations)
 	var plan []string
 	for index := 0; index < iterations; index++ {
-		db, err := sql.Open("sqlite", readOnlyDSN(path))
+		db, err := openCompatibleReadOnly(ctx, path)
 		if err != nil {
 			return caseResult{}, err
 		}
@@ -413,6 +432,9 @@ func createSynthetic(ctx context.Context, path string, smallRows, largeRows int)
 		return fixtureInfo{}, err
 	}
 	defer func() { _ = db.Close() }()
+	if err := infra.VerifyStoreCompatibility(ctx, db); err != nil {
+		return fixtureInfo{}, fmt.Errorf("verify synthetic store compatibility: %w", err)
+	}
 	for _, stmt := range []string{`PRAGMA journal_mode=WAL`, `PRAGMA wal_autocheckpoint=0`} {
 		if _, err = db.ExecContext(ctx, stmt); err != nil {
 			return fixtureInfo{}, err
@@ -421,16 +443,31 @@ func createSynthetic(ctx context.Context, path string, smallRows, largeRows int)
 	if _, err = db.ExecContext(ctx, `INSERT INTO sessions(session_id,started_at,ended_at,client,agent,workspace) VALUES('synthetic-active','2026-01-01T00:00:00Z',NULL,'cli','codex','synthetic'),('synthetic-ended','2025-01-01T00:00:00Z','2025-01-02T00:00:00Z','cli','codex','synthetic')`); err != nil {
 		return fixtureInfo{}, err
 	}
-	if _, err = db.ExecContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES('synthetic-active-start','session_started','codex','synthetic-active','synthetic lifecycle','2026-01-01T00:00:00Z','cli','synthetic'),('synthetic-ended-start','session_started','codex','synthetic-ended','synthetic lifecycle','2025-01-01T00:00:00Z','cli','synthetic'),('synthetic-ended-end','session_ended','codex','synthetic-ended','synthetic lifecycle','2025-01-02T00:00:00Z','cli','synthetic')`); err != nil {
-		return fixtureInfo{}, err
+	insertEvent := func(id, kind, sessionID, body, createdAt string) error {
+		codec, version, plaintextBytes, encodedBytes, digest := identityPayloadMetadata(body)
+		_, execErr := db.ExecContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace,body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256) VALUES(?,?,'codex',?,?,?,'cli','synthetic',?,?,?,?,?)`, id, kind, sessionID, body, createdAt, codec, version, plaintextBytes, encodedBytes, digest)
+		return execErr
+	}
+	for _, event := range []struct{ id, kind, sessionID, body, createdAt string }{
+		{"synthetic-active-start", "session_started", "synthetic-active", "synthetic lifecycle", "2026-01-01T00:00:00Z"},
+		{"synthetic-ended-start", "session_started", "synthetic-ended", "synthetic lifecycle", "2025-01-01T00:00:00Z"},
+		{"synthetic-ended-end", "session_ended", "synthetic-ended", "synthetic lifecycle", "2025-01-02T00:00:00Z"},
+	} {
+		if err = insertEvent(event.id, event.kind, event.sessionID, event.body, event.createdAt); err != nil {
+			return fixtureInfo{}, err
+		}
 	}
 	for index := 0; index < 10; index++ {
 		eventID := fmt.Sprintf("synthetic-command-%02d", index)
 		created := time.Date(2026, 1, 2, 0, 0, index, 0, time.UTC).Format(time.RFC3339Nano)
-		if _, err = db.ExecContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'command_executed','codex','synthetic-active',?,?, 'cli','synthetic')`, eventID, "synthetic command", created); err != nil {
+		if err = insertEvent(eventID, "command_executed", "synthetic-active", "synthetic command", created); err != nil {
 			return fixtureInfo{}, err
 		}
-		if _, err = db.ExecContext(ctx, `INSERT INTO command_audits(event_id,command_text,input_text,output_text) VALUES(?,?,?,?)`, eventID, fmt.Sprintf("echo synthetic-%02d", index), "", "synthetic output"); err != nil {
+		command, input, output := fmt.Sprintf("echo synthetic-%02d", index), "", "synthetic output"
+		commandCodec, commandVersion, commandPlaintextBytes, commandEncodedBytes, commandDigest := identityPayloadMetadata(command)
+		inputCodec, inputVersion, inputPlaintextBytes, inputEncodedBytes, inputDigest := identityPayloadMetadata(input)
+		outputCodec, outputVersion, outputPlaintextBytes, outputEncodedBytes, outputDigest := identityPayloadMetadata(output)
+		if _, err = db.ExecContext(ctx, `INSERT INTO command_audits(event_id,command_text,input_text,output_text,command_codec,command_format_version,command_plaintext_bytes,command_encoded_bytes,command_sha256,input_codec,input_format_version,input_plaintext_bytes,input_encoded_bytes,input_sha256,output_codec,output_format_version,output_plaintext_bytes,output_encoded_bytes,output_sha256) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, eventID, command, input, output, commandCodec, commandVersion, commandPlaintextBytes, commandEncodedBytes, commandDigest, inputCodec, inputVersion, inputPlaintextBytes, inputEncodedBytes, inputDigest, outputCodec, outputVersion, outputPlaintextBytes, outputEncodedBytes, outputDigest); err != nil {
 			return fixtureInfo{}, err
 		}
 	}
@@ -444,7 +481,7 @@ func createSynthetic(ctx context.Context, path string, smallRows, largeRows int)
 	if err != nil {
 		return fixtureInfo{}, err
 	}
-	stmt, err := tx.PrepareContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'prompt','codex',?,?,?,'cli','synthetic')`)
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace,body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256) VALUES(?,'prompt','codex',?,?,?,'cli','synthetic',?,?,?,?,?)`)
 	if err != nil {
 		return fixtureInfo{}, err
 	}
@@ -462,7 +499,8 @@ func createSynthetic(ctx context.Context, path string, smallRows, largeRows int)
 			body = strings.Repeat("L", 1<<20)
 		}
 		createdAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(index) * time.Millisecond).Format(time.RFC3339Nano)
-		if _, err = stmt.ExecContext(ctx, fmt.Sprintf("%s-%09d", idPrefix, index), "synthetic-active", body, createdAt); err != nil {
+		codec, version, plaintextBytes, encodedBytes, digest := identityPayloadMetadata(body)
+		if _, err = stmt.ExecContext(ctx, fmt.Sprintf("%s-%09d", idPrefix, index), "synthetic-active", body, createdAt, codec, version, plaintextBytes, encodedBytes, digest); err != nil {
 			return fixtureInfo{}, err
 		}
 	}

--- a/cmd/store-benchmark/main_test.go
+++ b/cmd/store-benchmark/main_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
@@ -129,5 +131,90 @@ func TestSyntheticFixtureKeepsRequestedRowsWhileCreatingFreePages(t *testing.T) 
 	}
 	if count != 1 {
 		t.Fatalf("retained small rows = %d, want 1", count)
+	}
+}
+
+func TestSyntheticFixtureWritesCompleteIdentityPayloadMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metadata.db")
+	if _, err := createSynthetic(context.Background(), path, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	assertPayloadRows := func(query string) {
+		t.Helper()
+		rows, queryErr := db.Query(query)
+		if queryErr != nil {
+			t.Fatal(queryErr)
+		}
+		defer func() { _ = rows.Close() }()
+		count := 0
+		for rows.Next() {
+			var payload, codec, digest string
+			var version, plaintextBytes, encodedBytes int
+			if scanErr := rows.Scan(&payload, &codec, &version, &plaintextBytes, &encodedBytes, &digest); scanErr != nil {
+				t.Fatal(scanErr)
+			}
+			sum := sha256.Sum256([]byte(payload))
+			if codec != "identity" || version != 1 || plaintextBytes != len([]byte(payload)) || encodedBytes != len([]byte(payload)) || digest != hex.EncodeToString(sum[:]) {
+				t.Fatalf("invalid identity metadata: codec=%q version=%d plaintext=%d encoded=%d digest=%q payload=%q", codec, version, plaintextBytes, encodedBytes, digest, payload)
+			}
+			count++
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if count == 0 {
+			t.Fatal("metadata query returned no rows")
+		}
+	}
+	assertPayloadRows(`SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256 FROM events`)
+	for _, prefix := range []string{"command", "input", "output"} {
+		assertPayloadRows(fmt.Sprintf(`SELECT %[1]s_text, %[1]s_codec, %[1]s_format_version, %[1]s_plaintext_bytes, %[1]s_encoded_bytes, %[1]s_sha256 FROM command_audits`, prefix))
+	}
+}
+
+func TestOpenCompatibleReadOnlyRejectsUnsupportedStoreState(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		column string
+		value  int
+		match  string
+	}{
+		{"future reader", "minimum_reader_version", 35, "requires reader version 35"},
+		{"future payload format", "maximum_payload_format", 2, "payload format 2 is unsupported"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "unsupported.db")
+			if _, err := createSynthetic(context.Background(), path, 1, 1); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(fmt.Sprintf(`UPDATE store_format_state SET %s=? WHERE singleton=1`, tc.column), tc.value); err != nil {
+				_ = db.Close()
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+				_ = db.Close()
+				t.Fatal(err)
+			}
+			if err = db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			readDB, err := openCompatibleReadOnly(context.Background(), path)
+			if readDB != nil {
+				_ = readDB.Close()
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.match) {
+				t.Fatalf("openCompatibleReadOnly() error = %v, want substring %q", err, tc.match)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -133,6 +133,7 @@ require (
 	github.com/karamaru-alpha/copyloopvar v1.2.2 // indirect
 	github.com/kisielk/errcheck v1.10.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
+	github.com/klauspost/compress v1.19.1
 	github.com/kulti/thelper v0.7.1 // indirect
 	github.com/kunwardeep/paralleltest v1.0.15 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/kisielk/errcheck v1.10.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/ttjfJCE=
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/infrastructure/filesystem/file_retention_datasource_unix.go
+++ b/infrastructure/filesystem/file_retention_datasource_unix.go
@@ -30,6 +30,7 @@ import (
 	"github.com/duck8823/traceary/application"
 	apptypes "github.com/duck8823/traceary/application/types"
 	domtypes "github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
 const (
@@ -469,6 +470,9 @@ func sqliteFileRetentionGeneration(path string) (string, string, error) {
 		return "", "", xerrors.Errorf("open SQLite verification database: %w", err)
 	}
 	defer func() { _ = database.Close() }()
+	if err := sqliteinfra.VerifyStoreCompatibility(context.Background(), database); err != nil {
+		return "", "", xerrors.Errorf("verify SQLite store compatibility: %w", err)
+	}
 	var integrity string
 	if err := database.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
 		return "", "", xerrors.Errorf("run SQLite integrity check: %w", err)

--- a/infrastructure/filesystem/file_retention_datasource_unix_test.go
+++ b/infrastructure/filesystem/file_retention_datasource_unix_test.go
@@ -118,6 +118,32 @@ func TestFileRetentionBackupPlanApplyAndRetry(t *testing.T) {
 	}
 }
 
+func TestSQLiteFileRetentionGenerationRejectsFutureStoreFormat(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "future.db")
+	createFileRetentionSQLite(t, path)
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("Open(SQLite) error = %v", err)
+	}
+	if _, err := database.Exec(`CREATE TABLE store_format_state (
+		singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+		minimum_reader_version INTEGER NOT NULL,
+		maximum_payload_format INTEGER NOT NULL
+	); INSERT INTO store_format_state(singleton, minimum_reader_version, maximum_payload_format) VALUES (1, 35, 1)`); err != nil {
+		_ = database.Close()
+		t.Fatalf("seed future store format error = %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("Close(SQLite) error = %v", err)
+	}
+
+	if _, _, err := sqliteFileRetentionGeneration(path); err == nil || !strings.Contains(err.Error(), "requires reader version 35") {
+		t.Fatalf("sqliteFileRetentionGeneration() error = %v, want future reader rejection", err)
+	}
+}
+
 func TestFileRetentionInventoryReportsDescriptorBoundRootAccess(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -1039,6 +1039,13 @@ func scanBundleCommandAudit(row interface {
 	); err != nil {
 		return nil, xerrors.Errorf("scan command audit: %w", err)
 	}
+	for name, value := range map[string]*string{"command": &commandText, "input": &inputText, "output": &outputText} {
+		decoded, err := decodeStoredPayload(*value, maxDecodedPayloadBytes)
+		if err != nil {
+			return nil, xerrors.Errorf("decode bundle audit %s %s: %w", eventID, name, err)
+		}
+		*value = decoded
+	}
 	wrapper := types.None[types.CommandName]()
 	if commandWrapper != "" {
 		wrapper = types.Some(types.CommandName(commandWrapper))

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -137,6 +137,10 @@ ORDER BY event_id`)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to scan bundle command audit row: %w", err)
 		}
+		audit, err = hydrateCommandAudit(ctx, db, audit)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, audit)
 	}
 	if err := rows.Err(); err != nil {
@@ -534,8 +538,20 @@ func (t *bundleImportTx) ImportEvent(ctx context.Context, event *model.Event, po
 	if event == nil {
 		return false, xerrors.Errorf("event must not be nil")
 	}
+	payload, err := encodePayload([]byte(event.Body()), payloadCodecIdentity)
+	if err != nil {
+		return false, err
+	}
+	hasCodec, err := transactionColumnExists(ctx, t.tx, "events", "body_codec")
+	if err != nil {
+		return false, err
+	}
 	query := insertEventQuery
-	if policy == usecase.BundleConflictReplace {
+	if hasCodec {
+		query = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook,
+body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	}
+	if policy == usecase.BundleConflictReplace && !hasCodec {
 		query = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
@@ -547,20 +563,26 @@ ON CONFLICT(id) DO UPDATE SET
   body = excluded.body,
   created_at = excluded.created_at,
   source_hook = excluded.source_hook`
+	} else if policy == usecase.BundleConflictReplace {
+		query += ` ON CONFLICT(id) DO UPDATE SET kind=excluded.kind, client=excluded.client, agent=excluded.agent,
+session_id=excluded.session_id, workspace=excluded.workspace, body=excluded.body, created_at=excluded.created_at,
+source_hook=excluded.source_hook, body_codec=excluded.body_codec, body_format_version=excluded.body_format_version,
+body_plaintext_bytes=excluded.body_plaintext_bytes, body_encoded_bytes=excluded.body_encoded_bytes, body_sha256=excluded.body_sha256`
 	}
-	_, err := t.tx.ExecContext(
-		ctx,
-		query,
+	args := []any{
 		event.EventID().String(),
 		event.Kind().String(),
 		event.Client().String(),
 		event.Agent().String(),
 		event.SessionID().String(),
 		event.Workspace().String(),
-		event.Body(),
+		string(payload.Bytes),
 		formatTimestamp(event.CreatedAt()),
-		nullableString(event.SourceHook()),
-	)
+		nullableString(event.SourceHook())}
+	if hasCodec {
+		args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
+	}
+	_, err = t.tx.ExecContext(ctx, query, args...)
 	if err == nil {
 		return true, nil
 	}
@@ -589,8 +611,32 @@ func (t *bundleImportTx) ImportCommandAudit(ctx context.Context, audit *model.Co
 			return false, xerrors.Errorf("command audit conflict")
 		}
 	}
+	commandPayload, err := encodePayload([]byte(audit.Command()), payloadCodecIdentity)
+	if err != nil {
+		return false, err
+	}
+	inputPayload, err := encodePayload([]byte(audit.Input()), payloadCodecIdentity)
+	if err != nil {
+		return false, err
+	}
+	outputPayload, err := encodePayload([]byte(audit.Output()), payloadCodecIdentity)
+	if err != nil {
+		return false, err
+	}
+	hasCodec, err := transactionColumnExists(ctx, t.tx, "command_audits", "command_codec")
+	if err != nil {
+		return false, err
+	}
 	query := insertCommandAuditQuery
-	if policy == usecase.BundleConflictReplace {
+	if hasCodec {
+		query = `INSERT INTO command_audits(event_id, command_text, command_wrapper, command_name, input_text, output_text,
+input_truncated, output_truncated, input_original_bytes, output_original_bytes, exit_code, failed, failure_reason,
+command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	}
+	if policy == usecase.BundleConflictReplace && !hasCodec {
 		query = `INSERT INTO command_audits(event_id, command_text, command_wrapper, command_name, input_text, output_text, input_truncated, output_truncated, input_original_bytes, output_original_bytes, exit_code, failed, failure_reason)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(event_id) DO UPDATE SET
@@ -606,6 +652,18 @@ ON CONFLICT(event_id) DO UPDATE SET
   exit_code = excluded.exit_code,
   failed = excluded.failed,
   failure_reason = excluded.failure_reason`
+	} else if policy == usecase.BundleConflictReplace {
+		query += ` ON CONFLICT(event_id) DO UPDATE SET command_text=excluded.command_text, command_wrapper=excluded.command_wrapper,
+command_name=excluded.command_name, input_text=excluded.input_text, output_text=excluded.output_text,
+input_truncated=excluded.input_truncated, output_truncated=excluded.output_truncated,
+input_original_bytes=excluded.input_original_bytes, output_original_bytes=excluded.output_original_bytes,
+exit_code=excluded.exit_code, failed=excluded.failed, failure_reason=excluded.failure_reason,
+command_codec=excluded.command_codec, command_format_version=excluded.command_format_version,
+command_plaintext_bytes=excluded.command_plaintext_bytes, command_encoded_bytes=excluded.command_encoded_bytes, command_sha256=excluded.command_sha256,
+input_codec=excluded.input_codec, input_format_version=excluded.input_format_version,
+input_plaintext_bytes=excluded.input_plaintext_bytes, input_encoded_bytes=excluded.input_encoded_bytes, input_sha256=excluded.input_sha256,
+output_codec=excluded.output_codec, output_format_version=excluded.output_format_version,
+output_plaintext_bytes=excluded.output_plaintext_bytes, output_encoded_bytes=excluded.output_encoded_bytes, output_sha256=excluded.output_sha256`
 	}
 	var exitCodeSQL *int
 	if exitCode, ok := audit.ExitCode().Value(); ok {
@@ -615,23 +673,27 @@ ON CONFLICT(event_id) DO UPDATE SET
 	if value, ok := audit.CommandIdentity().Wrapper().Value(); ok {
 		wrapper = value.String()
 	}
-	_, err = t.tx.ExecContext(
-		ctx,
-		query,
+	args := []any{
 		audit.EventID().String(),
-		audit.Command(),
+		string(commandPayload.Bytes),
 		wrapper,
 		audit.CommandIdentity().Command().String(),
-		audit.Input(),
-		audit.Output(),
+		string(inputPayload.Bytes),
+		string(outputPayload.Bytes),
 		audit.InputTruncated(),
 		audit.OutputTruncated(),
 		audit.InputOriginalBytes(),
 		audit.OutputOriginalBytes(),
 		exitCodeSQL,
 		audit.Failed(),
-		audit.FailureReason().String(),
-	)
+		audit.FailureReason().String()}
+	if hasCodec {
+		args = append(args,
+			commandPayload.Codec, commandPayload.FormatVersion, commandPayload.PlaintextBytes, commandPayload.StoredBytes, commandPayload.SHA256,
+			inputPayload.Codec, inputPayload.FormatVersion, inputPayload.PlaintextBytes, inputPayload.StoredBytes, inputPayload.SHA256,
+			outputPayload.Codec, outputPayload.FormatVersion, outputPayload.PlaintextBytes, outputPayload.StoredBytes, outputPayload.SHA256)
+	}
+	_, err = t.tx.ExecContext(ctx, query, args...)
 	if err == nil {
 		return true, nil
 	}
@@ -1038,13 +1100,6 @@ func scanBundleCommandAudit(row interface {
 		&failureReason,
 	); err != nil {
 		return nil, xerrors.Errorf("scan command audit: %w", err)
-	}
-	for name, value := range map[string]*string{"command": &commandText, "input": &inputText, "output": &outputText} {
-		decoded, err := decodeStoredPayload(*value, maxDecodedPayloadBytes)
-		if err != nil {
-			return nil, xerrors.Errorf("decode bundle audit %s %s: %w", eventID, name, err)
-		}
-		*value = decoded
 	}
 	wrapper := types.None[types.CommandName]()
 	if commandWrapper != "" {

--- a/infrastructure/sqlite/content_event_dedupe_datasource.go
+++ b/infrastructure/sqlite/content_event_dedupe_datasource.go
@@ -289,6 +289,11 @@ func (d *StoreManagementDatasource) loadDedupeCandidates(
 		); err != nil {
 			return nil, xerrors.Errorf("failed to scan content-event dedupe candidate: %w", err)
 		}
+		plain, err := loadEventPlaintext(ctx, tx, row.id)
+		if err != nil {
+			return nil, xerrors.Errorf("decode dedupe candidate %s: %w", row.id, err)
+		}
+		row.body = string(plain)
 		parsed, parseErr := time.Parse(time.RFC3339Nano, row.createdAt)
 		row.parsedAt = parsed
 		row.parseOK = parseErr == nil
@@ -594,11 +599,22 @@ func (d *StoreManagementDatasource) RestoreContentEventDedupeRun(
 			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to check existing event %s: %w", r.id, err)
 		}
 
-		if _, err := tx.ExecContext(
-			ctx,
-			insertEventQuery,
-			r.id, r.kind, r.client, r.agent, r.sessionID, r.workspace, r.body, r.createdAt, r.sourceHook,
-		); err != nil {
+		payload, err := encodePayload([]byte(r.body), payloadCodecIdentity)
+		if err != nil {
+			return apptypes.ContentEventDedupeRestoreResult{}, err
+		}
+		hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+		if err != nil {
+			return apptypes.ContentEventDedupeRestoreResult{}, err
+		}
+		query := insertEventQuery
+		args := []any{r.id, r.kind, r.client, r.agent, r.sessionID, r.workspace, string(payload.Bytes), r.createdAt, r.sourceHook}
+		if hasCodec {
+			query = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook,
+body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
+		}
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to restore event %s: %w", r.id, err)
 		}
 		if _, err := tx.ExecContext(

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -2,8 +2,10 @@ package sqlite
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -40,6 +42,22 @@ func init() {
 		1,
 		normalizeTimestampSQLFunc,
 	)
+	sqlite.MustRegisterDeterministicScalarFunction("traceary_sha256", 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+		if len(args) != 1 {
+			return nil, xerrors.Errorf("traceary_sha256 expects one argument")
+		}
+		var data []byte
+		switch value := args[0].(type) {
+		case string:
+			data = []byte(value)
+		case []byte:
+			data = value
+		default:
+			return nil, xerrors.Errorf("traceary_sha256 expects text or blob")
+		}
+		digest := sha256.Sum256(data)
+		return hex.EncodeToString(digest[:]), nil
+	})
 }
 
 // normalizeTimestampSQLFunc adapts normalizeRFC3339NanoForCompare to the
@@ -103,7 +121,9 @@ func NewImmutableReadDatabase(ctx context.Context, dbPath string) (*Database, er
 		_ = db.Close()
 		return nil, xerrors.Errorf("ping immutable SQLite store: %w", err)
 	}
-	db.SetMaxOpenConns(1)
+	// Immutable benchmark stores cannot change while the group is open. A
+	// small pool permits row hydration while a metadata cursor is active.
+	db.SetMaxOpenConns(4)
 	if err := checkStoreCompatibility(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -212,10 +232,10 @@ func (d *Database) openReadOnly(ctx context.Context) (_ *sql.DB, err error) {
 	return db, nil
 }
 
-// checkStoreCompatibility is the single policy boundary used by every
-// Database connection mode. A missing state table denotes a legacy store and
-// is supported so initialize can apply migration 36.
-func checkStoreCompatibility(ctx context.Context, db *sql.DB) error {
+// VerifyStoreCompatibility applies the store-format policy to direct SQLite
+// consumers that intentionally do not use Database. A missing state table
+// denotes a supported legacy store so initialize can apply migration 36.
+func VerifyStoreCompatibility(ctx context.Context, db *sql.DB) error {
 	var exists int
 	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='store_format_state')`).Scan(&exists); err != nil {
 		return xerrors.Errorf("check store format state: %w", err)
@@ -234,6 +254,10 @@ func checkStoreCompatibility(ctx context.Context, db *sql.DB) error {
 		return xerrors.Errorf("store payload format %d is unsupported; maximum supported is %d", maximumPayload, maximumPayloadFormatVersion)
 	}
 	return nil
+}
+
+func checkStoreCompatibility(ctx context.Context, db *sql.DB) error {
+	return VerifyStoreCompatibility(ctx, db)
 }
 
 func sqliteImmutableDSN(dbPath string) string {

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -25,6 +25,11 @@ import (
 // normalizeRFC3339NanoForCompare and #1185.
 const sqlTimestampNormalizeFunc = "ts_norm"
 
+const (
+	currentReaderVersion        = 34
+	maximumPayloadFormatVersion = 1
+)
+
 // init registers ts_norm on the modernc SQLite driver. Registration is global
 // and applies to every connection opened afterwards, so the per-operation
 // connections this package opens all expose the function. It is registered as
@@ -99,6 +104,10 @@ func NewImmutableReadDatabase(ctx context.Context, dbPath string) (*Database, er
 		return nil, xerrors.Errorf("ping immutable SQLite store: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	if err := checkStoreCompatibility(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	return &Database{dbPath: strings.TrimSpace(dbPath), sharedReadOnly: db}, nil
 }
 
@@ -160,6 +169,9 @@ func (d *Database) openAt(ctx context.Context, dbPath string) (_ *sql.DB, err er
 	if err := db.PingContext(ctx); err != nil {
 		return nil, xerrors.Errorf("failed to ping SQLite DB: %w", err)
 	}
+	if err := checkStoreCompatibility(ctx, db); err != nil {
+		return nil, err
+	}
 
 	return db, nil
 }
@@ -194,7 +206,34 @@ func (d *Database) openReadOnly(ctx context.Context) (_ *sql.DB, err error) {
 	if err := db.PingContext(ctx); err != nil {
 		return nil, xerrors.Errorf("failed to ping read-only SQLite DB: %w", err)
 	}
+	if err := checkStoreCompatibility(ctx, db); err != nil {
+		return nil, err
+	}
 	return db, nil
+}
+
+// checkStoreCompatibility is the single policy boundary used by every
+// Database connection mode. A missing state table denotes a legacy store and
+// is supported so initialize can apply migration 36.
+func checkStoreCompatibility(ctx context.Context, db *sql.DB) error {
+	var exists int
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='store_format_state')`).Scan(&exists); err != nil {
+		return xerrors.Errorf("check store format state: %w", err)
+	}
+	if exists == 0 {
+		return nil
+	}
+	var minimumReader, maximumPayload int
+	if err := db.QueryRowContext(ctx, `SELECT minimum_reader_version, maximum_payload_format FROM store_format_state WHERE singleton = 1`).Scan(&minimumReader, &maximumPayload); err != nil {
+		return xerrors.Errorf("read store format state: %w", err)
+	}
+	if minimumReader > currentReaderVersion {
+		return xerrors.Errorf("store requires reader version %d; this reader supports %d", minimumReader, currentReaderVersion)
+	}
+	if maximumPayload > maximumPayloadFormatVersion {
+		return xerrors.Errorf("store payload format %d is unsupported; maximum supported is %d", maximumPayload, maximumPayloadFormatVersion)
+	}
+	return nil
 }
 
 func sqliteImmutableDSN(dbPath string) string {

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -2,10 +2,8 @@ package sqlite
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -42,22 +40,6 @@ func init() {
 		1,
 		normalizeTimestampSQLFunc,
 	)
-	sqlite.MustRegisterDeterministicScalarFunction("traceary_sha256", 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
-		if len(args) != 1 {
-			return nil, xerrors.Errorf("traceary_sha256 expects one argument")
-		}
-		var data []byte
-		switch value := args[0].(type) {
-		case string:
-			data = []byte(value)
-		case []byte:
-			data = value
-		default:
-			return nil, xerrors.Errorf("traceary_sha256 expects text or blob")
-		}
-		digest := sha256.Sum256(data)
-		return hex.EncodeToString(digest[:]), nil
-	})
 }
 
 // normalizeTimestampSQLFunc adapts normalizeRFC3339NanoForCompare to the

--- a/infrastructure/sqlite/event_bounded_datasource.go
+++ b/infrastructure/sqlite/event_bounded_datasource.go
@@ -240,7 +240,11 @@ func (d *EventDatasource) LoadCanonicalBodies(
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore canonical event ID: %w", err)
 		}
-		bodies[eventID] = body
+		plain, err := loadEventPlaintext(ctx, db, eventID.String())
+		if err != nil {
+			return nil, err
+		}
+		bodies[eventID] = string(plain)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("failed to iterate canonical event bodies: %w", err)
@@ -293,6 +297,7 @@ func hydrateBoundedEvents(
 	ctx context.Context,
 	queryer interface {
 		QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+		QueryRowContext(context.Context, string, ...any) *sql.Row
 	},
 	metadata []apptypes.EventMetadata,
 	bodyRuneLimit int,
@@ -336,13 +341,22 @@ func hydrateBoundedEvents(
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore bounded event ID: %w", err)
 		}
-		visibleRunes, err := checkedInt(visibleRunesValue, "visible body runes")
-		if err != nil {
-			return nil, err
+		if visibleRunesValue < 0 {
+			return nil, xerrors.Errorf("visible body runes must not be negative")
 		}
 		availability, err := types.BodyAvailabilityFrom(availabilityValue)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore bounded body availability: %w", err)
+		}
+		plain, err := loadEventPlaintext(ctx, queryer, eventID.String())
+		if err != nil {
+			return nil, err
+		}
+		body, canonicalEnvelope = visibleEventBody(string(plain), availability)
+		bodyRunes := []rune(body)
+		visibleRunes := len(bodyRunes)
+		if len(bodyRunes) > bodyRuneLimit {
+			body = string(bodyRunes[:bodyRuneLimit])
 		}
 		bodyRows[eventID] = boundedEventBodyRow{
 			body:              body,
@@ -375,6 +389,14 @@ func hydrateBoundedEvents(
 		events = append(events, event)
 	}
 	return events, nil
+}
+
+func visibleEventBody(body string, availability types.BodyAvailability) (string, bool) {
+	if !availability.IsAvailable() {
+		return "", false
+	}
+	_, canonical := apptypes.DecodeCanonicalEnvelope(body)
+	return apptypes.ExtractPlainBody(body), canonical
 }
 
 func marshalBoundedEventIDs(eventIDs []types.EventID) (string, error) {

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -737,6 +737,10 @@ func scanEvent(rowScanner interface {
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event row: %w", err)
 	}
+	bodyValue, err := decodeStoredPayload(bodyValue, maxDecodedPayloadBytes)
+	if err != nil {
+		return nil, xerrors.Errorf("decode event %s body: %w", eventIDValue, err)
+	}
 
 	return restoreEvent(
 		eventIDValue,
@@ -809,6 +813,19 @@ func scanEventWithAudit(
 		failureReasonValue,
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event details row: %w", err)
+	}
+	bodyValue, err := decodeStoredPayload(bodyValue, maxDecodedPayloadBytes)
+	if err != nil {
+		return nil, xerrors.Errorf("decode event %s body: %w", eventIDValue, err)
+	}
+	for name, value := range map[string]*sql.NullString{"command": commandTextValue, "input": inputTextValue, "output": outputTextValue} {
+		if !value.Valid {
+			continue
+		}
+		value.String, err = decodeStoredPayload(value.String, maxDecodedPayloadBytes)
+		if err != nil {
+			return nil, xerrors.Errorf("decode event %s audit %s: %w", eventIDValue, name, err)
+		}
 	}
 
 	return restoreEvent(

--- a/infrastructure/sqlite/event_datasource.go
+++ b/infrastructure/sqlite/event_datasource.go
@@ -79,7 +79,11 @@ func (d *EventDatasource) Save(ctx context.Context, event *model.Event) error {
 		}
 	}()
 
-	return saveEventTransaction(ctx, db, event, nil, nil)
+	codecMetadata, err := databaseColumnExists(ctx, db, "events", "body_codec")
+	if err != nil {
+		return err
+	}
+	return saveEventTransaction(ctx, db, event, nil, codecMetadata, nil)
 }
 
 // SaveWithAudit persists an event together with its command audit.
@@ -105,7 +109,11 @@ func (d *EventDatasource) SaveWithAudit(
 		}
 	}()
 
-	return saveEventTransaction(ctx, db, event, audit, nil)
+	codecMetadata, err := databaseColumnExists(ctx, db, "events", "body_codec")
+	if err != nil {
+		return err
+	}
+	return saveEventTransaction(ctx, db, event, audit, codecMetadata, nil)
 }
 
 // ListRecent returns events in descending time order.
@@ -160,6 +168,10 @@ func (d *EventDatasource) ListRecent(
 		event, err := scanEvent(rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore event row: %w", err)
+		}
+		event, err = hydrateEventPayload(ctx, db, event)
+		if err != nil {
+			return nil, err
 		}
 		events = append(events, event)
 	}
@@ -250,6 +262,11 @@ func (d *EventDatasource) ListWindow(
 					slog.Debug("failed to close resource", "error", closeErr)
 				}
 				return nil, xerrors.Errorf("failed to restore event window row: %w", err)
+			}
+			event, err = hydrateEventPayload(ctx, tx, event)
+			if err != nil {
+				_ = rows.Close()
+				return nil, err
 			}
 			events = append(events, event)
 			pageCount++
@@ -396,6 +413,10 @@ func (d *EventDatasource) Search(
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore search result row: %w", err)
 		}
+		event, err = hydrateEventPayload(ctx, db, event)
+		if err != nil {
+			return nil, err
+		}
 		events = append(events, event)
 	}
 	if err := rows.Err(); err != nil {
@@ -447,6 +468,10 @@ func (d *EventDatasource) GetContext(
 		event, err := scanEvent(rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore context event row: %w", err)
+		}
+		event, err = hydrateEventPayload(ctx, db, event)
+		if err != nil {
+			return nil, err
 		}
 		events = append(events, event)
 	}
@@ -513,6 +538,24 @@ func (d *EventDatasource) GetDetails(
 			return apptypes.EventDetails{}, xerrors.Errorf("event not found: %s", eventID)
 		}
 		return apptypes.EventDetails{}, xerrors.Errorf("failed to restore event details row: %w", err)
+	}
+	event, err = hydrateEventPayload(ctx, db, event)
+	if err != nil {
+		return apptypes.EventDetails{}, err
+	}
+	if commandTextValue.Valid {
+		commandTextValue, err = hydrateAuditPayload(ctx, db, eventID.String(), "command")
+		if err != nil {
+			return apptypes.EventDetails{}, err
+		}
+		inputTextValue, err = hydrateAuditPayload(ctx, db, eventID.String(), "input")
+		if err != nil {
+			return apptypes.EventDetails{}, err
+		}
+		outputTextValue, err = hydrateAuditPayload(ctx, db, eventID.String(), "output")
+		if err != nil {
+			return apptypes.EventDetails{}, err
+		}
 	}
 
 	commandAuditOpt := types.None[*model.CommandAudit]()
@@ -616,6 +659,9 @@ func (d *EventDatasource) ListTimelineBlocks(
 			wsEventCount        int
 			kinds               string
 			wsAgents            string
+			firstPromptID       string
+			compactSummaryID    string
+			firstTranscriptID   string
 			firstPromptBody     string
 			compactSummaryBody  string
 			firstTranscriptBody string
@@ -630,11 +676,24 @@ func (d *EventDatasource) ListTimelineBlocks(
 			&wsEventCount,
 			&kinds,
 			&wsAgents,
+			&firstPromptID,
+			&compactSummaryID,
+			&firstTranscriptID,
 			&firstPromptBody,
 			&compactSummaryBody,
 			&firstTranscriptBody,
 		); err != nil {
 			return nil, xerrors.Errorf("failed to scan timeline block: %w", err)
+		}
+		for id, target := range map[string]*string{firstPromptID: &firstPromptBody, compactSummaryID: &compactSummaryBody, firstTranscriptID: &firstTranscriptBody} {
+			if id == "" {
+				continue
+			}
+			plain, err := loadEventPlaintext(ctx, db, id)
+			if err != nil {
+				return nil, err
+			}
+			*target = string(plain)
 		}
 
 		accum, ok := blockMap[blockNum]
@@ -737,11 +796,6 @@ func scanEvent(rowScanner interface {
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event row: %w", err)
 	}
-	bodyValue, err := decodeStoredPayload(bodyValue, maxDecodedPayloadBytes)
-	if err != nil {
-		return nil, xerrors.Errorf("decode event %s body: %w", eventIDValue, err)
-	}
-
 	return restoreEvent(
 		eventIDValue,
 		eventKindValue,
@@ -814,20 +868,6 @@ func scanEventWithAudit(
 	); err != nil {
 		return nil, xerrors.Errorf("failed to scan event details row: %w", err)
 	}
-	bodyValue, err := decodeStoredPayload(bodyValue, maxDecodedPayloadBytes)
-	if err != nil {
-		return nil, xerrors.Errorf("decode event %s body: %w", eventIDValue, err)
-	}
-	for name, value := range map[string]*sql.NullString{"command": commandTextValue, "input": inputTextValue, "output": outputTextValue} {
-		if !value.Valid {
-			continue
-		}
-		value.String, err = decodeStoredPayload(value.String, maxDecodedPayloadBytes)
-		if err != nil {
-			return nil, xerrors.Errorf("decode event %s audit %s: %w", eventIDValue, name, err)
-		}
-	}
-
 	return restoreEvent(
 		eventIDValue,
 		eventKindValue,

--- a/infrastructure/sqlite/event_delivery_store.go
+++ b/infrastructure/sqlite/event_delivery_store.go
@@ -35,6 +35,7 @@ func saveEventTransaction(
 	db *sql.DB,
 	event *model.Event,
 	audit *model.CommandAudit,
+	codecMetadata bool,
 	afterInsert func(context.Context, *sql.Tx) error,
 ) error {
 	for attempt := 0; attempt < maxDeliveryDecisionAttempts; attempt++ {
@@ -43,7 +44,7 @@ func saveEventTransaction(
 			return xerrors.Errorf("failed to begin event delivery transaction: %w", err)
 		}
 
-		inserted, persistErr := persistEventDelivery(ctx, tx, event, audit)
+		inserted, persistErr := persistEventDelivery(ctx, tx, event, audit, codecMetadata)
 		if persistErr == nil && inserted && afterInsert != nil {
 			persistErr = afterInsert(ctx, tx)
 		}
@@ -87,6 +88,7 @@ func persistEventDelivery(
 	tx *sql.Tx,
 	event *model.Event,
 	audit *model.CommandAudit,
+	codecMetadata bool,
 ) (bool, error) {
 	if event == nil {
 		return false, xerrors.Errorf("event must not be nil")
@@ -128,7 +130,7 @@ func persistEventDelivery(
 		}
 	}
 
-	if err := insertEventAndAudit(ctx, tx, event, audit); err != nil {
+	if err := insertEventAndAudit(ctx, tx, event, audit, codecMetadata); err != nil {
 		return false, err
 	}
 
@@ -171,7 +173,7 @@ func insertHookDeliveryAttempt(ctx context.Context, tx *sql.Tx, event *model.Eve
 	return nil
 }
 
-func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, audit *model.CommandAudit) error {
+func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, audit *model.CommandAudit, codecMetadata bool) error {
 	// v0.34 deliberately encodes canonical writes as identity. The same adapter
 	// is used for zstd shadow/benchmark coverage, preventing a later activation
 	// from bypassing integrity metadata or the pre-existing redaction boundary.
@@ -179,9 +181,9 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 	if err != nil {
 		return xerrors.Errorf("encode event payload: %w", err)
 	}
-	if _, err := tx.ExecContext(
-		ctx,
-		insertEventQuery,
+	eventHasCodec := codecMetadata
+	eventQuery := insertEventQuery
+	eventArgs := []any{
 		event.EventID().String(),
 		event.Kind().String(),
 		event.Client().String(),
@@ -190,12 +192,15 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 		event.Workspace().String(),
 		string(eventPayload.Bytes),
 		formatTimestamp(event.CreatedAt()),
-		nullableString(event.SourceHook()),
-	); err != nil {
-		return xerrors.Errorf("failed to insert event: %w", err)
+		nullableString(event.SourceHook())}
+	if eventHasCodec {
+		eventQuery = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook,
+body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		eventArgs = append(eventArgs, eventPayload.Codec, eventPayload.FormatVersion, eventPayload.PlaintextBytes, eventPayload.StoredBytes, eventPayload.SHA256)
 	}
-	if err := recordEventPayloadMetadata(ctx, tx, event.EventID().String(), eventPayload); err != nil {
-		return err
+	if _, err := tx.ExecContext(ctx, eventQuery, eventArgs...); err != nil {
+		return xerrors.Errorf("failed to insert event: %w", err)
 	}
 	if audit == nil {
 		return nil
@@ -220,9 +225,9 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 	if value, ok := audit.CommandIdentity().Wrapper().Value(); ok {
 		wrapper = value.String()
 	}
-	if _, err := tx.ExecContext(
-		ctx,
-		insertCommandAuditQuery,
+	auditHasCodec := codecMetadata
+	auditQuery := insertCommandAuditQuery
+	auditArgs := []any{
 		audit.EventID().String(),
 		string(commandPayload.Bytes),
 		wrapper,
@@ -235,44 +240,21 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 		audit.OutputOriginalBytes(),
 		exitCodeSQL,
 		audit.Failed(),
-		audit.FailureReason().String(),
-	); err != nil {
+		audit.FailureReason().String()}
+	if auditHasCodec {
+		auditQuery = `INSERT INTO command_audits(event_id, command_text, command_wrapper, command_name, input_text, output_text,
+input_truncated, output_truncated, input_original_bytes, output_original_bytes, exit_code, failed, failure_reason,
+command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		auditArgs = append(auditArgs,
+			commandPayload.Codec, commandPayload.FormatVersion, commandPayload.PlaintextBytes, commandPayload.StoredBytes, commandPayload.SHA256,
+			inputPayload.Codec, inputPayload.FormatVersion, inputPayload.PlaintextBytes, inputPayload.StoredBytes, inputPayload.SHA256,
+			outputPayload.Codec, outputPayload.FormatVersion, outputPayload.PlaintextBytes, outputPayload.StoredBytes, outputPayload.SHA256)
+	}
+	if _, err := tx.ExecContext(ctx, auditQuery, auditArgs...); err != nil {
 		return xerrors.Errorf("failed to insert command audit: %w", err)
-	}
-	if err := recordAuditPayloadMetadata(ctx, tx, audit.EventID().String(), commandPayload, inputPayload, outputPayload); err != nil {
-		return err
-	}
-	return nil
-}
-
-func recordEventPayloadMetadata(ctx context.Context, tx *sql.Tx, eventID string, payload encodedPayload) error {
-	enabled, err := transactionColumnExists(ctx, tx, "events", "body_codec")
-	if err != nil || !enabled {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE events SET body_codec=?, body_format_version=?, body_plaintext_bytes=?, body_encoded_bytes=?, body_sha256=? WHERE id=?`,
-		payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256, eventID); err != nil {
-		return xerrors.Errorf("record event payload metadata: %w", err)
-	}
-	return nil
-}
-
-func recordAuditPayloadMetadata(ctx context.Context, tx *sql.Tx, eventID string, payloads ...encodedPayload) error {
-	enabled, err := transactionColumnExists(ctx, tx, "command_audits", "command_codec")
-	if err != nil || !enabled {
-		return err
-	}
-	if len(payloads) != 3 {
-		return xerrors.Errorf("command audit requires three payloads")
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE command_audits SET
-command_codec=?, command_format_version=?, command_plaintext_bytes=?, command_encoded_bytes=?, command_sha256=?,
-input_codec=?, input_format_version=?, input_plaintext_bytes=?, input_encoded_bytes=?, input_sha256=?,
-output_codec=?, output_format_version=?, output_plaintext_bytes=?, output_encoded_bytes=?, output_sha256=? WHERE event_id=?`,
-		payloads[0].Codec, payloads[0].FormatVersion, payloads[0].PlaintextBytes, payloads[0].StoredBytes, payloads[0].SHA256,
-		payloads[1].Codec, payloads[1].FormatVersion, payloads[1].PlaintextBytes, payloads[1].StoredBytes, payloads[1].SHA256,
-		payloads[2].Codec, payloads[2].FormatVersion, payloads[2].PlaintextBytes, payloads[2].StoredBytes, payloads[2].SHA256, eventID); err != nil {
-		return xerrors.Errorf("record command audit payload metadata: %w", err)
 	}
 	return nil
 }

--- a/infrastructure/sqlite/event_delivery_store.go
+++ b/infrastructure/sqlite/event_delivery_store.go
@@ -172,6 +172,13 @@ func insertHookDeliveryAttempt(ctx context.Context, tx *sql.Tx, event *model.Eve
 }
 
 func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, audit *model.CommandAudit) error {
+	// v0.34 deliberately encodes canonical writes as identity. The same adapter
+	// is used for zstd shadow/benchmark coverage, preventing a later activation
+	// from bypassing integrity metadata or the pre-existing redaction boundary.
+	eventPayload, err := encodePayload([]byte(event.Body()), payloadCodecIdentity)
+	if err != nil {
+		return xerrors.Errorf("encode event payload: %w", err)
+	}
 	if _, err := tx.ExecContext(
 		ctx,
 		insertEventQuery,
@@ -181,14 +188,29 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 		event.Agent().String(),
 		event.SessionID().String(),
 		event.Workspace().String(),
-		event.Body(),
+		string(eventPayload.Bytes),
 		formatTimestamp(event.CreatedAt()),
 		nullableString(event.SourceHook()),
 	); err != nil {
 		return xerrors.Errorf("failed to insert event: %w", err)
 	}
+	if err := recordEventPayloadMetadata(ctx, tx, event.EventID().String(), eventPayload); err != nil {
+		return err
+	}
 	if audit == nil {
 		return nil
+	}
+	commandPayload, err := encodePayload([]byte(audit.Command()), payloadCodecIdentity)
+	if err != nil {
+		return xerrors.Errorf("encode command payload: %w", err)
+	}
+	inputPayload, err := encodePayload([]byte(audit.Input()), payloadCodecIdentity)
+	if err != nil {
+		return xerrors.Errorf("encode command input payload: %w", err)
+	}
+	outputPayload, err := encodePayload([]byte(audit.Output()), payloadCodecIdentity)
+	if err != nil {
+		return xerrors.Errorf("encode command output payload: %w", err)
 	}
 	var exitCodeSQL *int
 	if exitCode, ok := audit.ExitCode().Value(); ok {
@@ -202,11 +224,11 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 		ctx,
 		insertCommandAuditQuery,
 		audit.EventID().String(),
-		audit.Command(),
+		string(commandPayload.Bytes),
 		wrapper,
 		audit.CommandIdentity().Command().String(),
-		audit.Input(),
-		audit.Output(),
+		string(inputPayload.Bytes),
+		string(outputPayload.Bytes),
 		audit.InputTruncated(),
 		audit.OutputTruncated(),
 		audit.InputOriginalBytes(),
@@ -217,7 +239,51 @@ func insertEventAndAudit(ctx context.Context, tx *sql.Tx, event *model.Event, au
 	); err != nil {
 		return xerrors.Errorf("failed to insert command audit: %w", err)
 	}
+	if err := recordAuditPayloadMetadata(ctx, tx, audit.EventID().String(), commandPayload, inputPayload, outputPayload); err != nil {
+		return err
+	}
 	return nil
+}
+
+func recordEventPayloadMetadata(ctx context.Context, tx *sql.Tx, eventID string, payload encodedPayload) error {
+	enabled, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+	if err != nil || !enabled {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE events SET body_codec=?, body_format_version=?, body_plaintext_bytes=?, body_encoded_bytes=?, body_sha256=? WHERE id=?`,
+		payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256, eventID); err != nil {
+		return xerrors.Errorf("record event payload metadata: %w", err)
+	}
+	return nil
+}
+
+func recordAuditPayloadMetadata(ctx context.Context, tx *sql.Tx, eventID string, payloads ...encodedPayload) error {
+	enabled, err := transactionColumnExists(ctx, tx, "command_audits", "command_codec")
+	if err != nil || !enabled {
+		return err
+	}
+	if len(payloads) != 3 {
+		return xerrors.Errorf("command audit requires three payloads")
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE command_audits SET
+command_codec=?, command_format_version=?, command_plaintext_bytes=?, command_encoded_bytes=?, command_sha256=?,
+input_codec=?, input_format_version=?, input_plaintext_bytes=?, input_encoded_bytes=?, input_sha256=?,
+output_codec=?, output_format_version=?, output_plaintext_bytes=?, output_encoded_bytes=?, output_sha256=? WHERE event_id=?`,
+		payloads[0].Codec, payloads[0].FormatVersion, payloads[0].PlaintextBytes, payloads[0].StoredBytes, payloads[0].SHA256,
+		payloads[1].Codec, payloads[1].FormatVersion, payloads[1].PlaintextBytes, payloads[1].StoredBytes, payloads[1].SHA256,
+		payloads[2].Codec, payloads[2].FormatVersion, payloads[2].PlaintextBytes, payloads[2].StoredBytes, payloads[2].SHA256, eventID); err != nil {
+		return xerrors.Errorf("record command audit payload metadata: %w", err)
+	}
+	return nil
+}
+
+func transactionColumnExists(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name FROM pragma_table_info(?) WHERE name = ?`, table, column)
+	if err != nil {
+		return false, xerrors.Errorf("inspect payload metadata column: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return rows.Next(), rows.Err()
 }
 
 func findHookDeliveryByFingerprint(

--- a/infrastructure/sqlite/event_preview_datasource.go
+++ b/infrastructure/sqlite/event_preview_datasource.go
@@ -56,6 +56,18 @@ func (d *EventDatasource) ListRecentCommandPreviews(ctx context.Context, session
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore command preview row: %w", err)
 		}
+		plain, err := loadEventPlaintext(ctx, db, preview.EventID().String())
+		if err != nil {
+			return nil, xerrors.Errorf("decode command preview: %w", err)
+		}
+		runes := []rune(string(plain))
+		if len(runes) > bodyRuneLimit {
+			runes = runes[:bodyRuneLimit]
+		}
+		preview, err = apptypes.EventBodyPreviewOf(preview.EventID(), string(runes), preview.StoredBytes(), preview.OriginalBytes(), preview.IngestTruncated(), preview.StorageTruncated(), preview.CreatedAt())
+		if err != nil {
+			return nil, xerrors.Errorf("rebuild decoded command preview: %w", err)
+		}
 		previews = append(previews, preview)
 	}
 	if err := rows.Err(); err != nil {
@@ -138,6 +150,10 @@ func (d *EventDatasource) FindLatestPostCompactSummary(ctx context.Context, sess
 			event, scanErr := scanEvent(db.QueryRowContext(ctx, selectEventByIDQuery, item.id))
 			if scanErr != nil {
 				return types.None[*model.Event](), xerrors.Errorf("failed to restore compact summary candidate: %w", scanErr)
+			}
+			event, scanErr = hydrateEventPayload(ctx, db, event)
+			if scanErr != nil {
+				return types.None[*model.Event](), scanErr
 			}
 			body := strings.TrimSpace(event.Body())
 			if event.SourceHook() == "pre_compact" || strings.HasPrefix(body, types.EventBodyMarkerCompactPreSnapshot) {

--- a/infrastructure/sqlite/event_search_backfill.go
+++ b/infrastructure/sqlite/event_search_backfill.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/types"
 )
 
 // eventSearchBackfillBatchSize bounds the body-bearing work performed by one
@@ -140,24 +142,34 @@ func catchUpEventSearchDocuments(
 	}
 
 	result.LastEventID = selectedIDs[len(selectedIDs)-1]
-	insertResult, err := tx.ExecContext(ctx, `
-		INSERT INTO event_search_documents(
-			event_id, body_text, command_text, input_text, output_text
-		)
-		SELECT event_id, body_text, command_text, input_text, output_text
-		  FROM event_search_projection
-		 WHERE event_id > ? AND event_id <= ?
-		 ORDER BY event_id
-		ON CONFLICT(event_id) DO NOTHING`,
-		lastEventID,
-		result.LastEventID,
-	)
-	if err != nil {
-		return result, xerrors.Errorf("failed to materialize event search backfill batch: %w", err)
-	}
-	result.Inserted, err = insertResult.RowsAffected()
-	if err != nil {
-		return result, xerrors.Errorf("failed to count event search backfill inserts: %w", err)
+	for _, eventID := range selectedIDs {
+		plain, err := loadEventPlaintext(ctx, tx, eventID)
+		if err != nil {
+			return result, xerrors.Errorf("decode event search backfill body: %w", err)
+		}
+		bodyText, _ := visibleEventBody(string(plain), types.BodyAvailabilityAvailable)
+		command, err := hydrateAuditPayload(ctx, tx, eventID, "command")
+		if err != nil {
+			return result, err
+		}
+		input, err := hydrateAuditPayload(ctx, tx, eventID, "input")
+		if err != nil {
+			return result, err
+		}
+		output, err := hydrateAuditPayload(ctx, tx, eventID, "output")
+		if err != nil {
+			return result, err
+		}
+		insertResult, err := tx.ExecContext(ctx, `INSERT INTO event_search_documents(event_id, body_text, command_text, input_text, output_text)
+VALUES (?, ?, ?, ?, ?) ON CONFLICT(event_id) DO NOTHING`, eventID, bodyText, command.String, input.String, output.String)
+		if err != nil {
+			return result, xerrors.Errorf("materialize event search backfill row: %w", err)
+		}
+		inserted, err := insertResult.RowsAffected()
+		if err != nil {
+			return result, xerrors.Errorf("count materialized event search row: %w", err)
+		}
+		result.Inserted += inserted
 	}
 
 	result.Completed = result.LastEventID >= result.TargetID

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -428,6 +428,10 @@ func hydrateEventSearchCandidates(
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore event search candidate: %w", err)
 		}
+		event, err = hydrateEventPayload(ctx, queryer, event)
+		if err != nil {
+			return nil, err
+		}
 		events = append(events, event)
 	}
 	if err := rows.Err(); err != nil {

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -104,10 +104,12 @@ func selectEventSearchCandidateIDs(
 	shortQuery := utf8.RuneCountInString(queryValue) < 3
 	missingProjection := false
 	nonIdentityPayload := false
-	if complete && hasBoundedLegacySearchScope(criteria) {
-		missingProjection, err = boundedSearchProjectionMissing(ctx, queryer, criteria)
-		if err != nil {
-			return nil, err
+	if complete {
+		if hasBoundedLegacySearchScope(criteria) {
+			missingProjection, err = boundedSearchProjectionMissing(ctx, queryer, criteria)
+			if err != nil {
+				return nil, err
+			}
 		}
 		nonIdentityPayload, err = boundedSearchHasNonIdentityPayload(ctx, queryer, criteria)
 		if err != nil {
@@ -161,6 +163,17 @@ func boundedSearchHasNonIdentityPayload(
 	}
 	if codecColumns == 0 {
 		return false, nil
+	}
+	if !hasBoundedLegacySearchScope(criteria) {
+		var found int
+		if err := queryer.QueryRowContext(ctx, `SELECT
+			EXISTS(SELECT 1 FROM events INDEXED BY idx_events_nonidentity_body_codec WHERE body_codec <> 'identity') OR
+			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_command_codec WHERE command_codec <> 'identity') OR
+			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_input_codec WHERE input_codec <> 'identity') OR
+			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_output_codec WHERE output_codec <> 'identity')`).Scan(&found); err != nil {
+			return false, xerrors.Errorf("failed to inspect global payload codecs: %w", err)
+		}
+		return found != 0, nil
 	}
 	var builder strings.Builder
 	builder.WriteString(`SELECT EXISTS(

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -12,6 +12,7 @@ import (
 	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
 )
 
 const eventSearchLegacyCandidateLimit = 10_000
@@ -101,7 +102,14 @@ func selectEventSearchCandidateIDs(
 		return nil, err
 	}
 	shortQuery := utf8.RuneCountInString(queryValue) < 3
-	needsLegacyCompleteness := shortQuery || !complete
+	missingProjection := false
+	if complete && hasBoundedLegacySearchScope(criteria) {
+		missingProjection, err = boundedSearchProjectionMissing(ctx, queryer, criteria)
+		if err != nil {
+			return nil, err
+		}
+	}
+	needsLegacyCompleteness := shortQuery || !complete || missingProjection
 	if needsLegacyCompleteness {
 		if !hasBoundedLegacySearchScope(criteria) {
 			reason := queryservice.EventSearchUnavailableScopeTooBroad
@@ -126,13 +134,31 @@ func selectEventSearchCandidateIDs(
 		}
 	}
 
-	if shortQuery {
-		return queryLegacyEventIDs(ctx, queryer, criteria, queryValue)
+	if needsLegacyCompleteness {
+		return queryDecodedLegacyEventIDs(ctx, queryer, criteria, queryValue)
 	}
 	if complete {
 		return queryFTSEventIDs(ctx, queryer, criteria, queryValue)
 	}
 	return queryIncompleteFTSEventIDs(ctx, queryer, criteria, queryValue)
+}
+
+func boundedSearchProjectionMissing(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+) (bool, error) {
+	var builder strings.Builder
+	builder.WriteString(`SELECT EXISTS(
+		SELECT 1 FROM events e LEFT JOIN command_audits a ON a.event_id=e.id
+		 WHERE NOT EXISTS (SELECT 1 FROM event_search_documents d WHERE d.event_id=e.id)`)
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	builder.WriteString(")")
+	var missing int
+	if err := queryer.QueryRowContext(ctx, builder.String(), args...).Scan(&missing); err != nil {
+		return false, xerrors.Errorf("failed to inspect bounded event search projection: %w", err)
+	}
+	return missing != 0, nil
 }
 
 func hasBoundedLegacySearchScope(criteria apptypes.EventSearchCriteria) bool {
@@ -221,6 +247,92 @@ func queryLegacyEventIDs(
 	appendEventSearchOrderAndPage(&builder, criteria)
 	args = appendEventSearchPageArgs(args, criteria)
 	return collectEventSearchIDs(ctx, queryer, builder.String(), args, "bounded legacy event search")
+}
+
+// queryDecodedLegacyEventIDs keeps fallback search independent of the physical
+// payload representation. SQL selects only a bounded set of IDs; payloads are
+// then decoded through the same adapter boundary as normal reads before
+// literal matching and pagination are applied.
+func queryDecodedLegacyEventIDs(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+	queryValue string,
+) ([]string, error) {
+	var builder strings.Builder
+	builder.WriteString("SELECT e.id FROM events e INDEXED BY ")
+	builder.WriteString(eventSearchScopeIndex(criteria))
+	builder.WriteString(" LEFT JOIN command_audits a ON a.event_id=e.id WHERE 1=1")
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	builder.WriteString(" ORDER BY e.created_at_norm DESC, e.id DESC LIMIT ?")
+	args = append(args, eventSearchLegacyCandidateLimit+1)
+	ids, err := collectEventSearchIDs(ctx, queryer, builder.String(), args, "bounded decoded event search")
+	if err != nil {
+		return nil, err
+	}
+
+	matched := make([]string, 0)
+	for _, eventID := range ids {
+		matches, err := decodedEventSearchMatch(ctx, queryer, eventID, queryValue)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			matched = append(matched, eventID)
+		}
+	}
+	start := criteria.Offset()
+	if start >= len(matched) {
+		return []string{}, nil
+	}
+	end := min(start+criteria.Limit(), len(matched))
+	return matched[start:end], nil
+}
+
+func decodedEventSearchMatch(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	eventID string,
+	queryValue string,
+) (bool, error) {
+	var availability string
+	if err := queryer.QueryRowContext(ctx, `SELECT body_availability FROM events WHERE id=?`, eventID).Scan(&availability); err != nil {
+		return false, xerrors.Errorf("read event search body availability: %w", err)
+	}
+	parts := make([]string, 0, 4)
+	if availability != "unavailable_retention" {
+		body, err := loadEventPlaintext(ctx, queryer, eventID)
+		if err != nil {
+			return false, xerrors.Errorf("decode event search body: %w", err)
+		}
+		visible, _ := visibleEventBody(string(body), types.BodyAvailability(availability))
+		parts = append(parts, visible)
+	}
+	for _, column := range []string{"command", "input", "output"} {
+		value, err := hydrateAuditPayload(ctx, queryer, eventID, column)
+		if err != nil {
+			return false, err
+		}
+		if value.Valid {
+			parts = append(parts, value.String)
+		}
+	}
+	needle := foldSearchASCII(queryValue)
+	for _, part := range parts {
+		if strings.Contains(foldSearchASCII(part), needle) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func foldSearchASCII(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}, value)
 }
 
 func queryFTSEventIDs(

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -103,13 +103,18 @@ func selectEventSearchCandidateIDs(
 	}
 	shortQuery := utf8.RuneCountInString(queryValue) < 3
 	missingProjection := false
+	nonIdentityPayload := false
 	if complete && hasBoundedLegacySearchScope(criteria) {
 		missingProjection, err = boundedSearchProjectionMissing(ctx, queryer, criteria)
 		if err != nil {
 			return nil, err
 		}
+		nonIdentityPayload, err = boundedSearchHasNonIdentityPayload(ctx, queryer, criteria)
+		if err != nil {
+			return nil, err
+		}
 	}
-	needsLegacyCompleteness := shortQuery || !complete || missingProjection
+	needsLegacyCompleteness := shortQuery || !complete || missingProjection || nonIdentityPayload
 	if needsLegacyCompleteness {
 		if !hasBoundedLegacySearchScope(criteria) {
 			reason := queryservice.EventSearchUnavailableScopeTooBroad
@@ -141,6 +146,36 @@ func selectEventSearchCandidateIDs(
 		return queryFTSEventIDs(ctx, queryer, criteria, queryValue)
 	}
 	return queryIncompleteFTSEventIDs(ctx, queryer, criteria, queryValue)
+}
+
+func boundedSearchHasNonIdentityPayload(
+	ctx context.Context,
+	queryer eventSearchQueryer,
+	criteria apptypes.EventSearchCriteria,
+) (bool, error) {
+	var codecColumns int
+	if err := queryer.QueryRowContext(ctx, `
+		SELECT count(*) FROM pragma_table_info('events')
+		 WHERE name='body_codec'`).Scan(&codecColumns); err != nil {
+		return false, xerrors.Errorf("failed to inspect event payload codec column: %w", err)
+	}
+	if codecColumns == 0 {
+		return false, nil
+	}
+	var builder strings.Builder
+	builder.WriteString(`SELECT EXISTS(
+		SELECT 1 FROM events e LEFT JOIN command_audits a ON a.event_id=e.id
+		 WHERE (COALESCE(e.body_codec, 'identity') <> 'identity'
+		    OR COALESCE(a.command_codec, 'identity') <> 'identity'
+		    OR COALESCE(a.input_codec, 'identity') <> 'identity'
+		    OR COALESCE(a.output_codec, 'identity') <> 'identity')`)
+	args := appendEventSearchFilters(&builder, nil, criteria)
+	builder.WriteString(")")
+	var found int
+	if err := queryer.QueryRowContext(ctx, builder.String(), args...).Scan(&found); err != nil {
+		return false, xerrors.Errorf("failed to inspect bounded payload codecs: %w", err)
+	}
+	return found != 0, nil
 }
 
 func boundedSearchProjectionMissing(

--- a/infrastructure/sqlite/one_shot_repair_datasource.go
+++ b/infrastructure/sqlite/one_shot_repair_datasource.go
@@ -280,7 +280,11 @@ func applyOneShotRepairRecord(ctx context.Context, tx *sql.Tx, evidenceHash stri
 		candidate.CompletedAt,
 	)
 	event.SetSourceHook("one_shot_repair")
-	if err := insertEventAndAudit(ctx, tx, event, nil); err != nil {
+	codecMetadata, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+	if err != nil {
+		return err
+	}
+	if err := insertEventAndAudit(ctx, tx, event, nil, codecMetadata); err != nil {
 		return xerrors.Errorf("failed to append one-shot repair boundary for %s: %w", candidate.SessionID, err)
 	}
 	candidate.Applied = true

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -1,0 +1,147 @@
+package sqlite
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const payloadEnvelopePrefix = "traceary-payload-v1:"
+
+const (
+	payloadFormatVersion         = 1
+	payloadCodecIdentity         = "identity"
+	payloadCodecZstd             = "zstd"
+	maxDecodedPayloadBytes int64 = 16 << 20
+)
+
+// PayloadIntegrityError identifies corruption or an unsupported row without
+// leaking payload contents. Callers may continue serving body-free metadata.
+type PayloadIntegrityError struct {
+	Codec  string
+	Reason string
+}
+
+func (e *PayloadIntegrityError) Error() string {
+	return fmt.Sprintf("payload integrity error (codec=%s): %s", e.Codec, e.Reason)
+}
+
+type encodedPayload struct {
+	Bytes          []byte
+	Codec          string
+	FormatVersion  int
+	PlaintextBytes int64
+	StoredBytes    int64
+	SHA256         string
+}
+
+type payloadEnvelope struct {
+	Codec          string `json:"codec"`
+	FormatVersion  int    `json:"format_version"`
+	PlaintextBytes int64  `json:"plaintext_bytes"`
+	SHA256         string `json:"sha256"`
+	Stored         []byte `json:"stored"`
+}
+
+// marshalPayloadEnvelope is reserved for zstd shadow rows in v0.34. Identity
+// canonical rows deliberately remain plain text for downgrade-safe rollout.
+func marshalPayloadEnvelope(payload encodedPayload) (string, error) {
+	data, err := json.Marshal(payloadEnvelope{Codec: payload.Codec, FormatVersion: payload.FormatVersion, PlaintextBytes: payload.PlaintextBytes, SHA256: payload.SHA256, Stored: payload.Bytes})
+	if err != nil {
+		return "", fmt.Errorf("marshal payload envelope: %w", err)
+	}
+	return payloadEnvelopePrefix + string(data), nil
+}
+
+// decodeStoredPayload accepts both legacy/plain identity text and the
+// self-describing shadow envelope, allowing existing query shapes to hydrate
+// mixed rows through one bounded adapter.
+func decodeStoredPayload(stored string, limit int64) (string, error) {
+	if !strings.HasPrefix(stored, payloadEnvelopePrefix) {
+		return stored, nil
+	}
+	var envelope payloadEnvelope
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(stored, payloadEnvelopePrefix)), &envelope); err != nil {
+		return "", &PayloadIntegrityError{Codec: "unknown", Reason: "invalid envelope"}
+	}
+	decoded, err := decodePayload(envelope.Stored, envelope.Codec, envelope.FormatVersion, envelope.PlaintextBytes, envelope.SHA256, limit)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+func encodePayload(plaintext []byte, codec string) (encodedPayload, error) {
+	result := encodedPayload{Codec: codec, FormatVersion: payloadFormatVersion, PlaintextBytes: int64(len(plaintext))}
+	sum := sha256.Sum256(plaintext)
+	result.SHA256 = hex.EncodeToString(sum[:])
+	switch codec {
+	case payloadCodecIdentity:
+		result.Bytes = bytes.Clone(plaintext)
+	case payloadCodecZstd:
+		encoder, err := zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1))
+		if err != nil {
+			return encodedPayload{}, fmt.Errorf("create zstd encoder: %w", err)
+		}
+		result.Bytes = encoder.EncodeAll(plaintext, nil)
+		if err := encoder.Close(); err != nil {
+			return encodedPayload{}, fmt.Errorf("close zstd encoder: %w", err)
+		}
+	default:
+		return encodedPayload{}, &PayloadIntegrityError{Codec: codec, Reason: "unsupported codec"}
+	}
+	result.StoredBytes = int64(len(result.Bytes))
+	return result, nil
+}
+
+func decodePayload(stored []byte, codec string, formatVersion int, plaintextBytes int64, checksum string, limit int64) ([]byte, error) {
+	if formatVersion != payloadFormatVersion {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "unsupported format version"}
+	}
+	if limit < 0 || plaintextBytes < 0 || plaintextBytes > limit {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "decoded length exceeds limit"}
+	}
+	var reader io.Reader
+	switch codec {
+	case payloadCodecIdentity:
+		reader = bytes.NewReader(stored)
+	case payloadCodecZstd:
+		decoder, err := zstd.NewReader(bytes.NewReader(stored), zstd.WithDecoderConcurrency(1), zstd.WithDecoderMaxMemory(uint64(limit)+1))
+		if err != nil {
+			return nil, &PayloadIntegrityError{Codec: codec, Reason: "invalid compressed stream"}
+		}
+		defer decoder.Close()
+		reader = decoder
+	default:
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "unsupported codec"}
+	}
+	bounded := io.LimitReader(reader, limit+1)
+	decoded, err := io.ReadAll(bounded)
+	if err != nil {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "decode failed"}
+	}
+	if int64(len(decoded)) > limit {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "decoded length exceeds limit"}
+	}
+	if int64(len(decoded)) != plaintextBytes {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "plaintext length mismatch"}
+	}
+	sum := sha256.Sum256(decoded)
+	expected, err := hex.DecodeString(checksum)
+	if err != nil || !bytes.Equal(sum[:], expected) {
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "checksum mismatch"}
+	}
+	return decoded, nil
+}
+
+func isPayloadIntegrityError(err error) bool {
+	var target *PayloadIntegrityError
+	return errors.As(err, &target)
+}

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -80,6 +80,9 @@ func (r payloadRow) decode(limit int64) ([]byte, error) {
 		}
 	}
 	if metadataCount == 0 {
+		if int64(len(r.Stored)) > limit {
+			return nil, &PayloadIntegrityError{Codec: payloadCodecIdentity, Reason: "decoded length exceeds limit"}
+		}
 		return bytes.Clone(r.Stored), nil
 	}
 	if metadataCount != 5 {

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -69,11 +69,21 @@ func (r *payloadRow) scanDestinations() []any {
 }
 
 func (r payloadRow) decode(limit int64) ([]byte, error) {
-	if !r.Codec.Valid {
+	metadataCount := 0
+	for _, valid := range []bool{r.Codec.Valid, r.FormatVersion.Valid, r.PlaintextBytes.Valid, r.StoredBytes.Valid, r.SHA256.Valid} {
+		if valid {
+			metadataCount++
+		}
+	}
+	if metadataCount == 0 {
 		return bytes.Clone(r.Stored), nil
 	}
-	if !r.FormatVersion.Valid || !r.PlaintextBytes.Valid || !r.StoredBytes.Valid || !r.SHA256.Valid {
-		return nil, &PayloadIntegrityError{Codec: r.Codec.String, Reason: "incomplete metadata"}
+	if metadataCount != 5 {
+		codec := r.Codec.String
+		if !r.Codec.Valid {
+			codec = "unknown"
+		}
+		return nil, &PayloadIntegrityError{Codec: codec, Reason: "incomplete metadata"}
 	}
 	if r.StoredBytes.Int64 != int64(len(r.Stored)) {
 		return nil, &PayloadIntegrityError{Codec: r.Codec.String, Reason: "stored length mismatch"}

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -17,6 +17,10 @@ const (
 	payloadCodecIdentity         = "identity"
 	payloadCodecZstd             = "zstd"
 	maxDecodedPayloadBytes int64 = 16 << 20
+	// zstd's MaxEncodedSize adds frame and block overhead to the plaintext.
+	// Keep a bounded margin larger than that overhead for a 16 MiB frame while
+	// retaining a hard allocation ceiling for corrupt physical values.
+	maxStoredPayloadBytes int64 = maxDecodedPayloadBytes + (64 << 10)
 )
 
 // PayloadIntegrityError identifies corruption or an unsupported row without

--- a/infrastructure/sqlite/payload_codec.go
+++ b/infrastructure/sqlite/payload_codec.go
@@ -3,17 +3,14 @@ package sqlite
 import (
 	"bytes"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/klauspost/compress/zstd"
 )
-
-const payloadEnvelopePrefix = "traceary-payload-v1:"
 
 const (
 	payloadFormatVersion         = 1
@@ -27,10 +24,24 @@ const (
 type PayloadIntegrityError struct {
 	Codec  string
 	Reason string
+	RowID  string
+	Field  string
 }
 
 func (e *PayloadIntegrityError) Error() string {
-	return fmt.Sprintf("payload integrity error (codec=%s): %s", e.Codec, e.Reason)
+	location := ""
+	if e.RowID != "" {
+		location = fmt.Sprintf(", row=%s, field=%s", e.RowID, e.Field)
+	}
+	return fmt.Sprintf("payload integrity error (codec=%s%s): %s", e.Codec, location, e.Reason)
+}
+
+func annotatePayloadError(err error, rowID, field string) error {
+	var integrity *PayloadIntegrityError
+	if errors.As(err, &integrity) {
+		integrity.RowID, integrity.Field = rowID, field
+	}
+	return err
 }
 
 type encodedPayload struct {
@@ -42,40 +53,32 @@ type encodedPayload struct {
 	SHA256         string
 }
 
-type payloadEnvelope struct {
-	Codec          string `json:"codec"`
-	FormatVersion  int    `json:"format_version"`
-	PlaintextBytes int64  `json:"plaintext_bytes"`
-	SHA256         string `json:"sha256"`
-	Stored         []byte `json:"stored"`
+// payloadRow is the only persisted payload contract. Legacy rows have NULL
+// metadata and are interpreted as identity; no plaintext prefix is reserved.
+type payloadRow struct {
+	Stored         []byte
+	Codec          sql.NullString
+	FormatVersion  sql.NullInt64
+	PlaintextBytes sql.NullInt64
+	StoredBytes    sql.NullInt64
+	SHA256         sql.NullString
 }
 
-// marshalPayloadEnvelope is reserved for zstd shadow rows in v0.34. Identity
-// canonical rows deliberately remain plain text for downgrade-safe rollout.
-func marshalPayloadEnvelope(payload encodedPayload) (string, error) {
-	data, err := json.Marshal(payloadEnvelope{Codec: payload.Codec, FormatVersion: payload.FormatVersion, PlaintextBytes: payload.PlaintextBytes, SHA256: payload.SHA256, Stored: payload.Bytes})
-	if err != nil {
-		return "", fmt.Errorf("marshal payload envelope: %w", err)
-	}
-	return payloadEnvelopePrefix + string(data), nil
+func (r *payloadRow) scanDestinations() []any {
+	return []any{&r.Stored, &r.Codec, &r.FormatVersion, &r.PlaintextBytes, &r.StoredBytes, &r.SHA256}
 }
 
-// decodeStoredPayload accepts both legacy/plain identity text and the
-// self-describing shadow envelope, allowing existing query shapes to hydrate
-// mixed rows through one bounded adapter.
-func decodeStoredPayload(stored string, limit int64) (string, error) {
-	if !strings.HasPrefix(stored, payloadEnvelopePrefix) {
-		return stored, nil
+func (r payloadRow) decode(limit int64) ([]byte, error) {
+	if !r.Codec.Valid {
+		return bytes.Clone(r.Stored), nil
 	}
-	var envelope payloadEnvelope
-	if err := json.Unmarshal([]byte(strings.TrimPrefix(stored, payloadEnvelopePrefix)), &envelope); err != nil {
-		return "", &PayloadIntegrityError{Codec: "unknown", Reason: "invalid envelope"}
+	if !r.FormatVersion.Valid || !r.PlaintextBytes.Valid || !r.StoredBytes.Valid || !r.SHA256.Valid {
+		return nil, &PayloadIntegrityError{Codec: r.Codec.String, Reason: "incomplete metadata"}
 	}
-	decoded, err := decodePayload(envelope.Stored, envelope.Codec, envelope.FormatVersion, envelope.PlaintextBytes, envelope.SHA256, limit)
-	if err != nil {
-		return "", err
+	if r.StoredBytes.Int64 != int64(len(r.Stored)) {
+		return nil, &PayloadIntegrityError{Codec: r.Codec.String, Reason: "stored length mismatch"}
 	}
-	return string(decoded), nil
+	return decodePayload(r.Stored, r.Codec.String, int(r.FormatVersion.Int64), r.PlaintextBytes.Int64, r.SHA256.String, limit)
 }
 
 func encodePayload(plaintext []byte, codec string) (encodedPayload, error) {

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -7,10 +7,16 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	domtypes "github.com/duck8823/traceary/domain/types"
 )
 
 func TestPayloadCodecRoundTripsIdentityAndZstd(t *testing.T) {
@@ -205,23 +211,209 @@ func TestMixedPayloadRowsKeepHealthyRowsAndMetadataAvailable(t *testing.T) {
 	}
 }
 
-func TestStoredPayloadHydrationSupportsLegacyIdentityAndZstdEnvelope(t *testing.T) {
-	if got, err := decodeStoredPayload("legacy identity", maxDecodedPayloadBytes); err != nil || got != "legacy identity" {
+func TestPayloadRowHydratesLegacyIdentityAndZstdWithoutReservedPrefix(t *testing.T) {
+	legacy := payloadRow{Stored: []byte("traceary-payload-v1:{legitimate plaintext}")}
+	got, err := legacy.decode(maxDecodedPayloadBytes)
+	if err != nil || string(got) != string(legacy.Stored) {
 		t.Fatalf("legacy = %q, %v", got, err)
 	}
 	encoded, err := encodePayload([]byte("zstd shadow row"), payloadCodecZstd)
 	if err != nil {
 		t.Fatal(err)
 	}
-	envelope, err := marshalPayloadEnvelope(encoded)
+	row := payloadRow{Stored: encoded.Bytes,
+		Codec:          sql.NullString{String: encoded.Codec, Valid: true},
+		FormatVersion:  sql.NullInt64{Int64: int64(encoded.FormatVersion), Valid: true},
+		PlaintextBytes: sql.NullInt64{Int64: encoded.PlaintextBytes, Valid: true},
+		StoredBytes:    sql.NullInt64{Int64: encoded.StoredBytes, Valid: true},
+		SHA256:         sql.NullString{String: encoded.SHA256, Valid: true}}
+	got, err = row.decode(maxDecodedPayloadBytes)
+	if err != nil || string(got) != "zstd shadow row" {
+		t.Fatalf("zstd = %q, %v", got, err)
+	}
+	row.StoredBytes.Int64++
+	if _, err := row.decode(maxDecodedPayloadBytes); !isPayloadIntegrityError(err) {
+		t.Fatalf("corrupt error = %v", err)
+	}
+}
+
+func TestProductionQueriesHydrateMixedRowsAndMetadataSurvivesCorruption(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/mixed.db"
+	database := NewDatabase(path, os.DirFS("../../schema/sqlite/migrations"))
+	if err := database.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := database.open(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := decodeStoredPayload(envelope, maxDecodedPayloadBytes)
-	if err != nil || got != "zstd shadow row" {
-		t.Fatalf("zstd = %q, %v", got, err)
+	defer func() { _ = raw.Close() }()
+	insert := func(id, session, plaintext, codec string, corrupt bool) {
+		t.Helper()
+		payload, err := encodePayload([]byte(plaintext), codec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checksum := payload.SHA256
+		if corrupt {
+			checksum = strings.Repeat("0", 64)
+		}
+		_, err = raw.ExecContext(ctx, `INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at,source_hook,
+body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256)
+VALUES(?, 'prompt','hook','codex',?,'/repo',?,'2026-08-01T00:00:00Z','user_prompt_submit',?,?,?,?,?)`,
+			id, session, payload.Bytes, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, checksum)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
-	if _, err := decodeStoredPayload(payloadEnvelopePrefix+"{", maxDecodedPayloadBytes); !isPayloadIntegrityError(err) {
-		t.Fatalf("corrupt error = %v", err)
+	insert("identity", "identity-session", "identity body", payloadCodecIdentity, false)
+	insert("zstd", "zstd-session", "compressed body", payloadCodecZstd, false)
+	insert("timeline-zstd", "tree-root", "timeline compressed prompt", payloadCodecZstd, false)
+	if _, err := raw.ExecContext(ctx, `UPDATE events SET workspace='/timeline', created_at='2026-08-01T01:00:00Z' WHERE id='timeline-zstd'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO sessions(session_id,started_at,client,agent,workspace,label,summary) VALUES('tree-root','2026-08-01T00:00:00Z','hook','codex','/timeline','','')`); err != nil {
+		t.Fatal(err)
+	}
+	command, _ := encodePayload([]byte("echo redacted"), payloadCodecZstd)
+	input, _ := encodePayload([]byte("input"), payloadCodecIdentity)
+	output, _ := encodePayload([]byte("output"), payloadCodecZstd)
+	_, err = raw.ExecContext(ctx, `INSERT INTO command_audits(event_id,command_text,command_wrapper,command_name,input_text,output_text,input_truncated,output_truncated,input_original_bytes,output_original_bytes,failed,failure_reason,
+command_codec,command_format_version,command_plaintext_bytes,command_encoded_bytes,command_sha256,
+input_codec,input_format_version,input_plaintext_bytes,input_encoded_bytes,input_sha256,
+output_codec,output_format_version,output_plaintext_bytes,output_encoded_bytes,output_sha256)
+VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		command.Bytes, input.Bytes, output.Bytes,
+		command.Codec, command.FormatVersion, command.PlaintextBytes, command.StoredBytes, command.SHA256,
+		input.Codec, input.FormatVersion, input.PlaintextBytes, input.StoredBytes, input.SHA256,
+		output.Codec, output.FormatVersion, output.PlaintextBytes, output.StoredBytes, output.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insert("corrupt", "corrupt-session", "corrupt body", payloadCodecZstd, true)
+	if _, err := raw.ExecContext(ctx, `UPDATE events SET created_at='2030-01-01T00:00:00Z' WHERE id='corrupt'`); err != nil {
+		t.Fatal(err)
+	}
+	datasource := NewEventDatasource(database)
+	eventUC := usecase.NewEventUsecase(datasource, datasource)
+	redacted, err := eventUC.Log(ctx, "Authorization: Bearer secret-token-value", domtypes.EventKindTranscript, "hook", "codex", "redaction-session", "/repo", apptypes.NewLogRedactionBuilder().Build())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var storedBody, checksum string
+	if err := raw.QueryRowContext(ctx, `SELECT CAST(body AS TEXT), body_sha256 FROM events WHERE id=?`, redacted.EventID().String()).Scan(&storedBody, &checksum); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(storedBody, "secret-token-value") || !strings.Contains(storedBody, "[REDACTED]") {
+		t.Fatalf("stored redaction body = %q", storedBody)
+	}
+	digest := sha256.Sum256([]byte(storedBody))
+	if checksum != hex.EncodeToString(digest[:]) {
+		t.Fatal("checksum was not computed after redaction")
+	}
+	timeline, err := datasource.ListTimelineBlocks(ctx, "/timeline", time.Time{}, time.Time{}, 1800, 10)
+	if err != nil || len(timeline) != 1 || timeline[0].WorkspaceBreakdown()[0].Summary() != "timeline compressed prompt" {
+		t.Fatalf("timeline = %#v, %v", timeline, err)
+	}
+	sessions := NewSessionDatasource(database)
+	tree, err := sessions.ListTreeSummaries(ctx, 10, "/timeline", "tree-root")
+	if err != nil || len(tree) != 1 || tree[0].LatestEventMessage() != "timeline compressed prompt" {
+		t.Fatalf("tree = %#v, %v", tree, err)
+	}
+	got, err := datasource.ListRecent(ctx, 10, 0, "", "", "", "zstd-session", "", false, time.Time{}, time.Time{}, "")
+	if err != nil || len(got) != 1 || got[0].Body() != "compressed body" {
+		t.Fatalf("zstd query = %#v, %v", got, err)
+	}
+	if _, err := raw.ExecContext(ctx, `UPDATE event_search_documents SET body_text='compressed body' WHERE event_id='zstd'`); err != nil {
+		t.Fatal(err)
+	}
+	searched, err := datasource.Search(ctx, "compressed", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil || len(searched) != 1 || searched[0].Body() != "compressed body" {
+		t.Fatalf("search = %#v, %v", searched, err)
+	}
+	details, err := datasource.GetDetails(ctx, "zstd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit, ok := details.CommandAudit().Value()
+	if !ok || audit.Command() != "echo redacted" || audit.Output() != "output" {
+		t.Fatalf("audit = %#v", audit)
+	}
+	_, err = datasource.ListRecent(ctx, 10, 0, "", "", "", "corrupt-session", "", false, time.Time{}, time.Time{}, "")
+	var integrity *PayloadIntegrityError
+	if !errors.As(err, &integrity) || integrity.RowID != "corrupt" || integrity.Field != "body" {
+		t.Fatalf("corrupt error = %#v, %v", integrity, err)
+	}
+	metadata, err := datasource.ListRecentMetadata(ctx, apptypes.NewEventListCriteriaBuilder(10).Build())
+	if err != nil || len(metadata) != 5 {
+		t.Fatalf("metadata = %d, %v", len(metadata), err)
+	}
+	bundle := NewBundleDatasource(database, datasource)
+	audits, err := bundle.ListBundleCommandAudits(ctx)
+	if err != nil || len(audits) != 1 || audits[0].Output() != "output" {
+		t.Fatalf("bundle audits = %#v, %v", audits, err)
+	}
+	manager := NewStoreManagementDatasource(database)
+	tables, err := manager.ListArchiveEligible(ctx, time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC), apptypes.GarbageCollectionTargetEvents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundZstd := false
+	for _, table := range tables {
+		if table.Name == "events" {
+			for _, row := range table.Rows {
+				if row["id"] == "zstd" && row["body"] == "compressed body" {
+					foundZstd = true
+				}
+			}
+		}
+	}
+	if !foundZstd {
+		t.Fatal("archive export did not expose decoded zstd body")
+	}
+	if _, err := manager.DeleteArchiveRows(ctx, map[string][]string{"events": {"identity", "zstd"}}); err != nil {
+		t.Fatal(err)
+	}
+	inserted, _, _, err := manager.RestoreArchiveRows(ctx, tables, false)
+	if err != nil || inserted < 3 {
+		t.Fatalf("archive restore = %d, %v", inserted, err)
+	}
+	restored, err := datasource.GetDetails(ctx, "zstd")
+	if err != nil || restored.Event().Body() != "compressed body" {
+		t.Fatalf("restored = %#v, %v", restored, err)
+	}
+}
+
+func TestPayloadDecodeBoundaryAndHighRatioBomb(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), int(maxDecodedPayloadBytes))
+	encoded, err := encodePayload(payload, payloadCodecZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodePayload(encoded.Bytes, encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, maxDecodedPayloadBytes); err != nil {
+		t.Fatalf("exact boundary: %v", err)
+	}
+	if _, err := decodePayload(encoded.Bytes, encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, maxDecodedPayloadBytes-1); !isPayloadIntegrityError(err) {
+		t.Fatalf("limit-1 error = %v", err)
+	}
+	bomb := encoded
+	bomb.PlaintextBytes = maxDecodedPayloadBytes + 1
+	if _, err := decodePayload(bomb.Bytes, bomb.Codec, bomb.FormatVersion, bomb.PlaintextBytes, bomb.SHA256, maxDecodedPayloadBytes); !isPayloadIntegrityError(err) {
+		t.Fatalf("bomb error = %v", err)
+	}
+}
+
+func TestStoreCompatibilityRejectsMissingStateRow(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE store_format_state(singleton INTEGER PRIMARY KEY, minimum_reader_version INTEGER NOT NULL, maximum_payload_format INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyStoreCompatibility(context.Background(), db); err == nil {
+		t.Fatal("missing singleton state was accepted")
 	}
 }

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
 	domtypes "github.com/duck8823/traceary/domain/types"
@@ -467,6 +468,11 @@ ON CONFLICT(event_id) DO UPDATE SET body_text=excluded.body_text, command_text=e
 	auditSearched, err := datasource.Search(ctx, "redacted", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
 	if err != nil || len(auditSearched) != 1 || auditSearched[0].EventID().String() != "zstd" {
 		t.Fatalf("audit decoded search = %#v, %v", auditSearched, err)
+	}
+	_, err = datasource.Search(ctx, "compressed", "", "", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	var unavailable *queryservice.EventSearchUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != queryservice.EventSearchUnavailableIndexIncomplete {
+		t.Fatalf("unbounded stale projection error = %v, want explicit index-incomplete error", err)
 	}
 	details, err := datasource.GetDetails(ctx, "zstd")
 	if err != nil {

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -1,0 +1,227 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestPayloadCodecRoundTripsIdentityAndZstd(t *testing.T) {
+	plaintext := bytes.Repeat([]byte("redacted synthetic payload "), 1024)
+	for _, codec := range []string{payloadCodecIdentity, payloadCodecZstd} {
+		t.Run(codec, func(t *testing.T) {
+			encoded, err := encodePayload(plaintext, codec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := decodePayload(encoded.Bytes, encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, maxDecodedPayloadBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(decoded, plaintext) {
+				t.Fatal("round trip changed bytes")
+			}
+			if encoded.StoredBytes != int64(len(encoded.Bytes)) {
+				t.Fatal("stored length mismatch")
+			}
+		})
+	}
+}
+
+func TestPayloadCodecRejectsUnknownCorruptAndOverLimitRows(t *testing.T) {
+	encoded, err := encodePayload(bytes.Repeat([]byte("a"), 4096), payloadCodecZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name          string
+		codec         string
+		version       int
+		bytes         []byte
+		length, limit int64
+		checksum      string
+	}{
+		{"unknown codec", "future", 1, encoded.Bytes, encoded.PlaintextBytes, maxDecodedPayloadBytes, encoded.SHA256},
+		{"unknown format", payloadCodecZstd, 2, encoded.Bytes, encoded.PlaintextBytes, maxDecodedPayloadBytes, encoded.SHA256},
+		{"corrupt stream", payloadCodecZstd, 1, []byte("not-zstd"), encoded.PlaintextBytes, maxDecodedPayloadBytes, encoded.SHA256},
+		{"checksum", payloadCodecZstd, 1, encoded.Bytes, encoded.PlaintextBytes, maxDecodedPayloadBytes, strings.Repeat("0", 64)},
+		{"bounded", payloadCodecZstd, 1, encoded.Bytes, encoded.PlaintextBytes, 1024, encoded.SHA256},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodePayload(tt.bytes, tt.codec, tt.version, tt.length, tt.checksum, tt.limit)
+			if !isPayloadIntegrityError(err) {
+				t.Fatalf("error = %v, want PayloadIntegrityError", err)
+			}
+		})
+	}
+}
+
+func TestStoreCompatibilityGate(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name        string
+		min, format int
+		wantErr     bool
+	}{
+		{"supported", 34, 1, false}, {"future reader", 35, 1, true}, {"future format", 34, 2, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite", ":memory:")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close() }()
+			if _, err := db.Exec(`CREATE TABLE store_format_state(singleton INTEGER PRIMARY KEY, minimum_reader_version INTEGER NOT NULL, maximum_payload_format INTEGER NOT NULL); INSERT INTO store_format_state VALUES(1, ?, ?)`, tc.min, tc.format); err != nil {
+				t.Fatal(err)
+			}
+			err = checkStoreCompatibility(ctx, db)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIdentityMetadataChecksum(t *testing.T) {
+	plaintext := []byte("secret=[REDACTED]")
+	encoded, err := encodePayload(plaintext, payloadCodecIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(plaintext)
+	if encoded.SHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatal("checksum was not computed over redacted plaintext")
+	}
+	var integrity *PayloadIntegrityError
+	_, err = decodePayload([]byte("secret=raw"), encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, maxDecodedPayloadBytes)
+	if !errors.As(err, &integrity) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func BenchmarkPayloadCodecSynthetic(b *testing.B) {
+	payload := bytes.Repeat([]byte(`{"type":"text","text":"synthetic redacted trace payload"}`), 16384)
+	b.Run("identity-write", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := encodePayload(payload, payloadCodecIdentity); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("zstd-write", func(b *testing.B) {
+		probe, err := encodePayload(payload, payloadCodecZstd)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportMetric(float64(probe.StoredBytes)/float64(probe.PlaintextBytes), "stored/plain")
+		for i := 0; i < b.N; i++ {
+			if _, err := encodePayload(payload, payloadCodecZstd); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	encoded, err := encodePayload(payload, payloadCodecZstd)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("maximum-bounded-decode", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := decodePayload(encoded.Bytes, encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.SHA256, int64(len(payload))); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestDatabaseOpenModesEnforceCompatibility(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/future.db"
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE store_format_state(singleton INTEGER PRIMARY KEY, minimum_reader_version INTEGER NOT NULL, maximum_payload_format INTEGER NOT NULL); INSERT INTO store_format_state VALUES(1, 35, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database := NewDatabase(path, nil)
+	if _, err := database.open(ctx); err == nil {
+		t.Fatal("writable open accepted future reader requirement")
+	}
+	if _, err := database.openReadOnly(ctx); err == nil {
+		t.Fatal("read-only open accepted future reader requirement")
+	}
+	if _, err := NewImmutableReadDatabase(ctx, path); err == nil {
+		t.Fatal("immutable open accepted future reader requirement")
+	}
+}
+
+func TestMixedPayloadRowsKeepHealthyRowsAndMetadataAvailable(t *testing.T) {
+	identity, err := encodePayload([]byte("identity row"), payloadCodecIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed, err := encodePayload([]byte("compressed row"), payloadCodecZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupt := compressed
+	corrupt.SHA256 = strings.Repeat("f", 64)
+
+	// Metadata is read before individual hydration, so one row-level error
+	// cannot erase the status of another row.
+	rows := []struct {
+		id, status string
+		payload    encodedPayload
+	}{{"one", "available", identity}, {"two", "available", corrupt}, {"three", "available", compressed}}
+	statuses := map[string]string{}
+	decoded := map[string]string{}
+	failures := 0
+	for _, row := range rows {
+		statuses[row.id] = row.status
+		plain, err := decodePayload(row.payload.Bytes, row.payload.Codec, row.payload.FormatVersion, row.payload.PlaintextBytes, row.payload.SHA256, maxDecodedPayloadBytes)
+		if err != nil {
+			failures++
+			continue
+		}
+		decoded[row.id] = string(plain)
+	}
+	if failures != 1 || len(statuses) != 3 {
+		t.Fatalf("failures=%d statuses=%d", failures, len(statuses))
+	}
+	if decoded["one"] != "identity row" || decoded["three"] != "compressed row" {
+		t.Fatalf("healthy rows = %#v", decoded)
+	}
+}
+
+func TestStoredPayloadHydrationSupportsLegacyIdentityAndZstdEnvelope(t *testing.T) {
+	if got, err := decodeStoredPayload("legacy identity", maxDecodedPayloadBytes); err != nil || got != "legacy identity" {
+		t.Fatalf("legacy = %q, %v", got, err)
+	}
+	encoded, err := encodePayload([]byte("zstd shadow row"), payloadCodecZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := marshalPayloadEnvelope(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeStoredPayload(envelope, maxDecodedPayloadBytes)
+	if err != nil || got != "zstd shadow row" {
+		t.Fatalf("zstd = %q, %v", got, err)
+	}
+	if _, err := decodeStoredPayload(payloadEnvelopePrefix+"{", maxDecodedPayloadBytes); !isPayloadIntegrityError(err) {
+		t.Fatalf("corrupt error = %v", err)
+	}
+}

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -237,6 +237,85 @@ func TestPayloadRowHydratesLegacyIdentityAndZstdWithoutReservedPrefix(t *testing
 	}
 }
 
+func TestPayloadRowRejectsEveryPartialMetadataCombination(t *testing.T) {
+	fields := []func(*payloadRow){
+		func(row *payloadRow) { row.Codec = sql.NullString{String: payloadCodecIdentity, Valid: true} },
+		func(row *payloadRow) { row.FormatVersion = sql.NullInt64{Int64: 1, Valid: true} },
+		func(row *payloadRow) { row.PlaintextBytes = sql.NullInt64{Int64: 1, Valid: true} },
+		func(row *payloadRow) { row.StoredBytes = sql.NullInt64{Int64: 1, Valid: true} },
+		func(row *payloadRow) { row.SHA256 = sql.NullString{String: strings.Repeat("0", 64), Valid: true} },
+	}
+	for index, set := range fields {
+		row := payloadRow{Stored: []byte("x")}
+		set(&row)
+		_, err := row.decode(maxDecodedPayloadBytes)
+		var integrity *PayloadIntegrityError
+		if !errors.As(err, &integrity) || integrity.Reason != "incomplete metadata" {
+			t.Fatalf("partial metadata %d error = %v", index, err)
+		}
+	}
+}
+
+func TestLoadEventPlaintextRejectsOversizedPhysicalValueBeforeScan(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/oversized.db"
+	database := NewDatabase(path, os.DirFS("../../schema/sqlite/migrations"))
+	if err := database.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	for _, codec := range []string{"legacy", payloadCodecIdentity, payloadCodecZstd} {
+		id := "oversized-" + codec
+		metadata := []any{nil, nil, nil, nil, nil}
+		if codec != "legacy" {
+			metadata = []any{codec, 1, maxDecodedPayloadBytes + 1, maxDecodedPayloadBytes + 1, strings.Repeat("0", 64)}
+		}
+		_, err = raw.ExecContext(ctx, `INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at,source_hook,
+body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256)
+VALUES(?, 'prompt','hook','codex',?,'/repo',zeroblob(?),'2026-08-01T00:00:00Z','user_prompt_submit',?,?,?,?,?)`,
+			id, id, maxDecodedPayloadBytes+1, metadata[0], metadata[1], metadata[2], metadata[3], metadata[4])
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = loadEventPlaintext(ctx, raw, id)
+		var integrity *PayloadIntegrityError
+		if !errors.As(err, &integrity) || integrity.RowID != id || integrity.Field != "body" || integrity.Reason != "stored length exceeds limit" {
+			t.Fatalf("%s error = %#v", codec, err)
+		}
+	}
+}
+
+func TestMigrationDoesNotInstallApplicationFunctionDependentPayloadTrigger(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/external-writer.db"
+	database := NewDatabase(path, os.DirFS("../../schema/sqlite/migrations"))
+	if err := database.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	var count int
+	if err := raw.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_master WHERE type='trigger' AND name='events_identity_payload_metadata_after_update'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("application-dependent triggers = %d", count)
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at,source_hook) VALUES('external','prompt','legacy','legacy','s','/repo','before','2026-08-01T00:00:00Z','user_prompt_submit')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.ExecContext(ctx, `UPDATE events SET body='after' WHERE id='external'`); err != nil {
+		t.Fatalf("external SQLite update failed: %v", err)
+	}
+}
+
 func TestProductionQueriesHydrateMixedRowsAndMetadataSurvivesCorruption(t *testing.T) {
 	ctx := context.Background()
 	path := t.TempDir() + "/mixed.db"
@@ -325,12 +404,22 @@ VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	if err != nil || len(got) != 1 || got[0].Body() != "compressed body" {
 		t.Fatalf("zstd query = %#v, %v", got, err)
 	}
-	if _, err := raw.ExecContext(ctx, `UPDATE event_search_documents SET body_text='compressed body' WHERE event_id='zstd'`); err != nil {
+	// Simulate a missing FTS projection. Bounded fallback must select IDs in
+	// SQL, then decode both the event and audit payloads before matching.
+	if _, err := raw.ExecContext(ctx, `DELETE FROM event_search_documents WHERE event_id='zstd'`); err != nil {
 		t.Fatal(err)
 	}
 	searched, err := datasource.Search(ctx, "compressed", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
 	if err != nil || len(searched) != 1 || searched[0].Body() != "compressed body" {
 		t.Fatalf("search = %#v, %v", searched, err)
+	}
+	shortSearched, err := datasource.Search(ctx, "ed", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil || len(shortSearched) != 1 || shortSearched[0].EventID().String() != "zstd" {
+		t.Fatalf("short decoded search = %#v, %v", shortSearched, err)
+	}
+	auditSearched, err := datasource.Search(ctx, "redacted", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)
+	if err != nil || len(auditSearched) != 1 || auditSearched[0].EventID().String() != "zstd" {
+		t.Fatalf("audit decoded search = %#v, %v", auditSearched, err)
 	}
 	details, err := datasource.GetDetails(ctx, "zstd")
 	if err != nil {

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -274,12 +274,12 @@ func TestLoadEventPlaintextRejectsOversizedPhysicalValueBeforeScan(t *testing.T)
 		id := "oversized-" + codec
 		metadata := []any{nil, nil, nil, nil, nil}
 		if codec != "legacy" {
-			metadata = []any{codec, 1, maxDecodedPayloadBytes + 1, maxDecodedPayloadBytes + 1, strings.Repeat("0", 64)}
+			metadata = []any{codec, 1, maxDecodedPayloadBytes + 1, maxStoredPayloadBytes + 1, strings.Repeat("0", 64)}
 		}
 		_, err = raw.ExecContext(ctx, `INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at,source_hook,
 body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256)
 VALUES(?, 'prompt','hook','codex',?,'/repo',zeroblob(?),'2026-08-01T00:00:00Z','user_prompt_submit',?,?,?,?,?)`,
-			id, id, maxDecodedPayloadBytes+1, metadata[0], metadata[1], metadata[2], metadata[3], metadata[4])
+			id, id, maxStoredPayloadBytes+1, metadata[0], metadata[1], metadata[2], metadata[3], metadata[4])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,6 +288,49 @@ VALUES(?, 'prompt','hook','codex',?,'/repo',zeroblob(?),'2026-08-01T00:00:00Z','
 		if !errors.As(err, &integrity) || integrity.RowID != id || integrity.Field != "body" || integrity.Reason != "stored length exceeds limit" {
 			t.Fatalf("%s error = %#v", codec, err)
 		}
+	}
+}
+
+func TestLoadEventPlaintextHydratesIncompressibleExactDecodedLimit(t *testing.T) {
+	ctx := context.Background()
+	plaintext := make([]byte, maxDecodedPayloadBytes)
+	state := uint64(0x9e3779b97f4a7c15)
+	for index := range plaintext {
+		state ^= state << 13
+		state ^= state >> 7
+		state ^= state << 17
+		plaintext[index] = byte(state)
+	}
+	encoded, err := encodePayload(plaintext, payloadCodecZstd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encoded.StoredBytes <= maxDecodedPayloadBytes || encoded.StoredBytes > maxStoredPayloadBytes {
+		t.Fatalf("stored bytes = %d, want (%d, %d]", encoded.StoredBytes, maxDecodedPayloadBytes, maxStoredPayloadBytes)
+	}
+	path := t.TempDir() + "/exact-limit.db"
+	database := NewDatabase(path, os.DirFS("../../schema/sqlite/migrations"))
+	if err := database.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	_, err = raw.ExecContext(ctx, `INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at,source_hook,
+body_codec,body_format_version,body_plaintext_bytes,body_encoded_bytes,body_sha256)
+VALUES('exact-limit','prompt','hook','codex','exact-limit','/repo',?,'2026-08-01T00:00:00Z','user_prompt_submit',?,?,?,?,?)`,
+		encoded.Bytes, encoded.Codec, encoded.FormatVersion, encoded.PlaintextBytes, encoded.StoredBytes, encoded.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadEventPlaintext(ctx, raw, "exact-limit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatal("hydrated payload differs at exact decoded limit")
 	}
 }
 
@@ -406,9 +449,11 @@ VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	if err != nil || len(got) != 1 || got[0].Body() != "compressed body" {
 		t.Fatalf("zstd query = %#v, %v", got, err)
 	}
-	// Simulate a missing FTS projection. Bounded fallback must select IDs in
-	// SQL, then decode both the event and audit payloads before matching.
-	if _, err := raw.ExecContext(ctx, `DELETE FROM event_search_documents WHERE event_id='zstd'`); err != nil {
+	// Simulate a stale trigger-produced projection that contains only physical
+	// compressed bytes. Its presence must not prevent canonical decoded search.
+	if _, err := raw.ExecContext(ctx, `INSERT INTO event_search_documents(event_id,body_text,command_text,input_text,output_text)
+VALUES('zstd','stale projection','stale command','stale input','stale output')
+ON CONFLICT(event_id) DO UPDATE SET body_text=excluded.body_text, command_text=excluded.command_text, input_text=excluded.input_text, output_text=excluded.output_text`); err != nil {
 		t.Fatal(err)
 	}
 	searched, err := datasource.Search(ctx, "compressed", "", "zstd-session", "", "", "", time.Time{}, time.Time{}, 10, 0, false)

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -259,6 +259,40 @@ func TestPayloadRowRejectsEveryPartialMetadataCombination(t *testing.T) {
 	}
 }
 
+func TestPayloadRowLegacyIdentityEnforcesDecodedLimit(t *testing.T) {
+	exact := payloadRow{Stored: make([]byte, maxDecodedPayloadBytes)}
+	if _, err := exact.decode(maxDecodedPayloadBytes); err != nil {
+		t.Fatalf("exact legacy limit: %v", err)
+	}
+	over := payloadRow{Stored: make([]byte, maxDecodedPayloadBytes+1)}
+	if _, err := over.decode(maxDecodedPayloadBytes); !isPayloadIntegrityError(err) {
+		t.Fatalf("oversized legacy error = %v", err)
+	}
+}
+
+func TestLegacySchemaHydrationEnforcesExactDecodedLimit(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE events(id TEXT PRIMARY KEY, body BLOB NOT NULL);
+INSERT INTO events VALUES('exact', zeroblob(16777216));
+INSERT INTO events VALUES('over', zeroblob(16777217));`); err != nil {
+		t.Fatal(err)
+	}
+	exact, err := loadEventPlaintext(ctx, db, "exact")
+	if err != nil || int64(len(exact)) != maxDecodedPayloadBytes {
+		t.Fatalf("exact legacy body = %d bytes, %v", len(exact), err)
+	}
+	_, err = loadEventPlaintext(ctx, db, "over")
+	var integrity *PayloadIntegrityError
+	if !errors.As(err, &integrity) || integrity.RowID != "over" || integrity.Reason != "stored length exceeds limit" {
+		t.Fatalf("oversized legacy error = %v", err)
+	}
+}
+
 func TestLoadEventPlaintextRejectsOversizedPhysicalValueBeforeScan(t *testing.T) {
 	ctx := context.Background()
 	path := t.TempDir() + "/oversized.db"

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -114,7 +114,9 @@ func TestIdentityMetadataChecksum(t *testing.T) {
 }
 
 func BenchmarkPayloadCodecSynthetic(b *testing.B) {
-	payload := bytes.Repeat([]byte(`{"type":"text","text":"synthetic redacted trace payload"}`), 16384)
+	fragment := []byte(`{"type":"text","text":"synthetic redacted trace payload"}`)
+	payload := bytes.Repeat(fragment, int(maxDecodedPayloadBytes)/len(fragment)+1)
+	payload = payload[:maxDecodedPayloadBytes]
 	b.Run("identity-write", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			if _, err := encodePayload(payload, payloadCodecIdentity); err != nil {

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -1,0 +1,141 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/domain/model"
+)
+
+type queryRowContexter interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// hydrateEventPayload is the central logical-body boundary. Metadata-free rows
+// are legacy identity. Physical bytes never escape this adapter.
+func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.Event) (*model.Event, error) {
+	if event == nil || !event.BodyAvailability().IsAvailable() {
+		return event, nil
+	}
+	var has int
+	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name='body_codec')`).Scan(&has); err != nil {
+		return nil, xerrors.Errorf("inspect event payload metadata: %w", err)
+	}
+	if has == 0 {
+		return event, nil
+	}
+	var row payloadRow
+	destinations := row.scanDestinations()
+	if err := q.QueryRowContext(ctx, `SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256 FROM events WHERE id=?`, event.EventID().String()).Scan(destinations...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, xerrors.Errorf("event payload disappeared: %s", event.EventID())
+		}
+		return nil, xerrors.Errorf("read event payload row: %w", err)
+	}
+	plain, err := row.decode(maxDecodedPayloadBytes)
+	if err != nil {
+		return nil, xerrors.Errorf("decode event %s body: %w", event.EventID(), annotatePayloadError(err, event.EventID().String(), "body"))
+	}
+	return model.EventOfWithBodyAvailabilityAndSourceHook(event.EventID(), event.Kind(), event.Client(), event.Agent(), event.SessionID(), event.Workspace(), string(plain), event.BodyAvailability(), event.CreatedAt(), event.SourceHook()), nil
+}
+
+func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID string, column string) (sql.NullString, error) {
+	allowed := map[string]string{
+		"command": "command_text, command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256",
+		"input":   "input_text, input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256",
+		"output":  "output_text, output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256",
+	}
+	projection, ok := allowed[column]
+	if !ok {
+		return sql.NullString{}, xerrors.Errorf("unsupported audit payload column")
+	}
+	var has int
+	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('command_audits') WHERE name='command_codec')`).Scan(&has); err != nil {
+		return sql.NullString{}, xerrors.Errorf("inspect audit payload metadata: %w", err)
+	}
+	if has == 0 {
+		var value sql.NullString
+		if err := q.QueryRowContext(ctx, `SELECT CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END FROM command_audits WHERE event_id=?`, column, eventID).Scan(&value); errors.Is(err, sql.ErrNoRows) {
+			return sql.NullString{}, nil
+		} else if err != nil {
+			return sql.NullString{}, xerrors.Errorf("read legacy audit payload: %w", err)
+		}
+		return value, nil
+	}
+	var row payloadRow
+	if err := q.QueryRowContext(ctx, `SELECT `+projection+` FROM command_audits WHERE event_id=?`, eventID).Scan(row.scanDestinations()...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.NullString{}, nil
+		}
+		return sql.NullString{}, xerrors.Errorf("read audit payload row: %w", err)
+	}
+	plain, err := row.decode(maxDecodedPayloadBytes)
+	if err != nil {
+		return sql.NullString{}, xerrors.Errorf("decode audit %s %s: %w", eventID, column, annotatePayloadError(err, eventID, column))
+	}
+	return sql.NullString{String: string(plain), Valid: true}, nil
+}
+
+func hydrateCommandAudit(ctx context.Context, q queryRowContexter, audit *model.CommandAudit) (*model.CommandAudit, error) {
+	if audit == nil {
+		return nil, nil
+	}
+	command, err := hydrateAuditPayload(ctx, q, audit.EventID().String(), "command")
+	if err != nil {
+		return nil, err
+	}
+	input, err := hydrateAuditPayload(ctx, q, audit.EventID().String(), "input")
+	if err != nil {
+		return nil, err
+	}
+	output, err := hydrateAuditPayload(ctx, q, audit.EventID().String(), "output")
+	if err != nil {
+		return nil, err
+	}
+	wrapper := audit.CommandIdentity().Wrapper()
+	restored, err := model.CommandAuditFromSnapshot(model.CommandAuditSnapshot{
+		EventID: audit.EventID(), Command: command.String, Wrapper: wrapper,
+		CommandName: audit.CommandIdentity().Command(), Input: input.String, Output: output.String,
+		InputTruncated: audit.InputTruncated(), OutputTruncated: audit.OutputTruncated(),
+		InputOriginalBytes: audit.InputOriginalBytes(), OutputOriginalBytes: audit.OutputOriginalBytes(),
+		ExitCode: audit.ExitCode(), Failed: audit.Failed(), FailureReason: audit.FailureReason(),
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("restore hydrated command audit: %w", err)
+	}
+	return restored, nil
+}
+
+func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string) ([]byte, error) {
+	var has int
+	if err := q.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info('events') WHERE name='body_codec')`).Scan(&has); err != nil {
+		return nil, xerrors.Errorf("inspect event payload metadata: %w", err)
+	}
+	if has == 0 {
+		var body []byte
+		if err := q.QueryRowContext(ctx, `SELECT body FROM events WHERE id=?`, eventID).Scan(&body); err != nil {
+			return nil, xerrors.Errorf("read legacy event payload: %w", err)
+		}
+		return body, nil
+	}
+	var row payloadRow
+	if err := q.QueryRowContext(ctx, `SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256 FROM events WHERE id=?`, eventID).Scan(row.scanDestinations()...); err != nil {
+		return nil, xerrors.Errorf("read event payload row: %w", err)
+	}
+	plain, err := row.decode(maxDecodedPayloadBytes)
+	if err != nil {
+		return nil, annotatePayloadError(err, eventID, "body")
+	}
+	return plain, nil
+}
+
+func databaseColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	var exists int
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pragma_table_info(?) WHERE name=?)`, table, column).Scan(&exists); err != nil {
+		return false, xerrors.Errorf("inspect payload metadata column: %w", err)
+	}
+	return exists != 0, nil
+}

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -25,6 +25,9 @@ func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.
 		return nil, xerrors.Errorf("inspect event payload metadata: %w", err)
 	}
 	if has == 0 {
+		if int64(len(event.Body())) > maxDecodedPayloadBytes {
+			return nil, &PayloadIntegrityError{Codec: payloadCodecIdentity, RowID: event.EventID().String(), Field: "body", Reason: "decoded length exceeds limit"}
+		}
 		return event, nil
 	}
 	var row payloadRow
@@ -63,12 +66,12 @@ func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID strin
 	if has == 0 {
 		var value sql.NullString
 		var storedLength sql.NullInt64
-		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) <= ? THEN CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END END, length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) FROM command_audits WHERE event_id=?`, column, maxStoredPayloadBytes, column, column, eventID).Scan(&value, &storedLength); errors.Is(err, sql.ErrNoRows) {
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) <= ? THEN CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END END, length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) FROM command_audits WHERE event_id=?`, column, maxDecodedPayloadBytes, column, column, eventID).Scan(&value, &storedLength); errors.Is(err, sql.ErrNoRows) {
 			return sql.NullString{}, nil
 		} else if err != nil {
 			return sql.NullString{}, xerrors.Errorf("read legacy audit payload: %w", err)
 		}
-		if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
+		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
 			return sql.NullString{}, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: column, Reason: "stored length exceeds limit"}
 		}
 		return value, nil
@@ -133,10 +136,10 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	if has == 0 {
 		var body []byte
 		var storedLength sql.NullInt64
-		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {
 			return nil, xerrors.Errorf("read legacy event payload: %w", err)
 		}
-		if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
+		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
 			return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "body", Reason: "stored length exceeds limit"}
 		}
 		return body, nil

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -28,12 +28,16 @@ func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.
 		return event, nil
 	}
 	var row payloadRow
-	destinations := row.scanDestinations()
-	if err := q.QueryRowContext(ctx, `SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256 FROM events WHERE id=?`, event.EventID().String()).Scan(destinations...); err != nil {
+	var storedLength sql.NullInt64
+	destinations := append(row.scanDestinations(), &storedLength)
+	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, event.EventID().String()).Scan(destinations...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, xerrors.Errorf("event payload disappeared: %s", event.EventID())
 		}
 		return nil, xerrors.Errorf("read event payload row: %w", err)
+	}
+	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+		return nil, &PayloadIntegrityError{Codec: row.Codec.String, RowID: event.EventID().String(), Field: "body", Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)
 	if err != nil {
@@ -44,9 +48,9 @@ func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.
 
 func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID string, column string) (sql.NullString, error) {
 	allowed := map[string]string{
-		"command": "command_text, command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256",
-		"input":   "input_text, input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256",
-		"output":  "output_text, output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256",
+		"command": "command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256",
+		"input":   "input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256",
+		"output":  "output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256",
 	}
 	projection, ok := allowed[column]
 	if !ok {
@@ -58,19 +62,31 @@ func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID strin
 	}
 	if has == 0 {
 		var value sql.NullString
-		if err := q.QueryRowContext(ctx, `SELECT CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END FROM command_audits WHERE event_id=?`, column, eventID).Scan(&value); errors.Is(err, sql.ErrNoRows) {
+		var storedLength sql.NullInt64
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) <= ? THEN CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END END, length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) FROM command_audits WHERE event_id=?`, column, maxDecodedPayloadBytes, column, column, eventID).Scan(&value, &storedLength); errors.Is(err, sql.ErrNoRows) {
 			return sql.NullString{}, nil
 		} else if err != nil {
 			return sql.NullString{}, xerrors.Errorf("read legacy audit payload: %w", err)
 		}
+		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+			return sql.NullString{}, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: column, Reason: "stored length exceeds limit"}
+		}
 		return value, nil
 	}
+	physicalColumns := map[string]string{"command": "command_text", "input": "input_text", "output": "output_text"}
+	physicalColumn := physicalColumns[column]
 	var row payloadRow
-	if err := q.QueryRowContext(ctx, `SELECT `+projection+` FROM command_audits WHERE event_id=?`, eventID).Scan(row.scanDestinations()...); err != nil {
+	var storedLength sql.NullInt64
+	destinations := append(row.scanDestinations(), &storedLength)
+	boundedProjection := `CASE WHEN length(CAST(` + physicalColumn + ` AS BLOB)) <= ? THEN ` + physicalColumn + ` END, ` + projection + `, length(CAST(` + physicalColumn + ` AS BLOB))`
+	if err := q.QueryRowContext(ctx, `SELECT `+boundedProjection+` FROM command_audits WHERE event_id=?`, maxDecodedPayloadBytes, eventID).Scan(destinations...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return sql.NullString{}, nil
 		}
 		return sql.NullString{}, xerrors.Errorf("read audit payload row: %w", err)
+	}
+	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+		return sql.NullString{}, &PayloadIntegrityError{Codec: row.Codec.String, RowID: eventID, Field: column, Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)
 	if err != nil {
@@ -116,14 +132,23 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	}
 	if has == 0 {
 		var body []byte
-		if err := q.QueryRowContext(ctx, `SELECT body FROM events WHERE id=?`, eventID).Scan(&body); err != nil {
+		var storedLength sql.NullInt64
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {
 			return nil, xerrors.Errorf("read legacy event payload: %w", err)
+		}
+		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+			return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "body", Reason: "stored length exceeds limit"}
 		}
 		return body, nil
 	}
 	var row payloadRow
-	if err := q.QueryRowContext(ctx, `SELECT body, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256 FROM events WHERE id=?`, eventID).Scan(row.scanDestinations()...); err != nil {
+	var storedLength sql.NullInt64
+	destinations := append(row.scanDestinations(), &storedLength)
+	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(destinations...); err != nil {
 		return nil, xerrors.Errorf("read event payload row: %w", err)
+	}
+	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+		return nil, &PayloadIntegrityError{Codec: row.Codec.String, RowID: eventID, Field: "body", Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)
 	if err != nil {

--- a/infrastructure/sqlite/payload_hydration.go
+++ b/infrastructure/sqlite/payload_hydration.go
@@ -30,13 +30,13 @@ func hydrateEventPayload(ctx context.Context, q queryRowContexter, event *model.
 	var row payloadRow
 	var storedLength sql.NullInt64
 	destinations := append(row.scanDestinations(), &storedLength)
-	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, event.EventID().String()).Scan(destinations...); err != nil {
+	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, event.EventID().String()).Scan(destinations...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, xerrors.Errorf("event payload disappeared: %s", event.EventID())
 		}
 		return nil, xerrors.Errorf("read event payload row: %w", err)
 	}
-	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+	if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
 		return nil, &PayloadIntegrityError{Codec: row.Codec.String, RowID: event.EventID().String(), Field: "body", Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)
@@ -63,12 +63,12 @@ func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID strin
 	if has == 0 {
 		var value sql.NullString
 		var storedLength sql.NullInt64
-		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) <= ? THEN CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END END, length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) FROM command_audits WHERE event_id=?`, column, maxDecodedPayloadBytes, column, column, eventID).Scan(&value, &storedLength); errors.Is(err, sql.ErrNoRows) {
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) <= ? THEN CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END END, length(CAST(CASE ? WHEN 'command' THEN command_text WHEN 'input' THEN input_text ELSE output_text END AS BLOB)) FROM command_audits WHERE event_id=?`, column, maxStoredPayloadBytes, column, column, eventID).Scan(&value, &storedLength); errors.Is(err, sql.ErrNoRows) {
 			return sql.NullString{}, nil
 		} else if err != nil {
 			return sql.NullString{}, xerrors.Errorf("read legacy audit payload: %w", err)
 		}
-		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+		if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
 			return sql.NullString{}, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: column, Reason: "stored length exceeds limit"}
 		}
 		return value, nil
@@ -79,13 +79,13 @@ func hydrateAuditPayload(ctx context.Context, q queryRowContexter, eventID strin
 	var storedLength sql.NullInt64
 	destinations := append(row.scanDestinations(), &storedLength)
 	boundedProjection := `CASE WHEN length(CAST(` + physicalColumn + ` AS BLOB)) <= ? THEN ` + physicalColumn + ` END, ` + projection + `, length(CAST(` + physicalColumn + ` AS BLOB))`
-	if err := q.QueryRowContext(ctx, `SELECT `+boundedProjection+` FROM command_audits WHERE event_id=?`, maxDecodedPayloadBytes, eventID).Scan(destinations...); err != nil {
+	if err := q.QueryRowContext(ctx, `SELECT `+boundedProjection+` FROM command_audits WHERE event_id=?`, maxStoredPayloadBytes, eventID).Scan(destinations...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return sql.NullString{}, nil
 		}
 		return sql.NullString{}, xerrors.Errorf("read audit payload row: %w", err)
 	}
-	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+	if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
 		return sql.NullString{}, &PayloadIntegrityError{Codec: row.Codec.String, RowID: eventID, Field: column, Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)
@@ -133,10 +133,10 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	if has == 0 {
 		var body []byte
 		var storedLength sql.NullInt64
-		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {
+		if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, eventID).Scan(&body, &storedLength); err != nil {
 			return nil, xerrors.Errorf("read legacy event payload: %w", err)
 		}
-		if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+		if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
 			return nil, &PayloadIntegrityError{Codec: "identity", RowID: eventID, Field: "body", Reason: "stored length exceeds limit"}
 		}
 		return body, nil
@@ -144,10 +144,10 @@ func loadEventPlaintext(ctx context.Context, q queryRowContexter, eventID string
 	var row payloadRow
 	var storedLength sql.NullInt64
 	destinations := append(row.scanDestinations(), &storedLength)
-	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxDecodedPayloadBytes, eventID).Scan(destinations...); err != nil {
+	if err := q.QueryRowContext(ctx, `SELECT CASE WHEN length(CAST(body AS BLOB)) <= ? THEN body END, body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256, length(CAST(body AS BLOB)) FROM events WHERE id=?`, maxStoredPayloadBytes, eventID).Scan(destinations...); err != nil {
 		return nil, xerrors.Errorf("read event payload row: %w", err)
 	}
-	if storedLength.Valid && storedLength.Int64 > maxDecodedPayloadBytes {
+	if storedLength.Valid && storedLength.Int64 > maxStoredPayloadBytes {
 		return nil, &PayloadIntegrityError{Codec: row.Codec.String, RowID: eventID, Field: "body", Reason: "stored length exceeds limit"}
 	}
 	plain, err := row.decode(maxDecodedPayloadBytes)

--- a/infrastructure/sqlite/raw_body_retention_datasource.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource.go
@@ -74,12 +74,17 @@ SELECT e.id, e.created_at, e.body_stored_bytes, e.body
 		if !stored.Valid || stored.Int64 < 0 {
 			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("event %s has indeterminate stored body bytes", id)
 		}
+		plain, err := loadEventPlaintext(ctx, tx, id)
+		if err != nil {
+			return apptypes.RawBodyRetentionSnapshot{}, err
+		}
+		body = string(plain)
 		createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
 		if err != nil {
 			return apptypes.RawBodyRetentionSnapshot{}, xerrors.Errorf("failed to parse candidate created_at: %w", err)
 		}
 		digest := sha256.Sum256([]byte(body))
-		storedBytes, err := checkedInt(stored.Int64, "stored body bytes")
+		storedBytes, err := checkedInt(int64(len(plain)), "stored body bytes")
 		if err != nil {
 			return apptypes.RawBodyRetentionSnapshot{}, err
 		}
@@ -233,9 +238,25 @@ func applyRawBodyCandidate(ctx context.Context, db *sql.DB, sourcePath, database
 	if executionStatus != "running" {
 		return false, xerrors.Errorf("completed raw-body execution contains an unpruned candidate %s", candidate.EventID)
 	}
-	res, err := tx.ExecContext(ctx, `UPDATE events
-SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
-WHERE id = ? AND body_availability = 'available' AND body = ?`, domtypes.EventBodyUnavailableRetentionMarker, stamp, planID, candidate.EventID, body)
+	marker, err := encodePayload([]byte(domtypes.EventBodyUnavailableRetentionMarker), payloadCodecIdentity)
+	if err != nil {
+		return false, err
+	}
+	hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+	if err != nil {
+		return false, err
+	}
+	query := `UPDATE events SET body = ?, body_availability = 'unavailable_retention', body_pruned_at = ?, body_pruned_plan_id = ?
+WHERE id = ? AND body_availability = 'available' AND body = ?`
+	args := []any{string(marker.Bytes), stamp, planID, candidate.EventID, body}
+	if hasCodec {
+		query = `UPDATE events SET body=?, body_codec=?, body_format_version=?, body_plaintext_bytes=?, body_encoded_bytes=?, body_sha256=?,
+body_availability='unavailable_retention', body_pruned_at=?, body_pruned_plan_id=?
+WHERE id=? AND body_availability='available' AND body_sha256=?`
+		args = []any{string(marker.Bytes), marker.Codec, marker.FormatVersion, marker.PlaintextBytes, marker.StoredBytes, marker.SHA256,
+			stamp, planID, candidate.EventID, candidate.BodySHA256}
+	}
+	res, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return false, xerrors.Errorf("failed to prune raw body %s: %w", candidate.EventID, err)
 	}
@@ -303,6 +324,12 @@ FROM events AS e WHERE e.id = ?`, candidate.EventID).Scan(&body, &createdAt, &av
 	if activeSession {
 		return "", false, xerrors.Errorf("raw-body plan is stale because event %s belongs to an active session", candidate.EventID)
 	}
+	plain, decodeErr := loadEventPlaintext(ctx, tx, candidate.EventID)
+	if decodeErr != nil {
+		return "", false, decodeErr
+	}
+	body = string(plain)
+	stored = len(plain)
 	persistedCreatedAt, parseErr := time.Parse(time.RFC3339Nano, createdAt)
 	if parseErr != nil {
 		return "", false, xerrors.Errorf("failed to parse raw-body candidate timestamp %s: %w", candidate.EventID, parseErr)
@@ -425,7 +452,11 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 			if !ledgerRestoredAt.Valid {
 				return result, xerrors.Errorf("event %s is available before its restore was recorded", recovery.Candidate.EventID)
 			}
-			current := sha256.Sum256([]byte(body))
+			plain, err := loadEventPlaintext(ctx, tx, recovery.Candidate.EventID)
+			if err != nil {
+				return result, err
+			}
+			current := sha256.Sum256(plain)
 			if hex.EncodeToString(current[:]) != recovery.Candidate.BodySHA256 {
 				return result, xerrors.Errorf("available body conflicts with recovery for event %s", recovery.Candidate.EventID)
 			}
@@ -435,7 +466,22 @@ func (d *StoreManagementDatasource) RestoreRawBodyPlan(ctx context.Context, data
 		if availability != domtypes.BodyAvailabilityUnavailableRetention.String() || prunedPlan.String != planID {
 			return result, xerrors.Errorf("event %s was not pruned by plan %s", recovery.Candidate.EventID, planID)
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE events SET body = ?, body_availability = 'available', body_pruned_at = NULL, body_pruned_plan_id = NULL WHERE id = ?`, recovery.Body, recovery.Candidate.EventID); err != nil {
+		payload, err := encodePayload([]byte(recovery.Body), payloadCodecIdentity)
+		if err != nil {
+			return result, err
+		}
+		hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+		if err != nil {
+			return result, err
+		}
+		query := `UPDATE events SET body=?, body_availability='available', body_pruned_at=NULL, body_pruned_plan_id=NULL WHERE id=?`
+		args := []any{string(payload.Bytes), recovery.Candidate.EventID}
+		if hasCodec {
+			query = `UPDATE events SET body=?, body_codec=?, body_format_version=?, body_plaintext_bytes=?, body_encoded_bytes=?, body_sha256=?,
+body_availability='available', body_pruned_at=NULL, body_pruned_plan_id=NULL WHERE id=?`
+			args = []any{string(payload.Bytes), payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256, recovery.Candidate.EventID}
+		}
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return result, xerrors.Errorf("failed to restore raw body %s: %w", recovery.Candidate.EventID, err)
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE raw_body_retention_entries SET restored_at = ? WHERE plan_id = ? AND event_id = ?`, stamp, planID, recovery.Candidate.EventID); err != nil {

--- a/infrastructure/sqlite/raw_body_retention_datasource_test.go
+++ b/infrastructure/sqlite/raw_body_retention_datasource_test.go
@@ -170,7 +170,7 @@ func TestRawBodyRetention_rejectsStaleCandidateWithoutPruning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open() error = %v", err)
 	}
-	if _, err := db.Exec(`UPDATE events SET body = 'changed' WHERE id = 'stale-event'`); err != nil {
+	if _, err := db.Exec(`UPDATE events SET body = 'changed', body_codec=NULL, body_format_version=NULL, body_plaintext_bytes=NULL, body_encoded_bytes=NULL, body_sha256=NULL WHERE id = 'stale-event'`); err != nil {
 		t.Fatalf("mutate body: %v", err)
 	}
 	_ = db.Close()
@@ -364,7 +364,7 @@ func TestRawBodyRetention_partialExecutionCanBeRestored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open() error = %v", err)
 	}
-	if _, err := db.Exec(`UPDATE events SET body = 'post-plan-change' WHERE id = 'partial-b'`); err != nil {
+	if _, err := db.Exec(`UPDATE events SET body = 'post-plan-change', body_codec=NULL, body_format_version=NULL, body_plaintext_bytes=NULL, body_encoded_bytes=NULL, body_sha256=NULL WHERE id = 'partial-b'`); err != nil {
 		t.Fatalf("update unprocessed candidate: %v", err)
 	}
 	_ = db.Close()

--- a/infrastructure/sqlite/session_datasource.go
+++ b/infrastructure/sqlite/session_datasource.go
@@ -109,7 +109,11 @@ func (d *SessionDatasource) SaveBoundary(ctx context.Context, session *model.Ses
 		}
 	}()
 
-	return saveEventTransaction(ctx, db, event, nil, func(ctx context.Context, tx *sql.Tx) error {
+	codecMetadata, err := databaseColumnExists(ctx, db, "events", "body_codec")
+	if err != nil {
+		return err
+	}
+	return saveEventTransaction(ctx, db, event, nil, codecMetadata, func(ctx context.Context, tx *sql.Tx) error {
 		if err := saveSessionBoundary(ctx, tx, session); err != nil {
 			return xerrors.Errorf("failed to save session: %w", err)
 		}
@@ -568,6 +572,10 @@ func (d *SessionDatasource) FindLatest(
 		if scanErr != nil {
 			return types.None[*model.Event](), xerrors.Errorf("failed to restore latest session event: %w", scanErr)
 		}
+		event, scanErr = hydrateEventPayload(ctx, db, event)
+		if scanErr != nil {
+			return types.None[*model.Event](), scanErr
+		}
 		return types.Some(event), nil
 	}
 
@@ -583,6 +591,10 @@ func (d *SessionDatasource) FindLatest(
 			return types.None[*model.Event](), nil
 		}
 		return types.None[*model.Event](), xerrors.Errorf("failed to restore latest session event: %w", err)
+	}
+	event, err = hydrateEventPayload(ctx, db, event)
+	if err != nil {
+		return types.None[*model.Event](), err
 	}
 
 	return types.Some(event), nil
@@ -634,7 +646,7 @@ func (d *SessionDatasource) ListSummaries(
 
 	summaries := make([]apptypes.SessionSummary, 0)
 	for rows.Next() {
-		summary, err := scanSessionSummary(rows)
+		summary, err := scanSessionSummary(ctx, db, rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to scan session summary row: %w", err)
 		}
@@ -690,7 +702,7 @@ func (d *SessionDatasource) ListTreeSummaries(
 
 	summaries := make([]apptypes.SessionSummary, 0)
 	for rows.Next() {
-		summary, err := scanSessionSummary(rows)
+		summary, err := scanSessionSummary(ctx, db, rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to scan session tree summary row: %w", err)
 		}
@@ -728,7 +740,7 @@ func (d *SessionDatasource) LineageOf(ctx context.Context, sessionID types.Sessi
 
 	summaries := make([]apptypes.SessionSummary, 0)
 	for rows.Next() {
-		summary, err := scanSessionSummary(rows)
+		summary, err := scanSessionSummary(ctx, db, rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to scan session lineage row: %w", err)
 		}
@@ -741,7 +753,7 @@ func (d *SessionDatasource) LineageOf(ctx context.Context, sessionID types.Sessi
 	return summaries, nil
 }
 
-func scanSessionSummary(row interface {
+func scanSessionSummary(ctx context.Context, q queryRowContexter, row interface {
 	Scan(dest ...any) error
 }) (apptypes.SessionSummary, error) {
 	var (
@@ -788,6 +800,13 @@ func scanSessionSummary(row interface {
 		&latestEventRawBody,
 	); err != nil {
 		return apptypes.SessionSummary{}, xerrors.Errorf("failed to scan session summary: %w", err)
+	}
+	if latestEventID != "" {
+		plain, err := loadEventPlaintext(ctx, q, latestEventID)
+		if err != nil {
+			return apptypes.SessionSummary{}, err
+		}
+		latestEventRawBody = string(plain)
 	}
 
 	startedAt, err := time.Parse(time.RFC3339Nano, startedAtStr)

--- a/infrastructure/sqlite/sql/list_timeline_blocks.sql
+++ b/infrastructure/sqlite/sql/list_timeline_blocks.sql
@@ -61,6 +61,7 @@ prompt_ranked AS (
   SELECT
     block_num,
     workspace,
+    id,
     body,
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
@@ -68,7 +69,7 @@ prompt_ranked AS (
     AND TRIM(body) != ''
 ),
 first_prompt AS (
-  SELECT block_num, workspace, body AS first_prompt_body
+  SELECT block_num, workspace, id AS first_prompt_id, body AS first_prompt_body
   FROM prompt_ranked
   WHERE rn = 1
 ),
@@ -76,6 +77,7 @@ compact_ranked AS (
   SELECT
     block_num,
     workspace,
+    id,
     body,
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm DESC, id DESC) AS rn
   FROM blocks
@@ -83,7 +85,7 @@ compact_ranked AS (
     AND TRIM(body) != ''
 ),
 last_compact AS (
-  SELECT block_num, workspace, body AS compact_summary_body
+  SELECT block_num, workspace, id AS compact_summary_id, body AS compact_summary_body
   FROM compact_ranked
   WHERE rn = 1
 ),
@@ -91,6 +93,7 @@ transcript_ranked AS (
   SELECT
     block_num,
     workspace,
+    id,
     body,
     ROW_NUMBER() OVER (PARTITION BY block_num, workspace ORDER BY created_at_norm, id) AS rn
   FROM blocks
@@ -98,7 +101,7 @@ transcript_ranked AS (
     AND TRIM(body) != ''
 ),
 first_transcript AS (
-  SELECT block_num, workspace, body AS first_transcript_body
+  SELECT block_num, workspace, id AS first_transcript_id, body AS first_transcript_body
   FROM transcript_ranked
   WHERE rn = 1
 ),
@@ -109,6 +112,9 @@ ws_rows AS (
     COUNT(*) AS ws_event_count,
     GROUP_CONCAT(b.kind, '|') AS kinds,
     GROUP_CONCAT(DISTINCT b.agent) AS ws_agents,
+    MAX(fp.first_prompt_id) AS first_prompt_id,
+    MAX(lc.compact_summary_id) AS compact_summary_id,
+    MAX(ft.first_transcript_id) AS first_transcript_id,
     MAX(fp.first_prompt_body) AS first_prompt_body,
     MAX(lc.compact_summary_body) AS compact_summary_body,
     MAX(ft.first_transcript_body) AS first_transcript_body
@@ -133,6 +139,9 @@ SELECT
   wr.ws_event_count,
   wr.kinds,
   COALESCE(wr.ws_agents, '') AS ws_agents,
+  COALESCE(wr.first_prompt_id, '') AS first_prompt_id,
+  COALESCE(wr.compact_summary_id, '') AS compact_summary_id,
+  COALESCE(wr.first_transcript_id, '') AS first_transcript_id,
   COALESCE(wr.first_prompt_body, '') AS first_prompt_body,
   COALESCE(wr.compact_summary_body, '') AS compact_summary_body,
   COALESCE(wr.first_transcript_body, '') AS first_transcript_body

--- a/infrastructure/sqlite/store_archive.go
+++ b/infrastructure/sqlite/store_archive.go
@@ -43,6 +43,14 @@ SELECT id, kind, client, agent, session_id, workspace, body, created_at, source_
 		if err != nil {
 			return nil, xerrors.Errorf("list archive events: %w", err)
 		}
+		for _, row := range events {
+			id, _ := row["id"].(string)
+			plain, err := loadEventPlaintext(ctx, db, id)
+			if err != nil {
+				return nil, xerrors.Errorf("decode archive event %s: %w", id, err)
+			}
+			row["body"] = string(plain)
+		}
 		tables = append(tables, application.ArchiveTableData{
 			Name: "events", PrimaryKey: []string{"id"}, Rows: events,
 		})
@@ -61,6 +69,16 @@ SELECT event_id, command_text, command_wrapper, command_name, input_text, output
  ORDER BY event_id`, ids)
 			if err != nil {
 				return nil, xerrors.Errorf("list archive command_audits: %w", err)
+			}
+			for _, row := range audits {
+				id, _ := row["event_id"].(string)
+				for _, field := range []string{"command", "input", "output"} {
+					plain, err := hydrateAuditPayload(ctx, db, id, field)
+					if err != nil {
+						return nil, xerrors.Errorf("decode archive audit %s: %w", id, err)
+					}
+					row[field+"_text"] = plain.String
+				}
 			}
 			tables = append(tables, application.ArchiveTableData{
 				Name: "command_audits", PrimaryKey: []string{"event_id"}, Rows: audits,
@@ -479,21 +497,64 @@ func archiveRowExistsQuerier(ctx context.Context, q queryRower, table applicatio
 func insertArchiveRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
 	switch table {
 	case "events":
-		_, err := tx.ExecContext(ctx, insertEventQuery,
+		body := fmt.Sprint(nullStr(row["body"]))
+		payload, err := encodePayload([]byte(body), payloadCodecIdentity)
+		if err != nil {
+			return err
+		}
+		hasCodec, err := transactionColumnExists(ctx, tx, "events", "body_codec")
+		if err != nil {
+			return err
+		}
+		query := insertEventQuery
+		args := []any{
 			row["id"], row["kind"], nullStr(row["client"]), row["agent"], row["session_id"],
-			nullStr(row["workspace"]), row["body"], row["created_at"], nullStr(row["source_hook"]),
-		)
+			nullStr(row["workspace"]), string(payload.Bytes), row["created_at"], nullStr(row["source_hook"])}
+		if hasCodec {
+			query = `INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at, source_hook,
+body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
+		}
+		_, err = tx.ExecContext(ctx, query, args...)
 		if err != nil {
 			return xerrors.Errorf("insert events: %w", err)
 		}
 		return nil
 	case "command_audits":
-		_, err := tx.ExecContext(ctx, insertCommandAuditQuery,
-			row["event_id"], row["command_text"], nullStr(row["command_wrapper"]), archiveStringOr(row, "command_name", "unknown"), row["input_text"], row["output_text"],
+		command, err := encodePayload([]byte(fmt.Sprint(nullStr(row["command_text"]))), payloadCodecIdentity)
+		if err != nil {
+			return err
+		}
+		input, err := encodePayload([]byte(fmt.Sprint(nullStr(row["input_text"]))), payloadCodecIdentity)
+		if err != nil {
+			return err
+		}
+		output, err := encodePayload([]byte(fmt.Sprint(nullStr(row["output_text"]))), payloadCodecIdentity)
+		if err != nil {
+			return err
+		}
+		hasCodec, err := transactionColumnExists(ctx, tx, "command_audits", "command_codec")
+		if err != nil {
+			return err
+		}
+		query := insertCommandAuditQuery
+		args := []any{row["event_id"], string(command.Bytes), nullStr(row["command_wrapper"]), archiveStringOr(row, "command_name", "unknown"), string(input.Bytes), string(output.Bytes),
 			asInt(row["input_truncated"]), asInt(row["output_truncated"]),
 			row["input_original_bytes"], row["output_original_bytes"],
-			row["exit_code"], asInt(row["failed"]), archiveStringOr(row, "failure_reason", "unknown"),
-		)
+			row["exit_code"], asInt(row["failed"]), archiveStringOr(row, "failure_reason", "unknown")}
+		if hasCodec {
+			query = `INSERT INTO command_audits(event_id, command_text, command_wrapper, command_name, input_text, output_text,
+input_truncated, output_truncated, input_original_bytes, output_original_bytes, exit_code, failed, failure_reason,
+command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			args = append(args,
+				command.Codec, command.FormatVersion, command.PlaintextBytes, command.StoredBytes, command.SHA256,
+				input.Codec, input.FormatVersion, input.PlaintextBytes, input.StoredBytes, input.SHA256,
+				output.Codec, output.FormatVersion, output.PlaintextBytes, output.StoredBytes, output.SHA256)
+		}
+		_, err = tx.ExecContext(ctx, query, args...)
 		if err != nil {
 			return xerrors.Errorf("insert command_audits: %w", err)
 		}

--- a/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
+++ b/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
@@ -1,0 +1,31 @@
+-- Reader-first payload codec foundation. v0.34 writes identity only; zstd
+-- activation and legacy backfill are intentionally deferred to v0.35.
+CREATE TABLE store_format_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    minimum_reader_version INTEGER NOT NULL,
+    maximum_payload_format INTEGER NOT NULL
+);
+INSERT INTO store_format_state(singleton, minimum_reader_version, maximum_payload_format)
+VALUES (1, 34, 1);
+
+ALTER TABLE events ADD COLUMN body_codec TEXT NOT NULL DEFAULT 'identity';
+ALTER TABLE events ADD COLUMN body_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE events ADD COLUMN body_plaintext_bytes INTEGER;
+ALTER TABLE events ADD COLUMN body_encoded_bytes INTEGER;
+ALTER TABLE events ADD COLUMN body_sha256 TEXT;
+
+ALTER TABLE command_audits ADD COLUMN command_codec TEXT NOT NULL DEFAULT 'identity';
+ALTER TABLE command_audits ADD COLUMN command_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN command_plaintext_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN command_encoded_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN command_sha256 TEXT;
+ALTER TABLE command_audits ADD COLUMN input_codec TEXT NOT NULL DEFAULT 'identity';
+ALTER TABLE command_audits ADD COLUMN input_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN input_plaintext_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN input_encoded_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN input_sha256 TEXT;
+ALTER TABLE command_audits ADD COLUMN output_codec TEXT NOT NULL DEFAULT 'identity';
+ALTER TABLE command_audits ADD COLUMN output_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN output_plaintext_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN output_encoded_bytes INTEGER;
+ALTER TABLE command_audits ADD COLUMN output_sha256 TEXT;

--- a/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
+++ b/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
@@ -29,18 +29,3 @@ ALTER TABLE command_audits ADD COLUMN output_format_version INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_sha256 TEXT;
-
--- Compatibility for tools that directly edit legacy identity payload text.
--- Codec-aware writers update body and metadata atomically, so the checksum
--- equality guard prevents this trigger from overriding their values.
-CREATE TRIGGER events_identity_payload_metadata_after_update
-AFTER UPDATE OF body ON events
-WHEN OLD.body_codec = 'identity' AND NEW.body_codec = 'identity'
- AND NEW.body_sha256 = OLD.body_sha256
-BEGIN
-  UPDATE events SET
-    body_plaintext_bytes = length(CAST(NEW.body AS BLOB)),
-    body_encoded_bytes = length(CAST(NEW.body AS BLOB)),
-    body_sha256 = traceary_sha256(NEW.body)
-  WHERE id = NEW.id;
-END;

--- a/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
+++ b/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
@@ -29,3 +29,15 @@ ALTER TABLE command_audits ADD COLUMN output_format_version INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_sha256 TEXT;
+
+-- These partial indexes make the global "compressed payload exists" guard
+-- proportional to compressed rows rather than total retained history. Search
+-- uses the guard to avoid treating a stale plaintext projection as complete.
+CREATE INDEX idx_events_nonidentity_body_codec ON events(body_codec)
+WHERE body_codec IS NOT NULL AND body_codec <> 'identity';
+CREATE INDEX idx_command_audits_nonidentity_command_codec ON command_audits(command_codec)
+WHERE command_codec IS NOT NULL AND command_codec <> 'identity';
+CREATE INDEX idx_command_audits_nonidentity_input_codec ON command_audits(input_codec)
+WHERE input_codec IS NOT NULL AND input_codec <> 'identity';
+CREATE INDEX idx_command_audits_nonidentity_output_codec ON command_audits(output_codec)
+WHERE output_codec IS NOT NULL AND output_codec <> 'identity';

--- a/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
+++ b/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
@@ -8,24 +8,39 @@ CREATE TABLE store_format_state (
 INSERT INTO store_format_state(singleton, minimum_reader_version, maximum_payload_format)
 VALUES (1, 34, 1);
 
-ALTER TABLE events ADD COLUMN body_codec TEXT NOT NULL DEFAULT 'identity';
-ALTER TABLE events ADD COLUMN body_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE events ADD COLUMN body_codec TEXT;
+ALTER TABLE events ADD COLUMN body_format_version INTEGER;
 ALTER TABLE events ADD COLUMN body_plaintext_bytes INTEGER;
 ALTER TABLE events ADD COLUMN body_encoded_bytes INTEGER;
 ALTER TABLE events ADD COLUMN body_sha256 TEXT;
 
-ALTER TABLE command_audits ADD COLUMN command_codec TEXT NOT NULL DEFAULT 'identity';
-ALTER TABLE command_audits ADD COLUMN command_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN command_codec TEXT;
+ALTER TABLE command_audits ADD COLUMN command_format_version INTEGER;
 ALTER TABLE command_audits ADD COLUMN command_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN command_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN command_sha256 TEXT;
-ALTER TABLE command_audits ADD COLUMN input_codec TEXT NOT NULL DEFAULT 'identity';
-ALTER TABLE command_audits ADD COLUMN input_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN input_codec TEXT;
+ALTER TABLE command_audits ADD COLUMN input_format_version INTEGER;
 ALTER TABLE command_audits ADD COLUMN input_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN input_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN input_sha256 TEXT;
-ALTER TABLE command_audits ADD COLUMN output_codec TEXT NOT NULL DEFAULT 'identity';
-ALTER TABLE command_audits ADD COLUMN output_format_version INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE command_audits ADD COLUMN output_codec TEXT;
+ALTER TABLE command_audits ADD COLUMN output_format_version INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_sha256 TEXT;
+
+-- Compatibility for tools that directly edit legacy identity payload text.
+-- Codec-aware writers update body and metadata atomically, so the checksum
+-- equality guard prevents this trigger from overriding their values.
+CREATE TRIGGER events_identity_payload_metadata_after_update
+AFTER UPDATE OF body ON events
+WHEN OLD.body_codec = 'identity' AND NEW.body_codec = 'identity'
+ AND NEW.body_sha256 = OLD.body_sha256
+BEGIN
+  UPDATE events SET
+    body_plaintext_bytes = length(CAST(NEW.body AS BLOB)),
+    body_encoded_bytes = length(CAST(NEW.body AS BLOB)),
+    body_sha256 = traceary_sha256(NEW.body)
+  WHERE id = NEW.id;
+END;


### PR DESCRIPTION
## Summary

- add a reader-first identity/zstd payload contract with format, length, and SHA-256 metadata
- keep v0.34 canonical writes identity-only while making event, audit, search, retention, archive, bundle, backup, CLI, and MCP reads codec-aware
- enforce store-format compatibility across Database and direct SQLite open paths
- bound decoded and stored allocations, preserve row-level metadata access on corruption, and fail closed for incomplete global search coverage
- record deterministic synthetic compression/write/decode evidence at the exact 16 MiB limit

## Two-release boundary

v0.34 does not activate compressed-only canonical writes or backfill live history. Canonical zstd activation remains deferred to v0.35 after the v0.34 reader boundary is deployed.

## Validation

- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- `git diff --check origin/main...HEAD`
- independent GPT-5.6 Sol integrity review: APPROVE, no findings

## Delivery notes

Kimi K3 max was attempted first as requested, but did not produce a usable scoped implementation. The implementation was completed by the internal Codex worker and independently reviewed.

Closes #1609
