### PR TITLE
feat: add conservative catalog summaries

### DIFF
--- a/.ai/spec/1663-conservative-catalog-summaries.md
+++ b/.ai/spec/1663-conservative-catalog-summaries.md
@@ -1,0 +1,51 @@
+# Issue #1663: conservative Catalog summaries
+
+## Structure-Behavior Design Note
+
+### Requirement summary
+
+- Generate deterministic format-v1 summaries from metadata columns only, using a versioned keyed HMAC, exact tokens, bounded Bloom filters, and keyed session aggregates.
+- Route supported positive equality predicates through exact then Bloom evidence; every incomplete, mismatched, saturated, short, negative, or unsupported case is unknown and therefore selected.
+- Reconcile only metadata-verified immutable segments already bound by the append-only Catalog ledger. Rebuild is bounded, per-segment resumable and never reads `history_units.payload`.
+- Expose only aggregate coverage, storage, state, and drift diagnostics.
+
+### Conceptual model
+
+| Concept | State / behavior | Invariant |
+|---|---|---|
+| Summary generator | keyed metadata facts and fixed caps | cap transitions discard negative evidence, never facts selectively |
+| Candidate evidence | exact hit, Bloom answer, or unknown | only a complete Bloom miss may exclude |
+| Reconciled metadata | verified segment summary copied into derived Hot tables | epoch ledger and immutable binding remain sole authority |
+| Rebuild checkpoint | durable full-ledger audit cursor plus per-segment cache cursor | retry is deterministic and idempotent; incomplete audit never reaches reconciliation |
+| Diagnostics | aggregate counts only | no identity, token, digest, basename, key ID, or payload leaves the adapter |
+
+### Responsibility assignment
+
+| Responsibility | Owner | Not owner |
+|---|---|---|
+| HMAC/Bloom construction and conservative matching | `domain` | SQLite and filesystem |
+| Request/result and aggregate diagnostics | `application/types` | raw metadata |
+| verified manifest reconciliation and resumable derived tables | `infrastructure/sqlite` | authority reconstruction |
+
+### Boundaries / interfaces
+
+| Boundary | Consumer | Hidden detail | Error contract |
+|---|---|---|---|
+| `GenerateSegmentCatalogSummaryV1` | segment builder | HMAC and Bloom hashing | invalid/cap errors contain no raw values |
+| `SegmentSummaryMayMatch` | later search router | exact/Bloom representation | unknown returns `true` |
+| `RebuildCatalogSummaries` | maintenance/release gate | archive names, tokens and digests | ledger/binding drift fails closed |
+| `CatalogSummaryDiagnostics` | operators | all identifiers | aggregate-only result |
+
+### Behavior tests / TDD plan
+
+Tests cover deterministic generation, exact-cap transition, Bloom saturation, key mismatch, short/negative/unsupported predicates, zero false negatives for inserted values, session aggregation, metadata-only reconciliation, interruption/resume/idempotency, ledger loss/drift, and diagnostics privacy.
+
+### Risks / rollback
+
+- Migration 47 is additive and contains derived data only; rollback drops its tables.
+- Bloom saturation is detected before publication and degrades to unknown. Missing or malformed derived data never repairs authority from files.
+- Reconciliation first completes the existing paged ledger audit, including reservation deltas, then verifies every immutable binding field, canonical manifest digest, sealed file digest, and reconstructed normalized summary before one per-segment transaction. Existing cache children are canonicalized and digest-checked again rather than trusted.
+- A completed audit/cache cursor is consumed by that validation cycle, never permanent trust. A later rebuild or diagnostic restarts the full ledger audit and bounded child-cache canonicalization, so post-completion offline damage is detected.
+- The format, generator, reader, and Hot schema share the v1 Bloom cap. SQL count/byte preflight and `cap+1` limits precede every derived child allocation.
+- Diagnostics owns a separate durable audit/cache phase machine. Bounded pages CAS-save their cursor before returning `audit_incomplete`; only a completed cycle is restarted by the next invocation. Unreconciled bindings are ordinary coverage, while every existing parent is reconstructed into the canonical manifest digest and every child into the canonical summary digest.
+- Publication and placement transitions remain outside this issue.

--- a/application/catalog_summary.go
+++ b/application/catalog_summary.go
@@ -1,0 +1,12 @@
+package application
+
+import (
+	"context"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+// CatalogSummaryDiagnosticsReader exposes privacy-bounded aggregate evidence.
+type CatalogSummaryDiagnosticsReader interface {
+	CatalogSummaryDiagnostics(context.Context, apptypes.CatalogHead, apptypes.CatalogBudget) (apptypes.CatalogSummaryDiagnostics, error)
+}

--- a/application/types/catalog_summary.go
+++ b/application/types/catalog_summary.go
@@ -1,0 +1,30 @@
+package types
+
+// CatalogSummaryRebuildResult is aggregate-only evidence for one bounded run.
+// The durable per-segment checkpoint remains private to the adapter.
+type CatalogSummaryRebuildResult struct {
+	Processed int
+	Inserted  int
+	Existing  int
+	Remaining int
+	Done      bool
+}
+
+// CatalogSummaryDiagnostics deliberately contains no segment identity, key
+// identifier, token, digest, basename, timestamp, or payload field.
+type CatalogSummaryDiagnostics struct {
+	BoundSegments      int64
+	ReconciledSegments int64
+	ExactKindRows      int64
+	BloomKindRows      int64
+	UnknownKindSlots   int64
+	SessionRows        int64
+	UnitCount          int64
+	AuditCount         int64
+	StoredBytes        int64
+	SummaryBytes       int64
+	HotRanges          int64
+	ReservedRanges     int64
+	SegmentRanges      int64
+	DriftCount         int64
+}

--- a/application/types/segment_catalog.go
+++ b/application/types/segment_catalog.go
@@ -42,6 +42,8 @@ var (
 	ErrSegmentTargetNotFound = domain.ErrSegmentTargetNotFound
 	// ErrSegmentTargetRetryProof rejects an unmeasured or non-shortening retry.
 	ErrSegmentTargetRetryProof = errors.New("segment target retry proof invalid")
+	// ErrCatalogAuditIncomplete means a durable bounded audit must be resumed.
+	ErrCatalogAuditIncomplete = errors.New("segment catalog audit incomplete")
 )
 
 const (

--- a/domain/archive_segment_summary.go
+++ b/domain/archive_segment_summary.go
@@ -12,6 +12,9 @@ import (
 // SegmentSummaryV1 is the immutable, privacy-preserving summary descriptor.
 const SegmentSummaryV1 uint32 = 1
 
+// SegmentSummaryBloomMaxBitsV1 is the shared format/generator/reader cap.
+const SegmentSummaryBloomMaxBitsV1 uint32 = 8 << 20
+
 // SummaryTokenKind identifies a fixed metadata dimension. Values are HMACs;
 // plaintext metadata is deliberately not representable by this API.
 type SummaryTokenKind uint8
@@ -143,7 +146,7 @@ func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) 
 	b = binary.AppendUvarint(b, uint64(len(blooms)))
 	var previousKind SummaryTokenKind
 	for _, bloom := range blooms {
-		if bloom.Kind < SummaryTokenWorkspace || bloom.Kind > SummaryTokenEventKind || bloom.Kind <= previousKind || bloom.BitCount == 0 || bloom.HashCount == 0 || uint64(len(bloom.Bits))*8 != uint64(bloom.BitCount) {
+		if bloom.Kind < SummaryTokenWorkspace || bloom.Kind > SummaryTokenEventKind || bloom.Kind <= previousKind || bloom.BitCount == 0 || bloom.BitCount > SegmentSummaryBloomMaxBitsV1 || bloom.HashCount == 0 || bloom.HashCount > 16 || uint64(len(bloom.Bits))*8 != uint64(bloom.BitCount) {
 			return nil, fmt.Errorf("invalid summary bloom descriptor")
 		}
 		previousKind = bloom.Kind
@@ -173,7 +176,7 @@ func (s SegmentCatalogSummaryV1) CanonicalBytes(maxBytes int64) ([]byte, error) 
 // TimeFilterMayMatch prevents a negative time decision when legacy timestamps
 // were malformed and the segment's time summary is therefore incomplete.
 func (s SegmentCatalogSummaryV1) TimeFilterMayMatch(segmentMin, segmentMax, queryStart, queryEnd time.Time) bool {
-	if !s.TimeComplete || segmentMin.IsZero() || segmentMax.IsZero() {
+	if !s.TimeComplete || segmentMin.IsZero() || segmentMax.IsZero() || segmentMax.Before(segmentMin) || queryStart.IsZero() || queryEnd.IsZero() || queryEnd.Before(queryStart) {
 		return true
 	}
 	return !segmentMax.Before(queryStart) && !segmentMin.After(queryEnd)

--- a/domain/archive_segment_summary_test.go
+++ b/domain/archive_segment_summary_test.go
@@ -37,6 +37,12 @@ func TestIncompleteTimeSummaryCannotProduceNegativeCandidate(t *testing.T) {
 	if s.TimeFilterMayMatch(time.Unix(1, 0), time.Unix(2, 0), time.Unix(100, 0), time.Unix(200, 0)) {
 		t.Fatal("disjoint complete bounds matched")
 	}
+	if !s.TimeFilterMayMatch(time.Unix(2, 0), time.Unix(1, 0), time.Unix(1, 0), time.Unix(2, 0)) {
+		t.Fatal("reversed segment bounds produced a negative decision")
+	}
+	if !s.TimeFilterMayMatch(time.Time{}, time.Time{}, time.Unix(1, 0), time.Unix(2, 0)) {
+		t.Fatal("zero segment bounds produced a negative decision")
+	}
 }
 
 func TestArchiveEventAllowsMalformedLegacyCreatedAt(t *testing.T) {
@@ -73,5 +79,16 @@ func TestSegmentSummaryPreflightUsesExactCanonicalSize(t *testing.T) {
 	}
 	if _, err = s.CanonicalBytes(int64(len(encoded) - 1)); err == nil {
 		t.Fatal("one-byte-short cap accepted")
+	}
+}
+
+func TestSegmentSummaryBloomV1SharedBitCapBoundary(t *testing.T) {
+	atCap := SegmentCatalogSummaryV1{FilterKeyID: "key-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: SegmentSummaryBloomMaxBitsV1, HashCount: 1, Bits: make([]byte, SegmentSummaryBloomMaxBitsV1/8)}}}
+	if _, err := atCap.CanonicalBytes(2 << 20); err != nil {
+		t.Fatalf("at-cap Bloom rejected: %v", err)
+	}
+	above := SegmentCatalogSummaryV1{FilterKeyID: "key-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: SegmentSummaryBloomMaxBitsV1 + 8, HashCount: 1, Bits: make([]byte, (SegmentSummaryBloomMaxBitsV1+8)/8)}}}
+	if _, err := above.CanonicalBytes(2 << 20); err == nil {
+		t.Fatal("above-cap Bloom accepted")
 	}
 }

--- a/domain/segment_summary_generator.go
+++ b/domain/segment_summary_generator.go
@@ -1,0 +1,223 @@
+package domain
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math/bits"
+	"sort"
+	"time"
+)
+
+// ErrSegmentSummaryGeneration rejects invalid input or a configured cap.
+var ErrSegmentSummaryGeneration = errors.New("segment summary generation failed")
+
+// SegmentSummaryHMACV1 identifies the fixed token derivation algorithm.
+const SegmentSummaryHMACV1 uint32 = 1
+
+const (
+	segmentSummaryGeneratorMaxUnits          = 100_000
+	segmentSummaryGeneratorMaxDistinct       = 100_000
+	segmentSummaryGeneratorMaxSessions       = 100_000
+	segmentSummaryReaderMaxRows              = 100_000
+	segmentSummaryReaderMaxBytes       int64 = 64 << 20
+)
+
+// SegmentSummaryGeneratorConfig fixes all output-affecting bounds.
+type SegmentSummaryGeneratorConfig struct {
+	FilterKeyID         string
+	HMACVersion         uint32
+	MaxUnits            int
+	MaxDistinctPerKind  int
+	MaxSessions         int
+	BloomBitCount       uint32
+	BloomHashCount      uint8
+	BloomMaxSetPermille uint16
+}
+
+func (c SegmentSummaryGeneratorConfig) valid() bool {
+	return c.FilterKeyID != "" && len(c.FilterKeyID) <= 255 && c.HMACVersion == SegmentSummaryHMACV1 && c.MaxUnits > 0 && c.MaxUnits <= segmentSummaryGeneratorMaxUnits &&
+		c.MaxDistinctPerKind > 0 && c.MaxDistinctPerKind <= segmentSummaryGeneratorMaxDistinct && c.MaxSessions > 0 && c.MaxSessions <= segmentSummaryGeneratorMaxSessions && c.BloomBitCount >= 8 && c.BloomBitCount <= SegmentSummaryBloomMaxBitsV1 && c.BloomBitCount%8 == 0 &&
+		c.BloomHashCount > 0 && c.BloomHashCount <= 16 && c.BloomMaxSetPermille > 0 && c.BloomMaxSetPermille < 1000
+}
+
+// GenerateSegmentCatalogSummaryV1 reads only fixed event metadata fields. The
+// caller-owned key is used transiently and is not representable in the result.
+func GenerateSegmentCatalogSummaryV1(units []HistoryUnit, key []byte, cfg SegmentSummaryGeneratorConfig) (SegmentCatalogSummaryV1, error) {
+	if !cfg.valid() || len(key) < 16 || len(units) == 0 || len(units) > cfg.MaxUnits {
+		return SegmentCatalogSummaryV1{}, ErrSegmentSummaryGeneration
+	}
+	tokens := make(map[SummaryTokenKind]map[[sha256.Size]byte]struct{}, int(SummaryTokenEventKind))
+	sessions := make(map[[sha256.Size]byte]SegmentSessionAggregateV1)
+	completeTime := true
+	for _, unit := range units {
+		if unit.Sequence == 0 || unit.CreatedAt().IsZero() {
+			completeTime = false
+		}
+		values := unit.Event.values
+		metadata := [...]struct {
+			kind  SummaryTokenKind
+			index int
+		}{{SummaryTokenWorkspace, 7}, {SummaryTokenSession, 3}, {SummaryTokenClient, 6}, {SummaryTokenAgent, 2}, {SummaryTokenEventKind, 1}}
+		for _, field := range metadata {
+			value := values[field.index]
+			if value.Class == SQLiteNull || ((value.Class == SQLiteText || value.Class == SQLiteBlob) && len(value.Bytes) == 0) {
+				continue
+			}
+			if value.Class != SQLiteText && value.Class != SQLiteBlob {
+				return SegmentCatalogSummaryV1{}, ErrSegmentSummaryGeneration
+			}
+			token := summaryHMAC(key, field.kind, value.Bytes)
+			if tokens[field.kind] == nil {
+				tokens[field.kind] = make(map[[sha256.Size]byte]struct{})
+			}
+			tokens[field.kind][token] = struct{}{}
+			if field.kind == SummaryTokenSession {
+				agg := sessions[token]
+				agg.SessionToken = token
+				agg.UnitCount++
+				if unit.Audit != nil {
+					agg.AuditCount++
+				}
+				sessions[token] = agg
+			}
+		}
+	}
+	result := SegmentCatalogSummaryV1{FilterKeyID: cfg.FilterKeyID, TimeComplete: completeTime}
+	for kind := SummaryTokenWorkspace; kind <= SummaryTokenEventKind; kind++ {
+		set := tokens[kind]
+		ordered := make([][sha256.Size]byte, 0, len(set))
+		for token := range set {
+			ordered = append(ordered, token)
+		}
+		sort.Slice(ordered, func(i, j int) bool { return bytes.Compare(ordered[i][:], ordered[j][:]) < 0 })
+		if len(ordered) <= cfg.MaxDistinctPerKind {
+			for _, token := range ordered {
+				result.ExactTokens = append(result.ExactTokens, SegmentSummaryToken{Kind: kind, Value: token})
+			}
+		}
+		bloom := SegmentBloomV1{Kind: kind, BitCount: cfg.BloomBitCount, HashCount: cfg.BloomHashCount, Bits: make([]byte, cfg.BloomBitCount/8)}
+		for _, token := range ordered {
+			bloomAdd(&bloom, token)
+		}
+		setBits := 0
+		for _, value := range bloom.Bits {
+			setBits += bits.OnesCount8(value)
+		}
+		// A saturated Bloom is omitted. Its absence is explicit unknown evidence.
+		if uint64(setBits)*1000 <= uint64(cfg.BloomMaxSetPermille)*uint64(cfg.BloomBitCount) {
+			result.Blooms = append(result.Blooms, bloom)
+		}
+	}
+	if len(sessions) <= cfg.MaxSessions {
+		for _, aggregate := range sessions {
+			result.Sessions = append(result.Sessions, aggregate)
+		}
+	}
+	return result, nil
+}
+
+// SegmentSummaryPredicateOperator is the fixed conservative predicate set.
+type SegmentSummaryPredicateOperator uint8
+
+const (
+	// SegmentSummaryPredicateEqual is the only predicate that may exclude.
+	SegmentSummaryPredicateEqual SegmentSummaryPredicateOperator = iota + 1
+	// SegmentSummaryPredicateNotEqual always degrades to unknown.
+	SegmentSummaryPredicateNotEqual
+	// SegmentSummaryPredicateContains always degrades to unknown.
+	SegmentSummaryPredicateContains
+)
+
+// SegmentSummaryPredicate is one metadata predicate without stored tokens.
+type SegmentSummaryPredicate struct {
+	Kind     SummaryTokenKind
+	Operator SegmentSummaryPredicateOperator
+	Value    []byte
+}
+
+// SegmentSummaryMayMatch returns false only for a complete Bloom miss. Exact
+// hits are a fast positive; every unsupported or incomplete case fails open.
+func SegmentSummaryMayMatch(summary SegmentCatalogSummaryV1, expectedKeyID string, key []byte, predicate SegmentSummaryPredicate) bool {
+	if len(summary.ExactTokens)+len(summary.Blooms)+len(summary.Sessions) > segmentSummaryReaderMaxRows {
+		return true
+	}
+	if _, err := summary.CanonicalBytes(segmentSummaryReaderMaxBytes); err != nil {
+		return true
+	}
+	if summary.FilterKeyID == "" || summary.FilterKeyID != expectedKeyID || len(key) < 16 || predicate.Operator != SegmentSummaryPredicateEqual ||
+		predicate.Kind < SummaryTokenWorkspace || predicate.Kind > SummaryTokenEventKind || len(predicate.Value) < 3 {
+		return true
+	}
+	token := summaryHMAC(key, predicate.Kind, predicate.Value)
+	for _, exact := range summary.ExactTokens {
+		if exact.Kind == predicate.Kind && hmac.Equal(exact.Value[:], token[:]) {
+			return true
+		}
+	}
+	for _, bloom := range summary.Blooms {
+		if bloom.Kind == predicate.Kind {
+			if bloom.BitCount == 0 || bloom.HashCount == 0 || uint64(len(bloom.Bits))*8 != uint64(bloom.BitCount) {
+				return true
+			}
+			return bloomMayContain(bloom, token)
+		}
+	}
+	return true
+}
+
+// SegmentCatalogCandidateMayMatch applies the time envelope first and then
+// supported positive metadata predicates. Invalid query bounds and all unknown
+// metadata evidence fail open; a disjoint complete time envelope may exclude.
+func SegmentCatalogCandidateMayMatch(summary SegmentCatalogSummaryV1, segmentMin, segmentMax, queryStart, queryEnd time.Time, expectedKeyID string, key []byte, predicates []SegmentSummaryPredicate) bool {
+	if queryStart.IsZero() || queryEnd.IsZero() || queryEnd.Before(queryStart) {
+		return true
+	}
+	if !summary.TimeFilterMayMatch(segmentMin, segmentMax, queryStart, queryEnd) {
+		return false
+	}
+	for _, predicate := range predicates {
+		if !SegmentSummaryMayMatch(summary, expectedKeyID, key, predicate) {
+			return false
+		}
+	}
+	return true
+}
+
+func summaryHMAC(key []byte, kind SummaryTokenKind, value []byte) [sha256.Size]byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte("traceary/segment-summary-token/v1\x00"))
+	_, _ = h.Write([]byte{byte(kind)})
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(value)
+	var result [sha256.Size]byte
+	copy(result[:], h.Sum(nil))
+	return result
+}
+
+func bloomLocations(token [sha256.Size]byte, bitCount uint32, hashCount uint8) []uint32 {
+	a := binary.BigEndian.Uint64(token[:8])
+	b := binary.BigEndian.Uint64(token[8:16]) | 1
+	result := make([]uint32, hashCount)
+	for i := range result {
+		result[i] = uint32((a + uint64(i)*b) % uint64(bitCount))
+	}
+	return result
+}
+func bloomAdd(bloom *SegmentBloomV1, token [sha256.Size]byte) {
+	for _, location := range bloomLocations(token, bloom.BitCount, bloom.HashCount) {
+		bloom.Bits[location/8] |= byte(1 << (location % 8))
+	}
+}
+func bloomMayContain(bloom SegmentBloomV1, token [sha256.Size]byte) bool {
+	for _, location := range bloomLocations(token, bloom.BitCount, bloom.HashCount) {
+		if bloom.Bits[location/8]&byte(1<<(location%8)) == 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/domain/segment_summary_generator_test.go
+++ b/domain/segment_summary_generator_test.go
@@ -1,0 +1,163 @@
+package domain
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func summaryTestUnit(t *testing.T, sequence uint64, workspace, session, kind string, audit bool) HistoryUnit {
+	t.Helper()
+	values := make([]SQLiteValue, len(ArchiveEventV1Columns()))
+	for i := range values {
+		values[i] = NullValue()
+	}
+	values[0] = TextValue([]byte("event" + string(rune(sequence))))
+	values[1] = TextValue([]byte(kind))
+	values[2] = TextValue([]byte("agent"))
+	values[3] = TextValue([]byte(session))
+	values[5] = TextValue([]byte(time.Unix(int64(sequence), 0).UTC().Format(time.RFC3339Nano)))
+	values[6] = TextValue([]byte("client"))
+	values[7] = TextValue([]byte(workspace))
+	event, err := NewArchiveEventV1(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := HistoryUnit{Sequence: sequence, Event: event}
+	if audit {
+		auditValues := make([]SQLiteValue, len(ArchiveAuditV1Columns()))
+		for i := range auditValues {
+			auditValues[i] = NullValue()
+		}
+		row, buildErr := NewArchiveAuditV1(auditValues)
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+		unit.Audit = &row
+	}
+	return unit
+}
+
+func summaryTestConfig() SegmentSummaryGeneratorConfig {
+	return SegmentSummaryGeneratorConfig{FilterKeyID: "filter-v1", HMACVersion: SegmentSummaryHMACV1, MaxUnits: 100, MaxDistinctPerKind: 2, MaxSessions: 10, BloomBitCount: 1024, BloomHashCount: 5, BloomMaxSetPermille: 900}
+}
+
+func TestGenerateSegmentSummaryIsDeterministicAndHasNoFalseNegatives(t *testing.T) {
+	key := bytes.Repeat([]byte{7}, 32)
+	units := []HistoryUnit{summaryTestUnit(t, 1, "alpha", "s1", "note", true), summaryTestUnit(t, 2, "β/作業場", "s1", "command", false), summaryTestUnit(t, 3, "gamma", "s2", "note", true)}
+	first, err := GenerateSegmentCatalogSummaryV1(units, key, summaryTestConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := GenerateSegmentCatalogSummaryV1(units, key, summaryTestConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := first.CanonicalBytes(1 << 20)
+	b, _ := second.CanonicalBytes(1 << 20)
+	if !bytes.Equal(a, b) {
+		t.Fatal("generation is not deterministic")
+	}
+	for _, workspace := range []string{"alpha", "β/作業場", "gamma"} {
+		if !SegmentSummaryMayMatch(first, "filter-v1", key, SegmentSummaryPredicate{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte(workspace)}) {
+			t.Fatalf("false negative for %q", workspace)
+		}
+	}
+	workspaceExact := 0
+	for _, token := range first.ExactTokens {
+		if token.Kind == SummaryTokenWorkspace {
+			workspaceExact++
+		}
+	}
+	if workspaceExact != 0 {
+		t.Fatalf("exact cap transition retained partial set: %d", workspaceExact)
+	}
+	if len(first.Sessions) != 2 {
+		t.Fatalf("sessions = %d", len(first.Sessions))
+	}
+}
+
+func TestSegmentSummaryUnknownCasesSelectAndBloomMissExcludes(t *testing.T) {
+	key := bytes.Repeat([]byte{3}, 32)
+	summary, err := GenerateSegmentCatalogSummaryV1([]HistoryUnit{summaryTestUnit(t, 1, "alpha", "session", "note", false)}, key, summaryTestConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []SegmentSummaryPredicate{
+		{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateNotEqual, Value: []byte("alpha")},
+		{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateContains, Value: []byte("alpha")},
+		{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte("a")},
+		{Kind: 99, Operator: SegmentSummaryPredicateEqual, Value: []byte("alpha")},
+	}
+	for _, predicate := range cases {
+		if !SegmentSummaryMayMatch(summary, "filter-v1", key, predicate) {
+			t.Fatal("unknown predicate excluded segment")
+		}
+	}
+	if !SegmentSummaryMayMatch(summary, "other-key", key, SegmentSummaryPredicate{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte("absent")}) {
+		t.Fatal("key mismatch excluded segment")
+	}
+	if SegmentSummaryMayMatch(summary, "filter-v1", key, SegmentSummaryPredicate{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte("definitely-absent")}) {
+		t.Fatal("complete Bloom miss did not exclude")
+	}
+}
+
+func TestBloomSaturationDegradesToUnknown(t *testing.T) {
+	key := bytes.Repeat([]byte{9}, 32)
+	cfg := summaryTestConfig()
+	cfg.BloomBitCount = 8
+	cfg.BloomHashCount = 8
+	cfg.BloomMaxSetPermille = 100
+	cfg.MaxDistinctPerKind = 1
+	summary, err := GenerateSegmentCatalogSummaryV1([]HistoryUnit{summaryTestUnit(t, 1, "alpha", "session", "note", false), summaryTestUnit(t, 2, "beta", "session", "note", false)}, key, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bloom := range summary.Blooms {
+		if bloom.Kind == SummaryTokenWorkspace {
+			t.Fatal("saturated Bloom was published")
+		}
+	}
+	if !SegmentSummaryMayMatch(summary, "filter-v1", key, SegmentSummaryPredicate{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte("absent")}) {
+		t.Fatal("saturation did not degrade to unknown")
+	}
+}
+
+func TestNoncanonicalBloomAlwaysDegradesToUnknown(t *testing.T) {
+	key := bytes.Repeat([]byte{4}, 32)
+	predicate := SegmentSummaryPredicate{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateEqual, Value: []byte("absent")}
+	for _, summary := range []SegmentCatalogSummaryV1{
+		{FilterKeyID: "filter-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: 8, HashCount: 17, Bits: []byte{0}}}},
+		{FilterKeyID: "filter-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: 8, HashCount: 1, Bits: []byte{0}}, {Kind: SummaryTokenWorkspace, BitCount: 8, HashCount: 1, Bits: []byte{0}}}},
+		{FilterKeyID: "filter-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: 16, HashCount: 1, Bits: []byte{0}}}},
+		{FilterKeyID: "filter-v1", Blooms: []SegmentBloomV1{{Kind: SummaryTokenWorkspace, BitCount: SegmentSummaryBloomMaxBitsV1 + 8, HashCount: 1, Bits: make([]byte, (SegmentSummaryBloomMaxBitsV1+8)/8)}}},
+	} {
+		if !SegmentSummaryMayMatch(summary, "filter-v1", key, predicate) {
+			t.Fatal("noncanonical Bloom produced negative evidence")
+		}
+	}
+}
+
+func TestConservativeCandidatePlannerKeepsUnknownOnlyInsideTimeEnvelope(t *testing.T) {
+	key := bytes.Repeat([]byte{5}, 32)
+	summary, err := GenerateSegmentCatalogSummaryV1([]HistoryUnit{summaryTestUnit(t, 1, "alpha", "session", "note", false)}, key, summaryTestConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	segmentMin, segmentMax := time.Unix(10, 0), time.Unix(20, 0)
+	negative := []SegmentSummaryPredicate{{Kind: SummaryTokenWorkspace, Operator: SegmentSummaryPredicateNotEqual, Value: []byte("alpha")}}
+	if !SegmentCatalogCandidateMayMatch(summary, segmentMin, segmentMax, time.Unix(15, 0), time.Unix(16, 0), "filter-v1", key, negative) {
+		t.Fatal("unknown predicate excluded an overlapping segment")
+	}
+	if SegmentCatalogCandidateMayMatch(summary, segmentMin, segmentMax, time.Unix(30, 0), time.Unix(40, 0), "filter-v1", key, negative) {
+		t.Fatal("disjoint complete time envelope matched")
+	}
+	summary.TimeComplete = false
+	if !SegmentCatalogCandidateMayMatch(summary, segmentMin, segmentMax, time.Unix(30, 0), time.Unix(40, 0), "filter-v1", key, negative) {
+		t.Fatal("incomplete time evidence excluded a segment")
+	}
+	summary.TimeComplete = true
+	if !SegmentCatalogCandidateMayMatch(summary, time.Unix(20, 0), time.Unix(10, 0), time.Unix(15, 0), time.Unix(16, 0), "filter-v1", key, nil) {
+		t.Fatal("reversed segment bounds excluded a segment")
+	}
+}

--- a/infrastructure/sqlite/archive_segment.go
+++ b/infrastructure/sqlite/archive_segment.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -94,6 +95,23 @@ type ArchiveSegmentManifest struct {
 	TimeSummaryComplete bool   `json:"time_summary_complete"`
 	SummaryRowCount     uint64 `json:"summary_row_count"`
 	SummaryByteCount    int64  `json:"summary_byte_count"`
+}
+
+// ArchiveSegmentManifestDigest returns the canonical binding digest for the
+// fixed, field-ordered v1 manifest. JSON is deterministic for this struct and
+// the domain separator prevents reuse as another digest class.
+func ArchiveSegmentManifestDigest(manifest ArchiveSegmentManifest) (string, error) {
+	if manifest.FormatVersion != domain.SegmentFormatV1 || manifest.SummaryVersion != domain.SegmentSummaryV1 || manifest.StoreID == "" || manifest.Basename == "" || manifest.FileDigest == "" || manifest.LogicalDigest == "" || manifest.SummaryDigest == "" {
+		return "", ErrSegmentCorrupt
+	}
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		return "", fmt.Errorf("encode archive segment manifest: %w", err)
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("traceary/archive-segment-manifest/v1\x00"))
+	_, _ = h.Write(encoded)
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // ArchiveHistoryUnit carries the canonical unit and an optional ordering time.
@@ -338,7 +356,7 @@ CREATE TABLE segment_manifest(id INTEGER PRIMARY KEY CHECK(id=1), format_version
 CREATE TABLE history_units(sequence INTEGER PRIMARY KEY, codec TEXT NOT NULL, plaintext_length INTEGER NOT NULL, checksum BLOB NOT NULL, payload BLOB NOT NULL);
 CREATE TABLE segment_summary(id INTEGER PRIMARY KEY CHECK(id=1), summary_version INTEGER NOT NULL, filter_key_id TEXT NOT NULL, time_summary_complete INTEGER NOT NULL CHECK(time_summary_complete IN (0,1)), canonical_bytes BLOB NOT NULL, summary_digest BLOB NOT NULL);
 CREATE TABLE segment_exact_filters(kind INTEGER NOT NULL, token BLOB NOT NULL, PRIMARY KEY(kind,token));
-CREATE TABLE segment_bloom_filters(kind INTEGER PRIMARY KEY, bit_count INTEGER NOT NULL, hash_count INTEGER NOT NULL, bits BLOB NOT NULL);
+CREATE TABLE segment_bloom_filters(kind INTEGER PRIMARY KEY, bit_count INTEGER NOT NULL CHECK(bit_count>0 AND bit_count<=8388608), hash_count INTEGER NOT NULL CHECK(hash_count BETWEEN 1 AND 16), bits BLOB NOT NULL CHECK(length(bits)*8=bit_count));
 CREATE TABLE segment_session_aggregates(session_token BLOB PRIMARY KEY, unit_count INTEGER NOT NULL, audit_count INTEGER NOT NULL);
 `
 

--- a/infrastructure/sqlite/catalog_summary.go
+++ b/infrastructure/sqlite/catalog_summary.go
@@ -1,0 +1,726 @@
+//nolint:wrapcheck // This dedicated SQLite adapter preserves typed Catalog failures.
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/duck8823/traceary/application"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+var _ application.CatalogSummaryDiagnosticsReader = (*Database)(nil)
+
+type catalogSummaryBinding struct {
+	segmentID, storeID, basename, logicalDigest, fileDigest, manifestDigest, summaryDigest, storageClass string
+	start, end, boundEpoch                                                                               int64
+	formatVersion, manifestVersion, summaryVersion                                                       int
+}
+
+// RebuildCatalogSummaries reconciles at most maxSegments previously
+// unreconciled bindings. Each segment is its own durable checkpoint, so a
+// cancelled invocation resumes without replaying completed files.
+func (d *Database) RebuildCatalogSummaries(ctx context.Context, archiveRoot string, expected apptypes.CatalogHead, maxSegments int, limits ArchiveSegmentLimits, budget apptypes.CatalogBudget) (apptypes.CatalogSummaryRebuildResult, error) {
+	if maxSegments <= 0 || maxSegments > 1000 || !budget.Valid() || limits.validate() != nil {
+		return apptypes.CatalogSummaryRebuildResult{}, apptypes.ErrCatalogLimit
+	}
+	if err := validateArchiveRoot(archiveRoot); err != nil {
+		return apptypes.CatalogSummaryRebuildResult{}, err
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	state, err := d.ensureCatalogSummaryAudit(opCtx, expected, budget)
+	if err != nil {
+		return apptypes.CatalogSummaryRebuildResult{}, err
+	}
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogSummaryRebuildResult{}, err
+	}
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil || head != expected || verifyCatalogLedgerPresence(opCtx, db, head) != nil || verifyCatalogHeadIncremental(opCtx, db, head) != nil {
+		d.release(db)
+		return apptypes.CatalogSummaryRebuildResult{}, apptypes.ErrCatalogDrift
+	}
+	rows, err := db.QueryContext(opCtx, `SELECT segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class,bound_epoch FROM archive_catalog_segment_bindings WHERE bound_epoch>? OR (bound_epoch=? AND segment_id>?) ORDER BY bound_epoch,segment_id LIMIT ?`, state.cacheBoundEpoch, state.cacheBoundEpoch, state.cacheSegmentID, maxSegments)
+	if err != nil {
+		d.release(db)
+		return apptypes.CatalogSummaryRebuildResult{}, err
+	}
+	var bindings []catalogSummaryBinding
+	for rows.Next() {
+		var b catalogSummaryBinding
+		if err = rows.Scan(&b.segmentID, &b.storeID, &b.start, &b.end, &b.formatVersion, &b.manifestVersion, &b.summaryVersion, &b.logicalDigest, &b.fileDigest, &b.manifestDigest, &b.summaryDigest, &b.basename, &b.storageClass, &b.boundEpoch); err != nil {
+			_ = rows.Close()
+			d.release(db)
+			return apptypes.CatalogSummaryRebuildResult{}, err
+		}
+		bindings = append(bindings, b)
+	}
+	err = rows.Err()
+	_ = rows.Close()
+	d.release(db)
+	if err != nil {
+		return apptypes.CatalogSummaryRebuildResult{}, err
+	}
+	result := apptypes.CatalogSummaryRebuildResult{}
+	for _, binding := range bindings {
+		if err = opCtx.Err(); err != nil {
+			return result, err
+		}
+		manifest, summary, loadErr := loadBoundSegmentSummary(opCtx, archiveRoot, binding, limits)
+		if loadErr != nil {
+			return result, loadErr
+		}
+		inserted, reconcileErr := d.reconcileCatalogSummary(opCtx, expected, binding, manifest, summary, limits, budget)
+		if reconcileErr != nil {
+			return result, reconcileErr
+		}
+		result.Processed++
+		if inserted {
+			result.Inserted++
+		} else {
+			result.Existing++
+		}
+		if err = d.advanceCatalogSummaryCacheCursor(opCtx, expected, binding.boundEpoch, binding.segmentID, false, budget); err != nil {
+			return result, err
+		}
+		state.cacheBoundEpoch, state.cacheSegmentID = binding.boundEpoch, binding.segmentID
+	}
+	db, err = d.openReadOnly(opCtx)
+	if err != nil {
+		return result, err
+	}
+	defer d.release(db)
+	if err = db.QueryRowContext(opCtx, `SELECT count(*) FROM archive_catalog_segment_bindings WHERE bound_epoch>? OR (bound_epoch=? AND segment_id>?)`, state.cacheBoundEpoch, state.cacheBoundEpoch, state.cacheSegmentID).Scan(&result.Remaining); err != nil {
+		return result, err
+	}
+	result.Done = result.Remaining == 0
+	if result.Done {
+		if err = d.advanceCatalogSummaryCacheCursor(opCtx, expected, state.cacheBoundEpoch, state.cacheSegmentID, true, budget); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+type catalogSummaryRebuildState struct {
+	expectedEpoch, auditEpoch, cacheBoundEpoch  int64
+	expectedDigest, auditDigest, cacheSegmentID string
+	auditComplete, cacheComplete                bool
+}
+
+func (d *Database) ensureCatalogSummaryAudit(ctx context.Context, expected apptypes.CatalogHead, budget apptypes.CatalogBudget) (catalogSummaryRebuildState, error) {
+	db, err := d.open(ctx)
+	if err != nil {
+		return catalogSummaryRebuildState{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return catalogSummaryRebuildState{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	head, err := readCatalogHead(ctx, tx)
+	if err != nil || head != expected {
+		return catalogSummaryRebuildState{}, apptypes.ErrCatalogDrift
+	}
+	var s catalogSummaryRebuildState
+	if err = tx.QueryRowContext(ctx, `SELECT expected_epoch,expected_ledger_digest,audit_epoch,audit_ledger_digest,cache_bound_epoch,cache_segment_id,audit_complete,cache_complete FROM archive_catalog_summary_rebuild_state WHERE singleton=1`).Scan(&s.expectedEpoch, &s.expectedDigest, &s.auditEpoch, &s.auditDigest, &s.cacheBoundEpoch, &s.cacheSegmentID, &s.auditComplete, &s.cacheComplete); err != nil {
+		return s, err
+	}
+	if s.expectedEpoch != expected.Epoch || s.expectedDigest != expected.LedgerDigest {
+		s = catalogSummaryRebuildState{expectedEpoch: expected.Epoch, expectedDigest: expected.LedgerDigest, auditDigest: emptyCatalogDigestValue}
+		if _, err = tx.ExecContext(ctx, `UPDATE archive_catalog_summary_rebuild_state SET expected_epoch=?,expected_ledger_digest=?,audit_epoch=0,audit_ledger_digest=?,cache_bound_epoch=0,cache_segment_id='',audit_complete=0,cache_complete=0 WHERE singleton=1`, expected.Epoch, expected.LedgerDigest, emptyCatalogDigestValue); err != nil {
+			return s, err
+		}
+	} else if s.auditComplete && s.cacheComplete {
+		// Completion authenticates only the finished cycle. Every explicit
+		// subsequent validation starts from genesis so offline historical damage
+		// cannot hide behind a permanent complete bit.
+		s = catalogSummaryRebuildState{expectedEpoch: expected.Epoch, expectedDigest: expected.LedgerDigest, auditDigest: emptyCatalogDigestValue}
+		if _, err = tx.ExecContext(ctx, `UPDATE archive_catalog_summary_rebuild_state SET audit_epoch=0,audit_ledger_digest=?,cache_bound_epoch=0,cache_segment_id='',audit_complete=0,cache_complete=0 WHERE singleton=1`, emptyCatalogDigestValue); err != nil {
+			return s, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return s, err
+	}
+	if s.auditComplete {
+		return s, nil
+	}
+	page, err := d.AuditCatalogLedgerPage(ctx, apptypes.CatalogAuditCursor{Epoch: s.auditEpoch, LedgerDigest: s.auditDigest}, budget)
+	if err != nil {
+		return s, err
+	}
+	if !page.Done && page.Verified < budget.Ranges {
+		return s, apptypes.ErrCatalogDrift
+	}
+	if err = d.verifyCatalogReservationAuditPage(ctx, s.auditEpoch, page.Next.Epoch, budget); err != nil {
+		return s, err
+	}
+	db, err = d.open(ctx)
+	if err != nil {
+		return s, err
+	}
+	defer d.release(db)
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		return s, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	head, err = readCatalogHead(ctx, tx)
+	if err != nil || head != expected {
+		return s, apptypes.ErrCatalogDrift
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE archive_catalog_summary_rebuild_state SET audit_epoch=?,audit_ledger_digest=?,audit_complete=? WHERE singleton=1 AND expected_epoch=? AND expected_ledger_digest=? AND audit_epoch=? AND audit_ledger_digest=?`, page.Next.Epoch, page.Next.LedgerDigest, page.Done, expected.Epoch, expected.LedgerDigest, s.auditEpoch, s.auditDigest)
+	if err != nil {
+		return s, err
+	}
+	n, _ := result.RowsAffected()
+	if n != 1 {
+		return s, apptypes.ErrCatalogDrift
+	}
+	if err = tx.Commit(); err != nil {
+		return s, err
+	}
+	s.auditEpoch, s.auditDigest, s.auditComplete = page.Next.Epoch, page.Next.LedgerDigest, page.Done
+	if !page.Done {
+		return s, apptypes.ErrCatalogAuditIncomplete
+	}
+	return s, nil
+}
+
+func (d *Database) verifyCatalogReservationAuditPage(ctx context.Context, after, through int64, budget apptypes.CatalogBudget) error {
+	if through <= after {
+		return nil
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return err
+	}
+	defer d.release(db)
+	var invalid int64
+	query := `SELECT count(*) FROM (SELECT t.epoch,t.transition_index FROM archive_catalog_range_transitions t LEFT JOIN archive_catalog_reservation_deltas d ON d.epoch=t.epoch AND d.reservation_id=t.reservation_id AND d.start_sequence=t.start_sequence AND d.end_sequence=t.end_sequence AND d.delta=CASE WHEN t.to_state='reserved' THEN 'reserve' ELSE 'release' END WHERE t.epoch>? AND t.epoch<=? AND (t.from_state='reserved' OR t.to_state='reserved') AND d.epoch IS NULL UNION ALL SELECT d.epoch,0 FROM archive_catalog_reservation_deltas d LEFT JOIN archive_catalog_range_transitions t ON t.epoch=d.epoch AND t.reservation_id=d.reservation_id AND t.start_sequence=d.start_sequence AND t.end_sequence=d.end_sequence AND ((d.delta='reserve' AND t.to_state='reserved') OR (d.delta='release' AND t.from_state='reserved')) WHERE d.epoch>? AND d.epoch<=? AND t.epoch IS NULL)`
+	if err = db.QueryRowContext(opCtx, query, after, through, after, through).Scan(&invalid); err != nil || invalid != 0 {
+		return apptypes.ErrCatalogDrift
+	}
+	return nil
+}
+
+func (d *Database) advanceCatalogSummaryCacheCursor(ctx context.Context, expected apptypes.CatalogHead, epoch int64, segmentID string, complete bool, budget apptypes.CatalogBudget) error {
+	opCtx, cancel := boundedCatalogContext(ctx, budget)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return err
+	}
+	defer d.release(db)
+	result, err := db.ExecContext(opCtx, `UPDATE archive_catalog_summary_rebuild_state SET cache_bound_epoch=?,cache_segment_id=?,cache_complete=? WHERE singleton=1 AND expected_epoch=? AND expected_ledger_digest=? AND audit_complete=1`, epoch, segmentID, complete, expected.Epoch, expected.LedgerDigest)
+	if err != nil {
+		return err
+	}
+	n, _ := result.RowsAffected()
+	if n != 1 {
+		return apptypes.ErrCatalogDrift
+	}
+	return nil
+}
+
+func loadBoundSegmentSummary(ctx context.Context, root string, binding catalogSummaryBinding, limits ArchiveSegmentLimits) (ArchiveSegmentManifest, domain.SegmentCatalogSummaryV1, error) {
+	if binding.formatVersion != int(domain.SegmentFormatV1) || binding.manifestVersion != 1 || binding.summaryVersion != int(domain.SegmentSummaryV1) || binding.storageClass != "sealed_sqlite_zstd_v1" || binding.segmentID != binding.basename ||
+		!domain.ValidCatalogDigest(binding.logicalDigest) || !domain.ValidCatalogDigest(binding.fileDigest) || !domain.ValidCatalogDigest(binding.manifestDigest) || !domain.ValidCatalogDigest(binding.summaryDigest) {
+		return ArchiveSegmentManifest{}, domain.SegmentCatalogSummaryV1{}, apptypes.ErrCatalogBindingMismatch
+	}
+	path, err := safeArchivePath(root, binding.basename, true)
+	if err != nil {
+		return ArchiveSegmentManifest{}, domain.SegmentCatalogSummaryV1{}, err
+	}
+	db, pinned, err := openPinnedImmutableSegment(ctx, path, true)
+	if err != nil {
+		return ArchiveSegmentManifest{}, domain.SegmentCatalogSummaryV1{}, err
+	}
+	defer func() { _ = db.Close(); _ = pinned.Close() }()
+	manifest, err := inspectArchiveSegmentOpen(ctx, db, pinned, binding.basename, limits.MaxFileBytes)
+	if err != nil {
+		return manifest, domain.SegmentCatalogSummaryV1{}, err
+	}
+	if manifest.StoreID != binding.storeID || int64(manifest.StartSequence) != binding.start || int64(manifest.EndSequence) != binding.end || manifest.LogicalDigest != binding.logicalDigest || manifest.FileDigest != "" || manifest.SummaryDigest != binding.summaryDigest || int(manifest.SummaryVersion) != binding.summaryVersion || manifest.Basename != binding.segmentID || manifest.Basename != binding.basename {
+		return manifest, domain.SegmentCatalogSummaryV1{}, apptypes.ErrCatalogBindingMismatch
+	}
+	manifest.FileDigest = binding.fileDigest
+	if _, err = verifyArchiveSegmentMetadataOpen(ctx, db, pinned, manifest, limits); err != nil {
+		return manifest, domain.SegmentCatalogSummaryV1{}, err
+	}
+	manifestDigest, digestErr := ArchiveSegmentManifestDigest(manifest)
+	if digestErr != nil || manifestDigest != binding.manifestDigest {
+		return manifest, domain.SegmentCatalogSummaryV1{}, apptypes.ErrCatalogBindingMismatch
+	}
+	summary, err := readNormalizedSegmentSummary(ctx, db, manifest.FilterKeyID, manifest.TimeSummaryComplete, limits)
+	return manifest, summary, err
+}
+
+func readNormalizedSegmentSummary(ctx context.Context, db interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, keyID string, timeComplete bool, limits ArchiveSegmentLimits) (domain.SegmentCatalogSummaryV1, error) {
+	result := domain.SegmentCatalogSummaryV1{FilterKeyID: keyID, TimeComplete: timeComplete}
+	rows, err := db.QueryContext(ctx, `SELECT kind,token FROM segment_exact_filters ORDER BY kind,token`)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		var kind uint8
+		var raw []byte
+		if err = rows.Scan(&kind, &raw); err != nil || len(raw) != sha256.Size {
+			_ = rows.Close()
+			return result, ErrSegmentCorrupt
+		}
+		var token [sha256.Size]byte
+		copy(token[:], raw)
+		result.ExactTokens = append(result.ExactTokens, domain.SegmentSummaryToken{Kind: domain.SummaryTokenKind(kind), Value: token})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	rows, err = db.QueryContext(ctx, `SELECT kind,bit_count,hash_count,bits FROM segment_bloom_filters ORDER BY kind`)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		var kind uint8
+		var count uint32
+		var hashes uint8
+		var raw []byte
+		if err = rows.Scan(&kind, &count, &hashes, &raw); err != nil {
+			_ = rows.Close()
+			return result, err
+		}
+		result.Blooms = append(result.Blooms, domain.SegmentBloomV1{Kind: domain.SummaryTokenKind(kind), BitCount: count, HashCount: hashes, Bits: raw})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	rows, err = db.QueryContext(ctx, `SELECT session_token,unit_count,audit_count FROM segment_session_aggregates ORDER BY session_token`)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		var raw []byte
+		var units, audits uint64
+		if err = rows.Scan(&raw, &units, &audits); err != nil || len(raw) != sha256.Size {
+			_ = rows.Close()
+			return result, ErrSegmentCorrupt
+		}
+		var token [sha256.Size]byte
+		copy(token[:], raw)
+		result.Sessions = append(result.Sessions, domain.SegmentSessionAggregateV1{SessionToken: token, UnitCount: units, AuditCount: audits})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	if _, err = result.CanonicalBytes(limits.MaxSummaryBytes); err != nil {
+		return result, ErrSegmentCorrupt
+	}
+	return result, nil
+}
+
+func (d *Database) reconcileCatalogSummary(ctx context.Context, expected apptypes.CatalogHead, binding catalogSummaryBinding, manifest ArchiveSegmentManifest, summary domain.SegmentCatalogSummaryV1, limits ArchiveSegmentLimits, budget apptypes.CatalogBudget) (bool, error) {
+	opCtx, cancel := boundedCatalogContext(ctx, budget)
+	defer cancel()
+	db, err := d.open(opCtx)
+	if err != nil {
+		return false, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(opCtx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	head, err := readCatalogHead(opCtx, tx)
+	if err != nil || head != expected || verifyCatalogLedgerPresence(opCtx, tx, head) != nil || verifyCatalogHeadIncremental(opCtx, tx, head) != nil {
+		return false, apptypes.ErrCatalogDrift
+	}
+	var actual catalogSummaryBinding
+	err = tx.QueryRowContext(opCtx, `SELECT segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class,bound_epoch FROM archive_catalog_segment_bindings WHERE segment_id=?`, binding.segmentID).Scan(&actual.segmentID, &actual.storeID, &actual.start, &actual.end, &actual.formatVersion, &actual.manifestVersion, &actual.summaryVersion, &actual.logicalDigest, &actual.fileDigest, &actual.manifestDigest, &actual.summaryDigest, &actual.basename, &actual.storageClass, &actual.boundEpoch)
+	if err != nil || actual != binding {
+		return false, apptypes.ErrCatalogBindingMismatch
+	}
+	canonical, err := summary.CanonicalBytes(manifest.SummaryByteCount)
+	if err != nil || hex.EncodeToString(digestBytes(canonical)) != binding.summaryDigest {
+		return false, apptypes.ErrCatalogBindingMismatch
+	}
+	var existingDigest, keyID, minCreated, maxCreated string
+	var existingEpoch int64
+	var version int
+	var complete bool
+	var units, audits uint64
+	var plainValues, zstdValues uint64
+	var totalPlain, stored, rowsCount, byteCount int64
+	err = tx.QueryRowContext(opCtx, `SELECT bound_epoch,summary_version,filter_key_id,time_summary_complete,min_created_at,max_created_at,unit_count,audit_count,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,summary_row_count,summary_byte_count,summary_digest FROM archive_catalog_summary_segments WHERE segment_id=?`, binding.segmentID).Scan(&existingEpoch, &version, &keyID, &complete, &minCreated, &maxCreated, &units, &audits, &plainValues, &zstdValues, &totalPlain, &stored, &rowsCount, &byteCount, &existingDigest)
+	if err == nil {
+		if existingDigest != binding.summaryDigest || existingEpoch != binding.boundEpoch || version != binding.summaryVersion || keyID != manifest.FilterKeyID || complete != manifest.TimeSummaryComplete || minCreated != manifest.MinCreatedAt || maxCreated != manifest.MaxCreatedAt || units != manifest.UnitCount || audits != manifest.AuditCount || plainValues != manifest.PlainValueCount || zstdValues != manifest.ZstdValueCount || totalPlain != manifest.TotalPlainBytes || stored != manifest.TotalStoredBytes || uint64(rowsCount) != manifest.SummaryRowCount || byteCount != manifest.SummaryByteCount {
+			return false, apptypes.ErrCatalogDrift
+		}
+		cached, cacheErr := readCatalogNormalizedSummary(opCtx, tx, binding.segmentID, keyID, complete, manifest.SummaryRowCount, limits.MaxSummaryRows, manifest.SummaryByteCount)
+		if cacheErr != nil {
+			return false, apptypes.ErrCatalogDrift
+		}
+		cachedBytes, cacheErr := cached.CanonicalBytes(manifest.SummaryByteCount)
+		if cacheErr != nil || !bytes.Equal(cachedBytes, canonical) {
+			return false, apptypes.ErrCatalogDrift
+		}
+		return false, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	_, err = tx.ExecContext(opCtx, `INSERT INTO archive_catalog_summary_segments(segment_id,bound_epoch,summary_version,filter_key_id,time_summary_complete,min_created_at,max_created_at,unit_count,audit_count,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,summary_row_count,summary_byte_count,summary_digest,reconciled_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, binding.segmentID, binding.boundEpoch, manifest.SummaryVersion, manifest.FilterKeyID, manifest.TimeSummaryComplete, manifest.MinCreatedAt, manifest.MaxCreatedAt, manifest.UnitCount, manifest.AuditCount, manifest.PlainValueCount, manifest.ZstdValueCount, manifest.TotalPlainBytes, manifest.TotalStoredBytes, manifest.SummaryRowCount, manifest.SummaryByteCount, binding.summaryDigest, time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return false, err
+	}
+	for _, v := range summary.ExactTokens {
+		if _, err = tx.ExecContext(opCtx, `INSERT INTO archive_catalog_summary_exact(segment_id,kind,token) VALUES(?,?,?)`, binding.segmentID, v.Kind, v.Value[:]); err != nil {
+			return false, err
+		}
+	}
+	for _, v := range summary.Blooms {
+		if _, err = tx.ExecContext(opCtx, `INSERT INTO archive_catalog_summary_blooms(segment_id,kind,bit_count,hash_count,bits) VALUES(?,?,?,?,?)`, binding.segmentID, v.Kind, v.BitCount, v.HashCount, v.Bits); err != nil {
+			return false, err
+		}
+	}
+	for _, v := range summary.Sessions {
+		if _, err = tx.ExecContext(opCtx, `INSERT INTO archive_catalog_summary_sessions(segment_id,session_token,unit_count,audit_count) VALUES(?,?,?,?)`, binding.segmentID, v.SessionToken[:], v.UnitCount, v.AuditCount); err != nil {
+			return false, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func readCatalogNormalizedSummary(ctx context.Context, q interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, segmentID, keyID string, complete bool, expectedRows, maxRows uint64, maxBytes int64) (domain.SegmentCatalogSummaryV1, error) {
+	result := domain.SegmentCatalogSummaryV1{FilterKeyID: keyID, TimeComplete: complete}
+	if maxRows == 0 || expectedRows > maxRows || maxBytes <= 0 {
+		return result, apptypes.ErrCatalogDrift
+	}
+	var exactCount, bloomCount, sessionCount uint64
+	var exactBytes, bloomBytes, sessionBytes int64
+	var maxBloomBits uint32
+	var maxBloomHashes uint8
+	if err := q.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(token)),0) FROM archive_catalog_summary_exact WHERE segment_id=?`, segmentID).Scan(&exactCount, &exactBytes); err != nil {
+		return result, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(bits)),0),COALESCE(max(bit_count),0),COALESCE(max(hash_count),0) FROM archive_catalog_summary_blooms WHERE segment_id=?`, segmentID).Scan(&bloomCount, &bloomBytes, &maxBloomBits, &maxBloomHashes); err != nil {
+		return result, err
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*),COALESCE(sum(length(session_token)),0) FROM archive_catalog_summary_sessions WHERE segment_id=?`, segmentID).Scan(&sessionCount, &sessionBytes); err != nil {
+		return result, err
+	}
+	total := exactCount + bloomCount + sessionCount
+	if total != expectedRows || total > maxRows || exactBytes < 0 || bloomBytes < 0 || sessionBytes < 0 || exactBytes > maxBytes-bloomBytes || exactBytes+bloomBytes > maxBytes-sessionBytes || maxBloomBits > domain.SegmentSummaryBloomMaxBitsV1 || maxBloomHashes > 16 {
+		return result, apptypes.ErrCatalogDrift
+	}
+	limit := int64(maxRows) + 1
+	rows, err := q.QueryContext(ctx, `SELECT kind,token FROM archive_catalog_summary_exact WHERE segment_id=? ORDER BY kind,token LIMIT ?`, segmentID, limit)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		if uint64(len(result.ExactTokens)) >= maxRows {
+			_ = rows.Close()
+			return result, apptypes.ErrCatalogDrift
+		}
+		var kind uint8
+		var raw []byte
+		if err = rows.Scan(&kind, &raw); err != nil || len(raw) != sha256.Size {
+			_ = rows.Close()
+			return result, apptypes.ErrCatalogDrift
+		}
+		var token [sha256.Size]byte
+		copy(token[:], raw)
+		result.ExactTokens = append(result.ExactTokens, domain.SegmentSummaryToken{Kind: domain.SummaryTokenKind(kind), Value: token})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	rows, err = q.QueryContext(ctx, `SELECT kind,bit_count,hash_count,bits FROM archive_catalog_summary_blooms WHERE segment_id=? ORDER BY kind LIMIT ?`, segmentID, limit)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		if uint64(len(result.ExactTokens)+len(result.Blooms)) >= maxRows {
+			_ = rows.Close()
+			return result, apptypes.ErrCatalogDrift
+		}
+		var kind uint8
+		var bitCount uint32
+		var hashCount uint8
+		var bits []byte
+		if err = rows.Scan(&kind, &bitCount, &hashCount, &bits); err != nil {
+			_ = rows.Close()
+			return result, err
+		}
+		result.Blooms = append(result.Blooms, domain.SegmentBloomV1{Kind: domain.SummaryTokenKind(kind), BitCount: bitCount, HashCount: hashCount, Bits: bits})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	rows, err = q.QueryContext(ctx, `SELECT session_token,unit_count,audit_count FROM archive_catalog_summary_sessions WHERE segment_id=? ORDER BY session_token LIMIT ?`, segmentID, limit)
+	if err != nil {
+		return result, err
+	}
+	for rows.Next() {
+		if uint64(len(result.ExactTokens)+len(result.Blooms)+len(result.Sessions)) >= maxRows {
+			_ = rows.Close()
+			return result, apptypes.ErrCatalogDrift
+		}
+		var raw []byte
+		var units, audits uint64
+		if err = rows.Scan(&raw, &units, &audits); err != nil || len(raw) != sha256.Size {
+			_ = rows.Close()
+			return result, apptypes.ErrCatalogDrift
+		}
+		var token [sha256.Size]byte
+		copy(token[:], raw)
+		result.Sessions = append(result.Sessions, domain.SegmentSessionAggregateV1{SessionToken: token, UnitCount: units, AuditCount: audits})
+	}
+	if err = rows.Close(); err != nil {
+		return result, err
+	}
+	if _, err = result.CanonicalBytes(maxBytes); err != nil {
+		return result, apptypes.ErrCatalogDrift
+	}
+	return result, nil
+}
+
+// CatalogSummaryDiagnostics returns aggregates only and fails closed on a
+// missing or inconsistent ledger.
+func (d *Database) CatalogSummaryDiagnostics(ctx context.Context, expected apptypes.CatalogHead, budget apptypes.CatalogBudget) (apptypes.CatalogSummaryDiagnostics, error) {
+	if !budget.Valid() {
+		return apptypes.CatalogSummaryDiagnostics{}, apptypes.ErrCatalogLimit
+	}
+	opCtx, cancel := context.WithTimeout(ctx, budget.WallTime)
+	defer cancel()
+	state, err := d.ensureCatalogDiagnosticsAudit(opCtx, expected, budget)
+	if err != nil {
+		return apptypes.CatalogSummaryDiagnostics{}, err
+	}
+	if err = d.validateCatalogDiagnosticsCachePage(opCtx, expected, state, budget); err != nil {
+		return apptypes.CatalogSummaryDiagnostics{}, err
+	}
+	db, err := d.openReadOnly(opCtx)
+	if err != nil {
+		return apptypes.CatalogSummaryDiagnostics{}, err
+	}
+	defer d.release(db)
+	head, err := readCatalogHead(opCtx, db)
+	if err != nil || head != expected || verifyCatalogLedgerPresence(opCtx, db, head) != nil || verifyCatalogHeadIncremental(opCtx, db, head) != nil {
+		return apptypes.CatalogSummaryDiagnostics{}, apptypes.ErrCatalogDrift
+	}
+	var r apptypes.CatalogSummaryDiagnostics
+	queries := []struct {
+		q   string
+		dst *int64
+	}{
+		{`SELECT count(*) FROM archive_catalog_segment_bindings`, &r.BoundSegments}, {`SELECT count(*) FROM archive_catalog_summary_segments`, &r.ReconciledSegments}, {`SELECT count(*) FROM archive_catalog_summary_exact`, &r.ExactKindRows}, {`SELECT count(*) FROM archive_catalog_summary_blooms`, &r.BloomKindRows}, {`SELECT count(*) FROM archive_catalog_summary_sessions`, &r.SessionRows}, {`SELECT COALESCE(sum(unit_count),0) FROM archive_catalog_summary_segments`, &r.UnitCount}, {`SELECT COALESCE(sum(audit_count),0) FROM archive_catalog_summary_segments`, &r.AuditCount}, {`SELECT COALESCE(sum(total_stored_bytes),0) FROM archive_catalog_summary_segments`, &r.StoredBytes}, {`SELECT COALESCE(sum(summary_byte_count),0) FROM archive_catalog_summary_segments`, &r.SummaryBytes}, {`SELECT count(*) FROM archive_catalog_current_ranges WHERE placement_state='hot'`, &r.HotRanges}, {`SELECT count(*) FROM archive_catalog_current_ranges WHERE placement_state='reserved'`, &r.ReservedRanges}, {`SELECT count(*) FROM archive_catalog_current_ranges WHERE placement_state IN ('sealed','verified_shadow','segment_authoritative','evicting','cold')`, &r.SegmentRanges}, {`SELECT count(*) FROM archive_catalog_summary_segments s LEFT JOIN archive_catalog_segment_bindings b ON b.segment_id=s.segment_id WHERE b.segment_id IS NULL OR b.summary_digest<>s.summary_digest OR b.bound_epoch<>s.bound_epoch`, &r.DriftCount}}
+	for _, query := range queries {
+		if err = db.QueryRowContext(opCtx, query.q).Scan(query.dst); err != nil {
+			return r, err
+		}
+	}
+	r.UnknownKindSlots = r.ReconciledSegments*int64(summaryTokenKindCount) - r.BloomKindRows
+	if r.UnknownKindSlots < 0 {
+		r.DriftCount++
+		r.UnknownKindSlots = 0
+	}
+	return r, nil
+}
+
+const summaryTokenKindCount = 5
+const catalogSummaryMaxRows uint64 = 100_000
+const catalogSummaryMaxBytes int64 = 64 << 20
+
+type catalogDiagnosticsState struct {
+	expectedEpoch, auditEpoch, cacheEpoch       int64
+	expectedDigest, auditDigest, cacheID        string
+	auditComplete, cacheComplete, cycleComplete bool
+}
+
+func (d *Database) ensureCatalogDiagnosticsAudit(ctx context.Context, expected apptypes.CatalogHead, budget apptypes.CatalogBudget) (catalogDiagnosticsState, error) {
+	db, err := d.open(ctx)
+	if err != nil {
+		return catalogDiagnosticsState{}, err
+	}
+	defer d.release(db)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return catalogDiagnosticsState{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	head, err := readCatalogHead(ctx, tx)
+	if err != nil || head != expected {
+		return catalogDiagnosticsState{}, apptypes.ErrCatalogDrift
+	}
+	var s catalogDiagnosticsState
+	if err = tx.QueryRowContext(ctx, `SELECT expected_epoch,expected_ledger_digest,audit_epoch,audit_ledger_digest,cache_bound_epoch,cache_segment_id,audit_complete,cache_complete,cycle_complete FROM archive_catalog_summary_diagnostics_state WHERE singleton=1`).Scan(&s.expectedEpoch, &s.expectedDigest, &s.auditEpoch, &s.auditDigest, &s.cacheEpoch, &s.cacheID, &s.auditComplete, &s.cacheComplete, &s.cycleComplete); err != nil {
+		return s, err
+	}
+	if s.expectedEpoch != expected.Epoch || s.expectedDigest != expected.LedgerDigest || s.cycleComplete {
+		s = catalogDiagnosticsState{expectedEpoch: expected.Epoch, expectedDigest: expected.LedgerDigest, auditDigest: emptyCatalogDigestValue}
+		if _, err = tx.ExecContext(ctx, `UPDATE archive_catalog_summary_diagnostics_state SET expected_epoch=?,expected_ledger_digest=?,audit_epoch=0,audit_ledger_digest=?,cache_bound_epoch=0,cache_segment_id='',audit_complete=0,cache_complete=0,cycle_complete=0 WHERE singleton=1`, expected.Epoch, expected.LedgerDigest, emptyCatalogDigestValue); err != nil {
+			return s, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return s, err
+	}
+	if s.auditComplete {
+		return s, nil
+	}
+	page, err := d.AuditCatalogLedgerPage(ctx, apptypes.CatalogAuditCursor{Epoch: s.auditEpoch, LedgerDigest: s.auditDigest}, budget)
+	if err != nil {
+		return s, err
+	}
+	if !page.Done && page.Verified < budget.Ranges {
+		return s, apptypes.ErrCatalogDrift
+	}
+	if err = d.verifyCatalogReservationAuditPage(ctx, s.auditEpoch, page.Next.Epoch, budget); err != nil {
+		return s, err
+	}
+	db, err = d.open(ctx)
+	if err != nil {
+		return s, err
+	}
+	defer d.release(db)
+	result, err := db.ExecContext(ctx, `UPDATE archive_catalog_summary_diagnostics_state SET audit_epoch=?,audit_ledger_digest=?,audit_complete=? WHERE singleton=1 AND expected_epoch=? AND expected_ledger_digest=? AND audit_epoch=? AND audit_ledger_digest=?`, page.Next.Epoch, page.Next.LedgerDigest, page.Done, expected.Epoch, expected.LedgerDigest, s.auditEpoch, s.auditDigest)
+	if err != nil {
+		return s, err
+	}
+	n, _ := result.RowsAffected()
+	if n != 1 {
+		return s, apptypes.ErrCatalogDrift
+	}
+	s.auditEpoch, s.auditDigest, s.auditComplete = page.Next.Epoch, page.Next.LedgerDigest, page.Done
+	if !page.Done {
+		return s, apptypes.ErrCatalogAuditIncomplete
+	}
+	return s, nil
+}
+
+type diagnosticCacheRow struct {
+	binding                                     catalogSummaryBinding
+	parentEpoch                                 int64
+	parentSummaryVersion                        int
+	parentDigest, keyID, minCreated, maxCreated string
+	complete                                    bool
+	units, audits, plainValues, zstdValues      uint64
+	totalPlain, totalStored                     int64
+	rowCount                                    uint64
+	byteCount                                   int64
+}
+
+func (d *Database) validateCatalogDiagnosticsCachePage(ctx context.Context, expected apptypes.CatalogHead, state catalogDiagnosticsState, budget apptypes.CatalogBudget) error {
+	if state.cacheComplete {
+		return nil
+	}
+	db, err := d.openReadOnly(ctx)
+	if err != nil {
+		return err
+	}
+	defer d.release(db)
+	rows, err := db.QueryContext(ctx, `SELECT b.segment_id,b.store_id,b.start_sequence,b.end_sequence,b.format_version,b.manifest_version,b.summary_version,b.logical_digest,b.file_digest,b.manifest_digest,b.summary_digest,b.relative_basename,b.storage_class,b.bound_epoch,s.bound_epoch,s.summary_version,s.summary_digest,s.filter_key_id,s.time_summary_complete,s.min_created_at,s.max_created_at,s.unit_count,s.audit_count,s.plain_value_count,s.zstd_value_count,s.total_plain_bytes,s.total_stored_bytes,s.summary_row_count,s.summary_byte_count FROM archive_catalog_summary_segments s JOIN archive_catalog_segment_bindings b ON b.segment_id=s.segment_id WHERE s.bound_epoch>? OR (s.bound_epoch=? AND s.segment_id>?) ORDER BY s.bound_epoch,s.segment_id LIMIT ?`, state.cacheEpoch, state.cacheEpoch, state.cacheID, budget.Ranges+1)
+	if err != nil {
+		return err
+	}
+	page := make([]diagnosticCacheRow, 0, budget.Ranges)
+	more := false
+	for rows.Next() {
+		if len(page) >= budget.Ranges {
+			more = true
+			break
+		}
+		var r diagnosticCacheRow
+		if err = rows.Scan(&r.binding.segmentID, &r.binding.storeID, &r.binding.start, &r.binding.end, &r.binding.formatVersion, &r.binding.manifestVersion, &r.binding.summaryVersion, &r.binding.logicalDigest, &r.binding.fileDigest, &r.binding.manifestDigest, &r.binding.summaryDigest, &r.binding.basename, &r.binding.storageClass, &r.binding.boundEpoch, &r.parentEpoch, &r.parentSummaryVersion, &r.parentDigest, &r.keyID, &r.complete, &r.minCreated, &r.maxCreated, &r.units, &r.audits, &r.plainValues, &r.zstdValues, &r.totalPlain, &r.totalStored, &r.rowCount, &r.byteCount); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		page = append(page, r)
+	}
+	_ = rows.Close()
+	for _, r := range page {
+		b := r.binding
+		if r.parentEpoch != b.boundEpoch || r.parentSummaryVersion != int(domain.SegmentSummaryV1) || r.parentSummaryVersion != b.summaryVersion || r.parentDigest != b.summaryDigest || b.formatVersion != 1 || b.manifestVersion != 1 || b.summaryVersion != 1 || b.storageClass != "sealed_sqlite_zstd_v1" || r.rowCount > catalogSummaryMaxRows || r.byteCount <= 0 || r.byteCount > catalogSummaryMaxBytes {
+			return apptypes.ErrCatalogDrift
+		}
+		manifest := ArchiveSegmentManifest{StoreID: b.storeID, FormatVersion: uint32(b.formatVersion), StartSequence: uint64(b.start), EndSequence: uint64(b.end), UnitCount: r.units, AuditCount: r.audits, MinCreatedAt: r.minCreated, MaxCreatedAt: r.maxCreated, PlainValueCount: r.plainValues, ZstdValueCount: r.zstdValues, TotalPlainBytes: r.totalPlain, TotalStoredBytes: r.totalStored, LogicalDigest: b.logicalDigest, FileDigest: b.fileDigest, Basename: b.basename, SummaryVersion: uint32(r.parentSummaryVersion), SummaryDigest: b.summaryDigest, FilterKeyID: r.keyID, TimeSummaryComplete: r.complete, SummaryRowCount: r.rowCount, SummaryByteCount: r.byteCount}
+		digest, digestErr := ArchiveSegmentManifestDigest(manifest)
+		if digestErr != nil || digest != b.manifestDigest {
+			return apptypes.ErrCatalogDrift
+		}
+		summary, readErr := readCatalogNormalizedSummary(ctx, db, b.segmentID, r.keyID, r.complete, r.rowCount, catalogSummaryMaxRows, r.byteCount)
+		if readErr != nil {
+			return apptypes.ErrCatalogDrift
+		}
+		canonical, readErr := summary.CanonicalBytes(r.byteCount)
+		if readErr != nil || hex.EncodeToString(digestBytes(canonical)) != b.summaryDigest {
+			return apptypes.ErrCatalogDrift
+		}
+	}
+	lastEpoch, lastID := state.cacheEpoch, state.cacheID
+	if len(page) > 0 {
+		lastEpoch, lastID = page[len(page)-1].binding.boundEpoch, page[len(page)-1].binding.segmentID
+	}
+	complete := !more
+	writer, err := d.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer d.release(writer)
+	result, err := writer.ExecContext(ctx, `UPDATE archive_catalog_summary_diagnostics_state SET cache_bound_epoch=?,cache_segment_id=?,cache_complete=?,cycle_complete=? WHERE singleton=1 AND expected_epoch=? AND expected_ledger_digest=? AND audit_complete=1 AND cache_bound_epoch=? AND cache_segment_id=?`, lastEpoch, lastID, complete, complete, expected.Epoch, expected.LedgerDigest, state.cacheEpoch, state.cacheID)
+	if err != nil {
+		return err
+	}
+	n, _ := result.RowsAffected()
+	if n != 1 {
+		return apptypes.ErrCatalogDrift
+	}
+	if !complete {
+		return apptypes.ErrCatalogAuditIncomplete
+	}
+	return nil
+}
+
+func verifyCatalogLedgerPresence(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, head apptypes.CatalogHead) error {
+	var count, minimum, maximum, broken int64
+	if err := q.QueryRowContext(ctx, `SELECT count(*),COALESCE(min(epoch),0),COALESCE(max(epoch),0),COALESCE(sum(CASE WHEN parent_epoch<>epoch-1 THEN 1 ELSE 0 END),0) FROM archive_catalog_epochs`).Scan(&count, &minimum, &maximum, &broken); err != nil {
+		return apptypes.ErrCatalogDrift
+	}
+	if head.Epoch == 0 {
+		if count != 0 {
+			return apptypes.ErrCatalogDrift
+		}
+		return nil
+	}
+	if count != head.Epoch || minimum != 1 || maximum != head.Epoch || broken != 0 {
+		return apptypes.ErrCatalogDrift
+	}
+	if err := q.QueryRowContext(ctx, `SELECT count(*) FROM archive_catalog_epochs child LEFT JOIN archive_catalog_epochs parent ON parent.epoch=child.parent_epoch WHERE child.parent_epoch>0 AND (parent.epoch IS NULL OR parent.ledger_digest<>child.parent_ledger_digest)`).Scan(&broken); err != nil || broken != 0 {
+		return apptypes.ErrCatalogDrift
+	}
+	return nil
+}

--- a/infrastructure/sqlite/catalog_summary_internal_test.go
+++ b/infrastructure/sqlite/catalog_summary_internal_test.go
@@ -1,0 +1,302 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/domain"
+)
+
+func TestCatalogSummaryRebuildIsResumableIdempotentAndAggregateOnly(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 11)
+	defer func() { _ = raw.Close() }()
+	initial, err := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "summary-fixture", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: strings.Repeat("a", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var storeID string
+	if err = raw.QueryRow(`SELECT store_id FROM archive_store_lineage WHERE singleton=1`).Scan(&storeID); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	manifest, err := BuildArchiveSegmentV1(ctx, root, testArchiveUnits(), ArchiveSegmentConfig{StoreID: storeID, CompressionFloor: 32, Limits: testSegmentLimits(), Summary: testSegmentSummary()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest, err := ArchiveSegmentManifestDigest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtureBinding := catalogSummaryBinding{segmentID: manifest.Basename, storeID: storeID, basename: manifest.Basename, logicalDigest: manifest.LogicalDigest, fileDigest: manifest.FileDigest, manifestDigest: strings.Repeat("9", 64), summaryDigest: manifest.SummaryDigest, storageClass: "sealed_sqlite_zstd_v1", start: int64(manifest.StartSequence), end: int64(manifest.EndSequence), boundEpoch: head.Epoch, formatVersion: 1, manifestVersion: 1, summaryVersion: 1}
+	if _, _, err = loadBoundSegmentSummary(ctx, root, fixtureBinding, testSegmentLimits()); !errors.Is(err, apptypes.ErrCatalogBindingMismatch) {
+		t.Fatalf("manifest mutation error = %v", err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_segment_bindings(segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class,bound_epoch) VALUES(?,?,?,?,1,1,1,?,?,?,?,?,'sealed_sqlite_zstd_v1',?)`, manifest.Basename, storeID, manifest.StartSequence, manifest.EndSequence, manifest.LogicalDigest, manifest.FileDigest, manifestDigest, manifest.SummaryDigest, manifest.Basename, head.Epoch); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Processed != 1 || first.Inserted != 1 || !first.Done || first.Remaining != 0 {
+		t.Fatalf("first = %+v", first)
+	}
+	second, err := database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Processed != 1 || second.Existing != 1 || !second.Done {
+		t.Fatalf("idempotent = %+v", second)
+	}
+	diagnostics, err := database.CatalogSummaryDiagnostics(ctx, head, catalogTestBudget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diagnostics.BoundSegments != 1 || diagnostics.ReconciledSegments != 1 || diagnostics.DriftCount != 0 || diagnostics.StoredBytes <= 0 {
+		t.Fatalf("diagnostics = %+v", diagnostics)
+	}
+	for i := 0; i < reflect.TypeOf(diagnostics).NumField(); i++ {
+		name := strings.ToLower(reflect.TypeOf(diagnostics).Field(i).Name)
+		for _, forbidden := range []string{"id", "token", "digest", "basename", "payload", "key", "time"} {
+			if strings.Contains(name, forbidden) {
+				t.Fatalf("diagnostic field %q exposes %q", name, forbidden)
+			}
+		}
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_summary_segments SET unit_count=unit_count+1 WHERE segment_id=?`, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.CatalogSummaryDiagnostics(ctx, head, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("parent mutation error = %v", err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_summary_segments SET unit_count=? WHERE segment_id=?`, manifest.UnitCount, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_summary_segments SET summary_version=2 WHERE segment_id=?`, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.CatalogSummaryDiagnostics(ctx, head, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("parent summary-version mutation error = %v", err)
+	}
+	if _, err = raw.Exec(`UPDATE archive_catalog_summary_segments SET summary_version=? WHERE segment_id=?`, domain.SegmentSummaryV1, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := raw.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	statement, err := tx.Prepare(`INSERT INTO archive_catalog_summary_exact(segment_id,kind,token) VALUES(?,5,?)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 1001; index++ {
+		var number [8]byte
+		binary.BigEndian.PutUint64(number[:], uint64(index))
+		token := sha256.Sum256(number[:])
+		if _, err = statement.Exec(manifest.Basename, token[:]); err != nil {
+			_ = statement.Close()
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+	}
+	_ = statement.Close()
+	if err = tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("over-cap child error = %v", err)
+	}
+	if _, err = raw.Exec(`DELETE FROM archive_catalog_summary_exact WHERE segment_id=? AND kind=5`, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget()); err != nil || !result.Done {
+		t.Fatalf("post-cleanup rebuild=%+v err=%v", result, err)
+	}
+	if _, err = raw.Exec(`DELETE FROM archive_catalog_summary_exact WHERE segment_id=?`, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("deleted child error = %v", err)
+	}
+	if _, err = database.CatalogSummaryDiagnostics(ctx, head, catalogTestBudget()); !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("diagnostic deleted-child error = %v", err)
+	}
+	if _, err = raw.Exec(`DELETE FROM archive_catalog_summary_segments WHERE segment_id=?`, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	coverage, err := database.CatalogSummaryDiagnostics(ctx, head, catalogTestBudget())
+	if err != nil || coverage.BoundSegments != 1 || coverage.ReconciledSegments != 0 {
+		t.Fatalf("partial coverage=%+v err=%v", coverage, err)
+	}
+	if result, err := database.RebuildCatalogSummaries(ctx, root, head, 1, testSegmentLimits(), catalogTestBudget()); err != nil || !result.Done {
+		t.Fatalf("coverage rebuild=%+v err=%v", result, err)
+	}
+	cloneLogical := strings.Repeat("2", 64)
+	cloneBase := "segment-v1-" + cloneLogical + ".sqlite"
+	cloneManifest := manifest
+	cloneManifest.LogicalDigest = cloneLogical
+	cloneManifest.Basename = cloneBase
+	cloneManifest.FileDigest = strings.Repeat("3", 64)
+	cloneManifestDigest, err := ArchiveSegmentManifestDigest(cloneManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_segment_bindings(segment_id,store_id,start_sequence,end_sequence,format_version,manifest_version,summary_version,logical_digest,file_digest,manifest_digest,summary_digest,relative_basename,storage_class,bound_epoch) VALUES(?,?,?,?,1,1,1,?,?,?,?,?,'sealed_sqlite_zstd_v1',?)`, cloneBase, storeID, cloneManifest.StartSequence, cloneManifest.EndSequence, cloneLogical, cloneManifest.FileDigest, cloneManifestDigest, cloneManifest.SummaryDigest, cloneBase, head.Epoch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_summary_segments SELECT ?,bound_epoch,summary_version,filter_key_id,time_summary_complete,min_created_at,max_created_at,unit_count,audit_count,plain_value_count,zstd_value_count,total_plain_bytes,total_stored_bytes,summary_row_count,summary_byte_count,summary_digest,reconciled_at FROM archive_catalog_summary_segments WHERE segment_id=?`, cloneBase, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_summary_exact SELECT ?,kind,token FROM archive_catalog_summary_exact WHERE segment_id=?`, cloneBase, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_summary_blooms SELECT ?,kind,bit_count,hash_count,bits FROM archive_catalog_summary_blooms WHERE segment_id=?`, cloneBase, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`INSERT INTO archive_catalog_summary_sessions SELECT ?,session_token,unit_count,audit_count FROM archive_catalog_summary_sessions WHERE segment_id=?`, cloneBase, manifest.Basename); err != nil {
+		t.Fatal(err)
+	}
+	pageBudget := catalogTestBudget()
+	pageBudget.Ranges = 1
+	if _, err = database.CatalogSummaryDiagnostics(ctx, head, pageBudget); !errors.Is(err, apptypes.ErrCatalogAuditIncomplete) {
+		t.Fatalf("diagnostic cache page error = %v", err)
+	}
+	var cacheCursor string
+	if err = raw.QueryRow(`SELECT cache_segment_id FROM archive_catalog_summary_diagnostics_state WHERE singleton=1`).Scan(&cacheCursor); err != nil || cacheCursor == "" {
+		t.Fatalf("diagnostic cache cursor=%q err=%v", cacheCursor, err)
+	}
+	finalDiagnostics, err := database.CatalogSummaryDiagnostics(ctx, head, pageBudget)
+	if err != nil || finalDiagnostics.BoundSegments != 2 || finalDiagnostics.ReconciledSegments != 2 {
+		t.Fatalf("diagnostic resume=%+v err=%v", finalDiagnostics, err)
+	}
+}
+
+func TestCatalogSummaryAuditRejectsHistoricalReservationLoss(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "lost-delta", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: strings.Repeat("e", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`DROP TRIGGER archive_catalog_reservations_no_delete`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`DELETE FROM archive_catalog_reservation_deltas WHERE reservation_id='lost-delta'`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 1, testSegmentLimits(), catalogTestBudget())
+	if !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("historical reservation loss error = %v", err)
+	}
+}
+
+func TestCatalogSummaryAuditRejectsHistoricalTransitionLoss(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	reserved, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "lost-transition", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: strings.Repeat("f", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: "lost-transition", EvidenceDigest: strings.Repeat("f", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, completeErr := database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 2, testSegmentLimits(), catalogTestBudget()); completeErr != nil || !result.Done {
+		t.Fatalf("initial complete = %+v, %v", result, completeErr)
+	}
+	if _, err = raw.Exec(`DROP TRIGGER archive_catalog_transitions_no_delete`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.Exec(`DELETE FROM archive_catalog_range_transitions WHERE epoch=1`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 2, testSegmentLimits(), catalogTestBudget())
+	if !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("historical transition loss error = %v", err)
+	}
+}
+
+func TestCatalogSummaryFullAuditResumesDurablyBeforeRebuild(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	reserved, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "paged-audit", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: strings.Repeat("1", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := database.ReleaseCatalogReservation(ctx, apptypes.CatalogRelease{ExpectedHead: reserved, ReservationID: "paged-audit", EvidenceDigest: strings.Repeat("2", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget := catalogTestBudget()
+	budget.Ranges = 1
+	if _, err = database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 1, testSegmentLimits(), budget); !errors.Is(err, apptypes.ErrCatalogAuditIncomplete) {
+		t.Fatalf("first page error = %v", err)
+	}
+	var cursor int64
+	if err = raw.QueryRow(`SELECT audit_epoch FROM archive_catalog_summary_rebuild_state WHERE singleton=1`).Scan(&cursor); err != nil || cursor != 1 {
+		t.Fatalf("durable cursor=%d err=%v", cursor, err)
+	}
+	result, err := database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 1, testSegmentLimits(), budget)
+	if err != nil || !result.Done {
+		t.Fatalf("resumed result=%+v err=%v", result, err)
+	}
+}
+
+func TestCatalogSummaryRebuildFailsClosedWhenLedgerIsMissing(t *testing.T) {
+	ctx := context.Background()
+	database, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	initial, _ := database.CurrentCatalogRanges(ctx, catalogTestBudget())
+	head, err := database.ReserveCatalogTarget(ctx, apptypes.CatalogReservation{ExpectedHead: initial.Head, ReservationID: "ledger-loss", Range: domain.CatalogRange{Start: 1, End: 1}, EvidenceDigest: strings.Repeat("c", 64), Budget: catalogTestBudget()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point the mutable head at a missing append-only epoch. Rebuild must not
+	// infer authority from bindings or segment files.
+	head.Epoch++
+	head.LedgerDigest = strings.Repeat("d", 64)
+	if _, err = raw.Exec(`UPDATE archive_catalog_head SET current_epoch=?,ledger_digest=? WHERE singleton=1`, head.Epoch, head.LedgerDigest); err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.RebuildCatalogSummaries(ctx, t.TempDir(), head, 1, testSegmentLimits(), catalogTestBudget())
+	if !errors.Is(err, apptypes.ErrCatalogDrift) {
+		t.Fatalf("ledger loss error = %v", err)
+	}
+}
+
+func TestCatalogSummaryMigrationDoesNotCreateAuthority(t *testing.T) {
+	_, raw := newActivatedCatalogStore(t, 1)
+	defer func() { _ = raw.Close() }()
+	var bindings, summaries int
+	if err := raw.QueryRow(`SELECT (SELECT count(*) FROM archive_catalog_segment_bindings),(SELECT count(*) FROM archive_catalog_summary_segments)`).Scan(&bindings, &summaries); err != nil {
+		t.Fatal(err)
+	}
+	if bindings != 0 || summaries != 0 {
+		t.Fatalf("migration invented authority: bindings=%d summaries=%d", bindings, summaries)
+	}
+}
+
+func TestCatalogSummaryBindingRejectsNoncanonicalVersionsBeforeFileAccess(t *testing.T) {
+	binding := catalogSummaryBinding{segmentID: "segment-v1-" + strings.Repeat("a", 64) + ".sqlite", basename: "segment-v1-" + strings.Repeat("a", 64) + ".sqlite", formatVersion: 2, manifestVersion: 1, summaryVersion: 1, storageClass: "sealed_sqlite_zstd_v1", logicalDigest: strings.Repeat("a", 64), fileDigest: strings.Repeat("b", 64), manifestDigest: strings.Repeat("c", 64), summaryDigest: strings.Repeat("d", 64)}
+	if _, _, err := loadBoundSegmentSummary(context.Background(), t.TempDir(), binding, testSegmentLimits()); !errors.Is(err, apptypes.ErrCatalogBindingMismatch) {
+		t.Fatalf("version error = %v", err)
+	}
+}

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -45,6 +45,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	44: {44, "000044_add_archive_sequence_inventory.sql", "18e270f1b4b974f54529fac3aa2ab1daf273797a51217c3bf3601bdbcbcc79f6", MigrationConstantInPlace},
 	45: {45, "000045_add_segment_catalog_ledger.sql", "00802c1fe48e30ef1fd5ffc2e1c22e33bc8f32c6ea66d52e869d0362172d0982", MigrationConstantInPlace},
 	46: {46, "000046_add_segment_target_plans.sql", "f6759e9883580436e6717d9009e91108212bff9d5376ede8f82c9700231ccc65", MigrationConstantInPlace},
+	47: {47, "000047_add_catalog_summary_reconciliation.sql", "885c32336046359393f7ef35a96b81e418058d706233edab4ccf1fca60c1fb47", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 46 || len(plan.Pending) != 12 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 47 || len(plan.Pending) != 13 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -44,6 +44,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		44: MigrationConstantInPlace,
 		45: MigrationConstantInPlace,
 		46: MigrationConstantInPlace,
+		47: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 46 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 47 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/schema/sqlite/migrations/000047_add_catalog_summary_reconciliation.sql
+++ b/schema/sqlite/migrations/000047_add_catalog_summary_reconciliation.sql
@@ -1,0 +1,85 @@
+-- Reconciled summary metadata is a disposable, payload-free cache. The
+-- append-only Catalog ledger and immutable segment bindings remain authority.
+CREATE TABLE archive_catalog_summary_segments (
+    segment_id TEXT PRIMARY KEY REFERENCES archive_catalog_segment_bindings(segment_id),
+    bound_epoch INTEGER NOT NULL CHECK(bound_epoch > 0),
+    summary_version INTEGER NOT NULL CHECK(summary_version > 0),
+    filter_key_id TEXT NOT NULL CHECK(length(filter_key_id) BETWEEN 1 AND 255),
+    time_summary_complete INTEGER NOT NULL CHECK(time_summary_complete IN (0,1)),
+    min_created_at TEXT NOT NULL,
+    max_created_at TEXT NOT NULL,
+    unit_count INTEGER NOT NULL CHECK(unit_count > 0),
+    audit_count INTEGER NOT NULL CHECK(audit_count >= 0),
+    plain_value_count INTEGER NOT NULL CHECK(plain_value_count >= 0),
+    zstd_value_count INTEGER NOT NULL CHECK(zstd_value_count >= 0),
+    total_plain_bytes INTEGER NOT NULL CHECK(total_plain_bytes >= 0),
+    total_stored_bytes INTEGER NOT NULL CHECK(total_stored_bytes >= 0),
+    summary_row_count INTEGER NOT NULL CHECK(summary_row_count >= 0),
+    summary_byte_count INTEGER NOT NULL CHECK(summary_byte_count > 0),
+    summary_digest TEXT NOT NULL CHECK(length(summary_digest)=64),
+    reconciled_at TEXT NOT NULL
+);
+
+CREATE TABLE archive_catalog_summary_exact (
+    segment_id TEXT NOT NULL REFERENCES archive_catalog_summary_segments(segment_id) ON DELETE CASCADE,
+    kind INTEGER NOT NULL CHECK(kind BETWEEN 1 AND 5),
+    token BLOB NOT NULL CHECK(length(token)=32),
+    PRIMARY KEY(segment_id,kind,token)
+);
+CREATE TABLE archive_catalog_summary_blooms (
+    segment_id TEXT NOT NULL REFERENCES archive_catalog_summary_segments(segment_id) ON DELETE CASCADE,
+    kind INTEGER NOT NULL CHECK(kind BETWEEN 1 AND 5),
+    bit_count INTEGER NOT NULL CHECK(bit_count > 0 AND bit_count <= 8388608),
+    hash_count INTEGER NOT NULL CHECK(hash_count BETWEEN 1 AND 16),
+    bits BLOB NOT NULL CHECK(length(bits)*8=bit_count),
+    PRIMARY KEY(segment_id,kind)
+);
+CREATE TABLE archive_catalog_summary_sessions (
+    segment_id TEXT NOT NULL REFERENCES archive_catalog_summary_segments(segment_id) ON DELETE CASCADE,
+    session_token BLOB NOT NULL CHECK(length(session_token)=32),
+    unit_count INTEGER NOT NULL CHECK(unit_count > 0),
+    audit_count INTEGER NOT NULL CHECK(audit_count >= 0),
+    PRIMARY KEY(segment_id,session_token)
+);
+
+CREATE INDEX idx_archive_catalog_summary_epoch ON archive_catalog_summary_segments(bound_epoch,segment_id);
+
+-- Both cursors are internal and durable. Public evidence reports counts only.
+CREATE TABLE archive_catalog_summary_rebuild_state (
+    singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+    expected_epoch INTEGER NOT NULL CHECK(expected_epoch>=0),
+    expected_ledger_digest TEXT NOT NULL CHECK(length(expected_ledger_digest)=64),
+    audit_epoch INTEGER NOT NULL CHECK(audit_epoch>=0),
+    audit_ledger_digest TEXT NOT NULL CHECK(length(audit_ledger_digest)=64),
+    cache_bound_epoch INTEGER NOT NULL CHECK(cache_bound_epoch>=0),
+    cache_segment_id TEXT NOT NULL,
+    audit_complete INTEGER NOT NULL CHECK(audit_complete IN (0,1)),
+    cache_complete INTEGER NOT NULL CHECK(cache_complete IN (0,1))
+);
+INSERT INTO archive_catalog_summary_rebuild_state VALUES(
+    1,0,
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    0,
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    0,'',0,0
+);
+
+CREATE TABLE archive_catalog_summary_diagnostics_state (
+    singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+    expected_epoch INTEGER NOT NULL CHECK(expected_epoch>=0),
+    expected_ledger_digest TEXT NOT NULL CHECK(length(expected_ledger_digest)=64),
+    audit_epoch INTEGER NOT NULL CHECK(audit_epoch>=0),
+    audit_ledger_digest TEXT NOT NULL CHECK(length(audit_ledger_digest)=64),
+    cache_bound_epoch INTEGER NOT NULL CHECK(cache_bound_epoch>=0),
+    cache_segment_id TEXT NOT NULL,
+    audit_complete INTEGER NOT NULL CHECK(audit_complete IN (0,1)),
+    cache_complete INTEGER NOT NULL CHECK(cache_complete IN (0,1)),
+    cycle_complete INTEGER NOT NULL CHECK(cycle_complete IN (0,1))
+);
+INSERT INTO archive_catalog_summary_diagnostics_state VALUES(
+    1,0,
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    0,
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    0,'',0,0,0
+);


### PR DESCRIPTION
## Summary
- generate versioned keyed exact, Bloom, and session summary metadata with conservative fallback
- reconcile immutable segment metadata into a derived Catalog cache without changing ledger authority
- add resumable full-ledger/cache validation and aggregate-only diagnostics
- validate canonical manifest, binding, parent and child facts with bounded allocation
- add migration 47 plus no-false-negative, tamper, pagination, privacy, and cap regressions

## Validation
- go test ./... -count=1
- go vet ./...
- go tool golangci-lint run --timeout=5m
- focused race tests
- independent GPT-5.6 Sol review: APPROVE

Closes #1663