### PR TITLE
v0.34.0-17: add deterministic rehearsal interruption checkpoints

### DIFF
--- a/.ai/spec/1635-rehearsal-interruption-checkpoints.md
+++ b/.ai/spec/1635-rehearsal-interruption-checkpoints.md
@@ -1,0 +1,33 @@
+# #1635 deterministic rehearsal interruption checkpoints
+
+## Requirement and design
+
+Add a rehearsal-only `--stop-after-batches N` boundary. Zero preserves the
+existing behavior. A positive value counts only batches reported after a
+successful `AdvanceField`; after exactly N committed batches the use case
+persists `paused`, releases the handle, and returns success with aggregate
+`batch_count`, row/byte counters, and `more_pending=true`. The stop value is
+orchestration policy, not codec configuration, so a fresh resume may choose a
+new stop count without invalidating the persisted target/config binding.
+
+The application use case owns the boundary. SQLite continues to own the atomic
+shadow-row/checkpoint commit. Cancellation or an error before a successful
+advance follows the existing pause/error path and cannot be reported as a
+deterministic stop. Completion, scrub, rollback, live-target fencing, and the
+v0.34 activation prohibition are unchanged.
+
+## Behavior/TDD and rollback
+
+- Stop after one or multiple committed batches and return paused success.
+- Resume counts only newly committed batches; persisted checkpoints prevent
+  reprocessing and duplicate shadow rows.
+- Cancellation before commit does not advance; cancellation after commit is
+  reconciled by the atomic checkpoint on resume.
+- A stopped run remains compatible with scrub after completion and physical
+  rollback while paused.
+- Negative limits fail validation; zero is backward compatible.
+
+Rollback is removal of the additive CLI/config/result fields. Persisted schema
+and codec data are unchanged. Self-review focuses on counting committed
+results, avoiding stop-policy inclusion in `config_hash`, and never returning
+`more_pending` for completed work.

--- a/application/types/payload_rehearsal.go
+++ b/application/types/payload_rehearsal.go
@@ -85,6 +85,9 @@ type PayloadRehearsalConfig struct {
 	ScrubByteLimit   int64         `json:"scrub_byte_limit"`
 	ScrubTimeLimit   time.Duration `json:"scrub_time_limit"`
 	MaxWALBytes      int64         `json:"max_wal_bytes"`
+	// StopAfterBatches is a rehearsal-only orchestration boundary. It is not
+	// part of the persisted codec configuration and zero means no batch limit.
+	StopAfterBatches int64 `json:"-"`
 }
 
 // MaxPayloadRehearsalBatchRows bounds query and in-memory page cardinality.
@@ -94,7 +97,7 @@ const MaxPayloadRehearsalBatchRows = 4096
 func (c PayloadRehearsalConfig) Valid() bool {
 	return c.TargetPath != "" && c.LivePath != "" && c.BatchRows > 0 && c.BatchRows <= MaxPayloadRehearsalBatchRows && c.StoredByteLimit > 0 &&
 		c.DecodedByteLimit > 0 && c.WallTimeLimit > 0 && c.LockTimeLimit > 0 &&
-		c.ScrubByteLimit > 0 && c.ScrubTimeLimit > 0 && c.MaxWALBytes > 0
+		c.ScrubByteLimit > 0 && c.ScrubTimeLimit > 0 && c.MaxWALBytes > 0 && c.StopAfterBatches >= 0
 }
 
 // ReadinessGateStatus is an evidence-backed prerequisite outcome.
@@ -155,6 +158,7 @@ type PayloadRehearsalMetrics struct {
 	PlaintextBytes         int64                       `json:"plaintext_bytes"`
 	StoredBytes            int64                       `json:"stored_bytes"`
 	BatchCount             int64                       `json:"batch_count"`
+	MorePending            bool                        `json:"more_pending"`
 	BatchDurationHistogram map[string]int64            `json:"batch_duration_histogram"`
 	ConflictRows           int64                       `json:"conflict_rows"`
 	PeakWALBytes           int64                       `json:"peak_wal_bytes"`

--- a/application/usecase/payload_rehearsal.go
+++ b/application/usecase/payload_rehearsal.go
@@ -123,7 +123,9 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 				return result, err
 			}
 			if c.StopAfterBatches > 0 && result.BatchCount-initialBatches >= c.StopAfterBatches && (!done || fieldIndex != len(fields)-1) {
-				result, err = u.workflow.Pause(ctx, handle)
+				pauseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+				result, err = u.workflow.Pause(pauseCtx, handle)
+				cancel()
 				if err != nil {
 					return result, xerrors.Errorf("pause payload rehearsal at committed batch boundary: %w", err)
 				}

--- a/application/usecase/payload_rehearsal.go
+++ b/application/usecase/payload_rehearsal.go
@@ -122,7 +122,7 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 				_, _ = u.workflow.Pause(context.WithoutCancel(ctx), handle)
 				return result, err
 			}
-			if c.StopAfterBatches > 0 && result.BatchCount-initialBatches >= c.StopAfterBatches && !(done && fieldIndex == len(fields)-1) {
+			if c.StopAfterBatches > 0 && result.BatchCount-initialBatches >= c.StopAfterBatches && (!done || fieldIndex != len(fields)-1) {
 				result, err = u.workflow.Pause(ctx, handle)
 				if err != nil {
 					return result, xerrors.Errorf("pause payload rehearsal at committed batch boundary: %w", err)

--- a/application/usecase/payload_rehearsal.go
+++ b/application/usecase/payload_rehearsal.go
@@ -106,7 +106,9 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 		}
 	}()
 	deadline := time.Now().Add(c.WallTimeLimit)
-	for _, field := range types.OrderedPayloadRehearsalFields() {
+	initialBatches := result.BatchCount
+	fields := types.OrderedPayloadRehearsalFields()
+	for fieldIndex, field := range fields {
 		for time.Now().Before(deadline) {
 			var done bool
 			result, done, err = u.workflow.AdvanceField(ctx, handle, field)
@@ -119,6 +121,14 @@ func (u *payloadRehearsalUsecase) run(ctx context.Context, c types.PayloadRehear
 			if result, err = liveResult(result); err != nil {
 				_, _ = u.workflow.Pause(context.WithoutCancel(ctx), handle)
 				return result, err
+			}
+			if c.StopAfterBatches > 0 && result.BatchCount-initialBatches >= c.StopAfterBatches && !(done && fieldIndex == len(fields)-1) {
+				result, err = u.workflow.Pause(ctx, handle)
+				if err != nil {
+					return result, xerrors.Errorf("pause payload rehearsal at committed batch boundary: %w", err)
+				}
+				result.MorePending = true
+				return liveResult(result)
 			}
 			if done {
 				break

--- a/application/usecase/payload_rehearsal_test.go
+++ b/application/usecase/payload_rehearsal_test.go
@@ -22,6 +22,8 @@ type rehearsalBackendFake struct {
 	driftRunComplete     bool
 	driftScrubAdvance    bool
 	advancesRemaining    int
+	cancelAfterAdvance   func()
+	pauseContextErr      error
 }
 type fakeRunHandle struct{}
 type fakeScrubHandle struct{}
@@ -50,6 +52,9 @@ func (f *rehearsalBackendFake) AdvanceField(_ context.Context, _ application.Pay
 		f.advancesRemaining--
 		f.run.BatchCount++
 		f.run.EncodedRows++
+		if f.cancelAfterAdvance != nil {
+			f.cancelAfterAdvance()
+		}
 		return f.run, false, nil
 	}
 	return f.run, true, nil
@@ -71,9 +76,26 @@ func TestPayloadRehearsalStopsAfterCommittedBatchBoundary(t *testing.T) {
 		t.Fatalf("unexpected deterministic stop result: %+v", result)
 	}
 }
-func (f *rehearsalBackendFake) Pause(context.Context, application.PayloadRehearsalRunHandle) (apptypes.PayloadRehearsalMetrics, error) {
+func (f *rehearsalBackendFake) Pause(ctx context.Context, _ application.PayloadRehearsalRunHandle) (apptypes.PayloadRehearsalMetrics, error) {
+	f.pauseContextErr = ctx.Err()
 	f.run.State = "paused"
 	return f.run, nil
+}
+
+func TestPayloadRehearsalCommittedStopPersistsPauseAfterCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := &rehearsalBackendFake{
+		preview:            apptypes.PayloadRehearsalMetrics{State: "planned", DryRunZeroWrite: true, LiveIdentityOnly: true, FreeBytes: 100, EstimatedHeadroom: 50},
+		run:                apptypes.PayloadRehearsalMetrics{State: "running", LiveIdentityOnly: true},
+		advancesRemaining:  2,
+		cancelAfterAdvance: cancel,
+	}
+	config := validRehearsalConfig()
+	config.StopAfterBatches = 1
+	result, err := usecase.NewPayloadRehearsalUsecase(backend, backend, backend, backend).Run(ctx, config)
+	if err != nil || result.State != "paused" || !result.MorePending || backend.pauseContextErr != nil {
+		t.Fatalf("result=%+v pause_ctx=%v err=%v", result, backend.pauseContextErr, err)
+	}
 }
 func (f *rehearsalBackendFake) Complete(context.Context, application.PayloadRehearsalRunHandle) (apptypes.PayloadRehearsalMetrics, error) {
 	f.run.State = "completed"

--- a/application/usecase/payload_rehearsal_test.go
+++ b/application/usecase/payload_rehearsal_test.go
@@ -21,6 +21,7 @@ type rehearsalBackendFake struct {
 	driftRunAdvance      bool
 	driftRunComplete     bool
 	driftScrubAdvance    bool
+	advancesRemaining    int
 }
 type fakeRunHandle struct{}
 type fakeScrubHandle struct{}
@@ -45,7 +46,30 @@ func (f *rehearsalBackendFake) AdvanceField(_ context.Context, _ application.Pay
 	if f.driftRunAdvance {
 		f.run.LiveIdentityOnly = false
 	}
+	if f.advancesRemaining > 0 {
+		f.advancesRemaining--
+		f.run.BatchCount++
+		f.run.EncodedRows++
+		return f.run, false, nil
+	}
 	return f.run, true, nil
+}
+
+func TestPayloadRehearsalStopsAfterCommittedBatchBoundary(t *testing.T) {
+	backend := &rehearsalBackendFake{
+		preview: apptypes.PayloadRehearsalMetrics{State: "planned", DryRunZeroWrite: true, LiveIdentityOnly: true, FreeBytes: 100, EstimatedHeadroom: 50},
+		run:     apptypes.PayloadRehearsalMetrics{State: "running", LiveIdentityOnly: true},
+	}
+	backend.advancesRemaining = 3
+	config := validRehearsalConfig()
+	config.StopAfterBatches = 2
+	result, err := usecase.NewPayloadRehearsalUsecase(backend, backend, backend, backend).Run(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != "paused" || result.BatchCount != 2 || result.EncodedRows != 2 || !result.MorePending {
+		t.Fatalf("unexpected deterministic stop result: %+v", result)
+	}
 }
 func (f *rehearsalBackendFake) Pause(context.Context, application.PayloadRehearsalRunHandle) (apptypes.PayloadRehearsalMetrics, error) {
 	f.run.State = "paused"

--- a/infrastructure/sqlite/payload_rehearsal_swap_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_swap_internal_test.go
@@ -23,6 +23,40 @@ type liveDriftAfterPreview struct {
 	live string
 }
 
+func TestPayloadRehearsalCancellationBeforeFirstBatchCommitDoesNotAdvance(t *testing.T) {
+	adapter, config, _ := newSwapRehearsalFixture(t)
+	u := usecase.NewPayloadRehearsalUsecase(adapter, adapter, adapter, adapter)
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter.beforePersistence = func(kind string) {
+		if kind == "batch" {
+			cancel()
+		}
+	}
+	if _, err := u.Run(ctx, config); !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error=%v, want cancellation", err)
+	}
+	db, err := sql.Open("sqlite", config.TargetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shadows, advanced int
+	if err = db.QueryRow(`SELECT count(*) FROM payload_rehearsal_rows`).Scan(&shadows); err != nil {
+		t.Fatal(err)
+	}
+	if err = db.QueryRow(`SELECT count(*) FROM payload_rehearsal_checkpoints WHERE last_primary_key<>'' OR changed_rows<>0`).Scan(&advanced); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if shadows != 0 || advanced != 0 {
+		t.Fatalf("precommit cancellation advanced shadows/checkpoints=%d/%d", shadows, advanced)
+	}
+	adapter.beforePersistence = nil
+	resumed, err := u.Resume(context.Background(), config)
+	if err != nil || resumed.State != "completed" {
+		t.Fatalf("fresh resume=%+v err=%v", resumed, err)
+	}
+}
+
 //nolint:wrapcheck // test fault injector preserves the underlying failure.
 func (p liveDriftAfterPreview) Preview(ctx context.Context, c apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
 	m, err := p.PayloadRehearsalPreview.Preview(ctx, c)

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -15,9 +15,79 @@ import (
 	_ "modernc.org/sqlite"
 
 	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
 	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 	sqliteschema "github.com/duck8823/traceary/schema/sqlite"
 )
+
+func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {
+	ctx := context.Background()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, target, backup := filepath.Join(dir, "live.db"), filepath.Join(dir, "target.db"), filepath.Join(dir, "backup.db")
+	migrations, err := sqliteschema.Migrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = infra.NewStoreManagementDatasource(infra.NewDatabase(live, migrations)).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at) VALUES(?,'prompt','test','session','body','2026-08-01T00:00:00Z')`, fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	copyTestFile(t, live, target)
+	adapter := newRehearsalAdapter(t, migrations, live)
+	u := usecase.NewPayloadRehearsalUsecase(adapter, adapter, adapter, adapter)
+	config := rehearsalTestConfig(target, live, backup)
+	config.BatchRows = 1
+	config.StopAfterBatches = 1
+	stopped, err := u.Run(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.State != "paused" || stopped.BatchCount != 1 || !stopped.MorePending {
+		t.Fatalf("stop result=%+v", stopped)
+	}
+	config.StopAfterBatches = 0
+	resumed, err := u.Resume(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed.State != "completed" || resumed.EncodedRows <= stopped.EncodedRows {
+		t.Fatalf("resume=%+v", resumed)
+	}
+	check, err := sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count, distinct int
+	if err = check.QueryRow(`SELECT count(*),count(DISTINCT table_kind||':'||field_kind||':'||source_primary_key) FROM payload_rehearsal_rows`).Scan(&count, &distinct); err != nil {
+		t.Fatal(err)
+	}
+	_ = check.Close()
+	if count != 3 || distinct != count {
+		t.Fatalf("shadow count/distinct=%d/%d", count, distinct)
+	}
+	scrubbed, err := u.Scrub(ctx, config)
+	if err != nil || !scrubbed.ActivationReadiness.ScrubPassed || scrubbed.ActivationReadiness.ActivationAllowed {
+		t.Fatalf("scrub=%+v err=%v", scrubbed, err)
+	}
+	rolledBack, err := u.Rollback(ctx, config)
+	if err != nil || !rolledBack.RollbackVerified {
+		t.Fatalf("rollback=%+v err=%v", rolledBack, err)
+	}
+}
 
 func TestPayloadRehearsalPreservesCanonicalRowsAndScrubsShadowRows(t *testing.T) {
 	ctx := context.Background()

--- a/presentation/cli/store_payload_rehearsal.go
+++ b/presentation/cli/store_payload_rehearsal.go
@@ -16,11 +16,12 @@ type payloadRehearsalFlags struct {
 	batchRows                             int
 	storedBytes, decodedBytes, scrubBytes int64
 	maxWALBytes                           int64
+	stopAfterBatches                      int64
 	wall, lock, scrubTime                 time.Duration
 }
 
 func (f *payloadRehearsalFlags) config() apptypes.PayloadRehearsalConfig {
-	return apptypes.PayloadRehearsalConfig{TargetPath: f.target, LivePath: f.live, BackupPath: f.backup, BatchRows: f.batchRows, StoredByteLimit: f.storedBytes, DecodedByteLimit: f.decodedBytes, WallTimeLimit: f.wall, LockTimeLimit: f.lock, ScrubByteLimit: f.scrubBytes, ScrubTimeLimit: f.scrubTime, MaxWALBytes: f.maxWALBytes}
+	return apptypes.PayloadRehearsalConfig{TargetPath: f.target, LivePath: f.live, BackupPath: f.backup, BatchRows: f.batchRows, StoredByteLimit: f.storedBytes, DecodedByteLimit: f.decodedBytes, WallTimeLimit: f.wall, LockTimeLimit: f.lock, ScrubByteLimit: f.scrubBytes, ScrubTimeLimit: f.scrubTime, MaxWALBytes: f.maxWALBytes, StopAfterBatches: f.stopAfterBatches}
 }
 func bindPayloadRehearsalFlags(cmd *cobra.Command, f *payloadRehearsalFlags, backup bool) {
 	cmd.Flags().StringVar(&f.target, "target", "", "explicit copied SQLite target")
@@ -36,6 +37,7 @@ func bindPayloadRehearsalFlags(cmd *cobra.Command, f *payloadRehearsalFlags, bac
 	cmd.Flags().Int64Var(&f.scrubBytes, "scrub-byte-limit", 1<<30, "maximum stored bytes scrubbed")
 	cmd.Flags().DurationVar(&f.scrubTime, "scrub-time-limit", 30*time.Minute, "maximum scrub duration")
 	cmd.Flags().Int64Var(&f.maxWALBytes, "max-wal-bytes", 1<<30, "hard WAL growth cap")
+	cmd.Flags().Int64Var(&f.stopAfterBatches, "stop-after-batches", 0, "pause successfully after this many committed batches (rehearsal evidence only)")
 	_ = cmd.MarkFlagRequired("target")
 	_ = cmd.MarkFlagRequired("live-db")
 	if backup {

--- a/presentation/cli/store_payload_rehearsal_internal_test.go
+++ b/presentation/cli/store_payload_rehearsal_internal_test.go
@@ -73,6 +73,28 @@ func (b neverCalledRehearsalBackend) Rollback(context.Context, apptypes.PayloadR
 
 type readinessRehearsalStub struct{}
 
+type recordingRehearsalStub struct {
+	configs []apptypes.PayloadRehearsalConfig
+}
+
+func (r *recordingRehearsalStub) Preview(context.Context, apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
+	return apptypes.PayloadRehearsalMetrics{}, nil
+}
+func (r *recordingRehearsalStub) Run(_ context.Context, c apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
+	r.configs = append(r.configs, c)
+	return apptypes.PayloadRehearsalMetrics{}, nil
+}
+func (r *recordingRehearsalStub) Resume(_ context.Context, c apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
+	r.configs = append(r.configs, c)
+	return apptypes.PayloadRehearsalMetrics{}, nil
+}
+func (*recordingRehearsalStub) Scrub(context.Context, apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
+	return apptypes.PayloadRehearsalMetrics{}, nil
+}
+func (*recordingRehearsalStub) Rollback(context.Context, apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
+	return apptypes.PayloadRehearsalMetrics{}, nil
+}
+
 func (readinessRehearsalStub) Preview(context.Context, apptypes.PayloadRehearsalConfig) (apptypes.PayloadRehearsalMetrics, error) {
 	return apptypes.PayloadRehearsalMetrics{}, nil
 }
@@ -142,5 +164,30 @@ func TestPayloadRehearsalCLIRejectsUnboundedBatchWithoutWritesOrPanic(t *testing
 	}
 	if _, err := os.Stat(backup); !os.IsNotExist(err) {
 		t.Fatalf("backup created: %v", err)
+	}
+}
+
+func TestPayloadRehearsalCLIRejectsNegativeStopBeforeBackend(t *testing.T) {
+	b := neverCalledRehearsalBackend{}
+	root := NewRootCLI(WithPayloadRehearsal(usecase.NewPayloadRehearsalUsecase(b, b, b, b)))
+	cmd := root.newStorePayloadRehearsalCommand()
+	cmd.SetArgs([]string{"run", "--target", "target", "--live-db", "live", "--backup", "backup", "--stop-after-batches", "-1"})
+	if err := cmd.Execute(); !errors.Is(err, usecase.ErrInvalidPayloadRehearsalConfig) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestPayloadRehearsalCLIPropagatesPositiveStopToRunAndResume(t *testing.T) {
+	stub := &recordingRehearsalStub{}
+	for _, operation := range []string{"run", "resume"} {
+		root := NewRootCLI(WithPayloadRehearsal(stub))
+		cmd := root.newStorePayloadRehearsalCommand()
+		cmd.SetArgs([]string{operation, "--target", "target", "--live-db", "live", "--backup", "backup", "--stop-after-batches", "3"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(stub.configs) != 2 || stub.configs[0].StopAfterBatches != 3 || stub.configs[1].StopAfterBatches != 3 {
+		t.Fatalf("configs=%+v", stub.configs)
 	}
 }


### PR DESCRIPTION
## Summary

- add a rehearsal-only `--stop-after-batches` boundary that pauses only after committed checkpoints
- report aggregate progress and `more_pending` without exposing payloads or identifiers
- resume from the durable checkpoint without duplicate shadow rows
- make commit-after-cancel cleanup bounded and independent from caller cancellation
- preserve scrub, rollback, live-store fencing, and compressed-write activation prohibitions

## Validation

- deterministic stop-after-one and stop-after-multiple tests
- pre-commit and post-commit cancellation tests
- fresh resume, no-duplicate, scrub, and rollback integration test
- CLI rejection/propagation tests
- `go test ./... -count=1`
- `go vet ./...`
- `go tool golangci-lint run`
- Linux and Windows builds
- independent Structure-Behavior review at `621222df099b461cf1de189461d3d4ffb558bc87`: APPROVE, no findings

Closes #1635
