### PR TITLE
v0.34.0-12: add historical search candidates and continuation

### DIFF
--- a/.ai/spec/1622.md
+++ b/.ai/spec/1622.md
@@ -1,0 +1,60 @@
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Purpose: add a bounded, resumable historical literal-search lane whose candidate index can never justify a false complete negative.
+- Current state: legacy search is authoritative; recent FTS is not a safe exclusion filter and compressed payloads require codec hydration.
+- Expected behavior: characterize only literals for which deterministic Unicode rune trigrams are safe; use fingerprints only as a candidate superset; verify every candidate against codec-decoded visible event text and decoded audits; return explicit tier, coverage, partial reason, and a stable continuation even when a page has zero matches.
+- Non-goals: replacing legacy search authority before #1612, changing literal semantics, fuzzy/regex search, or making `--deep` select a different algorithm.
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Literal query | raw, canonical runes, filterability | classifies candidate-safe literals | fewer than 3 runes or context-sensitive Unicode are unfilterable |
+| Fingerprint projection | generation, high-water, query revision, version | yields candidate supersets | missing/unknown rows are included; fixed-size hashes; deterministic rebuild |
+| Verification budget | source rows/bytes, decoded bytes, result limit | bounds canonical hydration | `deep` changes limits only, never semantics/tier selection |
+| Search cursor | source sequence/tuple, criteria hash, generation/high-water/revision | resumes after the last fully processed source | advances on zero-match pages; rejects changed criteria/projection |
+| Literal search page | matches, provenance, coverage, continuation | reports honest completeness | partial result never masquerades as a complete negative |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| Literal classification/fingerprint construction/cursor envelope | application types | portable invariants and protocol-neutral result model | SQLite/CLI must not redefine semantics |
+| Candidate SQL, missing-row inclusion, canonical codec hydration | SQLite adapter | storage layout, paging, byte accounting | presentation must not know tables/codecs |
+| Budget choice and output mapping | CLI/MCP | surface contract and shallow/deep resource profiles | adapter must not interpret flags |
+| Legacy authority | existing event search APIs | compatibility until #1612 | tiered lane is additive |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `TieredEventSearchQuery.SearchLiteralPage` | CLI/MCP | fingerprint schema, SQL, codecs | invalid/stale cursor is explicit; budget exhaustion returns partial page, not error |
+| `LiteralSearchRequest` | query adapter | protocol flags | validated positive byte/row budgets |
+| `LiteralSearchPage` | presentation | physical row IDs and payload encoding | coverage/provenance/partial reason always populated |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| no candidate false negatives | mixed Unicode/case/path/ID/error literals | classify/build/query fingerprints | every filterable canonical match is a candidate | property/unit + SQLite |
+| canonical verification | identity/zstd event and audit fields | candidate is verified | only decoded visible plaintext matches | integration |
+| bounded fallback | short/unsafe literal | budget ends | partial reason and advancing continuation returned | integration |
+| zero-match progress | candidates contain no verified match | page ends | continuation records last fully processed sequence | integration |
+| cursor binding | criteria or projection revision changes | resume | stable invalid-continuation error | integration |
+| deep semantics | same request, larger deep budget | search | same tier/criteria semantics; only coverage increases | CLI/MCP |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| classification and fingerprints | table/property tests for Unicode/case/path/IDs/errors | pure application value objects | isolate normalization contract |
+| migration integrity | migration tests for deterministic fixed-size rows/triggers | additive migration 39 | keep trigger work bounded |
+| verification/continuation | SQLite tests for compressed bodies/audits, partial/zero match | sibling query implementation | extract cursor and budget ledger |
+| surface contract | CLI/MCP JSON tests | additive flags/fields | shared budget profiles |
+
+### Risks / rollback
+- Procedural risk: candidate selection, verification, and cursor accounting could accumulate in one SQL transaction; keep the invariant owners separate and checkpoint only fully processed sources.
+- Premature abstraction: provide one sibling literal-page contract, not flags on existing slice APIs.
+- Migration / compatibility: migration 39 is additive and rebuildable. Legacy APIs and tables remain unchanged and authoritative until #1612. Older binaries ignore new tables; missing/unknown fingerprint data is never exclusionary.
+- Rollback trigger: cursor instability, any candidate false negative, unbounded allocation, or query-plan regression. Roll back callers to legacy search and drop/rebuild only the additive candidate projection in a later migration.
+- Split plan: (1) additive types + migration + adapter tests, (2) CLI/MCP exposure, (3) #1612 authority cutover after independent semantic evidence.
+
+### Implementation checkpoint
+- Approved implementation shape: sibling `TieredEventSearchQuery -> LiteralSearchPage`; immutable, versioned fingerprint rows; source-sequence keyset continuation; codec-decoded verification.
+- Explicitly rejected: treating migration-32 FTS as an exclusion filter, encoding deep as a search-mode switch, offset paging, and omitting continuation from zero-match partial pages.

--- a/application/queryservice/event_query.go
+++ b/application/queryservice/event_query.go
@@ -83,3 +83,10 @@ type EventBoundedQueryService interface {
 	// canonical envelopes whose visible body was not response-truncated.
 	LoadCanonicalBodies(ctx context.Context, eventIDs []types.EventID) (map[types.EventID]string, error)
 }
+
+// TieredEventSearchQuery is additive while the legacy Search methods remain
+// authoritative. It returns honest bounded coverage rather than overloading a
+// slice API with flags whose empty result could be mistaken for completeness.
+type TieredEventSearchQuery interface {
+	SearchLiteralPage(ctx context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error)
+}

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -1,0 +1,129 @@
+package queryservice
+
+import (
+	"errors"
+	"fmt"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// LiteralSourceObservation describes the persistence facts for one ordered source.
+type LiteralSourceObservation struct {
+	Sequence        int64
+	Stored, Decoded int64
+	Eligible        bool
+}
+
+// LiteralProgressDecision tells the persistence driver what operation is safe next.
+type LiteralProgressDecision struct {
+	Verify        bool
+	Stop          bool
+	PartialReason string
+}
+
+// LiteralSearchProgress is the narrow driver-facing view of application search progress.
+// Its implementation and phase state remain private to this package.
+type LiteralSearchProgress interface {
+	ObserveSource(LiteralSourceObservation) (LiteralProgressDecision, error)
+	FinishVerification(sequence int64, matched bool) (LiteralProgressDecision, error)
+	FinishPage(moreSources bool) LiteralProgressResult
+}
+
+// LiteralProgressResult is the application-owned page progress decision.
+type LiteralProgressResult struct {
+	Processed, Examined int64
+	Complete            bool
+	PartialReason       string
+}
+
+type literalProgressPhase uint8
+
+const (
+	literalProgressReady literalProgressPhase = iota
+	literalProgressVerifying
+	literalProgressStopped
+)
+
+type literalSearchProgress struct {
+	ledger      apptypes.LiteralVerificationLedger
+	start       int64
+	highWater   int64
+	sourceLimit int
+	resultLimit int
+	examined    int64
+	results     int
+	phase       literalProgressPhase
+	partial     string
+	pending     LiteralSourceObservation
+}
+
+// NewLiteralSearchProgress creates the private application state machine.
+func NewLiteralSearchProgress(start, highWater int64, budget apptypes.LiteralSearchBudget, resultLimit int) LiteralSearchProgress {
+	return &literalSearchProgress{ledger: apptypes.LiteralVerificationLedger{Budget: budget, FullyProcessed: start}, start: start, highWater: highWater, sourceLimit: budget.SourceRows, resultLimit: resultLimit}
+}
+
+func (p *literalSearchProgress) ObserveSource(source LiteralSourceObservation) (LiteralProgressDecision, error) {
+	if p.phase != literalProgressReady {
+		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: source observed in phase %d", p.phase)
+	}
+	if p.examined >= int64(p.sourceLimit) {
+		return p.stop("source_rows"), nil
+	}
+	p.examined++
+	if !source.Eligible {
+		p.ledger.Skip(source.Sequence)
+		return LiteralProgressDecision{}, nil
+	}
+	if err := p.ledger.AdmitVerification(source.Stored, source.Decoded); err != nil {
+		if p.ledger.FullyProcessed == p.start {
+			return LiteralProgressDecision{}, fmt.Errorf("admit literal verification: %w", err)
+		}
+		return p.stop(progressBudgetReason(err)), nil
+	}
+	p.pending = source
+	p.phase = literalProgressVerifying
+	return LiteralProgressDecision{Verify: true}, nil
+}
+
+func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool) (LiteralProgressDecision, error) {
+	if p.phase != literalProgressVerifying || sequence != p.pending.Sequence {
+		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: verification completed out of phase")
+	}
+	if err := p.ledger.FinishVerification(sequence, p.pending.Stored, p.pending.Decoded, matched); err != nil {
+		if p.ledger.FullyProcessed == p.start {
+			return LiteralProgressDecision{}, fmt.Errorf("finish matched literal verification: %w", err)
+		}
+		return p.stop(progressBudgetReason(err)), nil
+	}
+	p.phase = literalProgressReady
+	if matched {
+		p.results++
+		if p.results >= p.resultLimit {
+			return p.stop("result_limit"), nil
+		}
+	}
+	return LiteralProgressDecision{}, nil
+}
+
+func (p *literalSearchProgress) FinishPage(moreSources bool) LiteralProgressResult {
+	complete := p.ledger.FullyProcessed >= p.highWater
+	partial := p.partial
+	if !complete && partial == "" && moreSources {
+		partial = "source_rows"
+	}
+	return LiteralProgressResult{Processed: p.ledger.FullyProcessed, Examined: p.examined, Complete: complete, PartialReason: partial}
+}
+
+func (p *literalSearchProgress) stop(reason string) LiteralProgressDecision {
+	p.phase = literalProgressStopped
+	p.partial = reason
+	return LiteralProgressDecision{Stop: true, PartialReason: reason}
+}
+
+func progressBudgetReason(err error) string {
+	var oversized *apptypes.SearchProjectionOversizeError
+	if errors.As(err, &oversized) {
+		return oversized.Class
+	}
+	return "resource_budget"
+}

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -7,11 +7,21 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 )
 
+// LiteralSourceDisposition makes source admission observations explicit.
+type LiteralSourceDisposition uint8
+
+const (
+	// LiteralSourceSkipped identifies a tombstone or criteria/candidate rejection.
+	LiteralSourceSkipped LiteralSourceDisposition = iota
+	// LiteralSourceEligible identifies a source that requires canonical verification.
+	LiteralSourceEligible
+)
+
 // LiteralSourceObservation describes the persistence facts for one ordered source.
 type LiteralSourceObservation struct {
 	Sequence        int64
 	Stored, Decoded int64
-	Eligible        bool
+	Disposition     LiteralSourceDisposition
 }
 
 // LiteralProgressDecision tells the persistence driver what operation is safe next.
@@ -71,9 +81,12 @@ func (p *literalSearchProgress) ObserveSource(source LiteralSourceObservation) (
 		return p.stop("source_rows"), nil
 	}
 	p.examined++
-	if !source.Eligible {
+	if source.Disposition == LiteralSourceSkipped {
 		p.ledger.Skip(source.Sequence)
 		return LiteralProgressDecision{}, nil
+	}
+	if source.Disposition != LiteralSourceEligible {
+		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: unknown source disposition %d", source.Disposition)
 	}
 	if err := p.ledger.AdmitVerification(source.Stored, source.Decoded); err != nil {
 		if p.ledger.FullyProcessed == p.start {

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -17,17 +17,27 @@ const (
 	LiteralSourceEligible
 )
 
-// LiteralSourceObservation describes the persistence facts for one ordered source.
-type LiteralSourceObservation struct {
+// LiteralSource describes the ordered source and its verification costs.
+type LiteralSource struct {
 	Sequence        int64
 	Stored, Decoded int64
-	Disposition     LiteralSourceDisposition
 }
+
+// LiteralProgressAction tells the persistence driver the only safe next operation.
+type LiteralProgressAction uint8
+
+const (
+	LiteralProgressContinue LiteralProgressAction = iota
+	LiteralProgressCheckDisposition
+	LiteralProgressVerify
+	LiteralProgressRecordMatch
+	LiteralProgressRecordMatchAndStop
+	LiteralProgressStop
+)
 
 // LiteralProgressDecision tells the persistence driver what operation is safe next.
 type LiteralProgressDecision struct {
-	Verify        bool
-	Stop          bool
+	Action        LiteralProgressAction
 	PartialReason string
 	ResumeBefore  int64
 }
@@ -35,9 +45,10 @@ type LiteralProgressDecision struct {
 // LiteralSearchProgress is the narrow driver-facing view of application search progress.
 // Its implementation and phase state remain private to this package.
 type LiteralSearchProgress interface {
-	ObserveSource(LiteralSourceObservation) (LiteralProgressDecision, error)
+	BeginSource(LiteralSource) (LiteralProgressDecision, error)
+	ObserveDisposition(LiteralSourceDisposition) (LiteralProgressDecision, error)
 	FinishVerification(sequence int64, matched bool) (LiteralProgressDecision, error)
-	FinishPage(moreSources bool) LiteralProgressResult
+	FinishPage() LiteralProgressResult
 }
 
 // LiteralProgressResult is the application-owned page progress decision.
@@ -51,6 +62,7 @@ type literalProgressPhase uint8
 
 const (
 	literalProgressReady literalProgressPhase = iota
+	literalProgressCheckingDisposition
 	literalProgressVerifying
 	literalProgressStopped
 )
@@ -65,7 +77,7 @@ type literalSearchProgress struct {
 	results     int
 	phase       literalProgressPhase
 	partial     string
-	pending     LiteralSourceObservation
+	pending     LiteralSource
 }
 
 // NewLiteralSearchProgress creates the private application state machine.
@@ -73,7 +85,7 @@ func NewLiteralSearchProgress(start, highWater int64, budget apptypes.LiteralSea
 	return &literalSearchProgress{ledger: apptypes.LiteralVerificationLedger{Budget: budget, FullyProcessed: start}, start: start, highWater: highWater, sourceLimit: budget.SourceRows, resultLimit: resultLimit}
 }
 
-func (p *literalSearchProgress) ObserveSource(source LiteralSourceObservation) (LiteralProgressDecision, error) {
+func (p *literalSearchProgress) BeginSource(source LiteralSource) (LiteralProgressDecision, error) {
 	if p.phase != literalProgressReady {
 		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: source observed in phase %d", p.phase)
 	}
@@ -81,22 +93,32 @@ func (p *literalSearchProgress) ObserveSource(source LiteralSourceObservation) (
 		return p.stop("source_rows"), nil
 	}
 	p.examined++
-	if source.Disposition == LiteralSourceSkipped {
-		p.ledger.Skip(source.Sequence)
-		return LiteralProgressDecision{}, nil
+	p.pending = source
+	p.phase = literalProgressCheckingDisposition
+	return LiteralProgressDecision{Action: LiteralProgressCheckDisposition}, nil
+}
+
+func (p *literalSearchProgress) ObserveDisposition(disposition LiteralSourceDisposition) (LiteralProgressDecision, error) {
+	if p.phase != literalProgressCheckingDisposition {
+		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: disposition observed in phase %d", p.phase)
 	}
-	if source.Disposition != LiteralSourceEligible {
-		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: unknown source disposition %d", source.Disposition)
+	if disposition == LiteralSourceSkipped {
+		p.ledger.Skip(p.pending.Sequence)
+		p.phase = literalProgressReady
+		return LiteralProgressDecision{Action: LiteralProgressContinue}, nil
 	}
+	if disposition != LiteralSourceEligible {
+		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: unknown source disposition %d", disposition)
+	}
+	source := p.pending
 	if err := p.ledger.AdmitVerification(source.Stored, source.Decoded); err != nil {
 		if p.ledger.FullyProcessed == p.start {
 			return LiteralProgressDecision{}, fmt.Errorf("admit literal verification: %w", err)
 		}
 		return p.stop(progressBudgetReason(err)), nil
 	}
-	p.pending = source
 	p.phase = literalProgressVerifying
-	return LiteralProgressDecision{Verify: true, ResumeBefore: p.ledger.FullyProcessed}, nil
+	return LiteralProgressDecision{Action: LiteralProgressVerify, ResumeBefore: p.ledger.FullyProcessed}, nil
 }
 
 func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool) (LiteralProgressDecision, error) {
@@ -113,13 +135,16 @@ func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool)
 	if matched {
 		p.results++
 		if p.results >= p.resultLimit {
-			return p.stop("result_limit"), nil
+			decision := p.stop("result_limit")
+			decision.Action = LiteralProgressRecordMatchAndStop
+			return decision, nil
 		}
+		return LiteralProgressDecision{Action: LiteralProgressRecordMatch}, nil
 	}
-	return LiteralProgressDecision{}, nil
+	return LiteralProgressDecision{Action: LiteralProgressContinue}, nil
 }
 
-func (p *literalSearchProgress) FinishPage(_ bool) LiteralProgressResult {
+func (p *literalSearchProgress) FinishPage() LiteralProgressResult {
 	complete := p.ledger.FullyProcessed >= p.highWater
 	partial := p.partial
 	if complete {
@@ -134,7 +159,7 @@ func (p *literalSearchProgress) FinishPage(_ bool) LiteralProgressResult {
 func (p *literalSearchProgress) stop(reason string) LiteralProgressDecision {
 	p.phase = literalProgressStopped
 	p.partial = reason
-	return LiteralProgressDecision{Stop: true, PartialReason: reason}
+	return LiteralProgressDecision{Action: LiteralProgressStop, PartialReason: reason}
 }
 
 func progressBudgetReason(err error) string {

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -27,11 +27,17 @@ type LiteralSource struct {
 type LiteralProgressAction uint8
 
 const (
+	// LiteralProgressContinue advances the driver without persistence work.
 	LiteralProgressContinue LiteralProgressAction = iota
+	// LiteralProgressCheckDisposition permits the driver to classify a source.
 	LiteralProgressCheckDisposition
+	// LiteralProgressVerify permits canonical decoding and verification.
 	LiteralProgressVerify
+	// LiteralProgressRecordMatch accepts a match and continues scanning.
 	LiteralProgressRecordMatch
+	// LiteralProgressRecordMatchAndStop accepts a match and stops at the result limit.
 	LiteralProgressRecordMatchAndStop
+	// LiteralProgressStop stops without accepting the current source as a match.
 	LiteralProgressStop
 )
 

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -75,7 +75,6 @@ const (
 
 type literalSearchProgress struct {
 	ledger      apptypes.LiteralVerificationLedger
-	start       int64
 	highWater   int64
 	sourceLimit int
 	resultLimit int
@@ -88,7 +87,7 @@ type literalSearchProgress struct {
 
 // NewLiteralSearchProgress creates the private application state machine.
 func NewLiteralSearchProgress(start, highWater int64, budget apptypes.LiteralSearchBudget, resultLimit int) LiteralSearchProgress {
-	return &literalSearchProgress{ledger: apptypes.LiteralVerificationLedger{Budget: budget, FullyProcessed: start}, start: start, highWater: highWater, sourceLimit: budget.SourceRows, resultLimit: resultLimit}
+	return &literalSearchProgress{ledger: apptypes.LiteralVerificationLedger{Budget: budget, FullyProcessed: start}, highWater: highWater, sourceLimit: budget.SourceRows, resultLimit: resultLimit}
 }
 
 func (p *literalSearchProgress) BeginSource(source LiteralSource) (LiteralProgressDecision, error) {
@@ -118,9 +117,6 @@ func (p *literalSearchProgress) ObserveDisposition(disposition LiteralSourceDisp
 	}
 	source := p.pending
 	if err := p.ledger.AdmitVerification(source.Stored, source.Decoded); err != nil {
-		if p.ledger.FullyProcessed == p.start {
-			return LiteralProgressDecision{}, fmt.Errorf("admit literal verification: %w", err)
-		}
 		return p.stop(progressBudgetReason(err)), nil
 	}
 	p.phase = literalProgressVerifying
@@ -132,9 +128,6 @@ func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool)
 		return LiteralProgressDecision{}, fmt.Errorf("literal search progress: verification completed out of phase")
 	}
 	if err := p.ledger.FinishVerification(sequence, p.pending.Stored, p.pending.Decoded, matched); err != nil {
-		if p.ledger.FullyProcessed == p.start {
-			return LiteralProgressDecision{}, fmt.Errorf("finish matched literal verification: %w", err)
-		}
 		return p.stop(progressBudgetReason(err)), nil
 	}
 	p.phase = literalProgressReady

--- a/application/queryservice/literal_search_progress.go
+++ b/application/queryservice/literal_search_progress.go
@@ -19,6 +19,7 @@ type LiteralProgressDecision struct {
 	Verify        bool
 	Stop          bool
 	PartialReason string
+	ResumeBefore  int64
 }
 
 // LiteralSearchProgress is the narrow driver-facing view of application search progress.
@@ -82,7 +83,7 @@ func (p *literalSearchProgress) ObserveSource(source LiteralSourceObservation) (
 	}
 	p.pending = source
 	p.phase = literalProgressVerifying
-	return LiteralProgressDecision{Verify: true}, nil
+	return LiteralProgressDecision{Verify: true, ResumeBefore: p.ledger.FullyProcessed}, nil
 }
 
 func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool) (LiteralProgressDecision, error) {
@@ -105,10 +106,13 @@ func (p *literalSearchProgress) FinishVerification(sequence int64, matched bool)
 	return LiteralProgressDecision{}, nil
 }
 
-func (p *literalSearchProgress) FinishPage(moreSources bool) LiteralProgressResult {
+func (p *literalSearchProgress) FinishPage(_ bool) LiteralProgressResult {
 	complete := p.ledger.FullyProcessed >= p.highWater
 	partial := p.partial
-	if !complete && partial == "" && moreSources {
+	if complete {
+		partial = ""
+	}
+	if !complete && partial == "" {
 		partial = "source_rows"
 	}
 	return LiteralProgressResult{Processed: p.ledger.FullyProcessed, Examined: p.examined, Complete: complete, PartialReason: partial}

--- a/application/queryservice/literal_search_progress_test.go
+++ b/application/queryservice/literal_search_progress_test.go
@@ -1,7 +1,6 @@
 package queryservice
 
 import (
-	"errors"
 	"testing"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -9,13 +8,12 @@ import (
 
 func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	budget := apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}
-	t.Run("initial oversize is retryable error", func(t *testing.T) {
+	t.Run("initial oversize is retryable partial", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 2, budget, 2)
 		_, _ = p.BeginSource(LiteralSource{Sequence: 1, Stored: 11, Decoded: 1})
-		_, err := p.ObserveDisposition(LiteralSourceEligible)
-		var oversized *apptypes.SearchProjectionOversizeError
-		if !errors.As(err, &oversized) {
-			t.Fatalf("error=%v", err)
+		d, err := p.ObserveDisposition(LiteralSourceEligible)
+		if err != nil || d.Action != LiteralProgressStop || d.PartialReason != "stored_bytes" {
+			t.Fatalf("decision=%+v error=%v", d, err)
 		}
 	})
 	t.Run("skip then oversize returns partial anchored at skip", func(t *testing.T) {
@@ -40,8 +38,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 			t.Fatalf("decision=%+v", d)
 		}
 		d, err := p.FinishVerification(2, true)
-		var oversized *apptypes.SearchProjectionOversizeError
-		if !errors.As(err, &oversized) || d.Action == LiteralProgressStop {
+		if err != nil || d.Action != LiteralProgressStop || d.PartialReason != "verified_hydration_bytes" {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
 		if got := p.FinishPage(); got.Processed != 1 {

--- a/application/queryservice/literal_search_progress_test.go
+++ b/application/queryservice/literal_search_progress_test.go
@@ -1,0 +1,79 @@
+package queryservice
+
+import (
+	"errors"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestLiteralSearchProgressCharacterization(t *testing.T) {
+	budget := apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}
+	t.Run("initial oversize is retryable error", func(t *testing.T) {
+		p := NewLiteralSearchProgress(0, 2, budget, 2)
+		_, err := p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 11, Decoded: 1})
+		var oversized *apptypes.SearchProjectionOversizeError
+		if !errors.As(err, &oversized) {
+			t.Fatalf("error=%v", err)
+		}
+	})
+	t.Run("skip then oversize returns partial anchored at skip", func(t *testing.T) {
+		p := NewLiteralSearchProgress(0, 3, budget, 2)
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1})
+		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Eligible: true, Stored: 11})
+		if err != nil || !d.Stop || d.PartialReason != "stored_bytes" {
+			t.Fatalf("decision=%+v error=%v", d, err)
+		}
+		got := p.FinishPage(true)
+		if got.Processed != 1 || got.Examined != 2 {
+			t.Fatalf("result=%+v", got)
+		}
+	})
+	t.Run("hydration oversize retries before match", func(t *testing.T) {
+		p := NewLiteralSearchProgress(1, 3, budget, 2)
+		d, _ := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Eligible: true, Stored: 6, Decoded: 6})
+		if !d.Verify {
+			t.Fatalf("decision=%+v", d)
+		}
+		d, err := p.FinishVerification(2, true)
+		var oversized *apptypes.SearchProjectionOversizeError
+		if !errors.As(err, &oversized) || d.Stop {
+			t.Fatalf("decision=%+v error=%v", d, err)
+		}
+		if got := p.FinishPage(true); got.Processed != 1 {
+			t.Fatalf("result=%+v", got)
+		}
+	})
+	t.Run("zero matches advance and complete without continuation", func(t *testing.T) {
+		p := NewLiteralSearchProgress(0, 2, budget, 2)
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1})
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 2})
+		got := p.FinishPage(false)
+		if !got.Complete || got.Processed != 2 || got.Examined != 2 || got.PartialReason != "" {
+			t.Fatalf("result=%+v", got)
+		}
+	})
+	t.Run("result and source limits are distinct", func(t *testing.T) {
+		p := NewLiteralSearchProgress(0, 4, budget, 1)
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+		d, err := p.FinishVerification(1, true)
+		if err != nil || !d.Stop || d.PartialReason != "result_limit" {
+			t.Fatalf("decision=%+v error=%v", d, err)
+		}
+		got := p.FinishPage(true)
+		if got.Processed != 1 || got.Examined != 1 {
+			t.Fatalf("result=%+v", got)
+		}
+	})
+}
+
+func TestLiteralSearchProgressRejectsPhaseViolations(t *testing.T) {
+	p := NewLiteralSearchProgress(0, 2, apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}, 2)
+	_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+	if _, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2}); err == nil {
+		t.Fatal("accepted source while verifying")
+	}
+	if _, err := p.FinishVerification(2, false); err == nil {
+		t.Fatal("accepted wrong sequence")
+	}
+}

--- a/application/queryservice/literal_search_progress_test.go
+++ b/application/queryservice/literal_search_progress_test.go
@@ -11,7 +11,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	budget := apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}
 	t.Run("initial oversize is retryable error", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 2, budget, 2)
-		_, err := p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 11, Decoded: 1})
+		_, err := p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 11, Decoded: 1})
 		var oversized *apptypes.SearchProjectionOversizeError
 		if !errors.As(err, &oversized) {
 			t.Fatalf("error=%v", err)
@@ -20,7 +20,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	t.Run("skip then oversize returns partial anchored at skip", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 3, budget, 2)
 		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1})
-		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Eligible: true, Stored: 11})
+		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Disposition: LiteralSourceEligible, Stored: 11})
 		if err != nil || !d.Stop || d.PartialReason != "stored_bytes" {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
@@ -31,7 +31,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	})
 	t.Run("hydration oversize retries before match", func(t *testing.T) {
 		p := NewLiteralSearchProgress(1, 3, budget, 2)
-		d, _ := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Eligible: true, Stored: 6, Decoded: 6})
+		d, _ := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Disposition: LiteralSourceEligible, Stored: 6, Decoded: 6})
 		if !d.Verify {
 			t.Fatalf("decision=%+v", d)
 		}
@@ -55,7 +55,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	})
 	t.Run("result and source limits are distinct", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 4, budget, 1)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
 		d, err := p.FinishVerification(1, true)
 		if err != nil || !d.Stop || d.PartialReason != "result_limit" {
 			t.Fatalf("decision=%+v error=%v", d, err)
@@ -79,7 +79,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	})
 	t.Run("result limit on high water completes without partial", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 1, budget, 1)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
 		_, _ = p.FinishVerification(1, true)
 		got := p.FinishPage(false)
 		if !got.Complete || got.PartialReason != "" || got.Processed != 1 || got.Examined != 1 {
@@ -90,7 +90,7 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 
 func TestLiteralSearchProgressRejectsPhaseViolations(t *testing.T) {
 	p := NewLiteralSearchProgress(0, 2, apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}, 2)
-	_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+	_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
 	if _, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2}); err == nil {
 		t.Fatal("accepted source while verifying")
 	}

--- a/application/queryservice/literal_search_progress_test.go
+++ b/application/queryservice/literal_search_progress_test.go
@@ -65,6 +65,27 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 			t.Fatalf("result=%+v", got)
 		}
 	})
+	t.Run("source row limit preserves processed and examined", func(t *testing.T) {
+		p := NewLiteralSearchProgress(3, 9, apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 10, DecodedBytes: 10}, 2)
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 4})
+		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 5})
+		if err != nil || !d.Stop || d.PartialReason != "source_rows" {
+			t.Fatalf("decision=%+v error=%v", d, err)
+		}
+		got := p.FinishPage(true)
+		if got.Processed != 4 || got.Examined != 1 || got.Complete {
+			t.Fatalf("result=%+v", got)
+		}
+	})
+	t.Run("result limit on high water completes without partial", func(t *testing.T) {
+		p := NewLiteralSearchProgress(0, 1, budget, 1)
+		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Eligible: true, Stored: 1, Decoded: 1})
+		_, _ = p.FinishVerification(1, true)
+		got := p.FinishPage(false)
+		if !got.Complete || got.PartialReason != "" || got.Processed != 1 || got.Examined != 1 {
+			t.Fatalf("result=%+v", got)
+		}
+	})
 }
 
 func TestLiteralSearchProgressRejectsPhaseViolations(t *testing.T) {

--- a/application/queryservice/literal_search_progress_test.go
+++ b/application/queryservice/literal_search_progress_test.go
@@ -11,7 +11,8 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	budget := apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}
 	t.Run("initial oversize is retryable error", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 2, budget, 2)
-		_, err := p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 11, Decoded: 1})
+		_, _ = p.BeginSource(LiteralSource{Sequence: 1, Stored: 11, Decoded: 1})
+		_, err := p.ObserveDisposition(LiteralSourceEligible)
 		var oversized *apptypes.SearchProjectionOversizeError
 		if !errors.As(err, &oversized) {
 			t.Fatalf("error=%v", err)
@@ -19,69 +20,77 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 	})
 	t.Run("skip then oversize returns partial anchored at skip", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 3, budget, 2)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1})
-		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Disposition: LiteralSourceEligible, Stored: 11})
-		if err != nil || !d.Stop || d.PartialReason != "stored_bytes" {
+		_, _ = p.BeginSource(LiteralSource{Sequence: 1})
+		_, _ = p.ObserveDisposition(LiteralSourceSkipped)
+		_, _ = p.BeginSource(LiteralSource{Sequence: 2, Stored: 11})
+		d, err := p.ObserveDisposition(LiteralSourceEligible)
+		if err != nil || d.Action != LiteralProgressStop || d.PartialReason != "stored_bytes" {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
-		got := p.FinishPage(true)
+		got := p.FinishPage()
 		if got.Processed != 1 || got.Examined != 2 {
 			t.Fatalf("result=%+v", got)
 		}
 	})
 	t.Run("hydration oversize retries before match", func(t *testing.T) {
 		p := NewLiteralSearchProgress(1, 3, budget, 2)
-		d, _ := p.ObserveSource(LiteralSourceObservation{Sequence: 2, Disposition: LiteralSourceEligible, Stored: 6, Decoded: 6})
-		if !d.Verify {
+		_, _ = p.BeginSource(LiteralSource{Sequence: 2, Stored: 6, Decoded: 6})
+		d, _ := p.ObserveDisposition(LiteralSourceEligible)
+		if d.Action != LiteralProgressVerify {
 			t.Fatalf("decision=%+v", d)
 		}
 		d, err := p.FinishVerification(2, true)
 		var oversized *apptypes.SearchProjectionOversizeError
-		if !errors.As(err, &oversized) || d.Stop {
+		if !errors.As(err, &oversized) || d.Action == LiteralProgressStop {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
-		if got := p.FinishPage(true); got.Processed != 1 {
+		if got := p.FinishPage(); got.Processed != 1 {
 			t.Fatalf("result=%+v", got)
 		}
 	})
 	t.Run("zero matches advance and complete without continuation", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 2, budget, 2)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1})
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 2})
-		got := p.FinishPage(false)
+		_, _ = p.BeginSource(LiteralSource{Sequence: 1})
+		_, _ = p.ObserveDisposition(LiteralSourceSkipped)
+		_, _ = p.BeginSource(LiteralSource{Sequence: 2})
+		_, _ = p.ObserveDisposition(LiteralSourceSkipped)
+		got := p.FinishPage()
 		if !got.Complete || got.Processed != 2 || got.Examined != 2 || got.PartialReason != "" {
 			t.Fatalf("result=%+v", got)
 		}
 	})
 	t.Run("result and source limits are distinct", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 4, budget, 1)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
+		_, _ = p.BeginSource(LiteralSource{Sequence: 1, Stored: 1, Decoded: 1})
+		_, _ = p.ObserveDisposition(LiteralSourceEligible)
 		d, err := p.FinishVerification(1, true)
-		if err != nil || !d.Stop || d.PartialReason != "result_limit" {
+		if err != nil || d.Action != LiteralProgressRecordMatchAndStop || d.PartialReason != "result_limit" {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
-		got := p.FinishPage(true)
+		got := p.FinishPage()
 		if got.Processed != 1 || got.Examined != 1 {
 			t.Fatalf("result=%+v", got)
 		}
 	})
 	t.Run("source row limit preserves processed and examined", func(t *testing.T) {
 		p := NewLiteralSearchProgress(3, 9, apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 10, DecodedBytes: 10}, 2)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 4})
-		d, err := p.ObserveSource(LiteralSourceObservation{Sequence: 5})
-		if err != nil || !d.Stop || d.PartialReason != "source_rows" {
+		_, _ = p.BeginSource(LiteralSource{Sequence: 4})
+		_, _ = p.ObserveDisposition(LiteralSourceSkipped)
+		d, err := p.BeginSource(LiteralSource{Sequence: 5})
+		if err != nil || d.Action != LiteralProgressStop || d.PartialReason != "source_rows" {
 			t.Fatalf("decision=%+v error=%v", d, err)
 		}
-		got := p.FinishPage(true)
+		got := p.FinishPage()
 		if got.Processed != 4 || got.Examined != 1 || got.Complete {
 			t.Fatalf("result=%+v", got)
 		}
 	})
 	t.Run("result limit on high water completes without partial", func(t *testing.T) {
 		p := NewLiteralSearchProgress(0, 1, budget, 1)
-		_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
+		_, _ = p.BeginSource(LiteralSource{Sequence: 1, Stored: 1, Decoded: 1})
+		_, _ = p.ObserveDisposition(LiteralSourceEligible)
 		_, _ = p.FinishVerification(1, true)
-		got := p.FinishPage(false)
+		got := p.FinishPage()
 		if !got.Complete || got.PartialReason != "" || got.Processed != 1 || got.Examined != 1 {
 			t.Fatalf("result=%+v", got)
 		}
@@ -90,8 +99,9 @@ func TestLiteralSearchProgressCharacterization(t *testing.T) {
 
 func TestLiteralSearchProgressRejectsPhaseViolations(t *testing.T) {
 	p := NewLiteralSearchProgress(0, 2, apptypes.LiteralSearchBudget{SourceRows: 2, StoredBytes: 10, DecodedBytes: 10}, 2)
-	_, _ = p.ObserveSource(LiteralSourceObservation{Sequence: 1, Disposition: LiteralSourceEligible, Stored: 1, Decoded: 1})
-	if _, err := p.ObserveSource(LiteralSourceObservation{Sequence: 2}); err == nil {
+	_, _ = p.BeginSource(LiteralSource{Sequence: 1, Stored: 1, Decoded: 1})
+	_, _ = p.ObserveDisposition(LiteralSourceEligible)
+	if _, err := p.BeginSource(LiteralSource{Sequence: 2}); err == nil {
 		t.Fatal("accepted source while verifying")
 	}
 	if _, err := p.FinishVerification(2, false); err == nil {

--- a/application/queryservice/literal_search_service.go
+++ b/application/queryservice/literal_search_service.go
@@ -1,0 +1,35 @@
+package queryservice
+
+import (
+	"context"
+	"fmt"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// LiteralSearchPageSource is the persistence-facing canonical search port.
+type LiteralSearchPageSource interface {
+	SearchLiteralPage(context.Context, apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error)
+}
+
+// LiteralSearchService owns the application boundary for tiered literal pages.
+type LiteralSearchService struct{ source LiteralSearchPageSource }
+
+// NewLiteralSearchService constructs the validated tiered search service.
+func NewLiteralSearchService(source LiteralSearchPageSource) *LiteralSearchService {
+	return &LiteralSearchService{source: source}
+}
+
+// SearchLiteralPage validates protocol-neutral invariants before persistence.
+func (s *LiteralSearchService) SearchLiteralPage(ctx context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
+	if err := request.Validate(); err != nil {
+		return apptypes.LiteralSearchPage{}, fmt.Errorf("validate literal search request: %w", err)
+	}
+	page, err := s.source.SearchLiteralPage(ctx, request)
+	if err != nil {
+		return apptypes.LiteralSearchPage{}, fmt.Errorf("search canonical literal page: %w", err)
+	}
+	return page, nil
+}
+
+var _ TieredEventSearchQuery = (*LiteralSearchService)(nil)

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -1,0 +1,148 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// LiteralFingerprintBytes is the fixed persisted fingerprint width.
+	LiteralFingerprintBytes = 16
+	// LiteralSearchCursorVersion identifies the continuation envelope.
+	LiteralSearchCursorVersion = 1
+)
+
+// LiteralQuery owns the normalization shared by candidate construction and
+// canonical verification. Fingerprints are only available for three-rune
+// literals; an unavailable fingerprint must never be interpreted as no match.
+type LiteralQuery struct {
+	canonical    string
+	filterable   bool
+	fingerprints []string
+}
+
+// CharacterizeLiteralQuery normalizes a literal and derives safe fingerprints.
+func CharacterizeLiteralQuery(raw string) LiteralQuery {
+	canonical := strings.ToLower(strings.TrimSpace(raw))
+	runes := []rune(canonical)
+	q := LiteralQuery{canonical: canonical, filterable: len(runes) >= 3}
+	if !q.filterable {
+		return q
+	}
+	seen := make(map[string]struct{}, len(runes)-2)
+	for i := 0; i+3 <= len(runes); i++ {
+		sum := sha256.Sum256([]byte(string(runes[i : i+3])))
+		fp := string(sum[:LiteralFingerprintBytes])
+		if _, exists := seen[fp]; exists {
+			continue
+		}
+		seen[fp] = struct{}{}
+		q.fingerprints = append(q.fingerprints, fp)
+	}
+	return q
+}
+
+// Canonical returns verification text.
+func (q LiteralQuery) Canonical() string { return q.canonical }
+
+// Filterable reports whether fingerprints may narrow candidates.
+func (q LiteralQuery) Filterable() bool { return q.filterable }
+
+// Fingerprints returns cloned fixed-size hashes.
+func (q LiteralQuery) Fingerprints() []string { return append([]string(nil), q.fingerprints...) }
+
+// Contains applies canonical literal semantics.
+func (q LiteralQuery) Contains(needle LiteralQuery) bool {
+	return needle.canonical != "" && strings.Contains(q.canonical, needle.canonical)
+}
+
+// LiteralSearchTier identifies candidate provenance.
+type LiteralSearchTier string
+
+const (
+	// LiteralSearchTierFingerprint identifies the historical candidate table.
+	LiteralSearchTierFingerprint LiteralSearchTier = "historical_fingerprint"
+	// LiteralSearchTierBoundedVerification identifies an inclusive source scan.
+	LiteralSearchTierBoundedVerification LiteralSearchTier = "bounded_verification"
+)
+
+// LiteralSearchCoverage describes fully processed source coverage.
+type LiteralSearchCoverage struct {
+	ProcessedSources int64 `json:"processed_sources"`
+	HighWater        int64 `json:"high_water"`
+	Complete         bool  `json:"complete"`
+}
+
+// LiteralSearchBudget bounds physical and decoded work.
+type LiteralSearchBudget struct {
+	SourceRows                int
+	StoredBytes, DecodedBytes int64
+}
+
+// Valid reports whether every hard bound is positive.
+func (b LiteralSearchBudget) Valid() bool {
+	return b.SourceRows > 0 && b.StoredBytes > 0 && b.DecodedBytes > 0
+}
+
+// LiteralSearchRequest is the sibling tier-aware query contract.
+type LiteralSearchRequest struct {
+	Criteria     EventSearchCriteria
+	Budget       LiteralSearchBudget
+	Continuation string
+}
+
+// LiteralSearchPage exposes matches and honest completeness metadata.
+type LiteralSearchPage struct {
+	Events        []BoundedEvent        `json:"events"`
+	Tier          LiteralSearchTier     `json:"tier"`
+	Coverage      LiteralSearchCoverage `json:"coverage"`
+	PartialReason string                `json:"partial_reason,omitempty"`
+	Continuation  string                `json:"continuation,omitempty"`
+}
+
+// ErrLiteralSearchCursorMismatch rejects replay against changed inputs.
+var ErrLiteralSearchCursorMismatch = errors.New("literal search continuation does not match the request or active projection")
+
+// LiteralSearchCursor binds progress to query and projection identity.
+type LiteralSearchCursor struct {
+	Version       int    `json:"v"`
+	LastSequence  int64  `json:"last_sequence"`
+	CriteriaHash  string `json:"criteria_hash"`
+	Generation    string `json:"generation"`
+	HighWater     int64  `json:"high_water"`
+	QueryRevision int64  `json:"query_revision"`
+}
+
+// Encode serializes a URL-safe opaque continuation.
+func (c LiteralSearchCursor) Encode() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode literal search cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// DecodeLiteralSearchCursor parses and validates the envelope version.
+func DecodeLiteralSearchCursor(value string) (LiteralSearchCursor, error) {
+	b, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	var c LiteralSearchCursor
+	if json.Unmarshal(b, &c) != nil || c.Version != LiteralSearchCursorVersion || c.LastSequence < 0 {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	return c, nil
+}
+
+// Validate binds a decoded cursor to current immutable query inputs.
+func (c LiteralSearchCursor) Validate(criteriaHash, generation string, highWater, revision int64) error {
+	if c.Version != LiteralSearchCursorVersion || c.CriteriaHash != criteriaHash || c.Generation != generation || c.HighWater != highWater || c.QueryRevision != revision {
+		return ErrLiteralSearchCursorMismatch
+	}
+	return nil
+}

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -148,6 +148,9 @@ var ErrLiteralSearchCursorMismatch = errors.New("literal search continuation doe
 // ErrLiteralSearchQueryTooLarge rejects input before rune/gram allocation.
 var ErrLiteralSearchQueryTooLarge = errors.New("literal search query exceeds byte limit")
 
+// ErrLiteralSearchInvalidRequest identifies caller-controlled invariants.
+var ErrLiteralSearchInvalidRequest = errors.New("invalid literal search request")
+
 // LiteralSearchCursor binds progress to query and projection identity.
 type LiteralSearchCursor struct {
 	Version       int    `json:"v"`

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -1,19 +1,22 @@
 package types
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 const (
 	// LiteralFingerprintBytes is the fixed persisted fingerprint width.
 	LiteralFingerprintBytes = 16
 	// LiteralSearchCursorVersion identifies the continuation envelope.
-	LiteralSearchCursorVersion = 1
+	LiteralSearchCursorVersion  = 1
+	maxLiteralQueryFingerprints = 128
 )
 
 // LiteralQuery owns the normalization shared by candidate construction and
@@ -27,9 +30,16 @@ type LiteralQuery struct {
 
 // CharacterizeLiteralQuery normalizes a literal and derives safe fingerprints.
 func CharacterizeLiteralQuery(raw string) LiteralQuery {
-	canonical := strings.ToLower(strings.TrimSpace(raw))
+	canonical := foldLiteralASCII(strings.TrimSpace(raw))
 	runes := []rune(canonical)
-	q := LiteralQuery{canonical: canonical, filterable: len(runes) >= 3}
+	caseStable := true
+	for _, r := range runes {
+		if r > unicode.MaxASCII && (unicode.ToLower(r) != r || unicode.ToUpper(r) != r) {
+			caseStable = false
+			break
+		}
+	}
+	q := LiteralQuery{canonical: canonical, filterable: len(runes) >= 3 && caseStable}
 	if !q.filterable {
 		return q
 	}
@@ -42,8 +52,22 @@ func CharacterizeLiteralQuery(raw string) LiteralQuery {
 		}
 		seen[fp] = struct{}{}
 		q.fingerprints = append(q.fingerprints, fp)
+		if len(q.fingerprints) > maxLiteralQueryFingerprints {
+			q.filterable = false
+			q.fingerprints = nil
+			break
+		}
 	}
 	return q
+}
+
+func foldLiteralASCII(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}, value)
 }
 
 // Canonical returns verification text.
@@ -73,6 +97,7 @@ const (
 // LiteralSearchCoverage describes fully processed source coverage.
 type LiteralSearchCoverage struct {
 	ProcessedSources int64 `json:"processed_sources"`
+	ExaminedSources  int64 `json:"examined_sources"`
 	HighWater        int64 `json:"high_water"`
 	Complete         bool  `json:"complete"`
 }
@@ -96,9 +121,10 @@ func (b LiteralSearchBudget) Valid() bool {
 
 // LiteralSearchRequest is the sibling tier-aware query contract.
 type LiteralSearchRequest struct {
-	Criteria     EventSearchCriteria
-	Budget       LiteralSearchBudget
-	Continuation string
+	Criteria      EventSearchCriteria
+	Budget        LiteralSearchBudget
+	Continuation  string
+	BodyRuneLimit int
 }
 
 // LiteralSearchPage exposes matches and honest completeness metadata.
@@ -121,6 +147,52 @@ type LiteralSearchCursor struct {
 	Generation    string `json:"generation"`
 	HighWater     int64  `json:"high_water"`
 	QueryRevision int64  `json:"query_revision"`
+}
+
+type authenticatedLiteralCursor struct {
+	Cursor LiteralSearchCursor `json:"cursor"`
+	MAC    string              `json:"mac"`
+}
+
+// EncodeAuthenticated serializes a cursor with a store-owned integrity MAC.
+func (c LiteralSearchCursor) EncodeAuthenticated(key []byte) (string, error) {
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode literal cursor payload: %w", err)
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(payload)
+	envelope, err := json.Marshal(authenticatedLiteralCursor{Cursor: c, MAC: base64.RawURLEncoding.EncodeToString(mac.Sum(nil))})
+	if err != nil {
+		return "", fmt.Errorf("encode authenticated literal cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(envelope), nil
+}
+
+// DecodeAuthenticatedLiteralSearchCursor verifies store ownership and integrity.
+func DecodeAuthenticatedLiteralSearchCursor(value string, key []byte) (LiteralSearchCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	var env authenticatedLiteralCursor
+	if json.Unmarshal(raw, &env) != nil {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	payload, err := json.Marshal(env.Cursor)
+	if err != nil {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	got, err := base64.RawURLEncoding.DecodeString(env.MAC)
+	if err != nil {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(payload)
+	if !hmac.Equal(got, mac.Sum(nil)) || env.Cursor.Version != LiteralSearchCursorVersion || env.Cursor.LastSequence < 0 {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
+	return env.Cursor, nil
 }
 
 // Encode serializes a URL-safe opaque continuation.

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -83,6 +83,12 @@ type LiteralSearchBudget struct {
 	StoredBytes, DecodedBytes int64
 }
 
+// NormalLiteralSearchBudget is the default preview resource envelope.
+var NormalLiteralSearchBudget = LiteralSearchBudget{SourceRows: 512, StoredBytes: 8 << 20, DecodedBytes: 16 << 20}
+
+// DeepLiteralSearchBudget increases resources without changing semantics.
+var DeepLiteralSearchBudget = LiteralSearchBudget{SourceRows: 4096, StoredBytes: 64 << 20, DecodedBytes: 128 << 20}
+
 // Valid reports whether every hard bound is positive.
 func (b LiteralSearchBudget) Valid() bool {
 	return b.SourceRows > 0 && b.StoredBytes > 0 && b.DecodedBytes > 0

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -17,6 +17,8 @@ const (
 	// LiteralSearchCursorVersion identifies the continuation envelope.
 	LiteralSearchCursorVersion  = 1
 	maxLiteralQueryFingerprints = 128
+	// MaxLiteralSearchQueryBytes bounds normalization and gram allocation.
+	MaxLiteralSearchQueryBytes = 64 << 10
 )
 
 // LiteralQuery owns the normalization shared by candidate construction and
@@ -31,6 +33,9 @@ type LiteralQuery struct {
 // CharacterizeLiteralQuery normalizes a literal and derives safe fingerprints.
 func CharacterizeLiteralQuery(raw string) LiteralQuery {
 	canonical := foldLiteralASCII(strings.TrimSpace(raw))
+	if len(canonical) > MaxLiteralSearchQueryBytes {
+		return LiteralQuery{canonical: canonical}
+	}
 	runes := []rune(canonical)
 	caseStable := true
 	for _, r := range runes {
@@ -129,15 +134,19 @@ type LiteralSearchRequest struct {
 
 // LiteralSearchPage exposes matches and honest completeness metadata.
 type LiteralSearchPage struct {
-	Events        []BoundedEvent        `json:"events"`
-	Tier          LiteralSearchTier     `json:"tier"`
-	Coverage      LiteralSearchCoverage `json:"coverage"`
-	PartialReason string                `json:"partial_reason,omitempty"`
-	Continuation  string                `json:"continuation,omitempty"`
+	Events             []BoundedEvent        `json:"events"`
+	Tier               LiteralSearchTier     `json:"tier"`
+	Coverage           LiteralSearchCoverage `json:"coverage"`
+	PartialReason      string                `json:"partial_reason,omitempty"`
+	Continuation       string                `json:"continuation,omitempty"`
+	MatchContinuations []string              `json:"-"`
 }
 
 // ErrLiteralSearchCursorMismatch rejects replay against changed inputs.
 var ErrLiteralSearchCursorMismatch = errors.New("literal search continuation does not match the request or active projection")
+
+// ErrLiteralSearchQueryTooLarge rejects input before rune/gram allocation.
+var ErrLiteralSearchQueryTooLarge = errors.New("literal search query exceeds byte limit")
 
 // LiteralSearchCursor binds progress to query and projection identity.
 type LiteralSearchCursor struct {

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -158,12 +158,69 @@ func (r LiteralSearchRequest) Validate() error {
 
 // LiteralSearchPage exposes matches and honest completeness metadata.
 type LiteralSearchPage struct {
-	Events             []BoundedEvent        `json:"events"`
-	Tier               LiteralSearchTier     `json:"tier"`
-	Coverage           LiteralSearchCoverage `json:"coverage"`
-	PartialReason      string                `json:"partial_reason,omitempty"`
-	Continuation       string                `json:"continuation,omitempty"`
-	MatchContinuations []string              `json:"-"`
+	Events        []BoundedEvent        `json:"events"`
+	Tier          LiteralSearchTier     `json:"tier"`
+	Coverage      LiteralSearchCoverage `json:"coverage"`
+	PartialReason string                `json:"partial_reason,omitempty"`
+	Continuation  string                `json:"continuation,omitempty"`
+	Matches       []LiteralSearchMatch  `json:"-"`
+}
+
+// LiteralSearchMatch pairs an event with its resume-before source anchor.
+type LiteralSearchMatch struct {
+	Event        BoundedEvent
+	ResumeBefore string
+}
+
+// PrefixWithContinuation returns a contiguous prefix and its safe cursor.
+func (p LiteralSearchPage) PrefixWithContinuation(n int) ([]BoundedEvent, string, error) {
+	if n < 0 || n > len(p.Matches) {
+		return nil, "", fmt.Errorf("%w: invalid literal match prefix", ErrLiteralSearchInvalidRequest)
+	}
+	events := make([]BoundedEvent, 0, n)
+	for _, match := range p.Matches[:n] {
+		events = append(events, match.Event)
+	}
+	if n < len(p.Matches) {
+		return events, p.Matches[n].ResumeBefore, nil
+	}
+	return events, p.Continuation, nil
+}
+
+// LiteralVerificationLedger owns pure byte admission and source progress.
+type LiteralVerificationLedger struct {
+	Budget                  LiteralSearchBudget
+	UsedStored, UsedDecoded int64
+	FullyProcessed          int64
+}
+
+// Skip advances an ineligible or tombstoned source.
+func (l *LiteralVerificationLedger) Skip(sequence int64) { l.FullyProcessed = sequence }
+
+// AdmitVerification reserves canonical verification without advancing.
+func (l *LiteralVerificationLedger) AdmitVerification(stored, decoded int64) error {
+	if l.UsedStored+stored > l.Budget.StoredBytes {
+		return &SearchProjectionOversizeError{Class: "stored_bytes", Bytes: l.UsedStored + stored, Limit: l.Budget.StoredBytes}
+	}
+	if l.UsedDecoded+decoded > l.Budget.DecodedBytes {
+		return &SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: l.UsedDecoded + decoded, Limit: l.Budget.DecodedBytes}
+	}
+	l.UsedStored += stored
+	l.UsedDecoded += decoded
+	return nil
+}
+
+// FinishVerification reserves match hydration before advancing.
+func (l *LiteralVerificationLedger) FinishVerification(sequence, stored, decoded int64, matched bool) error {
+	if matched {
+		if l.UsedStored+stored > l.Budget.StoredBytes || l.UsedDecoded+decoded > l.Budget.DecodedBytes {
+			return &SearchProjectionOversizeError{Class: "verified_hydration_bytes", Bytes: max(l.UsedStored+stored, l.UsedDecoded+decoded), Limit: max(l.Budget.StoredBytes, l.Budget.DecodedBytes)}
+		}
+		l.UsedStored += stored
+		l.UsedDecoded += decoded
+	}
+	l.FullyProcessed = sequence
+	return nil
 }
 
 // ErrLiteralSearchCursorMismatch rejects replay against changed inputs.

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -19,6 +19,10 @@ const (
 	maxLiteralQueryFingerprints = 128
 	// MaxLiteralSearchQueryBytes bounds normalization and gram allocation.
 	MaxLiteralSearchQueryBytes = 64 << 10
+	// MaxLiteralSearchLimit bounds result allocation independently of protocols.
+	MaxLiteralSearchLimit = 100
+	// MaxLiteralSearchSourceRows bounds source-page allocation and SQL LIMIT.
+	MaxLiteralSearchSourceRows = 4096
 )
 
 // LiteralQuery owns the normalization shared by candidate construction and
@@ -130,6 +134,26 @@ type LiteralSearchRequest struct {
 	Budget        LiteralSearchBudget
 	Continuation  string
 	BodyRuneLimit int
+}
+
+// Validate checks caller-controlled allocation and paging invariants.
+func (r LiteralSearchRequest) Validate() error {
+	if !r.Budget.Valid() {
+		return fmt.Errorf("%w: budget must be positive", ErrLiteralSearchInvalidRequest)
+	}
+	if r.Budget.SourceRows > MaxLiteralSearchSourceRows {
+		return fmt.Errorf("%w: source rows exceed maximum", ErrLiteralSearchInvalidRequest)
+	}
+	if r.Criteria.Limit() <= 0 || r.Criteria.Limit() > MaxLiteralSearchLimit {
+		return fmt.Errorf("%w: limit is outside the supported range", ErrLiteralSearchInvalidRequest)
+	}
+	if !r.Criteria.From().IsZero() && !r.Criteria.To().IsZero() && r.Criteria.From().After(r.Criteria.To()) {
+		return fmt.Errorf("%w: from must not be after to", ErrLiteralSearchInvalidRequest)
+	}
+	if r.Criteria.Offset() != 0 || !r.Criteria.PageAnchor().IsZero() {
+		return fmt.Errorf("%w: offset and page anchor are unsupported", ErrLiteralSearchInvalidRequest)
+	}
+	return nil
 }
 
 // LiteralSearchPage exposes matches and honest completeness metadata.

--- a/application/types/literal_search.go
+++ b/application/types/literal_search.go
@@ -23,6 +23,8 @@ const (
 	MaxLiteralSearchLimit = 100
 	// MaxLiteralSearchSourceRows bounds source-page allocation and SQL LIMIT.
 	MaxLiteralSearchSourceRows = 4096
+	// MaxLiteralSearchContinuationBytes bounds decoding and authentication allocation.
+	MaxLiteralSearchContinuationBytes = 16 << 10
 )
 
 // LiteralQuery owns the normalization shared by candidate construction and
@@ -138,6 +140,12 @@ type LiteralSearchRequest struct {
 
 // Validate checks caller-controlled allocation and paging invariants.
 func (r LiteralSearchRequest) Validate() error {
+	if len(r.Criteria.Query()) > MaxLiteralSearchQueryBytes {
+		return ErrLiteralSearchQueryTooLarge
+	}
+	if len(r.Continuation) > MaxLiteralSearchContinuationBytes {
+		return fmt.Errorf("%w: continuation exceeds maximum", ErrLiteralSearchInvalidRequest)
+	}
 	if !r.Budget.Valid() {
 		return fmt.Errorf("%w: budget must be positive", ErrLiteralSearchInvalidRequest)
 	}
@@ -264,6 +272,9 @@ func (c LiteralSearchCursor) EncodeAuthenticated(key []byte) (string, error) {
 
 // DecodeAuthenticatedLiteralSearchCursor verifies store ownership and integrity.
 func DecodeAuthenticatedLiteralSearchCursor(value string, key []byte) (LiteralSearchCursor, error) {
+	if len(value) > MaxLiteralSearchContinuationBytes {
+		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch
+	}
 	raw, err := base64.RawURLEncoding.DecodeString(value)
 	if err != nil {
 		return LiteralSearchCursor{}, ErrLiteralSearchCursorMismatch

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -156,6 +156,23 @@ func TestLiteralSearchRequestAllocationBounds(t *testing.T) {
 	}
 }
 
+func TestLiteralSearchRequestRejectsOversizedRawQueryAndContinuation(t *testing.T) {
+	t.Parallel()
+	budget := apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1, DecodedBytes: 1}
+	query := strings.Repeat(" ", apptypes.MaxLiteralSearchQueryBytes+1)
+	request := apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query(query).Build(), Budget: budget}
+	if err := request.Validate(); !errors.Is(err, apptypes.ErrLiteralSearchQueryTooLarge) {
+		t.Fatalf("raw query error=%v", err)
+	}
+	request = apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Build(), Budget: budget, Continuation: strings.Repeat("A", apptypes.MaxLiteralSearchContinuationBytes+1)}
+	if err := request.Validate(); !errors.Is(err, apptypes.ErrLiteralSearchInvalidRequest) {
+		t.Fatalf("continuation error=%v", err)
+	}
+	if _, err := apptypes.DecodeAuthenticatedLiteralSearchCursor(request.Continuation, []byte("key")); !errors.Is(err, apptypes.ErrLiteralSearchCursorMismatch) {
+		t.Fatalf("decode error=%v", err)
+	}
+}
+
 func TestLiteralVerificationLedgerDeterministicProgressAndRetry(t *testing.T) {
 	t.Parallel()
 	ledger := apptypes.LiteralVerificationLedger{Budget: apptypes.LiteralSearchBudget{SourceRows: 4, StoredBytes: 7, DecodedBytes: 7}}

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -1,0 +1,76 @@
+package types_test
+
+import (
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestLiteralQueryCharacterizationAndFingerprints(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, query string
+		filterable  bool
+	}{
+		{"unicode", "障害/経路", true},
+		{"case", "Not Found", true},
+		{"path", "/Users/a/src", true},
+		{"identifier", "evt_01JABC", true},
+		{"error fragment", "EOF: reset", true},
+		{"short", "ßx", false},
+		{"empty", "  ", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := apptypes.CharacterizeLiteralQuery(tc.query)
+			if got.Filterable() != tc.filterable {
+				t.Fatalf("Filterable() = %v, want %v", got.Filterable(), tc.filterable)
+			}
+			if tc.filterable && len(got.Fingerprints()) == 0 {
+				t.Fatal("Fingerprints() is empty")
+			}
+		})
+	}
+}
+
+func TestLiteralFingerprintsAreDeterministicFixedSizeAndMatchCaseInsensitively(t *testing.T) {
+	t.Parallel()
+	query := apptypes.CharacterizeLiteralQuery("ERR/Path-01")
+	body := apptypes.CharacterizeLiteralQuery("prefix err/path-01 suffix")
+	if !body.Contains(query) {
+		t.Fatal("Contains() = false, want true")
+	}
+	first, second := query.Fingerprints(), apptypes.CharacterizeLiteralQuery("err/path-01").Fingerprints()
+	if len(first) != len(second) {
+		t.Fatalf("fingerprint lengths = %d/%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("fingerprint[%d] differs", i)
+		}
+		if len(first[i]) != apptypes.LiteralFingerprintBytes {
+			t.Fatalf("fingerprint bytes = %d", len(first[i]))
+		}
+	}
+}
+
+func TestLiteralSearchCursorBindsCriteriaAndProjection(t *testing.T) {
+	t.Parallel()
+	cursor := apptypes.LiteralSearchCursor{Version: 1, LastSequence: 42, CriteriaHash: "criteria", Generation: "g1", HighWater: 90, QueryRevision: 3}
+	encoded, err := cursor.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := apptypes.DecodeLiteralSearchCursor(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded != cursor {
+		t.Fatalf("decoded = %+v, want %+v", decoded, cursor)
+	}
+	if err := decoded.Validate("criteria", "g1", 90, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := decoded.Validate("changed", "g1", 90, 3); err == nil {
+		t.Fatal("Validate() error = nil")
+	}
+}

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -155,3 +155,24 @@ func TestLiteralSearchRequestAllocationBounds(t *testing.T) {
 		}
 	}
 }
+
+func TestLiteralVerificationLedgerDeterministicProgressAndRetry(t *testing.T) {
+	t.Parallel()
+	ledger := apptypes.LiteralVerificationLedger{Budget: apptypes.LiteralSearchBudget{SourceRows: 4, StoredBytes: 7, DecodedBytes: 7}}
+	ledger.Skip(1)
+	if err := ledger.AdmitVerification(2, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.FinishVerification(2, 2, 2, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.AdmitVerification(3, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.FinishVerification(3, 3, 3, true); err == nil {
+		t.Fatal("match hydration should exceed remaining budget")
+	}
+	if ledger.FullyProcessed != 2 {
+		t.Fatalf("fully processed=%d, want retry at 2", ledger.FullyProcessed)
+	}
+}

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -1,7 +1,9 @@
 package types_test
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -137,5 +139,19 @@ func TestLiteralQueryOversizeFingerprintSetFallsBackToInclusiveVerification(t *t
 	}
 	if apptypes.CharacterizeLiteralQuery(b.String()).Filterable() {
 		t.Fatal("oversize query remained filterable")
+	}
+}
+
+func TestLiteralSearchRequestAllocationBounds(t *testing.T) {
+	t.Parallel()
+	validBudget := apptypes.LiteralSearchBudget{SourceRows: apptypes.MaxLiteralSearchSourceRows, StoredBytes: 1, DecodedBytes: 1}
+	boundary := apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(apptypes.MaxLiteralSearchLimit).Query("needle").Build(), Budget: validBudget}
+	if err := boundary.Validate(); err != nil {
+		t.Fatalf("boundary error=%v", err)
+	}
+	for _, request := range []apptypes.LiteralSearchRequest{{Criteria: apptypes.NewEventSearchCriteriaBuilder(math.MaxInt).Query("needle").Build(), Budget: validBudget}, {Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Build(), Budget: apptypes.LiteralSearchBudget{SourceRows: math.MaxInt, StoredBytes: 1, DecodedBytes: 1}}} {
+		if err := request.Validate(); !errors.Is(err, apptypes.ErrLiteralSearchInvalidRequest) {
+			t.Fatalf("error=%v", err)
+		}
 	}
 }

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -53,6 +53,34 @@ func TestLiteralFingerprintsAreDeterministicFixedSizeAndMatchCaseInsensitively(t
 	}
 }
 
+func TestLiteralFingerprintCandidatesHaveNoFalseNegativesForCharacterizedClass(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, needle, body string }{
+		{"unicode", "障害/経路", "prefix 障害/経路 suffix"},
+		{"case", "NOT FOUND", "error: not found while opening"},
+		{"path", "/Users/a/src", "open /users/a/src/main.go"},
+		{"identifier", "evt_01JABC", "id=EVT_01jabc accepted"},
+		{"error fragment", "EOF: RESET", "transport eof: reset by peer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			query := apptypes.CharacterizeLiteralQuery(tc.needle)
+			body := apptypes.CharacterizeLiteralQuery(tc.body)
+			if !body.Contains(query) {
+				t.Fatal("fixture is not a canonical match")
+			}
+			available := map[string]bool{}
+			for _, fp := range body.Fingerprints() {
+				available[fp] = true
+			}
+			for _, fp := range query.Fingerprints() {
+				if !available[fp] {
+					t.Fatalf("query fingerprint absent from matching body")
+				}
+			}
+		})
+	}
+}
+
 func TestLiteralSearchCursorBindsCriteriaAndProjection(t *testing.T) {
 	t.Parallel()
 	cursor := apptypes.LiteralSearchCursor{Version: 1, LastSequence: 42, CriteriaHash: "criteria", Generation: "g1", HighWater: 90, QueryRevision: 3}

--- a/application/types/literal_search_test.go
+++ b/application/types/literal_search_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -18,6 +20,7 @@ func TestLiteralQueryCharacterizationAndFingerprints(t *testing.T) {
 		{"identifier", "evt_01JABC", true},
 		{"error fragment", "EOF: reset", true},
 		{"short", "ßx", false},
+		{"unicode case mapping", "ΟΣΣ", false},
 		{"empty", "  ", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -100,5 +103,39 @@ func TestLiteralSearchCursorBindsCriteriaAndProjection(t *testing.T) {
 	}
 	if err := decoded.Validate("changed", "g1", 90, 3); err == nil {
 		t.Fatal("Validate() error = nil")
+	}
+}
+
+func TestLiteralSearchCursorAuthenticationRejectsTampering(t *testing.T) {
+	t.Parallel()
+	key := []byte("01234567890123456789012345678901")
+	cursor := apptypes.LiteralSearchCursor{Version: 1, LastSequence: 42, CriteriaHash: "criteria", Generation: "g", HighWater: 90, QueryRevision: 3}
+	encoded, err := cursor.EncodeAuthenticated(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := apptypes.DecodeAuthenticatedLiteralSearchCursor(encoded, key)
+	if err != nil || decoded != cursor {
+		t.Fatalf("decoded=%+v err=%v", decoded, err)
+	}
+	raw := []byte(encoded)
+	if raw[len(raw)-1] == 'A' {
+		raw[len(raw)-1] = 'B'
+	} else {
+		raw[len(raw)-1] = 'A'
+	}
+	if _, err := apptypes.DecodeAuthenticatedLiteralSearchCursor(string(raw), key); err == nil {
+		t.Fatal("tampered cursor accepted")
+	}
+}
+
+func TestLiteralQueryOversizeFingerprintSetFallsBackToInclusiveVerification(t *testing.T) {
+	t.Parallel()
+	var b strings.Builder
+	for i := 0; i < 300; i++ {
+		fmt.Fprintf(&b, "%03x", i)
+	}
+	if apptypes.CharacterizeLiteralQuery(b.String()).Filterable() {
+		t.Fatal("oversize query remained filterable")
 	}
 }

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -72,11 +72,12 @@ type ProjectionCleanupCandidate struct {
 }
 
 type ProjectionWrite struct {
-	Document     ProjectionDocument
-	Summary      string
-	Keywords     map[string]int
-	LogicalBytes int64
-	RetainRecent bool
+	Document            ProjectionDocument
+	Summary             string
+	Keywords            map[string]int
+	LogicalBytes        int64
+	RetainRecent        bool
+	LiteralFingerprints []string
 }
 
 // ProjectionBatchPlan is a pure application-owned decision. Adapters may only
@@ -150,29 +151,32 @@ func (*SearchProjectionDriftError) Error() string {
 }
 
 type SearchProjectionStatus struct {
-	SchemaVersion          string           `json:"schema_version"`
-	State                  string           `json:"state"`
-	Phase                  string           `json:"phase"`
-	ProjectionVersion      int              `json:"projection_version"`
-	FTSDesign              string           `json:"fts_design"`
-	ConfigHash             string           `json:"config_hash"`
-	SourceRevision         int64            `json:"source_revision"`
-	HighWater              int64            `json:"high_water"`
-	Checkpoint             int64            `json:"checkpoint"`
-	Completed              bool             `json:"completed"`
-	RecentAgeSeconds       int64            `json:"recent_age_seconds"`
-	RecentByteLimit        int64            `json:"recent_byte_limit"`
-	RecentBytes            int64            `json:"recent_bytes"`
-	RecentDocuments        int64            `json:"recent_documents"`
-	SummarySessions        int64            `json:"summary_sessions"`
-	KeywordRows            int64            `json:"keyword_rows"`
-	SummaryLogicalBytes    int64            `json:"summary_logical_bytes"`
-	KeywordLogicalBytes    int64            `json:"keyword_logical_bytes"`
-	FTSLogicalBytes        int64            `json:"fts_logical_bytes"`
-	PhysicalBytes          int64            `json:"physical_bytes"`
-	PhysicalEvidence       CapacityEvidence `json:"physical_evidence"`
-	LastBatchMilliseconds  int64            `json:"last_batch_milliseconds"`
-	InspectionMilliseconds int64            `json:"inspection_milliseconds"`
-	MatchProbeMilliseconds int64            `json:"match_probe_milliseconds"`
-	KeywordVersion         int              `json:"keyword_version"`
+	SchemaVersion           string           `json:"schema_version"`
+	State                   string           `json:"state"`
+	Phase                   string           `json:"phase"`
+	ProjectionVersion       int              `json:"projection_version"`
+	FTSDesign               string           `json:"fts_design"`
+	ConfigHash              string           `json:"config_hash"`
+	SourceRevision          int64            `json:"source_revision"`
+	HighWater               int64            `json:"high_water"`
+	Checkpoint              int64            `json:"checkpoint"`
+	Completed               bool             `json:"completed"`
+	RecentAgeSeconds        int64            `json:"recent_age_seconds"`
+	RecentByteLimit         int64            `json:"recent_byte_limit"`
+	RecentBytes             int64            `json:"recent_bytes"`
+	RecentDocuments         int64            `json:"recent_documents"`
+	SummarySessions         int64            `json:"summary_sessions"`
+	KeywordRows             int64            `json:"keyword_rows"`
+	SummaryLogicalBytes     int64            `json:"summary_logical_bytes"`
+	KeywordLogicalBytes     int64            `json:"keyword_logical_bytes"`
+	FTSLogicalBytes         int64            `json:"fts_logical_bytes"`
+	PhysicalBytes           int64            `json:"physical_bytes"`
+	PhysicalEvidence        CapacityEvidence `json:"physical_evidence"`
+	LastBatchMilliseconds   int64            `json:"last_batch_milliseconds"`
+	InspectionMilliseconds  int64            `json:"inspection_milliseconds"`
+	MatchProbeMilliseconds  int64            `json:"match_probe_milliseconds"`
+	KeywordVersion          int              `json:"keyword_version"`
+	FingerprintVersion      int              `json:"fingerprint_version"`
+	FingerprintRows         int64            `json:"fingerprint_rows"`
+	FingerprintLogicalBytes int64            `json:"fingerprint_logical_bytes"`
 }

--- a/application/usecase/search_projection_plan.go
+++ b/application/usecase/search_projection_plan.go
@@ -60,6 +60,7 @@ func PlanProjectionBatch(s apptypes.ProjectionSnapshot, b apptypes.SearchProject
 			return p, &apptypes.SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: d.DecodedBytes, Limit: b.DecodedBytes}
 		}
 		w := apptypes.ProjectionWrite{Document: d, Keywords: map[string]int{}}
+		w.LiteralFingerprints = apptypes.CharacterizeLiteralQuery(d.Text).Fingerprints()
 		if created, err := time.Parse(time.RFC3339Nano, d.CreatedAt); err == nil {
 			w.RetainRecent = !created.Before(s.Now.Add(-b.RecentAge))
 		}
@@ -127,6 +128,9 @@ func projectionWriteLogicalBytes(generation string, w apptypes.ProjectionWrite) 
 	}
 	for keyword := range w.Keywords {
 		n += int64(len(generation)+len(d.SessionID)+len(keyword)) + projectionIntegerBytes*2
+	}
+	for range w.LiteralFingerprints {
+		n += int64(len(generation)+len(d.EventID)+apptypes.LiteralFingerprintBytes) + projectionIntegerBytes*2
 	}
 	return n
 }

--- a/application/usecase/search_projection_plan_test.go
+++ b/application/usecase/search_projection_plan_test.go
@@ -67,8 +67,8 @@ func TestProjectionBatchPlanEnforcesStrictLogicalMutationByteCap(t *testing.T) {
 	if got := p.Ledger.LogicalWriteBytes; got > b.WriteBytes {
 		t.Fatalf("reserved bytes = %d > %d", got, b.WriteBytes)
 	}
-	if len(p.Writes) != 1 || p.Writes[0].LogicalBytes != 47 {
-		t.Fatalf("logical formula = %+v, want one 47-byte mutation", p.Writes)
+	if len(p.Writes) != 1 || p.Writes[0].LogicalBytes != 146 {
+		t.Fatalf("logical formula = %+v, want one 146-byte mutation including fingerprints", p.Writes)
 	}
 }
 

--- a/infrastructure/sqlite/literal_search_hash_internal_test.go
+++ b/infrastructure/sqlite/literal_search_hash_internal_test.go
@@ -1,0 +1,19 @@
+package sqlite
+
+import (
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestLiteralCriteriaHashSeparatesNULDelimitedFields(t *testing.T) {
+	t.Parallel()
+	first := apptypes.NewEventSearchCriteriaBuilder(1).Query("a\x00b").Workspace(types.Workspace("c")).Build()
+	second := apptypes.NewEventSearchCriteriaBuilder(1).Query("a").Workspace(types.Workspace("b\x00c")).Build()
+	firstHash := literalCriteriaHash(first, apptypes.CharacterizeLiteralQuery(first.Query()).Canonical(), 500)
+	secondHash := literalCriteriaHash(second, apptypes.CharacterizeLiteralQuery(second.Query()).Canonical(), 500)
+	if firstHash == secondHash {
+		t.Fatalf("ambiguous criteria hashes collided: %q", firstHash)
+	}
+}

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -89,7 +89,11 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		if eligibleErr != nil {
 			return apptypes.LiteralSearchPage{}, eligibleErr
 		}
-		decision, progressErr := progress.ObserveSource(queryservice.LiteralSourceObservation{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded, Eligible: eligible})
+		disposition := queryservice.LiteralSourceSkipped
+		if eligible {
+			disposition = queryservice.LiteralSourceEligible
+		}
+		decision, progressErr := progress.ObserveSource(queryservice.LiteralSourceObservation{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded, Disposition: disposition})
 		if progressErr != nil {
 			return apptypes.LiteralSearchPage{}, progressErr
 		}

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -85,6 +85,13 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	matchContinuations := make([]string, 0, resultCapacity)
 	progress := queryservice.NewLiteralSearchProgress(after, highWater, request.Budget, request.Criteria.Limit())
 	for _, s := range sources {
+		begin, progressErr := progress.BeginSource(queryservice.LiteralSource{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded})
+		if progressErr != nil {
+			return apptypes.LiteralSearchPage{}, progressErr
+		}
+		if begin.Action == queryservice.LiteralProgressStop {
+			break
+		}
 		eligible, eligibleErr := literalSourceEligible(ctx, tx, s.id, request.Criteria, generation, query.Fingerprints(), useFingerprints)
 		if eligibleErr != nil {
 			return apptypes.LiteralSearchPage{}, eligibleErr
@@ -93,14 +100,14 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		if eligible {
 			disposition = queryservice.LiteralSourceEligible
 		}
-		decision, progressErr := progress.ObserveSource(queryservice.LiteralSourceObservation{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded, Disposition: disposition})
+		decision, progressErr := progress.ObserveDisposition(disposition)
 		if progressErr != nil {
 			return apptypes.LiteralSearchPage{}, progressErr
 		}
-		if decision.Stop {
+		if decision.Action == queryservice.LiteralProgressStop {
 			break
 		}
-		if !decision.Verify {
+		if decision.Action != queryservice.LiteralProgressVerify {
 			continue
 		}
 		ok, matchErr := decodedEventSearchMatch(ctx, tx, s.id, query.Canonical())
@@ -111,7 +118,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		if finishErr != nil {
 			return apptypes.LiteralSearchPage{}, finishErr
 		}
-		includeMatch := ok && (!finish.Stop || finish.PartialReason == "result_limit")
+		includeMatch := finish.Action == queryservice.LiteralProgressRecordMatch || finish.Action == queryservice.LiteralProgressRecordMatchAndStop
 		if includeMatch {
 			resume, encodeErr := (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: decision.ResumeBefore, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 			if encodeErr != nil {
@@ -120,11 +127,11 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 			matched = append(matched, s.id)
 			matchContinuations = append(matchContinuations, resume)
 		}
-		if finish.Stop {
+		if finish.Action == queryservice.LiteralProgressStop || finish.Action == queryservice.LiteralProgressRecordMatchAndStop {
 			break
 		}
 	}
-	progressResult := progress.FinishPage(len(sources) > request.Budget.SourceRows)
+	progressResult := progress.FinishPage()
 	last := progressResult.Processed
 	complete := progressResult.Complete
 	partialReason := progressResult.PartialReason

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -83,8 +84,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	resultCapacity := min(request.Criteria.Limit(), request.Budget.SourceRows, apptypes.MaxLiteralSearchLimit)
 	matched := make([]string, 0, resultCapacity)
 	matchContinuations := make([]string, 0, resultCapacity)
-	var usedStored, usedDecoded int64
-	last := after
+	ledger := apptypes.LiteralVerificationLedger{Budget: request.Budget, FullyProcessed: after}
 	var examined int64
 	partialReason := ""
 	for i, s := range sources {
@@ -93,52 +93,40 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 			break
 		}
 		examined++
-		before := last
+		before := ledger.FullyProcessed
 		eligible, eligibleErr := literalSourceEligible(ctx, tx, s.id, request.Criteria, generation, query.Fingerprints(), useFingerprints)
 		if eligibleErr != nil {
 			return apptypes.LiteralSearchPage{}, eligibleErr
 		}
 		if !eligible {
-			last = s.sequence
+			ledger.Skip(s.sequence)
 			continue
 		}
-		if usedStored+s.stored > request.Budget.StoredBytes {
-			if usedStored == 0 {
-				return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "stored_bytes", Bytes: s.stored, Limit: request.Budget.StoredBytes}
+		if admissionErr := ledger.AdmitVerification(s.stored, s.decoded); admissionErr != nil {
+			if ledger.FullyProcessed == after {
+				return apptypes.LiteralSearchPage{}, xerrors.Errorf("admit literal verification: %w", admissionErr)
 			}
-			partialReason = "stored_bytes"
-			break
-		}
-		if usedDecoded+s.decoded > request.Budget.DecodedBytes {
-			if usedDecoded == 0 {
-				return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: s.decoded, Limit: request.Budget.DecodedBytes}
-			}
-			partialReason = "decoded_bytes"
+			partialReason = literalBudgetReason(admissionErr)
 			break
 		}
 		ok, matchErr := decodedEventSearchMatch(ctx, tx, s.id, query.Canonical())
 		if matchErr != nil {
 			return apptypes.LiteralSearchPage{}, matchErr
 		}
-		usedStored += s.stored
-		usedDecoded += s.decoded
 		if ok {
-			if usedStored+s.stored > request.Budget.StoredBytes || usedDecoded+s.decoded > request.Budget.DecodedBytes {
+			if finishErr := ledger.FinishVerification(s.sequence, s.stored, s.decoded, true); finishErr != nil {
 				if before == after {
-					return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "verified_hydration_bytes", Bytes: max(usedStored+s.stored, usedDecoded+s.decoded), Limit: max(request.Budget.StoredBytes, request.Budget.DecodedBytes)}
+					return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish matched literal verification: %w", finishErr)
 				}
-				partialReason = "verified_hydration_bytes"
+				partialReason = literalBudgetReason(finishErr)
 				break
 			}
-			usedStored += s.stored
-			usedDecoded += s.decoded
 			resume, encodeErr := (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: before, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 			if encodeErr != nil {
 				return apptypes.LiteralSearchPage{}, xerrors.Errorf("encode match continuation: %w", encodeErr)
 			}
 			matched = append(matched, s.id)
 			matchContinuations = append(matchContinuations, resume)
-			last = s.sequence
 			if len(matched) >= request.Criteria.Limit() {
 				if i+1 < len(sources) {
 					partialReason = "result_limit"
@@ -146,9 +134,12 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 				break
 			}
 		} else {
-			last = s.sequence
+			if finishErr := ledger.FinishVerification(s.sequence, s.stored, s.decoded, false); finishErr != nil {
+				return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish literal verification: %w", finishErr)
+			}
 		}
 	}
+	last := ledger.FullyProcessed
 	complete := last >= highWater
 	if !complete && partialReason == "" {
 		partialReason = "source_rows"
@@ -170,7 +161,11 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if useFingerprints {
 		tier = apptypes.LiteralSearchTierFingerprint
 	}
-	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason, MatchContinuations: matchContinuations}
+	matches := make([]apptypes.LiteralSearchMatch, 0, len(events))
+	for i, event := range events {
+		matches = append(matches, apptypes.LiteralSearchMatch{Event: event, ResumeBefore: matchContinuations[i]})
+	}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason, Matches: matches}
 	if !complete {
 		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 		if err != nil {
@@ -181,6 +176,14 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish tiered literal search: %w", err)
 	}
 	return page, nil
+}
+
+func literalBudgetReason(err error) string {
+	var oversized *apptypes.SearchProjectionOversizeError
+	if errors.As(err, &oversized) {
+		return oversized.Class
+	}
+	return "resource_budget"
 }
 
 func orderLiteralMetadata(metadata []apptypes.EventMetadata, ids []string) []apptypes.EventMetadata {

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -25,6 +25,9 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("literal search budget must be positive")
 	}
 	query := apptypes.CharacterizeLiteralQuery(request.Criteria.Query())
+	if len(query.Canonical()) > apptypes.MaxLiteralSearchQueryBytes {
+		return apptypes.LiteralSearchPage{}, apptypes.ErrLiteralSearchQueryTooLarge
+	}
 	if query.Canonical() == "" {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("literal search query must not be empty")
 	}
@@ -81,6 +84,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	}
 
 	matched := make([]string, 0, request.Criteria.Limit())
+	matchContinuations := make([]string, 0, request.Criteria.Limit())
 	var usedStored, usedDecoded int64
 	last := after
 	var examined int64
@@ -90,13 +94,14 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 			partialReason = "source_rows"
 			break
 		}
-		last = s.sequence
 		examined++
+		before := last
 		eligible, eligibleErr := literalSourceEligible(ctx, tx, s.id, request.Criteria, generation, query.Fingerprints(), useFingerprints)
 		if eligibleErr != nil {
 			return apptypes.LiteralSearchPage{}, eligibleErr
 		}
 		if !eligible {
+			last = s.sequence
 			continue
 		}
 		if usedStored+s.stored > request.Budget.StoredBytes {
@@ -120,13 +125,30 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		usedStored += s.stored
 		usedDecoded += s.decoded
 		if ok {
+			if usedStored+s.stored > request.Budget.StoredBytes || usedDecoded+s.decoded > request.Budget.DecodedBytes {
+				if before == after {
+					return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "verified_hydration_bytes", Bytes: max(usedStored+s.stored, usedDecoded+s.decoded), Limit: max(request.Budget.StoredBytes, request.Budget.DecodedBytes)}
+				}
+				partialReason = "verified_hydration_bytes"
+				break
+			}
+			usedStored += s.stored
+			usedDecoded += s.decoded
+			resume, encodeErr := (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: before, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
+			if encodeErr != nil {
+				return apptypes.LiteralSearchPage{}, xerrors.Errorf("encode match continuation: %w", encodeErr)
+			}
 			matched = append(matched, s.id)
+			matchContinuations = append(matchContinuations, resume)
+			last = s.sequence
 			if len(matched) >= request.Criteria.Limit() {
 				if i+1 < len(sources) {
 					partialReason = "result_limit"
 				}
 				break
 			}
+		} else {
+			last = s.sequence
 		}
 	}
 	complete := last >= highWater
@@ -149,7 +171,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if useFingerprints {
 		tier = apptypes.LiteralSearchTierFingerprint
 	}
-	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason, MatchContinuations: matchContinuations}
 	if !complete {
 		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 		if err != nil {

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -43,7 +43,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&highWater); err != nil {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search source high-water: %w", err)
 	}
-	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical())
+	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical(), request.Budget)
 	var after int64
 	if request.Continuation != "" {
 		cursor, decodeErr := apptypes.DecodeLiteralSearchCursor(request.Continuation)
@@ -52,7 +52,8 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		}
 		after = cursor.LastSequence
 	}
-	rows, err := queryLiteralSources(ctx, tx, request.Criteria, after, request.Budget.SourceRows+1)
+	useFingerprints := state == "complete" && query.Filterable()
+	rows, err := queryLiteralSources(ctx, tx, request.Criteria, after, request.Budget.SourceRows+1, generation, query.Fingerprints(), useFingerprints)
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
@@ -120,7 +121,11 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
-	page := apptypes.LiteralSearchPage{Events: events, Tier: apptypes.LiteralSearchTierBoundedVerification, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
+	tier := apptypes.LiteralSearchTierBoundedVerification
+	if useFingerprints {
+		tier = apptypes.LiteralSearchTierFingerprint
+	}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
 	if !complete {
 		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).Encode()
 		if err != nil {
@@ -130,15 +135,27 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err := tx.Commit(); err != nil {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish tiered literal search: %w", err)
 	}
-	_ = state // retained for future complete-generation fingerprint selection.
 	return page, nil
 }
 
-func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, after int64, limit int) (*sql.Rows, error) {
+func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, after int64, limit int, generation string, fingerprints []string, useFingerprints bool) (*sql.Rows, error) {
 	var b strings.Builder
 	b.WriteString(`SELECT q.sequence,e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE q.sequence>?`)
 	args := []any{after}
 	args = appendEventSearchFilters(&b, args, criteria)
+	if useFingerprints {
+		b.WriteString(" AND (NOT EXISTS(SELECT 1 FROM literal_search_fingerprints known WHERE known.generation_id=? AND known.event_id=e.id AND known.fingerprint_version=1) OR (SELECT COUNT(DISTINCT matched.fingerprint) FROM literal_search_fingerprints matched WHERE matched.generation_id=? AND matched.event_id=e.id AND matched.fingerprint_version=1 AND matched.fingerprint IN (")
+		args = append(args, generation, generation)
+		for i, fingerprint := range fingerprints {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('?')
+			args = append(args, []byte(fingerprint))
+		}
+		b.WriteString("))=?)")
+		args = append(args, len(fingerprints))
+	}
 	b.WriteString(" ORDER BY q.sequence LIMIT ?")
 	args = append(args, limit)
 	rows, err := tx.QueryContext(ctx, b.String(), args...)
@@ -148,8 +165,8 @@ func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.Even
 	return rows, nil
 }
 
-func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string) string {
-	raw := fmt.Sprintf("v1\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.To().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.FailuresOnly())
+func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string, budget apptypes.LiteralSearchBudget) string {
+	raw := fmt.Sprintf("v1\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t\x00%d\x00%d\x00%d", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.To().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.FailuresOnly(), budget.SourceRows, budget.StoredBytes, budget.DecodedBytes)
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
 }

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
 
@@ -87,7 +87,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	for _, s := range sources {
 		begin, progressErr := progress.BeginSource(queryservice.LiteralSource{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded})
 		if progressErr != nil {
-			return apptypes.LiteralSearchPage{}, progressErr
+			return apptypes.LiteralSearchPage{}, xerrors.Errorf("begin literal search source: %w", progressErr)
 		}
 		if begin.Action == queryservice.LiteralProgressStop {
 			break
@@ -102,7 +102,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		}
 		decision, progressErr := progress.ObserveDisposition(disposition)
 		if progressErr != nil {
-			return apptypes.LiteralSearchPage{}, progressErr
+			return apptypes.LiteralSearchPage{}, xerrors.Errorf("observe literal source disposition: %w", progressErr)
 		}
 		if decision.Action == queryservice.LiteralProgressStop {
 			break
@@ -116,7 +116,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		}
 		finish, finishErr := progress.FinishVerification(s.sequence, ok)
 		if finishErr != nil {
-			return apptypes.LiteralSearchPage{}, finishErr
+			return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish literal source verification: %w", finishErr)
 		}
 		includeMatch := finish.Action == queryservice.LiteralProgressRecordMatch || finish.Action == queryservice.LiteralProgressRecordMatchAndStop
 		if includeMatch {
@@ -226,7 +226,34 @@ func literalSourceEligible(ctx context.Context, tx *sql.Tx, eventID string, crit
 }
 
 func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string, bodyLimit int) string {
-	raw := fmt.Sprintf("v2\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t\x00%d\x00%d\x00%d", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format(time.RFC3339Nano), c.To().UTC().Format(time.RFC3339Nano), c.FailuresOnly(), c.Limit(), c.Offset(), bodyLimit)
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
+	h := sha256.New()
+	writeString := func(value string) {
+		var size [8]byte
+		binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+		_, _ = h.Write(size[:])
+		_, _ = h.Write([]byte(value))
+	}
+	writeInt := func(value int64) {
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], uint64(value))
+		_, _ = h.Write(encoded[:])
+	}
+	writeString("v3")
+	writeString(canonical)
+	writeString(c.Workspace().String())
+	writeString(c.SessionID().String())
+	writeString(c.Client().String())
+	writeString(c.Agent().String())
+	writeString(c.Kind().String())
+	writeString(c.From().UTC().Format(time.RFC3339Nano))
+	writeString(c.To().UTC().Format(time.RFC3339Nano))
+	if c.FailuresOnly() {
+		_, _ = h.Write([]byte{1})
+	} else {
+		_, _ = h.Write([]byte{0})
+	}
+	writeInt(int64(c.Limit()))
+	writeInt(int64(c.Offset()))
+	writeInt(int64(bodyLimit))
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -84,66 +83,47 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	resultCapacity := min(request.Criteria.Limit(), request.Budget.SourceRows, apptypes.MaxLiteralSearchLimit)
 	matched := make([]string, 0, resultCapacity)
 	matchContinuations := make([]string, 0, resultCapacity)
-	ledger := apptypes.LiteralVerificationLedger{Budget: request.Budget, FullyProcessed: after}
-	var examined int64
-	partialReason := ""
-	for i, s := range sources {
-		if i >= request.Budget.SourceRows {
-			partialReason = "source_rows"
-			break
-		}
-		examined++
-		before := ledger.FullyProcessed
+	progress := queryservice.NewLiteralSearchProgress(after, highWater, request.Budget, request.Criteria.Limit())
+	for _, s := range sources {
 		eligible, eligibleErr := literalSourceEligible(ctx, tx, s.id, request.Criteria, generation, query.Fingerprints(), useFingerprints)
 		if eligibleErr != nil {
 			return apptypes.LiteralSearchPage{}, eligibleErr
 		}
-		if !eligible {
-			ledger.Skip(s.sequence)
-			continue
+		decision, progressErr := progress.ObserveSource(queryservice.LiteralSourceObservation{Sequence: s.sequence, Stored: s.stored, Decoded: s.decoded, Eligible: eligible})
+		if progressErr != nil {
+			return apptypes.LiteralSearchPage{}, progressErr
 		}
-		if admissionErr := ledger.AdmitVerification(s.stored, s.decoded); admissionErr != nil {
-			if ledger.FullyProcessed == after {
-				return apptypes.LiteralSearchPage{}, xerrors.Errorf("admit literal verification: %w", admissionErr)
-			}
-			partialReason = literalBudgetReason(admissionErr)
+		if decision.Stop {
 			break
+		}
+		if !decision.Verify {
+			continue
 		}
 		ok, matchErr := decodedEventSearchMatch(ctx, tx, s.id, query.Canonical())
 		if matchErr != nil {
 			return apptypes.LiteralSearchPage{}, matchErr
 		}
-		if ok {
-			if finishErr := ledger.FinishVerification(s.sequence, s.stored, s.decoded, true); finishErr != nil {
-				if before == after {
-					return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish matched literal verification: %w", finishErr)
-				}
-				partialReason = literalBudgetReason(finishErr)
-				break
-			}
-			resume, encodeErr := (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: before, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
+		finish, finishErr := progress.FinishVerification(s.sequence, ok)
+		if finishErr != nil {
+			return apptypes.LiteralSearchPage{}, finishErr
+		}
+		includeMatch := ok && (!finish.Stop || finish.PartialReason == "result_limit")
+		if includeMatch {
+			resume, encodeErr := (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: decision.ResumeBefore, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 			if encodeErr != nil {
 				return apptypes.LiteralSearchPage{}, xerrors.Errorf("encode match continuation: %w", encodeErr)
 			}
 			matched = append(matched, s.id)
 			matchContinuations = append(matchContinuations, resume)
-			if len(matched) >= request.Criteria.Limit() {
-				if i+1 < len(sources) {
-					partialReason = "result_limit"
-				}
-				break
-			}
-		} else {
-			if finishErr := ledger.FinishVerification(s.sequence, s.stored, s.decoded, false); finishErr != nil {
-				return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish literal verification: %w", finishErr)
-			}
+		}
+		if finish.Stop {
+			break
 		}
 	}
-	last := ledger.FullyProcessed
-	complete := last >= highWater
-	if !complete && partialReason == "" {
-		partialReason = "source_rows"
-	}
+	progressResult := progress.FinishPage(len(sources) > request.Budget.SourceRows)
+	last := progressResult.Processed
+	complete := progressResult.Complete
+	partialReason := progressResult.PartialReason
 	metadata, err := hydrateEventSearchMetadataCandidates(ctx, tx, request.Criteria, matched)
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
@@ -165,7 +145,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	for i, event := range events {
 		matches = append(matches, apptypes.LiteralSearchMatch{Event: event, ResumeBefore: matchContinuations[i]})
 	}
-	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason, Matches: matches}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: progressResult.Examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason, Matches: matches}
 	if !complete {
 		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 		if err != nil {
@@ -176,14 +156,6 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish tiered literal search: %w", err)
 	}
 	return page, nil
-}
-
-func literalBudgetReason(err error) string {
-	var oversized *apptypes.SearchProjectionOversizeError
-	if errors.As(err, &oversized) {
-		return oversized.Class
-	}
-	return "resource_budget"
 }
 
 func orderLiteralMetadata(metadata []apptypes.EventMetadata, ids []string) []apptypes.EventMetadata {

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -21,17 +21,8 @@ var _ queryservice.TieredEventSearchQuery = (*EventDatasource)(nil)
 // fingerprints are deliberately treated as an optional candidate accelerator:
 // until a complete matching generation exists, every source remains eligible.
 func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
-	if !request.Budget.Valid() {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: budget must be positive", apptypes.ErrLiteralSearchInvalidRequest)
-	}
-	if request.Criteria.Limit() <= 0 {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: limit must be positive", apptypes.ErrLiteralSearchInvalidRequest)
-	}
-	if !request.Criteria.From().IsZero() && !request.Criteria.To().IsZero() && request.Criteria.From().After(request.Criteria.To()) {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: from must not be after to", apptypes.ErrLiteralSearchInvalidRequest)
-	}
-	if request.Criteria.Offset() != 0 || !request.Criteria.PageAnchor().IsZero() {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: offset and page anchor are unsupported", apptypes.ErrLiteralSearchInvalidRequest)
+	if validateErr := request.Validate(); validateErr != nil {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("validate literal search request: %w", validateErr)
 	}
 	query := apptypes.CharacterizeLiteralQuery(request.Criteria.Query())
 	if len(query.Canonical()) > apptypes.MaxLiteralSearchQueryBytes {
@@ -89,8 +80,9 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("iterate literal verification sources: %w", err)
 	}
 
-	matched := make([]string, 0, request.Criteria.Limit())
-	matchContinuations := make([]string, 0, request.Criteria.Limit())
+	resultCapacity := min(request.Criteria.Limit(), request.Budget.SourceRows, apptypes.MaxLiteralSearchLimit)
+	matched := make([]string, 0, resultCapacity)
+	matchContinuations := make([]string, 0, resultCapacity)
 	var usedStored, usedDecoded int64
 	last := after
 	var examined int64

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -35,7 +36,8 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 
 	var generation, state string
 	var highWater, revision int64
-	if err := tx.QueryRowContext(ctx, `SELECT generation_id,high_water,query_revision,state FROM literal_search_projection_state WHERE singleton=1`).Scan(&generation, &highWater, &revision, &state); err != nil {
+	var cursorKey []byte
+	if err := tx.QueryRowContext(ctx, `SELECT generation_id,high_water,query_revision,state,cursor_key FROM literal_search_projection_state WHERE singleton=1`).Scan(&generation, &highWater, &revision, &state, &cursorKey); err != nil {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search projection: %w", err)
 	}
 	// The source sequence is authoritative and can be ahead of a missing/stale
@@ -43,17 +45,20 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&highWater); err != nil {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search source high-water: %w", err)
 	}
-	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical(), request.Budget)
+	if request.Criteria.Offset() != 0 || !request.Criteria.PageAnchor().IsZero() {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("tiered literal search does not support offset or page anchor")
+	}
+	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical(), request.BodyRuneLimit)
 	var after int64
 	if request.Continuation != "" {
-		cursor, decodeErr := apptypes.DecodeLiteralSearchCursor(request.Continuation)
+		cursor, decodeErr := apptypes.DecodeAuthenticatedLiteralSearchCursor(request.Continuation, cursorKey)
 		if decodeErr != nil || cursor.Validate(criteriaHash, generation, highWater, revision) != nil {
 			return apptypes.LiteralSearchPage{}, apptypes.ErrLiteralSearchCursorMismatch
 		}
 		after = cursor.LastSequence
 	}
 	useFingerprints := state == "complete" && query.Filterable()
-	rows, err := queryLiteralSources(ctx, tx, request.Criteria, after, request.Budget.SourceRows+1, generation, query.Fingerprints(), useFingerprints)
+	rows, err := queryLiteralSources(ctx, tx, after, request.Budget.SourceRows+1)
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
@@ -78,17 +83,33 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	matched := make([]string, 0, request.Criteria.Limit())
 	var usedStored, usedDecoded int64
 	last := after
+	var examined int64
 	partialReason := ""
 	for i, s := range sources {
 		if i >= request.Budget.SourceRows {
 			partialReason = "source_rows"
 			break
 		}
+		last = s.sequence
+		examined++
+		eligible, eligibleErr := literalSourceEligible(ctx, tx, s.id, request.Criteria, generation, query.Fingerprints(), useFingerprints)
+		if eligibleErr != nil {
+			return apptypes.LiteralSearchPage{}, eligibleErr
+		}
+		if !eligible {
+			continue
+		}
 		if usedStored+s.stored > request.Budget.StoredBytes {
+			if usedStored == 0 {
+				return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "stored_bytes", Bytes: s.stored, Limit: request.Budget.StoredBytes}
+			}
 			partialReason = "stored_bytes"
 			break
 		}
 		if usedDecoded+s.decoded > request.Budget.DecodedBytes {
+			if usedDecoded == 0 {
+				return apptypes.LiteralSearchPage{}, &apptypes.SearchProjectionOversizeError{Class: "decoded_bytes", Bytes: s.decoded, Limit: request.Budget.DecodedBytes}
+			}
 			partialReason = "decoded_bytes"
 			break
 		}
@@ -98,7 +119,6 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		}
 		usedStored += s.stored
 		usedDecoded += s.decoded
-		last = s.sequence
 		if ok {
 			matched = append(matched, s.id)
 			if len(matched) >= request.Criteria.Limit() {
@@ -117,7 +137,11 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
-	events, err := hydrateBoundedEvents(ctx, tx, metadata, int(min(request.Budget.DecodedBytes, int64(^uint(0)>>1))))
+	bodyLimit := request.BodyRuneLimit
+	if bodyLimit <= 0 {
+		bodyLimit = 500
+	}
+	events, err := hydrateBoundedEvents(ctx, tx, metadata, bodyLimit)
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
@@ -125,9 +149,9 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if useFingerprints {
 		tier = apptypes.LiteralSearchTierFingerprint
 	}
-	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: tier, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, ExaminedSources: examined, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
 	if !complete {
-		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).Encode()
+		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).EncodeAuthenticated(cursorKey)
 		if err != nil {
 			return apptypes.LiteralSearchPage{}, xerrors.Errorf("encode literal search continuation: %w", err)
 		}
@@ -138,24 +162,10 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	return page, nil
 }
 
-func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, after int64, limit int, generation string, fingerprints []string, useFingerprints bool) (*sql.Rows, error) {
+func queryLiteralSources(ctx context.Context, tx *sql.Tx, after int64, limit int) (*sql.Rows, error) {
 	var b strings.Builder
-	b.WriteString(`SELECT q.sequence,e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE q.sequence>?`)
+	b.WriteString(`SELECT q.sequence,COALESCE(e.id,''),COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q LEFT JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE q.sequence>?`)
 	args := []any{after}
-	args = appendEventSearchFilters(&b, args, criteria)
-	if useFingerprints {
-		b.WriteString(" AND (NOT EXISTS(SELECT 1 FROM literal_search_fingerprints known WHERE known.generation_id=? AND known.event_id=e.id AND known.fingerprint_version=1) OR (SELECT COUNT(DISTINCT matched.fingerprint) FROM literal_search_fingerprints matched WHERE matched.generation_id=? AND matched.event_id=e.id AND matched.fingerprint_version=1 AND matched.fingerprint IN (")
-		args = append(args, generation, generation)
-		for i, fingerprint := range fingerprints {
-			if i > 0 {
-				b.WriteByte(',')
-			}
-			b.WriteByte('?')
-			args = append(args, []byte(fingerprint))
-		}
-		b.WriteString("))=?)")
-		args = append(args, len(fingerprints))
-	}
 	b.WriteString(" ORDER BY q.sequence LIMIT ?")
 	args = append(args, limit)
 	rows, err := tx.QueryContext(ctx, b.String(), args...)
@@ -165,8 +175,37 @@ func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.Even
 	return rows, nil
 }
 
-func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string, budget apptypes.LiteralSearchBudget) string {
-	raw := fmt.Sprintf("v1\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t\x00%d\x00%d\x00%d", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.To().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.FailuresOnly(), budget.SourceRows, budget.StoredBytes, budget.DecodedBytes)
+func literalSourceEligible(ctx context.Context, tx *sql.Tx, eventID string, criteria apptypes.EventSearchCriteria, generation string, fingerprints []string, useFingerprints bool) (bool, error) {
+	if eventID == "" {
+		return false, nil
+	}
+	var b strings.Builder
+	b.WriteString("SELECT EXISTS(SELECT 1 FROM events e LEFT JOIN command_audits a ON a.event_id=e.id WHERE e.id=?")
+	args := []any{eventID}
+	args = appendEventSearchFilters(&b, args, criteria)
+	if useFingerprints {
+		b.WriteString(" AND (NOT EXISTS(SELECT 1 FROM literal_search_fingerprints known WHERE known.generation_id=? AND known.event_id=e.id AND known.fingerprint_version=1) OR (SELECT COUNT(DISTINCT matched.fingerprint) FROM literal_search_fingerprints matched WHERE matched.generation_id=? AND matched.event_id=e.id AND matched.fingerprint_version=1 AND matched.fingerprint IN (")
+		args = append(args, generation, generation)
+		for i, fp := range fingerprints {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('?')
+			args = append(args, []byte(fp))
+		}
+		b.WriteString("))=?)")
+		args = append(args, len(fingerprints))
+	}
+	b.WriteByte(')')
+	var eligible int
+	if err := tx.QueryRowContext(ctx, b.String(), args...).Scan(&eligible); err != nil {
+		return false, xerrors.Errorf("classify literal source eligibility: %w", err)
+	}
+	return eligible != 0, nil
+}
+
+func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string, bodyLimit int) string {
+	raw := fmt.Sprintf("v2\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t\x00%d\x00%d\x00%d", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format(time.RFC3339Nano), c.To().UTC().Format(time.RFC3339Nano), c.FailuresOnly(), c.Limit(), c.Offset(), bodyLimit)
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
 }

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -22,7 +22,16 @@ var _ queryservice.TieredEventSearchQuery = (*EventDatasource)(nil)
 // until a complete matching generation exists, every source remains eligible.
 func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
 	if !request.Budget.Valid() {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("literal search budget must be positive")
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: budget must be positive", apptypes.ErrLiteralSearchInvalidRequest)
+	}
+	if request.Criteria.Limit() <= 0 {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: limit must be positive", apptypes.ErrLiteralSearchInvalidRequest)
+	}
+	if !request.Criteria.From().IsZero() && !request.Criteria.To().IsZero() && request.Criteria.From().After(request.Criteria.To()) {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: from must not be after to", apptypes.ErrLiteralSearchInvalidRequest)
+	}
+	if request.Criteria.Offset() != 0 || !request.Criteria.PageAnchor().IsZero() {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("%w: offset and page anchor are unsupported", apptypes.ErrLiteralSearchInvalidRequest)
 	}
 	query := apptypes.CharacterizeLiteralQuery(request.Criteria.Query())
 	if len(query.Canonical()) > apptypes.MaxLiteralSearchQueryBytes {
@@ -47,9 +56,6 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	// candidate projection. Bind cursors to its high-water for honest coverage.
 	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&highWater); err != nil {
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search source high-water: %w", err)
-	}
-	if request.Criteria.Offset() != 0 || !request.Criteria.PageAnchor().IsZero() {
-		return apptypes.LiteralSearchPage{}, xerrors.Errorf("tiered literal search does not support offset or page anchor")
 	}
 	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical(), request.BodyRuneLimit)
 	var after int64
@@ -159,6 +165,7 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 	if err != nil {
 		return apptypes.LiteralSearchPage{}, err
 	}
+	metadata = orderLiteralMetadata(metadata, matched)
 	bodyLimit := request.BodyRuneLimit
 	if bodyLimit <= 0 {
 		bodyLimit = 500
@@ -182,6 +189,20 @@ func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptype
 		return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish tiered literal search: %w", err)
 	}
 	return page, nil
+}
+
+func orderLiteralMetadata(metadata []apptypes.EventMetadata, ids []string) []apptypes.EventMetadata {
+	byID := make(map[string]apptypes.EventMetadata, len(metadata))
+	for _, item := range metadata {
+		byID[item.EventID().String()] = item
+	}
+	ordered := make([]apptypes.EventMetadata, 0, len(metadata))
+	for _, id := range ids {
+		if item, ok := byID[id]; ok {
+			ordered = append(ordered, item)
+		}
+	}
+	return ordered
 }
 
 func queryLiteralSources(ctx context.Context, tx *sql.Tx, after int64, limit int) (*sql.Rows, error) {

--- a/infrastructure/sqlite/literal_search_query.go
+++ b/infrastructure/sqlite/literal_search_query.go
@@ -1,0 +1,155 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+var _ queryservice.TieredEventSearchQuery = (*EventDatasource)(nil)
+
+// SearchLiteralPage is an additive bounded verification lane. Migration 39's
+// fingerprints are deliberately treated as an optional candidate accelerator:
+// until a complete matching generation exists, every source remains eligible.
+func (d *EventDatasource) SearchLiteralPage(ctx context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
+	if !request.Budget.Valid() {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("literal search budget must be positive")
+	}
+	query := apptypes.CharacterizeLiteralQuery(request.Criteria.Query())
+	if query.Canonical() == "" {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("literal search query must not be empty")
+	}
+	db, tx, err := d.beginEventProjectionRead(ctx, "tiered literal search")
+	if err != nil {
+		return apptypes.LiteralSearchPage{}, err
+	}
+	defer closeEventProjectionRead(db, tx)
+
+	var generation, state string
+	var highWater, revision int64
+	if err := tx.QueryRowContext(ctx, `SELECT generation_id,high_water,query_revision,state FROM literal_search_projection_state WHERE singleton=1`).Scan(&generation, &highWater, &revision, &state); err != nil {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search projection: %w", err)
+	}
+	// The source sequence is authoritative and can be ahead of a missing/stale
+	// candidate projection. Bind cursors to its high-water for honest coverage.
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&highWater); err != nil {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("read literal search source high-water: %w", err)
+	}
+	criteriaHash := literalCriteriaHash(request.Criteria, query.Canonical())
+	var after int64
+	if request.Continuation != "" {
+		cursor, decodeErr := apptypes.DecodeLiteralSearchCursor(request.Continuation)
+		if decodeErr != nil || cursor.Validate(criteriaHash, generation, highWater, revision) != nil {
+			return apptypes.LiteralSearchPage{}, apptypes.ErrLiteralSearchCursorMismatch
+		}
+		after = cursor.LastSequence
+	}
+	rows, err := queryLiteralSources(ctx, tx, request.Criteria, after, request.Budget.SourceRows+1)
+	if err != nil {
+		return apptypes.LiteralSearchPage{}, err
+	}
+	defer func() { _ = rows.Close() }()
+	type source struct {
+		sequence        int64
+		id              string
+		stored, decoded int64
+	}
+	sources := make([]source, 0, request.Budget.SourceRows+1)
+	for rows.Next() {
+		var s source
+		if err := rows.Scan(&s.sequence, &s.id, &s.stored, &s.decoded); err != nil {
+			return apptypes.LiteralSearchPage{}, xerrors.Errorf("scan literal verification source: %w", err)
+		}
+		sources = append(sources, s)
+	}
+	if err := rows.Err(); err != nil {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("iterate literal verification sources: %w", err)
+	}
+
+	matched := make([]string, 0, request.Criteria.Limit())
+	var usedStored, usedDecoded int64
+	last := after
+	partialReason := ""
+	for i, s := range sources {
+		if i >= request.Budget.SourceRows {
+			partialReason = "source_rows"
+			break
+		}
+		if usedStored+s.stored > request.Budget.StoredBytes {
+			partialReason = "stored_bytes"
+			break
+		}
+		if usedDecoded+s.decoded > request.Budget.DecodedBytes {
+			partialReason = "decoded_bytes"
+			break
+		}
+		ok, matchErr := decodedEventSearchMatch(ctx, tx, s.id, query.Canonical())
+		if matchErr != nil {
+			return apptypes.LiteralSearchPage{}, matchErr
+		}
+		usedStored += s.stored
+		usedDecoded += s.decoded
+		last = s.sequence
+		if ok {
+			matched = append(matched, s.id)
+			if len(matched) >= request.Criteria.Limit() {
+				if i+1 < len(sources) {
+					partialReason = "result_limit"
+				}
+				break
+			}
+		}
+	}
+	complete := last >= highWater
+	if !complete && partialReason == "" {
+		partialReason = "source_rows"
+	}
+	metadata, err := hydrateEventSearchMetadataCandidates(ctx, tx, request.Criteria, matched)
+	if err != nil {
+		return apptypes.LiteralSearchPage{}, err
+	}
+	events, err := hydrateBoundedEvents(ctx, tx, metadata, int(min(request.Budget.DecodedBytes, int64(^uint(0)>>1))))
+	if err != nil {
+		return apptypes.LiteralSearchPage{}, err
+	}
+	page := apptypes.LiteralSearchPage{Events: events, Tier: apptypes.LiteralSearchTierBoundedVerification, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: last, HighWater: highWater, Complete: complete}, PartialReason: partialReason}
+	if !complete {
+		page.Continuation, err = (apptypes.LiteralSearchCursor{Version: apptypes.LiteralSearchCursorVersion, LastSequence: last, CriteriaHash: criteriaHash, Generation: generation, HighWater: highWater, QueryRevision: revision}).Encode()
+		if err != nil {
+			return apptypes.LiteralSearchPage{}, xerrors.Errorf("encode literal search continuation: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return apptypes.LiteralSearchPage{}, xerrors.Errorf("finish tiered literal search: %w", err)
+	}
+	_ = state // retained for future complete-generation fingerprint selection.
+	return page, nil
+}
+
+func queryLiteralSources(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, after int64, limit int) (*sql.Rows, error) {
+	var b strings.Builder
+	b.WriteString(`SELECT q.sequence,e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE q.sequence>?`)
+	args := []any{after}
+	args = appendEventSearchFilters(&b, args, criteria)
+	b.WriteString(" ORDER BY q.sequence LIMIT ?")
+	args = append(args, limit)
+	rows, err := tx.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, xerrors.Errorf("query literal verification sources: %w", err)
+	}
+	return rows, nil
+}
+
+func literalCriteriaHash(c apptypes.EventSearchCriteria, canonical string) string {
+	raw := fmt.Sprintf("v1\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t", canonical, c.Workspace(), c.SessionID(), c.Client(), c.Agent(), c.Kind(), c.From().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.To().UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), c.FailuresOnly())
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -74,8 +74,8 @@ func TestLiteralSearchPageFingerprintCandidatesRemainInclusiveForMissingRows(t *
 	if page.Tier != apptypes.LiteralSearchTierFingerprint || len(page.Events) != 2 {
 		t.Fatalf("page = %+v", page)
 	}
-	if page.Events[0].Metadata().EventID().String() != "literal-fp-match" || page.Events[1].Metadata().EventID().String() != "literal-fp-missing" || len(page.MatchContinuations) != 2 {
-		t.Fatalf("source order/continuations=%v/%d", []string{page.Events[0].Metadata().EventID().String(), page.Events[1].Metadata().EventID().String()}, len(page.MatchContinuations))
+	if page.Events[0].Metadata().EventID().String() != "literal-fp-match" || page.Events[1].Metadata().EventID().String() != "literal-fp-missing" || len(page.Matches) != 2 {
+		t.Fatalf("source order/continuations=%v/%d", []string{page.Events[0].Metadata().EventID().String(), page.Events[1].Metadata().EventID().String()}, len(page.Matches))
 	}
 }
 

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -11,7 +11,26 @@ import (
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 )
+
+func TestLiteralSearchPageValidatesBeforeDatabaseAndAllocation(t *testing.T) {
+	t.Parallel()
+	sut := infra.NewEventDatasource(nil)
+	budget := apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1, DecodedBytes: 1}
+	now := time.Now().UTC()
+	tests := []struct {
+		name    string
+		request apptypes.LiteralSearchRequest
+	}{{"zero limit", apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(0).Query("needle").Build(), Budget: budget}}, {"negative limit", apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(-1).Query("needle").Build(), Budget: budget}}, {"negative budget", apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Build(), Budget: apptypes.LiteralSearchBudget{SourceRows: -1, StoredBytes: 1, DecodedBytes: 1}}}, {"reversed interval", apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").From(now).To(now.Add(-time.Second)).Build(), Budget: budget}}, {"offset", apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Offset(1).Build(), Budget: budget}}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := sut.SearchLiteralPage(context.Background(), tc.request); !errors.Is(err, apptypes.ErrLiteralSearchInvalidRequest) {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
 
 func TestLiteralSearchPageFingerprintCandidatesRemainInclusiveForMissingRows(t *testing.T) {
 	t.Parallel()
@@ -54,6 +73,9 @@ func TestLiteralSearchPageFingerprintCandidatesRemainInclusiveForMissingRows(t *
 	}
 	if page.Tier != apptypes.LiteralSearchTierFingerprint || len(page.Events) != 2 {
 		t.Fatalf("page = %+v", page)
+	}
+	if page.Events[0].Metadata().EventID().String() != "literal-fp-match" || page.Events[1].Metadata().EventID().String() != "literal-fp-missing" || len(page.MatchContinuations) != 2 {
+		t.Fatalf("source order/continuations=%v/%d", []string{page.Events[0].Metadata().EventID().String(), page.Events[1].Metadata().EventID().String()}, len(page.MatchContinuations))
 	}
 }
 

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -77,18 +78,14 @@ func TestLiteralSearchPageReturnsPartialCoverageAndAdvancingZeroMatchCursor(t *t
 	if len(page.Events) != 0 || page.Coverage.Complete || page.Continuation == "" || page.PartialReason != "source_rows" {
 		t.Fatalf("page = %+v", page)
 	}
-	cursor, err := apptypes.DecodeLiteralSearchCursor(page.Continuation)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cursor.LastSequence == 0 {
+	if page.Coverage.ProcessedSources == 0 {
 		t.Fatal("zero-match continuation did not advance")
 	}
-	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1024, DecodedBytes: 1024}, Continuation: page.Continuation})
+	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}, Continuation: page.Continuation})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if page2.Coverage.ProcessedSources <= page.Coverage.ProcessedSources || page2.Continuation == "" {
+	if page2.Coverage.ProcessedSources <= page.Coverage.ProcessedSources || !page2.Coverage.Complete {
 		t.Fatalf("resumed page = %+v", page2)
 	}
 }
@@ -114,5 +111,48 @@ func TestLiteralSearchPageVerifiesUnicodeCaseAgainstCanonicalVisibleText(t *test
 	}
 	if page.Tier != apptypes.LiteralSearchTierBoundedVerification || !page.Coverage.Complete {
 		t.Fatalf("page = %+v", page)
+	}
+}
+
+func TestLiteralSearchContinuationRejectsMembershipRevisionAndUnsupportedOffset(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	event := model.EventOf(mustEventIDForSQLite(t, "literal-revision"), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("workspace-a"), "needle body", time.Now().UTC())
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	second := model.EventOf(mustEventIDForSQLite(t, "literal-revision-second"), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("workspace-b"), "other body", time.Now().UTC())
+	if err := sut.Save(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(1).Query("absent").Workspace(types.Workspace("workspace-a")).Build()
+	request := apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1024, DecodedBytes: 1024}, BodyRuneLimit: 20}
+	page, err := sut.SearchLiteralPage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Continuation == "" {
+		t.Fatal("missing continuation")
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE events SET workspace='workspace-b' WHERE id='literal-revision'`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	request.Continuation = page.Continuation
+	if _, err = sut.SearchLiteralPage(ctx, request); !errors.Is(err, apptypes.ErrLiteralSearchCursorMismatch) {
+		t.Fatalf("revision resume error=%v", err)
+	}
+	offset := apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Offset(1).Build()
+	if _, err = sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: offset, Budget: request.Budget}); err == nil {
+		t.Fatal("offset accepted")
 	}
 }

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -103,12 +103,81 @@ func TestLiteralSearchPageReturnsPartialCoverageAndAdvancingZeroMatchCursor(t *t
 	if page.Coverage.ProcessedSources == 0 {
 		t.Fatal("zero-match continuation did not advance")
 	}
+	if page.Coverage.ExaminedSources != 1 {
+		t.Fatalf("source sentinel was examined: coverage=%+v", page.Coverage)
+	}
 	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}, Continuation: page.Continuation})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if page2.Coverage.ProcessedSources <= page.Coverage.ProcessedSources || !page2.Coverage.Complete {
 		t.Fatalf("resumed page = %+v", page2)
+	}
+}
+
+func TestLiteralSearchPageResultLimitAcceptsMatchWithResumeBefore(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sut, store := newEventDatasource(t, filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"literal-result-a", "literal-result-b"} {
+		event := model.EventOf(mustEventIDForSQLite(t, id), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("literal-workspace"), "needle", time.Now().UTC())
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Workspace(types.Workspace("literal-workspace")).Build()
+	request := apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}}
+	page, err := sut.SearchLiteralPage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 1 || len(page.Matches) != 1 || page.Matches[0].ResumeBefore == "" || page.PartialReason != "result_limit" {
+		t.Fatalf("page=%+v matches=%+v", page, page.Matches)
+	}
+	request.Continuation = page.Matches[0].ResumeBefore
+	retry, err := sut.SearchLiteralPage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retry.Events) != 1 || retry.Events[0].Metadata().EventID() != page.Events[0].Metadata().EventID() {
+		t.Fatalf("resume-before did not retry accepted match: first=%+v retry=%+v", page.Events, retry.Events)
+	}
+}
+
+func TestLiteralSearchPageExcludesHydrationOversizeAfterProgress(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	fixtures := []struct{ id, workspace, body string }{{"literal-skipped", "other", "ignored"}, {"literal-oversize", "target", "needle payload for hydration"}}
+	for _, fixture := range fixtures {
+		event := model.EventOf(mustEventIDForSQLite(t, fixture.id), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace(fixture.workspace), fixture.body, time.Now().UTC())
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var stored, decoded int64
+	if err := db.QueryRow(`SELECT COALESCE(body_encoded_bytes,length(body),0),COALESCE(body_plaintext_bytes,length(body),0) FROM events WHERE id='literal-oversize'`).Scan(&stored, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(2).Query("needle").Workspace(types.Workspace("target")).Build()
+	page, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: stored, DecodedBytes: decoded}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 0 || page.PartialReason != "verified_hydration_bytes" || page.Coverage.ProcessedSources != 1 || page.Coverage.ExaminedSources != 2 {
+		t.Fatalf("page=%+v", page)
 	}
 }
 

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -247,3 +247,31 @@ func TestLiteralSearchContinuationRejectsMembershipRevisionAndUnsupportedOffset(
 		t.Fatal("offset accepted")
 	}
 }
+
+func TestLiteralSearchContinuationRejectsFormerNULFieldCollision(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sut, store := newEventDatasource(t, filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"literal-collision-a", "literal-collision-b"} {
+		event := model.EventOf(mustEventIDForSQLite(t, id), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("c"), "body", time.Now().UTC())
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	budget := apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1024, DecodedBytes: 1024}
+	first := apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("a\x00b").Workspace(types.Workspace("c")).Build(), Budget: budget}
+	page, err := sut.SearchLiteralPage(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Continuation == "" {
+		t.Fatal("missing continuation")
+	}
+	second := apptypes.LiteralSearchRequest{Criteria: apptypes.NewEventSearchCriteriaBuilder(1).Query("a").Workspace(types.Workspace("b\x00c")).Build(), Budget: budget, Continuation: page.Continuation}
+	if _, err := sut.SearchLiteralPage(ctx, second); !errors.Is(err, apptypes.ErrLiteralSearchCursorMismatch) {
+		t.Fatalf("formerly colliding continuation error=%v", err)
+	}
+}

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -179,6 +179,13 @@ func TestLiteralSearchPageExcludesHydrationOversizeAfterProgress(t *testing.T) {
 	if len(page.Events) != 0 || page.PartialReason != "verified_hydration_bytes" || page.Coverage.ProcessedSources != 1 || page.Coverage.ExaminedSources != 2 {
 		t.Fatalf("page=%+v", page)
 	}
+	retry, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.DeepLiteralSearchBudget, Continuation: page.Continuation})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retry.Events) != 1 || retry.Events[0].Metadata().EventID().String() != "literal-oversize" {
+		t.Fatalf("deep retry=%+v", retry)
+	}
 }
 
 func TestLiteralSearchPageVerifiesUnicodeCaseAgainstCanonicalVisibleText(t *testing.T) {

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -1,0 +1,73 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+func TestLiteralSearchPageReturnsPartialCoverageAndAdvancingZeroMatchCursor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sut, store := newEventDatasource(t, filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for i, body := range []string{"alpha", "beta", "Unicode 障害/経路 ERR/Path-01"} {
+		event := model.EventOf(mustEventIDForSQLite(t, "literal-event-"+string(rune('a'+i))), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("literal-workspace"), body, time.Date(2026, 8, 1, 0, 0, i, 0, time.UTC))
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(1).Query("not-present").Workspace(types.Workspace("literal-workspace")).Build()
+	page, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1024, DecodedBytes: 1024}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 0 || page.Coverage.Complete || page.Continuation == "" || page.PartialReason != "source_rows" {
+		t.Fatalf("page = %+v", page)
+	}
+	cursor, err := apptypes.DecodeLiteralSearchCursor(page.Continuation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursor.LastSequence == 0 {
+		t.Fatal("zero-match continuation did not advance")
+	}
+	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}, Continuation: page.Continuation})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page2.Coverage.Complete || page2.Continuation != "" {
+		t.Fatalf("resumed page = %+v", page2)
+	}
+}
+
+func TestLiteralSearchPageVerifiesUnicodeCaseAgainstCanonicalVisibleText(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sut, store := newEventDatasource(t, filepath.Join(t.TempDir(), "traceary.db"), onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	event := model.EventOf(mustEventIDForSQLite(t, "literal-unicode"), types.EventKindTranscript, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("literal-workspace"), `{"blocks":[{"type":"thinking","text":"ERR/PATH-01 hidden"},{"type":"text","text":"障害/経路 err/path-01 visible"}]}`, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	if err := sut.Save(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(2).Query("ERR/PATH-01").Workspace(types.Workspace("literal-workspace")).Build()
+	page, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 1 || page.Events[0].Body() != "障害/経路 err/path-01 visible" {
+		t.Fatalf("events = %+v", page.Events)
+	}
+	if page.Tier != apptypes.LiteralSearchTierBoundedVerification || !page.Coverage.Complete {
+		t.Fatalf("page = %+v", page)
+	}
+}

--- a/infrastructure/sqlite/literal_search_query_test.go
+++ b/infrastructure/sqlite/literal_search_query_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +11,50 @@ import (
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 )
+
+func TestLiteralSearchPageFingerprintCandidatesRemainInclusiveForMissingRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	sut, store := newEventDatasource(t, dbPath, onDiskSQLiteMigrations(t))
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range []struct{ id, body string }{{"literal-fp-match", "path ERR/Path-01"}, {"literal-fp-missing", "also err/path-01"}, {"literal-fp-other", "unrelated body"}} {
+		event := model.EventOf(mustEventIDForSQLite(t, fixture.id), types.EventKindNote, types.Client("hook"), mustAgentForSQLite(t, "codex"), mustSessionIDForSQLite(t, "literal-session"), types.Workspace("literal-workspace"), fixture.body, time.Now().UTC())
+		if err := sut.Save(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	query := apptypes.CharacterizeLiteralQuery("ERR/Path-01")
+	for _, id := range []string{"literal-fp-match", "literal-fp-other"} {
+		body := query
+		if id == "literal-fp-other" {
+			body = apptypes.CharacterizeLiteralQuery("unrelated body")
+		}
+		for _, fp := range body.Fingerprints() {
+			if _, err := db.Exec(`INSERT INTO literal_search_fingerprints(generation_id,source_sequence,event_id,fingerprint,fingerprint_version) SELECT 'g1',sequence,?, ?,1 FROM search_projection_source_sequence WHERE event_id=?`, id, []byte(fp), id); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if _, err := db.Exec(`UPDATE literal_search_projection_state SET generation_id='g1',state='complete'`); err != nil {
+		t.Fatal(err)
+	}
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("err/path-01").Workspace(types.Workspace("literal-workspace")).Build()
+	page, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 4096, DecodedBytes: 4096}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Tier != apptypes.LiteralSearchTierFingerprint || len(page.Events) != 2 {
+		t.Fatalf("page = %+v", page)
+	}
+}
 
 func TestLiteralSearchPageReturnsPartialCoverageAndAdvancingZeroMatchCursor(t *testing.T) {
 	t.Parallel()
@@ -39,11 +84,11 @@ func TestLiteralSearchPageReturnsPartialCoverageAndAdvancingZeroMatchCursor(t *t
 	if cursor.LastSequence == 0 {
 		t.Fatal("zero-match continuation did not advance")
 	}
-	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 10, StoredBytes: 4096, DecodedBytes: 4096}, Continuation: page.Continuation})
+	page2, err := sut.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 1, StoredBytes: 1024, DecodedBytes: 1024}, Continuation: page.Continuation})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !page2.Coverage.Complete || page2.Continuation != "" {
+	if page2.Coverage.ProcessedSources <= page.Coverage.ProcessedSources || page2.Continuation == "" {
 		t.Fatalf("resumed page = %+v", page2)
 	}
 }

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -467,6 +467,17 @@ VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		t.Fatal(err)
 	}
 	datasource := NewEventDatasource(database)
+	literalCriteria := apptypes.NewEventSearchCriteriaBuilder(2).Query("echo redacted").SessionID(domtypes.SessionID("zstd-session")).Build()
+	if _, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1, DecodedBytes: 1}, BodyRuneLimit: 100}); literalErr == nil {
+		t.Fatal("compressed literal search ignored decode ledger")
+	}
+	literalPage, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1 << 20, DecodedBytes: 1 << 20}, BodyRuneLimit: 100})
+	if literalErr != nil {
+		t.Fatal(literalErr)
+	}
+	if len(literalPage.Events) != 1 || literalPage.Events[0].Metadata().EventID().String() != "zstd" {
+		t.Fatalf("compressed literal events=%+v", literalPage.Events)
+	}
 	eventUC := usecase.NewEventUsecase(datasource, datasource)
 	redacted, err := eventUC.Log(ctx, "Authorization: Bearer secret-token-value", domtypes.EventKindTranscript, "hook", "codex", "redaction-session", "/repo", apptypes.NewLogRedactionBuilder().Build())
 	if err != nil {

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -468,7 +468,8 @@ VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	}
 	datasource := NewEventDatasource(database)
 	literalCriteria := apptypes.NewEventSearchCriteriaBuilder(2).Query("echo redacted").SessionID(domtypes.SessionID("zstd-session")).Build()
-	if _, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1, DecodedBytes: 1}, BodyRuneLimit: 100}); literalErr == nil {
+	tinyPage, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1, DecodedBytes: 1}, BodyRuneLimit: 100})
+	if literalErr == nil && (tinyPage.PartialReason == "" || tinyPage.Continuation == "") {
 		t.Fatal("compressed literal search ignored decode ledger")
 	}
 	literalPage, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1 << 20, DecodedBytes: 1 << 20}, BodyRuneLimit: 100})

--- a/infrastructure/sqlite/payload_codec_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_internal_test.go
@@ -469,8 +469,8 @@ VALUES('zstd',?,'','echo',?,?,0,0,5,6,0,'unknown',?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	datasource := NewEventDatasource(database)
 	literalCriteria := apptypes.NewEventSearchCriteriaBuilder(2).Query("echo redacted").SessionID(domtypes.SessionID("zstd-session")).Build()
 	tinyPage, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1, DecodedBytes: 1}, BodyRuneLimit: 100})
-	if literalErr == nil && (tinyPage.PartialReason == "" || tinyPage.Continuation == "") {
-		t.Fatal("compressed literal search ignored decode ledger")
+	if literalErr != nil || tinyPage.PartialReason == "" || tinyPage.Continuation == "" {
+		t.Fatalf("compressed literal search page=%+v error=%v", tinyPage, literalErr)
 	}
 	literalPage, literalErr := datasource.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: literalCriteria, Budget: apptypes.LiteralSearchBudget{SourceRows: 20, StoredBytes: 1 << 20, DecodedBytes: 1 << 20}, BodyRuneLimit: 100})
 	if literalErr != nil {

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -54,6 +54,9 @@ func (d *Database) Start(ctx context.Context, b apptypes.SearchProjectionBudget,
 		if n, x := result.RowsAffected(); x != nil || n != 1 {
 			return g, &apptypes.SearchProjectionNoProgressError{Reason: "a generation is already rebuilding"}
 		}
+		if _, x := tx.ExecContext(lockCtx, `UPDATE literal_search_projection_state SET generation_id=?,high_water=?,fingerprint_version=1,state='rebuilding',updated_at=? WHERE singleton=1`, g.GenerationID, g.HighWater, formatTimestamp(now.UTC())); x != nil {
+			return g, x
+		}
 		e = tx.Commit()
 	}
 	return g, e
@@ -172,11 +175,11 @@ func selectProjectionCleanup(ctx context.Context, db *sql.DB, out apptypes.Proje
  ORDER BY created_at_norm,event_id,document_id LIMIT ?`
 		args = []any{out.Generation.GenerationID, projectionCutoff(now.Add(-b.RecentAge)), b.RecentBytes, b.Rows + 1}
 	} else if out.CleanupAll {
-		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords LIMIT ?`
+		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints LIMIT ?`
 		args = []any{b.Rows + 1}
 	} else {
-		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents WHERE generation_id<>? UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries WHERE generation_id<>? UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates WHERE generation_id<>? UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords WHERE generation_id<>? LIMIT ?`
-		args = []any{out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, b.Rows + 1}
+		q = `SELECT 'recent',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(CAST(created_at_norm AS BLOB))+2*length(CAST(body_text AS BLOB))+32 FROM search_projection_recent_documents WHERE generation_id<>? UNION ALL SELECT 'summary',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(summary_text AS BLOB))+24 FROM search_projection_session_summaries WHERE generation_id<>? UNION ALL SELECT 'aggregate',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+16 FROM search_projection_command_aggregates WHERE generation_id<>? UNION ALL SELECT 'keyword',rowid,length(CAST(generation_id AS BLOB))+length(CAST(session_id AS BLOB))+length(CAST(keyword AS BLOB))+16 FROM search_projection_session_keywords WHERE generation_id<>? UNION ALL SELECT 'fingerprint',rowid,length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16 FROM literal_search_fingerprints WHERE generation_id<>? LIMIT ?`
+		args = []any{out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, out.Generation.GenerationID, b.Rows + 1}
 	}
 	rows, e := db.QueryContext(ctx, q, args...)
 	if e != nil {
@@ -299,6 +302,11 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 					return out, e
 				}
 			}
+			for _, fingerprint := range w.LiteralFingerprints {
+				if _, e = tx.ExecContext(lockCtx, `INSERT OR IGNORE INTO literal_search_fingerprints(generation_id,source_sequence,event_id,fingerprint,fingerprint_version) VALUES(?,?,?,?,1)`, p.GenerationID, d.Sequence, d.EventID, []byte(fingerprint)); e != nil {
+					return out, e
+				}
+			}
 			out.Written++
 		}
 		out.Selected++
@@ -314,6 +322,8 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 			table = "search_projection_command_aggregates"
 		case "keyword":
 			table = "search_projection_session_keywords"
+		case "fingerprint":
+			table = "literal_search_fingerprints"
 		default:
 			continue
 		}
@@ -338,6 +348,11 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 		state = p.FinalState
 		if state == "" {
 			state = "complete"
+		}
+	}
+	if p.Completed && state == "complete" {
+		if _, e = tx.ExecContext(lockCtx, `UPDATE literal_search_projection_state SET state='complete',updated_at=? WHERE singleton=1 AND generation_id=? AND state='rebuilding'`, formatTimestamp(now), p.GenerationID); e != nil {
+			return out, e
 		}
 	}
 	r, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?))`, p.NextCheckpoint, next, state, p.Completed, state, time.Since(started).Milliseconds(), formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision)
@@ -370,6 +385,7 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	defer db.Close()
 	s.SchemaVersion = "traceary.search-projection-status/v1"
 	s.KeywordVersion = searchProjectionKeywordVersion
+	s.FingerprintVersion = 1
 	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds)
 	if e != nil {
 		return s, e
@@ -383,6 +399,9 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	if e = db.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(length(CAST(keyword AS BLOB))),0) FROM search_projection_session_keywords WHERE generation_id=(SELECT active_generation_id FROM search_projection_state)`).Scan(&s.KeywordRows, &s.KeywordLogicalBytes); e != nil {
 		return s, e
 	}
+	if e = db.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(length(CAST(generation_id AS BLOB))+length(CAST(event_id AS BLOB))+length(fingerprint)+16),0) FROM literal_search_fingerprints WHERE generation_id=(SELECT active_generation_id FROM search_projection_state)`).Scan(&s.FingerprintRows, &s.FingerprintLogicalBytes); e != nil {
+		return s, e
+	}
 	s.FTSLogicalBytes = s.RecentBytes
 	probeStarted := time.Now()
 	var ignored int
@@ -392,7 +411,7 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	s.MatchProbeMilliseconds = time.Since(probeStarted).Milliseconds()
 	var page int64
 	if db.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&page) == nil {
-		if e = db.QueryRowContext(ctx, `SELECT COALESCE(SUM(pgsize),0) FROM dbstat WHERE name IN (SELECT name FROM sqlite_schema WHERE name LIKE 'search_projection_%' OR tbl_name LIKE 'search_projection_%')`).Scan(&s.PhysicalBytes); e == nil {
+		if e = db.QueryRowContext(ctx, `SELECT COALESCE(SUM(pgsize),0) FROM dbstat WHERE name IN (SELECT name FROM sqlite_schema WHERE name LIKE 'search_projection_%' OR tbl_name LIKE 'search_projection_%' OR name LIKE 'literal_search_%' OR tbl_name LIKE 'literal_search_%')`).Scan(&s.PhysicalBytes); e == nil {
 			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "complete", Method: "dbstat"}
 		} else {
 			s.PhysicalEvidence = apptypes.CapacityEvidence{Status: "unavailable", Method: "pragma", Reason: "dbstat unavailable"}

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -109,6 +109,24 @@ func TestSearchProjectionRebuildIsBoundedResumableAndEvictsDeterministically(t *
 	if err = db.QueryRow(`SELECT fts_design FROM search_projection_state`).Scan(&design); err != nil || design != "external_content" {
 		t.Fatalf("design=%q err=%v", design, err)
 	}
+	var fingerprintRows, distinctFingerprints int
+	if err = db.QueryRow(`SELECT COUNT(*),COUNT(DISTINCT generation_id||':'||event_id||':'||hex(fingerprint)) FROM literal_search_fingerprints`).Scan(&fingerprintRows, &distinctFingerprints); err != nil {
+		t.Fatal(err)
+	}
+	if fingerprintRows == 0 || fingerprintRows != distinctFingerprints {
+		t.Fatalf("fingerprints rows/distinct=%d/%d", fingerprintRows, distinctFingerprints)
+	}
+	var literalState string
+	if err = db.QueryRow(`SELECT state FROM literal_search_projection_state`).Scan(&literalState); err != nil || literalState != "complete" {
+		t.Fatalf("literal state=%q err=%v", literalState, err)
+	}
+	status, statusErr := store.SearchProjectionStatus(ctx)
+	if statusErr != nil {
+		t.Fatal(statusErr)
+	}
+	if status.FingerprintVersion != 1 || status.FingerprintRows != int64(fingerprintRows) || status.FingerprintLogicalBytes <= 0 {
+		t.Fatalf("fingerprint status=%+v", status)
+	}
 }
 
 func projectionBudget() apptypes.SearchProjectionBudget {

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func run() error {
 		storeManagementUsecase,
 		mcpserver.WithEventMetadata(eventMetadataUsecase),
 		mcpserver.WithEventBounded(eventBoundedUsecase),
+		mcpserver.WithTieredEventSearch(eventDatasource),
 		mcpserver.WithReport(reportUsecase),
 	)
 	if err != nil {
@@ -238,6 +239,7 @@ func run() error {
 	rootCmd := cli.NewRootCLI(
 		cli.WithEvent(eventUsecase),
 		cli.WithEventMetadata(eventMetadataUsecase),
+		cli.WithTieredEventSearch(eventDatasource),
 		cli.WithReport(reportUsecase),
 		cli.WithCodexCaptureDiagnostic(codexCaptureDiagnosticUsecase),
 		cli.WithSession(sessionUsecase),

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/filesystem"
@@ -203,6 +204,7 @@ func run() error {
 	fileRetentionUsecase := usecase.NewFileRetentionUsecase(fileRetentionDatasource, fileRetentionDatasource)
 	oneShotRepairUsecase := usecase.NewOneShotRepairUsecase(storeManagementDatasource, storeManagementDatasource)
 	workspaceIdentityUsecase := usecase.NewWorkspaceIdentityUsecase(workspaceIdentityDatasource, workspaceIdentityDatasource, types.SystemClock{})
+	tieredSearchService := queryservice.NewLiteralSearchService(eventDatasource)
 
 	mcpServer, err := mcpserver.NewServer(
 		resolvedVersion,
@@ -217,7 +219,7 @@ func run() error {
 		storeManagementUsecase,
 		mcpserver.WithEventMetadata(eventMetadataUsecase),
 		mcpserver.WithEventBounded(eventBoundedUsecase),
-		mcpserver.WithTieredEventSearch(eventDatasource),
+		mcpserver.WithTieredEventSearch(tieredSearchService),
 		mcpserver.WithReport(reportUsecase),
 	)
 	if err != nil {
@@ -239,7 +241,7 @@ func run() error {
 	rootCmd := cli.NewRootCLI(
 		cli.WithEvent(eventUsecase),
 		cli.WithEventMetadata(eventMetadataUsecase),
-		cli.WithTieredEventSearch(eventDatasource),
+		cli.WithTieredEventSearch(tieredSearchService),
 		cli.WithReport(reportUsecase),
 		cli.WithCodexCaptureDiagnostic(codexCaptureDiagnosticUsecase),
 		cli.WithSession(sessionUsecase),

--- a/presentation/cli/input.go
+++ b/presentation/cli/input.go
@@ -202,6 +202,9 @@ type searchCommandInput struct {
 	failuresOnlySet bool
 	color           string
 	colorSet        bool
+	tieredPreview   bool
+	deep            bool
+	continuation    string
 }
 
 // sessionBoundaryCommandInput is the resolved input to

--- a/presentation/cli/root.go
+++ b/presentation/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/duck8823/traceary/application"
+	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/redaction"
 	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/presentation"
@@ -17,6 +18,7 @@ import (
 type RootCLI struct {
 	event                      usecase.EventUsecase
 	eventMetadata              usecase.EventMetadataUsecase
+	tieredSearch               queryservice.TieredEventSearchQuery
 	reportCommand              usecase.ReportCommandUsecase
 	report                     usecase.ReportUsecase
 	codexCaptureDiagnostic     usecase.CodexCaptureDiagnosticUsecase
@@ -83,6 +85,11 @@ func WithEvent(event usecase.EventUsecase) RootCLIOption {
 // WithEventMetadata injects body-free event reads used by metadata projections.
 func WithEventMetadata(eventMetadata usecase.EventMetadataUsecase) RootCLIOption {
 	return func(c *RootCLI) { c.eventMetadata = eventMetadata }
+}
+
+// WithTieredEventSearch injects the explicit historical literal preview.
+func WithTieredEventSearch(search queryservice.TieredEventSearchQuery) RootCLIOption {
+	return func(c *RootCLI) { c.tieredSearch = search }
 }
 
 // WithReportCommand injects structured command-audit aggregation for report.

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -202,7 +202,7 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		if input.deep {
 			budget = apptypes.DeepLiteralSearchBudget
 		}
-		page, searchErr := c.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.continuation})
+		page, searchErr := c.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.continuation, BodyRuneLimit: 500})
 		if searchErr != nil {
 			return xerrors.Errorf("failed to search tiered literal preview: %w", searchErr)
 		}

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"time"
@@ -15,26 +16,29 @@ import (
 
 func (c *RootCLI) newSearchCommand() *cobra.Command {
 	var (
-		dbPath       string
-		repo         string
-		sessionID    string
-		client       string
-		agent        string
-		kind         string
-		from         string
-		since        string
-		to           string
-		until        string
-		timezone     string
-		limit        int
-		offset       int
-		failuresOnly bool
-		asJSON       bool
-		wide         bool
-		utc          bool
-		fields       []string
-		preset       string
-		color        string
+		dbPath        string
+		repo          string
+		sessionID     string
+		client        string
+		agent         string
+		kind          string
+		from          string
+		since         string
+		to            string
+		until         string
+		timezone      string
+		limit         int
+		offset        int
+		failuresOnly  bool
+		asJSON        bool
+		wide          bool
+		utc           bool
+		fields        []string
+		preset        string
+		color         string
+		tieredPreview bool
+		deep          bool
+		continuation  string
 	)
 
 	searchCmd := &cobra.Command{
@@ -77,6 +81,9 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 				failuresOnlySet: cmd.Flags().Changed("failures"),
 				color:           color,
 				colorSet:        cmd.Flags().Changed("color"),
+				tieredPreview:   tieredPreview,
+				deep:            deep,
+				continuation:    continuation,
 			})
 		},
 	}
@@ -108,6 +115,9 @@ func (c *RootCLI) newSearchCommand() *cobra.Command {
 	searchCmd.Flags().StringSliceVar(&fields, "fields", nil, readFieldsFlagUsage())
 	searchCmd.Flags().StringVar(&preset, "preset", "", readPresetsFlagUsage())
 	searchCmd.Flags().StringVar(&color, "color", "", readColorFlagUsage())
+	searchCmd.Flags().BoolVar(&tieredPreview, "tiered-preview", false, "use bounded historical literal preview with explicit coverage")
+	searchCmd.Flags().BoolVar(&deep, "deep", false, "increase tiered preview resource budgets without changing search semantics")
+	searchCmd.Flags().StringVar(&continuation, "continuation", "", "resume an incomplete tiered preview")
 
 	return searchCmd
 }
@@ -181,6 +191,42 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		Offset(input.offset).
 		FailuresOnly(input.failuresOnly).
 		Build()
+	if input.tieredPreview {
+		if !input.asJSON {
+			return xerrors.New("--tiered-preview requires --json")
+		}
+		if c.tieredSearch == nil {
+			return xerrors.New("tiered event search is not configured")
+		}
+		budget := apptypes.NormalLiteralSearchBudget
+		if input.deep {
+			budget = apptypes.DeepLiteralSearchBudget
+		}
+		page, searchErr := c.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.continuation})
+		if searchErr != nil {
+			return xerrors.Errorf("failed to search tiered literal preview: %w", searchErr)
+		}
+		type event struct {
+			EventID               string `json:"event_id"`
+			Body                  string `json:"body"`
+			BodyResponseTruncated bool   `json:"body_response_truncated"`
+		}
+		events := make([]event, 0, len(page.Events))
+		for _, e := range page.Events {
+			events = append(events, event{EventID: e.Metadata().EventID().String(), Body: e.Body(), BodyResponseTruncated: e.BodyResponseTruncated()})
+		}
+		out := struct {
+			Events        []event                        `json:"events"`
+			Tier          apptypes.LiteralSearchTier     `json:"tier"`
+			Coverage      apptypes.LiteralSearchCoverage `json:"coverage"`
+			PartialReason string                         `json:"partial_reason,omitempty"`
+			Continuation  string                         `json:"continuation,omitempty"`
+		}{events, page.Tier, page.Coverage, page.PartialReason, page.Continuation}
+		if err := json.NewEncoder(output).Encode(out); err != nil {
+			return xerrors.Errorf("failed to print tiered literal preview: %w", err)
+		}
+		return nil
+	}
 	resolvedFields, err := c.resolveReadFieldsForCommand(input.fields, input.fieldsSet, input.wide, input.asJSON, preset.fields)
 	if err != nil {
 		return err

--- a/presentation/cli/search.go
+++ b/presentation/cli/search.go
@@ -179,6 +179,10 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		return err
 	}
 
+	criteriaTo := interval.EffectiveToExclusive()
+	if input.tieredPreview && !interval.HasRequestedTo() {
+		criteriaTo = time.Time{}
+	}
 	criteria := apptypes.NewEventSearchCriteriaBuilder(input.limit).
 		Query(input.query).
 		Workspace(types.Workspace(resolveWorkspaceValue(ctx, input.repo))).
@@ -187,7 +191,7 @@ func (c *RootCLI) runSearch(ctx context.Context, warnWriter io.Writer, output io
 		Agent(types.Agent(input.agent)).
 		Kind(types.EventKind(resolvedKind)).
 		From(interval.EffectiveFromInclusive()).
-		To(interval.EffectiveToExclusive()).
+		To(criteriaTo).
 		Offset(input.offset).
 		FailuresOnly(input.failuresOnly).
 		Build()

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -3,13 +3,44 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/presentation/cli"
 )
+
+func TestRootCLI_SearchTieredPreviewExposesZeroMatchContinuation(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	stub := &cliTieredSearchStub{page: apptypes.LiteralSearchPage{Tier: apptypes.LiteralSearchTierBoundedVerification, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: 4, HighWater: 9}, PartialReason: "source_rows", Continuation: "next"}}
+	stdout := &bytes.Buffer{}
+	root := cli.NewRootCLI(cli.WithStoreManagement(&storeManagementUsecaseStub{}), cli.WithEvent(&eventUsecaseStub{}), cli.WithTieredEventSearch(stub)).Command()
+	root.SetOut(stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"search", "needle", "--tiered-preview", "--deep", "--continuation", "previous", "--json", "--workspace", "repo"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"tier":"bounded_verification"`) || !strings.Contains(got, `"continuation":"next"`) || !strings.Contains(got, `"partial_reason":"source_rows"`) {
+		t.Fatalf("stdout = %s", got)
+	}
+	if stub.request.Continuation != "previous" || stub.request.Budget != apptypes.DeepLiteralSearchBudget {
+		t.Fatalf("request = %+v", stub.request)
+	}
+}
+
+type cliTieredSearchStub struct {
+	page    apptypes.LiteralSearchPage
+	request apptypes.LiteralSearchRequest
+}
+
+func (s *cliTieredSearchStub) SearchLiteralPage(_ context.Context, r apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
+	s.request = r
+	return s.page, nil
+}
 
 func TestRootCLI_SearchCommand(t *testing.T) {
 	t.Setenv("TRACEARY_WORKSPACE", "")

--- a/presentation/cli/search_test.go
+++ b/presentation/cli/search_test.go
@@ -3,13 +3,19 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	sqliteinfra "github.com/duck8823/traceary/infrastructure/sqlite"
 	"github.com/duck8823/traceary/presentation/cli"
 )
 
@@ -30,6 +36,56 @@ func TestRootCLI_SearchTieredPreviewExposesZeroMatchContinuation(t *testing.T) {
 	if stub.request.Continuation != "previous" || stub.request.Budget != apptypes.DeepLiteralSearchBudget {
 		t.Fatalf("request = %+v", stub.request)
 	}
+}
+
+func TestRootCLI_SearchTieredPreviewResumesWithoutImplicitTo(t *testing.T) {
+	t.Setenv("TRACEARY_WORKSPACE", "")
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	db := sqliteinfra.NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	eventDS := sqliteinfra.NewEventDatasource(db)
+	storeUC := usecase.NewStoreManagementUsecase(sqliteinfra.NewStoreManagementDatasource(db))
+	eventUC := usecase.NewEventUsecase(eventDS, eventDS)
+	if err := storeUC.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"cli-tiered-a", "cli-tiered-b"} {
+		eventID, _ := types.EventIDFrom(id)
+		agent, _ := types.AgentFrom("codex")
+		sessionID, _ := types.SessionIDFrom("cli-tiered-session")
+		if err := eventDS.Save(ctx, model.EventOf(eventID, types.EventKindNote, types.Client("cli"), agent, sessionID, types.Workspace("repo"), "needle", time.Now().UTC())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	search := queryservice.NewLiteralSearchService(eventDS)
+	run := func(continuation string) string {
+		t.Helper()
+		stdout := &bytes.Buffer{}
+		root := cli.NewRootCLI(cli.WithStoreManagement(storeUC), cli.WithEvent(eventUC), cli.WithTieredEventSearch(search), cli.WithDatabasePathSetter(db.SetPath)).Command()
+		root.SetOut(stdout)
+		root.SetErr(&bytes.Buffer{})
+		args := []string{"search", "needle", "--tiered-preview", "--json", "--workspace", "repo", "--limit", "1", "--db-path", dbPath}
+		if continuation != "" {
+			args = append(args, "--continuation", continuation)
+		}
+		root.SetArgs(args)
+		if err := root.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		var output struct {
+			Continuation string `json:"continuation"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+			t.Fatal(err)
+		}
+		return output.Continuation
+	}
+	continuation := run("")
+	if continuation == "" {
+		t.Fatal("missing continuation")
+	}
+	time.Sleep(time.Millisecond)
+	_ = run(continuation)
 }
 
 type cliTieredSearchStub struct {

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -154,6 +154,32 @@ func TestSearchAndContext_MetadataProjectionUseBodyFreeQueries(t *testing.T) {
 	}
 }
 
+func TestSearchTieredPreviewExposesZeroMatchProgressAndDeepBudget(t *testing.T) {
+	t.Parallel()
+	stub := &tieredSearchStub{page: apptypes.LiteralSearchPage{Tier: apptypes.LiteralSearchTierBoundedVerification, Coverage: apptypes.LiteralSearchCoverage{ProcessedSources: 7, HighWater: 20}, PartialReason: "source_rows", Continuation: "next"}}
+	server := &Server{tieredSearch: stub}
+	_, output, err := server.search()(context.Background(), nil, searchInput{Query: "needle", TieredPreview: true, Deep: true, Continuation: "previous"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Events) != 0 || !output.Partial || output.Continuation != "next" || output.Tier != "bounded_verification" || len(output.Reasons) != 1 || output.Reasons[0] != "source_rows" {
+		t.Fatalf("output = %+v", output)
+	}
+	if stub.request.Continuation != "previous" || stub.request.Budget != apptypes.DeepLiteralSearchBudget {
+		t.Fatalf("request = %+v", stub.request)
+	}
+}
+
+type tieredSearchStub struct {
+	page    apptypes.LiteralSearchPage
+	request apptypes.LiteralSearchRequest
+}
+
+func (s *tieredSearchStub) SearchLiteralPage(_ context.Context, request apptypes.LiteralSearchRequest) (apptypes.LiteralSearchPage, error) {
+	s.request = request
+	return s.page, nil
+}
+
 func TestDefaultBoundedProjectionUsesBoundedQueriesBeforeFullEvents(t *testing.T) {
 	t.Parallel()
 

--- a/presentation/mcpserver/event_projection_internal_test.go
+++ b/presentation/mcpserver/event_projection_internal_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"strings"
@@ -167,6 +168,26 @@ func TestSearchTieredPreviewExposesZeroMatchProgressAndDeepBudget(t *testing.T) 
 	}
 	if stub.request.Continuation != "previous" || stub.request.Budget != apptypes.DeepLiteralSearchBudget {
 		t.Fatalf("request = %+v", stub.request)
+	}
+}
+
+func TestSearchTieredMetadataOmitsAllBodyDerivedKeys(t *testing.T) {
+	t.Parallel()
+	bounded := newMCPBoundedFixture(t, "visible secret", 20, false)
+	stub := &tieredSearchStub{page: apptypes.LiteralSearchPage{Events: []apptypes.BoundedEvent{bounded}, Tier: apptypes.LiteralSearchTierBoundedVerification, Coverage: apptypes.LiteralSearchCoverage{ExaminedSources: 1, ProcessedSources: 1, HighWater: 1, Complete: true}}}
+	server := &Server{tieredSearch: stub}
+	_, output, err := server.search()(context.Background(), nil, searchInput{Query: "visible", TieredPreview: true, Projection: "metadata"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{`"body"`, `"body_blocks"`, `"body_unavailable_reason"`, `"body_response_truncated"`, `"visible_body_runes"`} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("metadata contains %s: %s", forbidden, encoded)
+		}
 	}
 }
 

--- a/presentation/mcpserver/input.go
+++ b/presentation/mcpserver/input.go
@@ -151,16 +151,18 @@ type listEventsInput struct {
 
 // searchInput is the MCP input for the search tool.
 type searchInput struct {
-	Query        string `json:"query" jsonschema:"literal search text; boolean-looking OR is treated as text, not any-match syntax"`
-	Workspace    string `json:"workspace,omitempty" jsonschema:"work context filter"`
-	From         string `json:"from,omitempty" jsonschema:"start time (YYYY-MM-DD or RFC3339)"`
-	To           string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
-	Timezone     string `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only bounds (default: UTC)"`
-	Limit        int    `json:"limit,omitempty" jsonschema:"result limit (default: 20, maximum: 100)"`
-	Projection   string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
-	BodyLimit    *int   `json:"body_limit,omitempty" jsonschema:"truncate event body in this response to this many runes; default 500, maximum 16384. Set to 0 or pass full_body=true to disable response truncation. Audit payloads truncated at ingestion remain truncated."`
-	FullBody     bool   `json:"full_body,omitempty" jsonschema:"return the full stored body even when it is long. Equivalent to body_limit=0; does not restore audit payload bytes dropped at ingestion"`
-	Continuation string `json:"continuation,omitempty" jsonschema:"opaque continuation returned by this same tool"`
+	Query         string `json:"query" jsonschema:"literal search text; boolean-looking OR is treated as text, not any-match syntax"`
+	Workspace     string `json:"workspace,omitempty" jsonschema:"work context filter"`
+	From          string `json:"from,omitempty" jsonschema:"start time (YYYY-MM-DD or RFC3339)"`
+	To            string `json:"to,omitempty" jsonschema:"end time (YYYY-MM-DD or RFC3339)"`
+	Timezone      string `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only bounds (default: UTC)"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"result limit (default: 20, maximum: 100)"`
+	Projection    string `json:"projection,omitempty" jsonschema:"event projection: metadata omits body fields, bounded reads only a limited visible-text body from storage, full returns the full stored body; omitted preserves body_limit/full_body compatibility"`
+	BodyLimit     *int   `json:"body_limit,omitempty" jsonschema:"truncate event body in this response to this many runes; default 500, maximum 16384. Set to 0 or pass full_body=true to disable response truncation. Audit payloads truncated at ingestion remain truncated."`
+	FullBody      bool   `json:"full_body,omitempty" jsonschema:"return the full stored body even when it is long. Equivalent to body_limit=0; does not restore audit payload bytes dropped at ingestion"`
+	Continuation  string `json:"continuation,omitempty" jsonschema:"opaque continuation returned by this same tool"`
+	TieredPreview bool   `json:"tiered_preview,omitempty" jsonschema:"use bounded historical literal preview with explicit coverage and provenance"`
+	Deep          bool   `json:"deep,omitempty" jsonschema:"increase tiered preview resource budgets without changing search semantics"`
 }
 
 // getContextInput is the MCP input for the get_context tool.

--- a/presentation/mcpserver/output.go
+++ b/presentation/mcpserver/output.go
@@ -49,6 +49,7 @@ type eventsOutput struct {
 	Partial      bool                `json:"partial" jsonschema:"whether another page or body-budget reduction remains"`
 	Reasons      []string            `json:"reasons,omitempty" jsonschema:"machine-readable partial reasons: more_results, aggregate_body_budget"`
 	Continuation string              `json:"continuation,omitempty" jsonschema:"opaque cursor for the next page; use only with the same tool and filters"`
+	Tier         string              `json:"tier,omitempty" jsonschema:"candidate provenance for tiered literal preview"`
 }
 
 type eventCoverageOutput struct {

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -841,11 +841,30 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 				to = time.Time{}
 			}
 			criteria := apptypes.NewEventSearchCriteriaBuilder(normalizedEventPageLimit(input.Limit)).Query(strings.TrimSpace(input.Query)).Workspace(types.Workspace(strings.TrimSpace(input.Workspace))).From(from).To(to).Build()
+			if projection == apptypes.EventProjectionFull {
+				return nil, eventsOutput{}, xerrors.Errorf("tiered preview does not support full projection")
+			}
+			responseBudget, budgetErr := apptypes.NewEventResponseBudget(normalizedEventPageLimit(input.Limit), bodyLimit)
+			if budgetErr != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("resolve tiered response budget: %w", budgetErr)
+			}
+			effectiveBodyLimit := bodyLimit
+			if projection == apptypes.EventProjectionMetadata {
+				effectiveBodyLimit = 1
+			} else {
+				safe := responseBudget.AggregateBodyBytes() / (normalizedEventPageLimit(input.Limit) * 6)
+				if safe < 1 {
+					safe = 1
+				}
+				if effectiveBodyLimit > safe {
+					effectiveBodyLimit = safe
+				}
+			}
 			budget := apptypes.NormalLiteralSearchBudget
 			if input.Deep {
 				budget = apptypes.DeepLiteralSearchBudget
 			}
-			literalPage, searchErr := s.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.Continuation})
+			literalPage, searchErr := s.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.Continuation, BodyRuneLimit: effectiveBodyLimit})
 			if searchErr != nil {
 				return nil, eventsOutput{}, xerrors.Errorf("failed to search tiered literal preview: %w", searchErr)
 			}
@@ -854,8 +873,18 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 				reasons = append(reasons, literalPage.PartialReason)
 			}
 			converted := convertBoundedEvents(literalPage.Events)
+			if projection == apptypes.EventProjectionMetadata {
+				for i := range converted {
+					converted[i].Body = nil
+					converted[i].BodyBlocks = nil
+				}
+			}
 			intervalOut := newIntervalOutput(interval)
-			return nil, eventsOutput{Events: converted, Interval: &intervalOut, Coverage: eventCoverageOutput{CandidateCount: int(literalPage.Coverage.ProcessedSources), ReturnedCount: len(converted)}, Partial: !literalPage.Coverage.Complete, Reasons: reasons, Continuation: literalPage.Continuation, Tier: string(literalPage.Tier)}, nil
+			bodyBytes := 0
+			for _, event := range converted {
+				bodyBytes += encodedEventBodyBytes(event)
+			}
+			return nil, eventsOutput{Events: converted, Interval: &intervalOut, Coverage: eventCoverageOutput{CandidateCount: int(literalPage.Coverage.ExaminedSources), ReturnedCount: len(converted), AggregateBodyBytes: bodyBytes, AggregateBodyBudget: responseBudget.AggregateBodyBytes()}, Partial: !literalPage.Coverage.Complete, Reasons: reasons, Continuation: literalPage.Continuation, Tier: string(literalPage.Tier)}, nil
 		}
 		snapshotAt := time.Now().UTC()
 		continuation, err := resolveEventContinuation("search", input.Continuation)

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -886,10 +886,11 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 			}
 			if aggregate.hasUnreturned {
 				idx := len(aggregate.events)
-				if idx >= len(literalPage.MatchContinuations) {
-					return nil, eventsOutput{}, xerrors.Errorf("tiered aggregate continuation is unavailable")
+				_, continuation, prefixErr := literalPage.PrefixWithContinuation(idx)
+				if prefixErr != nil {
+					return nil, eventsOutput{}, xerrors.Errorf("resolve tiered aggregate prefix: %w", prefixErr)
 				}
-				literalPage.Continuation = literalPage.MatchContinuations[idx]
+				literalPage.Continuation = continuation
 			}
 			converted = aggregate.events
 			intervalOut := newIntervalOutput(interval)

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/xerrors"
 
+	"github.com/duck8823/traceary/application/queryservice"
 	"github.com/duck8823/traceary/application/redaction"
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
@@ -45,6 +46,7 @@ type Server struct {
 	context               usecase.ContextUsecase
 	storeManagement       usecase.StoreManagementUsecase
 	report                usecase.ReportUsecase
+	tieredSearch          queryservice.TieredEventSearchQuery
 }
 
 // NewServer creates a new MCP server.
@@ -116,6 +118,11 @@ func WithEventMetadata(eventMetadata usecase.EventMetadataUsecase) ServerOption 
 // hydration for the default MCP projection.
 func WithEventBounded(eventBounded usecase.EventBoundedUsecase) ServerOption {
 	return func(server *Server) { server.eventBounded = eventBounded }
+}
+
+// WithTieredEventSearch configures the explicit historical literal preview.
+func WithTieredEventSearch(search queryservice.TieredEventSearchQuery) ServerOption {
+	return func(server *Server) { server.tieredSearch = search }
 }
 
 // WithReport configures the shared body-free aggregate report.
@@ -817,6 +824,38 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 		projection, bodyLimit, err := resolveEventProjection(input.Projection, input.BodyLimit, input.FullBody)
 		if err != nil {
 			return nil, eventsOutput{}, err
+		}
+		if input.TieredPreview {
+			if s.tieredSearch == nil {
+				return nil, eventsOutput{}, xerrors.Errorf("tiered event search is not configured")
+			}
+			interval, intervalErr := apptypes.RequestedIntervalFrom(input.From, input.To, input.Timezone, time.Now().UTC())
+			if intervalErr != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to resolve time interval: %w", intervalErr)
+			}
+			from, to := interval.EffectiveFromInclusive(), interval.EffectiveToExclusive()
+			if strings.TrimSpace(input.From) == "" {
+				from = time.Time{}
+			}
+			if strings.TrimSpace(input.To) == "" {
+				to = time.Time{}
+			}
+			criteria := apptypes.NewEventSearchCriteriaBuilder(normalizedEventPageLimit(input.Limit)).Query(strings.TrimSpace(input.Query)).Workspace(types.Workspace(strings.TrimSpace(input.Workspace))).From(from).To(to).Build()
+			budget := apptypes.NormalLiteralSearchBudget
+			if input.Deep {
+				budget = apptypes.DeepLiteralSearchBudget
+			}
+			literalPage, searchErr := s.tieredSearch.SearchLiteralPage(ctx, apptypes.LiteralSearchRequest{Criteria: criteria, Budget: budget, Continuation: input.Continuation})
+			if searchErr != nil {
+				return nil, eventsOutput{}, xerrors.Errorf("failed to search tiered literal preview: %w", searchErr)
+			}
+			reasons := []string{}
+			if literalPage.PartialReason != "" {
+				reasons = append(reasons, literalPage.PartialReason)
+			}
+			converted := convertBoundedEvents(literalPage.Events)
+			intervalOut := newIntervalOutput(interval)
+			return nil, eventsOutput{Events: converted, Interval: &intervalOut, Coverage: eventCoverageOutput{CandidateCount: int(literalPage.Coverage.ProcessedSources), ReturnedCount: len(converted)}, Partial: !literalPage.Coverage.Complete, Reasons: reasons, Continuation: literalPage.Continuation, Tier: string(literalPage.Tier)}, nil
 		}
 		snapshotAt := time.Now().UTC()
 		continuation, err := resolveEventContinuation("search", input.Continuation)

--- a/presentation/mcpserver/server.go
+++ b/presentation/mcpserver/server.go
@@ -874,17 +874,33 @@ func (s *Server) search() mcp.ToolHandlerFor[searchInput, eventsOutput] {
 			}
 			converted := convertBoundedEvents(literalPage.Events)
 			if projection == apptypes.EventProjectionMetadata {
-				for i := range converted {
-					converted[i].Body = nil
-					converted[i].BodyBlocks = nil
+				metadata := make([]apptypes.EventMetadata, 0, len(literalPage.Events))
+				for _, event := range literalPage.Events {
+					metadata = append(metadata, event.Metadata())
 				}
+				converted = convertEventMetadata(metadata)
 			}
+			aggregate := applyEventAggregateBudget(converted, responseBudget)
+			if aggregate.partial {
+				reasons = append(reasons, "aggregate_body_budget")
+			}
+			if aggregate.hasUnreturned {
+				idx := len(aggregate.events)
+				if idx >= len(literalPage.MatchContinuations) {
+					return nil, eventsOutput{}, xerrors.Errorf("tiered aggregate continuation is unavailable")
+				}
+				literalPage.Continuation = literalPage.MatchContinuations[idx]
+			}
+			converted = aggregate.events
 			intervalOut := newIntervalOutput(interval)
 			bodyBytes := 0
 			for _, event := range converted {
 				bodyBytes += encodedEventBodyBytes(event)
 			}
-			return nil, eventsOutput{Events: converted, Interval: &intervalOut, Coverage: eventCoverageOutput{CandidateCount: int(literalPage.Coverage.ExaminedSources), ReturnedCount: len(converted), AggregateBodyBytes: bodyBytes, AggregateBodyBudget: responseBudget.AggregateBodyBytes()}, Partial: !literalPage.Coverage.Complete, Reasons: reasons, Continuation: literalPage.Continuation, Tier: string(literalPage.Tier)}, nil
+			if bodyBytes > responseBudget.AggregateBodyBytes() {
+				return nil, eventsOutput{}, xerrors.Errorf("tiered aggregate body budget exceeded")
+			}
+			return nil, eventsOutput{Events: converted, Interval: &intervalOut, Coverage: eventCoverageOutput{CandidateCount: int(literalPage.Coverage.ExaminedSources), ReturnedCount: len(converted), AggregateBodyBytes: bodyBytes, AggregateBodyBudget: responseBudget.AggregateBodyBytes()}, Partial: !literalPage.Coverage.Complete || aggregate.partial, Reasons: reasons, Continuation: literalPage.Continuation, Tier: string(literalPage.Tier)}, nil
 		}
 		snapshotAt := time.Now().UTC()
 		continuation, err := resolveEventContinuation("search", input.Continuation)

--- a/presentation/mcpserver/testdata/tool_registry.golden.json
+++ b/presentation/mcpserver/testdata/tool_registry.golden.json
@@ -268,6 +268,10 @@
             "null",
             "array"
           ]
+        },
+        "tier": {
+          "description": "candidate provenance for tiered literal preview",
+          "type": "string"
         }
       },
       "required": [
@@ -1473,6 +1477,10 @@
             "null",
             "array"
           ]
+        },
+        "tier": {
+          "description": "candidate provenance for tiered literal preview",
+          "type": "string"
         }
       },
       "required": [
@@ -2141,6 +2149,10 @@
           "description": "opaque continuation returned by this same tool",
           "type": "string"
         },
+        "deep": {
+          "description": "increase tiered preview resource budgets without changing search semantics",
+          "type": "boolean"
+        },
         "from": {
           "description": "start time (YYYY-MM-DD or RFC3339)",
           "type": "string"
@@ -2160,6 +2172,10 @@
         "query": {
           "description": "literal search text; boolean-looking OR is treated as text, not any-match syntax",
           "type": "string"
+        },
+        "tiered_preview": {
+          "description": "use bounded historical literal preview with explicit coverage and provenance",
+          "type": "boolean"
         },
         "timezone": {
           "description": "IANA timezone for date-only bounds (default: UTC)",
@@ -2404,6 +2420,10 @@
             "null",
             "array"
           ]
+        },
+        "tier": {
+          "description": "candidate provenance for tiered literal preview",
+          "type": "string"
         }
       },
       "required": [

--- a/presentation/mcpserver/testdata/tool_schema_budget.golden.json
+++ b/presentation/mcpserver/testdata/tool_schema_budget.golden.json
@@ -1,12 +1,12 @@
 {
-  "listToolsBytes": 46044,
-  "inputSchemaBytes": 14999,
+  "listToolsBytes": 46557,
+  "inputSchemaBytes": 15245,
   "tools": [
     {
       "name": "get_context",
-      "toolBytes": 6122,
+      "toolBytes": 6211,
       "inputSchemaBytes": 1067,
-      "outputSchemaBytes": 4822
+      "outputSchemaBytes": 4911
     },
     {
       "name": "get_report",
@@ -16,9 +16,9 @@
     },
     {
       "name": "list_events",
-      "toolBytes": 6969,
+      "toolBytes": 7058,
       "inputSchemaBytes": 1948,
-      "outputSchemaBytes": 4822
+      "outputSchemaBytes": 4911
     },
     {
       "name": "manage_memory",
@@ -46,9 +46,9 @@
     },
     {
       "name": "search",
-      "toolBytes": 6418,
-      "inputSchemaBytes": 1381,
-      "outputSchemaBytes": 4822
+      "toolBytes": 6753,
+      "inputSchemaBytes": 1627,
+      "outputSchemaBytes": 4911
     },
     {
       "name": "session_status",

--- a/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
+++ b/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
@@ -20,7 +20,7 @@ CREATE TABLE literal_search_fingerprints(
  fingerprint_version INTEGER NOT NULL CHECK(fingerprint_version=1),
  PRIMARY KEY(generation_id,event_id,fingerprint),
  FOREIGN KEY(source_sequence) REFERENCES search_projection_source_sequence(sequence) ON DELETE CASCADE
-) WITHOUT ROWID;
+);
 CREATE INDEX idx_literal_search_fingerprint_candidate
 ON literal_search_fingerprints(generation_id,fingerprint,source_sequence,event_id);
 

--- a/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
+++ b/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
@@ -8,6 +8,7 @@ CREATE TABLE literal_search_projection_state(
  fingerprint_version INTEGER NOT NULL DEFAULT 1,
  state TEXT NOT NULL DEFAULT 'missing' CHECK(state IN('missing','rebuilding','complete','stale')),
  updated_at TEXT NOT NULL
+	,cursor_key BLOB NOT NULL DEFAULT (randomblob(32)) CHECK(length(cursor_key)=32)
 );
 INSERT INTO literal_search_projection_state(singleton,updated_at)
 VALUES(1,strftime('%Y-%m-%dT%H:%M:%fZ','now'));
@@ -29,7 +30,7 @@ ON literal_search_fingerprints(generation_id,fingerprint,source_sequence,event_i
 CREATE TRIGGER literal_search_event_insert AFTER INSERT ON events BEGIN
  UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
 END;
-CREATE TRIGGER literal_search_event_update AFTER UPDATE OF body,body_availability ON events BEGIN
+CREATE TRIGGER literal_search_event_update AFTER UPDATE OF workspace,client,agent,session_id,kind,created_at,body,body_availability ON events BEGIN
  UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
 END;
 CREATE TRIGGER literal_search_event_delete AFTER DELETE ON events BEGIN

--- a/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
+++ b/schema/sqlite/migrations/000039_add_literal_search_fingerprints.sql
@@ -1,0 +1,46 @@
+-- Additive, deterministically rebuildable historical literal candidates.
+-- Absence of a row is unknown, never proof that an event cannot match.
+CREATE TABLE literal_search_projection_state(
+ singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+ generation_id TEXT NOT NULL DEFAULT '',
+ high_water INTEGER NOT NULL DEFAULT 0,
+ query_revision INTEGER NOT NULL DEFAULT 0,
+ fingerprint_version INTEGER NOT NULL DEFAULT 1,
+ state TEXT NOT NULL DEFAULT 'missing' CHECK(state IN('missing','rebuilding','complete','stale')),
+ updated_at TEXT NOT NULL
+);
+INSERT INTO literal_search_projection_state(singleton,updated_at)
+VALUES(1,strftime('%Y-%m-%dT%H:%M:%fZ','now'));
+
+CREATE TABLE literal_search_fingerprints(
+ generation_id TEXT NOT NULL,
+ source_sequence INTEGER NOT NULL,
+ event_id TEXT NOT NULL,
+ fingerprint BLOB NOT NULL CHECK(length(fingerprint)=16),
+ fingerprint_version INTEGER NOT NULL CHECK(fingerprint_version=1),
+ PRIMARY KEY(generation_id,event_id,fingerprint),
+ FOREIGN KEY(source_sequence) REFERENCES search_projection_source_sequence(sequence) ON DELETE CASCADE
+) WITHOUT ROWID;
+CREATE INDEX idx_literal_search_fingerprint_candidate
+ON literal_search_fingerprints(generation_id,fingerprint,source_sequence,event_id);
+
+-- Writers only invalidate the projection in constant work. A bounded rebuild
+-- later creates sorted/deduplicated hashes from codec-decoded canonical text.
+CREATE TRIGGER literal_search_event_insert AFTER INSERT ON events BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+CREATE TRIGGER literal_search_event_update AFTER UPDATE OF body,body_availability ON events BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+CREATE TRIGGER literal_search_event_delete AFTER DELETE ON events BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+CREATE TRIGGER literal_search_audit_insert AFTER INSERT ON command_audits BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+CREATE TRIGGER literal_search_audit_update AFTER UPDATE ON command_audits BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;
+CREATE TRIGGER literal_search_audit_delete AFTER DELETE ON command_audits BEGIN
+ UPDATE literal_search_projection_state SET query_revision=query_revision+1,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1;
+END;


### PR DESCRIPTION
## Summary
- add authenticated, projection-bound historical literal-search continuations
- add bounded codec-decoded canonical verification with explicit coverage, provenance, and partial reasons
- add versioned fixed-size fingerprints populated and cleaned through the search-projection workflow
- expose explicit tiered preview in CLI and MCP; `--deep` changes resource budgets only
- preserve legacy search as the authoritative default

## Validation
- `go test -count=1 ./...`
- `go vet ./...`
- `go tool golangci-lint run --allow-parallel-runners`
- focused and race tests for literal/tiered search across application, SQLite, CLI, and MCP
- `git diff --check origin/main...HEAD`
- security/correctness reviewer: APPROVE at `da5566d5`
- Structure-Behavior reviewer: APPROVE at `da5566d5`

## Review state
The application layer owns source admission, progress, budget, match acceptance, and partial-page state transitions. SQLite remains the imperative shell for SQL, codec verification, hydration, cursor signing, and transaction management. Full validation and both independent reviews pass on the same head.

Closes #1622
