### PR TITLE
docs: define hot-cold segmented history architecture

### DIFF
--- a/docs/architecture/hot-cold-segmented-history.ja.md
+++ b/docs/architecture/hot-cold-segmented-history.ja.md
@@ -1,0 +1,128 @@
+# Hot/cold 分離による履歴セグメント設計
+
+[English](hot-cold-segmented-history.md)
+
+状態: #1648 の設計チェックポイント。実装は #1649〜#1654 に分割する。
+
+## 決定
+
+Traceary は canonical な event と command audit を全件保持しつつ、書き込み先 Hot SQLite のサイズを制限する。最近の詳細と active/latest/handoff は Hot に残し、古い履歴を immutable・圧縮 SQLite segment に移す。Hot 内の軽量 Segment Catalog が配置と集計情報を管理する。reader は Catalog epoch を固定し、Hot と必要な segment だけを読み、重複なく結果を統合する。
+
+比較した案は、(a) immutable SQLite segment、(b) 独自 append-only bundle、(c) 単一 Cold SQLite である。(a) を採用する。SQLite の検証・query 特性を再利用でき、新しい storage engine を作らずに済むためである。独自 bundle は codec/recovery リスクが大きい。単一 Cold DB は無制限な肥大化と全履歴単位 resume を再発させる。
+
+全履歴 search projection の完走と45分以内の generation は v0.34.0 のリリース条件にしない。段階移行中も既存検索を維持する。
+
+## 要求と非対象
+
+- canonical `events` と `command_audits` を全件保持する。圧縮は表現を変えるだけで、retention は変えない。
+- active/latest/handoff と最近の詳細取得を Hot path に保つ。
+- resume と検証を segment 単位にする。
+- offline candidate、advisory lock、atomic exchange、durable recovery、migration catalog、resource cap、source 不変検証を再利用する。
+- copied-store release-gate runner を汎用運用基盤にしない。
+- legacy archive/GC/retention deletion を canonical history の第二の authority にしない。
+
+## 概念モデルと不変条件
+
+| 概念 | 状態・振る舞い | 不変条件 |
+|---|---|---|
+| History Unit | event と optional command audit。event 単位の単調増加 archive sequence を一つ持つ | audit は親 event に従属し、unit の authoritative placement は一つだけ。 |
+| Segment | 閉じた sequence 区間、圧縮 payload、index、manifest | seal 後の bytes と論理内容は変更しない。 |
+| Catalog epoch | segment metadata と placement の immutable view | 一回の read は一つの epoch を固定する。publication は atomic。 |
+| Migration run | 一つの segment を copy、verify、publish、必要なら evict | durable journal の境界ごとに冪等 resume できる。 |
+| Authority | publication 前は Hot、placement publication 後は segment | 物理的な重複を論理結果の重複にしない。 |
+| Legacy compatibility | 未移行 record は既存 Hot projection で読む | 検証済み coverage より前に旧 projection を削除しない。 |
+
+新規 event の insert transaction で trigger が archive sequence を割り当てる。#1650 は stable store UUID/lineage を作成後、既存 event を bounded/resumable に backfill する。inventory の complete、gap-free、unique が証明されるまで activation しない。optional command audit は親 event と同じ History Unit/segment に配置する。migration は high-water event sequence を固定する。それ以降の late/backdated event はより大きい sequence で後続 segment に入り、segment の time range は重複し得る。building/frozen range 内の既存 event/audit の update/delete は拒否する。v0.34 は cold unit の mutation を扱わず、将来の訂正は append-only で versioned な tombstone/correction record とする。
+
+target は最小の未配置 sequence から始まり、Hot time horizon と max rows、plain bytes、stored bytes、wall time の全条件を満たす最大の連続閉区間とする。大きな segment を作るために sequence を飛ばさない。
+
+Segment ID は `store_id + format version + start sequence + end sequence + logical digest` とし、manifest と Catalog を全要素へ binding する。location は archive root 相対の content-addressed basename に限定し、absolute path、traversal、symlink を拒否する。sealed schema は segment format version のまま immutable とし、Hot migration を適用しない。logical digest は versioned canonical record encoding から計算し、物理破損検出用 file digest と分ける。
+
+## 責務と境界
+
+| 責務 | owner | 境界 |
+|---|---|---|
+| canonical record/sequence の不変条件 | `domain` | SQLite/file 詳細を持たない。 |
+| segment construction と migration orchestration | `application/usecase` | candidate、journal、publication、verification の port。 |
+| Catalog snapshot と federated query | `application/queryservice` | consumer-oriented な Hot/segment reader interface。 |
+| schema、segment file、lock、exchange、codec | `infrastructure/sqlite` | storage failure を typed application error に変換する。 |
+| 明示的な maintenance command と診断 | `presentation/cli` | 通常 read で暗黙 migration しない。 |
+
+Hot store と隣接 archive directory を一つの logical store とする。backup/restore は Hot DB、固定した Catalog snapshot、参照される全 segment manifest/file を一体で扱う。最初の segment publication 後、SQLite-only backup は完全な履歴ではない。
+
+## Segment と Catalog の契約
+
+sealed segment は一つの有界な event-sequence 区間の完全な History Unit、最小限の lookup/order index、segment-local search representation を持つ。format v1 は大きな text/blob に zstd を採用する。長さ付き canonical digest encoding で SQLite storage class、NULL、raw bytes を保存し、decode value は元と一致しなければならない。manifest は format/catalog version、区間、件数、logical/file digest、codec、作成 provenance、集計検証結果を持ち、machine-specific source path は持たない。全 table を `[]map[string]any` と JSON/gzip に materialize する既存 `StoreArchiver` は segment construction に再利用しない。
+
+Catalog は区間、time bounds、件数、state、location、digest、format version、有界な検索候補要約だけを保持し、raw body を複製しない。no-false-negative filter は time overlap、workspace/session/client/agent/kind の exact または Bloom membership、keyed literal n-gram Bloom とする。filter 不可の predicate は time-overlap する全 segment を選ぶ。false positive は許せるが false negative は許さず、exact filtering は source で行う。
+
+状態遷移は `building -> sealed -> verified_shadow -> segment_authoritative -> evicting -> cold` とする。`verified_shadow` までは Hot だけが authority で、segment は parity 専用である。parity 後の短い Catalog transaction が新 epoch と `segment_authoritative` を作る。通常 reader が二つの physical copy を同時に authority として扱う状態は作らない。Hot duplicate は rollback material としてのみ残す。`evicting` は rollback evidence が deletion を許可してから開始し、reclaim 検証後に `cold` へ進む。Catalog placement state と external journal phase は分離し、forward resume しない recovery は `abandoned` または `rolled_back` で終える。
+
+filesystem publish と Hot Catalog transaction は一操作では atomic にできない。segment を fsync し、content-addressed no-replace rename で配置し、directory fsync、durable intent 記録の後に Catalog transaction を commit する。Catalog commit 前の crash は検出可能な orphan を残す。commit 後は journal と観測した Catalog/file state から reconcile する。未検証または欠落 file を Catalog が参照してはならない。
+
+## Federated read と search
+
+reader は Hot read transaction を開始し、現在の Catalog epoch を固定し、その epoch が参照する正確な immutable segment version を開く。`created_at_norm DESC, event_id DESC` で統合する。plan 段階で segment-authoritative interval の Hot row を除外し、post-hoc ID dedupe を authority 判定の代用にしない。continuation は query hash、Catalog epoch、source set、各 source anchor を認証する。v0.34 の epoch は append-only とし、resume 可能な epoch の参照 segment を削除しない。
+
+sessions は Hot canonical のまま残す。各 segment の session aggregate と、late event で transactionally 更新する Hot delta を重複なく合成する。Hot session-resume projection は active lifecycle、latest metadata、有界な recent-command preview、latest compact summary を保持する。v0.34 で CLI `--recent` と MCP context-pack criteria に共通の明示 public max を導入し、projection も同数を保持する。超過は typed validation error、既存 default output は維持する。active/latest/handoff はこの projection を使い、無関係な cold segment が利用不能でも成功する。古い search は安全な Catalog filter の後、候補 segment だけを開く。
+
+必要な segment の欠落・破損時は aggregate diagnostics を伴う明示的な partial/unavailable error を返し、完全な結果であると黙って扱わない。
+
+## Migration、rollback、reclaim
+
+各 run は一つの target interval だけを所有する。
+
+1. 短時間の exclusive store advisory lock 下で source identity、Catalog epoch、target range、high-water を固定する。
+2. exclusive lease を解放して cap 下で owned offline candidate へ copy し、seal 前の短い freeze で whole-file SHA ではなく frozen range identity/logical digest を検証する。
+3. checkpoint、fsync、seal 後、件数、logical digest、参照、decode parity、source 不変性を検証して `verified_shadow` にする。Hot は唯一の authority のまま。
+4. file を配置し、durable intent を reconcile し、router parity 後に短い Catalog transaction で authority を segment へ切り替える。
+5. その区間で segment-authoritative と証明された identity だけを削除する。
+7. offline Hot candidate を rebuild/compact して atomic exchange し、rollback evidence を保持する。
+
+eviction 前の rollback は interval を Hot placement に戻す新 epoch を publish し、未参照 candidate のみ削除する。eviction 後は sealed segment から offline Hot candidate を再構築・検証・atomic exchange した後、Hot placement epoch を publish する。全 durable boundary の crash から冪等 resume できなければならない。apply/resume/rollback 前には非協調な旧 process と旧 binary を停止する。eviction 後の direct SQLite compatibility は保証しない。
+
+## 既存 maintenance surface
+
+| surface | v0.34 rule |
+|---|---|
+| event/audit GC、archive `--delete-after-verify`、raw-body retention、dedupe apply/restore | frozen または segment-authoritative ID を含めば typed conflict で fail closed。exact segment ID と Catalog epoch に binding した eviction capability だけが canonical unit を削除できる。 |
+| backup/restore | complete-history backup を要求する場面では SQLite-only backup を incomplete として拒否する。 |
+| compact | stable Catalog epoch かつ active migration run なしの場合だけ許可する。 |
+| legacy search maintenance | Hot compatibility projection だけを更新し、segment authority を変更しない。 |
+
+#1652 は Federated read facade を追加して composition root の read port を差し替える。Hot writer の `EventDatasource` に segment orchestration を詰め込まない。
+
+## 振る舞いテストと release gate
+
+| Given | When | Then |
+|---|---|---|
+| high-water 固定後の concurrent write | 一区間を migrate | 新 record は Hot に残り、対象 record の loss/duplicate がない。 |
+| event/audit の任意 byte | segment decode | decode bytes と logical digest が source と一致する。 |
+| file/Catalog publication 前後の crash | resume | authoritative placement が厳密に一つへ復旧する。 |
+| 物理 duplicate | federated list/search | canonical identity ごとに一件、stable order で返る。 |
+| 選択的な古い query | router plan | false negative なく Catalog 選択 segment だけを開く。 |
+| segment 欠落・破損 | complete query | typed incomplete result を返す。 |
+| 無関係な cold segment が利用不能 | active/latest/handoff | Hot session-resume projection から完全な結果を返す。 |
+| verified segment の eviction/reclaim 後 | rollback | history と source invariants を復元する。 |
+| rollout 中の legacy/federated reader | coverage 増加 | observable result の互換性を維持する。 |
+
+v0.34.0 release gate はレビュー済み copy のみを使い、少なくとも一 segment を publish し、crash/resume、実 eviction と physical reclaim、新 router 経由の既存 CLI/MCP list/search/session/active/latest/handoff の before/after parity、rollback を実証し、aggregate-only evidence を出す。全履歴 projection 完走は要求しない。互換対象はこの read surface であり、eviction 後の旧 binary/direct SQLite reader ではない。
+
+## 実装分割と TDD
+
+- #1649: format v1 と codec/validation（activation なし）。
+- #1650: schema-only の store lineage、bounded sequence inventory、Catalog/epoch/placement invariant。
+- #1651: shadow construction、file publication、journal/recovery（authority cutover なし）。
+- #1652: federated read/search、parity、stable pagination、authority cutover（delete なし）。
+- #1653: eviction、physical reclaim、post-eviction rollback。
+- #1654: CLI、完全 backup/restore、診断、日英 docs。
+- #1620: same-head segment gate evidence。#1621: release preparation。
+
+schema migration number は実装時点の shared migration catalog から直列に割り当て、Issue 番号ごとに先取りしない。各 Issue は最新 `main` から開始し、observable behavior test を先に追加する。中止した full-history runner はコピーしない。
+
+## リスクと rollback trigger
+
+- Catalog false negative、mixed-epoch read、digest mismatch、missing segment、source mutation 未証明は publication/eviction を停止する。
+- capacity は candidate、WAL、segment、rollback、exchange の headroom を含める。
+- compression/encryption/privacy policy は segment ごとに versioning し、log と公開 evidence は aggregate-only にする。
+- 最初の rollout では segment read 検証まで Hot duplicate を残す。破壊的 eviction は先行 invariant がすべて証明されるまで release-gate copy に限定する。

--- a/docs/architecture/hot-cold-segmented-history.md
+++ b/docs/architecture/hot-cold-segmented-history.md
@@ -1,0 +1,132 @@
+# Hot/cold segmented history architecture
+
+[日本語](hot-cold-segmented-history.ja.md)
+
+Status: design checkpoint for #1648. Implementation is split across #1649–#1654.
+
+## Decision
+
+Traceary will keep every canonical event and command audit while bounding the writable Hot SQLite database. Recent records and latency-sensitive views stay in Hot. Older records move into immutable, compressed SQLite segment files. A lightweight Segment Catalog in Hot records placement and summary metadata. Federated readers pin a Catalog epoch, query Hot and only the selected segments, and merge the results without duplicates.
+
+The alternatives were (a) immutable SQLite segments, (b) a custom append-only bundle, and (c) one Cold SQLite database. We select (a): it reuses SQLite validation and query behavior without creating a new storage engine. A custom bundle adds codec and recovery risk. A single Cold database recreates the unbounded database and full-history resume problem.
+
+This design does not make a full-history search projection or a 45-minute generation run a v0.34.0 release condition. Existing search remains available during staged migration.
+
+## Requirements and non-goals
+
+- Preserve all canonical `events` and `command_audits`; compression changes representation, not retention.
+- Keep active/latest/handoff and recent-detail latency on the Hot path.
+- Resume and verify one segment at a time.
+- Reuse prepared offline candidates, advisory locks, atomic exchange, durable recovery, migration catalog, resource caps, and source-invariance checks.
+- Do not turn the copied-store release-gate runner into a general operational framework.
+- Do not use legacy archive, GC, or retention deletion as a second authority for canonical history.
+
+## Conceptual model and invariants
+
+| Concept | State / behavior | Invariant |
+|---|---|---|
+| History unit | An event and its optional command audit, with one monotonically assigned event archive sequence | The audit follows its parent event; a unit has one authoritative placement. |
+| Segment | Closed sequence interval plus compressed payload, indexes, and manifest | Once sealed, its bytes and logical contents never change. |
+| Catalog epoch | Immutable view of segment metadata and placement | A read pins one epoch; publication is atomic. |
+| Migration run | Copies, verifies, publishes, then optionally evicts one segment | Its durable journal resumes at an idempotent boundary. |
+| Authority | Hot before publication; segment after placement publication | Duplicate physical copies never produce duplicate logical results. |
+| Legacy compatibility | Existing Hot projection remains available for records not cut over | Removal follows verified segment coverage; it never precedes it. |
+
+Archive sequence is assigned transactionally by a trigger when a new event is inserted. #1650 first creates a stable store UUID/lineage and then inventories existing events with a bounded, resumable backfill. Activation is forbidden until the inventory is complete, gap-free, and unique. Its optional command audit belongs to the same History Unit and follows the parent event into the same segment. A migration captures a high-water event sequence. Later or backdated events receive greater sequences and enter a later segment; segment time ranges may therefore overlap. Existing units in a building or frozen range reject event/audit update and delete. v0.34 does not support mutation of a cold unit; a future correction must be an append-only, versioned tombstone/correction record rather than rewriting a sealed segment.
+
+A target starts at the smallest unplaced sequence and is the largest contiguous closed prefix satisfying the Hot time horizon plus configured maximum rows, uncompressed bytes, stored bytes, and wall time. It never skips a sequence to make a larger segment.
+
+Segment identity is `store_id + format version + start sequence + end sequence + logical digest`. The manifest and Catalog bind all five values. Location is a content-addressed basename relative to the configured archive root; absolute paths, traversal, and symlinks are rejected. The sealed schema remains at its segment format version and never receives Hot database migrations. The logical digest is computed over a versioned canonical record encoding; a separate file digest detects physical corruption. This avoids assuming that equivalent SQLite files are byte-identical.
+
+## Responsibilities and boundaries
+
+| Responsibility | Owner | Boundary |
+|---|---|---|
+| Canonical record and sequence invariants | `domain` | No SQLite/file details. |
+| Segment construction and migration orchestration | `application/usecase` | Ports for candidate building, journal, publication, and verification. |
+| Catalog snapshot and federated query | `application/queryservice` | Consumer-oriented Hot/segment reader interfaces. |
+| SQLite schema, segment files, locks, exchange, codecs | `infrastructure/sqlite` | Maps storage failures to typed application errors. |
+| Explicit maintenance commands and diagnostics | `presentation/cli` | No hidden migration on ordinary reads. |
+
+The Hot store and its adjacent archive directory form one logical store. Backup/restore must capture the Hot database, a pinned Catalog snapshot, and every referenced segment manifest/file. A SQLite-only backup is incomplete after the first segment is published.
+
+## Segment and Catalog contract
+
+A sealed segment contains complete History Units for one bounded event-sequence interval, minimal lookup/order indexes, and a segment-local search representation. Segment format v1 uses zstd for large text/blob values. Its length-delimited canonical digest encoding preserves SQLite storage class, NULL, and raw bytes; decoded values must equal the originals. Its manifest records format/catalog versions, interval, counts, logical/file digests, codec facts, creation provenance, and aggregate validation results. It contains no machine-specific source path. The existing JSON/gzip `StoreArchiver`, which materializes whole tables as `[]map[string]any`, is not reused for segment construction.
+
+The Catalog stores interval, time bounds, counts, state, location, digests, format version, and bounded candidate-search summaries. It must not duplicate raw bodies. No-false-negative filters are time overlap; exact or Bloom membership for workspace, session, client, agent, and kind; and a keyed literal n-gram Bloom. Non-filterable predicates select every time-overlapping segment. Candidate structures may return false positives but not false negatives. Exact filtering always occurs against Hot or the selected segment.
+
+Catalog state transitions are:
+
+`building -> sealed -> verified_shadow -> segment_authoritative -> evicting -> cold`
+
+Through `verified_shadow`, Hot alone is authoritative and the segment is parity-only. After parity, one short Catalog transaction creates a new epoch and changes the interval to `segment_authoritative`; readers never treat both physical copies as authorities. Hot duplicates remain only as rollback material. `evicting` starts only after rollback evidence permits deletion, and `cold` follows verified reclaim. Catalog placement state is separate from the external journal phase; recovery ends explicitly in `abandoned` or `rolled_back` when it does not resume forward.
+
+File publication and the Hot Catalog transaction cannot be one filesystem/SQLite atomic operation. The publisher fsyncs the segment, installs it by content-addressed no-replace rename, fsyncs the directory, records durable intent, and only then commits a Catalog transaction. A crash before the Catalog commit leaves a detectable orphan. A crash afterward is reconciled from the journal plus observed Catalog/file state. A Catalog transaction must never reference an unverified or missing file.
+
+## Federated reads and search
+
+A reader starts a Hot read transaction, pins the current Catalog epoch, opens the exact immutable segment versions referenced by that epoch, and queries sources in parallel or bounded sequence. Results merge by the existing contract `created_at_norm DESC, event_id DESC`. The plan excludes Hot rows in segment-authoritative intervals; post-hoc ID deduplication is defense-in-depth, not authority selection. A continuation authenticates the query hash, Catalog epoch, source set, and each source anchor. v0.34 epochs are append-only and their referenced segments are not deleted while an epoch can be resumed.
+
+Sessions remain canonical in Hot. Each segment contributes a session aggregate; it combines without duplication with a transactionally updated Hot delta for late events. A Hot session-resume projection retains active lifecycle, latest metadata, a bounded recent-command preview, and the latest compact summary. v0.34 introduces one explicit public maximum for CLI `--recent` and MCP context-pack criteria; the projection retains exactly that maximum, over-limit requests return a typed validation error, and existing default output is unchanged. Active/latest/handoff use that Hot projection and must succeed even when an unrelated cold segment is unavailable. Historical search first applies workspace/session/time/type and safe Catalog candidate filters, then opens only candidate segments. Unsupported or nonselective predicates may scan bounded segments but never trigger a persistent full-history generation.
+
+Missing or corrupt required segments produce an explicit partial/unavailable error with aggregate diagnostics; Traceary must not silently claim a complete result.
+
+## Migration, rollback, and reclaim
+
+Each migration run owns exactly one target interval:
+
+1. Briefly pin source identity, Catalog epoch, target range, and high-water sequence under the exclusive store advisory lock.
+2. Release the exclusive lease and copy into an owned offline candidate with disk/time/row/write/decoded-byte caps; before seal, briefly freeze and verify the frozen range identity/logical digest rather than a whole-file SHA.
+3. Checkpoint, fsync, seal, and verify counts, logical digests, references, decode parity, and source invariance; the result is `verified_shadow` and Hot remains the sole authority.
+4. Install the file, reconcile durable intent, run router parity, then use a short Catalog transaction to cut authority over to the segment.
+5. Delete only identities proven segment-authoritative in that exact interval.
+7. Rebuild/compact an offline Hot candidate, atomically exchange it, and retain rollback evidence.
+
+Before eviction, rollback publishes a new epoch placing the interval back in Hot and removes only an unreferenced candidate. After eviction, rollback reconstructs an offline Hot candidate from the sealed segment, verifies it, atomically exchanges Hot, then publishes the returning placement epoch. A process crash at every durable boundary must resume idempotently. Non-cooperating old processes and old binaries must be stopped before apply/resume/rollback; direct SQLite compatibility after eviction is not promised.
+
+## Existing maintenance surface
+
+| Surface | v0.34 rule |
+|---|---|
+| Event/audit GC, archive `--delete-after-verify`, raw-body retention, dedupe apply/restore | Fail closed with a typed conflict if selected IDs are frozen or segment-authoritative. Only an eviction capability bound to an exact segment ID and Catalog epoch may delete canonical units. |
+| Backup/restore | A SQLite-only backup is explicitly incomplete and is rejected where complete-history backup is requested. |
+| Compact | Allowed only at a stable Catalog epoch with no active migration run. |
+| Legacy search maintenance | Maintains the Hot compatibility projection only and cannot change segment authority. |
+
+#1652 introduces a Federated read facade and swaps composition-root read ports; it does not add segment orchestration to the Hot-writing `EventDatasource`.
+
+## Observable behavior tests and release gate
+
+| Given | When | Then |
+|---|---|---|
+| Concurrent writes after captured high-water | one interval migrates | new records stay Hot and no captured record is lost or duplicated. |
+| Arbitrary bytes in event/audit fields | segment decode runs | decoded bytes and logical digest match the source. |
+| Crash before/after file and Catalog publication | resume runs | exactly one authoritative placement is recovered. |
+| Dual physical copies | federated list/search runs | each canonical identity appears once in stable order. |
+| Selective historical query | router plans it | only Catalog-selected segments open, with no false negatives. |
+| Segment unavailable/corrupt | a complete query needs it | a typed incomplete result is returned. |
+| An unrelated cold segment is unavailable | active/latest/handoff runs | the Hot session-resume projection still returns a complete result. |
+| Verified segment is evicted and Hot reclaimed | rollback runs | history is restored and source invariants hold. |
+| Legacy and federated readers during rollout | covered ranges increase | observable results stay compatible. |
+
+The v0.34.0 release gate uses only a reviewed copy, publishes at least one segment, exercises crash/resume, performs real eviction and physical reclaim, proves before/after parity for the existing CLI/MCP list, search, session, active/latest/handoff surfaces through the new router, proves rollback, and emits aggregate-only evidence. It does not require full-history projection completion. Compatibility means those supported surfaces, not an old binary or direct SQLite reader after eviction.
+
+## Delivery split
+
+- #1649 defines/builds format v1 and its codec/validation without activation.
+- #1650 owns schema-only store lineage, bounded sequence inventory, Catalog, epochs, and placement invariants.
+- #1651 owns shadow construction, file publication, journal, and recovery without authority cutover.
+- #1652 owns federated reads/search, parity, stable pagination, and authority cutover without deletion.
+- #1653 owns eviction, physical reclaim, and post-eviction rollback.
+- #1654 owns CLI operations, complete backup/restore, diagnostics, and bilingual docs.
+- #1620 owns same-head segment-gate evidence; #1621 owns release preparation.
+
+Schema migrations are allocated serially by the implementing issue from the then-current shared migration catalog; issue numbers do not pre-reserve migration numbers. Every implementation starts from current `main`, adds behavior tests first, and must not copy the abandoned full-history runner.
+
+## Risks and rollback triggers
+
+- Catalog false negatives, mixed-epoch reads, digest mismatch, missing segments, or an unproven source mutation block publication/eviction.
+- Capacity estimates must include candidate, WAL, segment, rollback, and exchange headroom.
+- Compression/encryption/privacy policy is versioned per segment; logs and public evidence remain aggregate-only.
+- The first v0.34.0 rollout retains Hot duplicates until segment reads pass. Destructive eviction is limited to the release-gate copy until all preceding invariants are proven.


### PR DESCRIPTION
## Summary
- select immutable compressed SQLite segments over a custom bundle or monolithic Cold DB
- define History Unit, Catalog epoch, authority cutover, federated read, recovery, and maintenance boundaries
- fix the safe delivery order for #1649-#1654 and the segment-scoped v0.34.0 release gate

## Validation
- `make docs/check`
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run --timeout=5m`
- GPT-5.6 Sol architecture review: APPROVE, no findings

## External planning
Claude Fable 5 was explicitly attempted in plan/read-only mode, but the installed CLI returned `Not logged in · Please run /login`. Per policy, no login or implicit engine substitution was attempted. The design checkpoint was completed by the configured GPT-5.6 Sol architect fallback; this is not represented as Fable 5 evidence.

Closes #1648
