### PR TITLE
v0.34.0-15: keep compaction verification sidecar-free

### DIFF
--- a/.ai/spec/1633-sidecar-free-compaction-verification.md
+++ b/.ai/spec/1633-sidecar-free-compaction-verification.md
@@ -1,0 +1,47 @@
+# Issue 1633: sidecar-free compaction verification
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- 目的: compaction自身のSQLite検証がWAL/SHMを生成してswap guardを壊す自己干渉をなくす。
+- 現状: direct read-only接続が通常のSQLite read-only DSNを使い、WAL-mode DBでzero-byte sidecarを作り得る。
+- 期待する振る舞い: source/candidateのcompatibility・scrubとVACUUM元読取をimmutable接続で行い、sidecarを生成せずone-shot applyをcommitする。
+- 非対象: pre-existing sidecarの削除、sidecar ownership推測、guardの緩和。
+
+### Conceptual model
+| Concept | State | Behavior | Constraint / Invariant |
+|---|---|---|---|
+| Verification snapshot | immutable main DB file | compatibility and logical scrub | sidecarを作成・参照しない |
+| Sidecar guard | absent / pre-existing | swapを許可または拒否 | zero-byteでも自動削除しない |
+| Compaction run | prepared → verified → committed | resume/rollback可能 | 検証がfile setを変えない |
+
+### Responsibility assignment
+| Responsibility | Owner | Reason to change | Not owner / reason |
+|---|---|---|---|
+| direct SQLite open mode | `compaction_sqlite.go` | SQLite接続副作用 | usecaseはDSNを知らない |
+| sidecar fail-closed | `compaction_files.go` | filesystem replacement invariant | verifierは削除しない |
+| workflow state | compaction usecase/domain | resume/rollback | infraは状態遷移を決めない |
+
+### Boundaries / interfaces
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `SQLiteCompactionBuilder` | compaction usecase | immutable DSN, scrub | compatibility/SQLite errorを文脈付きで返す |
+| `StoreReplacementFiles` | compaction usecase | inode/sidecar inspection | pre-existing sidecarはfail closed |
+
+### Behavior tests / TDD plan
+| Behavior | Red | Green | Refactor target |
+|---|---|---|---|
+| VerifyPair leaves no sidecars | WAL-mode source/candidateの検証後sidecar不在 | immutable direct open | shared immutable opener |
+| one-shot apply commits | apply直後のguardが自己生成sidecarで失敗 | build/verifyをsidecar-free化 | DSN責務のみ変更 |
+| pre-existing sidecar rejects | zero/nonzero sidecarを配置 | guard維持 | 自動cleanup禁止 |
+| resume/rollback remain safe | verified/swap_intent journalから再開 | existing transitions維持 | なし |
+
+### Risks / rollback
+- immutableはmain DBだけを読むため、事前guardでsidecar不在を必須とする。
+- migrationなし。問題時はdirect openerを旧DSNへ戻せる。
+- 分割: behavior testsと接続修正を1 issue/1 PRで行う。
+- design checkpoint: sidecar削除ではなくsidecar非生成を採用する。
+
+### Self-review
+- guardを緩和せず、zero-byte sidecarも削除しない。
+- source/candidateへ同じcompatibility/scrubを適用する。

--- a/infrastructure/sqlite/compaction_sqlite.go
+++ b/infrastructure/sqlite/compaction_sqlite.go
@@ -32,22 +32,34 @@ func (SQLiteCompactionBuilder) Build(ctx context.Context, source, candidate stri
 	if candidateID.Size != 0 {
 		return errors.New("prepared compaction candidate must be empty before VACUUM INTO")
 	}
-	db, err := sql.Open("sqlite", directSQLiteRWDSN(source))
+	sourceDB, err := openDirectReadOnly(ctx, source)
+	if err != nil {
+		return err
+	}
+	if err := VerifyStoreCompatibility(ctx, sourceDB); err != nil {
+		_ = sourceDB.Close()
+		return fmt.Errorf("source compatibility: %w", err)
+	}
+	if err := requireStaticSearchState(ctx, sourceDB); err != nil {
+		_ = sourceDB.Close()
+		return err
+	}
+	if err := sourceDB.Close(); err != nil {
+		return err
+	}
+	// Run VACUUM from a transient writable database with the source attached as
+	// immutable. This lets SQLite write the candidate without ever opening the
+	// WAL-mode source as a writer (and therefore without creating WAL/SHM).
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		return err
 	}
 	db.SetMaxOpenConns(1)
 	defer db.Close()
-	if err := db.PingContext(ctx); err != nil {
-		return err
+	if _, err := db.ExecContext(ctx, `ATTACH DATABASE `+quoteSQLiteStringLiteral(sqliteImmutableDSN(source))+` AS compact_source`); err != nil {
+		return fmt.Errorf("attach immutable compaction source: %w", err)
 	}
-	if err := VerifyStoreCompatibility(ctx, db); err != nil {
-		return fmt.Errorf("source compatibility: %w", err)
-	}
-	if err := requireStaticSearchState(ctx, db); err != nil {
-		return err
-	}
-	if _, err := db.ExecContext(ctx, `VACUUM INTO `+quoteSQLiteStringLiteral(candidate)); err != nil {
+	if _, err := db.ExecContext(ctx, `VACUUM compact_source INTO `+quoteSQLiteStringLiteral(candidate)); err != nil {
 		return fmt.Errorf("VACUUM INTO candidate: %w", err)
 	}
 	return nil
@@ -330,7 +342,7 @@ func requireStaticSearchState(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 func openDirectReadOnly(ctx context.Context, path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", sqliteReadOnlyDSN(path))
+	db, err := sql.Open("sqlite", sqliteImmutableDSN(path))
 	if err != nil {
 		return nil, err
 	}

--- a/infrastructure/sqlite/compaction_sqlite_test.go
+++ b/infrastructure/sqlite/compaction_sqlite_test.go
@@ -65,6 +65,41 @@ func TestSQLiteCompactionBuilderBuildAndVerifyPair(t *testing.T) {
 	}
 }
 
+func TestSQLiteCompactionVerificationDoesNotCreateSidecars(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	candidate := filepath.Join(dir, "candidate.db")
+	db, err := sql.Open("sqlite", directSQLiteRWDSNCreate(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`PRAGMA journal_mode=WAL; CREATE TABLE sample(id INTEGER PRIMARY KEY, body TEXT); INSERT INTO sample(body) VALUES('value'); PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		t.Fatal(err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		_ = os.Remove(source + suffix)
+	}
+	if err = os.WriteFile(candidate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builder := SQLiteCompactionBuilder{}
+	if err = builder.Build(ctx, source, candidate); err != nil {
+		t.Fatal(err)
+	}
+	if err = builder.VerifyPair(ctx, source, candidate); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{source + "-wal", source + "-shm", candidate + "-wal", candidate + "-shm"} {
+		if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("verification created sidecar %s: %v", path, statErr)
+		}
+	}
+}
+
 func TestStoreCompactionSmallAllocatedShapeE2E(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- verify compaction sources and candidates through immutable, query-only SQLite connections
- build candidates from a writable in-memory database with the source attached read-only and immutable
- prevent Traceary's own verification from leaving WAL/SHM sidecars that block atomic exchange
- preserve all existing sidecar, identity, lease, resume, and rollback fail-closed boundaries

## Validation

- focused sidecar-free compaction and recovery tests
- focused race tests
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run`
- Linux and Windows SQLite test cross-compiles
- 21.4 GiB compaction E2E: PASS (502.29 s), one-shot apply committed and rollback restored the original inode
- independent security/correctness review at `89744e6f6385f373ba912e8380a31d39840009c7`: APPROVE, no findings

Closes #1633
