### PR TITLE
fix: guard session refinement lower bounds

### DIFF
--- a/infrastructure/sqlite/session_refinement_datasource.go
+++ b/infrastructure/sqlite/session_refinement_datasource.go
@@ -62,8 +62,10 @@ func (d *SessionRefinementDatasource) FindBySessionID(
 }
 
 // SaveIfAdvances stores refinement only when the persisted row is still at
-// expectedGeneration (0 means "no row yet") and the incoming covers_to
-// strictly advances coverage under canonical event order.
+// expectedGeneration (0 means "no row yet") and the incoming range subsumes the
+// stored one under canonical event order: covers_to strictly advances, and
+// covers_from does not move forward. Coverage authorises an irreversible body
+// discard, so it may widen but never shrink.
 func (d *SessionRefinementDatasource) SaveIfAdvances(
 	ctx context.Context,
 	refinement *model.SessionRefinement,

--- a/infrastructure/sqlite/session_refinement_datasource_test.go
+++ b/infrastructure/sqlite/session_refinement_datasource_test.go
@@ -475,6 +475,21 @@ func TestSessionRefinementDatasource_SaveIfAdvances_LowerBoundGuard(t *testing.T
 			wantWritten:    true,
 			wantStoredFrom: "evt-1",
 		},
+		// The tie-break is the part of the comparison a mutation would slip
+		// through: with equal timestamps the guard falls back to id order, and
+		// both cases below pass under either <= or >= unless they are paired.
+		{
+			name:           "accepts an equal timestamp with a lower id",
+			coversFrom:     "evt-0-tie",
+			wantWritten:    true,
+			wantStoredFrom: "evt-0-tie",
+		},
+		{
+			name:           "rejects an equal timestamp with a higher id",
+			coversFrom:     "evt-1-zz",
+			wantWritten:    false,
+			wantStoredFrom: "evt-1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -484,6 +499,9 @@ func TestSessionRefinementDatasource_SaveIfAdvances_LowerBoundGuard(t *testing.T
 				{id: "evt-1", at: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)},
 				{id: "evt-2", at: time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC)},
 				{id: "evt-3", at: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)},
+				// Same instant as evt-1, sorting either side of it by id.
+				{id: "evt-0-tie", at: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)},
+				{id: "evt-1-zz", at: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)},
 			})
 			seed, err := model.NewSessionRefinement(
 				sessionID, 1, "evt-1", "evt-2", "seed summary", "", "agent",

--- a/infrastructure/sqlite/session_refinement_datasource_test.go
+++ b/infrastructure/sqlite/session_refinement_datasource_test.go
@@ -448,6 +448,104 @@ func TestSessionRefinementDatasource_SaveIfAdvances_CASGuards(t *testing.T) {
 	assertRefinementUnchanged(ctx, t, fx.sut, sessionID, 2, "evt-3", "advanced summary")
 }
 
+func TestSessionRefinementDatasource_SaveIfAdvances_LowerBoundGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		coversFrom     string
+		wantWritten    bool
+		wantStoredFrom string
+	}{
+		{
+			name:           "rejects advancing upper bound with a forward lower bound",
+			coversFrom:     "evt-2",
+			wantWritten:    false,
+			wantStoredFrom: "evt-1",
+		},
+		{
+			name:           "accepts advancing both bounds in the widening direction",
+			coversFrom:     "sess-lower-bound-start",
+			wantWritten:    true,
+			wantStoredFrom: "sess-lower-bound-start",
+		},
+		{
+			name:           "accepts an unchanged lower bound",
+			coversFrom:     "evt-1",
+			wantWritten:    true,
+			wantStoredFrom: "evt-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newSessionRefinementFixture(t)
+			sessionID := seedRefinementSession(context.Background(), t, fx.sessions, fx.events, "sess-lower-bound", []eventSeed{
+				{id: "evt-1", at: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)},
+				{id: "evt-2", at: time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC)},
+				{id: "evt-3", at: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)},
+			})
+			seed, err := model.NewSessionRefinement(
+				sessionID, 1, "evt-1", "evt-2", "seed summary", "", "agent",
+				time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC), false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if written, err := fx.sut.SaveIfAdvances(context.Background(), seed, 0); err != nil || !written {
+				t.Fatalf("seed SaveIfAdvances() = (%v, %v), want (true, nil)", written, err)
+			}
+
+			candidate, err := model.NewSessionRefinement(
+				sessionID, 2, types.EventID(tt.coversFrom), "evt-3", "candidate summary", "", "agent",
+				time.Date(2026, 8, 1, 13, 0, 0, 0, time.UTC), false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			written, err := fx.sut.SaveIfAdvances(context.Background(), candidate, 1)
+			if err != nil {
+				t.Fatalf("SaveIfAdvances() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.wantWritten, written); diff != "" {
+				t.Fatalf("SaveIfAdvances() written mismatch (-want +got):\n%s", diff)
+			}
+
+			got, err := fx.sut.FindBySessionID(context.Background(), sessionID)
+			if err != nil {
+				t.Fatalf("FindBySessionID() error = %v", err)
+			}
+			stored, ok := got.Value()
+			if !ok {
+				t.Fatal("refinement missing")
+			}
+			want := struct {
+				Generation int
+				From       string
+				To         string
+				Summary    string
+			}{1, tt.wantStoredFrom, "evt-2", "seed summary"}
+			if tt.wantWritten {
+				want = struct {
+					Generation int
+					From       string
+					To         string
+					Summary    string
+				}{2, tt.wantStoredFrom, "evt-3", "candidate summary"}
+			}
+			gotSnapshot := struct {
+				Generation int
+				From       string
+				To         string
+				Summary    string
+			}{stored.Generation(), stored.CoversFromEventID().String(), stored.CoversToEventID().String(), stored.Summary()}
+			if diff := cmp.Diff(want, gotSnapshot); diff != "" {
+				t.Fatalf("stored refinement mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func assertRefinementUnchanged(
 	ctx context.Context,
 	t *testing.T,

--- a/infrastructure/sqlite/sql/upsert_session_refinement.sql
+++ b/infrastructure/sqlite/sql/upsert_session_refinement.sql
@@ -47,3 +47,17 @@ WHERE session_refinements.generation = ?
           JOIN events AS right_event ON right_event.id = session_refinements.covers_to_event_id
          WHERE left_event.id = excluded.covers_to_event_id
       ) = 1
+  -- The lower bound must stay at or before its predecessor's lower bound.
+  -- Keep this comparison explicit: unlike covers_to, equality is accepted.
+  -- Missing event rows produce NULL and therefore fail closed, as above.
+  AND (
+        SELECT CASE
+                 WHEN ts_norm(left_event.created_at) < ts_norm(right_event.created_at) THEN 1
+                 WHEN ts_norm(left_event.created_at) > ts_norm(right_event.created_at) THEN 0
+                 WHEN left_event.id <= right_event.id THEN 1
+                 ELSE 0
+               END
+          FROM events AS left_event
+          JOIN events AS right_event ON right_event.id = session_refinements.covers_from_event_id
+         WHERE left_event.id = excluded.covers_from_event_id
+      ) = 1


### PR DESCRIPTION
Closes #1758

## What

`infrastructure/sqlite/sql/upsert_session_refinement.sql` states this invariant in its own header:

> a newer refinement strictly subsumes its predecessor (coverage only advances; re-summarisation is cumulative)

It enforced half of it. The `DO UPDATE` guard compared only `covers_to_event_id` under canonical `(ts_norm(created_at), id)` order; `covers_from_event_id` was written unconditionally from `excluded`. A write covering `[e2, e4]` over a stored `[e1, e3]` passed, and `e1` silently left the covered range.

This adds the mirrored comparison for the lower bound: `excluded.covers_from_event_id` must be **at or before** the stored one. Equality is accepted — the ordinary re-summarisation keeps the same start and extends the end.

## Why it is worth the pre-gate slot

After #1676, `gc --target events` discards a transcript body **only if a refinement covers it**. Coverage is now the sole authority for an irreversible discard and simultaneously the thing that keeps a body safe.

## Honest scope: this is defence at the boundary, not a live data-loss bug

I checked the production path before accepting the change rather than after. `application/usecase/session_refinement_usecase_impl.go:141` passes `existing.CoversFromEventID()` through on every supersede, with the comment "Coverage only advances: keep the earlier covers_from". **No current caller can trigger the defect.**

That does not make the fix pointless — `SaveIfAdvances` is a domain repository contract whose SQL promises an invariant it did not enforce, and the guarantee now has to hold for any future caller as well as this one — but the PR should not claim to be fixing observed corruption. It is not.

The same check also confirmed the fix cannot reject a legitimate write, which was the real risk: had a producer legitimately computed a later start, this guard would have thrown away the new summary text entirely. It cannot, because the usecase never moves the lower bound.

## Implementation notes

- The comparison is a second explicit scalar `CASE` rather than a CTE. gpt-5.6-luna's reasoning, which I accept: there are no new placeholders either way, and the explicit form keeps the fail-closed behaviour legible next to the existing one.
- **No `?` was added or moved.** `session_refinement_datasource.go:85-102` binds arguments positionally under a comment describing the layout; a silent placeholder shift there writes the wrong columns, so this was the highest-risk part of the change and it was avoided entirely.
- Missing event rows yield NULL and therefore fail closed, matching the existing upper-bound behaviour. `gc --target events` blanks bodies with `UPDATE` and does not delete rows — but **`store dedupe` does**: `content_event_dedupe_datasource.go:801` runs `DELETE FROM events WHERE id = ?` after archiving. So the NULL branch is reachable, and reaching it freezes that session's refinement permanently. That is pre-existing behaviour of the upper-bound guard, not something this PR introduces; filed as **#1777** rather than widened into here.

## Verification

Five subtests, table-driven: forward lower bound rejected, widening accepted, unchanged accepted, and the two equal-timestamp tie-break cases.

I re-ran the new test against the pre-fix SQL myself rather than taking the implementer's word:

```
--- FAIL: .../rejects_advancing_upper_bound_with_a_forward_lower_bound
    SaveIfAdvances() written mismatch (-want +got):
      bool(
    - 	false,
    + 	true,
      )
```

The tie-break cases came out of review: the original three all passed with the guard's `<=` mutated to `>=`, because none of them placed two events at the same instant. Confirmed the new pair closes that by mutating the SQL and watching exactly those two fail:

```
--- FAIL: .../accepts_an_equal_timestamp_with_a_lower_id
--- FAIL: .../rejects_an_equal_timestamp_with_a_higher_id
```

`go build ./...` ✅ / `go test ./...` ✅ / `go tool golangci-lint run` → 0 issues ✅ — run independently of the implementer.

## Review notes

Implementation delegated to gpt-5.6-luna; reviewed by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oWFTGboP1ysRFisUgwDFd
