### PR TITLE
feat: add deterministic segment target planner

### DIFF
--- a/.ai/spec/1662-deterministic-segment-target-planner.md
+++ b/.ai/spec/1662-deterministic-segment-target-planner.md
@@ -1,0 +1,54 @@
+# #1662 deterministic segment target planner
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Select and reserve exactly one deterministic, contiguous archive target, beginning at the smallest currently Hot sequence and ending no later than the captured source high-water.
+- Eligibility is fixed by a captured UTC time and Hot horizon. Capacity is fixed by row count, canonical history-unit bytes, and a versioned conservative stored-byte bound.
+- A wall deadline is an invocation budget, never an input to prefix length. An incomplete scan returns `selection_incomplete` without publishing a Catalog epoch.
+- Recent-first, oversize-first, malformed timestamp, concurrent append, and backdated append behavior is explicit and fail-closed.
+- A measured stored/file-cap failure may shorten a released target only under a new reservation identity.
+
+### Conceptual model
+
+| Concept | State / behavior | Invariant |
+|---|---|---|
+| Planning snapshot | Expected Catalog head, captured source high-water, captured time, policy version | Same snapshot and policy yield the same target; the ordered canonical source digest is durable. |
+| Candidate prefix | Consecutive canonical History Units starting at the smallest Hot sequence | No sequence is skipped; a recent or malformed unit closes/rejects at its exact position. |
+| Reservation | One append-only Hot-to-reserved Catalog transition and immutable target plan/unit rows | It is committed only after the complete bounded selection scan; reserved event/sequence/audit mutation and late audit insertion are trigger-fenced. |
+| Shortening proof | Released prior plan plus canonical measured stored/file cap evidence | The same failure digest must be the append-only release evidence and retry evidence; a new ID, same captured snapshot/invariant policy/source prefix, lower row cap, and strictly smaller end are required. |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Not owner |
+|---|---|---|
+| Prefix/cap/time policy and canonical plan digest | `domain` | SQLite transaction and row hydration |
+| Request/result/error contract | `application/types` | SQL details |
+| Writer-fenced snapshot, preflight metadata sizing, incremental canonical hydration, expected-head reservation | `infrastructure/sqlite` | Segment construction/publication |
+
+### Boundaries / interfaces
+
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `CatalogTargetPlanner` | #1651 migration orchestration | SQLite snapshot and Catalog commit | typed incomplete/recent/oversize/malformed/stale errors |
+| `SegmentTargetPolicy` | SQLite adapter and tests | canonical framing arithmetic | deterministic target or typed outcome |
+
+### Behavior tests / TDD plan
+
+| Given | When | Then |
+|---|---|---|
+| Same rows/config at different execution speeds | plan | identical range and digest |
+| Timeout/cancellation before a deterministic boundary | plan | `selection_incomplete`; no epoch/reservation |
+| First row recent / oversize / malformed | plan | typed outcome; no reservation |
+| Later recent / oversize | plan | preceding closed prefix is reserved |
+| Concurrent/backdated append, late audit, or competing planner after snapshot | plan | writer serialization yields one reservation; append stays Hot and frozen mutation fails |
+| Measured retry | shorten | canonical proof exceeds the old versioned cap; released old ID, new ID, unchanged source prefix/invariants, same start, smaller end |
+
+### Risks / rollback
+
+- Catalog publication is append-only; rollback is the existing append-only release delta.
+- A no-op Catalog-head write acquires the SQLite writer slot before snapshot selection. Selection itself never mutates canonical rows. Any hydration inconsistency, sequence gap, head drift, or deadline prevents reservation.
+- Timestamp storage class/parse validation precedes size inspection. SQLite TEXT/BLOB accounting always uses BLOB byte length, including decoded-size fallback. Each admitted row is metadata-preflighted before allocation; recent and oversize boundaries are never hydrated.
+- Stored-bound v1 deliberately uses canonical plaintext length as a conservative upper bound because format v1 stores compression only when it is smaller. A later codec changes the version, not v1 semantics.
+- #1651 owns actual stored/file measurement and may request a shorter retry only through the proof-bearing fields defined here.

--- a/application/segment_catalog.go
+++ b/application/segment_catalog.go
@@ -17,6 +17,11 @@ type CatalogTargetReservationStore interface {
 	ReleaseCatalogReservation(context.Context, apptypes.CatalogRelease) (apptypes.CatalogHead, error)
 }
 
+// CatalogTargetPlanner atomically selects and reserves one deterministic prefix.
+type CatalogTargetPlanner interface {
+	PlanAndReserveCatalogTarget(context.Context, apptypes.CatalogTargetPlanRequest) (apptypes.CatalogTargetPlan, error)
+}
+
 // CatalogRangeReader returns current or epoch-pinned derived source ranges.
 type CatalogRangeReader interface {
 	CurrentCatalogRanges(context.Context, apptypes.CatalogBudget) (apptypes.CatalogSnapshot, error)

--- a/application/types/segment_catalog.go
+++ b/application/types/segment_catalog.go
@@ -30,6 +30,18 @@ var (
 	ErrCatalogReservationConflict = errors.New("segment catalog reservation conflict")
 	// ErrCatalogLimit identifies an invalid or exceeded operation bound.
 	ErrCatalogLimit = errors.New("segment catalog operation limit exceeded")
+	// ErrSegmentTargetSelectionIncomplete means the bounded snapshot was not fully read.
+	ErrSegmentTargetSelectionIncomplete = errors.New("segment target selection incomplete")
+	// ErrSegmentTargetRecentFirst means the smallest unplaced unit must remain Hot.
+	ErrSegmentTargetRecentFirst = domain.ErrSegmentTargetRecentFirst
+	// ErrSegmentTargetOversizeFirst means no non-empty prefix fits the configured caps.
+	ErrSegmentTargetOversizeFirst = domain.ErrSegmentTargetOversizeFirst
+	// ErrSegmentTargetMalformedTimestamp means deterministic horizon evaluation is impossible.
+	ErrSegmentTargetMalformedTimestamp = domain.ErrSegmentTargetMalformedTimestamp
+	// ErrSegmentTargetNotFound means no Hot sequence exists at the captured high-water.
+	ErrSegmentTargetNotFound = domain.ErrSegmentTargetNotFound
+	// ErrSegmentTargetRetryProof rejects an unmeasured or non-shortening retry.
+	ErrSegmentTargetRetryProof = errors.New("segment target retry proof invalid")
 )
 
 const (
@@ -86,6 +98,56 @@ type CatalogRelease struct {
 	ReservationID  string
 	EvidenceDigest string
 	Budget         CatalogBudget
+}
+
+const (
+	// SegmentStoredBoundV1 is the immutable bound used by segment format v1.
+	SegmentStoredBoundV1 uint32 = domain.SegmentStoredBoundV1
+	// SegmentTargetFailureStoredCap permits a measured stored-byte retry.
+	SegmentTargetFailureStoredCap = "stored_cap"
+	// SegmentTargetFailureFileCap permits a measured segment-file retry.
+	SegmentTargetFailureFileCap = "file_cap"
+)
+
+// SegmentTargetPolicy fixes every input that can affect deterministic prefix selection.
+type SegmentTargetPolicy = domain.SegmentTargetPolicy
+
+// CatalogTargetRetry proves why #1651 is asking for a strictly shorter target.
+// Empty PreviousReservationID means this is an initial selection.
+type CatalogTargetRetry struct {
+	PreviousReservationID string
+	PreviousRange         domain.CatalogRange
+	FailureClass          string
+	MeasuredBytes         int64
+	FailedCapBytes        int64
+	EvidenceDigest        string
+}
+
+// CatalogTargetPlanRequest selects and reserves against one expected snapshot.
+type CatalogTargetPlanRequest struct {
+	ExpectedHead      CatalogHead
+	ReservationID     string
+	CapturedHighWater int64
+	Policy            SegmentTargetPolicy
+	Retry             CatalogTargetRetry
+	Budget            CatalogBudget
+}
+
+// SegmentTargetCandidate is one fully hydrated immutable planning input.
+type SegmentTargetCandidate = domain.SegmentTargetCandidate
+
+// CatalogTargetPlan is the reserved deterministic target and aggregate-only evidence.
+type CatalogTargetPlan struct {
+	Head                      CatalogHead
+	ReservationID             string
+	Range                     domain.CatalogRange
+	Rows                      int
+	CanonicalPlainBytes       int64
+	DecodedBytes              int64
+	StoredUpperBytes          int64
+	CapturedHighWater         int64
+	PlanDigest                string
+	ReservationEvidenceDigest string
 }
 
 // CatalogCurrentRange is one non-overlapping derived placement interval.

--- a/domain/segment_target.go
+++ b/domain/segment_target.go
@@ -1,0 +1,187 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrSegmentTargetRecentFirst means the first candidate must remain Hot.
+	ErrSegmentTargetRecentFirst = errors.New("segment target starts inside hot horizon")
+	// ErrSegmentTargetOversizeFirst means no non-empty target fits the policy.
+	ErrSegmentTargetOversizeFirst = errors.New("segment target first unit exceeds cap")
+	// ErrSegmentTargetMalformedTimestamp means the Hot horizon cannot be evaluated.
+	ErrSegmentTargetMalformedTimestamp = errors.New("segment target contains malformed timestamp")
+	// ErrSegmentTargetNotFound means no eligible contiguous Hot prefix exists.
+	ErrSegmentTargetNotFound = errors.New("segment target not found")
+)
+
+const (
+	// SegmentStoredBoundV1 identifies the immutable format-v1 conservative bound.
+	SegmentStoredBoundV1 uint32 = 1
+	// SegmentTargetMaxRows is the hard per-invocation hydration bound.
+	SegmentTargetMaxRows = 100_000
+	// SegmentTargetMaxBytes is the hard aggregate planning byte bound.
+	SegmentTargetMaxBytes int64 = 4 << 30
+)
+
+// SegmentTargetPolicy fixes every value that can affect deterministic selection.
+type SegmentTargetPolicy struct {
+	CapturedAt             time.Time
+	HotHorizon             time.Duration
+	MaxRows                int
+	MaxCanonicalPlainBytes int64
+	MaxDecodedBytes        int64
+	MaxStoredUpperBytes    int64
+	MaxFileBytes           int64
+	StoredBoundVersion     uint32
+}
+
+// SegmentTargetCandidate contains no body, only deterministic aggregate facts.
+type SegmentTargetCandidate struct {
+	Sequence            int64
+	CreatedAt           time.Time
+	TimestampValid      bool
+	CanonicalPlainBytes int64
+	DecodedBytes        int64
+}
+
+// SegmentTargetSelection is one non-empty contiguous closed prefix.
+type SegmentTargetSelection struct {
+	Range               CatalogRange
+	Rows                int
+	CanonicalPlainBytes int64
+	DecodedBytes        int64
+	StoredUpperBytes    int64
+}
+
+// Valid reports whether the policy completely fixes bounded v1 selection.
+func (p SegmentTargetPolicy) Valid() bool {
+	return !p.CapturedAt.IsZero() && p.HotHorizon > 0 &&
+		p.MaxRows > 0 && p.MaxRows <= SegmentTargetMaxRows &&
+		p.MaxCanonicalPlainBytes > 0 && p.MaxCanonicalPlainBytes <= SegmentTargetMaxBytes &&
+		p.MaxDecodedBytes > 0 && p.MaxDecodedBytes <= SegmentTargetMaxBytes &&
+		p.MaxStoredUpperBytes > 0 && p.MaxStoredUpperBytes <= SegmentTargetMaxBytes &&
+		p.MaxFileBytes > 0 && p.MaxFileBytes <= SegmentTargetMaxBytes &&
+		p.StoredBoundVersion == SegmentStoredBoundV1
+}
+
+// Complete reports whether the selection is closed by its deterministic row cap.
+func (s SegmentTargetSelection) Complete(policy SegmentTargetPolicy) bool {
+	return s.Rows >= policy.MaxRows
+}
+
+// Consider admits one candidate or deterministically closes/rejects the prefix.
+// The boolean is false only for a non-first recent or oversize boundary.
+func (s *SegmentTargetSelection) Consider(candidate SegmentTargetCandidate, policy SegmentTargetPolicy) (bool, error) {
+	if s == nil || !policy.Valid() || candidate.Sequence <= 0 || candidate.CanonicalPlainBytes <= 0 || candidate.DecodedBytes < 0 ||
+		(s.Rows > 0 && candidate.Sequence != s.Range.End+1) {
+		return false, ErrSegmentTargetNotFound
+	}
+	if s.Complete(policy) {
+		return false, nil
+	}
+	if !candidate.TimestampValid || candidate.CreatedAt.IsZero() {
+		return false, ErrSegmentTargetMalformedTimestamp
+	}
+	if candidate.CreatedAt.After(policy.CapturedAt.Add(-policy.HotHorizon)) {
+		if s.Rows == 0 {
+			return false, ErrSegmentTargetRecentFirst
+		}
+		return false, nil
+	}
+	plain := s.CanonicalPlainBytes + candidate.CanonicalPlainBytes
+	decoded := s.DecodedBytes + candidate.DecodedBytes
+	stored := s.StoredUpperBytes + candidate.CanonicalPlainBytes
+	if plain < s.CanonicalPlainBytes || decoded < s.DecodedBytes || stored < s.StoredUpperBytes || plain > policy.MaxCanonicalPlainBytes || decoded > policy.MaxDecodedBytes || stored > policy.MaxStoredUpperBytes {
+		if s.Rows == 0 {
+			return false, ErrSegmentTargetOversizeFirst
+		}
+		return false, nil
+	}
+	if s.Rows == 0 {
+		s.Range.Start = candidate.Sequence
+	}
+	s.Range.End = candidate.Sequence
+	s.Rows++
+	s.CanonicalPlainBytes = plain
+	s.DecodedBytes = decoded
+	s.StoredUpperBytes = stored
+	return true, nil
+}
+
+// SelectSegmentTarget chooses a prefix from a completely-read snapshot page.
+// Format v1 compresses only when the encoded value is smaller, therefore its
+// worst-case stored payload is the canonical plaintext length itself.
+func SelectSegmentTarget(candidates []SegmentTargetCandidate, capturedHighWater int64, policy SegmentTargetPolicy) (SegmentTargetSelection, error) {
+	if !policy.Valid() || capturedHighWater <= 0 {
+		return SegmentTargetSelection{}, ErrSegmentTargetNotFound
+	}
+	if len(candidates) == 0 {
+		return SegmentTargetSelection{}, ErrSegmentTargetNotFound
+	}
+	var result SegmentTargetSelection
+	for index, candidate := range candidates {
+		if candidate.Sequence > capturedHighWater || index >= policy.MaxRows {
+			break
+		}
+		admitted, err := result.Consider(candidate, policy)
+		if err != nil {
+			return SegmentTargetSelection{}, err
+		}
+		if !admitted {
+			break
+		}
+	}
+	if result.Rows == 0 {
+		return SegmentTargetSelection{}, ErrSegmentTargetNotFound
+	}
+	return result, nil
+}
+
+// SegmentTargetPlanDigest authenticates the complete selection policy and result.
+func SegmentTargetPlanDigest(storeID, reservationID string, catalogEpoch int64, catalogLedgerDigest, catalogRangesDigest, sourceDigest string, capturedHighWater int64, policy SegmentTargetPolicy, selection SegmentTargetSelection) (string, error) {
+	if storeID == "" || reservationID == "" || catalogEpoch < 0 || !ValidCatalogDigest(catalogLedgerDigest) || !ValidCatalogDigest(catalogRangesDigest) || !ValidCatalogDigest(sourceDigest) || !policy.Valid() || capturedHighWater <= 0 || selection.Rows <= 0 {
+		return "", ErrSegmentTargetNotFound
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary-segment-target-plan-v1\x00"))
+	writeTargetFrame(h, []byte(storeID))
+	writeTargetFrame(h, []byte(reservationID))
+	writeTargetFrame(h, []byte(catalogLedgerDigest))
+	writeTargetFrame(h, []byte(catalogRangesDigest))
+	writeTargetFrame(h, []byte(sourceDigest))
+	for _, value := range []int64{catalogEpoch, capturedHighWater, policy.CapturedAt.UnixNano(), int64(policy.HotHorizon), int64(policy.MaxRows), policy.MaxCanonicalPlainBytes, policy.MaxDecodedBytes, policy.MaxStoredUpperBytes, policy.MaxFileBytes, int64(policy.StoredBoundVersion), selection.Range.Start, selection.Range.End, int64(selection.Rows), selection.CanonicalPlainBytes, selection.DecodedBytes, selection.StoredUpperBytes} {
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], uint64(value))
+		_, _ = h.Write(encoded[:])
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// SegmentTargetRetryEvidenceDigest authenticates measured failure evidence.
+func SegmentTargetRetryEvidenceDigest(previousPlanDigest, failureClass string, measuredBytes, failedCapBytes int64) (string, error) {
+	if !ValidCatalogDigest(previousPlanDigest) || (failureClass != "stored_cap" && failureClass != "file_cap") || measuredBytes <= failedCapBytes || failedCapBytes <= 0 {
+		return "", ErrSegmentTargetNotFound
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary-segment-target-measured-failure-v1\x00"))
+	writeTargetFrame(h, []byte(previousPlanDigest))
+	writeTargetFrame(h, []byte(failureClass))
+	for _, value := range []int64{measuredBytes, failedCapBytes} {
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], uint64(value))
+		_, _ = h.Write(encoded[:])
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeTargetFrame(h interface{ Write([]byte) (int, error) }, value []byte) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = h.Write(size[:])
+	_, _ = h.Write(value)
+}

--- a/domain/segment_target_test.go
+++ b/domain/segment_target_test.go
@@ -1,0 +1,85 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/duck8823/traceary/domain"
+)
+
+func targetPolicy() domain.SegmentTargetPolicy {
+	return domain.SegmentTargetPolicy{CapturedAt: time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC), HotHorizon: 24 * time.Hour, MaxRows: 3, MaxCanonicalPlainBytes: 100, MaxDecodedBytes: 100, MaxStoredUpperBytes: 100, MaxFileBytes: 200, StoredBoundVersion: domain.SegmentStoredBoundV1}
+}
+
+func targetCandidate(sequence, bytes int64, createdAt time.Time) domain.SegmentTargetCandidate {
+	return domain.SegmentTargetCandidate{Sequence: sequence, CreatedAt: createdAt, TimestampValid: true, CanonicalPlainBytes: bytes, DecodedBytes: bytes}
+}
+
+func TestSelectSegmentTargetUsesOnlyDeterministicPrefixInputs(t *testing.T) {
+	policy := targetPolicy()
+	old := policy.CapturedAt.Add(-48 * time.Hour)
+	candidates := []domain.SegmentTargetCandidate{targetCandidate(7, 20, old), targetCandidate(8, 30, old), targetCandidate(9, 40, old), targetCandidate(10, 1, old)}
+	first, err := domain.SelectSegmentTarget(candidates, 10, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := domain.SelectSegmentTarget(candidates, 10, policy)
+	if err != nil || second != first {
+		t.Fatalf("repeat = %+v, %v; first=%+v", second, err, first)
+	}
+	if first.Range != (domain.CatalogRange{Start: 7, End: 9}) || first.Rows != 3 || first.CanonicalPlainBytes != 90 || first.StoredUpperBytes != 90 {
+		t.Fatalf("selection = %+v", first)
+	}
+	const emptyDigest = "0000000000000000000000000000000000000000000000000000000000000000"
+	digestA, err := domain.SegmentTargetPlanDigest("store", "reservation", 0, emptyDigest, emptyDigest, emptyDigest, 10, policy, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestB, _ := domain.SegmentTargetPlanDigest("store", "reservation", 0, emptyDigest, emptyDigest, emptyDigest, 10, policy, second)
+	if digestA != digestB {
+		t.Fatalf("digest changed: %s != %s", digestA, digestB)
+	}
+}
+
+func TestSelectSegmentTargetHasTypedBoundaryOutcomes(t *testing.T) {
+	policy := targetPolicy()
+	old := policy.CapturedAt.Add(-48 * time.Hour)
+	recent := policy.CapturedAt.Add(-time.Hour)
+	tests := []struct {
+		name       string
+		candidates []domain.SegmentTargetCandidate
+		wantErr    error
+		wantEnd    int64
+	}{
+		{name: "recent first", candidates: []domain.SegmentTargetCandidate{targetCandidate(1, 1, recent)}, wantErr: domain.ErrSegmentTargetRecentFirst},
+		{name: "oversize first", candidates: []domain.SegmentTargetCandidate{targetCandidate(1, 101, old)}, wantErr: domain.ErrSegmentTargetOversizeFirst},
+		{name: "malformed first", candidates: []domain.SegmentTargetCandidate{{Sequence: 1, CanonicalPlainBytes: 1}}, wantErr: domain.ErrSegmentTargetMalformedTimestamp},
+		{name: "later recent closes prefix", candidates: []domain.SegmentTargetCandidate{targetCandidate(1, 10, old), targetCandidate(2, 10, recent)}, wantEnd: 1},
+		{name: "later oversize closes prefix", candidates: []domain.SegmentTargetCandidate{targetCandidate(1, 60, old), targetCandidate(2, 60, old)}, wantEnd: 1},
+		{name: "later malformed fails closed", candidates: []domain.SegmentTargetCandidate{targetCandidate(1, 10, old), {Sequence: 2, CanonicalPlainBytes: 10}}, wantErr: domain.ErrSegmentTargetMalformedTimestamp},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			selection, err := domain.SelectSegmentTarget(test.candidates, 2, policy)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("error = %v", err)
+				}
+				return
+			}
+			if err != nil || selection.Range.End != test.wantEnd {
+				t.Fatalf("selection=%+v error=%v", selection, err)
+			}
+		})
+	}
+}
+
+func TestSelectSegmentTargetRejectsSequenceGap(t *testing.T) {
+	policy := targetPolicy()
+	old := policy.CapturedAt.Add(-48 * time.Hour)
+	_, err := domain.SelectSegmentTarget([]domain.SegmentTargetCandidate{targetCandidate(1, 1, old), targetCandidate(3, 1, old)}, 3, policy)
+	if !errors.Is(err, domain.ErrSegmentTargetNotFound) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -149,6 +149,16 @@ type Database struct {
 	// searchMaintenanceHook is a package-private transaction-boundary seam used
 	// by deterministic atomicity tests. Production databases leave it nil.
 	searchMaintenanceHook func(string) error
+	// segmentTargetPlannerHook is a package-private synchronization seam for
+	// two-connection snapshot/reservation tests. Production leaves it nil.
+	segmentTargetPlannerHook func(string) error
+}
+
+func (d *Database) runSegmentTargetPlannerHook(point string) error {
+	if d.segmentTargetPlannerHook != nil {
+		return d.segmentTargetPlannerHook(point)
+	}
+	return nil
 }
 
 func (d *Database) runSearchMaintenanceHook(point string) error {

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -44,6 +44,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	43: {43, "000043_add_payload_codec_compatibility_mode.sql", "020c6dbb5dbea86c3c9989ad29babe333dc7c423ded6152aeddb37a67aa907e0", MigrationConstantInPlace},
 	44: {44, "000044_add_archive_sequence_inventory.sql", "18e270f1b4b974f54529fac3aa2ab1daf273797a51217c3bf3601bdbcbcc79f6", MigrationConstantInPlace},
 	45: {45, "000045_add_segment_catalog_ledger.sql", "00802c1fe48e30ef1fd5ffc2e1c22e33bc8f32c6ea66d52e869d0362172d0982", MigrationConstantInPlace},
+	46: {46, "000046_add_segment_target_plans.sql", "f6759e9883580436e6717d9009e91108212bff9d5376ede8f82c9700231ccc65", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 45 || len(plan.Pending) != 11 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 46 || len(plan.Pending) != 12 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -43,6 +43,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		43: MigrationConstantInPlace,
 		44: MigrationConstantInPlace,
 		45: MigrationConstantInPlace,
+		46: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 45 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 46 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/segment_target_planner.go
+++ b/infrastructure/sqlite/segment_target_planner.go
@@ -1,0 +1,534 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+const segmentTargetMaxValueBytes int64 = 64 << 20
+
+var _ application.CatalogTargetPlanner = (*Database)(nil)
+
+type segmentTargetUnitEvidence struct {
+	sequence int64
+	bytes    int64
+	digest   string
+}
+
+// PlanAndReserveCatalogTarget selects and reserves one deterministic prefix.
+// A no-op head write obtains the SQLite writer slot before the snapshot, so a
+// competing writer cannot invalidate a selected source between read and freeze.
+//
+//nolint:wrapcheck // Typed Catalog and selection failures cross this adapter unchanged.
+func (d *Database) PlanAndReserveCatalogTarget(ctx context.Context, request apptypes.CatalogTargetPlanRequest) (apptypes.CatalogTargetPlan, error) {
+	request.ReservationID = strings.TrimSpace(request.ReservationID)
+	request.Retry.PreviousReservationID = strings.TrimSpace(request.Retry.PreviousReservationID)
+	if !request.Budget.Valid() || !request.Policy.Valid() || request.ReservationID == "" || len(request.ReservationID) > 255 || request.CapturedHighWater <= 0 {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, request.Budget.WallTime)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	defer d.release(db)
+	lockMillis := max64(1, request.Budget.LockTime.Milliseconds())
+	if _, err = db.ExecContext(opCtx, fmt.Sprintf("PRAGMA busy_timeout=%d", lockMillis)); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	tx, err := db.BeginTx(opCtx, nil)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(opCtx, `UPDATE archive_catalog_head SET current_epoch=current_epoch WHERE singleton=1`); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	highWater, err := checkCatalogInventoryGate(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if request.CapturedHighWater > highWater {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrCatalogGap
+	}
+	actual, err := readCatalogHead(opCtx, tx)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if actual != request.ExpectedHead {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrCatalogStaleHead
+	}
+	if err = verifyCatalogHeadIncremental(opCtx, tx, actual); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if err = validateCatalogTargetRetryRelease(opCtx, tx, request.Retry); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	ranges, err := replayCatalogRanges(opCtx, tx, actual.Epoch, highWater, request.Budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	start, end, found := smallestUnplacedTargetWindow(ranges, request.CapturedHighWater)
+	if !found {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrSegmentTargetNotFound
+	}
+	if err = d.runSegmentTargetPlannerHook("snapshot-pinned"); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	selection, units, sourceDigest, err := planSegmentTargetSelection(opCtx, tx, start, end, request.Policy)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if err = d.runSegmentTargetPlannerHook("selection-complete"); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if err = validateCatalogTargetRetry(opCtx, tx, request, selection, units); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	var storeID string
+	if err = tx.QueryRowContext(opCtx, `SELECT store_id FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	planDigest, err := domain.SegmentTargetPlanDigest(storeID, request.ReservationID, actual.Epoch, actual.LedgerDigest, actual.CurrentRangesDigest, sourceDigest, request.CapturedHighWater, request.Policy, selection)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrCatalogLimit
+	}
+	evidenceDigest := catalogTargetEvidenceDigest(planDigest, request.Retry)
+	transition, err := domain.ReservationTransition(selection.Range, request.ReservationID)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, apptypes.ErrCatalogIllegalTransition
+	}
+	if err = d.runSegmentTargetPlannerHook("before-reserve"); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	head, err := commitCatalogEpoch(opCtx, tx, catalogEpochCommit{expected: actual, highWater: highWater, transitions: []domain.CatalogTransition{transition}, evidenceDigest: evidenceDigest, reservationID: request.ReservationID, delta: "reserve"}, request.Budget.Ranges)
+	if err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if err = insertCatalogTargetPlan(opCtx, tx, head.Epoch, storeID, actual, request, selection, units, sourceDigest, planDigest, evidenceDigest, d.runSegmentTargetPlannerHook); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	if err = tx.Commit(); err != nil {
+		return apptypes.CatalogTargetPlan{}, targetSelectionContextError(opCtx, err)
+	}
+	return apptypes.CatalogTargetPlan{Head: head, ReservationID: request.ReservationID, Range: selection.Range, Rows: selection.Rows, CanonicalPlainBytes: selection.CanonicalPlainBytes, DecodedBytes: selection.DecodedBytes, StoredUpperBytes: selection.StoredUpperBytes, CapturedHighWater: request.CapturedHighWater, PlanDigest: planDigest, ReservationEvidenceDigest: evidenceDigest}, nil
+}
+
+//nolint:wrapcheck // Internal append-only release proof lookup preserves typed errors.
+func validateCatalogTargetRetryRelease(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, retry apptypes.CatalogTargetRetry) error {
+	if retry.PreviousReservationID == "" {
+		return nil
+	}
+	historyRange, reserved, released, _, releaseEvidence, err := catalogReservationHistory(ctx, q, retry.PreviousReservationID)
+	if err != nil {
+		return err
+	}
+	if !reserved || !released || historyRange != retry.PreviousRange || releaseEvidence != retry.EvidenceDigest {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	return nil
+}
+
+//nolint:wrapcheck // Operation cancellation and typed adapter errors are part of this port contract.
+func targetSelectionContextError(operation context.Context, err error) error {
+	if operation.Err() != nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return apptypes.ErrSegmentTargetSelectionIncomplete
+	}
+	return err
+}
+
+func smallestUnplacedTargetWindow(ranges []apptypes.CatalogCurrentRange, highWater int64) (int64, int64, bool) {
+	for _, current := range ranges {
+		if current.Range.Start > highWater {
+			break
+		}
+		if current.Placement == domain.CatalogPlacementHot {
+			end := min64(current.Range.End, highWater)
+			return current.Range.Start, end, current.Range.Start <= end
+		}
+	}
+	return 0, 0, false
+}
+
+//nolint:wrapcheck // Internal SQLite hydration preserves errors for the public boundary.
+func planSegmentTargetSelection(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, start, end int64, policy domain.SegmentTargetPolicy) (domain.SegmentTargetSelection, []segmentTargetUnitEvidence, string, error) {
+	if start <= 0 || end < start || !policy.Valid() {
+		return domain.SegmentTargetSelection{}, nil, "", apptypes.ErrCatalogLimit
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary-segment-target-source-v1\x00"))
+	selection := domain.SegmentTargetSelection{}
+	units := make([]segmentTargetUnitEvidence, 0, min(policy.MaxRows, 1024))
+	for sequence := start; sequence <= end && !selection.Complete(policy); sequence++ {
+		if err := ctx.Err(); err != nil {
+			return domain.SegmentTargetSelection{}, nil, "", err
+		}
+		createdAt, timestampValid, err := readSegmentTargetTimestamp(ctx, q, sequence)
+		if err != nil {
+			return domain.SegmentTargetSelection{}, nil, "", err
+		}
+		if !timestampValid {
+			return domain.SegmentTargetSelection{}, nil, "", apptypes.ErrSegmentTargetMalformedTimestamp
+		}
+		if createdAt.After(policy.CapturedAt.Add(-policy.HotHorizon)) {
+			_, boundaryErr := selection.Consider(domain.SegmentTargetCandidate{Sequence: sequence, CreatedAt: createdAt, TimestampValid: true, CanonicalPlainBytes: 1}, policy)
+			if boundaryErr != nil {
+				return domain.SegmentTargetSelection{}, nil, "", boundaryErr
+			}
+			break
+		}
+		meta, err := readSegmentTargetMetadata(ctx, q, sequence, policy)
+		if err != nil {
+			if errors.Is(err, apptypes.ErrSegmentTargetOversizeFirst) && selection.Rows > 0 {
+				break
+			}
+			return domain.SegmentTargetSelection{}, nil, "", err
+		}
+		admitted, err := selection.Consider(domain.SegmentTargetCandidate{Sequence: sequence, CreatedAt: createdAt, TimestampValid: true, CanonicalPlainBytes: meta.canonicalBytes, DecodedBytes: meta.decodedBytes}, policy)
+		if err != nil {
+			return domain.SegmentTargetSelection{}, nil, "", err
+		}
+		if !admitted {
+			break
+		}
+		unit, err := hydrateSegmentTargetUnit(ctx, q, sequence)
+		if err != nil {
+			return domain.SegmentTargetSelection{}, nil, "", err
+		}
+		encoded, err := unit.CanonicalBytes()
+		if err != nil || int64(len(encoded)) != meta.canonicalBytes {
+			return domain.SegmentTargetSelection{}, nil, "", apptypes.ErrCatalogDrift
+		}
+		digest := sha256.Sum256(encoded)
+		var frame [8]byte
+		binary.BigEndian.PutUint64(frame[:], uint64(len(encoded)))
+		_, _ = h.Write(frame[:])
+		_, _ = h.Write(encoded)
+		units = append(units, segmentTargetUnitEvidence{sequence: sequence, bytes: int64(len(encoded)), digest: hex.EncodeToString(digest[:])})
+	}
+	if selection.Rows == 0 {
+		return domain.SegmentTargetSelection{}, nil, "", apptypes.ErrSegmentTargetNotFound
+	}
+	return selection, units, hex.EncodeToString(h.Sum(nil)), nil
+}
+
+type segmentTargetMetadata struct {
+	canonicalBytes int64
+	decodedBytes   int64
+}
+
+//nolint:wrapcheck // Internal timestamp scan preserves errors for its boundary.
+func readSegmentTargetTimestamp(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, sequence int64) (time.Time, bool, error) {
+	var storageClass string
+	var length sql.NullInt64
+	var value sql.NullString
+	err := q.QueryRowContext(ctx, `SELECT typeof(e.created_at),length(CAST(e.created_at AS BLOB)),CASE WHEN typeof(e.created_at)='text' AND length(CAST(e.created_at AS BLOB))<=64 THEN e.created_at ELSE NULL END FROM archive_event_sequences s JOIN events e ON e.id=s.event_id WHERE s.sequence=?`, sequence).Scan(&storageClass, &length, &value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, false, apptypes.ErrCatalogDrift
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if storageClass != "text" || !length.Valid || length.Int64 > 64 || !value.Valid {
+		return time.Time{}, false, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value.String)
+	if err != nil {
+		return time.Time{}, false, nil
+	}
+	return parsed.UTC(), true, nil
+}
+
+//nolint:wrapcheck // Internal SQLite metadata scan preserves errors for its boundary.
+func readSegmentTargetMetadata(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, sequence int64, policy domain.SegmentTargetPolicy) (segmentTargetMetadata, error) {
+	eventColumns, auditColumns := domain.ArchiveEventV1Columns(), domain.ArchiveAuditV1Columns()
+	query := `SELECT (a.event_id IS NOT NULL),COALESCE(e.body_plaintext_bytes,length(CAST(e.body AS BLOB)),0),COALESCE(a.command_plaintext_bytes,length(CAST(a.command_text AS BLOB)),0),COALESCE(a.input_plaintext_bytes,length(CAST(a.input_text AS BLOB)),0),COALESCE(a.output_plaintext_bytes,length(CAST(a.output_text AS BLOB)),0),` +
+		targetMetadataColumns("e", eventColumns) + `,` + targetMetadataColumns("a", auditColumns) +
+		` FROM archive_event_sequences s JOIN events e ON e.id=s.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE s.sequence=?`
+	var hasAudit int
+	var decoded [4]int64
+	eventTypes, eventLengths := make([]string, len(eventColumns)), make([]sql.NullInt64, len(eventColumns))
+	auditTypes, auditLengths := make([]string, len(auditColumns)), make([]sql.NullInt64, len(auditColumns))
+	dest := []any{&hasAudit, &decoded[0], &decoded[1], &decoded[2], &decoded[3]}
+	for index := range eventTypes {
+		dest = append(dest, &eventTypes[index], &eventLengths[index])
+	}
+	for index := range auditTypes {
+		dest = append(dest, &auditTypes[index], &auditLengths[index])
+	}
+	if err := q.QueryRowContext(ctx, query, sequence).Scan(dest...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return segmentTargetMetadata{}, apptypes.ErrCatalogDrift
+		}
+		return segmentTargetMetadata{}, err
+	}
+	meta := segmentTargetMetadata{}
+	for _, bytes := range decoded {
+		if bytes < 0 || bytes > maxDecodedPayloadBytes {
+			return segmentTargetMetadata{}, apptypes.ErrSegmentTargetOversizeFirst
+		}
+		if bytes > policy.MaxDecodedBytes-meta.decodedBytes {
+			return segmentTargetMetadata{}, apptypes.ErrSegmentTargetOversizeFirst
+		}
+		meta.decodedBytes += bytes
+	}
+	size, err := canonicalTargetSize(sequence, eventTypes, eventLengths, hasAudit != 0, auditTypes, auditLengths, policy)
+	if err != nil {
+		return segmentTargetMetadata{}, err
+	}
+	meta.canonicalBytes = size
+	return meta, nil
+}
+
+func targetMetadataColumns(alias string, columns []string) string {
+	items := make([]string, 0, len(columns)*2)
+	for _, column := range columns {
+		items = append(items, "typeof("+alias+"."+column+")", "length(CAST("+alias+"."+column+" AS BLOB))")
+	}
+	return strings.Join(items, ",")
+}
+
+func canonicalTargetSize(sequence int64, eventTypes []string, eventLengths []sql.NullInt64, hasAudit bool, auditTypes []string, auditLengths []sql.NullInt64, policy domain.SegmentTargetPolicy) (int64, error) {
+	if len(eventTypes) == 0 || eventTypes[0] != "text" || !eventLengths[0].Valid || eventLengths[0].Int64 <= 0 {
+		return 0, apptypes.ErrCatalogDrift
+	}
+	size := int64(8+targetUvarintSize(uint64(sequence))+targetUvarintSize(uint64(eventLengths[0].Int64))+targetUvarintSize(uint64(len(eventTypes)))+1) + eventLengths[0].Int64
+	var err error
+	size, err = addTargetValueSizes(size, eventTypes, eventLengths, policy)
+	if err != nil {
+		return 0, err
+	}
+	if hasAudit {
+		size += int64(targetUvarintSize(uint64(len(auditTypes))))
+		size, err = addTargetValueSizes(size, auditTypes, auditLengths, policy)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return size, nil
+}
+
+func addTargetValueSizes(size int64, types []string, lengths []sql.NullInt64, policy domain.SegmentTargetPolicy) (int64, error) {
+	for index, storageClass := range types {
+		add := int64(1)
+		switch storageClass {
+		case "null":
+		case "integer", "real":
+			add += 8
+		case "text", "blob":
+			if !lengths[index].Valid || lengths[index].Int64 < 0 || lengths[index].Int64 > segmentTargetMaxValueBytes || lengths[index].Int64 > policy.MaxCanonicalPlainBytes-size {
+				return 0, apptypes.ErrSegmentTargetOversizeFirst
+			}
+			add += int64(targetUvarintSize(uint64(lengths[index].Int64))) + lengths[index].Int64
+		default:
+			return 0, apptypes.ErrCatalogDrift
+		}
+		if add > policy.MaxCanonicalPlainBytes-size {
+			return 0, apptypes.ErrSegmentTargetOversizeFirst
+		}
+		size += add
+	}
+	return size, nil
+}
+
+func targetUvarintSize(value uint64) int {
+	var buffer [binary.MaxVarintLen64]byte
+	return binary.PutUvarint(buffer[:], value)
+}
+
+//nolint:wrapcheck // Internal SQLite hydration preserves errors for its boundary.
+func hydrateSegmentTargetUnit(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, sequence int64) (domain.HistoryUnit, error) {
+	eventColumns, auditColumns := domain.ArchiveEventV1Columns(), domain.ArchiveAuditV1Columns()
+	query := `SELECT a.event_id,` + prefixedTargetColumns("e", eventColumns) + `,` + prefixedTargetColumns("a", auditColumns) +
+		` FROM archive_event_sequences s JOIN events e ON e.id=s.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE s.sequence=?`
+	var auditID any
+	eventRaw, auditRaw := make([]any, len(eventColumns)), make([]any, len(auditColumns))
+	dest := []any{&auditID}
+	for index := range eventRaw {
+		dest = append(dest, &eventRaw[index])
+	}
+	for index := range auditRaw {
+		dest = append(dest, &auditRaw[index])
+	}
+	if err := q.QueryRowContext(ctx, query, sequence).Scan(dest...); err != nil {
+		return domain.HistoryUnit{}, err
+	}
+	eventValues, err := targetSQLiteValues(eventRaw)
+	if err != nil {
+		return domain.HistoryUnit{}, apptypes.ErrCatalogDrift
+	}
+	event, err := domain.NewArchiveEventV1(eventValues)
+	if err != nil {
+		return domain.HistoryUnit{}, apptypes.ErrCatalogDrift
+	}
+	unit := domain.HistoryUnit{Sequence: uint64(sequence), Event: event}
+	if auditID != nil {
+		auditValues, conversionErr := targetSQLiteValues(auditRaw)
+		if conversionErr != nil {
+			return domain.HistoryUnit{}, apptypes.ErrCatalogDrift
+		}
+		audit, constructionErr := domain.NewArchiveAuditV1(auditValues)
+		if constructionErr != nil {
+			return domain.HistoryUnit{}, apptypes.ErrCatalogDrift
+		}
+		unit.Audit = &audit
+	}
+	return unit, nil
+}
+
+func prefixedTargetColumns(alias string, columns []string) string {
+	qualified := make([]string, len(columns))
+	for index, column := range columns {
+		qualified[index] = alias + "." + column
+	}
+	return strings.Join(qualified, ",")
+}
+
+func targetSQLiteValues(raw []any) ([]domain.SQLiteValue, error) {
+	values := make([]domain.SQLiteValue, len(raw))
+	for index, value := range raw {
+		switch typed := value.(type) {
+		case nil:
+			values[index] = domain.NullValue()
+		case int64:
+			values[index] = domain.IntegerValue(typed)
+		case float64:
+			values[index] = domain.RealValue(typed)
+		case string:
+			values[index] = domain.TextValue([]byte(typed))
+		case []byte:
+			values[index] = domain.BlobValue(typed)
+		default:
+			return nil, fmt.Errorf("unsupported SQLite storage class %T", value)
+		}
+	}
+	return values, nil
+}
+
+//nolint:wrapcheck // Internal SQLite proof lookup preserves errors for its boundary.
+func validateCatalogTargetRetry(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, request apptypes.CatalogTargetPlanRequest, selection domain.SegmentTargetSelection, units []segmentTargetUnitEvidence) error {
+	retry := request.Retry
+	priorID, priorRange, hasLargerPrior, err := latestReleasedLargerTarget(ctx, q, selection.Range)
+	if err != nil {
+		return err
+	}
+	if retry.PreviousReservationID == "" {
+		if retry.PreviousRange != (domain.CatalogRange{}) || retry.FailureClass != "" || retry.MeasuredBytes != 0 || retry.FailedCapBytes != 0 || retry.EvidenceDigest != "" || hasLargerPrior {
+			return apptypes.ErrSegmentTargetRetryProof
+		}
+		return nil
+	}
+	if !hasLargerPrior || priorID != retry.PreviousReservationID || priorRange != retry.PreviousRange || retry.PreviousReservationID == request.ReservationID || selection.Range.Start != priorRange.Start || selection.Range.End >= priorRange.End {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	historyRange, reserved, released, _, releaseEvidence, historyErr := catalogReservationHistory(ctx, q, retry.PreviousReservationID)
+	if historyErr != nil || !reserved || !released || historyRange != retry.PreviousRange || releaseEvidence != retry.EvidenceDigest {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	var oldPlanDigest, oldCapturedAt string
+	var oldHighWater, oldHorizon, oldMaxRows, oldPlainCap, oldDecodedCap, oldStoredCap, oldFileCap int64
+	var oldBoundVersion int64
+	err = q.QueryRowContext(ctx, `SELECT plan_digest,captured_high_water,captured_at,hot_horizon_ns,max_rows,max_canonical_plain_bytes,max_decoded_bytes,max_stored_upper_bytes,max_file_bytes,stored_bound_version FROM archive_segment_target_plans WHERE reservation_id=?`, retry.PreviousReservationID).Scan(&oldPlanDigest, &oldHighWater, &oldCapturedAt, &oldHorizon, &oldMaxRows, &oldPlainCap, &oldDecodedCap, &oldStoredCap, &oldFileCap, &oldBoundVersion)
+	if err != nil {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	if oldHighWater != request.CapturedHighWater || oldCapturedAt != request.Policy.CapturedAt.UTC().Format(time.RFC3339Nano) || oldHorizon != int64(request.Policy.HotHorizon) || oldPlainCap != request.Policy.MaxCanonicalPlainBytes || oldDecodedCap != request.Policy.MaxDecodedBytes || oldStoredCap != request.Policy.MaxStoredUpperBytes || oldFileCap != request.Policy.MaxFileBytes || oldBoundVersion != int64(request.Policy.StoredBoundVersion) || int64(request.Policy.MaxRows) >= oldMaxRows {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	relevantCap := oldStoredCap
+	if retry.FailureClass == apptypes.SegmentTargetFailureFileCap {
+		relevantCap = oldFileCap
+	} else if retry.FailureClass != apptypes.SegmentTargetFailureStoredCap {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	wantEvidence, digestErr := domain.SegmentTargetRetryEvidenceDigest(oldPlanDigest, retry.FailureClass, retry.MeasuredBytes, retry.FailedCapBytes)
+	if digestErr != nil || retry.FailedCapBytes != relevantCap || retry.EvidenceDigest != wantEvidence {
+		return apptypes.ErrSegmentTargetRetryProof
+	}
+	for _, unit := range units {
+		var oldBytes int64
+		var oldDigest string
+		if err = q.QueryRowContext(ctx, `SELECT canonical_bytes,canonical_digest FROM archive_segment_target_plan_units WHERE reservation_id=? AND sequence=?`, retry.PreviousReservationID, unit.sequence).Scan(&oldBytes, &oldDigest); err != nil || oldBytes != unit.bytes || oldDigest != unit.digest {
+			return apptypes.ErrSegmentTargetRetryProof
+		}
+	}
+	return nil
+}
+
+//nolint:wrapcheck // Internal SQLite helper preserves errors for its boundary.
+func latestReleasedLargerTarget(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, selection domain.CatalogRange) (string, domain.CatalogRange, bool, error) {
+	rows, err := q.QueryContext(ctx, `SELECT rs.reservation_id,rs.start_sequence,rs.end_sequence FROM archive_catalog_reservation_deltas rs JOIN archive_catalog_reservation_deltas rl ON rl.reservation_id=rs.reservation_id AND rl.delta='release' WHERE rs.delta='reserve' AND rs.start_sequence=? AND rs.end_sequence>? ORDER BY rl.epoch DESC LIMIT 1`, selection.Start, selection.End)
+	if err != nil {
+		return "", domain.CatalogRange{}, false, err
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		return "", domain.CatalogRange{}, false, rows.Err()
+	}
+	var reservationID string
+	var target domain.CatalogRange
+	if err = rows.Scan(&reservationID, &target.Start, &target.End); err != nil {
+		return "", domain.CatalogRange{}, false, err
+	}
+	return reservationID, target, true, rows.Err()
+}
+
+//nolint:wrapcheck // Transaction-local durable plan writes preserve SQLite errors.
+func insertCatalogTargetPlan(ctx context.Context, tx *sql.Tx, boundEpoch int64, storeID string, parent apptypes.CatalogHead, request apptypes.CatalogTargetPlanRequest, selection domain.SegmentTargetSelection, units []segmentTargetUnitEvidence, sourceDigest, planDigest, evidenceDigest string, afterUnit func(string) error) error {
+	retry := request.Retry
+	_, err := tx.ExecContext(ctx, `INSERT INTO archive_segment_target_plans(reservation_id,bound_epoch,store_id,catalog_parent_epoch,catalog_parent_ledger_digest,catalog_parent_ranges_digest,captured_high_water,captured_at,hot_horizon_ns,max_rows,max_canonical_plain_bytes,max_decoded_bytes,max_stored_upper_bytes,max_file_bytes,stored_bound_version,start_sequence,end_sequence,selected_rows,canonical_plain_bytes,decoded_bytes,stored_upper_bytes,source_digest,plan_digest,reservation_evidence_digest,retry_previous_reservation_id,retry_failure_class,retry_measured_bytes,retry_failed_cap_bytes,retry_evidence_digest) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, request.ReservationID, boundEpoch, storeID, parent.Epoch, parent.LedgerDigest, parent.CurrentRangesDigest, request.CapturedHighWater, request.Policy.CapturedAt.UTC().Format(time.RFC3339Nano), int64(request.Policy.HotHorizon), request.Policy.MaxRows, request.Policy.MaxCanonicalPlainBytes, request.Policy.MaxDecodedBytes, request.Policy.MaxStoredUpperBytes, request.Policy.MaxFileBytes, request.Policy.StoredBoundVersion, selection.Range.Start, selection.Range.End, selection.Rows, selection.CanonicalPlainBytes, selection.DecodedBytes, selection.StoredUpperBytes, sourceDigest, planDigest, evidenceDigest, retry.PreviousReservationID, retry.FailureClass, retry.MeasuredBytes, retry.FailedCapBytes, retry.EvidenceDigest)
+	if err != nil {
+		return err
+	}
+	for _, unit := range units {
+		if _, err = tx.ExecContext(ctx, `INSERT INTO archive_segment_target_plan_units(reservation_id,sequence,canonical_bytes,canonical_digest) VALUES(?,?,?,?)`, request.ReservationID, unit.sequence, unit.bytes, unit.digest); err != nil {
+			return err
+		}
+		if afterUnit != nil {
+			if err = afterUnit("plan-unit-inserted"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func catalogTargetEvidenceDigest(planDigest string, retry apptypes.CatalogTargetRetry) string {
+	if retry.PreviousReservationID == "" {
+		return planDigest
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary-segment-target-retry-v2\x00"))
+	for _, value := range []string{planDigest, retry.PreviousReservationID, retry.FailureClass, retry.EvidenceDigest, fmt.Sprint(retry.PreviousRange.Start), fmt.Sprint(retry.PreviousRange.End), fmt.Sprint(retry.MeasuredBytes), fmt.Sprint(retry.FailedCapBytes)} {
+		_, _ = h.Write([]byte(value))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/infrastructure/sqlite/segment_target_planner_internal_test.go
+++ b/infrastructure/sqlite/segment_target_planner_internal_test.go
@@ -1,0 +1,527 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+func plannerPolicy(maxRows int) apptypes.SegmentTargetPolicy {
+	return apptypes.SegmentTargetPolicy{CapturedAt: time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC), HotHorizon: 24 * time.Hour, MaxRows: maxRows, MaxCanonicalPlainBytes: 1 << 20, MaxDecodedBytes: 64 << 20, MaxStoredUpperBytes: 1 << 20, MaxFileBytes: 2 << 20, StoredBoundVersion: apptypes.SegmentStoredBoundV1}
+}
+
+func TestSegmentTargetSerializesTwoConnectionRacesAfterSnapshot(t *testing.T) {
+	tests := []struct {
+		name       string
+		compete    func(context.Context, *Database, *sql.DB, apptypes.CatalogTargetPlanRequest) error
+		wantWriter bool
+	}{
+		{name: "backdated event waits then remains hot", wantWriter: true, compete: func(_ context.Context, _ *Database, raw *sql.DB, _ apptypes.CatalogTargetPlanRequest) error {
+			_, err := raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES('race-backdated','note','a','s','body','2020-01-01T00:00:00Z','c','w')`)
+			if err != nil {
+				return fmt.Errorf("insert racing event: %w", err)
+			}
+			return nil
+		}},
+		{name: "late audit waits then freeze rejects it", compete: func(_ context.Context, _ *Database, raw *sql.DB, _ apptypes.CatalogTargetPlanRequest) error {
+			_, err := raw.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text,input_truncated,output_truncated,exit_code,failed,input_original_bytes,output_original_bytes,command_wrapper,command_name,failure_reason) VALUES('catalog-event-b','echo','','',0,0,0,0,0,0,'direct','echo','none')`)
+			if err != nil {
+				return fmt.Errorf("insert racing audit: %w", err)
+			}
+			return nil
+		}},
+		{name: "competing planner loses expected head", compete: func(ctx context.Context, other *Database, _ *sql.DB, request apptypes.CatalogTargetPlanRequest) error {
+			request.ReservationID = "race-loser"
+			_, err := other.PlanAndReserveCatalogTarget(ctx, request)
+			return err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 1)
+			defer func() { _ = raw.Close() }()
+			initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			request := plannerRequest(initial.Head, 1, "race-winner", 1)
+			other := NewDatabase(database.Path(), preparedMigrations(t))
+			started := make(chan struct{})
+			result := make(chan error, 1)
+			var once sync.Once
+			database.segmentTargetPlannerHook = func(point string) error {
+				if point != "snapshot-pinned" {
+					return nil
+				}
+				once.Do(func() {
+					go func() {
+						close(started)
+						result <- test.compete(ctx, other, raw, request)
+					}()
+				})
+				<-started
+				select {
+				case err := <-result:
+					t.Fatalf("competitor escaped writer fence before publication: %v", err)
+				default:
+				}
+				return nil
+			}
+			plan, err := database.PlanAndReserveCatalogTarget(ctx, request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			competitorErr := <-result
+			if test.wantWriter {
+				if competitorErr != nil {
+					t.Fatal(competitorErr)
+				}
+			} else if competitorErr == nil {
+				t.Fatal("competing mutation/planner unexpectedly succeeded")
+			}
+			var reservations int
+			if err = raw.QueryRow(`SELECT count(*) FROM archive_catalog_reservation_deltas WHERE delta='reserve'`).Scan(&reservations); err != nil || reservations != 1 {
+				t.Fatalf("reservations=%d err=%v", reservations, err)
+			}
+			current, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if err != nil || current.Head != plan.Head || current.Ranges[0].Placement != domain.CatalogPlacementReserved {
+				t.Fatalf("current=%+v err=%v", current, err)
+			}
+			if test.wantWriter {
+				var sequence int64
+				var covered int
+				if err = raw.QueryRow(`SELECT sequence FROM archive_event_sequences WHERE event_id='race-backdated'`).Scan(&sequence); err != nil {
+					t.Fatal(err)
+				}
+				if err = raw.QueryRow(`SELECT count(*) FROM archive_catalog_current_ranges WHERE placement_state<>'hot' AND ? BETWEEN start_sequence AND end_sequence`, sequence).Scan(&covered); err != nil || sequence != 2 || covered != 0 {
+					t.Fatalf("backdated sequence=%d non-hot coverage=%d err=%v", sequence, covered, err)
+				}
+			}
+		})
+	}
+}
+
+func TestReservedTargetFreezesSameLengthEventMutationAndLateAudit(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 2)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	plan, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 2, "freeze-target", 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE events SET body='same' WHERE id='catalog-event-b'`); err == nil || !strings.Contains(err.Error(), "reserved archive history") {
+		t.Fatalf("same-length update error = %v", err)
+	}
+	if _, err = raw.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text,input_truncated,output_truncated,exit_code,failed,input_original_bytes,output_original_bytes,command_wrapper,command_name,failure_reason) VALUES('catalog-event-b','echo','','',0,0,0,0,0,0,'direct','echo','none')`); err == nil || !strings.Contains(err.Error(), "reserved archive history") {
+		t.Fatalf("late audit error = %v", err)
+	}
+	var plans, units int
+	if err = raw.QueryRow(`SELECT count(*) FROM archive_segment_target_plans WHERE reservation_id=?`, plan.ReservationID).Scan(&plans); err != nil {
+		t.Fatal(err)
+	}
+	if err = raw.QueryRow(`SELECT count(*) FROM archive_segment_target_plan_units WHERE reservation_id=?`, plan.ReservationID).Scan(&units); err != nil {
+		t.Fatal(err)
+	}
+	if plans != 1 || units != 2 {
+		t.Fatalf("durable evidence plans=%d units=%d", plans, units)
+	}
+}
+
+func TestPlanAndReserveCatalogTargetNormalizesTimestampStorageFailures(t *testing.T) {
+	mutations := []string{
+		`UPDATE events SET created_at='not-a-time'`,
+		`UPDATE events SET created_at=CAST('2020-01-01T00:00:00Z' AS BLOB)`,
+		`UPDATE events SET created_at=42`,
+	}
+	for index, mutation := range mutations {
+		t.Run(strings.ReplaceAll(mutation, " ", "_"), func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 1)
+			defer func() { _ = raw.Close() }()
+			if _, err := raw.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			_, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 1, fmt.Sprintf("malformed-%d", index), 1))
+			if !errors.Is(err, apptypes.ErrSegmentTargetMalformedTimestamp) {
+				t.Fatalf("error = %v", err)
+			}
+			after, readErr := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if readErr != nil || after.Head != initial.Head {
+				t.Fatalf("head changed: %+v %v", after.Head, readErr)
+			}
+		})
+	}
+}
+
+func TestSegmentTargetStopsBeforeHydratingRecentOrOversizeBoundary(t *testing.T) {
+	ctx := context.Background()
+	t.Run("recent", func(t *testing.T) {
+		database, raw := newActivatedCatalogStore(t, 2)
+		defer func() { _ = raw.Close() }()
+		if _, err := raw.Exec(`UPDATE events SET created_at='2026-08-05T11:30:00Z',body_plaintext_bytes=999999999 WHERE id='catalog-event-c'`); err != nil {
+			t.Fatal(err)
+		}
+		initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+		plan, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 2, "stop-recent", 2))
+		if err != nil || plan.Range.End != 1 {
+			t.Fatalf("plan=%+v error=%v", plan, err)
+		}
+	})
+	t.Run("oversize", func(t *testing.T) {
+		database, raw := newActivatedCatalogStore(t, 2)
+		defer func() { _ = raw.Close() }()
+		if _, err := raw.Exec(`UPDATE events SET body=zeroblob(?) WHERE id='catalog-event-c'`, segmentTargetMaxValueBytes+1); err != nil {
+			t.Fatal(err)
+		}
+		initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+		plan, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 2, "stop-oversize", 2))
+		if err != nil || plan.Range.End != 1 {
+			t.Fatalf("plan=%+v error=%v", plan, err)
+		}
+	})
+}
+
+func TestSegmentTargetByteAccountingMatchesCanonicalEncoding(t *testing.T) {
+	values := []struct {
+		name  string
+		value any
+		bytes int64
+	}{
+		{name: "japanese", value: "日本語", bytes: int64(len([]byte("日本語")))},
+		{name: "combining", value: "e\u0301", bytes: int64(len([]byte("e\u0301")))},
+		{name: "emoji", value: "🙂", bytes: int64(len([]byte("🙂")))},
+		{name: "nul", value: "a\x00b", bytes: 3},
+		{name: "invalid utf8 equivalent blob", value: []byte{0xff, 0xfe, 0x80}, bytes: 3},
+	}
+	for _, test := range values {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 1)
+			defer func() { _ = raw.Close() }()
+			if _, err := raw.Exec(`UPDATE events SET body=?`, test.value); err != nil {
+				t.Fatal(err)
+			}
+			policy := plannerPolicy(1)
+			meta, err := readSegmentTargetMetadata(ctx, raw, 1, policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unit, err := hydrateSegmentTargetUnit(ctx, raw, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			canonical, err := unit.CanonicalBytes()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.canonicalBytes != int64(len(canonical)) || meta.decodedBytes != test.bytes {
+				t.Fatalf("metadata=%+v canonical=%d decoded-want=%d", meta, len(canonical), test.bytes)
+			}
+			_ = database
+		})
+	}
+}
+
+func TestSegmentTargetCanonicalByteCapBoundaryIsExact(t *testing.T) {
+	const body = "日本語e\u0301🙂\x00"
+	measure := func(t *testing.T) int64 {
+		t.Helper()
+		database, raw := newActivatedCatalogStore(t, 1)
+		defer func() { _ = raw.Close() }()
+		if _, err := raw.Exec(`UPDATE events SET body=?`, body); err != nil {
+			t.Fatal(err)
+		}
+		meta, err := readSegmentTargetMetadata(context.Background(), raw, 1, plannerPolicy(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = database
+		return meta.canonicalBytes
+	}
+	wantBytes := measure(t)
+	for _, test := range []struct {
+		name    string
+		cap     int64
+		wantErr error
+	}{
+		{name: "exact", cap: wantBytes},
+		{name: "one byte below", cap: wantBytes - 1, wantErr: apptypes.ErrSegmentTargetOversizeFirst},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 1)
+			defer func() { _ = raw.Close() }()
+			if _, err := raw.Exec(`UPDATE events SET body=?`, body); err != nil {
+				t.Fatal(err)
+			}
+			initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			request := plannerRequest(initial.Head, 1, "byte-cap-"+strings.ReplaceAll(test.name, " ", "-"), 1)
+			request.Policy.MaxCanonicalPlainBytes = test.cap
+			request.Policy.MaxStoredUpperBytes = test.cap
+			plan, err := database.PlanAndReserveCatalogTarget(ctx, request)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("error = %v", err)
+				}
+				after, readErr := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+				if readErr != nil || after.Head != initial.Head {
+					t.Fatalf("head changed: %+v %v", after.Head, readErr)
+				}
+				return
+			}
+			if err != nil || plan.CanonicalPlainBytes != wantBytes {
+				t.Fatalf("plan=%+v error=%v want=%d", plan, err, wantBytes)
+			}
+		})
+	}
+}
+
+func plannerRequest(head apptypes.CatalogHead, highWater int64, reservationID string, maxRows int) apptypes.CatalogTargetPlanRequest {
+	return apptypes.CatalogTargetPlanRequest{ExpectedHead: head, ReservationID: reservationID, CapturedHighWater: highWater, Policy: plannerPolicy(maxRows), Budget: catalogTestBudget()}
+}
+
+func TestPlanAndReserveCatalogTargetExcludesConcurrentBackdatedAppend(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO command_audits(event_id,command_text,input_text,output_text,input_truncated,output_truncated,exit_code,failed,input_original_bytes,output_original_bytes,command_wrapper,command_name,failure_reason) VALUES('catalog-event-b','echo test','','test',0,0,0,0,0,4,'direct','echo','none')`); err != nil {
+		t.Fatal(err)
+	}
+	// A backdated write is newer in archive sequence and therefore remains Hot.
+	if _, err = raw.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES('planner-backdated','note','a','s','body','2020-01-01T00:00:00Z','c','w')`); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 3, "target-three", 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Range != (domain.CatalogRange{Start: 1, End: 3}) || plan.Rows != 3 || plan.CapturedHighWater != 3 || !domain.ValidCatalogDigest(plan.PlanDigest) {
+		t.Fatalf("plan = %+v", plan)
+	}
+	snapshot, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Ranges) != 2 || snapshot.Ranges[0].Placement != domain.CatalogPlacementReserved || snapshot.Ranges[1].Range != (domain.CatalogRange{Start: 4, End: 4}) || snapshot.Ranges[1].Placement != domain.CatalogPlacementHot {
+		t.Fatalf("ranges = %+v", snapshot.Ranges)
+	}
+}
+
+func TestPlanAndReserveCatalogTargetTypedFailuresDoNotPublish(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*apptypes.CatalogTargetPlanRequest)
+		createdAt string
+		want      error
+	}{
+		{name: "recent first", createdAt: "2026-08-05T11:30:00Z", want: apptypes.ErrSegmentTargetRecentFirst},
+		{name: "malformed timestamp", createdAt: "not-a-time", want: apptypes.ErrSegmentTargetMalformedTimestamp},
+		{name: "oversize first", createdAt: "2020-01-01T00:00:00Z", mutate: func(r *apptypes.CatalogTargetPlanRequest) {
+			r.Policy.MaxCanonicalPlainBytes = 1
+			r.Policy.MaxStoredUpperBytes = 1
+		}, want: apptypes.ErrSegmentTargetOversizeFirst},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 1)
+			defer func() { _ = raw.Close() }()
+			if _, err := raw.Exec(`UPDATE events SET created_at=?`, test.createdAt); err != nil {
+				t.Fatal(err)
+			}
+			initial, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := plannerRequest(initial.Head, 1, "typed-failure", 10)
+			if test.mutate != nil {
+				test.mutate(&request)
+			}
+			_, err = database.PlanAndReserveCatalogTarget(ctx, request)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v", err)
+			}
+			after, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if err != nil || after.Head != initial.Head {
+				t.Fatalf("head changed: before=%+v after=%+v error=%v", initial.Head, after.Head, err)
+			}
+		})
+	}
+}
+
+func TestPlanAndReserveCatalogTargetDeadlineIsIncompleteAndDoesNotReserve(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	request := plannerRequest(initial.Head, 1, "deadline", 10)
+	request.Budget.WallTime = time.Nanosecond
+	_, err := database.PlanAndReserveCatalogTarget(ctx, request)
+	if !errors.Is(err, apptypes.ErrSegmentTargetSelectionIncomplete) {
+		t.Fatalf("error = %v", err)
+	}
+	after, readErr := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if readErr != nil || after.Head != initial.Head {
+		t.Fatalf("head changed: %+v %v", after.Head, readErr)
+	}
+}
+
+func TestSegmentTargetDeadlineAtTransactionalBoundariesRollsBackEverything(t *testing.T) {
+	for _, point := range []string{"selection-complete", "plan-unit-inserted"} {
+		t.Run(point, func(t *testing.T) {
+			ctx := context.Background()
+			database, raw := newActivatedCatalogStore(t, 2)
+			defer func() { _ = raw.Close() }()
+			initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			fired := make(chan struct{})
+			var once sync.Once
+			database.segmentTargetPlannerHook = func(observed string) error {
+				if observed != point {
+					return nil
+				}
+				once.Do(func() { close(fired) })
+				return context.DeadlineExceeded
+			}
+			_, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 2, "deadline-"+point, 2))
+			if !errors.Is(err, apptypes.ErrSegmentTargetSelectionIncomplete) {
+				t.Fatalf("error = %v", err)
+			}
+			select {
+			case <-fired:
+			default:
+				t.Fatal("deadline seam was not reached")
+			}
+			after, readErr := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if readErr != nil || after.Head != initial.Head {
+				t.Fatalf("head changed: before=%+v after=%+v err=%v", initial.Head, after.Head, readErr)
+			}
+			var epochs, deltas, plans, units int
+			if err = raw.QueryRow(`SELECT (SELECT count(*) FROM archive_catalog_epochs),(SELECT count(*) FROM archive_catalog_reservation_deltas),(SELECT count(*) FROM archive_segment_target_plans),(SELECT count(*) FROM archive_segment_target_plan_units)`).Scan(&epochs, &deltas, &plans, &units); err != nil {
+				t.Fatal(err)
+			}
+			if epochs != 0 || deltas != 0 || plans != 0 || units != 0 {
+				t.Fatalf("partial publication epochs=%d deltas=%d plans=%d units=%d", epochs, deltas, plans, units)
+			}
+		})
+	}
+}
+
+func TestPlanAndReserveCatalogTargetShorteningRequiresReleasedMeasuredProofAndNewID(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	first, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 3, "original-target", 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	retryDigest, err := domain.SegmentTargetRetryEvidenceDigest(first.PlanDigest, apptypes.SegmentTargetFailureFileCap, 3<<20, 2<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preRelease := plannerRequest(first.Head, 3, "pre-release-shorter", 2)
+	preRelease.Retry = apptypes.CatalogTargetRetry{PreviousReservationID: first.ReservationID, PreviousRange: first.Range, FailureClass: apptypes.SegmentTargetFailureFileCap, MeasuredBytes: 3 << 20, FailedCapBytes: 2 << 20, EvidenceDigest: retryDigest}
+	if _, err = database.PlanAndReserveCatalogTarget(ctx, preRelease); !errors.Is(err, apptypes.ErrSegmentTargetRetryProof) {
+		t.Fatalf("pre-release retry error = %v", err)
+	}
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: first.Head, ReservationID: first.ReservationID, EvidenceDigest: retryDigest, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unproven := plannerRequest(released, 3, "silent-shorter-target", 2)
+	if _, err = database.PlanAndReserveCatalogTarget(ctx, unproven); !errors.Is(err, apptypes.ErrSegmentTargetRetryProof) {
+		t.Fatalf("unproven shortening error = %v", err)
+	}
+	retry := plannerRequest(released, 3, "shorter-target", 2)
+	retry.Retry = apptypes.CatalogTargetRetry{PreviousReservationID: first.ReservationID, PreviousRange: first.Range, FailureClass: apptypes.SegmentTargetFailureFileCap, MeasuredBytes: 3 << 20, FailedCapBytes: 2 << 20, EvidenceDigest: retryDigest}
+	invalid := []struct {
+		name   string
+		mutate func(*apptypes.CatalogTargetPlanRequest)
+	}{
+		{name: "forged digest", mutate: func(r *apptypes.CatalogTargetPlanRequest) { r.Retry.EvidenceDigest = strings.Repeat("a", 64) }},
+		{name: "below cap", mutate: func(r *apptypes.CatalogTargetPlanRequest) {
+			r.Retry.MeasuredBytes = r.Retry.FailedCapBytes
+			r.Retry.EvidenceDigest = strings.Repeat("b", 64)
+		}},
+		{name: "different high water", mutate: func(r *apptypes.CatalogTargetPlanRequest) { r.CapturedHighWater = 2 }},
+		{name: "different horizon", mutate: func(r *apptypes.CatalogTargetPlanRequest) { r.Policy.HotHorizon += time.Hour }},
+		{name: "unrelated plain cap", mutate: func(r *apptypes.CatalogTargetPlanRequest) { r.Policy.MaxCanonicalPlainBytes-- }},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := retry
+			test.mutate(&candidate)
+			if _, retryErr := database.PlanAndReserveCatalogTarget(ctx, candidate); !errors.Is(retryErr, apptypes.ErrSegmentTargetRetryProof) {
+				t.Fatalf("error = %v", retryErr)
+			}
+			after, readErr := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+			if readErr != nil || after.Head != released {
+				t.Fatalf("head changed: %+v %v", after.Head, readErr)
+			}
+		})
+	}
+	shorter, err := database.PlanAndReserveCatalogTarget(ctx, retry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shorter.Range != (domain.CatalogRange{Start: 1, End: 2}) {
+		t.Fatalf("shorter = %+v", shorter)
+	}
+}
+
+func TestShorteningRejectsSameLengthSourceChangeAfterRelease(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	first, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 3, "changed-source-original", 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, _ := domain.SegmentTargetRetryEvidenceDigest(first.PlanDigest, apptypes.SegmentTargetFailureFileCap, 3<<20, 2<<20)
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: first.Head, ReservationID: first.ReservationID, EvidenceDigest: digest, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE events SET body='same' WHERE id='catalog-event-b'`); err != nil {
+		t.Fatal(err)
+	}
+	retry := plannerRequest(released, 3, "changed-source-shorter", 2)
+	retry.Retry = apptypes.CatalogTargetRetry{PreviousReservationID: first.ReservationID, PreviousRange: first.Range, FailureClass: apptypes.SegmentTargetFailureFileCap, MeasuredBytes: 3 << 20, FailedCapBytes: 2 << 20, EvidenceDigest: digest}
+	if _, err = database.PlanAndReserveCatalogTarget(ctx, retry); !errors.Is(err, apptypes.ErrSegmentTargetRetryProof) {
+		t.Fatalf("changed source retry error = %v", err)
+	}
+}
+
+func TestShorteningRejectsReleaseThatWasNotBoundToFailureProof(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 3)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	first, err := database.PlanAndReserveCatalogTarget(ctx, plannerRequest(initial.Head, 3, "wrong-release-original", 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	released, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: first.Head, ReservationID: first.ReservationID, EvidenceDigest: first.PlanDigest, Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, _ := domain.SegmentTargetRetryEvidenceDigest(first.PlanDigest, apptypes.SegmentTargetFailureFileCap, 3<<20, 2<<20)
+	retry := plannerRequest(released, 3, "wrong-release-shorter", 2)
+	retry.Retry = apptypes.CatalogTargetRetry{PreviousReservationID: first.ReservationID, PreviousRange: first.Range, FailureClass: apptypes.SegmentTargetFailureFileCap, MeasuredBytes: 3 << 20, FailedCapBytes: 2 << 20, EvidenceDigest: digest}
+	if _, err = database.PlanAndReserveCatalogTarget(ctx, retry); !errors.Is(err, apptypes.ErrSegmentTargetRetryProof) {
+		t.Fatalf("wrong release proof retry error = %v", err)
+	}
+}

--- a/schema/sqlite/migrations/000046_add_segment_target_plans.sql
+++ b/schema/sqlite/migrations/000046_add_segment_target_plans.sql
@@ -1,0 +1,99 @@
+-- Durable target plans bind a reservation to its exact source snapshot,
+-- policy, ordered canonical input, and any measured shortening proof.
+CREATE TABLE archive_segment_target_plans (
+    reservation_id TEXT PRIMARY KEY CHECK(length(reservation_id) BETWEEN 1 AND 255),
+    bound_epoch INTEGER NOT NULL UNIQUE REFERENCES archive_catalog_epochs(epoch),
+    store_id TEXT NOT NULL CHECK(length(store_id)=32),
+    catalog_parent_epoch INTEGER NOT NULL CHECK(catalog_parent_epoch>=0),
+    catalog_parent_ledger_digest TEXT NOT NULL CHECK(length(catalog_parent_ledger_digest)=64),
+    catalog_parent_ranges_digest TEXT NOT NULL CHECK(length(catalog_parent_ranges_digest)=64),
+    captured_high_water INTEGER NOT NULL CHECK(captured_high_water>0),
+    captured_at TEXT NOT NULL,
+    hot_horizon_ns INTEGER NOT NULL CHECK(hot_horizon_ns>0),
+    max_rows INTEGER NOT NULL CHECK(max_rows>0),
+    max_canonical_plain_bytes INTEGER NOT NULL CHECK(max_canonical_plain_bytes>0),
+    max_decoded_bytes INTEGER NOT NULL CHECK(max_decoded_bytes>0),
+    max_stored_upper_bytes INTEGER NOT NULL CHECK(max_stored_upper_bytes>0),
+    max_file_bytes INTEGER NOT NULL CHECK(max_file_bytes>0),
+    stored_bound_version INTEGER NOT NULL CHECK(stored_bound_version>0),
+    start_sequence INTEGER NOT NULL CHECK(start_sequence>0),
+    end_sequence INTEGER NOT NULL CHECK(end_sequence>=start_sequence),
+    selected_rows INTEGER NOT NULL CHECK(selected_rows=end_sequence-start_sequence+1),
+    canonical_plain_bytes INTEGER NOT NULL CHECK(canonical_plain_bytes>0),
+    decoded_bytes INTEGER NOT NULL CHECK(decoded_bytes>=0),
+    stored_upper_bytes INTEGER NOT NULL CHECK(stored_upper_bytes>0),
+    source_digest TEXT NOT NULL CHECK(length(source_digest)=64),
+    plan_digest TEXT NOT NULL UNIQUE CHECK(length(plan_digest)=64),
+    reservation_evidence_digest TEXT NOT NULL CHECK(length(reservation_evidence_digest)=64),
+    retry_previous_reservation_id TEXT NOT NULL DEFAULT '',
+    retry_failure_class TEXT NOT NULL DEFAULT '' CHECK(retry_failure_class IN ('','stored_cap','file_cap')),
+    retry_measured_bytes INTEGER NOT NULL DEFAULT 0 CHECK(retry_measured_bytes>=0),
+    retry_failed_cap_bytes INTEGER NOT NULL DEFAULT 0 CHECK(retry_failed_cap_bytes>=0),
+    retry_evidence_digest TEXT NOT NULL DEFAULT '',
+    CHECK ((length(retry_previous_reservation_id)>0) = (length(retry_failure_class)>0)),
+    CHECK ((length(retry_previous_reservation_id)>0) = (retry_measured_bytes>0)),
+    CHECK ((length(retry_previous_reservation_id)>0) = (retry_failed_cap_bytes>0)),
+    CHECK ((length(retry_previous_reservation_id)>0) = (length(retry_evidence_digest)=64))
+);
+
+CREATE TABLE archive_segment_target_plan_units (
+    reservation_id TEXT NOT NULL REFERENCES archive_segment_target_plans(reservation_id),
+    sequence INTEGER NOT NULL CHECK(sequence>0),
+    canonical_bytes INTEGER NOT NULL CHECK(canonical_bytes>0),
+    canonical_digest TEXT NOT NULL CHECK(length(canonical_digest)=64),
+    PRIMARY KEY(reservation_id,sequence)
+);
+
+CREATE TRIGGER archive_segment_target_plans_no_update
+BEFORE UPDATE ON archive_segment_target_plans BEGIN SELECT RAISE(ABORT,'segment target plans are immutable'); END;
+CREATE TRIGGER archive_segment_target_plans_no_delete
+BEFORE DELETE ON archive_segment_target_plans BEGIN SELECT RAISE(ABORT,'segment target plans are immutable'); END;
+CREATE TRIGGER archive_segment_target_plan_units_no_update
+BEFORE UPDATE ON archive_segment_target_plan_units BEGIN SELECT RAISE(ABORT,'segment target plan units are immutable'); END;
+CREATE TRIGGER archive_segment_target_plan_units_no_delete
+BEFORE DELETE ON archive_segment_target_plan_units BEGIN SELECT RAISE(ABORT,'segment target plan units are immutable'); END;
+
+-- A reserved range is a durable source freeze. Late audit creation is a source
+-- mutation just like event/audit update or delete.
+CREATE TRIGGER archive_reserved_events_no_update
+BEFORE UPDATE ON events WHEN EXISTS (
+    SELECT 1 FROM archive_event_sequences s JOIN archive_catalog_current_ranges r
+      ON s.sequence BETWEEN r.start_sequence AND r.end_sequence
+     WHERE s.event_id=OLD.id AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_events_no_delete
+BEFORE DELETE ON events WHEN EXISTS (
+    SELECT 1 FROM archive_event_sequences s JOIN archive_catalog_current_ranges r
+      ON s.sequence BETWEEN r.start_sequence AND r.end_sequence
+     WHERE s.event_id=OLD.id AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_sequences_no_update
+BEFORE UPDATE ON archive_event_sequences WHEN EXISTS (
+    SELECT 1 FROM archive_catalog_current_ranges r
+     WHERE OLD.sequence BETWEEN r.start_sequence AND r.end_sequence
+       AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_sequences_no_delete
+BEFORE DELETE ON archive_event_sequences WHEN EXISTS (
+    SELECT 1 FROM archive_catalog_current_ranges r
+     WHERE OLD.sequence BETWEEN r.start_sequence AND r.end_sequence
+       AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_audits_no_insert
+BEFORE INSERT ON command_audits WHEN EXISTS (
+    SELECT 1 FROM archive_event_sequences s JOIN archive_catalog_current_ranges r
+      ON s.sequence BETWEEN r.start_sequence AND r.end_sequence
+     WHERE s.event_id=NEW.event_id AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_audits_no_update
+BEFORE UPDATE ON command_audits WHEN EXISTS (
+    SELECT 1 FROM archive_event_sequences s JOIN archive_catalog_current_ranges r
+      ON s.sequence BETWEEN r.start_sequence AND r.end_sequence
+     WHERE s.event_id IN (OLD.event_id,NEW.event_id) AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;
+CREATE TRIGGER archive_reserved_audits_no_delete
+BEFORE DELETE ON command_audits WHEN EXISTS (
+    SELECT 1 FROM archive_event_sequences s JOIN archive_catalog_current_ranges r
+      ON s.sequence BETWEEN r.start_sequence AND r.end_sequence
+     WHERE s.event_id=OLD.event_id AND r.placement_state='reserved'
+) BEGIN SELECT RAISE(ABORT,'reserved archive history is immutable'); END;


### PR DESCRIPTION
## Summary
- plan the smallest contiguous Hot prefix against a captured Catalog snapshot and policy caps
- bind reservations to ordered canonical source evidence and freeze reserved source history
- persist measured cap-failure proofs for append-only release and strictly smaller retries
- normalize all deadline paths to typed selection-incomplete rollback
- add migration 46 and concurrency, Unicode byte-boundary, freeze, retry-proof, and timeout regressions

## Validation
- go test ./... -count=1
- go vet ./...
- go tool golangci-lint run --timeout=5m
- focused race tests
- independent GPT-5.6 Sol review: APPROVE

Closes #1662