### PR TITLE
v0.34.0-14: add growth warnings and maintenance guidance

### DIFF
--- a/.ai/spec/1624-growth-warnings-guidance.md
+++ b/.ai/spec/1624-growth-warnings-guidance.md
@@ -1,0 +1,63 @@
+# Issue #1624 — growth warnings and safe maintenance guidance
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- 目的: doctor の増大警告を固定DBサイズだけでなく、metadata-onlyのpayload/projection容量、filesystem headroom、実測診断latencyから判断し、安全なpreview-first maintenanceへ案内する。
+- 現状: 1 GiBのfile sizeだけで警告し、GC以後の安全なscrub/compact/swap/rollbackと中断復旧が案内されない。
+- 期待する振る舞い: いずれかの独立signalが予算超過ならwarning。hintは常にnon-destructive previewを最初にし、#1613 safe compactionへ誘導する。
+- 非対象: 自動GC/compact、payload内容の読取り、v0.35 activation、閾値のremote設定。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Growth evidence | DB/payload/projection/reclaimable/filesystem-free/latency | independent signalsを評価 | aggregate metadata only |
+| Growth warning | pass/warn/unavailable | preview-first hintを生成 | mutationしない |
+| Safe maintenance | copy→preflight→scrub→compact→swap→rollback | operator guidance | in-place VACUUM禁止 |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| aggregate容量取得 | CapacityInspector | SQLite metadata schema | CLIはSQLを持たない |
+| filesystem free取得 | CLI platform adapter | OS差分 | evaluatorはplatform非依存 |
+| threshold/evidence評価 | doctor_store_size | operator policy | datasourceはseverityを決めない |
+| runbook | bilingual docs | operation lifecycle | warning messageへ全手順を埋めない |
+
+### Boundaries / interfaces
+| Boundary or interface | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| CapacityInspector | doctor | PRAGMA/dbstat/aggregate query | unavailableはsize-onlyへ縮退 |
+| inspectDoctorDiskFree | doctor | Statfs | errorはsignal unavailable |
+| evaluateStoreGrowth | tests/doctor | thresholds | deterministic pass/warn |
+
+### Behavior tests
+| Behavior | Given | When | Then | Level |
+|---|---|---|---|---|
+| payload warning | small DB, large payload aggregate | evaluate | warn + preview first | unit |
+| projection warning | large projection | evaluate | warn | unit |
+| headroom warning | free < compaction working set | evaluate | warn | unit |
+| latency warning | capacity inspectionのopen開始から全aggregate完了までがslow | evaluate | warn | unit |
+| healthy | all budgets below | evaluate | pass | unit |
+| privacy | capacity report | doctor | values are aggregates only | integration |
+
+### TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| multi-signal thresholds | table tests fail fixed-size evaluator | evidence evaluator | signal helpers |
+| preview-first remediation | hint ordering assertion | safe command sequence | localized constants |
+| docs safety | forbidden in-place VACUUM grep | bilingual runbook | shared headings |
+
+### Risks / rollback
+- 手続き化リスク: CLIがSQLを持たないようCapacityInspectorを再利用する。
+- premature abstraction: public config/strategyは追加しない。
+- migration / compatibility: schema/API変更なし。capacity unavailable時は既存size signalへ縮退。
+- rollback trigger: doctor latency/lock regression、またはwarning誤検知が通常運用を阻害。
+- 分割案: evaluator+tests、CLI wiring、bilingual docs。1 issue内のcoherent changeとして1 PRに統合。
+- design checkpoint: metadata-only aggregate以外を読まず、mutation commandを自動実行しないことを実装前条件とする。
+
+### Self-review checklist
+- [x] 固定DB sizeだけでseverityを決めない
+- [x] FixCommandはsafe `store compact plan --db-path` preview（GCではない）
+- [x] content/identifierをmessageへ出さない
+- [x] unsafe in-place VACUUMを推奨しない
+- [x] v0.35 activationは明示的にdefer

--- a/.ai/spec/1624-growth-warnings-guidance.md
+++ b/.ai/spec/1624-growth-warnings-guidance.md
@@ -11,7 +11,7 @@
 ### Conceptual model
 | Concept | State | Behavior | Constraint / Invariant |
 |---|---|---|---|
-| Growth evidence | DB/payload/projection/reclaimable/filesystem-free/latency | independent signalsを評価 | aggregate metadata only |
+| Growth evidence | DB/event-payload/projection/reclaimable/filesystem-free/latency | independent signalsを評価 | event payloadはevent_metadata_projection aggregate。audit payloadは含むと主張しない |
 | Growth warning | pass/warn/unavailable | preview-first hintを生成 | mutationしない |
 | Safe maintenance | copy→preflight→scrub→compact→swap→rollback | operator guidance | in-place VACUUM禁止 |
 
@@ -54,6 +54,9 @@
 - rollback trigger: doctor latency/lock regression、またはwarning誤検知が通常運用を阻害。
 - 分割案: evaluator+tests、CLI wiring、bilingual docs。1 issue内のcoherent changeとして1 PRに統合。
 - design checkpoint: metadata-only aggregate以外を読まず、mutation commandを自動実行しないことを実装前条件とする。
+- large-store checkpoint: 2 GiB以上の既定doctorはcapacity inspectorより先に分岐し、SQLite openを0回にする。詳細signalはreview済みcopyで取得する。
+- latency definition: capacity inspectorのopen開始からPRAGMA/dbstat/event-payload aggregate完了まで。warning 1.5s、hard timeout 2s。
+- free-space model: availabilityとvalueを分離し、取得成功時の0/1/threshold以下はwarning、unsupported/errorだけunknownとする。DB×2はsaturating計算する。
 
 ### Self-review checklist
 - [x] 固定DB sizeだけでseverityを決めない

--- a/.ai/spec/1624-growth-warnings-guidance.md
+++ b/.ai/spec/1624-growth-warnings-guidance.md
@@ -57,6 +57,8 @@
 - large-store checkpoint: 2 GiB以上の既定doctorはcapacity inspectorより先に分岐し、SQLite openを0回にする。詳細signalはreview済みcopyで取得する。
 - latency definition: capacity inspectorのopen開始からPRAGMA/dbstat/event-payload aggregate完了まで。warning 1.5s、hard timeout 2s。
 - free-space model: availabilityとvalueを分離し、取得成功時の0/1/threshold以下はwarning、unsupported/errorだけunknownとする。DB×2はsaturating計算する。
+- stat snapshot: doctorはDB pathを1回だけstatし、同じimmutable snapshotでregular/size/large/reportを決める。直後のdelete/renameでもpanicやSQLite openへfallbackしない。
+- message contract: Statfs成功0 bytesは`free=0 B`、unsupported/errorは`free=unknown`。signed rangeと乗算overflowを事前拒否する。
 
 ### Self-review checklist
 - [x] 固定DB sizeだけでseverityを決めない

--- a/docs/operations/README.ja.md
+++ b/docs/operations/README.ja.md
@@ -90,7 +90,9 @@ session end の精度が重要なら、明示的な end hook を持つ client in
 
 ### active ingestion 中に cleanup を強く走らせる
 
-`traceary store gc` は古い row を削除したあとに `VACUUM` を実行します。
+`traceary store gc` は論理rowだけを回収します。filesystem容量の回収は
+`traceary store compact plan --db-path PATH`でpreviewし、in-place `VACUUM`ではなく
+safe compaction engineに物理置換とrollbackを任せます。
 同じ DB に対して多くの session が書き込んでいる最中に、強めの cleanup を background maintenance のように常時回す前提ではありません。
 先に backup を取り、比較的静かなタイミングで実行してください。
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -90,7 +90,9 @@ Treat this as a dogfood review signal, not as automatic cleanup. The check inten
 
 ### Concurrent cleanup versus active ingestion
 
-`traceary store gc` deletes old rows and then runs `VACUUM`.
+`traceary store gc` reclaims logical rows only. Preview filesystem reclamation
+with `traceary store compact plan --db-path PATH`; the safe compaction engine,
+not an in-place `VACUUM`, owns physical replacement and rollback.
 Do not treat aggressive cleanup as a background maintenance task while many sessions are actively writing to the same DB.
 Take a backup first and prefer running cleanup during a quieter period.
 

--- a/docs/operations/search-maintenance.ja.md
+++ b/docs/operations/search-maintenance.ja.md
@@ -2,6 +2,10 @@
 
 [English](search-maintenance.md)
 
+storage compactionの前に[`safe-compaction.ja.md`](../storage/safe-compaction.ja.md)
+のpreview-first手順を実行してください。compaction成功後もv0.35のsearch policy
+activationはdeferしたままです。
+
 Traceary v0.34 は、通常検索の authority を projection table の存在とは
 独立して記録します。既存 store と upgrade 済み store の初期状態は
 `legacy/active` です。migration と通常起動は legacy 検索データを削除、

--- a/docs/operations/search-maintenance.md
+++ b/docs/operations/search-maintenance.md
@@ -2,6 +2,10 @@
 
 [日本語](search-maintenance.ja.md)
 
+Before storage compaction, follow the preview-first sequence in
+[`safe-compaction.md`](../storage/safe-compaction.md). Search-policy activation
+for v0.35 remains deferred even when compaction succeeds.
+
 Traceary v0.34 records normal-search authority independently of projection
 table presence. Existing and upgraded stores start in `legacy/active`.
 Migration and normal startup never delete, drop, or vacuum legacy search data.

--- a/docs/storage/README.ja.md
+++ b/docs/storage/README.ja.md
@@ -163,7 +163,8 @@ Durable memory に紐づく artifact ref です。
 - 既定 target: `all` (`--target all`)
 - 利用可能な target: `events`, `sessions`, `memories`, `memory_edges`, `all`
 - `--dry-run`: 同じ削除計画を rollback される transaction 内で実行し、候補件数だけ表示
-- 非 dry-run で削除があった場合は `VACUUM` を実行
+- 物理容量回収は分離し、`traceary store compact plan --db-path PATH`でpreviewする。
+  GCはin-place `VACUUM`を実行しない
 
 target ごとの policy:
 

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -164,7 +164,8 @@ If you need a portable copy, use `traceary store backup create` instead of editi
 - default target: `all` (`--target all`)
 - available targets: `events`, `sessions`, `memories`, `memory_edges`, `all`
 - `--dry-run`: run the same deletion plan inside a rolled-back transaction and print only the candidate count
-- after a non-dry-run deletion, Traceary runs `VACUUM`
+- physical reclamation is separate: preview `traceary store compact plan
+  --db-path PATH`; GC never runs an in-place `VACUUM`
 
 Target policies:
 

--- a/docs/storage/archive-before-gc.ja.md
+++ b/docs/storage/archive-before-gc.ja.md
@@ -12,7 +12,7 @@ Epic #1309 · 設計スライス #1370 · 親カット #1360。
 |---|---|
 | **目的** | マルチ GB の live SQLite を、履歴を黙って捨てずに縮小する。対象行を版付き・完全性検証済み（任意で暗号化）archive に export し、**検証後に限り** archive 済み identity だけを live DB から削除する。 |
 | **現状** | `traceary store gc` は `--keep-days` に基づき hard delete。フルファイル backup と portable bundle はあるが、GC 対象 cold 行の stream archive + verify-before-delete ではない。 |
-| **期待する振る舞い** | dry-run 優先の plan → stream export → manifest / digest 検証（密封時は decrypt 往復）→ 厳密 ID 削除 → 任意 VACUUM。restore は idempotent。失敗時 live DB は不変。 |
+| **期待する振る舞い** | dry-run優先plan → stream export → manifest/digest検証（密封時はdecrypt往復）→厳密ID削除。物理容量回収は別のsafe-compaction plan/applyで行い、in-place VACUUMは使わない。restoreはidempotent。失敗時live DBは不変。 |
 | **非対象** | Compressed VFS / ZIPVFS、ネットワーク退避、既定 retention の auto-archive 化、フル backup の置換、memory の auto-accept。 |
 
 ### v0.28.0 リリース姿勢
@@ -105,7 +105,7 @@ traceary store archive restore --input PATH [--dry-run] [--passphrase-env NAME]
 | export 途中 | 不完全ファイル | `PATH.partial` + fsync + atomic rename |
 | export 済・未 verify | 孤児 archive | 安全。verify 再実行可 |
 | verify 後・delete 途中 | 部分削除 | 単一トランザクション |
-| delete 後 VACUUM 失敗 | 領域未回収 | データ整合は維持、エラー報告 |
+| delete後compaction未適用 | 領域未回収 | データ整合を維持し、別のsafe-compaction planをpreview |
 | 自動 worker 競合 | 二重 archive | DB 単位 lease + interval (#1372) |
 | restore 衝突 | 黙上書き | v1: skip+報告 |
 

--- a/docs/storage/archive-before-gc.md
+++ b/docs/storage/archive-before-gc.md
@@ -12,7 +12,7 @@ This document is the **Structure-Behavior Design Note** and **versioned archive 
 |---|---|
 | **Purpose** | Let operators shrink multi-GB live SQLite stores without silently losing cold history: export eligible rows into a versioned, integrity-checked (and optionally encrypted) archive, **verify**, then delete only the exact archived identities from the live DB. |
 | **Status quo** | `traceary store gc` hard-deletes aged rows (events/sessions/memories/edges) under `--keep-days`. There is full-file backup (`store backup`) and portable encrypted bundle (`store bundle`), but neither is a stream archive of GC-eligible cold rows with verify-before-delete. |
-| **Expected behavior** | Dry-run-first archive plan → stream export → manifest + digest verification (+ decrypt round-trip when sealed) → delete exact IDs → optional VACUUM. Restore re-imports archived identities idempotently. Failures leave the live DB unchanged. |
+| **Expected behavior** | Dry-run-first archive plan → stream export → manifest + digest verification (+ decrypt round-trip when sealed) → delete exact IDs. Physical reclamation is a separate safe-compaction plan/apply workflow; no in-place VACUUM. Restore re-imports archived identities idempotently. Failures leave the live DB unchanged. |
 | **Non-goals (this design)** | Compressed VFS / ZIPVFS; network offload; changing default retention to auto-archive; rewriting full-file backup; auto-accept of memories. |
 
 ### Release posture (v0.28.0)
@@ -158,7 +158,7 @@ Any failure → abort; live DB unchanged; leave archive file as-is for inspectio
 | Mid-export write | Partial file | Write to `PATH.partial` + fsync + atomic rename |
 | Export done, verify not run | Orphan archive | Safe; operator re-runs verify |
 | Verify OK, delete mid-transaction | Partial delete | Single SQLite transaction for all deletes; rollback on error |
-| Delete committed, VACUUM fails | Space not reclaimed | Report VACUUM error; data already consistent |
+| Delete committed, compaction not yet applied | Space not reclaimed | Keep data consistent; preview the separate safe-compaction plan |
 | Auto worker concurrent | Double archive / race | Per-DB exclusive lease file + interval marker (#1372) |
 | Restore into divergent live row | Silent clobber | v1 skip+report conflict; never overwrite different content |
 

--- a/docs/storage/safe-compaction.ja.md
+++ b/docs/storage/safe-compaction.ja.md
@@ -30,3 +30,21 @@ filesystem安全性は協調モデルです。参加するlive openerはすべ�
 中断後は `resume` を使います。journalの最終行ではなくファイルidentity
 から向きを判定します。元へ戻す場合は `rollback` を使います。確認完了前に
 `.traceary-compaction` journalやrollback artifactを削除しないでください。
+
+## preview-first maintenance手順
+
+1. live storeをcopyまたはbackupし、旧版・非協調processを停止します。
+2. `traceary store compact plan --db-path /path/to/traceary.db`を実行します。
+   payload/projection allocation、reclaimable page、filesystem headroom、実測診断
+   latencyを確認し、file sizeだけでapplyを決めません。
+3. review済みcopyで互換性preflightとscrubを完了します。in-place `VACUUM`は
+   実行しません。
+4. plan成功後だけ`compact apply RUN_ID`を実行します。safe engineがcandidateを
+   構築・scrubし、atomic swap後も元inodeをrollback用に保持します。
+5. 通常readを検証してからrollback artifactを削除します。失敗時は
+   `compact rollback RUN_ID`を使います。
+6. 中断後は`compact status RUN_ID`と`compact resume RUN_ID`を使い、candidateや
+   rollback fileを手動renameしません。
+
+v0.35のpayload/search policy activationは明示的にdeferします。v0.34 compaction
+成功はstorage mechanicsの証明であり、次のpolicyを有効化する許可ではありません。

--- a/docs/storage/safe-compaction.md
+++ b/docs/storage/safe-compaction.md
@@ -39,3 +39,22 @@ After interruption, use `resume`; it derives file orientation from identities.
 Use `rollback` to atomically restore the retained original. Never delete the
 external `.traceary-compaction` journal or rollback artifact until the run has
 been inspected and accepted.
+
+## Preview-first maintenance sequence
+
+1. Copy or back up the live store and stop older/non-cooperating processes.
+2. Run `traceary store compact plan --db-path /path/to/traceary.db`. Review
+   payload/projection allocation, reclaimable pages, filesystem headroom, and
+   measured diagnostic latency; file size alone is not an apply decision.
+3. Complete compatibility preflight and scrub on the reviewed copy. Never run
+   an in-place `VACUUM`.
+4. Run `compact apply RUN_ID` only after the plan passes. The safe engine builds
+   and scrubs a candidate, atomically swaps it, and retains the original inode.
+5. Verify normal reads before deleting rollback artifacts. Use `compact
+   rollback RUN_ID` if verification fails.
+6. After interruption, use `compact status RUN_ID` and `compact resume RUN_ID`;
+   never manually rename candidate or rollback files.
+
+Activation of the v0.35 payload/search policy is deliberately deferred. A
+successful v0.34 compaction proves storage mechanics, not permission to enable
+the next policy.

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -282,16 +282,16 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved DB path: %s", "解決した DB パス: %s", resolvedDBPath),
 	})
-	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
-		info, _ := os.Stat(resolvedDBPath)
-		report.Checks = append(report.Checks, unknownStoreGrowthCheck(info.Size(), resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
+	snapshot := inspectStoreFileSnapshot(resolvedDBPath, os.Stat)
+	if isLargeStoreForBoundedDoctor(snapshot) {
+		report.Checks = append(report.Checks, unknownStoreGrowthCheck(snapshot.Size, resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
 	} else {
-		report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath))
+		report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath, snapshot))
 	}
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
-	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
+	if isLargeStoreForBoundedDoctor(snapshot) {
 		report.Mode = doctorModeMetadataOnlyLargeStore
-		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(resolvedDBPath))
+		report.Checks = append(report.Checks, boundedLargeStoreDoctorCheck(snapshot))
 		// This is an intentional, successful bounded outcome. Do not initialize
 		// SQLite, list events, scan hook spools, or inspect client state here:
 		// those operations can block behind a live writer and some inspect event

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -281,7 +282,12 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved DB path: %s", "解決した DB パス: %s", resolvedDBPath),
 	})
-	report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath))
+	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
+		info, _ := os.Stat(resolvedDBPath)
+		report.Checks = append(report.Checks, unknownStoreGrowthCheck(info.Size(), resolvedDBPath, "default doctor is filesystem-metadata-only for stores at or above 2 GiB; inspect a reviewed copy for detailed signals"))
+	} else {
+		report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath))
+	}
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
 	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
 		report.Mode = doctorModeMetadataOnlyLargeStore

--- a/presentation/cli/doctor.go
+++ b/presentation/cli/doctor.go
@@ -281,7 +281,7 @@ func (c *RootCLI) buildDoctorReport(ctx context.Context, input doctorCommandInpu
 		Status:  doctorStatusPass,
 		Message: localizef("resolved DB path: %s", "解決した DB パス: %s", resolvedDBPath),
 	})
-	report.Checks = append(report.Checks, inspectStoreSizeBudget(resolvedDBPath))
+	report.Checks = append(report.Checks, c.inspectStoreGrowthBudget(ctx, resolvedDBPath))
 	report.Checks = append(report.Checks, inspectTracearyOnPath())
 	if isLargeStoreForBoundedDoctor(resolvedDBPath) {
 		report.Mode = doctorModeMetadataOnlyLargeStore

--- a/presentation/cli/doctor_disk_unix.go
+++ b/presentation/cli/doctor_disk_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package cli
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"path/filepath"
+)
+
+func inspectDoctorDiskFree(path string) (int64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(filepath.Dir(path), &stat); err != nil {
+		return 0, fmt.Errorf("inspect doctor disk headroom: %w", err)
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/presentation/cli/doctor_disk_unix.go
+++ b/presentation/cli/doctor_disk_unix.go
@@ -3,8 +3,10 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"golang.org/x/sys/unix"
+	"math"
 	"path/filepath"
 )
 
@@ -13,5 +15,19 @@ func inspectDoctorDiskFree(path string) (int64, error) {
 	if err := unix.Statfs(filepath.Dir(path), &stat); err != nil {
 		return 0, fmt.Errorf("inspect doctor disk headroom: %w", err)
 	}
-	return int64(stat.Bavail) * int64(stat.Bsize), nil
+	bavail, blockSize := uint64(stat.Bavail), uint64(stat.Bsize)
+	if bavail > math.MaxInt64 || blockSize > math.MaxInt64 {
+		return 0, errors.New("doctor disk headroom fields exceed signed range")
+	}
+	return checkedDoctorDiskFree(int64(bavail), int64(blockSize))
+}
+
+func checkedDoctorDiskFree(availableBlocks, blockSize int64) (int64, error) {
+	if availableBlocks < 0 || blockSize <= 0 {
+		return 0, errors.New("doctor disk headroom fields are negative or zero")
+	}
+	if availableBlocks > math.MaxInt64/blockSize {
+		return 0, errors.New("doctor disk headroom overflows")
+	}
+	return availableBlocks * blockSize, nil
 }

--- a/presentation/cli/doctor_disk_unix_test.go
+++ b/presentation/cli/doctor_disk_unix_test.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package cli
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCheckedDoctorDiskFreeRejectsInvalidAndOverflow(t *testing.T) {
+	for _, tc := range []struct {
+		blocks, size int64
+		ok           bool
+	}{{0, 4096, true}, {1, 4096, true}, {-1, 4096, false}, {1, -1, false}, {math.MaxInt64, 2, false}, {math.MaxInt64, 1, true}} {
+		got, err := checkedDoctorDiskFree(tc.blocks, tc.size)
+		if (err == nil) != tc.ok {
+			t.Fatalf("blocks=%d size=%d got=%d err=%v", tc.blocks, tc.size, got, err)
+		}
+	}
+}

--- a/presentation/cli/doctor_disk_unsupported.go
+++ b/presentation/cli/doctor_disk_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package cli
+
+import "errors"
+
+func inspectDoctorDiskFree(string) (int64, error) {
+	return 0, errors.New("disk headroom inspection unsupported")
+}

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -14,17 +14,23 @@ import (
 const storeSizeWarnBytes int64 = 1 << 30 // 1 GiB
 
 const (
-	payloadGrowthWarnBytes    = int64(512 << 20)
-	projectionGrowthWarnBytes = int64(256 << 20)
-	doctorGrowthLatencyWarn   = 2 * time.Second
+	payloadGrowthWarnBytes     = int64(512 << 20)
+	projectionGrowthWarnBytes  = int64(256 << 20)
+	doctorGrowthLatencyWarn    = 1500 * time.Millisecond
+	doctorGrowthInspectTimeout = 2 * time.Second
 )
 
 type storeGrowthEvidence struct {
-	DatabaseBytes, PayloadBytes, ProjectionBytes, ReclaimableBytes, FilesystemFreeBytes int64
-	MeasuredLatency                                                                     time.Duration
+	DatabaseBytes, EventPayloadBytes, ProjectionBytes, ReclaimableBytes, FilesystemFreeBytes int64
+	FilesystemFreeAvailable                                                                  bool
+	MeasuredLatency                                                                          time.Duration
 }
 
 func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) doctorCheck {
+	return c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, time.Now)
+}
+
+func (c *RootCLI) inspectStoreGrowthBudgetWithClock(ctx context.Context, dbPath string, now func() time.Time) doctorCheck {
 	info, err := os.Stat(dbPath)
 	if err != nil {
 		return inspectStoreSizeBudget(dbPath)
@@ -32,11 +38,11 @@ func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) d
 	if c.capacityInspector == nil {
 		return unknownStoreGrowthCheck(info.Size(), dbPath, "capacity inspector unavailable")
 	}
-	inspectCtx, cancel := context.WithTimeout(ctx, doctorGrowthLatencyWarn)
+	inspectCtx, cancel := context.WithTimeout(ctx, doctorGrowthInspectTimeout)
 	defer cancel()
-	started := time.Now()
+	started := now()
 	report, err := c.capacityInspector.InspectCapacity(inspectCtx)
-	latency := time.Since(started)
+	latency := now().Sub(started)
 	if err != nil {
 		return unknownStoreGrowthCheck(info.Size(), dbPath, "bounded capacity signals unavailable or timed out")
 	}
@@ -45,7 +51,7 @@ func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) d
 		evidence.DatabaseBytes = info.Size()
 	}
 	for _, payload := range report.PayloadClasses {
-		evidence.PayloadBytes += payload.Bytes
+		evidence.EventPayloadBytes += payload.Bytes
 	}
 	for _, object := range report.Objects {
 		name := strings.ToLower(object.Name)
@@ -55,6 +61,7 @@ func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) d
 	}
 	if free, freeErr := inspectDoctorDiskFree(dbPath); freeErr == nil {
 		evidence.FilesystemFreeBytes = free
+		evidence.FilesystemFreeAvailable = true
 	}
 	check := evaluateStoreGrowthBudget(evidence)
 	check.FixCommand = "traceary store compact plan --db-path " + shellQuote(dbPath)
@@ -67,28 +74,41 @@ func unknownStoreGrowthCheck(size int64, dbPath, reason string) doctorCheck {
 
 func evaluateStoreGrowthBudget(e storeGrowthEvidence) doctorCheck {
 	reasons := make([]string, 0, 5)
-	if e.DatabaseBytes >= storeSizeWarnBytes {
-		reasons = append(reasons, "database")
-	}
-	if e.PayloadBytes >= payloadGrowthWarnBytes {
-		reasons = append(reasons, "payload")
+	if e.EventPayloadBytes >= payloadGrowthWarnBytes {
+		reasons = append(reasons, "event_payload")
 	}
 	if e.ProjectionBytes >= projectionGrowthWarnBytes {
 		reasons = append(reasons, "projection")
 	}
-	if e.ReclaimableBytes >= 256<<20 && e.ReclaimableBytes*10 >= e.DatabaseBytes {
+	if e.ReclaimableBytes >= 256<<20 && ratioAtLeast(e.ReclaimableBytes, e.DatabaseBytes, 10) {
 		reasons = append(reasons, "reclaimable")
 	}
-	if e.FilesystemFreeBytes > 0 && e.FilesystemFreeBytes < maxInt64(1<<30, e.DatabaseBytes*2) {
+	if !e.FilesystemFreeAvailable {
+		reasons = append(reasons, "headroom_unknown")
+	} else if e.FilesystemFreeBytes <= compactionHeadroomThreshold(e.DatabaseBytes) {
 		reasons = append(reasons, "headroom")
 	}
 	if e.MeasuredLatency >= doctorGrowthLatencyWarn {
 		reasons = append(reasons, "latency")
 	}
 	if len(reasons) == 0 {
-		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: localizef("store growth signals are within budget: database=%s payload=%s projection=%s free=%s latency=%s", "store growth signal は予算内です: database=%s payload=%s projection=%s free=%s latency=%s", formatByteSize(e.DatabaseBytes), formatByteSize(e.PayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond))}
+		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: localizef("store growth signals are within budget: database=%s event_payload=%s projection=%s free=%s latency=%s", "store growth signal は予算内です: database=%s event_payload=%s projection=%s free=%s latency=%s", formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond))}
 	}
-	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth warning (%s): database=%s payload=%s projection=%s free=%s measured_latency=%s", "store growth warning (%s): database=%s payload=%s projection=%s free=%s measured_latency=%s", strings.Join(reasons, ","), formatByteSize(e.DatabaseBytes), formatByteSize(e.PayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond)), Hint: Localize("preview safe compaction first, then follow the reviewed copy/preflight/scrub/compact/swap workflow; retain rollback artifacts until verification succeeds", "まずsafe compactionをpreviewし、その後review済みのcopy/preflight/scrub/compact/swap手順を実行してください。検証成功までrollback artifactを保持してください"), FixCommand: "traceary store compact plan"}
+	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", "store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", strings.Join(reasons, ","), formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond)), Hint: Localize("preview safe compaction first, then follow the reviewed copy/preflight/scrub/compact/swap workflow; retain rollback artifacts until verification succeeds", "まずsafe compactionをpreviewし、その後review済みのcopy/preflight/scrub/compact/swap手順を実行してください。検証成功までrollback artifactを保持してください"), FixCommand: "traceary store compact plan"}
+}
+
+func compactionHeadroomThreshold(databaseBytes int64) int64 {
+	if databaseBytes > (int64(^uint64(0)>>1))/2 {
+		return int64(^uint64(0) >> 1)
+	}
+	return maxInt64(1<<30, databaseBytes*2)
+}
+
+func ratioAtLeast(part, total, denominator int64) bool {
+	if part <= 0 || total <= 0 || denominator <= 0 {
+		return false
+	}
+	return part >= (total+denominator-1)/denominator
 }
 
 func maxInt64(a, b int64) int64 {

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -26,17 +26,39 @@ type storeGrowthEvidence struct {
 	MeasuredLatency                                                                          time.Duration
 }
 
-func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) doctorCheck {
-	return c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, time.Now)
+type storeFileSnapshot struct {
+	Size            int64
+	Regular, Exists bool
+	Err             error
 }
 
-func (c *RootCLI) inspectStoreGrowthBudgetWithClock(ctx context.Context, dbPath string, now func() time.Time) doctorCheck {
-	info, err := os.Stat(dbPath)
+func inspectStoreFileSnapshot(path string, stat func(string) (os.FileInfo, error)) storeFileSnapshot {
+	info, err := stat(path)
 	if err != nil {
-		return inspectStoreSizeBudget(dbPath)
+		if os.IsNotExist(err) {
+			return storeFileSnapshot{}
+		}
+		return storeFileSnapshot{Err: err}
+	}
+	return storeFileSnapshot{Size: info.Size(), Regular: info.Mode().IsRegular(), Exists: true}
+}
+
+func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string, snapshot storeFileSnapshot) doctorCheck {
+	return c.inspectStoreGrowthBudgetWithClock(ctx, dbPath, snapshot, time.Now)
+}
+
+func (c *RootCLI) inspectStoreGrowthBudgetWithClock(ctx context.Context, dbPath string, snapshot storeFileSnapshot, now func() time.Time) doctorCheck {
+	if snapshot.Err != nil {
+		return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("failed to inspect SQLite store metadata: %v", "SQLite store metadataを確認できません: %v", snapshot.Err)}
+	}
+	if !snapshot.Exists {
+		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: Localize("SQLite store file does not exist yet (no size budget concern)", "SQLite ストアファイルはまだありません（サイズ予算の懸念なし）")}
+	}
+	if !snapshot.Regular {
+		return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: Localize("SQLite store path is not a regular file", "SQLite store pathはregular fileではありません")}
 	}
 	if c.capacityInspector == nil {
-		return unknownStoreGrowthCheck(info.Size(), dbPath, "capacity inspector unavailable")
+		return unknownStoreGrowthCheck(snapshot.Size, dbPath, "capacity inspector unavailable")
 	}
 	inspectCtx, cancel := context.WithTimeout(ctx, doctorGrowthInspectTimeout)
 	defer cancel()
@@ -44,11 +66,11 @@ func (c *RootCLI) inspectStoreGrowthBudgetWithClock(ctx context.Context, dbPath 
 	report, err := c.capacityInspector.InspectCapacity(inspectCtx)
 	latency := now().Sub(started)
 	if err != nil {
-		return unknownStoreGrowthCheck(info.Size(), dbPath, "bounded capacity signals unavailable or timed out")
+		return unknownStoreGrowthCheck(snapshot.Size, dbPath, "bounded capacity signals unavailable or timed out")
 	}
 	evidence := storeGrowthEvidence{DatabaseBytes: report.DatabaseBytes, ReclaimableBytes: report.FreeBytes, MeasuredLatency: latency}
 	if evidence.DatabaseBytes == 0 {
-		evidence.DatabaseBytes = info.Size()
+		evidence.DatabaseBytes = snapshot.Size
 	}
 	for _, payload := range report.PayloadClasses {
 		evidence.EventPayloadBytes += payload.Bytes
@@ -92,9 +114,16 @@ func evaluateStoreGrowthBudget(e storeGrowthEvidence) doctorCheck {
 		reasons = append(reasons, "latency")
 	}
 	if len(reasons) == 0 {
-		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: localizef("store growth signals are within budget: database=%s event_payload=%s projection=%s free=%s latency=%s", "store growth signal は予算内です: database=%s event_payload=%s projection=%s free=%s latency=%s", formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond))}
+		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: localizef("store growth signals are within budget: database=%s event_payload=%s projection=%s free=%s latency=%s", "store growth signal は予算内です: database=%s event_payload=%s projection=%s free=%s latency=%s", formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatDoctorFree(e), e.MeasuredLatency.Round(time.Millisecond))}
 	}
-	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", "store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", strings.Join(reasons, ","), formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond)), Hint: Localize("preview safe compaction first, then follow the reviewed copy/preflight/scrub/compact/swap workflow; retain rollback artifacts until verification succeeds", "まずsafe compactionをpreviewし、その後review済みのcopy/preflight/scrub/compact/swap手順を実行してください。検証成功までrollback artifactを保持してください"), FixCommand: "traceary store compact plan"}
+	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", "store growth warning (%s): database=%s event_payload=%s projection=%s free=%s measured_latency=%s", strings.Join(reasons, ","), formatByteSize(e.DatabaseBytes), formatByteSize(e.EventPayloadBytes), formatByteSize(e.ProjectionBytes), formatDoctorFree(e), e.MeasuredLatency.Round(time.Millisecond)), Hint: Localize("preview safe compaction first, then follow the reviewed copy/preflight/scrub/compact/swap workflow; retain rollback artifacts until verification succeeds", "まずsafe compactionをpreviewし、その後review済みのcopy/preflight/scrub/compact/swap手順を実行してください。検証成功までrollback artifactを保持してください"), FixCommand: "traceary store compact plan"}
+}
+
+func formatDoctorFree(e storeGrowthEvidence) string {
+	if !e.FilesystemFreeAvailable {
+		return "unknown"
+	}
+	return formatByteSize(e.FilesystemFreeBytes)
 }
 
 func compactionHeadroomThreshold(databaseBytes int64) int64 {
@@ -130,18 +159,16 @@ const (
 // isLargeStoreForBoundedDoctor uses only filesystem metadata. It must remain
 // independent of SQLite so the bounded doctor outcome is still available when
 // a writer holds the database lock or the store is otherwise unhealthy.
-func isLargeStoreForBoundedDoctor(dbPath string) bool {
-	info, err := os.Stat(dbPath)
-	return err == nil && info.Mode().IsRegular() && info.Size() >= doctorLargeStoreMetadataOnlyBytes
+func isLargeStoreForBoundedDoctor(snapshot storeFileSnapshot) bool {
+	return snapshot.Err == nil && snapshot.Exists && snapshot.Regular && snapshot.Size >= doctorLargeStoreMetadataOnlyBytes
 }
 
-func boundedLargeStoreDoctorCheck(dbPath string) doctorCheck {
-	info, err := os.Stat(dbPath)
-	if err != nil {
+func boundedLargeStoreDoctorCheck(snapshot storeFileSnapshot) doctorCheck {
+	if snapshot.Err != nil || !snapshot.Exists || !snapshot.Regular {
 		return doctorCheck{
 			Name:    "large-store-diagnostics",
 			Status:  doctorStatusFail,
-			Message: localizef("failed to stat large SQLite store metadata: %v", "大容量 SQLite ストアの metadata を確認できませんでした: %v", err),
+			Message: Localize("failed to use large SQLite store metadata snapshot", "大容量SQLite storeのmetadata snapshotを使用できません"),
 		}
 	}
 	return doctorCheck{
@@ -150,7 +177,7 @@ func boundedLargeStoreDoctorCheck(dbPath string) doctorCheck {
 		Message: localizef(
 			"bounded metadata-only doctor result for %s store: SQLite open, migrations, event bodies, command payloads, hook spools, credentials, and identifier samples were not read",
 			"%s のストアに対する bounded metadata-only doctor 結果です。SQLite の open、migration、event body、command payload、hook spool、credential、identifier sample は読み取りませんでした",
-			formatByteSize(info.Size()),
+			formatByteSize(snapshot.Size),
 		),
 		Hint: Localize(
 			"this is capacity-safe, not a lock diagnosis. Stop competing writers or use a reviewed bounded copy, then retry diagnostics. Preview safe remediation with `traceary store compact plan --db-path PATH`.",

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -137,7 +137,11 @@ func ratioAtLeast(part, total, denominator int64) bool {
 	if part <= 0 || total <= 0 || denominator <= 0 {
 		return false
 	}
-	return part >= (total+denominator-1)/denominator
+	threshold := total / denominator
+	if total%denominator > 0 {
+		threshold++
+	}
+	return part >= threshold
 }
 
 func maxInt64(a, b int64) int64 {

--- a/presentation/cli/doctor_store_size.go
+++ b/presentation/cli/doctor_store_size.go
@@ -1,14 +1,102 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 )
 
 // storeSizeWarnBytes is the on-disk size above which multi-GB cold opens
 // routinely approach host hook budgets (10s packaged). Measured dogfood
 // stores around 2.4 GB already spend 2–4 s on cold open alone.
 const storeSizeWarnBytes int64 = 1 << 30 // 1 GiB
+
+const (
+	payloadGrowthWarnBytes    = int64(512 << 20)
+	projectionGrowthWarnBytes = int64(256 << 20)
+	doctorGrowthLatencyWarn   = 2 * time.Second
+)
+
+type storeGrowthEvidence struct {
+	DatabaseBytes, PayloadBytes, ProjectionBytes, ReclaimableBytes, FilesystemFreeBytes int64
+	MeasuredLatency                                                                     time.Duration
+}
+
+func (c *RootCLI) inspectStoreGrowthBudget(ctx context.Context, dbPath string) doctorCheck {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return inspectStoreSizeBudget(dbPath)
+	}
+	if c.capacityInspector == nil {
+		return unknownStoreGrowthCheck(info.Size(), dbPath, "capacity inspector unavailable")
+	}
+	inspectCtx, cancel := context.WithTimeout(ctx, doctorGrowthLatencyWarn)
+	defer cancel()
+	started := time.Now()
+	report, err := c.capacityInspector.InspectCapacity(inspectCtx)
+	latency := time.Since(started)
+	if err != nil {
+		return unknownStoreGrowthCheck(info.Size(), dbPath, "bounded capacity signals unavailable or timed out")
+	}
+	evidence := storeGrowthEvidence{DatabaseBytes: report.DatabaseBytes, ReclaimableBytes: report.FreeBytes, MeasuredLatency: latency}
+	if evidence.DatabaseBytes == 0 {
+		evidence.DatabaseBytes = info.Size()
+	}
+	for _, payload := range report.PayloadClasses {
+		evidence.PayloadBytes += payload.Bytes
+	}
+	for _, object := range report.Objects {
+		name := strings.ToLower(object.Name)
+		if strings.Contains(name, "search") || strings.Contains(name, "projection") {
+			evidence.ProjectionBytes += object.Bytes
+		}
+	}
+	if free, freeErr := inspectDoctorDiskFree(dbPath); freeErr == nil {
+		evidence.FilesystemFreeBytes = free
+	}
+	check := evaluateStoreGrowthBudget(evidence)
+	check.FixCommand = "traceary store compact plan --db-path " + shellQuote(dbPath)
+	return check
+}
+
+func unknownStoreGrowthCheck(size int64, dbPath, reason string) doctorCheck {
+	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth signals are unknown (%s); database metadata size=%s alone is not enough to select remediation", "store growth signal は不明です (%s)。database metadata size=%s だけではremediationを選択できません", reason, formatByteSize(size)), Hint: Localize("retry bounded diagnostics without competing writers; preview the safe compaction plan before any mutation", "競合writerなしでbounded diagnosticsを再実行し、変更前にsafe compaction planをpreviewしてください"), FixCommand: "traceary store compact plan --db-path " + shellQuote(dbPath)}
+}
+
+func evaluateStoreGrowthBudget(e storeGrowthEvidence) doctorCheck {
+	reasons := make([]string, 0, 5)
+	if e.DatabaseBytes >= storeSizeWarnBytes {
+		reasons = append(reasons, "database")
+	}
+	if e.PayloadBytes >= payloadGrowthWarnBytes {
+		reasons = append(reasons, "payload")
+	}
+	if e.ProjectionBytes >= projectionGrowthWarnBytes {
+		reasons = append(reasons, "projection")
+	}
+	if e.ReclaimableBytes >= 256<<20 && e.ReclaimableBytes*10 >= e.DatabaseBytes {
+		reasons = append(reasons, "reclaimable")
+	}
+	if e.FilesystemFreeBytes > 0 && e.FilesystemFreeBytes < maxInt64(1<<30, e.DatabaseBytes*2) {
+		reasons = append(reasons, "headroom")
+	}
+	if e.MeasuredLatency >= doctorGrowthLatencyWarn {
+		reasons = append(reasons, "latency")
+	}
+	if len(reasons) == 0 {
+		return doctorCheck{Name: "store-size", Status: doctorStatusPass, Message: localizef("store growth signals are within budget: database=%s payload=%s projection=%s free=%s latency=%s", "store growth signal は予算内です: database=%s payload=%s projection=%s free=%s latency=%s", formatByteSize(e.DatabaseBytes), formatByteSize(e.PayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond))}
+	}
+	return doctorCheck{Name: "store-size", Status: doctorStatusWarn, Message: localizef("store growth warning (%s): database=%s payload=%s projection=%s free=%s measured_latency=%s", "store growth warning (%s): database=%s payload=%s projection=%s free=%s measured_latency=%s", strings.Join(reasons, ","), formatByteSize(e.DatabaseBytes), formatByteSize(e.PayloadBytes), formatByteSize(e.ProjectionBytes), formatByteSize(e.FilesystemFreeBytes), e.MeasuredLatency.Round(time.Millisecond)), Hint: Localize("preview safe compaction first, then follow the reviewed copy/preflight/scrub/compact/swap workflow; retain rollback artifacts until verification succeeds", "まずsafe compactionをpreviewし、その後review済みのcopy/preflight/scrub/compact/swap手順を実行してください。検証成功までrollback artifactを保持してください"), FixCommand: "traceary store compact plan"}
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
 
 const (
 	doctorModeMetadataOnlyLargeStore = "metadata_only_large_store"
@@ -45,10 +133,10 @@ func boundedLargeStoreDoctorCheck(dbPath string) doctorCheck {
 			formatByteSize(info.Size()),
 		),
 		Hint: Localize(
-			"this is capacity-safe, not a lock diagnosis. If an application needs a content diagnostic, first stop competing writers or use a reviewed bounded copy; then run the specific read command. Preview safe remediation with `traceary store gc --dry-run` and archive before applying retention.",
-			"これは capacity-safe な結果であり lock 診断ではありません。content diagnostic が必要なら、競合 writer を停止するか、review 済みの bounded copy を使用してから個別の read command を実行してください。安全な remediation は `traceary store gc --dry-run` でプレビューし、retention を適用する前に archive を作成してください。",
+			"this is capacity-safe, not a lock diagnosis. Stop competing writers or use a reviewed bounded copy, then retry diagnostics. Preview safe remediation with `traceary store compact plan --db-path PATH`.",
+			"これは capacity-safe な結果であり lock 診断ではありません。競合 writer を停止するかreview済みbounded copyを使って診断を再実行し、`traceary store compact plan --db-path PATH`で安全なremediationをpreviewしてください。",
 		),
-		FixCommand: "traceary store gc --dry-run",
+		FixCommand: "traceary store compact plan",
 	}
 }
 
@@ -90,10 +178,10 @@ func inspectStoreSizeBudget(dbPath string) doctorCheck {
 			formatByteSize(size),
 		),
 		Hint: Localize(
-			"run `traceary store gc --dry-run` then apply when safe; archive-before-GC is tracked separately. Prefer keeping the live store under ~1 GiB for multi-host dogfood.",
-			"`traceary store gc --dry-run` で確認後、安全なら適用してください。archive-before-GC は別 issue です。multi-host dogfood では live store をおおよそ 1 GiB 未満に保つことを推奨します。",
+			"preview `traceary store compact plan --db-path PATH`; do not run in-place VACUUM or infer cleanup solely from file size.",
+			"`traceary store compact plan --db-path PATH`でpreviewしてください。in-place VACUUMやfile sizeだけに基づくcleanup判断は行わないでください。",
 		),
-		FixCommand: "traceary store gc --dry-run",
+		FixCommand: "traceary store compact plan --db-path " + shellQuote(dbPath),
 	}
 }
 

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -178,3 +178,27 @@ func TestStoreGrowthMessageDistinguishesUnknownAndMeasuredZeroFree(t *testing.T)
 		t.Fatalf("zero=%q", zero.Message)
 	}
 }
+
+func TestRatioAtLeastIsOverflowSafe(t *testing.T) {
+	maximum := int64(^uint64(0) >> 1)
+	for _, tc := range []struct {
+		name                     string
+		part, total, denominator int64
+		want                     bool
+	}{
+		{"max denominator one equal", maximum, maximum, 1, true},
+		{"max denominator one below", maximum - 1, maximum, 1, false},
+		{"max denominator ten equal", maximum/10 + 1, maximum, 10, true},
+		{"max denominator ten below", maximum / 10, maximum, 10, false},
+		{"max minus nine exact", (maximum-9)/10 + 1, maximum - 9, 10, true},
+		{"max minus nine below", (maximum - 9) / 10, maximum - 9, 10, false},
+		{"zero denominator", 1, maximum, 0, false},
+		{"negative total", 1, -1, 10, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ratioAtLeast(tc.part, tc.total, tc.denominator); got != tc.want {
+				t.Fatalf("got=%t want=%t", got, tc.want)
+			}
+		})
+	}
+}

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -1,17 +1,40 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
 )
 
 func TestInspectStoreSizeBudget_MissingFilePasses(t *testing.T) {
 	check := inspectStoreSizeBudget(filepath.Join(t.TempDir(), "missing.db"))
 	if check.Status != doctorStatusPass {
 		t.Fatalf("check = %#v", check)
+	}
+}
+
+type growthCapacityStub struct{ report apptypes.CapacityReport }
+
+func (s growthCapacityStub) InspectCapacity(context.Context) (apptypes.CapacityReport, error) {
+	return s.report, nil
+}
+
+func TestInspectStoreGrowthBudgetMeasuresCompletedInspectionLatency(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	if err := os.WriteFile(path, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := &RootCLI{capacityInspector: growthCapacityStub{report: apptypes.CapacityReport{DatabaseBytes: 128 << 20}}}
+	times := []time.Time{time.Unix(0, 0), time.Unix(0, 0).Add(1600 * time.Millisecond)}
+	index := 0
+	check := root.inspectStoreGrowthBudgetWithClock(context.Background(), path, func() time.Time { value := times[index]; index++; return value })
+	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "latency") {
+		t.Fatalf("check=%#v", check)
 	}
 }
 
@@ -67,12 +90,12 @@ func TestFormatByteSize(t *testing.T) {
 }
 
 func TestEvaluateStoreGrowthBudgetUsesIndependentSignals(t *testing.T) {
-	base := storeGrowthEvidence{DatabaseBytes: 256 << 20, PayloadBytes: 64 << 20, ProjectionBytes: 32 << 20, FilesystemFreeBytes: 4 << 30, MeasuredLatency: 100 * time.Millisecond}
+	base := storeGrowthEvidence{DatabaseBytes: 256 << 20, EventPayloadBytes: 64 << 20, ProjectionBytes: 32 << 20, FilesystemFreeBytes: 4 << 30, FilesystemFreeAvailable: true, MeasuredLatency: 100 * time.Millisecond}
 	for _, tc := range []struct {
 		name   string
 		mutate func(*storeGrowthEvidence)
 	}{
-		{"payload", func(e *storeGrowthEvidence) { e.PayloadBytes = 512 << 20 }},
+		{"event payload", func(e *storeGrowthEvidence) { e.EventPayloadBytes = 512 << 20 }},
 		{"projection", func(e *storeGrowthEvidence) { e.ProjectionBytes = 256 << 20 }},
 		{"headroom", func(e *storeGrowthEvidence) { e.FilesystemFreeBytes = e.DatabaseBytes }},
 		{"latency", func(e *storeGrowthEvidence) { e.MeasuredLatency = 2 * time.Second }},
@@ -91,5 +114,21 @@ func TestEvaluateStoreGrowthBudgetUsesIndependentSignals(t *testing.T) {
 	}
 	if check := evaluateStoreGrowthBudget(base); check.Status != doctorStatusPass {
 		t.Fatalf("healthy=%#v", check)
+	}
+}
+
+func TestStoreGrowthHeadroomAvailabilityAndOverflow(t *testing.T) {
+	threshold := compactionHeadroomThreshold(512 << 20)
+	for _, free := range []int64{0, 1, threshold - 1, threshold} {
+		check := evaluateStoreGrowthBudget(storeGrowthEvidence{DatabaseBytes: 512 << 20, FilesystemFreeBytes: free, FilesystemFreeAvailable: true})
+		if check.Status != doctorStatusWarn {
+			t.Fatalf("free=%d check=%#v", free, check)
+		}
+	}
+	if check := evaluateStoreGrowthBudget(storeGrowthEvidence{DatabaseBytes: 512 << 20, FilesystemFreeAvailable: false}); check.Status != doctorStatusWarn {
+		t.Fatalf("unavailable=%#v", check)
+	}
+	if got := compactionHeadroomThreshold(int64(^uint64(0) >> 1)); got != int64(^uint64(0)>>1) {
+		t.Fatalf("overflow threshold=%d", got)
 	}
 }

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func TestInspectStoreGrowthBudgetMeasuresCompletedInspectionLatency(t *testing.T
 	root := &RootCLI{capacityInspector: growthCapacityStub{report: apptypes.CapacityReport{DatabaseBytes: 128 << 20}}}
 	times := []time.Time{time.Unix(0, 0), time.Unix(0, 0).Add(1600 * time.Millisecond)}
 	index := 0
-	check := root.inspectStoreGrowthBudgetWithClock(context.Background(), path, func() time.Time { value := times[index]; index++; return value })
+	check := root.inspectStoreGrowthBudgetWithClock(context.Background(), path, inspectStoreFileSnapshot(path, os.Stat), func() time.Time { value := times[index]; index++; return value })
 	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "latency") {
 		t.Fatalf("check=%#v", check)
 	}
@@ -130,5 +131,50 @@ func TestStoreGrowthHeadroomAvailabilityAndOverflow(t *testing.T) {
 	}
 	if got := compactionHeadroomThreshold(int64(^uint64(0) >> 1)); got != int64(^uint64(0)>>1) {
 		t.Fatalf("overflow threshold=%d", got)
+	}
+}
+
+func TestStoreSnapshotSurvivesDeleteAfterSingleStat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.db")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(2 << 30); err != nil {
+		t.Fatal(err)
+	}
+	_ = file.Close()
+	calls := 0
+	snapshot := inspectStoreFileSnapshot(path, func(name string) (os.FileInfo, error) {
+		calls++
+		info, statErr := os.Stat(name)
+		if statErr == nil {
+			_ = os.Remove(name)
+		}
+		if statErr != nil {
+			return nil, fmt.Errorf("stat test store: %w", statErr)
+		}
+		return info, nil
+	})
+	if calls != 1 {
+		t.Fatalf("stat calls=%d", calls)
+	}
+	if !isLargeStoreForBoundedDoctor(snapshot) {
+		t.Fatal("snapshot lost large-store decision after delete")
+	}
+	check := boundedLargeStoreDoctorCheck(snapshot)
+	if check.Status != doctorStatusWarn || !strings.Contains(check.Message, "were not read") {
+		t.Fatalf("check=%#v", check)
+	}
+}
+
+func TestStoreGrowthMessageDistinguishesUnknownAndMeasuredZeroFree(t *testing.T) {
+	unknown := evaluateStoreGrowthBudget(storeGrowthEvidence{DatabaseBytes: 1})
+	zero := evaluateStoreGrowthBudget(storeGrowthEvidence{DatabaseBytes: 1, FilesystemFreeAvailable: true})
+	if !strings.Contains(unknown.Message, "free=unknown") {
+		t.Fatalf("unknown=%q", unknown.Message)
+	}
+	if !strings.Contains(zero.Message, "free=0 B") {
+		t.Fatalf("zero=%q", zero.Message)
 	}
 }

--- a/presentation/cli/doctor_store_size_test.go
+++ b/presentation/cli/doctor_store_size_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestInspectStoreSizeBudget_MissingFilePasses(t *testing.T) {
@@ -51,7 +52,7 @@ func TestInspectStoreSizeBudget_LargeFileWarns(t *testing.T) {
 	if !strings.Contains(check.Message, "large") {
 		t.Fatalf("message = %q", check.Message)
 	}
-	if !strings.Contains(check.Hint, "store gc") {
+	if !strings.Contains(check.Hint, "store compact plan") {
 		t.Fatalf("hint = %q", check.Hint)
 	}
 }
@@ -62,5 +63,33 @@ func TestFormatByteSize(t *testing.T) {
 	}
 	if got := formatByteSize(storeSizeWarnBytes); !strings.Contains(got, "GiB") {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEvaluateStoreGrowthBudgetUsesIndependentSignals(t *testing.T) {
+	base := storeGrowthEvidence{DatabaseBytes: 256 << 20, PayloadBytes: 64 << 20, ProjectionBytes: 32 << 20, FilesystemFreeBytes: 4 << 30, MeasuredLatency: 100 * time.Millisecond}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*storeGrowthEvidence)
+	}{
+		{"payload", func(e *storeGrowthEvidence) { e.PayloadBytes = 512 << 20 }},
+		{"projection", func(e *storeGrowthEvidence) { e.ProjectionBytes = 256 << 20 }},
+		{"headroom", func(e *storeGrowthEvidence) { e.FilesystemFreeBytes = e.DatabaseBytes }},
+		{"latency", func(e *storeGrowthEvidence) { e.MeasuredLatency = 2 * time.Second }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evidence := base
+			tc.mutate(&evidence)
+			check := evaluateStoreGrowthBudget(evidence)
+			if check.Status != doctorStatusWarn {
+				t.Fatalf("check=%#v", check)
+			}
+			if !strings.HasPrefix(check.FixCommand, "traceary store compact plan") {
+				t.Fatalf("fix=%q", check.FixCommand)
+			}
+		})
+	}
+	if check := evaluateStoreGrowthBudget(base); check.Status != doctorStatusPass {
+		t.Fatalf("healthy=%#v", check)
 	}
 }

--- a/presentation/cli/doctor_test.go
+++ b/presentation/cli/doctor_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,13 @@ type doctorReport struct {
 	Summary  doctorSummary   `json:"summary"`
 	ExitCode int             `json:"exit_code"`
 	Fixes    []doctorFixLog  `json:"fixes"`
+}
+
+type panicCapacityInspector struct{ calls int }
+
+func (p *panicCapacityInspector) InspectCapacity(context.Context) (apptypes.CapacityReport, error) {
+	p.calls++
+	panic("capacity inspector must not run for large store")
 }
 
 type doctorSection struct {
@@ -525,9 +533,11 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 
 	store := &storeManagementUsecaseStub{}
 	events := &eventUsecaseStub{}
+	capacity := &panicCapacityInspector{}
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(store),
 		cli.WithEvent(events),
+		cli.WithCapacityInspector(capacity),
 	).Command()
 	stdout := &bytes.Buffer{}
 	rootCmd.SetOut(stdout)
@@ -551,6 +561,9 @@ func TestRootCLI_DoctorLargeStoreReturnsBoundedMetadataOnlyReport(t *testing.T) 
 	}
 	if events.listCalls != 0 {
 		t.Fatalf("large-store doctor listed %d events, want no event/payload reads", events.listCalls)
+	}
+	if capacity.calls != 0 {
+		t.Fatalf("large-store capacity calls=%d, want zero", capacity.calls)
 	}
 	check := statusByName(report, "large-store-diagnostics")
 	if check.Status != "warn" || !strings.Contains(check.Message, "were not read") {


### PR DESCRIPTION
## Summary

- derive doctor growth warnings from event payload, search projection, reclaimable-space, filesystem headroom, and measured inspection-latency signals
- preserve the bounded large-store doctor contract by avoiding SQLite opens and reporting detailed signals as unknown
- recommend the non-destructive `store compact plan` preview before any apply operation
- document copied-store preflight, scrub, compaction, swap, rollback, interruption recovery, and the v0.35 activation boundary in English and Japanese
- redirect unsafe in-place VACUUM guidance to the reviewed copy-and-swap engine

## Safety and compatibility

- diagnostics remain aggregate and metadata-only
- database size alone does not select a remediation
- zero free space is distinct from unavailable free-space metadata
- filesystem and ratio arithmetic is overflow-safe
- large-store reports use one immutable filesystem metadata snapshot and do not open SQLite
- existing doctor JSON/check surfaces remain compatible

## Validation

- `go test ./... -count=1`
- focused race tests for doctor growth and large-store behavior
- `go vet ./...`
- `go tool golangci-lint run`
- `git diff --check origin/main...HEAD`
- Linux and Windows CLI cross-compiles
- independent security/correctness review at `5274386508d30e91a2b18c3946dc60288a23a304`: APPROVE, no findings

Closes #1624
