### PR TITLE
docs: record what wave 4 settled about deprecation notices

### DIFF
--- a/.ai/spec/1606.md
+++ b/.ai/spec/1606.md
@@ -386,6 +386,7 @@ stop(畳む) ── やりとり ── stop(スルー) ── compact
 | D12 | compact 到達時に未精製範囲を stop 圧力から**切り離して gc 所有へ移し、圧力をリセット**する。compact hook を持たない Antigravity は対象外（残存リスクを受け入れ） | compact 後の素材は文脈にないので、以後 stop を繰り返しても畳めない |
 | D13 | 対話 surface は `memory inbox review` **だけ**残す。cockpit・`sessions` live dashboard・bare `traceary` の TTY 既定は **v0.34 告知 / v0.35 削除**。削除後の bare `traceary` は TTY でも help | D10 は「即削除」を前提にしていたが、`docs/cli-stability.md` に公約が無いだけで README / docs/interactive が `tui` を stable と明記していた。`top` (D11) と同じ扱いに揃える |
 | D14 | 「backing table が空」を根拠にした退役は、**述語全体**と**deprecation 契約**の両方を満たす場合に限る | Wave 4 spike で 4 件中 2 件が脱落した。`list --failures` は `failed = 1` で 1,943 件ヒットする（exit code だけを見た evidence が誤り）。`store workspace-alias` は canonical replacement が無く、`docs/cli-stability.md:98-115` の notice 形式を満たせない |
+| D15 | 告知は **command / behaviour / no-replacement** の 3 形態を 1 実装・1 stderr 経路で出す。notice は **run step** に付ける（pre-run hook ではない）。help / usage text は stdout byte-identity 保証の**対象外** | Wave 4 実装で判明。cobra は `--help`・引数エラー・required flag 検証を RunE より前に処理するので、pre-run hook では実行されない invocation にも notice が出る（`memory admin graph add` で実測）。逆に「実行時のみ告知」にすると `--help` が何も言わなくなるため、`Short` / `Long` に非推奨を書くことを義務化した。それは親の command listing を変えるので、help を byte-identity に含めたままだと流儀自体が自己矛盾する |
 
 ### D13 — 対話 surface を一本に絞る（Wave 4 spike 2026-08-10）
 
@@ -415,3 +416,28 @@ stop(畳む) ── やりとり ── stop(スルー) ── compact
 `store workspace-alias` は table こそ 0 行だが、deprecation 契約そのものが通せない。`docs/cli-stability.md:98-115` は notice に canonical replacement を必ず名指しさせるが、alias の代替は存在しない。加えて alias は死んだデータではなく、report での再分類（`workspace_identity_datasource.go:100-121`）、conflict sample の抑制（`:202-217`）、将来 observation の直接 `explicit_alias` 化（`event_delivery_store.go:400-422`）に効いている。→ #1768。
 
 その #1768 で判明したこと: conflict 14,684 行は distinct `(session_id, workspace)` にすると **147 組**（117 session / 36 workspace）にすぎない。`codex` / `post_tool_use` だけで 13,664 行を 16 組から出している。「手作業では捌けない量」という当初の見立ては誤りで、実際には捌ける量を、行数で数えているせいで捌けない量に見せていた。report が組数ではなく行数を出していること自体が defect である。
+
+### D15 — 告知の形式と発火点（Wave 4 実装 2026-08-10）
+
+Wave 4 は 4 issue とも「v0.34 では何も消さない、告知だけ」で着地した。実装 gpt-5.6-luna、review Claude Opus 5（主）+ gpt-5.6-sol（独立第二）。
+
+| issue | PR | 告知対象 | 形態 |
+|---|---|---|---|
+| #1688 | #1769 | `traceary top` | command |
+| #1687 | #1770 | `tui` / `dashboard` と bare `traceary` の TTY 既定 | command + behaviour |
+| #1689 | #1772 | `memory admin graph add` / `graph list`、`session label` 一式 | no-replacement |
+| #1765 | #1773 | `sessions` の対話的既定描画 | behaviour |
+
+削除は v0.35（#1764 / #1766 / #1690 / #1691）。
+
+**3 形態は 1 実装に集約した。** `presentation/cli/deprecation.go` の `writeDeprecationNotice` が唯一の stderr 経路で、`replacement == noReplacement` のときだけ「置き換え先はありません」に切り替わる。command 形態だけが `applyCommandDeprecation` で hook を挿し、behaviour 形態は挙動が起きる直前に直接呼ぶ。当初 luna が置いた `applyBehaviorDeprecation` は素通しの wrapper で、`apply*` という名前が hook 設置を示唆するのに即時書き込みだったため削除した。
+
+**発火点は run step。** `PreRunE` に置いた初期実装が誤りだったことは #1689 の review で sol が実測した: cobra v1.10.2 は `command.go:1007` の `ValidateRequiredFlags` を `PreRunE`（`:999`）の**後**に走らせるので、`traceary memory admin graph add memory-a`（`--to` / `--relation` 欠落）は notice を出してから exit 1 する。`--help`（`:934`）と `ValidateArgs`（`:968`）も同様に前段で短絡する。私は #1688 の review でこの順序を見ていながら「`top` には required flag が無い」で流しており、`graph add` には有る。RunE 差し替えに変えると、この 3 つの短絡すべてに対して「実行されたときだけ出る」が真になる。回帰テストは旧実装で落ちることを確認してから入れた。
+
+**その代償として help text を byte-identity 保証から外した。** 実行時のみ告知にすると `--help` が非推奨を伝えなくなるので、`Short` / `Long` に非推奨と削除目標を書くことを義務化した。sol はこれを「`tui` の `Short` 変更で bare 非 TTY stdout が 2114 → 2161 バイトに動いた」と HIGH で挙げたが、計測は正しく結論が誤りである。`Short` 変更が契約違反なら、この流儀ではどの subcommand も非推奨にできない。コードを戻すのではなく `docs/cli-stability.md` 側に「help / usage は保証の対象外、automation は `--help` を parse しない」を明記して解いた。
+
+**1 invocation 1 notice は `top` で危うかった。** `top` と `sessions` は同じ live runner を通るので、#1765 の mode notice をそのまま出すと `top` の command notice と 2 行になる。`interactiveDashboardNoticeApplies(commandName) bool` という名前付き述語に理由コメントごと閉じ込め、v0.35 で `top` が消えるまで削除されないようにした。sol が実 PTY で確認: `sessions` 1 行 / `top` 1 行（command notice のみ）/ `top --snapshot` 1 行 / `sessions --snapshot` 0 行 / 非 TTY `sessions` 0 行。制御シーケンス順は `notice → ?1049h → paint → ?1049l` で、alt-screen に飲まれず、復帰後の画面に残る。
+
+**sol の HIGH は 3 件中 2 件を却下した。** 上記の help byte-identity に加えて「`CHANGELOG.md:387,391` が今も permanent と書いている」も却下。この 2 行は `## [v0.19.0] - 2026-05-26`（header は `:379`）の中にあり、公開済み release notes と対になる不変記録である。書き換えは公約の撤回ではなく記録の改竄になる。採用したのは required flag の 1 件のみ。
+
+副産物として #1771（`memory_usecase_hygiene_test.go:644` の `MaxDuration: time.Millisecond` に依存した flaky test）を起票した。PR #1770 の CI 赤の原因で、branch は当該ファイルに触れていない。

--- a/.ai/spec/1606.md
+++ b/.ai/spec/1606.md
@@ -385,7 +385,7 @@ stop(畳む) ── やりとり ── stop(スルー) ── compact
 | D11 | `top` は v0.34 告知 / v0.35 削除 | `docs/cli-stability.md:52` の permanent 公約の撤回が先 |
 | D12 | compact 到達時に未精製範囲を stop 圧力から**切り離して gc 所有へ移し、圧力をリセット**する。compact hook を持たない Antigravity は対象外（残存リスクを受け入れ） | compact 後の素材は文脈にないので、以後 stop を繰り返しても畳めない |
 | D13 | 対話 surface は `memory inbox review` **だけ**残す。cockpit・`sessions` live dashboard・bare `traceary` の TTY 既定は **v0.34 告知 / v0.35 削除**。削除後の bare `traceary` は TTY でも help | D10 は「即削除」を前提にしていたが、`docs/cli-stability.md` に公約が無いだけで README / docs/interactive が `tui` を stable と明記していた。`top` (D11) と同じ扱いに揃える |
-| D14 | 「backing table が空」を根拠にした退役は、**述語全体**と**deprecation 契約**の両方を満たす場合に限る | Wave 4 spike で 4 件中 2 件が脱落した。`list --failures` は `failed = 1` で 1,943 件ヒットする（exit code だけを見た evidence が誤り）。`store workspace-alias` は canonical replacement が無く、`docs/cli-stability.md:98-115` の notice 形式を満たせない |
+| D14 | 「backing table が空」を根拠にした退役は、**述語全体**と**deprecation 契約**の両方を満たす場合に限る | Wave 4 spike で 4 件中 2 件が脱落した。`list --failures` は `failed = 1` で 1,943 件ヒットする（exit code だけを見た evidence が誤り）。`store workspace-alias` は canonical replacement が無く、`docs/cli-stability.md:98-115` の notice 形式を満たせない（この後半の根拠は **D15 で無効化**。no-replacement 形態が追加されたので、残る根拠は alias が現役であることだけ） |
 | D15 | 告知は **command / behaviour / no-replacement** の 3 形態を 1 実装・1 stderr 経路で出す。notice は **run step** に付ける（pre-run hook ではない）。help / usage text は stdout byte-identity 保証の**対象外** | Wave 4 実装で判明。cobra は `--help`・引数エラー・required flag 検証を RunE より前に処理するので、pre-run hook では実行されない invocation にも notice が出る（`memory admin graph add` で実測）。逆に「実行時のみ告知」にすると `--help` が何も言わなくなるため、`Short` / `Long` に非推奨を書くことを義務化した。それは親の command listing を変えるので、help を byte-identity に含めたままだと流儀自体が自己矛盾する |
 
 ### D13 — 対話 surface を一本に絞る（Wave 4 spike 2026-08-10）
@@ -432,12 +432,25 @@ Wave 4 は 4 issue とも「v0.34 では何も消さない、告知だけ」で�
 
 **3 形態は 1 実装に集約した。** `presentation/cli/deprecation.go` の `writeDeprecationNotice` が唯一の stderr 経路で、`replacement == noReplacement` のときだけ「置き換え先はありません」に切り替わる。command 形態だけが `applyCommandDeprecation` で hook を挿し、behaviour 形態は挙動が起きる直前に直接呼ぶ。当初 luna が置いた `applyBehaviorDeprecation` は素通しの wrapper で、`apply*` という名前が hook 設置を示唆するのに即時書き込みだったため削除した。
 
+**no-replacement 形態の追加は D14 の根拠を一つ無効化する。** D14 は `store workspace-alias` が退役できない理由として「canonical replacement が無いので deprecation 契約そのものを通せない」（`.ai/spec/1606.md:416`）を挙げたが、`docs/cli-stability.md:123` が後継なしの告知を明示的に許した以上、この根拠はもう成立しない。残るのは #1768 が実際に測った方——alias は死んだデータではなく、report の再分類・conflict sample の抑制・将来 observation の `explicit_alias` 化に効いている——だけである。v0.35 の退役判定は「後継が有るか」ではなく「失われるものが無いことを示せるか」で分岐させる。
+
 **発火点は run step。** `PreRunE` に置いた初期実装が誤りだったことは #1689 の review で sol が実測した: cobra v1.10.2 は `command.go:1007` の `ValidateRequiredFlags` を `PreRunE`（`:999`）の**後**に走らせるので、`traceary memory admin graph add memory-a`（`--to` / `--relation` 欠落）は notice を出してから exit 1 する。`--help`（`:934`）と `ValidateArgs`（`:968`）も同様に前段で短絡する。私は #1688 の review でこの順序を見ていながら「`top` には required flag が無い」で流しており、`graph add` には有る。RunE 差し替えに変えると、この 3 つの短絡すべてに対して「実行されたときだけ出る」が真になる。回帰テストは旧実装で落ちることを確認してから入れた。
 
-**その代償として help text を byte-identity 保証から外した。** 実行時のみ告知にすると `--help` が非推奨を伝えなくなるので、`Short` / `Long` に非推奨と削除目標を書くことを義務化した。sol はこれを「`tui` の `Short` 変更で bare 非 TTY stdout が 2114 → 2161 バイトに動いた」と HIGH で挙げたが、計測は正しく結論が誤りである。`Short` 変更が契約違反なら、この流儀ではどの subcommand も非推奨にできない。コードを戻すのではなく `docs/cli-stability.md` 側に「help / usage は保証の対象外、automation は `--help` を parse しない」を明記して解いた。
+**その代償として help text を byte-identity 保証から外した。** 実行時のみ告知にすると `--help` が非推奨を伝えなくなるので、`Short` / `Long` に非推奨と削除目標を書くことを義務化した。この除外は sol の #1770 HIGH（`tui` の `Short` 変更で bare 非 TTY stdout が 2114 → 2161 バイトに動いた）から出ている。コードを戻すのではなく `docs/cli-stability.md` 側に「help / usage は保証の対象外、automation は `--help` を parse しない」を明記して解いた。詳細は下の表。
 
 **1 invocation 1 notice は `top` で危うかった。** `top` と `sessions` は同じ live runner を通るので、#1765 の mode notice をそのまま出すと `top` の command notice と 2 行になる。`interactiveDashboardNoticeApplies(commandName) bool` という名前付き述語に理由コメントごと閉じ込め、v0.35 で `top` が消えるまで削除されないようにした。sol が実 PTY で確認: `sessions` 1 行 / `top` 1 行（command notice のみ）/ `top --snapshot` 1 行 / `sessions --snapshot` 0 行 / 非 TTY `sessions` 0 行。制御シーケンス順は `notice → ?1049h → paint → ?1049l` で、alt-screen に飲まれず、復帰後の画面に残る。
 
-**sol の HIGH は 3 件中 2 件を却下した。** 上記の help byte-identity に加えて「`CHANGELOG.md:387,391` が今も permanent と書いている」も却下。この 2 行は `## [v0.19.0] - 2026-05-26`（header は `:379`）の中にあり、公開済み release notes と対になる不変記録である。書き換えは公約の撤回ではなく記録の改竄になる。採用したのは required flag の 1 件のみ。
+**sol の HIGH は 4 件で、2 件を採用、2 件を却下した。**
+
+| PR | 指摘 | 扱い |
+|---|---|---|
+| #1769 | `--help` / 引数エラーで notice が出ない | **採用（別解）**。cobra の hook では直せないので、境界を policy に明記し test で固定した |
+| #1769 | CHANGELOG が今も permanent と書いている | 却下 |
+| #1770 | `tui` の `Short` 変更で bare 非 TTY stdout が動いた | 却下。ただし policy 矛盾を露出させ、help 除外規則を生んだ |
+| #1772 | required flag 欠落時に notice が出て失敗する | **採用**。上の run step 変更 |
+
+却下した CHANGELOG の件は、当該 2 行が `## [v0.19.0] - 2026-05-26` 節（Sessions dashboard #1083 と bare CLI #1060 のエントリ）の中にあるためである。公開済み release notes と対になる不変記録なので、書き換えは公約の撤回ではなく記録の改竄になる。行番号は Wave 4 自身の CHANGELOG 追記で動くため、ここには残さない。
+
+`tui` の件を「却下」と書くのは結論部分だけの話である。計測（2114 → 2161 バイト）は正しく、当時の policy に照らせば違反でもあった。`Short` 変更が契約違反ならこの流儀ではどの subcommand も非推奨にできないので、コードではなく policy を直した。指摘が無ければ矛盾は残っていた。
 
 副産物として #1771（`memory_usecase_hygiene_test.go:644` の `MaxDuration: time.Millisecond` に依存した flaky test）を起票した。PR #1770 の CI 赤の原因で、branch は当該ファイルに触れていない。


### PR DESCRIPTION
Records Wave 4 in the spec. Refs #1606 — **closes nothing**; all four Wave 4 sub-issues (#1688 / #1687 / #1689 / #1765) are already closed by their own PRs, and #1606 is the parent, which stays open until the tagged release.

## What

One row (D15) and one prose section in `.ai/spec/1606.md`. Spec-only; no code, no docs under `docs/`.

## Why this and not just the PR bodies

The four Wave 4 PRs each record their own issue. What none of them records is the thing that outlived them: the notice flow changed shape three times while Wave 4 was being implemented, and v0.35's four removal issues (#1764 / #1766 / #1690 / #1691) inherit the result.

- **Three notice forms**, one implementation, one stderr path — command, behaviour-change, no-replacement.
- **The notice is attached to the run step**, not a pre-run hook. This came from a measured defect, not a preference: cobra v1.10.2 validates required flags at `command.go:1007`, *after* `PreRunE` at `:999`, so `traceary memory admin graph add memory-a` emitted a notice and then exited 1. `--help` (`:934`) and `ValidateArgs` (`:968`) short-circuit the same way. I had seen that ordering during the #1688 review and waved it off because `top` has no required flags; `graph add` has two.
- **Help text is exempt from the stdout byte-identity guarantee.** Requiring a deprecated command to change its `Short` is what makes `--help` still useful once the notice only fires on real runs — but changing `Short` moves the parent's command listing. Freezing help bytes would have made the flow unable to deprecate anything.

D15 also records the two `gpt-5.6-sol` HIGH findings I rejected and why, so neither gets re-raised in v0.35: the `CHANGELOG.md:387,391` "permanent" lines sit inside the shipped `## [v0.19.0]` section and rewriting them would falsify the record, and the `tui` `Short` byte-count change is the flow working, not violating it.

## Verification

Spec-only change; `git show --stat` is one file. No build or test surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
