### PR TITLE
fix: make Kimi transcript recording idempotent per turn

### DIFF
--- a/presentation/cli/export_test.go
+++ b/presentation/cli/export_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/duck8823/traceary/domain/types"
 )
 
 // ResolveDBPath exposes resolveDBPath for tests.
@@ -123,6 +125,22 @@ func AntigravityWorkspaceCwd(payload []byte) string {
 // a conversation/step pair so tests can age or inspect it directly.
 func AntigravityPendingCommandPath(conversationID, stepIdx string) (string, error) {
 	return antigravityPendingCommandPath(conversationID, stepIdx)
+}
+
+// SetResolveHookTranscriptSessionIDFunc overrides the session-ID resolver
+// runHookTranscriptWithBlocks uses. Tests use it to force the "session
+// resolution yielded nothing" fail-soft skip (recorded=false, err=nil) in
+// isolation from any particular caller's own upstream preconditions — e.g.
+// Kimi's idempotency guard (#1681), whose own turn-resolution check would
+// otherwise make that skip unreachable through payload manipulation alone.
+func SetResolveHookTranscriptSessionIDFunc(f func([]byte, string) (types.SessionID, error)) {
+	resolveHookTranscriptSessionIDFunc = f
+}
+
+// ResetResolveHookTranscriptSessionIDFunc restores the default session-ID
+// resolver for runHookTranscriptWithBlocks.
+func ResetResolveHookTranscriptSessionIDFunc() {
+	resolveHookTranscriptSessionIDFunc = resolveHookSessionID
 }
 
 // SetDetectRepoContextFunc replaces the work-context resolver for tests.

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -191,6 +191,17 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 // firing is skipped only when both the turn ID and the fingerprint of its
 // extracted blocks match the marker.
 //
+// The blocks extracted here for the fingerprint are the SAME blocks passed
+// to runHookTranscriptWithBlocks below — the shared recorder never
+// re-extracts from the wire log on this path. Two independent reads of
+// wire.jsonl (one for the fingerprint, one inside the recorder) used to run
+// per firing; besides doubling the per-firing cost of a bufio scan of the
+// whole session wire log, it meant the fingerprint keyed one read while the
+// persisted row came from a second, later read of a file that can change
+// between the two (rotated, truncated, rewritten). Passing the blocks
+// through closes that window: the fingerprint and the persisted body are
+// now guaranteed to describe the same content (#1681 HIGH finding).
+//
 // This deliberately does not delete or supersede the earlier, shorter row
 // that a growing turn leaves behind — that needs a delete port this hook
 // does not have. Recording each growth snapshot still collapses ~24
@@ -200,7 +211,13 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 // The check-then-record-then-mark sequence runs inside
 // withKimiTranscriptTurnStateLock so two racing firings for the same
 // (turn ID, fingerprint) cannot both observe "not yet recorded" and both
-// write a row.
+// write a row. Marking is additionally gated on the recorder's own
+// recorded=true return value, never inferred from a nil error: the shared
+// recorder fails soft on several unrelated conditions (e.g. an unresolved
+// session), and treating any of those nil-error returns as "a row was
+// persisted" would let a turn that was never actually stored get marked as
+// done — silently discarding every later redelivery of that turn forever
+// (#1681 CRITICAL finding).
 //
 // When the wire turn cannot be resolved (missing index entry, missing wire
 // log, escaped path, ...), the fingerprint cannot be computed, or the turn
@@ -212,12 +229,14 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 	blocks, turnID, turnResolved := extractKimiTranscriptTurn(payload)
 	turnID = strings.TrimSpace(turnID)
 	if !turnResolved || sessionID == "" || turnID == "" {
-		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+		_, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, nil)
+		return err
 	}
 	fingerprint, fingerprintErr := kimiTranscriptBlocksFingerprint(blocks)
 	if fingerprintErr != nil {
 		slog.Debug("Kimi transcript fingerprint unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", fingerprintErr)
-		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+		_, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		return err
 	}
 
 	var recordErr error
@@ -225,20 +244,26 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 		if kimiTranscriptTurnAlreadyRecorded(sessionID, turnID, fingerprint) {
 			return nil
 		}
-		if err := c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath); err != nil {
+		recorded, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		if err != nil {
 			recordErr = err
 			return err
 		}
-		markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint)
+		if recorded {
+			markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint)
+		}
 		return nil
 	})
 	if lockErr != nil && recordErr == nil {
 		// The lock itself was unavailable (contention timeout or a
 		// filesystem error unrelated to the actual recording). Fail open:
 		// record unguarded rather than silently dropping a possibly-new
-		// turn.
+		// turn. No marker is written on this path either way — it runs
+		// outside withKimiTranscriptTurnStateLock, so writing one here
+		// would race the very lock this falls back from.
 		slog.Debug("Kimi transcript turn lock unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", lockErr)
-		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+		_, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
+		return err
 	}
 	return lockErr
 }

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -173,39 +173,63 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 }
 
 // runHookKimiTranscript wraps the shared transcript recorder with a
-// per-(session, wire turn) idempotency guard. Kimi's Stop hook fires
-// roughly two dozen times per completed turn while the session's
-// wire.jsonl is unchanged, with redeliveries observed as little as ~0.14s
-// apart — including effectively concurrent firings. Extraction itself is
-// correct (it already resolves only the final turn's blocks), so without
-// this guard the same unchanged turn is re-recorded on every firing,
-// measured at 23x live (#1681). The check-then-record-then-mark sequence
-// runs inside withKimiTranscriptTurnStateLock so two racing firings for the
-// same turn cannot both observe "not yet recorded" and both write a row.
+// per-(session, wire turn ID, content fingerprint) idempotency guard. Kimi's
+// Stop hook fires roughly two dozen times per completed turn, with
+// redeliveries observed as little as ~0.14s apart — including effectively
+// concurrent firings. Extraction itself is correct (it already resolves only
+// the final turn's blocks), so without this guard the same turn is
+// re-recorded on every firing, measured at 23x live (#1681).
+//
+// Turn ID alone is not a completed-turn boundary: Kimi's Stop can re-fire
+// while a turn is still streaming, so a later firing with the same turn ID
+// can carry strictly more content than an earlier one (measured live: 2,053
+// of 52,475 consecutive same-session pairs grew, 153 of those gained the
+// only "text" block the turn ever produced). Keying on turn ID alone would
+// record the marker on the first, incomplete firing and silently discard
+// everything the turn produced afterwards — a worse failure than the
+// duplication being fixed. The content fingerprint catches that growth: a
+// firing is skipped only when both the turn ID and the fingerprint of its
+// extracted blocks match the marker.
+//
+// This deliberately does not delete or supersede the earlier, shorter row
+// that a growing turn leaves behind — that needs a delete port this hook
+// does not have. Recording each growth snapshot still collapses ~24
+// same-turn firings to roughly 2-3 rows (turn ID unchanged, fingerprint
+// growing), a ~95% reduction with zero content loss.
+//
+// The check-then-record-then-mark sequence runs inside
+// withKimiTranscriptTurnStateLock so two racing firings for the same
+// (turn ID, fingerprint) cannot both observe "not yet recorded" and both
+// write a row.
 //
 // When the wire turn cannot be resolved (missing index entry, missing wire
-// log, escaped path, ...) or the turn lock itself is unavailable, this
-// falls through to the shared recorder unguarded — a hook must never fail
-// or silently drop a turn over housekeeping state, even at the cost of an
-// occasional duplicate.
+// log, escaped path, ...), the fingerprint cannot be computed, or the turn
+// lock itself is unavailable, this falls through to the shared recorder
+// unguarded — a hook must never fail or silently drop a turn over
+// housekeeping state, even at the cost of an occasional duplicate.
 func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbPath string) error {
 	sessionID := strings.TrimSpace(hookPayloadString(payload, "session_id", ""))
-	_, turnID, turnResolved := extractKimiTranscriptTurn(payload)
+	blocks, turnID, turnResolved := extractKimiTranscriptTurn(payload)
 	turnID = strings.TrimSpace(turnID)
 	if !turnResolved || sessionID == "" || turnID == "" {
+		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+	}
+	fingerprint, fingerprintErr := kimiTranscriptBlocksFingerprint(blocks)
+	if fingerprintErr != nil {
+		slog.Debug("Kimi transcript fingerprint unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", fingerprintErr)
 		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
 	}
 
 	var recordErr error
 	lockErr := withKimiTranscriptTurnStateLock(sessionID, func() error {
-		if kimiTranscriptTurnAlreadyRecorded(sessionID, turnID) {
+		if kimiTranscriptTurnAlreadyRecorded(sessionID, turnID, fingerprint) {
 			return nil
 		}
 		if err := c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath); err != nil {
 			recordErr = err
 			return err
 		}
-		markKimiTranscriptTurnRecorded(sessionID, turnID)
+		markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint)
 		return nil
 	})
 	if lockErr != nil && recordErr == nil {

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -166,9 +167,56 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 	if err != nil {
 		return err
 	}
-	transcriptErr := c.runHookTranscript(ctx, bytes.NewReader(normalized), kimiHookClient, dbPath)
+	transcriptErr := c.runHookKimiTranscript(ctx, normalized, dbPath)
 	usageErr := c.captureKimiUsage(ctx, normalized, dbPath, usecase.KimiUsageBoundaryStop)
 	return errors.Join(transcriptErr, usageErr)
+}
+
+// runHookKimiTranscript wraps the shared transcript recorder with a
+// per-(session, wire turn) idempotency guard. Kimi's Stop hook fires
+// roughly two dozen times per completed turn while the session's
+// wire.jsonl is unchanged, with redeliveries observed as little as ~0.14s
+// apart — including effectively concurrent firings. Extraction itself is
+// correct (it already resolves only the final turn's blocks), so without
+// this guard the same unchanged turn is re-recorded on every firing,
+// measured at 23x live (#1681). The check-then-record-then-mark sequence
+// runs inside withKimiTranscriptTurnStateLock so two racing firings for the
+// same turn cannot both observe "not yet recorded" and both write a row.
+//
+// When the wire turn cannot be resolved (missing index entry, missing wire
+// log, escaped path, ...) or the turn lock itself is unavailable, this
+// falls through to the shared recorder unguarded — a hook must never fail
+// or silently drop a turn over housekeeping state, even at the cost of an
+// occasional duplicate.
+func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbPath string) error {
+	sessionID := strings.TrimSpace(hookPayloadString(payload, "session_id", ""))
+	_, turnID, turnResolved := extractKimiTranscriptTurn(payload)
+	turnID = strings.TrimSpace(turnID)
+	if !turnResolved || sessionID == "" || turnID == "" {
+		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+	}
+
+	var recordErr error
+	lockErr := withKimiTranscriptTurnStateLock(sessionID, func() error {
+		if kimiTranscriptTurnAlreadyRecorded(sessionID, turnID) {
+			return nil
+		}
+		if err := c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath); err != nil {
+			recordErr = err
+			return err
+		}
+		markKimiTranscriptTurnRecorded(sessionID, turnID)
+		return nil
+	})
+	if lockErr != nil && recordErr == nil {
+		// The lock itself was unavailable (contention timeout or a
+		// filesystem error unrelated to the actual recording). Fail open:
+		// record unguarded rather than silently dropping a possibly-new
+		// turn.
+		slog.Debug("Kimi transcript turn lock unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", lockErr)
+		return c.runHookTranscript(ctx, bytes.NewReader(payload), kimiHookClient, dbPath)
+	}
+	return lockErr
 }
 
 func (c *RootCLI) captureKimiUsage(

--- a/presentation/cli/hook_kimi.go
+++ b/presentation/cli/hook_kimi.go
@@ -220,10 +220,14 @@ func (c *RootCLI) runHookKimiStop(ctx context.Context, input io.Reader, dbPath s
 // (#1681 CRITICAL finding).
 //
 // When the wire turn cannot be resolved (missing index entry, missing wire
-// log, escaped path, ...), the fingerprint cannot be computed, or the turn
-// lock itself is unavailable, this falls through to the shared recorder
+// log, escaped path, ...), the fingerprint cannot be computed, or the marker
+// infrastructure is unusable, this falls through to the shared recorder
 // unguarded — a hook must never fail or silently drop a turn over
 // housekeeping state, even at the cost of an occasional duplicate.
+//
+// Losing the race for the lock is the one case that does NOT fall open: it
+// means another firing is recording this turn, and Kimi will redeliver it
+// ~0.14s later anyway. See errKimiTranscriptTurnLockBusy.
 func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbPath string) error {
 	sessionID := strings.TrimSpace(hookPayloadString(payload, "session_id", ""))
 	blocks, turnID, turnResolved := extractKimiTranscriptTurn(payload)
@@ -254,13 +258,27 @@ func (c *RootCLI) runHookKimiTranscript(ctx context.Context, payload []byte, dbP
 		}
 		return nil
 	})
+	if errors.Is(lockErr, errKimiTranscriptTurnLockBusy) {
+		// Another firing held the lock for the whole acquisition budget,
+		// so it is recording this turn right now. Yield instead of
+		// recording unguarded: the budget is the same 1s as SQLite's
+		// busy_timeout, so a contended store exhausts it routinely, and
+		// recording here would put a duplicate in the store on exactly
+		// the workload #1681 is about. Kimi redelivers Stop for this turn
+		// roughly two dozen times, so skipping costs at most one more
+		// redelivery (~0.14s) — and if the holder succeeds, the marker it
+		// writes makes those redeliveries correctly no-ops.
+		slog.Debug("Kimi transcript turn is being recorded by another firing; skipping", "session_id", sessionID, "turn_id", turnID)
+		return nil
+	}
 	if lockErr != nil && recordErr == nil {
-		// The lock itself was unavailable (contention timeout or a
-		// filesystem error unrelated to the actual recording). Fail open:
-		// record unguarded rather than silently dropping a possibly-new
-		// turn. No marker is written on this path either way — it runs
-		// outside withKimiTranscriptTurnStateLock, so writing one here
-		// would race the very lock this falls back from.
+		// The marker infrastructure itself is unusable (an unresolvable
+		// state directory, a failed mkdir) — no firing can take the lock,
+		// so yielding would drop the turn entirely. Fail open: record
+		// unguarded rather than silently dropping a possibly-new turn. No
+		// marker is written on this path either way — it runs outside
+		// withKimiTranscriptTurnStateLock, so writing one here would race
+		// the very lock this falls back from.
 		slog.Debug("Kimi transcript turn lock unavailable; recording unguarded", "session_id", sessionID, "turn_id", turnID, "error", lockErr)
 		_, err := c.runHookTranscriptWithBlocks(ctx, bytes.NewReader(payload), kimiHookClient, dbPath, blocks)
 		return err

--- a/presentation/cli/hook_kimi_test.go
+++ b/presentation/cli/hook_kimi_test.go
@@ -173,12 +173,20 @@ func TestRootCLI_HookKimiCoreEvents(t *testing.T) {
 	})
 
 	t.Run("tolerates numeric turnId in wire log rows", func(t *testing.T) {
-		seedKimiSession(t, homeDir, "session_00000000-0000-4000-8000-000000000001", []string{
+		// Use a session ID distinct from the fixture default: the prior
+		// subtest already recorded turn "0" for that session under the
+		// per-session transcript-turn idempotency marker (#1681), and this
+		// subtest's fresh wire log also starts at turn 0 — a coincidence of
+		// two independent test fixtures, not an advancing real session, so
+		// it must not collide with that marker.
+		const sessionID = "session_44444444-4444-4444-8444-444444444444"
+		payload := strings.Replace(readKimiFixture(t, "stop.json"), "session_00000000-0000-4000-8000-000000000001", sessionID, 1)
+		seedKimiSession(t, homeDir, sessionID, []string{
 			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
 			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":0,"part":{"type":"text","text":"pong"}},"time":1784466740000}`,
 		})
 
-		stdout, eventStub, _ := runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), nil, nil)
+		stdout, eventStub, _ := runKimiHook(t, "stop", payload, nil, nil)
 
 		if stdout != "" {
 			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -226,13 +227,33 @@ func kimiCodeHome() string {
 const kimiTranscriptTurnsStateDir = "kimi-transcript-turns"
 
 // kimiTranscriptTurnLockTimeout bounds how long a Stop firing waits to
-// acquire the per-session turn-marker lock before falling open. The Kimi
-// Stop hook's host timeout is 5s (integrations/kimi-plugin/kimi.plugin.json)
-// and the critical section runs a DB migration check plus an event insert
-// against a store that can be tens of GB, so this budget leaves several
-// seconds of headroom inside the host deadline for that work to finish even
-// after a fully contended lock wait.
+// acquire the per-session turn-marker lock. The Kimi Stop hook's host timeout
+// is 5s (integrations/kimi-plugin/kimi.plugin.json) and the critical section
+// runs a DB migration check plus an event insert against a store that can be
+// tens of GB, so this budget leaves several seconds of headroom inside the
+// host deadline for that work to finish even after a fully contended wait.
+//
+// The wait can genuinely be exhausted: the insert inside the critical section
+// is itself bounded by SQLite's busy_timeout, which is also 1000ms
+// (infrastructure/sqlite/database.go), so a store under write contention
+// holds this lock for about as long as a contending firing is willing to wait
+// for it. That is why exhausting the wait is handled as
+// errKimiTranscriptTurnLockBusy rather than as a fall-open case.
 const kimiTranscriptTurnLockTimeout = 1 * time.Second
+
+// errKimiTranscriptTurnLockBusy reports that another process held the turn
+// lock for the whole acquisition budget — meaning it is recording this very
+// turn right now. This is distinct from the marker infrastructure being
+// unusable (an unresolvable state directory, a failed mkdir), which leaves no
+// process able to record and must fall open.
+//
+// The distinction decides whether a firing records unguarded or skips.
+// Skipping is safe here and falling open is not: Kimi redelivers Stop for the
+// same turn roughly two dozen times, so a firing that yields is retried
+// ~0.14s later by the next redelivery, whereas recording unguarded under
+// exactly the contention that produced the timeout reproduces the duplicate
+// storm this guard exists to stop (#1681).
+var errKimiTranscriptTurnLockBusy = errors.New("kimi transcript turn state lock is held by another firing")
 
 // kimiTranscriptTurnLockRetryDelay is the poll interval TryLockContext uses
 // while waiting up to kimiTranscriptTurnLockTimeout for the lock.
@@ -311,9 +332,10 @@ func kimiTranscriptTurnStatePath(sessionID string) (string, error) {
 // migration check plus an insert against a multi-GB store, inside a 5s host
 // hook timeout) cannot leave a stale lock behind. No PID check, TTL, or
 // cleanup is needed. Acquisition is bounded by kimiTranscriptTurnLockTimeout
-// so a firing never spins past its host budget; failure to acquire falls
-// open in the caller (records unguarded) exactly like any other
-// unresolvable-state case.
+// so a firing never spins past its host budget; exhausting that budget
+// returns errKimiTranscriptTurnLockBusy, which the caller treats as "another
+// firing owns this turn" and skips. Every other failure means no process can
+// take the lock at all, and falls open in the caller (records unguarded).
 func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
 	path, err := kimiTranscriptTurnStatePath(sessionID)
 	if err != nil {
@@ -327,10 +349,16 @@ func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
 	defer cancel()
 	locked, err := lock.TryLockContext(lockCtx, kimiTranscriptTurnLockRetryDelay)
 	if err != nil {
+		// TryLockContext surfaces the expired acquisition budget as the
+		// context's own error, so that case is the busy one, not a
+		// broken-lock one.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return errKimiTranscriptTurnLockBusy
+		}
 		return xerrors.Errorf("failed to lock Kimi transcript turn state: %w", err)
 	}
 	if !locked {
-		return xerrors.Errorf("failed to lock Kimi transcript turn state: timed out")
+		return errKimiTranscriptTurnLockBusy
 	}
 	defer func() {
 		if unlockErr := lock.Unlock(); unlockErr != nil {

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -9,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
 	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
@@ -221,17 +225,68 @@ func kimiCodeHome() string {
 // wire.jsonl), not a field carried on any hook payload.
 const kimiTranscriptTurnsStateDir = "kimi-transcript-turns"
 
-// kimiTranscriptTurnLockRetries and kimiTranscriptTurnLockDelay bound the
-// mkdir-lock spin below, matching the retry budget
-// withHookActiveSubagentStateLock (hook_state.go) already uses for the same
-// kind of tiny, short-held hook-state lock.
-const (
-	kimiTranscriptTurnLockRetries = 100
-	kimiTranscriptTurnLockDelay   = 10 * time.Millisecond
-)
+// kimiTranscriptTurnLockTimeout bounds how long a Stop firing waits to
+// acquire the per-session turn-marker lock before falling open. The Kimi
+// Stop hook's host timeout is 5s (integrations/kimi-plugin/kimi.plugin.json)
+// and the critical section runs a DB migration check plus an event insert
+// against a store that can be tens of GB, so this budget leaves several
+// seconds of headroom inside the host deadline for that work to finish even
+// after a fully contended lock wait.
+const kimiTranscriptTurnLockTimeout = 1 * time.Second
+
+// kimiTranscriptTurnLockRetryDelay is the poll interval TryLockContext uses
+// while waiting up to kimiTranscriptTurnLockTimeout for the lock.
+const kimiTranscriptTurnLockRetryDelay = 20 * time.Millisecond
+
+// kimiTranscriptBlocksFingerprint computes a stable content fingerprint over
+// an assistant turn's extracted blocks. Kimi's Stop hook can re-fire while a
+// turn is still streaming: a firing whose wire turn ID matches the marker
+// but whose fingerprint differs means the turn grew since the marker was
+// written, not that it redelivered, and must still be recorded (#1681).
+// json.Marshal over a fixed struct slice shape is deterministic within one
+// process/Go version, which is all a same-host comparison needs — this
+// fingerprint is never compared across hosts or persisted long-term. On
+// error the returned string is always empty; callers must check err rather
+// than rely on that as a sentinel.
+func kimiTranscriptBlocksFingerprint(blocks []apptypes.EventBodyBlock) (string, error) {
+	encoded, err := json.Marshal(blocks)
+	if err != nil {
+		return "", xerrors.Errorf("failed to encode Kimi transcript blocks for fingerprinting: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// kimiTranscriptTurnMarkerSeparator joins the turn ID and content
+// fingerprint fields inside the marker file. Neither field can contain a
+// tab (the turn ID is a Kimi-issued opaque identifier normalized to a
+// trimmed string; the fingerprint is hex), so a single split is
+// unambiguous.
+const kimiTranscriptTurnMarkerSeparator = "\t"
+
+// encodeKimiTranscriptTurnMarker renders the marker file content for a
+// recorded (turn ID, content fingerprint) pair.
+func encodeKimiTranscriptTurnMarker(turnID, fingerprint string) []byte {
+	return []byte(turnID + kimiTranscriptTurnMarkerSeparator + fingerprint)
+}
+
+// decodeKimiTranscriptTurnMarker parses a marker file's content into its
+// (turn ID, fingerprint) pair. It returns ok=false for anything that is not
+// exactly two nonempty tab-separated fields — including a marker written by
+// the pre-fingerprint format (turn ID only, no separator), which must never
+// be mistaken for a match against a real fingerprint.
+func decodeKimiTranscriptTurnMarker(data []byte) (turnID, fingerprint string, ok bool) {
+	trimmed := strings.TrimSpace(string(data))
+	parts := strings.SplitN(trimmed, kimiTranscriptTurnMarkerSeparator, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
 
 // kimiTranscriptTurnStatePath returns the marker file path recording the
-// last wire turn ID whose transcript was recorded for a Kimi session.
+// last (wire turn ID, content fingerprint) pair whose transcript was
+// recorded for a Kimi session.
 func kimiTranscriptTurnStatePath(sessionID string) (string, error) {
 	stateDir, err := resolveHookStateDir()
 	if err != nil {
@@ -240,13 +295,25 @@ func kimiTranscriptTurnStatePath(sessionID string) (string, error) {
 	return filepath.Join(stateDir, kimiTranscriptTurnsStateDir, sanitizeHookStateKey(sessionID)), nil
 }
 
-// withKimiTranscriptTurnStateLock runs fn while holding an exclusive,
-// directory-mkdir-based lock scoped to sessionID's turn marker. Kimi
-// redelivers Stop for the same completed turn with observed gaps as small
-// as ~0.14s, including effectively concurrent firings, so the check
-// ("already recorded?") and the record-then-mark sequence inside fn must be
-// one atomic critical section — otherwise two racing firings can both
-// observe "not yet recorded" and each write a row (#1681).
+// withKimiTranscriptTurnStateLock runs fn while holding an exclusive
+// github.com/gofrs/flock lock scoped to sessionID's turn marker, matching
+// the idiom hook_memory_extract_queue.go and hook_archive_auto.go already
+// use for hook-state locks. Kimi redelivers Stop for the same turn with
+// observed gaps as small as ~0.14s, including effectively concurrent
+// firings, so the check ("already recorded?") and the record-then-mark
+// sequence inside fn must be one atomic critical section — otherwise two
+// racing firings can both observe "not yet recorded" and each write a row
+// (#1681).
+//
+// flock (unlike the prior mkdir-based lock) is released by the kernel when
+// the holding process dies for any reason, including SIGKILL — so a host
+// kill mid-critical-section (a real risk here: the section runs a DB
+// migration check plus an insert against a multi-GB store, inside a 5s host
+// hook timeout) cannot leave a stale lock behind. No PID check, TTL, or
+// cleanup is needed. Acquisition is bounded by kimiTranscriptTurnLockTimeout
+// so a firing never spins past its host budget; failure to acquire falls
+// open in the caller (records unguarded) exactly like any other
+// unresolvable-state case.
 func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
 	path, err := kimiTranscriptTurnStatePath(sessionID)
 	if err != nil {
@@ -255,36 +322,40 @@ func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return xerrors.Errorf("failed to create Kimi transcript turn state directory: %w", err)
 	}
-	lockPath := path + ".lock"
-	for attempt := 0; ; attempt++ {
-		err := os.Mkdir(lockPath, 0o700)
-		if err == nil {
-			defer func() { _ = os.Remove(lockPath) }()
-			return fn()
-		}
-		if !os.IsExist(err) {
-			return xerrors.Errorf("failed to lock Kimi transcript turn state: %w", err)
-		}
-		if attempt >= kimiTranscriptTurnLockRetries {
-			return xerrors.Errorf("failed to lock Kimi transcript turn state: timed out")
-		}
-		time.Sleep(kimiTranscriptTurnLockDelay)
+	lock := flock.New(path + ".lock")
+	lockCtx, cancel := context.WithTimeout(context.Background(), kimiTranscriptTurnLockTimeout)
+	defer cancel()
+	locked, err := lock.TryLockContext(lockCtx, kimiTranscriptTurnLockRetryDelay)
+	if err != nil {
+		return xerrors.Errorf("failed to lock Kimi transcript turn state: %w", err)
 	}
+	if !locked {
+		return xerrors.Errorf("failed to lock Kimi transcript turn state: timed out")
+	}
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			slog.Debug("failed to release Kimi transcript turn state lock", "session_id", sessionID, "error", unlockErr)
+		}
+	}()
+	return fn()
 }
 
-// kimiTranscriptTurnAlreadyRecorded reports whether turnID was already
-// recorded as sessionID's last transcript turn. Kimi's Stop hook fires
-// roughly two dozen times per completed turn while wire.jsonl is
-// unchanged (#1681); this is the read half of the guard that collapses
-// those redeliveries to a single recorded transcript event. Callers must
-// hold withKimiTranscriptTurnStateLock for correctness under concurrent
-// firings.
+// kimiTranscriptTurnAlreadyRecorded reports whether the (turnID,
+// fingerprint) pair was already recorded as sessionID's last transcript
+// turn. Kimi's Stop hook fires roughly two dozen times per completed turn,
+// and can also re-fire while a turn is still streaming (#1681); this is the
+// read half of the guard that collapses unchanged redeliveries to a single
+// recorded transcript event while still recording a turn that grew content
+// between firings (turnID matches, fingerprint does not). Callers must hold
+// withKimiTranscriptTurnStateLock for correctness under concurrent firings.
 //
-// Any inability to read the marker (including a missing state directory)
-// fails open — returns false, treating the turn as not yet recorded.
-// Traceary prefers an occasional duplicate over silently dropping a
-// genuinely new turn because of transient marker-file trouble.
-func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID string) bool {
+// Any inability to read or parse the marker (including a missing state
+// directory, or a marker written by the pre-fingerprint single-field
+// format) fails open — returns false, treating the turn as not yet
+// recorded. Traceary prefers an occasional duplicate over silently dropping
+// a genuinely new or grown turn because of transient marker-file trouble or
+// a marker-format change.
+func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID, fingerprint string) bool {
 	path, err := kimiTranscriptTurnStatePath(sessionID)
 	if err != nil {
 		slog.Debug("failed to resolve Kimi transcript turn state path", "session_id", sessionID, "error", err)
@@ -297,23 +368,27 @@ func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID string) bool {
 		}
 		return false
 	}
-	return strings.TrimSpace(string(data)) == turnID
+	recordedTurnID, recordedFingerprint, ok := decodeKimiTranscriptTurnMarker(data)
+	if !ok {
+		return false
+	}
+	return recordedTurnID == turnID && recordedFingerprint == fingerprint
 }
 
-// markKimiTranscriptTurnRecorded persists turnID as the last recorded
-// transcript turn for sessionID. Failures are logged and swallowed:
-// losing the marker only risks one extra duplicate on the next Stop
-// firing, never a lost turn, and a hook must never fail the host's turn
-// over housekeeping state. Callers must hold
+// markKimiTranscriptTurnRecorded persists (turnID, fingerprint) as the last
+// recorded transcript turn for sessionID. Failures are logged and
+// swallowed: losing the marker only risks one extra duplicate on the next
+// Stop firing, never a lost turn, and a hook must never fail the host's
+// turn over housekeeping state. Callers must hold
 // withKimiTranscriptTurnStateLock for correctness under concurrent
 // firings.
-func markKimiTranscriptTurnRecorded(sessionID, turnID string) {
+func markKimiTranscriptTurnRecorded(sessionID, turnID, fingerprint string) {
 	path, err := kimiTranscriptTurnStatePath(sessionID)
 	if err != nil {
 		slog.Debug("failed to resolve Kimi transcript turn state path", "session_id", sessionID, "error", err)
 		return
 	}
-	if err := os.WriteFile(path, []byte(turnID), 0o600); err != nil {
+	if err := os.WriteFile(path, encodeKimiTranscriptTurnMarker(turnID, fingerprint), 0o600); err != nil {
 		slog.Debug("failed to write Kimi transcript turn state", "path", path, "error", err)
 	}
 }

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -346,8 +346,12 @@ func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
 // and can also re-fire while a turn is still streaming (#1681); this is the
 // read half of the guard that collapses unchanged redeliveries to a single
 // recorded transcript event while still recording a turn that grew content
-// between firings (turnID matches, fingerprint does not). Callers must hold
-// withKimiTranscriptTurnStateLock for correctness under concurrent firings.
+// between firings (turnID matches, fingerprint does not). The fingerprint
+// keys the exact blocks runHookKimiTranscript passes to the recorder (not a
+// second, independent re-extraction), so a "recorded" answer here always
+// corresponds to a row that was actually persisted with that content.
+// Callers must hold withKimiTranscriptTurnStateLock for correctness under
+// concurrent firings.
 //
 // Any inability to read or parse the marker (including a missing state
 // directory, or a marker written by the pre-fingerprint single-field
@@ -376,7 +380,13 @@ func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID, fingerprint string) bo
 }
 
 // markKimiTranscriptTurnRecorded persists (turnID, fingerprint) as the last
-// recorded transcript turn for sessionID. Failures are logged and
+// recorded transcript turn for sessionID. Callers MUST call this only after
+// confirming a row was actually persisted (runHookTranscriptWithBlocks
+// returned recorded=true) — never merely because the recorder returned a
+// nil error, since it fails soft (nil error, nothing written) on several
+// unrelated conditions. Marking on a skip would silently drop every later
+// redelivery of a turn that was never actually stored (#1681 CRITICAL
+// finding). Failures to write the marker file itself are logged and
 // swallowed: losing the marker only risks one extra duplicate on the next
 // Stop firing, never a lost turn, and a hook must never fail the host's
 // turn over housekeeping state. Callers must hold

--- a/presentation/cli/hook_kimi_transcript.go
+++ b/presentation/cli/hook_kimi_transcript.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 )
@@ -60,21 +63,32 @@ func kimiWireTurnID(raw json.RawMessage) string {
 // soft skip — transcript capture is best-effort and must never block the
 // host's Stop hook.
 func extractKimiTranscript(payload []byte) ([]apptypes.EventBodyBlock, bool) {
+	blocks, _, ok := extractKimiTranscriptTurn(payload)
+	return blocks, ok
+}
+
+// extractKimiTranscriptTurn resolves the same assistant turn as
+// extractKimiTranscript, additionally returning the wire turn identifier the
+// blocks were read from. Kimi's Stop hook fires roughly two dozen times per
+// completed turn while the session's wire.jsonl is unchanged; callers use
+// the turn identifier to guard against re-recording that unchanged turn
+// (#1681) without re-deriving it from the raw event.Turn shape themselves.
+func extractKimiTranscriptTurn(payload []byte) ([]apptypes.EventBodyBlock, string, bool) {
 	sessionID := strings.TrimSpace(hookPayloadString(payload, "session_id", ""))
 	if sessionID == "" {
-		return nil, false
+		return nil, "", false
 	}
 	sessionDir := lookupKimiSessionDir(sessionID)
 	if sessionDir == "" {
-		return nil, false
+		return nil, "", false
 	}
 	sessionDir = containKimiSessionsPath(sessionDir)
 	if sessionDir == "" {
-		return nil, false
+		return nil, "", false
 	}
 	wirePath := containKimiSessionsPath(filepath.Join(sessionDir, "agents", "main", "wire.jsonl"))
 	if wirePath == "" {
-		return nil, false
+		return nil, "", false
 	}
 	return readKimiWireTranscriptBlocks(wirePath)
 }
@@ -137,14 +151,15 @@ func lookupKimiSessionDir(sessionID string) string {
 }
 
 // readKimiWireTranscriptBlocks reads the wire log and returns the ordered
-// think/text blocks of the LAST turn that produced assistant content.
-// Thinking blocks map to EventBodyBlockTypeThinking so downstream consumers
-// can collapse reasoning, matching the Claude transcript shape.
-func readKimiWireTranscriptBlocks(path string) ([]apptypes.EventBodyBlock, bool) {
+// think/text blocks of the LAST turn that produced assistant content, along
+// with that turn's identifier. Thinking blocks map to
+// EventBodyBlockTypeThinking so downstream consumers can collapse
+// reasoning, matching the Claude transcript shape.
+func readKimiWireTranscriptBlocks(path string) ([]apptypes.EventBodyBlock, string, bool) {
 	file, err := os.Open(path) // #nosec G304 -- path resolved through the Kimi session index
 	if err != nil {
 		slog.Debug("failed to open Kimi wire log", "path", path, "error", err)
-		return nil, false
+		return nil, "", false
 	}
 	defer func() { _ = file.Close() }()
 
@@ -175,14 +190,14 @@ func readKimiWireTranscriptBlocks(path string) ([]apptypes.EventBodyBlock, bool)
 	}
 	if err := scanner.Err(); err != nil {
 		slog.Debug("failed while scanning Kimi wire log", "path", path, "error", err)
-		return nil, false
+		return nil, "", false
 	}
 
 	blocks := blocksByTurn[lastTurn]
 	if len(blocks) == 0 {
-		return nil, false
+		return nil, "", false
 	}
-	return blocks, true
+	return blocks, lastTurn, true
 }
 
 // kimiCodeHome resolves the Kimi Code data home: $KIMI_CODE_HOME when set,
@@ -196,4 +211,109 @@ func kimiCodeHome() string {
 		return ""
 	}
 	return filepath.Join(home, kimiDefaultHomeDir)
+}
+
+// kimiTranscriptTurnsStateDir is the hook-state subdirectory holding, per
+// session, a marker file naming the wire turn whose transcript was most
+// recently recorded. It follows the same fixed-name marker-file idiom as
+// the session-end markers in hook_state.go rather than a SQL table, because
+// the wire turn identifier is host side-channel state (read from
+// wire.jsonl), not a field carried on any hook payload.
+const kimiTranscriptTurnsStateDir = "kimi-transcript-turns"
+
+// kimiTranscriptTurnLockRetries and kimiTranscriptTurnLockDelay bound the
+// mkdir-lock spin below, matching the retry budget
+// withHookActiveSubagentStateLock (hook_state.go) already uses for the same
+// kind of tiny, short-held hook-state lock.
+const (
+	kimiTranscriptTurnLockRetries = 100
+	kimiTranscriptTurnLockDelay   = 10 * time.Millisecond
+)
+
+// kimiTranscriptTurnStatePath returns the marker file path recording the
+// last wire turn ID whose transcript was recorded for a Kimi session.
+func kimiTranscriptTurnStatePath(sessionID string) (string, error) {
+	stateDir, err := resolveHookStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, kimiTranscriptTurnsStateDir, sanitizeHookStateKey(sessionID)), nil
+}
+
+// withKimiTranscriptTurnStateLock runs fn while holding an exclusive,
+// directory-mkdir-based lock scoped to sessionID's turn marker. Kimi
+// redelivers Stop for the same completed turn with observed gaps as small
+// as ~0.14s, including effectively concurrent firings, so the check
+// ("already recorded?") and the record-then-mark sequence inside fn must be
+// one atomic critical section — otherwise two racing firings can both
+// observe "not yet recorded" and each write a row (#1681).
+func withKimiTranscriptTurnStateLock(sessionID string, fn func() error) error {
+	path, err := kimiTranscriptTurnStatePath(sessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return xerrors.Errorf("failed to create Kimi transcript turn state directory: %w", err)
+	}
+	lockPath := path + ".lock"
+	for attempt := 0; ; attempt++ {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			defer func() { _ = os.Remove(lockPath) }()
+			return fn()
+		}
+		if !os.IsExist(err) {
+			return xerrors.Errorf("failed to lock Kimi transcript turn state: %w", err)
+		}
+		if attempt >= kimiTranscriptTurnLockRetries {
+			return xerrors.Errorf("failed to lock Kimi transcript turn state: timed out")
+		}
+		time.Sleep(kimiTranscriptTurnLockDelay)
+	}
+}
+
+// kimiTranscriptTurnAlreadyRecorded reports whether turnID was already
+// recorded as sessionID's last transcript turn. Kimi's Stop hook fires
+// roughly two dozen times per completed turn while wire.jsonl is
+// unchanged (#1681); this is the read half of the guard that collapses
+// those redeliveries to a single recorded transcript event. Callers must
+// hold withKimiTranscriptTurnStateLock for correctness under concurrent
+// firings.
+//
+// Any inability to read the marker (including a missing state directory)
+// fails open — returns false, treating the turn as not yet recorded.
+// Traceary prefers an occasional duplicate over silently dropping a
+// genuinely new turn because of transient marker-file trouble.
+func kimiTranscriptTurnAlreadyRecorded(sessionID, turnID string) bool {
+	path, err := kimiTranscriptTurnStatePath(sessionID)
+	if err != nil {
+		slog.Debug("failed to resolve Kimi transcript turn state path", "session_id", sessionID, "error", err)
+		return false
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed name under the hook state directory
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Debug("failed to read Kimi transcript turn state", "path", path, "error", err)
+		}
+		return false
+	}
+	return strings.TrimSpace(string(data)) == turnID
+}
+
+// markKimiTranscriptTurnRecorded persists turnID as the last recorded
+// transcript turn for sessionID. Failures are logged and swallowed:
+// losing the marker only risks one extra duplicate on the next Stop
+// firing, never a lost turn, and a hook must never fail the host's turn
+// over housekeeping state. Callers must hold
+// withKimiTranscriptTurnStateLock for correctness under concurrent
+// firings.
+func markKimiTranscriptTurnRecorded(sessionID, turnID string) {
+	path, err := kimiTranscriptTurnStatePath(sessionID)
+	if err != nil {
+		slog.Debug("failed to resolve Kimi transcript turn state path", "session_id", sessionID, "error", err)
+		return
+	}
+	if err := os.WriteFile(path, []byte(turnID), 0o600); err != nil {
+		slog.Debug("failed to write Kimi transcript turn state", "path", path, "error", err)
+	}
 }

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -1,0 +1,252 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/duck8823/traceary/domain/types"
+	cli "github.com/duck8823/traceary/presentation/cli"
+)
+
+// TestRootCLI_HookKimiStop_TranscriptTurnIdempotency reproduces and fixes
+// #1681: Kimi Code fires Stop roughly two dozen times per completed turn
+// while the session's wire.jsonl is unchanged. Extraction itself was always
+// correct (it resolves only the final turn's blocks), but nothing guarded
+// against re-recording that unchanged turn on every redelivery, measured at
+// 23.6x duplication on the live store. These cases pin the fix: a stable
+// (session, wire turn) pair collapses to one recorded transcript event, and
+// an advancing turn still produces one distinct event per turn.
+func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
+	const sessionID = "session_00000000-0000-4000-8000-000000000001"
+
+	t.Run("repeated Stop against an unadvanced wire log records exactly one transcript event", func(t *testing.T) {
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-unadvanced")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"first reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+
+		for fire := 0; fire < 3; fire++ {
+			stdout, _, _ := runKimiHook(t, "stop", payload, eventStub, sessionStub)
+			if stdout != "" {
+				t.Fatalf("Stop fire %d output = %q, want empty passive-hook output", fire, stdout)
+			}
+		}
+
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls = %d, want 1 (unadvanced turn must collapse to one event)", got)
+		}
+		if got, want := eventStub.logCalls[0].kind, types.EventKindTranscript; got != want {
+			t.Fatalf("kind = %q, want %q", got, want)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "first reply") {
+			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
+		}
+	})
+
+	t.Run("an advancing turn between firings records one event per turn with distinct bodies", func(t *testing.T) {
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-advancing")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"first reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+
+		// Re-fire against the still-unadvanced turn once first, mirroring the
+		// live redelivery pattern, then advance the wire log to a new turn.
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls after two same-turn fires = %d, want 1", got)
+		}
+
+		appendKimiWireRow(t, homeDir, sessionID,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"1","part":{"type":"text","text":"second reply"}}}`,
+		)
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+
+		if got := len(eventStub.logCalls); got != 2 {
+			t.Fatalf("transcript log calls after the turn advanced = %d, want 2", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "first reply") {
+			t.Fatalf("first transcript body = %q, want it to contain the first turn's text", eventStub.logCalls[0].message)
+		}
+		if !strings.Contains(eventStub.logCalls[1].message, "second reply") {
+			t.Fatalf("second transcript body = %q, want it to contain the second turn's text", eventStub.logCalls[1].message)
+		}
+		if eventStub.logCalls[0].message == eventStub.logCalls[1].message {
+			t.Fatalf("distinct turns recorded identical bodies: %q", eventStub.logCalls[0].message)
+		}
+	})
+
+	t.Run("concurrent Stop firings for the same turn record exactly one transcript event", func(t *testing.T) {
+		// Kimi's live redeliveries land as little as ~0.14s apart, including
+		// effectively concurrent firings (#1681). Fire the Stop hook from
+		// several goroutines at once against the same (session, turn) pair
+		// to prove withKimiTranscriptTurnStateLock serializes the
+		// check-then-record-then-mark sequence instead of letting two
+		// racing firings both observe "not yet recorded" and both write a
+		// row.
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-concurrent")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"racing reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+
+		const invocations = 8
+		start := make(chan struct{})
+		errs := make(chan error, invocations)
+		var wg sync.WaitGroup
+		for i := 0; i < invocations; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				cmd := newTestRootCLI(
+					cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+					cli.WithEvent(eventStub),
+					cli.WithSession(&sessionUsecaseStub{}),
+				).Command()
+				cmd.SetOut(&bytes.Buffer{})
+				cmd.SetErr(&bytes.Buffer{})
+				cmd.SetIn(strings.NewReader(payload))
+				cmd.SetArgs([]string{"hook", "kimi", "stop"})
+				errs <- cmd.Execute()
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent Stop firing error = %v", err)
+			}
+		}
+
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls = %d, want 1 (concurrent firings for the same turn must collapse to one event)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "racing reply") {
+			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
+		}
+	})
+
+	t.Run("idempotency state unavailable falls open and still records without failing the hook", func(t *testing.T) {
+		// Pre-create a plain file at the exact path
+		// withKimiTranscriptTurnStateLock needs as a directory
+		// (<state-dir>/kimi-transcript-turns), so only the turn-marker
+		// guard's own os.MkdirAll fails (ENOTDIR). The rest of the state
+		// dir stays a real, writable directory so sibling hook-state
+		// subsystems (e.g. active-subagent-state, consulted while
+		// resolving the session ID) are unaffected. The guard must fail
+		// open (treat the turn as unrecorded) rather than block the
+		// transcript, and the command must still exit clean.
+		stateDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(stateDir, "kimi-transcript-turns"), []byte("blocking file"), 0o600); err != nil {
+			t.Fatalf("seed blocking state path: %v", err)
+		}
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-state-unavailable")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"state unavailable reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+
+		// runKimiHook itself asserts Execute() returns nil, i.e. the hook
+		// command exits 0 despite the marker state being unreachable.
+		stdout, _, _ := runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls = %d, want 1 (fail-open must still record)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "state unavailable reply") {
+			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
+		}
+	})
+
+	t.Run("event store error exits 0 without crashing the hook", func(t *testing.T) {
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-store-error")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"db error reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{logErr: errors.New("simulated event store failure")}
+		sessionStub := &sessionUsecaseStub{}
+
+		// A hook must never fail the host's turn. runKimiHook asserts
+		// Execute() returns nil; the outer hook runtime swallows the
+		// propagated event-store error and exits 0.
+		stdout, _, _ := runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log attempts = %d, want 1", got)
+		}
+	})
+}
+
+// appendKimiWireRow appends one more row to an already-seeded session's
+// wire.jsonl, simulating the host's turn advancing between Stop firings.
+func appendKimiWireRow(t *testing.T, homeDir, sessionID, row string) {
+	t.Helper()
+	wirePath := filepath.Join(homeDir, ".kimi-code", "sessions", "wd_probe_000000000000", sessionID, "agents", "main", "wire.jsonl")
+	file, err := os.OpenFile(wirePath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open wire log for append: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.WriteString(row + "\n"); err != nil {
+		t.Fatalf("append wire log row: %v", err)
+	}
+}

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gofrs/flock"
+
 	"github.com/duck8823/traceary/domain/types"
 	cli "github.com/duck8823/traceary/presentation/cli"
 )
@@ -100,6 +102,56 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		}
 		if eventStub.logCalls[0].message == eventStub.logCalls[1].message {
 			t.Fatalf("distinct turns recorded identical bodies: %q", eventStub.logCalls[0].message)
+		}
+	})
+
+	t.Run("a turn that grows content between firings records a second event containing the new content", func(t *testing.T) {
+		// Kimi's Stop hook is not a completed-turn boundary: it can re-fire
+		// while a turn is still streaming, so the SAME wire turn ID can gain
+		// blocks between firings (measured live: 2,053 of 52,475 consecutive
+		// same-session pairs grew, 153 of those gained the turn's only
+		// "text" block). Every other fixture in this suite seeds a turn
+		// that is already complete before the first Stop firing, which
+		// bakes the wrong "turn ID alone means unchanged" premise into the
+		// old guard. This reproduces the growth case directly: the first
+		// firing sees only a thinking block, then a text block is appended
+		// under the SAME turnId before the second firing.
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-growing")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"think","think":"reasoning about the reply"}}}`,
+		})
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls after the first firing = %d, want 1", got)
+		}
+		if strings.Contains(eventStub.logCalls[0].message, "final answer text") {
+			t.Fatalf("first transcript body = %q, want it to NOT yet contain the not-yet-appended text block", eventStub.logCalls[0].message)
+		}
+
+		// Same turnId as above: the wire turn ID does not advance, only its
+		// content does.
+		appendKimiWireRow(t, homeDir, sessionID,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"final answer text"}}}`,
+		)
+		runKimiHook(t, "stop", payload, eventStub, sessionStub)
+
+		if got := len(eventStub.logCalls); got != 2 {
+			t.Fatalf("transcript log calls after the turn grew = %d, want 2 (turn ID unchanged but content grew must still record)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[1].message, "final answer text") {
+			t.Fatalf("second transcript body = %q, want it to contain the newly appended text block", eventStub.logCalls[1].message)
 		}
 	})
 
@@ -207,7 +259,7 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		}
 	})
 
-	t.Run("event store error exits 0 without crashing the hook", func(t *testing.T) {
+	t.Run("event store error exits 0 without crashing the hook, and a later healthy firing still records", func(t *testing.T) {
 		t.Setenv("TRACEARY_HOOK_STATE_DIR", t.TempDir())
 		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-store-error")
 		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
@@ -222,16 +274,90 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 
 		eventStub := &eventUsecaseStub{logErr: errors.New("simulated event store failure")}
 		sessionStub := &sessionUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
 
 		// A hook must never fail the host's turn. runKimiHook asserts
 		// Execute() returns nil; the outer hook runtime swallows the
 		// propagated event-store error and exits 0.
-		stdout, _, _ := runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), eventStub, sessionStub)
+		stdout, _, _ := runKimiHook(t, "stop", payload, eventStub, sessionStub)
 		if stdout != "" {
 			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
 		}
 		if got := len(eventStub.logCalls); got != 1 {
 			t.Fatalf("transcript log attempts = %d, want 1", got)
+		}
+
+		// This pins the invariant that the guard only marks the turn as
+		// recorded AFTER a successful record: a failing firing must leave
+		// the marker unwritten so the SAME turn is retried on the next
+		// firing, rather than being dropped forever because a refactor
+		// moved the mark ahead of the error check. Clear the simulated
+		// failure and fire again for the identical (session, turn) pair.
+		eventStub.logErr = nil
+		stdout, _, _ = runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 2 {
+			t.Fatalf("transcript log attempts after the retry = %d, want 2 (a failed record must leave the turn unmarked and retried)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[1].message, "db error reply") {
+			t.Fatalf("retried transcript body = %q, want it to contain the wire log text", eventStub.logCalls[1].message)
+		}
+	})
+
+	t.Run("lock acquisition timeout falls open and still records without failing the hook", func(t *testing.T) {
+		// The turn-marker lock now uses github.com/gofrs/flock (crash-safe
+		// release on process death, unlike the former mkdir lock) instead
+		// of a directory-mkdir spin. Forcing a genuine *lock-acquisition
+		// timeout* — as opposed to the state-dir-unavailable path covered
+		// above — requires contending on the exact lock file the hook will
+		// try to acquire. flock(2) locks are scoped to the open file
+		// description, not the process, so a second, independent
+		// *flock.Flock opened on the same path from this same test process
+		// blocks the hook's own TryLockContext exactly as a second process
+		// would; gofrs/flock's own test suite relies on the same property.
+		// That lock file's path is derived deterministically from
+		// TRACEARY_HOOK_STATE_DIR plus the fixed "kimi-transcript-turns"
+		// subdirectory plus the session ID (already unadorned enough that
+		// sanitizeHookStateKey leaves it unchanged), mirroring the
+		// state-dir-unavailable test above.
+		stateDir := t.TempDir()
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-lock-timeout")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"lock contention reply"}}}`,
+		})
+
+		markerDir := filepath.Join(stateDir, "kimi-transcript-turns")
+		if err := os.MkdirAll(markerDir, 0o755); err != nil {
+			t.Fatalf("mkdir marker dir: %v", err)
+		}
+		externalLock := flock.New(filepath.Join(markerDir, sessionID+".lock"))
+		locked, err := externalLock.TryLock()
+		if err != nil || !locked {
+			t.Fatalf("acquire external contending lock: locked=%v err=%v", locked, err)
+		}
+		t.Cleanup(func() { _ = externalLock.Unlock() })
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+
+		stdout, _, _ := runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls = %d, want 1 (lock-acquisition timeout must still fall open and record)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "lock contention reply") {
+			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
 		}
 	})
 }

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -15,6 +15,27 @@ import (
 	cli "github.com/duck8823/traceary/presentation/cli"
 )
 
+// kimiTranscriptMarkerPath returns the turn-marker file path
+// markKimiTranscriptTurnRecorded would write for sessionID under stateDir
+// (as set via TRACEARY_HOOK_STATE_DIR). Every sessionID used in this suite
+// is already unadorned enough that sanitizeHookStateKey leaves it
+// unchanged (see the lock-acquisition-timeout subtest below).
+func kimiTranscriptMarkerPath(stateDir, sessionID string) string {
+	return filepath.Join(stateDir, "kimi-transcript-turns", sessionID)
+}
+
+// assertKimiTranscriptMarkerAbsent fails the test if a turn marker file
+// exists for sessionID under stateDir.
+func assertKimiTranscriptMarkerAbsent(t *testing.T, stateDir, sessionID string) {
+	t.Helper()
+	path := kimiTranscriptMarkerPath(stateDir, sessionID)
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("marker file %s exists, want none", path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker file %s: %v", path, err)
+	}
+}
+
 // TestRootCLI_HookKimiStop_TranscriptTurnIdempotency reproduces and fixes
 // #1681: Kimi Code fires Stop roughly two dozen times per completed turn
 // while the session's wire.jsonl is unchanged. Extraction itself was always
@@ -152,6 +173,72 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		}
 		if !strings.Contains(eventStub.logCalls[1].message, "final answer text") {
 			t.Fatalf("second transcript body = %q, want it to contain the newly appended text block", eventStub.logCalls[1].message)
+		}
+	})
+
+	t.Run("a recorder skip without error leaves the marker unwritten and the next firing retries", func(t *testing.T) {
+		// #1681 CRITICAL: the guard used to treat runHookTranscript
+		// returning a nil error as proof that a row was persisted, and
+		// marked the turn recorded on that basis alone. But the shared
+		// recorder fails soft (nil error, nothing written) on several
+		// conditions unrelated to whether extraction succeeded — e.g. an
+		// unresolved session. If the guard ever marks on that kind of
+		// skip, the turn is lost forever: every later redelivery of the
+		// SAME unchanged turn matches the marker and is skipped, with no
+		// row ever having been written.
+		//
+		// Force exactly that: override the recorder's session-resolution
+		// step to no-op (recorded=false, err=nil) on the first firing
+		// only, even though the guard has already resolved a real turn
+		// and real blocks for that firing and holds the turn lock. A
+		// fixed guard must leave the turn unmarked so the second,
+		// healthy firing for the identical (session, turn, content)
+		// still records.
+		stateDir := t.TempDir()
+		t.Setenv("TRACEARY_HOOK_STATE_DIR", stateDir)
+		t.Setenv("TRACEARY_HOOK_STATE_KEY", "kimi-turn-idempotency-recorder-skip")
+		t.Setenv("TRACEARY_WORKSPACE", "github.com/duck8823/traceary")
+		homeDir := t.TempDir()
+		cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+		t.Cleanup(cli.ResetUserHomeDirFunc)
+
+		seedKimiSession(t, homeDir, sessionID, []string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1784466738324}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","turnId":"0","part":{"type":"text","text":"skip regression reply"}}}`,
+		})
+
+		var resolveCalls int
+		cli.SetResolveHookTranscriptSessionIDFunc(func(_ []byte, _ string) (types.SessionID, error) {
+			resolveCalls++
+			if resolveCalls == 1 {
+				return "", nil
+			}
+			return types.SessionID(sessionID), nil
+		})
+		t.Cleanup(cli.ResetResolveHookTranscriptSessionIDFunc)
+
+		eventStub := &eventUsecaseStub{}
+		sessionStub := &sessionUsecaseStub{}
+		payload := readKimiFixture(t, "stop.json")
+
+		stdout, _, _ := runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 0 {
+			t.Fatalf("transcript log calls after the forced recorder skip = %d, want 0", got)
+		}
+		assertKimiTranscriptMarkerAbsent(t, stateDir, sessionID)
+
+		stdout, _, _ = runKimiHook(t, "stop", payload, eventStub, sessionStub)
+		if stdout != "" {
+			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
+		}
+		if got := len(eventStub.logCalls); got != 1 {
+			t.Fatalf("transcript log calls after the healthy retry = %d, want 1 (a skipped firing must not permanently mark the turn as recorded)", got)
+		}
+		if !strings.Contains(eventStub.logCalls[0].message, "skip regression reply") {
+			t.Fatalf("retried transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
 		}
 	})
 
@@ -359,6 +446,17 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		if !strings.Contains(eventStub.logCalls[0].message, "lock contention reply") {
 			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
 		}
+
+		// stdout/logCalls/body content alone don't distinguish this from
+		// the uncontended happy path — both look identical on those
+		// three signals (proven by removing the contention: the subtest
+		// still passed in 0.00s). The lock-timeout fallback runs
+		// c.runHookTranscriptWithBlocks directly, outside
+		// withKimiTranscriptTurnStateLock, and never calls
+		// markKimiTranscriptTurnRecorded; only the uncontended path
+		// would leave a marker behind. Assert its absence so this
+		// subtest actually exercises the lock-unavailable branch.
+		assertKimiTranscriptMarkerAbsent(t, stateDir, sessionID)
 	})
 }
 

--- a/presentation/cli/hook_kimi_transcript_idempotency_test.go
+++ b/presentation/cli/hook_kimi_transcript_idempotency_test.go
@@ -393,7 +393,7 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		}
 	})
 
-	t.Run("lock acquisition timeout falls open and still records without failing the hook", func(t *testing.T) {
+	t.Run("lock acquisition timeout yields to the holder instead of recording a duplicate", func(t *testing.T) {
 		// The turn-marker lock now uses github.com/gofrs/flock (crash-safe
 		// release on process death, unlike the former mkdir lock) instead
 		// of a directory-mkdir spin. Forcing a genuine *lock-acquisition
@@ -440,23 +440,36 @@ func TestRootCLI_HookKimiStop_TranscriptTurnIdempotency(t *testing.T) {
 		if stdout != "" {
 			t.Fatalf("Stop output = %q, want empty passive-hook output", stdout)
 		}
-		if got := len(eventStub.logCalls); got != 1 {
-			t.Fatalf("transcript log calls = %d, want 1 (lock-acquisition timeout must still fall open and record)", got)
-		}
-		if !strings.Contains(eventStub.logCalls[0].message, "lock contention reply") {
-			t.Fatalf("transcript body = %q, want it to contain the wire log text", eventStub.logCalls[0].message)
+		// The holder of the lock is, by construction, the firing that
+		// records this turn. Recording here too would put a second row in
+		// the store for content another firing is already persisting —
+		// exactly the duplication #1681 is about, and reachable on any
+		// contended store because the acquisition budget and SQLite's
+		// busy_timeout are both 1s. So this firing must record nothing.
+		if got := len(eventStub.logCalls); got != 0 {
+			t.Fatalf("transcript log calls = %d, want 0 (a firing that loses the lock race must yield, not record a duplicate)", got)
 		}
 
-		// stdout/logCalls/body content alone don't distinguish this from
-		// the uncontended happy path — both look identical on those
-		// three signals (proven by removing the contention: the subtest
-		// still passed in 0.00s). The lock-timeout fallback runs
-		// c.runHookTranscriptWithBlocks directly, outside
-		// withKimiTranscriptTurnStateLock, and never calls
-		// markKimiTranscriptTurnRecorded; only the uncontended path
-		// would leave a marker behind. Assert its absence so this
-		// subtest actually exercises the lock-unavailable branch.
+		// And it must not mark the turn either: it did not persist the
+		// turn, so claiming it did would suppress the redeliveries that
+		// are this turn's remaining chances to be recorded.
 		assertKimiTranscriptMarkerAbsent(t, stateDir, sessionID)
+
+		// Yielding is only safe because the turn is not lost by it. Kimi
+		// redelivers Stop for the same turn roughly two dozen times, so
+		// release the contending lock and fire again: the next
+		// redelivery takes the lock and records the turn normally.
+		if err := externalLock.Unlock(); err != nil {
+			t.Fatalf("release external contending lock: %v", err)
+		}
+		retryEvent := &eventUsecaseStub{}
+		runKimiHook(t, "stop", readKimiFixture(t, "stop.json"), retryEvent, &sessionUsecaseStub{})
+		if got := len(retryEvent.logCalls); got != 1 {
+			t.Fatalf("transcript log calls after the lock was released = %d, want 1 (yielding must delay the turn, never drop it)", got)
+		}
+		if !strings.Contains(retryEvent.logCalls[0].message, "lock contention reply") {
+			t.Fatalf("transcript body = %q, want it to contain the wire log text", retryEvent.logCalls[0].message)
+		}
 	})
 }
 

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -758,6 +758,14 @@ func (c *RootCLI) runHookPrompt(
 	return nil
 }
 
+// resolveHookTranscriptSessionIDFunc resolves the session ID
+// runHookTranscriptWithBlocks records the transcript event against. It
+// defaults to resolveHookSessionID; tests override it to force the
+// "session resolution yielded nothing" fail-soft skip in isolation, so the
+// (recorded, err) contract can be pinned independently of any particular
+// caller's own upstream preconditions (#1681 CRITICAL regression coverage).
+var resolveHookTranscriptSessionIDFunc = resolveHookSessionID
+
 // runHookTranscript records the last assistant-message turn as a
 // `transcript` event. It reads Stop-hook stdin to find
 // the last assistant turn and stores it as a `transcript` event. The
@@ -778,17 +786,51 @@ func (c *RootCLI) runHookPrompt(
 // If the host payload is missing or empty we fail soft — transcript
 // capture is a nice-to-have, not a requirement for sessions to close
 // cleanly.
+//
+// This is a thin wrapper around runHookTranscriptWithBlocks that always
+// uses the client's registered extractor; every caller except Kimi's
+// idempotency guard (hook_kimi.go) goes through here and is unaffected by
+// that guard's pre-extracted-blocks path.
 func (c *RootCLI) runHookTranscript(
 	ctx context.Context,
 	input io.Reader,
 	client string,
 	dbPath string,
 ) error {
+	_, err := c.runHookTranscriptWithBlocks(ctx, input, client, dbPath, nil)
+	return err
+}
+
+// runHookTranscriptWithBlocks is the shared implementation behind
+// runHookTranscript. When blocks is non-empty, it is recorded as-is and the
+// client's registered extractor never runs — this lets a caller that has
+// already extracted a turn (Kimi's Stop-hook idempotency guard, #1681) pass
+// those exact blocks straight through, so the wire log is read once per
+// firing instead of twice, and so any idempotency fingerprint the caller
+// computed over those blocks keys the exact content this call persists.
+// When blocks is empty, behavior is unchanged from before this function
+// existed: the extractor registered for client runs against payload.
+//
+// It reports recorded=true only when a row was actually persisted to the
+// store, and recorded=false with a nil error on every fail-soft skip below
+// (unknown client, no extractable content, unresolved session). Callers
+// MUST NOT infer "a row was written" from "err == nil" alone — that
+// conflation was #1681's CRITICAL defect: a caller marked a turn as
+// recorded whenever this returned a nil error, even on firings where
+// nothing was ever persisted, permanently losing every later redelivery of
+// that turn.
+func (c *RootCLI) runHookTranscriptWithBlocks(
+	ctx context.Context,
+	input io.Reader,
+	client string,
+	dbPath string,
+	blocks []apptypes.EventBodyBlock,
+) (bool, error) {
 	if c.storeManagement == nil {
-		return xerrors.Errorf("initialize store usecase is not configured")
+		return false, xerrors.Errorf("initialize store usecase is not configured")
 	}
 	if c.event == nil {
-		return xerrors.Errorf("record log usecase is not configured")
+		return false, xerrors.Errorf("record log usecase is not configured")
 	}
 	// Tag for #672: transcript comes from Claude / Codex Stop or
 	// Gemini AfterAgent. Downstream readers can distinguish via
@@ -801,20 +843,23 @@ func (c *RootCLI) runHookTranscript(
 
 	payload, err := readHookPayload(input)
 	if err != nil {
-		return err
+		return false, err
 	}
 	ctx = withResolvedHookDelivery(ctx, payload, client)
-	extractor, ok := transcriptExtractorFor(client)
-	if !ok {
-		// Unknown client — silently skip so a packaged hook invoking an
-		// unsupported client never aborts the host's Stop / SessionEnd
-		// hook. New clients must register an extractor in
-		// `transcriptExtractorFor` before their hook is wired.
-		return nil
-	}
-	blocks, ok := extractor(payload)
-	if !ok || len(blocks) == 0 {
-		return nil
+	if len(blocks) == 0 {
+		extractor, ok := transcriptExtractorFor(client)
+		if !ok {
+			// Unknown client — silently skip so a packaged hook invoking an
+			// unsupported client never aborts the host's Stop / SessionEnd
+			// hook. New clients must register an extractor in
+			// `transcriptExtractorFor` before their hook is wired.
+			return false, nil
+		}
+		extracted, ok := extractor(payload)
+		if !ok || len(extracted) == 0 {
+			return false, nil
+		}
+		blocks = extracted
 	}
 	// Serialize the structured blocks into the canonical JSON
 	// envelope Traceary persists for kind=transcript bodies. Readers
@@ -823,7 +868,7 @@ func (c *RootCLI) runHookTranscript(
 	// through apptypes.ExtractPlainBody.
 	body, err := apptypes.MarshalEventBodyBlocks(blocks)
 	if err != nil {
-		return xerrors.Errorf("failed to serialize transcript blocks: %w", err)
+		return false, xerrors.Errorf("failed to serialize transcript blocks: %w", err)
 	}
 	// Transcript bodies can echo secrets the assistant saw earlier in
 	// the turn (API keys from .env, Bearer tokens from header dumps,
@@ -837,32 +882,32 @@ func (c *RootCLI) runHookTranscript(
 		StructuredRules(c.structuredRedactRules).
 		Build()
 
-	sessionID, err := resolveHookSessionID(payload, client)
+	sessionID, err := resolveHookTranscriptSessionIDFunc(payload, client)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if sessionID == "" {
-		return nil
+		return false, nil
 	}
 	workspace, err := resolveHookWorkspace(ctx, payload, client, true)
 	if err != nil {
-		return err
+		return false, err
 	}
 	agent, err := resolveHookAgent(client, payload)
 	if err != nil {
-		return err
+		return false, err
 	}
 	resolvedDBPath, err := resolveDBPath(dbPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	c.applyDatabasePath(resolvedDBPath)
 	if err := c.storeManagement.Initialize(ctx); err != nil {
-		return xerrors.Errorf("failed to initialize store: %w", err)
+		return false, xerrors.Errorf("failed to initialize store: %w", err)
 	}
 	if _, err := c.event.Log(ctx, body, types.EventKindTranscript, types.Client("hook"), agent, sessionID, workspace, logCfg); err != nil {
-		return xerrors.Errorf("failed to record hook transcript: %w", err)
+		return false, xerrors.Errorf("failed to record hook transcript: %w", err)
 	}
 
-	return nil
+	return true, nil
 }

--- a/presentation/cli/usecase_stubs_test.go
+++ b/presentation/cli/usecase_stubs_test.go
@@ -46,6 +46,12 @@ type eventUsecaseStub struct {
 	searchCalls         int
 	timelineCriteria    apptypes.TimelineCriteria
 
+	// logMu guards logCall/logCalls against concurrent Log() invocations.
+	// Kimi's Stop hook can fire effectively concurrently for the same turn
+	// (#1681); tests exercising that race invoke Log() from multiple
+	// goroutines and need this stub to record calls safely rather than
+	// racing on the slice append.
+	logMu     sync.Mutex
 	logCall   eventLogCall
 	logCalls  []eventLogCall
 	auditCall struct {
@@ -64,6 +70,8 @@ type eventUsecaseStub struct {
 }
 
 func (s *eventUsecaseStub) Log(ctx context.Context, message string, kind types.EventKind, client types.Client, agent types.Agent, sessionID types.SessionID, workspace types.Workspace, logCfg apptypes.LogRedaction) (*model.Event, error) {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
 	s.logCall.message = message
 	s.logCall.kind = kind
 	s.logCall.client = client


### PR DESCRIPTION
## Problem

Kimi's `Stop` hook fires roughly two dozen times per turn, and Traceary recorded a transcript event every time. Measured on the live store: **175,983 kimi rows for 7,644 distinct bodies — a 23.0x repeat ratio**, one body appearing 40,382 times. That is 2.5 GiB of phantom events, and every per-event statistic over Kimi history is inflated by the same factor.

## What was actually wrong

Not the extraction. `readKimiWireTranscriptBlocks` already returns only the last turn's blocks (`blocksByTurn[lastTurn]`), and that is unchanged here.

The gap is that nothing prevented re-recording a turn that had not changed. Traceary already has an exact-redelivery ledger, but it never engaged for Kimi transcripts: `provenHookDeliveryIDFields("kimi")` keys on `tool_use_id`, a field Kimi's `Stop` payload never carries — `Stop` is a turn boundary, not a tool call. So `resolveHookDeliveryNativeID` always returned `""`, `attachHookDelivery` returned early without recording evidence, and every redelivery was inserted as a new row.

## The fix

Idempotency keyed on `(session_id, wire turn ID, content fingerprint)`. A firing is skipped only when **both** the turn ID and a SHA-256 fingerprint of its extracted blocks match the marker.

The fingerprint is not redundant. `Stop` is **not** a completed-turn boundary — it re-fires while a turn is still streaming, so a later firing can carry strictly more content under the same turn ID. Measured over 52,475 consecutive same-session pairs (2026-08-01..07):

| | pairs |
|---|---|
| identical bodies | 49,718 |
| **same turn gained blocks** | **2,053** |
| of those, gained the turn's only `"type":"text"` block | 153 |
| unrelated (a genuinely new turn) | 704 |

2.34 MB of content exists only in the later snapshot. Keying on the turn ID alone would write the marker on the first, incomplete firing and silently discard everything the turn produced afterwards — trading 23x duplication for silent transcript truncation, which is strictly worse than the bug being fixed. (Bodies are `{"blocks":[...]}` JSON, so a grown snapshot is not a byte-prefix of the earlier one; a naive prefix test reports zero growth and is what made this easy to miss.)

State is a per-session marker file under the existing `resolveHookStateDir()`, holding `<turnID>\t<fingerprint>`. A marker that is not exactly two nonempty tab-separated fields — including one written by an earlier turn-ID-only build — decodes as "not recorded" and falls open toward recording rather than risk a false match.

Live duplicates arrive as little as **0.14 s** apart, including effectively concurrently, so check-then-record-then-mark runs inside an exclusive lock. That lock is `github.com/gofrs/flock` (already used by `hook_memory_extract_queue.go`), not the mkdir idiom: the critical section runs a migration check plus an insert against a store that can be tens of GB, inside Kimi's 5 s host timeout, and a mkdir lock's deferred cleanup does not run on SIGKILL. A stale mkdir lock would have had no PID check, no TTL, and no cleanup — every later firing in that session would spin the full budget, time out, and fall open, permanently disabling the guard. flock is released by the kernel on process death.

**The marker is written only on confirmed persistence.** The guard originally treated a nil error from the shared recorder as proof a row had been written. It is not: the recorder fails soft — nil error, nothing persisted — on several conditions unrelated to whether extraction succeeded (unknown client, no extractable content, an unresolved session). Marking on any of those would have burned the marker for a turn that was never stored, and every later redelivery of that unchanged turn would then match the marker and be dropped forever — the exact permanent-loss failure this guard exists to avoid. The recorder now reports `(recorded bool, err error)`, and the guard marks only when `recorded` is true.

**The wire log is read once per firing, not twice.** The guard extracted the turn to compute the fingerprint, then the recorder independently re-extracted it from `wire.jsonl`. Besides doubling a full `bufio` scan of the session wire log inside Kimi's 5 s budget, it meant the fingerprint keyed one read while the persisted body came from a second, later read of a file that can change between the two — precisely the window the CRITICAL above needed. `runHookTranscriptWithBlocks` now accepts the already-extracted blocks; supplying none falls back to the registered extractor, so every other client's path is byte-for-byte unchanged.

Everything fails open. An unresolvable turn, an uncomputable fingerprint, an unavailable lock, or an unwritable marker all fall through to recording unguarded: a hook must never fail the host's turn or silently drop a genuinely new turn over housekeeping state.

## What this deliberately does not do

It does not supersede the earlier, shorter row a growing turn leaves behind — that needs a delete port the hook does not have. Recording each growth snapshot collapses ~24 firings to roughly 2–3 rows: a ~95% reduction with **zero content loss**. Filed as #1697.

Note those growth snapshots are not collapsible by `store dedupe content-events` (#1682) either, since a prefix is not byte-identical to its extension.

## Scope

Kimi only. Measured repeat ratios: **kimi 23.0x**, codex 1.8x, claude 1.1x, antigravity 1.3x, grok 1.0x. Kimi is the only pathological host; the others sit within the range explained by legitimately identical short content, and their behaviour is deliberately unchanged.

## Tests

`presentation/cli/hook_kimi_transcript_idempotency_test.go`:

- three `Stop` firings against an unadvanced `wire.jsonl` → exactly one transcript event
- the turn advances between firings → one event per turn, distinct bodies
- **the same turn gains a block between firings → two events, the second carrying the appended content** (the case the first design lost)
- **eight goroutines firing concurrently on the same turn → exactly one event** (verified under `-race`, repeated 10x)
- **a failed record leaves the marker unwritten → the next firing retries the turn** (pins the invariant that would otherwise silently drop a turn forever)
- **the recorder skips without error → the marker is left unwritten and the next, healthy firing records** (verified by mutation: marking unconditionally on nil error makes this subtest fail)
- **lock acquisition times out under real flock contention → records unguarded, and the marker is absent** (the earlier assertions did not distinguish this from the uncontended happy path)
- marker state unavailable → records unguarded, exit 0
- event store error → exit 0

## Known gap (follow-up, not this PR)

`traceary hook transcript kimi` is unwired in every plugin manifest, and the Kimi spool replay path routes through `replayKimiSpoolRecord` → `runHookKimiStop`, which **is** guarded. #1696 tracks the remaining generic entry point.

## Verification

```
go build ./...                     exit 0
go vet ./...                       exit 0
go test ./...                      exit 0
go test -race -run Kimi ./presentation/cli/   exit 0
go tool golangci-lint run          0 issues.
```

Closes #1681

