### PR TITLE
feat: take the compact digest from the hook that carries it

### DIFF
--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -617,6 +618,8 @@ func (c *RootCLI) runHookCompact(
 		if err != nil {
 			return err
 		}
+		// The real host digest (Claude) arrives here; Codex / Kimi / Grok
+		// deliver marker-only payloads with an empty compact_summary field.
 		compactSummary := hookPayloadString(payload, "compact_summary", "")
 		body := compactSummary
 		kind := types.EventKindCompactSummary
@@ -627,20 +630,26 @@ func (c *RootCLI) runHookCompact(
 				kind = types.EventKind("")
 			}
 		}
-		_, err = c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
+		logged, err := c.event.Log(ctx, body, kind, types.Client("hook"), agent, sessionID, workspace, apptypes.LogRedaction{})
 		if err != nil {
 			return xerrors.Errorf("failed to record compact hook event: %w", err)
 		}
-
+		// Non-empty compact_summary is the sole discriminator — no
+		// minimum-length heuristic. Marker-only hosts create no refinement.
+		if logged != nil && strings.TrimSpace(compactSummary) != "" {
+			c.applyPostCompactDigest(ctx, sessionID, logged.EventID(), compactSummary, client)
+		}
 		return nil
 	case "pre-compact":
 		// Claude Code 2026-01+ fires PreCompact before context is compacted.
-		// Record the snapshot as a compact_summary with a `phase:pre` body
-		// marker so replay / retrospective surfaces can tell the
-		// before-compact snapshot apart from the post-compact digest.
-		// The context_pack_builder's post-compact loader filters on body
-		// prefix so the retrospective/handoff path only picks up the
-		// post-compact summary, not this pre-compact snapshot.
+		// Record the snapshot as a compact_summary with source_hook =
+		// pre_compact so #1683 can treat it as an orphan-range signal.
+		// The real digest arrives at post-compact; do not write summary
+		// material here (pre_compact_context is a before-compact snapshot,
+		// not the host's compacted digest).
+		// The context_pack_builder's post-compact loader filters so the
+		// retrospective/handoff path only picks up the post-compact
+		// summary, not this pre-compact snapshot.
 		if c.event == nil || sessionID == "" {
 			return nil
 		}
@@ -664,18 +673,6 @@ func (c *RootCLI) runHookCompact(
 		if err != nil {
 			return xerrors.Errorf("failed to record pre-compact hook event: %w", err)
 		}
-		// Sync the digest into sessions.summary so timeline / handoff
-		// surfaces have a useful header without waiting for SessionEnd.
-		// Only Claude carries a real digest — Gemini's PreCompress body
-		// is just the trigger value, not a summary.
-		if client == "claude" && c.session != nil {
-			rawDigest := hookPayloadString(payload, "pre_compact_context", "")
-			if strings.TrimSpace(rawDigest) != "" {
-				if _, err := c.session.SetSummaryIfEmpty(ctx, sessionID, rawDigest); err != nil {
-					return xerrors.Errorf("failed to sync pre-compact summary into session: %w", err)
-				}
-			}
-		}
 		return nil
 	case "session-start-compact":
 		if output == nil {
@@ -688,6 +685,49 @@ func (c *RootCLI) runHookCompact(
 		})
 	default:
 		return xerrors.Errorf("unsupported hook compact action: %s", action)
+	}
+}
+
+// applyPostCompactDigest stores a host-supplied compact digest as an L2
+// refinement and seeds sessions.summary for timeline / handoff headers
+// until the sessions.summary column is retired. Both writes are best-effort:
+// sessions rows are created by the session-boundary hooks, not by
+// event.Log, so a compact can legitimately arrive for a session that has
+// no row; and the digest is opportunistic material covering a small
+// fraction of events, with the gc fallback covering any range that never
+// got one. Returning the error would re-spool the whole compact delivery
+// for replay and risk a duplicate event, which is a worse trade than
+// losing one opportunistic summary. The warn lines are the observability.
+func (c *RootCLI) applyPostCompactDigest(
+	ctx context.Context,
+	sessionID types.SessionID,
+	coversTo types.EventID,
+	digest string,
+	client string,
+) {
+	if c.sessionRefinement != nil {
+		if _, err := c.sessionRefinement.Refine(ctx, usecase.SessionRefineInput{
+			SessionID:  sessionID,
+			CoversTo:   coversTo,
+			Summary:    digest,
+			ProducedBy: "hook:post-compact:" + client,
+			Degraded:   false,
+		}); err != nil {
+			slog.Warn(
+				"post-compact session refinement failed",
+				"session_id", sessionID,
+				"error", err,
+			)
+		}
+	}
+	if c.session != nil {
+		if _, err := c.session.SetSummaryIfEmpty(ctx, sessionID, digest); err != nil {
+			slog.Warn(
+				"post-compact session summary sync failed",
+				"session_id", sessionID,
+				"error", err,
+			)
+		}
 	}
 }
 

--- a/presentation/cli/hook_runtime.go
+++ b/presentation/cli/hook_runtime.go
@@ -698,6 +698,13 @@ func (c *RootCLI) runHookCompact(
 // got one. Returning the error would re-spool the whole compact delivery
 // for replay and risk a duplicate event, which is a worse trade than
 // losing one opportunistic summary. The warn lines are the observability.
+//
+// coversTo names the event event.Log just returned. No host's compact
+// payload carries a field on the proven delivery-ID allowlist, so a compact
+// event never takes the exact-redelivery branch and always inserts. Should a
+// host add one, Log would hand back an event it did not persist and Refine
+// would reject the unknown covers_to before writing — the warn below, and
+// then the gc fallback. See #1710.
 func (c *RootCLI) applyPostCompactDigest(
 	ctx context.Context,
 	sessionID types.SessionID,

--- a/presentation/cli/hook_runtime_test.go
+++ b/presentation/cli/hook_runtime_test.go
@@ -2438,7 +2438,7 @@ func TestRootCLI_HookCompactCommand_RecordsCodexPostCompactMarker(t *testing.T) 
 	}
 }
 
-func TestRootCLI_HookCompactCommand_PreCompactSyncsSessionSummaryWhenEmpty(t *testing.T) {
+func TestRootCLI_HookCompactCommand_PreCompactDoesNotSyncSessionSummary(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 
 	homeDir := t.TempDir()
@@ -2469,14 +2469,18 @@ func TestRootCLI_HookCompactCommand_PreCompactSyncsSessionSummaryWhenEmpty(t *te
 		),
 	}
 	sessionStub := &sessionUsecaseStub{}
+	refineStub := &sessionRefinementUsecaseStub{}
 
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithEvent(eventStub),
 		cli.WithSession(sessionStub),
+		cli.WithSessionRefinement(refineStub),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
+	// pre_compact_context is a before-compact snapshot, not the host digest.
+	// Digest material is written only on post-compact.
 	rootCmd.SetIn(strings.NewReader(`{"pre_compact_context":"Discussed compact behavior, agreed on PreCompact body sync."}`))
 	rootCmd.SetArgs([]string{"hook", "compact", "claude", "pre-compact"})
 
@@ -2486,16 +2490,70 @@ func TestRootCLI_HookCompactCommand_PreCompactSyncsSessionSummaryWhenEmpty(t *te
 	if got := eventStub.logCall.message; got == "" {
 		t.Fatalf("pre-compact log body must not be empty when pre_compact_context is provided")
 	}
+	if _, ok := sessionStub.setSummaryCalls[types.SessionID("sync-session")]; ok {
+		t.Fatalf("SetSummaryIfEmpty must not be called on pre-compact")
+	}
+	if refineStub.calls != 0 {
+		t.Fatalf("Refine calls = %d, want 0 on pre-compact", refineStub.calls)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_PostCompactSyncsSessionSummaryWhenEmpty(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("sync-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	const digest = "Discussed compact behavior, agreed on PostCompact body sync."
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-post-compact-sync"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("sync-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			digest,
+			time.Now(),
+		),
+	}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"compact_summary":"` + digest + `"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "post-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(post-compact) error = %v", err)
+	}
 	got, ok := sessionStub.setSummaryCalls[types.SessionID("sync-session")]
 	if !ok {
 		t.Fatalf("SetSummaryIfEmpty was not called for the active session")
 	}
-	if want := "Discussed compact behavior, agreed on PreCompact body sync."; got != want {
+	if want := digest; got != want {
 		t.Fatalf("SetSummaryIfEmpty body = %q, want %q", got, want)
 	}
 }
 
-func TestRootCLI_HookCompactCommand_PreCompactSkipsSessionSummarySyncForEmptyBody(t *testing.T) {
+func TestRootCLI_HookCompactCommand_PostCompactSkipsSessionSummarySyncForEmptyBody(t *testing.T) {
 	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
 
 	homeDir := t.TempDir()
@@ -2521,27 +2579,211 @@ func TestRootCLI_HookCompactCommand_PreCompactSkipsSessionSummarySyncForEmptyBod
 			types.Agent("claude"),
 			types.SessionID("trigger-only"),
 			types.Workspace("github.com/duck8823/traceary"),
-			"",
+			"size-threshold",
 			time.Now(),
 		),
 	}
+	sessionStub := &sessionUsecaseStub{}
+	refineStub := &sessionRefinementUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+		cli.WithSessionRefinement(refineStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	// Marker-only shape: trigger set, compact_summary absent/empty.
+	rootCmd.SetIn(strings.NewReader(`{"trigger":"size-threshold"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "post-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(post-compact) error = %v", err)
+	}
+	if _, ok := sessionStub.setSummaryCalls[types.SessionID("trigger-only")]; ok {
+		t.Fatalf("SetSummaryIfEmpty must not be called when compact_summary is empty (marker-only payload)")
+	}
+	if refineStub.calls != 0 {
+		t.Fatalf("Refine calls = %d, want 0 for marker-only payload", refineStub.calls)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_PostCompactRefinesWithHostDigest(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("refine-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	const digest = "Remember the failing shard and the flake owner."
+	logged := model.EventOf(
+		types.EventID("evt-post-compact-refine"),
+		types.EventKindCompactSummary,
+		types.Client("hook"),
+		types.Agent("claude"),
+		types.SessionID("refine-session"),
+		types.Workspace("github.com/duck8823/traceary"),
+		digest,
+		time.Now(),
+	)
+	eventStub := &eventUsecaseStub{logEvent: logged}
+	refineStub := &sessionRefinementUsecaseStub{}
 	sessionStub := &sessionUsecaseStub{}
 
 	rootCmd := newTestRootCLI(
 		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
 		cli.WithEvent(eventStub),
 		cli.WithSession(sessionStub),
+		cli.WithSessionRefinement(refineStub),
 	).Command()
 	rootCmd.SetOut(&bytes.Buffer{})
 	rootCmd.SetErr(&bytes.Buffer{})
-	rootCmd.SetIn(strings.NewReader(`{"trigger":"size-threshold"}`))
-	rootCmd.SetArgs([]string{"hook", "compact", "claude", "pre-compact"})
+	rootCmd.SetIn(strings.NewReader(`{"compact_summary":"` + digest + `"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "post-compact"})
 
 	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute(pre-compact) error = %v", err)
+		t.Fatalf("Execute(post-compact) error = %v", err)
 	}
-	if _, ok := sessionStub.setSummaryCalls[types.SessionID("trigger-only")]; ok {
-		t.Fatalf("SetSummaryIfEmpty must not be called when pre_compact_context is empty (trigger-only payload)")
+	if refineStub.calls != 1 {
+		t.Fatalf("Refine calls = %d, want 1", refineStub.calls)
+	}
+	want := usecase.SessionRefineInput{
+		SessionID:  types.SessionID("refine-session"),
+		Summary:    digest,
+		ProducedBy: "hook:post-compact:claude",
+		CoversTo:   logged.EventID(),
+		Degraded:   false,
+	}
+	if diff := cmp.Diff(want, refineStub.input); diff != "" {
+		t.Fatalf("Refine input mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_PostCompactMarkerOnlySkipsRefine(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-test-key"), []byte("codex-marker-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "codex-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-codex-marker"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("codex"),
+			types.SessionID("codex-marker-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			"auto",
+			time.Now(),
+		),
+	}
+	refineStub := &sessionRefinementUsecaseStub{}
+	sessionStub := &sessionUsecaseStub{}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSession(sessionStub),
+		cli.WithSessionRefinement(refineStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	// Codex/Kimi/Grok shape: trigger set, empty compact_summary.
+	rootCmd.SetIn(strings.NewReader(`{"session_id":"codex-marker-session","trigger":"auto"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "codex", "post-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(post-compact) error = %v", err)
+	}
+	if refineStub.calls != 0 {
+		t.Fatalf("Refine calls = %d, want 0 for marker-only payload", refineStub.calls)
+	}
+	if _, ok := sessionStub.setSummaryCalls[types.SessionID("codex-marker-session")]; ok {
+		t.Fatalf("SetSummaryIfEmpty must not be called for marker-only payload")
+	}
+	if got, want := eventStub.logCall.message, "auto"; got != want {
+		t.Fatalf("post-compact log message = %q, want %q", got, want)
+	}
+}
+
+func TestRootCLI_HookCompactCommand_PostCompactRefineErrorDoesNotFailHook(t *testing.T) {
+	t.Setenv("TRACEARY_HOOK_STATE_KEY", "test-key")
+
+	homeDir := t.TempDir()
+	cli.SetUserHomeDirFunc(func() (string, error) { return homeDir, nil })
+	t.Cleanup(cli.ResetUserHomeDirFunc)
+
+	stateDir := filepath.Join(homeDir, ".config", "traceary", "hooks")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key"), []byte("refine-err-session"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "claude-test-key-repo"), []byte("github.com/duck8823/traceary"), 0o600); err != nil {
+		t.Fatalf("WriteFile(workspace state) error = %v", err)
+	}
+
+	const digest = "Host digest that refinement cannot store."
+	eventStub := &eventUsecaseStub{
+		logEvent: model.EventOf(
+			types.EventID("evt-post-compact-refine-err"),
+			types.EventKindCompactSummary,
+			types.Client("hook"),
+			types.Agent("claude"),
+			types.SessionID("refine-err-session"),
+			types.Workspace("github.com/duck8823/traceary"),
+			digest,
+			time.Now(),
+		),
+	}
+	refineStub := &sessionRefinementUsecaseStub{err: errors.New("session row missing")}
+
+	rootCmd := newTestRootCLI(
+		cli.WithStoreManagement(&storeManagementUsecaseStub{}),
+		cli.WithEvent(eventStub),
+		cli.WithSessionRefinement(refineStub),
+	).Command()
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	rootCmd.SetIn(strings.NewReader(`{"compact_summary":"` + digest + `"}`))
+	rootCmd.SetArgs([]string{"hook", "compact", "claude", "post-compact"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute(post-compact) error = %v, want nil (refine is best-effort)", err)
+	}
+	if refineStub.calls != 1 {
+		t.Fatalf("Refine calls = %d, want 1", refineStub.calls)
+	}
+	if got, want := eventStub.logCall.message, digest; got != want {
+		t.Fatalf("compact event must still be logged; message = %q, want %q", got, want)
+	}
+	if got, want := eventStub.logCall.kind, types.EventKindCompactSummary; got != want {
+		t.Fatalf("compact event kind = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

Reads the compact digest at `post-compact`, where the host actually delivers it, and routes it through the #1673 refinement port.

`hook_runtime.go` called `SetSummaryIfEmpty` on the **pre-compact** branch. Claude's `pre_compact_context` is a before-compact snapshot, not the compacted digest — the digest arrives one hook later. Measured cost: 4 digests across 26,728 sessions.

## Changes

- **post-compact** — when `compact_summary` is non-empty after trimming, call `SessionRefinementUsecase.Refine` with the just-logged compact event as `covers_to`, `produced_by = "hook:post-compact:<client>"`, `degraded = false`. Also seeds `sessions.summary` from the same text so timeline / handoff headers keep working until #1706 retires the column.
- **pre-compact** — the `SetSummaryIfEmpty` call is gone. The branch keeps logging its marker with `source_hook = "pre_compact"`, which is the orphan-range signal #1683 consumes.
- The `client == "claude"` allowlist is replaced by the payload check. Codex (964), Kimi (309) and Grok (38) send marker-only payloads and now produce no refinement instead of a row built from a trigger word.

## Best-effort, deliberately

Both writes log at `slog.Warn` on failure and let the hook succeed. `sessions` rows are created by the session-boundary hooks, not by `event.Log`, so a compact can legitimately arrive for a session with no row. Returning the error would re-spool the whole compact delivery for replay and risk a duplicate event — a worse trade than losing one opportunistic summary, since the digest covers 6.8% of events and the #1683 gc fallback covers any range that never got one.

## Tests

| Test | Asserts |
|---|---|
| `PreCompactDoesNotSyncSessionSummary` | pre-compact calls neither `SetSummaryIfEmpty` nor `Refine` |
| `PostCompactSyncsSessionSummaryWhenEmpty` | digest reaches `sessions.summary` |
| `PostCompactSkipsSessionSummarySyncForEmptyBody` | marker-only writes nothing |
| `PostCompactRefinesWithHostDigest` | exactly one `Refine`, with the logged event ID as `covers_to` and `degraded = false` |
| `PostCompactMarkerOnlySkipsRefine` | Codex shape produces no `Refine` and no error |
| `PostCompactRefineErrorDoesNotFailHook` | a failing `Refine` still leaves the hook green and the event recorded |

## Verification

```
go build ./...                    ok
go vet ./...                      ok
go test ./presentation/cli/...    ok
go tool golangci-lint run         0 issues
```

Spec: [`.ai/spec/1606.md`](https://github.com/duck8823/traceary/blob/main/.ai/spec/1606.md)

Closes #1672
