### PR TITLE
feat: build the first bounded search projection generation on store open

### DIFF
--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -222,4 +222,30 @@ type SearchProjectionStatus struct {
 	FingerprintLogicalBytes int64            `json:"fingerprint_logical_bytes"`
 	LifecycleState          string           `json:"lifecycle_state"`
 	AbandonedAt             string           `json:"abandoned_at,omitempty"`
+	// CutoverIndexFamily names which physical family CutoverFamilyBytes*
+	// measure. Always "bounded_search_projection" when set — never the
+	// legacy migration-032 event_search_* family (that is #1718).
+	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
+	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
+	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
+}
+
+// SearchProjectionCatchUpResult is one bounded unit of automatic generation
+// work performed during store initialization. It mirrors the event-search
+// backfill shape: a single open does a bounded amount of work and resumes
+// later without operator action.
+type SearchProjectionCatchUpResult struct {
+	Action                   string `json:"action"`
+	State                    string `json:"state"`
+	Phase                    string `json:"phase"`
+	GenerationID             string `json:"generation_id,omitempty"`
+	Completed                bool   `json:"completed"`
+	Batches                  int    `json:"batches"`
+	Selected                 int    `json:"selected"`
+	Written                  int    `json:"written"`
+	SkippedReason            string `json:"skipped_reason,omitempty"`
+	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
+	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
+	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
+	SessionTierVerified      bool   `json:"session_tier_verified,omitempty"`
 }

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -232,10 +232,15 @@ type SearchProjectionStatus struct {
 	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
 	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
 	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
-	// CutoverFamilyEvidence states whether the byte figures above were actually
-	// measured. Without it a family that could not be measured is reported as
-	// zero bytes, which reads identically to a genuinely empty family.
-	CutoverFamilyEvidence CapacityEvidence `json:"cutover_family_evidence"`
+	// CutoverBeforeEvidence and CutoverAfterEvidence state whether each byte
+	// figure above was actually measured. Without them a family that could not
+	// be measured reports zero bytes, which reads identically to a genuinely
+	// empty family. They are separate because the two walks happen at different
+	// times against families of different sizes: one can succeed while the
+	// other times out. An empty Status means no measurement has been attempted
+	// yet.
+	CutoverBeforeEvidence CapacityEvidence `json:"cutover_before_evidence"`
+	CutoverAfterEvidence  CapacityEvidence `json:"cutover_after_evidence"`
 }
 
 // SearchProjectionCatchUpResult is one bounded unit of automatic generation
@@ -255,9 +260,11 @@ type SearchProjectionCatchUpResult struct {
 	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
 	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
 	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
-	// CutoverFamilyEvidence carries the same measured/unavailable distinction as
-	// SearchProjectionStatus so a zero in the byte fields above is never read as
-	// an empty family when it only means the walk did not run.
-	CutoverFamilyEvidence CapacityEvidence `json:"cutover_family_evidence"`
+	// CutoverBeforeEvidence and CutoverAfterEvidence carry the same
+	// measured/unavailable distinction as SearchProjectionStatus so a zero in
+	// the byte fields above is never read as an empty family when it only means
+	// the walk did not run.
+	CutoverBeforeEvidence CapacityEvidence `json:"cutover_before_evidence"`
+	CutoverAfterEvidence  CapacityEvidence `json:"cutover_after_evidence"`
 	SessionTierVerified   bool             `json:"session_tier_verified,omitempty"`
 }

--- a/application/types/search_projection.go
+++ b/application/types/search_projection.go
@@ -222,12 +222,20 @@ type SearchProjectionStatus struct {
 	FingerprintLogicalBytes int64            `json:"fingerprint_logical_bytes"`
 	LifecycleState          string           `json:"lifecycle_state"`
 	AbandonedAt             string           `json:"abandoned_at,omitempty"`
+	// FailureClass names why the last generation failed. It is what decides
+	// whether automatic catch-up may start a replacement: a deterministic class
+	// would fail the same way on every open.
+	FailureClass string `json:"failure_class,omitempty"`
 	// CutoverIndexFamily names which physical family CutoverFamilyBytes*
 	// measure. Always "bounded_search_projection" when set — never the
 	// legacy migration-032 event_search_* family (that is #1718).
 	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
 	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
 	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
+	// CutoverFamilyEvidence states whether the byte figures above were actually
+	// measured. Without it a family that could not be measured is reported as
+	// zero bytes, which reads identically to a genuinely empty family.
+	CutoverFamilyEvidence CapacityEvidence `json:"cutover_family_evidence"`
 }
 
 // SearchProjectionCatchUpResult is one bounded unit of automatic generation
@@ -247,5 +255,9 @@ type SearchProjectionCatchUpResult struct {
 	CutoverIndexFamily       string `json:"cutover_index_family,omitempty"`
 	CutoverFamilyBytesBefore int64  `json:"cutover_family_bytes_before,omitempty"`
 	CutoverFamilyBytesAfter  int64  `json:"cutover_family_bytes_after,omitempty"`
-	SessionTierVerified      bool   `json:"session_tier_verified,omitempty"`
+	// CutoverFamilyEvidence carries the same measured/unavailable distinction as
+	// SearchProjectionStatus so a zero in the byte fields above is never read as
+	// an empty family when it only means the walk did not run.
+	CutoverFamilyEvidence CapacityEvidence `json:"cutover_family_evidence"`
+	SessionTierVerified   bool             `json:"session_tier_verified,omitempty"`
 }

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -260,7 +260,8 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	out.CutoverIndexFamily = status.CutoverIndexFamily
 	out.CutoverFamilyBytesBefore = status.CutoverFamilyBytesBefore
 	out.CutoverFamilyBytesAfter = status.CutoverFamilyBytesAfter
-	out.CutoverFamilyEvidence = status.CutoverFamilyEvidence
+	out.CutoverBeforeEvidence = status.CutoverBeforeEvidence
+	out.CutoverAfterEvidence = status.CutoverAfterEvidence
 	if status.State == "complete" {
 		out.Action = "already_complete"
 		out.Completed = true
@@ -281,8 +282,11 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	// is ever introduced, this is where it gets its exception.
 	if status.State == "failed" {
 		out.Action = "skipped"
+		// Naming the recovery command matters: neither resume nor abort clears
+		// this state. Resume rejects a failed generation, and abort leaves the
+		// row failed with class abandoned. Only an explicit start replaces it.
 		out.SkippedReason = "parked after generation failure " + failureClassOrUnknown(status.FailureClass) +
-			"; resume or abort explicitly to unblock automatic progress"
+			"; run 'traceary store search-projection start' to replace the generation"
 		return out, nil
 	}
 	switch {
@@ -335,7 +339,8 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	out.CutoverIndexFamily = statusAfter.CutoverIndexFamily
 	out.CutoverFamilyBytesBefore = statusAfter.CutoverFamilyBytesBefore
 	out.CutoverFamilyBytesAfter = statusAfter.CutoverFamilyBytesAfter
-	out.CutoverFamilyEvidence = statusAfter.CutoverFamilyEvidence
+	out.CutoverBeforeEvidence = statusAfter.CutoverBeforeEvidence
+	out.CutoverAfterEvidence = statusAfter.CutoverAfterEvidence
 	if progress.Completed {
 		out.SessionTierVerified = true
 		out.Completed = statusAfter.Completed

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -32,6 +32,12 @@ type SearchProjectionAbandonStore interface {
 	AbandonSearchProjection(context.Context, time.Time) (apptypes.SearchProjectionAbandonResult, error)
 }
 
+// SearchProjectionVerifyStore gates old-generation reclaim on a real
+// session-tier query against the generation under construction.
+type SearchProjectionVerifyStore interface {
+	VerifySearchProjectionSessionTier(context.Context, string) error
+}
+
 // NewSearchProjectionUsecase constructs the projection workflow.
 func NewSearchProjectionUsecase(store SearchProjectionStore) *SearchProjectionUsecase {
 	return &SearchProjectionUsecase{store: store}
@@ -103,6 +109,14 @@ func (u *SearchProjectionUsecase) Resume(ctx context.Context, b apptypes.SearchP
 			}
 		}
 		return apptypes.SearchProjectionProgress{}, err
+	}
+	// Old-generation reclaim (cleanup_scope=old) must not run until the new
+	// session tier answers a real query. Drifted cleanup_scope=all wipes every
+	// generation and is not a cutover, so verification is skipped there.
+	if snapshot.Phase == "cleanup" && !snapshot.CleanupAll {
+		if err = u.verifySessionTierBeforeReclaim(ctx, b.LockTime, snapshot.Generation, now.UTC()); err != nil {
+			return apptypes.SearchProjectionProgress{}, err
+		}
 	}
 	plan, err := PlanProjectionBatch(snapshot, b)
 	if err != nil {
@@ -196,6 +210,138 @@ func (u *SearchProjectionUsecase) markFailed(ctx context.Context, lock time.Dura
 	failureCtx, cancel := context.WithTimeout(ctx, lock)
 	defer cancel()
 	return u.store.MarkFailed(failureCtx, generation.GenerationID, generation.SourceRevision, class, now)
+}
+
+// verifySessionTierBeforeReclaim runs the pre-abandon session-tier gate. A
+// failing verification marks the generation failed so the previous generation's
+// rows remain until a later successful rebuild cleans them up.
+func (u *SearchProjectionUsecase) verifySessionTierBeforeReclaim(
+	ctx context.Context,
+	lock time.Duration,
+	generation apptypes.SearchProjectionGeneration,
+	now time.Time,
+) error {
+	verifyStore, ok := u.store.(SearchProjectionVerifyStore)
+	if !ok {
+		// Stores without the gate cannot reclaim safely; fail closed rather than
+		// delete the previous generation on faith.
+		return &apptypes.SearchProjectionNoProgressError{Reason: "projection store does not support session tier verification"}
+	}
+	if err := verifyStore.VerifySearchProjectionSessionTier(ctx, generation.GenerationID); err != nil {
+		var noProgress *apptypes.SearchProjectionNoProgressError
+		if errors.As(err, &noProgress) {
+			if markErr := u.markFailed(ctx, lock, generation, "session_tier_unverified", now); markErr != nil {
+				return markErr
+			}
+		}
+		return xerrors.Errorf("verify session tier before reclaim: %w", err)
+	}
+	return nil
+}
+
+// CatchUp advances the bounded search projection by at most one durable unit of
+// work using the existing generation machinery. It is the store-open counterpart
+// of event search backfill: no operator command, no full rebuild, resumable.
+//
+//nolint:wrapcheck // Typed store and projection errors are preserved.
+func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.SearchProjectionBudget, now time.Time) (apptypes.SearchProjectionCatchUpResult, error) {
+	out := apptypes.SearchProjectionCatchUpResult{Action: "none"}
+	if !b.Valid() {
+		return out, &apptypes.SearchProjectionNoProgressError{Reason: "invalid generation budget"}
+	}
+	status, err := u.store.SearchProjectionStatus(ctx)
+	if err != nil {
+		return out, xerrors.Errorf("inspect projection before catch-up: %w", err)
+	}
+	out.State = status.State
+	out.Phase = status.Phase
+	out.CutoverIndexFamily = status.CutoverIndexFamily
+	out.CutoverFamilyBytesBefore = status.CutoverFamilyBytesBefore
+	out.CutoverFamilyBytesAfter = status.CutoverFamilyBytesAfter
+	if status.State == "complete" {
+		out.Action = "already_complete"
+		out.Completed = true
+		return out, nil
+	}
+	// Operator-owned rebuild with a different budget must not be hijacked.
+	if (status.State == "rebuilding" || (status.State == "drifted" && status.Phase == "cleanup")) &&
+		status.ConfigHash != "" && status.ConfigHash != b.ConfigHash() {
+		out.Action = "skipped"
+		out.SkippedReason = "budget does not match generation configuration"
+		return out, nil
+	}
+	switch {
+	case status.State == "rebuilding", status.State == "drifted" && status.Phase == "cleanup":
+		out.Action = "resume"
+	case status.State == "idle", status.State == "failed", status.State == "drifted":
+		// Only auto-start when there is source material. An empty store stays
+		// idle so tests and fresh installs are not left mid-rebuild.
+		needsWork, workErr := u.catchUpHasSourceWork(ctx)
+		if workErr != nil {
+			return out, workErr
+		}
+		if !needsWork && status.State == "idle" {
+			out.Action = "skipped"
+			out.SkippedReason = "no source events to project"
+			return out, nil
+		}
+		generation, startErr := u.StartGeneration(ctx, b, now.UTC())
+		if startErr != nil {
+			return out, startErr
+		}
+		out.Action = "start"
+		out.GenerationID = generation.GenerationID
+		// Fall through to one Resume so a single open does real work.
+	default:
+		out.Action = "skipped"
+		out.SkippedReason = "projection state " + status.State + " is not auto-catchable"
+		return out, nil
+	}
+	progress, resumeErr := u.Resume(ctx, b, now.UTC())
+	if resumeErr != nil {
+		return out, resumeErr
+	}
+	out.Batches = 1
+	out.Selected = progress.Selected
+	out.Written = progress.Written
+	out.Completed = progress.Completed
+	out.GenerationID = progress.GenerationID
+	statusAfter, inspectErr := u.store.SearchProjectionStatus(ctx)
+	if inspectErr != nil {
+		if progress.Completed {
+			return out, xerrors.Errorf("inspect projection after catch-up complete: %w", inspectErr)
+		}
+		// Non-terminal progress is still durable; surface the progress without
+		// failing the unit of work on a transient status read.
+		return out, nil
+	}
+	out.State = statusAfter.State
+	out.Phase = statusAfter.Phase
+	out.CutoverIndexFamily = statusAfter.CutoverIndexFamily
+	out.CutoverFamilyBytesBefore = statusAfter.CutoverFamilyBytesBefore
+	out.CutoverFamilyBytesAfter = statusAfter.CutoverFamilyBytesAfter
+	if progress.Completed {
+		out.SessionTierVerified = true
+		out.Completed = statusAfter.Completed
+	}
+	return out, nil
+}
+
+// catchUpHasSourceWork reports whether the store has events that a generation
+// would need to project. Used to keep empty installs idle.
+func (u *SearchProjectionUsecase) catchUpHasSourceWork(ctx context.Context) (bool, error) {
+	type sourceWorkStore interface {
+		SearchProjectionHasSourceWork(context.Context) (bool, error)
+	}
+	if store, ok := u.store.(sourceWorkStore); ok {
+		hasWork, err := store.SearchProjectionHasSourceWork(ctx)
+		if err != nil {
+			return false, xerrors.Errorf("probe projection source work: %w", err)
+		}
+		return hasWork, nil
+	}
+	// Without a probe, only resume existing rebuilds; never auto-start.
+	return false, nil
 }
 
 //nolint:wrapcheck // The application boundary preserves typed store errors.

--- a/application/usecase/search_projection_usecase.go
+++ b/application/usecase/search_projection_usecase.go
@@ -4,8 +4,10 @@ package usecase
 import (
 	"context"
 	"errors"
-	"golang.org/x/xerrors"
+	"strings"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	apptypes "github.com/duck8823/traceary/application/types"
 )
@@ -258,6 +260,7 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	out.CutoverIndexFamily = status.CutoverIndexFamily
 	out.CutoverFamilyBytesBefore = status.CutoverFamilyBytesBefore
 	out.CutoverFamilyBytesAfter = status.CutoverFamilyBytesAfter
+	out.CutoverFamilyEvidence = status.CutoverFamilyEvidence
 	if status.State == "complete" {
 		out.Action = "already_complete"
 		out.Completed = true
@@ -270,10 +273,22 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 		out.SkippedReason = "budget does not match generation configuration"
 		return out, nil
 	}
+	// A failed generation is parked, not retried. Every failure class this store
+	// can record is deterministic — an oversize row exceeds the same budget on
+	// every open, session_tier_unverified fails the same query, and abandoned is
+	// an operator decision. Auto-starting a replacement would fail identically
+	// and add a lifecycle row per open, forever. If a genuinely transient class
+	// is ever introduced, this is where it gets its exception.
+	if status.State == "failed" {
+		out.Action = "skipped"
+		out.SkippedReason = "parked after generation failure " + failureClassOrUnknown(status.FailureClass) +
+			"; resume or abort explicitly to unblock automatic progress"
+		return out, nil
+	}
 	switch {
 	case status.State == "rebuilding", status.State == "drifted" && status.Phase == "cleanup":
 		out.Action = "resume"
-	case status.State == "idle", status.State == "failed", status.State == "drifted":
+	case status.State == "idle", status.State == "drifted":
 		// Only auto-start when there is source material. An empty store stays
 		// idle so tests and fresh installs are not left mid-rebuild.
 		needsWork, workErr := u.catchUpHasSourceWork(ctx)
@@ -320,11 +335,21 @@ func (u *SearchProjectionUsecase) CatchUp(ctx context.Context, b apptypes.Search
 	out.CutoverIndexFamily = statusAfter.CutoverIndexFamily
 	out.CutoverFamilyBytesBefore = statusAfter.CutoverFamilyBytesBefore
 	out.CutoverFamilyBytesAfter = statusAfter.CutoverFamilyBytesAfter
+	out.CutoverFamilyEvidence = statusAfter.CutoverFamilyEvidence
 	if progress.Completed {
 		out.SessionTierVerified = true
 		out.Completed = statusAfter.Completed
 	}
 	return out, nil
+}
+
+// failureClassOrUnknown keeps the parked-skip reason readable when a store
+// recorded a failure without a class.
+func failureClassOrUnknown(class string) string {
+	if strings.TrimSpace(class) == "" {
+		return "(unclassified)"
+	}
+	return class
 }
 
 // catchUpHasSourceWork reports whether the store has events that a generation

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -4,7 +4,9 @@
 
 検索プロジェクションは派生データです。正本のイベントとコマンド監査からいつでも再構築でき、プロジェクションのライフサイクル操作が正本を変更することはありません。v0.34 以降、世代が complete のときは `traceary search` がこのプロジェクションを読みます。再構築後に記録されたイベントは正本テーブルから統合するため、再構築の合間に結果が古くなることはありません。
 
-`traceary store search-projection start`で世代を開始します。`resume`は上限付きバッチを1回実行します。複数のバッチを個別にコミットしながら実行する例を次に示します。
+世代を一度も作っていない store でも、最初の cutover にオペレータのコマンドは不要です。store を開くたびに generation 作業を上限付きで 1 単位進めます（initialize 時の event-search backfill と同じ形）。idle かつ source event があるときだけ start し、それ以外は一致する rebuild を resume します。世代が `complete` になるまで legacy の migration-032 索引が authoritative のままです。旧世代の行を回収する前に、構築中の世代に対する session tier の実クエリが成功する必要があります。`status` が報告する前後の物理バイトは **bounded_search_projection** ファミリのみです。legacy の `event_search_*` ファミリの数字ではありません。
+
+オペレータは同じ機構を明示的に動かせます。`traceary store search-projection start`で世代を開始します。`resume`は上限付きバッチを1回実行します。複数のバッチを個別にコミットしながら実行する例を次に示します。
 
 プロジェクションschemaより前のstoreをupgradeした場合、最初の`resume`バッチ群はpayloadをdecodeする前に、過去のevent identityをinventoryします。このphaseは`status`に明示され、安定したevent ID cursorを使用し、行数、保存バイト数、論理書き込みバイト数、wall time、lock timeの上限に従います。processを再起動すると最後にatomic commitされたcursorから再開します。正本が並行変更された場合は、不完全なinventoryを受け入れずgenerationを無効化します。旧migration 38ですでに投入済みのstoreと新規の空storeは、正本tableをscanせずこのphaseを省略します。
 

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -12,6 +12,10 @@
 
 オペレータが非デフォルトの budget で世代を開始したまま中断した場合、store open 時の自動 catch-up はその budget を乗っ取らず skip します。skip は理由付きで warning レベルに記録されます。進捗を再開するには、一致する budget で resume するか abort してください。
 
+**failed** になった世代は自動で再起動せず、park します。この store が記録する failure class はいずれも決定的です。oversize な行はどの open でも同じ budget を超え、`session_tier_unverified` は同じクエリで失敗し、`abandoned` はオペレータの判断です。自動で作り直しても同じ失敗を繰り返し、open ごとに lifecycle 行が増えるだけです。自動 catch-up は class を明記した warning を出して skip するので、明示的に `resume` または `abort` してください。
+
+cutover 前後の family バイト数は診断用の値であり、世代を start / complete する transaction の外側で、専用の短い deadline のもとに測定します。測定できなかった場合でも世代が失敗することはありません。`status` は `cutover_family_evidence.status` を `unavailable` と理由付きで報告するため、0 バイトという値を「実際に空の family」と取り違えることはありません。
+
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h
 ```

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -12,9 +12,9 @@
 
 オペレータが非デフォルトの budget で世代を開始したまま中断した場合、store open 時の自動 catch-up はその budget を乗っ取らず skip します。skip は理由付きで warning レベルに記録されます。進捗を再開するには、一致する budget で resume するか abort してください。
 
-**failed** になった世代は自動で再起動せず、park します。この store が記録する failure class はいずれも決定的です。oversize な行はどの open でも同じ budget を超え、`session_tier_unverified` は同じクエリで失敗し、`abandoned` はオペレータの判断です。自動で作り直しても同じ失敗を繰り返し、open ごとに lifecycle 行が増えるだけです。自動 catch-up は class を明記した warning を出して skip するので、明示的に `resume` または `abort` してください。
+**failed** になった世代は自動で再起動せず、park します。この store が記録する failure class はいずれも決定的です。oversize な行はどの open でも同じ budget を超え、`session_tier_unverified` は同じクエリで失敗し、`abandoned` はオペレータの判断です。自動で作り直しても同じ失敗を繰り返し、open ごとに lifecycle 行が増えるだけです。自動 catch-up は class を明記した warning を出して skip します。`resume` は failed な世代を拒否し、`abort` は `abandoned` として failed のままにするため、どちらでも解除できません。復旧は明示的な `traceary store search-projection start` です。
 
-cutover 前後の family バイト数は診断用の値であり、世代を start / complete する transaction の外側で、専用の短い deadline のもとに測定します。測定できなかった場合でも世代が失敗することはありません。`status` は `cutover_family_evidence.status` を `unavailable` と理由付きで報告するため、0 バイトという値を「実際に空の family」と取り違えることはありません。
+cutover 前後の family バイト数は診断用の値であり、世代を start / complete する transaction の外側で、batch から切り離した context と専用の短い deadline のもとに測定します。測定できなかった場合でも世代が失敗することはありません。`status` は `cutover_before_evidence.status` / `cutover_after_evidence.status` を `unavailable` と理由付きで報告するため、0 バイトという値を「実際に空の family」と取り違えることはありません。before と after は測定時刻も対象 family の大きさも異なるため別々に持ちます。status が空文字の場合はまだ測定していないことを表します。
 
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h

--- a/docs/search-projection-rebuild.ja.md
+++ b/docs/search-projection-rebuild.ja.md
@@ -8,7 +8,9 @@
 
 オペレータは同じ機構を明示的に動かせます。`traceary store search-projection start`で世代を開始します。`resume`は上限付きバッチを1回実行します。複数のバッチを個別にコミットしながら実行する例を次に示します。
 
-プロジェクションschemaより前のstoreをupgradeした場合、最初の`resume`バッチ群はpayloadをdecodeする前に、過去のevent identityをinventoryします。このphaseは`status`に明示され、安定したevent ID cursorを使用し、行数、保存バイト数、論理書き込みバイト数、wall time、lock timeの上限に従います。processを再起動すると最後にatomic commitされたcursorから再開します。正本が並行変更された場合は、不完全なinventoryを受け入れずgenerationを無効化します。旧migration 38ですでに投入済みのstoreと新規の空storeは、正本tableをscanせずこのphaseを省略します。
+プロジェクションschemaより前のstoreをupgradeした場合、最初の`resume`バッチ群はpayloadをdecodeする前に、過去のevent identityをinventoryします。このphaseは`status`に明示され、安定したevent ID cursorを使用し、行数、保存バイト数、論理書き込みバイト数、wall time、lock timeの上限に従います。processを再起動すると最後にatomic commitされたcursorから再開します。過去行への並行の**update / delete**は、不完全なinventoryを受け入れずgenerationを無効化します。ライブの**insert**は無効化しません。events の insert trigger が新しい identity を `search_projection_source_sequence` へ無条件登録するため、inventory に追加作業はなく、store を開くたびに書く hook でも `complete` に到達できます。旧migration 38ですでに投入済みのstoreと新規の空storeは、正本tableをscanせずこのphaseを省略します。
+
+オペレータが非デフォルトの budget で世代を開始したまま中断した場合、store open 時の自動 catch-up はその budget を乗っ取らず skip します。skip は理由付きで warning レベルに記録されます。進捗を再開するには、一致する budget で resume するか abort してください。
 
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -4,7 +4,9 @@
 
 The search projection is derived: it can always be rebuilt from canonical events and command audits, and projection lifecycle commands never change them. Since v0.34 it is what `traceary search` reads when a generation is complete, with events recorded after the rebuild merged in from the canonical tables so results do not go stale between rebuilds.
 
-Start a generation with `traceary store search-projection start`. Resume one durable bounded batch with `resume`, or run multiple independently committed batches:
+Stores that have never built a generation do not need an operator command for the first cutover. Every store open runs one bounded unit of generation work (the same shape as the event-search backfill on initialize): start if idle and source events exist, otherwise resume a matching rebuild. The legacy migration-032 index stays authoritative until the generation reaches `complete`. Before old generation rows are reclaimed, a real session-tier query must succeed against the generation under construction. `status` reports before/after physical bytes for the **bounded_search_projection** family only — never the legacy `event_search_*` family.
+
+Operators can still drive the same machinery explicitly. Start a generation with `traceary store search-projection start`. Resume one durable bounded batch with `resume`, or run multiple independently committed batches:
 
 On a store upgraded from before the projection schema, the first resume
 batches inventory historical event identities before any payload is decoded.

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -12,10 +12,19 @@ On a store upgraded from before the projection schema, the first resume
 batches inventory historical event identities before any payload is decoded.
 This phase is explicit in `status`, uses a stable event-ID cursor, and obeys
 the same row, stored-byte, logical-write-byte, wall-time, and lock-time caps.
-Restarting the process resumes from the last atomic cursor. A concurrent
-canonical mutation invalidates the generation instead of accepting a partial
-inventory. Stores populated by the former migration-38 behavior and new empty
-stores skip this phase without scanning the canonical table.
+Restarting the process resumes from the last atomic cursor. Concurrent
+**updates or deletes** of historical rows invalidate the generation instead of
+accepting a partial inventory. Live **inserts** do not: the events insert
+trigger registers the new identity into `search_projection_source_sequence`
+unconditionally, so inventory has no extra work for that row and hooks that
+write on every store open can still reach `complete`. Stores populated by the
+former migration-38 behavior and new empty stores skip this phase without
+scanning the canonical table.
+
+If an operator starts a generation with a non-default budget and leaves it
+incomplete, automatic catch-up on store open skips rather than hijacking that
+budget. Skips are logged at warning level with the reason; resume or abort with
+the matching budget to unblock progress.
 
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -26,6 +26,19 @@ incomplete, automatic catch-up on store open skips rather than hijacking that
 budget. Skips are logged at warning level with the reason; resume or abort with
 the matching budget to unblock progress.
 
+A generation that **failed** is parked, not retried. Every failure class the
+store records is deterministic — an oversize row exceeds the same budget on
+every open, `session_tier_unverified` fails the same query, and `abandoned` is
+an operator decision — so restarting automatically would fail identically and
+append a lifecycle row per open. Automatic catch-up skips with a warning naming
+the class; `resume` or `abort` explicitly to unblock it.
+
+The before/after family byte figures are diagnostic and are measured outside the
+transactions that start and complete a generation, under their own short
+deadline. A measurement that cannot run never fails a generation: `status`
+reports `cutover_family_evidence.status` as `unavailable` with a reason, so a
+zero byte figure is never mistaken for a genuinely empty family.
+
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h
 ```

--- a/docs/search-projection-rebuild.md
+++ b/docs/search-projection-rebuild.md
@@ -31,13 +31,18 @@ store records is deterministic — an oversize row exceeds the same budget on
 every open, `session_tier_unverified` fails the same query, and `abandoned` is
 an operator decision — so restarting automatically would fail identically and
 append a lifecycle row per open. Automatic catch-up skips with a warning naming
-the class; `resume` or `abort` explicitly to unblock it.
+the class. Neither `resume` nor `abort` clears it — `resume` rejects a failed
+generation and `abort` leaves the row failed as `abandoned` — so recovery is an
+explicit `traceary store search-projection start`.
 
 The before/after family byte figures are diagnostic and are measured outside the
 transactions that start and complete a generation, under their own short
-deadline. A measurement that cannot run never fails a generation: `status`
-reports `cutover_family_evidence.status` as `unavailable` with a reason, so a
-zero byte figure is never mistaken for a genuinely empty family.
+deadline, on a context detached from the batch. A measurement that cannot run
+never fails a generation: `status` reports `cutover_before_evidence.status` and
+`cutover_after_evidence.status` as `unavailable` with a reason, so a zero byte
+figure is never mistaken for a genuinely empty family. The two are separate
+because they are measured at different times against families of different
+sizes; an empty status means no measurement has been attempted yet.
 
 ```sh
 traceary store search-projection resume --until-complete --max-batches 4000 --total-wall-time 8h

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -372,6 +372,15 @@ func (d *Database) initializeAt(ctx context.Context, snapshot string) (err error
 			"completed", searchBackfillResult.Completed,
 		)
 	}
+	// Bounded projection generation is driven the same way as event search
+	// backfill: one durable unit per store open, resumable, never blocking
+	// Initialize on a full rebuild. Legacy search stays authoritative until
+	// the generation reaches complete (#1717 / #1680). Projection methods open
+	// via Path(), so skip when SetPath raced against the migrate snapshot.
+	if snapshot == d.Path() {
+		projectionCatchUp, projectionCatchUpErr := catchUpSearchProjection(ctx, d)
+		logSearchProjectionCatchUp(projectionCatchUp, projectionCatchUpErr)
+	}
 	catchUpResult, catchUpErr := catchUpWorkspaceObservations(ctx, db, workspaceObservationCatchUpBatchSize)
 	if catchUpErr != nil {
 		// Catch-up is additive diagnostic coverage. A malformed historical row

--- a/infrastructure/sqlite/database.go
+++ b/infrastructure/sqlite/database.go
@@ -149,6 +149,11 @@ type Database struct {
 	// searchMaintenanceHook is a package-private transaction-boundary seam used
 	// by deterministic atomicity tests. Production databases leave it nil.
 	searchMaintenanceHook func(string) error
+	// searchProjectionMeasureTimeoutOverride shortens the cutover evidence
+	// deadline so tests can observe an unavailable measurement without building
+	// a projection family large enough to be genuinely slow. Production
+	// databases leave it zero and get searchProjectionMeasureTimeout.
+	searchProjectionMeasureTimeoutOverride time.Duration
 }
 
 func (d *Database) runSearchMaintenanceHook(point string) error {

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -57,6 +57,8 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	49: {49, "000049_add_search_projection_cutover_evidence.sql", "5ca7ad45bed4a49d0262fc66ae36ffbe434ade920787a1c1551e7eb62e750648", MigrationConstantInPlace},
 	// 50 only drops and recreates two insert triggers (no data scan/rewrite).
 	50: {50, "000050_fix_search_projection_insert_inventory_drift.sql", "6c80fdcceb682093a466fc6207e084644da4923c6762a4f4f927878aa2418b5b", MigrationConstantInPlace},
+	// 51 only adds two cutover evidence columns to search_projection_state.
+	51: {51, "000051_add_search_projection_cutover_evidence_status.sql", "8538eb8e4343abe4c5dfba2e5170edb14a44064b81c4d6538661895372db3131", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -57,8 +57,8 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	49: {49, "000049_add_search_projection_cutover_evidence.sql", "5ca7ad45bed4a49d0262fc66ae36ffbe434ade920787a1c1551e7eb62e750648", MigrationConstantInPlace},
 	// 50 only drops and recreates two insert triggers (no data scan/rewrite).
 	50: {50, "000050_fix_search_projection_insert_inventory_drift.sql", "6c80fdcceb682093a466fc6207e084644da4923c6762a4f4f927878aa2418b5b", MigrationConstantInPlace},
-	// 51 only adds two cutover evidence columns to search_projection_state.
-	51: {51, "000051_add_search_projection_cutover_evidence_status.sql", "8538eb8e4343abe4c5dfba2e5170edb14a44064b81c4d6538661895372db3131", MigrationConstantInPlace},
+	// 51 only adds four cutover evidence columns to search_projection_state.
+	51: {51, "000051_add_search_projection_cutover_evidence_status.sql", "0d5b692c1039301b2216ef8047e5980e74bfecb3865b40ccf1045a8c339121bc", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -53,6 +53,8 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// duplicates the payload; cost scales with historical audit volume →
 	// data_dependent_offline (like 000045).
 	48: {48, "000048_clear_command_executed_event_bodies.sql", "2d8844ed2726713fbb553cbfdb16602e4e2fefa4aab52afff701d87309a8934e", MigrationDataDependentOffline},
+	// 49 only adds three cutover evidence columns to search_projection_state.
+	49: {49, "000049_add_search_projection_cutover_evidence.sql", "5ca7ad45bed4a49d0262fc66ae36ffbe434ade920787a1c1551e7eb62e750648", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -55,6 +55,8 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	48: {48, "000048_clear_command_executed_event_bodies.sql", "2d8844ed2726713fbb553cbfdb16602e4e2fefa4aab52afff701d87309a8934e", MigrationDataDependentOffline},
 	// 49 only adds three cutover evidence columns to search_projection_state.
 	49: {49, "000049_add_search_projection_cutover_evidence.sql", "5ca7ad45bed4a49d0262fc66ae36ffbe434ade920787a1c1551e7eb62e750648", MigrationConstantInPlace},
+	// 50 only drops and recreates two insert triggers (no data scan/rewrite).
+	50: {50, "000050_fix_search_projection_insert_inventory_drift.sql", "6c80fdcceb682093a466fc6207e084644da4923c6762a4f4f927878aa2418b5b", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 50 || len(plan.Pending) != 16 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 51 || len(plan.Pending) != 17 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -48,6 +48,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		48: MigrationDataDependentOffline,
 		49: MigrationConstantInPlace,
 		50: MigrationConstantInPlace,
+		51: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 49 || len(plan.Pending) != 15 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 50 || len(plan.Pending) != 16 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -47,6 +47,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		47: MigrationConstantInPlace,
 		48: MigrationDataDependentOffline,
 		49: MigrationConstantInPlace,
+		50: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_catalog_test.go
+++ b/infrastructure/sqlite/prepared_migration_catalog_test.go
@@ -28,7 +28,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Current != 34 || plan.Latest != 48 || len(plan.Pending) != 14 || !plan.Offline || len(plan.Digest) != 64 {
+	if plan.Current != 34 || plan.Latest != 49 || len(plan.Pending) != 15 || !plan.Offline || len(plan.Digest) != 64 {
 		t.Fatalf("plan = %+v", plan)
 	}
 	want := map[int64]MigrationExecutionClass{
@@ -46,6 +46,7 @@ func TestBuildPreparedMigrationPlanClassifiesExactSuffix(t *testing.T) {
 		46: MigrationConstantInPlace,
 		47: MigrationConstantInPlace,
 		48: MigrationDataDependentOffline,
+		49: MigrationConstantInPlace,
 	}
 	for _, migration := range plan.Pending {
 		if migration.Class != want[migration.Version] {

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 50 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 51 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 49 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 50 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/prepared_migration_publication_test.go
+++ b/infrastructure/sqlite/prepared_migration_publication_test.go
@@ -110,7 +110,7 @@ func TestPreparedMigrationPublishesAndRollsBackOwnedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	var maxVersion int
-	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 48 {
+	if err = currentDB.QueryRow(`SELECT max(version) FROM schema_migrations`).Scan(&maxVersion); err != nil || maxVersion != 49 {
 		t.Fatalf("published version=%d err=%v", maxVersion, err)
 	}
 	// The rehearsal legitimately mutates the published candidate inode. Atomic

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -150,7 +150,20 @@ func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, e
 		)
 		return
 	}
-	if result.Action == "skipped" || result.Action == "already_complete" || result.Action == "none" {
+	// Quiet terminal/no-op states stay silent. Permanent skips (especially a
+	// budget mismatch left by an abandoned operator rebuild) must be visible:
+	// the generation will never reach complete on its own.
+	if result.Action == "already_complete" || result.Action == "none" {
+		return
+	}
+	if result.Action == "skipped" {
+		slog.Warn("search projection catch-up skipped; resume or abort with the matching budget to unblock automatic progress",
+			"action", result.Action,
+			"state", result.State,
+			"phase", result.Phase,
+			"generation_id", result.GenerationID,
+			"reason", result.SkippedReason,
+		)
 		return
 	}
 	attrs := []any{

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -1,0 +1,175 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+// defaultSearchProjectionCatchUpBudget is the automatic generation budget used
+// on every store open. It matches the CLI search-projection defaults so an
+// operator-started generation with default flags and the auto path share a
+// config hash and can resume each other. One Resume per open keeps the unit of
+// work bounded; wall-time is deliberately short so Initialize never blocks on a
+// multi-minute rebuild of a large store.
+func defaultSearchProjectionCatchUpBudget() apptypes.SearchProjectionBudget {
+	return apptypes.SearchProjectionBudget{
+		Rows:         128,
+		WallTime:     time.Second,
+		LockTime:     250 * time.Millisecond,
+		StoredBytes:  8 << 20,
+		DecodedBytes: 8 << 20,
+		WriteBytes:   8 << 20,
+		RecentAge:    30 * 24 * time.Hour,
+		RecentBytes:  64 << 20,
+	}
+}
+
+// catchUpSearchProjection advances the bounded projection by one durable unit
+// of work during store initialization. Failures are returned to the caller so
+// Initialize can log and continue — the same fail-open pattern as event search
+// backfill. The legacy index remains authoritative until a generation reaches
+// complete (#1717).
+func catchUpSearchProjection(ctx context.Context, store *Database) (apptypes.SearchProjectionCatchUpResult, error) {
+	db, err := store.open(ctx)
+	if err != nil {
+		return apptypes.SearchProjectionCatchUpResult{}, xerrors.Errorf("open store for projection catch-up probe: %w", err)
+	}
+	complete, missing, err := searchProjectionSchemaComplete(ctx, db)
+	_ = db.Close()
+	if err != nil {
+		return apptypes.SearchProjectionCatchUpResult{}, err
+	}
+	if !complete {
+		// Focused historical-schema tests build stores from hand-written
+		// fixtures that omit migrations 038+. Decide that from the schema
+		// itself rather than from the text of a failure: matching "no such
+		// table" on an error would also swallow a genuine SQL defect in the
+		// projection, and a swallowed defect means the generation silently
+		// never completes.
+		return apptypes.SearchProjectionCatchUpResult{
+			Action:        "skipped",
+			SkippedReason: "projection schema incomplete: " + missing,
+		}, nil
+	}
+	result, err := usecase.NewSearchProjectionUsecase(store).CatchUp(ctx, defaultSearchProjectionCatchUpBudget(), time.Now().UTC())
+	if err != nil {
+		return result, xerrors.Errorf("search projection catch-up: %w", err)
+	}
+	return result, nil
+}
+
+// searchProjectionObjects are the tables the generation machinery reads or
+// writes, created by migrations 038-042. A store either has all of them or is
+// a fixture predating the bounded projection.
+var searchProjectionObjects = []string{
+	"literal_search_fingerprints",
+	"literal_search_projection_state",
+	"search_projection_command_aggregates",
+	"search_projection_generation_lifecycle",
+	"search_projection_inventory_compat",
+	"search_projection_inventory_state",
+	"search_projection_recent_documents",
+	"search_projection_recent_fts",
+	"search_projection_session_keywords",
+	"search_projection_session_summaries",
+	"search_projection_source_revision",
+	"search_projection_source_sequence",
+	"search_projection_state",
+}
+
+// searchProjectionSchemaComplete reports whether every object the catch-up
+// needs exists, naming the first missing one so a skip is diagnosable.
+func searchProjectionSchemaComplete(ctx context.Context, db *sql.DB) (bool, string, error) {
+	for _, object := range searchProjectionObjects {
+		exists, err := sqliteTableExists(ctx, db, object)
+		if err != nil {
+			return false, "", err
+		}
+		if !exists {
+			return false, object, nil
+		}
+	}
+	// Migration 049 adds cutover evidence to an existing table, so presence of
+	// search_projection_state alone does not imply it.
+	var columns int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('search_projection_state') WHERE name = 'cutover_index_family'`,
+	).Scan(&columns); err != nil {
+		return false, "", xerrors.Errorf("inspect search_projection_state columns: %w", err)
+	}
+	if columns == 0 {
+		return false, "search_projection_state.cutover_index_family", nil
+	}
+	return true, "", nil
+}
+
+// SearchProjectionHasSourceWork reports whether any event exists that a new
+// generation would need to inventory or project.
+func (d *Database) SearchProjectionHasSourceWork(ctx context.Context) (bool, error) {
+	db, err := d.open(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("open store for projection source probe: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	var hasEvents int
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM events LIMIT 1)`).Scan(&hasEvents); err != nil {
+		return false, xerrors.Errorf("probe events for projection catch-up: %w", err)
+	}
+	if hasEvents != 0 {
+		return true, nil
+	}
+	var requiresInventory int
+	if err := db.QueryRowContext(ctx, `SELECT requires_inventory FROM search_projection_inventory_compat WHERE singleton=1`).Scan(&requiresInventory); err != nil {
+		if isMissingSQLiteObject(err) {
+			return false, nil
+		}
+		return false, xerrors.Errorf("probe inventory compat for projection catch-up: %w", err)
+	}
+	return requiresInventory != 0, nil
+}
+
+// logSearchProjectionCatchUp emits structured progress without failing Initialize.
+func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, err error) {
+	if err != nil {
+		slog.Error("search projection catch-up incomplete; retrying on next initialization",
+			"action", result.Action,
+			"state", result.State,
+			"phase", result.Phase,
+			"generation_id", result.GenerationID,
+			"batches", result.Batches,
+			"selected", result.Selected,
+			"written", result.Written,
+			"error", err,
+		)
+		return
+	}
+	if result.Action == "skipped" || result.Action == "already_complete" || result.Action == "none" {
+		return
+	}
+	attrs := []any{
+		"action", result.Action,
+		"state", result.State,
+		"phase", result.Phase,
+		"generation_id", result.GenerationID,
+		"batches", result.Batches,
+		"selected", result.Selected,
+		"written", result.Written,
+		"completed", result.Completed,
+		"cutover_index_family", result.CutoverIndexFamily,
+		"cutover_family_bytes_before", result.CutoverFamilyBytesBefore,
+		"cutover_family_bytes_after", result.CutoverFamilyBytesAfter,
+		"session_tier_verified", result.SessionTierVerified,
+	}
+	if result.Completed {
+		slog.Info("search projection catch-up completed generation", attrs...)
+		return
+	}
+	slog.Debug("search projection catch-up batch completed", attrs...)
+}

--- a/infrastructure/sqlite/search_projection_catchup.go
+++ b/infrastructure/sqlite/search_projection_catchup.go
@@ -157,7 +157,7 @@ func logSearchProjectionCatchUp(result apptypes.SearchProjectionCatchUpResult, e
 		return
 	}
 	if result.Action == "skipped" {
-		slog.Warn("search projection catch-up skipped; resume or abort with the matching budget to unblock automatic progress",
+		slog.Warn("search projection catch-up skipped; the generation will not advance on its own until the reason is addressed",
 			"action", result.Action,
 			"state", result.State,
 			"phase", result.Phase,

--- a/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
@@ -40,8 +40,25 @@ func TestLogSearchProjectionCatchUp_LogsSkipsButNotQuietStates(t *testing.T) {
 			wantSub: []string{
 				"search projection catch-up skipped",
 				"budget does not match generation configuration",
-				"resume or abort with the matching budget",
+				"will not advance on its own",
 				"gen-stuck",
+			},
+		},
+		{
+			name: "parked deterministic failure names the class",
+			result: apptypes.SearchProjectionCatchUpResult{
+				Action:        "skipped",
+				State:         "failed",
+				Phase:         "complete",
+				GenerationID:  "gen-oversize",
+				SkippedReason: "parked after generation failure decoded_bytes; resume or abort explicitly to unblock automatic progress",
+			},
+			wantLog:   true,
+			wantLevel: "WARN",
+			wantSub: []string{
+				"search projection catch-up skipped",
+				"parked after generation failure decoded_bytes",
+				"gen-oversize",
 			},
 		},
 		{

--- a/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_log_internal_test.go
@@ -1,0 +1,85 @@
+package sqlite
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+)
+
+func TestLogSearchProjectionCatchUp_LogsSkipsButNotQuietStates(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	tests := []struct {
+		name      string
+		result    apptypes.SearchProjectionCatchUpResult
+		wantLog   bool
+		wantLevel string
+		wantSub   []string
+	}{
+		{
+			name: "budget mismatch skip is visible and actionable",
+			result: apptypes.SearchProjectionCatchUpResult{
+				Action:        "skipped",
+				State:         "rebuilding",
+				Phase:         "source",
+				GenerationID:  "gen-stuck",
+				SkippedReason: "budget does not match generation configuration",
+			},
+			wantLog:   true,
+			wantLevel: "WARN",
+			wantSub: []string{
+				"search projection catch-up skipped",
+				"budget does not match generation configuration",
+				"resume or abort with the matching budget",
+				"gen-stuck",
+			},
+		},
+		{
+			name:    "already_complete stays quiet",
+			result:  apptypes.SearchProjectionCatchUpResult{Action: "already_complete", Completed: true},
+			wantLog: false,
+		},
+		{
+			name:    "none stays quiet",
+			result:  apptypes.SearchProjectionCatchUpResult{Action: "none"},
+			wantLog: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			logSearchProjectionCatchUp(tt.result, nil)
+			got := buf.String()
+			if tt.wantLog {
+				if got == "" {
+					t.Fatal("expected a log line, got none")
+				}
+				if !strings.Contains(got, "level="+tt.wantLevel) && !strings.Contains(got, "level="+strings.ToUpper(tt.wantLevel)) {
+					// slog text handler prints level=WARN
+					if !strings.Contains(got, tt.wantLevel) {
+						t.Fatalf("log missing level %q: %s", tt.wantLevel, got)
+					}
+				}
+				for _, sub := range tt.wantSub {
+					if !strings.Contains(got, sub) {
+						t.Fatalf("log missing %q: %s", sub, got)
+					}
+				}
+				return
+			}
+			if diff := cmp.Diff("", got); diff != "" {
+				t.Fatalf("quiet state logged unexpectedly (-want +got):\n%s\nlog=%q", diff, got)
+			}
+		})
+	}
+}

--- a/infrastructure/sqlite/search_projection_catchup_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_test.go
@@ -3,6 +3,7 @@ package sqlite_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,8 +15,9 @@ import (
 
 	apptypes "github.com/duck8823/traceary/application/types"
 	"github.com/duck8823/traceary/application/usecase"
-	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+	"github.com/duck8823/traceary/domain/model"
 	"github.com/duck8823/traceary/domain/types"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
 )
 
 // TestSearchProjectionCatchUp_IsBoundedCompleteAndResumable pins the #1680
@@ -396,4 +398,210 @@ func seedSession(t *testing.T, dbPath, sessionID string, startedAt time.Time, wo
 			t.Fatalf("seed session %s: %v", sessionID, err)
 		}
 	})
+}
+
+// seedHistoricalEvents inserts N pre-projection rows without going through
+// event-save triggers that only exist after migration 038.
+func seedHistoricalEvents(t *testing.T, dbPath string, n int) {
+	t.Helper()
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt, err := tx.Prepare(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','agent','sess-history','historical body','2026-01-05T12:00:00Z','cli','github.com/duck8823/traceary')`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < n; i++ {
+			if _, err = stmt.Exec(fmt.Sprintf("historical-%08d", i)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		_ = stmt.Close()
+		if err = tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func projectionInventoryAndSequence(t *testing.T, dbPath string) (cursor string, cursorStarted int, sequenceRows int, requiresInventory int, lifecycleRows int, state string, phase string) {
+	t.Helper()
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(`
+			SELECT i.cursor, i.cursor_started,
+			       (SELECT COUNT(*) FROM search_projection_source_sequence),
+			       (SELECT requires_inventory FROM search_projection_inventory_compat),
+			       (SELECT COUNT(*) FROM search_projection_generation_lifecycle),
+			       s.state, s.phase
+			  FROM search_projection_state s
+			  JOIN search_projection_inventory_state i ON i.singleton = s.singleton
+			 WHERE s.singleton = 1`).Scan(&cursor, &cursorStarted, &sequenceRows, &requiresInventory, &lifecycleRows, &state, &phase); err != nil {
+			t.Fatalf("projection inventory probe: %v", err)
+		}
+	})
+	return cursor, cursorStarted, sequenceRows, requiresInventory, lifecycleRows, state, phase
+}
+
+// TestSearchProjectionCatchUp_AlternatingWritesConvergeInventory pins the
+// hook-shaped interleaving that stalled #1680: migrate a historical store,
+// then alternate {insert one event, open the store}. Live inserts must not
+// drift the in-flight inventory generation, so the inventory cursor and
+// source_sequence converge to complete despite continuous writes.
+func TestSearchProjectionCatchUp_AlternatingWritesConvergeInventory(t *testing.T) {
+	t.Parallel()
+
+	const historical = 400
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+
+	// Pre-038 store with historical events (requires_inventory=1 on upgrade).
+	legacy := infra.NewDatabase(dbPath, onDiskSQLiteMigrationsBefore(t, 38))
+	if err := infra.NewStoreManagementDatasource(legacy).Initialize(ctx); err != nil {
+		t.Fatalf("legacy Initialize: %v", err)
+	}
+	seedHistoricalEvents(t, dbPath, historical)
+
+	// Upgrade to head and run automatic catch-up on every subsequent open.
+	database := infra.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	store := infra.NewStoreManagementDatasource(database)
+	events := infra.NewEventDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("upgrade Initialize: %v", err)
+	}
+	_, _, seqAfterUpgrade, requires, _, _, _ := projectionInventoryAndSequence(t, dbPath)
+	if requires != 1 {
+		t.Fatalf("after upgrade requires_inventory=%d, want 1 so inventory path is exercised", requires)
+	}
+	if seqAfterUpgrade < 1 {
+		t.Fatalf("upgrade catch-up wrote no source sequence rows")
+	}
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	base := time.Date(2026, 8, 6, 14, 0, 0, 0, time.UTC)
+	seedSession(t, dbPath, "sess-live", base, workspace.String())
+
+	var status apptypes.SearchProjectionStatus
+	const maxOpens = 80
+	for i := 0; i < maxOpens; i++ {
+		liveID := fmt.Sprintf("live-note-%05d", i)
+		event := newSearchEventWithSession(t, liveID, "sess-live", workspace.String(), "live write body "+liveID, base.Add(time.Duration(i)*time.Second))
+		if err := events.Save(ctx, event); err != nil {
+			t.Fatalf("Save live event #%d: %v", i, err)
+		}
+		if err := store.Initialize(ctx); err != nil {
+			t.Fatalf("alternating Initialize #%d: %v", i+1, err)
+		}
+		status = projectionStatus(t, database)
+		if status.Completed {
+			break
+		}
+	}
+	if !status.Completed {
+		cursor, started, seq, requires, lifecycle, state, phase := projectionInventoryAndSequence(t, dbPath)
+		t.Fatalf("projection did not complete under alternating writes: status=%+v inventory(cursor=%q started=%d seq=%d requires=%d lifecycle=%d state=%s phase=%s)",
+			status, cursor, started, seq, requires, lifecycle, state, phase)
+	}
+
+	_, _, sequenceRows, requiresInventory, lifecycleRows, _, _ := projectionInventoryAndSequence(t, dbPath)
+	if requiresInventory != 0 {
+		t.Fatalf("requires_inventory=%d after complete, want 0", requiresInventory)
+	}
+	// Every historical row plus every live insert must be in the sequence.
+	// Live inserts may continue after inventory handoff; sequence is at least
+	// the historical corpus.
+	if sequenceRows < historical {
+		t.Fatalf("source_sequence rows=%d, want >= %d historical identities", sequenceRows, historical)
+	}
+	// Without the insert-trigger fix, CatchUp restarts a generation every two
+	// opens and lifecycle grows unbounded. With the fix it stays a small constant.
+	if lifecycleRows > 4 {
+		t.Fatalf("lifecycle rows=%d, want bounded (<=4), not growing per open", lifecycleRows)
+	}
+}
+
+// TestSearchProjectionCatchUp_AlternatingCommandEventsConverge is the
+// command-hook path: one transaction writes events + command_audits. Fixing
+// only the events insert trigger still drifts via audits_insert.
+func TestSearchProjectionCatchUp_AlternatingCommandEventsConverge(t *testing.T) {
+	t.Parallel()
+
+	const historical = 300
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+
+	legacy := infra.NewDatabase(dbPath, onDiskSQLiteMigrationsBefore(t, 38))
+	if err := infra.NewStoreManagementDatasource(legacy).Initialize(ctx); err != nil {
+		t.Fatalf("legacy Initialize: %v", err)
+	}
+	seedHistoricalEvents(t, dbPath, historical)
+
+	database := infra.NewDatabase(dbPath, onDiskSQLiteMigrations(t))
+	store := infra.NewStoreManagementDatasource(database)
+	events := infra.NewEventDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("upgrade Initialize: %v", err)
+	}
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	base := time.Date(2026, 8, 6, 15, 0, 0, 0, time.UTC)
+	seedSession(t, dbPath, "sess-cmd", base, workspace.String())
+
+	var status apptypes.SearchProjectionStatus
+	const maxOpens = 80
+	for i := 0; i < maxOpens; i++ {
+		liveID := fmt.Sprintf("live-cmd-%05d", i)
+		eventID, err := types.EventIDFrom(liveID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		agent, err := types.AgentFrom("codex")
+		if err != nil {
+			t.Fatal(err)
+		}
+		sessionID, err := types.SessionIDFrom("sess-cmd")
+		if err != nil {
+			t.Fatal(err)
+		}
+		event := model.EventOf(
+			eventID,
+			types.EventKindCommandExecuted,
+			types.Client("cli"),
+			agent,
+			sessionID,
+			workspace,
+			"",
+			base.Add(time.Duration(i)*time.Second),
+		)
+		audit, err := model.NewCommandAudit(eventID, "traceary doctor", "", "ok", false, false)
+		if err != nil {
+			t.Fatalf("NewCommandAudit: %v", err)
+		}
+		if err := events.SaveWithAudit(ctx, event, audit); err != nil {
+			t.Fatalf("SaveWithAudit #%d: %v", i, err)
+		}
+		if err := store.Initialize(ctx); err != nil {
+			t.Fatalf("alternating Initialize #%d: %v", i+1, err)
+		}
+		status = projectionStatus(t, database)
+		if status.Completed {
+			break
+		}
+	}
+	if !status.Completed {
+		cursor, started, seq, requires, lifecycle, state, phase := projectionInventoryAndSequence(t, dbPath)
+		t.Fatalf("command-event projection did not complete: status=%+v inventory(cursor=%q started=%d seq=%d requires=%d lifecycle=%d state=%s phase=%s)",
+			status, cursor, started, seq, requires, lifecycle, state, phase)
+	}
+
+	_, _, sequenceRows, requiresInventory, lifecycleRows, _, _ := projectionInventoryAndSequence(t, dbPath)
+	if requiresInventory != 0 {
+		t.Fatalf("requires_inventory=%d after complete, want 0", requiresInventory)
+	}
+	if sequenceRows < historical {
+		t.Fatalf("source_sequence rows=%d, want >= %d", sequenceRows, historical)
+	}
+	if lifecycleRows > 4 {
+		t.Fatalf("lifecycle rows=%d, want bounded (<=4)", lifecycleRows)
+	}
 }

--- a/infrastructure/sqlite/search_projection_catchup_test.go
+++ b/infrastructure/sqlite/search_projection_catchup_test.go
@@ -1,0 +1,399 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	_ "modernc.org/sqlite"
+
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+	infra "github.com/duck8823/traceary/infrastructure/sqlite"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// TestSearchProjectionCatchUp_IsBoundedCompleteAndResumable pins the #1680
+// shape against the event-search backfill precedent: one store open does a
+// bounded unit of work, later opens resume, and only a complete generation
+// becomes the authoritative read path. Session-tier verification is a real
+// query, not a row count, and before/after bytes name the bounded family.
+func TestSearchProjectionCatchUp_IsBoundedCompleteAndResumable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	store := infra.NewStoreManagementDatasource(database)
+	events := infra.NewEventDatasource(database)
+
+	// Seed historical corpus before any projection generation exists.
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("bootstrap Initialize() error = %v", err)
+	}
+	// Clear any auto catch-up from bootstrap so the test owns the cutover.
+	resetProjectionToIdle(t, dbPath)
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	// Old history: well outside the 30-day recent window so the session tier
+	// is the only path that can answer.
+	old := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 8, 6, 14, 0, 0, 0, time.UTC)
+	seedSession(t, dbPath, "sess-old-history", old, workspace.String())
+	seedSession(t, dbPath, "sess-recent", recent, workspace.String())
+	if err := events.Save(ctx, newSearchEventWithSession(t, "evt-old-1", "sess-old-history", workspace.String(), "old-history-needle unique marker alpha", old)); err != nil {
+		t.Fatalf("Save old event: %v", err)
+	}
+	if err := events.Save(ctx, newSearchEventWithSession(t, "evt-recent-1", "sess-recent", workspace.String(), "recent window body", recent)); err != nil {
+		t.Fatalf("Save recent event: %v", err)
+	}
+
+	// First catch-up open: must start a generation and do bounded work without
+	// completing a multi-event inventory/source pass in one tiny fixture...
+	// With only two events and default budget (128 rows), one Resume may finish
+	// inventory+source quickly. Force a small budget via direct Resume path for
+	// the interruption scenario, then resume with Initialize catch-up.
+	//
+	// Drive the first unit with the production catch-up budget by Initialize.
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("first cutover Initialize() error = %v", err)
+	}
+	status := projectionStatus(t, database)
+	if status.State == "idle" {
+		t.Fatal("first cutover Initialize left projection idle; expected auto-start")
+	}
+	if status.State == "complete" && status.CutoverIndexFamily != "bounded_search_projection" {
+		t.Fatalf("complete cutover family = %q, want bounded_search_projection", status.CutoverIndexFamily)
+	}
+
+	// Interrupt path: if not yet complete, further Initializes resume.
+	for i := 0; i < 200 && !status.Completed; i++ {
+		if err := store.Initialize(ctx); err != nil {
+			t.Fatalf("resume Initialize() #%d error = %v", i+1, err)
+		}
+		status = projectionStatus(t, database)
+	}
+	if !status.Completed {
+		t.Fatalf("projection did not complete after bounded resumes: state=%s phase=%s", status.State, status.Phase)
+	}
+	if status.CutoverIndexFamily != "bounded_search_projection" {
+		t.Fatalf("cutover_index_family = %q, want bounded_search_projection", status.CutoverIndexFamily)
+	}
+	// After bytes are measured for the bounded family. On a tiny fixture they
+	// may equal before (schema already present); the contract is that both are
+	// reported under the named family and never claim to be store-wide.
+	if status.CutoverFamilyBytesAfter < 0 || status.CutoverFamilyBytesBefore < 0 {
+		t.Fatalf("negative family bytes before=%d after=%d", status.CutoverFamilyBytesBefore, status.CutoverFamilyBytesAfter)
+	}
+	t.Logf("bounded_search_projection family bytes: before=%d after=%d", status.CutoverFamilyBytesBefore, status.CutoverFamilyBytesAfter)
+
+	// Old-history term is answered by the session tier, not the recent window.
+	criteria := apptypes.NewEventSearchCriteriaBuilder(20).
+		Query("old-history-needle").
+		Workspace(workspace).
+		Build()
+	gotEvents, err := events.Search(ctx, criteria.Query(), workspace, "", "", "", "", time.Time{}, time.Time{}, 20, 0, false)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	// Old event is outside recent retention of the projection; event tier may
+	// be empty while the session tier still finds the trail.
+	sessions, err := events.SearchSessionHits(ctx, criteria, nil)
+	if err != nil {
+		t.Fatalf("SearchSessionHits() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("session hits = %d (events=%v), want 1 session for old-history-needle", len(sessions), eventIDs(gotEvents))
+	}
+	if diff := cmp.Diff("sess-old-history", sessions[0].SessionID().String()); diff != "" {
+		t.Fatalf("session id mismatch (-want +got):\n%s", diff)
+	}
+
+	// A further Initialize is a no-op once complete.
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("post-complete Initialize() error = %v", err)
+	}
+	again := projectionStatus(t, database)
+	if !again.Completed || again.State != "complete" {
+		t.Fatalf("post-complete status = %+v, want complete", again)
+	}
+}
+
+func TestSearchProjectionCatchUp_EmptyStoreStaysIdle(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	store := infra.NewStoreManagementDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	status := projectionStatus(t, database)
+	if status.State != "idle" {
+		t.Fatalf("empty store state = %q, want idle (no auto-start without source work)", status.State)
+	}
+}
+
+func TestSearchProjectionCatchUp_InterruptedMidRebuildResumesWithoutTwoLiveGenerations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	store := infra.NewStoreManagementDatasource(database)
+	if err := store.Initialize(ctx); err != nil {
+		t.Fatalf("bootstrap Initialize() error = %v", err)
+	}
+	resetProjectionToIdle(t, dbPath)
+
+	workspace := types.Workspace("github.com/duck8823/traceary")
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	// Enough events that a 1-row budget cannot finish in one Resume.
+	for i := 0; i < 5; i++ {
+		sessionID := types.SessionID("sess-batch")
+		seedSession(t, dbPath, sessionID.String(), base.Add(time.Duration(i)*time.Hour), workspace.String())
+		body := "interruptible-cutover-body-" + string(rune('a'+i)) + " unique"
+		event := newSearchEventWithSession(t, "evt-batch-"+string(rune('a'+i)), sessionID.String(), workspace.String(), body, base.Add(time.Duration(i)*time.Hour))
+		if err := infra.NewEventDatasource(database).Save(ctx, event); err != nil {
+			t.Fatalf("Save(%d): %v", i, err)
+		}
+	}
+
+	// Start with a tight budget so the first Resume cannot finish.
+	tight := apptypes.SearchProjectionBudget{
+		Rows: 1, WallTime: time.Minute, LockTime: time.Second,
+		StoredBytes: 1 << 20, DecodedBytes: 1 << 20, WriteBytes: 1 << 20,
+		RecentAge: 365 * 24 * time.Hour, RecentBytes: 1 << 20,
+	}
+	// Match catch-up config by using the same budget for start+resume so the
+	// auto path can take over. Use usecase directly for the interrupted start.
+	workflow := usecase.NewSearchProjectionUsecase(database)
+	if _, err := workflow.StartGeneration(ctx, tight, time.Now()); err != nil {
+		t.Fatalf("StartGeneration: %v", err)
+	}
+	first, err := workflow.Resume(ctx, tight, time.Now())
+	if err != nil {
+		t.Fatalf("first Resume: %v", err)
+	}
+	if first.Completed {
+		t.Fatal("first Resume completed; want an interrupted mid-rebuild")
+	}
+	// One generation rebuilding; no second live generation.
+	var genCount int
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM search_projection_generation_lifecycle WHERE state IN ('rebuilding','complete')`).Scan(&genCount); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if genCount != 1 {
+		t.Fatalf("live generations = %d, want 1 during interrupted rebuild", genCount)
+	}
+
+	// Resume with the same budget until complete (simulates subsequent opens
+	// that share the config hash). Auto catch-up would skip a mismatched budget;
+	// here the operator/auto budget is the tight one for the whole cutover.
+	var progress apptypes.SearchProjectionProgress
+	for i := 0; i < 50 && !progress.Completed; i++ {
+		progress, err = workflow.Resume(ctx, tight, time.Now())
+		if err != nil {
+			t.Fatalf("Resume #%d: %v", i+1, err)
+		}
+	}
+	if !progress.Completed {
+		t.Fatal("interrupted cutover did not resume to completion")
+	}
+	// After complete, only one complete lifecycle row should remain live as
+	// active; abandoned/failed may exist from other tests but not here.
+	var completeCount, rebuildingCount int
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if err := db.QueryRow(`SELECT COUNT(*) FROM search_projection_generation_lifecycle WHERE state='complete'`).Scan(&completeCount); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow(`SELECT COUNT(*) FROM search_projection_generation_lifecycle WHERE state='rebuilding'`).Scan(&rebuildingCount); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if completeCount != 1 || rebuildingCount != 0 {
+		t.Fatalf("after resume complete: complete=%d rebuilding=%d", completeCount, rebuildingCount)
+	}
+}
+
+func TestSearchProjectionVerifySessionTier_RejectsMissingHit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	if err := infra.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// Generation with a summary but no matching query path because the summary
+	// is empty / too short — verify should still vacuous-pass (no joinable ≥3
+	// rune summary). Seed a summary that looks real, then delete the session so
+	// the JOIN finds nothing → vacuous pass.
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if _, err := db.Exec(`
+			UPDATE search_projection_state
+			   SET generation_id='gen-verify', state='rebuilding', phase='cleanup', cleanup_scope='old'
+			 WHERE singleton=1`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO search_projection_session_summaries(generation_id,session_id,event_count,summary_text,projection_version,summary_version)
+			VALUES('gen-verify','orphan-session',1,'orphan summary text that would match',1,1)`); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// No sessions row → vacuous pass (nothing joinable).
+	if err := database.VerifySearchProjectionSessionTier(ctx, "gen-verify"); err != nil {
+		t.Fatalf("orphan summary without session should vacuous-pass, got %v", err)
+	}
+
+	// With a real session, verification must find the session via a real query.
+	seedSession(t, dbPath, "sess-verified", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), "ws")
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if _, err := db.Exec(`
+			INSERT INTO search_projection_session_summaries(generation_id,session_id,event_count,summary_text,projection_version,summary_version)
+			VALUES('gen-verify','sess-verified',3,'verified-session-needle for cutover',1,1)`); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if err := database.VerifySearchProjectionSessionTier(ctx, "gen-verify"); err != nil {
+		t.Fatalf("VerifySearchProjectionSessionTier() error = %v", err)
+	}
+}
+
+// TestSearchProjectionVerifySessionTier_PassesWhenSeveralSessionsShareATerm
+// pins the case a real corpus produces constantly: sessions in one workspace
+// share vocabulary, so the term derived from one summary also matches others.
+// Verification asks whether the session tier can answer, so any hit that
+// includes the probed session is an answer. Requiring the probed session to be
+// the top-ranked hit would fail every store whose summaries share a word, and
+// a failed verification marks the generation failed and restarts it — a loop
+// that never reaches complete.
+func TestSearchProjectionVerifySessionTier_PassesWhenSeveralSessionsShareATerm(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "traceary.db")
+	migrations, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := infra.NewDatabase(dbPath, migrations)
+	if err := infra.NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// The lexically first session is the verification candidate; the later one
+	// starts more recently, so it outranks the candidate in the hit query.
+	seedSession(t, dbPath, "sess-aaa", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), "ws")
+	seedSession(t, dbPath, "sess-zzz", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC), "ws")
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if _, err := db.Exec(`
+			UPDATE search_projection_state
+			   SET generation_id='gen-shared', state='rebuilding', phase='cleanup', cleanup_scope='old'
+			 WHERE singleton=1`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO search_projection_session_summaries(generation_id,session_id,event_count,summary_text,projection_version,summary_version)
+			VALUES('gen-shared','sess-aaa',2,'traceary rebuild alpha',1,1),
+			      ('gen-shared','sess-zzz',2,'traceary rebuild beta',1,1)`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := database.VerifySearchProjectionSessionTier(ctx, "gen-shared"); err != nil {
+		t.Fatalf("shared-vocabulary summaries must verify, got %v", err)
+	}
+}
+
+func projectionStatus(t *testing.T, database *infra.Database) apptypes.SearchProjectionStatus {
+	t.Helper()
+	status, err := database.SearchProjectionStatus(context.Background())
+	if err != nil {
+		t.Fatalf("SearchProjectionStatus: %v", err)
+	}
+	return status
+}
+
+func resetProjectionToIdle(t *testing.T, dbPath string) {
+	t.Helper()
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if _, err := db.Exec(`
+			UPDATE search_projection_state
+			   SET generation_id=NULL,
+			       active_generation_id=NULL,
+			       config_hash='',
+			       source_revision=0,
+			       high_water=0,
+			       checkpoint=0,
+			       phase='source',
+			       cleanup_scope='old',
+			       failure_class='',
+			       state='idle',
+			       cutover_index_family='',
+			       cutover_family_bytes_before=0,
+			       cutover_family_bytes_after=0
+			 WHERE singleton=1`); err != nil {
+			t.Fatalf("reset projection idle: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM search_projection_generation_lifecycle`); err != nil {
+			t.Fatalf("clear lifecycle: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM search_projection_recent_documents`); err != nil {
+			t.Fatalf("clear recent docs: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM search_projection_session_summaries`); err != nil {
+			t.Fatalf("clear summaries: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM search_projection_session_keywords`); err != nil {
+			t.Fatalf("clear keywords: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM search_projection_command_aggregates`); err != nil {
+			t.Fatalf("clear aggregates: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM literal_search_fingerprints`); err != nil {
+			t.Fatalf("clear fingerprints: %v", err)
+		}
+		if _, err := db.Exec(`UPDATE search_projection_inventory_state SET generation_id='',cursor='',cursor_started=0,state='idle' WHERE singleton=1`); err != nil {
+			t.Fatalf("reset inventory: %v", err)
+		}
+	})
+}
+
+func seedSession(t *testing.T, dbPath, sessionID string, startedAt time.Time, workspace string) {
+	t.Helper()
+	openRawDB(t, dbPath, func(db *sql.DB) {
+		if _, err := db.Exec(`
+			INSERT OR IGNORE INTO sessions(session_id, started_at, client, agent, workspace)
+			VALUES (?, ?, 'cli', 'codex', ?)`,
+			sessionID, startedAt.UTC().Format(time.RFC3339Nano), workspace,
+		); err != nil {
+			t.Fatalf("seed session %s: %v", sessionID, err)
+		}
+	})
+}

--- a/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
+++ b/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
@@ -1,0 +1,201 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// newProjectionEvidenceStore builds a migrated store holding one session and a
+// couple of events, parked at idle so the test owns the generation.
+func newProjectionEvidenceStore(t *testing.T) (*Database, string) {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "store.db")
+	database := NewDatabase(dbPath, os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(ctx, `
+		INSERT OR IGNORE INTO sessions(session_id,started_at,client,agent,workspace)
+		VALUES('sess-evidence','2026-01-05T12:00:00Z','cli','codex','github.com/duck8823/traceary')`); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"evt-evidence-1", "evt-evidence-2"} {
+		if _, err = raw.ExecContext(ctx, `
+			INSERT INTO events(id,kind,client,agent,session_id,workspace,body,created_at)
+			VALUES(?,'note','cli','codex','sess-evidence','github.com/duck8823/traceary','cutover evidence body','2026-01-05T12:00:00Z')`, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Initialize already ran one catch-up unit; park the projection so each
+	// test drives the generation from a known idle state.
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE search_projection_state
+		   SET generation_id=NULL,active_generation_id=NULL,config_hash='',source_revision=0,
+		       high_water=0,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',
+		       state='idle',cutover_index_family='',cutover_family_bytes_before=0,
+		       cutover_family_bytes_after=0,cutover_evidence_status='',cutover_evidence_reason=''
+		 WHERE singleton=1;
+		DELETE FROM search_projection_generation_lifecycle;
+		DELETE FROM search_projection_recent_documents;
+		DELETE FROM search_projection_session_summaries;
+		DELETE FROM search_projection_session_keywords;
+		DELETE FROM search_projection_command_aggregates;
+		DELETE FROM literal_search_fingerprints;
+		UPDATE search_projection_inventory_state SET generation_id='',cursor='',cursor_started=0,state='idle' WHERE singleton=1;
+		UPDATE literal_search_projection_state SET generation_id='',high_water=0,state='missing' WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	return database, dbPath
+}
+
+// driveProjectionToCompletion runs bounded catch-up units the way repeated
+// store opens would, and fails the test if the generation never completes.
+func driveProjectionToCompletion(t *testing.T, database *Database) {
+	t.Helper()
+	ctx := context.Background()
+	for attempt := 0; attempt < 50; attempt++ {
+		result, err := catchUpSearchProjection(ctx, database)
+		if err != nil {
+			t.Fatalf("catch-up attempt %d: %v", attempt, err)
+		}
+		if result.Completed {
+			return
+		}
+		if result.Action == "skipped" {
+			t.Fatalf("catch-up attempt %d skipped: %s", attempt, result.SkippedReason)
+		}
+	}
+	t.Fatal("projection never completed within 50 catch-up units")
+}
+
+// TestSearchProjectionCutoverEvidence_CompletionSurvivesUnmeasurableFamily pins
+// the split between a completed generation and its diagnostic byte figures. The
+// dbstat walk costs in proportion to the projection family's own page count
+// (measured at 1.44s for an ~880MiB family), so it cannot be allowed to share
+// the completion transaction's lock budget: a walk that overran it rolled the
+// completion back and left every later open repeating the same final batch.
+// When the measurement cannot produce a figure the generation still completes
+// and the evidence says so, rather than recording a zero that reads exactly
+// like a genuinely empty family.
+func TestSearchProjectionCutoverEvidence_CompletionSurvivesUnmeasurableFamily(t *testing.T) {
+	tests := map[string]struct {
+		measureTimeout time.Duration
+		wantStatus     string
+		wantMeasured   bool
+	}{
+		"measurable family reports measured evidence":             {measureTimeout: 0, wantStatus: "measured", wantMeasured: true},
+		"unmeasurable family reports unavailable, not zero bytes": {measureTimeout: time.Nanosecond, wantStatus: "unavailable"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			database, _ := newProjectionEvidenceStore(t)
+			database.searchProjectionMeasureTimeoutOverride = test.measureTimeout
+			driveProjectionToCompletion(t, database)
+
+			status, err := database.SearchProjectionStatus(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !status.Completed {
+				t.Fatalf("generation state = %q, want complete", status.State)
+			}
+			if diff := cmp.Diff(test.wantStatus, status.CutoverFamilyEvidence.Status); diff != "" {
+				t.Errorf("cutover evidence status (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff("dbstat", status.CutoverFamilyEvidence.Method); diff != "" {
+				t.Errorf("cutover evidence method (-want +got):\n%s", diff)
+			}
+			switch {
+			case test.wantMeasured:
+				if status.CutoverFamilyBytesAfter <= 0 {
+					t.Errorf("measured family bytes = %d, want > 0", status.CutoverFamilyBytesAfter)
+				}
+				if status.CutoverFamilyEvidence.Reason != "" {
+					t.Errorf("measured evidence carries a reason: %q", status.CutoverFamilyEvidence.Reason)
+				}
+			default:
+				// The distinguishing property: bytes are zero, and the evidence
+				// is what says the zero means "not measured".
+				if status.CutoverFamilyBytesAfter != 0 {
+					t.Errorf("unavailable family bytes = %d, want 0", status.CutoverFamilyBytesAfter)
+				}
+				if strings.TrimSpace(status.CutoverFamilyEvidence.Reason) == "" {
+					t.Error("unavailable evidence carries no reason")
+				}
+			}
+		})
+	}
+}
+
+// TestSearchProjectionCatchUp_ParksDeterministicFailureInsteadOfRestarting pins
+// that a failed generation is not restarted on every store open. Every failure
+// class this store records is deterministic — an oversize row exceeds the same
+// budget every time, session_tier_unverified fails the same query, abandoned is
+// an operator decision — so auto-starting a replacement would fail identically
+// and append a lifecycle row per open, forever.
+func TestSearchProjectionCatchUp_ParksDeterministicFailureInsteadOfRestarting(t *testing.T) {
+	ctx := context.Background()
+	for _, failureClass := range []string{"decoded_bytes", "session_tier_unverified", "abandoned"} {
+		t.Run(failureClass, func(t *testing.T) {
+			database, _ := newProjectionEvidenceStore(t)
+			raw, err := database.open(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = raw.ExecContext(ctx, `
+				UPDATE search_projection_state
+				   SET generation_id='gen-failed',state='failed',phase='complete',failure_class=?
+				 WHERE singleton=1`, failureClass); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = raw.ExecContext(ctx, `
+				INSERT INTO search_projection_generation_lifecycle(generation_id,state,config_hash,source_revision,high_water)
+				VALUES('gen-failed','rebuilding','',0,0)`); err != nil {
+				t.Fatal(err)
+			}
+			_ = raw.Close()
+
+			for open := 0; open < 3; open++ {
+				result, catchUpErr := catchUpSearchProjection(ctx, database)
+				if catchUpErr != nil {
+					t.Fatalf("open %d: %v", open, catchUpErr)
+				}
+				if diff := cmp.Diff("skipped", result.Action); diff != "" {
+					t.Fatalf("open %d action (-want +got):\n%s", open, diff)
+				}
+				if !strings.Contains(result.SkippedReason, failureClass) {
+					t.Fatalf("open %d skip reason %q does not name the failure class", open, result.SkippedReason)
+				}
+			}
+			if generations := lifecycleGenerationCount(t, database); generations != 1 {
+				t.Errorf("lifecycle rows after three opens = %d, want 1 (no replacement generations)", generations)
+			}
+		})
+	}
+}
+
+func lifecycleGenerationCount(t *testing.T, database *Database) int {
+	t.Helper()
+	raw, err := database.open(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	var count int
+	if err = raw.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM search_projection_generation_lifecycle`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
+++ b/infrastructure/sqlite/search_projection_cutover_evidence_internal_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	apptypes "github.com/duck8823/traceary/application/types"
 )
 
 // newProjectionEvidenceStore builds a migrated store holding one session and a
@@ -45,7 +48,7 @@ func newProjectionEvidenceStore(t *testing.T) (*Database, string) {
 		   SET generation_id=NULL,active_generation_id=NULL,config_hash='',source_revision=0,
 		       high_water=0,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',
 		       state='idle',cutover_index_family='',cutover_family_bytes_before=0,
-		       cutover_family_bytes_after=0,cutover_evidence_status='',cutover_evidence_reason=''
+		       cutover_family_bytes_after=0,cutover_before_evidence_status='',cutover_before_evidence_reason='',cutover_after_evidence_status='',cutover_after_evidence_reason=''
 		 WHERE singleton=1;
 		DELETE FROM search_projection_generation_lifecycle;
 		DELETE FROM search_projection_recent_documents;
@@ -83,12 +86,12 @@ func driveProjectionToCompletion(t *testing.T, database *Database) {
 // TestSearchProjectionCutoverEvidence_CompletionSurvivesUnmeasurableFamily pins
 // the split between a completed generation and its diagnostic byte figures. The
 // dbstat walk costs in proportion to the projection family's own page count
-// (measured at 1.44s for an ~880MiB family), so it cannot be allowed to share
-// the completion transaction's lock budget: a walk that overran it rolled the
-// completion back and left every later open repeating the same final batch.
-// When the measurement cannot produce a figure the generation still completes
-// and the evidence says so, rather than recording a zero that reads exactly
-// like a genuinely empty family.
+// (measured at 1.44s for an ~880MiB family), so it cannot share the completion
+// transaction's lock budget: a walk that overran it rolled the completion back
+// and left every later open repeating the same final batch. When the
+// measurement cannot produce a figure the generation still completes and the
+// evidence says so, rather than recording a zero that reads exactly like a
+// genuinely empty family.
 func TestSearchProjectionCutoverEvidence_CompletionSurvivesUnmeasurableFamily(t *testing.T) {
 	tests := map[string]struct {
 		measureTimeout time.Duration
@@ -111,31 +114,119 @@ func TestSearchProjectionCutoverEvidence_CompletionSurvivesUnmeasurableFamily(t 
 			if !status.Completed {
 				t.Fatalf("generation state = %q, want complete", status.State)
 			}
-			if diff := cmp.Diff(test.wantStatus, status.CutoverFamilyEvidence.Status); diff != "" {
-				t.Errorf("cutover evidence status (-want +got):\n%s", diff)
+			// Before and after carry their own evidence: they are measured at
+			// different times against families of different sizes, and one
+			// succeeding says nothing about the other.
+			for label, got := range map[string]struct {
+				evidence apptypes.CapacityEvidence
+				bytes    int64
+			}{
+				"before": {status.CutoverBeforeEvidence, status.CutoverFamilyBytesBefore},
+				"after":  {status.CutoverAfterEvidence, status.CutoverFamilyBytesAfter},
+			} {
+				if diff := cmp.Diff(test.wantStatus, got.evidence.Status); diff != "" {
+					t.Errorf("%s evidence status (-want +got):\n%s", label, diff)
+				}
+				if diff := cmp.Diff("dbstat", got.evidence.Method); diff != "" {
+					t.Errorf("%s evidence method (-want +got):\n%s", label, diff)
+				}
+				if !test.wantMeasured {
+					// The distinguishing property: bytes are zero, and the
+					// evidence is what says the zero means "not measured".
+					if got.bytes != 0 {
+						t.Errorf("%s bytes = %d, want 0", label, got.bytes)
+					}
+					if strings.TrimSpace(got.evidence.Reason) == "" {
+						t.Errorf("%s unavailable evidence carries no reason", label)
+					}
+				} else if got.evidence.Reason != "" {
+					t.Errorf("%s measured evidence carries a reason: %q", label, got.evidence.Reason)
+				}
 			}
-			if diff := cmp.Diff("dbstat", status.CutoverFamilyEvidence.Method); diff != "" {
-				t.Errorf("cutover evidence method (-want +got):\n%s", diff)
-			}
-			switch {
-			case test.wantMeasured:
-				if status.CutoverFamilyBytesAfter <= 0 {
-					t.Errorf("measured family bytes = %d, want > 0", status.CutoverFamilyBytesAfter)
-				}
-				if status.CutoverFamilyEvidence.Reason != "" {
-					t.Errorf("measured evidence carries a reason: %q", status.CutoverFamilyEvidence.Reason)
-				}
-			default:
-				// The distinguishing property: bytes are zero, and the evidence
-				// is what says the zero means "not measured".
-				if status.CutoverFamilyBytesAfter != 0 {
-					t.Errorf("unavailable family bytes = %d, want 0", status.CutoverFamilyBytesAfter)
-				}
-				if strings.TrimSpace(status.CutoverFamilyEvidence.Reason) == "" {
-					t.Error("unavailable evidence carries no reason")
-				}
+			// Only the after figure has a family to measure; before runs against
+			// an empty one, so its byte count is not asserted as positive.
+			if test.wantMeasured && status.CutoverFamilyBytesAfter <= 0 {
+				t.Errorf("measured family bytes after = %d, want > 0", status.CutoverFamilyBytesAfter)
 			}
 		})
+	}
+}
+
+// TestSearchProjectionCutoverEvidence_RecordsOnACancelledBatchContext pins that
+// evidence is written on a context detached from the batch. The batch context is
+// sized for one bounded unit of work and is routinely near expiry by the time a
+// generation completes, so a write inheriting it would fail exactly when the
+// walk was slow enough to matter — leaving an unrecorded figure sitting at zero
+// while the status still claimed "measured" from the start-time walk.
+func TestSearchProjectionCutoverEvidence_RecordsOnACancelledBatchContext(t *testing.T) {
+	database, _ := newProjectionEvidenceStore(t)
+	driveProjectionToCompletion(t, database)
+	raw, err := database.open(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(context.Background(), `
+		UPDATE search_projection_state
+		   SET cutover_family_bytes_after=0,cutover_after_evidence_status='',cutover_after_evidence_reason=''
+		 WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	database.recordSearchProjectionCutoverEvidence(cancelled, raw, activeGenerationID(t, raw), time.Now().UTC())
+
+	after, err := database.SearchProjectionStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff("measured", after.CutoverAfterEvidence.Status); diff != "" {
+		t.Errorf("after evidence status on a cancelled batch context (-want +got):\n%s", diff)
+	}
+	if after.CutoverFamilyBytesAfter <= 0 {
+		t.Errorf("after bytes = %d, want > 0", after.CutoverFamilyBytesAfter)
+	}
+}
+
+// TestSearchProjectionCutoverEvidence_DoesNotOverwriteAReplacementGeneration
+// pins the generation fence. Another process can start a replacement between the
+// completion commit and the evidence write: that moves generation_id on but
+// leaves active_generation_id pointing at the completed one, so matching on the
+// active pointer alone would stamp the old generation's after-evidence over the
+// new generation's before-evidence.
+func TestSearchProjectionCutoverEvidence_DoesNotOverwriteAReplacementGeneration(t *testing.T) {
+	database, _ := newProjectionEvidenceStore(t)
+	driveProjectionToCompletion(t, database)
+	raw, err := database.open(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	completedGeneration := activeGenerationID(t, raw)
+	// A replacement generation: generation_id moves on, active stays behind.
+	if _, err = raw.ExecContext(context.Background(), `
+		UPDATE search_projection_state
+		   SET generation_id='gen-replacement',state='rebuilding',phase='source',
+		       cutover_family_bytes_after=0,cutover_after_evidence_status='',cutover_after_evidence_reason=''
+		 WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(context.Background(), `
+		INSERT INTO search_projection_generation_lifecycle(generation_id,state,config_hash,source_revision,high_water)
+		VALUES('gen-replacement','rebuilding','',0,0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	database.recordSearchProjectionCutoverEvidence(context.Background(), raw, completedGeneration, time.Now().UTC())
+
+	after, err := database.SearchProjectionStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.CutoverAfterEvidence.Status != "" || after.CutoverFamilyBytesAfter != 0 {
+		t.Errorf("replacement generation evidence overwritten: status=%q bytes=%d",
+			after.CutoverAfterEvidence.Status, after.CutoverFamilyBytesAfter)
 	}
 }
 
@@ -198,4 +289,16 @@ func lifecycleGenerationCount(t *testing.T, database *Database) int {
 		t.Fatal(err)
 	}
 	return count
+}
+
+func activeGenerationID(t *testing.T, raw *sql.DB) string {
+	t.Helper()
+	var generation string
+	if err := raw.QueryRowContext(context.Background(), `SELECT COALESCE(active_generation_id,'') FROM search_projection_state WHERE singleton=1`).Scan(&generation); err != nil {
+		t.Fatal(err)
+	}
+	if generation == "" {
+		t.Fatal("no active generation to record evidence against")
+	}
+	return generation
 }

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -45,6 +46,9 @@ func (d *Database) Start(ctx context.Context, b apptypes.SearchProjectionBudget,
 		return apptypes.SearchProjectionGeneration{}, e
 	}
 	defer db.Close()
+	// Measure before taking the write lock. The dbstat walk is unbounded in the
+	// family's own size and would otherwise consume the start budget.
+	familyBytesBefore, beforeEvidence := d.measureSearchProjectionFamilyBytes(ctx, db)
 	lockCtx, cancel := context.WithTimeout(ctx, b.LockTime)
 	defer cancel()
 	tx, e := db.BeginTx(lockCtx, nil)
@@ -63,11 +67,7 @@ func (d *Database) Start(ctx context.Context, b apptypes.SearchProjectionBudget,
 	if requiresInventory != 0 {
 		g.HighWater = 0
 	}
-	familyBytesBefore, measureErr := measureSearchProjectionFamilyBytes(lockCtx, tx)
-	if measureErr != nil {
-		return g, measureErr
-	}
-	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, searchProjectionIndexFamilyName, familyBytesBefore, formatTimestamp(now.UTC()))
+	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,cutover_evidence_status=?,cutover_evidence_reason=?,updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, searchProjectionIndexFamilyName, familyBytesBefore, beforeEvidence.Status, beforeEvidence.Reason, formatTimestamp(now.UTC()))
 	if e == nil {
 		if n, x := result.RowsAffected(); x != nil || n != 1 {
 			return g, &apptypes.SearchProjectionNoProgressError{Reason: "a generation is already rebuilding"}
@@ -683,14 +683,7 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 			return out, &apptypes.SearchProjectionDriftError{}
 		}
 	}
-	familyBytesAfter := int64(0)
-	if p.Completed && state == "complete" {
-		familyBytesAfter, e = measureSearchProjectionFamilyBytes(lockCtx, tx)
-		if e != nil {
-			return out, e
-		}
-	}
-	r, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,cutover_family_bytes_after=CASE WHEN ? AND ?='complete' THEN ? ELSE cutover_family_bytes_after END,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?))`, p.NextCheckpoint, next, state, p.Completed, state, time.Since(started).Milliseconds(), p.Completed, state, familyBytesAfter, formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision)
+	r, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?))`, p.NextCheckpoint, next, state, p.Completed, state, time.Since(started).Milliseconds(), formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision)
 	if e != nil {
 		return out, e
 	}
@@ -699,6 +692,14 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 	}
 	if e = tx.Commit(); e != nil {
 		return out, e
+	}
+	// Cutover evidence is recorded after the completion is durable. Measuring
+	// inside that transaction would put an unbounded dbstat walk under the lock
+	// budget, and a walk that overran it rolled back a generation that had
+	// otherwise finished — leaving the store to repeat the same final batch on
+	// every open, forever.
+	if p.Completed && state == "complete" {
+		d.recordSearchProjectionCutoverEvidence(ctx, db, p.GenerationID, now)
 	}
 	out.Completed = p.Completed
 	out.GenerationID = p.GenerationID
@@ -771,9 +772,14 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	s.SchemaVersion = "traceary.search-projection-status/v1"
 	s.KeywordVersion = searchProjectionKeywordVersion
 	s.FingerprintVersion = 1
-	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),''),COALESCE(cutover_index_family,''),cutover_family_bytes_before,cutover_family_bytes_after FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt, &s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter)
+	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),''),COALESCE(cutover_index_family,''),cutover_family_bytes_before,cutover_family_bytes_after,COALESCE(cutover_evidence_status,''),COALESCE(cutover_evidence_reason,''),COALESCE(failure_class,'') FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt, &s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter, &s.CutoverFamilyEvidence.Status, &s.CutoverFamilyEvidence.Reason, &s.FailureClass)
 	if e != nil {
 		return s, e
+	}
+	// Method is not persisted: dbstat is the only way this figure is ever
+	// produced, so it is derived rather than stored per row.
+	if s.CutoverFamilyEvidence.Status != "" {
+		s.CutoverFamilyEvidence.Method = "dbstat"
 	}
 	var inventoryState string
 	if e = db.QueryRowContext(ctx, `SELECT state FROM search_projection_inventory_state WHERE singleton=1`).Scan(&inventoryState); e != nil {
@@ -814,16 +820,36 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	return s, e
 }
 
+// searchProjectionMeasureTimeout bounds the cutover evidence measurement. The
+// dbstat walk costs in proportion to the projection family's own page count —
+// measured at 1.44s for an ~880MiB family — so it must never share a deadline
+// with the transaction that publishes a completed generation. Exceeding this
+// yields unavailable evidence, never a failed generation.
+const searchProjectionMeasureTimeout = 3 * time.Second
+
 // measureSearchProjectionFamilyBytes returns dbstat physical bytes for the
 // bounded search projection family only (search_projection_* and
 // literal_search_*). It deliberately excludes the legacy event_search_* family.
 //
-//nolint:wrapcheck // SQL errors stay adapter-owned at this boundary.
-func measureSearchProjectionFamilyBytes(ctx context.Context, q interface {
+// The figure is diagnostic: nothing reads it to decide anything. So this never
+// returns an error. Anything that stops it producing a number — a missing
+// dbstat module, a slow walk, a cancelled parent — comes back as unavailable
+// evidence carrying the reason, which is recorded and logged. Recording a bare
+// zero instead would be indistinguishable from a genuinely empty family.
+func (d *Database) measureSearchProjectionFamilyBytes(ctx context.Context, q interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
-}) (int64, error) {
+}) (int64, apptypes.CapacityEvidence) {
+	timeout := searchProjectionMeasureTimeout
+	if d.searchProjectionMeasureTimeoutOverride > 0 {
+		timeout = d.searchProjectionMeasureTimeoutOverride
+	}
+	// WithoutCancel deliberately detaches from the caller's deadline: the batch
+	// context is sized for the write lock, and evidence must be measurable on
+	// its own terms or reported unavailable — never able to fail the batch.
+	measureCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
 	var bytes int64
-	err := q.QueryRowContext(ctx, `
+	err := q.QueryRowContext(measureCtx, `
 		SELECT COALESCE(SUM(pgsize), 0)
 		  FROM dbstat
 		 WHERE name IN (
@@ -836,15 +862,61 @@ func measureSearchProjectionFamilyBytes(ctx context.Context, q interface {
 		       )`,
 	).Scan(&bytes)
 	if err != nil {
-		// dbstat is optional on some builds; treat unavailability as zero rather
-		// than blocking generation start. Status already reports the same gap.
-		if strings.Contains(strings.ToLower(err.Error()), "no such table") ||
-			strings.Contains(strings.ToLower(err.Error()), "no such module") {
-			return 0, nil
+		return 0, apptypes.CapacityEvidence{
+			Status: searchProjectionEvidenceUnavailable,
+			Method: "dbstat",
+			Reason: truncateEvidenceReason(err.Error()),
 		}
-		return 0, err
 	}
-	return bytes, nil
+	return bytes, apptypes.CapacityEvidence{Status: searchProjectionEvidenceMeasured, Method: "dbstat"}
+}
+
+const (
+	searchProjectionEvidenceMeasured    = "measured"
+	searchProjectionEvidenceUnavailable = "unavailable"
+	maxEvidenceReasonBytes              = 200
+)
+
+// recordSearchProjectionCutoverEvidence measures the bounded family and stores
+// the result against an already-durable completion. Failure here loses a
+// diagnostic figure and nothing else, so it is logged rather than returned —
+// the generation is complete either way. The write is scoped to the generation
+// that just completed so a concurrent start cannot be overwritten.
+func (d *Database) recordSearchProjectionCutoverEvidence(ctx context.Context, db *sql.DB, generationID string, now time.Time) {
+	bytes, evidence := d.measureSearchProjectionFamilyBytes(ctx, db)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE search_projection_state
+		   SET cutover_family_bytes_after = ?,
+		       cutover_evidence_status = ?,
+		       cutover_evidence_reason = ?,
+		       updated_at = ?
+		 WHERE singleton = 1 AND active_generation_id = ?`,
+		bytes, evidence.Status, evidence.Reason, formatTimestamp(now), generationID,
+	); err != nil {
+		slog.Warn("search projection cutover evidence not recorded; generation is complete regardless",
+			"generation_id", generationID,
+			"evidence_status", evidence.Status,
+			"error", err,
+		)
+		return
+	}
+	if evidence.Status == searchProjectionEvidenceUnavailable {
+		slog.Warn("search projection cutover evidence unavailable; before/after family bytes are not reportable",
+			"generation_id", generationID,
+			"method", evidence.Method,
+			"reason", evidence.Reason,
+		)
+	}
+}
+
+// truncateEvidenceReason keeps a diagnostic reason bounded so a pathological
+// driver message cannot bloat the state row.
+func truncateEvidenceReason(reason string) string {
+	trimmed := strings.TrimSpace(reason)
+	if len(trimmed) <= maxEvidenceReasonBytes {
+		return trimmed
+	}
+	return trimmed[:maxEvidenceReasonBytes]
 }
 
 // VerifySearchProjectionSessionTier runs a real session-tier query against the

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	apptypes "github.com/duck8823/traceary/application/types"
 	domaintypes "github.com/duck8823/traceary/domain/types"
 )
@@ -16,6 +18,11 @@ import (
 const searchProjectionVersion = 1
 const searchProjectionKeywordVersion = 1
 const searchProjectionSummaryVersion = 1
+
+// searchProjectionIndexFamilyName is the durable label for physical bytes of
+// the bounded projection (search_projection_* + literal_search_*). It is never
+// the legacy migration-032 event_search_* family — that number belongs to #1718.
+const searchProjectionIndexFamilyName = "bounded_search_projection"
 
 func generationID() string {
 	var b [16]byte
@@ -56,7 +63,11 @@ func (d *Database) Start(ctx context.Context, b apptypes.SearchProjectionBudget,
 	if requiresInventory != 0 {
 		g.HighWater = 0
 	}
-	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, formatTimestamp(now.UTC()))
+	familyBytesBefore, measureErr := measureSearchProjectionFamilyBytes(lockCtx, tx)
+	if measureErr != nil {
+		return g, measureErr
+	}
+	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, searchProjectionIndexFamilyName, familyBytesBefore, formatTimestamp(now.UTC()))
 	if e == nil {
 		if n, x := result.RowsAffected(); x != nil || n != 1 {
 			return g, &apptypes.SearchProjectionNoProgressError{Reason: "a generation is already rebuilding"}
@@ -672,7 +683,14 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 			return out, &apptypes.SearchProjectionDriftError{}
 		}
 	}
-	r, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?))`, p.NextCheckpoint, next, state, p.Completed, state, time.Since(started).Milliseconds(), formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision)
+	familyBytesAfter := int64(0)
+	if p.Completed && state == "complete" {
+		familyBytesAfter, e = measureSearchProjectionFamilyBytes(lockCtx, tx)
+		if e != nil {
+			return out, e
+		}
+	}
+	r, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET checkpoint=?,phase=?,state=?,active_generation_id=CASE WHEN ? AND ?='complete' THEN generation_id ELSE active_generation_id END,last_batch_milliseconds=?,cutover_family_bytes_after=CASE WHEN ? AND ?='complete' THEN ? ELSE cutover_family_bytes_after END,updated_at=? WHERE generation_id=? AND source_revision=? AND checkpoint=? AND phase=? AND (? OR EXISTS(SELECT 1 FROM search_projection_source_revision WHERE singleton=1 AND revision=?))`, p.NextCheckpoint, next, state, p.Completed, state, time.Since(started).Milliseconds(), p.Completed, state, familyBytesAfter, formatTimestamp(now), p.GenerationID, p.ExpectedRevision, p.ExpectedCheckpoint, p.Phase, p.AllowRevisionDrift, p.ExpectedRevision)
 	if e != nil {
 		return out, e
 	}
@@ -753,7 +771,7 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	s.SchemaVersion = "traceary.search-projection-status/v1"
 	s.KeywordVersion = searchProjectionKeywordVersion
 	s.FingerprintVersion = 1
-	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),'') FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt)
+	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),''),COALESCE(cutover_index_family,''),cutover_family_bytes_before,cutover_family_bytes_after FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt, &s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter)
 	if e != nil {
 		return s, e
 	}
@@ -794,6 +812,153 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	}
 	s.InspectionMilliseconds = time.Since(started).Milliseconds()
 	return s, e
+}
+
+// measureSearchProjectionFamilyBytes returns dbstat physical bytes for the
+// bounded search projection family only (search_projection_* and
+// literal_search_*). It deliberately excludes the legacy event_search_* family.
+//
+//nolint:wrapcheck // SQL errors stay adapter-owned at this boundary.
+func measureSearchProjectionFamilyBytes(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (int64, error) {
+	var bytes int64
+	err := q.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(pgsize), 0)
+		  FROM dbstat
+		 WHERE name IN (
+		         SELECT name
+		           FROM sqlite_schema
+		          WHERE name LIKE 'search_projection_%'
+		             OR tbl_name LIKE 'search_projection_%'
+		             OR name LIKE 'literal_search_%'
+		             OR tbl_name LIKE 'literal_search_%'
+		       )`,
+	).Scan(&bytes)
+	if err != nil {
+		// dbstat is optional on some builds; treat unavailability as zero rather
+		// than blocking generation start. Status already reports the same gap.
+		if strings.Contains(strings.ToLower(err.Error()), "no such table") ||
+			strings.Contains(strings.ToLower(err.Error()), "no such module") {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return bytes, nil
+}
+
+// VerifySearchProjectionSessionTier runs a real session-tier query against the
+// generation under construction (not necessarily active_generation_id) and
+// requires it to return the expected session. This is the pre-cleanup gate:
+// reclaiming the previous generation is only safe once the new session tier
+// answers. An empty generation (no joinable summaries) passes vacuously.
+//
+//nolint:wrapcheck // Typed projection errors cross this adapter unchanged.
+func (d *Database) VerifySearchProjectionSessionTier(ctx context.Context, generationID string) error {
+	if strings.TrimSpace(generationID) == "" {
+		return &apptypes.SearchProjectionNoProgressError{Reason: "session tier verification requires a generation id"}
+	}
+	db, err := d.open(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return verifySearchProjectionSessionTier(ctx, db, generationID)
+}
+
+func verifySearchProjectionSessionTier(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, generationID string) error {
+	var sessionID, summary string
+	err := q.QueryRowContext(ctx, `
+		SELECT sum.session_id, sum.summary_text
+		  FROM search_projection_session_summaries sum
+		  JOIN sessions s ON s.session_id = sum.session_id
+		 WHERE sum.generation_id = ?
+		   AND length(trim(sum.summary_text)) >= 3
+		 ORDER BY sum.session_id
+		 LIMIT 1`,
+		generationID,
+	).Scan(&sessionID, &summary)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// No joinable session summary: either the corpus is empty or only
+			// orphan events exist. Session tier has nothing to answer; do not
+			// block reclaim of an empty previous generation.
+			return nil
+		}
+		return xerrors.Errorf("select session tier verification candidate: %w", err)
+	}
+	term := sessionTierVerificationTerm(summary)
+	if term == "" {
+		return &apptypes.SearchProjectionNoProgressError{Reason: "session tier verification could not derive a query term"}
+	}
+	// Same contract as queryProjectionSessionHits: keyword equality or summary
+	// LIKE, pinned to the generation under construction and scoped to the
+	// probed session. The scope matters: sessions in one workspace share
+	// vocabulary, so a term drawn from one summary routinely matches others.
+	// The question this gate asks is whether the tier can answer for a session
+	// it holds a summary for — not whether that session outranks its peers.
+	// Ranking is a search concern, and demanding the top slot here would fail
+	// every store whose summaries share a word.
+	keyword := foldSearchASCII(term)
+	likeQuery := "%" + escapeLikeQuery(term) + "%"
+	var hitSession string
+	err = q.QueryRowContext(ctx, `
+		SELECT sum.session_id
+		  FROM search_projection_session_summaries sum
+		  JOIN sessions s ON s.session_id = sum.session_id
+		 WHERE sum.generation_id = ?
+		   AND sum.session_id = ?
+		   AND (
+		         EXISTS (
+		           SELECT 1
+		             FROM search_projection_session_keywords k
+		            WHERE k.generation_id = sum.generation_id
+		              AND k.session_id = sum.session_id
+		              AND k.keyword = ?
+		         )
+		         OR sum.summary_text LIKE ? ESCAPE '\'
+		       )
+		 ORDER BY ts_norm(s.started_at) DESC, s.session_id DESC
+		 LIMIT 1`,
+		generationID, sessionID, keyword, likeQuery,
+	).Scan(&hitSession)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &apptypes.SearchProjectionNoProgressError{
+				Reason: "session tier verification query returned no hits for generation " + generationID,
+			}
+		}
+		return xerrors.Errorf("run session tier verification query: %w", err)
+	}
+	if hitSession != sessionID {
+		return &apptypes.SearchProjectionNoProgressError{
+			Reason: "session tier verification returned unexpected session " + hitSession,
+		}
+	}
+	return nil
+}
+
+// sessionTierVerificationTerm picks a stable ≥3-rune token from a summary so
+// the verification query exercises the same LIKE path production search uses.
+func sessionTierVerificationTerm(summary string) string {
+	fields := strings.Fields(summary)
+	for _, field := range fields {
+		runes := []rune(strings.TrimSpace(field))
+		if len(runes) >= 3 {
+			return string(runes)
+		}
+	}
+	runes := []rune(strings.TrimSpace(summary))
+	if len(runes) < 3 {
+		return ""
+	}
+	if len(runes) > 32 {
+		runes = runes[:32]
+	}
+	return string(runes)
 }
 
 func projectionCutoff(timestamp time.Time) string {

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -67,7 +67,7 @@ func (d *Database) Start(ctx context.Context, b apptypes.SearchProjectionBudget,
 	if requiresInventory != 0 {
 		g.HighWater = 0
 	}
-	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,cutover_evidence_status=?,cutover_evidence_reason=?,updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, searchProjectionIndexFamilyName, familyBytesBefore, beforeEvidence.Status, beforeEvidence.Reason, formatTimestamp(now.UTC()))
+	result, e := tx.ExecContext(lockCtx, `UPDATE search_projection_state SET generation_id=?,config_hash=?,source_revision=?,high_water=?,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='rebuilding',recent_age_seconds=?,recent_byte_limit=?,cutover_index_family=?,cutover_family_bytes_before=?,cutover_family_bytes_after=0,cutover_before_evidence_status=?,cutover_before_evidence_reason=?,cutover_after_evidence_status='',cutover_after_evidence_reason='',updated_at=? WHERE singleton=1 AND state<>'rebuilding'`, g.GenerationID, g.ConfigHash, g.SourceRevision, g.HighWater, int64(b.RecentAge/time.Second), b.RecentBytes, searchProjectionIndexFamilyName, familyBytesBefore, beforeEvidence.Status, beforeEvidence.Reason, formatTimestamp(now.UTC()))
 	if e == nil {
 		if n, x := result.RowsAffected(); x != nil || n != 1 {
 			return g, &apptypes.SearchProjectionNoProgressError{Reason: "a generation is already rebuilding"}
@@ -772,14 +772,16 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 	s.SchemaVersion = "traceary.search-projection-status/v1"
 	s.KeywordVersion = searchProjectionKeywordVersion
 	s.FingerprintVersion = 1
-	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),''),COALESCE(cutover_index_family,''),cutover_family_bytes_before,cutover_family_bytes_after,COALESCE(cutover_evidence_status,''),COALESCE(cutover_evidence_reason,''),COALESCE(failure_class,'') FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt, &s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter, &s.CutoverFamilyEvidence.Status, &s.CutoverFamilyEvidence.Reason, &s.FailureClass)
+	e = db.QueryRowContext(ctx, `SELECT state,phase,projection_version,fts_design,config_hash,source_revision,high_water,checkpoint,state='complete',recent_age_seconds,recent_byte_limit,last_batch_milliseconds,CASE WHEN COALESCE(generation_id,'')='' THEN '' ELSE (SELECT state FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id) END,COALESCE((SELECT abandoned_at FROM search_projection_generation_lifecycle WHERE generation_id=search_projection_state.generation_id),''),COALESCE(cutover_index_family,''),cutover_family_bytes_before,cutover_family_bytes_after,COALESCE(cutover_before_evidence_status,''),COALESCE(cutover_before_evidence_reason,''),COALESCE(cutover_after_evidence_status,''),COALESCE(cutover_after_evidence_reason,''),COALESCE(failure_class,'') FROM search_projection_state WHERE singleton=1`).Scan(&s.State, &s.Phase, &s.ProjectionVersion, &s.FTSDesign, &s.ConfigHash, &s.SourceRevision, &s.HighWater, &s.Checkpoint, &s.Completed, &s.RecentAgeSeconds, &s.RecentByteLimit, &s.LastBatchMilliseconds, &s.LifecycleState, &s.AbandonedAt, &s.CutoverIndexFamily, &s.CutoverFamilyBytesBefore, &s.CutoverFamilyBytesAfter, &s.CutoverBeforeEvidence.Status, &s.CutoverBeforeEvidence.Reason, &s.CutoverAfterEvidence.Status, &s.CutoverAfterEvidence.Reason, &s.FailureClass)
 	if e != nil {
 		return s, e
 	}
 	// Method is not persisted: dbstat is the only way this figure is ever
 	// produced, so it is derived rather than stored per row.
-	if s.CutoverFamilyEvidence.Status != "" {
-		s.CutoverFamilyEvidence.Method = "dbstat"
+	for _, evidence := range []*apptypes.CapacityEvidence{&s.CutoverBeforeEvidence, &s.CutoverAfterEvidence} {
+		if evidence.Status != "" {
+			evidence.Method = "dbstat"
+		}
 	}
 	var inventoryState string
 	if e = db.QueryRowContext(ctx, `SELECT state FROM search_projection_inventory_state WHERE singleton=1`).Scan(&inventoryState); e != nil {
@@ -827,6 +829,17 @@ func (d *Database) SearchProjectionStatus(ctx context.Context) (s apptypes.Searc
 // yields unavailable evidence, never a failed generation.
 const searchProjectionMeasureTimeout = 3 * time.Second
 
+// searchProjectionEvidenceWriteTimeout is the extra allowance the detached
+// evidence context gets for its single-row write, on top of the walk.
+const searchProjectionEvidenceWriteTimeout = time.Second
+
+func (d *Database) measureTimeout() time.Duration {
+	if d.searchProjectionMeasureTimeoutOverride > 0 {
+		return d.searchProjectionMeasureTimeoutOverride
+	}
+	return searchProjectionMeasureTimeout
+}
+
 // measureSearchProjectionFamilyBytes returns dbstat physical bytes for the
 // bounded search projection family only (search_projection_* and
 // literal_search_*). It deliberately excludes the legacy event_search_* family.
@@ -839,10 +852,7 @@ const searchProjectionMeasureTimeout = 3 * time.Second
 func (d *Database) measureSearchProjectionFamilyBytes(ctx context.Context, q interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }) (int64, apptypes.CapacityEvidence) {
-	timeout := searchProjectionMeasureTimeout
-	if d.searchProjectionMeasureTimeoutOverride > 0 {
-		timeout = d.searchProjectionMeasureTimeoutOverride
-	}
+	timeout := d.measureTimeout()
 	// WithoutCancel deliberately detaches from the caller's deadline: the batch
 	// context is sized for the write lock, and evidence must be measurable on
 	// its own terms or reported unavailable — never able to fail the batch.
@@ -880,18 +890,30 @@ const (
 // recordSearchProjectionCutoverEvidence measures the bounded family and stores
 // the result against an already-durable completion. Failure here loses a
 // diagnostic figure and nothing else, so it is logged rather than returned —
-// the generation is complete either way. The write is scoped to the generation
-// that just completed so a concurrent start cannot be overwritten.
+// the generation is complete either way.
+//
+// Both the walk and the write run on a context detached from the batch. The
+// batch context is sized for one bounded unit of work (one second by default)
+// and is routinely near expiry by the time a generation completes; a write that
+// inherited it would fail exactly when the walk was slow enough to matter,
+// leaving an unrecorded figure sitting at zero.
 func (d *Database) recordSearchProjectionCutoverEvidence(ctx context.Context, db *sql.DB, generationID string, now time.Time) {
-	bytes, evidence := d.measureSearchProjectionFamilyBytes(ctx, db)
-	if _, err := db.ExecContext(ctx, `
+	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), d.measureTimeout()+searchProjectionEvidenceWriteTimeout)
+	defer cancel()
+	bytes, evidence := d.measureSearchProjectionFamilyBytes(recordCtx, db)
+	// Fenced on generation_id as well as active_generation_id: another process
+	// may have started a replacement generation since the commit, which moves
+	// generation_id on but leaves active_generation_id pointing at this one.
+	// Matching on the active pointer alone would overwrite the new generation's
+	// before-evidence with this generation's after-evidence.
+	if _, err := db.ExecContext(recordCtx, `
 		UPDATE search_projection_state
 		   SET cutover_family_bytes_after = ?,
-		       cutover_evidence_status = ?,
-		       cutover_evidence_reason = ?,
+		       cutover_after_evidence_status = ?,
+		       cutover_after_evidence_reason = ?,
 		       updated_at = ?
-		 WHERE singleton = 1 AND active_generation_id = ?`,
-		bytes, evidence.Status, evidence.Reason, formatTimestamp(now), generationID,
+		 WHERE singleton = 1 AND active_generation_id = ? AND generation_id = ?`,
+		bytes, evidence.Status, evidence.Reason, formatTimestamp(now), generationID, generationID,
 	); err != nil {
 		slog.Warn("search projection cutover evidence not recorded; generation is complete regardless",
 			"generation_id", generationID,
@@ -901,7 +923,7 @@ func (d *Database) recordSearchProjectionCutoverEvidence(ctx context.Context, db
 		return
 	}
 	if evidence.Status == searchProjectionEvidenceUnavailable {
-		slog.Warn("search projection cutover evidence unavailable; before/after family bytes are not reportable",
+		slog.Warn("search projection cutover evidence unavailable; family bytes after cutover are not reportable",
 			"generation_id", generationID,
 			"method", evidence.Method,
 			"reason", evidence.Reason,

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -78,8 +78,11 @@ func TestSearchProjectionMigrationIsSchemaOnlyUnderOneSecond(t *testing.T) {
 	if err = NewDatabase(path, all).initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if elapsed := time.Since(started); elapsed >= time.Second {
-		t.Fatalf("schema-only projection migration took %s, want <1s", elapsed)
+	// Schema install stays cheap; initialize also runs one bounded catch-up
+	// unit (same 128-row budget as the CLI default). That must not scan the
+	// full 20k historical set in one open.
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
+		t.Fatalf("bounded projection initialize took %s, want <5s", elapsed)
 	}
 	db, err = sql.Open("sqlite", sqliteDSN(path))
 	if err != nil {
@@ -90,8 +93,8 @@ func TestSearchProjectionMigrationIsSchemaOnlyUnderOneSecond(t *testing.T) {
 	if err = db.QueryRow(`SELECT COUNT(*),(SELECT requires_inventory FROM search_projection_inventory_compat) FROM search_projection_source_sequence`).Scan(&sequenceRows, &requires); err != nil {
 		t.Fatal(err)
 	}
-	if sequenceRows != 0 || requires != 1 {
-		t.Fatalf("source sequence rows=%d requires_inventory=%d", sequenceRows, requires)
+	if sequenceRows != 128 || requires != 1 {
+		t.Fatalf("source sequence rows=%d requires_inventory=%d, want one catch-up batch of 128 with inventory still required", sequenceRows, requires)
 	}
 }
 
@@ -117,6 +120,10 @@ func TestSearchProjectionHistoricalInventoryIsBoundedCancelableAndFreshResumable
 	if err = store.initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
+	// Initialize may auto-start and even finish inventory for these three
+	// events (#1680). Reset to a clean pre-inventory state so this test owns
+	// the 1-row inventory budget and resume contract.
+	resetProjectionForInventoryTest(t, path)
 	b := projectionBudget()
 	b.Rows = 1
 	if _, err = store.Start(ctx, b, time.Now()); err != nil {
@@ -232,11 +239,28 @@ func TestSearchProjectionInventoryAdvancesAcrossRegisteredAndEmptyIdentities(t *
 	if err = store.initialize(ctx); err != nil {
 		t.Fatal(err)
 	}
+	// Initialize may auto-start a catch-up generation and admit identities into
+	// the source sequence. Clear that work so the test controls admission.
+	if _, err = store.AbandonSearchProjection(ctx, time.Now()); err != nil {
+		t.Fatal(err)
+	}
 	db, err = sql.Open("sqlite", sqliteDSN(path))
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err = db.Exec(`DELETE FROM search_projection_source_sequence`); err != nil {
+		t.Fatal(err)
+	}
 	if _, err = db.Exec(`INSERT INTO search_projection_source_sequence(event_id) VALUES('already')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE search_projection_state SET state='failed',phase='complete',generation_id=NULL,active_generation_id=NULL,config_hash='',checkpoint=0,high_water=0 WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE search_projection_inventory_state SET generation_id='',cursor='',cursor_started=0,state='idle' WHERE singleton=1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.Exec(`UPDATE search_projection_inventory_compat SET requires_inventory=1 WHERE singleton=1`); err != nil {
 		t.Fatal(err)
 	}
 	_ = db.Close()
@@ -433,6 +457,40 @@ func TestSearchProjectionAbandonIsIdempotentAndRestartKeepsCanonicalHistory(t *t
 
 func projectionBudget() apptypes.SearchProjectionBudget {
 	return apptypes.SearchProjectionBudget{Rows: 1, WallTime: time.Minute, LockTime: time.Second, StoredBytes: 1 << 20, DecodedBytes: 1 << 20, WriteBytes: 1 << 20, RecentAge: time.Hour, RecentBytes: 1 << 20}
+}
+
+// resetProjectionForInventoryTest undoes auto catch-up so inventory-phase tests
+// can Start with requires_inventory=1 and an empty source sequence.
+func resetProjectionForInventoryTest(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", sqliteDSN(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	statements := []string{
+		`DELETE FROM search_projection_source_sequence`,
+		`DELETE FROM sqlite_sequence WHERE name='search_projection_source_sequence'`,
+		`DELETE FROM search_projection_recent_documents`,
+		`DELETE FROM search_projection_session_summaries`,
+		`DELETE FROM search_projection_session_keywords`,
+		`DELETE FROM search_projection_command_aggregates`,
+		`DELETE FROM literal_search_fingerprints`,
+		`DELETE FROM search_projection_generation_lifecycle`,
+		`UPDATE search_projection_state SET generation_id=NULL,active_generation_id=NULL,config_hash='',source_revision=0,high_water=0,checkpoint=0,phase='source',cleanup_scope='old',failure_class='',state='idle' WHERE singleton=1`,
+		`UPDATE search_projection_inventory_state SET generation_id='',cursor='',cursor_started=0,state='idle' WHERE singleton=1`,
+		`UPDATE search_projection_inventory_compat SET requires_inventory=1 WHERE singleton=1`,
+		`UPDATE literal_search_projection_state SET generation_id='',high_water=0,state='stale',updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE singleton=1`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			// sqlite_sequence is absent until the first AUTOINCREMENT insert.
+			if strings.Contains(statement, "sqlite_sequence") && strings.Contains(err.Error(), "no such table") {
+				continue
+			}
+			t.Fatalf("reset inventory fixture (%s): %v", statement, err)
+		}
+	}
 }
 
 func TestSearchProjectionGenerationFreezesInsertsAndDetectsMutation(t *testing.T) {

--- a/infrastructure/sqlite/search_projection_rebuild_internal_test.go
+++ b/infrastructure/sqlite/search_projection_rebuild_internal_test.go
@@ -540,6 +540,84 @@ func TestSearchProjectionGenerationFreezesInsertsAndDetectsMutation(t *testing.T
 	}
 }
 
+// TestSearchProjectionInventory_UpdateAndDeleteStillDrift pins the
+// deliberately unchanged update/delete trigger behaviour during inventory:
+// while requires_inventory=1 there is no reliable membership for historical
+// rows the walk has not reached, so mutations still bump source_revision.
+func TestSearchProjectionInventory_UpdateAndDeleteStillDrift(t *testing.T) {
+	mutations := map[string]string{
+		"event update": `UPDATE events SET body='mutated-during-inventory' WHERE id='historical-b'`,
+		"event delete": `DELETE FROM events WHERE id='historical-c'`,
+	}
+	for name, mutation := range mutations {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			path := filepath.Join(t.TempDir(), "store.db")
+			legacy := NewDatabase(path, migrationsBeforeSearchProjection(t))
+			if err := legacy.initialize(ctx); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite", sqliteDSN(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, id := range []string{"historical-a", "historical-b", "historical-c"} {
+				if _, err = db.Exec(`INSERT INTO events(id,kind,agent,session_id,body,created_at,client,workspace) VALUES(?,'note','a','s','body','2026-08-03T00:00:00Z','c','w')`, id); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_ = db.Close()
+
+			all, err := fs.Sub(os.DirFS("../.."), "schema/sqlite/migrations")
+			if err != nil {
+				t.Fatal(err)
+			}
+			store := NewDatabase(path, all)
+			if err = store.initialize(ctx); err != nil {
+				t.Fatal(err)
+			}
+			resetProjectionForInventoryTest(t, path)
+
+			b := projectionBudget()
+			b.Rows = 1
+			if _, err = store.Start(ctx, b, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			// One inventory unit so the generation is live and still rebuilding.
+			if _, err = resumeProjection(ctx, store, b, time.Now()); err != nil {
+				t.Fatalf("inventory resume before mutation: %v", err)
+			}
+
+			db, err = sql.Open("sqlite", sqliteDSN(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var beforeRevision int64
+			if err = db.QueryRow(`SELECT revision FROM search_projection_source_revision WHERE singleton=1`).Scan(&beforeRevision); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = db.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			var afterRevision int64
+			var state string
+			if err = db.QueryRow(`SELECT r.revision,s.state FROM search_projection_source_revision r, search_projection_state s WHERE r.singleton=1 AND s.singleton=1`).Scan(&afterRevision, &state); err != nil {
+				t.Fatal(err)
+			}
+			_ = db.Close()
+			if afterRevision <= beforeRevision {
+				t.Fatalf("mutation %q did not bump source_revision: before=%d after=%d", name, beforeRevision, afterRevision)
+			}
+
+			_, err = resumeProjection(ctx, store, b, time.Now())
+			var drift *apptypes.SearchProjectionDriftError
+			if !errors.As(err, &drift) {
+				t.Fatalf("resume after %q error=%T %v, want SearchProjectionDriftError", name, err, err)
+			}
+		})
+	}
+}
+
 func TestSearchProjectionUnavailableBodyAndOversizeArePublicBehavior(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "store.db")

--- a/schema/sqlite/migrations/000049_add_search_projection_cutover_evidence.sql
+++ b/schema/sqlite/migrations/000049_add_search_projection_cutover_evidence.sql
@@ -1,0 +1,6 @@
+-- Durable cutover evidence for the bounded search projection family.
+-- before/after measure only that family (search_projection_* + literal_search_*),
+-- never the legacy migration-032 event_search_* family.
+ALTER TABLE search_projection_state ADD COLUMN cutover_index_family TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_family_bytes_before INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE search_projection_state ADD COLUMN cutover_family_bytes_after INTEGER NOT NULL DEFAULT 0;

--- a/schema/sqlite/migrations/000050_fix_search_projection_insert_inventory_drift.sql
+++ b/schema/sqlite/migrations/000050_fix_search_projection_insert_inventory_drift.sql
@@ -1,0 +1,15 @@
+-- Inserts during historical inventory must not bump source_revision.
+-- The events insert trigger already registers the new identity into
+-- search_projection_source_sequence unconditionally, so inventory has
+-- nothing further to do for that row and the generation is not invalidated
+-- by live writers (hooks) that open the store and append an event.
+-- Membership (sequence <= high_water) remains the only insert-time drift
+-- signal. Update/delete triggers keep requires_inventory=1: they can change
+-- rows the inventory walk has not yet reached, with no membership info
+-- available while inventory is still required.
+
+DROP TRIGGER search_projection_events_insert;
+CREATE TRIGGER search_projection_events_insert AFTER INSERT ON events BEGIN INSERT OR IGNORE INTO search_projection_source_sequence(event_id) VALUES(new.id); UPDATE search_projection_source_revision SET revision=revision+1 WHERE EXISTS(SELECT 1 FROM search_projection_state s WHERE s.state='rebuilding' AND EXISTS(SELECT 1 FROM search_projection_source_sequence q WHERE q.event_id=new.id AND q.sequence<=s.high_water)); END;
+
+DROP TRIGGER search_projection_audits_insert;
+CREATE TRIGGER search_projection_audits_insert AFTER INSERT ON command_audits WHEN EXISTS(SELECT 1 FROM search_projection_state s WHERE s.state='rebuilding' AND EXISTS(SELECT 1 FROM search_projection_source_sequence q WHERE q.event_id=new.event_id AND q.sequence<=s.high_water)) BEGIN UPDATE search_projection_source_revision SET revision=revision+1; END;

--- a/schema/sqlite/migrations/000051_add_search_projection_cutover_evidence_status.sql
+++ b/schema/sqlite/migrations/000051_add_search_projection_cutover_evidence_status.sql
@@ -1,0 +1,11 @@
+-- Distinguish "the projection family measured zero bytes" from "the
+-- measurement could not be taken". Migration 049 recorded only the byte
+-- figures, so an unavailable dbstat walk and a genuinely empty family were
+-- indistinguishable at zero.
+--
+-- The measurement is diagnostic and now runs outside the transactions that
+-- start and complete a generation: a dbstat walk costs in proportion to the
+-- projection family's page count and must never be able to abort a completion
+-- that is otherwise durable.
+ALTER TABLE search_projection_state ADD COLUMN cutover_evidence_status TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_evidence_reason TEXT NOT NULL DEFAULT '';

--- a/schema/sqlite/migrations/000051_add_search_projection_cutover_evidence_status.sql
+++ b/schema/sqlite/migrations/000051_add_search_projection_cutover_evidence_status.sql
@@ -3,9 +3,16 @@
 -- figures, so an unavailable dbstat walk and a genuinely empty family were
 -- indistinguishable at zero.
 --
--- The measurement is diagnostic and now runs outside the transactions that
--- start and complete a generation: a dbstat walk costs in proportion to the
+-- Before and after are measured at different times, by different transactions,
+-- against families of different sizes, so each carries its own evidence. A
+-- single shared status would let a successful after-measurement report the
+-- whole row as measured while the before figure was never taken.
+--
+-- The measurement is diagnostic and runs outside the transactions that start
+-- and complete a generation: a dbstat walk costs in proportion to the
 -- projection family's page count and must never be able to abort a completion
 -- that is otherwise durable.
-ALTER TABLE search_projection_state ADD COLUMN cutover_evidence_status TEXT NOT NULL DEFAULT '';
-ALTER TABLE search_projection_state ADD COLUMN cutover_evidence_reason TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_before_evidence_status TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_before_evidence_reason TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_after_evidence_status TEXT NOT NULL DEFAULT '';
+ALTER TABLE search_projection_state ADD COLUMN cutover_after_evidence_reason TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
Closes #1680

## Why this is not a re-run

Migrations 035–047 have never shipped — v0.33.1 tops out at 034 — so no store in the field has ever built a projection generation. Every store today answers search from the legacy migration-032 index, and the authoritative-projection switch #1717 added has never once been reachable. #1718 deletes that legacy index, so a generation has to exist before it lands. This PR is where the first cutover actually happens, and it happens on upgrade rather than on a command nobody will run.

## How the first generation gets built

The same way event search backfill is driven: `Initialize` performs one bounded, durable unit of work per store open, resumable across opens, no operator command and no new subcommand. The batch size is the existing `eventSearchBackfillBatchSize` value (128), so the precedent this repository already accepted for the same corpus carries over unchanged. Legacy search stays authoritative until the generation reaches `complete`, so the read path needs no change — `searchProjectionReadReady` already makes the switch automatic.

An empty store stays idle rather than starting a generation, and an operator-started rebuild with a different budget is not hijacked.

## What the verification gate actually asks

Reclaiming the previous generation is gated on a real session-tier query against the generation under construction, using the same match contract production search uses — keyword equality on the keyword table, or summary `LIKE` — with the same `ts_norm` ordering. Not a row count.

The gate asks whether the tier can answer *for a session it holds a summary for*, scoped to that session. Two things drove that shape:

- Sessions in one workspace share vocabulary, so a term drawn from one summary routinely matches others. Requiring the probed session to come back as the top-ranked hit fails on any store whose summaries share a word, which is essentially all of them.
- A failed verification marks the generation failed, and a failed generation restarts on the next open. So a spurious failure is not a warning — it is an unbounded rebuild loop that never reaches `complete`, on a code path whose entire purpose is reaching `complete` before #1718 removes the alternative.

`TestSearchProjectionVerifySessionTier_PassesWhenSeveralSessionsShareATerm` pins this. It fails on the pre-fix gate with `session tier verification returned unexpected session sess-zzz`.

## Schema completeness is decided from the schema

The implementation originally decided "the projection schema is incomplete, skip" by matching `no such table` / `no such column` / `no such module` against the text of a failure, in the catch-up path and in three fallbacks inside the rebuild path.

That test also matches a genuine SQL defect in the projection. A typo in the primary statement would fall through to a secondary statement or to a silent skip, the generation would never build, and after #1718 search would return nothing with no error anywhere — the same fail-silent class this issue exists to close.

Replaced with an explicit probe of the objects migrations 038–042 create, plus migration 049's column, naming the first missing object so a skip is diagnosable. The three rebuild-path fallbacks turned out to be dead — removing them leaves the full suite green.

## Interruption and reclaim

An interrupted rebuild resumes on the next open from its checkpoint, and only one generation is live while it does. `TestSearchProjectionCatchUp_InterruptedMidRebuildResumesWithoutTwoLiveGenerations` drives a rebuild that cannot finish in one Resume, asserts exactly one generation in `rebuilding`/`complete` mid-flight, then resumes to completion with one complete and zero rebuilding.

## Bytes

Migration 049 records `cutover_index_family` alongside before/after bytes, always naming `bounded_search_projection`. The measurement covers `search_projection_*` + `literal_search_*` only. The legacy family's 16.15 GiB is #1718's number and is deliberately not reported here, so nothing in `status` output can be read as a store-wide reduction. On a fixture store the two figures are close, since the fixture's corpus is tiny and the schema is already present; the value of the field is that the number is attributed to a family rather than to the store.

## Carried to #1718, not fixed here

After #1718 removes the legacy family, both remaining fallback routes in `selectEventSearchCandidateIDs` — "no complete generation" and "the tail is too long to answer within budget" — currently land on `selectLegacyEventSearchCandidateIDs`. This PR makes the first case rare rather than universal, but it does not make it impossible: a store that upgrades and is then queried before the generation finishes is in exactly that state. #1718 has to degrade rather than break there. Noted on that issue rather than pre-empted here.

## Verification

```
go build ./...              clean
go tool golangci-lint run   0 issues
go test ./...               exit 0
```
