### PR TITLE
feat: add stable archive sequence inventory

### DIFF
--- a/.ai/spec/1660.md
+++ b/.ai/spec/1660.md
@@ -1,0 +1,72 @@
+# Issue #1660: stable archive sequence inventory
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Install a constant-time schema migration that creates one durable store identity and a dedicated archive sequence allocator/mapping. It must not scan or backfill `events`.
+- Assign every event inserted after migration 44 a unique, increasing archive sequence in the insert transaction, independent of the retired search sequence.
+- Inventory pre-migration events through bounded, resumable select/apply operations and verify the frozen range in a separate bounded phase before activation.
+- Fail closed until verification proves every sequence in `1..high_water` is unique, references an event, and agrees with the allocator snapshot.
+- Keep generic event, bundle, archive restore, and deduplication write paths unchanged; integration tests prove their existing inserts pass through the trigger.
+
+### Conceptual model
+
+| Concept | State | Behavior | Constraint / invariant |
+|---|---|---|---|
+| Store lineage | store ID, private filter key | identifies one physical logical store | singleton, immutable after creation; key is never returned by inventory evidence |
+| Archive allocator | next sequence | allocates inside the caller transaction | positive; update and mapping insert roll back together; overflow aborts the event insert |
+| Event placement | event ID, archive sequence | binds an event to archive order | one-to-one, positive, independent from search projection sequence |
+| Inventory generation | generation, cursor, phase, high water, revision | selects and applies bounded keyset pages, then verifies bounded sequence pages | cursor advances only by CAS against the observed generation/cursor/revision |
+| Activation | active generation | authorizes archive consumers | absent until the verifying phase reaches its frozen high water and allocator consistency is proven |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Not owner / reason |
+|---|---|---|
+| Store/allocator/mapping durability and trigger | migration 44 | event repositories: all insert paths must share one mechanism |
+| Budget and progress contracts | `application/types` | SQLite adapter does not invent caller policy |
+| Sequence/generation invariants | `domain` value types | SQL rows are not the public contract |
+| Keyset selection, transactional allocation, cursor CAS, verification | SQLite adapter | application orchestration owns repeated resume calls later |
+| Activation decision | SQLite verifier transaction | CLI must not infer readiness from counts |
+
+### Boundaries / interfaces
+
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `StartArchiveSequenceInventory` | migration workflow | random generation creation, state revision | rejects an active generation and invalid budgets |
+| `SelectArchiveSequenceInventory` | bounded runner | SQL keyset and byte accounting | no mutation; context/wall cap is honored |
+| `ApplyArchiveSequenceInventory` | bounded runner | allocator statements and state CAS | whole page and allocator consumption roll back on any error |
+| `VerifyArchiveSequenceInventory` | release/migration gate | gap/event/allocator SQL checks | marks failed and never activates on contradiction; only the terminal verified page activates |
+| `ArchiveSequenceStatus` | archive services/gates | private filter key | exposes aggregate state and store ID, never filter-key bytes |
+
+### Behavior tests
+
+| Given | When | Then | Level |
+|---|---|---|---|
+| a large pre-44 store | migration 44 runs | no event mapping is backfilled | migration integration |
+| a post-44 insert in a transaction | commit/rollback | committed inserts receive unique increasing values; rollback consumes none | SQLite integration |
+| allocator at max int64 | insert event | insert fails and neither event nor mapping persists | SQLite integration |
+| bounded pre-44 rows | select/apply/resume | row/stored/write/wall/lock/context caps and cursor CAS are enforced | adapter integration |
+| complete inventory | verify pages after frozen high water | exact `1..H`, event existence, and allocator agreement activate the generation | adapter integration |
+| a gap/orphan/wrong allocator | verify | generation fails closed | adapter integration |
+| bundle/archive/dedupe insert paths | write after migration | each resulting event has an archive mapping | cross-path integration |
+
+### TDD plan
+
+1. Add migration tests for constant-time installation, singleton identity, trigger rollback, uniqueness, overflow, and catalog identity.
+2. Add failing adapter tests for bounded inventory, stale CAS, resume, separate verification, and fail-closed activation.
+3. Implement domain/application contracts and the SQLite adapter with transactions at allocation and activation boundaries.
+4. Add existing-path integration assertions and run the complete Go validation suite.
+
+### Risks / rollback
+
+- A trigger is deliberately used so no current or future direct `events` insert path can omit placement. It contains only constant-time singleton update plus mapping insert.
+- Migration 44 is additive and performs only singleton inserts/schema creation. Rolling back the binary leaves inert additive tables/triggers; schema downgrade requires restoring a pre-migration backup.
+- Inventory never deletes or rewrites canonical events. Abandoning a generation clears no mappings because mappings are stable facts and a later generation resumes over already-mapped rows.
+- Activation is the rollback boundary: archive readers must continue using Hot-only behavior until `active_generation_id` is non-empty.
+- Catalog/placement/segment publication remain owned by later issues; this issue does not add an operational CLI or reuse the search generation tables.
+
+### Design checkpoint
+
+Approved implementation shape: additive migration + trigger, stable mapping facts, two bounded phases (inventory then verification), and fail-closed activation. No existing projection or archive publication behavior changes in this issue.

--- a/application/types/archive_sequence_inventory.go
+++ b/application/types/archive_sequence_inventory.go
@@ -1,0 +1,105 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+var (
+	// ErrArchiveSequenceStaleGeneration identifies a failed generation/cursor CAS.
+	ErrArchiveSequenceStaleGeneration = errors.New("archive sequence stale generation")
+	// ErrArchiveSequenceDrift identifies a selected page or mapping that changed before apply.
+	ErrArchiveSequenceDrift = errors.New("archive sequence inventory drift")
+	// ErrArchiveSequenceGap identifies a non-contiguous or orphaned verified range.
+	ErrArchiveSequenceGap = errors.New("archive sequence gap")
+	// ErrArchiveSequenceOverflow identifies exhaustion of the signed SQLite sequence space.
+	ErrArchiveSequenceOverflow = errors.New("archive sequence overflow")
+	// ErrArchiveSequenceLimit identifies an invalid or exceeded bounded-operation cap.
+	ErrArchiveSequenceLimit = errors.New("archive sequence limit exceeded")
+	// ErrArchiveSequenceIncomplete identifies a phase or coverage that is not activation-ready.
+	ErrArchiveSequenceIncomplete = errors.New("archive sequence inventory incomplete")
+	// ErrArchiveSequenceActivation identifies a failed terminal activation proof.
+	ErrArchiveSequenceActivation = errors.New("archive sequence activation failed")
+)
+
+const (
+	// ArchiveSequenceMaxRows is the hard per-call row cap.
+	ArchiveSequenceMaxRows = 10_000
+	// ArchiveSequenceMaxStoredBytes is the hard per-call identity-read cap.
+	ArchiveSequenceMaxStoredBytes = int64(64 << 20)
+	// ArchiveSequenceMaxWriteBytes is the hard per-call logical-write cap.
+	ArchiveSequenceMaxWriteBytes = int64(64 << 20)
+	// ArchiveSequenceMaxWallTime is the hard per-call elapsed cap.
+	ArchiveSequenceMaxWallTime = 10 * time.Minute
+	// ArchiveSequenceMaxLockTime is the hard per-call write-lock cap.
+	ArchiveSequenceMaxLockTime = 30 * time.Second
+)
+
+// ArchiveSequenceBudget bounds one select/apply/verify call. StoredBytes caps
+// identities read, WriteBytes caps mapping bytes, WallTime caps total work,
+// and LockTime caps the write transaction lock wait.
+type ArchiveSequenceBudget struct {
+	Rows        int
+	StoredBytes int64
+	WriteBytes  int64
+	WallTime    time.Duration
+	LockTime    time.Duration
+}
+
+// Valid reports whether every independent cap is positive.
+func (b ArchiveSequenceBudget) Valid() bool {
+	return b.Rows > 0 && b.Rows <= ArchiveSequenceMaxRows && b.StoredBytes > 0 && b.StoredBytes <= ArchiveSequenceMaxStoredBytes && b.WriteBytes > 0 && b.WriteBytes <= ArchiveSequenceMaxWriteBytes && b.WallTime > 0 && b.WallTime <= ArchiveSequenceMaxWallTime && b.LockTime > 0 && b.LockTime <= ArchiveSequenceMaxLockTime
+}
+
+// ConfigHash binds resume calls to the exact reviewed caps.
+func (b ArchiveSequenceBudget) ConfigHash() string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary/archive-sequence-budget/v1"))
+	var frame [8]byte
+	for _, value := range []int64{int64(b.Rows), b.StoredBytes, b.WriteBytes, int64(b.WallTime), int64(b.LockTime)} {
+		binary.BigEndian.PutUint64(frame[:], uint64(value))
+		_, _ = h.Write(frame[:])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ArchiveSequenceInventoryItem is one selected historical event identity.
+type ArchiveSequenceInventoryItem struct {
+	EventID      string
+	Missing      bool
+	LogicalBytes int64
+}
+
+// ArchiveSequenceInventorySnapshot binds a selected page to its CAS cursor.
+type ArchiveSequenceInventorySnapshot struct {
+	Generation    domain.ArchiveInventoryGeneration
+	ConfigHash    string
+	Cursor        string
+	CursorStarted bool
+	Items         []ArchiveSequenceInventoryItem
+	Done          bool
+	PageDigest    string
+}
+
+// ArchiveSequenceProgress reports aggregate progress without event identities.
+type ArchiveSequenceProgress struct {
+	Generation domain.ArchiveInventoryGeneration
+	Processed  int
+	Assigned   int
+	Done       bool
+}
+
+// ArchiveSequenceStatus is aggregate-only and never exposes the filter key.
+type ArchiveSequenceStatus struct {
+	StoreID            string
+	Generation         domain.ArchiveInventoryGeneration
+	ActiveGenerationID string
+	VerifiedHighWater  int64
+	MappedEvents       int64
+	AllocatorNext      int64
+}

--- a/application/types/archive_sequence_inventory_test.go
+++ b/application/types/archive_sequence_inventory_test.go
@@ -1,0 +1,27 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestArchiveSequenceBudgetEnforcesHardMaxima(t *testing.T) {
+	t.Parallel()
+	valid := apptypes.ArchiveSequenceBudget{Rows: apptypes.ArchiveSequenceMaxRows, StoredBytes: apptypes.ArchiveSequenceMaxStoredBytes, WriteBytes: apptypes.ArchiveSequenceMaxWriteBytes, WallTime: apptypes.ArchiveSequenceMaxWallTime, LockTime: apptypes.ArchiveSequenceMaxLockTime}
+	if !valid.Valid() {
+		t.Fatal("maximum budget rejected")
+	}
+	tests := []apptypes.ArchiveSequenceBudget{valid, valid, valid, valid, valid}
+	tests[0].Rows++
+	tests[1].StoredBytes++
+	tests[2].WriteBytes++
+	tests[3].WallTime += time.Nanosecond
+	tests[4].LockTime += time.Nanosecond
+	for index, budget := range tests {
+		if budget.Valid() {
+			t.Fatalf("over-limit budget %d accepted", index)
+		}
+	}
+}

--- a/domain/archive_sequence.go
+++ b/domain/archive_sequence.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+)
+
+// ArchiveSequence is the positive, store-local order assigned to a canonical
+// event. It is deliberately distinct from every search projection sequence.
+type ArchiveSequence int64
+
+// NewArchiveSequence validates a persisted archive sequence.
+func NewArchiveSequence(value int64) (ArchiveSequence, error) {
+	if value <= 0 {
+		return 0, errors.New("archive sequence must be positive")
+	}
+	return ArchiveSequence(value), nil
+}
+
+// Int64 returns the SQLite-compatible representation.
+func (s ArchiveSequence) Int64() int64 { return int64(s) }
+
+// ArchiveInventoryPhase is the durable phase of one sequence inventory.
+type ArchiveInventoryPhase string
+
+const (
+	// ArchiveInventoryIdle has no active inventory generation.
+	ArchiveInventoryIdle ArchiveInventoryPhase = "idle"
+	// ArchiveInventoryScanning assigns stable sequences to historical events.
+	ArchiveInventoryScanning ArchiveInventoryPhase = "inventory"
+	// ArchiveInventoryVerifying checks the frozen contiguous prefix.
+	ArchiveInventoryVerifying ArchiveInventoryPhase = "verifying"
+	// ArchiveInventoryComplete is the only activation-eligible terminal phase.
+	ArchiveInventoryComplete ArchiveInventoryPhase = "complete"
+	// ArchiveInventoryFailed is a fail-closed terminal phase.
+	ArchiveInventoryFailed ArchiveInventoryPhase = "failed"
+)
+
+// ArchiveInventoryGeneration identifies a resumable inventory and its frozen
+// verification boundary. HighWater is zero until scanning finishes.
+type ArchiveInventoryGeneration struct {
+	ID        string
+	Phase     ArchiveInventoryPhase
+	HighWater int64
+	Revision  int64
+}
+
+// Validate rejects states that could accidentally authorize an unverified
+// archive prefix.
+func (g ArchiveInventoryGeneration) Validate() error {
+	if strings.TrimSpace(g.ID) == "" || g.Revision < 0 || g.HighWater < 0 {
+		return errors.New("invalid archive inventory generation")
+	}
+	switch g.Phase {
+	case ArchiveInventoryScanning, ArchiveInventoryVerifying, ArchiveInventoryComplete, ArchiveInventoryFailed:
+		return nil
+	default:
+		return errors.New("unknown archive inventory phase")
+	}
+}

--- a/domain/archive_sequence_test.go
+++ b/domain/archive_sequence_test.go
@@ -1,0 +1,20 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestNewArchiveSequenceRejectsNonPositiveValues(t *testing.T) {
+	t.Parallel()
+	for _, value := range []int64{-1, 0} {
+		if _, err := domain.NewArchiveSequence(value); err == nil {
+			t.Fatalf("NewArchiveSequence(%d) error = nil", value)
+		}
+	}
+	got, err := domain.NewArchiveSequence(1)
+	if err != nil || got.Int64() != 1 {
+		t.Fatalf("NewArchiveSequence(1) = (%d, %v)", got, err)
+	}
+}

--- a/infrastructure/sqlite/archive_sequence_inventory.go
+++ b/infrastructure/sqlite/archive_sequence_inventory.go
@@ -1,0 +1,490 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+func newArchiveInventoryGenerationID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("create archive inventory generation ID: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+// StartArchiveSequenceInventory starts a new bounded historical inventory.
+// Stable mappings from an abandoned generation are retained and skipped.
+//
+//nolint:wrapcheck // SQL errors retain context at this dedicated adapter boundary.
+func (d *Database) StartArchiveSequenceInventory(ctx context.Context, budget apptypes.ArchiveSequenceBudget) (domain.ArchiveInventoryGeneration, error) {
+	if !budget.Valid() {
+		return domain.ArchiveInventoryGeneration{}, apptypes.ErrArchiveSequenceLimit
+	}
+	id, err := newArchiveInventoryGenerationID()
+	if err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	operationCtx, cancel := boundedArchiveContext(ctx, budget.WallTime, budget.LockTime)
+	defer cancel()
+	db, err := d.open(operationCtx)
+	if err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(operationCtx, nil)
+	if err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(operationCtx, `
+UPDATE archive_sequence_inventory_state
+SET generation_id=?, config_hash=?, phase='inventory', event_cursor='', event_cursor_started=0,
+    verify_cursor=0, high_water=0, revision=revision+1, failure_class=''
+WHERE singleton=1 AND phase NOT IN ('inventory','verifying')`, id, budget.ConfigHash())
+	if err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	if changed, changeErr := result.RowsAffected(); changeErr != nil || changed != 1 {
+		return domain.ArchiveInventoryGeneration{}, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	if _, err = tx.ExecContext(operationCtx, `UPDATE archive_sequence_activation SET active_generation_id='',verified_high_water=0 WHERE singleton=1`); err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	var revision int64
+	if err = tx.QueryRowContext(operationCtx, `SELECT revision FROM archive_sequence_inventory_state WHERE singleton=1`).Scan(&revision); err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return domain.ArchiveInventoryGeneration{}, err
+	}
+	return domain.ArchiveInventoryGeneration{ID: id, Phase: domain.ArchiveInventoryScanning, Revision: revision}, nil
+}
+
+// SelectArchiveSequenceInventory returns one stable ID-keyset page without a
+// write lock. Apply performs the generation/cursor CAS.
+//
+//nolint:wrapcheck // SQL errors retain context at this dedicated adapter boundary.
+func (d *Database) SelectArchiveSequenceInventory(ctx context.Context, budget apptypes.ArchiveSequenceBudget) (out apptypes.ArchiveSequenceInventorySnapshot, err error) {
+	if !budget.Valid() {
+		return out, apptypes.ErrArchiveSequenceLimit
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.open(operationCtx)
+	if err != nil {
+		return out, err
+	}
+	defer d.release(db)
+	var phase string
+	if err = db.QueryRowContext(operationCtx, `SELECT generation_id,config_hash,phase,event_cursor,event_cursor_started,revision FROM archive_sequence_inventory_state WHERE singleton=1`).Scan(
+		&out.Generation.ID, &out.ConfigHash, &phase, &out.Cursor, &out.CursorStarted, &out.Generation.Revision,
+	); err != nil {
+		return out, err
+	}
+	out.Generation.Phase = domain.ArchiveInventoryPhase(phase)
+	if out.Generation.Phase != domain.ArchiveInventoryScanning {
+		return out, apptypes.ErrArchiveSequenceIncomplete
+	}
+	if out.ConfigHash != budget.ConfigHash() {
+		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	out, err = selectArchiveInventoryPage(operationCtx, db, budget, out)
+	if err != nil {
+		return out, err
+	}
+	out.PageDigest = archiveInventoryPageDigest(out)
+	return out, nil
+}
+
+// ApplyArchiveSequenceInventory allocates a selected page and advances its
+// cursor atomically. A rollback therefore consumes no archive sequence.
+//
+//nolint:wrapcheck // SQL errors retain context at this dedicated adapter boundary.
+func (d *Database) ApplyArchiveSequenceInventory(ctx context.Context, budget apptypes.ArchiveSequenceBudget, snapshot apptypes.ArchiveSequenceInventorySnapshot) (out apptypes.ArchiveSequenceProgress, err error) {
+	if !budget.Valid() {
+		return out, apptypes.ErrArchiveSequenceLimit
+	}
+	if snapshot.ConfigHash != budget.ConfigHash() || snapshot.Generation.Phase != domain.ArchiveInventoryScanning || snapshot.Generation.ID == "" {
+		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	operationCtx, cancel := boundedArchiveContext(ctx, budget.WallTime, budget.LockTime)
+	defer cancel()
+	db, err := d.open(operationCtx)
+	if err != nil {
+		return out, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(operationCtx, nil)
+	if err != nil {
+		return out, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err = assertArchiveInventoryCAS(operationCtx, tx, snapshot); err != nil {
+		return out, err
+	}
+	exact := apptypes.ArchiveSequenceInventorySnapshot{Generation: snapshot.Generation, ConfigHash: snapshot.ConfigHash, Cursor: snapshot.Cursor, CursorStarted: snapshot.CursorStarted}
+	exact, err = selectArchiveInventoryPage(operationCtx, tx, budget, exact)
+	if err != nil {
+		return out, err
+	}
+	exact.PageDigest = archiveInventoryPageDigest(exact)
+	if snapshot.PageDigest == "" || snapshot.PageDigest != exact.PageDigest {
+		return out, apptypes.ErrArchiveSequenceDrift
+	}
+	snapshot = exact
+	lastCursor := snapshot.Cursor
+	lastStarted := snapshot.CursorStarted
+	for _, item := range snapshot.Items {
+		if item.EventID == "" || item.LogicalBytes < 0 {
+			return out, apptypes.ErrArchiveSequenceDrift
+		}
+		var exists int
+		if err = tx.QueryRowContext(operationCtx, `SELECT EXISTS(SELECT 1 FROM events WHERE id=?)`, item.EventID).Scan(&exists); err != nil || exists != 1 {
+			if err == nil {
+				err = apptypes.ErrArchiveSequenceDrift
+			}
+			return out, err
+		}
+		var mapped int
+		if err = tx.QueryRowContext(operationCtx, `SELECT EXISTS(SELECT 1 FROM archive_event_sequences WHERE event_id=?)`, item.EventID).Scan(&mapped); err != nil {
+			return out, err
+		}
+		if mapped == 0 {
+			if !item.Missing {
+				return out, apptypes.ErrArchiveSequenceDrift
+			}
+			if err = allocateArchiveSequence(operationCtx, tx, item.EventID); err != nil {
+				return out, err
+			}
+			out.Assigned++
+		}
+		out.Processed++
+		lastCursor, lastStarted = item.EventID, true
+	}
+
+	phase := "inventory"
+	highWater := int64(0)
+	if snapshot.Done {
+		phase = "verifying"
+		if err = tx.QueryRowContext(operationCtx, `SELECT next_sequence-1 FROM archive_sequence_allocator WHERE singleton=1`).Scan(&highWater); err != nil {
+			return out, err
+		}
+	}
+	result, err := tx.ExecContext(operationCtx, `UPDATE archive_sequence_inventory_state SET event_cursor=?,event_cursor_started=?,phase=?,high_water=?,verify_cursor=0,revision=revision+1 WHERE singleton=1 AND generation_id=? AND config_hash=? AND phase='inventory' AND revision=? AND event_cursor=? AND event_cursor_started=?`,
+		lastCursor, boolInt(lastStarted), phase, highWater, snapshot.Generation.ID, snapshot.ConfigHash, snapshot.Generation.Revision, snapshot.Cursor, boolInt(snapshot.CursorStarted))
+	if err != nil {
+		return out, err
+	}
+	if changed, changeErr := result.RowsAffected(); changeErr != nil || changed != 1 {
+		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	if err = tx.Commit(); err != nil {
+		return out, err
+	}
+	out.Generation = domain.ArchiveInventoryGeneration{ID: snapshot.Generation.ID, Phase: domain.ArchiveInventoryPhase(phase), HighWater: highWater, Revision: snapshot.Generation.Revision + 1}
+	out.Done = snapshot.Done
+	return out, nil
+}
+
+// VerifyArchiveSequenceInventory verifies one bounded sequence page. The last
+// page activates the generation only after the allocator and maximum mapping
+// agree in the same transaction snapshot.
+//
+//nolint:wrapcheck // SQL errors retain context at this dedicated adapter boundary.
+func (d *Database) VerifyArchiveSequenceInventory(ctx context.Context, budget apptypes.ArchiveSequenceBudget, generation domain.ArchiveInventoryGeneration) (out apptypes.ArchiveSequenceProgress, err error) {
+	if !budget.Valid() {
+		return out, apptypes.ErrArchiveSequenceLimit
+	}
+	if generation.Phase != domain.ArchiveInventoryVerifying || generation.ID == "" {
+		return out, apptypes.ErrArchiveSequenceIncomplete
+	}
+	if budget.StoredBytes < 16 || budget.WriteBytes < 8 {
+		return out, apptypes.ErrArchiveSequenceLimit
+	}
+	operationCtx, cancel := boundedArchiveContext(ctx, budget.WallTime, budget.LockTime)
+	defer cancel()
+	db, err := d.open(operationCtx)
+	if err != nil {
+		return out, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(operationCtx, nil)
+	if err != nil {
+		return out, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var configHash, phase string
+	var cursor, highWater, revision int64
+	if err = tx.QueryRowContext(operationCtx, `SELECT config_hash,phase,verify_cursor,high_water,revision FROM archive_sequence_inventory_state WHERE singleton=1 AND generation_id=?`, generation.ID).Scan(&configHash, &phase, &cursor, &highWater, &revision); err != nil {
+		return out, err
+	}
+	if configHash != budget.ConfigHash() || phase != "verifying" || revision != generation.Revision || highWater != generation.HighWater {
+		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	rows, err := tx.QueryContext(operationCtx, `SELECT m.sequence,e.id IS NOT NULL FROM archive_event_sequences m LEFT JOIN events e ON e.id=m.event_id WHERE m.sequence>? AND m.sequence<=? ORDER BY m.sequence LIMIT ?`, cursor, highWater, budget.Rows+1)
+	if err != nil {
+		return out, err
+	}
+	var stored int64
+	processed := 0
+	newCursor := cursor
+	expected := cursor + 1
+	more := false
+	for rows.Next() {
+		var sequence int64
+		var eventExists bool
+		if err = rows.Scan(&sequence, &eventExists); err != nil {
+			_ = rows.Close()
+			return out, err
+		}
+		if processed >= budget.Rows || stored+16 > budget.StoredBytes {
+			more = true
+			break
+		}
+		if sequence != expected || !eventExists {
+			_ = rows.Close()
+			return d.failArchiveVerification(operationCtx, tx, generation.ID, "sequence_gap_or_orphan")
+		}
+		newCursor = sequence
+		expected++
+		processed++
+		stored += 16
+	}
+	if err = rows.Close(); err != nil {
+		return out, err
+	}
+	if processed == 0 && cursor < highWater {
+		return d.failArchiveVerification(operationCtx, tx, generation.ID, "sequence_gap")
+	}
+	done := newCursor == highWater && !more
+	if done {
+		var next, maximum int64
+		if err = tx.QueryRowContext(operationCtx, `SELECT next_sequence FROM archive_sequence_allocator WHERE singleton=1`).Scan(&next); err != nil {
+			return out, err
+		}
+		if err = tx.QueryRowContext(operationCtx, `SELECT COALESCE(MAX(sequence),0) FROM archive_event_sequences`).Scan(&maximum); err != nil {
+			return out, err
+		}
+		if next <= 0 || next == math.MinInt64 || maximum != next-1 || maximum < highWater {
+			return d.failArchiveVerification(operationCtx, tx, generation.ID, "allocator_mismatch")
+		}
+		var unmapped int
+		if err = tx.QueryRowContext(operationCtx, `SELECT EXISTS(SELECT 1 FROM events e LEFT JOIN archive_event_sequences m ON m.event_id=e.id WHERE m.event_id IS NULL LIMIT 1)`).Scan(&unmapped); err != nil {
+			return out, err
+		}
+		if unmapped != 0 {
+			return d.failArchiveVerification(operationCtx, tx, generation.ID, "unmapped_event")
+		}
+	}
+	newPhase := "verifying"
+	if done {
+		newPhase = "complete"
+	}
+	result, err := tx.ExecContext(operationCtx, `UPDATE archive_sequence_inventory_state SET verify_cursor=?,phase=?,revision=revision+1 WHERE singleton=1 AND generation_id=? AND phase='verifying' AND revision=? AND verify_cursor=?`, newCursor, newPhase, generation.ID, revision, cursor)
+	if err != nil {
+		return out, err
+	}
+	if changed, changeErr := result.RowsAffected(); changeErr != nil || changed != 1 {
+		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	if done {
+		if _, err = tx.ExecContext(operationCtx, `UPDATE archive_sequence_activation SET active_generation_id=?,verified_high_water=? WHERE singleton=1`, generation.ID, highWater); err != nil {
+			return out, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return out, err
+	}
+	out.Generation = domain.ArchiveInventoryGeneration{ID: generation.ID, Phase: domain.ArchiveInventoryPhase(newPhase), HighWater: highWater, Revision: revision + 1}
+	out.Processed = processed
+	out.Done = done
+	return out, nil
+}
+
+// ArchiveSequenceStatus returns aggregate-only readiness evidence.
+//
+//nolint:wrapcheck // SQL errors retain context at this dedicated adapter boundary.
+func (d *Database) ArchiveSequenceStatus(ctx context.Context) (out apptypes.ArchiveSequenceStatus, err error) {
+	db, err := d.open(ctx)
+	if err != nil {
+		return out, err
+	}
+	defer d.release(db)
+	var phase string
+	if err = db.QueryRowContext(ctx, `SELECT l.store_id,s.generation_id,s.phase,s.high_water,s.revision,a.active_generation_id,a.verified_high_water,q.next_sequence FROM archive_store_lineage l JOIN archive_sequence_inventory_state s ON s.singleton=l.singleton JOIN archive_sequence_activation a ON a.singleton=l.singleton JOIN archive_sequence_allocator q ON q.singleton=l.singleton WHERE l.singleton=1`).Scan(
+		&out.StoreID, &out.Generation.ID, &phase, &out.Generation.HighWater, &out.Generation.Revision, &out.ActiveGenerationID, &out.VerifiedHighWater, &out.AllocatorNext,
+	); err != nil {
+		return out, err
+	}
+	out.Generation.Phase = domain.ArchiveInventoryPhase(phase)
+	out.MappedEvents = out.AllocatorNext - 1
+	return out, nil
+}
+
+func boundedArchiveContext(parent context.Context, wall, lock time.Duration) (context.Context, context.CancelFunc) {
+	limit := wall
+	if lock < limit {
+		limit = lock
+	}
+	return context.WithTimeout(parent, limit)
+}
+
+//nolint:wrapcheck // internal SQL helper preserves the driver error for its caller.
+func assertArchiveInventoryCAS(ctx context.Context, tx *sql.Tx, snapshot apptypes.ArchiveSequenceInventorySnapshot) error {
+	var generation, config, phase, cursor string
+	var started bool
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `SELECT generation_id,config_hash,phase,event_cursor,event_cursor_started,revision FROM archive_sequence_inventory_state WHERE singleton=1`).Scan(&generation, &config, &phase, &cursor, &started, &revision); err != nil {
+		return err
+	}
+	if generation != snapshot.Generation.ID || config != snapshot.ConfigHash || phase != "inventory" || cursor != snapshot.Cursor || started != snapshot.CursorStarted || revision != snapshot.Generation.Revision {
+		return apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	return nil
+}
+
+//nolint:wrapcheck // internal SQL helper preserves the driver error for its caller.
+func allocateArchiveSequence(ctx context.Context, tx *sql.Tx, eventID string) error {
+	var next int64
+	if err := tx.QueryRowContext(ctx, `SELECT next_sequence FROM archive_sequence_allocator WHERE singleton=1`).Scan(&next); err != nil {
+		return err
+	}
+	if next == math.MaxInt64 {
+		return apptypes.ErrArchiveSequenceOverflow
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE archive_sequence_allocator SET next_sequence=next_sequence+1 WHERE singleton=1 AND next_sequence=?`, next)
+	if err != nil {
+		return err
+	}
+	if changed, changeErr := result.RowsAffected(); changeErr != nil || changed != 1 {
+		return apptypes.ErrArchiveSequenceDrift
+	}
+	if _, err = tx.ExecContext(ctx, `INSERT INTO archive_event_sequences(event_id,sequence) VALUES(?,?)`, eventID, next); err != nil {
+		return err
+	}
+	return nil
+}
+
+//nolint:wrapcheck // internal SQL helper preserves the driver error for its caller.
+func (d *Database) failArchiveVerification(ctx context.Context, tx *sql.Tx, generationID, class string) (apptypes.ArchiveSequenceProgress, error) {
+	if _, err := tx.ExecContext(ctx, `UPDATE archive_sequence_inventory_state SET phase='failed',failure_class=?,revision=revision+1 WHERE singleton=1 AND generation_id=? AND phase='verifying'`, class, generationID); err != nil {
+		return apptypes.ArchiveSequenceProgress{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE archive_sequence_activation SET active_generation_id='',verified_high_water=0 WHERE singleton=1`); err != nil {
+		return apptypes.ArchiveSequenceProgress{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return apptypes.ArchiveSequenceProgress{}, err
+	}
+	cause := apptypes.ErrArchiveSequenceGap
+	if class == "unmapped_event" {
+		cause = apptypes.ErrArchiveSequenceIncomplete
+	}
+	return apptypes.ArchiveSequenceProgress{}, fmt.Errorf("%w: %w (%s)", apptypes.ErrArchiveSequenceActivation, cause, class)
+}
+
+type archivePageQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+//nolint:wrapcheck // internal SQL helper preserves driver errors for the adapter boundary.
+func selectArchiveInventoryPage(ctx context.Context, q archivePageQueryer, budget apptypes.ArchiveSequenceBudget, out apptypes.ArchiveSequenceInventorySnapshot) (apptypes.ArchiveSequenceInventorySnapshot, error) {
+	query := `SELECT length(CAST(e.id AS BLOB)),CASE WHEN length(CAST(e.id AS BLOB))<=? THEN e.id ELSE NULL END,m.event_id IS NULL FROM events e LEFT JOIN archive_event_sequences m ON m.event_id=e.id ORDER BY e.id COLLATE BINARY LIMIT ?`
+	args := []any{budget.StoredBytes, budget.Rows + 1}
+	if out.CursorStarted {
+		query = `SELECT length(CAST(e.id AS BLOB)),CASE WHEN length(CAST(e.id AS BLOB))<=? THEN e.id ELSE NULL END,m.event_id IS NULL FROM events e LEFT JOIN archive_event_sequences m ON m.event_id=e.id WHERE e.id>? COLLATE BINARY ORDER BY e.id COLLATE BINARY LIMIT ?`
+		args = []any{budget.StoredBytes, out.Cursor, budget.Rows + 1}
+	}
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return out, err
+	}
+	defer func() { _ = rows.Close() }()
+	var stored, written int64
+	more := false
+	for rows.Next() {
+		var length int64
+		var id sql.NullString
+		var missing bool
+		if err = rows.Scan(&length, &id, &missing); err != nil {
+			return out, err
+		}
+		if !id.Valid {
+			return out, apptypes.ErrArchiveSequenceLimit
+		}
+		wb := int64(0)
+		if missing {
+			wb = length + 16
+		}
+		if len(out.Items) >= budget.Rows || stored+length > budget.StoredBytes || written+wb > budget.WriteBytes {
+			more = true
+			break
+		}
+		out.Items = append(out.Items, apptypes.ArchiveSequenceInventoryItem{EventID: id.String, Missing: missing, LogicalBytes: wb})
+		stored += length
+		written += wb
+	}
+	if err = rows.Err(); err != nil {
+		return out, err
+	}
+	if len(out.Items) == 0 && more {
+		return out, apptypes.ErrArchiveSequenceLimit
+	}
+	out.Done = !more
+	return out, nil
+}
+
+func archiveInventoryPageDigest(page apptypes.ArchiveSequenceInventorySnapshot) string {
+	h := sha256.New()
+	h.Write([]byte("traceary/archive-inventory-page/v1"))
+	frame := func(b []byte) {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(b)))
+		h.Write(n[:])
+		h.Write(b)
+	}
+	frame([]byte(page.Generation.ID))
+	frame([]byte(page.ConfigHash))
+	frame([]byte(page.Cursor))
+	if page.CursorStarted {
+		frame([]byte{1})
+	} else {
+		frame([]byte{0})
+	}
+	for _, i := range page.Items {
+		frame([]byte(i.EventID))
+		if i.Missing {
+			frame([]byte{1})
+		} else {
+			frame([]byte{0})
+		}
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(i.LogicalBytes))
+		frame(n[:])
+	}
+	if page.Done {
+		frame([]byte{1})
+	} else {
+		frame([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/infrastructure/sqlite/archive_sequence_inventory.go
+++ b/infrastructure/sqlite/archive_sequence_inventory.go
@@ -115,8 +115,11 @@ func (d *Database) ApplyArchiveSequenceInventory(ctx context.Context, budget app
 	if !budget.Valid() {
 		return out, apptypes.ErrArchiveSequenceLimit
 	}
-	if snapshot.ConfigHash != budget.ConfigHash() || snapshot.Generation.Phase != domain.ArchiveInventoryScanning || snapshot.Generation.ID == "" {
+	if snapshot.ConfigHash != budget.ConfigHash() || snapshot.Generation.ID == "" {
 		return out, apptypes.ErrArchiveSequenceStaleGeneration
+	}
+	if snapshot.Generation.Phase != domain.ArchiveInventoryScanning {
+		return out, apptypes.ErrArchiveSequenceIncomplete
 	}
 	operationCtx, cancel := boundedArchiveContext(ctx, budget.WallTime, budget.LockTime)
 	defer cancel()

--- a/infrastructure/sqlite/archive_sequence_inventory_internal_test.go
+++ b/infrastructure/sqlite/archive_sequence_inventory_internal_test.go
@@ -14,6 +14,8 @@ import (
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/domain"
+	"github.com/duck8823/traceary/domain/model"
+	domaintypes "github.com/duck8823/traceary/domain/types"
 )
 
 func TestMigration44InstallsConstantTimeArchiveSequenceFoundation(t *testing.T) {
@@ -132,6 +134,32 @@ func TestArchiveSequenceTriggerIsTransactionalMonotonicAndOverflowSafe(t *testin
 	var overflowRows int
 	if err = raw.QueryRow(`SELECT COUNT(*) FROM events WHERE id='overflow'`).Scan(&overflowRows); err != nil || overflowRows != 0 {
 		t.Fatalf("overflow event count = %d, err=%v", overflowRows, err)
+	}
+}
+
+func TestArchiveSequenceOverflowIsTypedThroughEventWriteBoundary(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	database := NewDatabase(path, preparedMigrations(t))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_sequence_allocator SET next_sequence=? WHERE singleton=1`, int64(math.MaxInt64)); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+	eventID, _ := domaintypes.EventIDFrom("typed-overflow")
+	agent, _ := domaintypes.AgentFrom("codex")
+	sessionID, _ := domaintypes.SessionIDFrom("session-overflow")
+	event := model.EventOf(eventID, domaintypes.EventKindNote, domaintypes.Client("cli"), agent, sessionID, domaintypes.Workspace("workspace"), "body", time.Now().UTC())
+	if err = NewEventDatasource(database).Save(ctx, event); !errors.Is(err, apptypes.ErrArchiveSequenceOverflow) {
+		t.Fatalf("Save() error = %v, want ErrArchiveSequenceOverflow", err)
 	}
 }
 

--- a/infrastructure/sqlite/archive_sequence_inventory_internal_test.go
+++ b/infrastructure/sqlite/archive_sequence_inventory_internal_test.go
@@ -1,0 +1,384 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestMigration44InstallsConstantTimeArchiveSequenceFoundation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	legacy := NewDatabase(path, preparedMigrationsBefore(t, 44))
+	if err := NewStoreManagementDatasource(legacy).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 20; index++ {
+		if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-01T00:00:00Z','c','w')`, fmt.Sprintf("legacy-%02d", index)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = raw.Close()
+
+	database := NewDatabase(path, preparedMigrations(t))
+	if err = NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	var mapped int
+	if err = raw.QueryRow(`SELECT COUNT(*) FROM archive_event_sequences`).Scan(&mapped); err != nil {
+		t.Fatal(err)
+	}
+	if mapped != 0 {
+		t.Fatalf("migration backfilled %d events, want zero", mapped)
+	}
+	var storeID string
+	var key []byte
+	if err = raw.QueryRow(`SELECT store_id,filter_key FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID, &key); err != nil {
+		t.Fatal(err)
+	}
+	if len(storeID) != 32 || len(key) != 32 {
+		t.Fatalf("lineage lengths = %d/%d", len(storeID), len(key))
+	}
+	if err = NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var secondID string
+	var secondKey []byte
+	if err = raw.QueryRow(`SELECT store_id,filter_key FROM archive_store_lineage WHERE singleton=1`).Scan(&secondID, &secondKey); err != nil {
+		t.Fatal(err)
+	}
+	if secondID != storeID || string(secondKey) != string(key) {
+		t.Fatal("store lineage changed across initialize")
+	}
+}
+
+func TestArchiveSequenceTriggerIsTransactionalMonotonicAndOverflowSafe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	database := NewDatabase(path, preparedMigrations(t))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	insert := func(exec interface {
+		ExecContext(context.Context, string, ...any) (sql.Result, error)
+	}, id string) error {
+		_, execErr := exec.ExecContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-01T00:00:00Z','c','w')`, id)
+		if execErr != nil {
+			return fmt.Errorf("insert event: %w", execErr)
+		}
+		return nil
+	}
+	if err = insert(raw, "committed-1"); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = insert(tx, "rolled-back"); err != nil {
+		t.Fatal(err)
+	}
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err = insert(raw, "committed-2"); err != nil {
+		t.Fatal(err)
+	}
+	var first, second, next int64
+	if err = raw.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='committed-1'`).Scan(&first); err != nil {
+		t.Fatal(err)
+	}
+	if err = raw.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='committed-2'`).Scan(&second); err != nil {
+		t.Fatal(err)
+	}
+	if err = raw.QueryRow(`SELECT next_sequence FROM archive_sequence_allocator WHERE singleton=1`).Scan(&next); err != nil {
+		t.Fatal(err)
+	}
+	if first != 1 || second != 2 || next != 3 {
+		t.Fatalf("sequence state = %d/%d next=%d", first, second, next)
+	}
+	if _, err = raw.Exec(`UPDATE archive_sequence_allocator SET next_sequence=? WHERE singleton=1`, int64(math.MaxInt64)); err != nil {
+		t.Fatal(err)
+	}
+	if err = insert(raw, "overflow"); err == nil {
+		t.Fatal("overflow insert succeeded")
+	}
+	var overflowRows int
+	if err = raw.QueryRow(`SELECT COUNT(*) FROM events WHERE id='overflow'`).Scan(&overflowRows); err != nil || overflowRows != 0 {
+		t.Fatalf("overflow event count = %d, err=%v", overflowRows, err)
+	}
+}
+
+func TestArchiveSequenceTriggerSerializesConcurrentInsertPaths(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	if err := NewStoreManagementDatasource(NewDatabase(path, preparedMigrations(t))).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	const count = 16
+	var wg sync.WaitGroup
+	errorsByWriter := make(chan error, count)
+	for index := 0; index < count; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			db, openErr := sql.Open("sqlite", sqliteDSN(path))
+			if openErr != nil {
+				errorsByWriter <- openErr
+				return
+			}
+			defer func() { _ = db.Close() }()
+			_, execErr := db.ExecContext(ctx, `INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-01T00:00:00Z','c','w')`, fmt.Sprintf("event-%02d", index))
+			errorsByWriter <- execErr
+		}(index)
+	}
+	wg.Wait()
+	close(errorsByWriter)
+	for err := range errorsByWriter {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, _ := sql.Open("sqlite", sqliteDSN(path))
+	defer func() { _ = raw.Close() }()
+	var rows, distinct, minimum, maximum int
+	if err := raw.QueryRow(`SELECT COUNT(*),COUNT(DISTINCT sequence),MIN(sequence),MAX(sequence) FROM archive_event_sequences`).Scan(&rows, &distinct, &minimum, &maximum); err != nil {
+		t.Fatal(err)
+	}
+	if rows != count || distinct != count || minimum != 1 || maximum != count {
+		t.Fatalf("mapping aggregate = rows:%d distinct:%d range:%d..%d", rows, distinct, minimum, maximum)
+	}
+}
+
+func TestArchiveSequenceInventoryResumesAndActivatesOnlyAfterBoundedVerification(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database := newPre44ArchiveInventoryStore(t, 7)
+	budget := apptypes.ArchiveSequenceBudget{Rows: 2, StoredBytes: 128, WriteBytes: 128, WallTime: 2 * time.Second, LockTime: time.Second}
+	_, err := database.StartArchiveSequenceInventory(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := database.SelectArchiveSequenceInventory(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := first
+	tampered.Items = nil
+	tampered.Done = !first.Done
+	progress, err := database.ApplyArchiveSequenceInventory(ctx, budget, tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.ApplyArchiveSequenceInventory(ctx, budget, first); !errors.Is(err, apptypes.ErrArchiveSequenceStaleGeneration) {
+		t.Fatal("stale inventory page applied twice")
+	}
+	generation := progress.Generation
+	for generation.Phase == domain.ArchiveInventoryScanning {
+		page, selectErr := database.SelectArchiveSequenceInventory(ctx, budget)
+		if selectErr != nil {
+			t.Fatal(selectErr)
+		}
+		progress, err = database.ApplyArchiveSequenceInventory(ctx, budget, page)
+		if err != nil {
+			t.Fatal(err)
+		}
+		generation = progress.Generation
+	}
+	status, err := database.ArchiveSequenceStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ActiveGenerationID != "" || generation.HighWater != 7 {
+		t.Fatalf("pre-verification status = %+v generation=%+v", status, generation)
+	}
+	verificationCalls := 0
+	for generation.Phase == domain.ArchiveInventoryVerifying {
+		progress, err = database.VerifyArchiveSequenceInventory(ctx, budget, generation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		verificationCalls++
+		generation = progress.Generation
+	}
+	if verificationCalls < 4 || generation.Phase != domain.ArchiveInventoryComplete {
+		t.Fatalf("verification calls=%d generation=%+v", verificationCalls, generation)
+	}
+	status, err = database.ArchiveSequenceStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ActiveGenerationID != generation.ID || status.VerifiedHighWater != 7 || status.MappedEvents != 7 {
+		t.Fatalf("active status = %+v", status)
+	}
+}
+
+func TestArchiveSequenceInventoryHonorsCapsCancellationAndFailsClosedOnGap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database := newPre44ArchiveInventoryStore(t, 2)
+	tiny := apptypes.ArchiveSequenceBudget{Rows: 1, StoredBytes: 1, WriteBytes: 1, WallTime: time.Second, LockTime: time.Second}
+	if _, err := database.StartArchiveSequenceInventory(ctx, tiny); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.SelectArchiveSequenceInventory(ctx, tiny); err == nil {
+		t.Fatal("identity exceeding caps was selected")
+	}
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := database.SelectArchiveSequenceInventory(cancelled, tiny); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled select error = %v", err)
+	}
+
+	budget := apptypes.ArchiveSequenceBudget{Rows: 10, StoredBytes: 1024, WriteBytes: 1024, WallTime: time.Second, LockTime: time.Second}
+	// A new generation may replace the non-mutating generation.
+	raw, err := sql.Open("sqlite", sqliteDSN(database.Path()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_sequence_inventory_state SET phase='failed' WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+	_, err = database.StartArchiveSequenceInventory(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := database.SelectArchiveSequenceInventory(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	progress, err := database.ApplyArchiveSequenceInventory(ctx, budget, page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := progress.Generation
+	raw, _ = sql.Open("sqlite", sqliteDSN(database.Path()))
+	if _, err = raw.Exec(`DELETE FROM archive_event_sequences WHERE sequence=1`); err != nil {
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+	if _, err = database.VerifyArchiveSequenceInventory(ctx, budget, generation); !errors.Is(err, apptypes.ErrArchiveSequenceActivation) || !errors.Is(err, apptypes.ErrArchiveSequenceGap) {
+		t.Fatal("gap verification succeeded")
+	}
+	status, err := database.ArchiveSequenceStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ActiveGenerationID != "" || status.Generation.Phase != domain.ArchiveInventoryFailed {
+		t.Fatalf("failed verification activated: %+v", status)
+	}
+}
+
+func TestArchiveSequenceInventoryRejectsHugeIdentityBeforeMaterializingIt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	if err := NewStoreManagementDatasource(NewDatabase(path, preparedMigrationsBefore(t, 44))).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	huge := strings.Repeat("x", 1<<20)
+	if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','b','2026-08-01T00:00:00Z','c','w')`, huge); err != nil {
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+	database := NewDatabase(path, preparedMigrations(t))
+	if err = NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	budget := apptypes.ArchiveSequenceBudget{Rows: 1, StoredBytes: 64, WriteBytes: 128, WallTime: time.Second, LockTime: time.Second}
+	if _, err = database.StartArchiveSequenceInventory(ctx, budget); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.SelectArchiveSequenceInventory(ctx, budget); !errors.Is(err, apptypes.ErrArchiveSequenceLimit) {
+		t.Fatalf("huge identity error = %v", err)
+	}
+}
+
+func TestArchiveSequenceApplyRejectsPageDigestDriftAndTypedOverflow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database := newPre44ArchiveInventoryStore(t, 1)
+	budget := apptypes.ArchiveSequenceBudget{Rows: 1, StoredBytes: 128, WriteBytes: 128, WallTime: time.Second, LockTime: time.Second}
+	if _, err := database.StartArchiveSequenceInventory(ctx, budget); err != nil {
+		t.Fatal(err)
+	}
+	page, err := database.SelectArchiveSequenceInventory(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page.PageDigest = strings.Repeat("0", 64)
+	if _, err = database.ApplyArchiveSequenceInventory(ctx, budget, page); !errors.Is(err, apptypes.ErrArchiveSequenceDrift) {
+		t.Fatalf("digest drift error = %v", err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(database.Path()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.Exec(`UPDATE archive_sequence_allocator SET next_sequence=? WHERE singleton=1`, int64(math.MaxInt64)); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err = allocateArchiveSequence(ctx, tx, "historical-000"); !errors.Is(err, apptypes.ErrArchiveSequenceOverflow) {
+		t.Fatalf("overflow error = %v", err)
+	}
+}
+
+func newPre44ArchiveInventoryStore(t *testing.T, eventCount int) *Database {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	if err := NewStoreManagementDatasource(NewDatabase(path, preparedMigrationsBefore(t, 44))).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < eventCount; index++ {
+		if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-01T00:00:00Z','c','w')`, fmt.Sprintf("historical-%03d", index)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = raw.Close()
+	database := NewDatabase(path, preparedMigrations(t))
+	if err = NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return database
+}

--- a/infrastructure/sqlite/archive_sequence_write_error.go
+++ b/infrastructure/sqlite/archive_sequence_write_error.go
@@ -1,0 +1,31 @@
+package sqlite
+
+import (
+	"errors"
+	"strings"
+
+	sqlitelib "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+const (
+	sqliteCodeTriggerConstraint       = 1811
+	archiveSequenceExhaustedTriggerID = "archive sequence exhausted"
+)
+
+// mapArchiveSequenceWriteError translates the fixed migration-44 trigger
+// failure into the stable application error used by every event write path.
+// Both the driver code and the trigger class must match; unrelated trigger
+// constraints retain their original error.
+func mapArchiveSequenceWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var sqliteErr *sqlitelib.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqliteCodeTriggerConstraint &&
+		strings.Contains(sqliteErr.Error(), archiveSequenceExhaustedTriggerID) {
+		return apptypes.ErrArchiveSequenceOverflow
+	}
+	return err
+}

--- a/infrastructure/sqlite/bundle_datasource.go
+++ b/infrastructure/sqlite/bundle_datasource.go
@@ -583,6 +583,7 @@ body_plaintext_bytes=excluded.body_plaintext_bytes, body_encoded_bytes=excluded.
 		args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
 	}
 	_, err = t.tx.ExecContext(ctx, query, args...)
+	err = mapArchiveSequenceWriteError(err)
 	if err == nil {
 		return true, nil
 	}

--- a/infrastructure/sqlite/bundle_datasource_test.go
+++ b/infrastructure/sqlite/bundle_datasource_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,37 @@ import (
 	"github.com/duck8823/traceary/domain/types"
 	"github.com/duck8823/traceary/infrastructure/sqlite"
 )
+
+func TestBundleDatasource_ImportEventReceivesArchiveSequence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "traceary.db")
+	database := sqlite.NewDatabase(path, onDiskSQLiteMigrations(t))
+	if err := sqlite.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := sqlite.NewBundleDatasource(database, sqlite.NewEventDatasource(database)).BeginBundleImport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := model.EventOf(types.EventID("bundle-sequenced"), types.EventKindNote, types.Client("cli"), types.Agent("codex"), types.SessionID("s"), types.Workspace("w"), "body", time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC))
+	if imported, importErr := tx.ImportEvent(ctx, event, usecase.BundleConflictSkip); importErr != nil || !imported {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("ImportEvent() = %v/%v", imported, importErr)
+	}
+	if err = tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	var sequence int64
+	if err = raw.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='bundle-sequenced'`).Scan(&sequence); err != nil || sequence != 1 {
+		t.Fatalf("bundle archive sequence = %d, err=%v", sequence, err)
+	}
+}
 
 func TestBundleDatasource_ImportSessionRejectsConflictingTerminalReplace(t *testing.T) {
 	t.Parallel()

--- a/infrastructure/sqlite/content_event_dedupe_datasource.go
+++ b/infrastructure/sqlite/content_event_dedupe_datasource.go
@@ -615,7 +615,7 @@ body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_
 			args = append(args, payload.Codec, payload.FormatVersion, payload.PlaintextBytes, payload.StoredBytes, payload.SHA256)
 		}
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to restore event %s: %w", r.id, err)
+			return apptypes.ContentEventDedupeRestoreResult{}, xerrors.Errorf("failed to restore event %s: %w", r.id, mapArchiveSequenceWriteError(err))
 		}
 		if _, err := tx.ExecContext(
 			ctx,

--- a/infrastructure/sqlite/content_event_dedupe_test.go
+++ b/infrastructure/sqlite/content_event_dedupe_test.go
@@ -225,6 +225,7 @@ func TestStoreManagementDatasource_DedupeContentEvents_ApplyAndIdempotent(t *tes
 	if dedupeArchiveCount(t, dbPath) != 3 {
 		t.Fatalf("archive count = %d, want 3 after apply", dedupeArchiveCount(t, dbPath))
 	}
+	assertArchiveSequenceMappingCount(t, dbPath, 15)
 
 	// Read-surface exclusion: quarantined rows must not come back from ListRecent.
 	// Scope to workspace w1 so the deliberately malformed-timestamp fixture rows
@@ -287,6 +288,23 @@ func TestStoreManagementDatasource_RestoreContentEventDedupeRun(t *testing.T) {
 	// Restoring an unknown / already-restored run fails rather than silently succeeding.
 	if _, err := storeManager.RestoreContentEventDedupeRun(context.Background(), "dedupe-run-1"); err == nil {
 		t.Fatalf("expected error restoring an empty run")
+	}
+	assertArchiveSequenceMappingCount(t, dbPath, 15)
+}
+
+func assertArchiveSequenceMappingCount(t *testing.T, dbPath string, want int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var got int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM archive_event_sequences`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("archive sequence mapping count = %d, want %d", got, want)
 	}
 }
 

--- a/infrastructure/sqlite/event_delivery_store.go
+++ b/infrastructure/sqlite/event_delivery_store.go
@@ -200,7 +200,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		eventArgs = append(eventArgs, eventPayload.Codec, eventPayload.FormatVersion, eventPayload.PlaintextBytes, eventPayload.StoredBytes, eventPayload.SHA256)
 	}
 	if _, err := tx.ExecContext(ctx, eventQuery, eventArgs...); err != nil {
-		return xerrors.Errorf("failed to insert event: %w", err)
+		return xerrors.Errorf("failed to insert event: %w", mapArchiveSequenceWriteError(err))
 	}
 	if audit == nil {
 		return nil

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -42,6 +42,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	41: {41, "000041_add_search_projection_generation_lifecycle.sql", "f5fefcb1389cff1889fdd05cf1654838ac2e57556565dd96df32695e48d4c964", MigrationDataDependentOffline},
 	42: {42, "000042_add_bounded_search_projection_inventory.sql", "8d272ed8157458c864ac3ed84e6cfb9969b91b2c3ac31464b084ff1b5f4f8a53", MigrationDataDependentOffline},
 	43: {43, "000043_add_payload_codec_compatibility_mode.sql", "020c6dbb5dbea86c3c9989ad29babe333dc7c423ded6152aeddb37a67aa907e0", MigrationConstantInPlace},
+	44: {44, "000044_add_archive_sequence_inventory.sql", "18e270f1b4b974f54529fac3aa2ab1daf273797a51217c3bf3601bdbcbcc79f6", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 43 || len(plan.Pending) != 9 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 44 || len(plan.Pending) != 10 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -41,6 +41,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		41: MigrationDataDependentOffline,
 		42: MigrationDataDependentOffline,
 		43: MigrationConstantInPlace,
+		44: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 43 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 44 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/store_archive.go
+++ b/infrastructure/sqlite/store_archive.go
@@ -512,7 +512,7 @@ body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_
 		}
 		_, err = tx.ExecContext(ctx, query, args...)
 		if err != nil {
-			return xerrors.Errorf("insert events: %w", err)
+			return xerrors.Errorf("insert events: %w", mapArchiveSequenceWriteError(err))
 		}
 		return nil
 	case "command_audits":

--- a/infrastructure/sqlite/store_archive_test.go
+++ b/infrastructure/sqlite/store_archive_test.go
@@ -40,6 +40,10 @@ VALUES ('new-e1', 'note', 'cli', 'manual', 's1', '', 'body', '2099-01-01T00:00:0
 	if err != nil {
 		t.Fatal(err)
 	}
+	var oldSequence int64
+	if err := conn.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='old-e1'`).Scan(&oldSequence); err != nil {
+		t.Fatalf("archive insert did not receive sequence: %v", err)
+	}
 
 	sut := usecase.NewStoreManagementUsecase(storeManager)
 	archivePath := filepath.Join(dir, "out.trcaryar")
@@ -88,6 +92,13 @@ VALUES ('new-e1', 'note', 'cli', 'manual', 's1', '', 'body', '2099-01-01T00:00:0
 	if count != 1 {
 		t.Fatalf("old event not restored")
 	}
+	var restoredSequence int64
+	if err := conn.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='old-e1'`).Scan(&restoredSequence); err != nil {
+		t.Fatal(err)
+	}
+	if restoredSequence != oldSequence {
+		t.Fatalf("archive restore sequence = %d, want preserved %d", restoredSequence, oldSequence)
+	}
 
 	again, err := sut.RestoreStoreArchive(context.Background(), archivePath, nil, false)
 	if err != nil {
@@ -97,7 +108,6 @@ VALUES ('new-e1', 'note', 'cli', 'manual', 's1', '', 'body', '2099-01-01T00:00:0
 		t.Fatalf("second restore skipped=%d want >=1", again.Skipped)
 	}
 }
-
 
 func TestStoreArchive_listsLargeCommandAuditSetsWithoutVariableLimit(t *testing.T) {
 	t.Parallel()

--- a/schema/sqlite/migrations/000044_add_archive_sequence_inventory.sql
+++ b/schema/sqlite/migrations/000044_add_archive_sequence_inventory.sql
@@ -1,0 +1,67 @@
+-- Archive sequence state is independent from the retired search projection.
+-- This migration is intentionally data-independent: it installs singleton
+-- state and triggers, but never scans or backfills historical events.
+CREATE TABLE archive_store_lineage (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    store_id TEXT NOT NULL UNIQUE CHECK (length(store_id) = 32),
+    filter_key BLOB NOT NULL CHECK (typeof(filter_key) = 'blob' AND length(filter_key) = 32)
+);
+
+INSERT INTO archive_store_lineage(singleton, store_id, filter_key)
+VALUES (1, lower(hex(randomblob(16))), randomblob(32));
+
+CREATE TABLE archive_sequence_allocator (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    next_sequence INTEGER NOT NULL CHECK (next_sequence > 0)
+);
+
+INSERT INTO archive_sequence_allocator(singleton, next_sequence) VALUES (1, 1);
+
+CREATE TABLE archive_event_sequences (
+    event_id TEXT PRIMARY KEY,
+    sequence INTEGER NOT NULL UNIQUE CHECK (sequence > 0)
+);
+
+CREATE INDEX idx_archive_event_sequences_sequence_event
+    ON archive_event_sequences(sequence, event_id);
+
+CREATE TABLE archive_sequence_inventory_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    generation_id TEXT NOT NULL DEFAULT '',
+    config_hash TEXT NOT NULL DEFAULT '',
+    phase TEXT NOT NULL DEFAULT 'idle'
+        CHECK (phase IN ('idle', 'inventory', 'verifying', 'complete', 'failed')),
+    event_cursor TEXT NOT NULL DEFAULT '',
+    event_cursor_started INTEGER NOT NULL DEFAULT 0 CHECK (event_cursor_started IN (0, 1)),
+    verify_cursor INTEGER NOT NULL DEFAULT 0 CHECK (verify_cursor >= 0),
+    high_water INTEGER NOT NULL DEFAULT 0 CHECK (high_water >= 0),
+    revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+    failure_class TEXT NOT NULL DEFAULT ''
+);
+
+INSERT INTO archive_sequence_inventory_state(singleton) VALUES (1);
+
+CREATE TABLE archive_sequence_activation (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    active_generation_id TEXT NOT NULL DEFAULT '',
+    verified_high_water INTEGER NOT NULL DEFAULT 0 CHECK (verified_high_water >= 0)
+);
+
+INSERT INTO archive_sequence_activation(singleton) VALUES (1);
+
+CREATE TRIGGER archive_events_assign_sequence
+AFTER INSERT ON events
+BEGIN
+    SELECT CASE
+        WHEN NOT EXISTS (SELECT 1 FROM archive_event_sequences WHERE event_id = NEW.id)
+         AND (SELECT next_sequence FROM archive_sequence_allocator WHERE singleton = 1) >= 9223372036854775807
+        THEN RAISE(ABORT, 'archive sequence exhausted')
+    END;
+    UPDATE archive_sequence_allocator
+       SET next_sequence = next_sequence + 1
+     WHERE singleton = 1
+       AND NOT EXISTS (SELECT 1 FROM archive_event_sequences WHERE event_id = NEW.id);
+    INSERT INTO archive_event_sequences(event_id, sequence)
+    VALUES (NEW.id, (SELECT next_sequence - 1 FROM archive_sequence_allocator WHERE singleton = 1))
+    ON CONFLICT(event_id) DO NOTHING;
+END;


### PR DESCRIPTION
## Summary
- add migration 44 with stable store lineage, private filter key, and transactional event archive sequence allocation
- add bounded resumable inventory plus separate gap-free high-water verification and fail-closed activation
- cover ordinary, bundle, archive-restore, and dedupe event paths, including typed production overflow errors

## Validation
- `go test ./...`
- `go vet ./...`
- `go tool golangci-lint run --timeout=5m`
- GPT-5.6 Sol concurrency/integrity review: APPROVE after all blocking fixes

## Residual boundary
Terminal unmapped-event verification is context-bounded and may scan the event index. Catalog consumption remains in later #1650 children.

Closes #1660
