### PR TITLE
feat: add append-only segment catalog ledger

### DIFF
--- a/.ai/spec/1661-segment-catalog-ledger.md
+++ b/.ai/spec/1661-segment-catalog-ledger.md
@@ -1,0 +1,43 @@
+# Issue #1661: append-only Segment Catalog ledger
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Add a constant-time migration containing an append-only epoch/range ledger, immutable segment bindings, reservation/release deltas, and a rebuildable current-range cache.
+- Make an expected-head compare-and-swap the only epoch publication boundary. Each epoch binds its parent, canonical transition digest, caller evidence digest, and the preceding ledger digest.
+- Reconstruct a bounded source set at an old epoch from append-only boundary facts and one indexed latest covering transition with `epoch <= requested_epoch` per elementary range; never replay every epoch or copy the complete Catalog into every epoch.
+- Expose only the inventory gate, target reservation/release, bounded epoch reads, current reads, and deterministic cache rebuild in this issue. Proof-specific sealed/verified/authority/eviction ports remain owned by #1651-#1653.
+
+### Conceptual model
+
+| Concept | Invariant |
+|---|---|
+| Catalog head | Singleton epoch and ledger digest; advances only by expected-head CAS. |
+| Epoch | Immutable parent-linked commit binding source high-water, canonical transitions, and evidence. Ordinary head operations verify only the head and parent; a cursor-paged audit verifies the complete chain. |
+| Range transition | Append-only change over one closed archive-sequence interval; overlapping transitions in one epoch are invalid. |
+| Boundary set | Append-only distinct placement change points whose sorted digest/count is bound into every epoch and ledger digest; `source_high_water + 1` is an epoch-derived endpoint and is never persisted as a redundant boundary. Loss or drift fails closed. |
+| Range caps | Internal authenticated change-point scanning has its own hard cap; caller `Ranges` limits only the coalesced returned/current ranges, so redundant historical change points cannot publish an unreadable head. |
+| Reservation delta | `reserve` or `release`; release returns placement to `hot` and never creates an `abandoned` placement. |
+| Segment binding | Immutable store/lineage, interval, format, manifest, summary, logical/file digest, basename, and storage class facts. |
+| Current ranges | Derived cache only; its digest must equal deterministic replay of the ledger. |
+
+### Responsibilities and boundaries
+
+Domain values validate epochs, ranges, placement transitions, digests, and bindings without SQL. Application types define bounded commands/results and typed errors. SQLite owns expected-head transactions, append ordering, indexed replay, cache replacement, and migration identity. Callers own proof evidence; later issues receive separate proof-specific ports and cannot use a generic state setter.
+
+### Behavior tests and TDD plan
+
+1. Prove migration 45 is data-independent and its exact name/digest/class is cataloged.
+2. Prove reservation requires an activated, gap-free archive inventory and rejects stale heads, overlap, gaps, lineage drift, invalid digests, reservation-ID reuse, and every transition except `hot -> reserved -> hot`.
+3. Prove release appends a delta and restores `hot` without deleting history or inventing `abandoned`.
+4. Prove indexed old-epoch reconstruction, cursor-paged full audit, deterministic/idempotent current rebuild, ledger/cache digest agreement, and constant head-path work beyond 10,000 epochs.
+5. Prove segment binding mismatch/immutability, boundary-cache deletion detection, canonical reservation-ID whitespace behavior, missing audit-tail detection, and that metadata discovery alone cannot create authority.
+
+### Rollback and risks
+
+Migration 45 is additive and constant-time. An older binary ignores the tables. Ledger rows and bindings are protected from update/delete by triggers. Cache loss is repairable from the ledger; cache drift fails closed until explicit rebuild. Ledger loss, parent/digest drift, unknown transitions, and binding contradictions are not repaired from manifests because that would invent authority. Schema downgrade requires restoring a pre-migration backup.
+
+### Design checkpoint
+
+Approved shape: one append-only hash-chained epoch ledger, interval deltas, immutable bindings, and a non-authoritative current cache. This issue permits only `hot -> reserved -> hot`; later proof-bearing operations add their dedicated transitions.

--- a/application/segment_catalog.go
+++ b/application/segment_catalog.go
@@ -1,0 +1,30 @@
+package application
+
+import (
+	"context"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// CatalogInventoryGateReader proves archive-sequence readiness without exposing private keys.
+type CatalogInventoryGateReader interface {
+	CatalogInventoryGate(context.Context, apptypes.CatalogBudget) (apptypes.CatalogInventoryGate, error)
+}
+
+// CatalogTargetReservationStore owns proof-free target reserve/release epochs.
+type CatalogTargetReservationStore interface {
+	ReserveCatalogTarget(context.Context, apptypes.CatalogReservation) (apptypes.CatalogHead, error)
+	ReleaseCatalogReservation(context.Context, apptypes.CatalogRelease) (apptypes.CatalogHead, error)
+}
+
+// CatalogRangeReader returns current or epoch-pinned derived source ranges.
+type CatalogRangeReader interface {
+	CurrentCatalogRanges(context.Context, apptypes.CatalogBudget) (apptypes.CatalogSnapshot, error)
+	CatalogRangesAtEpoch(context.Context, int64, apptypes.CatalogBudget) (apptypes.CatalogSnapshot, error)
+}
+
+// CatalogCurrentRebuilder repairs only the non-authoritative derived cache.
+type CatalogCurrentRebuilder interface {
+	RebuildCatalogCurrentRanges(context.Context, apptypes.CatalogHead, apptypes.CatalogBudget) (apptypes.CatalogRebuildResult, error)
+	AuditCatalogLedgerPage(context.Context, apptypes.CatalogAuditCursor, apptypes.CatalogBudget) (apptypes.CatalogAuditPage, error)
+}

--- a/application/types/segment_catalog.go
+++ b/application/types/segment_catalog.go
@@ -1,0 +1,129 @@
+package types
+
+import (
+	"errors"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+var (
+	// ErrCatalogStaleHead identifies a failed expected-head compare-and-swap.
+	ErrCatalogStaleHead = errors.New("segment catalog stale head")
+	// ErrCatalogInventoryGate identifies an inactive or contradictory sequence inventory.
+	ErrCatalogInventoryGate = errors.New("segment catalog inventory gate failed")
+	// ErrCatalogOverlap identifies a transition over a non-Hot reserved range.
+	ErrCatalogOverlap = errors.New("segment catalog range overlap")
+	// ErrCatalogGap identifies a transition outside the proven source range.
+	ErrCatalogGap = errors.New("segment catalog illegal gap")
+	// ErrCatalogIllegalTransition identifies an unproven placement state edge.
+	ErrCatalogIllegalTransition = errors.New("segment catalog illegal transition")
+	// ErrCatalogLineageMismatch identifies metadata for another logical store.
+	ErrCatalogLineageMismatch = errors.New("segment catalog lineage mismatch")
+	// ErrCatalogBindingMismatch identifies contradictory immutable segment metadata.
+	ErrCatalogBindingMismatch = errors.New("segment catalog binding mismatch")
+	// ErrCatalogDrift identifies ledger, chain, or derived-cache corruption.
+	ErrCatalogDrift = errors.New("segment catalog ledger or cache drift")
+	// ErrCatalogNotFound identifies a missing active reservation.
+	ErrCatalogNotFound = errors.New("segment catalog reservation not found")
+	// ErrCatalogReservationConflict identifies reuse of an immutable reservation ID.
+	ErrCatalogReservationConflict = errors.New("segment catalog reservation conflict")
+	// ErrCatalogLimit identifies an invalid or exceeded operation bound.
+	ErrCatalogLimit = errors.New("segment catalog operation limit exceeded")
+)
+
+const (
+	// CatalogMaxRanges is the hard per-call replay range/epoch cap.
+	CatalogMaxRanges = 10_000
+	// CatalogMaxTransitionsPerEpoch bounds one atomic epoch independently of age.
+	CatalogMaxTransitionsPerEpoch = 1_000
+	// CatalogMaxBoundaryPoints bounds internal change-point validation independently of returned ranges.
+	CatalogMaxBoundaryPoints = 100_000
+	// CatalogMaxWallTime is the hard per-call elapsed cap.
+	CatalogMaxWallTime = 2 * time.Minute
+	// CatalogMaxLockTime is the hard per-call lock-wait cap.
+	CatalogMaxLockTime = 30 * time.Second
+)
+
+// CatalogBudget bounds one ledger operation.
+type CatalogBudget struct {
+	Ranges   int
+	WallTime time.Duration
+	LockTime time.Duration
+}
+
+// Valid reports whether each independent cap is positive and bounded.
+func (b CatalogBudget) Valid() bool {
+	return b.Ranges > 0 && b.Ranges <= CatalogMaxRanges && b.WallTime > 0 && b.WallTime <= CatalogMaxWallTime && b.LockTime > 0 && b.LockTime <= CatalogMaxLockTime
+}
+
+// CatalogHead is the expected-head CAS token and derived-cache digest.
+type CatalogHead struct {
+	Epoch               int64
+	LedgerDigest        string
+	CurrentRangesDigest string
+}
+
+// CatalogInventoryGate is aggregate-only readiness for target planning.
+type CatalogInventoryGate struct {
+	StoreID   string
+	HighWater int64
+	Head      CatalogHead
+}
+
+// CatalogReservation requests one proof-free Hot-to-reserved transition.
+type CatalogReservation struct {
+	ExpectedHead   CatalogHead
+	ReservationID  string
+	Range          domain.CatalogRange
+	EvidenceDigest string
+	Budget         CatalogBudget
+}
+
+// CatalogRelease requests release of one exact active reservation.
+type CatalogRelease struct {
+	ExpectedHead   CatalogHead
+	ReservationID  string
+	EvidenceDigest string
+	Budget         CatalogBudget
+}
+
+// CatalogCurrentRange is one non-overlapping derived placement interval.
+type CatalogCurrentRange struct {
+	Range         domain.CatalogRange
+	Placement     domain.CatalogPlacement
+	ReservationID string
+	SegmentID     string
+	SourceEpoch   int64
+}
+
+// CatalogSnapshot is an epoch-pinned bounded source set.
+type CatalogSnapshot struct {
+	Head   CatalogHead
+	Ranges []CatalogCurrentRange
+}
+
+// CatalogRebuildResult reports aggregate cache rebuild evidence.
+type CatalogRebuildResult struct {
+	Head    CatalogHead
+	Ranges  int
+	Changed bool
+}
+
+// CatalogAuditCursor is a resumable hash-chain checkpoint.
+type CatalogAuditCursor struct {
+	Epoch        int64
+	LedgerDigest string
+}
+
+// InitialCatalogAuditCursor returns the canonical genesis checkpoint.
+func InitialCatalogAuditCursor() CatalogAuditCursor {
+	return CatalogAuditCursor{LedgerDigest: "0000000000000000000000000000000000000000000000000000000000000000"}
+}
+
+// CatalogAuditPage is aggregate-only bounded full-ledger audit evidence.
+type CatalogAuditPage struct {
+	Next     CatalogAuditCursor
+	Verified int
+	Done     bool
+}

--- a/domain/segment_catalog.go
+++ b/domain/segment_catalog.go
@@ -1,0 +1,262 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"strings"
+)
+
+var (
+	// ErrCatalogRangeInvalid identifies an invalid or overlapping closed range.
+	ErrCatalogRangeInvalid = errors.New("catalog range is invalid")
+	// ErrCatalogDigestInvalid identifies a malformed or contradictory digest chain.
+	ErrCatalogDigestInvalid = errors.New("catalog digest is invalid")
+	// ErrCatalogTransitionIllegal identifies an unsupported placement edge.
+	ErrCatalogTransitionIllegal = errors.New("catalog transition is illegal")
+	// ErrCatalogBindingInvalid identifies malformed immutable segment metadata.
+	ErrCatalogBindingInvalid = errors.New("catalog segment binding is invalid")
+)
+
+// CatalogPlacement is the authority placement of a closed sequence range.
+type CatalogPlacement string
+
+const (
+	// CatalogPlacementHot means the canonical unit is authoritative in Hot.
+	CatalogPlacementHot CatalogPlacement = "hot"
+	// CatalogPlacementReserved means a target owns the range without changing authority.
+	CatalogPlacementReserved CatalogPlacement = "reserved"
+	// CatalogPlacementSealed means a proof-bearing immutable candidate exists.
+	CatalogPlacementSealed CatalogPlacement = "sealed"
+	// CatalogPlacementVerifiedShadow means the segment passed shadow verification.
+	CatalogPlacementVerifiedShadow CatalogPlacement = "verified_shadow"
+	// CatalogPlacementSegmentAuthoritative means the segment is the read authority.
+	CatalogPlacementSegmentAuthoritative CatalogPlacement = "segment_authoritative"
+	// CatalogPlacementEvicting means proven Hot duplicates are being reclaimed.
+	CatalogPlacementEvicting CatalogPlacement = "evicting"
+	// CatalogPlacementCold means physical reclaim completed.
+	CatalogPlacementCold CatalogPlacement = "cold"
+)
+
+// Valid reports whether placement is part of the versioned state vocabulary.
+func (p CatalogPlacement) Valid() bool {
+	switch p {
+	case CatalogPlacementHot, CatalogPlacementReserved, CatalogPlacementSealed,
+		CatalogPlacementVerifiedShadow, CatalogPlacementSegmentAuthoritative,
+		CatalogPlacementEvicting, CatalogPlacementCold:
+		return true
+	default:
+		return false
+	}
+}
+
+// CatalogRange is a closed positive archive-sequence range.
+type CatalogRange struct {
+	Start int64
+	End   int64
+}
+
+// NewCatalogRange validates and constructs a closed positive interval.
+func NewCatalogRange(start, end int64) (CatalogRange, error) {
+	if start <= 0 || end < start {
+		return CatalogRange{}, ErrCatalogRangeInvalid
+	}
+	return CatalogRange{Start: start, End: end}, nil
+}
+
+// Overlaps reports whether two closed intervals share a sequence.
+func (r CatalogRange) Overlaps(other CatalogRange) bool {
+	return r.Start <= other.End && other.Start <= r.End
+}
+
+// CatalogTransition is one canonical append-only range delta.
+type CatalogTransition struct {
+	Range         CatalogRange
+	From          CatalogPlacement
+	To            CatalogPlacement
+	ReservationID string
+	SegmentID     string
+}
+
+// NewCatalogTransition validates one canonical range delta.
+func NewCatalogTransition(r CatalogRange, from, to CatalogPlacement, reservationID, segmentID string) (CatalogTransition, error) {
+	if _, err := NewCatalogRange(r.Start, r.End); err != nil {
+		return CatalogTransition{}, err
+	}
+	if !from.Valid() || !to.Valid() || from == to {
+		return CatalogTransition{}, ErrCatalogTransitionIllegal
+	}
+	reservationID = strings.TrimSpace(reservationID)
+	segmentID = strings.TrimSpace(segmentID)
+	if (from == CatalogPlacementReserved || to == CatalogPlacementReserved) != (reservationID != "") {
+		return CatalogTransition{}, ErrCatalogTransitionIllegal
+	}
+	allowedReservationEdge := (from == CatalogPlacementHot && to == CatalogPlacementReserved) || (from == CatalogPlacementReserved && to == CatalogPlacementHot)
+	if !allowedReservationEdge || segmentID != "" {
+		return CatalogTransition{}, ErrCatalogTransitionIllegal
+	}
+	return CatalogTransition{Range: r, From: from, To: to, ReservationID: reservationID, SegmentID: segmentID}, nil
+}
+
+// ReservationTransition permits only the proof-free #1661 state edge.
+func ReservationTransition(r CatalogRange, reservationID string) (CatalogTransition, error) {
+	return NewCatalogTransition(r, CatalogPlacementHot, CatalogPlacementReserved, reservationID, "")
+}
+
+// ReleaseReservationTransition returns a reservation to Hot. It deliberately
+// does not introduce an abandoned placement state.
+func ReleaseReservationTransition(r CatalogRange, reservationID string) (CatalogTransition, error) {
+	return NewCatalogTransition(r, CatalogPlacementReserved, CatalogPlacementHot, reservationID, "")
+}
+
+// CanonicalCatalogTransitionDigest deterministically binds an ordered epoch.
+func CanonicalCatalogTransitionDigest(transitions []CatalogTransition) (string, error) {
+	h := sha256.New()
+	writeCatalogFrame(h, []byte("traceary/catalog-transitions/v1"))
+	previousEnd := int64(0)
+	for i, transition := range transitions {
+		validated, err := NewCatalogTransition(transition.Range, transition.From, transition.To, transition.ReservationID, transition.SegmentID)
+		if err != nil {
+			return "", err
+		}
+		if i > 0 && validated.Range.Start <= previousEnd {
+			return "", ErrCatalogRangeInvalid
+		}
+		previousEnd = validated.Range.End
+		var number [8]byte
+		binary.BigEndian.PutUint64(number[:], uint64(validated.Range.Start))
+		writeCatalogFrame(h, number[:])
+		binary.BigEndian.PutUint64(number[:], uint64(validated.Range.End))
+		writeCatalogFrame(h, number[:])
+		writeCatalogFrame(h, []byte(validated.From))
+		writeCatalogFrame(h, []byte(validated.To))
+		writeCatalogFrame(h, []byte(validated.ReservationID))
+		writeCatalogFrame(h, []byte(validated.SegmentID))
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeCatalogFrame(h interface{ Write([]byte) (int, error) }, value []byte) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = h.Write(size[:])
+	_, _ = h.Write(value)
+}
+
+// ValidCatalogDigest accepts only lower-case SHA-256 hex.
+func ValidCatalogDigest(value string) bool {
+	if len(value) != sha256.Size*2 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+// CatalogLedgerDigest chains an epoch to its exact parent and evidence.
+func CatalogLedgerDigest(parentDigest string, epoch, parentEpoch, sourceHighWater, boundaryCount int64, transitionDigest, boundaryDigest, evidenceDigest string) (string, error) {
+	if epoch <= 0 || parentEpoch != epoch-1 || sourceHighWater <= 0 || boundaryCount < 1 || !ValidCatalogDigest(parentDigest) || !ValidCatalogDigest(transitionDigest) || !ValidCatalogDigest(boundaryDigest) || !ValidCatalogDigest(evidenceDigest) {
+		return "", ErrCatalogDigestInvalid
+	}
+	h := sha256.New()
+	writeCatalogFrame(h, []byte("traceary/catalog-ledger/v1"))
+	writeCatalogFrame(h, []byte(parentDigest))
+	var number [8]byte
+	binary.BigEndian.PutUint64(number[:], uint64(epoch))
+	writeCatalogFrame(h, number[:])
+	binary.BigEndian.PutUint64(number[:], uint64(parentEpoch))
+	writeCatalogFrame(h, number[:])
+	binary.BigEndian.PutUint64(number[:], uint64(sourceHighWater))
+	writeCatalogFrame(h, number[:])
+	writeCatalogFrame(h, []byte(transitionDigest))
+	binary.BigEndian.PutUint64(number[:], uint64(boundaryCount))
+	writeCatalogFrame(h, number[:])
+	writeCatalogFrame(h, []byte(boundaryDigest))
+	writeCatalogFrame(h, []byte(evidenceDigest))
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// CanonicalCatalogBoundaryDigest binds a sorted unique positive boundary set.
+func CanonicalCatalogBoundaryDigest(boundaries []int64) (string, error) {
+	h := sha256.New()
+	writeCatalogFrame(h, []byte("traceary/catalog-boundaries/v1"))
+	previous := int64(0)
+	for _, boundary := range boundaries {
+		if boundary <= previous {
+			return "", ErrCatalogRangeInvalid
+		}
+		var number [8]byte
+		binary.BigEndian.PutUint64(number[:], uint64(boundary))
+		writeCatalogFrame(h, number[:])
+		previous = boundary
+	}
+	if len(boundaries) < 1 {
+		return "", ErrCatalogRangeInvalid
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// CatalogSegmentBinding contains fixed immutable, non-authority metadata.
+type CatalogSegmentBinding struct {
+	identity                                  SegmentIdentity
+	fileDigest, manifestDigest, summaryDigest [sha256.Size]byte
+}
+
+// NewCatalogSegmentBinding constructs fixed format-v1 metadata from the
+// canonical #1649 identity and validated SHA-256 values.
+func NewCatalogSegmentBinding(identity SegmentIdentity, fileDigest, manifestDigest, summaryDigest [sha256.Size]byte) (CatalogSegmentBinding, error) {
+	if identity.FormatVersion != SegmentFormatV1 || identity.StoreID == "" || identity.StartSequence == 0 || identity.EndSequence < identity.StartSequence {
+		return CatalogSegmentBinding{}, ErrCatalogBindingInvalid
+	}
+	return CatalogSegmentBinding{identity: identity, fileDigest: fileDigest, manifestDigest: manifestDigest, summaryDigest: summaryDigest}, nil
+}
+
+// Validate checks the fixed identity lineage.
+func (b CatalogSegmentBinding) Validate(expectedStoreID string) error {
+	if b.identity.StoreID != expectedStoreID || len(expectedStoreID) != 32 || b.identity.FormatVersion != SegmentFormatV1 || b.identity.Basename() == "" {
+		return ErrCatalogBindingInvalid
+	}
+	return nil
+}
+
+// SegmentID returns the content-addressed identity.
+func (b CatalogSegmentBinding) SegmentID() string { return b.identity.Basename() }
+
+// StoreID returns the bound lineage.
+func (b CatalogSegmentBinding) StoreID() string { return b.identity.StoreID }
+
+// Range returns the bound closed archive-sequence range.
+func (b CatalogSegmentBinding) Range() CatalogRange {
+	return CatalogRange{Start: int64(b.identity.StartSequence), End: int64(b.identity.EndSequence)}
+}
+
+// FormatVersion returns the fixed segment format.
+func (b CatalogSegmentBinding) FormatVersion() int { return int(SegmentFormatV1) }
+
+// ManifestVersion returns the fixed manifest schema version.
+func (b CatalogSegmentBinding) ManifestVersion() int { return 1 }
+
+// SummaryVersion returns the fixed Catalog summary version.
+func (b CatalogSegmentBinding) SummaryVersion() int { return int(SegmentSummaryV1) }
+
+// LogicalDigest returns the canonical logical SHA-256.
+func (b CatalogSegmentBinding) LogicalDigest() string {
+	return hex.EncodeToString(b.identity.LogicalDigest[:])
+}
+
+// FileDigest returns the sealed file SHA-256.
+func (b CatalogSegmentBinding) FileDigest() string { return hex.EncodeToString(b.fileDigest[:]) }
+
+// ManifestDigest returns the manifest SHA-256.
+func (b CatalogSegmentBinding) ManifestDigest() string {
+	return hex.EncodeToString(b.manifestDigest[:])
+}
+
+// SummaryDigest returns the immutable summary SHA-256.
+func (b CatalogSegmentBinding) SummaryDigest() string { return hex.EncodeToString(b.summaryDigest[:]) }
+
+// RelativeBasename returns the recomputed content-addressed basename.
+func (b CatalogSegmentBinding) RelativeBasename() string { return b.identity.Basename() }
+
+// StorageClass returns the fixed format-v1 storage class.
+func (b CatalogSegmentBinding) StorageClass() string { return "sealed_sqlite_zstd_v1" }

--- a/domain/segment_catalog_test.go
+++ b/domain/segment_catalog_test.go
@@ -1,0 +1,60 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestCatalogTransitionDigestRejectsOverlap(t *testing.T) {
+	one, _ := domain.ReservationTransition(domain.CatalogRange{Start: 1, End: 3}, "a")
+	two, _ := domain.ReservationTransition(domain.CatalogRange{Start: 3, End: 4}, "b")
+	_, err := domain.CanonicalCatalogTransitionDigest([]domain.CatalogTransition{one, two})
+	if !errors.Is(err, domain.ErrCatalogRangeInvalid) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestReleaseReservationReturnsHotWithoutAbandonedState(t *testing.T) {
+	transition, err := domain.ReleaseReservationTransition(domain.CatalogRange{Start: 2, End: 5}, "target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.From != domain.CatalogPlacementReserved || transition.To != domain.CatalogPlacementHot {
+		t.Fatalf("transition = %+v", transition)
+	}
+}
+
+func TestGenericCatalogTransitionRejectsProofBearingEdges(t *testing.T) {
+	_, err := domain.NewCatalogTransition(domain.CatalogRange{Start: 1, End: 1}, domain.CatalogPlacementReserved, domain.CatalogPlacementSealed, "target", "segment")
+	if !errors.Is(err, domain.ErrCatalogTransitionIllegal) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCatalogLedgerDigestBindsParent(t *testing.T) {
+	zero := "0000000000000000000000000000000000000000000000000000000000000000"
+	boundaryDigest, err := domain.CanonicalCatalogBoundaryDigest([]int64{1, 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	one, err := domain.CatalogLedgerDigest(zero, 1, 0, 1, 2, zero, boundaryDigest, zero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := domain.CatalogLedgerDigest(one, 2, 1, 2, 2, zero, boundaryDigest, zero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if one == two {
+		t.Fatal("ledger digest did not change")
+	}
+	otherHighWater, err := domain.CatalogLedgerDigest(zero, 1, 0, 2, 2, zero, boundaryDigest, zero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherHighWater == one {
+		t.Fatal("source high-water was not digest-bound")
+	}
+}

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -43,6 +43,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	42: {42, "000042_add_bounded_search_projection_inventory.sql", "8d272ed8157458c864ac3ed84e6cfb9969b91b2c3ac31464b084ff1b5f4f8a53", MigrationDataDependentOffline},
 	43: {43, "000043_add_payload_codec_compatibility_mode.sql", "020c6dbb5dbea86c3c9989ad29babe333dc7c423ded6152aeddb37a67aa907e0", MigrationConstantInPlace},
 	44: {44, "000044_add_archive_sequence_inventory.sql", "18e270f1b4b974f54529fac3aa2ab1daf273797a51217c3bf3601bdbcbcc79f6", MigrationConstantInPlace},
+	45: {45, "000045_add_segment_catalog_ledger.sql", "00802c1fe48e30ef1fd5ffc2e1c22e33bc8f32c6ea66d52e869d0362172d0982", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 44 || len(plan.Pending) != 10 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 45 || len(plan.Pending) != 11 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -42,6 +42,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		42: MigrationDataDependentOffline,
 		43: MigrationConstantInPlace,
 		44: MigrationConstantInPlace,
+		45: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 44 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 45 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/segment_catalog.go
+++ b/infrastructure/sqlite/segment_catalog.go
@@ -1,0 +1,969 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+const emptyCatalogDigestValue = "0000000000000000000000000000000000000000000000000000000000000000"
+
+var (
+	_ application.CatalogInventoryGateReader    = (*Database)(nil)
+	_ application.CatalogTargetReservationStore = (*Database)(nil)
+	_ application.CatalogRangeReader            = (*Database)(nil)
+	_ application.CatalogCurrentRebuilder       = (*Database)(nil)
+)
+
+type catalogEpochCommit struct {
+	expected       apptypes.CatalogHead
+	highWater      int64
+	transitions    []domain.CatalogTransition
+	evidenceDigest string
+	reservationID  string
+	delta          string
+	// boundaryPointLimit is a test-only lower hard-cap seam. Zero selects the
+	// production CatalogMaxBoundaryPoints constant.
+	boundaryPointLimit int
+}
+
+func boundedCatalogContext(parent context.Context, budget apptypes.CatalogBudget) (context.Context, context.CancelFunc) {
+	timeout := budget.WallTime
+	if budget.LockTime < timeout {
+		timeout = budget.LockTime
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func readCatalogHead(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (apptypes.CatalogHead, error) {
+	var head apptypes.CatalogHead
+	err := q.QueryRowContext(ctx, `SELECT current_epoch,ledger_digest,current_ranges_digest FROM archive_catalog_head WHERE singleton=1`).Scan(&head.Epoch, &head.LedgerDigest, &head.CurrentRangesDigest)
+	return head, err
+}
+
+// ReserveCatalogTarget appends a Hot-to-reserved transition after proving the
+// sequence inventory is active and the expected Catalog head is current.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) ReserveCatalogTarget(ctx context.Context, command apptypes.CatalogReservation) (apptypes.CatalogHead, error) {
+	command.ReservationID = strings.TrimSpace(command.ReservationID)
+	if !command.Budget.Valid() || command.ReservationID == "" || len(command.ReservationID) > 255 || !domain.ValidCatalogDigest(command.EvidenceDigest) {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogLimit
+	}
+	transition, err := domain.ReservationTransition(command.Range, command.ReservationID)
+	if err != nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogIllegalTransition
+	}
+	opCtx, cancel := boundedCatalogContext(ctx, command.Budget)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(opCtx, nil)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	highWater, err := checkCatalogInventoryGate(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if command.Range.End > highWater {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogGap
+	}
+	actual, err := readCatalogHead(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	reserveRange, reserved, released, reserveEvidence, _, err := catalogReservationHistory(opCtx, tx, command.ReservationID)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if reserved {
+		if reserveRange != command.Range || released || reserveEvidence != command.EvidenceDigest {
+			return apptypes.CatalogHead{}, apptypes.ErrCatalogReservationConflict
+		}
+		if err = verifyCatalogHeadIncremental(opCtx, tx, actual); err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+		return actual, nil
+	}
+	head, err := commitCatalogEpoch(opCtx, tx, catalogEpochCommit{expected: command.ExpectedHead, highWater: highWater, transitions: []domain.CatalogTransition{transition}, evidenceDigest: command.EvidenceDigest, reservationID: command.ReservationID, delta: "reserve"}, command.Budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	return head, nil
+}
+
+// ReleaseCatalogReservation appends the inverse delta for the exact active
+// reservation. History is retained; placement returns to Hot.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) ReleaseCatalogReservation(ctx context.Context, command apptypes.CatalogRelease) (apptypes.CatalogHead, error) {
+	command.ReservationID = strings.TrimSpace(command.ReservationID)
+	if !command.Budget.Valid() || command.ReservationID == "" || !domain.ValidCatalogDigest(command.EvidenceDigest) {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := boundedCatalogContext(ctx, command.Budget)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(opCtx, nil)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	highWater, err := checkCatalogInventoryGate(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	actual, err := readCatalogHead(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	reserveRange, reserved, released, _, releaseEvidence, err := catalogReservationHistory(opCtx, tx, command.ReservationID)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if !reserved {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogNotFound
+	}
+	if released {
+		if releaseEvidence != command.EvidenceDigest {
+			return apptypes.CatalogHead{}, apptypes.ErrCatalogReservationConflict
+		}
+		if err = verifyCatalogHeadIncremental(opCtx, tx, actual); err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+		return actual, nil
+	}
+	replayHighWater := highWater
+	if actual.Epoch > 0 {
+		if err = tx.QueryRowContext(opCtx, `SELECT source_high_water FROM archive_catalog_epochs WHERE epoch=?`, actual.Epoch).Scan(&replayHighWater); err != nil {
+			return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+		}
+	}
+	ranges, err := replayCatalogRanges(opCtx, tx, actual.Epoch, replayHighWater, command.Budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	var found *apptypes.CatalogCurrentRange
+	for i := range ranges {
+		if ranges[i].Placement == domain.CatalogPlacementReserved && ranges[i].ReservationID == command.ReservationID {
+			if found != nil {
+				return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+			}
+			found = &ranges[i]
+		}
+	}
+	if found == nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+	}
+	if found.Range != reserveRange {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+	}
+	transition, err := domain.ReleaseReservationTransition(found.Range, command.ReservationID)
+	if err != nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogIllegalTransition
+	}
+	head, err := commitCatalogEpoch(opCtx, tx, catalogEpochCommit{expected: command.ExpectedHead, highWater: highWater, transitions: []domain.CatalogTransition{transition}, evidenceDigest: command.EvidenceDigest, reservationID: command.ReservationID, delta: "release"}, command.Budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	return head, nil
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func catalogReservationHistory(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, reservationID string) (domain.CatalogRange, bool, bool, string, string, error) {
+	rows, err := q.QueryContext(ctx, `SELECT d.delta,d.start_sequence,d.end_sequence,e.evidence_digest FROM archive_catalog_reservation_deltas d JOIN archive_catalog_epochs e ON e.epoch=d.epoch WHERE d.reservation_id=? ORDER BY d.epoch`, reservationID)
+	if err != nil {
+		return domain.CatalogRange{}, false, false, "", "", err
+	}
+	defer func() { _ = rows.Close() }()
+	var result domain.CatalogRange
+	var reserved, released bool
+	var reserveEvidence, releaseEvidence string
+	for rows.Next() {
+		var delta, evidence string
+		var current domain.CatalogRange
+		if err = rows.Scan(&delta, &current.Start, &current.End, &evidence); err != nil {
+			return domain.CatalogRange{}, false, false, "", "", err
+		}
+		switch delta {
+		case "reserve":
+			if reserved {
+				return domain.CatalogRange{}, false, false, "", "", apptypes.ErrCatalogDrift
+			}
+			result = current
+			reserveEvidence = evidence
+			reserved = true
+		case "release":
+			if !reserved || released || current != result {
+				return domain.CatalogRange{}, false, false, "", "", apptypes.ErrCatalogDrift
+			}
+			releaseEvidence = evidence
+			released = true
+		default:
+			return domain.CatalogRange{}, false, false, "", "", apptypes.ErrCatalogDrift
+		}
+	}
+	return result, reserved, released, reserveEvidence, releaseEvidence, rows.Err()
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func checkCatalogInventoryGate(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (int64, error) {
+	var activeID, generationID, phase string
+	var verified, next int64
+	err := q.QueryRowContext(ctx, `SELECT a.active_generation_id,a.verified_high_water,s.generation_id,s.phase,x.next_sequence FROM archive_sequence_activation a JOIN archive_sequence_inventory_state s ON s.singleton=1 JOIN archive_sequence_allocator x ON x.singleton=1 WHERE a.singleton=1`).Scan(&activeID, &verified, &generationID, &phase, &next)
+	if err != nil {
+		return 0, err
+	}
+	if activeID == "" || activeID != generationID || phase != "complete" || verified <= 0 || next <= verified || next <= 1 {
+		return 0, apptypes.ErrCatalogInventoryGate
+	}
+	var mapped, events int64
+	if err = q.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM archive_event_sequences),(SELECT count(*) FROM events)`).Scan(&mapped, &events); err != nil {
+		return 0, err
+	}
+	if mapped != events || mapped != next-1 {
+		return 0, apptypes.ErrCatalogInventoryGate
+	}
+	return next - 1, nil
+}
+
+// CatalogInventoryGate returns aggregate sequence readiness and current head.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) CatalogInventoryGate(ctx context.Context, budget apptypes.CatalogBudget) (apptypes.CatalogInventoryGate, error) {
+	if !budget.Valid() {
+		return apptypes.CatalogInventoryGate{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogInventoryGate{}, err
+	}
+	defer d.release(db)
+	highWater, err := checkCatalogInventoryGate(opCtx, db)
+	if err != nil {
+		return apptypes.CatalogInventoryGate{}, err
+	}
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil {
+		return apptypes.CatalogInventoryGate{}, err
+	}
+	var storeID string
+	if err = db.QueryRowContext(opCtx, `SELECT store_id FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID); err != nil {
+		return apptypes.CatalogInventoryGate{}, err
+	}
+	return apptypes.CatalogInventoryGate{StoreID: storeID, HighWater: highWater, Head: head}, nil
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func commitCatalogEpoch(ctx context.Context, tx *sql.Tx, commit catalogEpochCommit, maxRanges int) (apptypes.CatalogHead, error) {
+	actual, err := readCatalogHead(ctx, tx)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if actual != commit.expected {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogStaleHead
+	}
+	if err = verifyCatalogHeadIncremental(ctx, tx, actual); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if !domain.ValidCatalogDigest(commit.evidenceDigest) || commit.highWater <= 0 {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+	}
+	transitionDigest, err := domain.CanonicalCatalogTransitionDigest(commit.transitions)
+	if err != nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogOverlap
+	}
+	previousHighWater := commit.highWater
+	if actual.Epoch > 0 {
+		if err = tx.QueryRowContext(ctx, `SELECT source_high_water FROM archive_catalog_epochs WHERE epoch=?`, actual.Epoch).Scan(&previousHighWater); err != nil {
+			return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+		}
+		if previousHighWater > commit.highWater {
+			return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+		}
+	}
+	current, err := replayCatalogRanges(ctx, tx, actual.Epoch, previousHighWater, maxRanges)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	tailWasHot := current[len(current)-1].Placement == domain.CatalogPlacementHot
+	if commit.highWater > previousHighWater {
+		tail := &current[len(current)-1]
+		if tail.Placement == domain.CatalogPlacementHot {
+			tail.Range.End = commit.highWater
+		} else {
+			current = append(current, apptypes.CatalogCurrentRange{Range: domain.CatalogRange{Start: previousHighWater + 1, End: commit.highWater}, Placement: domain.CatalogPlacementHot})
+		}
+	}
+	for _, transition := range commit.transitions {
+		current, err = applyCatalogTransition(current, transition)
+		if err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+	}
+	current = coalesceCatalogRanges(current)
+	if len(current) > maxRanges {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogLimit
+	}
+	newEpoch := actual.Epoch + 1
+	boundaries, err := catalogBoundarySet(ctx, tx, actual.Epoch, previousHighWater)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if commit.highWater > previousHighWater && !tailWasHot {
+		boundaries = append(boundaries, previousHighWater+1)
+	}
+	for _, transition := range commit.transitions {
+		boundaries = append(boundaries, transition.Range.Start)
+		if transition.Range.End < commit.highWater {
+			boundaries = append(boundaries, transition.Range.End+1)
+		}
+	}
+	boundaries = uniqueSortedBoundaries(boundaries)
+	boundaryPointLimit := commit.boundaryPointLimit
+	if boundaryPointLimit == 0 {
+		boundaryPointLimit = apptypes.CatalogMaxBoundaryPoints
+	}
+	if len(boundaries) > boundaryPointLimit {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogLimit
+	}
+	boundaryDigest, err := domain.CanonicalCatalogBoundaryDigest(boundaries)
+	if err != nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+	}
+	ledgerDigest, err := domain.CatalogLedgerDigest(actual.LedgerDigest, newEpoch, actual.Epoch, commit.highWater, int64(len(boundaries)), transitionDigest, boundaryDigest, commit.evidenceDigest)
+	if err != nil {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogDrift
+	}
+	currentDigest := digestCatalogRanges(current)
+	result, err := tx.ExecContext(ctx, `UPDATE archive_catalog_head SET current_epoch=?,ledger_digest=?,current_ranges_digest=? WHERE singleton=1 AND current_epoch=? AND ledger_digest=? AND current_ranges_digest=?`, newEpoch, ledgerDigest, currentDigest, actual.Epoch, actual.LedgerDigest, actual.CurrentRangesDigest)
+	if err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil || changed != 1 {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogStaleHead
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_epochs(epoch,parent_epoch,transition_digest,evidence_digest,parent_ledger_digest,source_high_water,boundary_count,boundary_digest,ledger_digest,committed_at) VALUES(?,?,?,?,?,?,?,?,?,?)`, newEpoch, actual.Epoch, transitionDigest, commit.evidenceDigest, actual.LedgerDigest, commit.highWater, len(boundaries), boundaryDigest, ledgerDigest, now); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if commit.highWater > previousHighWater && !tailWasHot {
+		if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_boundaries(sequence,first_epoch) VALUES(?,?) ON CONFLICT(sequence) DO NOTHING`, previousHighWater+1, newEpoch); err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+	}
+	for index, transition := range commit.transitions {
+		if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_range_transitions(epoch,transition_index,start_sequence,end_sequence,from_state,to_state,reservation_id,segment_id) VALUES(?,?,?,?,?,?,?,?)`, newEpoch, index, transition.Range.Start, transition.Range.End, transition.From, transition.To, transition.ReservationID, transition.SegmentID); err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+		if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_boundaries(sequence,first_epoch) VALUES(?,?) ON CONFLICT(sequence) DO NOTHING`, transition.Range.Start, newEpoch); err != nil {
+			return apptypes.CatalogHead{}, err
+		}
+		if transition.Range.End < commit.highWater {
+			if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_boundaries(sequence,first_epoch) VALUES(?,?) ON CONFLICT(sequence) DO NOTHING`, transition.Range.End+1, newEpoch); err != nil {
+				return apptypes.CatalogHead{}, err
+			}
+		}
+	}
+	if commit.delta != "reserve" && commit.delta != "release" {
+		return apptypes.CatalogHead{}, apptypes.ErrCatalogIllegalTransition
+	}
+	transition := commit.transitions[0]
+	if _, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_reservation_deltas(epoch,reservation_id,delta,start_sequence,end_sequence) VALUES(?,?,?,?,?)`, newEpoch, commit.reservationID, commit.delta, transition.Range.Start, transition.Range.End); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	if err = replaceCatalogCurrent(ctx, tx, current); err != nil {
+		return apptypes.CatalogHead{}, err
+	}
+	return apptypes.CatalogHead{Epoch: newEpoch, LedgerDigest: ledgerDigest, CurrentRangesDigest: currentDigest}, nil
+}
+
+// verifyCatalogHeadIncremental checks only the immutable head epoch, its
+// parent link, and that epoch's bounded canonical transition set. It does not
+// make ordinary reads or commits proportional to the lifetime epoch count.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func verifyCatalogHeadIncremental(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, head apptypes.CatalogHead) error {
+	if head.Epoch == 0 {
+		if head.LedgerDigest != emptyCatalogDigestValue {
+			return apptypes.ErrCatalogDrift
+		}
+		return nil
+	}
+	var parent, highWater, boundaryCount int64
+	var transitionDigest, boundaryDigest, evidenceDigest, parentDigest, ledgerDigest string
+	if err := q.QueryRowContext(ctx, `SELECT parent_epoch,source_high_water,boundary_count,boundary_digest,transition_digest,evidence_digest,parent_ledger_digest,ledger_digest FROM archive_catalog_epochs WHERE epoch=?`, head.Epoch).Scan(&parent, &highWater, &boundaryCount, &boundaryDigest, &transitionDigest, &evidenceDigest, &parentDigest, &ledgerDigest); err != nil {
+		return apptypes.ErrCatalogDrift
+	}
+	if ledgerDigest != head.LedgerDigest || parent != head.Epoch-1 {
+		return apptypes.ErrCatalogDrift
+	}
+	if parent == 0 {
+		if parentDigest != emptyCatalogDigestValue {
+			return apptypes.ErrCatalogDrift
+		}
+	} else {
+		var storedParent string
+		if err := q.QueryRowContext(ctx, `SELECT ledger_digest FROM archive_catalog_epochs WHERE epoch=?`, parent).Scan(&storedParent); err != nil || storedParent != parentDigest {
+			return apptypes.ErrCatalogDrift
+		}
+	}
+	rows, err := q.QueryContext(ctx, `SELECT start_sequence,end_sequence,from_state,to_state,reservation_id,segment_id FROM archive_catalog_range_transitions WHERE epoch=? ORDER BY transition_index LIMIT ?`, head.Epoch, apptypes.CatalogMaxTransitionsPerEpoch+1)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	var transitions []domain.CatalogTransition
+	for rows.Next() {
+		if len(transitions) >= apptypes.CatalogMaxTransitionsPerEpoch {
+			return apptypes.ErrCatalogLimit
+		}
+		var start, end int64
+		var from, to domain.CatalogPlacement
+		var reservationID, segmentID string
+		if err = rows.Scan(&start, &end, &from, &to, &reservationID, &segmentID); err != nil {
+			return err
+		}
+		transition, validationErr := domain.NewCatalogTransition(domain.CatalogRange{Start: start, End: end}, from, to, reservationID, segmentID)
+		if validationErr != nil {
+			return apptypes.ErrCatalogDrift
+		}
+		transitions = append(transitions, transition)
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+	digest, digestErr := domain.CanonicalCatalogTransitionDigest(transitions)
+	if digestErr != nil || digest != transitionDigest {
+		return apptypes.ErrCatalogDrift
+	}
+	boundaries, boundaryErr := catalogBoundarySet(ctx, q, head.Epoch, highWater)
+	if boundaryErr != nil {
+		return boundaryErr
+	}
+	observedBoundaryDigest, digestBoundaryErr := domain.CanonicalCatalogBoundaryDigest(boundaries)
+	if digestBoundaryErr != nil || boundaryCount != int64(len(boundaries)) || boundaryDigest != observedBoundaryDigest {
+		return apptypes.ErrCatalogDrift
+	}
+	want, chainErr := domain.CatalogLedgerDigest(parentDigest, head.Epoch, parent, highWater, boundaryCount, transitionDigest, boundaryDigest, evidenceDigest)
+	if chainErr != nil || want != ledgerDigest {
+		return apptypes.ErrCatalogDrift
+	}
+	return nil
+}
+
+func applyCatalogTransition(ranges []apptypes.CatalogCurrentRange, transition domain.CatalogTransition) ([]apptypes.CatalogCurrentRange, error) {
+	result := make([]apptypes.CatalogCurrentRange, 0, len(ranges)+2)
+	covered := int64(0)
+	for _, current := range ranges {
+		if !current.Range.Overlaps(transition.Range) {
+			result = append(result, current)
+			continue
+		}
+		start := max64(current.Range.Start, transition.Range.Start)
+		end := min64(current.Range.End, transition.Range.End)
+		covered += end - start + 1
+		if current.Placement != transition.From {
+			if current.Placement == domain.CatalogPlacementReserved {
+				return nil, apptypes.ErrCatalogOverlap
+			}
+			return nil, apptypes.ErrCatalogIllegalTransition
+		}
+		if current.Range.Start < start {
+			left := current
+			left.Range.End = start - 1
+			result = append(result, left)
+		}
+		changed := apptypes.CatalogCurrentRange{Range: domain.CatalogRange{Start: start, End: end}, Placement: transition.To, ReservationID: transition.ReservationID, SegmentID: transition.SegmentID}
+		if transition.To == domain.CatalogPlacementHot {
+			changed.ReservationID = ""
+			changed.SegmentID = ""
+		}
+		result = append(result, changed)
+		if end < current.Range.End {
+			right := current
+			right.Range.Start = end + 1
+			result = append(result, right)
+		}
+	}
+	if covered != transition.Range.End-transition.Range.Start+1 {
+		return nil, apptypes.ErrCatalogGap
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Range.Start < result[j].Range.Start })
+	return result, nil
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func replayCatalogRanges(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, epoch, highWater int64, maxRanges int) ([]apptypes.CatalogCurrentRange, error) {
+	if highWater <= 0 || maxRanges <= 0 {
+		return nil, apptypes.ErrCatalogLimit
+	}
+	boundaries, err := catalogBoundarySet(ctx, q, epoch, highWater)
+	if err != nil {
+		return nil, err
+	}
+	if epoch > 0 {
+		var expectedCount int64
+		var expectedDigest string
+		if err = q.QueryRowContext(ctx, `SELECT boundary_count,boundary_digest FROM archive_catalog_epochs WHERE epoch=?`, epoch).Scan(&expectedCount, &expectedDigest); err != nil {
+			return nil, apptypes.ErrCatalogDrift
+		}
+		digest, digestErr := domain.CanonicalCatalogBoundaryDigest(boundaries)
+		if digestErr != nil || expectedCount != int64(len(boundaries)) || expectedDigest != digest {
+			return nil, apptypes.ErrCatalogDrift
+		}
+	}
+	boundaries = append(boundaries, highWater+1)
+	result := make([]apptypes.CatalogCurrentRange, 0, len(boundaries)-1)
+	for index := 0; index < len(boundaries)-1; index++ {
+		start, end := boundaries[index], boundaries[index+1]-1
+		if start > highWater {
+			break
+		}
+		if end > highWater {
+			end = highWater
+		}
+		item := apptypes.CatalogCurrentRange{Range: domain.CatalogRange{Start: start, End: end}, Placement: domain.CatalogPlacementHot}
+		var from domain.CatalogPlacement
+		err = q.QueryRowContext(ctx, `SELECT epoch,from_state,to_state,reservation_id,segment_id FROM archive_catalog_range_transitions WHERE epoch<=? AND start_sequence<=? AND end_sequence>=? ORDER BY epoch DESC,transition_index DESC LIMIT 1`, epoch, start, start).Scan(&item.SourceEpoch, &from, &item.Placement, &item.ReservationID, &item.SegmentID)
+		if errors.Is(err, sql.ErrNoRows) {
+			item.SourceEpoch = 0
+			item.Placement = domain.CatalogPlacementHot
+			item.ReservationID = ""
+			item.SegmentID = ""
+		} else if err != nil {
+			return nil, err
+		}
+		if item.Placement == domain.CatalogPlacementHot {
+			item.ReservationID = ""
+			item.SegmentID = ""
+		}
+		result = append(result, item)
+	}
+	result = coalesceCatalogRanges(result)
+	if len(result) > maxRanges {
+		return nil, apptypes.ErrCatalogLimit
+	}
+	return result, nil
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func catalogBoundarySet(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, epoch, highWater int64) ([]int64, error) {
+	rows, err := q.QueryContext(ctx, `SELECT sequence FROM archive_catalog_boundaries WHERE first_epoch<=? AND sequence<=? ORDER BY sequence LIMIT ?`, epoch, highWater, apptypes.CatalogMaxBoundaryPoints+1)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	boundaries := make([]int64, 0, min(apptypes.CatalogMaxBoundaryPoints, 1024))
+	for rows.Next() {
+		var boundary int64
+		if err = rows.Scan(&boundary); err != nil {
+			return nil, err
+		}
+		boundaries = append(boundaries, boundary)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(boundaries) == 0 || boundaries[0] != 1 {
+		return nil, apptypes.ErrCatalogDrift
+	}
+	if len(boundaries) > apptypes.CatalogMaxBoundaryPoints {
+		return nil, apptypes.ErrCatalogLimit
+	}
+	return boundaries, nil
+}
+
+func uniqueSortedBoundaries(values []int64) []int64 {
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	out := values[:0]
+	for _, value := range values {
+		if len(out) == 0 || out[len(out)-1] != value {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func coalesceCatalogRanges(ranges []apptypes.CatalogCurrentRange) []apptypes.CatalogCurrentRange {
+	if len(ranges) < 2 {
+		return ranges
+	}
+	out := []apptypes.CatalogCurrentRange{ranges[0]}
+	for _, next := range ranges[1:] {
+		last := &out[len(out)-1]
+		if last.Range.End+1 == next.Range.Start && last.Placement == next.Placement && last.ReservationID == next.ReservationID && last.SegmentID == next.SegmentID {
+			last.Range.End = next.Range.End
+			if next.SourceEpoch > last.SourceEpoch {
+				last.SourceEpoch = next.SourceEpoch
+			}
+		} else {
+			out = append(out, next)
+		}
+	}
+	return out
+}
+
+func digestCatalogRanges(ranges []apptypes.CatalogCurrentRange) string {
+	h := sha256.New()
+	write := func(v []byte) {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(v)))
+		_, _ = h.Write(n[:])
+		_, _ = h.Write(v)
+	}
+	write([]byte("traceary/catalog-current-ranges/v1"))
+	for _, current := range ranges {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(current.Range.Start))
+		write(n[:])
+		binary.BigEndian.PutUint64(n[:], uint64(current.Range.End))
+		write(n[:])
+		write([]byte(current.Placement))
+		write([]byte(current.ReservationID))
+		write([]byte(current.SegmentID))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func replaceCatalogCurrent(ctx context.Context, tx *sql.Tx, ranges []apptypes.CatalogCurrentRange) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM archive_catalog_current_ranges`); err != nil {
+		return err
+	}
+	for _, current := range ranges {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO archive_catalog_current_ranges(start_sequence,end_sequence,placement_state,reservation_id,segment_id,source_epoch) VALUES(?,?,?,?,?,?)`, current.Range.Start, current.Range.End, current.Placement, current.ReservationID, current.SegmentID, current.SourceEpoch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CatalogRangesAtEpoch reconstructs a bounded, immutable source set. Its
+// source high-water is read from that epoch, not from mutable allocator state.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) CatalogRangesAtEpoch(ctx context.Context, epoch int64, budget apptypes.CatalogBudget) (apptypes.CatalogSnapshot, error) {
+	if !budget.Valid() || epoch <= 0 {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	defer d.release(db)
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	if epoch > head.Epoch {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogStaleHead
+	}
+	var highWater int64
+	var ledger string
+	if err = db.QueryRowContext(opCtx, `SELECT source_high_water,ledger_digest FROM archive_catalog_epochs WHERE epoch=?`, epoch).Scan(&highWater, &ledger); err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	historicalHead := apptypes.CatalogHead{Epoch: epoch, LedgerDigest: ledger}
+	if err = verifyCatalogHeadIncremental(opCtx, db, historicalHead); err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	ranges, err := replayCatalogRanges(opCtx, db, epoch, highWater, budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	return apptypes.CatalogSnapshot{Head: apptypes.CatalogHead{Epoch: epoch, LedgerDigest: ledger, CurrentRangesDigest: digestCatalogRanges(ranges)}, Ranges: ranges}, nil
+}
+
+// CurrentCatalogRanges fails closed when the derived cache differs from a
+// deterministic ledger replay.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) CurrentCatalogRanges(ctx context.Context, budget apptypes.CatalogBudget) (apptypes.CatalogSnapshot, error) {
+	if !budget.Valid() {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	defer d.release(db)
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	if head.Epoch == 0 {
+		return apptypes.CatalogSnapshot{Head: head}, nil
+	}
+	if err = verifyCatalogHeadIncremental(opCtx, db, head); err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	var highWater int64
+	if err = db.QueryRowContext(opCtx, `SELECT source_high_water FROM archive_catalog_epochs WHERE epoch=?`, head.Epoch).Scan(&highWater); err != nil {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogDrift
+	}
+	ranges, err := readCurrentCatalogRanges(opCtx, db, budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	if digestCatalogRanges(ranges) != head.CurrentRangesDigest {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogDrift
+	}
+	replayed, err := replayCatalogRanges(opCtx, db, head.Epoch, highWater, budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogSnapshot{}, err
+	}
+	if digestCatalogRanges(replayed) != head.CurrentRangesDigest {
+		return apptypes.CatalogSnapshot{}, apptypes.ErrCatalogDrift
+	}
+	return apptypes.CatalogSnapshot{Head: head, Ranges: ranges}, nil
+}
+
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func readCurrentCatalogRanges(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, maxRanges int) ([]apptypes.CatalogCurrentRange, error) {
+	rows, err := q.QueryContext(ctx, `SELECT start_sequence,end_sequence,placement_state,reservation_id,segment_id,source_epoch FROM archive_catalog_current_ranges ORDER BY start_sequence`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []apptypes.CatalogCurrentRange
+	for rows.Next() {
+		if len(out) >= maxRanges {
+			return nil, apptypes.ErrCatalogLimit
+		}
+		var item apptypes.CatalogCurrentRange
+		if err = rows.Scan(&item.Range.Start, &item.Range.End, &item.Placement, &item.ReservationID, &item.SegmentID, &item.SourceEpoch); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+// RebuildCatalogCurrentRanges deterministically replaces only the derived
+// cache. It never reads manifests or segment bindings and therefore cannot
+// invent authority.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) RebuildCatalogCurrentRanges(ctx context.Context, expected apptypes.CatalogHead, budget apptypes.CatalogBudget) (apptypes.CatalogRebuildResult, error) {
+	if !budget.Valid() {
+		return apptypes.CatalogRebuildResult{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := boundedCatalogContext(ctx, budget)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(opCtx, nil)
+	if err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	head, err := readCatalogHead(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	if head.Epoch != expected.Epoch || head.LedgerDigest != expected.LedgerDigest {
+		return apptypes.CatalogRebuildResult{}, apptypes.ErrCatalogStaleHead
+	}
+	if head.Epoch == 0 {
+		return apptypes.CatalogRebuildResult{Head: head}, nil
+	}
+	if err = verifyCatalogHeadIncremental(opCtx, tx, head); err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	var highWater int64
+	if err = tx.QueryRowContext(opCtx, `SELECT source_high_water FROM archive_catalog_epochs WHERE epoch=?`, head.Epoch).Scan(&highWater); err != nil {
+		return apptypes.CatalogRebuildResult{}, apptypes.ErrCatalogDrift
+	}
+	ranges, err := replayCatalogRanges(opCtx, tx, head.Epoch, highWater, budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	digest := digestCatalogRanges(ranges)
+	cached, cacheErr := readCurrentCatalogRanges(opCtx, tx, budget.Ranges)
+	if cacheErr != nil {
+		return apptypes.CatalogRebuildResult{}, cacheErr
+	}
+	changed := digestCatalogRanges(cached) != digest || head.CurrentRangesDigest != digest
+	if err = replaceCatalogCurrent(opCtx, tx, ranges); err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	result, err := tx.ExecContext(opCtx, `UPDATE archive_catalog_head SET current_ranges_digest=? WHERE singleton=1 AND current_epoch=? AND ledger_digest=?`, digest, head.Epoch, head.LedgerDigest)
+	if err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	n, _ := result.RowsAffected()
+	if n != 1 {
+		return apptypes.CatalogRebuildResult{}, apptypes.ErrCatalogStaleHead
+	}
+	head.CurrentRangesDigest = digest
+	if err = tx.Commit(); err != nil {
+		return apptypes.CatalogRebuildResult{}, err
+	}
+	return apptypes.CatalogRebuildResult{Head: head, Ranges: len(ranges), Changed: changed}, nil
+}
+
+// AuditCatalogLedgerPage verifies one bounded epoch page and returns a durable
+// value checkpoint suitable for caller-controlled resume.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func (d *Database) AuditCatalogLedgerPage(ctx context.Context, cursor apptypes.CatalogAuditCursor, budget apptypes.CatalogBudget) (apptypes.CatalogAuditPage, error) {
+	if !budget.Valid() || cursor.Epoch < 0 || (cursor.Epoch == 0 && cursor.LedgerDigest != emptyCatalogDigestValue) || (cursor.Epoch > 0 && !domain.ValidCatalogDigest(cursor.LedgerDigest)) {
+		return apptypes.CatalogAuditPage{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogAuditPage{}, err
+	}
+	defer d.release(db)
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil {
+		return apptypes.CatalogAuditPage{}, err
+	}
+	if cursor.Epoch > head.Epoch {
+		return apptypes.CatalogAuditPage{}, apptypes.ErrCatalogStaleHead
+	}
+	if cursor.Epoch > 0 {
+		var stored string
+		if err = db.QueryRowContext(opCtx, `SELECT ledger_digest FROM archive_catalog_epochs WHERE epoch=?`, cursor.Epoch).Scan(&stored); err != nil || stored != cursor.LedgerDigest {
+			return apptypes.CatalogAuditPage{}, apptypes.ErrCatalogDrift
+		}
+	}
+	rows, err := db.QueryContext(opCtx, `SELECT epoch,ledger_digest,parent_ledger_digest FROM archive_catalog_epochs WHERE epoch>? ORDER BY epoch LIMIT ?`, cursor.Epoch, budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogAuditPage{}, err
+	}
+	var checkpoints []apptypes.CatalogAuditCursor
+	var parents []string
+	for rows.Next() {
+		var item apptypes.CatalogAuditCursor
+		var parent string
+		if err = rows.Scan(&item.Epoch, &item.LedgerDigest, &parent); err != nil {
+			_ = rows.Close()
+			return apptypes.CatalogAuditPage{}, err
+		}
+		checkpoints = append(checkpoints, item)
+		parents = append(parents, parent)
+	}
+	if err = rows.Err(); err != nil {
+		_ = rows.Close()
+		return apptypes.CatalogAuditPage{}, err
+	}
+	_ = rows.Close()
+	previous := cursor
+	if len(checkpoints) == 0 && cursor.Epoch < head.Epoch {
+		return apptypes.CatalogAuditPage{}, apptypes.ErrCatalogDrift
+	}
+	for index, item := range checkpoints {
+		if item.Epoch != previous.Epoch+1 || parents[index] != previous.LedgerDigest {
+			return apptypes.CatalogAuditPage{}, apptypes.ErrCatalogDrift
+		}
+		if err = verifyCatalogHeadIncremental(opCtx, db, apptypes.CatalogHead{Epoch: item.Epoch, LedgerDigest: item.LedgerDigest}); err != nil {
+			return apptypes.CatalogAuditPage{}, err
+		}
+		previous = item
+	}
+	return apptypes.CatalogAuditPage{Next: previous, Verified: len(checkpoints), Done: previous.Epoch == head.Epoch}, nil
+}
+
+// bindCatalogSegment records metadata only. It is intentionally unexported:
+// #1651 must wrap it in a proof-specific port before production use.
+//
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed SQL failures.
+func bindCatalogSegment(ctx context.Context, tx *sql.Tx, epoch int64, binding domain.CatalogSegmentBinding) error {
+	var storeID string
+	if err := tx.QueryRowContext(ctx, `SELECT store_id FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID); err != nil {
+		return err
+	}
+	if err := binding.Validate(storeID); err != nil {
+		return apptypes.ErrCatalogLineageMismatch
+	}
+	var segmentID, existingStore, logical, file, manifest, summary, basename, storage string
+	var start, end int64
+	var formatVersion, manifestVersion, summaryVersion int
+	err := tx.QueryRowContext(ctx, `SELECT segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class FROM archive_catalog_segment_bindings WHERE segment_id=?`, binding.SegmentID()).Scan(&segmentID, &existingStore, &start, &end, &formatVersion, &manifestVersion, &summaryVersion, &logical, &file, &manifest, &summary, &basename, &storage)
+	if err == nil {
+		r := binding.Range()
+		if segmentID == binding.SegmentID() && existingStore == binding.StoreID() && start == r.Start && end == r.End && formatVersion == binding.FormatVersion() && manifestVersion == binding.ManifestVersion() && summaryVersion == binding.SummaryVersion() && logical == binding.LogicalDigest() && file == binding.FileDigest() && manifest == binding.ManifestDigest() && summary == binding.SummaryDigest() && basename == binding.RelativeBasename() && storage == binding.StorageClass() {
+			return nil
+		}
+		return apptypes.ErrCatalogBindingMismatch
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	r := binding.Range()
+	_, err = tx.ExecContext(ctx, `INSERT INTO archive_catalog_segment_bindings(segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class,bound_epoch) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, binding.SegmentID(), binding.StoreID(), r.Start, r.End, binding.FormatVersion(), binding.ManifestVersion(), binding.SummaryVersion(), binding.LogicalDigest(), binding.FileDigest(), binding.ManifestDigest(), binding.SummaryDigest(), binding.RelativeBasename(), binding.StorageClass(), epoch)
+	if err != nil {
+		return fmt.Errorf("bind segment metadata: %w", err)
+	}
+	return nil
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/infrastructure/sqlite/segment_catalog_internal_test.go
+++ b/infrastructure/sqlite/segment_catalog_internal_test.go
@@ -1,0 +1,466 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+func catalogTestBudget() apptypes.CatalogBudget {
+	return apptypes.CatalogBudget{Ranges: 100, WallTime: 10 * time.Second, LockTime: 5 * time.Second}
+}
+
+func TestCatalogProspectiveBoundaryCapRejectsBeforePublishingHead(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	transition, err := domain.ReservationTransition(domain.CatalogRange{Start: 2, End: 2}, "cap-cross")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = commitCatalogEpoch(ctx, tx, catalogEpochCommit{expected: initial.Head, highWater: 3, transitions: []domain.CatalogTransition{transition}, evidenceDigest: "acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac", reservationID: "cap-cross", delta: "reserve", boundaryPointLimit: 2}, 10)
+	if !errors.Is(err, apptypes.ErrCatalogLimit) {
+		_ = tx.Rollback()
+		t.Fatalf("cap error = %v", err)
+	}
+	_ = tx.Rollback()
+	after, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Head != initial.Head {
+		t.Fatalf("head published after cap failure: before=%+v after=%+v", initial.Head, after.Head)
+	}
+	var epochs int
+	if err = raw.QueryRow(`SELECT count(*) FROM archive_catalog_epochs`).Scan(&epochs); err != nil || epochs != 0 {
+		t.Fatalf("epochs=%d err=%v", epochs, err)
+	}
+}
+
+func TestCatalogReservationIDIsGloballyUniqueAndRequestsAreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "7777777777777777777777777777777777777777777777777777777777777777"
+	command := apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "  stable-id  ", Range: domain.CatalogRange{Start: 1, End: 2}, EvidenceDigest: evidence, Budget: catalogTestBudget()}
+	reserved, err := database.ReserveCatalogTarget(ctx, command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := database.ReserveCatalogTarget(ctx, command)
+	if err != nil || again != reserved {
+		t.Fatalf("idempotent reserve = %+v, %v", again, err)
+	}
+	conflict := command
+	conflict.Range = domain.CatalogRange{Start: 2, End: 3}
+	if _, err = database.ReserveCatalogTarget(ctx, conflict); !errors.Is(err, apptypes.ErrCatalogReservationConflict) {
+		t.Fatalf("conflict error = %v", err)
+	}
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: "stable-id ", EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retried, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: " stable-id", EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil || retried != released {
+		t.Fatalf("idempotent release = %+v, %v", retried, err)
+	}
+	var distinct int
+	if err = raw.QueryRow(`SELECT count(DISTINCT reservation_id) FROM archive_catalog_reservation_deltas WHERE reservation_id='stable-id'`).Scan(&distinct); err != nil || distinct != 1 {
+		t.Fatalf("canonical reservation id count=%d err=%v", distinct, err)
+	}
+}
+
+func TestCatalogBoundaryScanDoesNotConsumeReturnedRangeCap(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	budget := catalogTestBudget()
+	budget.Ranges = 1
+	initial, err := database.CurrentCatalogRanges(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef"
+	reserved, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "cap-one", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: evidence, Budget: budget})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES('cap-extension','note','a','s','body','2026-08-01T00:00:01Z','c','w')`); err != nil {
+		t.Fatal(err)
+	}
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: "cap-one", EvidenceDigest: evidence, Budget: budget})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := database.CurrentCatalogRanges(ctx, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Head != released || len(current.Ranges) != 1 || current.Ranges[0].Range.End != 2 || current.Ranges[0].Placement != domain.CatalogPlacementHot {
+		t.Fatalf("current = %+v", current)
+	}
+	old, err := database.CatalogRangesAtEpoch(ctx, reserved.Epoch, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(old.Ranges) != 1 || old.Ranges[0].Range.End != 1 || old.Ranges[0].Placement != domain.CatalogPlacementReserved {
+		t.Fatalf("old = %+v", old)
+	}
+	var boundaries int
+	if err = raw.QueryRow(`SELECT count(*) FROM archive_catalog_boundaries`).Scan(&boundaries); err != nil || boundaries != 2 {
+		t.Fatalf("boundaries=%d err=%v", boundaries, err)
+	}
+}
+
+func TestCatalogHeadPathDoesNotScanAllEpochs(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := emptyCatalogDigestValue
+	evidence := "8888888888888888888888888888888888888888888888888888888888888888"
+	boundaryDigest, _ := domain.CanonicalCatalogBoundaryDigest([]int64{1})
+	const epochs = 10_001
+	transitionDigest, _ := domain.CanonicalCatalogTransitionDigest(nil)
+	for epoch := int64(1); epoch <= epochs; epoch++ {
+		ledger, _ := domain.CatalogLedgerDigest(parent, epoch, epoch-1, epoch, 1, transitionDigest, boundaryDigest, evidence)
+		if _, err = tx.Exec(`INSERT INTO archive_catalog_epochs(epoch,parent_epoch,transition_digest,evidence_digest,parent_ledger_digest,source_high_water,boundary_count,boundary_digest,ledger_digest,committed_at) VALUES(?,?,?,?,?,?,1,?,?,'2026-08-01T00:00:00Z')`, epoch, epoch-1, transitionDigest, evidence, parent, epoch, boundaryDigest, ledger); err != nil {
+			t.Fatal(err)
+		}
+		parent = ledger
+	}
+	current := []apptypes.CatalogCurrentRange{{Range: domain.CatalogRange{Start: 1, End: epochs}, Placement: domain.CatalogPlacementHot}}
+	digest := digestCatalogRanges(current)
+	if _, err = tx.Exec(`DELETE FROM archive_catalog_current_ranges`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tx.Exec(`INSERT INTO archive_catalog_current_ranges VALUES(1,?,'hot','','',0)`, epochs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tx.Exec(`UPDATE archive_catalog_head SET current_epoch=?,ledger_digest=?,current_ranges_digest=? WHERE singleton=1`, epochs, parent, digest); err != nil {
+		t.Fatal(err)
+	}
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := database.CurrentCatalogRanges(ctx, apptypes.CatalogBudget{Ranges: 10, WallTime: 10 * time.Second, LockTime: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Head.Epoch != epochs {
+		t.Fatalf("head = %+v", snapshot.Head)
+	}
+	historical, err := database.CatalogRangesAtEpoch(ctx, 9_999, apptypes.CatalogBudget{Ranges: 2, WallTime: 10 * time.Second, LockTime: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(historical.Ranges) != 1 || historical.Ranges[0].Range.End != 9_999 {
+		t.Fatalf("historical ranges = %+v", historical.Ranges)
+	}
+	var boundaryRows int
+	if err = raw.QueryRow(`SELECT count(*) FROM archive_catalog_boundaries`).Scan(&boundaryRows); err != nil || boundaryRows != 1 {
+		t.Fatalf("boundary rows=%d err=%v", boundaryRows, err)
+	}
+	planRows, err := raw.Query(`EXPLAIN QUERY PLAN SELECT epoch,from_state,to_state,reservation_id,segment_id FROM archive_catalog_range_transitions WHERE epoch<=? AND start_sequence<=? AND end_sequence>=? ORDER BY epoch DESC,transition_index DESC LIMIT 1`, epochs, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = planRows.Close() }()
+	var plan strings.Builder
+	for planRows.Next() {
+		var id, parentID, unused int
+		var detail string
+		if err = planRows.Scan(&id, &parentID, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+	}
+	if !strings.Contains(plan.String(), "INDEX") {
+		t.Fatalf("query plan = %s", plan.String())
+	}
+}
+
+func newActivatedCatalogStore(t *testing.T, events int) (*Database, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.db")
+	database := NewDatabase(path, preparedMigrations(t))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= events; i++ {
+		if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?, 'note','a','s','body','2026-08-01T00:00:00Z','c','w')`, "catalog-event-"+string(rune('a'+i))); err != nil {
+			_ = raw.Close()
+			t.Fatal(err)
+		}
+	}
+	if _, err = raw.Exec(`UPDATE archive_sequence_inventory_state SET generation_id='verified',phase='complete',high_water=?,revision=1 WHERE singleton=1`, events); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_sequence_activation SET active_generation_id='verified',verified_high_water=? WHERE singleton=1`, events); err != nil {
+		t.Fatal(err)
+	}
+	return database, raw
+}
+
+func TestCatalogReservationReleaseAndOldEpochReplay(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 6)
+	defer func() { _ = raw.Close() }()
+	initial, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := "1111111111111111111111111111111111111111111111111111111111111111"
+	reserved, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "target-1", Range: domain.CatalogRange{Start: 2, End: 4}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Ranges) != 3 || snapshot.Ranges[1].Placement != domain.CatalogPlacementReserved {
+		t.Fatalf("ranges = %+v", snapshot.Ranges)
+	}
+	if _, err = database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: reserved, ReservationID: "overlap", Range: domain.CatalogRange{Start: 3, End: 5}, EvidenceDigest: evidence, Budget: catalogTestBudget()}); !errors.Is(err, apptypes.ErrCatalogOverlap) {
+		t.Fatalf("overlap error = %v", err)
+	}
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: "target-1", EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(current.Ranges) != 1 || current.Ranges[0].Placement != domain.CatalogPlacementHot {
+		t.Fatalf("released ranges = %+v", current.Ranges)
+	}
+	old, err := database.CatalogRangesAtEpoch(ctx, reserved.Epoch, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(old.Ranges) != 3 || old.Ranges[1].Placement != domain.CatalogPlacementReserved {
+		t.Fatalf("old ranges = %+v", old.Ranges)
+	}
+	if released.Epoch != 2 {
+		t.Fatalf("released head = %+v", released)
+	}
+	auditBudget := catalogTestBudget()
+	auditBudget.Ranges = 1
+	firstAudit, err := database.AuditCatalogLedgerPage(ctx, apptypes.InitialCatalogAuditCursor(), auditBudget)
+	if err != nil || firstAudit.Done || firstAudit.Verified != 1 {
+		t.Fatalf("first audit = %+v, %v", firstAudit, err)
+	}
+	secondAudit, err := database.AuditCatalogLedgerPage(ctx, firstAudit.Next, auditBudget)
+	if err != nil || !secondAudit.Done || secondAudit.Next.Epoch != 2 {
+		t.Fatalf("second audit = %+v, %v", secondAudit, err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_head SET current_epoch=3,ledger_digest=? WHERE singleton=1`, "abababababababababababababababababababababababababababababababab"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.AuditCatalogLedgerPage(ctx, secondAudit.Next, auditBudget); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("missing audit tail error = %v", err)
+	}
+	var reserve, release, abandoned int
+	if err = raw.QueryRow(`SELECT sum(delta='reserve'),sum(delta='release'),sum(delta='abandoned') FROM archive_catalog_reservation_deltas`).Scan(&reserve, &release, &abandoned); err != nil {
+		t.Fatal(err)
+	}
+	if reserve != 1 || release != 1 || abandoned != 0 {
+		t.Fatalf("deltas = %d/%d/%d", reserve, release, abandoned)
+	}
+}
+
+func TestCatalogSQLRejectsProofBearingGenericTransition(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "9999999999999999999999999999999999999999999999999999999999999999"
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "proof", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_range_transitions(epoch,transition_index,start_sequence,end_sequence,from_state,to_state,reservation_id,segment_id) VALUES(?,1,1,1,'reserved','sealed','proof','segment')`, head.Epoch); err == nil {
+		t.Fatal("proof-bearing generic transition succeeded")
+	}
+}
+
+func TestCatalogExpectedHeadCASAndGapFailClosed(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "2222222222222222222222222222222222222222222222222222222222222222"
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "one", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "stale", Range: domain.CatalogRange{Start: 2, End: 2}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if !errors.Is(err, apptypes.ErrCatalogStaleHead) {
+		t.Fatalf("stale error = %v", err)
+	}
+	_, err = database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: head, ReservationID: "gap", Range: domain.CatalogRange{Start: 4, End: 4}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if !errors.Is(err, apptypes.ErrCatalogGap) {
+		t.Fatalf("gap error = %v", err)
+	}
+}
+
+func TestCatalogCurrentCacheRebuildIsDeterministicAndDoesNotReadBindings(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 4)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "3333333333333333333333333333333333333333333333333333333333333333"
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "one", Range: domain.CatalogRange{Start: 1, End: 2}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_current_ranges SET placement_state='hot',reservation_id='' WHERE start_sequence=1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.CurrentCatalogRanges(ctx, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("drift error = %v", err)
+	}
+	result, err := database.RebuildCatalogCurrentRanges(ctx, head, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Changed {
+		t.Fatal("rebuild did not report drift repair")
+	}
+	first, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := database.RebuildCatalogCurrentRanges(ctx, first.Head, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Changed || second.Head.CurrentRangesDigest != first.Head.CurrentRangesDigest {
+		t.Fatalf("second rebuild = %+v", second)
+	}
+}
+
+func TestCatalogLedgerDriftFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 2)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "5555555555555555555555555555555555555555555555555555555555555555"
+	if _, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "one", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: evidence, Budget: catalogTestBudget()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`DROP TRIGGER archive_catalog_epochs_no_update`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`UPDATE archive_catalog_epochs SET evidence_digest=? WHERE epoch=1`, "6666666666666666666666666666666666666666666666666666666666666666"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.CurrentCatalogRanges(ctx, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("drift error = %v", err)
+	}
+}
+
+func TestCatalogBoundaryCacheLossFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 4)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+	if _, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "boundary", Range: domain.CatalogRange{Start: 2, End: 3}, EvidenceDigest: evidence, Budget: catalogTestBudget()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`DROP TRIGGER archive_catalog_boundaries_no_delete`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`DELETE FROM archive_catalog_boundaries WHERE sequence=2`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.CurrentCatalogRanges(ctx, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("boundary drift error = %v", err)
+	}
+}
+
+func TestCatalogSegmentBindingIsImmutableAndCannotCreateAuthority(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 2)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	evidence := "4444444444444444444444444444444444444444444444444444444444444444"
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "one", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: evidence, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var storeID string
+	if err = raw.QueryRow(`SELECT store_id FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logical, fileDigest, manifestDigest, summaryDigest := [32]byte{0xaa}, [32]byte{0xbb}, [32]byte{0xcc}, [32]byte{0xdd}
+	identity, err := domain.NewSegmentIdentity(storeID, 1, 1, logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := domain.NewCatalogSegmentBinding(identity, fileDigest, manifestDigest, summaryDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = bindCatalogSegment(ctx, tx, head.Epoch, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	mismatchTx, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mismatchedSummary := [32]byte{0xee}
+	mismatched, err := domain.NewCatalogSegmentBinding(identity, fileDigest, manifestDigest, mismatchedSummary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = bindCatalogSegment(ctx, mismatchTx, head.Epoch, mismatched); !errors.Is(err, apptypes.ErrCatalogBindingMismatch) {
+		_ = mismatchTx.Rollback()
+		t.Fatalf("binding mismatch error = %v", err)
+	}
+	_ = mismatchTx.Rollback()
+	if _, err = raw.Exec(`UPDATE archive_catalog_segment_bindings SET summary_digest=? WHERE segment_id=?`, evidence, binding.SegmentID()); err == nil {
+		t.Fatal("immutable binding update succeeded")
+	}
+	snapshot, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Ranges[0].Placement != domain.CatalogPlacementReserved {
+		t.Fatalf("binding invented authority: %+v", snapshot.Ranges)
+	}
+}

--- a/schema/sqlite/migrations/000045_add_segment_catalog_ledger.sql
+++ b/schema/sqlite/migrations/000045_add_segment_catalog_ledger.sql
@@ -1,0 +1,141 @@
+-- The Segment Catalog ledger is installed without reading canonical history.
+-- Authority is carried only by immutable epochs and transitions; current
+-- ranges are a derived cache that may be rebuilt from the ledger.
+CREATE TABLE archive_catalog_head (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    current_epoch INTEGER NOT NULL CHECK (current_epoch >= 0),
+    ledger_digest TEXT NOT NULL CHECK (length(ledger_digest) = 64),
+    current_ranges_digest TEXT NOT NULL CHECK (length(current_ranges_digest) = 64)
+);
+
+INSERT INTO archive_catalog_head(singleton, current_epoch, ledger_digest, current_ranges_digest)
+VALUES (1, 0,
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        '0000000000000000000000000000000000000000000000000000000000000000');
+
+CREATE TABLE archive_catalog_epochs (
+    epoch INTEGER PRIMARY KEY CHECK (epoch > 0),
+    parent_epoch INTEGER NOT NULL CHECK (parent_epoch >= 0 AND parent_epoch < epoch),
+    transition_digest TEXT NOT NULL CHECK (length(transition_digest) = 64),
+    evidence_digest TEXT NOT NULL CHECK (length(evidence_digest) = 64),
+    parent_ledger_digest TEXT NOT NULL CHECK (length(parent_ledger_digest) = 64),
+    source_high_water INTEGER NOT NULL CHECK (source_high_water > 0),
+    boundary_count INTEGER NOT NULL CHECK (boundary_count >= 1),
+    boundary_digest TEXT NOT NULL CHECK (length(boundary_digest) = 64),
+    ledger_digest TEXT NOT NULL UNIQUE CHECK (length(ledger_digest) = 64),
+    committed_at TEXT NOT NULL
+);
+
+CREATE TABLE archive_catalog_segment_bindings (
+    segment_id TEXT PRIMARY KEY CHECK (length(segment_id) BETWEEN 1 AND 255),
+    store_id TEXT NOT NULL CHECK (length(store_id) = 32),
+    start_sequence INTEGER NOT NULL CHECK (start_sequence > 0),
+    end_sequence INTEGER NOT NULL CHECK (end_sequence >= start_sequence),
+    format_version INTEGER NOT NULL CHECK (format_version > 0),
+    manifest_version INTEGER NOT NULL CHECK (manifest_version > 0),
+    summary_version INTEGER NOT NULL CHECK (summary_version > 0),
+    logical_digest TEXT NOT NULL CHECK (length(logical_digest) = 64),
+    file_digest TEXT NOT NULL CHECK (length(file_digest) = 64),
+    manifest_digest TEXT NOT NULL CHECK (length(manifest_digest) = 64),
+    summary_digest TEXT NOT NULL CHECK (length(summary_digest) = 64),
+    relative_basename TEXT NOT NULL CHECK (
+        length(relative_basename) BETWEEN 1 AND 255
+        AND instr(relative_basename, '/') = 0
+        AND instr(relative_basename, char(92)) = 0
+        AND relative_basename NOT IN ('.', '..')
+    ),
+    storage_class TEXT NOT NULL CHECK (storage_class IN ('sealed_sqlite_zstd_v1')),
+    bound_epoch INTEGER NOT NULL REFERENCES archive_catalog_epochs(epoch),
+    UNIQUE(store_id, start_sequence, end_sequence, logical_digest)
+);
+
+CREATE TABLE archive_catalog_range_transitions (
+    epoch INTEGER NOT NULL REFERENCES archive_catalog_epochs(epoch),
+    transition_index INTEGER NOT NULL CHECK (transition_index >= 0),
+    start_sequence INTEGER NOT NULL CHECK (start_sequence > 0),
+    end_sequence INTEGER NOT NULL CHECK (end_sequence >= start_sequence),
+    from_state TEXT NOT NULL CHECK (from_state IN
+        ('hot', 'reserved', 'sealed', 'verified_shadow', 'segment_authoritative', 'evicting', 'cold')),
+    to_state TEXT NOT NULL CHECK (to_state IN
+        ('hot', 'reserved', 'sealed', 'verified_shadow', 'segment_authoritative', 'evicting', 'cold')),
+    reservation_id TEXT NOT NULL DEFAULT '',
+    segment_id TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY(epoch, transition_index),
+    CHECK (from_state <> to_state),
+    CHECK ((to_state = 'reserved' OR from_state = 'reserved') = (length(reservation_id) > 0))
+);
+
+CREATE INDEX idx_archive_catalog_transitions_epoch_range
+    ON archive_catalog_range_transitions(epoch, start_sequence, end_sequence);
+CREATE INDEX idx_archive_catalog_transitions_range_epoch
+    ON archive_catalog_range_transitions(start_sequence, end_sequence, epoch DESC);
+CREATE INDEX idx_archive_catalog_transitions_latest_covering
+    ON archive_catalog_range_transitions(epoch DESC, start_sequence, end_sequence);
+
+-- Boundary facts make an old epoch reconstructable by one indexed latest
+-- transition lookup per elementary range, without replaying every epoch.
+CREATE TABLE archive_catalog_boundaries (
+    sequence INTEGER PRIMARY KEY CHECK (sequence > 0),
+    first_epoch INTEGER NOT NULL CHECK (first_epoch >= 0)
+);
+INSERT INTO archive_catalog_boundaries(sequence, first_epoch) VALUES(1, 0);
+
+CREATE TABLE archive_catalog_reservation_deltas (
+    epoch INTEGER NOT NULL REFERENCES archive_catalog_epochs(epoch),
+    reservation_id TEXT NOT NULL CHECK (length(reservation_id) BETWEEN 1 AND 255),
+    delta TEXT NOT NULL CHECK (delta IN ('reserve', 'release')),
+    start_sequence INTEGER NOT NULL CHECK (start_sequence > 0),
+    end_sequence INTEGER NOT NULL CHECK (end_sequence >= start_sequence),
+    PRIMARY KEY(epoch, reservation_id)
+);
+
+CREATE INDEX idx_archive_catalog_reservation_history
+    ON archive_catalog_reservation_deltas(reservation_id, epoch);
+CREATE UNIQUE INDEX idx_archive_catalog_one_reserve_per_id
+    ON archive_catalog_reservation_deltas(reservation_id) WHERE delta='reserve';
+CREATE UNIQUE INDEX idx_archive_catalog_one_release_per_id
+    ON archive_catalog_reservation_deltas(reservation_id) WHERE delta='release';
+
+CREATE TABLE archive_catalog_current_ranges (
+    start_sequence INTEGER PRIMARY KEY CHECK (start_sequence > 0),
+    end_sequence INTEGER NOT NULL CHECK (end_sequence >= start_sequence),
+    placement_state TEXT NOT NULL CHECK (placement_state IN
+        ('hot', 'reserved', 'sealed', 'verified_shadow', 'segment_authoritative', 'evicting', 'cold')),
+    reservation_id TEXT NOT NULL DEFAULT '',
+    segment_id TEXT NOT NULL DEFAULT '',
+    source_epoch INTEGER NOT NULL CHECK (source_epoch >= 0),
+    UNIQUE(end_sequence)
+);
+
+CREATE INDEX idx_archive_catalog_current_end
+    ON archive_catalog_current_ranges(end_sequence, start_sequence);
+
+CREATE TRIGGER archive_catalog_epochs_no_update
+BEFORE UPDATE ON archive_catalog_epochs BEGIN SELECT RAISE(ABORT, 'catalog epochs are append-only'); END;
+CREATE TRIGGER archive_catalog_epochs_no_delete
+BEFORE DELETE ON archive_catalog_epochs BEGIN SELECT RAISE(ABORT, 'catalog epochs are append-only'); END;
+CREATE TRIGGER archive_catalog_transitions_no_update
+BEFORE UPDATE ON archive_catalog_range_transitions BEGIN SELECT RAISE(ABORT, 'catalog transitions are append-only'); END;
+CREATE TRIGGER archive_catalog_transitions_no_delete
+BEFORE DELETE ON archive_catalog_range_transitions BEGIN SELECT RAISE(ABORT, 'catalog transitions are append-only'); END;
+CREATE TRIGGER archive_catalog_reservations_no_update
+BEFORE UPDATE ON archive_catalog_reservation_deltas BEGIN SELECT RAISE(ABORT, 'catalog reservations are append-only'); END;
+CREATE TRIGGER archive_catalog_reservations_no_delete
+BEFORE DELETE ON archive_catalog_reservation_deltas BEGIN SELECT RAISE(ABORT, 'catalog reservations are append-only'); END;
+CREATE TRIGGER archive_catalog_bindings_no_update
+BEFORE UPDATE ON archive_catalog_segment_bindings BEGIN SELECT RAISE(ABORT, 'catalog segment bindings are immutable'); END;
+CREATE TRIGGER archive_catalog_bindings_no_delete
+BEFORE DELETE ON archive_catalog_segment_bindings BEGIN SELECT RAISE(ABORT, 'catalog segment bindings are immutable'); END;
+CREATE TRIGGER archive_catalog_boundaries_no_update
+BEFORE UPDATE ON archive_catalog_boundaries BEGIN SELECT RAISE(ABORT, 'catalog boundaries are append-only'); END;
+CREATE TRIGGER archive_catalog_boundaries_no_delete
+BEFORE DELETE ON archive_catalog_boundaries BEGIN SELECT RAISE(ABORT, 'catalog boundaries are append-only'); END;
+
+CREATE TRIGGER archive_catalog_transitions_edge_guard
+BEFORE INSERT ON archive_catalog_range_transitions
+WHEN NOT (
+    (NEW.from_state='hot' AND NEW.to_state='reserved' AND length(NEW.reservation_id)>0 AND NEW.segment_id='')
+    OR
+    (NEW.from_state='reserved' AND NEW.to_state='hot' AND length(NEW.reservation_id)>0 AND NEW.segment_id='')
+)
+BEGIN SELECT RAISE(ABORT, 'catalog transition requires a proof-specific port'); END;


### PR DESCRIPTION
## Summary
- add migration 45 for an append-only Segment Catalog epoch/range ledger
- enforce legal reservation/release transitions, content-addressed segment binding, lineage and boundary integrity
- rebuild the current cache deterministically from authenticated ledger state
- separate internal boundary scan limits from coalesced output limits and fail before publishing an unreadable head

## Validation
- go test ./...
- go vet ./...
- go tool golangci-lint run --timeout=5m
- independent GPT-5.6 Sol review: APPROVE

Closes #1661