### PR TITLE
feat: add immutable archive segment format v1

### DIFF
--- a/.ai/spec/1649-archive-segment-v1.md
+++ b/.ai/spec/1649-archive-segment-v1.md
@@ -13,7 +13,7 @@
 
 | Concept | State | Behavior | Invariant |
 |---|---|---|---|
-| History Unit | one event identity, event fields, and optional audit fields | emits fields in a fixed event-then-audit order | the event identity is encoded once, so an audit cannot name another parent |
+| History Unit | fixed 23-column event v1 plus optional fixed 27-column audit v1 | derives identity and time from the event row | `event_id` is absent from audit input and is encoded once, so an audit cannot name another parent |
 | Canonical value | SQLite storage class and bytes/value | length-delimited v1 encoding | NULL, TEXT, and BLOB remain distinguishable |
 | Segment identity | store, format, closed sequence range, logical digest | produces a content-addressed basename | every identity component is digest-bound |
 | Candidate | writable SQLite file | accumulates bounded encoded units | it is never reported as sealed after an error |
@@ -29,7 +29,7 @@
 
 ### Boundaries / interfaces
 
-The builder accepts already ordered History Units and explicit resource caps. The verifier accepts an archive root plus a durable expected manifest, pins the leaf with `O_NOFOLLOW`, and verifies the expected file digest and logical identity before accepting it. Typed sentinel errors distinguish unsupported format/codec, corruption, cap exhaustion, and unsafe location.
+The builder accepts already ordered History Units and explicit resource caps in a caller-owned candidate directory pinned with `os.Root`; it performs no archive publication. The verifier accepts an archive root plus a durable expected manifest, pins the directory and leaf with `openat`/`O_NOFOLLOW`, preflights SQLite payload lengths before loading BLOBs, and verifies the expected file digest and logical identity before accepting it. Manifest-only inspection is bounded but untrusted structural evidence; it does not hash or decode payloads. Typed sentinel errors distinguish unsupported format/codec, corruption, cap exhaustion, and unsafe location.
 
 ### Behavior tests and TDD plan
 

--- a/.ai/spec/1649-archive-segment-v1.md
+++ b/.ai/spec/1649-archive-segment-v1.md
@@ -1,0 +1,42 @@
+# #1649 archive segment format v1
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Preserve one event and its optional audit as an indivisible History Unit.
+- Encode SQLite values canonically without collapsing NULL, INTEGER, REAL, TEXT, or BLOB.
+- Build and independently verify bounded, immutable, zstd-compressed SQLite segment files.
+- Do not implement Catalog state, Hot migration, publication, cutover, deletion, or CLI behavior.
+
+### Conceptual model
+
+| Concept | State | Behavior | Invariant |
+|---|---|---|---|
+| History Unit | event plus optional audit | emits fields in a fixed event-then-audit order | an audit never exists without its event |
+| Canonical value | SQLite storage class and bytes/value | length-delimited v1 encoding | NULL, TEXT, and BLOB remain distinguishable |
+| Segment identity | store, format, closed sequence range, logical digest | produces a content-addressed basename | every identity component is digest-bound |
+| Candidate | writable SQLite file | accumulates bounded encoded units | it is never reported as sealed after an error |
+| Sealed segment | read-only format-v1 SQLite file | supports manifest-only and full verification | Hot migrations never run against it |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Not owner |
+|---|---|---|
+| Canonical values, History Unit, identity invariants | `domain` | filesystem and SQLite |
+| Bounded codec, file layout, construction and verification | `infrastructure/sqlite` | Catalog/publication orchestration |
+| Catalog, placement, migration journal | later issues | this format implementation |
+
+### Boundaries / interfaces
+
+The builder accepts already ordered History Units and explicit resource caps. The verifier accepts an archive root plus a content-addressed basename, never an arbitrary path. Typed sentinel errors distinguish unsupported format/codec, corruption, cap exhaustion, and unsafe location.
+
+### Behavior tests and TDD plan
+
+Tests first cover canonical mixed values, identity determinism, zstd/plain boundaries, corruption, caps, cancellation, unsafe locations, symlinks, unknown format/codec, manifest-only inspection, file mode, and incomplete candidate cleanup. Green uses small explicit v1 types; no generic archive framework is introduced.
+
+### Risks / rollback
+
+- SQLite files are not required to be byte-deterministic; logical bytes and manifest logical fields are.
+- The format is additive and not activated. Rollback is removal of these unused types/files.
+- No-replace publication and directory fsync intentionally remain #1651 responsibilities.

--- a/.ai/spec/1649-archive-segment-v1.md
+++ b/.ai/spec/1649-archive-segment-v1.md
@@ -13,7 +13,7 @@
 
 | Concept | State | Behavior | Invariant |
 |---|---|---|---|
-| History Unit | event plus optional audit | emits fields in a fixed event-then-audit order | an audit never exists without its event |
+| History Unit | one event identity, event fields, and optional audit fields | emits fields in a fixed event-then-audit order | the event identity is encoded once, so an audit cannot name another parent |
 | Canonical value | SQLite storage class and bytes/value | length-delimited v1 encoding | NULL, TEXT, and BLOB remain distinguishable |
 | Segment identity | store, format, closed sequence range, logical digest | produces a content-addressed basename | every identity component is digest-bound |
 | Candidate | writable SQLite file | accumulates bounded encoded units | it is never reported as sealed after an error |
@@ -29,7 +29,7 @@
 
 ### Boundaries / interfaces
 
-The builder accepts already ordered History Units and explicit resource caps. The verifier accepts an archive root plus a content-addressed basename, never an arbitrary path. Typed sentinel errors distinguish unsupported format/codec, corruption, cap exhaustion, and unsafe location.
+The builder accepts already ordered History Units and explicit resource caps. The verifier accepts an archive root plus a durable expected manifest, pins the leaf with `O_NOFOLLOW`, and verifies the expected file digest and logical identity before accepting it. Typed sentinel errors distinguish unsupported format/codec, corruption, cap exhaustion, and unsafe location.
 
 ### Behavior tests and TDD plan
 

--- a/domain/archive_segment.go
+++ b/domain/archive_segment.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"math/bits"
+	"time"
 )
 
 // SegmentFormatV1 is the first immutable archive segment format.
@@ -57,19 +59,27 @@ func byteValue(c SQLiteStorageClass, v []byte) SQLiteValue {
 // HistoryUnit is the indivisible archive unit. Field order is schema-defined.
 type HistoryUnit struct {
 	Sequence uint64
-	Event    []SQLiteValue
-	Audit    []SQLiteValue
+	// EventID is encoded once for both rows. Audit fields deliberately exclude
+	// a second foreign-key value, so an audit cannot claim another parent.
+	EventID   []byte
+	CreatedAt time.Time
+	Event     []SQLiteValue
+	Audit     []SQLiteValue
 }
 
 // CanonicalBytes returns the versioned, length-delimited logical encoding.
 func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
-	if u.Sequence == 0 || len(u.Event) == 0 {
-		return nil, fmt.Errorf("history unit requires a positive sequence and event")
+	if u.Sequence == 0 || len(u.EventID) == 0 || u.CreatedAt.IsZero() || len(u.Event) == 0 {
+		return nil, fmt.Errorf("history unit requires a positive sequence, event identity, and event")
 	}
 	b := make([]byte, 0, 128)
 	b = append(b, 'T', 'R', 'H', 'U')
 	b = binary.BigEndian.AppendUint32(b, SegmentFormatV1)
 	b = binary.AppendUvarint(b, u.Sequence)
+	b = binary.AppendUvarint(b, uint64(len(u.EventID)))
+	b = append(b, u.EventID...)
+	b = binary.BigEndian.AppendUint64(b, uint64(u.CreatedAt.UTC().Unix()))
+	b = binary.BigEndian.AppendUint32(b, uint32(u.CreatedAt.UTC().Nanosecond()))
 	b = binary.AppendUvarint(b, uint64(len(u.Event)))
 	var err error
 	b, err = appendValues(b, u.Event)
@@ -88,6 +98,55 @@ func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
 	}
 	return b, nil
 }
+
+// ValidateCanonicalSize rejects an encoding before allocating its duplicate
+// canonical byte stream.
+func (u HistoryUnit) ValidateCanonicalSize(maxBytes int64) error {
+	if maxBytes <= 0 {
+		return fmt.Errorf("canonical size cap must be positive")
+	}
+	if u.Sequence == 0 || len(u.EventID) == 0 || u.CreatedAt.IsZero() || len(u.Event) == 0 {
+		return fmt.Errorf("invalid history unit")
+	}
+	size := int64(8 + uvarintSize(u.Sequence) + uvarintSize(uint64(len(u.EventID))) + len(u.EventID) + 12 + uvarintSize(uint64(len(u.Event))) + 1)
+	var err error
+	size, err = addValuesSize(size, u.Event, maxBytes)
+	if err != nil {
+		return err
+	}
+	if u.Audit != nil {
+		size += int64(uvarintSize(uint64(len(u.Audit))))
+		size, err = addValuesSize(size, u.Audit, maxBytes)
+		if err != nil {
+			return err
+		}
+	}
+	if size > maxBytes {
+		return fmt.Errorf("canonical history unit exceeds byte cap")
+	}
+	return nil
+}
+
+func addValuesSize(size int64, values []SQLiteValue, limit int64) (int64, error) {
+	for _, v := range values {
+		add := int64(1)
+		switch v.Class {
+		case SQLiteNull:
+		case SQLiteInteger, SQLiteReal:
+			add += 8
+		case SQLiteText, SQLiteBlob:
+			add += int64(uvarintSize(uint64(len(v.Bytes))) + len(v.Bytes))
+		default:
+			return 0, fmt.Errorf("unknown SQLite storage class %d", v.Class)
+		}
+		if add > limit-size {
+			return 0, fmt.Errorf("canonical history unit exceeds byte cap")
+		}
+		size += add
+	}
+	return size, nil
+}
+func uvarintSize(value uint64) int { return (bits.Len64(value|1) + 6) / 7 }
 
 func appendValues(dst []byte, values []SQLiteValue) ([]byte, error) {
 	for _, v := range values {
@@ -118,6 +177,23 @@ func DecodeHistoryUnitCanonical(encoded []byte) (HistoryUnit, error) {
 	if err != nil || sequence == 0 {
 		return HistoryUnit{}, fmt.Errorf("decode history unit sequence")
 	}
+	eventIDLength, err := binary.ReadUvarint(r)
+	if err != nil || eventIDLength == 0 || eventIDLength > uint64(r.Len()) {
+		return HistoryUnit{}, fmt.Errorf("decode history unit event identity")
+	}
+	eventID := make([]byte, eventIDLength)
+	if _, err = r.Read(eventID); err != nil {
+		return HistoryUnit{}, fmt.Errorf("decode history unit event identity bytes")
+	}
+	var seconds [8]byte
+	var nanos [4]byte
+	if _, err = r.Read(seconds[:]); err != nil {
+		return HistoryUnit{}, fmt.Errorf("decode history unit created_at seconds")
+	}
+	if _, err = r.Read(nanos[:]); err != nil {
+		return HistoryUnit{}, fmt.Errorf("decode history unit created_at nanos")
+	}
+	createdAt := time.Unix(int64(binary.BigEndian.Uint64(seconds[:])), int64(binary.BigEndian.Uint32(nanos[:]))).UTC()
 	eventCount, err := binary.ReadUvarint(r)
 	if err != nil || eventCount == 0 {
 		return HistoryUnit{}, fmt.Errorf("decode history unit event count")
@@ -144,7 +220,7 @@ func DecodeHistoryUnitCanonical(encoded []byte) (HistoryUnit, error) {
 	if r.Len() != 0 {
 		return HistoryUnit{}, fmt.Errorf("trailing history unit bytes")
 	}
-	return HistoryUnit{Sequence: sequence, Event: event, Audit: audit}, nil
+	return HistoryUnit{Sequence: sequence, EventID: eventID, CreatedAt: createdAt, Event: event, Audit: audit}, nil
 }
 
 func readValues(r *bytes.Reader, count uint64) ([]SQLiteValue, error) {

--- a/domain/archive_segment.go
+++ b/domain/archive_segment.go
@@ -1,0 +1,223 @@
+package domain
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+)
+
+// SegmentFormatV1 is the first immutable archive segment format.
+const SegmentFormatV1 uint32 = 1
+
+// SQLiteStorageClass preserves the class returned by SQLite.
+type SQLiteStorageClass byte
+
+const (
+	// SQLiteNull identifies the NULL storage class.
+	SQLiteNull SQLiteStorageClass = iota
+	// SQLiteInteger identifies the INTEGER storage class.
+	SQLiteInteger
+	// SQLiteReal identifies the REAL storage class.
+	SQLiteReal
+	// SQLiteText identifies the TEXT storage class.
+	SQLiteText
+	// SQLiteBlob identifies the BLOB storage class.
+	SQLiteBlob
+)
+
+// SQLiteValue is a canonical SQLite value. Bytes are copied on construction.
+type SQLiteValue struct {
+	Class SQLiteStorageClass
+	Int   int64
+	Real  float64
+	Bytes []byte
+}
+
+// NullValue constructs a NULL value.
+func NullValue() SQLiteValue { return SQLiteValue{Class: SQLiteNull} }
+
+// IntegerValue constructs an INTEGER value.
+func IntegerValue(v int64) SQLiteValue { return SQLiteValue{Class: SQLiteInteger, Int: v} }
+
+// RealValue constructs a REAL value.
+func RealValue(v float64) SQLiteValue { return SQLiteValue{Class: SQLiteReal, Real: v} }
+
+// TextValue constructs a TEXT value without interpreting its bytes.
+func TextValue(v []byte) SQLiteValue { return byteValue(SQLiteText, v) }
+
+// BlobValue constructs a BLOB value.
+func BlobValue(v []byte) SQLiteValue { return byteValue(SQLiteBlob, v) }
+func byteValue(c SQLiteStorageClass, v []byte) SQLiteValue {
+	return SQLiteValue{Class: c, Bytes: append([]byte(nil), v...)}
+}
+
+// HistoryUnit is the indivisible archive unit. Field order is schema-defined.
+type HistoryUnit struct {
+	Sequence uint64
+	Event    []SQLiteValue
+	Audit    []SQLiteValue
+}
+
+// CanonicalBytes returns the versioned, length-delimited logical encoding.
+func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
+	if u.Sequence == 0 || len(u.Event) == 0 {
+		return nil, fmt.Errorf("history unit requires a positive sequence and event")
+	}
+	b := make([]byte, 0, 128)
+	b = append(b, 'T', 'R', 'H', 'U')
+	b = binary.BigEndian.AppendUint32(b, SegmentFormatV1)
+	b = binary.AppendUvarint(b, u.Sequence)
+	b = binary.AppendUvarint(b, uint64(len(u.Event)))
+	var err error
+	b, err = appendValues(b, u.Event)
+	if err != nil {
+		return nil, err
+	}
+	if u.Audit == nil {
+		b = append(b, 0)
+	} else {
+		b = append(b, 1)
+		b = binary.AppendUvarint(b, uint64(len(u.Audit)))
+		b, err = appendValues(b, u.Audit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+func appendValues(dst []byte, values []SQLiteValue) ([]byte, error) {
+	for _, v := range values {
+		dst = append(dst, byte(v.Class))
+		switch v.Class {
+		case SQLiteNull:
+		case SQLiteInteger:
+			dst = binary.BigEndian.AppendUint64(dst, uint64(v.Int))
+		case SQLiteReal:
+			dst = binary.BigEndian.AppendUint64(dst, math.Float64bits(v.Real))
+		case SQLiteText, SQLiteBlob:
+			dst = binary.AppendUvarint(dst, uint64(len(v.Bytes)))
+			dst = append(dst, v.Bytes...)
+		default:
+			return nil, fmt.Errorf("unknown SQLite storage class %d", v.Class)
+		}
+	}
+	return dst, nil
+}
+
+// DecodeHistoryUnitCanonical decodes exactly one v1 History Unit.
+func DecodeHistoryUnitCanonical(encoded []byte) (HistoryUnit, error) {
+	if len(encoded) < 8 || !bytes.Equal(encoded[:4], []byte("TRHU")) || binary.BigEndian.Uint32(encoded[4:8]) != SegmentFormatV1 {
+		return HistoryUnit{}, fmt.Errorf("unsupported history unit encoding")
+	}
+	r := bytes.NewReader(encoded[8:])
+	sequence, err := binary.ReadUvarint(r)
+	if err != nil || sequence == 0 {
+		return HistoryUnit{}, fmt.Errorf("decode history unit sequence")
+	}
+	eventCount, err := binary.ReadUvarint(r)
+	if err != nil || eventCount == 0 {
+		return HistoryUnit{}, fmt.Errorf("decode history unit event count")
+	}
+	event, err := readValues(r, eventCount)
+	if err != nil {
+		return HistoryUnit{}, err
+	}
+	present, err := r.ReadByte()
+	if err != nil || present > 1 {
+		return HistoryUnit{}, fmt.Errorf("decode history unit audit marker")
+	}
+	var audit []SQLiteValue
+	if present == 1 {
+		count, readErr := binary.ReadUvarint(r)
+		if readErr != nil {
+			return HistoryUnit{}, fmt.Errorf("decode history unit audit count")
+		}
+		audit, err = readValues(r, count)
+		if err != nil {
+			return HistoryUnit{}, err
+		}
+	}
+	if r.Len() != 0 {
+		return HistoryUnit{}, fmt.Errorf("trailing history unit bytes")
+	}
+	return HistoryUnit{Sequence: sequence, Event: event, Audit: audit}, nil
+}
+
+func readValues(r *bytes.Reader, count uint64) ([]SQLiteValue, error) {
+	if count > uint64(r.Len()) {
+		return nil, fmt.Errorf("impossible SQLite value count")
+	}
+	values := make([]SQLiteValue, 0, count)
+	for range count {
+		class, err := r.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("decode SQLite storage class")
+		}
+		value := SQLiteValue{Class: SQLiteStorageClass(class)}
+		switch value.Class {
+		case SQLiteNull:
+		case SQLiteInteger, SQLiteReal:
+			var raw [8]byte
+			if _, err = r.Read(raw[:]); err != nil {
+				return nil, fmt.Errorf("decode numeric SQLite value")
+			}
+			bits := binary.BigEndian.Uint64(raw[:])
+			if value.Class == SQLiteInteger {
+				value.Int = int64(bits)
+			} else {
+				value.Real = math.Float64frombits(bits)
+			}
+		case SQLiteText, SQLiteBlob:
+			length, readErr := binary.ReadUvarint(r)
+			if readErr != nil || length > uint64(r.Len()) {
+				return nil, fmt.Errorf("decode byte SQLite value length")
+			}
+			value.Bytes = make([]byte, length)
+			if length > 0 {
+				_, readErr = r.Read(value.Bytes)
+			}
+			if readErr != nil {
+				return nil, fmt.Errorf("decode byte SQLite value")
+			}
+		default:
+			return nil, fmt.Errorf("unknown SQLite storage class %d", class)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+// SegmentIdentity binds a logical segment to its lineage and closed range.
+type SegmentIdentity struct {
+	StoreID       string
+	FormatVersion uint32
+	StartSequence uint64
+	EndSequence   uint64
+	LogicalDigest [sha256.Size]byte
+}
+
+// NewSegmentIdentity validates and creates a format-v1 identity.
+func NewSegmentIdentity(storeID string, start, end uint64, digest [sha256.Size]byte) (SegmentIdentity, error) {
+	if storeID == "" || start == 0 || end < start {
+		return SegmentIdentity{}, fmt.Errorf("invalid segment identity")
+	}
+	return SegmentIdentity{StoreID: storeID, FormatVersion: SegmentFormatV1, StartSequence: start, EndSequence: end, LogicalDigest: digest}, nil
+}
+
+// Basename is content-addressed and safe to join beneath an archive root.
+func (i SegmentIdentity) Basename() string {
+	h := sha256.New()
+	h.Write([]byte("traceary-segment-identity-v1\x00"))
+	h.Write([]byte(i.StoreID))
+	var b [20]byte
+	binary.BigEndian.PutUint32(b[:4], i.FormatVersion)
+	binary.BigEndian.PutUint64(b[4:12], i.StartSequence)
+	binary.BigEndian.PutUint64(b[12:20], i.EndSequence)
+	h.Write(b[:])
+	h.Write(i.LogicalDigest[:])
+	return "segment-v1-" + hex.EncodeToString(h.Sum(nil)) + ".sqlite"
+}

--- a/domain/archive_segment.go
+++ b/domain/archive_segment.go
@@ -56,33 +56,87 @@ func byteValue(c SQLiteStorageClass, v []byte) SQLiteValue {
 	return SQLiteValue{Class: c, Bytes: append([]byte(nil), v...)}
 }
 
-// HistoryUnit is the indivisible archive unit. Field order is schema-defined.
+var archiveEventV1Columns = [...]string{"id", "kind", "agent", "session_id", "body", "created_at", "client", "workspace", "source_hook", "body_original_bytes", "body_stored_bytes", "body_ingest_truncated", "body_storage_truncated", "body_metadata_version", "body_availability", "body_pruned_at", "body_pruned_plan_id", "created_at_norm", "body_codec", "body_format_version", "body_plaintext_bytes", "body_encoded_bytes", "body_sha256"}
+var archiveAuditV1Columns = [...]string{"command_text", "input_text", "output_text", "input_truncated", "output_truncated", "exit_code", "failed", "input_original_bytes", "output_original_bytes", "command_wrapper", "command_name", "failure_reason", "command_codec", "command_format_version", "command_plaintext_bytes", "command_encoded_bytes", "command_sha256", "input_codec", "input_format_version", "input_plaintext_bytes", "input_encoded_bytes", "input_sha256", "output_codec", "output_format_version", "output_plaintext_bytes", "output_encoded_bytes", "output_sha256"}
+
+// ArchiveEventV1Columns returns the fixed events descriptor.
+func ArchiveEventV1Columns() []string { return append([]string(nil), archiveEventV1Columns[:]...) }
+
+// ArchiveAuditV1Columns returns the fixed command_audits descriptor excluding event_id.
+func ArchiveAuditV1Columns() []string { return append([]string(nil), archiveAuditV1Columns[:]...) }
+
+// ArchiveEventV1 fixes every format-v1 events column and its order.
+type ArchiveEventV1 struct {
+	values    [len(archiveEventV1Columns)]SQLiteValue
+	eventID   []byte
+	createdAt time.Time
+}
+
+// NewArchiveEventV1 constructs the fixed event row and derives identity/time from canonical columns.
+func NewArchiveEventV1(values []SQLiteValue) (ArchiveEventV1, error) {
+	if len(values) != len(archiveEventV1Columns) {
+		return ArchiveEventV1{}, fmt.Errorf("archive event v1 requires %d columns", len(archiveEventV1Columns))
+	}
+	if values[0].Class != SQLiteText || len(values[0].Bytes) == 0 || values[5].Class != SQLiteText {
+		return ArchiveEventV1{}, fmt.Errorf("archive event v1 id and created_at must be text")
+	}
+	created, err := time.Parse(time.RFC3339Nano, string(values[5].Bytes))
+	if err != nil {
+		return ArchiveEventV1{}, fmt.Errorf("parse archive event created_at: %w", err)
+	}
+	var event ArchiveEventV1
+	copy(event.values[:], values)
+	event.eventID = append([]byte(nil), values[0].Bytes...)
+	event.createdAt = created.UTC()
+	return event, nil
+}
+
+// Values returns a defensive copy in the fixed v1 order.
+func (e ArchiveEventV1) Values() []SQLiteValue { return append([]SQLiteValue(nil), e.values[:]...) }
+
+// ArchiveAuditV1 fixes every format-v1 command_audits column except event_id.
+// The parent event_id is derived solely from HistoryUnit.Event.
+type ArchiveAuditV1 struct {
+	values [len(archiveAuditV1Columns)]SQLiteValue
+}
+
+// NewArchiveAuditV1 constructs the fixed audit row without a parent-id slot.
+func NewArchiveAuditV1(values []SQLiteValue) (ArchiveAuditV1, error) {
+	if len(values) != len(archiveAuditV1Columns) {
+		return ArchiveAuditV1{}, fmt.Errorf("archive audit v1 requires %d columns", len(archiveAuditV1Columns))
+	}
+	var audit ArchiveAuditV1
+	copy(audit.values[:], values)
+	return audit, nil
+}
+
+// Values returns a defensive copy in the fixed v1 order.
+func (a ArchiveAuditV1) Values() []SQLiteValue { return append([]SQLiteValue(nil), a.values[:]...) }
+
+// HistoryUnit is the indivisible archive unit.
 type HistoryUnit struct {
 	Sequence uint64
-	// EventID is encoded once for both rows. Audit fields deliberately exclude
-	// a second foreign-key value, so an audit cannot claim another parent.
-	EventID   []byte
-	CreatedAt time.Time
-	Event     []SQLiteValue
-	Audit     []SQLiteValue
+	Event    ArchiveEventV1
+	Audit    *ArchiveAuditV1
 }
+
+// CreatedAt returns the timestamp derived from the fixed event created_at column.
+func (u HistoryUnit) CreatedAt() time.Time { return u.Event.createdAt }
 
 // CanonicalBytes returns the versioned, length-delimited logical encoding.
 func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
-	if u.Sequence == 0 || len(u.EventID) == 0 || u.CreatedAt.IsZero() || len(u.Event) == 0 {
+	if u.Sequence == 0 || len(u.Event.eventID) == 0 || u.Event.createdAt.IsZero() {
 		return nil, fmt.Errorf("history unit requires a positive sequence, event identity, and event")
 	}
 	b := make([]byte, 0, 128)
 	b = append(b, 'T', 'R', 'H', 'U')
 	b = binary.BigEndian.AppendUint32(b, SegmentFormatV1)
 	b = binary.AppendUvarint(b, u.Sequence)
-	b = binary.AppendUvarint(b, uint64(len(u.EventID)))
-	b = append(b, u.EventID...)
-	b = binary.BigEndian.AppendUint64(b, uint64(u.CreatedAt.UTC().Unix()))
-	b = binary.BigEndian.AppendUint32(b, uint32(u.CreatedAt.UTC().Nanosecond()))
-	b = binary.AppendUvarint(b, uint64(len(u.Event)))
+	b = binary.AppendUvarint(b, uint64(len(u.Event.eventID)))
+	b = append(b, u.Event.eventID...)
+	b = binary.AppendUvarint(b, uint64(len(archiveEventV1Columns)))
 	var err error
-	b, err = appendValues(b, u.Event)
+	b, err = appendValues(b, u.Event.values[:])
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +144,8 @@ func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
 		b = append(b, 0)
 	} else {
 		b = append(b, 1)
-		b = binary.AppendUvarint(b, uint64(len(u.Audit)))
-		b, err = appendValues(b, u.Audit)
+		b = binary.AppendUvarint(b, uint64(len(archiveAuditV1Columns)))
+		b, err = appendValues(b, u.Audit.values[:])
 		if err != nil {
 			return nil, err
 		}
@@ -105,18 +159,18 @@ func (u HistoryUnit) ValidateCanonicalSize(maxBytes int64) error {
 	if maxBytes <= 0 {
 		return fmt.Errorf("canonical size cap must be positive")
 	}
-	if u.Sequence == 0 || len(u.EventID) == 0 || u.CreatedAt.IsZero() || len(u.Event) == 0 {
+	if u.Sequence == 0 || len(u.Event.eventID) == 0 || u.Event.createdAt.IsZero() {
 		return fmt.Errorf("invalid history unit")
 	}
-	size := int64(8 + uvarintSize(u.Sequence) + uvarintSize(uint64(len(u.EventID))) + len(u.EventID) + 12 + uvarintSize(uint64(len(u.Event))) + 1)
+	size := int64(8 + uvarintSize(u.Sequence) + uvarintSize(uint64(len(u.Event.eventID))) + len(u.Event.eventID) + uvarintSize(uint64(len(archiveEventV1Columns))) + 1)
 	var err error
-	size, err = addValuesSize(size, u.Event, maxBytes)
+	size, err = addValuesSize(size, u.Event.values[:], maxBytes)
 	if err != nil {
 		return err
 	}
 	if u.Audit != nil {
-		size += int64(uvarintSize(uint64(len(u.Audit))))
-		size, err = addValuesSize(size, u.Audit, maxBytes)
+		size += int64(uvarintSize(uint64(len(archiveAuditV1Columns))))
+		size, err = addValuesSize(size, u.Audit.values[:], maxBytes)
 		if err != nil {
 			return err
 		}
@@ -185,42 +239,49 @@ func DecodeHistoryUnitCanonical(encoded []byte) (HistoryUnit, error) {
 	if _, err = r.Read(eventID); err != nil {
 		return HistoryUnit{}, fmt.Errorf("decode history unit event identity bytes")
 	}
-	var seconds [8]byte
-	var nanos [4]byte
-	if _, err = r.Read(seconds[:]); err != nil {
-		return HistoryUnit{}, fmt.Errorf("decode history unit created_at seconds")
-	}
-	if _, err = r.Read(nanos[:]); err != nil {
-		return HistoryUnit{}, fmt.Errorf("decode history unit created_at nanos")
-	}
-	createdAt := time.Unix(int64(binary.BigEndian.Uint64(seconds[:])), int64(binary.BigEndian.Uint32(nanos[:]))).UTC()
 	eventCount, err := binary.ReadUvarint(r)
-	if err != nil || eventCount == 0 {
+	if err != nil || eventCount != uint64(len(archiveEventV1Columns)) {
 		return HistoryUnit{}, fmt.Errorf("decode history unit event count")
 	}
 	event, err := readValues(r, eventCount)
 	if err != nil {
 		return HistoryUnit{}, err
 	}
+	eventRow, err := NewArchiveEventV1(event)
+	if err != nil {
+		return HistoryUnit{}, err
+	}
+	if !bytes.Equal(eventID, eventRow.eventID) {
+		return HistoryUnit{}, fmt.Errorf("history unit parent identity mismatch")
+	}
 	present, err := r.ReadByte()
 	if err != nil || present > 1 {
 		return HistoryUnit{}, fmt.Errorf("decode history unit audit marker")
 	}
-	var audit []SQLiteValue
+	var audit *ArchiveAuditV1
 	if present == 1 {
 		count, readErr := binary.ReadUvarint(r)
 		if readErr != nil {
 			return HistoryUnit{}, fmt.Errorf("decode history unit audit count")
 		}
-		audit, err = readValues(r, count)
+		if count != uint64(len(archiveAuditV1Columns)) {
+			return HistoryUnit{}, fmt.Errorf("decode history unit audit count")
+		}
+		auditValues, readValuesErr := readValues(r, count)
+		err = readValuesErr
 		if err != nil {
 			return HistoryUnit{}, err
 		}
+		auditRow, auditErr := NewArchiveAuditV1(auditValues)
+		if auditErr != nil {
+			return HistoryUnit{}, auditErr
+		}
+		audit = &auditRow
 	}
 	if r.Len() != 0 {
 		return HistoryUnit{}, fmt.Errorf("trailing history unit bytes")
 	}
-	return HistoryUnit{Sequence: sequence, EventID: eventID, CreatedAt: createdAt, Event: event, Audit: audit}, nil
+	return HistoryUnit{Sequence: sequence, Event: eventRow, Audit: audit}, nil
 }
 
 func readValues(r *bytes.Reader, count uint64) ([]SQLiteValue, error) {

--- a/domain/archive_segment_test.go
+++ b/domain/archive_segment_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"testing"
+	"time"
 
 	"github.com/duck8823/traceary/domain"
 )
 
 func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
-	u := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{
+	u := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{
 		domain.NullValue(), domain.IntegerValue(-2), domain.RealValue(-0),
 		domain.TextValue([]byte{0, 0xff}), domain.BlobValue([]byte{0, 0xff}),
 	}, Audit: []domain.SQLiteValue{domain.TextValue(nil)}}
@@ -45,8 +46,8 @@ func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
 	if bytes.Equal(a, c) {
 		t.Fatal("missing audit collapsed into present empty values")
 	}
-	text := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{domain.TextValue([]byte("x"))}}
-	blob := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{domain.BlobValue([]byte("x"))}}
+	text := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{domain.TextValue([]byte("x"))}}
+	blob := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{domain.BlobValue([]byte("x"))}}
 	tb, _ := text.CanonicalBytes()
 	bb, _ := blob.CanonicalBytes()
 	if bytes.Equal(tb, bb) {

--- a/domain/archive_segment_test.go
+++ b/domain/archive_segment_test.go
@@ -10,10 +10,32 @@ import (
 )
 
 func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
-	u := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{
-		domain.NullValue(), domain.IntegerValue(-2), domain.RealValue(-0),
-		domain.TextValue([]byte{0, 0xff}), domain.BlobValue([]byte{0, 0xff}),
-	}, Audit: []domain.SQLiteValue{domain.TextValue(nil)}}
+	eventValues := make([]domain.SQLiteValue, 23)
+	for i := range eventValues {
+		eventValues[i] = domain.NullValue()
+	}
+	eventValues[0] = domain.TextValue([]byte("event-7"))
+	eventValues[5] = domain.TextValue([]byte(time.Unix(1, 2).UTC().Format(time.RFC3339Nano)))
+	eventValues[4] = domain.TextValue([]byte{0, 0xff})
+	eventValues[10] = domain.IntegerValue(-2)
+	eventValues[18] = domain.BlobValue([]byte{0, 0xff})
+	event, err := domain.NewArchiveEventV1(eventValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditValues := make([]domain.SQLiteValue, 27)
+	for i := range auditValues {
+		auditValues[i] = domain.NullValue()
+	}
+	auditValues[0] = domain.TextValue([]byte("cmd"))
+	auditValues[1] = domain.BlobValue([]byte{0xff})
+	auditValues[5] = domain.IntegerValue(-1)
+	auditValues[6] = domain.RealValue(1.25)
+	audit, err := domain.NewArchiveAuditV1(auditValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := domain.HistoryUnit{Sequence: 7, Event: event, Audit: &audit}
 	a, err := u.CanonicalBytes()
 	if err != nil {
 		t.Fatal(err)
@@ -36,6 +58,21 @@ func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
 	if !bytes.Equal(a, roundTrip) {
 		t.Fatal("canonical round trip changed bytes or storage classes")
 	}
+	for i, value := range decoded.Event.Values() {
+		want := eventValues[i]
+		if value.Class != want.Class || value.Int != want.Int || value.Real != want.Real || !bytes.Equal(value.Bytes, want.Bytes) {
+			t.Fatalf("event column %d did not round trip", i)
+		}
+	}
+	if decoded.Audit == nil {
+		t.Fatal("audit missing after round trip")
+	}
+	for i, value := range decoded.Audit.Values() {
+		want := auditValues[i]
+		if value.Class != want.Class || value.Int != want.Int || value.Real != want.Real || !bytes.Equal(value.Bytes, want.Bytes) {
+			t.Fatalf("audit column %d did not round trip", i)
+		}
+	}
 
 	withoutAudit := u
 	withoutAudit.Audit = nil
@@ -46,8 +83,14 @@ func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
 	if bytes.Equal(a, c) {
 		t.Fatal("missing audit collapsed into present empty values")
 	}
-	text := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{domain.TextValue([]byte("x"))}}
-	blob := domain.HistoryUnit{Sequence: 7, EventID: []byte("event-7"), CreatedAt: time.Unix(1, 2), Event: []domain.SQLiteValue{domain.BlobValue([]byte("x"))}}
+	textValues := append([]domain.SQLiteValue(nil), eventValues...)
+	textValues[4] = domain.TextValue([]byte("x"))
+	textEvent, _ := domain.NewArchiveEventV1(textValues)
+	blobValues := append([]domain.SQLiteValue(nil), eventValues...)
+	blobValues[4] = domain.BlobValue([]byte("x"))
+	blobEvent, _ := domain.NewArchiveEventV1(blobValues)
+	text := domain.HistoryUnit{Sequence: 7, Event: textEvent}
+	blob := domain.HistoryUnit{Sequence: 7, Event: blobEvent}
 	tb, _ := text.CanonicalBytes()
 	bb, _ := blob.CanonicalBytes()
 	if bytes.Equal(tb, bb) {

--- a/domain/archive_segment_test.go
+++ b/domain/archive_segment_test.go
@@ -1,0 +1,70 @@
+package domain_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestHistoryUnitCanonicalBytesPreserveStorageClassesAndBytes(t *testing.T) {
+	u := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{
+		domain.NullValue(), domain.IntegerValue(-2), domain.RealValue(-0),
+		domain.TextValue([]byte{0, 0xff}), domain.BlobValue([]byte{0, 0xff}),
+	}, Audit: []domain.SQLiteValue{domain.TextValue(nil)}}
+	a, err := u.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := u.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatal("canonical encoding is not deterministic")
+	}
+	decoded, err := domain.DecodeHistoryUnitCanonical(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTrip, err := decoded.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, roundTrip) {
+		t.Fatal("canonical round trip changed bytes or storage classes")
+	}
+
+	withoutAudit := u
+	withoutAudit.Audit = nil
+	c, err := withoutAudit.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(a, c) {
+		t.Fatal("missing audit collapsed into present empty values")
+	}
+	text := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{domain.TextValue([]byte("x"))}}
+	blob := domain.HistoryUnit{Sequence: 7, Event: []domain.SQLiteValue{domain.BlobValue([]byte("x"))}}
+	tb, _ := text.CanonicalBytes()
+	bb, _ := blob.CanonicalBytes()
+	if bytes.Equal(tb, bb) {
+		t.Fatal("text and blob storage classes collapsed")
+	}
+}
+
+func TestSegmentIdentityIsDeterministicAndRangeBound(t *testing.T) {
+	d := sha256.Sum256([]byte("logical"))
+	a, err := domain.NewSegmentIdentity("store", 1, 2, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := domain.NewSegmentIdentity("store", 1, 3, d)
+	if a.Basename() == b.Basename() {
+		t.Fatal("range is not identity-bound")
+	}
+	if got := a.Basename(); len(got) != len("segment-v1-")+64+len(".sqlite") {
+		t.Fatalf("unexpected basename %q", got)
+	}
+}

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -379,8 +379,11 @@ func validateArchiveRoot(root string) error {
 	if err != nil {
 		return err
 	}
-	resolved, err := filepath.EvalSymlinks(abs)
-	if err != nil || resolved != abs {
+	// macOS exposes /var as an alias of /private/var. Ancestor resolution may
+	// therefore differ from filepath.Abs even when the archive root itself is
+	// not a symlink. Lstat above rejects a replaceable root symlink; resolving
+	// ancestors here only proves that the complete root exists.
+	if _, err := filepath.EvalSymlinks(abs); err != nil {
 		return ErrSegmentUnsafeLocation
 	}
 	return nil

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -4,6 +4,7 @@ package sqlite
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -112,16 +113,27 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 		return manifest, err
 	}
 
-	tmp, err := os.CreateTemp(root, ".segment-v1-*.candidate")
+	ownedRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return manifest, fmt.Errorf("pin owned candidate root: %w", err)
+	}
+	defer func() { _ = ownedRoot.Close() }()
+	var random [16]byte
+	if _, err = rand.Read(random[:]); err != nil {
+		return manifest, fmt.Errorf("name segment candidate: %w", err)
+	}
+	tmpName := ".segment-v1-" + hex.EncodeToString(random[:]) + ".candidate"
+	tmp, err := ownedRoot.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return manifest, fmt.Errorf("create segment candidate: %w", err)
 	}
-	tmpPath := tmp.Name()
+	tmpPath := filepath.Join(ownedRoot.Name(), tmpName)
+	cleanupName := tmpName
 	defer func() { _ = tmp.Close() }()
 	defer func() {
 		if err != nil {
-			_ = os.Chmod(tmpPath, 0o600)
-			_ = os.Remove(tmpPath)
+			_ = tmp.Chmod(0o600)
+			_ = ownedRoot.Remove(cleanupName)
 		}
 	}()
 
@@ -185,8 +197,8 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 		if item.Unit.Audit != nil {
 			manifest.AuditCount++
 		}
-		if !item.Unit.CreatedAt.IsZero() {
-			ts := item.Unit.CreatedAt.UTC()
+		if !item.Unit.CreatedAt().IsZero() {
+			ts := item.Unit.CreatedAt().UTC()
 			if minCreatedAt.IsZero() || ts.Before(minCreatedAt) {
 				minCreatedAt = ts
 			}
@@ -240,24 +252,24 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if err = b.sealFile(tmp, 0o400); err != nil {
 		return manifest, fmt.Errorf("seal segment: %w", err)
 	}
+	if err = b.syncFile(tmp); err != nil {
+		return manifest, fmt.Errorf("fsync sealed segment metadata: %w", err)
+	}
 	fileDigest, err := digestOpenFile(ctx, tmp, cfg.Limits.MaxFileBytes)
 	if err != nil {
 		return manifest, err
 	}
 	manifest.FileDigest = fileDigest
-	// A hard link installs the content-addressed name without replacing an
-	// existing inode. Directory durability and publication journaling remain
-	// the responsibility of #1651.
-	if err = os.Link(tmpPath, finalPath); err != nil {
-		return manifest, fmt.Errorf("install segment candidate without replacement: %w", err)
+	if _, statErr := ownedRoot.Lstat(manifest.Basename); statErr == nil {
+		return manifest, fmt.Errorf("seal candidate name: %w", os.ErrExist)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return manifest, fmt.Errorf("inspect candidate name: %w", statErr)
 	}
-	if err = os.Remove(tmpPath); err != nil {
-		_ = os.Remove(finalPath)
-		return manifest, fmt.Errorf("remove installed candidate name: %w", err)
+	if err = ownedRoot.Rename(tmpName, manifest.Basename); err != nil {
+		return manifest, fmt.Errorf("name sealed candidate: %w", err)
 	}
+	cleanupName = manifest.Basename
 	if _, err = verifyArchiveSegmentPath(ctx, finalPath, manifest, cfg.Limits, true); err != nil {
-		_ = os.Chmod(finalPath, 0o600)
-		_ = os.Remove(finalPath)
 		return manifest, fmt.Errorf("verify sealed segment candidate: %w", err)
 	}
 	return manifest, nil
@@ -268,7 +280,9 @@ CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT
 CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
 `
 
-// InspectArchiveSegmentManifest reads aggregate metadata without decoding payload rows.
+// InspectArchiveSegmentManifest performs bounded structural inspection of an
+// untrusted sealed file. It neither decodes payloads nor computes a file digest;
+// callers must use VerifyArchiveSegment before trusting the returned facts.
 func InspectArchiveSegmentManifest(ctx context.Context, root, basename string, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
 	if err := limits.validate(); err != nil {
 		return ArchiveSegmentManifest{}, err
@@ -287,6 +301,7 @@ func inspectArchiveSegmentPath(ctx context.Context, path, expectedBasename strin
 	}
 	defer func() { _ = db.Close() }()
 	defer func() { _ = pinned.Close() }()
+	db.SetMaxOpenConns(2)
 	info, err := pinned.Stat()
 	if err != nil {
 		return ArchiveSegmentManifest{}, fmt.Errorf("stat segment: %w", err)
@@ -347,6 +362,7 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 	}
 	defer func() { _ = db.Close() }()
 	defer func() { _ = pinned.Close() }()
+	db.SetMaxOpenConns(2)
 	if requireFileDigest {
 		m.FileDigest, err = digestOpenFile(ctx, pinned, limits.MaxFileBytes)
 		if err != nil {
@@ -356,7 +372,7 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 			return m, fmt.Errorf("%w: expected file digest mismatch", ErrSegmentCorrupt)
 		}
 	}
-	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,payload FROM history_units ORDER BY sequence`)
+	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,length(payload) FROM history_units ORDER BY sequence`)
 	if err != nil {
 		return m, fmt.Errorf("%w: query payloads: %v", ErrSegmentCorrupt, err)
 	}
@@ -379,8 +395,9 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 		var seq uint64
 		var codec string
 		var plainLen int64
-		var checksum, stored []byte
-		if err = rows.Scan(&seq, &codec, &plainLen, &checksum, &stored); err != nil {
+		var checksum []byte
+		var storedLen int64
+		if err = rows.Scan(&seq, &codec, &plainLen, &checksum, &storedLen); err != nil {
 			return m, fmt.Errorf("%w: scan payload", ErrSegmentCorrupt)
 		}
 		if count > 0 && seq != previous+1 {
@@ -390,8 +407,15 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 			first = seq
 		}
 		previous = seq
-		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || int64(len(stored)) > limits.MaxValueStoredBytes {
+		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || storedLen < 0 || storedLen > limits.MaxValueStoredBytes || totalPlain+plainLen > limits.MaxTotalPlainBytes || totalStored+storedLen > limits.MaxTotalStoredBytes {
 			return m, fmt.Errorf("%w: value", ErrSegmentLimit)
+		}
+		var stored []byte
+		if err = db.QueryRowContext(ctx, `SELECT payload FROM history_units WHERE sequence=?`, seq).Scan(&stored); err != nil {
+			return m, fmt.Errorf("%w: load bounded payload", ErrSegmentCorrupt)
+		}
+		if int64(len(stored)) != storedLen {
+			return m, fmt.Errorf("%w: payload length changed", ErrSegmentCorrupt)
 		}
 		var plain []byte
 		switch codec {
@@ -417,11 +441,11 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 		if unit.Audit != nil {
 			auditCount++
 		}
-		if minCreatedAt.IsZero() || unit.CreatedAt.Before(minCreatedAt) {
-			minCreatedAt = unit.CreatedAt
+		if minCreatedAt.IsZero() || unit.CreatedAt().Before(minCreatedAt) {
+			minCreatedAt = unit.CreatedAt()
 		}
-		if maxCreatedAt.IsZero() || unit.CreatedAt.After(maxCreatedAt) {
-			maxCreatedAt = unit.CreatedAt
+		if maxCreatedAt.IsZero() || unit.CreatedAt().After(maxCreatedAt) {
+			maxCreatedAt = unit.CreatedAt()
 		}
 		totalPlain += int64(len(plain))
 		totalStored += int64(len(stored))

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -1,0 +1,417 @@
+//nolint:wrapcheck // This infrastructure boundary preserves causes while adding typed segment errors where relevant.
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+const (
+	segmentCodecPlain = "plain"
+	segmentCodecZstd  = "zstd"
+)
+
+var (
+	// ErrSegmentUnsafeLocation rejects paths outside the archive root or through symlinks.
+	ErrSegmentUnsafeLocation = errors.New("unsafe archive segment location")
+	// ErrSegmentUnsupportedFormat identifies an unreadable future schema.
+	ErrSegmentUnsupportedFormat = errors.New("unsupported archive segment format")
+	// ErrSegmentUnsupportedCodec identifies an unreadable payload codec.
+	ErrSegmentUnsupportedCodec = errors.New("unsupported archive segment codec")
+	// ErrSegmentCorrupt identifies checksum, encoding, or aggregate mismatches.
+	ErrSegmentCorrupt = errors.New("corrupt archive segment")
+	// ErrSegmentLimit identifies a configured cap violation.
+	ErrSegmentLimit   = errors.New("archive segment resource limit exceeded")
+	segmentBasenameRE = regexp.MustCompile(`^segment-v1-[0-9a-f]{64}\.sqlite$`)
+)
+
+// ArchiveSegmentLimits bounds both construction and independent verification.
+type ArchiveSegmentLimits struct {
+	MaxValuePlainBytes  int64
+	MaxValueStoredBytes int64
+	MaxTotalPlainBytes  int64
+	MaxTotalStoredBytes int64
+}
+
+func (l ArchiveSegmentLimits) validate() error {
+	if l.MaxValuePlainBytes <= 0 || l.MaxValueStoredBytes <= 0 || l.MaxTotalPlainBytes <= 0 || l.MaxTotalStoredBytes <= 0 {
+		return fmt.Errorf("%w: every cap must be positive", ErrSegmentLimit)
+	}
+	return nil
+}
+
+// ArchiveSegmentConfig fixes all logical format choices.
+type ArchiveSegmentConfig struct {
+	StoreID          string
+	CompressionFloor int
+	Limits           ArchiveSegmentLimits
+}
+
+// ArchiveSegmentManifest is machine-independent aggregate evidence.
+type ArchiveSegmentManifest struct {
+	StoreID          string `json:"store_id"`
+	FormatVersion    uint32 `json:"format_version"`
+	StartSequence    uint64 `json:"start_sequence"`
+	EndSequence      uint64 `json:"end_sequence"`
+	UnitCount        uint64 `json:"unit_count"`
+	AuditCount       uint64 `json:"audit_count"`
+	MinCreatedAt     string `json:"min_created_at,omitempty"`
+	MaxCreatedAt     string `json:"max_created_at,omitempty"`
+	PlainValueCount  uint64 `json:"plain_value_count"`
+	ZstdValueCount   uint64 `json:"zstd_value_count"`
+	TotalPlainBytes  int64  `json:"total_plain_bytes"`
+	TotalStoredBytes int64  `json:"total_stored_bytes"`
+	LogicalDigest    string `json:"logical_digest"`
+	FileDigest       string `json:"file_digest"`
+	Basename         string `json:"basename"`
+}
+
+// ArchiveHistoryUnit carries the canonical unit and an optional ordering time.
+type ArchiveHistoryUnit struct {
+	Unit      domain.HistoryUnit
+	CreatedAt time.Time
+}
+
+type archiveSegmentBuilder struct{ syncFile func(*os.File) error }
+
+// BuildArchiveSegmentV1 creates and seals one immutable, content-addressed segment.
+func BuildArchiveSegmentV1(ctx context.Context, root string, units []ArchiveHistoryUnit, cfg ArchiveSegmentConfig) (ArchiveSegmentManifest, error) {
+	return archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }}.build(ctx, root, units, cfg)
+}
+
+func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []ArchiveHistoryUnit, cfg ArchiveSegmentConfig) (manifest ArchiveSegmentManifest, err error) {
+	if err := cfg.Limits.validate(); err != nil {
+		return manifest, err
+	}
+	if cfg.StoreID == "" || len(units) == 0 || cfg.CompressionFloor < 0 {
+		return manifest, fmt.Errorf("invalid archive segment configuration")
+	}
+	if err := validateArchiveRoot(root); err != nil {
+		return manifest, err
+	}
+
+	logical := sha256.New()
+	canonical := make([][]byte, len(units))
+	var previous uint64
+	for i, item := range units {
+		if err := ctx.Err(); err != nil {
+			return manifest, err
+		}
+		if i > 0 && item.Unit.Sequence != previous+1 {
+			return manifest, fmt.Errorf("history unit sequence is not contiguous")
+		}
+		previous = item.Unit.Sequence
+		value, encodeErr := item.Unit.CanonicalBytes()
+		if encodeErr != nil {
+			return manifest, encodeErr
+		}
+		canonical[i] = value
+		logical.Write(value)
+	}
+	var logicalDigest [sha256.Size]byte
+	copy(logicalDigest[:], logical.Sum(nil))
+	identity, err := domain.NewSegmentIdentity(cfg.StoreID, units[0].Unit.Sequence, units[len(units)-1].Unit.Sequence, logicalDigest)
+	if err != nil {
+		return manifest, err
+	}
+	basename := identity.Basename()
+	finalPath, err := safeArchivePath(root, basename, false)
+	if err != nil {
+		return manifest, err
+	}
+	tmp, err := os.CreateTemp(root, ".segment-v1-*.candidate")
+	if err != nil {
+		return manifest, fmt.Errorf("create segment candidate: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if closeErr := tmp.Close(); closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return manifest, closeErr
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Chmod(tmpPath, 0o600)
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=rwc&_pragma=journal_mode(DELETE)&_pragma=synchronous(FULL)")
+	if err != nil {
+		return manifest, err
+	}
+	defer func() { _ = db.Close() }()
+	if _, err = db.ExecContext(ctx, segmentSchemaV1); err != nil {
+		return manifest, fmt.Errorf("create segment schema: %w", err)
+	}
+	encoder, err := zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1), zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		return manifest, err
+	}
+	defer func() { _ = encoder.Close() }()
+
+	manifest = ArchiveSegmentManifest{StoreID: cfg.StoreID, FormatVersion: domain.SegmentFormatV1, StartSequence: identity.StartSequence, EndSequence: identity.EndSequence, UnitCount: uint64(len(units)), LogicalDigest: hex.EncodeToString(logicalDigest[:]), Basename: basename}
+	for i, item := range units {
+		if err = ctx.Err(); err != nil {
+			return manifest, err
+		}
+		plain := canonical[i]
+		if int64(len(plain)) > cfg.Limits.MaxValuePlainBytes {
+			return manifest, fmt.Errorf("%w: plaintext value", ErrSegmentLimit)
+		}
+		codec := segmentCodecPlain
+		stored := plain
+		if len(plain) >= cfg.CompressionFloor {
+			compressed := encoder.EncodeAll(plain, nil)
+			if len(compressed) < len(plain) {
+				codec, stored = segmentCodecZstd, compressed
+			}
+		}
+		if int64(len(stored)) > cfg.Limits.MaxValueStoredBytes {
+			return manifest, fmt.Errorf("%w: stored value", ErrSegmentLimit)
+		}
+		manifest.TotalPlainBytes += int64(len(plain))
+		manifest.TotalStoredBytes += int64(len(stored))
+		if manifest.TotalPlainBytes > cfg.Limits.MaxTotalPlainBytes || manifest.TotalStoredBytes > cfg.Limits.MaxTotalStoredBytes {
+			return manifest, fmt.Errorf("%w: aggregate bytes", ErrSegmentLimit)
+		}
+		if codec == segmentCodecZstd {
+			manifest.ZstdValueCount++
+		} else {
+			manifest.PlainValueCount++
+		}
+		if item.Unit.Audit != nil {
+			manifest.AuditCount++
+		}
+		if !item.CreatedAt.IsZero() {
+			ts := item.CreatedAt.UTC().Format(time.RFC3339Nano)
+			if manifest.MinCreatedAt == "" || ts < manifest.MinCreatedAt {
+				manifest.MinCreatedAt = ts
+			}
+			if manifest.MaxCreatedAt == "" || ts > manifest.MaxCreatedAt {
+				manifest.MaxCreatedAt = ts
+			}
+		}
+		checksum := sha256.Sum256(plain)
+		if _, err = db.ExecContext(ctx, `INSERT INTO history_units(sequence, codec, plaintext_length, checksum, payload) VALUES(?,?,?,?,?)`, item.Unit.Sequence, codec, len(plain), checksum[:], stored); err != nil {
+			return manifest, fmt.Errorf("write segment unit: %w", err)
+		}
+	}
+	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename); err != nil {
+		return manifest, fmt.Errorf("write segment manifest: %w", err)
+	}
+	if _, err = db.ExecContext(ctx, `PRAGMA user_version=1`); err != nil {
+		return manifest, err
+	}
+	if _, err = db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		return manifest, err
+	}
+	if err = db.Close(); err != nil {
+		return manifest, fmt.Errorf("close segment: %w", err)
+	}
+	f, err := os.OpenFile(tmpPath, os.O_RDONLY, 0)
+	if err != nil {
+		return manifest, err
+	}
+	if err = b.syncFile(f); err != nil {
+		_ = f.Close()
+		return manifest, fmt.Errorf("fsync segment: %w", err)
+	}
+	if err = f.Close(); err != nil {
+		return manifest, err
+	}
+	if err = os.Chmod(tmpPath, 0o400); err != nil {
+		return manifest, fmt.Errorf("seal segment: %w", err)
+	}
+	fileDigest, err := digestFile(tmpPath)
+	if err != nil {
+		return manifest, err
+	}
+	manifest.FileDigest = fileDigest
+	if _, statErr := os.Lstat(finalPath); statErr == nil {
+		return manifest, fmt.Errorf("install segment candidate: %w", os.ErrExist)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return manifest, fmt.Errorf("inspect segment destination: %w", statErr)
+	}
+	if err = os.Rename(tmpPath, finalPath); err != nil {
+		return manifest, fmt.Errorf("install segment candidate: %w", err)
+	}
+	return manifest, nil
+}
+
+const segmentSchemaV1 = `
+CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL);
+CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
+`
+
+// InspectArchiveSegmentManifest reads aggregate metadata without decoding payload rows.
+func InspectArchiveSegmentManifest(ctx context.Context, root, basename string) (ArchiveSegmentManifest, error) {
+	path, err := safeArchivePath(root, basename, true)
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	defer func() { _ = db.Close() }()
+	var m ArchiveSegmentManifest
+	var digest []byte
+	err = db.QueryRowContext(ctx, `SELECT format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename FROM segment_manifest`).Scan(&m.FormatVersion, &m.StoreID, &m.StartSequence, &m.EndSequence, &m.UnitCount, &m.AuditCount, &m.MinCreatedAt, &m.MaxCreatedAt, &m.PlainValueCount, &m.ZstdValueCount, &m.TotalPlainBytes, &m.TotalStoredBytes, &digest, &m.Basename)
+	if err != nil {
+		return m, fmt.Errorf("%w: read manifest: %v", ErrSegmentCorrupt, err)
+	}
+	if m.FormatVersion != domain.SegmentFormatV1 {
+		return m, fmt.Errorf("%w: %d", ErrSegmentUnsupportedFormat, m.FormatVersion)
+	}
+	if m.Basename != basename || len(digest) != sha256.Size {
+		return m, fmt.Errorf("%w: manifest identity", ErrSegmentCorrupt)
+	}
+	m.LogicalDigest = hex.EncodeToString(digest)
+	m.FileDigest, err = digestFile(path)
+	return m, err
+}
+
+// VerifyArchiveSegment fully decodes and validates a sealed segment within caps.
+func VerifyArchiveSegment(ctx context.Context, root, basename string, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
+	if err := limits.validate(); err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	m, err := InspectArchiveSegmentManifest(ctx, root, basename)
+	if err != nil {
+		return m, err
+	}
+	path, _ := safeArchivePath(root, basename, true)
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		return m, err
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,payload FROM history_units ORDER BY sequence`)
+	if err != nil {
+		return m, fmt.Errorf("%w: query payloads: %v", ErrSegmentCorrupt, err)
+	}
+	defer func() { _ = rows.Close() }()
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1), zstd.WithDecoderMaxMemory(uint64(limits.MaxValuePlainBytes)))
+	if err != nil {
+		return m, err
+	}
+	defer decoder.Close()
+	logical := sha256.New()
+	var count uint64
+	var totalPlain, totalStored int64
+	var previous uint64
+	for rows.Next() {
+		if err = ctx.Err(); err != nil {
+			return m, err
+		}
+		var seq uint64
+		var codec string
+		var plainLen int64
+		var checksum, stored []byte
+		if err = rows.Scan(&seq, &codec, &plainLen, &checksum, &stored); err != nil {
+			return m, fmt.Errorf("%w: scan payload", ErrSegmentCorrupt)
+		}
+		if count > 0 && seq != previous+1 {
+			return m, fmt.Errorf("%w: non-contiguous sequence", ErrSegmentCorrupt)
+		}
+		previous = seq
+		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || int64(len(stored)) > limits.MaxValueStoredBytes {
+			return m, fmt.Errorf("%w: value", ErrSegmentLimit)
+		}
+		var plain []byte
+		switch codec {
+		case segmentCodecPlain:
+			plain = append([]byte(nil), stored...)
+		case segmentCodecZstd:
+			plain, err = decoder.DecodeAll(stored, make([]byte, 0, plainLen))
+			if err != nil {
+				return m, fmt.Errorf("%w: zstd payload: %v", ErrSegmentCorrupt, err)
+			}
+		default:
+			return m, fmt.Errorf("%w: %s", ErrSegmentUnsupportedCodec, codec)
+		}
+		if int64(len(plain)) != plainLen || !bytes.Equal(checksum, digestBytes(plain)) {
+			return m, fmt.Errorf("%w: payload checksum", ErrSegmentCorrupt)
+		}
+		totalPlain += int64(len(plain))
+		totalStored += int64(len(stored))
+		if totalPlain > limits.MaxTotalPlainBytes || totalStored > limits.MaxTotalStoredBytes {
+			return m, fmt.Errorf("%w: aggregate", ErrSegmentLimit)
+		}
+		logical.Write(plain)
+		count++
+	}
+	if err = rows.Err(); err != nil {
+		return m, err
+	}
+	if count != m.UnitCount || totalPlain != m.TotalPlainBytes || totalStored != m.TotalStoredBytes || hex.EncodeToString(logical.Sum(nil)) != m.LogicalDigest {
+		return m, fmt.Errorf("%w: aggregate mismatch", ErrSegmentCorrupt)
+	}
+	if count == 0 || previous != m.EndSequence {
+		return m, fmt.Errorf("%w: range mismatch", ErrSegmentCorrupt)
+	}
+	return m, nil
+}
+
+func validateArchiveRoot(root string) error {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return ErrSegmentUnsafeLocation
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil || resolved != abs {
+		return ErrSegmentUnsafeLocation
+	}
+	return nil
+}
+func safeArchivePath(root, basename string, mustExist bool) (string, error) {
+	if filepath.IsAbs(basename) || filepath.Base(basename) != basename || !segmentBasenameRE.MatchString(basename) {
+		return "", ErrSegmentUnsafeLocation
+	}
+	if err := validateArchiveRoot(root); err != nil {
+		return "", err
+	}
+	path := filepath.Join(root, basename)
+	info, err := os.Lstat(path)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", ErrSegmentUnsafeLocation
+	}
+	if mustExist && err != nil {
+		return "", err
+	}
+	return path, nil
+}
+func digestBytes(v []byte) []byte { d := sha256.Sum256(v); return d[:] }
+func digestFile(path string) (string, error) {
+	f, e := os.Open(path)
+	if e != nil {
+		return "", e
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, e = io.Copy(h, f); e != nil {
+		return "", e
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -10,12 +10,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
+	"golang.org/x/sys/unix"
 
 	"github.com/duck8823/traceary/domain"
 )
@@ -45,10 +48,11 @@ type ArchiveSegmentLimits struct {
 	MaxValueStoredBytes int64
 	MaxTotalPlainBytes  int64
 	MaxTotalStoredBytes int64
+	MaxFileBytes        int64
 }
 
 func (l ArchiveSegmentLimits) validate() error {
-	if l.MaxValuePlainBytes <= 0 || l.MaxValueStoredBytes <= 0 || l.MaxTotalPlainBytes <= 0 || l.MaxTotalStoredBytes <= 0 {
+	if l.MaxValuePlainBytes <= 0 || l.MaxValueStoredBytes <= 0 || l.MaxTotalPlainBytes <= 0 || l.MaxTotalStoredBytes <= 0 || l.MaxFileBytes <= 0 {
 		return fmt.Errorf("%w: every cap must be positive", ErrSegmentLimit)
 	}
 	return nil
@@ -82,15 +86,19 @@ type ArchiveSegmentManifest struct {
 
 // ArchiveHistoryUnit carries the canonical unit and an optional ordering time.
 type ArchiveHistoryUnit struct {
-	Unit      domain.HistoryUnit
-	CreatedAt time.Time
+	Unit domain.HistoryUnit
 }
 
-type archiveSegmentBuilder struct{ syncFile func(*os.File) error }
+type archiveSegmentBuilder struct {
+	syncFile  func(*os.File) error
+	sealFile  func(*os.File, os.FileMode) error
+	afterUnit func(int) error
+}
 
-// BuildArchiveSegmentV1 creates and seals one immutable, content-addressed segment.
+// BuildArchiveSegmentV1 creates and seals one immutable segment in an owned
+// candidate directory. Publishing it into the archive root belongs to #1651.
 func BuildArchiveSegmentV1(ctx context.Context, root string, units []ArchiveHistoryUnit, cfg ArchiveSegmentConfig) (ArchiveSegmentManifest, error) {
-	return archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }}.build(ctx, root, units, cfg)
+	return archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }, sealFile: func(f *os.File, m os.FileMode) error { return f.Chmod(m) }}.build(ctx, root, units, cfg)
 }
 
 func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []ArchiveHistoryUnit, cfg ArchiveSegmentConfig) (manifest ArchiveSegmentManifest, err error) {
@@ -104,44 +112,12 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 		return manifest, err
 	}
 
-	logical := sha256.New()
-	canonical := make([][]byte, len(units))
-	var previous uint64
-	for i, item := range units {
-		if err := ctx.Err(); err != nil {
-			return manifest, err
-		}
-		if i > 0 && item.Unit.Sequence != previous+1 {
-			return manifest, fmt.Errorf("history unit sequence is not contiguous")
-		}
-		previous = item.Unit.Sequence
-		value, encodeErr := item.Unit.CanonicalBytes()
-		if encodeErr != nil {
-			return manifest, encodeErr
-		}
-		canonical[i] = value
-		logical.Write(value)
-	}
-	var logicalDigest [sha256.Size]byte
-	copy(logicalDigest[:], logical.Sum(nil))
-	identity, err := domain.NewSegmentIdentity(cfg.StoreID, units[0].Unit.Sequence, units[len(units)-1].Unit.Sequence, logicalDigest)
-	if err != nil {
-		return manifest, err
-	}
-	basename := identity.Basename()
-	finalPath, err := safeArchivePath(root, basename, false)
-	if err != nil {
-		return manifest, err
-	}
 	tmp, err := os.CreateTemp(root, ".segment-v1-*.candidate")
 	if err != nil {
 		return manifest, fmt.Errorf("create segment candidate: %w", err)
 	}
 	tmpPath := tmp.Name()
-	if closeErr := tmp.Close(); closeErr != nil {
-		_ = os.Remove(tmpPath)
-		return manifest, closeErr
-	}
+	defer func() { _ = tmp.Close() }()
 	defer func() {
 		if err != nil {
 			_ = os.Chmod(tmpPath, 0o600)
@@ -149,7 +125,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 		}
 	}()
 
-	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=rwc&_pragma=journal_mode(DELETE)&_pragma=synchronous(FULL)")
+	db, err := sql.Open("sqlite", segmentSQLiteDSN(tmpPath, "rw", false)+"&_pragma=journal_mode(OFF)&_pragma=synchronous(FULL)")
 	if err != nil {
 		return manifest, err
 	}
@@ -163,12 +139,25 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	}
 	defer func() { _ = encoder.Close() }()
 
-	manifest = ArchiveSegmentManifest{StoreID: cfg.StoreID, FormatVersion: domain.SegmentFormatV1, StartSequence: identity.StartSequence, EndSequence: identity.EndSequence, UnitCount: uint64(len(units)), LogicalDigest: hex.EncodeToString(logicalDigest[:]), Basename: basename}
+	manifest = ArchiveSegmentManifest{StoreID: cfg.StoreID, FormatVersion: domain.SegmentFormatV1, StartSequence: units[0].Unit.Sequence, EndSequence: units[len(units)-1].Unit.Sequence, UnitCount: uint64(len(units))}
+	logical := sha256.New()
+	var previous uint64
+	var minCreatedAt, maxCreatedAt time.Time
 	for i, item := range units {
 		if err = ctx.Err(); err != nil {
 			return manifest, err
 		}
-		plain := canonical[i]
+		if i > 0 && item.Unit.Sequence != previous+1 {
+			return manifest, fmt.Errorf("history unit sequence is not contiguous")
+		}
+		previous = item.Unit.Sequence
+		if sizeErr := item.Unit.ValidateCanonicalSize(cfg.Limits.MaxValuePlainBytes); sizeErr != nil {
+			return manifest, fmt.Errorf("%w: %v", ErrSegmentLimit, sizeErr)
+		}
+		plain, encodeErr := item.Unit.CanonicalBytes()
+		if encodeErr != nil {
+			return manifest, fmt.Errorf("encode history unit: %w", encodeErr)
+		}
 		if int64(len(plain)) > cfg.Limits.MaxValuePlainBytes {
 			return manifest, fmt.Errorf("%w: plaintext value", ErrSegmentLimit)
 		}
@@ -196,19 +185,39 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 		if item.Unit.Audit != nil {
 			manifest.AuditCount++
 		}
-		if !item.CreatedAt.IsZero() {
-			ts := item.CreatedAt.UTC().Format(time.RFC3339Nano)
-			if manifest.MinCreatedAt == "" || ts < manifest.MinCreatedAt {
-				manifest.MinCreatedAt = ts
+		if !item.Unit.CreatedAt.IsZero() {
+			ts := item.Unit.CreatedAt.UTC()
+			if minCreatedAt.IsZero() || ts.Before(minCreatedAt) {
+				minCreatedAt = ts
 			}
-			if manifest.MaxCreatedAt == "" || ts > manifest.MaxCreatedAt {
-				manifest.MaxCreatedAt = ts
+			if maxCreatedAt.IsZero() || ts.After(maxCreatedAt) {
+				maxCreatedAt = ts
 			}
 		}
+		logical.Write(plain)
 		checksum := sha256.Sum256(plain)
 		if _, err = db.ExecContext(ctx, `INSERT INTO history_units(sequence, codec, plaintext_length, checksum, payload) VALUES(?,?,?,?,?)`, item.Unit.Sequence, codec, len(plain), checksum[:], stored); err != nil {
 			return manifest, fmt.Errorf("write segment unit: %w", err)
 		}
+		if b.afterUnit != nil {
+			if err = b.afterUnit(i); err != nil {
+				return manifest, fmt.Errorf("archive segment interrupted after unit: %w", err)
+			}
+		}
+	}
+	manifest.MinCreatedAt = formatOptionalTime(minCreatedAt)
+	manifest.MaxCreatedAt = formatOptionalTime(maxCreatedAt)
+	var logicalDigest [sha256.Size]byte
+	copy(logicalDigest[:], logical.Sum(nil))
+	identity, identityErr := domain.NewSegmentIdentity(cfg.StoreID, manifest.StartSequence, manifest.EndSequence, logicalDigest)
+	if identityErr != nil {
+		return manifest, fmt.Errorf("create segment identity: %w", identityErr)
+	}
+	manifest.LogicalDigest = hex.EncodeToString(logicalDigest[:])
+	manifest.Basename = identity.Basename()
+	finalPath, pathErr := safeArchivePath(root, manifest.Basename, false)
+	if pathErr != nil {
+		return manifest, pathErr
 	}
 	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename); err != nil {
 		return manifest, fmt.Errorf("write segment manifest: %w", err)
@@ -222,32 +231,34 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if err = db.Close(); err != nil {
 		return manifest, fmt.Errorf("close segment: %w", err)
 	}
-	f, err := os.OpenFile(tmpPath, os.O_RDONLY, 0)
-	if err != nil {
-		return manifest, err
+	if _, err = verifyArchiveSegmentPath(ctx, tmpPath, manifest, cfg.Limits, false); err != nil {
+		return manifest, fmt.Errorf("verify segment candidate before seal: %w", err)
 	}
-	if err = b.syncFile(f); err != nil {
-		_ = f.Close()
+	if err = b.syncFile(tmp); err != nil {
 		return manifest, fmt.Errorf("fsync segment: %w", err)
 	}
-	if err = f.Close(); err != nil {
-		return manifest, err
-	}
-	if err = os.Chmod(tmpPath, 0o400); err != nil {
+	if err = b.sealFile(tmp, 0o400); err != nil {
 		return manifest, fmt.Errorf("seal segment: %w", err)
 	}
-	fileDigest, err := digestFile(tmpPath)
+	fileDigest, err := digestOpenFile(ctx, tmp, cfg.Limits.MaxFileBytes)
 	if err != nil {
 		return manifest, err
 	}
 	manifest.FileDigest = fileDigest
-	if _, statErr := os.Lstat(finalPath); statErr == nil {
-		return manifest, fmt.Errorf("install segment candidate: %w", os.ErrExist)
-	} else if !errors.Is(statErr, os.ErrNotExist) {
-		return manifest, fmt.Errorf("inspect segment destination: %w", statErr)
+	// A hard link installs the content-addressed name without replacing an
+	// existing inode. Directory durability and publication journaling remain
+	// the responsibility of #1651.
+	if err = os.Link(tmpPath, finalPath); err != nil {
+		return manifest, fmt.Errorf("install segment candidate without replacement: %w", err)
 	}
-	if err = os.Rename(tmpPath, finalPath); err != nil {
-		return manifest, fmt.Errorf("install segment candidate: %w", err)
+	if err = os.Remove(tmpPath); err != nil {
+		_ = os.Remove(finalPath)
+		return manifest, fmt.Errorf("remove installed candidate name: %w", err)
+	}
+	if _, err = verifyArchiveSegmentPath(ctx, finalPath, manifest, cfg.Limits, true); err != nil {
+		_ = os.Chmod(finalPath, 0o600)
+		_ = os.Remove(finalPath)
+		return manifest, fmt.Errorf("verify sealed segment candidate: %w", err)
 	}
 	return manifest, nil
 }
@@ -258,16 +269,31 @@ CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, pl
 `
 
 // InspectArchiveSegmentManifest reads aggregate metadata without decoding payload rows.
-func InspectArchiveSegmentManifest(ctx context.Context, root, basename string) (ArchiveSegmentManifest, error) {
+func InspectArchiveSegmentManifest(ctx context.Context, root, basename string, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
+	if err := limits.validate(); err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
 	path, err := safeArchivePath(root, basename, true)
 	if err != nil {
 		return ArchiveSegmentManifest{}, err
 	}
-	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	return inspectArchiveSegmentPath(ctx, path, basename, true, limits.MaxFileBytes)
+}
+
+func inspectArchiveSegmentPath(ctx context.Context, path, expectedBasename string, requireSealed bool, maxFileBytes int64) (ArchiveSegmentManifest, error) {
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireSealed)
 	if err != nil {
 		return ArchiveSegmentManifest{}, err
 	}
 	defer func() { _ = db.Close() }()
+	defer func() { _ = pinned.Close() }()
+	info, err := pinned.Stat()
+	if err != nil {
+		return ArchiveSegmentManifest{}, fmt.Errorf("stat segment: %w", err)
+	}
+	if info.Size() > maxFileBytes {
+		return ArchiveSegmentManifest{}, fmt.Errorf("%w: file bytes", ErrSegmentLimit)
+	}
 	var m ArchiveSegmentManifest
 	var digest []byte
 	err = db.QueryRowContext(ctx, `SELECT format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename FROM segment_manifest`).Scan(&m.FormatVersion, &m.StoreID, &m.StartSequence, &m.EndSequence, &m.UnitCount, &m.AuditCount, &m.MinCreatedAt, &m.MaxCreatedAt, &m.PlainValueCount, &m.ZstdValueCount, &m.TotalPlainBytes, &m.TotalStoredBytes, &digest, &m.Basename)
@@ -277,29 +303,59 @@ func InspectArchiveSegmentManifest(ctx context.Context, root, basename string) (
 	if m.FormatVersion != domain.SegmentFormatV1 {
 		return m, fmt.Errorf("%w: %d", ErrSegmentUnsupportedFormat, m.FormatVersion)
 	}
-	if m.Basename != basename || len(digest) != sha256.Size {
+	if (expectedBasename != "" && m.Basename != expectedBasename) || len(digest) != sha256.Size {
 		return m, fmt.Errorf("%w: manifest identity", ErrSegmentCorrupt)
 	}
 	m.LogicalDigest = hex.EncodeToString(digest)
-	m.FileDigest, err = digestFile(path)
-	return m, err
+	return m, nil
 }
 
-// VerifyArchiveSegment fully decodes and validates a sealed segment within caps.
-func VerifyArchiveSegment(ctx context.Context, root, basename string, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
+// VerifyArchiveSegment fully decodes a sealed segment and binds it to the
+// durable expected manifest supplied by its caller.
+func VerifyArchiveSegment(ctx context.Context, root string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
 	if err := limits.validate(); err != nil {
 		return ArchiveSegmentManifest{}, err
 	}
-	m, err := InspectArchiveSegmentManifest(ctx, root, basename)
+	path, err := safeArchivePath(root, expected.Basename, true)
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	return verifyArchiveSegmentPath(ctx, path, expected, limits, true)
+}
+
+func verifyArchiveSegmentPath(ctx context.Context, path string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits, requireFileDigest bool) (ArchiveSegmentManifest, error) {
+	m, err := inspectArchiveSegmentPath(ctx, path, expected.Basename, requireFileDigest, limits.MaxFileBytes)
 	if err != nil {
 		return m, err
 	}
-	path, _ := safeArchivePath(root, basename, true)
-	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if !sameLogicalManifest(m, expected) {
+		return m, fmt.Errorf("%w: expected manifest mismatch", ErrSegmentCorrupt)
+	}
+	digest, decodeErr := hex.DecodeString(m.LogicalDigest)
+	if decodeErr != nil || len(digest) != sha256.Size {
+		return m, fmt.Errorf("%w: logical digest", ErrSegmentCorrupt)
+	}
+	var logicalDigest [sha256.Size]byte
+	copy(logicalDigest[:], digest)
+	identity, identityErr := domain.NewSegmentIdentity(m.StoreID, m.StartSequence, m.EndSequence, logicalDigest)
+	if identityErr != nil || identity.Basename() != m.Basename {
+		return m, fmt.Errorf("%w: content-addressed identity", ErrSegmentCorrupt)
+	}
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireFileDigest)
 	if err != nil {
 		return m, err
 	}
 	defer func() { _ = db.Close() }()
+	defer func() { _ = pinned.Close() }()
+	if requireFileDigest {
+		m.FileDigest, err = digestOpenFile(ctx, pinned, limits.MaxFileBytes)
+		if err != nil {
+			return m, err
+		}
+		if expected.FileDigest == "" || m.FileDigest != expected.FileDigest {
+			return m, fmt.Errorf("%w: expected file digest mismatch", ErrSegmentCorrupt)
+		}
+	}
 	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,payload FROM history_units ORDER BY sequence`)
 	if err != nil {
 		return m, fmt.Errorf("%w: query payloads: %v", ErrSegmentCorrupt, err)
@@ -312,8 +368,10 @@ func VerifyArchiveSegment(ctx context.Context, root, basename string, limits Arc
 	defer decoder.Close()
 	logical := sha256.New()
 	var count uint64
+	var auditCount, plainCount, zstdCount uint64
 	var totalPlain, totalStored int64
-	var previous uint64
+	var first, previous uint64
+	var minCreatedAt, maxCreatedAt time.Time
 	for rows.Next() {
 		if err = ctx.Err(); err != nil {
 			return m, err
@@ -328,6 +386,9 @@ func VerifyArchiveSegment(ctx context.Context, root, basename string, limits Arc
 		if count > 0 && seq != previous+1 {
 			return m, fmt.Errorf("%w: non-contiguous sequence", ErrSegmentCorrupt)
 		}
+		if count == 0 {
+			first = seq
+		}
 		previous = seq
 		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || int64(len(stored)) > limits.MaxValueStoredBytes {
 			return m, fmt.Errorf("%w: value", ErrSegmentLimit)
@@ -336,7 +397,9 @@ func VerifyArchiveSegment(ctx context.Context, root, basename string, limits Arc
 		switch codec {
 		case segmentCodecPlain:
 			plain = append([]byte(nil), stored...)
+			plainCount++
 		case segmentCodecZstd:
+			zstdCount++
 			plain, err = decoder.DecodeAll(stored, make([]byte, 0, plainLen))
 			if err != nil {
 				return m, fmt.Errorf("%w: zstd payload: %v", ErrSegmentCorrupt, err)
@@ -346,6 +409,19 @@ func VerifyArchiveSegment(ctx context.Context, root, basename string, limits Arc
 		}
 		if int64(len(plain)) != plainLen || !bytes.Equal(checksum, digestBytes(plain)) {
 			return m, fmt.Errorf("%w: payload checksum", ErrSegmentCorrupt)
+		}
+		unit, decodeUnitErr := domain.DecodeHistoryUnitCanonical(plain)
+		if decodeUnitErr != nil || unit.Sequence != seq {
+			return m, fmt.Errorf("%w: canonical history unit", ErrSegmentCorrupt)
+		}
+		if unit.Audit != nil {
+			auditCount++
+		}
+		if minCreatedAt.IsZero() || unit.CreatedAt.Before(minCreatedAt) {
+			minCreatedAt = unit.CreatedAt
+		}
+		if maxCreatedAt.IsZero() || unit.CreatedAt.After(maxCreatedAt) {
+			maxCreatedAt = unit.CreatedAt
 		}
 		totalPlain += int64(len(plain))
 		totalStored += int64(len(stored))
@@ -358,13 +434,63 @@ func VerifyArchiveSegment(ctx context.Context, root, basename string, limits Arc
 	if err = rows.Err(); err != nil {
 		return m, err
 	}
-	if count != m.UnitCount || totalPlain != m.TotalPlainBytes || totalStored != m.TotalStoredBytes || hex.EncodeToString(logical.Sum(nil)) != m.LogicalDigest {
+	if count != m.UnitCount || auditCount != m.AuditCount || plainCount != m.PlainValueCount || zstdCount != m.ZstdValueCount || totalPlain != m.TotalPlainBytes || totalStored != m.TotalStoredBytes || hex.EncodeToString(logical.Sum(nil)) != m.LogicalDigest || formatOptionalTime(minCreatedAt) != m.MinCreatedAt || formatOptionalTime(maxCreatedAt) != m.MaxCreatedAt {
 		return m, fmt.Errorf("%w: aggregate mismatch", ErrSegmentCorrupt)
 	}
-	if count == 0 || previous != m.EndSequence {
+	if count == 0 || first != m.StartSequence || previous != m.EndSequence || m.StartSequence+count-1 != m.EndSequence {
 		return m, fmt.Errorf("%w: range mismatch", ErrSegmentCorrupt)
 	}
 	return m, nil
+}
+
+func sameLogicalManifest(a, b ArchiveSegmentManifest) bool {
+	a.FileDigest, b.FileDigest = "", ""
+	return a == b
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func segmentSQLiteDSN(path, mode string, immutable bool) string {
+	query := url.Values{"mode": []string{mode}}
+	if immutable {
+		query.Set("immutable", "1")
+	}
+	return (&url.URL{Scheme: "file", Path: path, RawQuery: query.Encode()}).String()
+}
+
+func openPinnedImmutableSegment(ctx context.Context, path string, requireSealed bool) (*sql.DB, *os.File, error) {
+	dirFD, err := unix.Open(filepath.Dir(path), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pin segment directory: %w", err)
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+	fd, err := unix.Openat(dirFD, filepath.Base(path), unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open immutable segment without following symlinks: %w", err)
+	}
+	pinned := os.NewFile(uintptr(fd), filepath.Base(path))
+	info, err := pinned.Stat()
+	if err != nil || !info.Mode().IsRegular() || (requireSealed && info.Mode().Perm() != 0o400) {
+		_ = pinned.Close()
+		return nil, nil, fmt.Errorf("%w: segment must be a regular 0400 file", ErrSegmentCorrupt)
+	}
+	db, err := sql.Open("sqlite", segmentSQLiteDSN(filepath.Join("/dev/fd", strconv.Itoa(fd)), "ro", true))
+	if err != nil {
+		_ = pinned.Close()
+		return nil, nil, fmt.Errorf("open pinned immutable segment: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		_ = pinned.Close()
+		return nil, nil, fmt.Errorf("ping pinned immutable segment: %w", err)
+	}
+	return db, pinned, nil
 }
 
 func validateArchiveRoot(root string) error {
@@ -412,9 +538,38 @@ func digestFile(path string) (string, error) {
 		return "", e
 	}
 	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	return digestOpenFile(context.Background(), f, info.Size())
+}
+
+func digestOpenFile(ctx context.Context, f *os.File, maxBytes int64) (string, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("seek segment digest input: %w", err)
+	}
 	h := sha256.New()
-	if _, e = io.Copy(h, f); e != nil {
-		return "", e
+	buffer := make([]byte, 64*1024)
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", fmt.Errorf("digest segment canceled: %w", err)
+		}
+		n, readErr := f.Read(buffer)
+		total += int64(n)
+		if total > maxBytes {
+			return "", fmt.Errorf("%w: file bytes", ErrSegmentLimit)
+		}
+		if n > 0 {
+			_, _ = h.Write(buffer[:n])
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("digest segment file: %w", readErr)
+		}
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -1,0 +1,227 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func testSegmentLimits() ArchiveSegmentLimits {
+	return ArchiveSegmentLimits{MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20}
+}
+
+func testArchiveUnits() []ArchiveHistoryUnit {
+	return []ArchiveHistoryUnit{
+		{Unit: domain.HistoryUnit{Sequence: 10, Event: []domain.SQLiteValue{domain.NullValue(), domain.TextValue([]byte(strings.Repeat("compressible-", 100))), domain.BlobValue([]byte{0, 0xff})}}, CreatedAt: time.Unix(2, 3)},
+		{Unit: domain.HistoryUnit{Sequence: 11, Event: []domain.SQLiteValue{domain.IntegerValue(-5), domain.RealValue(1.25)}, Audit: []domain.SQLiteValue{domain.TextValue([]byte("cmd"))}}, CreatedAt: time.Unix(4, 5)},
+	}
+}
+
+func TestArchiveSegmentBuildInspectAndVerify(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "store-a", CompressionFloor: 32, Limits: testSegmentLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ZstdValueCount == 0 || m.PlainValueCount == 0 || m.AuditCount != 1 {
+		t.Fatalf("unexpected codec/count facts: %+v", m)
+	}
+	path := filepath.Join(root, m.Basename)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o400 {
+		t.Fatalf("mode = %o", info.Mode().Perm())
+	}
+	inspected, err := InspectArchiveSegmentManifest(context.Background(), root, m.Basename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspected.LogicalDigest != m.LogicalDigest || inspected.FileDigest == "" {
+		t.Fatalf("inspection mismatch: %+v", inspected)
+	}
+	verified, err := VerifyArchiveSegment(context.Background(), root, m.Basename, testSegmentLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verified.Basename != m.Basename {
+		t.Fatalf("verified basename = %q", verified.Basename)
+	}
+}
+
+func TestArchiveSegmentLogicalOutputIsDeterministic(t *testing.T) {
+	cfg := ArchiveSegmentConfig{StoreID: "same", CompressionFloor: 20, Limits: testSegmentLimits()}
+	a, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), testArchiveUnits(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), testArchiveUnits(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.FileDigest, b.FileDigest = "", ""
+	if a != b {
+		t.Fatalf("logical manifests differ:\n%+v\n%+v", a, b)
+	}
+}
+
+func TestArchiveSegmentRejectsUnsafeLocations(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"/tmp/x", "../segment-v1-" + strings.Repeat("a", 64) + ".sqlite", "not-content-addressed.sqlite"} {
+		if _, err := InspectArchiveSegmentManifest(context.Background(), root, name); !errors.Is(err, ErrSegmentUnsafeLocation) {
+			t.Fatalf("%q error = %v", name, err)
+		}
+	}
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "archive")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildArchiveSegmentV1(context.Background(), link, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}); !errors.Is(err, ErrSegmentUnsafeLocation) {
+		t.Fatalf("symlink root error = %v", err)
+	}
+	name := "segment-v1-" + strings.Repeat("a", 64) + ".sqlite"
+	if err := os.Symlink(filepath.Join(root, "missing"), filepath.Join(root, name)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectArchiveSegmentManifest(context.Background(), root, name); !errors.Is(err, ErrSegmentUnsafeLocation) {
+		t.Fatalf("symlink file error = %v", err)
+	}
+}
+
+func TestArchiveSegmentCapsCancellationAndIncompleteOutput(t *testing.T) {
+	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}
+	root := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := BuildArchiveSegmentV1(ctx, root, testArchiveUnits(), cfg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel error = %v", err)
+	}
+	assertNoSegmentFiles(t, root)
+	cfg.Limits.MaxValuePlainBytes = 4
+	if _, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), cfg); !errors.Is(err, ErrSegmentLimit) {
+		t.Fatalf("limit error = %v", err)
+	}
+	assertNoSegmentFiles(t, root)
+	unit := testArchiveUnits()[:1]
+	encoded, err := unit[0].Unit.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exact := ArchiveSegmentLimits{MaxValuePlainBytes: int64(len(encoded)), MaxValueStoredBytes: int64(len(encoded)), MaxTotalPlainBytes: int64(len(encoded)), MaxTotalStoredBytes: int64(len(encoded))}
+	if _, err = BuildArchiveSegmentV1(context.Background(), t.TempDir(), unit, ArchiveSegmentConfig{StoreID: "exact", CompressionFloor: len(encoded) + 1, Limits: exact}); err != nil {
+		t.Fatalf("exact maximum rejected: %v", err)
+	}
+}
+
+func TestArchiveSegmentFsyncFailureDoesNotSeal(t *testing.T) {
+	root := t.TempDir()
+	sentinel := errors.New("sync failed")
+	_, err := (archiveSegmentBuilder{syncFile: func(*os.File) error { return sentinel }}).build(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v", err)
+	}
+	assertNoSegmentFiles(t, root)
+}
+
+func TestArchiveSegmentVerifierSeparatesUnknownCodecAndCorruption(t *testing.T) {
+	for _, tc := range []struct {
+		name, codec string
+		corrupt     bool
+		floor       int
+		want        error
+	}{
+		{name: "unknown codec", codec: "future", floor: 1 << 20, want: ErrSegmentUnsupportedCodec},
+		{name: "corrupt zstd payload", codec: segmentCodecZstd, corrupt: true, floor: 1, want: ErrSegmentCorrupt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: tc.floor, Limits: testSegmentLimits()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, m.Basename)
+			if err = os.Chmod(path, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.corrupt {
+				_, err = db.Exec(`UPDATE history_units SET payload=x'00' WHERE sequence=10`)
+			} else {
+				_, err = db.Exec(`UPDATE history_units SET codec=? WHERE sequence=10`, tc.codec)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.Chmod(path, 0o400); err != nil {
+				t.Fatal(err)
+			}
+			_, err = VerifyArchiveSegment(context.Background(), root, m.Basename, testSegmentLimits())
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestArchiveSegmentRejectsUnknownFormatButManifestInspectionDoesNotDecodePayload(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	_ = os.Chmod(path, 0o600)
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE history_units SET codec='future'`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	_ = os.Chmod(path, 0o400)
+	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename); err != nil {
+		t.Fatalf("manifest inspection decoded payload: %v", err)
+	}
+	_ = os.Chmod(path, 0o600)
+	db, err = sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE segment_manifest SET format_version=2`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	_ = os.Chmod(path, 0o400)
+	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename); !errors.Is(err, ErrSegmentUnsupportedFormat) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func assertNoSegmentFiles(t *testing.T, root string) {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sqlite") || strings.Contains(e.Name(), "candidate") {
+			t.Fatalf("incomplete output remains: %s", e.Name())
+		}
+	}
+}

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -19,14 +19,41 @@ func testSegmentLimits() ArchiveSegmentLimits {
 
 func testArchiveUnits() []ArchiveHistoryUnit {
 	return []ArchiveHistoryUnit{
-		{Unit: domain.HistoryUnit{Sequence: 10, EventID: []byte("event-10"), CreatedAt: time.Unix(2, 3), Event: []domain.SQLiteValue{domain.NullValue(), domain.TextValue([]byte(strings.Repeat("compressible-", 100))), domain.BlobValue([]byte{0, 0xff})}}},
-		{Unit: domain.HistoryUnit{Sequence: 11, EventID: []byte("event-11"), CreatedAt: time.Unix(4, 5), Event: []domain.SQLiteValue{domain.IntegerValue(-5), domain.RealValue(1.25)}, Audit: []domain.SQLiteValue{domain.TextValue([]byte("cmd"))}}},
+		{Unit: domain.HistoryUnit{Sequence: 10, Event: testArchiveEvent("event-10", time.Unix(2, 3), domain.TextValue([]byte(strings.Repeat("compressible-", 100))))}},
+		{Unit: domain.HistoryUnit{Sequence: 11, Event: testArchiveEvent("event-11", time.Unix(4, 5), domain.TextValue([]byte("body"))), Audit: testArchiveAudit()}},
 	}
+}
+
+func testArchiveEvent(id string, created time.Time, body domain.SQLiteValue) domain.ArchiveEventV1 {
+	values := make([]domain.SQLiteValue, 23)
+	for i := range values {
+		values[i] = domain.NullValue()
+	}
+	values[0] = domain.TextValue([]byte(id))
+	values[4] = body
+	values[5] = domain.TextValue([]byte(created.UTC().Format(time.RFC3339Nano)))
+	event, err := domain.NewArchiveEventV1(values)
+	if err != nil {
+		panic(err)
+	}
+	return event
+}
+func testArchiveAudit() *domain.ArchiveAuditV1 {
+	values := make([]domain.SQLiteValue, 27)
+	for i := range values {
+		values[i] = domain.NullValue()
+	}
+	values[0] = domain.TextValue([]byte("cmd"))
+	audit, err := domain.NewArchiveAuditV1(values)
+	if err != nil {
+		panic(err)
+	}
+	return &audit
 }
 
 func TestArchiveSegmentBuildInspectAndVerify(t *testing.T) {
 	root := t.TempDir()
-	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "store-a", CompressionFloor: 32, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "store-a", CompressionFloor: 500, Limits: testSegmentLimits()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,8 +86,8 @@ func TestArchiveSegmentBuildInspectAndVerify(t *testing.T) {
 
 func TestArchiveSegmentTimeBoundsUseChronologicalOrder(t *testing.T) {
 	units := testArchiveUnits()
-	units[0].Unit.CreatedAt = time.Unix(10, 1)
-	units[1].Unit.CreatedAt = time.Unix(10, 0)
+	units[0].Unit.Event = testArchiveEvent("event-10", time.Unix(10, 1), domain.TextValue([]byte("body")))
+	units[1].Unit.Event = testArchiveEvent("event-11", time.Unix(10, 0), domain.TextValue([]byte("body")))
 	m, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), units, ArchiveSegmentConfig{StoreID: "time", CompressionFloor: 32, Limits: testSegmentLimits()})
 	if err != nil {
 		t.Fatal(err)
@@ -254,6 +281,40 @@ func TestArchiveSegmentVerifierSeparatesUnknownCodecAndCorruption(t *testing.T) 
 				t.Fatalf("error = %v", err)
 			}
 		})
+	}
+}
+
+func TestArchiveSegmentVerifierRejectsOversizedStoredPayloadBeforeLoadingBlob(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "oversized", CompressionFloor: 500, Limits: testSegmentLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE history_units SET payload=zeroblob(2097152), plaintext_length=2097152 WHERE sequence=10`); err != nil {
+		t.Fatal(err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	m.FileDigest, err = digestFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	limits := testSegmentLimits()
+	limits.MaxValueStoredBytes = 1024
+	if _, err = VerifyArchiveSegment(context.Background(), root, m, limits); !errors.Is(err, ErrSegmentLimit) {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func testSegmentLimits() ArchiveSegmentLimits {
-	return ArchiveSegmentLimits{MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20}
+	return ArchiveSegmentLimits{MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20}
 }
 
 func testArchiveUnits() []ArchiveHistoryUnit {
 	return []ArchiveHistoryUnit{
-		{Unit: domain.HistoryUnit{Sequence: 10, Event: []domain.SQLiteValue{domain.NullValue(), domain.TextValue([]byte(strings.Repeat("compressible-", 100))), domain.BlobValue([]byte{0, 0xff})}}, CreatedAt: time.Unix(2, 3)},
-		{Unit: domain.HistoryUnit{Sequence: 11, Event: []domain.SQLiteValue{domain.IntegerValue(-5), domain.RealValue(1.25)}, Audit: []domain.SQLiteValue{domain.TextValue([]byte("cmd"))}}, CreatedAt: time.Unix(4, 5)},
+		{Unit: domain.HistoryUnit{Sequence: 10, EventID: []byte("event-10"), CreatedAt: time.Unix(2, 3), Event: []domain.SQLiteValue{domain.NullValue(), domain.TextValue([]byte(strings.Repeat("compressible-", 100))), domain.BlobValue([]byte{0, 0xff})}}},
+		{Unit: domain.HistoryUnit{Sequence: 11, EventID: []byte("event-11"), CreatedAt: time.Unix(4, 5), Event: []domain.SQLiteValue{domain.IntegerValue(-5), domain.RealValue(1.25)}, Audit: []domain.SQLiteValue{domain.TextValue([]byte("cmd"))}}},
 	}
 }
 
@@ -41,19 +41,71 @@ func TestArchiveSegmentBuildInspectAndVerify(t *testing.T) {
 	if info.Mode().Perm() != 0o400 {
 		t.Fatalf("mode = %o", info.Mode().Perm())
 	}
-	inspected, err := InspectArchiveSegmentManifest(context.Background(), root, m.Basename)
+	inspected, err := InspectArchiveSegmentManifest(context.Background(), root, m.Basename, testSegmentLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if inspected.LogicalDigest != m.LogicalDigest || inspected.FileDigest == "" {
+	if inspected.LogicalDigest != m.LogicalDigest || inspected.FileDigest != "" {
 		t.Fatalf("inspection mismatch: %+v", inspected)
 	}
-	verified, err := VerifyArchiveSegment(context.Background(), root, m.Basename, testSegmentLimits())
+	verified, err := VerifyArchiveSegment(context.Background(), root, m, testSegmentLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if verified.Basename != m.Basename {
 		t.Fatalf("verified basename = %q", verified.Basename)
+	}
+}
+
+func TestArchiveSegmentTimeBoundsUseChronologicalOrder(t *testing.T) {
+	units := testArchiveUnits()
+	units[0].Unit.CreatedAt = time.Unix(10, 1)
+	units[1].Unit.CreatedAt = time.Unix(10, 0)
+	m, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), units, ArchiveSegmentConfig{StoreID: "time", CompressionFloor: 32, Limits: testSegmentLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.MinCreatedAt != time.Unix(10, 0).UTC().Format(time.RFC3339Nano) || m.MaxCreatedAt != time.Unix(10, 1).UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("time bounds = %s .. %s", m.MinCreatedAt, m.MaxCreatedAt)
+	}
+}
+
+func TestArchiveSegmentVerifierBindsExpectedManifestAndCaps(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "binding", CompressionFloor: 32, Limits: testSegmentLimits()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := m
+	tampered.FileDigest = strings.Repeat("0", 64)
+	if _, err = VerifyArchiveSegment(context.Background(), root, tampered, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("file digest tamper error = %v", err)
+	}
+	info, err := os.Stat(filepath.Join(root, m.Basename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileLimited := testSegmentLimits()
+	fileLimited.MaxFileBytes = info.Size() - 1
+	if _, err = VerifyArchiveSegment(context.Background(), root, m, fileLimited); !errors.Is(err, ErrSegmentLimit) {
+		t.Fatalf("file cap error = %v", err)
+	}
+	for name, limits := range map[string]ArchiveSegmentLimits{
+		"aggregate plaintext": {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: m.TotalPlainBytes - 1, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20},
+		"aggregate stored":    {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: m.TotalStoredBytes - 1, MaxFileBytes: 16 << 20},
+		"decoded value":       {MaxValuePlainBytes: 16, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := VerifyArchiveSegment(context.Background(), root, m, limits); !errors.Is(err, ErrSegmentLimit) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+	if err = os.Chmod(filepath.Join(root, m.Basename), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("unsealed mode error = %v", err)
 	}
 }
 
@@ -76,7 +128,7 @@ func TestArchiveSegmentLogicalOutputIsDeterministic(t *testing.T) {
 func TestArchiveSegmentRejectsUnsafeLocations(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"/tmp/x", "../segment-v1-" + strings.Repeat("a", 64) + ".sqlite", "not-content-addressed.sqlite"} {
-		if _, err := InspectArchiveSegmentManifest(context.Background(), root, name); !errors.Is(err, ErrSegmentUnsafeLocation) {
+		if _, err := InspectArchiveSegmentManifest(context.Background(), root, name, testSegmentLimits()); !errors.Is(err, ErrSegmentUnsafeLocation) {
 			t.Fatalf("%q error = %v", name, err)
 		}
 	}
@@ -92,7 +144,7 @@ func TestArchiveSegmentRejectsUnsafeLocations(t *testing.T) {
 	if err := os.Symlink(filepath.Join(root, "missing"), filepath.Join(root, name)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := InspectArchiveSegmentManifest(context.Background(), root, name); !errors.Is(err, ErrSegmentUnsafeLocation) {
+	if _, err := InspectArchiveSegmentManifest(context.Background(), root, name, testSegmentLimits()); !errors.Is(err, ErrSegmentUnsafeLocation) {
 		t.Fatalf("symlink file error = %v", err)
 	}
 }
@@ -116,7 +168,7 @@ func TestArchiveSegmentCapsCancellationAndIncompleteOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	exact := ArchiveSegmentLimits{MaxValuePlainBytes: int64(len(encoded)), MaxValueStoredBytes: int64(len(encoded)), MaxTotalPlainBytes: int64(len(encoded)), MaxTotalStoredBytes: int64(len(encoded))}
+	exact := ArchiveSegmentLimits{MaxValuePlainBytes: int64(len(encoded)), MaxValueStoredBytes: int64(len(encoded)), MaxTotalPlainBytes: int64(len(encoded)), MaxTotalStoredBytes: int64(len(encoded)), MaxFileBytes: 16 << 20}
 	if _, err = BuildArchiveSegmentV1(context.Background(), t.TempDir(), unit, ArchiveSegmentConfig{StoreID: "exact", CompressionFloor: len(encoded) + 1, Limits: exact}); err != nil {
 		t.Fatalf("exact maximum rejected: %v", err)
 	}
@@ -128,6 +180,29 @@ func TestArchiveSegmentFsyncFailureDoesNotSeal(t *testing.T) {
 	_, err := (archiveSegmentBuilder{syncFile: func(*os.File) error { return sentinel }}).build(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("error = %v", err)
+	}
+	assertNoSegmentFiles(t, root)
+}
+
+func TestArchiveSegmentMidOperationCancellationAndSealFailureLeaveNoOutput(t *testing.T) {
+	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}
+	root := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	b := archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }, sealFile: func(f *os.File, m os.FileMode) error { return f.Chmod(m) }, afterUnit: func(i int) error {
+		if i == 0 {
+			cancel()
+		}
+		return ctx.Err()
+	}}
+	if _, err := b.build(ctx, root, testArchiveUnits(), cfg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("mid-operation error = %v", err)
+	}
+	assertNoSegmentFiles(t, root)
+	root = t.TempDir()
+	sentinel := errors.New("seal failed")
+	b = archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }, sealFile: func(*os.File, os.FileMode) error { return sentinel }}
+	if _, err := b.build(context.Background(), root, testArchiveUnits(), cfg); !errors.Is(err, sentinel) {
+		t.Fatalf("seal error = %v", err)
 	}
 	assertNoSegmentFiles(t, root)
 }
@@ -170,7 +245,11 @@ func TestArchiveSegmentVerifierSeparatesUnknownCodecAndCorruption(t *testing.T) 
 			if err = os.Chmod(path, 0o400); err != nil {
 				t.Fatal(err)
 			}
-			_, err = VerifyArchiveSegment(context.Background(), root, m.Basename, testSegmentLimits())
+			m.FileDigest, err = digestFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = VerifyArchiveSegment(context.Background(), root, m, testSegmentLimits())
 			if !errors.Is(err, tc.want) {
 				t.Fatalf("error = %v", err)
 			}
@@ -195,7 +274,7 @@ func TestArchiveSegmentRejectsUnknownFormatButManifestInspectionDoesNotDecodePay
 	}
 	_ = db.Close()
 	_ = os.Chmod(path, 0o400)
-	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename); err != nil {
+	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename, testSegmentLimits()); err != nil {
 		t.Fatalf("manifest inspection decoded payload: %v", err)
 	}
 	_ = os.Chmod(path, 0o600)
@@ -208,7 +287,7 @@ func TestArchiveSegmentRejectsUnknownFormatButManifestInspectionDoesNotDecodePay
 	}
 	_ = db.Close()
 	_ = os.Chmod(path, 0o400)
-	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename); !errors.Is(err, ErrSegmentUnsupportedFormat) {
+	if _, err = InspectArchiveSegmentManifest(context.Background(), root, m.Basename, testSegmentLimits()); !errors.Is(err, ErrSegmentUnsupportedFormat) {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/infrastructure/sqlite/sqlite_open_inventory_test.go
+++ b/infrastructure/sqlite/sqlite_open_inventory_test.go
@@ -15,6 +15,7 @@ func TestRuntimeSQLiteOpenInventoryIsExplicit(t *testing.T) {
 	root := filepath.Clean(filepath.Join(filepath.Dir(current), "..", ".."))
 	allowed := map[string]int{
 		"infrastructure/filesystem/file_retention_datasource_unix.go": 1, // copied backup FD verification.
+		"infrastructure/sqlite/archive_segment.go":                    3, // owned offline candidate plus immutable sealed segment inspection/verification; never Hot.
 		"infrastructure/sqlite/compaction_sqlite.go":                  2, // EX-held source/candidate only.
 		"infrastructure/sqlite/database.go":                           1, // in-memory driver probe only.
 		"infrastructure/sqlite/payload_rehearsal.go":                  7, // copied rehearsal targets only.

--- a/infrastructure/sqlite/sqlite_open_inventory_test.go
+++ b/infrastructure/sqlite/sqlite_open_inventory_test.go
@@ -15,7 +15,7 @@ func TestRuntimeSQLiteOpenInventoryIsExplicit(t *testing.T) {
 	root := filepath.Clean(filepath.Join(filepath.Dir(current), "..", ".."))
 	allowed := map[string]int{
 		"infrastructure/filesystem/file_retention_datasource_unix.go": 1, // copied backup FD verification.
-		"infrastructure/sqlite/archive_segment.go":                    3, // owned offline candidate plus immutable sealed segment inspection/verification; never Hot.
+		"infrastructure/sqlite/archive_segment.go":                    2, // owned offline candidate plus O_NOFOLLOW-pinned immutable segment; never Hot.
 		"infrastructure/sqlite/compaction_sqlite.go":                  2, // EX-held source/candidate only.
 		"infrastructure/sqlite/database.go":                           1, // in-memory driver probe only.
 		"infrastructure/sqlite/payload_rehearsal.go":                  7, // copied rehearsal targets only.


### PR DESCRIPTION
## Summary
- add archive segment format v1 with fixed event/audit row schemas and History Unit parent binding
- add deterministic canonical encoding, zstd/identity codecs, bounded decode, identity, manifest, and immutable verification
- build and verify owned 0400 SQLite candidates while leaving final archive publication to #1651

## Validation
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run --timeout=5m`
- GPT-5.6 Sol integrity review: APPROVE, no findings after three blocking fixes

## Delegation evidence
Kimi K3 was prioritized and invoked twice through the scoped writer lease. Both runs were stopped after extended analysis without file changes. A local scoped worker completed the implementation, and an independent GPT-5.6 Sol reviewer required and verified the integrity fixes.

## Deferred boundary
Content-addressed archive installation, directory fsync, durable publication journal, and publication-time TOCTOU handling remain owned by #1651.

Closes #1649
