### PR TITLE
feat: bind catalog summaries into archive segment v1

### DIFF
--- a/.ai/spec/1658-segment-catalog-summary.md
+++ b/.ai/spec/1658-segment-catalog-summary.md
@@ -1,0 +1,34 @@
+# #1658 immutable segment Catalog summary
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Store a bounded immutable Catalog summary inside format-v1 segment SQLite; no sidecar is authoritative.
+- Accept only caller-produced canonical metadata structures: HMAC-SHA256 exact tokens, versioned Bloom bytes, and keyed session aggregates. Do not store raw metadata plaintext.
+- Bind the summary descriptor and normalized tables to the manifest, segment logical digest, and content-addressed identity.
+- Verify summary schema, caps, normalized contents, digest, and identity without decoding history payloads.
+- Preserve malformed legacy `created_at` raw bytes while preventing an incomplete time summary from excluding a segment.
+- Summary generation, Hot Catalog publication, routing, and segment placement remain later-issue responsibilities.
+
+### Conceptual model
+
+| Concept | State | Invariant |
+|---|---|---|
+| Summary descriptor v1 | key ID, completeness, exact tokens, Bloom descriptors, session aggregates | deterministic canonical bytes contain no raw metadata fields |
+| Normalized summary tables | immutable query-oriented copy inside the segment | reconstruction must byte-equal the canonical descriptor |
+| Manifest summary facts | version/digest/key/completeness/row and byte counts | all facts are independently cap checked |
+| Logical segment digest | domain-separated length frames for History Units and summary | concatenation ambiguity is impossible and summary changes segment identity |
+| Time summary | complete or incomplete | incomplete time metadata can never return a negative candidate decision |
+
+### Responsibilities and boundaries
+
+`domain` owns fixed descriptors, deterministic encoding, validation, and conservative time-filter behavior. `infrastructure/sqlite` owns immutable tables, bounded construction, manifest binding, and metadata/full verification. The caller owns HMAC/Bloom generation and key policy. #1650 owns the Hot Catalog, #1651 publication, and #1652 routing.
+
+### Behavior tests / TDD plan
+
+Tests prove deterministic order, duplicate/invalid descriptor rejection, malformed legacy timestamps, conservative incomplete-time selection, sealed build/full verification, metadata verification without payload decode, normalized-table tamper rejection, digest binding, and caps. Existing full verification remains the stronger payload-parity gate.
+
+### Rollback and risk
+
+The format is not activated, so rollback removes this additive implementation. The metadata verifier deliberately hashes the sealed file when an expected file digest is supplied, but never selects `history_units.payload`. HMAC keys are not stored; `filter_key_id` is only a non-secret identifier. False-negative properties of caller-generated Bloom contents cannot be proven at this storage boundary and must be tested by the generator/router issues.

--- a/.ai/spec/1658-segment-catalog-summary.md
+++ b/.ai/spec/1658-segment-catalog-summary.md
@@ -27,7 +27,7 @@
 
 ### Behavior tests / TDD plan
 
-Tests prove deterministic order, duplicate/invalid descriptor rejection, malformed legacy timestamps, conservative incomplete-time selection, sealed build/full verification, metadata verification without payload decode, normalized-table tamper rejection, digest binding, and caps. Existing full verification remains the stronger payload-parity gate.
+Tests prove deterministic order, duplicate/invalid descriptor rejection, mixed valid/malformed legacy timestamps, conservative incomplete-time selection, sealed build/full verification, metadata verification without payload decode, singleton and fixed-schema enforcement, normalized-table tamper rejection, allocation-before-cap behavior, one-inode verification across pathname exchange, digest binding, and caps. Existing full verification remains the stronger payload-parity gate.
 
 ### Rollback and risk
 

--- a/domain/archive_segment.go
+++ b/domain/archive_segment.go
@@ -80,10 +80,7 @@ func NewArchiveEventV1(values []SQLiteValue) (ArchiveEventV1, error) {
 	if values[0].Class != SQLiteText || len(values[0].Bytes) == 0 || values[5].Class != SQLiteText {
 		return ArchiveEventV1{}, fmt.Errorf("archive event v1 id and created_at must be text")
 	}
-	created, err := time.Parse(time.RFC3339Nano, string(values[5].Bytes))
-	if err != nil {
-		return ArchiveEventV1{}, fmt.Errorf("parse archive event created_at: %w", err)
-	}
+	created, _ := time.Parse(time.RFC3339Nano, string(values[5].Bytes))
 	var event ArchiveEventV1
 	copy(event.values[:], values)
 	event.eventID = append([]byte(nil), values[0].Bytes...)
@@ -125,8 +122,8 @@ func (u HistoryUnit) CreatedAt() time.Time { return u.Event.createdAt }
 
 // CanonicalBytes returns the versioned, length-delimited logical encoding.
 func (u HistoryUnit) CanonicalBytes() ([]byte, error) {
-	if u.Sequence == 0 || len(u.Event.eventID) == 0 || u.Event.createdAt.IsZero() {
-		return nil, fmt.Errorf("history unit requires a positive sequence, event identity, and event")
+	if u.Sequence == 0 || len(u.Event.eventID) == 0 {
+		return nil, fmt.Errorf("history unit requires a positive sequence and event identity")
 	}
 	b := make([]byte, 0, 128)
 	b = append(b, 'T', 'R', 'H', 'U')
@@ -159,7 +156,7 @@ func (u HistoryUnit) ValidateCanonicalSize(maxBytes int64) error {
 	if maxBytes <= 0 {
 		return fmt.Errorf("canonical size cap must be positive")
 	}
-	if u.Sequence == 0 || len(u.Event.eventID) == 0 || u.Event.createdAt.IsZero() {
+	if u.Sequence == 0 || len(u.Event.eventID) == 0 {
 		return fmt.Errorf("invalid history unit")
 	}
 	size := int64(8 + uvarintSize(u.Sequence) + uvarintSize(uint64(len(u.Event.eventID))) + len(u.Event.eventID) + uvarintSize(uint64(len(archiveEventV1Columns))) + 1)

--- a/domain/archive_segment_summary.go
+++ b/domain/archive_segment_summary.go
@@ -67,6 +67,33 @@ func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) 
 	if maxBytes <= 0 || s.FilterKeyID == "" {
 		return nil, fmt.Errorf("invalid segment summary descriptor")
 	}
+	// Preflight every caller-controlled count and byte length before copying,
+	// sorting, or growing the canonical buffer.
+	total := uint64(16)
+	add := func(n uint64) error {
+		if n > uint64(maxBytes) || total > uint64(maxBytes)-n {
+			return fmt.Errorf("segment summary exceeds byte cap")
+		}
+		total += n
+		return nil
+	}
+	if err := add(uint64(len(s.FilterKeyID))); err != nil {
+		return nil, err
+	}
+	if uint64(len(s.ExactTokens)) > uint64(maxBytes)/33 || uint64(len(s.Blooms)) > uint64(maxBytes)/7 || uint64(len(s.Sessions)) > uint64(maxBytes)/34 {
+		return nil, fmt.Errorf("segment summary exceeds row cap")
+	}
+	if err := add(uint64(len(s.ExactTokens)) * 33); err != nil {
+		return nil, err
+	}
+	if err := add(uint64(len(s.Sessions)) * 34); err != nil {
+		return nil, err
+	}
+	for _, bloom := range s.Blooms {
+		if err := add(7 + uint64(len(bloom.Bits))); err != nil {
+			return nil, err
+		}
+	}
 	tokens := append([]SegmentSummaryToken(nil), s.ExactTokens...)
 	sort.Slice(tokens, func(i, j int) bool {
 		if tokens[i].Kind != tokens[j].Kind {

--- a/domain/archive_segment_summary.go
+++ b/domain/archive_segment_summary.go
@@ -1,0 +1,142 @@
+package domain
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// SegmentSummaryV1 is the immutable, privacy-preserving summary descriptor.
+const SegmentSummaryV1 uint32 = 1
+
+// SummaryTokenKind identifies a fixed metadata dimension. Values are HMACs;
+// plaintext metadata is deliberately not representable by this API.
+type SummaryTokenKind uint8
+
+const (
+	// SummaryTokenWorkspace identifies a keyed workspace value. The remaining
+	// constants identify other fixed metadata dimensions.
+	SummaryTokenWorkspace SummaryTokenKind = iota + 1
+	// SummaryTokenSession identifies a keyed session value.
+	SummaryTokenSession
+	// SummaryTokenClient identifies a keyed client value.
+	SummaryTokenClient
+	// SummaryTokenAgent identifies a keyed agent value.
+	SummaryTokenAgent
+	// SummaryTokenEventKind identifies a keyed event-kind value.
+	SummaryTokenEventKind
+)
+
+// SegmentSummaryToken is an exact HMAC-SHA256 candidate token.
+type SegmentSummaryToken struct {
+	Kind  SummaryTokenKind
+	Value [sha256.Size]byte
+}
+
+// SegmentBloomV1 is a versioned Bloom filter supplied by the canonical
+// metadata summarizer. Bits are opaque here; generation belongs to #1650.
+type SegmentBloomV1 struct {
+	Kind      SummaryTokenKind
+	BitCount  uint32
+	HashCount uint8
+	Bits      []byte
+}
+
+// SegmentSessionAggregateV1 contains only a keyed session identity and counts.
+type SegmentSessionAggregateV1 struct {
+	SessionToken [sha256.Size]byte
+	UnitCount    uint64
+	AuditCount   uint64
+}
+
+// SegmentCatalogSummaryV1 is stored inside the immutable segment, never in a
+// sidecar. FilterKeyID is a non-secret key identifier.
+type SegmentCatalogSummaryV1 struct {
+	FilterKeyID  string
+	ExactTokens  []SegmentSummaryToken
+	Blooms       []SegmentBloomV1
+	Sessions     []SegmentSessionAggregateV1
+	TimeComplete bool
+}
+
+// CanonicalBytes validates, sorts, and encodes the fixed summary descriptor.
+func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 || s.FilterKeyID == "" {
+		return nil, fmt.Errorf("invalid segment summary descriptor")
+	}
+	tokens := append([]SegmentSummaryToken(nil), s.ExactTokens...)
+	sort.Slice(tokens, func(i, j int) bool {
+		if tokens[i].Kind != tokens[j].Kind {
+			return tokens[i].Kind < tokens[j].Kind
+		}
+		return bytes.Compare(tokens[i].Value[:], tokens[j].Value[:]) < 0
+	})
+	blooms := append([]SegmentBloomV1(nil), s.Blooms...)
+	sort.Slice(blooms, func(i, j int) bool { return blooms[i].Kind < blooms[j].Kind })
+	sessions := append([]SegmentSessionAggregateV1(nil), s.Sessions...)
+	sort.Slice(sessions, func(i, j int) bool {
+		return bytes.Compare(sessions[i].SessionToken[:], sessions[j].SessionToken[:]) < 0
+	})
+	b := append([]byte("TRSS"), 0, 0, 0, byte(SegmentSummaryV1))
+	b = binary.AppendUvarint(b, uint64(len(s.FilterKeyID)))
+	b = append(b, s.FilterKeyID...)
+	if s.TimeComplete {
+		b = append(b, 1)
+	} else {
+		b = append(b, 0)
+	}
+	b = binary.AppendUvarint(b, uint64(len(tokens)))
+	var previousToken []byte
+	for _, token := range tokens {
+		if token.Kind < SummaryTokenWorkspace || token.Kind > SummaryTokenEventKind {
+			return nil, fmt.Errorf("unknown summary token kind")
+		}
+		key := append([]byte{byte(token.Kind)}, token.Value[:]...)
+		if bytes.Equal(key, previousToken) {
+			return nil, fmt.Errorf("duplicate summary token")
+		}
+		previousToken = append(previousToken[:0], key...)
+		b = append(b, byte(token.Kind))
+		b = append(b, token.Value[:]...)
+	}
+	b = binary.AppendUvarint(b, uint64(len(blooms)))
+	var previousKind SummaryTokenKind
+	for _, bloom := range blooms {
+		if bloom.Kind < SummaryTokenWorkspace || bloom.Kind > SummaryTokenEventKind || bloom.Kind <= previousKind || bloom.BitCount == 0 || bloom.HashCount == 0 || uint64(len(bloom.Bits))*8 != uint64(bloom.BitCount) {
+			return nil, fmt.Errorf("invalid summary bloom descriptor")
+		}
+		previousKind = bloom.Kind
+		b = append(b, byte(bloom.Kind))
+		b = binary.BigEndian.AppendUint32(b, bloom.BitCount)
+		b = append(b, bloom.HashCount)
+		b = binary.AppendUvarint(b, uint64(len(bloom.Bits)))
+		b = append(b, bloom.Bits...)
+	}
+	b = binary.AppendUvarint(b, uint64(len(sessions)))
+	var previousSession []byte
+	for _, session := range sessions {
+		if session.UnitCount == 0 || (previousSession != nil && bytes.Compare(previousSession, session.SessionToken[:]) >= 0) {
+			return nil, fmt.Errorf("invalid session aggregate")
+		}
+		previousSession = append(previousSession[:0], session.SessionToken[:]...)
+		b = append(b, session.SessionToken[:]...)
+		b = binary.AppendUvarint(b, session.UnitCount)
+		b = binary.AppendUvarint(b, session.AuditCount)
+	}
+	if int64(len(b)) > maxBytes {
+		return nil, fmt.Errorf("segment summary exceeds byte cap")
+	}
+	return b, nil
+}
+
+// TimeFilterMayMatch prevents a negative time decision when legacy timestamps
+// were malformed and the segment's time summary is therefore incomplete.
+func (s SegmentCatalogSummaryV1) TimeFilterMayMatch(segmentMin, segmentMax, queryStart, queryEnd time.Time) bool {
+	if !s.TimeComplete || segmentMin.IsZero() || segmentMax.IsZero() {
+		return true
+	}
+	return !segmentMax.Before(queryStart) && !segmentMin.After(queryEnd)
+}

--- a/domain/archive_segment_summary.go
+++ b/domain/archive_segment_summary.go
@@ -69,7 +69,7 @@ func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) 
 	}
 	// Preflight every caller-controlled count and byte length before copying,
 	// sorting, or growing the canonical buffer.
-	total := uint64(16)
+	total := uint64(8)
 	add := func(n uint64) error {
 		if n > uint64(maxBytes) || total > uint64(maxBytes)-n {
 			return fmt.Errorf("segment summary exceeds byte cap")
@@ -77,20 +77,31 @@ func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) 
 		total += n
 		return nil
 	}
-	if err := add(uint64(len(s.FilterKeyID))); err != nil {
+	if err := add(uint64(uvarintSize(uint64(len(s.FilterKeyID)))) + uint64(len(s.FilterKeyID))); err != nil {
 		return nil, err
 	}
-	if uint64(len(s.ExactTokens)) > uint64(maxBytes)/33 || uint64(len(s.Blooms)) > uint64(maxBytes)/7 || uint64(len(s.Sessions)) > uint64(maxBytes)/34 {
-		return nil, fmt.Errorf("segment summary exceeds row cap")
+	if err := add(1 + uint64(uvarintSize(uint64(len(s.ExactTokens))))); err != nil {
+		return nil, err
+	}
+	if uint64(len(s.ExactTokens)) > uint64(maxBytes)/33 {
+		return nil, fmt.Errorf("segment summary exceeds byte cap")
 	}
 	if err := add(uint64(len(s.ExactTokens)) * 33); err != nil {
 		return nil, err
 	}
-	if err := add(uint64(len(s.Sessions)) * 34); err != nil {
+	if err := add(uint64(uvarintSize(uint64(len(s.Blooms))))); err != nil {
 		return nil, err
 	}
 	for _, bloom := range s.Blooms {
-		if err := add(7 + uint64(len(bloom.Bits))); err != nil {
+		if err := add(6 + uint64(uvarintSize(uint64(len(bloom.Bits)))) + uint64(len(bloom.Bits))); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(uint64(uvarintSize(uint64(len(s.Sessions))))); err != nil {
+		return nil, err
+	}
+	for _, session := range s.Sessions {
+		if err := add(32 + uint64(uvarintSize(session.UnitCount)) + uint64(uvarintSize(session.AuditCount))); err != nil {
 			return nil, err
 		}
 	}

--- a/domain/archive_segment_summary_test.go
+++ b/domain/archive_segment_summary_test.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"testing"
+	"time"
+)
+
+func TestSegmentSummaryCanonicalEncodingIsDeterministicAndRejectsDuplicates(t *testing.T) {
+	a := SegmentSummaryToken{Kind: SummaryTokenSession, Value: sha256.Sum256([]byte("a"))}
+	b := SegmentSummaryToken{Kind: SummaryTokenWorkspace, Value: sha256.Sum256([]byte("b"))}
+	s := SegmentCatalogSummaryV1{FilterKeyID: "key-v1", TimeComplete: true, ExactTokens: []SegmentSummaryToken{a, b}}
+	first, err := s.CanonicalBytes(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.ExactTokens = []SegmentSummaryToken{b, a}
+	second, err := s.CanonicalBytes(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("canonical summary depends on caller order")
+	}
+	s.ExactTokens = []SegmentSummaryToken{a, a}
+	if _, err = s.CanonicalBytes(4096); err == nil {
+		t.Fatal("duplicate exact token accepted")
+	}
+}
+
+func TestIncompleteTimeSummaryCannotProduceNegativeCandidate(t *testing.T) {
+	s := SegmentCatalogSummaryV1{TimeComplete: false}
+	if !s.TimeFilterMayMatch(time.Unix(1, 0), time.Unix(2, 0), time.Unix(100, 0), time.Unix(200, 0)) {
+		t.Fatal("incomplete time summary excluded a segment")
+	}
+	s.TimeComplete = true
+	if s.TimeFilterMayMatch(time.Unix(1, 0), time.Unix(2, 0), time.Unix(100, 0), time.Unix(200, 0)) {
+		t.Fatal("disjoint complete bounds matched")
+	}
+}
+
+func TestArchiveEventAllowsMalformedLegacyCreatedAt(t *testing.T) {
+	values := make([]SQLiteValue, len(ArchiveEventV1Columns()))
+	for i := range values {
+		values[i] = NullValue()
+	}
+	values[0] = TextValue([]byte("legacy"))
+	values[5] = TextValue([]byte{0xff, 'x'})
+	event, err := NewArchiveEventV1(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := HistoryUnit{Sequence: 1, Event: event}
+	if !unit.CreatedAt().IsZero() {
+		t.Fatal("malformed time became valid")
+	}
+	if _, err = unit.CanonicalBytes(); err != nil {
+		t.Fatalf("raw legacy timestamp not preserved: %v", err)
+	}
+}

--- a/domain/archive_segment_summary_test.go
+++ b/domain/archive_segment_summary_test.go
@@ -58,3 +58,20 @@ func TestArchiveEventAllowsMalformedLegacyCreatedAt(t *testing.T) {
 		t.Fatalf("raw legacy timestamp not preserved: %v", err)
 	}
 }
+
+func TestSegmentSummaryPreflightUsesExactCanonicalSize(t *testing.T) {
+	s := SegmentCatalogSummaryV1{FilterKeyID: string(make([]byte, 128)), TimeComplete: true,
+		Blooms:   []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: 1024, HashCount: 3, Bits: make([]byte, 128)}},
+		Sessions: []SegmentSessionAggregateV1{{SessionToken: sha256.Sum256([]byte("s")), UnitCount: 128, AuditCount: 128}},
+	}
+	encoded, err := s.CanonicalBytes(4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.CanonicalBytes(int64(len(encoded))); err != nil {
+		t.Fatalf("exact encoded cap rejected: %v", err)
+	}
+	if _, err = s.CanonicalBytes(int64(len(encoded) - 1)); err == nil {
+		t.Fatal("one-byte-short cap accepted")
+	}
+}

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -50,10 +51,12 @@ type ArchiveSegmentLimits struct {
 	MaxTotalPlainBytes  int64
 	MaxTotalStoredBytes int64
 	MaxFileBytes        int64
+	MaxSummaryBytes     int64
+	MaxSummaryRows      uint64
 }
 
 func (l ArchiveSegmentLimits) validate() error {
-	if l.MaxValuePlainBytes <= 0 || l.MaxValueStoredBytes <= 0 || l.MaxTotalPlainBytes <= 0 || l.MaxTotalStoredBytes <= 0 || l.MaxFileBytes <= 0 {
+	if l.MaxValuePlainBytes <= 0 || l.MaxValueStoredBytes <= 0 || l.MaxTotalPlainBytes <= 0 || l.MaxTotalStoredBytes <= 0 || l.MaxFileBytes <= 0 || l.MaxSummaryBytes <= 0 || l.MaxSummaryRows == 0 {
 		return fmt.Errorf("%w: every cap must be positive", ErrSegmentLimit)
 	}
 	return nil
@@ -64,25 +67,32 @@ type ArchiveSegmentConfig struct {
 	StoreID          string
 	CompressionFloor int
 	Limits           ArchiveSegmentLimits
+	Summary          domain.SegmentCatalogSummaryV1
 }
 
 // ArchiveSegmentManifest is machine-independent aggregate evidence.
 type ArchiveSegmentManifest struct {
-	StoreID          string `json:"store_id"`
-	FormatVersion    uint32 `json:"format_version"`
-	StartSequence    uint64 `json:"start_sequence"`
-	EndSequence      uint64 `json:"end_sequence"`
-	UnitCount        uint64 `json:"unit_count"`
-	AuditCount       uint64 `json:"audit_count"`
-	MinCreatedAt     string `json:"min_created_at,omitempty"`
-	MaxCreatedAt     string `json:"max_created_at,omitempty"`
-	PlainValueCount  uint64 `json:"plain_value_count"`
-	ZstdValueCount   uint64 `json:"zstd_value_count"`
-	TotalPlainBytes  int64  `json:"total_plain_bytes"`
-	TotalStoredBytes int64  `json:"total_stored_bytes"`
-	LogicalDigest    string `json:"logical_digest"`
-	FileDigest       string `json:"file_digest"`
-	Basename         string `json:"basename"`
+	StoreID             string `json:"store_id"`
+	FormatVersion       uint32 `json:"format_version"`
+	StartSequence       uint64 `json:"start_sequence"`
+	EndSequence         uint64 `json:"end_sequence"`
+	UnitCount           uint64 `json:"unit_count"`
+	AuditCount          uint64 `json:"audit_count"`
+	MinCreatedAt        string `json:"min_created_at,omitempty"`
+	MaxCreatedAt        string `json:"max_created_at,omitempty"`
+	PlainValueCount     uint64 `json:"plain_value_count"`
+	ZstdValueCount      uint64 `json:"zstd_value_count"`
+	TotalPlainBytes     int64  `json:"total_plain_bytes"`
+	TotalStoredBytes    int64  `json:"total_stored_bytes"`
+	LogicalDigest       string `json:"logical_digest"`
+	FileDigest          string `json:"file_digest"`
+	Basename            string `json:"basename"`
+	SummaryVersion      uint32 `json:"summary_version"`
+	SummaryDigest       string `json:"summary_digest"`
+	FilterKeyID         string `json:"filter_key_id"`
+	TimeSummaryComplete bool   `json:"time_summary_complete"`
+	SummaryRowCount     uint64 `json:"summary_row_count"`
+	SummaryByteCount    int64  `json:"summary_byte_count"`
 }
 
 // ArchiveHistoryUnit carries the canonical unit and an optional ordering time.
@@ -153,6 +163,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 
 	manifest = ArchiveSegmentManifest{StoreID: cfg.StoreID, FormatVersion: domain.SegmentFormatV1, StartSequence: units[0].Unit.Sequence, EndSequence: units[len(units)-1].Unit.Sequence, UnitCount: uint64(len(units))}
 	logical := sha256.New()
+	_, _ = logical.Write([]byte("traceary-segment-history-v1\x00"))
 	var previous uint64
 	var minCreatedAt, maxCreatedAt time.Time
 	for i, item := range units {
@@ -206,7 +217,8 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 				maxCreatedAt = ts
 			}
 		}
-		logical.Write(plain)
+		_, _ = logical.Write(binary.BigEndian.AppendUint64(nil, uint64(len(plain))))
+		_, _ = logical.Write(plain)
 		checksum := sha256.Sum256(plain)
 		if _, err = db.ExecContext(ctx, `INSERT INTO history_units(sequence, codec, plaintext_length, checksum, payload) VALUES(?,?,?,?,?)`, item.Unit.Sequence, codec, len(plain), checksum[:], stored); err != nil {
 			return manifest, fmt.Errorf("write segment unit: %w", err)
@@ -219,6 +231,43 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	}
 	manifest.MinCreatedAt = formatOptionalTime(minCreatedAt)
 	manifest.MaxCreatedAt = formatOptionalTime(maxCreatedAt)
+	if minCreatedAt.IsZero() || maxCreatedAt.IsZero() {
+		cfg.Summary.TimeComplete = false
+	}
+	summaryBytes, summaryErr := cfg.Summary.CanonicalBytes(cfg.Limits.MaxSummaryBytes)
+	if summaryErr != nil {
+		return manifest, fmt.Errorf("encode segment summary: %w", summaryErr)
+	}
+	manifest.SummaryVersion = domain.SegmentSummaryV1
+	manifest.SummaryDigest = hex.EncodeToString(digestBytes(summaryBytes))
+	manifest.FilterKeyID = cfg.Summary.FilterKeyID
+	manifest.TimeSummaryComplete = cfg.Summary.TimeComplete
+	manifest.SummaryRowCount = uint64(len(cfg.Summary.ExactTokens) + len(cfg.Summary.Blooms) + len(cfg.Summary.Sessions))
+	manifest.SummaryByteCount = int64(len(summaryBytes))
+	if manifest.SummaryRowCount > cfg.Limits.MaxSummaryRows {
+		return manifest, fmt.Errorf("%w: summary rows", ErrSegmentLimit)
+	}
+	if _, err = db.ExecContext(ctx, `INSERT INTO segment_summary(summary_version,filter_key_id,time_summary_complete,canonical_bytes,summary_digest) VALUES(?,?,?,?,?)`, manifest.SummaryVersion, manifest.FilterKeyID, manifest.TimeSummaryComplete, summaryBytes, digestBytes(summaryBytes)); err != nil {
+		return manifest, fmt.Errorf("write segment summary: %w", err)
+	}
+	for _, token := range cfg.Summary.ExactTokens {
+		if _, err = db.ExecContext(ctx, `INSERT INTO segment_exact_filters(kind,token) VALUES(?,?)`, token.Kind, token.Value[:]); err != nil {
+			return manifest, fmt.Errorf("write exact filter: %w", err)
+		}
+	}
+	for _, bloom := range cfg.Summary.Blooms {
+		if _, err = db.ExecContext(ctx, `INSERT INTO segment_bloom_filters(kind,bit_count,hash_count,bits) VALUES(?,?,?,?)`, bloom.Kind, bloom.BitCount, bloom.HashCount, bloom.Bits); err != nil {
+			return manifest, fmt.Errorf("write bloom filter: %w", err)
+		}
+	}
+	for _, session := range cfg.Summary.Sessions {
+		if _, err = db.ExecContext(ctx, `INSERT INTO segment_session_aggregates(session_token,unit_count,audit_count) VALUES(?,?,?)`, session.SessionToken[:], session.UnitCount, session.AuditCount); err != nil {
+			return manifest, fmt.Errorf("write session aggregate: %w", err)
+		}
+	}
+	_, _ = logical.Write([]byte("traceary-segment-summary-v1\x00"))
+	_, _ = logical.Write(binary.BigEndian.AppendUint64(nil, uint64(len(summaryBytes))))
+	_, _ = logical.Write(summaryBytes)
 	var logicalDigest [sha256.Size]byte
 	copy(logicalDigest[:], logical.Sum(nil))
 	identity, identityErr := domain.NewSegmentIdentity(cfg.StoreID, manifest.StartSequence, manifest.EndSequence, logicalDigest)
@@ -231,7 +280,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if pathErr != nil {
 		return manifest, pathErr
 	}
-	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename); err != nil {
+	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename, manifest.SummaryVersion, digestBytes(summaryBytes), manifest.FilterKeyID, manifest.TimeSummaryComplete, manifest.SummaryRowCount, manifest.SummaryByteCount); err != nil {
 		return manifest, fmt.Errorf("write segment manifest: %w", err)
 	}
 	if _, err = db.ExecContext(ctx, `PRAGMA user_version=1`); err != nil {
@@ -276,8 +325,12 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 }
 
 const segmentSchemaV1 = `
-CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL);
+CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL, summary_version INTEGER NOT NULL, summary_digest BLOB NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, summary_row_count INTEGER NOT NULL, summary_byte_count INTEGER NOT NULL);
 CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
+CREATE TABLE segment_summary(summary_version INTEGER NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, canonical_bytes BLOB NOT NULL, summary_digest BLOB NOT NULL);
+CREATE TABLE segment_exact_filters(kind INTEGER NOT NULL, token BLOB NOT NULL, PRIMARY KEY(kind,token));
+CREATE TABLE segment_bloom_filters(kind INTEGER PRIMARY KEY, bit_count INTEGER NOT NULL, hash_count INTEGER NOT NULL, bits BLOB NOT NULL);
+CREATE TABLE segment_session_aggregates(session_token BLOB PRIMARY KEY, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL);
 `
 
 // InspectArchiveSegmentManifest performs bounded structural inspection of an
@@ -310,18 +363,148 @@ func inspectArchiveSegmentPath(ctx context.Context, path, expectedBasename strin
 		return ArchiveSegmentManifest{}, fmt.Errorf("%w: file bytes", ErrSegmentLimit)
 	}
 	var m ArchiveSegmentManifest
-	var digest []byte
-	err = db.QueryRowContext(ctx, `SELECT format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename FROM segment_manifest`).Scan(&m.FormatVersion, &m.StoreID, &m.StartSequence, &m.EndSequence, &m.UnitCount, &m.AuditCount, &m.MinCreatedAt, &m.MaxCreatedAt, &m.PlainValueCount, &m.ZstdValueCount, &m.TotalPlainBytes, &m.TotalStoredBytes, &digest, &m.Basename)
+	var digest, summaryDigest []byte
+	err = db.QueryRowContext(ctx, `SELECT format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count FROM segment_manifest`).Scan(&m.FormatVersion, &m.StoreID, &m.StartSequence, &m.EndSequence, &m.UnitCount, &m.AuditCount, &m.MinCreatedAt, &m.MaxCreatedAt, &m.PlainValueCount, &m.ZstdValueCount, &m.TotalPlainBytes, &m.TotalStoredBytes, &digest, &m.Basename, &m.SummaryVersion, &summaryDigest, &m.FilterKeyID, &m.TimeSummaryComplete, &m.SummaryRowCount, &m.SummaryByteCount)
 	if err != nil {
 		return m, fmt.Errorf("%w: read manifest: %v", ErrSegmentCorrupt, err)
 	}
 	if m.FormatVersion != domain.SegmentFormatV1 {
 		return m, fmt.Errorf("%w: %d", ErrSegmentUnsupportedFormat, m.FormatVersion)
 	}
-	if (expectedBasename != "" && m.Basename != expectedBasename) || len(digest) != sha256.Size {
+	if (expectedBasename != "" && m.Basename != expectedBasename) || len(digest) != sha256.Size || len(summaryDigest) != sha256.Size || m.SummaryVersion != domain.SegmentSummaryV1 {
 		return m, fmt.Errorf("%w: manifest identity", ErrSegmentCorrupt)
 	}
 	m.LogicalDigest = hex.EncodeToString(digest)
+	m.SummaryDigest = hex.EncodeToString(summaryDigest)
+	return m, nil
+}
+
+// VerifyArchiveSegmentMetadata validates identity and bounded immutable summary
+// tables without loading or decoding any history_units payload.
+func VerifyArchiveSegmentMetadata(ctx context.Context, root string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
+	if err := limits.validate(); err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	path, err := safeArchivePath(root, expected.Basename, true)
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	return verifyArchiveSegmentMetadataPath(ctx, path, expected, limits, true)
+}
+
+func verifyArchiveSegmentMetadataPath(ctx context.Context, path string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits, requireSealed bool) (ArchiveSegmentManifest, error) {
+	m, err := inspectArchiveSegmentPath(ctx, path, expected.Basename, requireSealed, limits.MaxFileBytes)
+	if err != nil {
+		return m, err
+	}
+	if !sameLogicalManifest(m, expected) || m.SummaryRowCount > limits.MaxSummaryRows || m.SummaryByteCount > limits.MaxSummaryBytes {
+		return m, fmt.Errorf("%w: metadata manifest or cap", ErrSegmentCorrupt)
+	}
+	digest, err := hex.DecodeString(m.LogicalDigest)
+	if err != nil || len(digest) != sha256.Size {
+		return m, fmt.Errorf("%w: identity digest", ErrSegmentCorrupt)
+	}
+	var identityDigest [sha256.Size]byte
+	copy(identityDigest[:], digest)
+	identity, err := domain.NewSegmentIdentity(m.StoreID, m.StartSequence, m.EndSequence, identityDigest)
+	if err != nil || identity.Basename() != m.Basename {
+		return m, fmt.Errorf("%w: content-addressed identity", ErrSegmentCorrupt)
+	}
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireSealed)
+	if err != nil {
+		return m, err
+	}
+	defer func() { _ = db.Close(); _ = pinned.Close() }()
+	var version uint32
+	var keyID string
+	var complete bool
+	var canonical, storedDigest []byte
+	if err = db.QueryRowContext(ctx, `SELECT summary_version,filter_key_id,time_summary_complete,canonical_bytes,summary_digest FROM segment_summary`).Scan(&version, &keyID, &complete, &canonical, &storedDigest); err != nil {
+		return m, fmt.Errorf("%w: summary descriptor", ErrSegmentCorrupt)
+	}
+	if int64(len(canonical)) != m.SummaryByteCount || int64(len(canonical)) > limits.MaxSummaryBytes || version != m.SummaryVersion || keyID != m.FilterKeyID || complete != m.TimeSummaryComplete || !bytes.Equal(digestBytes(canonical), storedDigest) || hex.EncodeToString(storedDigest) != m.SummaryDigest {
+		return m, fmt.Errorf("%w: summary binding", ErrSegmentCorrupt)
+	}
+	var rows uint64
+	for _, table := range []string{"segment_exact_filters", "segment_bloom_filters", "segment_session_aggregates"} {
+		var n uint64
+		if err = db.QueryRowContext(ctx, `SELECT count(*) FROM `+table).Scan(&n); err != nil {
+			return m, fmt.Errorf("%w: summary rows", ErrSegmentCorrupt)
+		}
+		rows += n
+	}
+	if rows != m.SummaryRowCount || rows > limits.MaxSummaryRows {
+		return m, fmt.Errorf("%w: summary row count", ErrSegmentCorrupt)
+	}
+	rebuilt := domain.SegmentCatalogSummaryV1{FilterKeyID: keyID, TimeComplete: complete}
+	exactRows, queryErr := db.QueryContext(ctx, `SELECT kind,token FROM segment_exact_filters ORDER BY kind,token`)
+	if queryErr != nil {
+		return m, fmt.Errorf("%w: exact filters", ErrSegmentCorrupt)
+	}
+	for exactRows.Next() {
+		var kind uint8
+		var raw []byte
+		if queryErr = exactRows.Scan(&kind, &raw); queryErr != nil || len(raw) != sha256.Size {
+			_ = exactRows.Close()
+			return m, fmt.Errorf("%w: exact filter", ErrSegmentCorrupt)
+		}
+		var value [sha256.Size]byte
+		copy(value[:], raw)
+		rebuilt.ExactTokens = append(rebuilt.ExactTokens, domain.SegmentSummaryToken{Kind: domain.SummaryTokenKind(kind), Value: value})
+	}
+	if queryErr = exactRows.Close(); queryErr != nil {
+		return m, queryErr
+	}
+	bloomRows, queryErr := db.QueryContext(ctx, `SELECT kind,bit_count,hash_count,bits FROM segment_bloom_filters ORDER BY kind`)
+	if queryErr != nil {
+		return m, fmt.Errorf("%w: bloom filters", ErrSegmentCorrupt)
+	}
+	for bloomRows.Next() {
+		var kind uint8
+		var bits uint32
+		var hashes uint8
+		var raw []byte
+		if queryErr = bloomRows.Scan(&kind, &bits, &hashes, &raw); queryErr != nil {
+			_ = bloomRows.Close()
+			return m, fmt.Errorf("%w: bloom filter", ErrSegmentCorrupt)
+		}
+		rebuilt.Blooms = append(rebuilt.Blooms, domain.SegmentBloomV1{Kind: domain.SummaryTokenKind(kind), BitCount: bits, HashCount: hashes, Bits: raw})
+	}
+	if queryErr = bloomRows.Close(); queryErr != nil {
+		return m, queryErr
+	}
+	sessionRows, queryErr := db.QueryContext(ctx, `SELECT session_token,unit_count,audit_count FROM segment_session_aggregates ORDER BY session_token`)
+	if queryErr != nil {
+		return m, fmt.Errorf("%w: session aggregates", ErrSegmentCorrupt)
+	}
+	for sessionRows.Next() {
+		var raw []byte
+		var units, audits uint64
+		if queryErr = sessionRows.Scan(&raw, &units, &audits); queryErr != nil || len(raw) != sha256.Size {
+			_ = sessionRows.Close()
+			return m, fmt.Errorf("%w: session aggregate", ErrSegmentCorrupt)
+		}
+		var token [sha256.Size]byte
+		copy(token[:], raw)
+		rebuilt.Sessions = append(rebuilt.Sessions, domain.SegmentSessionAggregateV1{SessionToken: token, UnitCount: units, AuditCount: audits})
+	}
+	if queryErr = sessionRows.Close(); queryErr != nil {
+		return m, queryErr
+	}
+	rebuiltBytes, rebuildErr := rebuilt.CanonicalBytes(limits.MaxSummaryBytes)
+	if rebuildErr != nil || !bytes.Equal(rebuiltBytes, canonical) {
+		return m, fmt.Errorf("%w: normalized summary mismatch", ErrSegmentCorrupt)
+	}
+	if expected.FileDigest != "" {
+		actual, digestErr := digestOpenFile(ctx, pinned, limits.MaxFileBytes)
+		if digestErr != nil {
+			return m, digestErr
+		}
+		if actual != expected.FileDigest {
+			return m, fmt.Errorf("%w: expected file digest mismatch", ErrSegmentCorrupt)
+		}
+		m.FileDigest = actual
+	}
 	return m, nil
 }
 
@@ -345,6 +528,9 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 	}
 	if !sameLogicalManifest(m, expected) {
 		return m, fmt.Errorf("%w: expected manifest mismatch", ErrSegmentCorrupt)
+	}
+	if _, metadataErr := verifyArchiveSegmentMetadataPath(ctx, path, expected, limits, requireFileDigest); metadataErr != nil {
+		return m, metadataErr
 	}
 	digest, decodeErr := hex.DecodeString(m.LogicalDigest)
 	if decodeErr != nil || len(digest) != sha256.Size {
@@ -383,6 +569,7 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 	}
 	defer decoder.Close()
 	logical := sha256.New()
+	_, _ = logical.Write([]byte("traceary-segment-history-v1\x00"))
 	var count uint64
 	var auditCount, plainCount, zstdCount uint64
 	var totalPlain, totalStored int64
@@ -441,10 +628,10 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 		if unit.Audit != nil {
 			auditCount++
 		}
-		if minCreatedAt.IsZero() || unit.CreatedAt().Before(minCreatedAt) {
+		if !unit.CreatedAt().IsZero() && (minCreatedAt.IsZero() || unit.CreatedAt().Before(minCreatedAt)) {
 			minCreatedAt = unit.CreatedAt()
 		}
-		if maxCreatedAt.IsZero() || unit.CreatedAt().After(maxCreatedAt) {
+		if !unit.CreatedAt().IsZero() && (maxCreatedAt.IsZero() || unit.CreatedAt().After(maxCreatedAt)) {
 			maxCreatedAt = unit.CreatedAt()
 		}
 		totalPlain += int64(len(plain))
@@ -452,12 +639,20 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 		if totalPlain > limits.MaxTotalPlainBytes || totalStored > limits.MaxTotalStoredBytes {
 			return m, fmt.Errorf("%w: aggregate", ErrSegmentLimit)
 		}
-		logical.Write(plain)
+		_, _ = logical.Write(binary.BigEndian.AppendUint64(nil, uint64(len(plain))))
+		_, _ = logical.Write(plain)
 		count++
 	}
 	if err = rows.Err(); err != nil {
 		return m, err
 	}
+	var summaryBytes []byte
+	if err = db.QueryRowContext(ctx, `SELECT canonical_bytes FROM segment_summary`).Scan(&summaryBytes); err != nil {
+		return m, fmt.Errorf("%w: summary frame", ErrSegmentCorrupt)
+	}
+	_, _ = logical.Write([]byte("traceary-segment-summary-v1\x00"))
+	_, _ = logical.Write(binary.BigEndian.AppendUint64(nil, uint64(len(summaryBytes))))
+	_, _ = logical.Write(summaryBytes)
 	if count != m.UnitCount || auditCount != m.AuditCount || plainCount != m.PlainValueCount || zstdCount != m.ZstdValueCount || totalPlain != m.TotalPlainBytes || totalStored != m.TotalStoredBytes || hex.EncodeToString(logical.Sum(nil)) != m.LogicalDigest || formatOptionalTime(minCreatedAt) != m.MinCreatedAt || formatOptionalTime(maxCreatedAt) != m.MaxCreatedAt {
 		return m, fmt.Errorf("%w: aggregate mismatch", ErrSegmentCorrupt)
 	}

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -239,6 +239,10 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if !allTimesValid || minCreatedAt.IsZero() || maxCreatedAt.IsZero() {
 		cfg.Summary.TimeComplete = false
 	}
+	summaryRows := uint64(len(cfg.Summary.ExactTokens)) + uint64(len(cfg.Summary.Blooms)) + uint64(len(cfg.Summary.Sessions))
+	if summaryRows > cfg.Limits.MaxSummaryRows {
+		return manifest, fmt.Errorf("%w: summary rows", ErrSegmentLimit)
+	}
 	summaryBytes, summaryErr := cfg.Summary.CanonicalBytes(cfg.Limits.MaxSummaryBytes)
 	if summaryErr != nil {
 		return manifest, fmt.Errorf("encode segment summary: %w", summaryErr)
@@ -247,7 +251,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	manifest.SummaryDigest = hex.EncodeToString(digestBytes(summaryBytes))
 	manifest.FilterKeyID = cfg.Summary.FilterKeyID
 	manifest.TimeSummaryComplete = cfg.Summary.TimeComplete
-	manifest.SummaryRowCount = uint64(len(cfg.Summary.ExactTokens) + len(cfg.Summary.Blooms) + len(cfg.Summary.Sessions))
+	manifest.SummaryRowCount = summaryRows
 	manifest.SummaryByteCount = int64(len(summaryBytes))
 	if manifest.SummaryRowCount > cfg.Limits.MaxSummaryRows {
 		return manifest, fmt.Errorf("%w: summary rows", ErrSegmentLimit)
@@ -285,7 +289,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if pathErr != nil {
 		return manifest, pathErr
 	}
-	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename, manifest.SummaryVersion, digestBytes(summaryBytes), manifest.FilterKeyID, manifest.TimeSummaryComplete, manifest.SummaryRowCount, manifest.SummaryByteCount); err != nil {
+	if _, err = db.ExecContext(ctx, `INSERT INTO segment_manifest(id,format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count) VALUES(1,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, manifest.FormatVersion, manifest.StoreID, manifest.StartSequence, manifest.EndSequence, manifest.UnitCount, manifest.AuditCount, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, logicalDigest[:], manifest.Basename, manifest.SummaryVersion, digestBytes(summaryBytes), manifest.FilterKeyID, manifest.TimeSummaryComplete, manifest.SummaryRowCount, manifest.SummaryByteCount); err != nil {
 		return manifest, fmt.Errorf("write segment manifest: %w", err)
 	}
 	if _, err = db.ExecContext(ctx, `PRAGMA user_version=1`); err != nil {
@@ -330,7 +334,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 }
 
 const segmentSchemaV1 = `
-CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL, summary_version INTEGER NOT NULL, summary_digest BLOB NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, summary_row_count INTEGER NOT NULL, summary_byte_count INTEGER NOT NULL);
+CREATE TABLE segment_manifest(id INTEGER PRIMARY KEY CHECK(id=1), format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL, summary_version INTEGER NOT NULL, summary_digest BLOB NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, summary_row_count INTEGER NOT NULL, summary_byte_count INTEGER NOT NULL);
 CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
 CREATE TABLE segment_summary(id INTEGER PRIMARY KEY CHECK(id=1), summary_version INTEGER NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL CHECK(time_summary_complete IN (0,1)), canonical_bytes BLOB NOT NULL, summary_digest BLOB NOT NULL);
 CREATE TABLE segment_exact_filters(kind INTEGER NOT NULL, token BLOB NOT NULL, PRIMARY KEY(kind,token));
@@ -373,6 +377,10 @@ func inspectArchiveSegmentOpen(ctx context.Context, db *sql.DB, pinned *os.File,
 	}
 	var m ArchiveSegmentManifest
 	var digest, summaryDigest []byte
+	var manifestRows int64
+	if err = db.QueryRowContext(ctx, `SELECT count(*) FROM segment_manifest`).Scan(&manifestRows); err != nil || manifestRows != 1 {
+		return m, fmt.Errorf("%w: manifest singleton", ErrSegmentCorrupt)
+	}
 	err = db.QueryRowContext(ctx, `SELECT format_version,store_id,start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count FROM segment_manifest`).Scan(&m.FormatVersion, &m.StoreID, &m.StartSequence, &m.EndSequence, &m.UnitCount, &m.AuditCount, &m.MinCreatedAt, &m.MaxCreatedAt, &m.PlainValueCount, &m.ZstdValueCount, &m.TotalPlainBytes, &m.TotalStoredBytes, &digest, &m.Basename, &m.SummaryVersion, &summaryDigest, &m.FilterKeyID, &m.TimeSummaryComplete, &m.SummaryRowCount, &m.SummaryByteCount)
 	if err != nil {
 		return m, fmt.Errorf("%w: read manifest: %v", ErrSegmentCorrupt, err)

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -363,7 +363,6 @@ func inspectArchiveSegmentPath(ctx context.Context, path, expectedBasename strin
 	}
 	defer func() { _ = db.Close() }()
 	defer func() { _ = pinned.Close() }()
-	db.SetMaxOpenConns(2)
 	return inspectArchiveSegmentOpen(ctx, db, pinned, expectedBasename, maxFileBytes)
 }
 
@@ -629,7 +628,6 @@ func verifyArchiveSegmentPathWithHook(ctx context.Context, path string, expected
 		return ArchiveSegmentManifest{}, err
 	}
 	defer func() { _ = db.Close(); _ = pinned.Close() }()
-	db.SetMaxOpenConns(2)
 	m, err := inspectArchiveSegmentOpen(ctx, db, pinned, expected.Basename, limits.MaxFileBytes)
 	if err != nil {
 		return m, err
@@ -658,7 +656,46 @@ func verifyArchiveSegmentPathWithHook(ctx context.Context, path string, expected
 	if requireFileDigest && expected.FileDigest == "" {
 		return m, fmt.Errorf("%w: expected file digest missing", ErrSegmentCorrupt)
 	}
-	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,length(payload) FROM history_units ORDER BY sequence`)
+	// Preflight lengths on the already-open connection before requesting any
+	// payload BLOB. Keeping one connection is essential: reopening /dev/fd on
+	// Linux may resolve through a pathname that has since been exchanged.
+	preflight, err := db.QueryContext(ctx, `SELECT sequence,plaintext_length,length(payload) FROM history_units ORDER BY sequence`)
+	if err != nil {
+		return m, fmt.Errorf("%w: preflight payloads: %v", ErrSegmentCorrupt, err)
+	}
+	var preCount, prePrevious uint64
+	var prePlain, preStored int64
+	for preflight.Next() {
+		var seq uint64
+		var plainLen, storedLen int64
+		if err = preflight.Scan(&seq, &plainLen, &storedLen); err != nil {
+			_ = preflight.Close()
+			return m, fmt.Errorf("%w: preflight payload", ErrSegmentCorrupt)
+		}
+		if preCount > 0 && seq != prePrevious+1 {
+			_ = preflight.Close()
+			return m, fmt.Errorf("%w: non-contiguous sequence", ErrSegmentCorrupt)
+		}
+		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || storedLen < 0 || storedLen > limits.MaxValueStoredBytes || plainLen > limits.MaxTotalPlainBytes-prePlain || storedLen > limits.MaxTotalStoredBytes-preStored {
+			_ = preflight.Close()
+			return m, fmt.Errorf("%w: value", ErrSegmentLimit)
+		}
+		prePrevious = seq
+		preCount++
+		prePlain += plainLen
+		preStored += storedLen
+	}
+	if err = preflight.Err(); err != nil {
+		_ = preflight.Close()
+		return m, err
+	}
+	if err = preflight.Close(); err != nil {
+		return m, err
+	}
+	if preCount != m.UnitCount || prePlain != m.TotalPlainBytes || preStored != m.TotalStoredBytes {
+		return m, fmt.Errorf("%w: payload preflight aggregate", ErrSegmentCorrupt)
+	}
+	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,payload FROM history_units ORDER BY sequence`)
 	if err != nil {
 		return m, fmt.Errorf("%w: query payloads: %v", ErrSegmentCorrupt, err)
 	}
@@ -683,8 +720,8 @@ func verifyArchiveSegmentPathWithHook(ctx context.Context, path string, expected
 		var codec string
 		var plainLen int64
 		var checksum []byte
-		var storedLen int64
-		if err = rows.Scan(&seq, &codec, &plainLen, &checksum, &storedLen); err != nil {
+		var stored []byte
+		if err = rows.Scan(&seq, &codec, &plainLen, &checksum, &stored); err != nil {
 			return m, fmt.Errorf("%w: scan payload", ErrSegmentCorrupt)
 		}
 		if count > 0 && seq != previous+1 {
@@ -694,15 +731,9 @@ func verifyArchiveSegmentPathWithHook(ctx context.Context, path string, expected
 			first = seq
 		}
 		previous = seq
+		storedLen := int64(len(stored))
 		if plainLen < 0 || plainLen > limits.MaxValuePlainBytes || storedLen < 0 || storedLen > limits.MaxValueStoredBytes || totalPlain+plainLen > limits.MaxTotalPlainBytes || totalStored+storedLen > limits.MaxTotalStoredBytes {
 			return m, fmt.Errorf("%w: value", ErrSegmentLimit)
-		}
-		var stored []byte
-		if err = db.QueryRowContext(ctx, `SELECT payload FROM history_units WHERE sequence=?`, seq).Scan(&stored); err != nil {
-			return m, fmt.Errorf("%w: load bounded payload", ErrSegmentCorrupt)
-		}
-		if int64(len(stored)) != storedLen {
-			return m, fmt.Errorf("%w: payload length changed", ErrSegmentCorrupt)
 		}
 		var plain []byte
 		switch codec {

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -166,6 +167,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	_, _ = logical.Write([]byte("traceary-segment-history-v1\x00"))
 	var previous uint64
 	var minCreatedAt, maxCreatedAt time.Time
+	allTimesValid := true
 	for i, item := range units {
 		if err = ctx.Err(); err != nil {
 			return manifest, err
@@ -217,6 +219,9 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 				maxCreatedAt = ts
 			}
 		}
+		if item.Unit.CreatedAt().IsZero() {
+			allTimesValid = false
+		}
 		_, _ = logical.Write(binary.BigEndian.AppendUint64(nil, uint64(len(plain))))
 		_, _ = logical.Write(plain)
 		checksum := sha256.Sum256(plain)
@@ -231,7 +236,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	}
 	manifest.MinCreatedAt = formatOptionalTime(minCreatedAt)
 	manifest.MaxCreatedAt = formatOptionalTime(maxCreatedAt)
-	if minCreatedAt.IsZero() || maxCreatedAt.IsZero() {
+	if !allTimesValid || minCreatedAt.IsZero() || maxCreatedAt.IsZero() {
 		cfg.Summary.TimeComplete = false
 	}
 	summaryBytes, summaryErr := cfg.Summary.CanonicalBytes(cfg.Limits.MaxSummaryBytes)
@@ -247,7 +252,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 	if manifest.SummaryRowCount > cfg.Limits.MaxSummaryRows {
 		return manifest, fmt.Errorf("%w: summary rows", ErrSegmentLimit)
 	}
-	if _, err = db.ExecContext(ctx, `INSERT INTO segment_summary(summary_version,filter_key_id,time_summary_complete,canonical_bytes,summary_digest) VALUES(?,?,?,?,?)`, manifest.SummaryVersion, manifest.FilterKeyID, manifest.TimeSummaryComplete, summaryBytes, digestBytes(summaryBytes)); err != nil {
+	if _, err = db.ExecContext(ctx, `INSERT INTO segment_summary(id,summary_version,filter_key_id,time_summary_complete,canonical_bytes,summary_digest) VALUES(1,?,?,?,?,?)`, manifest.SummaryVersion, manifest.FilterKeyID, manifest.TimeSummaryComplete, summaryBytes, digestBytes(summaryBytes)); err != nil {
 		return manifest, fmt.Errorf("write segment summary: %w", err)
 	}
 	for _, token := range cfg.Summary.ExactTokens {
@@ -327,7 +332,7 @@ func (b archiveSegmentBuilder) build(ctx context.Context, root string, units []A
 const segmentSchemaV1 = `
 CREATE TABLE segment_manifest(format_version INTEGER NOT NULL, store_id TEXT NOT NULL, start_sequence INTEGER NOT NULL, end_sequence INTEGER NOT NULL, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL, min_created_at TEXT NOT NULL, max_created_at TEXT NOT NULL, plain_value_count INTEGER NOT NULL, zstd_value_count INTEGER NOT NULL, total_plain_bytes INTEGER NOT NULL, total_stored_bytes INTEGER NOT NULL, logical_digest BLOB NOT NULL, basename TEXT NOT NULL, summary_version INTEGER NOT NULL, summary_digest BLOB NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, summary_row_count INTEGER NOT NULL, summary_byte_count INTEGER NOT NULL);
 CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
-CREATE TABLE segment_summary(summary_version INTEGER NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL, canonical_bytes BLOB NOT NULL, summary_digest BLOB NOT NULL);
+CREATE TABLE segment_summary(id INTEGER PRIMARY KEY CHECK(id=1), summary_version INTEGER NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL CHECK(time_summary_complete IN (0,1)), canonical_bytes BLOB NOT NULL, summary_digest BLOB NOT NULL);
 CREATE TABLE segment_exact_filters(kind INTEGER NOT NULL, token BLOB NOT NULL, PRIMARY KEY(kind,token));
 CREATE TABLE segment_bloom_filters(kind INTEGER PRIMARY KEY, bit_count INTEGER NOT NULL, hash_count INTEGER NOT NULL, bits BLOB NOT NULL);
 CREATE TABLE segment_session_aggregates(session_token BLOB PRIMARY KEY, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL);
@@ -355,6 +360,10 @@ func inspectArchiveSegmentPath(ctx context.Context, path, expectedBasename strin
 	defer func() { _ = db.Close() }()
 	defer func() { _ = pinned.Close() }()
 	db.SetMaxOpenConns(2)
+	return inspectArchiveSegmentOpen(ctx, db, pinned, expectedBasename, maxFileBytes)
+}
+
+func inspectArchiveSegmentOpen(ctx context.Context, db *sql.DB, pinned *os.File, expectedBasename string, maxFileBytes int64) (ArchiveSegmentManifest, error) {
 	info, err := pinned.Stat()
 	if err != nil {
 		return ArchiveSegmentManifest{}, fmt.Errorf("stat segment: %w", err)
@@ -393,7 +402,16 @@ func VerifyArchiveSegmentMetadata(ctx context.Context, root string, expected Arc
 }
 
 func verifyArchiveSegmentMetadataPath(ctx context.Context, path string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits, requireSealed bool) (ArchiveSegmentManifest, error) {
-	m, err := inspectArchiveSegmentPath(ctx, path, expected.Basename, requireSealed, limits.MaxFileBytes)
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireSealed)
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	defer func() { _ = db.Close(); _ = pinned.Close() }()
+	return verifyArchiveSegmentMetadataOpen(ctx, db, pinned, expected, limits)
+}
+
+func verifyArchiveSegmentMetadataOpen(ctx context.Context, db *sql.DB, pinned *os.File, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
+	m, err := inspectArchiveSegmentOpen(ctx, db, pinned, expected.Basename, limits.MaxFileBytes)
 	if err != nil {
 		return m, err
 	}
@@ -410,11 +428,49 @@ func verifyArchiveSegmentMetadataPath(ctx context.Context, path string, expected
 	if err != nil || identity.Basename() != m.Basename {
 		return m, fmt.Errorf("%w: content-addressed identity", ErrSegmentCorrupt)
 	}
-	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireSealed)
-	if err != nil {
+	if err = validateSegmentTableSet(ctx, db); err != nil {
 		return m, err
 	}
-	defer func() { _ = db.Close(); _ = pinned.Close() }()
+	var singletonCount, canonicalLength, summaryDigestLength int64
+	if err = db.QueryRowContext(ctx, `SELECT count(*),COALESCE(max(length(canonical_bytes)),0),COALESCE(max(length(summary_digest)),0) FROM segment_summary`).Scan(&singletonCount, &canonicalLength, &summaryDigestLength); err != nil || singletonCount != 1 || canonicalLength != m.SummaryByteCount || canonicalLength > limits.MaxSummaryBytes || summaryDigestLength != sha256.Size {
+		return m, fmt.Errorf("%w: summary singleton or preflight", ErrSegmentCorrupt)
+	}
+	var exactCount, bloomCount, sessionCount uint64
+	var exactBytes, bloomBytes, sessionBytes int64
+	if err = db.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(token)),0) FROM segment_exact_filters WHERE length(token)=?`, sha256.Size).Scan(&exactCount, &exactBytes); err != nil {
+		return m, fmt.Errorf("%w: exact preflight", ErrSegmentCorrupt)
+	}
+	var allExact uint64
+	if err = db.QueryRowContext(ctx, `SELECT count(*) FROM segment_exact_filters`).Scan(&allExact); err != nil || allExact != exactCount {
+		return m, fmt.Errorf("%w: exact token shape", ErrSegmentCorrupt)
+	}
+	if err = db.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(bits)),0) FROM segment_bloom_filters WHERE bit_count>0 AND hash_count>0 AND bit_count=length(bits)*8`).Scan(&bloomCount, &bloomBytes); err != nil {
+		return m, fmt.Errorf("%w: bloom preflight", ErrSegmentCorrupt)
+	}
+	var allBloom uint64
+	if err = db.QueryRowContext(ctx, `SELECT count(*) FROM segment_bloom_filters`).Scan(&allBloom); err != nil || allBloom != bloomCount {
+		return m, fmt.Errorf("%w: bloom shape", ErrSegmentCorrupt)
+	}
+	if err = db.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(session_token)),0) FROM segment_session_aggregates WHERE length(session_token)=? AND unit_count>0`, sha256.Size).Scan(&sessionCount, &sessionBytes); err != nil {
+		return m, fmt.Errorf("%w: session preflight", ErrSegmentCorrupt)
+	}
+	var allSessions uint64
+	if err = db.QueryRowContext(ctx, `SELECT count(*) FROM segment_session_aggregates`).Scan(&allSessions); err != nil || allSessions != sessionCount {
+		return m, fmt.Errorf("%w: session shape", ErrSegmentCorrupt)
+	}
+	rows := exactCount + bloomCount + sessionCount
+	normalizedBytes := exactBytes
+	if exactBytes < 0 || bloomBytes < 0 || sessionBytes < 0 || normalizedBytes > limits.MaxSummaryBytes-bloomBytes {
+		return m, fmt.Errorf("%w: summary aggregate preflight", ErrSegmentLimit)
+	}
+	normalizedBytes += bloomBytes
+	if normalizedBytes > limits.MaxSummaryBytes-sessionBytes {
+		return m, fmt.Errorf("%w: summary aggregate preflight", ErrSegmentLimit)
+	}
+	normalizedBytes += sessionBytes
+	if rows != m.SummaryRowCount || rows > limits.MaxSummaryRows || canonicalLength > limits.MaxSummaryBytes-normalizedBytes {
+		return m, fmt.Errorf("%w: summary aggregate preflight", ErrSegmentLimit)
+	}
 	var version uint32
 	var keyID string
 	var complete bool
@@ -424,17 +480,6 @@ func verifyArchiveSegmentMetadataPath(ctx context.Context, path string, expected
 	}
 	if int64(len(canonical)) != m.SummaryByteCount || int64(len(canonical)) > limits.MaxSummaryBytes || version != m.SummaryVersion || keyID != m.FilterKeyID || complete != m.TimeSummaryComplete || !bytes.Equal(digestBytes(canonical), storedDigest) || hex.EncodeToString(storedDigest) != m.SummaryDigest {
 		return m, fmt.Errorf("%w: summary binding", ErrSegmentCorrupt)
-	}
-	var rows uint64
-	for _, table := range []string{"segment_exact_filters", "segment_bloom_filters", "segment_session_aggregates"} {
-		var n uint64
-		if err = db.QueryRowContext(ctx, `SELECT count(*) FROM `+table).Scan(&n); err != nil {
-			return m, fmt.Errorf("%w: summary rows", ErrSegmentCorrupt)
-		}
-		rows += n
-	}
-	if rows != m.SummaryRowCount || rows > limits.MaxSummaryRows {
-		return m, fmt.Errorf("%w: summary row count", ErrSegmentCorrupt)
 	}
 	rebuilt := domain.SegmentCatalogSummaryV1{FilterKeyID: keyID, TimeComplete: complete}
 	exactRows, queryErr := db.QueryContext(ctx, `SELECT kind,token FROM segment_exact_filters ORDER BY kind,token`)
@@ -508,6 +553,51 @@ func verifyArchiveSegmentMetadataPath(ctx context.Context, path string, expected
 	return m, nil
 }
 
+func validateSegmentTableSet(ctx context.Context, db *sql.DB) error {
+	var userVersion uint32
+	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion); err != nil || userVersion != domain.SegmentFormatV1 {
+		return fmt.Errorf("%w: segment schema version", ErrSegmentCorrupt)
+	}
+	expected := make(map[string]string)
+	for _, statement := range strings.Split(segmentSchemaV1, ";") {
+		normalized := strings.Join(strings.Fields(statement), " ")
+		if normalized == "" {
+			continue
+		}
+		fields := strings.Fields(normalized)
+		if len(fields) < 3 || fields[0] != "CREATE" || fields[1] != "TABLE" {
+			return fmt.Errorf("invalid built-in segment schema")
+		}
+		name := strings.SplitN(fields[2], "(", 2)[0]
+		expected[name] = normalized
+	}
+	rows, err := db.QueryContext(ctx, `SELECT type,name,sql FROM sqlite_schema ORDER BY type,name`)
+	if err != nil {
+		return fmt.Errorf("%w: inspect summary schema", ErrSegmentCorrupt)
+	}
+	defer func() { _ = rows.Close() }()
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var typ, name string
+		var sqlText sql.NullString
+		if err = rows.Scan(&typ, &name, &sqlText); err != nil {
+			return fmt.Errorf("%w: inspect summary schema", ErrSegmentCorrupt)
+		}
+		if typ == "index" && !sqlText.Valid && strings.HasPrefix(name, "sqlite_autoindex_") {
+			continue
+		}
+		want, ok := expected[name]
+		if !ok || typ != "table" || !sqlText.Valid || strings.Join(strings.Fields(sqlText.String), " ") != want {
+			return fmt.Errorf("%w: unexpected segment schema object", ErrSegmentCorrupt)
+		}
+		seen[name] = true
+	}
+	if len(seen) != len(expected) {
+		return fmt.Errorf("%w: incomplete segment schema", ErrSegmentCorrupt)
+	}
+	return nil
+}
+
 // VerifyArchiveSegment fully decodes a sealed segment and binds it to the
 // durable expected manifest supplied by its caller.
 func VerifyArchiveSegment(ctx context.Context, root string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, error) {
@@ -522,14 +612,29 @@ func VerifyArchiveSegment(ctx context.Context, root string, expected ArchiveSegm
 }
 
 func verifyArchiveSegmentPath(ctx context.Context, path string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits, requireFileDigest bool) (ArchiveSegmentManifest, error) {
-	m, err := inspectArchiveSegmentPath(ctx, path, expected.Basename, requireFileDigest, limits.MaxFileBytes)
+	return verifyArchiveSegmentPathWithHook(ctx, path, expected, limits, requireFileDigest, nil)
+}
+
+func verifyArchiveSegmentPathWithHook(ctx context.Context, path string, expected ArchiveSegmentManifest, limits ArchiveSegmentLimits, requireFileDigest bool, afterManifest func() error) (ArchiveSegmentManifest, error) {
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireFileDigest)
+	if err != nil {
+		return ArchiveSegmentManifest{}, err
+	}
+	defer func() { _ = db.Close(); _ = pinned.Close() }()
+	db.SetMaxOpenConns(2)
+	m, err := inspectArchiveSegmentOpen(ctx, db, pinned, expected.Basename, limits.MaxFileBytes)
 	if err != nil {
 		return m, err
+	}
+	if afterManifest != nil {
+		if err = afterManifest(); err != nil {
+			return m, err
+		}
 	}
 	if !sameLogicalManifest(m, expected) {
 		return m, fmt.Errorf("%w: expected manifest mismatch", ErrSegmentCorrupt)
 	}
-	if _, metadataErr := verifyArchiveSegmentMetadataPath(ctx, path, expected, limits, requireFileDigest); metadataErr != nil {
+	if _, metadataErr := verifyArchiveSegmentMetadataOpen(ctx, db, pinned, expected, limits); metadataErr != nil {
 		return m, metadataErr
 	}
 	digest, decodeErr := hex.DecodeString(m.LogicalDigest)
@@ -542,21 +647,8 @@ func verifyArchiveSegmentPath(ctx context.Context, path string, expected Archive
 	if identityErr != nil || identity.Basename() != m.Basename {
 		return m, fmt.Errorf("%w: content-addressed identity", ErrSegmentCorrupt)
 	}
-	db, pinned, err := openPinnedImmutableSegment(ctx, path, requireFileDigest)
-	if err != nil {
-		return m, err
-	}
-	defer func() { _ = db.Close() }()
-	defer func() { _ = pinned.Close() }()
-	db.SetMaxOpenConns(2)
-	if requireFileDigest {
-		m.FileDigest, err = digestOpenFile(ctx, pinned, limits.MaxFileBytes)
-		if err != nil {
-			return m, err
-		}
-		if expected.FileDigest == "" || m.FileDigest != expected.FileDigest {
-			return m, fmt.Errorf("%w: expected file digest mismatch", ErrSegmentCorrupt)
-		}
+	if requireFileDigest && expected.FileDigest == "" {
+		return m, fmt.Errorf("%w: expected file digest missing", ErrSegmentCorrupt)
 	}
 	rows, err := db.QueryContext(ctx, `SELECT sequence,codec,plaintext_length,checksum,length(payload) FROM history_units ORDER BY sequence`)
 	if err != nil {

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -183,6 +183,46 @@ func TestArchiveSegmentFullVerifierPinsOneInodeAcrossPathExchange(t *testing.T) 
 	}
 }
 
+func TestArchiveSegmentManifestRejectsDuplicateRawPlaintextRow(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "manifest-singleton", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`ALTER TABLE segment_manifest RENAME TO original_manifest; CREATE TABLE segment_manifest AS SELECT * FROM original_manifest; INSERT INTO segment_manifest SELECT 2,format_version,'raw-secret',start_sequence,end_sequence,unit_count,audit_count,min_created_at,max_created_at,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,logical_digest,basename,summary_version,summary_digest,filter_key_id,time_summary_complete,summary_row_count,summary_byte_count FROM original_manifest`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	expected := m
+	expected.FileDigest = ""
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, expected, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("duplicate manifest error = %v", err)
+	}
+}
+
+func TestArchiveSegmentBuildPreflightsSummaryRowsBeforeEncoding(t *testing.T) {
+	summary := testSegmentSummary()
+	summary.Blooms[0].Bits = make([]byte, 1<<20)
+	summary.Blooms[0].BitCount = 8 << 20
+	limits := testSegmentLimits()
+	limits.MaxSummaryRows = 2
+	_, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), testArchiveUnits(), ArchiveSegmentConfig{StoreID: "row-preflight", CompressionFloor: 32, Limits: limits, Summary: summary})
+	if !errors.Is(err, ErrSegmentLimit) || !strings.Contains(err.Error(), "summary rows") {
+		t.Fatalf("row preflight error = %v", err)
+	}
+}
+
 func testArchiveUnits() []ArchiveHistoryUnit {
 	return []ArchiveHistoryUnit{
 		{Unit: domain.HistoryUnit{Sequence: 10, Event: testArchiveEvent("event-10", time.Unix(2, 3), domain.TextValue([]byte(strings.Repeat("compressible-", 100))))}},

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -88,6 +88,101 @@ func TestArchiveSegmentMetadataVerifierBindsNormalizedSummary(t *testing.T) {
 	}
 }
 
+func TestArchiveSegmentMixedMalformedTimeMarksSummaryIncomplete(t *testing.T) {
+	units := testArchiveUnits()
+	values := units[1].Unit.Event.Values()
+	values[5] = domain.TextValue([]byte("not-a-time"))
+	malformed, err := domain.NewArchiveEventV1(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	units[1].Unit.Event = malformed
+	m, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), units, ArchiveSegmentConfig{StoreID: "mixed-time", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.TimeSummaryComplete {
+		t.Fatal("mixed valid and malformed timestamps reported complete")
+	}
+}
+
+func TestArchiveSegmentMetadataRejectsUnexpectedPlaintextTable(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "schema", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`CREATE TABLE leaked_plaintext(value TEXT); INSERT INTO leaked_plaintext VALUES('secret')`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	expected := m
+	expected.FileDigest = ""
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, expected, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("unexpected schema error = %v", err)
+	}
+}
+
+func TestArchiveSegmentMetadataPreflightsHugeBloomBeforeBlobScan(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "huge-summary", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE segment_bloom_filters SET bit_count=8388608,bits=zeroblob(1048576)`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	expected := m
+	expected.FileDigest = ""
+	limits := testSegmentLimits()
+	limits.MaxSummaryBytes = 1024
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, expected, limits); !errors.Is(err, ErrSegmentLimit) {
+		t.Fatalf("huge summary error = %v", err)
+	}
+}
+
+func TestArchiveSegmentFullVerifierPinsOneInodeAcrossPathExchange(t *testing.T) {
+	root := t.TempDir()
+	cfg := ArchiveSegmentConfig{StoreID: "pinned", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()}
+	original, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementRoot := t.TempDir()
+	replacement, err := BuildArchiveSegmentV1(context.Background(), replacementRoot, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "replacement", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, original.Basename)
+	_, err = verifyArchiveSegmentPathWithHook(context.Background(), path, original, testSegmentLimits(), true, func() error { return os.Rename(filepath.Join(replacementRoot, replacement.Basename), path) })
+	if err != nil {
+		t.Fatalf("pinned verifier mixed path inodes: %v", err)
+	}
+}
+
 func testArchiveUnits() []ArchiveHistoryUnit {
 	return []ArchiveHistoryUnit{
 		{Unit: domain.HistoryUnit{Sequence: 10, Event: testArchiveEvent("event-10", time.Unix(2, 3), domain.TextValue([]byte(strings.Repeat("compressible-", 100))))}},

--- a/infrastructure/sqlite/archive_segment_test.go
+++ b/infrastructure/sqlite/archive_segment_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"os"
@@ -14,7 +15,77 @@ import (
 )
 
 func testSegmentLimits() ArchiveSegmentLimits {
-	return ArchiveSegmentLimits{MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20}
+	return ArchiveSegmentLimits{MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20, MaxSummaryBytes: 1 << 20, MaxSummaryRows: 1000}
+}
+
+func testSegmentSummary() domain.SegmentCatalogSummaryV1 {
+	return domain.SegmentCatalogSummaryV1{FilterKeyID: "test-key-v1", TimeComplete: true,
+		ExactTokens: []domain.SegmentSummaryToken{{Kind: domain.SummaryTokenWorkspace, Value: sha256.Sum256([]byte("workspace"))}},
+		Blooms:      []domain.SegmentBloomV1{{Kind: domain.SummaryTokenSession, BitCount: 8, HashCount: 2, Bits: []byte{0x81}}},
+		Sessions:    []domain.SegmentSessionAggregateV1{{SessionToken: sha256.Sum256([]byte("session")), UnitCount: 2, AuditCount: 1}},
+	}
+}
+
+func TestArchiveSegmentMetadataVerificationDoesNotDecodePayload(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "metadata", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, m, testSegmentLimits()); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE history_units SET codec='future'`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	metadataExpected := m
+	metadataExpected.FileDigest = ""
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, metadataExpected, testSegmentLimits()); err != nil {
+		t.Fatalf("metadata verifier decoded payload: %v", err)
+	}
+	if _, err = VerifyArchiveSegment(context.Background(), root, m, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("full verifier error = %v", err)
+	}
+}
+
+func TestArchiveSegmentMetadataVerifierBindsNormalizedSummary(t *testing.T) {
+	root := t.TempDir()
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "summary-binding", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, m.Basename)
+	if err = os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE segment_session_aggregates SET unit_count=3`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+	if err = os.Chmod(path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	expected := m
+	expected.FileDigest = ""
+	if _, err = VerifyArchiveSegmentMetadata(context.Background(), root, expected, testSegmentLimits()); !errors.Is(err, ErrSegmentCorrupt) {
+		t.Fatalf("tampered summary error = %v", err)
+	}
 }
 
 func testArchiveUnits() []ArchiveHistoryUnit {
@@ -53,7 +124,7 @@ func testArchiveAudit() *domain.ArchiveAuditV1 {
 
 func TestArchiveSegmentBuildInspectAndVerify(t *testing.T) {
 	root := t.TempDir()
-	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "store-a", CompressionFloor: 500, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "store-a", CompressionFloor: 500, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +159,7 @@ func TestArchiveSegmentTimeBoundsUseChronologicalOrder(t *testing.T) {
 	units := testArchiveUnits()
 	units[0].Unit.Event = testArchiveEvent("event-10", time.Unix(10, 1), domain.TextValue([]byte("body")))
 	units[1].Unit.Event = testArchiveEvent("event-11", time.Unix(10, 0), domain.TextValue([]byte("body")))
-	m, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), units, ArchiveSegmentConfig{StoreID: "time", CompressionFloor: 32, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), units, ArchiveSegmentConfig{StoreID: "time", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +170,7 @@ func TestArchiveSegmentTimeBoundsUseChronologicalOrder(t *testing.T) {
 
 func TestArchiveSegmentVerifierBindsExpectedManifestAndCaps(t *testing.T) {
 	root := t.TempDir()
-	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "binding", CompressionFloor: 32, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "binding", CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,9 +189,9 @@ func TestArchiveSegmentVerifierBindsExpectedManifestAndCaps(t *testing.T) {
 		t.Fatalf("file cap error = %v", err)
 	}
 	for name, limits := range map[string]ArchiveSegmentLimits{
-		"aggregate plaintext": {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: m.TotalPlainBytes - 1, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20},
-		"aggregate stored":    {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: m.TotalStoredBytes - 1, MaxFileBytes: 16 << 20},
-		"decoded value":       {MaxValuePlainBytes: 16, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20},
+		"aggregate plaintext": {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: m.TotalPlainBytes - 1, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20, MaxSummaryBytes: 1 << 20, MaxSummaryRows: 1000},
+		"aggregate stored":    {MaxValuePlainBytes: 1 << 20, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: m.TotalStoredBytes - 1, MaxFileBytes: 16 << 20, MaxSummaryBytes: 1 << 20, MaxSummaryRows: 1000},
+		"decoded value":       {MaxValuePlainBytes: 16, MaxValueStoredBytes: 1 << 20, MaxTotalPlainBytes: 4 << 20, MaxTotalStoredBytes: 4 << 20, MaxFileBytes: 16 << 20, MaxSummaryBytes: 1 << 20, MaxSummaryRows: 1000},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := VerifyArchiveSegment(context.Background(), root, m, limits); !errors.Is(err, ErrSegmentLimit) {
@@ -137,7 +208,7 @@ func TestArchiveSegmentVerifierBindsExpectedManifestAndCaps(t *testing.T) {
 }
 
 func TestArchiveSegmentLogicalOutputIsDeterministic(t *testing.T) {
-	cfg := ArchiveSegmentConfig{StoreID: "same", CompressionFloor: 20, Limits: testSegmentLimits()}
+	cfg := ArchiveSegmentConfig{StoreID: "same", CompressionFloor: 20, Limits: testSegmentLimits(), Summary: testSegmentSummary()}
 	a, err := BuildArchiveSegmentV1(context.Background(), t.TempDir(), testArchiveUnits(), cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -164,7 +235,7 @@ func TestArchiveSegmentRejectsUnsafeLocations(t *testing.T) {
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := BuildArchiveSegmentV1(context.Background(), link, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}); !errors.Is(err, ErrSegmentUnsafeLocation) {
+	if _, err := BuildArchiveSegmentV1(context.Background(), link, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits(), Summary: testSegmentSummary()}); !errors.Is(err, ErrSegmentUnsafeLocation) {
 		t.Fatalf("symlink root error = %v", err)
 	}
 	name := "segment-v1-" + strings.Repeat("a", 64) + ".sqlite"
@@ -177,7 +248,7 @@ func TestArchiveSegmentRejectsUnsafeLocations(t *testing.T) {
 }
 
 func TestArchiveSegmentCapsCancellationAndIncompleteOutput(t *testing.T) {
-	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}
+	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits(), Summary: testSegmentSummary()}
 	root := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -195,8 +266,8 @@ func TestArchiveSegmentCapsCancellationAndIncompleteOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	exact := ArchiveSegmentLimits{MaxValuePlainBytes: int64(len(encoded)), MaxValueStoredBytes: int64(len(encoded)), MaxTotalPlainBytes: int64(len(encoded)), MaxTotalStoredBytes: int64(len(encoded)), MaxFileBytes: 16 << 20}
-	if _, err = BuildArchiveSegmentV1(context.Background(), t.TempDir(), unit, ArchiveSegmentConfig{StoreID: "exact", CompressionFloor: len(encoded) + 1, Limits: exact}); err != nil {
+	exact := ArchiveSegmentLimits{MaxValuePlainBytes: int64(len(encoded)), MaxValueStoredBytes: int64(len(encoded)), MaxTotalPlainBytes: int64(len(encoded)), MaxTotalStoredBytes: int64(len(encoded)), MaxFileBytes: 16 << 20, MaxSummaryBytes: 1 << 20, MaxSummaryRows: 1000}
+	if _, err = BuildArchiveSegmentV1(context.Background(), t.TempDir(), unit, ArchiveSegmentConfig{StoreID: "exact", CompressionFloor: len(encoded) + 1, Limits: exact, Summary: testSegmentSummary()}); err != nil {
 		t.Fatalf("exact maximum rejected: %v", err)
 	}
 }
@@ -204,7 +275,7 @@ func TestArchiveSegmentCapsCancellationAndIncompleteOutput(t *testing.T) {
 func TestArchiveSegmentFsyncFailureDoesNotSeal(t *testing.T) {
 	root := t.TempDir()
 	sentinel := errors.New("sync failed")
-	_, err := (archiveSegmentBuilder{syncFile: func(*os.File) error { return sentinel }}).build(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()})
+	_, err := (archiveSegmentBuilder{syncFile: func(*os.File) error { return sentinel }}).build(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("error = %v", err)
 	}
@@ -212,7 +283,7 @@ func TestArchiveSegmentFsyncFailureDoesNotSeal(t *testing.T) {
 }
 
 func TestArchiveSegmentMidOperationCancellationAndSealFailureLeaveNoOutput(t *testing.T) {
-	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()}
+	cfg := ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits(), Summary: testSegmentSummary()}
 	root := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())
 	b := archiveSegmentBuilder{syncFile: func(f *os.File) error { return f.Sync() }, sealFile: func(f *os.File, m os.FileMode) error { return f.Chmod(m) }, afterUnit: func(i int) error {
@@ -246,7 +317,7 @@ func TestArchiveSegmentVerifierSeparatesUnknownCodecAndCorruption(t *testing.T) 
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
-			m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: tc.floor, Limits: testSegmentLimits()})
+			m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: tc.floor, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -286,7 +357,7 @@ func TestArchiveSegmentVerifierSeparatesUnknownCodecAndCorruption(t *testing.T) 
 
 func TestArchiveSegmentVerifierRejectsOversizedStoredPayloadBeforeLoadingBlob(t *testing.T) {
 	root := t.TempDir()
-	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "oversized", CompressionFloor: 500, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "oversized", CompressionFloor: 500, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +391,7 @@ func TestArchiveSegmentVerifierRejectsOversizedStoredPayloadBeforeLoadingBlob(t 
 
 func TestArchiveSegmentRejectsUnknownFormatButManifestInspectionDoesNotDecodePayload(t *testing.T) {
 	root := t.TempDir()
-	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits()})
+	m, err := BuildArchiveSegmentV1(context.Background(), root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: "x", CompressionFloor: 1, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- embed bounded metadata-only Catalog summaries inside archive segment v1 without a sidecar artifact
- bind summary version, digest, filter key, time completeness, and size facts into the manifest and logical identity
- preserve malformed legacy timestamps conservatively and add pinned-inode metadata/full verification

## Validation
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run --timeout=5m`
- GPT-5.6 Sol integrity/privacy review: APPROVE after six blocking fixes

## Deferred boundary
HMAC/Bloom generation semantics and no-false-negative query behavior remain owned by #1650/#1652. Publication remains owned by #1651.

Closes #1658
