### PR TITLE
v0.34.0-19: bound payload codec compatibility migration

### DIFF
--- a/.ai/spec/1641-bounded-codec-compatibility.md
+++ b/.ai/spec/1641-bounded-codec-compatibility.md
@@ -1,0 +1,48 @@
+# #1641 bounded codec compatibility migration
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Migration 36 must add codec columns without scanning retained payload history.
+- Four constant-size counters represent non-identity event body, command, input, and output lanes.
+- Transactional triggers keep counters exact for insert/update/delete and roll back with the canonical mutation.
+- Already-applied development stores retain their partial indexes and use an explicit legacy-index compatibility mode without a backfill scan.
+- Unknown mode/state, negative counts, or underflow fail closed. Scoped search remains bounded and payload rehearsal preflight remains capped.
+
+### Conceptual model
+| Concept | State | Behavior | Invariant |
+|---|---|---|---|
+| Codec compatibility mode | `counter` / `legacy_index` | selects constant counter or historical indexed evidence | fresh shape never parses a missing index |
+| Four-lane counter | non-negative lane counts, `valid` state | changes transactionally with canonical rows | equals committed non-identity values; cannot underflow |
+| Legacy evidence | four partial indexes | answers existence only | no migration-time validation scan |
+| Compatibility decision | identity-only / non-identity / invalid | gates search and rehearsal | invalid evidence fails closed |
+
+### Responsibility assignment
+| Responsibility | Owner | Not owner |
+|---|---|---|
+| zero-scan schema and counter triggers | migration 36 | Go query layer |
+| old/new shape marker | forward migration 43 | migration runner heuristics |
+| mode-specific global evidence | SQLite compatibility helper | search orchestration |
+| bounded scope filter | existing search query | global counter helper |
+
+### Boundaries / interfaces
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| global non-identity inspection | search/rehearsal | mode, indexes, counters | invalid/unknown evidence returns error (fail closed) |
+| scoped codec inspection | search | canonical rows in bounded criteria | existing candidate cap remains authoritative |
+
+### Behavior tests
+- Migration 36-43 over a large pre-36 fixture completes below the unchanged one-second cap and creates no partial index on the fresh shape.
+- Fresh counter mode tracks all lanes through insert/update/delete and transaction rollback.
+- Empty/identity/non-identity transitions cannot underflow; corrupted/unknown state fails closed.
+- Legacy index-bearing shape selects `legacy_index` and does not reference counter-only assumptions.
+- Concurrent committed mutations produce exact counters.
+- Rehearsal run creation succeeds on identity-only counter mode and rejects non-identity/invalid evidence.
+
+### TDD plan
+Migration fixture -> counter transition tests -> shared mode query -> search and rehearsal integration -> concurrency/rollback -> full regression.
+
+### Risks / rollback
+- The change is pre-release schema correction plus a forward compatibility migration. Canonical payload columns are unchanged.
+- Existing index-bearing stores remain readable without scan. Fresh stores can roll back by ignoring the constant state while retaining identity payloads.
+- Trigger arithmetic is deliberately explicit rather than generalized dynamic SQL so every lane is reviewable.

--- a/docs/storage/payload-rehearsal.ja.md
+++ b/docs/storage/payload-rehearsal.ja.md
@@ -5,6 +5,11 @@
 v0.34が提供するのは、コピーしたストア上のリハーサルだけです。
 canonical圧縮書き込みを有効化せず、設定済みのliveストアを変更しません。
 
+codec互換性preflightは、新たにupgradeしたstoreではevent body、command、input、outputの4 laneをconstant-sizeのtransactional counterで管理します。
+このためcodec column追加時に保存済みhistoryをscanしません。
+旧migrationを適用済みの開発storeは、明示的なlegacy互換modeで既存partial indexを利用します。
+互換性証跡がunknown、invalid、または不整合の場合、rehearsal run作成前にfail closedします。
+
 1. writerを停止し、checkpoint済みの単一SQLiteファイルをコピーします。
    コピーには`-wal`と`-shm`を残しません。
 2. `traceary store payload-rehearsal preview --target COPY --live-db LIVE`を実行します。

--- a/docs/storage/payload-rehearsal.md
+++ b/docs/storage/payload-rehearsal.md
@@ -5,6 +5,13 @@
 v0.34 provides a copied-store rehearsal only. It never activates compressed
 canonical writes and never modifies the configured live store.
 
+Codec compatibility preflight uses constant-size transactional counters for
+the event-body, command, input, and output lanes on newly upgraded stores.
+Adding codec columns therefore does not scan retained history. Development
+stores that already applied the former migration keep their partial indexes
+under an explicit legacy compatibility mode. Unknown, invalid, or inconsistent
+compatibility evidence fails closed before a rehearsal run is created.
+
 1. Stop writers and create a checkpointed, single-file SQLite copy. The copied
    target must have no `-wal` or `-shm` sidecars.
 2. Run `traceary store payload-rehearsal preview --target COPY --live-db LIVE`.

--- a/infrastructure/sqlite/event_search_query.go
+++ b/infrastructure/sqlite/event_search_query.go
@@ -165,15 +165,11 @@ func boundedSearchHasNonIdentityPayload(
 		return false, nil
 	}
 	if !hasBoundedLegacySearchScope(criteria) {
-		var found int
-		if err := queryer.QueryRowContext(ctx, `SELECT
-			EXISTS(SELECT 1 FROM events INDEXED BY idx_events_nonidentity_body_codec WHERE body_codec <> 'identity') OR
-			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_command_codec WHERE command_codec <> 'identity') OR
-			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_input_codec WHERE input_codec <> 'identity') OR
-			EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_output_codec WHERE output_codec <> 'identity')`).Scan(&found); err != nil {
+		found, err := globalNonIdentityPayload(ctx, queryer)
+		if err != nil {
 			return false, xerrors.Errorf("failed to inspect global payload codecs: %w", err)
 		}
-		return found != 0, nil
+		return found, nil
 	}
 	var builder strings.Builder
 	builder.WriteString(`SELECT EXISTS(

--- a/infrastructure/sqlite/payload_codec_compatibility.go
+++ b/infrastructure/sqlite/payload_codec_compatibility.go
@@ -1,0 +1,42 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"golang.org/x/xerrors"
+)
+
+type payloadCodecCompatibilityQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// globalNonIdentityPayload uses only constant-size counters on the rewritten
+// schema and only the historical partial indexes on an already-applied v36
+// schema. Unknown or inconsistent evidence fails closed with an error.
+func globalNonIdentityPayload(ctx context.Context, q payloadCodecCompatibilityQueryer) (bool, error) {
+	var mode, state string
+	var eventBody, command, input, output int64
+	if err := q.QueryRowContext(ctx, `SELECT mode,state,event_body_nonidentity,audit_command_nonidentity,audit_input_nonidentity,audit_output_nonidentity FROM payload_codec_compatibility_state WHERE singleton=1`).Scan(&mode, &state, &eventBody, &command, &input, &output); err != nil {
+		return false, xerrors.Errorf("inspect payload codec compatibility state: %w", err)
+	}
+	if state != "valid" || eventBody < 0 || command < 0 || input < 0 || output < 0 {
+		return false, xerrors.New("payload codec compatibility state is invalid")
+	}
+	switch mode {
+	case "counter":
+		return eventBody+command+input+output != 0, nil
+	case "legacy_index":
+		var found int
+		if err := q.QueryRowContext(ctx, `SELECT
+EXISTS(SELECT 1 FROM events INDEXED BY idx_events_nonidentity_body_codec WHERE body_codec <> 'identity') OR
+EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_command_codec WHERE command_codec <> 'identity') OR
+EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_input_codec WHERE input_codec <> 'identity') OR
+EXISTS(SELECT 1 FROM command_audits INDEXED BY idx_command_audits_nonidentity_output_codec WHERE output_codec <> 'identity')`).Scan(&found); err != nil {
+			return false, xerrors.Errorf("inspect legacy indexed payload codecs: %w", err)
+		}
+		return found != 0, nil
+	default:
+		return false, xerrors.Errorf("unknown payload codec compatibility mode %q", mode)
+	}
+}

--- a/infrastructure/sqlite/payload_codec_compatibility.go
+++ b/infrastructure/sqlite/payload_codec_compatibility.go
@@ -25,7 +25,9 @@ func globalNonIdentityPayload(ctx context.Context, q payloadCodecCompatibilityQu
 	}
 	switch mode {
 	case "counter":
-		return eventBody+command+input+output != 0, nil
+		// Inspect lanes independently: valid SQLite INTEGER counters can be
+		// MaxInt64, so summing them could wrap and falsely report identity-only.
+		return eventBody > 0 || command > 0 || input > 0 || output > 0, nil
 	case "legacy_index":
 		var found int
 		if err := q.QueryRowContext(ctx, `SELECT

--- a/infrastructure/sqlite/payload_codec_compatibility_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_compatibility_internal_test.go
@@ -1,0 +1,182 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func migrationsBeforeCodecFoundation(t *testing.T) fs.FS {
+	t.Helper()
+	entries, err := os.ReadDir("../../schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := fstest.MapFS{}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() >= "000036" {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join("../../schema/sqlite/migrations", entry.Name()))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		out[entry.Name()] = &fstest.MapFile{Data: data}
+	}
+	return out
+}
+
+func TestCodecFoundationMigrationIsSchemaOnlyUnderOneSecond(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	if err := NewDatabase(path, migrationsBeforeCodecFoundation(t)).initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-03T00:00:00Z','c','w')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20_000; i++ {
+		if _, err = stmt.Exec(fmt.Sprintf("event-%08d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = stmt.Close()
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	all, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	started := time.Now()
+	if err = NewDatabase(path, all).initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("codec migrations took %s, want <1s", elapsed)
+	}
+	db, err = sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var mode string
+	var indexes int
+	if err = db.QueryRow(`SELECT mode,(SELECT COUNT(*) FROM sqlite_schema WHERE type='index' AND name LIKE '%nonidentity%') FROM payload_codec_compatibility_state`).Scan(&mode, &indexes); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "counter" || indexes != 0 {
+		t.Fatalf("mode=%q indexes=%d", mode, indexes)
+	}
+}
+
+func TestPayloadCodecCountersTrackCommitRollbackAndConcurrentLanes(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	migrations, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	store := NewDatabase(path, migrations)
+	if err := store.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	//nolint:wrapcheck // Test helper returns the driver error for assertion.
+	insertEvent := func(id string) error {
+		_, e := db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace,body_codec) VALUES(?,'note','a','s','body','2026-08-03T00:00:00Z','c','w','zstd')`, id)
+		return e
+	}
+	if err = insertEvent("base"); err != nil {
+		t.Fatal(err)
+	}
+	tx, _ := db.Begin()
+	if _, err = tx.Exec(`UPDATE events SET body_codec='identity' WHERE id='base'`); err != nil {
+		t.Fatal(err)
+	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) { defer wg.Done(); errs <- insertEvent(fmt.Sprintf("concurrent-%d", i)) }(i)
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Fatal(e)
+		}
+	}
+	if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES('audit-event','note','a','s','body','2026-08-03T00:00:00Z','c','w')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text,command_codec,input_codec,output_codec) VALUES('audit-event','c','i','o','zstd','identity','zstd')`); err != nil {
+		t.Fatal(err)
+	}
+	var body, command, input, output int
+	if err = db.QueryRow(`SELECT event_body_nonidentity,audit_command_nonidentity,audit_input_nonidentity,audit_output_nonidentity FROM payload_codec_compatibility_state`).Scan(&body, &command, &input, &output); err != nil {
+		t.Fatal(err)
+	}
+	if body != workers+1 || command != 1 || input != 0 || output != 1 {
+		t.Fatalf("counters=%d/%d/%d/%d", body, command, input, output)
+	}
+	if _, err = db.Exec(`DELETE FROM command_audits WHERE event_id='audit-event'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET event_body_nonidentity=0`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`DELETE FROM events WHERE id='base'`); err == nil {
+		t.Fatal("counter underflow did not fail closed")
+	}
+}
+
+func TestGlobalCodecCompatibilitySelectsCounterAndLegacyShapes(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	migrations, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err := NewDatabase(path, migrations).initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	found, err := globalNonIdentityPayload(ctx, db)
+	if err != nil || found {
+		t.Fatalf("counter identity found=%v err=%v", found, err)
+	}
+	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET state='invalid'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = globalNonIdentityPayload(ctx, db); err == nil {
+		t.Fatal("invalid state did not fail closed")
+	}
+	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET state='valid',mode='legacy_index'; CREATE INDEX idx_events_nonidentity_body_codec ON events(body_codec) WHERE body_codec IS NOT NULL AND body_codec<>'identity'; CREATE INDEX idx_command_audits_nonidentity_command_codec ON command_audits(command_codec) WHERE command_codec IS NOT NULL AND command_codec<>'identity'; CREATE INDEX idx_command_audits_nonidentity_input_codec ON command_audits(input_codec) WHERE input_codec IS NOT NULL AND input_codec<>'identity'; CREATE INDEX idx_command_audits_nonidentity_output_codec ON command_audits(output_codec) WHERE output_codec IS NOT NULL AND output_codec<>'identity'`); err != nil {
+		t.Fatal(err)
+	}
+	found, err = globalNonIdentityPayload(ctx, db)
+	if err != nil || found {
+		t.Fatalf("legacy identity found=%v err=%v", found, err)
+	}
+}

--- a/infrastructure/sqlite/payload_codec_compatibility_internal_test.go
+++ b/infrastructure/sqlite/payload_codec_compatibility_internal_test.go
@@ -166,6 +166,16 @@ func TestGlobalCodecCompatibilitySelectsCounterAndLegacyShapes(t *testing.T) {
 	if err != nil || found {
 		t.Fatalf("counter identity found=%v err=%v", found, err)
 	}
+	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET event_body_nonidentity=9223372036854775807,audit_command_nonidentity=1,audit_input_nonidentity=9223372036854775807,audit_output_nonidentity=1`); err != nil {
+		t.Fatal(err)
+	}
+	found, err = globalNonIdentityPayload(ctx, db)
+	if err != nil || !found {
+		t.Fatalf("extreme valid counters found=%v err=%v", found, err)
+	}
+	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET event_body_nonidentity=0,audit_command_nonidentity=0,audit_input_nonidentity=0,audit_output_nonidentity=0`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err = db.Exec(`UPDATE payload_codec_compatibility_state SET state='invalid'`); err != nil {
 		t.Fatal(err)
 	}

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -953,12 +953,11 @@ func inspectLiveCompatibility(ctx context.Context, path string) (bool, error) {
 	if codecColumns == 0 {
 		return true, nil
 	}
-	var n int64
-	err = db.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM events WHERE body_codec IS NOT NULL AND body_codec<>'identity')+(SELECT count(*) FROM command_audits WHERE (command_codec IS NOT NULL AND command_codec<>'identity') OR (input_codec IS NOT NULL AND input_codec<>'identity') OR (output_codec IS NOT NULL AND output_codec<>'identity'))`).Scan(&n)
-	if err != nil {
-		return false, xerrors.Errorf("inspect live payload codecs: %w", err)
+	nonIdentity, inspectErr := globalNonIdentityPayload(ctx, db)
+	if inspectErr != nil {
+		return false, xerrors.Errorf("inspect live payload codecs: %w", inspectErr)
 	}
-	return n == 0, nil
+	return !nonIdentity, nil
 }
 
 func minimumWALFrameBytes(ctx context.Context, path string) (int64, error) {

--- a/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
+++ b/schema/sqlite/migrations/000036_add_payload_codec_foundation.sql
@@ -30,14 +30,40 @@ ALTER TABLE command_audits ADD COLUMN output_plaintext_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_encoded_bytes INTEGER;
 ALTER TABLE command_audits ADD COLUMN output_sha256 TEXT;
 
--- These partial indexes make the global "compressed payload exists" guard
--- proportional to compressed rows rather than total retained history. Search
--- uses the guard to avoid treating a stale plaintext projection as complete.
-CREATE INDEX idx_events_nonidentity_body_codec ON events(body_codec)
-WHERE body_codec IS NOT NULL AND body_codec <> 'identity';
-CREATE INDEX idx_command_audits_nonidentity_command_codec ON command_audits(command_codec)
-WHERE command_codec IS NOT NULL AND command_codec <> 'identity';
-CREATE INDEX idx_command_audits_nonidentity_input_codec ON command_audits(input_codec)
-WHERE input_codec IS NOT NULL AND input_codec <> 'identity';
-CREATE INDEX idx_command_audits_nonidentity_output_codec ON command_audits(output_codec)
-WHERE output_codec IS NOT NULL AND output_codec <> 'identity';
+-- Constant-size compatibility evidence. ALTER initializes every new codec
+-- column to NULL, so all four counters are exactly zero without scanning rows.
+CREATE TABLE payload_codec_compatibility_state (
+    singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+    mode TEXT NOT NULL CHECK(mode IN('counter','legacy_index')),
+    state TEXT NOT NULL CHECK(state IN('valid','invalid')),
+    event_body_nonidentity INTEGER NOT NULL CHECK(event_body_nonidentity>=0),
+    audit_command_nonidentity INTEGER NOT NULL CHECK(audit_command_nonidentity>=0),
+    audit_input_nonidentity INTEGER NOT NULL CHECK(audit_input_nonidentity>=0),
+    audit_output_nonidentity INTEGER NOT NULL CHECK(audit_output_nonidentity>=0)
+);
+INSERT INTO payload_codec_compatibility_state VALUES(1,'counter','valid',0,0,0,0);
+
+CREATE TRIGGER payload_codec_events_insert AFTER INSERT ON events
+WHEN new.body_codec IS NOT NULL AND new.body_codec<>'identity'
+BEGIN UPDATE payload_codec_compatibility_state SET event_body_nonidentity=event_body_nonidentity+1 WHERE singleton=1 AND mode='counter' AND state='valid'; SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'invalid payload codec compatibility state') END; END;
+CREATE TRIGGER payload_codec_events_update_guard BEFORE UPDATE OF body_codec ON events
+WHEN old.body_codec IS NOT NULL AND old.body_codec<>'identity'
+BEGIN SELECT CASE WHEN NOT EXISTS(SELECT 1 FROM payload_codec_compatibility_state WHERE singleton=1 AND mode='counter' AND state='valid' AND event_body_nonidentity>0) THEN RAISE(ABORT,'payload codec counter underflow') END; END;
+CREATE TRIGGER payload_codec_events_update AFTER UPDATE OF body_codec ON events
+WHEN COALESCE(old.body_codec,'identity')<>COALESCE(new.body_codec,'identity')
+BEGIN UPDATE payload_codec_compatibility_state SET event_body_nonidentity=event_body_nonidentity-(old.body_codec IS NOT NULL AND old.body_codec<>'identity')+(new.body_codec IS NOT NULL AND new.body_codec<>'identity') WHERE singleton=1 AND mode='counter' AND state='valid'; SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'invalid payload codec compatibility state') END; END;
+CREATE TRIGGER payload_codec_events_delete BEFORE DELETE ON events
+WHEN old.body_codec IS NOT NULL AND old.body_codec<>'identity'
+BEGIN UPDATE payload_codec_compatibility_state SET event_body_nonidentity=event_body_nonidentity-1 WHERE singleton=1 AND mode='counter' AND state='valid' AND event_body_nonidentity>0; SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'payload codec counter underflow') END; END;
+
+CREATE TRIGGER payload_codec_audits_insert AFTER INSERT ON command_audits
+WHEN (new.command_codec IS NOT NULL AND new.command_codec<>'identity') OR (new.input_codec IS NOT NULL AND new.input_codec<>'identity') OR (new.output_codec IS NOT NULL AND new.output_codec<>'identity')
+BEGIN UPDATE payload_codec_compatibility_state SET audit_command_nonidentity=audit_command_nonidentity+(new.command_codec IS NOT NULL AND new.command_codec<>'identity'),audit_input_nonidentity=audit_input_nonidentity+(new.input_codec IS NOT NULL AND new.input_codec<>'identity'),audit_output_nonidentity=audit_output_nonidentity+(new.output_codec IS NOT NULL AND new.output_codec<>'identity') WHERE singleton=1 AND mode='counter' AND state='valid'; SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'invalid payload codec compatibility state') END; END;
+CREATE TRIGGER payload_codec_audits_update_guard BEFORE UPDATE OF command_codec,input_codec,output_codec ON command_audits
+BEGIN SELECT CASE WHEN NOT EXISTS(SELECT 1 FROM payload_codec_compatibility_state WHERE singleton=1 AND mode='counter' AND state='valid' AND audit_command_nonidentity >= (old.command_codec IS NOT NULL AND old.command_codec<>'identity') AND audit_input_nonidentity >= (old.input_codec IS NOT NULL AND old.input_codec<>'identity') AND audit_output_nonidentity >= (old.output_codec IS NOT NULL AND old.output_codec<>'identity')) THEN RAISE(ABORT,'payload codec counter underflow') END; END;
+CREATE TRIGGER payload_codec_audits_update AFTER UPDATE OF command_codec,input_codec,output_codec ON command_audits
+WHEN COALESCE(old.command_codec,'identity')<>COALESCE(new.command_codec,'identity') OR COALESCE(old.input_codec,'identity')<>COALESCE(new.input_codec,'identity') OR COALESCE(old.output_codec,'identity')<>COALESCE(new.output_codec,'identity')
+BEGIN UPDATE payload_codec_compatibility_state SET audit_command_nonidentity=audit_command_nonidentity-(old.command_codec IS NOT NULL AND old.command_codec<>'identity')+(new.command_codec IS NOT NULL AND new.command_codec<>'identity'),audit_input_nonidentity=audit_input_nonidentity-(old.input_codec IS NOT NULL AND old.input_codec<>'identity')+(new.input_codec IS NOT NULL AND new.input_codec<>'identity'),audit_output_nonidentity=audit_output_nonidentity-(old.output_codec IS NOT NULL AND old.output_codec<>'identity')+(new.output_codec IS NOT NULL AND new.output_codec<>'identity') WHERE singleton=1 AND mode='counter' AND state='valid'; SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'invalid payload codec compatibility state') END; END;
+CREATE TRIGGER payload_codec_audits_delete BEFORE DELETE ON command_audits
+WHEN (old.command_codec IS NOT NULL AND old.command_codec<>'identity') OR (old.input_codec IS NOT NULL AND old.input_codec<>'identity') OR (old.output_codec IS NOT NULL AND old.output_codec<>'identity')
+BEGIN UPDATE payload_codec_compatibility_state SET audit_command_nonidentity=audit_command_nonidentity-(old.command_codec IS NOT NULL AND old.command_codec<>'identity'),audit_input_nonidentity=audit_input_nonidentity-(old.input_codec IS NOT NULL AND old.input_codec<>'identity'),audit_output_nonidentity=audit_output_nonidentity-(old.output_codec IS NOT NULL AND old.output_codec<>'identity') WHERE singleton=1 AND mode='counter' AND state='valid' AND audit_command_nonidentity >= (old.command_codec IS NOT NULL AND old.command_codec<>'identity') AND audit_input_nonidentity >= (old.input_codec IS NOT NULL AND old.input_codec<>'identity') AND audit_output_nonidentity >= (old.output_codec IS NOT NULL AND old.output_codec<>'identity'); SELECT CASE WHEN changes()<>1 THEN RAISE(ABORT,'payload codec counter underflow') END; END;

--- a/schema/sqlite/migrations/000043_add_payload_codec_compatibility_mode.sql
+++ b/schema/sqlite/migrations/000043_add_payload_codec_compatibility_mode.sql
@@ -1,0 +1,14 @@
+-- An old development database that already applied the original migration 36
+-- has the four partial indexes and no marker. Select legacy mode without
+-- scanning canonical payload rows. Rewritten migration 36 creates counter mode
+-- first, so CREATE/INSERT OR IGNORE preserves that shape.
+CREATE TABLE IF NOT EXISTS payload_codec_compatibility_state (
+ singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+ mode TEXT NOT NULL CHECK(mode IN('counter','legacy_index')),
+ state TEXT NOT NULL CHECK(state IN('valid','invalid')),
+ event_body_nonidentity INTEGER NOT NULL CHECK(event_body_nonidentity>=0),
+ audit_command_nonidentity INTEGER NOT NULL CHECK(audit_command_nonidentity>=0),
+ audit_input_nonidentity INTEGER NOT NULL CHECK(audit_input_nonidentity>=0),
+ audit_output_nonidentity INTEGER NOT NULL CHECK(audit_output_nonidentity>=0)
+);
+INSERT OR IGNORE INTO payload_codec_compatibility_state VALUES(1,'legacy_index','valid',0,0,0,0);


### PR DESCRIPTION
## Summary

- remove four data-dependent partial codec indexes from the pre-release migration 36 path
- maintain constant-size four-lane non-identity codec counters transactionally
- preserve already-applied migration-36 developer stores through a scan-free legacy-index compatibility mode
- make global search and rehearsal compatibility checks select the correct fixed evidence shape
- add migration timing, counter lifecycle, rollback, concurrency, invalid-state, and legacy-shape tests

## Validation

- `GOCACHE=/private/tmp/traceary-1641-orch-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-1641-orch-cache go vet ./...`
- `GOCACHE=/private/tmp/traceary-1641-orch-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-1641-orch-lint go tool golangci-lint run --timeout=5m`
- `git diff --check origin/main...HEAD`

## Measured gate cause

Migration 36 previously spent approximately 22 seconds scanning the 24 GB store to build four empty partial indexes. The same migration set without those indexes measured approximately 0.4 seconds. #1620 will rerun the copied-store rehearsal on the merged final HEAD.

Closes #1641