### PR TITLE
feat: compress the command_audits text columns

### DIFF
--- a/application/types/payload_backfill.go
+++ b/application/types/payload_backfill.go
@@ -50,13 +50,16 @@ func (c PayloadBackfillConfig) Valid() bool {
 
 // PayloadBackfillResult is sanitized aggregate evidence for CLI/JSON output.
 type PayloadBackfillResult struct {
-	RunID               string `json:"run_id,omitempty"`
-	State               string `json:"state"`
-	RecipeVersion       string `json:"recipe_version,omitempty"`
-	HighWaterRowID      int64  `json:"high_water_rowid,omitempty"`
-	CursorRowID         int64  `json:"cursor_rowid,omitempty"`
-	PassCount           int64  `json:"pass_count,omitempty"`
-	EligibleRows        int64  `json:"eligible_rows,omitempty"`
+	RunID          string `json:"run_id,omitempty"`
+	State          string `json:"state"`
+	RecipeVersion  string `json:"recipe_version,omitempty"`
+	HighWaterRowID int64  `json:"high_water_rowid,omitempty"`
+	CursorRowID    int64  `json:"cursor_rowid,omitempty"`
+	PassCount      int64  `json:"pass_count,omitempty"`
+	EligibleRows   int64  `json:"eligible_rows,omitempty"`
+	// ScannedRows counts lane candidates examined (one events.body or one
+	// command_audits text field), not physical table rows. An audit row with
+	// three eligible fields contributes 3. The JSON field name is frozen.
 	ScannedRows         int64  `json:"scanned_rows"`
 	EncodedRows         int64  `json:"encoded_rows"`
 	IdentityKeptRows    int64  `json:"identity_kept_rows"`

--- a/application/types/payload_backfill.go
+++ b/application/types/payload_backfill.go
@@ -3,7 +3,10 @@ package types
 // PayloadBackfillRecipeVersion is the batch semantics identifier stored on
 // every run. Resume refuses a checkpoint whose version differs so a newer
 // binary cannot skip a prefix written under different rules.
-const PayloadBackfillRecipeVersion = "events-body-zstd-v1"
+//
+// v1 rewrote only events.body. v2 adds command_audits.{command,input,output}_text
+// through the same rowid high-water / cursor / fixpoint protocol.
+const PayloadBackfillRecipeVersion = "events-body-command-audits-zstd-v2"
 
 // PayloadBackfillState is the persisted live-store backfill workflow state.
 type PayloadBackfillState string

--- a/docs/storage/payload-backfill.ja.md
+++ b/docs/storage/payload-backfill.ja.md
@@ -2,8 +2,15 @@
 
 [English](payload-backfill.md)
 
-`traceary store payload-backfill` は、既存のすべての `events.body` を、すでに
-`payload_codec.go` に実装されているバージョン付き zstd codec 経由で書き直します。
+`traceary store payload-backfill` は、既存の圧縮可能なペイロードテキスト列を、
+すでに `payload_codec.go` に実装されているバージョン付き zstd codec 経由で
+書き直します。対象は次のとおりです。
+
+| テーブル | 列 |
+|---|---|
+| `events` | `body` |
+| `command_audits` | `command_text`, `input_text`, `output_text` |
+
 保持している履歴に圧縮を適用するオペレータ向けコマンドです。
 
 これは **`store payload-rehearsal` ではありません**。rehearsal は *コピー* 上の
@@ -16,10 +23,9 @@ identity / zstd が混在したコーパスをバッチ境界ごとに常に正�
 
 - マイグレーション 053（codec 対応の body 由来トリガ）と 054（バックフィル用
   ブックキーピング）を含むビルドへアップグレードしたあと
-- 圧縮済みイベント本文を前提にした #1620 のストアサイズゲート数値を使う前
+- 圧縮済みイベント本文 **および** 圧縮済み command_audits テキストを前提にした
+  #1620 のストアサイズゲート数値を使う前
 - 検索 projection の rebuild と、その後の `store compact` を行えるメンテ窓
-
-`command_audits` のテキスト列は **対象外** です（別チケットで追跡）。
 
 ## 手順
 
@@ -51,8 +57,10 @@ identity / zstd が混在したコーパスをバッチ境界ごとに常に正�
    ```
 
 6. **検索 projection を rebuild する。** backfill は `events.body` を更新するため、
-   無効化トリガが発火し projection は `drifted` / `stale` になります。これは正しい
-   終端状態です。既存コマンドで rebuild してください:
+   無効化トリガが発火し projection は `drifted` / `stale` になります。audit テキスト
+   の書き換えは projection 無効化を起こしません（migration 052 以降、検索 writer は
+   それらを読まない）が、body が変わった場合は rebuild が必要です。既存コマンドで
+   rebuild してください:
 
    ```sh
    traceary store search-projection rebuild
@@ -70,16 +78,17 @@ identity / zstd が混在したコーパスをバッチ境界ごとに常に正�
 
 | 性質 | 挙動 |
 |---|---|
-| 選択条件 | `body_codec IS NULL OR body_codec = 'identity'`。加えて codec 列 5 つが「すべて NULL」でも「すべて埋まっている」でもない行も選ぶ（run を fail closed させるため） |
+| 選択条件 | フィールドごと: `<field>_codec IS NULL OR <field>_codec = 'identity'`。加えて codec 列 5 つが「すべて NULL」でも「すべて埋まっている」でもないフィールドも選ぶ（run を fail closed させるため） |
+| レーン | `events.body`、続けて `command_audits.{command,input,output}_text`。共有の rowid カーソルが両テーブルを歩く。バッチは選択した各 rowid の全対象フィールドを読み、LIMIT で兄弟フィールドが取り残されないようにする |
 | アフィニティ | zstd は BLOB、identity は TEXT で保存し、他の writer と揃える。plaintext を読む SQL（マイグレーション 053 の `LIKE`）が壊れない |
-| カーソル | `events.rowid`（単調）。イベント `id` は乱数なのでカーソルに使わない |
-| ハイウォーター | 実行開始時の `max(rowid)`。実行中に取り込まれた行は identity のまま残り、次の実行対象になる |
+| カーソル | `events` と `command_audits` で共有する数値 `rowid` ハイウォーター（各テーブルの rowid 列は独立）。イベント `id` / audit `event_id` は乱数なのでカーソルに使わない |
+| ハイウォーター | 実行開始時の `max(max(events.rowid), max(command_audits.rowid))`。実行中に取り込まれた行は identity のまま残り、次の実行対象になる |
 | 不動点 | 書き換えも conflict skip もない完全走査になるまでパスを繰り返す |
-| アトミックバッチ | ソース再検証・エンコード・body + codec 列 5 つの書き込み・チェックポイント更新を 1 トランザクションで行う |
-| 部分メタデータ | 件数を数え結果に id を載せ、run を fail closed。行は書き換えない |
-| 由来情報 | `body_stored_bytes` / `body_original_bytes` / `source_hook`・`legacy_source_hook` は backfill が直接書かない。マイグレーション 053 が表現変更をまたいで引き継ぐ |
-| Projection | 抑制しない。`drifted`/`stale` を前提に rebuild する |
-| Recipe version | チェックポイントに記録。別 recipe の resume は拒否し、未書き込み prefix を飛ばさない |
+| アトミックバッチ | ソース再検証・エンコード・フィールド + codec 列 5 つの書き込み・チェックポイント更新を 1 トランザクションで行う |
+| 部分メタデータ | 件数を数え結果に id（event id / audit event_id）を載せ、run を fail closed。フィールドは書き換えない |
+| 由来情報 | `body_stored_bytes` / `body_original_bytes` / `source_hook`・`legacy_source_hook`、および `input_original_bytes` / `output_original_bytes` は backfill が直接書かない。body 由来はマイグレーション 053 が表現変更をまたいで引き継ぐ |
+| Projection | body 書き換えでは抑制しない。`drifted`/`stale` を前提に rebuild する |
+| Recipe version | チェックポイントに記録。別 recipe の resume は拒否し、未書き込み prefix を飛ばさない。現行 recipe: `events-body-command-audits-zstd-v2` |
 
 標準出力は集計カウンタだけの JSON です（本文は含みません）。
 

--- a/docs/storage/payload-backfill.ja.md
+++ b/docs/storage/payload-backfill.ja.md
@@ -81,8 +81,9 @@ identity / zstd が混在したコーパスをバッチ境界ごとに常に正�
 | 選択条件 | フィールドごと: `<field>_codec IS NULL OR <field>_codec = 'identity'`。加えて codec 列 5 つが「すべて NULL」でも「すべて埋まっている」でもないフィールドも選ぶ（run を fail closed させるため） |
 | レーン | `events.body`、続けて `command_audits.{command,input,output}_text`。共有の rowid カーソルが両テーブルを歩く。バッチは選択した各 rowid の全対象フィールドを読み、LIMIT で兄弟フィールドが取り残されないようにする |
 | アフィニティ | zstd は BLOB、identity は TEXT で保存し、他の writer と揃える。plaintext を読む SQL（マイグレーション 053 の `LIKE`）が壊れない |
-| カーソル | `events` と `command_audits` で共有する数値 `rowid` ハイウォーター（各テーブルの rowid 列は独立）。イベント `id` / audit `event_id` は乱数なのでカーソルに使わない |
-| ハイウォーター | 実行開始時の `max(max(events.rowid), max(command_audits.rowid))`。実行中に取り込まれた行は identity のまま残り、次の実行対象になる |
+| カーソル | `events` と `command_audits` で共有する数値 `rowid` カーソル（各テーブルの rowid 列は独立）。イベント `id` / audit `event_id` は乱数なのでカーソルに使わない |
+| ハイウォーター | 実行開始時にテーブルごとの天井を固定する: `high_water_rowid` = `MAX(events.rowid)`、`audit_high_water_rowid` = `MAX(command_audits.rowid)`。共有の max だと遅れている側の後続 insert が天井より下に入り、frontier が詰まったり未処理のまま completed になる。resume はチェックポイントから両天井を読み、再計算しない |
+| Scanned rows | **レーン候補**の検査数（`events.body` 1 件、または `command_audits` の text フィールド 1 件）。物理行数ではない。監査行で 3 フィールドが対象なら 3 を加算する。JSON フィールド名 `scanned_rows` は契約上固定 |
 | 不動点 | 書き換えも conflict skip もない完全走査になるまでパスを繰り返す |
 | アトミックバッチ | ソース再検証・エンコード・フィールド + codec 列 5 つの書き込み・チェックポイント更新を 1 トランザクションで行う |
 | 部分メタデータ | 件数を数え結果に id（event id / audit event_id）を載せ、run を fail closed。フィールドは書き換えない |

--- a/docs/storage/payload-backfill.md
+++ b/docs/storage/payload-backfill.md
@@ -2,9 +2,16 @@
 
 [日本語](payload-backfill.ja.md)
 
-`traceary store payload-backfill` rewrites every existing `events.body` through
-the versioned zstd codec already shipped in `payload_codec.go`. It is the
-operator command that applies compression to retained history.
+`traceary store payload-backfill` rewrites every existing compressible payload
+text column through the versioned zstd codec already shipped in
+`payload_codec.go`:
+
+| Table | Columns |
+|---|---|
+| `events` | `body` |
+| `command_audits` | `command_text`, `input_text`, `output_text` |
+
+It is the operator command that applies compression to retained history.
 
 This is **not** `store payload-rehearsal`. Rehearsal writes only to a shadow
 table on a *copy*, freezes inserts, and refuses to start once the live store
@@ -17,11 +24,9 @@ mixed identity/zstd corpus as a fully valid store at every batch boundary.
 - After upgrading to a build that includes migration 053 (codec-aware body
   provenance triggers) and 054 (backfill bookkeeping).
 - Before relying on the #1620 store-size gate numbers that assume compressed
-  event bodies.
+  event bodies **and** compressed command-audit text.
 - On a maintenance window where you can rebuild the search projection and run
   `store compact` afterwards.
-
-`command_audits` text columns are **out of scope** (tracked separately).
 
 ## Procedure
 
@@ -54,7 +59,9 @@ mixed identity/zstd corpus as a fully valid store at every batch boundary.
 
 6. **Rebuild the search projection.** The backfill updates `events.body`, so the
    projection invalidation triggers fire and leave the projection `drifted` /
-   `stale`. That end state is correct — rebuild with the existing command:
+   `stale`. Audit-text rewrites do not drive projection invalidation (no
+   search writer reads them after migration 052), but a rebuild is still
+   required whenever body rows changed. Rebuild with the existing command:
 
    ```sh
    traceary store search-projection rebuild
@@ -71,16 +78,17 @@ mixed identity/zstd corpus as a fully valid store at every batch boundary.
 
 | Property | Behaviour |
 |---|---|
-| Selection | `body_codec IS NULL OR body_codec = 'identity'`, plus any row whose five codec columns are neither all-NULL nor all-present — those are selected precisely so the run can fail closed on them |
-| Affinity | zstd bodies are stored as BLOB, identity bodies as TEXT, matching every other writer. SQL that still reads a plaintext body (migration 053's `LIKE`) keeps working |
-| Cursor | `events.rowid` (monotonic). Event `id` values are random and must not be used as a cursor |
-| High-water | `max(rowid)` fixed at run start. Rows ingested during the run stay identity and are left for a later run |
+| Selection | Per field: `<field>_codec IS NULL OR <field>_codec = 'identity'`, plus any field whose five codec columns are neither all-NULL nor all-present — those are selected precisely so the run can fail closed on them |
+| Lanes | `events.body`, then `command_audits.{command,input,output}_text`. One shared rowid cursor walks both tables; a batch loads every eligible field of each selected rowid so a limit cut cannot strand a sibling field |
+| Affinity | zstd values are stored as BLOB, identity values as TEXT, matching every other writer. SQL that still reads a plaintext body (migration 053's `LIKE`) keeps working |
+| Cursor | Shared numeric `rowid` high-water across `events` and `command_audits` (each table's rowid sequence is independent). Event `id` / audit `event_id` values are random and must not be used as a cursor |
+| High-water | `max(max(events.rowid), max(command_audits.rowid))` fixed at run start. Rows ingested during the run stay identity and are left for a later run |
 | Fixpoint | Passes repeat until a full walk rewrites nothing and skips no conflicts |
-| Atomic batch | Re-verify source, encode, write body + five codec columns, advance checkpoint — one transaction |
-| Partial metadata | Counted, named in the result, run fails closed; the row is not rewritten |
-| Provenance | `body_stored_bytes`, `body_original_bytes`, and `source_hook` / `legacy_source_hook` are not written by the backfill; migration 053 carries them across representation changes |
-| Projection | Not suppressed. Expect `drifted`/`stale` and rebuild |
-| Recipe version | Checkpointed. A different binary recipe refuses resume rather than skip a prefix |
+| Atomic batch | Re-verify source, encode, write field + five codec columns, advance checkpoint — one transaction |
+| Partial metadata | Counted, named in the result (event id / audit event_id), run fails closed; the field is not rewritten |
+| Provenance | `body_stored_bytes`, `body_original_bytes`, `source_hook` / `legacy_source_hook`, and `input_original_bytes` / `output_original_bytes` are not written by the backfill; migration 053 carries body provenance across representation changes |
+| Projection | Not suppressed for body rewrites. Expect `drifted`/`stale` and rebuild |
+| Recipe version | Checkpointed. A different binary recipe refuses resume rather than skip a prefix. Current recipe: `events-body-command-audits-zstd-v2` |
 
 Output is JSON on stdout with aggregate counters only (no body contents).
 

--- a/docs/storage/payload-backfill.md
+++ b/docs/storage/payload-backfill.md
@@ -81,8 +81,9 @@ mixed identity/zstd corpus as a fully valid store at every batch boundary.
 | Selection | Per field: `<field>_codec IS NULL OR <field>_codec = 'identity'`, plus any field whose five codec columns are neither all-NULL nor all-present — those are selected precisely so the run can fail closed on them |
 | Lanes | `events.body`, then `command_audits.{command,input,output}_text`. One shared rowid cursor walks both tables; a batch loads every eligible field of each selected rowid so a limit cut cannot strand a sibling field |
 | Affinity | zstd values are stored as BLOB, identity values as TEXT, matching every other writer. SQL that still reads a plaintext body (migration 053's `LIKE`) keeps working |
-| Cursor | Shared numeric `rowid` high-water across `events` and `command_audits` (each table's rowid sequence is independent). Event `id` / audit `event_id` values are random and must not be used as a cursor |
-| High-water | `max(max(events.rowid), max(command_audits.rowid))` fixed at run start. Rows ingested during the run stay identity and are left for a later run |
+| Cursor | Shared numeric `rowid` cursor across `events` and `command_audits` (each table's rowid sequence is independent). Event `id` / audit `event_id` values are random and must not be used as a cursor |
+| High-water | Per-table ceilings fixed at run start: `high_water_rowid` = `MAX(events.rowid)`, `audit_high_water_rowid` = `MAX(command_audits.rowid)`. Each table is bounded by its own ceiling so a later insert into the lagging sequence cannot land below a shared max. Resume reads both from the checkpoint and never recomputes them |
+| Scanned rows | Counts **lane candidates** examined (one `events.body` or one `command_audits` text field), not physical table rows. An audit row with three eligible fields contributes 3. The JSON field name `scanned_rows` is frozen |
 | Fixpoint | Passes repeat until a full walk rewrites nothing and skips no conflicts |
 | Atomic batch | Re-verify source, encode, write field + five codec columns, advance checkpoint — one transaction |
 | Partial metadata | Counted, named in the result (event id / audit event_id), run fails closed; the field is not rewritten |

--- a/infrastructure/sqlite/capacity_benchmark_queries.go
+++ b/infrastructure/sqlite/capacity_benchmark_queries.go
@@ -33,7 +33,7 @@ func CapacityBenchmarkQueries(ctx context.Context, db *sql.DB) ([]CapacityBenchm
 func CapacityHandoffPlanQueries() []CapacityBenchmarkQuery {
 	return []CapacityBenchmarkQuery{
 		{Name: "session_resolution", SQL: listSessionsQuery, Args: []any{"", "", "", "", "", "", "", "", "", "", "", "", false, "", "", "", "", 1, 0}},
-		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{"", "", 5, 512}},
+		{Name: "recent_command_previews", SQL: selectRecentCommandPreviewsQuery, Args: []any{"", "", 5}},
 		{Name: "compact_summary", SQL: selectLatestPostCompactSummaryQuery, Args: []any{"", "", "", "", "", "", "", 32}},
 	}
 }

--- a/infrastructure/sqlite/command_audit_byte_accounting_internal_test.go
+++ b/infrastructure/sqlite/command_audit_byte_accounting_internal_test.go
@@ -75,7 +75,8 @@ func TestRecentCommandPreviewsStoredBytesPreferPlaintextOnCompressedCorpus(t *te
 		t.Fatalf("compress command_text: %v", err)
 	}
 
-	got, err := ds.ListRecentCommandPreviews(ctx, types.SessionID("session-preview"), 10, 64)
+	const previewRunes = 64
+	got, err := ds.ListRecentCommandPreviews(ctx, types.SessionID("session-preview"), 10, previewRunes)
 	if err != nil {
 		t.Fatalf("ListRecentCommandPreviews: %v", err)
 	}
@@ -88,6 +89,12 @@ func TestRecentCommandPreviewsStoredBytesPreferPlaintextOnCompressedCorpus(t *te
 	}
 	if got[0].StoredBytes() == int(encoded.StoredBytes) {
 		t.Fatalf("stored bytes equals compressed size %d; plaintext preference is missing", encoded.StoredBytes)
+	}
+	// After removing the dead substr(command_text) column, the preview body is
+	// still the codec-decoded plaintext (bounded), not empty and not zstd bytes.
+	wantBody := string([]rune(commandPlain)[:previewRunes])
+	if diff := cmp.Diff(wantBody, got[0].Body()); diff != "" {
+		t.Fatalf("preview body mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/infrastructure/sqlite/command_audit_byte_accounting_internal_test.go
+++ b/infrastructure/sqlite/command_audit_byte_accounting_internal_test.go
@@ -1,0 +1,169 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/duck8823/traceary/domain/model"
+	"github.com/duck8823/traceary/domain/types"
+)
+
+// Once command_text is zstd-compressed, length(CAST(command_text AS BLOB)) is
+// the physical size. StoredBytes must report the logical command length so
+// handoff previews do not under-count retained history.
+func TestRecentCommandPreviewsStoredBytesPreferPlaintextOnCompressedCorpus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "preview-bytes.db")
+	database := NewDatabase(path, preparedMigrations(t))
+	if err := NewStoreManagementDatasource(database).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	ds := NewEventDatasource(database)
+
+	commandPlain := strings.Repeat("preview-command-payload-", 256)
+	event := model.EventOf(
+		mustEventID(t, "event-compressed-cmd"), types.EventKindCommandExecuted,
+		types.Client("cli"), mustAgent(t, "codex"),
+		mustSessionID(t, "session-preview"), types.Workspace("ws"), "",
+		time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC),
+	)
+	if err := ds.Save(ctx, event); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", directSQLiteRWDSN(path))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`
+		INSERT INTO command_audits(
+			event_id, command_text, input_text, output_text,
+			input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+			exit_code, failed
+		) VALUES (?, ?, '', '', 0, 0, 0, 0, 0, 0)`, event.EventID().String(), commandPlain); err != nil {
+		t.Fatalf("insert audit: %v", err)
+	}
+	encoded, err := encodePayload([]byte(commandPlain), payloadCodecZstd)
+	if err != nil {
+		t.Fatalf("encode zstd command: %v", err)
+	}
+	if encoded.StoredBytes >= encoded.PlaintextBytes {
+		t.Fatalf("zstd did not shrink command (%d → %d); test cannot detect length confusion",
+			encoded.PlaintextBytes, encoded.StoredBytes)
+	}
+	if _, err := db.Exec(`
+		UPDATE command_audits
+		   SET command_text = ?,
+		       command_codec = ?,
+		       command_format_version = ?,
+		       command_plaintext_bytes = ?,
+		       command_encoded_bytes = ?,
+		       command_sha256 = ?
+		 WHERE event_id = ?`,
+		encoded.Bytes, encoded.Codec, encoded.FormatVersion,
+		encoded.PlaintextBytes, encoded.StoredBytes, encoded.SHA256,
+		event.EventID().String(),
+	); err != nil {
+		t.Fatalf("compress command_text: %v", err)
+	}
+
+	got, err := ds.ListRecentCommandPreviews(ctx, types.SessionID("session-preview"), 10, 64)
+	if err != nil {
+		t.Fatalf("ListRecentCommandPreviews: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("previews = %d, want 1", len(got))
+	}
+	if got[0].StoredBytes() != len(commandPlain) {
+		t.Fatalf("stored bytes = %d, want plaintext %d (compressed physical size is %d)",
+			got[0].StoredBytes(), len(commandPlain), encoded.StoredBytes)
+	}
+	if got[0].StoredBytes() == int(encoded.StoredBytes) {
+		t.Fatalf("stored bytes equals compressed size %d; plaintext preference is missing", encoded.StoredBytes)
+	}
+}
+
+// search_projection_rebuild sizes each source row with a physical stored figure
+// (intentional length() terms) and a logical decoded figure that prefers
+// *_plaintext_bytes. Against a compressed audit corpus the two must diverge and
+// the logical figure must match the pre-codec plaintext sizes.
+func TestSearchProjectionSourceSizingPrefersAuditPlaintextBytes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _, _ := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	const id = "proj-size"
+	command := compressibleBody("proj-cmd")
+	input := compressibleBody("proj-in")
+	output := compressibleBody("proj-out")
+	insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+	insertPlaintextAudit(t, db, auditSeed{
+		EventID: id, Command: command, Input: input, Output: output,
+	})
+	reencodeAuditFieldToZstd(t, db, id, "command", command)
+	reencodeAuditFieldToZstd(t, db, id, "input", input)
+	reencodeAuditFieldToZstd(t, db, id, "output", output)
+
+	// Mirror the production SELECT list used by SelectSnapshot's source phase.
+	var stored, decoded int64
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(length(CAST(e.body AS BLOB)),0)
+		     + COALESCE(length(CAST(a.command_text AS BLOB)),0)
+		     + COALESCE(length(CAST(a.input_text AS BLOB)),0)
+		     + COALESCE(length(CAST(a.output_text AS BLOB)),0),
+		       CASE WHEN e.body_availability='available'
+		            THEN COALESCE(e.body_plaintext_bytes,e.body_stored_bytes,length(CAST(e.body AS BLOB)),0)
+		            ELSE 0 END
+		     + COALESCE(a.command_plaintext_bytes,length(CAST(a.command_text AS BLOB)),0)
+		     + COALESCE(a.input_plaintext_bytes,length(CAST(a.input_text AS BLOB)),0)
+		     + COALESCE(a.output_plaintext_bytes,length(CAST(a.output_text AS BLOB)),0)
+		  FROM events e
+		  LEFT JOIN command_audits a ON a.event_id = e.id
+		 WHERE e.id = ?`, id).Scan(&stored, &decoded); err != nil {
+		t.Fatalf("size query: %v", err)
+	}
+
+	wantDecoded := int64(len(command) + len(input) + len(output))
+	if diff := cmp.Diff(wantDecoded, decoded); diff != "" {
+		t.Fatalf("decoded bytes mismatch (-want +got):\n%s", diff)
+	}
+	if stored >= decoded {
+		t.Fatalf("stored=%d decoded=%d; compressed corpus must shrink the physical figure", stored, decoded)
+	}
+	// Guard against the regression that made length() alone the logical figure.
+	if decoded == stored {
+		t.Fatalf("decoded equals stored (%d); plaintext_bytes preference is not applied", decoded)
+	}
+}
+
+func mustEventID(t *testing.T, value string) types.EventID {
+	t.Helper()
+	id, err := types.EventIDFrom(value)
+	if err != nil {
+		t.Fatalf("EventIDFrom(%q): %v", value, err)
+	}
+	return id
+}
+
+func mustAgent(t *testing.T, value string) types.Agent {
+	t.Helper()
+	agent, err := types.AgentFrom(value)
+	if err != nil {
+		t.Fatalf("AgentFrom(%q): %v", value, err)
+	}
+	return agent
+}
+
+func mustSessionID(t *testing.T, value string) types.SessionID {
+	t.Helper()
+	return types.SessionID(value)
+}

--- a/infrastructure/sqlite/event_preview_datasource.go
+++ b/infrastructure/sqlite/event_preview_datasource.go
@@ -40,7 +40,9 @@ func (d *EventDatasource) ListRecentCommandPreviews(ctx context.Context, session
 		return nil, xerrors.Errorf("failed to open DB for command previews: %w", err)
 	}
 	defer d.db.release(db)
-	rows, err := db.QueryContext(ctx, selectRecentCommandPreviewsQuery, sessionID.String(), sessionID.String(), limit, bodyRuneLimit)
+	// bodyRuneLimit is applied after codec hydration; the SQL no longer binds
+	// a substr length because it does not select command_text at all.
+	rows, err := db.QueryContext(ctx, selectRecentCommandPreviewsQuery, sessionID.String(), sessionID.String(), limit)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to query recent command previews: %w", err)
 	}
@@ -52,13 +54,13 @@ func (d *EventDatasource) ListRecentCommandPreviews(ctx context.Context, session
 
 	previews := make([]apptypes.EventBodyPreview, 0, limit)
 	for rows.Next() {
-		preview, err := scanEventBodyPreview(rows)
+		meta, err := scanCommandPreviewMetadata(rows)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to restore command preview row: %w", err)
 		}
 		// Prefer the retained command_audits.command_text; fall back to the
 		// legacy composed events.body for pre-#1675 rows.
-		plain, err := loadCommandPreviewPlaintext(ctx, db, preview.EventID().String())
+		plain, err := loadCommandPreviewPlaintext(ctx, db, meta.eventID.String())
 		if err != nil {
 			return nil, xerrors.Errorf("decode command preview: %w", err)
 		}
@@ -66,7 +68,7 @@ func (d *EventDatasource) ListRecentCommandPreviews(ctx context.Context, session
 		if len(runes) > bodyRuneLimit {
 			runes = runes[:bodyRuneLimit]
 		}
-		preview, err = apptypes.EventBodyPreviewOf(preview.EventID(), string(runes), preview.StoredBytes(), preview.OriginalBytes(), preview.IngestTruncated(), preview.StorageTruncated(), preview.CreatedAt())
+		preview, err := apptypes.EventBodyPreviewOf(meta.eventID, string(runes), meta.storedBytes, meta.originalBytes, meta.ingestTruncated, meta.storageTruncated, meta.createdAt)
 		if err != nil {
 			return nil, xerrors.Errorf("rebuild decoded command preview: %w", err)
 		}
@@ -91,37 +93,51 @@ func loadCommandPreviewPlaintext(ctx context.Context, q queryRowContexter, event
 	return loadEventPlaintext(ctx, q, eventID)
 }
 
-func scanEventBodyPreview(row interface{ Scan(...any) error }) (apptypes.EventBodyPreview, error) {
-	var id, body, createdAtValue string
+// commandPreviewMetadata is the non-body columns returned by
+// select_recent_command_previews.sql. The command line is hydrated separately.
+type commandPreviewMetadata struct {
+	eventID          types.EventID
+	storedBytes      int
+	originalBytes    types.Optional[int]
+	ingestTruncated  types.Optional[bool]
+	storageTruncated types.Optional[bool]
+	createdAt        time.Time
+}
+
+func scanCommandPreviewMetadata(row interface{ Scan(...any) error }) (commandPreviewMetadata, error) {
+	var id, createdAtValue string
 	var stored, original sql.NullInt64
 	var ingest, storage sql.NullBool
-	if err := row.Scan(&id, &body, &stored, &original, &ingest, &storage, &createdAtValue); err != nil {
-		return apptypes.EventBodyPreview{}, xerrors.Errorf("failed to scan event body preview: %w", err)
+	if err := row.Scan(&id, &stored, &original, &ingest, &storage, &createdAtValue); err != nil {
+		return commandPreviewMetadata{}, xerrors.Errorf("failed to scan command preview metadata: %w", err)
 	}
 	eventID, err := types.EventIDFrom(id)
 	if err != nil {
-		return apptypes.EventBodyPreview{}, xerrors.Errorf("failed to restore preview event ID: %w", err)
+		return commandPreviewMetadata{}, xerrors.Errorf("failed to restore preview event ID: %w", err)
 	}
 	if !stored.Valid {
-		return apptypes.EventBodyPreview{}, xerrors.Errorf("stored body bytes are missing for event %s", eventID)
+		return commandPreviewMetadata{}, xerrors.Errorf("stored body bytes are missing for event %s", eventID)
 	}
 	storedBytes, err := checkedInt(stored.Int64, "stored body bytes")
 	if err != nil {
-		return apptypes.EventBodyPreview{}, err
+		return commandPreviewMetadata{}, err
 	}
 	originalBytes, err := optionalInt(original, "original body bytes")
 	if err != nil {
-		return apptypes.EventBodyPreview{}, err
+		return commandPreviewMetadata{}, err
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, createdAtValue)
 	if err != nil {
-		return apptypes.EventBodyPreview{}, xerrors.Errorf("failed to restore preview created_at: %w", err)
+		return commandPreviewMetadata{}, xerrors.Errorf("failed to restore preview created_at: %w", err)
 	}
-	preview, err := apptypes.EventBodyPreviewOf(eventID, body, storedBytes, originalBytes, optionalBool(ingest), optionalBool(storage), createdAt)
-	if err != nil {
-		return apptypes.EventBodyPreview{}, xerrors.Errorf("failed to restore event body preview: %w", err)
-	}
-	return preview, nil
+	return commandPreviewMetadata{
+		eventID:          eventID,
+		storedBytes:      storedBytes,
+		originalBytes:    originalBytes,
+		ingestTruncated:  optionalBool(ingest),
+		storageTruncated: optionalBool(storage),
+		createdAt:        createdAt,
+	}, nil
 }
 
 // FindLatestPostCompactSummary pages over body-free candidates and hydrates

--- a/infrastructure/sqlite/event_preview_query_internal_test.go
+++ b/infrastructure/sqlite/event_preview_query_internal_test.go
@@ -5,22 +5,32 @@ import (
 	"testing"
 )
 
-func TestEventPreviewQuery_SelectsBoundedCommandPrefix(t *testing.T) {
+func TestEventPreviewQuery_SelectsMetadataWithoutCompressedCommandText(t *testing.T) {
 	t.Parallel()
 	normalized := strings.ToLower(strings.Join(strings.Fields(selectRecentCommandPreviewsQuery), " "))
-	if !strings.Contains(normalized, "substr(coalesce(a.command_text, e.body), 1, ?)") {
-		t.Fatalf("preview query must select a bounded command_text prefix with body fallback: %s", normalized)
-	}
 	if !strings.Contains(normalized, "from event_metadata_projection m") || !strings.Contains(normalized, "join events e on e.id = selected.id") {
 		t.Fatalf("preview query must select metadata candidates before hydrating bounded bodies: %s", normalized)
 	}
 	if !strings.Contains(normalized, "left join command_audits a on a.event_id = selected.id") {
-		t.Fatalf("preview query must join command_audits for retained command text: %s", normalized)
+		t.Fatalf("preview query must join command_audits for retained command extent: %s", normalized)
 	}
 	// After payload compression, length(command_text) is the physical size.
 	// StoredBytes must prefer the codec plaintext figure.
 	if !strings.Contains(normalized, "coalesce(a.command_plaintext_bytes, length(cast(a.command_text as blob)), selected.body_stored_bytes)") {
 		t.Fatalf("preview query must prefer command_plaintext_bytes for stored extent: %s", normalized)
+	}
+	// The outer SELECT must not project a body/command prefix: codec hydration
+	// rebuilds the preview text in Go. Inspect only the result list.
+	selectIdx := strings.Index(normalized, ") select selected.id,")
+	if selectIdx < 0 {
+		t.Fatalf("preview query missing outer select: %s", normalized)
+	}
+	selectList := normalized[selectIdx:]
+	if strings.Contains(selectList, "substr(") {
+		t.Fatalf("preview query must not project a substr prefix of command_text: %s", selectList)
+	}
+	if strings.Contains(selectList, "a.command_text,") || strings.Contains(selectList, "coalesce(a.command_text") {
+		t.Fatalf("preview query must not project command_text as a result column: %s", selectList)
 	}
 	if strings.Contains(normalized, "select e.body,") || strings.Contains(normalized, ", e.body,") {
 		t.Fatalf("preview query selects an unbounded body column: %s", normalized)

--- a/infrastructure/sqlite/event_preview_query_internal_test.go
+++ b/infrastructure/sqlite/event_preview_query_internal_test.go
@@ -17,6 +17,11 @@ func TestEventPreviewQuery_SelectsBoundedCommandPrefix(t *testing.T) {
 	if !strings.Contains(normalized, "left join command_audits a on a.event_id = selected.id") {
 		t.Fatalf("preview query must join command_audits for retained command text: %s", normalized)
 	}
+	// After payload compression, length(command_text) is the physical size.
+	// StoredBytes must prefer the codec plaintext figure.
+	if !strings.Contains(normalized, "coalesce(a.command_plaintext_bytes, length(cast(a.command_text as blob)), selected.body_stored_bytes)") {
+		t.Fatalf("preview query must prefer command_plaintext_bytes for stored extent: %s", normalized)
+	}
 	if strings.Contains(normalized, "select e.body,") || strings.Contains(normalized, ", e.body,") {
 		t.Fatalf("preview query selects an unbounded body column: %s", normalized)
 	}

--- a/infrastructure/sqlite/payload_backfill.go
+++ b/infrastructure/sqlite/payload_backfill.go
@@ -64,6 +64,11 @@ type PayloadBackfillDatasource struct {
 	// onAfterCommitBatch is a test hook that fires after a batch commits and
 	// before the loop re-checks cancellation. Production leaves it nil.
 	onAfterCommitBatch func(batchCount int64)
+	// onAfterPickRowIDs is a test-only seam between distinct-rowid selection and
+	// candidate expansion. Production leaves it nil and uses a single statement
+	// so there is no intermediate window. When non-nil, selection splits so a
+	// test can make the picked rowids ineligible before expansion.
+	onAfterPickRowIDs func(rowIDs []int64)
 }
 
 // NewPayloadBackfillDatasource binds the live store path.
@@ -74,9 +79,14 @@ func NewPayloadBackfillDatasource(db *Database) *PayloadBackfillDatasource {
 var _ application.PayloadBackfill = (*PayloadBackfillDatasource)(nil)
 
 type backfillRunRow struct {
-	RunID               string
-	RecipeVersion       string
-	HighWaterRowID      int64
+	RunID string
+	RecipeVersion string
+	// HighWaterRowID is the inclusive events.rowid ceiling fixed at run start.
+	HighWaterRowID int64
+	// AuditHighWaterRowID is the inclusive command_audits.rowid ceiling fixed
+	// at run start. The two tables use independent rowid sequences, so a shared
+	// max would let later inserts into the lagging table land below the ceiling.
+	AuditHighWaterRowID int64
 	CursorRowID         int64
 	PassCount           int64
 	State               apptypes.PayloadBackfillState
@@ -156,18 +166,18 @@ func (d *PayloadBackfillDatasource) Preview(ctx context.Context, c apptypes.Payl
 		return apptypes.PayloadBackfillResult{}, err
 	}
 
-	highWater, err := maxBackfillHighWater(ctx, db)
+	ceilings, err := readBackfillHighWaters(ctx, db)
 	if err != nil {
 		return apptypes.PayloadBackfillResult{}, err
 	}
-	eligible, err := countEligibleBackfillRows(ctx, db, 0, highWater)
+	eligible, err := countEligibleBackfillRows(ctx, db, 0, ceilings)
 	if err != nil {
 		return apptypes.PayloadBackfillResult{}, err
 	}
 	return apptypes.PayloadBackfillResult{
 		State:          "planned",
 		RecipeVersion:  apptypes.PayloadBackfillRecipeVersion,
-		HighWaterRowID: highWater,
+		HighWaterRowID: ceilings.Events,
 		EligibleRows:   eligible,
 		MorePending:    eligible > 0,
 	}, nil
@@ -252,7 +262,11 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 			run.passDirty = false
 		}
 
-		batch, selectErr := selectBackfillBatch(ctx, db, run.CursorRowID, run.HighWaterRowID, c.BatchRows)
+		ceilings := backfillHighWaters{
+			Events: run.HighWaterRowID,
+			Audits: run.AuditHighWaterRowID,
+		}
+		batch, selectErr := d.selectBackfillBatch(ctx, db, run.CursorRowID, ceilings, c.BatchRows)
 		if selectErr != nil {
 			return d.abortRun(ctx, closeCtx, db, run, batchCount, selectErr)
 		}
@@ -260,7 +274,24 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 			// End of a cursor walk. Full identity (incompressible) rows stay
 			// selectable forever, so completion is a walk that rewrites nothing
 			// and skips no conflicts — not "zero eligible rows".
+			//
+			// An empty batch with eligible fields still past the cursor is not
+			// end-of-walk: it is the selector/loader split race (pick found
+			// rowids, expansion saw none). Refuse completed so unwalked rowids
+			// cannot be reported done. The production path merges pick and
+			// expansion into one statement, so this branch is only reachable
+			// from the test seam or a future regression of that merge.
 			if !run.passDirty {
+				remaining, countErr := countEligibleBackfillRows(ctx, db, run.CursorRowID, ceilings)
+				if countErr != nil {
+					return d.abortRun(ctx, closeCtx, db, run, batchCount, countErr)
+				}
+				if remaining > 0 {
+					return d.abortRun(ctx, closeCtx, db, run, batchCount, xerrors.Errorf(
+						"payload backfill selection returned no candidates while %d eligible fields remain past cursor %d",
+						remaining, run.CursorRowID,
+					))
+				}
 				if completeErr := completeBackfillRun(closeCtx, db, run); completeErr != nil {
 					return apptypes.PayloadBackfillResult{}, completeErr
 				}
@@ -271,7 +302,7 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 				return resultFromRun(loaded, batchCount, false), nil
 			}
 			// Conflicts or rewrites this pass: restart from rowid 0 under the
-			// same high-water so skipped rows are not stranded.
+			// same high-waters so skipped rows are not stranded.
 			if resetErr := resetBackfillCursor(closeCtx, db, run); resetErr != nil {
 				return apptypes.PayloadBackfillResult{}, resetErr
 			}
@@ -393,7 +424,7 @@ func prepareBackfillRun(ctx context.Context, db *sql.DB, resume bool) (backfillR
 	if err == nil {
 		return backfillRunHandle{}, ErrPayloadBackfillActiveRun
 	}
-	highWater, err := maxBackfillHighWater(ctx, db)
+	ceilings, err := readBackfillHighWaters(ctx, db)
 	if err != nil {
 		return backfillRunHandle{}, err
 	}
@@ -408,16 +439,18 @@ func prepareBackfillRun(ctx context.Context, db *sql.DB, resume bool) (backfillR
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err = db.ExecContext(ctx, `
 		INSERT INTO payload_backfill_runs(
-			run_id, recipe_version, high_water_rowid, cursor_rowid, pass_count, state,
+			run_id, recipe_version, high_water_rowid, audit_high_water_rowid,
+			cursor_rowid, pass_count, state,
 			worker_token, started_at, updated_at
-		) VALUES (?, ?, ?, 0, 0, 'running', ?, ?, ?)`,
-		runID, apptypes.PayloadBackfillRecipeVersion, highWater, token, now, now,
+		) VALUES (?, ?, ?, ?, 0, 0, 'running', ?, ?, ?)`,
+		runID, apptypes.PayloadBackfillRecipeVersion, ceilings.Events, ceilings.Audits, token, now, now,
 	); err != nil {
 		return backfillRunHandle{}, xerrors.Errorf("insert payload backfill run: %w", err)
 	}
 	return backfillRunHandle{backfillRunRow: backfillRunRow{
 		RunID: runID, RecipeVersion: apptypes.PayloadBackfillRecipeVersion,
-		HighWaterRowID: highWater, State: apptypes.PayloadBackfillRunning,
+		HighWaterRowID: ceilings.Events, AuditHighWaterRowID: ceilings.Audits,
+		State: apptypes.PayloadBackfillRunning,
 		WorkerToken: token, StartedAt: now, UpdatedAt: now,
 	}}, nil
 }
@@ -432,13 +465,16 @@ func requirePayloadBackfillSchema(ctx context.Context, db *sql.DB) error {
 		return xerrors.Errorf("inspect payload backfill schema: %w", err)
 	}
 	// Name the pre-release shape rather than letting every query fail with
-	// "no such column: worker_token" far from the cause.
-	fenced, err := databaseColumnExists(ctx, db, "payload_backfill_runs", "worker_token")
-	if err != nil {
-		return xerrors.Errorf("inspect payload backfill schema: %w", err)
-	}
-	if !fenced {
-		return ErrPayloadBackfillSchemaOutdated
+	// "no such column: worker_token" / "audit_high_water_rowid" far from the cause.
+	// Migration 054 is unreleased and was edited in place more than once.
+	for _, column := range []string{"worker_token", "audit_high_water_rowid"} {
+		exists, colErr := databaseColumnExists(ctx, db, "payload_backfill_runs", column)
+		if colErr != nil {
+			return xerrors.Errorf("inspect payload backfill schema: %w", colErr)
+		}
+		if !exists {
+			return ErrPayloadBackfillSchemaOutdated
+		}
 	}
 	return nil
 }
@@ -466,27 +502,33 @@ func requirePayloadBackfillCounterMode(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-// maxBackfillHighWater is the inclusive rowid ceiling fixed at run start. Both
-// tables share the numeric cursor: events.rowid and command_audits.rowid are
-// independent sequences, so a given number may address a row in one, both, or
-// neither. Taking the max of the two means a later insert into either table
-// lands above the ceiling and is left for a subsequent run.
-func maxBackfillHighWater(ctx context.Context, db *sql.DB) (int64, error) {
+// backfillHighWaters are the inclusive per-table rowid ceilings fixed at run
+// start. The shared cursor walks both sequences under one number, but each
+// table is bounded by its own ceiling so a later insert into the lagging
+// sequence cannot land below a shared max.
+type backfillHighWaters struct {
+	Events int64
+	Audits int64
+}
+
+// readBackfillHighWaters measures the ceilings for a new run. Resume must read
+// the checkpointed values instead — recomputing would move the boundary.
+func readBackfillHighWaters(ctx context.Context, db *sql.DB) (backfillHighWaters, error) {
 	var eventHigh, auditHigh sql.NullInt64
 	if err := db.QueryRowContext(ctx, `SELECT MAX(rowid) FROM events`).Scan(&eventHigh); err != nil {
-		return 0, xerrors.Errorf("read events high-water rowid: %w", err)
+		return backfillHighWaters{}, xerrors.Errorf("read events high-water rowid: %w", err)
 	}
 	if err := db.QueryRowContext(ctx, `SELECT MAX(rowid) FROM command_audits`).Scan(&auditHigh); err != nil {
-		return 0, xerrors.Errorf("read command_audits high-water rowid: %w", err)
+		return backfillHighWaters{}, xerrors.Errorf("read command_audits high-water rowid: %w", err)
 	}
-	var high int64
-	if eventHigh.Valid && eventHigh.Int64 > high {
-		high = eventHigh.Int64
+	var ceilings backfillHighWaters
+	if eventHigh.Valid {
+		ceilings.Events = eventHigh.Int64
 	}
-	if auditHigh.Valid && auditHigh.Int64 > high {
-		high = auditHigh.Int64
+	if auditHigh.Valid {
+		ceilings.Audits = auditHigh.Int64
 	}
-	return high, nil
+	return ceilings, nil
 }
 
 // eligibleLanePredicate selects field values the recipe may still rewrite. Full
@@ -518,14 +560,21 @@ func anyAuditLaneEligible() string {
 		` OR ` + eligibleLanePredicate("output") + `)`
 }
 
-func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID, highWater int64) (int64, error) {
+func laneHighWater(lane backfillLane, ceilings backfillHighWaters) int64 {
+	if lane.Table == "command_audits" {
+		return ceilings.Audits
+	}
+	return ceilings.Events
+}
+
+func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters) (int64, error) {
 	var total int64
 	for _, lane := range backfillLanes {
 		var n int64
 		if err := db.QueryRowContext(ctx, `
 			SELECT COUNT(*) FROM `+lane.Table+`
 			 WHERE rowid > ? AND rowid <= ?
-			   AND `+eligibleLanePredicate(lane.CodecPrefix), afterRowID, highWater).Scan(&n); err != nil {
+			   AND `+eligibleLanePredicate(lane.CodecPrefix), afterRowID, laneHighWater(lane, ceilings)).Scan(&n); err != nil {
 			return 0, xerrors.Errorf("count eligible payload backfill rows for %s.%s: %w", lane.Table, lane.Field, err)
 		}
 		total += n
@@ -537,21 +586,79 @@ func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID, high
 // distinct rowids, not field units: every eligible field of a selected rowid is
 // loaded so a LIMIT cut cannot strand command_text while taking body of the
 // same numeric rowid (or vice versa).
-func selectBackfillBatch(ctx context.Context, db *sql.DB, afterRowID, highWater int64, limit int) ([]backfillCandidate, error) {
+//
+// Pick and expansion are one statement so they share a read snapshot. A split
+// that found rowids then expanded them separately could return an empty batch
+// after every picked row became ineligible, and execute would treat that empty
+// batch as end-of-walk while later eligible rowids remained beyond the cursor.
+func (d *PayloadBackfillDatasource) selectBackfillBatch(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]backfillCandidate, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
-	rowIDs, err := selectEligibleBackfillRowIDs(ctx, db, afterRowID, highWater, limit)
-	if err != nil {
-		return nil, err
+	// Test seam: reintroduce the pick/expand split so a deterministic race can
+	// be injected. Production leaves the hook nil.
+	if d != nil && d.onAfterPickRowIDs != nil {
+		rowIDs, err := selectEligibleBackfillRowIDs(ctx, db, afterRowID, ceilings, limit)
+		if err != nil {
+			return nil, err
+		}
+		d.onAfterPickRowIDs(rowIDs)
+		return loadBackfillCandidatesForRowIDs(ctx, db, ceilings, rowIDs)
 	}
-	if len(rowIDs) == 0 {
-		return nil, nil
-	}
-	return loadBackfillCandidatesForRowIDs(ctx, db, rowIDs)
+	return selectBackfillBatchMerged(ctx, db, afterRowID, ceilings, limit)
 }
 
-func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID, highWater int64, limit int) ([]int64, error) {
+func selectBackfillBatchMerged(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]backfillCandidate, error) {
+	// Bound parameters:
+	//   ?1 afterRowID (shared cursor)
+	//   ?2 events high-water
+	//   ?3 command_audits high-water
+	//   ?4 batch rowid limit
+	parts := make([]string, 0, len(backfillLanes))
+	for _, lane := range backfillLanes {
+		ceilingParam := "?2"
+		if lane.Table == "command_audits" {
+			ceilingParam = "?3"
+		}
+		parts = append(parts, `
+			SELECT rowid, `+strconv.Itoa(lane.Ord)+` AS lane_ord, `+quoteSQLString(lane.Field)+` AS field,
+			       `+lane.PKColumn+` AS row_key, `+lane.Column+` AS stored,
+			       `+lane.CodecPrefix+`_codec, `+lane.CodecPrefix+`_format_version,
+			       `+lane.CodecPrefix+`_plaintext_bytes, `+lane.CodecPrefix+`_encoded_bytes,
+			       `+lane.CodecPrefix+`_sha256
+			  FROM `+lane.Table+`
+			 WHERE rowid IN (SELECT rowid FROM picked)
+			   AND rowid <= `+ceilingParam+`
+			   AND `+eligibleLanePredicate(lane.CodecPrefix))
+	}
+	query := `
+		WITH picked AS (
+			SELECT rowid FROM (
+				SELECT rowid FROM events
+				 WHERE rowid > ?1 AND rowid <= ?2
+				   AND ` + eligibleLanePredicate("body") + `
+				UNION
+				SELECT rowid FROM command_audits
+				 WHERE rowid > ?1 AND rowid <= ?3
+				   AND ` + anyAuditLaneEligible() + `
+			)
+			 ORDER BY rowid
+			 LIMIT ?4
+		)
+		` + strings.Join(parts, " UNION ALL ") + `
+		 ORDER BY rowid, lane_ord`
+
+	rows, err := db.QueryContext(ctx, query, afterRowID, ceilings.Events, ceilings.Audits, limit)
+	if err != nil {
+		return nil, xerrors.Errorf("select payload backfill candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return scanBackfillCandidates(rows, limit)
+}
+
+// selectEligibleBackfillRowIDs is the pick half of the test-only two-step path.
+func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]int64, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT rowid FROM (
 			SELECT rowid FROM events
@@ -563,7 +670,7 @@ func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID, h
 			   AND `+anyAuditLaneEligible()+`
 		)
 		 ORDER BY rowid
-		 LIMIT ?`, afterRowID, highWater, afterRowID, highWater, limit)
+		 LIMIT ?`, afterRowID, ceilings.Events, afterRowID, ceilings.Audits, limit)
 	if err != nil {
 		return nil, xerrors.Errorf("select payload backfill rowids: %w", err)
 	}
@@ -583,7 +690,11 @@ func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID, h
 	return ids, nil
 }
 
-func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []int64) ([]backfillCandidate, error) {
+// loadBackfillCandidatesForRowIDs expands picked rowids under each lane's own
+// ceiling. Used only by the test-only two-step path; production merges pick and
+// expansion so a concurrent insert above an audit ceiling cannot ride in on a
+// matching events.rowid number.
+func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, ceilings backfillHighWaters, rowIDs []int64) ([]backfillCandidate, error) {
 	if len(rowIDs) == 0 {
 		return nil, nil
 	}
@@ -595,11 +706,8 @@ func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []i
 	}
 	inList := strings.Join(placeholders, ",")
 
-	// One UNION ALL per lane keeps column names lane-local while preserving
-	// (rowid, lane_ord) order so commit walks deterministically.
 	parts := make([]string, 0, len(backfillLanes))
-	// Each lane reuses the same IN args; concatenate once per arm.
-	queryArgs := make([]any, 0, len(backfillLanes)*len(rowIDs))
+	queryArgs := make([]any, 0, len(backfillLanes)*(len(rowIDs)+1))
 	for _, lane := range backfillLanes {
 		parts = append(parts, `
 			SELECT rowid, `+strconv.Itoa(lane.Ord)+` AS lane_ord, `+quoteSQLString(lane.Field)+` AS field,
@@ -609,8 +717,10 @@ func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []i
 			       `+lane.CodecPrefix+`_sha256
 			  FROM `+lane.Table+`
 			 WHERE rowid IN (`+inList+`)
+			   AND rowid <= ?
 			   AND `+eligibleLanePredicate(lane.CodecPrefix))
 		queryArgs = append(queryArgs, args...)
+		queryArgs = append(queryArgs, laneHighWater(lane, ceilings))
 	}
 	query := strings.Join(parts, " UNION ALL ") + ` ORDER BY rowid, lane_ord`
 
@@ -620,7 +730,11 @@ func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []i
 	}
 	defer func() { _ = rows.Close() }()
 
-	batch := make([]backfillCandidate, 0, len(rowIDs)*len(backfillLanes))
+	return scanBackfillCandidates(rows, len(rowIDs))
+}
+
+func scanBackfillCandidates(rows *sql.Rows, rowIDHint int) ([]backfillCandidate, error) {
+	batch := make([]backfillCandidate, 0, rowIDHint*len(backfillLanes))
 	for rows.Next() {
 		var (
 			c       backfillCandidate
@@ -628,7 +742,7 @@ func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []i
 			field   string
 			stored  []byte
 		)
-		if err = rows.Scan(
+		if err := rows.Scan(
 			&c.RowID, &laneOrd, &field, &c.EventID, &stored,
 			&c.Row.Codec, &c.Row.FormatVersion, &c.Row.PlaintextBytes, &c.Row.StoredBytes, &c.Row.SHA256,
 		); err != nil {
@@ -645,7 +759,7 @@ func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []i
 		c.SourceSHA = hex.EncodeToString(sum[:])
 		batch = append(batch, c)
 	}
-	if err = rows.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, xerrors.Errorf("iterate payload backfill candidates: %w", err)
 	}
 	return batch, nil
@@ -876,7 +990,8 @@ func backfillRowAlreadyMatches(r payloadRow, target encodedPayload) bool {
 
 func loadActiveBackfillRun(ctx context.Context, db *sql.DB) (backfillRunRow, error) {
 	return scanBackfillRun(db.QueryRowContext(ctx, `
-		SELECT run_id, recipe_version, high_water_rowid, cursor_rowid, pass_count, state,
+		SELECT run_id, recipe_version, high_water_rowid, audit_high_water_rowid,
+		       cursor_rowid, pass_count, state,
 		       worker_token, started_at, updated_at, completed_at,
 		       scanned_rows, encoded_rows, identity_kept_rows, conflicted_rows,
 		       partial_metadata_rows, rewritten_rows, plaintext_bytes, stored_bytes,
@@ -889,7 +1004,8 @@ func loadActiveBackfillRun(ctx context.Context, db *sql.DB) (backfillRunRow, err
 
 func loadLatestBackfillRun(ctx context.Context, db *sql.DB) (backfillRunRow, error) {
 	return scanBackfillRun(db.QueryRowContext(ctx, `
-		SELECT run_id, recipe_version, high_water_rowid, cursor_rowid, pass_count, state,
+		SELECT run_id, recipe_version, high_water_rowid, audit_high_water_rowid,
+		       cursor_rowid, pass_count, state,
 		       worker_token, started_at, updated_at, completed_at,
 		       scanned_rows, encoded_rows, identity_kept_rows, conflicted_rows,
 		       partial_metadata_rows, rewritten_rows, plaintext_bytes, stored_bytes,
@@ -901,7 +1017,8 @@ func loadLatestBackfillRun(ctx context.Context, db *sql.DB) (backfillRunRow, err
 
 func loadBackfillRun(ctx context.Context, db *sql.DB, runID string) (backfillRunRow, error) {
 	return scanBackfillRun(db.QueryRowContext(ctx, `
-		SELECT run_id, recipe_version, high_water_rowid, cursor_rowid, pass_count, state,
+		SELECT run_id, recipe_version, high_water_rowid, audit_high_water_rowid,
+		       cursor_rowid, pass_count, state,
 		       worker_token, started_at, updated_at, completed_at,
 		       scanned_rows, encoded_rows, identity_kept_rows, conflicted_rows,
 		       partial_metadata_rows, rewritten_rows, plaintext_bytes, stored_bytes,
@@ -914,7 +1031,8 @@ func scanBackfillRun(row *sql.Row) (backfillRunRow, error) {
 	var r backfillRunRow
 	var state string
 	if err := row.Scan(
-		&r.RunID, &r.RecipeVersion, &r.HighWaterRowID, &r.CursorRowID, &r.PassCount, &state,
+		&r.RunID, &r.RecipeVersion, &r.HighWaterRowID, &r.AuditHighWaterRowID,
+		&r.CursorRowID, &r.PassCount, &state,
 		&r.WorkerToken, &r.StartedAt, &r.UpdatedAt, &r.CompletedAt,
 		&r.ScannedRows, &r.EncodedRows, &r.IdentityKeptRows, &r.ConflictedRows,
 		&r.PartialMetadataRows, &r.RewrittenRows, &r.PlaintextBytes, &r.StoredBytes,

--- a/infrastructure/sqlite/payload_backfill.go
+++ b/infrastructure/sqlite/payload_backfill.go
@@ -64,11 +64,11 @@ type PayloadBackfillDatasource struct {
 	// onAfterCommitBatch is a test hook that fires after a batch commits and
 	// before the loop re-checks cancellation. Production leaves it nil.
 	onAfterCommitBatch func(batchCount int64)
-	// onAfterPickRowIDs is a test-only seam between distinct-rowid selection and
-	// candidate expansion. Production leaves it nil and uses a single statement
-	// so there is no intermediate window. When non-nil, selection splits so a
-	// test can make the picked rowids ineligible before expansion.
-	onAfterPickRowIDs func(rowIDs []int64)
+	// onSelectedBatch is a test-only seam that can rewrite the selector result
+	// before the execute loop sees it. Production leaves it nil. Used to force
+	// an empty batch while eligible work remains, exercising the fail-safe that
+	// refuses completed in that case — without duplicating the candidate SQL.
+	onSelectedBatch func(batch []backfillCandidate) []backfillCandidate
 }
 
 // NewPayloadBackfillDatasource binds the live store path.
@@ -79,7 +79,7 @@ func NewPayloadBackfillDatasource(db *Database) *PayloadBackfillDatasource {
 var _ application.PayloadBackfill = (*PayloadBackfillDatasource)(nil)
 
 type backfillRunRow struct {
-	RunID string
+	RunID         string
 	RecipeVersion string
 	// HighWaterRowID is the inclusive events.rowid ceiling fixed at run start.
 	HighWaterRowID int64
@@ -270,17 +270,19 @@ func (d *PayloadBackfillDatasource) execute(ctx context.Context, c apptypes.Payl
 		if selectErr != nil {
 			return d.abortRun(ctx, closeCtx, db, run, batchCount, selectErr)
 		}
+		if d.onSelectedBatch != nil {
+			batch = d.onSelectedBatch(batch)
+		}
 		if len(batch) == 0 {
 			// End of a cursor walk. Full identity (incompressible) rows stay
 			// selectable forever, so completion is a walk that rewrites nothing
 			// and skips no conflicts — not "zero eligible rows".
 			//
 			// An empty batch with eligible fields still past the cursor is not
-			// end-of-walk: it is the selector/loader split race (pick found
-			// rowids, expansion saw none). Refuse completed so unwalked rowids
-			// cannot be reported done. The production path merges pick and
-			// expansion into one statement, so this branch is only reachable
-			// from the test seam or a future regression of that merge.
+			// end-of-walk: refuse completed so unwalked work cannot be reported
+			// done. Production selection is a single merged statement; this
+			// branch is a fail-safe for a future selector regression (and is
+			// exercised by the test-only onSelectedBatch seam).
 			if !run.passDirty {
 				remaining, countErr := countEligibleBackfillRows(ctx, db, run.CursorRowID, ceilings)
 				if countErr != nil {
@@ -450,7 +452,7 @@ func prepareBackfillRun(ctx context.Context, db *sql.DB, resume bool) (backfillR
 	return backfillRunHandle{backfillRunRow: backfillRunRow{
 		RunID: runID, RecipeVersion: apptypes.PayloadBackfillRecipeVersion,
 		HighWaterRowID: ceilings.Events, AuditHighWaterRowID: ceilings.Audits,
-		State: apptypes.PayloadBackfillRunning,
+		State:       apptypes.PayloadBackfillRunning,
 		WorkerToken: token, StartedAt: now, UpdatedAt: now,
 	}}, nil
 }
@@ -591,24 +593,13 @@ func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID int64
 // that found rowids then expanded them separately could return an empty batch
 // after every picked row became ineligible, and execute would treat that empty
 // batch as end-of-walk while later eligible rowids remained beyond the cursor.
+// Each expansion arm also bounds by its own table ceiling so an events.rowid
+// cannot pull a same-numbered command_audits row that is above the audit
+// ceiling.
 func (d *PayloadBackfillDatasource) selectBackfillBatch(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]backfillCandidate, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
-	// Test seam: reintroduce the pick/expand split so a deterministic race can
-	// be injected. Production leaves the hook nil.
-	if d != nil && d.onAfterPickRowIDs != nil {
-		rowIDs, err := selectEligibleBackfillRowIDs(ctx, db, afterRowID, ceilings, limit)
-		if err != nil {
-			return nil, err
-		}
-		d.onAfterPickRowIDs(rowIDs)
-		return loadBackfillCandidatesForRowIDs(ctx, db, ceilings, rowIDs)
-	}
-	return selectBackfillBatchMerged(ctx, db, afterRowID, ceilings, limit)
-}
-
-func selectBackfillBatchMerged(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]backfillCandidate, error) {
 	// Bound parameters:
 	//   ?1 afterRowID (shared cursor)
 	//   ?2 events high-water
@@ -655,82 +646,6 @@ func selectBackfillBatchMerged(ctx context.Context, db *sql.DB, afterRowID int64
 	defer func() { _ = rows.Close() }()
 
 	return scanBackfillCandidates(rows, limit)
-}
-
-// selectEligibleBackfillRowIDs is the pick half of the test-only two-step path.
-func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID int64, ceilings backfillHighWaters, limit int) ([]int64, error) {
-	rows, err := db.QueryContext(ctx, `
-		SELECT rowid FROM (
-			SELECT rowid FROM events
-			 WHERE rowid > ? AND rowid <= ?
-			   AND `+eligibleLanePredicate("body")+`
-			UNION
-			SELECT rowid FROM command_audits
-			 WHERE rowid > ? AND rowid <= ?
-			   AND `+anyAuditLaneEligible()+`
-		)
-		 ORDER BY rowid
-		 LIMIT ?`, afterRowID, ceilings.Events, afterRowID, ceilings.Audits, limit)
-	if err != nil {
-		return nil, xerrors.Errorf("select payload backfill rowids: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	ids := make([]int64, 0, limit)
-	for rows.Next() {
-		var id int64
-		if err = rows.Scan(&id); err != nil {
-			return nil, xerrors.Errorf("scan payload backfill rowid: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	if err = rows.Err(); err != nil {
-		return nil, xerrors.Errorf("iterate payload backfill rowids: %w", err)
-	}
-	return ids, nil
-}
-
-// loadBackfillCandidatesForRowIDs expands picked rowids under each lane's own
-// ceiling. Used only by the test-only two-step path; production merges pick and
-// expansion so a concurrent insert above an audit ceiling cannot ride in on a
-// matching events.rowid number.
-func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, ceilings backfillHighWaters, rowIDs []int64) ([]backfillCandidate, error) {
-	if len(rowIDs) == 0 {
-		return nil, nil
-	}
-	placeholders := make([]string, len(rowIDs))
-	args := make([]any, len(rowIDs))
-	for i, id := range rowIDs {
-		placeholders[i] = "?"
-		args[i] = id
-	}
-	inList := strings.Join(placeholders, ",")
-
-	parts := make([]string, 0, len(backfillLanes))
-	queryArgs := make([]any, 0, len(backfillLanes)*(len(rowIDs)+1))
-	for _, lane := range backfillLanes {
-		parts = append(parts, `
-			SELECT rowid, `+strconv.Itoa(lane.Ord)+` AS lane_ord, `+quoteSQLString(lane.Field)+` AS field,
-			       `+lane.PKColumn+` AS row_key, `+lane.Column+` AS stored,
-			       `+lane.CodecPrefix+`_codec, `+lane.CodecPrefix+`_format_version,
-			       `+lane.CodecPrefix+`_plaintext_bytes, `+lane.CodecPrefix+`_encoded_bytes,
-			       `+lane.CodecPrefix+`_sha256
-			  FROM `+lane.Table+`
-			 WHERE rowid IN (`+inList+`)
-			   AND rowid <= ?
-			   AND `+eligibleLanePredicate(lane.CodecPrefix))
-		queryArgs = append(queryArgs, args...)
-		queryArgs = append(queryArgs, laneHighWater(lane, ceilings))
-	}
-	query := strings.Join(parts, " UNION ALL ") + ` ORDER BY rowid, lane_ord`
-
-	rows, err := db.QueryContext(ctx, query, queryArgs...)
-	if err != nil {
-		return nil, xerrors.Errorf("select payload backfill candidates: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	return scanBackfillCandidates(rows, len(rowIDs))
 }
 
 func scanBackfillCandidates(rows *sql.Rows, rowIDHint int) ([]backfillCandidate, error) {

--- a/infrastructure/sqlite/payload_backfill.go
+++ b/infrastructure/sqlite/payload_backfill.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -52,7 +54,8 @@ const payloadCodecCompatibilityCounterMode = "counter"
 // take the store lease give up rather than hang.
 const payloadBackfillCheckpointTimeout = 10 * time.Second
 
-// PayloadBackfillDatasource rewrites events.body in place through the codec.
+// PayloadBackfillDatasource rewrites payload text columns in place through the
+// codec: events.body and command_audits.{command_text,input_text,output_text}.
 type PayloadBackfillDatasource struct {
 	db *Database
 	// onBeforeCommitBatch is a test hook that fires after a batch is selected
@@ -93,9 +96,29 @@ type backfillRunRow struct {
 	FailureReason       sql.NullString
 }
 
+// backfillLane is one (table, field) unit the recipe rewrites. Order is the
+// stable walk order within a shared rowid: body, then the three audit texts.
+type backfillLane struct {
+	Table       string
+	Field       string // logical field name used in errors and result naming
+	Column      string // physical TEXT/BLOB column
+	CodecPrefix string // prefix of the five codec metadata columns
+	PKColumn    string // human-facing row key column (id / event_id)
+	Ord         int    // stable order within a rowid
+}
+
+// backfillLanes is the full recipe. Preview/run/resume all walk this list.
+var backfillLanes = []backfillLane{
+	{Table: "events", Field: "body", Column: "body", CodecPrefix: "body", PKColumn: "id", Ord: 0},
+	{Table: "command_audits", Field: "command", Column: "command_text", CodecPrefix: "command", PKColumn: "event_id", Ord: 1},
+	{Table: "command_audits", Field: "input", Column: "input_text", CodecPrefix: "input", PKColumn: "event_id", Ord: 2},
+	{Table: "command_audits", Field: "output", Column: "output_text", CodecPrefix: "output", PKColumn: "event_id", Ord: 3},
+}
+
 type backfillCandidate struct {
+	Lane      backfillLane
 	RowID     int64
-	EventID   string
+	EventID   string // events.id or command_audits.event_id — failure naming
 	Stored    []byte
 	SourceSHA string
 	Row       payloadRow
@@ -133,7 +156,7 @@ func (d *PayloadBackfillDatasource) Preview(ctx context.Context, c apptypes.Payl
 		return apptypes.PayloadBackfillResult{}, err
 	}
 
-	highWater, err := maxEventRowID(ctx, db)
+	highWater, err := maxBackfillHighWater(ctx, db)
 	if err != nil {
 		return apptypes.PayloadBackfillResult{}, err
 	}
@@ -370,7 +393,7 @@ func prepareBackfillRun(ctx context.Context, db *sql.DB, resume bool) (backfillR
 	if err == nil {
 		return backfillRunHandle{}, ErrPayloadBackfillActiveRun
 	}
-	highWater, err := maxEventRowID(ctx, db)
+	highWater, err := maxBackfillHighWater(ctx, db)
 	if err != nil {
 		return backfillRunHandle{}, err
 	}
@@ -443,80 +466,202 @@ func requirePayloadBackfillCounterMode(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func maxEventRowID(ctx context.Context, db *sql.DB) (int64, error) {
-	var high sql.NullInt64
-	if err := db.QueryRowContext(ctx, `SELECT MAX(rowid) FROM events`).Scan(&high); err != nil {
+// maxBackfillHighWater is the inclusive rowid ceiling fixed at run start. Both
+// tables share the numeric cursor: events.rowid and command_audits.rowid are
+// independent sequences, so a given number may address a row in one, both, or
+// neither. Taking the max of the two means a later insert into either table
+// lands above the ceiling and is left for a subsequent run.
+func maxBackfillHighWater(ctx context.Context, db *sql.DB) (int64, error) {
+	var eventHigh, auditHigh sql.NullInt64
+	if err := db.QueryRowContext(ctx, `SELECT MAX(rowid) FROM events`).Scan(&eventHigh); err != nil {
 		return 0, xerrors.Errorf("read events high-water rowid: %w", err)
 	}
-	if !high.Valid {
-		return 0, nil
+	if err := db.QueryRowContext(ctx, `SELECT MAX(rowid) FROM command_audits`).Scan(&auditHigh); err != nil {
+		return 0, xerrors.Errorf("read command_audits high-water rowid: %w", err)
 	}
-	return high.Int64, nil
+	var high int64
+	if eventHigh.Valid && eventHigh.Int64 > high {
+		high = eventHigh.Int64
+	}
+	if auditHigh.Valid && auditHigh.Int64 > high {
+		high = auditHigh.Int64
+	}
+	return high, nil
 }
 
-// eligibleBackfillPredicate selects rows the recipe may still rewrite. Full
+// eligibleLanePredicate selects field values the recipe may still rewrite. Full
 // identity rows remain selected so a multi-hour run compresses post-v0.34
 // writes; the fixpoint loop terminates when a full pass rewrites nothing and
 // skips no conflicts (incompressible identity is a no-op rewrite).
 //
-// The second arm selects rows whose five codec columns are neither all-NULL
-// nor all-present, whatever the codec says. Such a row is unreadable, and the
-// run is specified to fail closed on it; selecting only identity rows would let
-// a corrupt zstd row pass a whole walk uninspected and report completed.
-const eligibleBackfillPredicate = `(
-		   (body_codec IS NULL OR body_codec = 'identity')
-		OR (  (body_codec IS NOT NULL)
-		    + (body_format_version IS NOT NULL)
-		    + (body_plaintext_bytes IS NOT NULL)
-		    + (body_encoded_bytes IS NOT NULL)
-		    + (body_sha256 IS NOT NULL)) NOT IN (0, 5)
+// The second arm selects fields whose five codec columns are neither all-NULL
+// nor all-present, whatever the codec says. Such a field is unreadable, and the
+// run is specified to fail closed on it; selecting only identity fields would
+// let a corrupt zstd field pass a whole walk uninspected and report completed.
+func eligibleLanePredicate(codecPrefix string) string {
+	return `(
+		   (` + codecPrefix + `_codec IS NULL OR ` + codecPrefix + `_codec = 'identity')
+		OR (  (` + codecPrefix + `_codec IS NOT NULL)
+		    + (` + codecPrefix + `_format_version IS NOT NULL)
+		    + (` + codecPrefix + `_plaintext_bytes IS NOT NULL)
+		    + (` + codecPrefix + `_encoded_bytes IS NOT NULL)
+		    + (` + codecPrefix + `_sha256 IS NOT NULL)) NOT IN (0, 5)
 	)`
-
-func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID, highWater int64) (int64, error) {
-	var n int64
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM events
-		 WHERE rowid > ? AND rowid <= ?
-		   AND `+eligibleBackfillPredicate, afterRowID, highWater).Scan(&n); err != nil {
-		return 0, xerrors.Errorf("count eligible payload backfill rows: %w", err)
-	}
-	return n, nil
 }
 
+// anyAuditLaneEligible is the OR of the three command_audits field predicates.
+// Used when collecting distinct rowids so a partial-metadata field is not
+// stranded because another field of the same row already holds zstd.
+func anyAuditLaneEligible() string {
+	return `(` + eligibleLanePredicate("command") +
+		` OR ` + eligibleLanePredicate("input") +
+		` OR ` + eligibleLanePredicate("output") + `)`
+}
+
+func countEligibleBackfillRows(ctx context.Context, db *sql.DB, afterRowID, highWater int64) (int64, error) {
+	var total int64
+	for _, lane := range backfillLanes {
+		var n int64
+		if err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM `+lane.Table+`
+			 WHERE rowid > ? AND rowid <= ?
+			   AND `+eligibleLanePredicate(lane.CodecPrefix), afterRowID, highWater).Scan(&n); err != nil {
+			return 0, xerrors.Errorf("count eligible payload backfill rows for %s.%s: %w", lane.Table, lane.Field, err)
+		}
+		total += n
+	}
+	return total, nil
+}
+
+// selectBackfillBatch walks both tables under one rowid cursor. BatchRows limits
+// distinct rowids, not field units: every eligible field of a selected rowid is
+// loaded so a LIMIT cut cannot strand command_text while taking body of the
+// same numeric rowid (or vice versa).
 func selectBackfillBatch(ctx context.Context, db *sql.DB, afterRowID, highWater int64, limit int) ([]backfillCandidate, error) {
-	rows, err := db.QueryContext(ctx, `
-		SELECT rowid, id, body,
-		       body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256
-		  FROM events
-		 WHERE rowid > ? AND rowid <= ?
-		   AND `+eligibleBackfillPredicate+`
-		 ORDER BY rowid
-		 LIMIT ?`, afterRowID, highWater, limit)
+	if limit <= 0 {
+		return nil, nil
+	}
+	rowIDs, err := selectEligibleBackfillRowIDs(ctx, db, afterRowID, highWater, limit)
 	if err != nil {
-		return nil, xerrors.Errorf("select payload backfill batch: %w", err)
+		return nil, err
+	}
+	if len(rowIDs) == 0 {
+		return nil, nil
+	}
+	return loadBackfillCandidatesForRowIDs(ctx, db, rowIDs)
+}
+
+func selectEligibleBackfillRowIDs(ctx context.Context, db *sql.DB, afterRowID, highWater int64, limit int) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT rowid FROM (
+			SELECT rowid FROM events
+			 WHERE rowid > ? AND rowid <= ?
+			   AND `+eligibleLanePredicate("body")+`
+			UNION
+			SELECT rowid FROM command_audits
+			 WHERE rowid > ? AND rowid <= ?
+			   AND `+anyAuditLaneEligible()+`
+		)
+		 ORDER BY rowid
+		 LIMIT ?`, afterRowID, highWater, afterRowID, highWater, limit)
+	if err != nil {
+		return nil, xerrors.Errorf("select payload backfill rowids: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	batch := make([]backfillCandidate, 0, limit)
+	ids := make([]int64, 0, limit)
 	for rows.Next() {
-		var c backfillCandidate
-		var body []byte
+		var id int64
+		if err = rows.Scan(&id); err != nil {
+			return nil, xerrors.Errorf("scan payload backfill rowid: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, xerrors.Errorf("iterate payload backfill rowids: %w", err)
+	}
+	return ids, nil
+}
+
+func loadBackfillCandidatesForRowIDs(ctx context.Context, db *sql.DB, rowIDs []int64) ([]backfillCandidate, error) {
+	if len(rowIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(rowIDs))
+	args := make([]any, len(rowIDs))
+	for i, id := range rowIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	inList := strings.Join(placeholders, ",")
+
+	// One UNION ALL per lane keeps column names lane-local while preserving
+	// (rowid, lane_ord) order so commit walks deterministically.
+	parts := make([]string, 0, len(backfillLanes))
+	// Each lane reuses the same IN args; concatenate once per arm.
+	queryArgs := make([]any, 0, len(backfillLanes)*len(rowIDs))
+	for _, lane := range backfillLanes {
+		parts = append(parts, `
+			SELECT rowid, `+strconv.Itoa(lane.Ord)+` AS lane_ord, `+quoteSQLString(lane.Field)+` AS field,
+			       `+lane.PKColumn+` AS row_key, `+lane.Column+` AS stored,
+			       `+lane.CodecPrefix+`_codec, `+lane.CodecPrefix+`_format_version,
+			       `+lane.CodecPrefix+`_plaintext_bytes, `+lane.CodecPrefix+`_encoded_bytes,
+			       `+lane.CodecPrefix+`_sha256
+			  FROM `+lane.Table+`
+			 WHERE rowid IN (`+inList+`)
+			   AND `+eligibleLanePredicate(lane.CodecPrefix))
+		queryArgs = append(queryArgs, args...)
+	}
+	query := strings.Join(parts, " UNION ALL ") + ` ORDER BY rowid, lane_ord`
+
+	rows, err := db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, xerrors.Errorf("select payload backfill candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	batch := make([]backfillCandidate, 0, len(rowIDs)*len(backfillLanes))
+	for rows.Next() {
+		var (
+			c       backfillCandidate
+			laneOrd int
+			field   string
+			stored  []byte
+		)
 		if err = rows.Scan(
-			&c.RowID, &c.EventID, &body,
+			&c.RowID, &laneOrd, &field, &c.EventID, &stored,
 			&c.Row.Codec, &c.Row.FormatVersion, &c.Row.PlaintextBytes, &c.Row.StoredBytes, &c.Row.SHA256,
 		); err != nil {
-			return nil, xerrors.Errorf("scan payload backfill row: %w", err)
+			return nil, xerrors.Errorf("scan payload backfill candidate: %w", err)
 		}
-		c.Stored = bytes.Clone(body)
+		lane, ok := backfillLaneByOrd(laneOrd)
+		if !ok || lane.Field != field {
+			return nil, xerrors.Errorf("unknown payload backfill lane ord %d field %q", laneOrd, field)
+		}
+		c.Lane = lane
+		c.Stored = bytes.Clone(stored)
 		c.Row.Stored = c.Stored
 		sum := sha256.Sum256(c.Stored)
 		c.SourceSHA = hex.EncodeToString(sum[:])
 		batch = append(batch, c)
 	}
 	if err = rows.Err(); err != nil {
-		return nil, xerrors.Errorf("iterate payload backfill batch: %w", err)
+		return nil, xerrors.Errorf("iterate payload backfill candidates: %w", err)
 	}
 	return batch, nil
+}
+
+func backfillLaneByOrd(ord int) (backfillLane, bool) {
+	for _, lane := range backfillLanes {
+		if lane.Ord == ord {
+			return lane, true
+		}
+	}
+	return backfillLane{}, false
+}
+
+func quoteSQLString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func commitBackfillBatch(ctx context.Context, db *sql.DB, run backfillRunHandle, batch []backfillCandidate) (backfillBatchStats, error) {
@@ -536,7 +681,7 @@ func commitBackfillBatch(ctx context.Context, db *sql.DB, run backfillRunHandle,
 			stats.LastCursor = candidate.RowID
 		}
 
-		current, err := reselectBackfillRow(ctx, tx, candidate.RowID)
+		current, err := reselectBackfillCandidate(ctx, tx, candidate)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				stats.Conflicted++
@@ -550,9 +695,9 @@ func commitBackfillBatch(ctx context.Context, db *sql.DB, run backfillRunHandle,
 			stats.Conflicted++
 			continue
 		}
-		// Corruption is checked before drift: a row can be both non-identity
+		// Corruption is checked before drift: a field can be both non-identity
 		// and incoherent, and skipping it as a conflict would report a clean
-		// completion over a row no reader can decode.
+		// completion over a field no reader can decode.
 		metaCount := payloadMetadataCount(current.Row)
 		if metaCount != 0 && metaCount != 5 {
 			stats.Partial++
@@ -573,12 +718,12 @@ func commitBackfillBatch(ctx context.Context, db *sql.DB, run backfillRunHandle,
 
 		plaintext, err := current.Row.decode(maxDecodedPayloadBytes)
 		if err != nil {
-			return stats, xerrors.Errorf("decode event %s for payload backfill: %w", current.EventID, err)
+			return stats, xerrors.Errorf("decode %s %s for payload backfill: %w", current.EventID, current.Lane.Field, err)
 		}
 
 		encoded, err := encodePayload(plaintext, payloadCodecZstd)
 		if err != nil {
-			return stats, xerrors.Errorf("encode event %s for payload backfill: %w", current.EventID, err)
+			return stats, xerrors.Errorf("encode %s %s for payload backfill: %w", current.EventID, current.Lane.Field, err)
 		}
 
 		// Recipe: shrink → zstd; otherwise keep identity with full metadata.
@@ -586,37 +731,36 @@ func commitBackfillBatch(ctx context.Context, db *sql.DB, run backfillRunHandle,
 		if encoded.StoredBytes >= encoded.PlaintextBytes {
 			identity, idErr := encodePayload(plaintext, payloadCodecIdentity)
 			if idErr != nil {
-				return stats, xerrors.Errorf("encode identity event %s for payload backfill: %w", current.EventID, idErr)
+				return stats, xerrors.Errorf("encode identity %s %s for payload backfill: %w", current.EventID, current.Lane.Field, idErr)
 			}
 			target = identity
 		}
 
-		// No-op when the row already carries identical codec metadata and body.
+		// No-op when the field already carries identical codec metadata and bytes.
 		if backfillRowAlreadyMatches(current.Row, target) {
 			continue
 		}
 
 		// Affinity is part of the stored representation, not an encoding
-		// detail. zstd bytes must be a BLOB; an identity body must stay TEXT
-		// because every other identity writer (event delivery, retention
-		// restore) binds string(...) and because migration 053 still re-derives
-		// legacy_source_hook from an identity body, where LIKE only matches
-		// TEXT. Rewriting an incompressible legacy row as a BLOB would silently
-		// drop it from --source-hook.
+		// detail. zstd bytes must be a BLOB; an identity value must stay TEXT
+		// because every other identity writer binds string(...) and because
+		// migration 053 still re-derives legacy_source_hook from an identity
+		// body, where LIKE only matches TEXT. Rewriting an incompressible
+		// legacy row as a BLOB would silently drop it from --source-hook.
 		if _, err = tx.ExecContext(ctx, `
-			UPDATE events
-			   SET body = ?,
-			       body_codec = ?,
-			       body_format_version = ?,
-			       body_plaintext_bytes = ?,
-			       body_encoded_bytes = ?,
-			       body_sha256 = ?
+			UPDATE `+current.Lane.Table+`
+			   SET `+current.Lane.Column+` = ?,
+			       `+current.Lane.CodecPrefix+`_codec = ?,
+			       `+current.Lane.CodecPrefix+`_format_version = ?,
+			       `+current.Lane.CodecPrefix+`_plaintext_bytes = ?,
+			       `+current.Lane.CodecPrefix+`_encoded_bytes = ?,
+			       `+current.Lane.CodecPrefix+`_sha256 = ?
 			 WHERE rowid = ?`,
 			storedBodyArg(target), target.Codec, target.FormatVersion,
 			target.PlaintextBytes, target.StoredBytes, target.SHA256,
 			current.RowID,
 		); err != nil {
-			return stats, xerrors.Errorf("rewrite event %s body: %w", current.EventID, err)
+			return stats, xerrors.Errorf("rewrite %s %s: %w", current.EventID, current.Lane.Field, err)
 		}
 		stats.Rewritten++
 		stats.PlaintextBytes += target.PlaintextBytes
@@ -675,21 +819,25 @@ func storedBodyArg(payload encodedPayload) any {
 	return payload.Bytes
 }
 
-func reselectBackfillRow(ctx context.Context, tx *sql.Tx, rowID int64) (backfillCandidate, error) {
+func reselectBackfillCandidate(ctx context.Context, tx *sql.Tx, candidate backfillCandidate) (backfillCandidate, error) {
+	lane := candidate.Lane
 	var c backfillCandidate
-	var body []byte
+	var stored []byte
 	err := tx.QueryRowContext(ctx, `
-		SELECT rowid, id, body,
-		       body_codec, body_format_version, body_plaintext_bytes, body_encoded_bytes, body_sha256
-		  FROM events
-		 WHERE rowid = ?`, rowID).Scan(
-		&c.RowID, &c.EventID, &body,
+		SELECT rowid, `+lane.PKColumn+`, `+lane.Column+`,
+		       `+lane.CodecPrefix+`_codec, `+lane.CodecPrefix+`_format_version,
+		       `+lane.CodecPrefix+`_plaintext_bytes, `+lane.CodecPrefix+`_encoded_bytes,
+		       `+lane.CodecPrefix+`_sha256
+		  FROM `+lane.Table+`
+		 WHERE rowid = ?`, candidate.RowID).Scan(
+		&c.RowID, &c.EventID, &stored,
 		&c.Row.Codec, &c.Row.FormatVersion, &c.Row.PlaintextBytes, &c.Row.StoredBytes, &c.Row.SHA256,
 	)
 	if err != nil {
-		return backfillCandidate{}, xerrors.Errorf("reselect payload backfill row %d: %w", rowID, err)
+		return backfillCandidate{}, xerrors.Errorf("reselect payload backfill %s rowid %d: %w", lane.Field, candidate.RowID, err)
 	}
-	c.Stored = bytes.Clone(body)
+	c.Lane = lane
+	c.Stored = bytes.Clone(stored)
 	c.Row.Stored = c.Stored
 	return c, nil
 }

--- a/infrastructure/sqlite/payload_backfill_test.go
+++ b/infrastructure/sqlite/payload_backfill_test.go
@@ -1430,10 +1430,9 @@ func TestPayloadBackfillPerTableHighWaterIgnoresLaterAuditInserts(t *testing.T) 
 	}
 }
 
-// The same numeric rowid may address a row in both tables. Each lane must be
-// processed exactly once against the correct table — the loader must not let
-// an events.rowid pull in a command_audits row created after the audit ceiling.
-func TestPayloadBackfillSameRowIDIsProcessedPerTable(t *testing.T) {
+// The same numeric rowid present in both tables before the run is processed
+// once per lane against the correct table.
+func TestPayloadBackfillSameRowIDPresentBeforeRunIsProcessedPerTable(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	db, ds, _ := openPayloadBackfillFixture(t)
@@ -1462,9 +1461,7 @@ func TestPayloadBackfillSameRowIDIsProcessedPerTable(t *testing.T) {
 	assertAuditCodec(t, db, "same-rowid-audit-host", "command", payloadCodecZstd)
 	assertAuditCodec(t, db, "same-rowid-audit-host", "input", payloadCodecZstd)
 	assertAuditCodec(t, db, "same-rowid-audit-host", "output", payloadCodecZstd)
-	// One body + three audit fields for the shared rowid, plus the host event
-	// body (empty, likely identity-kept or no-op). Encoded must cover the four
-	// compressible lanes at the shared rowid.
+	// One body + three audit fields for the shared rowid.
 	if result.EncodedRows < 4 {
 		t.Fatalf("encoded_rows = %d, want >= 4 (body + 3 audit fields)", result.EncodedRows)
 	}
@@ -1478,50 +1475,227 @@ func TestPayloadBackfillSameRowIDIsProcessedPerTable(t *testing.T) {
 	}
 }
 
-// Selector/loader split: if every picked rowid becomes ineligible between pick
-// and expansion, an empty batch must not report completed while eligible
-// rowids remain beyond the cursor. Production merges pick and expansion; this
-// test reintroduces the seam via onAfterPickRowIDs.
+// Expansion bounds each lane by its own ceiling: an events.rowid in the pick
+// set must not pull a same-numbered command_audits row created after the audit
+// ceiling was fixed. Without the audit-arm ceiling, the late insert rides in
+// on the events.rowid and is rewritten by this run.
+func TestPayloadBackfillSameRowIDAboveAuditCeilingIsNotLoaded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, path := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	const sharedRowID int64 = 500
+	// A low row so the first batch commits before the shared rowid is selected;
+	// the late audit is inserted then, above the audit ceiling of 1.
+	insertPlaintextEventAtRowID(t, db, 1, eventSeed{
+		ID: "ceiling-early", Kind: "note", Body: compressibleBody("early"),
+	})
+	insertPlaintextEventAtRowID(t, db, sharedRowID, eventSeed{
+		ID: "ceiling-event-500", Kind: "note", Body: compressibleBody("event-500"),
+	})
+	insertPlaintextEvent(t, db, eventSeed{ID: "ceiling-audit-host-1", Kind: "command_executed", Body: ""})
+	insertPlaintextAuditAtRowID(t, db, 1, auditSeed{
+		EventID: "ceiling-audit-host-1",
+		Command: compressibleBody("audit-at-1"),
+		Input:   compressibleBody("audit-in-1"),
+		Output:  compressibleBody("audit-out-1"),
+	})
+
+	var inserted bool
+	ds.onBeforeCommitBatch = func([]backfillCandidate) {
+		if inserted {
+			return
+		}
+		inserted = true
+		side, err := sql.Open("sqlite", directSQLiteRWDSN(path))
+		if err != nil {
+			t.Fatalf("open side conn: %v", err)
+		}
+		defer func() { _ = side.Close() }()
+		// Host for the late audit: auto rowid lands past the events ceiling.
+		insertPlaintextEvent(t, side, eventSeed{ID: "ceiling-late-host", Kind: "command_executed", Body: ""})
+		insertPlaintextAuditAtRowID(t, side, sharedRowID, auditSeed{
+			EventID: "ceiling-late-host",
+			Command: compressibleBody("late-audit-500"),
+			Input:   compressibleBody("late-in-500"),
+			Output:  compressibleBody("late-out-500"),
+		})
+	}
+
+	result, err := ds.Run(ctx, apptypes.PayloadBackfillConfig{BatchRows: 1})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if diff := cmp.Diff(string(apptypes.PayloadBackfillCompleted), result.State); diff != "" {
+		t.Fatalf("state mismatch (-want +got):\n%s", diff)
+	}
+	assertBodyCodec(t, db, "ceiling-event-500", payloadCodecZstd)
+	// Late audit at rowid 500 must stay unprocessed: above the audit ceiling.
+	var lateCodec sql.NullString
+	if err := db.QueryRow(`SELECT command_codec FROM command_audits WHERE event_id = ?`, "ceiling-late-host").Scan(&lateCodec); err != nil {
+		t.Fatalf("read late audit codec: %v", err)
+	}
+	if lateCodec.Valid {
+		t.Fatalf("late audit command_codec = %q, want NULL (loader must not pull it via events.rowid %d)", lateCodec.String, sharedRowID)
+	}
+	var auditHigh int64
+	if err := db.QueryRow(`SELECT audit_high_water_rowid FROM payload_backfill_runs WHERE run_id = ?`, result.RunID).Scan(&auditHigh); err != nil {
+		t.Fatalf("read audit high water: %v", err)
+	}
+	if auditHigh != 1 {
+		t.Fatalf("audit_high_water_rowid = %d, want 1", auditHigh)
+	}
+}
+
+// Empty selector result with eligible work still past the cursor must not
+// report completed. onSelectedBatch forces the empty result without duplicating
+// the candidate SQL.
 func TestPayloadBackfillDoesNotCompleteWhenPickExpandsEmptyWithRemainingWork(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	db, ds, _ := openPayloadBackfillFixture(t)
 	defer closePayloadBackfillFixture(t, db)
 
-	// Early rowids that the first pick will take, then a later row left beyond.
-	for _, id := range []string{"split-early-1", "split-early-2"} {
+	for _, id := range []string{"split-early-1", "split-early-2", "split-late"} {
 		insertIdentityEvent(t, db, eventSeed{ID: id, Kind: "note", Body: compressibleBody(id)})
 	}
-	insertIdentityEvent(t, db, eventSeed{
-		ID: "split-late", Kind: "note", Body: compressibleBody("split-late"),
-	})
 
-	var fired bool
-	ds.onAfterPickRowIDs = func(rowIDs []int64) {
-		if fired || len(rowIDs) == 0 {
-			return
+	var forcedEmpty bool
+	ds.onSelectedBatch = func(batch []backfillCandidate) []backfillCandidate {
+		if forcedEmpty || len(batch) == 0 {
+			return batch
 		}
-		fired = true
-		// Make every picked rowid ineligible (as if a concurrent writer already
-		// rewrote them to zstd) so expansion returns empty while "split-late"
-		// remains eligible beyond the cursor.
-		for _, id := range []string{"split-early-1", "split-early-2"} {
-			reencodeBodyToZstd(t, db, id, []byte(compressibleBody(id)))
-		}
+		forcedEmpty = true
+		return nil
 	}
 
 	result, err := ds.Run(ctx, apptypes.PayloadBackfillConfig{BatchRows: 2})
-	// Must not report completed over unwalked work. The fail-closed path
-	// returns an error naming the stranded eligible fields.
-	if err == nil && result.State == string(apptypes.PayloadBackfillCompleted) {
-		t.Fatalf("run reported completed after empty expansion with remaining work; late row codec=%q",
-			bodyCodecOrEmpty(t, db, "split-late"))
+	if err == nil {
+		t.Fatalf("Run err = nil, want remaining-work error; state=%q", result.State)
+	}
+	if !strings.Contains(err.Error(), "eligible fields remain past cursor") {
+		t.Fatalf("error = %v, want remaining-work condition naming eligible fields past cursor", err)
 	}
 	if result.State == string(apptypes.PayloadBackfillCompleted) {
-		t.Fatalf("state = completed; empty expansion must not finish the run while eligible rowids remain")
+		t.Fatalf("state = completed; empty selection must not finish the run while eligible work remains")
 	}
-	// The late row must still be eligible (identity) — never silently skipped.
+	// Fail-safe leaves the run resumable (running when the error is not a cancel).
+	var state string
+	if err := db.QueryRow(`SELECT state FROM payload_backfill_runs`).Scan(&state); err != nil {
+		t.Fatalf("read run state: %v", err)
+	}
+	if !apptypes.PayloadBackfillState(state).CanResume() {
+		t.Fatalf("persisted state = %q, want resumable (running or paused)", state)
+	}
+	// Seeded rows must still be eligible — never silently skipped.
 	assertBodyCodec(t, db, "split-late", payloadCodecIdentity)
+}
+
+// Resume must keep the ceilings fixed at run start. Growing either table while
+// paused must not move the checkpointed high-waters or process the new rows.
+func TestPayloadBackfillResumePreservesBothCeilings(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, _ := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	// Enough rows that StopAfterBatches=1 leaves work under the original ceilings.
+	for _, id := range []string{"resume-e1", "resume-e2", "resume-e3", "resume-e4"} {
+		insertIdentityEvent(t, db, eventSeed{ID: id, Kind: "note", Body: compressibleBody(id)})
+	}
+	insertPlaintextEvent(t, db, eventSeed{ID: "resume-a1-host", Kind: "command_executed", Body: ""})
+	insertPlaintextAudit(t, db, auditSeed{
+		EventID: "resume-a1-host",
+		Command: compressibleBody("resume-a1"),
+		Input:   compressibleBody("resume-a1-in"),
+		Output:  compressibleBody("resume-a1-out"),
+	})
+	insertPlaintextEvent(t, db, eventSeed{ID: "resume-a2-host", Kind: "command_executed", Body: ""})
+	insertPlaintextAudit(t, db, auditSeed{
+		EventID: "resume-a2-host",
+		Command: compressibleBody("resume-a2"),
+		Input:   compressibleBody("resume-a2-in"),
+		Output:  compressibleBody("resume-a2-out"),
+	})
+
+	var wantEventHigh, wantAuditHigh int64
+	if err := db.QueryRow(`SELECT MAX(rowid) FROM events`).Scan(&wantEventHigh); err != nil {
+		t.Fatalf("read events max: %v", err)
+	}
+	if err := db.QueryRow(`SELECT MAX(rowid) FROM command_audits`).Scan(&wantAuditHigh); err != nil {
+		t.Fatalf("read audits max: %v", err)
+	}
+
+	cfg := defaultBackfillConfig()
+	cfg.BatchRows = 2
+	cfg.StopAfterBatches = 1
+	paused, err := ds.Run(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Run (pause): %v", err)
+	}
+	if diff := cmp.Diff(string(apptypes.PayloadBackfillPaused), paused.State); diff != "" {
+		t.Fatalf("paused state mismatch (-want +got):\n%s", diff)
+	}
+
+	// Grow both tables past the recorded ceilings while paused.
+	const pastEventRowID int64 = 5000
+	const pastAuditRowID int64 = 5000
+	if pastEventRowID <= wantEventHigh || pastAuditRowID <= wantAuditHigh {
+		t.Fatalf("test ceiling constants too low: eventHigh=%d auditHigh=%d", wantEventHigh, wantAuditHigh)
+	}
+	insertPlaintextEventAtRowID(t, db, pastEventRowID, eventSeed{
+		ID: "resume-late-event", Kind: "note", Body: compressibleBody("late-event"),
+	})
+	insertPlaintextEvent(t, db, eventSeed{ID: "resume-late-audit-host", Kind: "command_executed", Body: ""})
+	insertPlaintextAuditAtRowID(t, db, pastAuditRowID, auditSeed{
+		EventID: "resume-late-audit-host",
+		Command: compressibleBody("late-audit"),
+		Input:   compressibleBody("late-audit-in"),
+		Output:  compressibleBody("late-audit-out"),
+	})
+
+	cfg.StopAfterBatches = 0
+	done, err := ds.Resume(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if diff := cmp.Diff(string(apptypes.PayloadBackfillCompleted), done.State); diff != "" {
+		t.Fatalf("completed state mismatch (-want +got):\n%s", diff)
+	}
+
+	var gotEventHigh, gotAuditHigh int64
+	if err := db.QueryRow(`
+		SELECT high_water_rowid, audit_high_water_rowid FROM payload_backfill_runs WHERE run_id = ?`,
+		done.RunID,
+	).Scan(&gotEventHigh, &gotAuditHigh); err != nil {
+		t.Fatalf("read checkpointed ceilings: %v", err)
+	}
+	if diff := cmp.Diff(wantEventHigh, gotEventHigh); diff != "" {
+		t.Fatalf("high_water_rowid mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantAuditHigh, gotAuditHigh); diff != "" {
+		t.Fatalf("audit_high_water_rowid mismatch (-want +got):\n%s", diff)
+	}
+
+	// Rows added while paused stay outside the walk.
+	var lateEventCodec sql.NullString
+	if err := db.QueryRow(`SELECT body_codec FROM events WHERE id = ?`, "resume-late-event").Scan(&lateEventCodec); err != nil {
+		t.Fatalf("read late event codec: %v", err)
+	}
+	if lateEventCodec.Valid {
+		t.Fatalf("late event body_codec = %q, want NULL (above checkpointed events ceiling)", lateEventCodec.String)
+	}
+	var lateAuditCodec sql.NullString
+	if err := db.QueryRow(`SELECT command_codec FROM command_audits WHERE event_id = ?`, "resume-late-audit-host").Scan(&lateAuditCodec); err != nil {
+		t.Fatalf("read late audit codec: %v", err)
+	}
+	if lateAuditCodec.Valid {
+		t.Fatalf("late audit command_codec = %q, want NULL (above checkpointed audit ceiling)", lateAuditCodec.String)
+	}
+	// In-ceiling rows finished.
+	assertBodyCodec(t, db, "resume-e1", payloadCodecZstd)
+	assertAuditCodec(t, db, "resume-a1-host", "command", payloadCodecZstd)
 }
 
 // Identity audit values are bound as TEXT, matching every other writer. Nothing
@@ -1598,16 +1772,4 @@ func insertPlaintextAuditAtRowID(t *testing.T, db *sql.DB, rowID int64, seed aud
 	); err != nil {
 		t.Fatalf("insert plaintext audit %s at rowid %d: %v", seed.EventID, rowID, err)
 	}
-}
-
-func bodyCodecOrEmpty(t *testing.T, db *sql.DB, id string) string {
-	t.Helper()
-	var got sql.NullString
-	if err := db.QueryRow(`SELECT body_codec FROM events WHERE id = ?`, id).Scan(&got); err != nil {
-		t.Fatalf("read body_codec %s: %v", id, err)
-	}
-	if !got.Valid {
-		return ""
-	}
-	return got.String
 }

--- a/infrastructure/sqlite/payload_backfill_test.go
+++ b/infrastructure/sqlite/payload_backfill_test.go
@@ -465,6 +465,17 @@ func TestPayloadBackfill(t *testing.T) {
 		insertPlaintextEvent(t, db, eventSeed{
 			ID: "canon-2", Kind: "note", Body: compressibleBody("canon-2"),
 		})
+		insertPlaintextEvent(t, db, eventSeed{
+			ID: "canon-cmd", Kind: "command_executed", Body: "",
+		})
+		insertPlaintextAudit(t, db, auditSeed{
+			EventID:             "canon-cmd",
+			Command:             compressibleBody("canon-cmd"),
+			Input:               compressibleBody("canon-in"),
+			Output:              compressibleBody("canon-out"),
+			InputOriginalBytes:  111,
+			OutputOriginalBytes: 222,
+		})
 
 		before, err := CanonicalEventAuditDigest(ctx, db)
 		if err != nil {
@@ -483,7 +494,379 @@ func TestPayloadBackfill(t *testing.T) {
 		if before.EventCount != after.EventCount {
 			t.Fatalf("event count %d → %d", before.EventCount, after.EventCount)
 		}
+		if before.AuditCount != after.AuditCount {
+			t.Fatalf("audit count %d → %d", before.AuditCount, after.AuditCount)
+		}
 	})
+}
+
+// Command-audit lanes share the events.body engine: same predicate, fixpoint,
+// high-water, and recipe version. These cases pin the three extra fields and
+// the provenance columns the issue forbids rewriting.
+func TestPayloadBackfillCommandAudits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round-trips all three audit text fields", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		const id = "audit-rt"
+		want := auditSeed{
+			EventID:             id,
+			Command:             compressibleBody("cmd"),
+			Input:               compressibleBody("in"),
+			Output:              compressibleBody("out"),
+			InputOriginalBytes:  9001,
+			OutputOriginalBytes: 9002,
+		}
+		insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+		insertPlaintextAudit(t, db, want)
+
+		result, err := ds.Run(ctx, defaultBackfillConfig())
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if diff := cmp.Diff(string(apptypes.PayloadBackfillCompleted), result.State); diff != "" {
+			t.Fatalf("state mismatch (-want +got):\n%s", diff)
+		}
+		assertAuditCodec(t, db, id, "command", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "input", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "output", payloadCodecZstd)
+		got := readDecodedAudit(t, db, id)
+		if diff := cmp.Diff(want.Command, got.Command); diff != "" {
+			t.Fatalf("command mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(want.Input, got.Input); diff != "" {
+			t.Fatalf("input mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(want.Output, got.Output); diff != "" {
+			t.Fatalf("output mismatch (-want +got):\n%s", diff)
+		}
+		assertAuditOriginalBytes(t, db, id, want.InputOriginalBytes, want.OutputOriginalBytes)
+	})
+
+	t.Run("round-trips identity write path for audits", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		const id = "audit-identity-rt"
+		want := auditSeed{
+			EventID:             id,
+			Command:             compressibleBody("id-cmd"),
+			Input:               compressibleBody("id-in"),
+			Output:              compressibleBody("id-out"),
+			InputOriginalBytes:  42,
+			OutputOriginalBytes: 43,
+		}
+		insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+		insertIdentityAudit(t, db, want)
+
+		if _, err := ds.Run(ctx, defaultBackfillConfig()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		assertAuditCodec(t, db, id, "command", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "input", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "output", payloadCodecZstd)
+		got := readDecodedAudit(t, db, id)
+		if diff := cmp.Diff(want.Command, got.Command); diff != "" {
+			t.Fatalf("command mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(want.Input, got.Input); diff != "" {
+			t.Fatalf("input mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(want.Output, got.Output); diff != "" {
+			t.Fatalf("output mismatch (-want +got):\n%s", diff)
+		}
+		assertAuditOriginalBytes(t, db, id, want.InputOriginalBytes, want.OutputOriginalBytes)
+	})
+
+	t.Run("partial audit metadata fails closed and leaves fields untouched", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		const id = "audit-partial"
+		seed := auditSeed{
+			EventID: id,
+			Command: "partial command stays plaintext",
+			Input:   "partial input stays plaintext",
+			Output:  "partial output stays plaintext",
+		}
+		insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+		insertPlaintextAudit(t, db, seed)
+		// command_codec NULL but command_sha256 set → incomplete metadata.
+		if _, err := db.Exec(`UPDATE command_audits SET command_sha256 = ? WHERE event_id = ?`, "deadbeef", id); err != nil {
+			t.Fatalf("seed partial metadata: %v", err)
+		}
+		before := readStoredAudit(t, db, id)
+
+		result, err := ds.Run(ctx, defaultBackfillConfig())
+		if !errors.Is(err, ErrPayloadBackfillPartialMetadata) {
+			t.Fatalf("error = %v, want ErrPayloadBackfillPartialMetadata", err)
+		}
+		if result.State != string(apptypes.PayloadBackfillFailed) {
+			t.Fatalf("state = %q, want failed", result.State)
+		}
+		if diff := cmp.Diff(id, result.FailureEventID); diff != "" {
+			t.Fatalf("failure_event_id mismatch (-want +got):\n%s", diff)
+		}
+		after := readStoredAudit(t, db, id)
+		if diff := cmp.Diff(before, after); diff != "" {
+			t.Fatalf("partial-metadata row was rewritten (-before +after):\n%s", diff)
+		}
+	})
+
+	t.Run("compatibility counters match encoded audit fields", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		for _, id := range []string{"cc-a1", "cc-a2"} {
+			insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+			insertIdentityAudit(t, db, auditSeed{
+				EventID: id,
+				Command: compressibleBody(id + "-cmd"),
+				Input:   compressibleBody(id + "-in"),
+				Output:  compressibleBody(id + "-out"),
+			})
+		}
+		result, err := ds.Run(ctx, defaultBackfillConfig())
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		var commandN, inputN, outputN int64
+		if err := db.QueryRow(`
+			SELECT audit_command_nonidentity, audit_input_nonidentity, audit_output_nonidentity
+			  FROM payload_codec_compatibility_state WHERE singleton = 1`).Scan(&commandN, &inputN, &outputN); err != nil {
+			t.Fatalf("read audit counters: %v", err)
+		}
+		if commandN != 2 || inputN != 2 || outputN != 2 {
+			t.Fatalf("audit nonidentity counters = command %d input %d output %d, want 2 each", commandN, inputN, outputN)
+		}
+		// Six audit fields encoded; event bodies empty/identity may or may not
+		// compress. EncodedRows must at least cover the six audit fields.
+		if result.EncodedRows < 6 {
+			t.Fatalf("encoded_rows = %d, want >= 6", result.EncodedRows)
+		}
+	})
+
+	t.Run("audit-only corpus completes under the shared high-water", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		// No event body work: empty bodies are tiny and stay identity. The
+		// run must still walk command_audits and terminate.
+		const id = "audit-only"
+		insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+		insertPlaintextAudit(t, db, auditSeed{
+			EventID: id,
+			Command: compressibleBody("only-cmd"),
+			Input:   compressibleBody("only-in"),
+			Output:  compressibleBody("only-out"),
+		})
+		result, err := ds.Run(ctx, defaultBackfillConfig())
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if result.State != string(apptypes.PayloadBackfillCompleted) {
+			t.Fatalf("state = %q, want completed", result.State)
+		}
+		assertAuditCodec(t, db, id, "command", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "input", payloadCodecZstd)
+		assertAuditCodec(t, db, id, "output", payloadCodecZstd)
+	})
+
+	t.Run("input_original_bytes and output_original_bytes are unchanged", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db, ds, _ := openPayloadBackfillFixture(t)
+		defer closePayloadBackfillFixture(t, db)
+
+		const id = "audit-orig"
+		const wantIn, wantOut int64 = 12345, 67890
+		insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+		insertIdentityAudit(t, db, auditSeed{
+			EventID:             id,
+			Command:             compressibleBody("orig-cmd"),
+			Input:               compressibleBody("orig-in"),
+			Output:              compressibleBody("orig-out"),
+			InputOriginalBytes:  wantIn,
+			OutputOriginalBytes: wantOut,
+		})
+		if _, err := ds.Run(ctx, defaultBackfillConfig()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		// Codecs must have changed so a silent no-op would not hide a write.
+		assertAuditCodec(t, db, id, "output", payloadCodecZstd)
+		assertAuditOriginalBytes(t, db, id, wantIn, wantOut)
+	})
+}
+
+type auditSeed struct {
+	EventID             string
+	Command             string
+	Input               string
+	Output              string
+	InputOriginalBytes  int64
+	OutputOriginalBytes int64
+}
+
+type decodedAudit struct {
+	Command string
+	Input   string
+	Output  string
+}
+
+type storedAudit struct {
+	Command []byte
+	Input   []byte
+	Output  []byte
+}
+
+func insertPlaintextAudit(t *testing.T, db *sql.DB, seed auditSeed) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO command_audits(
+			event_id, command_text, input_text, output_text,
+			input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+			exit_code, failed
+		) VALUES (?, ?, ?, ?, 0, 0, ?, ?, 0, 0)`,
+		seed.EventID, seed.Command, seed.Input, seed.Output,
+		seed.InputOriginalBytes, seed.OutputOriginalBytes,
+	); err != nil {
+		t.Fatalf("insert plaintext audit %s: %v", seed.EventID, err)
+	}
+}
+
+func insertIdentityAudit(t *testing.T, db *sql.DB, seed auditSeed) {
+	t.Helper()
+	command, err := encodePayload([]byte(seed.Command), payloadCodecIdentity)
+	if err != nil {
+		t.Fatalf("encode command identity: %v", err)
+	}
+	input, err := encodePayload([]byte(seed.Input), payloadCodecIdentity)
+	if err != nil {
+		t.Fatalf("encode input identity: %v", err)
+	}
+	output, err := encodePayload([]byte(seed.Output), payloadCodecIdentity)
+	if err != nil {
+		t.Fatalf("encode output identity: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO command_audits(
+			event_id, command_text, input_text, output_text,
+			input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+			exit_code, failed,
+			command_codec, command_format_version, command_plaintext_bytes, command_encoded_bytes, command_sha256,
+			input_codec, input_format_version, input_plaintext_bytes, input_encoded_bytes, input_sha256,
+			output_codec, output_format_version, output_plaintext_bytes, output_encoded_bytes, output_sha256
+		) VALUES (?, ?, ?, ?, 0, 0, ?, ?, 0, 0,
+		          ?, ?, ?, ?, ?,
+		          ?, ?, ?, ?, ?,
+		          ?, ?, ?, ?, ?)`,
+		seed.EventID, string(command.Bytes), string(input.Bytes), string(output.Bytes),
+		seed.InputOriginalBytes, seed.OutputOriginalBytes,
+		command.Codec, command.FormatVersion, command.PlaintextBytes, command.StoredBytes, command.SHA256,
+		input.Codec, input.FormatVersion, input.PlaintextBytes, input.StoredBytes, input.SHA256,
+		output.Codec, output.FormatVersion, output.PlaintextBytes, output.StoredBytes, output.SHA256,
+	); err != nil {
+		t.Fatalf("insert identity audit %s: %v", seed.EventID, err)
+	}
+}
+
+func reencodeAuditFieldToZstd(t *testing.T, db *sql.DB, eventID, field, plaintext string) {
+	t.Helper()
+	encoded, err := encodePayload([]byte(plaintext), payloadCodecZstd)
+	if err != nil {
+		t.Fatalf("encode zstd %s: %v", field, err)
+	}
+	if encoded.StoredBytes >= encoded.PlaintextBytes {
+		t.Fatalf("zstd did not shrink %s (%d → %d)", field, encoded.PlaintextBytes, encoded.StoredBytes)
+	}
+	column := field + "_text"
+	prefix := field
+	if field == "command" {
+		column = "command_text"
+		prefix = "command"
+	}
+	if _, err := db.Exec(`
+		UPDATE command_audits
+		   SET `+column+` = ?,
+		       `+prefix+`_codec = ?,
+		       `+prefix+`_format_version = ?,
+		       `+prefix+`_plaintext_bytes = ?,
+		       `+prefix+`_encoded_bytes = ?,
+		       `+prefix+`_sha256 = ?
+		 WHERE event_id = ?`,
+		encoded.Bytes, encoded.Codec, encoded.FormatVersion,
+		encoded.PlaintextBytes, encoded.StoredBytes, encoded.SHA256, eventID,
+	); err != nil {
+		t.Fatalf("re-encode audit %s to zstd: %v", field, err)
+	}
+}
+
+func readDecodedAudit(t *testing.T, db *sql.DB, eventID string) decodedAudit {
+	t.Helper()
+	ctx := context.Background()
+	command, err := hydrateAuditPayload(ctx, db, eventID, "command")
+	if err != nil {
+		t.Fatalf("hydrate command: %v", err)
+	}
+	input, err := hydrateAuditPayload(ctx, db, eventID, "input")
+	if err != nil {
+		t.Fatalf("hydrate input: %v", err)
+	}
+	output, err := hydrateAuditPayload(ctx, db, eventID, "output")
+	if err != nil {
+		t.Fatalf("hydrate output: %v", err)
+	}
+	return decodedAudit{Command: command.String, Input: input.String, Output: output.String}
+}
+
+func readStoredAudit(t *testing.T, db *sql.DB, eventID string) storedAudit {
+	t.Helper()
+	var got storedAudit
+	if err := db.QueryRow(`
+		SELECT command_text, input_text, output_text FROM command_audits WHERE event_id = ?`, eventID,
+	).Scan(&got.Command, &got.Input, &got.Output); err != nil {
+		t.Fatalf("read stored audit %s: %v", eventID, err)
+	}
+	return got
+}
+
+func assertAuditCodec(t *testing.T, db *sql.DB, eventID, field, want string) {
+	t.Helper()
+	var got sql.NullString
+	if err := db.QueryRow(`SELECT `+field+`_codec FROM command_audits WHERE event_id = ?`, eventID).Scan(&got); err != nil {
+		t.Fatalf("read %s_codec %s: %v", field, eventID, err)
+	}
+	if !got.Valid {
+		t.Fatalf("%s_codec for %s is NULL, want %q", field, eventID, want)
+	}
+	if diff := cmp.Diff(want, got.String); diff != "" {
+		t.Fatalf("%s_codec mismatch for %s (-want +got):\n%s", field, eventID, diff)
+	}
+}
+
+func assertAuditOriginalBytes(t *testing.T, db *sql.DB, eventID string, wantIn, wantOut int64) {
+	t.Helper()
+	var gotIn, gotOut int64
+	if err := db.QueryRow(`
+		SELECT input_original_bytes, output_original_bytes FROM command_audits WHERE event_id = ?`, eventID,
+	).Scan(&gotIn, &gotOut); err != nil {
+		t.Fatalf("read original bytes %s: %v", eventID, err)
+	}
+	if gotIn != wantIn || gotOut != wantOut {
+		t.Fatalf("original bytes = input %d output %d, want input %d output %d", gotIn, gotOut, wantIn, wantOut)
+	}
 }
 
 func defaultBackfillConfig() apptypes.PayloadBackfillConfig {

--- a/infrastructure/sqlite/payload_backfill_test.go
+++ b/infrastructure/sqlite/payload_backfill_test.go
@@ -1324,24 +1324,290 @@ func TestPayloadBackfillReportsTheRealErrorThatRacedACancellation(t *testing.T) 
 func TestPayloadBackfillRefusesAPreReleaseRunTable(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	db, ds, _ := openPayloadBackfillFixture(t)
-	defer closePayloadBackfillFixture(t, db)
-
-	if _, err := db.Exec(`ALTER TABLE payload_backfill_runs DROP COLUMN worker_token`); err != nil {
-		t.Fatalf("seed pre-release run table: %v", err)
-	}
 
 	// Every public entry point that reads the run table has to refuse it, not
 	// just the one an operator happens to try first.
-	entries := map[string]func() error{
-		"preview": func() error { _, err := ds.Preview(ctx, defaultBackfillConfig()); return err },
-		"status":  func() error { _, err := ds.Status(ctx); return err },
-		"run":     func() error { _, err := ds.Run(ctx, defaultBackfillConfig()); return err },
-		"resume":  func() error { _, err := ds.Resume(ctx, defaultBackfillConfig()); return err },
+	entries := map[string]func(*PayloadBackfillDatasource) error{
+		"preview": func(ds *PayloadBackfillDatasource) error {
+			_, err := ds.Preview(ctx, defaultBackfillConfig())
+			return err
+		},
+		"status": func(ds *PayloadBackfillDatasource) error { _, err := ds.Status(ctx); return err },
+		"run": func(ds *PayloadBackfillDatasource) error {
+			_, err := ds.Run(ctx, defaultBackfillConfig())
+			return err
+		},
+		"resume": func(ds *PayloadBackfillDatasource) error {
+			_, err := ds.Resume(ctx, defaultBackfillConfig())
+			return err
+		},
 	}
-	for name, call := range entries {
-		if err := call(); !errors.Is(err, ErrPayloadBackfillSchemaOutdated) {
-			t.Fatalf("%s error = %v, want ErrPayloadBackfillSchemaOutdated", name, err)
+
+	for _, missing := range []string{"worker_token", "audit_high_water_rowid"} {
+		missing := missing
+		t.Run("missing "+missing, func(t *testing.T) {
+			t.Parallel()
+			db, ds, _ := openPayloadBackfillFixture(t)
+			defer closePayloadBackfillFixture(t, db)
+			if _, err := db.Exec(`ALTER TABLE payload_backfill_runs DROP COLUMN ` + missing); err != nil {
+				t.Fatalf("seed pre-release run table without %s: %v", missing, err)
+			}
+			for name, call := range entries {
+				if err := call(ds); !errors.Is(err, ErrPayloadBackfillSchemaOutdated) {
+					t.Fatalf("%s error = %v, want ErrPayloadBackfillSchemaOutdated", name, err)
+				}
+			}
+		})
+	}
+}
+
+// Per-table high-waters: advancing events.rowid well past command_audits must
+// not put later audit inserts under a shared ceiling. An audit row created
+// above the audit start ceiling (but below the events ceiling) is left for a
+// later run, and this run still reaches completed.
+func TestPayloadBackfillPerTableHighWaterIgnoresLaterAuditInserts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, path := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	// Force events.rowid far above any audit rowid.
+	insertPlaintextEventAtRowID(t, db, 1000, eventSeed{
+		ID: "hw-event-high", Kind: "note", Body: compressibleBody("event-high"),
+	})
+	insertPlaintextEvent(t, db, eventSeed{ID: "hw-audit-host", Kind: "command_executed", Body: ""})
+	insertPlaintextAuditAtRowID(t, db, 1, auditSeed{
+		EventID: "hw-audit-host",
+		Command: compressibleBody("audit-at-1"),
+		Input:   compressibleBody("audit-in-1"),
+		Output:  compressibleBody("audit-out-1"),
+	})
+
+	var inserted bool
+	ds.onBeforeCommitBatch = func([]backfillCandidate) {
+		if inserted {
+			return
+		}
+		inserted = true
+		side, err := sql.Open("sqlite", directSQLiteRWDSN(path))
+		if err != nil {
+			t.Fatalf("open side conn: %v", err)
+		}
+		defer func() { _ = side.Close() }()
+		// Rowid 500 is below the events ceiling (1000) but above the audit
+		// ceiling (1). A shared max would have processed this insert.
+		insertPlaintextEvent(t, side, eventSeed{ID: "hw-late-host", Kind: "command_executed", Body: ""})
+		insertPlaintextAuditAtRowID(t, side, 500, auditSeed{
+			EventID: "hw-late-host",
+			Command: compressibleBody("late-audit"),
+			Input:   compressibleBody("late-in"),
+			Output:  compressibleBody("late-out"),
+		})
+	}
+
+	result, err := ds.Run(ctx, defaultBackfillConfig())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if diff := cmp.Diff(string(apptypes.PayloadBackfillCompleted), result.State); diff != "" {
+		t.Fatalf("state mismatch (-want +got):\n%s", diff)
+	}
+	assertAuditCodec(t, db, "hw-audit-host", "command", payloadCodecZstd)
+	// Late insert was plaintext and stays unprocessed: outside the audit ceiling.
+	var lateCodec sql.NullString
+	if err := db.QueryRow(`SELECT command_codec FROM command_audits WHERE event_id = ?`, "hw-late-host").Scan(&lateCodec); err != nil {
+		t.Fatalf("read late audit codec: %v", err)
+	}
+	if lateCodec.Valid {
+		t.Fatalf("late audit command_codec = %q, want NULL (not processed by this run)", lateCodec.String)
+	}
+	var auditHigh int64
+	if err := db.QueryRow(`SELECT audit_high_water_rowid FROM payload_backfill_runs WHERE run_id = ?`, result.RunID).Scan(&auditHigh); err != nil {
+		t.Fatalf("read audit high water: %v", err)
+	}
+	if auditHigh != 1 {
+		t.Fatalf("audit_high_water_rowid = %d, want 1", auditHigh)
+	}
+}
+
+// The same numeric rowid may address a row in both tables. Each lane must be
+// processed exactly once against the correct table — the loader must not let
+// an events.rowid pull in a command_audits row created after the audit ceiling.
+func TestPayloadBackfillSameRowIDIsProcessedPerTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, _ := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	const sharedRowID int64 = 42
+	insertPlaintextEventAtRowID(t, db, sharedRowID, eventSeed{
+		ID: "same-rowid-event", Kind: "note", Body: compressibleBody("event-42"),
+	})
+	insertPlaintextEvent(t, db, eventSeed{ID: "same-rowid-audit-host", Kind: "command_executed", Body: ""})
+	insertPlaintextAuditAtRowID(t, db, sharedRowID, auditSeed{
+		EventID: "same-rowid-audit-host",
+		Command: compressibleBody("audit-42"),
+		Input:   compressibleBody("audit-42-in"),
+		Output:  compressibleBody("audit-42-out"),
+	})
+
+	result, err := ds.Run(ctx, defaultBackfillConfig())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if diff := cmp.Diff(string(apptypes.PayloadBackfillCompleted), result.State); diff != "" {
+		t.Fatalf("state mismatch (-want +got):\n%s", diff)
+	}
+	assertBodyCodec(t, db, "same-rowid-event", payloadCodecZstd)
+	assertAuditCodec(t, db, "same-rowid-audit-host", "command", payloadCodecZstd)
+	assertAuditCodec(t, db, "same-rowid-audit-host", "input", payloadCodecZstd)
+	assertAuditCodec(t, db, "same-rowid-audit-host", "output", payloadCodecZstd)
+	// One body + three audit fields for the shared rowid, plus the host event
+	// body (empty, likely identity-kept or no-op). Encoded must cover the four
+	// compressible lanes at the shared rowid.
+	if result.EncodedRows < 4 {
+		t.Fatalf("encoded_rows = %d, want >= 4 (body + 3 audit fields)", result.EncodedRows)
+	}
+	gotEvent := readDecodedBody(t, db, "same-rowid-event")
+	if diff := cmp.Diff([]byte(compressibleBody("event-42")), gotEvent); diff != "" {
+		t.Fatalf("decoded event body mismatch (-want +got):\n%s", diff)
+	}
+	gotAudit := readDecodedAudit(t, db, "same-rowid-audit-host")
+	if diff := cmp.Diff(compressibleBody("audit-42"), gotAudit.Command); diff != "" {
+		t.Fatalf("decoded audit command mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Selector/loader split: if every picked rowid becomes ineligible between pick
+// and expansion, an empty batch must not report completed while eligible
+// rowids remain beyond the cursor. Production merges pick and expansion; this
+// test reintroduces the seam via onAfterPickRowIDs.
+func TestPayloadBackfillDoesNotCompleteWhenPickExpandsEmptyWithRemainingWork(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, _ := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	// Early rowids that the first pick will take, then a later row left beyond.
+	for _, id := range []string{"split-early-1", "split-early-2"} {
+		insertIdentityEvent(t, db, eventSeed{ID: id, Kind: "note", Body: compressibleBody(id)})
+	}
+	insertIdentityEvent(t, db, eventSeed{
+		ID: "split-late", Kind: "note", Body: compressibleBody("split-late"),
+	})
+
+	var fired bool
+	ds.onAfterPickRowIDs = func(rowIDs []int64) {
+		if fired || len(rowIDs) == 0 {
+			return
+		}
+		fired = true
+		// Make every picked rowid ineligible (as if a concurrent writer already
+		// rewrote them to zstd) so expansion returns empty while "split-late"
+		// remains eligible beyond the cursor.
+		for _, id := range []string{"split-early-1", "split-early-2"} {
+			reencodeBodyToZstd(t, db, id, []byte(compressibleBody(id)))
 		}
 	}
+
+	result, err := ds.Run(ctx, apptypes.PayloadBackfillConfig{BatchRows: 2})
+	// Must not report completed over unwalked work. The fail-closed path
+	// returns an error naming the stranded eligible fields.
+	if err == nil && result.State == string(apptypes.PayloadBackfillCompleted) {
+		t.Fatalf("run reported completed after empty expansion with remaining work; late row codec=%q",
+			bodyCodecOrEmpty(t, db, "split-late"))
+	}
+	if result.State == string(apptypes.PayloadBackfillCompleted) {
+		t.Fatalf("state = completed; empty expansion must not finish the run while eligible rowids remain")
+	}
+	// The late row must still be eligible (identity) — never silently skipped.
+	assertBodyCodec(t, db, "split-late", payloadCodecIdentity)
+}
+
+// Identity audit values are bound as TEXT, matching every other writer. Nothing
+// currently runs LIKE against the audit columns, so this pins the invariant
+// rather than fixing a live break (see #1685 for the events.body LIKE failure
+// when an identity value was stored as BLOB).
+func TestPayloadBackfillPreservesTextAffinityForIncompressibleAuditCommand(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, ds, _ := openPayloadBackfillFixture(t)
+	defer closePayloadBackfillFixture(t, db)
+
+	// High-entropy bytes zstd cannot shrink — recipe keeps identity.
+	raw := make([]byte, 256)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	const id = "audit-affinity"
+	insertPlaintextEvent(t, db, eventSeed{ID: id, Kind: "command_executed", Body: ""})
+	insertPlaintextAudit(t, db, auditSeed{
+		EventID: id,
+		Command: string(raw),
+		Input:   "short-in",
+		Output:  "short-out",
+	})
+
+	if _, err := ds.Run(ctx, defaultBackfillConfig()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertAuditCodec(t, db, id, "command", payloadCodecIdentity)
+	got := readDecodedAudit(t, db, id)
+	if diff := cmp.Diff(string(raw), got.Command); diff != "" {
+		t.Fatalf("decoded command mismatch (-want +got):\n%s", diff)
+	}
+	stored := readStoredAudit(t, db, id)
+	if diff := cmp.Diff(raw, stored.Command); diff != "" {
+		t.Fatalf("stored command bytes mismatch (-want +got):\n%s", diff)
+	}
+	var storedType string
+	if err := db.QueryRow(`SELECT typeof(command_text) FROM command_audits WHERE event_id = ?`, id).Scan(&storedType); err != nil {
+		t.Fatalf("read command_text type: %v", err)
+	}
+	if diff := cmp.Diff("text", storedType); diff != "" {
+		t.Fatalf("command_text affinity mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func insertPlaintextEventAtRowID(t *testing.T, db *sql.DB, rowID int64, seed eventSeed) {
+	t.Helper()
+	var sourceHook any
+	if seed.SourceHook != "" {
+		sourceHook = seed.SourceHook
+	}
+	if _, err := db.Exec(`
+		INSERT INTO events(
+			rowid, id, kind, client, agent, session_id, workspace, body, created_at, source_hook
+		) VALUES (?, ?, ?, 'cli', 'codex', 'session-codec', 'ws-codec', ?, '2026-08-09T00:00:00Z', ?)`,
+		rowID, seed.ID, seed.Kind, seed.Body, sourceHook,
+	); err != nil {
+		t.Fatalf("insert plaintext event %s at rowid %d: %v", seed.ID, rowID, err)
+	}
+}
+
+func insertPlaintextAuditAtRowID(t *testing.T, db *sql.DB, rowID int64, seed auditSeed) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO command_audits(
+			rowid, event_id, command_text, input_text, output_text,
+			input_truncated, output_truncated, input_original_bytes, output_original_bytes,
+			exit_code, failed
+		) VALUES (?, ?, ?, ?, ?, 0, 0, ?, ?, 0, 0)`,
+		rowID, seed.EventID, seed.Command, seed.Input, seed.Output,
+		seed.InputOriginalBytes, seed.OutputOriginalBytes,
+	); err != nil {
+		t.Fatalf("insert plaintext audit %s at rowid %d: %v", seed.EventID, rowID, err)
+	}
+}
+
+func bodyCodecOrEmpty(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var got sql.NullString
+	if err := db.QueryRow(`SELECT body_codec FROM events WHERE id = ?`, id).Scan(&got); err != nil {
+		t.Fatalf("read body_codec %s: %v", id, err)
+	}
+	if !got.Valid {
+		return ""
+	}
+	return got.String
 }

--- a/infrastructure/sqlite/prepared_migration_catalog.go
+++ b/infrastructure/sqlite/prepared_migration_catalog.go
@@ -65,7 +65,7 @@ var preparedMigrationManifest = map[int64]migrationManifestEntry{
 	// 53 only drops and recreates two body-derivation triggers (no data scan).
 	53: {53, "000053_codec_aware_body_derivations.sql", "dc8c32cc5397f5a6afe056e29c992f2e868c9e6ab22a3c4127afa31f3928d12b", MigrationConstantInPlace},
 	// 54 only creates the payload_backfill_runs bookkeeping table (no data scan).
-	54: {54, "000054_add_payload_backfill.sql", "18469d9e2d54d5237c2770b6f23a09b63482e964a02d23822383e24cabb54a9a", MigrationConstantInPlace},
+	54: {54, "000054_add_payload_backfill.sql", "8c59b480a1250eecf424bb014f4e2fc3c4c52079fcbf004db47903fd6fae3622", MigrationConstantInPlace},
 }
 
 // PreparedMigration identifies one exact pending embedded migration.

--- a/infrastructure/sqlite/session_orphan_range_datasource.go
+++ b/infrastructure/sqlite/session_orphan_range_datasource.go
@@ -266,11 +266,19 @@ func (d *SessionOrphanRangeDatasource) LoadMaterial(
 	}
 	defer func() { _ = cmdRows.Close() }()
 	for cmdRows.Next() {
-		var command string
-		if err := cmdRows.Scan(&command); err != nil {
-			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to scan orphan range command: %w", err)
+		var eventID string
+		if err := cmdRows.Scan(&eventID); err != nil {
+			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to scan orphan range command event id: %w", err)
 		}
-		material.Commands = append(material.Commands, command)
+		// command_text is codec-managed; decode through the shared boundary so
+		// a zstd-compressed audit never surfaces as binary garbage here.
+		command, err := hydrateAuditPayload(ctx, db, eventID, "command")
+		if err != nil {
+			return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to decode orphan range command for %s: %w", eventID, err)
+		}
+		if command.Valid {
+			material.Commands = append(material.Commands, command.String)
+		}
 	}
 	if err := cmdRows.Err(); err != nil {
 		return model.SessionOrphanMaterial{}, xerrors.Errorf("failed to iterate orphan range commands: %w", err)

--- a/infrastructure/sqlite/sql/select_orphan_range_commands.sql
+++ b/infrastructure/sqlite/sql/select_orphan_range_commands.sql
@@ -1,6 +1,8 @@
 -- Commands whose events fall inside an orphan range under canonical order.
 -- Bind order: session_id, from_event_id (empty-check + exclusive lower), to_event_id.
-SELECT a.command_text
+-- Select event_id only: command_text is codec-managed and must be decoded
+-- through hydrateAuditPayload, never read as a SQL string.
+SELECT a.event_id
   FROM command_audits AS a
   JOIN events AS e ON e.id = a.event_id
  WHERE e.session_id = ?

--- a/infrastructure/sqlite/sql/select_recent_command_previews.sql
+++ b/infrastructure/sqlite/sql/select_recent_command_previews.sql
@@ -16,7 +16,10 @@ WITH selected AS (
 )
 SELECT selected.id,
        substr(COALESCE(a.command_text, e.body), 1, ?),
-       COALESCE(length(CAST(a.command_text AS BLOB)), selected.body_stored_bytes),
+       -- Prefer command_plaintext_bytes: once the payload codec is on,
+       -- length(command_text) is the compressed (or BLOB) size, not the
+       -- logical command size callers report as StoredBytes.
+       COALESCE(a.command_plaintext_bytes, length(CAST(a.command_text AS BLOB)), selected.body_stored_bytes),
        selected.body_original_bytes,
        selected.body_ingest_truncated,
        selected.body_storage_truncated,

--- a/infrastructure/sqlite/sql/select_recent_command_previews.sql
+++ b/infrastructure/sqlite/sql/select_recent_command_previews.sql
@@ -1,5 +1,9 @@
 -- Handoff recent-command summaries read command_audits.command_text.
 -- events.body for command_executed is empty after #1675.
+--
+-- The command line itself is not selected here: ListRecentCommandPreviews
+-- hydrates through the payload codec and rebuilds the preview in Go. A SQL
+-- prefix of the physical column would read and truncate compressed bytes.
 WITH selected AS (
     SELECT m.id,
            m.body_stored_bytes,
@@ -15,7 +19,6 @@ WITH selected AS (
      LIMIT ?
 )
 SELECT selected.id,
-       substr(COALESCE(a.command_text, e.body), 1, ?),
        -- Prefer command_plaintext_bytes: once the payload codec is on,
        -- length(command_text) is the compressed (or BLOB) size, not the
        -- logical command size callers report as StoredBytes.

--- a/schema/sqlite/migrations/000054_add_payload_backfill.sql
+++ b/schema/sqlite/migrations/000054_add_payload_backfill.sql
@@ -1,11 +1,18 @@
 -- Resumable in-place payload backfill bookkeeping.
--- Walks events by rowid up to a high-water fixed at run start; recipe_version
--- refuses resume across batch-semantic changes. Constant cost: CREATE only.
+-- Walks events and command_audits by a shared numeric rowid cursor up to a
+-- per-table high-water fixed at run start. recipe_version refuses resume
+-- across batch-semantic changes. Constant cost: CREATE only.
 
 CREATE TABLE payload_backfill_runs (
   run_id TEXT PRIMARY KEY,
   recipe_version TEXT NOT NULL,
+  -- Inclusive events.rowid ceiling fixed at run start. Independent of the
+  -- command_audits sequence: the two tables do not share rowid allocation.
   high_water_rowid INTEGER NOT NULL CHECK (high_water_rowid >= 0),
+  -- Inclusive command_audits.rowid ceiling fixed at run start. Stored
+  -- separately so a later insert into the lagging table cannot land below a
+  -- shared max and either strand the audit frontier or silently skip work.
+  audit_high_water_rowid INTEGER NOT NULL DEFAULT 0 CHECK (audit_high_water_rowid >= 0),
   cursor_rowid INTEGER NOT NULL DEFAULT 0 CHECK (cursor_rowid >= 0),
   pass_count INTEGER NOT NULL DEFAULT 0 CHECK (pass_count >= 0),
   state TEXT NOT NULL CHECK (state IN ('running', 'paused', 'completed', 'failed')),


### PR DESCRIPTION
Closes #1742

`#1685` applied the payload codec to `events.body`. That is **0.584 GiB** of the 1.67 GiB the #1620 store gate counts on. The other **1.087 GiB** is in `command_audits`, and `output_text` alone is 0.925 GiB. This is that half, and it is a dependency of #1679 and #1620 — "#1685 merged" is not sufficient for either.

## 1. The recipe becomes a list of lanes

A lane is a `(table, field, codec prefix)` unit. Preview, run and resume walk the list. Selection, the all-NULL-or-all-present coherence rule, the fail-closed stop on partial metadata, the conflict re-check and the TEXT/BLOB affinity rule are all per lane and otherwise unchanged, so the three audit fields go through exactly the engine `events.body` already uses.

`BatchRows` now bounds **distinct rowids** rather than field units, so a limit cut cannot take `body` and strand `command_text` of the same rowid. `ScannedRows` therefore counts lane candidates, not rows — an audit row with three eligible fields contributes 3. The JSON name is frozen, so that is documented rather than renamed.

The recipe version becomes `v2`: a `v1` checkpoint is refused rather than resumed under different rules.

## 2. Byte accounting that had to move off the physical column

`length(command_text)` becomes the compressed size once the codec is on.

- `select_recent_command_previews.sql` prefers `command_plaintext_bytes`, so `StoredBytes` keeps reporting the logical command length.
- `select_orphan_range_commands.sql` returns event ids for the caller to decode through `hydrateAuditPayload` instead of reading `command_text` as a SQL string.
- `search_projection_rebuild.go:375` was **verified, not changed** — it already prefers `*_plaintext_bytes` for the logical figure and its `length()` terms are the physical figure on purpose.

Category (A) of #1685's D6 sweep really is empty here: nothing does `LIKE`, `json_extract` or `TRIM` on the three columns, and migration 052 dropped the last triggers that read them.

## 3. Review round — the shared ceiling was the flaw

The first implementation kept **one** high-water, `max(MAX(events.rowid), MAX(command_audits.rowid))`, for both tables. The two rowid sequences are independent, and on the live store they are far apart:

```
events         MAX(rowid) = 763403   (583882 rows)
command_audits MAX(rowid) = 428635   (277378 rows)
```

So the next ~335000 audit inserts — months of writes — land **below** the shared ceiling. That is not a conservative approximation of two ceilings; it is the loss of the guarantee that made the walk terminate, and it breaks in both directions:

1. the audit frontier stays ahead of the cursor, every pass is dirty, and `completed` becomes unreachable;
2. the cursor overtakes the frontier, later inserts land behind it, and a clean pass reports `completed` with unprocessed rows still in range.

Migration 054 carries a second ceiling now — one per table, both fixed at run start, both read from the checkpoint on resume and never recomputed. Selection, counting and the loader each bound their table by its own. 054 is unreleased, so the column lands there rather than in a 055 that would put "create a known-wrong table, then repair it" permanently in the released chain; `requirePayloadBackfillSchema` refuses the intermediate shape the same way it already refuses the pre-`worker_token` one.

Two further findings from the same round:

- **The loader had no ceiling at all.** Expanding picked rowids with `rowid IN (...)` let an `events` rowid of 500000 also pull `command_audits` rowid 500000 — a row created after the run started.
- **Pick and expand were two statements.** If every picked row became ineligible in between, the loader returned empty and the loop read that as end-of-walk. They are one statement now, sharing a read snapshot, and an empty batch that still counts eligible fields past the cursor is refused rather than completed.

## 4. One thing removed

`select_recent_command_previews.sql` still took a `substr` of `command_text` that `event_preview_datasource.go` discarded immediately in favour of the hydrated plaintext — a compressed column read and truncated for nothing. The column and its bind parameter are gone. Same "computed in SQL, recomputed and thrown away in Go" pattern #1685 removed from the timeline query.

## Verification

Every behavioural claim has a test that was confirmed red before the fix by mutation, not by assertion alone:

| test | mutation | failure |
|---|---|---|
| per-table ceiling ignores later audit inserts | restore the shared max | `late audit command_codec = "zstd", want NULL` |
| empty expansion does not complete the run | drop the `remaining > 0` guard | `run reported completed after empty expansion with remaining work` |
| incompressible audit command keeps TEXT affinity | drop the identity `string(...)` bind | `command_text affinity mismatch: "text" → "blob"` |
| preview StoredBytes prefers plaintext bytes | — | asserts against the compressed physical size directly |

Gates: `go build ./...`, `go test ./...`, `go tool golangci-lint run` → `0 issues.`

Implementation delegated to Grok 4.5 (high); design consultation and review by Claude Opus 5 with an adversarial round from gpt-5.6-sol.

## 5. Second review round — `cfb8a4d6`

No correctness defect, but the fix commit left the thing it replaced in place. The pick/expand split lived on behind a test hook so a test could inject the race — keeping the defective implementation and a duplicate copy of the candidate SQL in production for no production reason. It is gone; the empty-batch refusal it existed to exercise is a real fail-safe and now needs one hook that rewrites the selector result, not a second selector.

Two tests also read stronger than they were. The same-rowid case put both rows in before the run started, so the number was inside both ceilings and no loader-ceiling regression could fail it. And nothing covered resume, so a run that recomputed its ceilings instead of reading them from the checkpoint would have gone unnoticed.

| test | mutation | failure |
|---|---|---|
| same rowid above the audit ceiling is not loaded | point the audit arms at the events ceiling | `late audit command_codec = "zstd", want NULL (loader must not pull it via events.rowid 500)` |
| empty expansion does not complete the run | disable the remaining-work refusal | `Run err = nil, want remaining-work error; state="completed"` |
| resume preserves both ceilings | recompute the ceilings on resume | `late event body_codec = "zstd", want NULL (above checkpointed events ceiling)` |

Separately, the review found that `payload_rehearsal.go` sizes text columns with `length()`, which counts **characters** for TEXT and bytes only for BLOB (`length('あいう')` is 3, `length(CAST('あいう' AS BLOB))` is 9). It under-counts every non-ASCII payload and feeds the #1620 gate arithmetic. Pre-existing and out of scope here — filed as **#1749**.
