### PR TITLE
v0.34.0-20: make rehearsal migration journal planning explicit

### DIFF
--- a/.ai/spec/1643-explicit-rehearsal-migration-plan.md
+++ b/.ai/spec/1643-explicit-rehearsal-migration-plan.md
@@ -1,0 +1,36 @@
+# #1643 explicit rehearsal migration journal plan
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+- Determine migration work from embedded versions versus `schema_migrations`, never from WAL existence or a rehearsal table heuristic.
+- Normalize both exact clone and copied target to verified WAL mode in a separately timed, cancellable operation capped at one second.
+- Preflight executes the exact pending set in one `BEGIN IMMEDIATE` through `COMMIT`, measures elapsed time, and observes a non-zero live WAL while its connection remains open.
+- Actual execution occurs iff the measured plan says pending and uses the same journal mode and WAL reservation. Any failure after target mutation restores the verified physical backup.
+
+### Conceptual model
+| Concept | State | Behavior | Invariant |
+|---|---|---|---|
+| Migration plan | pending, WAL bytes, elapsed, journal mode | binds clone evidence to target execution | pending implies WAL >= one frame |
+| Journal normalization | DELETE/WAL/other | switches and verifies mode under its own deadline | success reports exactly `wal` |
+| Exact migration transaction | embedded missing versions | BEGIN IMMEDIATE, migrate, COMMIT | measured duration covers lock through commit |
+| Recovery boundary | target unmodified/mutated/restored | restores backup after post-mutation failure | failed start leaves no rehearsal objects |
+
+### Responsibility assignment
+- Migration inventory and clone measurement: `payload_rehearsal_migration.go`.
+- WAL reservation and transactional execution: existing budgeted mutation session.
+- Workflow recovery and evidence publication: payload rehearsal adapter.
+- Public aggregate evidence: application payload rehearsal types.
+
+### Behavior tests
+- DELETE-journal source with pending versions yields `Pending=true`, verified WAL mode, non-zero WAL, and exact migration elapsed time.
+- Current schema yields explicit no-pending skip.
+- Timeout/cancellation/mode mismatch fails before run creation.
+- WAL zero for pending migration fails closed.
+- Any post-target mutation failure restores the backup and leaves zero rehearsal objects.
+- Preview followed by stop-after-one produces a paused resumable run while live/source identities remain unchanged.
+
+### Risks / rollback
+- Journal switching mutates the copied target, so it is inside the physical-backup recovery boundary.
+- Source/live paths remain read-only and are rechecked before every target mutation.
+- Rollback restores the verified independent backup; no schema downgrade is attempted in place.

--- a/application/types/payload_rehearsal.go
+++ b/application/types/payload_rehearsal.go
@@ -149,28 +149,37 @@ type RehearsalDiskPlan struct {
 	TotalBytes          uint64 `json:"total_bytes"`
 }
 
+// PayloadRehearsalMigrationPlan records exact preflight and execution evidence.
+type PayloadRehearsalMigrationPlan struct {
+	Pending                      bool   `json:"pending"`
+	WALBytes                     int64  `json:"wal_bytes"`
+	MigrationElapsedMilliseconds int64  `json:"migration_elapsed_milliseconds"`
+	JournalMode                  string `json:"journal_mode"`
+}
+
 // PayloadRehearsalMetrics contains sanitized aggregate rehearsal evidence.
 type PayloadRehearsalMetrics struct {
-	RunID                  string                      `json:"run_id,omitempty"`
-	State                  string                      `json:"state"`
-	ScannedRows            int64                       `json:"scanned_rows"`
-	EncodedRows            int64                       `json:"encoded_rows"`
-	PlaintextBytes         int64                       `json:"plaintext_bytes"`
-	StoredBytes            int64                       `json:"stored_bytes"`
-	BatchCount             int64                       `json:"batch_count"`
-	MorePending            bool                        `json:"more_pending"`
-	BatchDurationHistogram map[string]int64            `json:"batch_duration_histogram"`
-	ConflictRows           int64                       `json:"conflict_rows"`
-	PeakWALBytes           int64                       `json:"peak_wal_bytes"`
-	FreeBytes              uint64                      `json:"free_bytes"`
-	EstimatedHeadroom      uint64                      `json:"estimated_headroom_bytes"`
-	DiskPlan               RehearsalDiskPlan           `json:"disk_plan"`
-	DryRunZeroWrite        bool                        `json:"dry_run_zero_write"`
-	MigrationRequired      bool                        `json:"migration_required"`
-	LiveIdentityOnly       bool                        `json:"live_identity_only"`
-	RollbackDigest         string                      `json:"rollback_digest,omitempty"`
-	RollbackVerified       bool                        `json:"rollback_verified"`
-	Before                 []PayloadRehearsalFileState `json:"before,omitempty"`
-	After                  []PayloadRehearsalFileState `json:"after,omitempty"`
-	ActivationReadiness    PayloadActivationReadiness  `json:"activation_readiness"`
+	RunID                  string                        `json:"run_id,omitempty"`
+	State                  string                        `json:"state"`
+	ScannedRows            int64                         `json:"scanned_rows"`
+	EncodedRows            int64                         `json:"encoded_rows"`
+	PlaintextBytes         int64                         `json:"plaintext_bytes"`
+	StoredBytes            int64                         `json:"stored_bytes"`
+	BatchCount             int64                         `json:"batch_count"`
+	MorePending            bool                          `json:"more_pending"`
+	BatchDurationHistogram map[string]int64              `json:"batch_duration_histogram"`
+	ConflictRows           int64                         `json:"conflict_rows"`
+	PeakWALBytes           int64                         `json:"peak_wal_bytes"`
+	FreeBytes              uint64                        `json:"free_bytes"`
+	EstimatedHeadroom      uint64                        `json:"estimated_headroom_bytes"`
+	DiskPlan               RehearsalDiskPlan             `json:"disk_plan"`
+	DryRunZeroWrite        bool                          `json:"dry_run_zero_write"`
+	MigrationRequired      bool                          `json:"migration_required"`
+	MigrationPlan          PayloadRehearsalMigrationPlan `json:"migration_plan"`
+	LiveIdentityOnly       bool                          `json:"live_identity_only"`
+	RollbackDigest         string                        `json:"rollback_digest,omitempty"`
+	RollbackVerified       bool                          `json:"rollback_verified"`
+	Before                 []PayloadRehearsalFileState   `json:"before,omitempty"`
+	After                  []PayloadRehearsalFileState   `json:"after,omitempty"`
+	ActivationReadiness    PayloadActivationReadiness    `json:"activation_readiness"`
 }

--- a/docs/storage/payload-rehearsal.ja.md
+++ b/docs/storage/payload-rehearsal.ja.md
@@ -14,6 +14,11 @@ codec互換性preflightは、新たにupgradeしたstoreではevent body、comma
    コピーには`-wal`と`-shm`を残しません。
 2. `traceary store payload-rehearsal preview --target COPY --live-db LIVE`を実行します。
    previewはimmutable/query-onlyで開き、検査前後のDB/WAL/SHM snapshotが一致しなければ失敗します。
+
+migrationの要否はembedded versionと`schema_migrations`の差分から判定します。
+run前にexact cloneを独立した1秒上限内で検証済みWAL modeへ切り替え、pending migration一式を単一の`BEGIN IMMEDIATE`/`COMMIT`で実行し、live WAL bytesとlock durationを記録します。
+コピーtargetは同じpending状態、journal mode、WAL予約を再現しなければなりません。
+targetのjournal変更後に失敗した場合は検証済みphysical backupを復元し、明示的なno-pending planの場合だけmigration実行を省略します。
 3. `... run --target COPY --live-db LIVE --backup ROLLBACK`を実行します。
    圧縮結果は`payload_rehearsal_rows`だけに保存し、event/auditのcanonical payloadは変更しません。
 4. 中断または上限到達後は、同じ設定とrollback artifactで`... resume`を実行します。

--- a/docs/storage/payload-rehearsal.md
+++ b/docs/storage/payload-rehearsal.md
@@ -17,6 +17,14 @@ compatibility evidence fails closed before a rehearsal run is created.
 2. Run `traceary store payload-rehearsal preview --target COPY --live-db LIVE`.
    Preview opens the copy immutable/query-only and fails unless DB/WAL/SHM
    snapshots are identical before and after inspection.
+
+Migration readiness is derived from embedded versions versus
+`schema_migrations`. Before a run, Traceary switches an exact clone to verified
+WAL mode under a separate one-second cap, executes the exact pending set in one
+`BEGIN IMMEDIATE`/`COMMIT`, and records its live WAL bytes and lock duration.
+The copied target must reproduce that pending state, journal mode, and WAL
+reservation. Any failure after target journal mutation restores the verified
+physical backup; only an explicit no-pending plan skips migration execution.
 3. Run `... run --target COPY --live-db LIVE --backup ROLLBACK`. Compression is
    written only to `payload_rehearsal_rows`; canonical event and audit payloads
    remain unchanged. Required row, byte, time, and lock caps are always active.

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -395,8 +395,17 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	if pendingErr != nil || actualPending != migrationPlan.pending {
 		return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("rehearsal migration plan changed after preflight")
 	}
-	actualMode, _, modeErr := normalizeRehearsalJournal(ctx, db, c.LockTimeLimit)
-	if modeErr != nil || actualMode != migrationPlan.journalMode {
+	actualMode := ""
+	var modeErr error
+	if resume {
+		modeErr = db.QueryRowContext(ctx, `PRAGMA journal_mode`).Scan(&actualMode)
+	} else {
+		actualMode, _, modeErr = normalizeRehearsalJournal(ctx, db, c.LockTimeLimit)
+	}
+	if modeErr != nil || actualMode != "wal" || actualMode != migrationPlan.journalMode || (resume && actualPending) {
+		if resume {
+			return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("resume requires no pending migration and existing WAL journal mode")
+		}
 		_ = db.Close()
 		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
 			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("journal normalization failed and rollback failed: %w", recoveryErr)
@@ -404,6 +413,9 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 		return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, errors.New("rehearsal journal mode does not match preflight")
 	}
 	recoverMutatedTarget := func(cause error) (apptypes.PayloadRehearsalMetrics, error) {
+		if resume {
+			return apptypes.PayloadRehearsalMetrics{}, cause
+		}
 		_ = db.Close()
 		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
 			return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("%v; restore verified backup: %w", cause, recoveryErr)
@@ -417,8 +429,7 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 			return nil, metrics, recoveryErr
 		}
 		reservedFrames := max(int64(1), (migrationPlan.walBytes-32+pageBytes-1)/pageBytes)
-		migrationSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: preMigrationIdentity.schema, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &peakWAL, lockLimit: c.LockTimeLimit}
-		migrationStarted := time.Now()
+		migrationSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: preMigrationIdentity.schema, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &peakWAL, lockLimit: c.LockTimeLimit, mutationElapsed: &migrationPlan.elapsed}
 		if err = migrationSession.run(ctx, reservedFrames, func(conn *sql.Conn) error {
 			return database.migrateOnBudgetedConnection(ctx, conn)
 		}); err != nil {
@@ -428,7 +439,6 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 			}
 			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, xerrors.Errorf("initialize rehearsal bookkeeping: %w", err)
 		}
-		migrationPlan.elapsed = time.Since(migrationStarted)
 		if migrationPlan.elapsed > c.LockTimeLimit {
 			_ = db.Close()
 			if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -186,11 +186,10 @@ func (a *PayloadRehearsalAdapter) Preview(ctx context.Context, c apptypes.Payloa
 	if err = VerifyStoreCompatibility(ctx, db); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, err
 	}
-	var bookkeeping int
-	if err = db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='payload_rehearsal_runs')`).Scan(&bookkeeping); err != nil {
-		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect rehearsal schema: %w", err)
+	migrationRequired, err := NewDatabase(id.canonical, a.migrations).rehearsalMigrationsPending(ctx, db)
+	if err != nil {
+		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect pending rehearsal migrations: %w", err)
 	}
-	migrationRequired := bookkeeping == 0
 	var eventRows, auditRows, eventBytes, auditBytes int64
 	if err = db.QueryRowContext(ctx, `SELECT count(*),coalesce(sum(length(body)),0) FROM events`).Scan(&eventRows, &eventBytes); err != nil {
 		return apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("inspect event aggregates: %w", err)
@@ -378,7 +377,7 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	if err != nil {
 		return nil, apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("fix migration target identity: %w", err)
 	}
-	measuredMigrationWAL, err := database.measureRehearsalMigrationWAL(ctx, id.canonical, c.LockTimeLimit)
+	migrationPlan, err := database.measureRehearsalMigrationWAL(ctx, id.canonical, c.LockTimeLimit)
 	if err != nil {
 		return nil, apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("preflight rehearsal bookkeeping migration: %w", err)
 	}
@@ -392,14 +391,49 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	if err = requireLiveIdentityOnly(ctx, c.LivePath); err != nil {
 		return nil, apptypes.PayloadRehearsalMetrics{}, err
 	}
-	if measuredMigrationWAL > 0 {
+	actualPending, pendingErr := database.rehearsalMigrationsPending(ctx, db)
+	if pendingErr != nil || actualPending != migrationPlan.pending {
+		return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("rehearsal migration plan changed after preflight")
+	}
+	actualMode, _, modeErr := normalizeRehearsalJournal(ctx, db, c.LockTimeLimit)
+	if modeErr != nil || actualMode != migrationPlan.journalMode {
+		_ = db.Close()
+		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("journal normalization failed and rollback failed: %w", recoveryErr)
+		}
+		return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, errors.New("rehearsal journal mode does not match preflight")
+	}
+	recoverMutatedTarget := func(cause error) (apptypes.PayloadRehearsalMetrics, error) {
+		_ = db.Close()
+		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+			return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("%v; restore verified backup: %w", cause, recoveryErr)
+		}
+		return apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, cause
+	}
+	if migrationPlan.pending {
 		pageBytes := minimumWAL - 32
-		reservedFrames := max(int64(1), (measuredMigrationWAL-32+pageBytes-1)/pageBytes)
+		if migrationPlan.walBytes < minimumWAL {
+			return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("pending migration WAL is smaller than one frame")
+		}
+		reservedFrames := max(int64(1), (migrationPlan.walBytes-32+pageBytes-1)/pageBytes)
 		migrationSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: preMigrationIdentity.schema, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &peakWAL, lockLimit: c.LockTimeLimit}
+		migrationStarted := time.Now()
 		if err = migrationSession.run(ctx, reservedFrames, func(conn *sql.Conn) error {
 			return database.migrateOnBudgetedConnection(ctx, conn)
 		}); err != nil {
-			return nil, apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("initialize rehearsal bookkeeping: %w", err)
+			_ = db.Close()
+			if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+				return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("migration failed and rollback failed: %w", recoveryErr)
+			}
+			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, xerrors.Errorf("initialize rehearsal bookkeeping: %w", err)
+		}
+		migrationPlan.elapsed = time.Since(migrationStarted)
+		if migrationPlan.elapsed > c.LockTimeLimit {
+			_ = db.Close()
+			if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+				return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("migration commit exceeded lock cap and rollback failed: %w", recoveryErr)
+			}
+			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, errors.New("rehearsal migration lock duration cap exceeded through commit")
 		}
 	}
 	if err = observeWALPeak(id.canonical, minimumWAL, c.MaxWALBytes, &peakWAL); err != nil {
@@ -413,20 +447,27 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 		return nil, apptypes.PayloadRehearsalMetrics{PeakWALBytes: peakWAL, RollbackDigest: backupDigest, RollbackVerified: true}, err
 	}
 	if err = VerifyStoreCompatibility(ctx, db); err != nil {
-		return nil, apptypes.PayloadRehearsalMetrics{}, err
+		_ = db.Close()
+		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
+			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("post-migration compatibility failed and rollback failed: %w", recoveryErr)
+		}
+		return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, err
 	}
 	rehearsalSchemaSHA, err := rehearsalSchemaFingerprint(ctx, db)
 	if err != nil {
-		return nil, apptypes.PayloadRehearsalMetrics{}, xerrors.Errorf("fingerprint rehearsal schema: %w", err)
+		metrics, recoveryErr := recoverMutatedTarget(xerrors.Errorf("fingerprint rehearsal schema: %w", err))
+		return nil, metrics, recoveryErr
 	}
 	if a.beforeStartRun != nil {
 		a.beforeStartRun()
 	}
 	if err = requireLiveIdentityOnly(ctx, c.LivePath); err != nil {
-		return nil, apptypes.PayloadRehearsalMetrics{}, err
+		metrics, recoveryErr := recoverMutatedTarget(err)
+		return nil, metrics, recoveryErr
 	}
 	if err = a.recheckExpectedTarget(id, c, true); err != nil {
-		return nil, apptypes.PayloadRehearsalMetrics{}, err
+		metrics, recoveryErr := recoverMutatedTarget(err)
+		return nil, metrics, recoveryErr
 	}
 	configHash := hashConfig(c, id.opaque)
 	guard := rehearsalMutationGuard(func() error { return a.recheckExpectedTarget(id, c, true) })
@@ -434,9 +475,13 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	startSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: rehearsalSchemaSHA, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &resumePeak, lockLimit: c.LockTimeLimit}
 	runID, eventHigh, auditHigh, leaseToken, err := loadOrCreateRun(ctx, startSession, id, configHash, backupDigest, resume, guard)
 	if err != nil {
-		return nil, apptypes.PayloadRehearsalMetrics{}, err
+		if resume {
+			return nil, apptypes.PayloadRehearsalMetrics{}, err
+		}
+		metrics, recoveryErr := recoverMutatedTarget(err)
+		return nil, metrics, recoveryErr
 	}
-	metrics := apptypes.PayloadRehearsalMetrics{RunID: runID, State: "running", RollbackDigest: backupDigest, RollbackVerified: true, LiveIdentityOnly: liveIdentity, Before: parts, FreeBytes: freeBytes, EstimatedHeadroom: requiredHeadroom, DiskPlan: diskPlan, PeakWALBytes: resumePeak, BatchDurationHistogram: map[string]int64{"lt_1ms": 0, "lt_10ms": 0, "lt_100ms": 0, "gte_100ms": 0}}
+	metrics := apptypes.PayloadRehearsalMetrics{RunID: runID, State: "running", RollbackDigest: backupDigest, RollbackVerified: true, LiveIdentityOnly: liveIdentity, Before: parts, FreeBytes: freeBytes, EstimatedHeadroom: requiredHeadroom, DiskPlan: diskPlan, PeakWALBytes: resumePeak, MigrationRequired: migrationPlan.pending, MigrationPlan: apptypes.PayloadRehearsalMigrationPlan{Pending: migrationPlan.pending, WALBytes: migrationPlan.walBytes, MigrationElapsedMilliseconds: migrationPlan.elapsed.Milliseconds(), JournalMode: migrationPlan.journalMode}, BatchDurationHistogram: map[string]int64{"lt_1ms": 0, "lt_10ms": 0, "lt_100ms": 0, "gte_100ms": 0}}
 	batchSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: rehearsalSchemaSHA, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &metrics.PeakWALBytes, lockLimit: c.LockTimeLimit}
 	if err = observeWALPeak(id.canonical, minimumWAL, c.MaxWALBytes, &metrics.PeakWALBytes); err != nil {
 		return nil, metrics, pauseRun(ctx, batchSession, runID, leaseToken, err, guard)

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -448,21 +448,16 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 		}
 	}
 	if err = observeWALPeak(id.canonical, minimumWAL, c.MaxWALBytes, &peakWAL); err != nil {
-		_ = db.Close()
-		if a.beforeMigrationRecovery != nil {
+		if !resume && a.beforeMigrationRecovery != nil {
 			a.beforeMigrationRecovery()
 		}
-		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
-			return nil, apptypes.PayloadRehearsalMetrics{PeakWALBytes: peakWAL, RollbackDigest: backupDigest, RollbackVerified: false}, xerrors.Errorf("migration WAL cap exceeded and rollback failed: %w", recoveryErr)
-		}
-		return nil, apptypes.PayloadRehearsalMetrics{PeakWALBytes: peakWAL, RollbackDigest: backupDigest, RollbackVerified: true}, err
+		metrics, recoveryErr := recoverMutatedTarget(err)
+		metrics.PeakWALBytes = peakWAL
+		return nil, metrics, recoveryErr
 	}
 	if err = VerifyStoreCompatibility(ctx, db); err != nil {
-		_ = db.Close()
-		if recoveryErr := restoreVerifiedRehearsalBackup(id.canonical, c.BackupPath, id, backupIdentity, backupDigest); recoveryErr != nil {
-			return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest}, xerrors.Errorf("post-migration compatibility failed and rollback failed: %w", recoveryErr)
-		}
-		return nil, apptypes.PayloadRehearsalMetrics{RollbackDigest: backupDigest, RollbackVerified: true}, err
+		metrics, recoveryErr := recoverMutatedTarget(err)
+		return nil, metrics, recoveryErr
 	}
 	rehearsalSchemaSHA, err := rehearsalSchemaFingerprint(ctx, db)
 	if err != nil {

--- a/infrastructure/sqlite/payload_rehearsal.go
+++ b/infrastructure/sqlite/payload_rehearsal.go
@@ -413,7 +413,8 @@ func (a *PayloadRehearsalAdapter) Prepare(ctx context.Context, c apptypes.Payloa
 	if migrationPlan.pending {
 		pageBytes := minimumWAL - 32
 		if migrationPlan.walBytes < minimumWAL {
-			return nil, apptypes.PayloadRehearsalMetrics{}, errors.New("pending migration WAL is smaller than one frame")
+			metrics, recoveryErr := recoverMutatedTarget(errors.New("pending migration WAL is smaller than one frame"))
+			return nil, metrics, recoveryErr
 		}
 		reservedFrames := max(int64(1), (migrationPlan.walBytes-32+pageBytes-1)/pageBytes)
 		migrationSession := walBudgetedMutationSession{db: db, path: id.canonical, expectedSchemaSHA: preMigrationIdentity.schema, frameBytes: minimumWAL, maximum: c.MaxWALBytes, peak: &peakWAL, lockLimit: c.LockTimeLimit}

--- a/infrastructure/sqlite/payload_rehearsal_migration.go
+++ b/infrastructure/sqlite/payload_rehearsal_migration.go
@@ -63,18 +63,89 @@ func exactFileClone(source, destination string) error {
 	return out.Close()
 }
 
-// measureRehearsalMigrationWAL executes the exact migration set on a byte clone.
-// The clone's uncheckpointed WAL is a strict reservation input for the target.
+type rehearsalMigrationPlan struct {
+	pending     bool
+	walBytes    int64
+	elapsed     time.Duration
+	journalMode string
+}
+
+//nolint:wrapcheck // internal migration inventory is classified by callers.
+func (d *Database) rehearsalMigrationsPending(ctx context.Context, db *sql.DB) (bool, error) {
+	var migrationTable int
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations')`).Scan(&migrationTable); err != nil {
+		return false, err
+	}
+	if migrationTable == 0 {
+		return true, nil
+	}
+	rows, err := db.QueryContext(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	applied := map[int64]struct{}{}
+	for rows.Next() {
+		var version int64
+		if err = rows.Scan(&version); err != nil {
+			return false, err
+		}
+		applied[version] = struct{}{}
+	}
+	if err = rows.Err(); err != nil {
+		return false, err
+	}
+	paths, err := fs.Glob(d.migrations, "*.sql")
+	if err != nil {
+		return false, err
+	}
+	for _, path := range paths {
+		version, parseErr := parseMigrationVersion(path)
+		if parseErr != nil {
+			return false, parseErr
+		}
+		if _, ok := applied[version]; !ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+//nolint:wrapcheck // journal normalization is classified by callers.
+func normalizeRehearsalJournal(ctx context.Context, db *sql.DB, limit time.Duration) (string, time.Duration, error) {
+	if limit <= 0 || limit > time.Second {
+		limit = time.Second
+	}
+	opCtx, cancel := context.WithTimeout(ctx, limit)
+	defer cancel()
+	started := time.Now()
+	var mode string
+	if err := db.QueryRowContext(opCtx, `PRAGMA journal_mode=WAL`).Scan(&mode); err != nil {
+		return "", time.Since(started), err
+	}
+	elapsed := time.Since(started)
+	if elapsed > limit {
+		return mode, elapsed, errors.New("rehearsal journal normalization duration cap exceeded")
+	}
+	if mode != "wal" {
+		return mode, elapsed, fmt.Errorf("rehearsal journal mode mismatch: %s", mode)
+	}
+	return mode, elapsed, nil
+}
+
+// measureRehearsalMigrationWAL executes the exact pending migration set in one
+// BEGIN IMMEDIATE/COMMIT on a byte clone and observes its live WAL.
 //
 //nolint:wrapcheck // internal preflight errors are classified at the Run boundary.
-func (d *Database) measureRehearsalMigrationWAL(ctx context.Context, target string, lock time.Duration) (int64, error) {
+func (d *Database) measureRehearsalMigrationWAL(ctx context.Context, target string, lock time.Duration) (rehearsalMigrationPlan, error) {
+	plan := rehearsalMigrationPlan{}
 	clone, err := os.CreateTemp(filepath.Dir(target), ".traceary-migration-preflight-*.db")
 	if err != nil {
-		return 0, err
+		return plan, err
 	}
 	clonePath := clone.Name()
 	if err = clone.Close(); err != nil {
-		return 0, err
+		return plan, err
 	}
 	defer func() {
 		for _, suffix := range []string{"", "-wal", "-shm"} {
@@ -82,32 +153,61 @@ func (d *Database) measureRehearsalMigrationWAL(ctx context.Context, target stri
 		}
 	}()
 	if err = exactFileClone(target, clonePath); err != nil {
-		return 0, err
+		return plan, err
 	}
 	db, err := sql.Open("sqlite", writableRehearsalDSN(clonePath, lock))
 	if err != nil {
-		return 0, err
+		return plan, err
 	}
 	defer func() { _ = db.Close() }()
 	db.SetMaxOpenConns(1)
+	plan.pending, err = d.rehearsalMigrationsPending(ctx, db)
+	if err != nil {
+		return plan, err
+	}
+	plan.journalMode, _, err = normalizeRehearsalJournal(ctx, db, lock)
+	if err != nil {
+		return plan, err
+	}
 	if _, err = db.ExecContext(ctx, `PRAGMA wal_autocheckpoint=0`); err != nil {
-		return 0, err
+		return plan, err
 	}
+	if !plan.pending {
+		return plan, nil
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return plan, err
+	}
+	defer func() { _ = conn.Close() }()
 	started := time.Now()
-	if err = d.migrate(ctx, db); err != nil {
-		return 0, err
+	if _, err = conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return plan, err
 	}
-	if time.Since(started) > lock {
-		return 0, errors.New("migration preflight lock duration cap exceeded")
+	defer func() { _, _ = conn.ExecContext(context.WithoutCancel(ctx), `ROLLBACK`) }()
+	if err = d.migrateOnBudgetedConnection(ctx, conn); err != nil {
+		return plan, err
 	}
-	info, err := os.Stat(clonePath + "-wal")
-	if errors.Is(err, os.ErrNotExist) {
-		return 0, nil
+	if _, err = conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return plan, err
 	}
-	if err != nil || !info.Mode().IsRegular() {
-		return 0, errors.New("cannot measure migration preflight WAL")
+	plan.elapsed = time.Since(started)
+	if plan.elapsed > lock {
+		return plan, errors.New("migration preflight lock duration cap exceeded")
 	}
-	return info.Size(), nil
+	info, statErr := os.Stat(clonePath + "-wal")
+	if statErr != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
+		return plan, errors.New("pending migration produced no valid WAL")
+	}
+	plan.walBytes = info.Size()
+	var pageSize int64
+	if err = conn.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&pageSize); err != nil || pageSize <= 0 {
+		return plan, errors.New("cannot inspect migration preflight WAL frame")
+	}
+	if plan.walBytes < 32+24+pageSize {
+		return plan, errors.New("pending migration WAL is smaller than one frame")
+	}
+	return plan, nil
 }
 
 // migrateOnBudgetedConnection applies pending migrations inside the caller's

--- a/infrastructure/sqlite/payload_rehearsal_migration_plan_internal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_migration_plan_internal_test.go
@@ -1,0 +1,60 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRehearsalMigrationPlanMeasuresPendingWALAndExplicitSkip(t *testing.T) {
+	ctx := context.Background()
+	all, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingPath := filepath.Join(t.TempDir(), "pending.db")
+	if err = NewDatabase(pendingPath, migrationsBeforeCodecFoundation(t)).initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pendingPlan, err := NewDatabase(pendingPath, all).measureRehearsalMigrationWAL(ctx, pendingPath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pendingPlan.pending || pendingPlan.journalMode != "wal" || pendingPlan.walBytes <= 0 || pendingPlan.elapsed <= 0 || pendingPlan.elapsed > time.Second {
+		t.Fatalf("pending migration plan=%+v", pendingPlan)
+	}
+	currentPath := filepath.Join(t.TempDir(), "current.db")
+	current := NewDatabase(currentPath, all)
+	if err = current.initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	currentPlan, err := current.measureRehearsalMigrationWAL(ctx, currentPath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currentPlan.pending || currentPlan.walBytes != 0 || currentPlan.elapsed != 0 || currentPlan.journalMode != "wal" {
+		t.Fatalf("no-pending migration plan=%+v", currentPlan)
+	}
+}
+
+func TestNormalizeRehearsalJournalHonorsCancellation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.db")
+	all, _ := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err := NewDatabase(path, all).initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", writableRehearsalDSN(path, time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err = normalizeRehearsalJournal(ctx, db, time.Second); err == nil {
+		t.Fatal("canceled journal normalization succeeded")
+	}
+}

--- a/infrastructure/sqlite/payload_rehearsal_store.go
+++ b/infrastructure/sqlite/payload_rehearsal_store.go
@@ -30,6 +30,9 @@ type walBudgetedMutationSession struct {
 	maximum           int64
 	peak              *int64
 	lockLimit         time.Duration
+	// mutationElapsed, when configured for schema migration, measures exactly
+	// BEGIN IMMEDIATE acquisition through COMMIT completion.
+	mutationElapsed *time.Duration
 }
 
 //nolint:wrapcheck // callers add the rehearsal operation classification.
@@ -73,6 +76,7 @@ func (s walBudgetedMutationSession) run(ctx context.Context, reservedFrames int6
 	if err = conn.QueryRowContext(ctx, `PRAGMA wal_autocheckpoint`).Scan(&autoCheckpoint); err != nil || autoCheckpoint != 0 {
 		return errors.New("cannot disable rehearsal WAL autocheckpoint")
 	}
+	mutationStarted := time.Now()
 	if _, err = conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
 		return err
 	}
@@ -104,11 +108,18 @@ func (s walBudgetedMutationSession) run(ctx context.Context, reservedFrames int6
 	if err = mutate(conn); err != nil {
 		return err
 	}
-	if time.Since(started) > s.lockLimit {
+	lockStarted := started
+	if s.mutationElapsed != nil {
+		lockStarted = mutationStarted
+	}
+	if time.Since(lockStarted) > s.lockLimit {
 		return errors.New("rehearsal lock duration cap exceeded before commit")
 	}
 	if _, err = conn.ExecContext(ctx, `COMMIT`); err != nil {
 		return err
+	}
+	if s.mutationElapsed != nil {
+		*s.mutationElapsed = time.Since(mutationStarted)
 	}
 	return observeWALPeak(s.path, s.frameBytes, s.maximum, s.peak)
 }

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -59,6 +59,33 @@ func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {
 	if stopped.State != "paused" || stopped.BatchCount != 1 || !stopped.MorePending {
 		t.Fatalf("stop result=%+v", stopped)
 	}
+	modeDB, err := sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = modeDB.Exec(`PRAGMA journal_mode=DELETE`); err != nil {
+		t.Fatal(err)
+	}
+	_ = modeDB.Close()
+	if _, err = u.Resume(ctx, config); err == nil {
+		t.Fatal("resume unexpectedly normalized a non-WAL paused target")
+	}
+	stateDB, err := sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pausedState string
+	var pausedRows int
+	if err = stateDB.QueryRow(`SELECT state,(SELECT count(*) FROM payload_rehearsal_rows) FROM payload_rehearsal_runs`).Scan(&pausedState, &pausedRows); err != nil {
+		t.Fatal(err)
+	}
+	if pausedState != "paused" || pausedRows == 0 {
+		t.Fatalf("failed resume erased paused overlay state=%q rows=%d", pausedState, pausedRows)
+	}
+	if _, err = stateDB.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		t.Fatal(err)
+	}
+	_ = stateDB.Close()
 	config.StopAfterBatches = 0
 	resumed, err := u.Resume(ctx, config)
 	if err != nil {

--- a/infrastructure/sqlite/payload_rehearsal_test.go
+++ b/infrastructure/sqlite/payload_rehearsal_test.go
@@ -59,6 +59,64 @@ func TestPayloadRehearsalDeterministicStopResumeScrubRollback(t *testing.T) {
 	if stopped.State != "paused" || stopped.BatchCount != 1 || !stopped.MorePending {
 		t.Fatalf("stop result=%+v", stopped)
 	}
+	compatDB, err := sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = compatDB.Exec(`UPDATE store_format_state SET minimum_reader_version=999`); err != nil {
+		t.Fatal(err)
+	}
+	_ = compatDB.Close()
+	if _, err = u.Resume(ctx, config); err == nil {
+		t.Fatal("resume unexpectedly accepted incompatible paused target")
+	}
+	compatDB, err = sql.Open("sqlite", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var compatibilityPausedState string
+	var compatibilityPausedRows int
+	if err = compatDB.QueryRow(`SELECT state,(SELECT count(*) FROM payload_rehearsal_rows) FROM payload_rehearsal_runs`).Scan(&compatibilityPausedState, &compatibilityPausedRows); err != nil {
+		t.Fatal(err)
+	}
+	if compatibilityPausedState != "paused" || compatibilityPausedRows == 0 {
+		t.Fatalf("compatibility failure erased paused overlay state=%q rows=%d", compatibilityPausedState, compatibilityPausedRows)
+	}
+	if _, err = compatDB.Exec(`UPDATE store_format_state SET minimum_reader_version=34`); err != nil {
+		t.Fatal(err)
+	}
+	_ = compatDB.Close()
+	if walInfo, walErr := os.Stat(target + "-wal"); walErr == nil {
+		pageDB, openErr := sql.Open("sqlite", target)
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		var pageSize int64
+		if err = pageDB.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
+			t.Fatal(err)
+		}
+		_ = pageDB.Close()
+		minimumFrame := int64(32 + 24 + pageSize)
+		if walInfo.Size() > minimumFrame {
+			oversized := config
+			oversized.MaxWALBytes = walInfo.Size() - 1
+			if _, err = u.Resume(ctx, oversized); err == nil {
+				t.Fatal("resume unexpectedly accepted oversized paused WAL")
+			}
+			checkDB, openCheckErr := sql.Open("sqlite", target)
+			if openCheckErr != nil {
+				t.Fatal(openCheckErr)
+			}
+			var state string
+			if err = checkDB.QueryRow(`SELECT state FROM payload_rehearsal_runs`).Scan(&state); err != nil {
+				t.Fatal(err)
+			}
+			_ = checkDB.Close()
+			if state != "paused" {
+				t.Fatalf("oversized WAL failure erased paused state=%q", state)
+			}
+		}
+	}
 	modeDB, err := sql.Open("sqlite", target)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- distinguish pending migrations from WAL-file existence through an explicit migration plan
- normalize clone and copied target from DELETE journal mode to WAL through bounded, cancellable operations
- measure the exact single-transaction migration path through COMMIT while the connection remains open
- require valid nonzero WAL reservation whenever migrations are pending
- restore the verified backup for failures after target journal/schema mutation without destroying a legitimate concurrent resume
- report sanitized migration plan evidence and add pending/no-pending/cancel/recovery regressions

## Validation

- `GOCACHE=/private/tmp/traceary-1643-orch-cache go test ./...`
- `GOCACHE=/private/tmp/traceary-1643-orch-cache go vet ./...`
- `GOCACHE=/private/tmp/traceary-1643-orch-cache GOLANGCI_LINT_CACHE=/private/tmp/traceary-1643-orch-lint go tool golangci-lint run --timeout=5m`
- `git diff --check origin/main...HEAD`

## Actual-gate cause

The copied store used DELETE journal mode. Pending migrations completed on the preflight clone without creating `-wal`; zero was then misinterpreted as no pending migration and the actual bookkeeping migration was skipped. #1620 will rerun the 24 GB copied-store workflow after this PR merges.

Closes #1643