### PR TITLE
fix: answer tiered search across the post-cutover tail

### DIFF
--- a/infrastructure/sqlite/event_search_authority.go
+++ b/infrastructure/sqlite/event_search_authority.go
@@ -131,19 +131,26 @@ func (d *EventDatasource) searchTieredMetadataTx(ctx context.Context, tx *sql.Tx
 		return nil, xerrors.New("offset must be greater than or equal to 0")
 	}
 	var literalState, literalGeneration, boundedState, boundedGeneration string
-	var literalHigh, sourceHigh int64
-	if err := tx.QueryRowContext(ctx, `SELECT generation_id,high_water,state FROM literal_search_projection_state WHERE singleton=1`).Scan(&literalGeneration, &literalHigh, &literalState); err == nil {
-		err = tx.QueryRowContext(ctx, `SELECT COALESCE(active_generation_id,''),state FROM search_projection_state WHERE singleton=1`).Scan(&boundedGeneration, &boundedState)
-		if err == nil {
-			err = tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&sourceHigh)
-		}
-		if err != nil {
-			return nil, xerrors.Errorf("read tiered authority projection state: %w", err)
-		}
-	} else {
+	// Generation consistency is a real "cannot answer" condition: mismatched
+	// or non-authoritative projections have no coherent candidate set.
+	// Literal state 'stale' is not one of those conditions — migration 039
+	// flips literal to stale on every events/command_audits write, including
+	// ordinary post-cutover appends whose fingerprint absence already fail-
+	// opens in the walk. Mutated already-projected rows are rejected by the
+	// bounded gate instead: search_projection_complete_* triggers set
+	// bounded state='drifted' and clear active_generation_id. A watermark
+	// gap after completion is also not "cannot answer" — sourceHigh always
+	// advances while literal high_water stays frozen. Post-cutover rows are
+	// visited by the ordered walk below and admitted by the fail-open
+	// fingerprint pre-filter when they lack generation fingerprint rows.
+	if err := tx.QueryRowContext(ctx, `SELECT generation_id,state FROM literal_search_projection_state WHERE singleton=1`).Scan(&literalGeneration, &literalState); err != nil {
 		return nil, xerrors.Errorf("read tiered authority projection state: %w", err)
 	}
-	if literalState != "complete" || boundedState != "complete" || literalGeneration == "" || literalGeneration != boundedGeneration || literalHigh != sourceHigh {
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(active_generation_id,''),state FROM search_projection_state WHERE singleton=1`).Scan(&boundedGeneration, &boundedState); err != nil {
+		return nil, xerrors.Errorf("read tiered authority projection state: %w", err)
+	}
+	literalReady := literalState == "complete" || literalState == "stale"
+	if !literalReady || boundedState != "complete" || literalGeneration == "" || literalGeneration != boundedGeneration {
 		return nil, xerrors.New("tiered search projection is incomplete or stale")
 	}
 	// Empty queries are structural-only searches. They do not require literal
@@ -155,21 +162,26 @@ func (d *EventDatasource) searchTieredMetadataTx(ctx context.Context, tx *sql.Tx
 		}
 		return hydrateEventSearchMetadataCandidates(ctx, tx, criteria, candidateIDs)
 	}
-	return d.searchTieredTopKMetadataTx(ctx, tx, criteria, literalGeneration, literalHigh)
+	return d.searchTieredTopKMetadataTx(ctx, tx, criteria, literalGeneration)
 }
 
 // searchTieredTopKMetadataTx separates the source-work budget from the public
-// result limit. Candidates are visited in the public order, so only
-// offset+limit matches need to be retained; broad queries do not become
+// result limit. Candidates are visited in the public order across the full
+// source sequence (including rows appended after the generation completed), so
+// only offset+limit matches need to be retained; broad queries do not become
 // unavailable merely because more than MaxLiteralSearchLimit rows match.
-func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, generation string, highWater int64) ([]apptypes.EventMetadata, error) {
+// Post-cutover rows are newest, so they are examined first and consume budget first.
+func (d *EventDatasource) searchTieredTopKMetadataTx(ctx context.Context, tx *sql.Tx, criteria apptypes.EventSearchCriteria, generation string) ([]apptypes.EventMetadata, error) {
 	if err := validateSearchCriteriaForAuthority(criteria); err != nil {
 		return nil, err
 	}
 	query := apptypes.CharacterizeLiteralQuery(criteria.Query())
 	var builder strings.Builder
-	builder.WriteString(`SELECT e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE q.sequence<=?`)
-	args := []any{highWater}
+	// No sequence<=high_water bound: post-completion source rows form the live
+	// tail and must participate in the same ordered walk as projected events.
+	// Fingerprint pre-filter is fail-open for events with no generation rows.
+	builder.WriteString(`SELECT e.id,COALESCE(e.body_encoded_bytes,length(e.body),0)+COALESCE(a.command_encoded_bytes,length(a.command_text),0)+COALESCE(a.input_encoded_bytes,length(a.input_text),0)+COALESCE(a.output_encoded_bytes,length(a.output_text),0),COALESCE(e.body_plaintext_bytes,length(e.body),0)+COALESCE(a.command_plaintext_bytes,length(a.command_text),0)+COALESCE(a.input_plaintext_bytes,length(a.input_text),0)+COALESCE(a.output_plaintext_bytes,length(a.output_text),0) FROM search_projection_source_sequence q JOIN events e ON e.id=q.event_id LEFT JOIN command_audits a ON a.event_id=e.id WHERE 1=1`)
+	args := []any{}
 	args = appendEventSearchFilters(&builder, args, criteria)
 	if query.Filterable() {
 		fingerprints := query.Fingerprints()

--- a/infrastructure/sqlite/event_search_authority_internal_test.go
+++ b/infrastructure/sqlite/event_search_authority_internal_test.go
@@ -1,0 +1,704 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/application/queryservice"
+	apptypes "github.com/duck8823/traceary/application/types"
+	"github.com/duck8823/traceary/application/usecase"
+)
+
+// seedTieredCompleteProjection freezes a complete generation at the current
+// source high-water and switches the store to tiered authority. Events saved
+// after this call form the post-cutover tail.
+func seedTieredCompleteProjection(t *testing.T, database *Database, generation string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	// Bind each statement separately: multi-statement Exec with shared
+	// placeholders is unreliable for generation_id across the two state tables.
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE literal_search_projection_state
+		   SET generation_id = ?,
+		       high_water = (SELECT COALESCE(MAX(sequence), 0) FROM search_projection_source_sequence),
+		       state = 'complete'
+		 WHERE singleton = 1`, generation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE search_projection_state
+		   SET generation_id = ?,
+		       active_generation_id = ?,
+		       high_water = (SELECT COALESCE(MAX(sequence), 0) FROM search_projection_source_sequence),
+		       state = 'complete',
+		       phase = 'complete'
+		 WHERE singleton = 1`, generation, generation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE search_maintenance_control
+		   SET authority = 'tiered',
+		       phase = 'retired'
+		 WHERE singleton = 1`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedLiteralFingerprints inserts the real CharacterizeLiteralQuery shape for a
+// pre-cutover event: generation_id + source_sequence + event_id + 16-byte
+// fingerprint blobs at fingerprint_version=1. Matching the rebuild writer in
+// search_projection_rebuild.go so the SQL pre-filter is exercised.
+func seedLiteralFingerprints(t *testing.T, database *Database, generation, eventID, body string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	for _, fp := range apptypes.CharacterizeLiteralQuery(body).Fingerprints() {
+		if _, err = raw.ExecContext(ctx, `
+			INSERT INTO literal_search_fingerprints(
+				generation_id, source_sequence, event_id, fingerprint, fingerprint_version
+			)
+			SELECT ?, sequence, ?, ?, 1
+			  FROM search_projection_source_sequence
+			 WHERE event_id = ?`,
+			generation, eventID, []byte(fp), eventID,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func insertTieredSearchEvent(t *testing.T, database *Database, id, body string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(ctx, `
+		INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at)
+		VALUES (?, 'note', 'codex', 'codex', 's', 'w', ?, ?)`,
+		id, body, at.UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertTieredCommandAudit(t *testing.T, database *Database, eventID, commandText string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err = raw.ExecContext(ctx, `
+		INSERT INTO command_audits(
+			event_id, command_text, input_text, output_text,
+			input_truncated, output_truncated, exit_code, failed,
+			input_original_bytes, output_original_bytes,
+			command_wrapper, command_name, failure_reason
+		) VALUES (?, ?, '', '', 0, 0, 0, 0, 0, 0, 'direct', 'echo', 'none')`,
+		eventID, commandText,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readProjectionStates(t *testing.T, database *Database) (literalState, boundedState string) {
+	t.Helper()
+	ctx := context.Background()
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = raw.Close() }()
+	if err = raw.QueryRowContext(ctx, `SELECT state FROM literal_search_projection_state WHERE singleton=1`).Scan(&literalState); err != nil {
+		t.Fatal(err)
+	}
+	if err = raw.QueryRowContext(ctx, `SELECT state FROM search_projection_state WHERE singleton=1`).Scan(&boundedState); err != nil {
+		t.Fatal(err)
+	}
+	return literalState, boundedState
+}
+
+func metadataIDs(rows []apptypes.EventMetadata) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.EventID().String())
+	}
+	return ids
+}
+
+func newTieredAuthorityFixture(t *testing.T) (*Database, *EventDatasource) {
+	t.Helper()
+	database := NewDatabase(
+		filepath.Join(t.TempDir(), "store.db"),
+		os.DirFS(filepath.Join("..", "..", "schema", "sqlite", "migrations")),
+	)
+	if err := NewStoreManagementDatasource(database).Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return database, NewEventDatasource(database)
+}
+
+func TestTieredAuthoritySearchIncludesPostCutoverTail(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "pre-match", "shared needle alpha", base)
+	insertTieredSearchEvent(t, database, "pre-noise", "unrelated body", base.Add(time.Second))
+	seedTieredCompleteProjection(t, database, "gen-tail")
+	// Real generation fingerprints for the pre-cutover match so historical
+	// rows are not universally fail-open. See TestTieredAuthorityFingerprintPreFilter
+	// for exclusion of non-matching fingerprints.
+	seedLiteralFingerprints(t, database, "gen-tail", "pre-match", "shared needle alpha")
+	seedLiteralFingerprints(t, database, "gen-tail", "pre-noise", "unrelated body")
+
+	// One ordinary post-cutover event widens sourceHigh past literal high_water
+	// and flips literal state to stale via migration-039 triggers.
+	insertTieredSearchEvent(t, database, "post-match", "shared needle beta", base.Add(2*time.Second))
+	insertTieredSearchEvent(t, database, "post-noise", "still unrelated", base.Add(3*time.Second))
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	wantIDs := []string{"post-match", "pre-match"}
+
+	t.Run("metadata path returns post-cutover matches", func(t *testing.T) {
+		got, err := datasource.SearchMetadata(ctx, criteria)
+		if err != nil {
+			t.Fatalf("SearchMetadata() error = %v", err)
+		}
+		if diff := cmp.Diff(wantIDs, metadataIDs(got)); diff != "" {
+			t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("full-event path returns post-cutover matches", func(t *testing.T) {
+		got, err := datasource.SearchPage(ctx, criteria)
+		if err != nil {
+			t.Fatalf("SearchPage() error = %v", err)
+		}
+		if diff := cmp.Diff(wantIDs, eventIDs(got)); diff != "" {
+			t.Fatalf("SearchPage() IDs mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("public order is created_at_norm DESC, id DESC across the cutover", func(t *testing.T) {
+		// Same timestamp, higher id must sort first among post/pre pairs.
+		insertTieredSearchEvent(t, database, "post-z", "shared needle zeta", base.Add(4*time.Second))
+		insertTieredSearchEvent(t, database, "post-a", "shared needle alpha-post", base.Add(4*time.Second))
+		got, err := datasource.SearchPage(ctx, criteria)
+		if err != nil {
+			t.Fatalf("SearchPage() error = %v", err)
+		}
+		// post-z and post-a share created_at; id DESC puts post-z first.
+		wantOrdered := []string{"post-z", "post-a", "post-match", "pre-match"}
+		if diff := cmp.Diff(wantOrdered, eventIDs(got)); diff != "" {
+			t.Fatalf("ordered IDs mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestTieredAuthorityFingerprintPreFilter(t *testing.T) {
+	// Fingerprints are the real CharacterizeLiteralQuery 16-byte SHA-256
+	// trigram digests at version 1, keyed by generation_id + event_id +
+	// source_sequence — identical to the rebuild writer.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	insertTieredSearchEvent(t, database, "pre-match", "shared needle alpha", base)
+	// Body would match "needle" if decoded, but fingerprints come from a
+	// non-overlapping string so the pre-filter must exclude the row.
+	insertTieredSearchEvent(t, database, "pre-excluded", "shared needle decoy", base.Add(time.Second))
+	insertTieredSearchEvent(t, database, "pre-noise", "zzzz other text", base.Add(2*time.Second))
+	const generation = "gen-fp"
+	seedTieredCompleteProjection(t, database, generation)
+	seedLiteralFingerprints(t, database, generation, "pre-match", "shared needle alpha")
+	seedLiteralFingerprints(t, database, generation, "pre-excluded", "zzzz other text")
+	seedLiteralFingerprints(t, database, generation, "pre-noise", "zzzz other text")
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	got, err := datasource.SearchMetadata(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"pre-match"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("fingerprint pre-filter IDs mismatch (-want +got):\n%s", diff)
+	}
+	full, err := datasource.SearchPage(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchPage() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"pre-match"}, eventIDs(full)); diff != "" {
+		t.Fatalf("SearchPage() fingerprint IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTieredAuthoritySearchStillFailsWhenProjectionCannotAnswer(t *testing.T) {
+	ctx := context.Background()
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, database *Database)
+	}{
+		{
+			// 'stale' is no longer a refuse condition (append-after-complete).
+			// Incomplete means rebuilding / missing / non-ready states.
+			name: "literal projection incomplete",
+			setup: func(t *testing.T, database *Database) {
+				insertTieredSearchEvent(t, database, "e1", "needle", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+				seedTieredCompleteProjection(t, database, "gen-a")
+				raw, err := database.open(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = raw.Close() }()
+				if _, err = raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET state='rebuilding' WHERE singleton=1`); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "bounded projection incomplete",
+			setup: func(t *testing.T, database *Database) {
+				insertTieredSearchEvent(t, database, "e1", "needle", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+				seedTieredCompleteProjection(t, database, "gen-a")
+				raw, err := database.open(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = raw.Close() }()
+				if _, err = raw.ExecContext(ctx, `UPDATE search_projection_state SET state='rebuilding' WHERE singleton=1`); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "generation mismatch",
+			setup: func(t *testing.T, database *Database) {
+				insertTieredSearchEvent(t, database, "e1", "needle", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+				seedTieredCompleteProjection(t, database, "gen-a")
+				raw, err := database.open(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = raw.Close() }()
+				if _, err = raw.ExecContext(ctx, `
+					UPDATE literal_search_projection_state SET generation_id='gen-literal' WHERE singleton=1;
+					UPDATE search_projection_state SET generation_id='gen-bounded', active_generation_id='gen-bounded' WHERE singleton=1`); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "empty literal generation",
+			setup: func(t *testing.T, database *Database) {
+				insertTieredSearchEvent(t, database, "e1", "needle", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+				seedTieredCompleteProjection(t, database, "gen-a")
+				raw, err := database.open(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = raw.Close() }()
+				if _, err = raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET generation_id='' WHERE singleton=1`); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			database, datasource := newTieredAuthorityFixture(t)
+			tc.setup(t, database)
+
+			const wantMsg = "tiered search projection is incomplete or stale"
+			_, err := datasource.SearchMetadata(ctx, criteria)
+			if err == nil || err.Error() != wantMsg {
+				t.Fatalf("SearchMetadata() error = %v, want %q", err, wantMsg)
+			}
+
+			_, err = datasource.SearchPage(ctx, criteria)
+			if err == nil || err.Error() != wantMsg {
+				t.Fatalf("SearchPage() error = %v, want %q", err, wantMsg)
+			}
+		})
+	}
+}
+
+func TestTieredAuthoritySearchBudgetExhaustionOnLargeTail(t *testing.T) {
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	// Pre-cutover match would answer the query if the walk ever reached it.
+	insertTieredSearchEvent(t, database, "pre-match", "budget needle", base)
+	seedTieredCompleteProjection(t, database, "gen-budget")
+
+	// Post-cutover rows are newest, so they are visited first and consume the
+	// DeepLiteralSearchBudget before the pre-cutover match is examined.
+	// Inflated encoded/plaintext sizes trip the byte budget without storing
+	// multi-megabyte bodies in the fixture.
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// StoredBytes budget is 64MiB; one inflated post-cutover row exceeds it.
+	inflatedStored := apptypes.DeepLiteralSearchBudget.StoredBytes + 1
+	if _, err = raw.ExecContext(ctx, `
+		INSERT INTO events(
+			id, kind, client, agent, session_id, workspace, body, created_at,
+			body_encoded_bytes, body_plaintext_bytes
+		) VALUES (
+			'post-heavy', 'note', 'codex', 'codex', 's', 'w', 'no match here', ?,
+			?, ?
+		)`,
+		base.Add(time.Minute).UTC().Format(time.RFC3339Nano),
+		inflatedStored,
+		inflatedStored,
+	); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(1).Query("needle").Build()
+	_, err = datasource.SearchMetadata(ctx, criteria)
+	var unavailable *queryservice.EventSearchUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("SearchMetadata() error = %v, want EventSearchUnavailableError", err)
+	}
+	if unavailable.Reason != queryservice.EventSearchUnavailableIndexIncomplete {
+		t.Fatalf("unavailable reason = %q, want %q", unavailable.Reason, queryservice.EventSearchUnavailableIndexIncomplete)
+	}
+	if unavailable.CandidateLimit != apptypes.DeepLiteralSearchBudget.SourceRows {
+		t.Fatalf("CandidateLimit = %d, want %d", unavailable.CandidateLimit, apptypes.DeepLiteralSearchBudget.SourceRows)
+	}
+
+	_, err = datasource.SearchPage(ctx, criteria)
+	if !errors.As(err, &unavailable) || unavailable.Reason != queryservice.EventSearchUnavailableIndexIncomplete {
+		t.Fatalf("SearchPage() error = %v, want index_incomplete", err)
+	}
+}
+
+func TestTieredAuthoritySearchWatermarkGapIsNotStale(t *testing.T) {
+	// Focused regression for the equality gate itself: generation is complete
+	// and consistent, only sourceHigh has advanced past literal high_water.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "pre-only", "gap needle", base)
+	seedTieredCompleteProjection(t, database, "gen-gap")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var literalHigh, sourceHigh int64
+	if err = raw.QueryRowContext(ctx, `SELECT high_water FROM literal_search_projection_state WHERE singleton=1`).Scan(&literalHigh); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	// Insert without matching body so the only success condition is "no stale error".
+	if _, err = raw.ExecContext(ctx, `
+		INSERT INTO events(id, kind, client, agent, session_id, workspace, body, created_at)
+		VALUES ('post-gap', 'note', 'codex', 'codex', 's', 'w', 'ordinary hook fire', ?)`,
+		base.Add(time.Second).UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	if err = raw.QueryRowContext(ctx, `SELECT COALESCE(MAX(sequence),0) FROM search_projection_source_sequence`).Scan(&sourceHigh); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+	if sourceHigh <= literalHigh {
+		t.Fatalf("fixture did not create a watermark gap: sourceHigh=%d literalHigh=%d", sourceHigh, literalHigh)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	got, err := datasource.SearchMetadata(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v (watermark gap must not be treated as stale)", err)
+	}
+	if diff := cmp.Diff([]string{"pre-only"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+	}
+
+	full, err := datasource.SearchPage(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchPage() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"pre-only"}, eventIDs(full)); diff != "" {
+		t.Fatalf("SearchPage() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTieredAuthorityAppendLeavesLiteralStaleAndStillAnswers(t *testing.T) {
+	// Case 1: complete generation, ordinary event append → literal stale,
+	// bounded complete → both search paths return matches including the tail.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	insertTieredSearchEvent(t, database, "pre-match", "append needle alpha", base)
+	seedTieredCompleteProjection(t, database, "gen-append")
+	seedLiteralFingerprints(t, database, "gen-append", "pre-match", "append needle alpha")
+	insertTieredSearchEvent(t, database, "post-match", "append needle beta", base.Add(time.Second))
+
+	literalState, boundedState := readProjectionStates(t, database)
+	if literalState != "stale" {
+		t.Fatalf("literal state = %q, want stale after append", literalState)
+	}
+	if boundedState != "complete" {
+		t.Fatalf("bounded state = %q, want complete after append", boundedState)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	want := []string{"post-match", "pre-match"}
+
+	got, err := datasource.SearchMetadata(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff(want, metadataIDs(got)); diff != "" {
+		t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+	}
+	full, err := datasource.SearchPage(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchPage() error = %v", err)
+	}
+	if diff := cmp.Diff(want, eventIDs(full)); diff != "" {
+		t.Fatalf("SearchPage() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTieredAuthorityBodyUpdateOfProjectedEventDriftsAndRefuses(t *testing.T) {
+	// Case 2: body update of an already-projected event → bounded drifted →
+	// search refused. Assert bounded became drifted so a silent trigger
+	// regression fails loudly rather than masking wrong answers.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	insertTieredSearchEvent(t, database, "projected", "update needle", base)
+	seedTieredCompleteProjection(t, database, "gen-update")
+	seedLiteralFingerprints(t, database, "gen-update", "projected", "update needle")
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = raw.ExecContext(ctx, `UPDATE events SET body='mutated needle' WHERE id='projected'`); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+
+	literalState, boundedState := readProjectionStates(t, database)
+	if boundedState != "drifted" {
+		t.Fatalf("bounded state = %q, want drifted after projected body update (trigger regression?)", boundedState)
+	}
+	if literalState != "stale" {
+		t.Fatalf("literal state = %q, want stale after body update", literalState)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	const wantMsg = "tiered search projection is incomplete or stale"
+	if _, err = datasource.SearchMetadata(ctx, criteria); err == nil || err.Error() != wantMsg {
+		t.Fatalf("SearchMetadata() error = %v, want %q", err, wantMsg)
+	}
+	if _, err = datasource.SearchPage(ctx, criteria); err == nil || err.Error() != wantMsg {
+		t.Fatalf("SearchPage() error = %v, want %q", err, wantMsg)
+	}
+}
+
+func TestTieredAuthorityAuditInsertOnProjectedEventDriftsAndRefuses(t *testing.T) {
+	// Case 3: command_audits insert against an already-projected event
+	// (sequence <= high_water) → bounded drifted → refused.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	insertTieredSearchEvent(t, database, "projected", "audit projected body", base)
+	seedTieredCompleteProjection(t, database, "gen-audit-pre")
+	insertTieredCommandAudit(t, database, "projected", "needle in command")
+
+	_, boundedState := readProjectionStates(t, database)
+	if boundedState != "drifted" {
+		t.Fatalf("bounded state = %q, want drifted after audit on projected event", boundedState)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	const wantMsg = "tiered search projection is incomplete or stale"
+	if _, err := datasource.SearchMetadata(ctx, criteria); err == nil || err.Error() != wantMsg {
+		t.Fatalf("SearchMetadata() error = %v, want %q", err, wantMsg)
+	}
+}
+
+func TestTieredAuthorityAuditInsertOnTailEventStaysCompleteAndMatches(t *testing.T) {
+	// Case 4: command_audits insert against a tail event (sequence > high_water)
+	// → bounded stays complete, no fingerprints → audit text is decoded and matches.
+	ctx := context.Background()
+	database, datasource := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	insertTieredSearchEvent(t, database, "pre-only", "no match here", base)
+	seedTieredCompleteProjection(t, database, "gen-audit-tail")
+	insertTieredSearchEvent(t, database, "tail-event", "tail body without needle", base.Add(time.Second))
+	insertTieredCommandAudit(t, database, "tail-event", "needle lives in the audit command")
+
+	literalState, boundedState := readProjectionStates(t, database)
+	if boundedState != "complete" {
+		t.Fatalf("bounded state = %q, want complete after audit on tail event", boundedState)
+	}
+	if literalState != "stale" {
+		t.Fatalf("literal state = %q, want stale after audit insert", literalState)
+	}
+
+	criteria := apptypes.NewEventSearchCriteriaBuilder(10).Query("needle").Build()
+	got, err := datasource.SearchMetadata(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchMetadata() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"tail-event"}, metadataIDs(got)); diff != "" {
+		t.Fatalf("SearchMetadata() IDs mismatch (-want +got):\n%s", diff)
+	}
+	full, err := datasource.SearchPage(ctx, criteria)
+	if err != nil {
+		t.Fatalf("SearchPage() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"tail-event"}, eventIDs(full)); diff != "" {
+		t.Fatalf("SearchPage() IDs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTieredAuthorityLiteralCompletionAcceptsStaleFromRebuildAppend(t *testing.T) {
+	// Case 5: event appended during a rebuild, then generation completes →
+	// literal transitions stale → complete and both projections end complete.
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "during-pre", "rebuild needle", base)
+
+	budget := projectionBudget()
+	budget.Rows = 8
+	now := base.Add(time.Hour)
+	if _, err := database.Start(ctx, budget, now); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	literalState, _ := readProjectionStates(t, database)
+	if literalState != "rebuilding" {
+		t.Fatalf("literal state after Start = %q, want rebuilding", literalState)
+	}
+
+	// Append during rebuild: migration-039 flips literal to stale.
+	insertTieredSearchEvent(t, database, "during-append", "appended while rebuilding", base.Add(time.Second))
+	literalState, _ = readProjectionStates(t, database)
+	if literalState != "stale" {
+		t.Fatalf("literal state after mid-rebuild append = %q, want stale", literalState)
+	}
+
+	uc := usecase.NewSearchProjectionUsecase(database)
+	var completed bool
+	for range 32 {
+		progress, err := uc.Resume(ctx, budget, now)
+		if err != nil {
+			t.Fatalf("Resume() error = %v", err)
+		}
+		if progress.Completed {
+			completed = true
+			break
+		}
+	}
+	if !completed {
+		t.Fatal("generation did not complete within batch budget")
+	}
+
+	literalState, boundedState := readProjectionStates(t, database)
+	if literalState != "complete" {
+		t.Fatalf("literal state after completion = %q, want complete (stale→complete transition)", literalState)
+	}
+	if boundedState != "complete" {
+		t.Fatalf("bounded state after completion = %q, want complete", boundedState)
+	}
+}
+
+func TestTieredAuthorityLiteralCompletionZeroRowsIsDrift(t *testing.T) {
+	// Case 6: literal completion UPDATE matching zero rows → batch fails with
+	// SearchProjectionDriftError rather than reporting success.
+	ctx := context.Background()
+	database, _ := newTieredAuthorityFixture(t)
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	insertTieredSearchEvent(t, database, "e1", "completion needle", base)
+
+	budget := projectionBudget()
+	now := base.Add(time.Hour)
+	g, err := database.Start(ctx, budget, now)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	raw, err := database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Point the singleton at a different generation so the completion UPDATE
+	// matches zero rows while bounded/lifecycle still look rebuildable.
+	if _, err = raw.ExecContext(ctx, `
+		UPDATE literal_search_projection_state
+		   SET generation_id = 'not-this-generation', state = 'rebuilding'
+		 WHERE singleton = 1`); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	var rev, checkpoint int64
+	var phase string
+	if err = raw.QueryRowContext(ctx, `
+		SELECT source_revision, checkpoint, phase
+		  FROM search_projection_state
+		 WHERE generation_id = ?`, g.GenerationID,
+	).Scan(&rev, &checkpoint, &phase); err != nil {
+		_ = raw.Close()
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+
+	plan := apptypes.ProjectionBatchPlan{
+		GenerationID:       g.GenerationID,
+		Phase:              phase,
+		ExpectedRevision:   rev,
+		ExpectedCheckpoint: checkpoint,
+		NextCheckpoint:     checkpoint,
+		NextPhase:          "complete",
+		Completed:          true,
+		FinalState:         "complete",
+		AllowRevisionDrift: true,
+	}
+	_, err = database.ApplyBatch(ctx, plan, budget.LockTime, now)
+	var drift *apptypes.SearchProjectionDriftError
+	if !errors.As(err, &drift) {
+		t.Fatalf("ApplyBatch() error = %T %v, want SearchProjectionDriftError", err, err)
+	}
+}

--- a/infrastructure/sqlite/search_maintenance_internal_test.go
+++ b/infrastructure/sqlite/search_maintenance_internal_test.go
@@ -466,13 +466,28 @@ func TestPersistedTieredAuthorityPreservesDescendingContinuationAndFailsClosed(t
 	if err != nil {
 		t.Fatal(err)
 	}
+	// 'stale' is what migration 039 writes on every ordinary append, so it is a
+	// tail condition the walk answers, not a "cannot answer" condition. See
+	// event_search_authority_internal_test.go for the append and mutation cases.
 	_, err = raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET state='stale'`)
 	_ = raw.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err = datasource.SearchPage(ctx, criteria); err != nil {
+		t.Fatalf("stale literal projection refused a tail-only condition: %v", err)
+	}
+	raw, err = database.open(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = raw.ExecContext(ctx, `UPDATE literal_search_projection_state SET state='rebuilding'`)
+	_ = raw.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err = datasource.SearchPage(ctx, criteria); err == nil {
-		t.Fatal("stale tiered projection did not fail closed")
+		t.Fatal("incomplete tiered projection did not fail closed")
 	}
 }
 

--- a/infrastructure/sqlite/search_projection_rebuild.go
+++ b/infrastructure/sqlite/search_projection_rebuild.go
@@ -670,8 +670,17 @@ func (d *Database) applyProjectionPlan(ctx context.Context, p apptypes.Projectio
 		}
 	}
 	if p.Completed && state == "complete" {
-		if _, e = tx.ExecContext(lockCtx, `UPDATE literal_search_projection_state SET state='complete',updated_at=? WHERE singleton=1 AND generation_id=? AND state='rebuilding'`, formatTimestamp(now), p.GenerationID); e != nil {
+		// Accept 'stale' as well as 'rebuilding': events recorded during a
+		// rebuild flip literal state to stale via migration-039 triggers, so
+		// requiring only 'rebuilding' left the row permanently incomplete on
+		// live stores. Zero rows means this generation is not the one the
+		// literal singleton is finishing — same drift fence as lifecycle.
+		var literalResult sql.Result
+		if literalResult, e = tx.ExecContext(lockCtx, `UPDATE literal_search_projection_state SET state='complete',updated_at=? WHERE singleton=1 AND generation_id=? AND state IN ('rebuilding','stale')`, formatTimestamp(now), p.GenerationID); e != nil {
 			return out, e
+		}
+		if n, rowErr := literalResult.RowsAffected(); rowErr != nil || n != 1 {
+			return out, &apptypes.SearchProjectionDriftError{}
 		}
 	}
 	if p.Completed && state == "complete" {


### PR DESCRIPTION
Closes #1733

## Problem

Once `search_maintenance_control.authority='tiered'`, every non-structural search went through `searchTieredMetadataTx` and returned `tiered search projection is incomplete or stale` after the first ordinary write, permanently. `CatchUp` sees `state='complete'` and returns `already_complete`, so it never recovers on its own. This blocks #1718, which flips the authority to tiered and deletes the legacy fallback.

Three independent mechanisms produce that same refusal. Fixing only the one the issue names leaves the bug intact — verified against the working tree.

| Mechanism | Where | Fires on |
|---|---|---|
| `literalHigh != sourceHigh` | `event_search_authority.go` gate | Migration 038 registers a source-sequence row for **every** event; literal `high_water` is frozen at completion. First append. |
| `literalState != "complete"` | same gate | Migration 039's six triggers set the literal row to `'stale'` on every `events` / `command_audits` insert, update and delete. First write. |
| Completion never recorded | `search_projection_rebuild.go:673` | The transition matched only `state='rebuilding'` and did not check `RowsAffected`. An append **during** a rebuild flips the row to `'stale'`, so on a live store the UPDATE routinely matches zero rows and `'complete'` is never reached at all. |

## Fix

- **Widen the candidate walk.** `searchTieredTopKMetadataTx` drops the `WHERE q.sequence<=high_water` bound. It already visits `search_projection_source_sequence JOIN events` in the public order (`created_at_norm DESC, id DESC`) and decodes each candidate, and its fingerprint pre-filter is fail-open for rows with no fingerprints for the generation. Post-cutover rows have none, so they are admitted and decided on their live content — same order, same offset/limit semantics, same `DeepLiteralSearchBudget`. They are newest, so they are visited first and consume budget first.
- **Drop the watermark equality.** A watermark gap is the normal steady state of a written-to store, not a "cannot answer" condition.
- **Accept `literalState='stale'`.** Kept unchanged: `boundedState=='complete'`, `literalGeneration != ""`, `literalGeneration == boundedGeneration`.
- **Fix the completion transition** to `state IN ('rebuilding','stale')` and treat zero affected rows as drift (`SearchProjectionDriftError`), matching the bounded lifecycle update immediately below it.

No migration, no trigger change.

## Why accepting `'stale'` is not a wrong-answer hole

`'stale'` conflates appends with mutations of already-projected rows. Appends are safe — no fingerprints, fail-open, decoded live. Mutations would be unsafe if the literal gate were the only guard, because the row's fingerprints are now wrong and the pre-filter would exclude it silently.

It is not the only guard. The `search_projection_complete_*` triggers in `schema/sqlite/migrations/000041_add_search_projection_generation_lifecycle.sql:16-40` fire on mutation of an already-projected event or audit and set the **bounded** row to `state='drifted'` with `active_generation_id=NULL`. So `boundedState=='complete'` is what rejects a mutated projection. The tests assert that `drifted` state directly, so if that trigger ever stops firing the suite fails loudly instead of degrading into silent omissions.

An earlier design that invalidated fingerprint rows from the mutation triggers was proposed and withdrawn — migration 041 already covers it, and it would have been a migration the issue does not need.

## Tests

`infrastructure/sqlite/event_search_authority_internal_test.go` (new, `package sqlite`). Every case was run against the pre-fix tree first:

| Test | Pre-fix | Post-fix |
|---|---|---|
| `...IncludesPostCutoverTail` (metadata / full / ordering across the cutover) | FAIL — stale error | pass |
| `...SearchWatermarkGapIsNotStale` | FAIL — stale error | pass |
| `...AppendLeavesLiteralStaleAndStillAnswers` | FAIL — stale error | pass |
| `...AuditInsertOnTailEventStaysCompleteAndMatches` | FAIL — stale error | pass |
| `...LiteralCompletionAcceptsStaleFromRebuildAppend` | FAIL — literal stuck at `stale` | pass |
| `...LiteralCompletionZeroRowsIsDrift` | FAIL — reported success | pass |
| `...SearchBudgetExhaustionOnLargeTail` | FAIL — stale error before budget | pass, `EventSearchUnavailableError` / `index_incomplete` |
| `...BodyUpdateOfProjectedEventDriftsAndRefuses` | pass (refused for the wrong reason) | pass, now asserts bounded `drifted` |
| `...AuditInsertOnProjectedEventDriftsAndRefuses` | pass | pass, asserts bounded `drifted` |
| `...FingerprintPreFilter` | pass | pass — real generation fingerprints seeded so the pre-filter is actually exercised |
| `...StillFailsWhenProjectionCannotAnswer` (4 cases: literal rebuilding, bounded rebuilding, generation mismatch, empty generation) | pass | pass |

Fingerprint fixtures use the real writer shape: `CharacterizeLiteralQuery(body).Fingerprints()`, 16-byte blobs at `fingerprint_version=1`, keyed by `generation_id + source_sequence + event_id`.

`TestPersistedTieredAuthorityPreservesDescendingContinuationAndFailsClosed` asserted the old contract (`'stale'` fails closed). Updated to assert the new one: `'stale'` answers, `'rebuilding'` still fails closed.

`go build ./...`, `go tool golangci-lint run` (0 issues) and `go test ./...` all pass.

## Deliberately out of scope

- Making generation completion non-terminal. `CatchUp`'s `already_complete` branch is untouched.
- Tiered availability while a generation is rebuilding, or parked in `failed` after #1732. Both still refuse — separate follow-up, and it blocks #1718.
- The empty-query structural branch sitting behind the literal gate despite its comment claiming it does not need literal traversal — separate follow-up.
- #1718 itself. No authority default is flipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
